### PR TITLE
fix: clear tmp files from previous run if exist before copy cni binaries again

### DIFF
--- a/cni/pkg/install/binaries_test.go
+++ b/cni/pkg/install/binaries_test.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	file2 "istio.io/istio/pkg/file"
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/test/util/file"
 )
@@ -73,4 +74,23 @@ func TestCopyBinaries(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCopyBinariesWhenTmpExist(t *testing.T) {
+	srcDir := t.TempDir()
+	file.WriteOrFail(t, filepath.Join(srcDir, "testFile1"), []byte("content"))
+	file.WriteOrFail(t, filepath.Join(srcDir, "testFile2"), []byte("content"))
+
+	targetDir := t.TempDir()
+	tmpFile1 := filepath.Join(targetDir, "testFile1.tmp.3816169537")
+	tmpFile2 := filepath.Join(targetDir, "testFile2.tmp.4977877")
+	file.WriteOrFail(t, tmpFile1, []byte("content"))
+	file.WriteOrFail(t, tmpFile2, []byte("content"))
+
+	_, err := copyBinaries(srcDir, []string{targetDir})
+	assert.NoError(t, err)
+
+	// check that all old temp files were removed
+	assert.Equal(t, file2.Exists(tmpFile1), false)
+	assert.Equal(t, file2.Exists(tmpFile2), false)
 }

--- a/releasenotes/notes/54311.yaml
+++ b/releasenotes/notes/54311.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+  - 54311
+releaseNotes:
+- |
+  **Fixed** an issue where the CNI installation left temporary files when a container was repeatedly killed during the binary copy, which could have filled the storage space.


### PR DESCRIPTION
**Please provide a description of this PR:**
Fix for https://github.com/istio/istio/issues/54311 