### PR TITLE
Partial backport: krt: move event processing to queue (#53994)

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -112,6 +112,14 @@ type index struct {
 	Network LookupNetwork
 	// LookupNetworkGateways provides a function to lookup all the known network gateways in the system.
 	LookupNetworkGateways LookupNetworkGateways
+	Flags                 FeatureFlags
+
+	stop chan struct{}
+}
+
+type FeatureFlags struct {
+	DefaultAllowFromWaypoint              bool
+	EnableK8SServiceSelectWorkloadEntries bool
 }
 
 type Options struct {
@@ -125,6 +133,17 @@ type Options struct {
 	LookupNetwork         LookupNetwork
 	LookupNetworkGateways LookupNetworkGateways
 	StatusNotifier        *activenotifier.ActiveNotifier
+	Flags                 FeatureFlags
+}
+
+// KrtOptions is a small wrapper around KRT options to make it easy to provide a common set of options to all collections
+// without excessive duplication.
+type KrtOptions struct {
+	stop chan struct{}
+}
+
+func (k KrtOptions) WithName(n string) []krt.CollectionOption {
+	return []krt.CollectionOption{krt.WithStop(k.stop), krt.WithName(n)}
 }
 
 func New(options Options) Index {
@@ -137,58 +156,63 @@ func New(options Options) Index {
 		XDSUpdater:            options.XDSUpdater,
 		Network:               options.LookupNetwork,
 		LookupNetworkGateways: options.LookupNetworkGateways,
+		Flags:                 options.Flags,
+		stop:                  make(chan struct{}),
 	}
 
 	filter := kclient.Filter{
 		ObjectFilter: options.Client.ObjectFilter(),
 	}
-	ConfigMaps := krt.NewInformerFiltered[*v1.ConfigMap](options.Client, filter, krt.WithName("ConfigMaps"))
+	opts := KrtOptions{
+		stop: a.stop,
+	}
+	ConfigMaps := krt.NewInformerFiltered[*v1.ConfigMap](options.Client, filter, opts.WithName("ConfigMaps")...)
 
 	authzPolicies := kclient.NewDelayedInformer[*securityclient.AuthorizationPolicy](options.Client,
 		gvr.AuthorizationPolicy, kubetypes.StandardInformer, filter)
-	AuthzPolicies := krt.WrapClient[*securityclient.AuthorizationPolicy](authzPolicies, krt.WithName("AuthorizationPolicies"))
+	AuthzPolicies := krt.WrapClient[*securityclient.AuthorizationPolicy](authzPolicies, opts.WithName("AuthorizationPolicies")...)
 
 	peerAuths := kclient.NewDelayedInformer[*securityclient.PeerAuthentication](options.Client,
 		gvr.PeerAuthentication, kubetypes.StandardInformer, filter)
-	PeerAuths := krt.WrapClient[*securityclient.PeerAuthentication](peerAuths, krt.WithName("PeerAuthentications"))
+	PeerAuths := krt.WrapClient[*securityclient.PeerAuthentication](peerAuths, opts.WithName("PeerAuthentications")...)
 
 	serviceEntries := kclient.NewDelayedInformer[*networkingclient.ServiceEntry](options.Client,
 		gvr.ServiceEntry, kubetypes.StandardInformer, filter)
-	ServiceEntries := krt.WrapClient[*networkingclient.ServiceEntry](serviceEntries, krt.WithName("ServiceEntries"))
+	ServiceEntries := krt.WrapClient[*networkingclient.ServiceEntry](serviceEntries, opts.WithName("ServiceEntries")...)
 
 	workloadEntries := kclient.NewDelayedInformer[*networkingclient.WorkloadEntry](options.Client,
 		gvr.WorkloadEntry, kubetypes.StandardInformer, filter)
-	WorkloadEntries := krt.WrapClient[*networkingclient.WorkloadEntry](workloadEntries, krt.WithName("WorkloadEntries"))
+	WorkloadEntries := krt.WrapClient[*networkingclient.WorkloadEntry](workloadEntries, opts.WithName("WorkloadEntries")...)
 
 	gatewayClient := kclient.NewDelayedInformer[*v1beta1.Gateway](options.Client, gvr.KubernetesGateway, kubetypes.StandardInformer, filter)
-	Gateways := krt.WrapClient[*v1beta1.Gateway](gatewayClient, krt.WithName("Gateways"))
+	Gateways := krt.WrapClient[*v1beta1.Gateway](gatewayClient, opts.WithName("Gateways")...)
 
 	gatewayClassClient := kclient.NewDelayedInformer[*v1beta1.GatewayClass](options.Client, gvr.GatewayClass, kubetypes.StandardInformer, filter)
-	GatewayClasses := krt.WrapClient[*v1beta1.GatewayClass](gatewayClassClient, krt.WithName("GatewayClasses"))
+	GatewayClasses := krt.WrapClient[*v1beta1.GatewayClass](gatewayClassClient, opts.WithName("GatewayClasses")...)
 
 	servicesClient := kclient.NewFiltered[*v1.Service](options.Client, filter)
-	Services := krt.WrapClient[*v1.Service](servicesClient, krt.WithName("Services"))
+	Services := krt.WrapClient[*v1.Service](servicesClient, opts.WithName("Services")...)
 	Nodes := krt.NewInformerFiltered[*v1.Node](options.Client, kclient.Filter{
 		ObjectFilter:    options.Client.ObjectFilter(),
 		ObjectTransform: kubeclient.StripNodeUnusedFields,
-	}, krt.WithName("Nodes"))
+	}, opts.WithName("Nodes")...)
 	Pods := krt.NewInformerFiltered[*v1.Pod](options.Client, kclient.Filter{
 		ObjectFilter:    options.Client.ObjectFilter(),
 		ObjectTransform: kubeclient.StripPodUnusedFields,
-	}, krt.WithName("Pods"))
+	}, opts.WithName("Pods")...)
 
 	// TODO: Should this go ahead and transform the full ns into some intermediary with just the details we care about?
