### PR TITLE
Skip test/try to diagnose test flakes

### DIFF
--- a/cni/pkg/cmd/root.go
+++ b/cni/pkg/cmd/root.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -123,6 +124,9 @@ var rootCmd = &cobra.Command{
 					log.Info("Ambient node agent safe upgrade explicitly disabled via env")
 					isUpgrade = false
 				} else {
+					// TODO seeing if this resolves test flakes - this should not be necessary
+					// but trying this to ensure the kclient in ShouldStopForUpgrade doesn't get stale info.
+					time.Sleep(time.Second)
 					isUpgrade = ambientAgent.ShouldStopForUpgrade("istio-cni", nodeagent.PodNamespace)
 				}
 				log.Infof("Ambient node agent shutting down - is upgrade shutdown? %t", isUpgrade)

--- a/cni/pkg/cmd/root.go
+++ b/cni/pkg/cmd/root.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -124,9 +123,6 @@ var rootCmd = &cobra.Command{
 					log.Info("Ambient node agent safe upgrade explicitly disabled via env")
 					isUpgrade = false
 				} else {
-					// TODO seeing if this resolves test flakes - this should not be necessary
-					// but trying this to ensure the kclient in ShouldStopForUpgrade doesn't get stale info.
-					time.Sleep(time.Second)
 					isUpgrade = ambientAgent.ShouldStopForUpgrade("istio-cni", nodeagent.PodNamespace)
 				}
 				log.Infof("Ambient node agent shutting down - is upgrade shutdown? %t", isUpgrade)

--- a/pkg/test/framework/components/istio/cleanup.go
+++ b/pkg/test/framework/components/istio/cleanup.go
@@ -95,9 +95,9 @@ func (i *istioImpl) Dump(ctx resource.Context) {
 			return nil
 		})
 	}
-	// Dump istio-cni.
+	// Dump kube-system as well.
 	g.Go(func() error {
-		kube2.DumpPods(ctx, d, "kube-system", []string{"k8s-app=istio-cni-node"})
+		kube2.DumpPods(ctx, d, "kube-system", []string{})
 		return nil
 	})
 }

--- a/pkg/test/framework/components/istio/installer.go
+++ b/pkg/test/framework/components/istio/installer.go
@@ -142,7 +142,7 @@ func (i *installer) Close(c cluster.Cluster) error {
 	if len(manifests) > 0 {
 		return i.ctx.ConfigKube(c).YAML("", removeCRDsSlice(manifests)).Delete()
 	}
-	scopes.Framework.Infof("Deleting yaml on cluster %s: %+v", c.Name(), manifests)
+	scopes.Framework.Debugf("Deleting yaml on cluster %s: %+v", c.Name(), manifests)
 	return nil
 }
 

--- a/pkg/test/framework/components/istio/installer.go
+++ b/pkg/test/framework/components/istio/installer.go
@@ -142,6 +142,7 @@ func (i *installer) Close(c cluster.Cluster) error {
 	if len(manifests) > 0 {
 		return i.ctx.ConfigKube(c).YAML("", removeCRDsSlice(manifests)).Delete()
 	}
+	scopes.Framework.Infof("Deleting yaml on cluster %s: %+v", c.Name(), manifests)
 	return nil
 }
 

--- a/tests/integration/ambient/cni/main_test.go
+++ b/tests/integration/ambient/cni/main_test.go
@@ -212,7 +212,7 @@ func TestCNIMisconfigHealsOnRestart(t *testing.T) {
 		TopLevel().
 		Run(func(t framework.TestContext) {
 			// TODO BML I have no solid reason to think this is causing test flakes yet
-			// t.Skip("suspected flaky")
+			t.Skip("suspected flaky: https://github.com/istio/istio/issues/54303")
 			c := t.Clusters().Default()
 			t.Log("Updating CNI Daemonset config")
 

--- a/tests/integration/ambient/cni/main_test.go
+++ b/tests/integration/ambient/cni/main_test.go
@@ -210,6 +210,7 @@ func TestTrafficWithEstablishedPodsIfCNIMissing(t *testing.T) {
 func TestCNIMisconfigHealsOnRestart(t *testing.T) {
 	framework.NewTest(t).
 		TopLevel().
+		Skip("suspected flaky").
 		Run(func(t framework.TestContext) {
 			c := t.Clusters().Default()
 			t.Log("Updating CNI Daemonset config")

--- a/tests/integration/ambient/cni/main_test.go
+++ b/tests/integration/ambient/cni/main_test.go
@@ -210,8 +210,9 @@ func TestTrafficWithEstablishedPodsIfCNIMissing(t *testing.T) {
 func TestCNIMisconfigHealsOnRestart(t *testing.T) {
 	framework.NewTest(t).
 		TopLevel().
-		Skip("suspected flaky").
 		Run(func(t framework.TestContext) {
+			// TODO BML I have no solid reason to think this is causing test flakes yet
+			// t.Skip("suspected flaky")
 			c := t.Clusters().Default()
 			t.Log("Updating CNI Daemonset config")
 


### PR DESCRIPTION
**Please provide a description of this PR:**
Trying a few things  to understand how/why https://github.com/istio/istio/issues/54303 can happen,  since it's still non-obvious to me how it could and I cannot coerce local repros.


There are, as far as I can see, only 2 possibilities here.

1. The `kubeclient` we use on shutdown is reporting stale data - the DS has been deleted, our pods get a SIGTERM, we `GET` the DS from inside the pod, and it's still there, even though our pod has been told to terminate _because_ it was deleted - e.g. racy/stale reads from the K8S API server. I haven't been able to repro this with `helm` or `istioctl` or plain old manifest deletion.  It is _very_ unlikely that this is the case.

2. `TestCNIMisconfigHealsOnRestart` is putting the installer into a bad state  because of it's net dir  munging, and this was made more manifest when we initialized the installer earlier in https://github.com/istio/istio/pull/54180.

This PR assumes No. 2, I want to see if it impacts the flakes. If it does not, then No. 1 is what we are left with.