### PR TITLE
debug: align ConfigDump behavior with Envoy Admin API

### DIFF
--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -585,7 +585,7 @@ func (s *DiscoveryServer) ConfigDump(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	includeEds := req.URL.Query().Get("include_eds") == "true"
+	includeEds := req.URL.Query().Has("include_eds")
 	dump, err := s.connectionConfigDump(con, includeEds)
 	if err != nil {
 		handleHTTPError(w, err)


### PR DESCRIPTION
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

**Please provide a description of this PR:**

Envoy Admin API only checks if include_eds exists: https://github.com/envoyproxy/envoy/blob/b87da3fa9f008d87ab02df53840c5246f1ba6209/source/server/admin/config_dump_handler.cc#L126.

It doesn't require the value to be "true".