### PR TITLE
[ambient] Fix some unit test flakes for ambient informer

### DIFF
--- a/cni/pkg/nodeagent/informers_test.go
+++ b/cni/pkg/nodeagent/informers_test.go
@@ -66,7 +66,7 @@ func TestExistingPodAddedWhenNsLabeled(t *testing.T) {
 		mock.IsType(pod),
 		util.GetPodIPsIfPresent(pod),
 		"",
-	).Return(nil)
+	).Once().Return(nil)
 
 	server := getFakeDP(fs, client.Kube())
 
@@ -125,7 +125,7 @@ func TestExistingPodAddedWhenDualStack(t *testing.T) {
 		mock.IsType(pod),
 		util.GetPodIPsIfPresent(pod),
 		"",
-	).Return(nil)
+	).Once().Return(nil)
 
 	server := getFakeDP(fs, client.Kube())
 
@@ -182,6 +182,9 @@ func TestExistingPodNotAddedIfNoIPInAnyStatusField(t *testing.T) {
 	client.RunAndWait(ctx.Done())
 	go handlers.Start()
 
+	// wait until at least one add event happens
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "add"}, monitortest.AtLeast(1))
+
 	// label the namespace
 	labelsPatch := []byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":"%s"}}}`,
 		label.IoIstioDataplaneMode.Name, constants.DataplaneModeAmbient))
@@ -189,8 +192,9 @@ func TestExistingPodNotAddedIfNoIPInAnyStatusField(t *testing.T) {
 		types.MergePatchType, labelsPatch, metav1.PatchOptions{})
 	assert.NoError(t, err)
 
-	// wait until at least one add event happens
-	mt.Assert(EventTotals.Name(), map[string]string{"type": "add"}, monitortest.AtLeast(1))
+	// wait for all update events to settle
+	// total 3: 1. init ns reconcile 2. ns label reconcile 3. pod reconcile
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.AtLeast(3))
 
 	assertPodNotAnnotated(t, client, pod)
 
@@ -236,15 +240,16 @@ func TestExistingPodRemovedWhenNsUnlabeled(t *testing.T) {
 		mock.IsType(pod),
 		util.GetPodIPsIfPresent(pod),
 		"",
-	).Return(nil)
+	).Once().Return(nil)
 
 	server := getFakeDP(fs, client.Kube())
 
 	handlers := setupHandlers(ctx, client, server, "istio-system")
 	client.RunAndWait(ctx.Done())
 	go handlers.Start()
+
 	// wait until pod add was called
-	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.AtLeast(1))
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "add"}, monitortest.AtLeast(1))
 
 	log.Debug("labeling namespace")
 	_, err := client.Kube().CoreV1().Namespaces().Patch(ctx, ns.Name,
@@ -252,8 +257,10 @@ func TestExistingPodRemovedWhenNsUnlabeled(t *testing.T) {
 			label.IoIstioDataplaneMode.Name, constants.DataplaneModeAmbient)), metav1.PatchOptions{})
 	assert.NoError(t, err)
 
-	// wait for an update event
-	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.AtLeast(2))
+	// wait for all update events to settle
+	// total 3: 1. init ns reconcile 2. ns label reconcile 3. pod reconcile
+	// for all that tho, we should only get 1 ADD, as enforced by mock
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.AtLeast(3))
 
 	// wait for the pod to be annotated
 	// after Pod annotated, another update event will be triggered.
@@ -276,9 +283,8 @@ func TestExistingPodRemovedWhenNsUnlabeled(t *testing.T) {
 		types.MergePatchType, labelsPatch, metav1.PatchOptions{})
 	assert.NoError(t, err)
 
-	// wait for another two update events
-	// total 3 update at before unlabel point: 1. init ns reconcile 2. ns label reconcile 3. pod annotation update
-	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.AtLeast(5))
+	// wait for another 3 update events for unabel, total of 6
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.AtLeast(6))
 
 	waitForMockCalls()
 
