### PR TITLE
Still some racy tests - there are more initial update events to wait on

### DIFF
--- a/cni/pkg/nodeagent/informers_test.go
+++ b/cni/pkg/nodeagent/informers_test.go
@@ -182,8 +182,9 @@ func TestExistingPodNotAddedIfNoIPInAnyStatusField(t *testing.T) {
 	client.RunAndWait(ctx.Done())
 	go handlers.Start()
 
-	// wait until all add events settle
+	// wait until all add + update events settle for initial startup
 	mt.Assert(EventTotals.Name(), map[string]string{"type": "add"}, monitortest.Exactly(2))
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.Exactly(1))
 
 	// label the namespace
 	labelsPatch := []byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":"%s"}}}`,
@@ -248,8 +249,9 @@ func TestExistingPodRemovedWhenNsUnlabeled(t *testing.T) {
 	client.RunAndWait(ctx.Done())
 	go handlers.Start()
 
-	// wait until pod add events settle
+	// wait until all add + update events settle for initial startup
 	mt.Assert(EventTotals.Name(), map[string]string{"type": "add"}, monitortest.Exactly(2))
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.Exactly(1))
 
 	log.Debug("labeling namespace")
 	_, err := client.Kube().CoreV1().Namespaces().Patch(ctx, ns.Name,
@@ -337,8 +339,9 @@ func TestExistingPodRemovedWhenPodLabelRemoved(t *testing.T) {
 	client.RunAndWait(ctx.Done())
 	go handlers.Start()
 
-	// wait until pod add events settle
+	// wait until all add + update events settle for initial startup
 	mt.Assert(EventTotals.Name(), map[string]string{"type": "add"}, monitortest.Exactly(2))
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.Exactly(1))
 
 	log.Debug("labeling namespace")
 	_, err := client.Kube().CoreV1().Namespaces().Patch(ctx, ns.Name,
@@ -440,8 +443,9 @@ func TestJobPodRemovedWhenPodTerminates(t *testing.T) {
 	client.RunAndWait(ctx.Done())
 	go handlers.Start()
 
-	// Wait for a pod add event (initial informer bootup)
+	// wait until all add + update events settle for initial startup
 	mt.Assert(EventTotals.Name(), map[string]string{"type": "add"}, monitortest.Exactly(2))
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.Exactly(1))
 
 	log.Debug("labeling namespace")
 	_, err := client.Kube().CoreV1().Namespaces().Patch(ctx, ns.Name,
@@ -792,8 +796,10 @@ func TestExistingPodAddedWhenItPreExists(t *testing.T) {
 	go handlers.Start()
 
 	waitForMockCalls()
-	// wait until pod add events settle
+
+	// wait until all add + update events settle for initial startup
 	mt.Assert(EventTotals.Name(), map[string]string{"type": "add"}, monitortest.Exactly(2))
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.Exactly(2))
 
 	assertPodAnnotated(t, client, pod)
 


### PR DESCRIPTION
**Please provide a description of this PR:**

https://github.com/istio/istio/pull/54320 still did not eliminate every race - for all tests we need to wait for both `add` AND `update` events to settle, or initial events can get delayed and skew later count expectations (I had thought it was just `ADD` events during the initial fake informer boot, but I was wrong).

See 

- https://prow.istio.io/view/gs/istio-prow/logs/unit-tests_istio_postsubmit/1868599546913755136
- https://prow.istio.io/view/gs/istio-prow/logs/unit-tests-arm64_istio_postsubmit/1868687172098330624