### PR TITLE
ambient: fix forgetting to pass feature flags

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -292,6 +292,10 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 			LookupNetworkGateways: c.NetworkGateways,
 			StatusNotifier:        options.StatusWritingEnabled,
 			Debugger:              krt.GlobalDebugHandler,
+			Flags: ambient.FeatureFlags{
+				DefaultAllowFromWaypoint:              features.DefaultAllowFromWaypoint,
+				EnableK8SServiceSelectWorkloadEntries: features.EnableK8SServiceSelectWorkloadEntries,
+			},
 		})
 	}
 	c.exports = newServiceExportCache(c)


### PR DESCRIPTION
Our tests set these, but not the real code (which makes this PR hard to
add tests for!). Regression from a recent change only on master.