@@ -310,9 +316,6 @@ func TestExistingPodRemovedWhenPodLabelRemoved(t *testing.T) {
 	}
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: "test"},
-		// TODO: once we if the add pod bug, re-enable this and remove the patch below
-		//		Labels: map[string]string{label.IoIstioDataplaneMode.Name: constants.DataplaneModeAmbient},
-
 	}
 
 	client := kube.NewFakeClient(ns, pod)
@@ -326,7 +329,7 @@ func TestExistingPodRemovedWhenPodLabelRemoved(t *testing.T) {
 		mock.IsType(pod),
 		util.GetPodIPsIfPresent(pod),
 		"",
-	).Return(nil)
+	).Once().Return(nil)
 
 	server := getFakeDP(fs, client.Kube())
 
@@ -334,7 +337,7 @@ func TestExistingPodRemovedWhenPodLabelRemoved(t *testing.T) {
 	client.RunAndWait(ctx.Done())
 	go handlers.Start()
 	// wait until pod add was called
-	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.AtLeast(1))
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "add"}, monitortest.AtLeast(1))
 
 	log.Debug("labeling namespace")
 	_, err := client.Kube().CoreV1().Namespaces().Patch(ctx, ns.Name,
@@ -342,8 +345,10 @@ func TestExistingPodRemovedWhenPodLabelRemoved(t *testing.T) {
 			label.IoIstioDataplaneMode.Name, constants.DataplaneModeAmbient)), metav1.PatchOptions{})
 	assert.NoError(t, err)
 
-	// wait for an update event
-	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.AtLeast(2))
+	// wait for all update events to settle
+	// total 3: 1. init ns reconcile 2. ns label reconcile 3. pod reconcile
+	// for all that tho, we should only get 1 ADD, as enforced by mock
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.AtLeast(3))
 
 	// wait for the pod to be annotated
 	// after Pod annotated, another update event will be triggered.
@@ -433,7 +438,8 @@ func TestJobPodRemovedWhenPodTerminates(t *testing.T) {
 	handlers := setupHandlers(ctx, client, server, "istio-system")
 	client.RunAndWait(ctx.Done())
 	go handlers.Start()
-	// wait until pod add was called
+
+	// Wait for a pod add event (initial informer bootup)
 	mt.Assert(EventTotals.Name(), map[string]string{"type": "add"}, monitortest.AtLeast(1))
 
 	log.Debug("labeling namespace")
@@ -442,8 +448,10 @@ func TestJobPodRemovedWhenPodTerminates(t *testing.T) {
 			label.IoIstioDataplaneMode.Name, constants.DataplaneModeAmbient)), metav1.PatchOptions{})
 	assert.NoError(t, err)
 
-	// wait for an update event
-	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.AtLeast(2))
+	// wait for all update events to settle
+	// total 3: 1. init ns reconcile 2. ns label reconcile 3. pod reconcile
+	// for all that tho, we should only get 1 ADD, as enforced by mock
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.AtLeast(3))
 
 	// wait for the pod to be annotated
 	// after Pod annotated, another update event will be triggered.
@@ -465,9 +473,8 @@ func TestJobPodRemovedWhenPodTerminates(t *testing.T) {
 		types.MergePatchType, phasePatch, metav1.PatchOptions{})
 	assert.NoError(t, err)
 
-	// wait for an update events
-	// total 3 update at before unlabel point: 1. init ns reconcile 2. ns label reconcile 3. pod status update
-	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.AtLeast(3))
+	// wait for an update event
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.AtLeast(4))
 
 	waitForMockCalls()
 
@@ -478,7 +485,7 @@ func TestJobPodRemovedWhenPodTerminates(t *testing.T) {
 		mock.Anything,
 		util.GetPodIPsIfPresent(pod),
 		"",
-	).Return(nil)
+	).Once().Return(nil)
 
 	// Now bring it back
 	// Patch the pod back to a running status
@@ -487,8 +494,8 @@ func TestJobPodRemovedWhenPodTerminates(t *testing.T) {
 		types.MergePatchType, phaseRunPatch, metav1.PatchOptions{})
 	assert.NoError(t, err)
 
