### PR TITLE
Allow waypoints servers to support hostnames in routing

### DIFF
--- a/pilot/pkg/features/ambient.go
+++ b/pilot/pkg/features/ambient.go
@@ -59,6 +59,9 @@ var (
 
 	EnableIngressWaypointRouting = registerAmbient("ENABLE_INGRESS_WAYPOINT_ROUTING", true, false,
 		"If true, Gateways will call service waypoints if the 'istio.io/ingress-use-waypoint' label set on the Service.")
+
+	EnableAmbientMultiNetwork = registerAmbient("AMBIENT_ENABLE_MULTI_NETWORK", false, false,
+		"If true, the multi-network functionality will be enabled.")
 )
 
 // registerAmbient registers a variable that is allowed only if EnableAmbient is set

--- a/pilot/pkg/networking/core/listener_waypoint.go
+++ b/pilot/pkg/networking/core/listener_waypoint.go
@@ -420,21 +420,24 @@ func (lb *ListenerBuilder) buildWaypointInternal(wls []model.WorkloadInfo, svcs 
 					},
 				},
 			},
-			OnNoMatch: &matcher.Matcher_OnMatch{
-				OnMatch: &matcher.Matcher_OnMatch_Matcher{
-					Matcher: &matcher.Matcher{
-						MatcherType: &matcher.Matcher_MatcherTree_{
-							MatcherTree: &matcher.Matcher_MatcherTree{
-								Input: match.AuthorityFilterStateInput,
-								TreeType: &matcher.Matcher_MatcherTree_ExactMatchMap{
-									ExactMatchMap: svcHostnameMap,
-								},
+		},
+	}
+
+	if len(svcHostnameMap.Map) > 0 {
+		l.FilterChainMatcher.OnNoMatch = &matcher.Matcher_OnMatch{
+			OnMatch: &matcher.Matcher_OnMatch_Matcher{
+				Matcher: &matcher.Matcher{
+					MatcherType: &matcher.Matcher_MatcherTree_{
+						MatcherTree: &matcher.Matcher_MatcherTree{
+							Input: match.AuthorityFilterStateInput,
+							TreeType: &matcher.Matcher_MatcherTree_ExactMatchMap{
+								ExactMatchMap: svcHostnameMap,
 							},
 						},
 					},
 				},
 			},
-		},
+		}
 	}
 	if tlsInspector != nil {
 		l.ListenerFilters = append(l.ListenerFilters, tlsInspector)

--- a/pilot/pkg/networking/core/listener_waypoint.go
+++ b/pilot/pkg/networking/core/listener_waypoint.go
@@ -291,7 +291,7 @@ func (lb *ListenerBuilder) buildWaypointInternal(wls []model.WorkloadInfo, svcs 
 			var tcpChain, httpChain *listener.FilterChain
 			origDst := svc.GetAddressForProxy(lb.node) + ":" + portString
 			httpClusterName := model.BuildSubsetKey(model.TrafficDirectionInboundVIP, "http", svc.Hostname, port.Port)
-			if len(svcAddresses) > 0 {
+			if len(svcAddresses) > 0 && features.EnableAmbientMultiNetwork {
 				setOrigDstForCluster := []*listener.Filter{getOrigDstSfs(origDst, false)}
 				tcpChain = &listener.FilterChain{
 					Filters: append(setOrigDstForCluster, lb.buildInboundNetworkFilters(cc)...),

--- a/pilot/pkg/networking/core/listener_waypoint.go
+++ b/pilot/pkg/networking/core/listener_waypoint.go
@@ -494,7 +494,7 @@ func (lb *ListenerBuilder) buildWaypointInternal(wls []model.WorkloadInfo, svcs 
 		},
 	}
 
-	if len(svcHostnameMap.Map) > 0 {
+	if len(svcHostnameMap.Map) > 0 && features.EnableAmbientMultiNetwork {
 		l.FilterChainMatcher.OnNoMatch = &matcher.Matcher_OnMatch{
 			OnMatch: &matcher.Matcher_OnMatch_Matcher{
 				Matcher: &matcher.Matcher{

--- a/pilot/pkg/networking/core/listener_waypoint.go
+++ b/pilot/pkg/networking/core/listener_waypoint.go
@@ -345,6 +345,11 @@ func (lb *ListenerBuilder) buildWaypointInternal(wls []model.WorkloadInfo, svcs 
 					portProtocols[port.Port] = port.Protocol
 				}
 			}
+
+			// If the service has no addresses, we don't want this waypoint to be able to serve its hostname
+			if len(svcAddresses) == 0 {
+				delete(svcHostnameMap.Map, authorityKey)
+			}
 		}
 		if len(portMapper.Map) > 0 {
 			ranges := slices.Map(svcAddresses, func(vip string) *xds.CidrRange {

--- a/pilot/pkg/networking/core/match/match.go
+++ b/pilot/pkg/networking/core/match/match.go
@@ -22,6 +22,7 @@ import (
 
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/util/protoconv"
+	"istio.io/istio/pilot/pkg/xds/filters"
 	"istio.io/istio/pkg/log"
 )
 
@@ -49,6 +50,12 @@ var (
 	TransportProtocolInput = &xds.TypedExtensionConfig{
 		Name:        "transport-protocol",
 		TypedConfig: protoconv.MessageToAny(&network.TransportProtocolInput{}),
+	}
+	AuthorityFilterStateInput = &xds.TypedExtensionConfig{
+		Name: "authority-filter-state",
+		TypedConfig: protoconv.MessageToAny(&network.FilterStateInput{
+			Key: filters.AuthorityFilterStateKey,
+		}),
 	}
 )
 

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -2890,6 +2890,14 @@ func TestDirect(t *testing.T) {
 				HBONE:   hbsvc,
 				Check:   check.OK(),
 			})
+			run("VIP destination, FQDN authority", echo.CallOptions{
+				To:      apps.ServiceAddressedWaypoint,
+				Count:   1,
+				Address: apps.ServiceAddressedWaypoint.ClusterLocalFQDN(),
+				Port:    echo.Port{Name: ports.HTTP.Name},
+				HBONE:   hbsvc,
+				Check:   check.OK(),
+			})
 			run("VIP destination, unknown port", echo.CallOptions{
 				To:      apps.ServiceAddressedWaypoint,
 				Count:   1,

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -36,13 +36,11 @@ import (
 
 	"istio.io/api/label"
 	"istio.io/api/networking/v1alpha3"
-	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/http/headers"
 	"istio.io/istio/pkg/kube/inject"
 	"istio.io/istio/pkg/ptr"
-	"istio.io/istio/pkg/test"
 	echot "istio.io/istio/pkg/test/echo"
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/env"
@@ -2868,7 +2866,7 @@ func TestDirect(t *testing.T) {
 				CaCert:             string(cert.RootCert),
 				InsecureSkipVerify: true,
 			}
-			run := func(name string, options echo.CallOptions, testOpts ...func(*testing.T)) {
+			run := func(name string, options echo.CallOptions) {
 				t.NewSubTest(name).Run(func(t framework.TestContext) {
 					_, err := c.CallEcho(nil, options)
 					if err != nil {
@@ -2892,23 +2890,13 @@ func TestDirect(t *testing.T) {
 				HBONE:   hbsvc,
 				Check:   check.OK(),
 			})
-			run("VIP destination, FQDN authority (without feature flag)", echo.CallOptions{
-				To:      apps.ServiceAddressedWaypoint,
-				Count:   1,
-				Address: apps.ServiceAddressedWaypoint.ClusterLocalFQDN(),
-				Port:    echo.Port{Name: ports.HTTP.Name},
-				HBONE:   hbsvc,
-				Check:   check.NotOK(),
-			})
-			run("VIP destination, FQDN authority (with feature flag)", echo.CallOptions{
+			run("VIP destination, FQDN authority", echo.CallOptions{
 				To:      apps.ServiceAddressedWaypoint,
 				Count:   1,
 				Address: apps.ServiceAddressedWaypoint.ClusterLocalFQDN(),
 				Port:    echo.Port{Name: ports.HTTP.Name},
 				HBONE:   hbsvc,
 				Check:   check.OK(),
-			}, func(t *testing.T) {
-				test.SetForTest(t, &features.EnableAmbientMultiNetwork, true)
 			})
 			run("VIP destination, unknown port", echo.CallOptions{
 				To:      apps.ServiceAddressedWaypoint,

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -36,11 +36,13 @@ import (
 
 	"istio.io/api/label"
 	"istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/http/headers"
 	"istio.io/istio/pkg/kube/inject"
 	"istio.io/istio/pkg/ptr"
+	"istio.io/istio/pkg/test"
 	echot "istio.io/istio/pkg/test/echo"
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/env"
@@ -2866,7 +2868,7 @@ func TestDirect(t *testing.T) {
 				CaCert:             string(cert.RootCert),
 				InsecureSkipVerify: true,
 			}
-			run := func(name string, options echo.CallOptions) {
+			run := func(name string, options echo.CallOptions, testOpts ...func(*testing.T)) {
 				t.NewSubTest(name).Run(func(t framework.TestContext) {
 					_, err := c.CallEcho(nil, options)
 					if err != nil {
@@ -2890,13 +2892,23 @@ func TestDirect(t *testing.T) {
 				HBONE:   hbsvc,
 				Check:   check.OK(),
 			})
-			run("VIP destination, FQDN authority", echo.CallOptions{
+			run("VIP destination, FQDN authority (without feature flag)", echo.CallOptions{
+				To:      apps.ServiceAddressedWaypoint,
+				Count:   1,
+				Address: apps.ServiceAddressedWaypoint.ClusterLocalFQDN(),
+				Port:    echo.Port{Name: ports.HTTP.Name},
+				HBONE:   hbsvc,
+				Check:   check.NotOK(),
+			})
+			run("VIP destination, FQDN authority (with feature flag)", echo.CallOptions{
 				To:      apps.ServiceAddressedWaypoint,
 				Count:   1,
 				Address: apps.ServiceAddressedWaypoint.ClusterLocalFQDN(),
 				Port:    echo.Port{Name: ports.HTTP.Name},
 				HBONE:   hbsvc,
 				Check:   check.OK(),
+			}, func(t *testing.T) {
+				test.SetForTest(t, &features.EnableAmbientMultiNetwork, true)
 			})
 			run("VIP destination, unknown port", echo.CallOptions{
 				To:      apps.ServiceAddressedWaypoint,

--- a/tests/integration/ambient/main_test.go
+++ b/tests/integration/ambient/main_test.go
@@ -104,6 +104,9 @@ func TestMain(m *testing.M) {
 			cfg.DeployEastWestGW = false
 			cfg.ControlPlaneValues = `
 values:
+  pilot:
+    env:
+      AMBIENT_ENABLE_MULTI_NETWORK: "true"
   cni:
     # The CNI repair feature is disabled for these tests because this is a controlled environment,
     # and it is important to catch issues that might otherwise be automatically fixed.


### PR DESCRIPTION
**Please provide a description of this PR:**
High level implementation as a fallback for if `:authority` matches a hostname. Since we always store the :authority in filter state, we can build a matcher tree off of it to use if the IP based matching doesn't work. Added a test using echo server as the client for now since we don't have the ztunnel implementation yet.