-	Namespaces := krt.NewInformer[*v1.Namespace](options.Client, krt.WithName("Namespaces"))
+	Namespaces := krt.NewInformer[*v1.Namespace](options.Client, opts.WithName("Namespaces")...)
 
 	EndpointSlices := krt.NewInformerFiltered[*discovery.EndpointSlice](options.Client, kclient.Filter{
 		ObjectFilter: options.Client.ObjectFilter(),
-	}, krt.WithName("EndpointSlices"))
+	}, opts.WithName("EndpointSlices")...)
 
-	MeshConfig := MeshConfigCollection(ConfigMaps, options)
-	Waypoints := a.WaypointsCollection(Gateways, GatewayClasses, Pods)
+	MeshConfig := MeshConfigCollection(ConfigMaps, options, opts)
+	Waypoints := a.WaypointsCollection(Gateways, GatewayClasses, Pods, opts)
 
 	// AllPolicies includes peer-authentication converted policies
-	AuthorizationPolicies, AllPolicies := PolicyCollections(AuthzPolicies, PeerAuths, MeshConfig, Waypoints)
+	AuthorizationPolicies, AllPolicies := PolicyCollections(AuthzPolicies, PeerAuths, MeshConfig, Waypoints, opts, a.Flags)
 	AllPolicies.RegisterBatch(PushXds(a.XDSUpdater,
 		func(i model.WorkloadAuthorization) model.ConfigKey {
 			if i.Authorization == nil {
@@ -201,7 +225,7 @@ func New(options Options) Index {
 	servicesWriter := kclient.NewWriteClient[*v1.Service](options.Client)
 
 	// these are workloadapi-style services combined from kube services and service entries
-	WorkloadServices := a.ServicesCollection(Services, ServiceEntries, Waypoints, Namespaces)
+	WorkloadServices := a.ServicesCollection(Services, ServiceEntries, Waypoints, Namespaces, opts)
 
 	WaypointPolicyStatus := WaypointPolicyStatusCollection(
 		AuthzPolicies,
@@ -209,6 +233,7 @@ func New(options Options) Index {
 		Services,
 		ServiceEntries,
 		Namespaces,
+		opts,
 	)
 
 	authorizationPoliciesWriter := kclient.NewWriteClient[*securityclient.AuthorizationPolicy](options.Client)
@@ -293,6 +318,7 @@ func New(options Options) Index {
 		ServiceEntries,
 		EndpointSlices,
 		Namespaces,
+		opts,
 	)
 
 	WorkloadAddressIndex := krt.NewIndex[networkAddress, model.WorkloadInfo](Workloads, networkAddressFromWorkload)
@@ -356,6 +382,7 @@ func New(options Options) Index {
 			WorkloadServiceIndex,
 			WorkloadServices,
 			ServiceAddressIndex,
+			opts,
 		)
 	}
 
@@ -620,6 +647,8 @@ func (a *index) Run(stop <-chan struct{}) {
 			a.statusQueue.Run(stop)
 		}()
 	}
+	<-stop
+	close(a.stop)
 }
 
 func (a *index) HasSynced() bool {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_serviceentry_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_serviceentry_test.go
@@ -22,7 +22,6 @@ import (
 
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/workloadapi"
 )
@@ -332,8 +331,10 @@ func TestAmbientIndex_ServiceEntry(t *testing.T) {
 }
 
 func TestAmbientIndex_ServiceEntry_DisableK8SServiceSelectWorkloadEntries(t *testing.T) {
-	test.SetForTest(t, &features.EnableK8SServiceSelectWorkloadEntries, false)
-	s := newAmbientTestServer(t, testC, testNW)
+	s := newAmbientTestServerWithFlags(t, testC, testNW, FeatureFlags{
+		DefaultAllowFromWaypoint:              features.DefaultAllowFromWaypoint,
+		EnableK8SServiceSelectWorkloadEntries: false,
+	})
 
 	s.addPods(t, "140.140.0.10", "pod1", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
 	s.assertEvent(t, s.podXdsName("pod1"))

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -595,14 +595,15 @@ func TestAmbientIndex_WaypointInboundBinding(t *testing.T) {
 		},
 	})
 	s.addWaypoint(t, "1.2.3.4", "proxy-sandwich", constants.AllTraffic, true)
-	// TODO needing this check seems suspicious. We should really wait for up to 2 pod events.
 	assert.EventuallyEqual(t, func() int { return len(s.waypoints.List()) }, 1)
 
 	s.addPods(t, "10.0.0.1", "proxy-sandwich-instance", "",
 		map[string]string{label.IoK8sNetworkingGatewayGatewayName.Name: "proxy-sandwich"}, nil, true, corev1.PodRunning)
 	s.assertEvent(t, s.podXdsName("proxy-sandwich-instance"))
-	appTunnel := s.lookup(s.podXdsName("proxy-sandwich-instance"))[0].GetWorkload().GetApplicationTunnel()
-	assert.Equal(t, appTunnel, &workloadapi.ApplicationTunnel{
+	// We may get 1 or 2 events, depending on ordering, so wait.
+	assert.EventuallyEqual(t, func() *workloadapi.ApplicationTunnel {
+		return s.lookup(s.podXdsName("proxy-sandwich-instance"))[0].GetWorkload().GetApplicationTunnel()
+	}, &workloadapi.ApplicationTunnel{
 		Protocol: workloadapi.ApplicationTunnel_PROXY,
 		Port:     15088,
 	})
@@ -1152,9 +1153,11 @@ func TestAmbientIndex_Policy(t *testing.T) {
 func TestDefaultAllowWaypointPolicy(t *testing.T) {
 	// while the Waypoint is in testNS, the policies live in the Pods' namespaces
 	policyName := "ns1/istio_allow_waypoint_" + testNS + "_" + "waypoint-ns"
-	test.SetForTest(t, &features.DefaultAllowFromWaypoint, true)
 
-	s := newAmbientTestServer(t, testC, testNW)
+	s := newAmbientTestServerWithFlags(t, testC, testNW, FeatureFlags{
+		DefaultAllowFromWaypoint:              true,
+		EnableK8SServiceSelectWorkloadEntries: features.EnableK8SServiceSelectWorkloadEntries,
+	})
 	setupPolicyTest(t, s)
 
 	t.Run("policy with service accounts", func(t *testing.T) {
@@ -1545,6 +1548,13 @@ type ambientTestServer struct {
 }
 
 func newAmbientTestServer(t *testing.T, clusterID cluster.ID, networkID network.ID) *ambientTestServer {
+	return newAmbientTestServerWithFlags(t, clusterID, networkID, FeatureFlags{
+		DefaultAllowFromWaypoint:              features.DefaultAllowFromWaypoint,
+		EnableK8SServiceSelectWorkloadEntries: features.EnableK8SServiceSelectWorkloadEntries,
+	})
+}
+
+func newAmbientTestServerWithFlags(t *testing.T, clusterID cluster.ID, networkID network.ID, flags FeatureFlags) *ambientTestServer {
 	up := xdsfake.NewFakeXDS()
 	up.SplitEvents = true
 	cl := kubeclient.NewFakeClient()
@@ -1572,6 +1582,7 @@ func newAmbientTestServer(t *testing.T, clusterID cluster.ID, networkID network.
 			return nil
 		},
 		StatusNotifier: activenotifier.New(true),
+		Flags:          flags,
 	})
 	idx.NetworksSynced()
 	cl.RunAndWait(test.NewStop(t))

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_workloadentry_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_workloadentry_test.go
@@ -25,7 +25,6 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/schema/gvk"
-	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/workloadapi"
 )
@@ -346,8 +345,10 @@ func TestAmbientIndex_InlinedWorkloadEntries(t *testing.T) {
 }
 
 func TestAmbientIndex_WorkloadEntries_DisableK8SServiceSelectWorkloadEntries(t *testing.T) {
-	test.SetForTest(t, &features.EnableK8SServiceSelectWorkloadEntries, false)
-	s := newAmbientTestServer(t, testC, testNW)
+	s := newAmbientTestServerWithFlags(t, testC, testNW, FeatureFlags{
+		DefaultAllowFromWaypoint:              features.DefaultAllowFromWaypoint,
+		EnableK8SServiceSelectWorkloadEntries: false,
+	})
 
 	s.addWorkloadEntries(t, "127.0.0.1", "name1", "sa1", map[string]string{"app": "a"})
 	s.assertEvent(t, s.wleXdsName("name1"))

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/authorization_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/authorization_test.go
@@ -257,7 +257,7 @@ func TestWaypointPolicyStatusCollection(t *testing.T) {
 		}
 	})
 
-	wpsCollection := WaypointPolicyStatusCollection(authzPolCol, waypointCol, svcCol, seCol, nsCol)
+	wpsCollection := WaypointPolicyStatusCollection(authzPolCol, waypointCol, svcCol, seCol, nsCol, KrtOptions{})
 	c.RunAndWait(ctx.Done())
 
 	_, err := clientNs.Create(&v1.Namespace{

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/meshconfig.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/meshconfig.go
@@ -35,7 +35,7 @@ func (m MeshConfig) ResourceName() string { return " " }
 
 func (m MeshConfig) Equals(other MeshConfig) bool { return proto.Equal(m.MeshConfig, other.MeshConfig) }
 
-func MeshConfigCollection(configMaps krt.Collection[*v1.ConfigMap], options Options) krt.Singleton[MeshConfig] {
+func MeshConfigCollection(configMaps krt.Collection[*v1.ConfigMap], options Options, opts KrtOptions) krt.Singleton[MeshConfig] {
 	cmName := "istio"
 	if options.Revision != "" && options.Revision != "default" {
 		cmName = cmName + "-" + options.Revision
@@ -60,7 +60,7 @@ func MeshConfigCollection(configMaps krt.Collection[*v1.ConfigMap], options Opti
 				meshCfg = n
 			}
 			return &MeshConfig{meshCfg}
-		}, krt.WithName("MeshConfig"),
+		}, opts.WithName("MeshConfig")...,
 	)
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
@@ -43,10 +43,13 @@ func (a *index) ServicesCollection(
 	serviceEntries krt.Collection[*networkingclient.ServiceEntry],
 	waypoints krt.Collection[Waypoint],
 	namespaces krt.Collection[*v1.Namespace],
+	opts KrtOptions,
 ) krt.Collection[model.ServiceInfo] {
-	ServicesInfo := krt.NewCollection(services, a.serviceServiceBuilder(waypoints, namespaces), krt.WithName("ServicesInfo"))
-	ServiceEntriesInfo := krt.NewManyCollection(serviceEntries, a.serviceEntryServiceBuilder(waypoints, namespaces), krt.WithName("ServiceEntriesInfo"))
-	WorkloadServices := krt.JoinCollection([]krt.Collection[model.ServiceInfo]{ServicesInfo, ServiceEntriesInfo}, krt.WithName("WorkloadServices"))
+	ServicesInfo := krt.NewCollection(services, a.serviceServiceBuilder(waypoints, namespaces),
+		opts.WithName("ServicesInfo")...)
+	ServiceEntriesInfo := krt.NewManyCollection(serviceEntries, a.serviceEntryServiceBuilder(waypoints, namespaces),
+		opts.WithName("ServiceEntriesInfo")...)
+	WorkloadServices := krt.JoinCollection([]krt.Collection[model.ServiceInfo]{ServicesInfo, ServiceEntriesInfo}, opts.WithName("WorkloadService")...)
 	return WorkloadServices
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/sidecar_interop.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/sidecar_interop.go
@@ -51,6 +51,7 @@ func RegisterEdsShim(
 	WorkloadsByServiceKey krt.Index[string, model.WorkloadInfo],
 	Services krt.Collection[model.ServiceInfo],
 	ServicesByAddress krt.Index[networkAddress, model.ServiceInfo],
+	opts KrtOptions,
 ) {
 	ServiceEds := krt.NewCollection(
 		Services,
@@ -91,7 +92,7 @@ func RegisterEdsShim(
 				}),
 			}
 		},
-		krt.WithName("ServiceEds"))
+		opts.WithName("ServiceEds")...)
 	ServiceEds.RegisterBatch(
 		PushXds(xdsUpdater, func(svc serviceEDS) model.ConfigKey {
 			ns, hostname, _ := strings.Cut(svc.ServiceKey, "/")

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
@@ -207,6 +207,7 @@ func (a *index) WaypointsCollection(
 	gateways krt.Collection[*v1beta1.Gateway],
 	gatewayClasses krt.Collection[*v1beta1.GatewayClass],
 	pods krt.Collection[*v1.Pod],
+	opts KrtOptions,
 ) krt.Collection[Waypoint] {
 	podsByNamespace := krt.NewNamespaceIndex(pods)
 	return krt.NewCollection(gateways, func(ctx krt.HandlerContext, gateway *v1beta1.Gateway) *Waypoint {
@@ -241,7 +242,7 @@ func (a *index) WaypointsCollection(
 		}
 
 		return a.makeWaypoint(gateway, gatewayClass, serviceAccounts, trafficType)
-	}, krt.WithName("Waypoints"))
+	}, opts.WithName("Waypoints")...)
 }
 
 func makeInboundBinding(gateway *v1beta1.Gateway, gatewayClass *v1beta1.GatewayClass) *InboundBinding {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
@@ -27,6 +27,7 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 	networkingclient "istio.io/client-go/pkg/apis/networking/v1"
 	securityclient "istio.io/client-go/pkg/apis/security/v1"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/labels"
@@ -1501,6 +1502,10 @@ func newAmbientUnitTest() *index {
 		DomainSuffix:         "domain.suffix",
 		Network: func(endpointIP string, labels labels.Instance) network.ID {
 			return testNW
+		},
+		Flags: FeatureFlags{
+			DefaultAllowFromWaypoint:              features.DefaultAllowFromWaypoint,
+			EnableK8SServiceSelectWorkloadEntries: features.EnableK8SServiceSelectWorkloadEntries,
 		},
 		LookupNetworkGateways: func() []model.NetworkGateway {
 			return []model.NetworkGateway{

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -290,6 +290,10 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 			LookupNetwork:         c.Network,
 			LookupNetworkGateways: c.NetworkGateways,
 			StatusNotifier:        options.StatusWritingEnabled,
+			Flags: ambient.FeatureFlags{
+				DefaultAllowFromWaypoint:              features.DefaultAllowFromWaypoint,
+				EnableK8SServiceSelectWorkloadEntries: features.EnableK8SServiceSelectWorkloadEntries,
+			},
 		})
 	}
 	c.exports = newServiceExportCache(c)

--- a/pkg/kube/kclient/client.go
+++ b/pkg/kube/kclient/client.go
@@ -176,7 +176,13 @@ func (n *informerClient[T]) ShutdownHandlers() {
 	}
 }
 
-func (n *informerClient[T]) AddEventHandler(h cache.ResourceEventHandler) {
+type neverReady struct{}
+
+func (a neverReady) HasSynced() bool {
+	return false
+}
+
+func (n *informerClient[T]) AddEventHandler(h cache.ResourceEventHandler) cache.ResourceEventHandlerRegistration {
 	fh := cache.FilteringResourceEventHandler{
 		FilterFunc: func(obj interface{}) bool {
 			if n.filter == nil {
@@ -195,9 +201,10 @@ func (n *informerClient[T]) AddEventHandler(h cache.ResourceEventHandler) {
 	reg, err := n.informer.AddEventHandler(fh)
 	if err != nil {
 		// Should only happen if its already stopped. We should exit early.
-		return
+		return neverReady{}
 	}
 	n.registeredHandlers = append(n.registeredHandlers, handlerRegistration{registration: reg, handler: h})
+	return reg
 }
 
 func (n *informerClient[T]) HasSynced() bool {
@@ -213,6 +220,10 @@ func (n *informerClient[T]) HasSynced() bool {
 		}
 	}
 	return true
+}
+
+func (n *informerClient[T]) HasSyncedIgnoringHandlers() bool {
+	return n.informer.HasSynced()
 }
 
 func (n *informerClient[T]) List(namespace string, selector klabels.Selector) []T {

--- a/pkg/kube/kclient/interfaces.go
+++ b/pkg/kube/kclient/interfaces.go
@@ -40,11 +40,15 @@ type Informer[T controllers.Object] interface {
 	ListUnfiltered(namespace string, selector klabels.Selector) []T
 	// AddEventHandler inserts a handler. The handler will be called for all Create/Update/Removals.
 	// When ShutdownHandlers is called, the handler is removed.
-	AddEventHandler(h cache.ResourceEventHandler)
+	AddEventHandler(h cache.ResourceEventHandler) cache.ResourceEventHandlerRegistration
 	// HasSynced returns true when the informer is initially populated and that all handlers added
 	// via AddEventHandler have been called with the initial state.
 	// note: this differs from a standard informer HasSynced, which does not check handlers have been called.
 	HasSynced() bool
+	// HasSyncedIgnoringHandlers returns true when the underlying informer has synced.
+	// Warning: this ignores whether handlers are ready! HasSynced, which takes handlers into account, is recommended.
+	// When using this, the ResourceEventHandlerRegistration from AddEventHandler can be used to check individual handlers
+	HasSyncedIgnoringHandlers() bool
 	// ShutdownHandlers terminates all handlers added by AddEventHandler.
 	// Warning: this only applies to handlers called via AddEventHandler; any handlers directly added
 	// to the underlying informer are not touched

--- a/pkg/kube/krt/collection_test.go
+++ b/pkg/kube/krt/collection_test.go
@@ -34,13 +34,23 @@ import (
 	"istio.io/istio/pkg/util/sets"
 )
 
+// KrtOptions is a small wrapper around KRT options to make it easy to provide a common set of options to all collections
+// without excessive duplication.
+type KrtOptions struct {
+	stop chan struct{}
+}
+
+func (k KrtOptions) WithName(n string) []krt.CollectionOption {
+	return []krt.CollectionOption{krt.WithStop(k.stop), krt.WithName(n)}
+}
+
 type SimplePod struct {
 	Named
 	Labeled
 	IP string
 }
 
-func SimplePodCollection(pods krt.Collection[*corev1.Pod]) krt.Collection[SimplePod] {
+func SimplePodCollection(pods krt.Collection[*corev1.Pod], opts KrtOptions) krt.Collection[SimplePod] {
 	return krt.NewCollection(pods, func(ctx krt.HandlerContext, i *corev1.Pod) *SimplePod {
 		if i.Status.PodIP == "" {
 			return nil
@@ -50,7 +60,7 @@ func SimplePodCollection(pods krt.Collection[*corev1.Pod]) krt.Collection[Simple
 			Labeled: NewLabeled(i.Labels),
 			IP:      i.Status.PodIP,
 		}
-	})
+	}, opts.WithName("SimplePods")...)
 }
 
 type SizedPod struct {
@@ -58,7 +68,7 @@ type SizedPod struct {
 	Size string
 }
 
-func SizedPodCollection(pods krt.Collection[*corev1.Pod]) krt.Collection[SizedPod] {
+func SizedPodCollection(pods krt.Collection[*corev1.Pod], opts KrtOptions) krt.Collection[SizedPod] {
 	return krt.NewCollection(pods, func(ctx krt.HandlerContext, i *corev1.Pod) *SizedPod {
 		s, f := i.Labels["size"]
 		if !f {
@@ -68,7 +78,7 @@ func SizedPodCollection(pods krt.Collection[*corev1.Pod]) krt.Collection[SizedPo
 			Named: NewNamed(i),
 			Size:  s,
 		}
-	})
+	}, opts.WithName("SizedPods")...)
 }
 
 func NewNamed(n config.Namer) Named {
@@ -104,16 +114,16 @@ type SimpleService struct {
 	Selector map[string]string
 }
 
-func SimpleServiceCollection(services krt.Collection[*corev1.Service]) krt.Collection[SimpleService] {
+func SimpleServiceCollection(services krt.Collection[*corev1.Service], opts KrtOptions) krt.Collection[SimpleService] {
 	return krt.NewCollection(services, func(ctx krt.HandlerContext, i *corev1.Service) *SimpleService {
 		return &SimpleService{
 			Named:    NewNamed(i),
 			Selector: i.Spec.Selector,
 		}
-	})
+	}, opts.WithName("SimpleService")...)
 }
 
-func SimpleServiceCollectionFromEntries(entries krt.Collection[*istioclient.ServiceEntry]) krt.Collection[SimpleService] {
+func SimpleServiceCollectionFromEntries(entries krt.Collection[*istioclient.ServiceEntry], opts KrtOptions) krt.Collection[SimpleService] {
 	return krt.NewCollection(entries, func(ctx krt.HandlerContext, i *istioclient.ServiceEntry) *SimpleService {
 		l := i.Spec.WorkloadSelector.GetLabels()
 		if l == nil {
@@ -123,7 +133,7 @@ func SimpleServiceCollectionFromEntries(entries krt.Collection[*istioclient.Serv
 			Named:    NewNamed(i),
 			Selector: l,
 		}
-	})
+	}, opts.WithName("SimpleService")...)
 }
 
 type SimpleEndpoint struct {
@@ -137,7 +147,7 @@ func (s SimpleEndpoint) ResourceName() string {
 	return slices.Join("/", s.Namespace+"/"+s.Service+"/"+s.Pod)
 }
 
-func SimpleEndpointsCollection(pods krt.Collection[SimplePod], services krt.Collection[SimpleService]) krt.Collection[SimpleEndpoint] {
+func SimpleEndpointsCollection(pods krt.Collection[SimplePod], services krt.Collection[SimpleService], opts KrtOptions) krt.Collection[SimpleEndpoint] {
 	return krt.NewManyCollection[SimpleService, SimpleEndpoint](services, func(ctx krt.HandlerContext, svc SimpleService) []SimpleEndpoint {
 		pods := krt.Fetch(ctx, pods, krt.FilterLabel(svc.Selector))
 		return slices.Map(pods, func(pod SimplePod) SimpleEndpoint {
@@ -148,7 +158,7 @@ func SimpleEndpointsCollection(pods krt.Collection[SimplePod], services krt.Coll
 				IP:        pod.IP,
 			}
 		})
-	})
+	}, opts.WithName("SimpleEndpoints")...)
 }
 
 func init() {
@@ -156,13 +166,14 @@ func init() {
 }
 
 func TestCollectionSimple(t *testing.T) {
+	stop := test.NewStop(t)
+	opts := KrtOptions{stop}
 	c := kube.NewFakeClient()
 	kpc := kclient.New[*corev1.Pod](c)
 	pc := clienttest.Wrap(t, kpc)
-	pods := krt.WrapClient[*corev1.Pod](kpc)
-	stop := test.NewStop(t)
+	pods := krt.WrapClient[*corev1.Pod](kpc, opts.WithName("Pods")...)
 	c.RunAndWait(stop)
-	SimplePods := SimplePodCollection(pods)
+	SimplePods := SimplePodCollection(pods, opts)
 
 	assert.Equal(t, fetcherSorted(SimplePods)(), nil)
 	pod := &corev1.Pod{
@@ -193,6 +204,8 @@ func TestCollectionSimple(t *testing.T) {
 }
 
 func TestCollectionInitialState(t *testing.T) {
+	stop := test.NewStop(t)
+	opts := KrtOptions{stop}
 	c := kube.NewFakeClient(
 		&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -210,29 +223,29 @@ func TestCollectionInitialState(t *testing.T) {
 			Spec: corev1.ServiceSpec{Selector: map[string]string{"app": "foo"}},
 		},
 	)
-	pods := krt.NewInformer[*corev1.Pod](c)
-	services := krt.NewInformer[*corev1.Service](c)
-	stop := test.NewStop(t)
+	pods := krt.NewInformer[*corev1.Pod](c, opts.WithName("Pods")...)
+	services := krt.NewInformer[*corev1.Service](c, opts.WithName("Services")...)
 	c.RunAndWait(stop)
-	SimplePods := SimplePodCollection(pods)
-	SimpleServices := SimpleServiceCollection(services)
-	SimpleEndpoints := SimpleEndpointsCollection(SimplePods, SimpleServices)
+	SimplePods := SimplePodCollection(pods, opts)
+	SimpleServices := SimpleServiceCollection(services, opts)
+	SimpleEndpoints := SimpleEndpointsCollection(SimplePods, SimpleServices, opts)
 	assert.Equal(t, SimpleEndpoints.Synced().WaitUntilSynced(stop), true)
 	// Assert Equal -- not EventuallyEqual -- to ensure our WaitForCacheSync is proper
 	assert.Equal(t, fetcherSorted(SimpleEndpoints)(), []SimpleEndpoint{{"pod", "svc", "namespace", "1.2.3.4"}})
 }
 
 func TestCollectionMerged(t *testing.T) {
-	c := kube.NewFakeClient()
-	pods := krt.NewInformer[*corev1.Pod](c)
-	services := krt.NewInformer[*corev1.Service](c)
 	stop := test.NewStop(t)
+	opts := KrtOptions{stop}
+	c := kube.NewFakeClient()
+	pods := krt.NewInformer[*corev1.Pod](c, opts.WithName("Pods")...)
+	services := krt.NewInformer[*corev1.Service](c, opts.WithName("Services")...)
 	c.RunAndWait(stop)
 	pc := clienttest.Wrap(t, kclient.New[*corev1.Pod](c))
 	sc := clienttest.Wrap(t, kclient.New[*corev1.Service](c))
-	SimplePods := SimplePodCollection(pods)
-	SimpleServices := SimpleServiceCollection(services)
-	SimpleEndpoints := SimpleEndpointsCollection(SimplePods, SimpleServices)
+	SimplePods := SimplePodCollection(pods, opts)
+	SimpleServices := SimpleServiceCollection(services, opts)
+	SimpleEndpoints := SimpleEndpointsCollection(SimplePods, SimpleServices, opts)
 
 	assert.Equal(t, fetcherSorted(SimpleEndpoints)(), nil)
 	pod := &corev1.Pod{
@@ -288,12 +301,14 @@ type PodSizeCount struct {
 }
 
 func TestCollectionCycle(t *testing.T) {
+	stop := test.NewStop(t)
+	opts := KrtOptions{stop}
 	c := kube.NewFakeClient()
-	pods := krt.NewInformer[*corev1.Pod](c)
-	c.RunAndWait(test.NewStop(t))
+	pods := krt.NewInformer[*corev1.Pod](c, opts.WithName("Pods")...)
+	c.RunAndWait(stop)
 	pc := clienttest.Wrap(t, kclient.New[*corev1.Pod](c))
-	SimplePods := SimplePodCollection(pods)
-	SizedPods := SizedPodCollection(pods)
+	SimplePods := SimplePodCollection(pods, opts)
+	SizedPods := SizedPodCollection(pods, opts)
 	Thingys := krt.NewCollection[SimplePod, PodSizeCount](SimplePods, func(ctx krt.HandlerContext, pd SimplePod) *PodSizeCount {
 		if _, f := pd.Labels["want-size"]; !f {
 			return nil
@@ -305,7 +320,7 @@ func TestCollectionCycle(t *testing.T) {
 			Named:         pd.Named,
 			MatchingSizes: len(matches),
 		}
-	})
+	}, opts.WithName("Thingys")...)
 	tt := assert.NewTracker[string](t)
 	Thingys.RegisterBatch(BatchedTrackerHandler[PodSizeCount](tt), true)
 
@@ -442,6 +457,8 @@ func fetcherSorted[T krt.ResourceNamer](c krt.Collection[T]) func() []T {
 }
 
 func TestCollectionMultipleFetch(t *testing.T) {
+	stop := test.NewStop(t)
+	opts := KrtOptions{stop}
 	type Result struct {
 		Named
 		Configs []string
@@ -451,9 +468,9 @@ func TestCollectionMultipleFetch(t *testing.T) {
 	kcc := kclient.New[*corev1.ConfigMap](c)
 	pc := clienttest.Wrap(t, kpc)
 	cc := clienttest.Wrap(t, kcc)
-	pods := krt.WrapClient[*corev1.Pod](kpc)
-	configMaps := krt.WrapClient[*corev1.ConfigMap](kcc)
-	c.RunAndWait(test.NewStop(t))
+	pods := krt.WrapClient[*corev1.Pod](kpc, opts.WithName("Pods")...)
+	configMaps := krt.WrapClient[*corev1.ConfigMap](kcc, opts.WithName("ConfigMaps")...)
+	c.RunAndWait(stop)
 
 	lblFoo := map[string]string{"app": "foo"}
 	lblBar := map[string]string{"app": "bar"}
@@ -468,7 +485,7 @@ func TestCollectionMultipleFetch(t *testing.T) {
 			Named:   NewNamed(i),
 			Configs: slices.Sort(names),
 		}
-	})
+	}, opts.WithName("Results")...)
 
 	assert.Equal(t, fetcherSorted(Results)(), nil)
 	pod := &corev1.Pod{

--- a/pkg/kube/krt/index_test.go
+++ b/pkg/kube/krt/index_test.go
@@ -32,13 +32,14 @@ import (
 )
 
 func TestIndex(t *testing.T) {
+	stop := test.NewStop(t)
+	opts := KrtOptions{stop}
 	c := kube.NewFakeClient()
 	kpc := kclient.New[*corev1.Pod](c)
 	pc := clienttest.Wrap(t, kpc)
-	pods := krt.WrapClient[*corev1.Pod](kpc)
-	stop := test.NewStop(t)
+	pods := krt.WrapClient[*corev1.Pod](kpc, opts.WithName("Pods")...)
 	c.RunAndWait(stop)
-	SimplePods := SimplePodCollection(pods)
+	SimplePods := SimplePodCollection(pods, opts)
 	tt := assert.NewTracker[string](t)
 	IPIndex := krt.NewIndex[string, SimplePod](SimplePods, func(o SimplePod) []string {
 		return []string{o.IP}
@@ -89,13 +90,14 @@ func TestIndex(t *testing.T) {
 }
 
 func TestIndexCollection(t *testing.T) {
+	stop := test.NewStop(t)
+	opts := KrtOptions{stop}
 	c := kube.NewFakeClient()
 	kpc := kclient.New[*corev1.Pod](c)
 	pc := clienttest.Wrap(t, kpc)
-	pods := krt.WrapClient[*corev1.Pod](kpc)
-	stop := test.NewStop(t)
+	pods := krt.WrapClient[*corev1.Pod](kpc, opts.WithName("Pods")...)
 	c.RunAndWait(stop)
-	SimplePods := SimplePodCollection(pods)
+	SimplePods := SimplePodCollection(pods, opts)
 	tt := assert.NewTracker[string](t)
 	IPIndex := krt.NewIndex[string, SimplePod](SimplePods, func(o SimplePod) []string {
 		return []string{o.IP}
@@ -104,7 +106,7 @@ func TestIndexCollection(t *testing.T) {
 		pods := krt.Fetch(ctx, SimplePods, krt.FilterIndex(IPIndex, "1.2.3.5"))
 		names := slices.Sort(slices.Map(pods, SimplePod.ResourceName))
 		return ptr.Of(strings.Join(names, ","))
-	})
+	}, opts.WithName("Collection")...)
 	Collection.AsCollection().Synced().WaitUntilSynced(stop)
 	fetchSorted := func(ip string) []SimplePod {
 		return slices.SortBy(IPIndex.Lookup(ip), func(t SimplePod) string {
@@ -128,7 +130,7 @@ func TestIndexCollection(t *testing.T) {
 	pod.Status.PodIP = "1.2.3.5"
 	pc.UpdateStatus(pod)
 	tt.WaitUnordered("update/namespace/name")
-	assert.Equal(t, Collection.Get(), ptr.Of("namespace/name"))
+	assert.EventuallyEqual(t, Collection.Get, ptr.Of("namespace/name"))
 
 	pod2 := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -139,7 +141,7 @@ func TestIndexCollection(t *testing.T) {
 	}
 	pc.CreateOrUpdateStatus(pod2)
 	tt.WaitUnordered("add/namespace/name2")
-	assert.Equal(t, Collection.Get(), ptr.Of("namespace/name,namespace/name2"))
+	assert.EventuallyEqual(t, Collection.Get, ptr.Of("namespace/name,namespace/name2"))
 
 	pc.Delete(pod.Name, pod.Namespace)
 	pc.Delete(pod2.Name, pod2.Namespace)

--- a/pkg/kube/krt/informer_test.go
+++ b/pkg/kube/krt/informer_test.go
@@ -34,9 +34,11 @@ import (
 )
 
 func TestNewInformer(t *testing.T) {
+	stop := test.NewStop(t)
+	opts := KrtOptions{stop}
 	c := kube.NewFakeClient()
-	ConfigMaps := krt.NewInformer[*corev1.ConfigMap](c)
-	c.RunAndWait(test.NewStop(t))
+	ConfigMaps := krt.NewInformer[*corev1.ConfigMap](c, opts.WithName("ConfigMaps")...)
+	c.RunAndWait(stop)
 	cmt := clienttest.NewWriter[*corev1.ConfigMap](t, c)
 	tt := assert.NewTracker[string](t)
 	ConfigMaps.Register(TrackerHandler[*corev1.ConfigMap](tt))
@@ -86,6 +88,8 @@ func TestNewInformer(t *testing.T) {
 }
 
 func TestUnregisteredTypeCollection(t *testing.T) {
+	stop := test.NewStop(t)
+	opts := KrtOptions{stop}
 	np := &v1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "netpol",
@@ -104,7 +108,7 @@ func TestUnregisteredTypeCollection(t *testing.T) {
 			return c.Kube().NetworkingV1().NetworkPolicies(namespace).Watch(context.Background(), o)
 		},
 	)
-	npcoll := krt.NewInformer[*v1.NetworkPolicy](c)
+	npcoll := krt.NewInformer[*v1.NetworkPolicy](c, opts.WithName("NetworkPolicies")...)
 	c.RunAndWait(test.NewStop(t))
 	assert.Equal(t, npcoll.List(), []*v1.NetworkPolicy{np})
 }

--- a/pkg/kube/krt/join_test.go
+++ b/pkg/kube/krt/join_test.go
@@ -69,25 +69,27 @@ func TestJoinCollection(t *testing.T) {
 }
 
 func TestCollectionJoin(t *testing.T) {
+	stop := test.NewStop(t)
+	opts := KrtOptions{stop}
 	c := kube.NewFakeClient()
-	pods := krt.NewInformer[*corev1.Pod](c)
-	services := krt.NewInformer[*corev1.Service](c)
-	serviceEntries := krt.NewInformer[*istioclient.ServiceEntry](c)
-	c.RunAndWait(test.NewStop(t))
+	pods := krt.NewInformer[*corev1.Pod](c, opts.WithName("Pods")...)
+	services := krt.NewInformer[*corev1.Service](c, opts.WithName("Services")...)
+	serviceEntries := krt.NewInformer[*istioclient.ServiceEntry](c, opts.WithName("ServiceEntrys")...)
+	c.RunAndWait(stop)
 	pc := clienttest.Wrap(t, kclient.New[*corev1.Pod](c))
 	sc := clienttest.Wrap(t, kclient.New[*corev1.Service](c))
 	sec := clienttest.Wrap(t, kclient.New[*istioclient.ServiceEntry](c))
-	SimplePods := SimplePodCollection(pods)
+	SimplePods := SimplePodCollection(pods, opts)
 	ExtraSimplePods := krt.NewStatic(&SimplePod{
 		Named:   Named{"namespace", "name-static"},
 		Labeled: Labeled{map[string]string{"app": "foo"}},
 		IP:      "9.9.9.9",
 	}, true)
-	SimpleServices := SimpleServiceCollection(services)
-	SimpleServiceEntries := SimpleServiceCollectionFromEntries(serviceEntries)
+	SimpleServices := SimpleServiceCollection(services, opts)
+	SimpleServiceEntries := SimpleServiceCollectionFromEntries(serviceEntries, opts)
 	AllServices := krt.JoinCollection([]krt.Collection[SimpleService]{SimpleServices, SimpleServiceEntries})
 	AllPods := krt.JoinCollection([]krt.Collection[SimplePod]{SimplePods, ExtraSimplePods.AsCollection()})
-	SimpleEndpoints := SimpleEndpointsCollection(AllPods, AllServices)
+	SimpleEndpoints := SimpleEndpointsCollection(AllPods, AllServices, opts)
 
 	fetch := func() []SimpleEndpoint {
 		return slices.SortBy(SimpleEndpoints.List(), func(s SimpleEndpoint) string { return s.ResourceName() })
@@ -165,6 +167,8 @@ func TestCollectionJoin(t *testing.T) {
 }
 
 func TestCollectionJoinSync(t *testing.T) {
+	stop := test.NewStop(t)
+	opts := KrtOptions{stop}
 	c := kube.NewFakeClient(&corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "name",
@@ -173,10 +177,9 @@ func TestCollectionJoinSync(t *testing.T) {
 		},
 		Status: corev1.PodStatus{PodIP: "1.2.3.4"},
 	})
-	pods := krt.NewInformer[*corev1.Pod](c)
-	stop := test.NewStop(t)
+	pods := krt.NewInformer[*corev1.Pod](c, opts.WithName("Pods")...)
 	c.RunAndWait(stop)
-	SimplePods := SimplePodCollection(pods)
+	SimplePods := SimplePodCollection(pods, opts)
 	ExtraSimplePods := krt.NewStatic(&SimplePod{
 		Named:   Named{"namespace", "name-static"},
 		Labeled: Labeled{map[string]string{"app": "foo"}},

--- a/pkg/kube/krt/recomputetrigger_test.go
+++ b/pkg/kube/krt/recomputetrigger_test.go
@@ -17,6 +17,8 @@ package krt_test
 import (
 	"testing"
 
+	"go.uber.org/atomic"
+
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/test"
@@ -26,11 +28,11 @@ import (
 func TestRecomputeTrigger(t *testing.T) {
 	rt := krt.NewRecomputeTrigger(false)
 	col1 := krt.NewStatic(ptr.Of("foo"), true).AsCollection()
-	response := "foo"
+	response := atomic.NewString("foo")
 	col2 := krt.NewCollection(col1, func(ctx krt.HandlerContext, i string) *string {
 		rt.MarkDependant(ctx)
-		return ptr.Of(response)
-	})
+		return ptr.Of(response.Load())
+	}, krt.WithStop(test.NewStop(t)))
 
 	assert.Equal(t, col2.Synced().HasSynced(), false)
 	rt.MarkSynced()
@@ -40,11 +42,11 @@ func TestRecomputeTrigger(t *testing.T) {
 	col2.Register(TrackerHandler[string](tt))
 	tt.WaitOrdered("add/foo")
 
-	response = "bar"
+	response.Store("bar")
 	rt.TriggerRecomputation()
 	tt.WaitUnordered("delete/foo", "add/bar")
 
-	response = "baz"
+	response.Store("baz")
 	rt.TriggerRecomputation()
 	tt.WaitUnordered("delete/bar", "add/baz")
 }

--- a/pkg/kube/krt/singleton_test.go
+++ b/pkg/kube/krt/singleton_test.go
@@ -32,9 +32,9 @@ import (
 )
 
 func TestSingleton(t *testing.T) {
-	c := kube.NewFakeClient()
-	ConfigMaps := krt.NewInformer[*corev1.ConfigMap](c)
 	stop := test.NewStop(t)
+	c := kube.NewFakeClient()
+	ConfigMaps := krt.NewInformer[*corev1.ConfigMap](c, krt.WithStop(stop))
 	c.RunAndWait(stop)
 	cmt := clienttest.NewWriter[*corev1.ConfigMap](t, c)
 	ConfigMapNames := krt.NewSingleton[string](
@@ -43,7 +43,7 @@ func TestSingleton(t *testing.T) {
 			return ptr.Of(slices.Join(",", slices.Map(cms, func(c *corev1.ConfigMap) string {
 				return config.NamespacedName(c).String()
 			})...))
-		},
+		}, krt.WithStop(stop),
 	)
 	ConfigMapNames.AsCollection().Synced().WaitUntilSynced(stop)
 	tt := assert.NewTracker[string](t)

--- a/pkg/kube/krt/sync.go
+++ b/pkg/kube/krt/sync.go
@@ -24,6 +24,7 @@ type Syncer interface {
 var (
 	_ Syncer = channelSyncer{}
 	_ Syncer = pollSyncer{}
+	_ Syncer = multiSyncer{}
 )
 
 type channelSyncer struct {


### PR DESCRIPTION
This **partially** backports https://github.com/istio/istio/pull/53994 to 1.24.

The overall PR has two portions:
* Misc refactoring to pass `stop` around everywhere and improve tests to be more resiliant. This is universally better and has no risk. **This is what the backport includes**
* Change the core of `krt` to use queues - this is **not included** in this PR.

The intent here is it prep for a possible full backport of the queue change. Getting the non-controversial parts in now will make that easier (for example, we may put the new changes behind a feature flag -- it will be easy to tell what is flag protected and what isn't).

I will discuss in the upcoming WG meeting a full backport