-	// wait for an update events
-	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.AtLeast(4))
+	// wait for an update event
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.AtLeast(5))
 
 	assertPodAnnotated(t, client, pod)
 
@@ -775,7 +782,7 @@ func TestExistingPodAddedWhenItPreExists(t *testing.T) {
 		mock.IsType(pod),
 		util.GetPodIPsIfPresent(pod),
 		"",
-	).Return(nil)
+	).Once().Return(nil)
 
 	server := getFakeDP(fs, client.Kube())
 

--- a/cni/pkg/nodeagent/informers_test.go
+++ b/cni/pkg/nodeagent/informers_test.go
@@ -283,7 +283,7 @@ func TestExistingPodRemovedWhenNsUnlabeled(t *testing.T) {
 		types.MergePatchType, labelsPatch, metav1.PatchOptions{})
 	assert.NoError(t, err)
 
-	// wait for another 3 update events for unabel, total of 6
+	// wait for another 3 update events for unlabel, total of 6
 	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.AtLeast(6))
 
 	waitForMockCalls()

--- a/cni/pkg/nodeagent/informers_test.go
+++ b/cni/pkg/nodeagent/informers_test.go
@@ -426,7 +426,7 @@ func TestJobPodRemovedWhenPodTerminates(t *testing.T) {
 		mock.IsType(pod),
 		util.GetPodIPsIfPresent(pod),
 		"",
-	).Return(nil)
+	).Once().Return(nil)
 
 	server := getFakeDP(fs, client.Kube())
 
@@ -434,7 +434,7 @@ func TestJobPodRemovedWhenPodTerminates(t *testing.T) {
 	client.RunAndWait(ctx.Done())
 	go handlers.Start()
 	// wait until pod add was called
-	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.AtLeast(1))
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "add"}, monitortest.AtLeast(1))
 
 	log.Debug("labeling namespace")
 	_, err := client.Kube().CoreV1().Namespaces().Patch(ctx, ns.Name,
@@ -467,7 +467,7 @@ func TestJobPodRemovedWhenPodTerminates(t *testing.T) {
 
 	// wait for an update events
 	// total 3 update at before unlabel point: 1. init ns reconcile 2. ns label reconcile 3. pod status update
-	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.AtLeast(4))
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.AtLeast(3))
 
 	waitForMockCalls()
 
@@ -488,7 +488,7 @@ func TestJobPodRemovedWhenPodTerminates(t *testing.T) {
 	assert.NoError(t, err)
 
 	// wait for an update events
-	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.AtLeast(5))
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.AtLeast(4))
 
 	assertPodAnnotated(t, client, pod)
 

--- a/cni/pkg/util/podutil.go
+++ b/cni/pkg/util/podutil.go
@@ -104,10 +104,6 @@ func AnnotateEnrolledPod(client kubernetes.Interface, pod *metav1.ObjectMeta) er
 }
 
 func AnnotateUnenrollPod(client kubernetes.Interface, pod *metav1.ObjectMeta) error {
-	if pod.Annotations[annotation.AmbientRedirection.Name] != constants.AmbientRedirectionEnabled {
-		return nil
-	}
-	// TODO: do not overwrite if already none
 	_, err := client.CoreV1().
 		Pods(pod.Namespace).
 		Patch(


### PR DESCRIPTION
**Please provide a description of this PR:**

After a recent PR flakes like https://prow.istio.io/view/gs/istio-prow/logs/unit-tests_istio_postsubmit/1866952380273135616 showed up, which are reproducible (eventually) with `stress`.

This is because some of these tests aren't waiting for the correct number of events before proceeding. Looking at them, it's obvious they aren't correct, but it wasn't obvious to the idiot that wrote them (me) at the time.

This PR 

- tightens up the event counting the unit tests use to keep things deterministic (actual cause of the flakes)
- puts explicit invocation counts on all mocks (these are good, the only reason the flake manifested in the first place in the one test they're used)

A 20 min `stress` run of the affected tests here seemed good enough to validate, given how it wasn't hard to repro.