### PR TITLE
POC: move networks code over to krt

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -141,12 +141,12 @@ type Options struct {
 // KrtOptions is a small wrapper around KRT options to make it easy to provide a common set of options to all collections
 // without excessive duplication.
 type KrtOptions struct {
-	stop     chan struct{}
-	debugger *krt.DebugHandler
+	Stop     chan struct{}
+	Debugger *krt.DebugHandler
 }
 
 func (k KrtOptions) WithName(n string) []krt.CollectionOption {
-	return []krt.CollectionOption{krt.WithDebugging(k.debugger), krt.WithStop(k.stop), krt.WithName(n)}
+	return []krt.CollectionOption{krt.WithDebugging(k.Debugger), krt.WithStop(k.Stop), krt.WithName(n)}
 }
 
 func New(options Options) Index {
@@ -167,8 +167,8 @@ func New(options Options) Index {
 		ObjectFilter: options.Client.ObjectFilter(),
 	}
 	opts := KrtOptions{
-		stop:     a.stop,
-		debugger: options.Debugger,
+		Stop:     a.stop,
+		Debugger: options.Debugger,
 	}
 	ConfigMaps := krt.NewInformerFiltered[*v1.ConfigMap](options.Client, filter, opts.WithName("ConfigMaps")...)
 

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -319,6 +319,17 @@ func TestProxyK8sHostnameLabel(t *testing.T) {
 	}
 }
 
+func setSystemNetwork(t test.Failer, c *FakeController, net network.ID) {
+	clienttest.NewWriter[*corev1.Namespace](t, c.client).Create(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: c.opts.SystemNamespace,
+			Labels: map[string]string{
+				label.TopologyNetwork.Name: string(net),
+			},
+		},
+	})
+}
+
 func TestGetProxyServiceTargets(t *testing.T) {
 	clusterID := cluster.ID("fakeCluster")
 	networkID := network.ID("fakeNetwork")
@@ -326,7 +337,7 @@ func TestGetProxyServiceTargets(t *testing.T) {
 		ClusterID: clusterID,
 	})
 	// add a network ID to test endpoints include topology.istio.io/network label
-	controller.network = networkID
+	setSystemNetwork(t, controller, networkID)
 
 	p := generatePod([]string{"128.0.0.1"}, "pod1", "nsa", "foo", "node1", map[string]string{"app": "test-app"}, map[string]string{})
 	addPods(t, controller, fx, p)

--- a/pilot/pkg/serviceregistry/kube/controller/endpoint_builder_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoint_builder_test.go
@@ -138,15 +138,23 @@ func TestNewEndpointBuilderTopologyLabels(t *testing.T) {
 			c.expected[labelutil.LabelHostname] = "fake"
 
 			loc := pkgmodel.ConvertLocality(c.ctl.locality)
-			fc := kube.NewFakeClient(&v1.Node{
-				ObjectMeta: metav1.ObjectMeta{Name: "fake", Labels: map[string]string{
-					NodeRegionLabelGA:          loc.Region,
-					NodeZoneLabel:              loc.Zone,
-					label.TopologySubzone.Name: loc.SubZone,
-				}},
-				Spec:   v1.NodeSpec{},
-				Status: v1.NodeStatus{},
-			})
+			fc := kube.NewFakeClient(
+				&v1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "fake", Labels: map[string]string{
+						NodeRegionLabelGA:          loc.Region,
+						NodeZoneLabel:              loc.Zone,
+						label.TopologySubzone.Name: loc.SubZone,
+					}},
+				},
+				&v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "istio-system",
+						Labels: map[string]string{
+							label.TopologyNetwork.Name: string(c.ctl.network),
+						},
+					},
+				},
+			)
 			nodes := kclient.New[*v1.Node](fc)
 			fc.RunAndWait(test.NewStop(t))
 			cc := &Controller{
@@ -154,7 +162,6 @@ func TestNewEndpointBuilderTopologyLabels(t *testing.T) {
 				meshWatcher: mesh.NewFixedWatcher(mesh.DefaultMeshConfig()),
 				networkManager: &networkManager{
 					clusterID: c.ctl.cluster,
-					network:   c.ctl.network,
 				},
 				opts: Options{ClusterID: c.ctl.cluster},
 			}
@@ -266,15 +273,23 @@ func TestNewEndpointBuilderFromMetadataTopologyLabels(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			loc := pkgmodel.ConvertLocality(c.ctl.locality)
-			fc := kube.NewFakeClient(&v1.Node{
-				ObjectMeta: metav1.ObjectMeta{Name: "fake", Labels: map[string]string{
-					NodeRegionLabelGA:          loc.Region,
-					NodeZoneLabel:              loc.Zone,
-					label.TopologySubzone.Name: loc.SubZone,
-				}},
-				Spec:   v1.NodeSpec{},
-				Status: v1.NodeStatus{},
-			})
+			fc := kube.NewFakeClient(
+				&v1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "fake", Labels: map[string]string{
+						NodeRegionLabelGA:          loc.Region,
+						NodeZoneLabel:              loc.Zone,
+						label.TopologySubzone.Name: loc.SubZone,
+					}},
+				},
+				&v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "istio-system",
+						Labels: map[string]string{
+							label.TopologyNetwork.Name: string(c.ctl.network),
+						},
+					},
+				},
+			)
 			nodes := kclient.New[*v1.Node](fc)
 			fc.RunAndWait(test.NewStop(t))
 			cc := &Controller{
@@ -282,7 +297,6 @@ func TestNewEndpointBuilderFromMetadataTopologyLabels(t *testing.T) {
 				meshWatcher: mesh.NewFixedWatcher(mesh.DefaultMeshConfig()),
 				networkManager: &networkManager{
 					clusterID: c.ctl.cluster,
-					network:   c.ctl.network,
 				},
 				opts: Options{ClusterID: c.ctl.cluster},
 			}

--- a/pilot/pkg/serviceregistry/kube/controller/fuzz_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/fuzz_test.go
@@ -22,18 +22,15 @@ import (
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/fuzz"
-	"istio.io/istio/pkg/network"
 )
 
 func FuzzKubeController(f *testing.F) {
 	fuzz.Fuzz(f, func(fg fuzz.Helper) {
-		networkID := network.ID("fakeNetwork")
 		fco := fuzz.Struct[FakeControllerOptions](fg)
 		fco.SkipRun = true
 		// Overlapping CRDs would fail, just remove them
 		fco.CRDs = nil
 		controller, _ := NewFakeControllerWithOptions(fg.T(), fco)
-		controller.network = networkID
 
 		p := fuzz.Struct[*corev1.Pod](fg)
 		controller.pods.onEvent(nil, p, model.EventAdd)

--- a/pilot/pkg/serviceregistry/kube/controller/network.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network.go
@@ -15,121 +15,103 @@
 package controller
 
 import (
-	"net"
-	"strconv"
-	"sync"
-
-	"github.com/yl2chen/cidranger"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
-
 	"istio.io/api/label"
-	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pilot/pkg/serviceregistry/kube"
+	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller/ambient"
 	"istio.io/istio/pkg/cluster"
-	"istio.io/istio/pkg/config/constants"
-	"istio.io/istio/pkg/config/host"
-	"istio.io/istio/pkg/config/mesh"
-	"istio.io/istio/pkg/config/schema/gvr"
+	"istio.io/istio/pkg/config/labels"
+	kubeclient "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/kclient"
-	"istio.io/istio/pkg/kube/kubetypes"
+	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/network"
-	"istio.io/istio/pkg/slices"
+	v1 "k8s.io/api/core/v1"
+	"net"
 )
 
+// nodeAddresses represents a kubernetes node that is reachable externally
+type nodeAddresses struct {
+	address string
+	labels  labels.Instance
+}
+
+func (n nodeAddresses) Equals(other nodeAddresses) bool {
+	return n.address == other.address && n.labels.Equals(other.labels)
+}
+
 type networkManager struct {
-	sync.RWMutex
-	// CIDR ranger based on path-compressed prefix trie
-	ranger    cidranger.Ranger
 	clusterID cluster.ID
-
-	gatewayResourceClient kclient.Informer[*v1beta1.Gateway]
-	meshNetworksWatcher   mesh.NetworksWatcher
-
-	// Network name for to be used when the meshNetworks fromRegistry nor network label on pod is specified
-	// This is defined by a topology.istio.io/network label on the system namespace.
-	network network.ID
-	// Network name for the registry as specified by the MeshNetworks configmap
-	networkFromMeshConfig network.ID
-	// map of svc fqdn to partially built network gateways; the actual gateways will be built from these into networkGatewaysBySvc
-	// this map just enumerates which networks/ports each Service is a gateway for
-	registryServiceNameGateways map[host.Name][]model.NetworkGateway
-	// gateways for each service
-	networkGatewaysBySvc map[host.Name]model.NetworkGatewaySet
-	// gateways from kubernetes Gateway resources
-	gatewaysFromResource map[types.UID]model.NetworkGatewaySet
-	// we don't want to discover gateways with class "istio-remote" from outside cluster's API servers.
-	discoverRemoteGatewayResources bool
-
-	// implements NetworkGatewaysWatcher; we need to call c.NotifyGatewayHandlers when our gateways change
-	model.NetworkGatewaysHandler
+	stop chan struct{}
 }
 
 func initNetworkManager(c *Controller, options Options) *networkManager {
 	n := &networkManager{
-		clusterID:           options.ClusterID,
-		meshNetworksWatcher: options.MeshNetworksWatcher,
-		// zero values are a workaround structcheck issue: https://github.com/golangci/golangci-lint/issues/826
-		ranger:                         nil,
-		network:                        "",
-		networkFromMeshConfig:          "",
-		registryServiceNameGateways:    make(map[host.Name][]model.NetworkGateway),
-		networkGatewaysBySvc:           make(map[host.Name]model.NetworkGatewaySet),
-		gatewaysFromResource:           make(map[types.UID]model.NetworkGatewaySet),
-		discoverRemoteGatewayResources: options.ConfigCluster,
+		stop: make(chan struct{}),
+		clusterID: c.clusterID,
 	}
-	// initialize the gateway resource client when any feature that uses it is enabled
-	if features.MultiNetworkGatewayAPI {
-		n.gatewayResourceClient = kclient.NewDelayedInformer[*v1beta1.Gateway](c.client, gvr.KubernetesGateway, kubetypes.StandardInformer, kubetypes.Filter{})
-		// conditionally register this handler
-		registerHandlers(c, n.gatewayResourceClient, "Gateways", n.handleGatewayResource, nil)
+	opts := ambient.KrtOptions{
+		Stop:     n.stop,
+		Debugger: krt.GlobalDebugHandler,
 	}
+	filter := kclient.Filter{
+		ObjectFilter: c.client.ObjectFilter(),
+	}
+	ConfigMaps := krt.NewInformerFiltered[*v1.ConfigMap](c.client, filter, opts.WithName("ConfigMaps")...)
+
+	ambOpts := ambient.Options{Revision: options.Revision, SystemNamespace: options.SystemNamespace}
+	MeshNetworks := ambient.MeshNetworksCollection(ConfigMaps, ambOpts, opts)
+	Nodes := krt.NewInformerFiltered[*v1.Node](c.client, kclient.Filter{
+		ObjectFilter:    c.client.ObjectFilter(),
+		ObjectTransform: kubeclient.StripNodeUnusedFields,
+	}, opts.WithName("Nodes")...)
+	NodeAddresses := krt.NewCollection(
+		Nodes,
+		n.nodeAddressesBuilder(),
+		opts.WithName("NodeAddresses")...,
+	)
+	_ = NodeAddresses
+	_ = MeshNetworks
+	// TODO event handlers for this
 	return n
 }
 
-// setNetworkFromNamespace sets network got from system namespace, returns whether it has changed
-func (n *networkManager) setNetworkFromNamespace(ns *v1.Namespace) bool {
-	nw := ns.Labels[label.TopologyNetwork.Name]
-	n.Lock()
-	defer n.Unlock()
-	oldDefaultNetwork := n.network
-	n.network = network.ID(nw)
-	return oldDefaultNetwork != n.network
+
+func (c *Controller) AppendNetworkGatewayHandler(h func()) {
+	//TODO implement me
+	panic("implement me")
 }
 
-func (n *networkManager) networkFromSystemNamespace() network.ID {
-	n.RLock()
-	defer n.RUnlock()
-	return n.network
+func (n *networkManager) nodeAddressesBuilder() krt.TransformationSingle[*v1.Node, nodeAddresses] {
+	return func(ctx krt.HandlerContext, node *v1.Node) *nodeAddresses {
+		n := nodeAddresses{labels: node.Labels}
+		for _, address := range node.Status.Addresses {
+			if address.Type == v1.NodeExternalIP && address.Address != "" {
+				n.address = address.Address
+				break
+			}
+		}
+		if n.address == "" {
+			return nil
+		}
+		return &n
+	}
 }
 
-func (n *networkManager) networkFromMeshNetworks(endpointIP string) network.ID {
-	n.RLock()
-	defer n.RUnlock()
-	if n.networkFromMeshConfig != "" {
-		return n.networkFromMeshConfig
+func (n *networkManager) Network(endpointIP string, labels labels.Instance) network.ID {
+	// 1. check the pod/workloadEntry label
+	if nw := labels[label.TopologyNetwork.Name]; nw != "" {
+		return network.ID(nw)
 	}
 
-	if n.ranger != nil {
-		ip := net.ParseIP(endpointIP)
-		if ip == nil {
-			return ""
-		}
-		entries, err := n.ranger.ContainingNetworks(ip)
-		if err != nil {
-			log.Errorf("error getting cidr ranger entry from endpoint ip %s", endpointIP)
-			return ""
-		}
-		if len(entries) > 1 {
-			log.Warnf("Found multiple networks CIDRs matching the endpoint IP: %s. Using the first match.", endpointIP)
-		}
-		if len(entries) > 0 {
-			return (entries[0].(namedRangerEntry)).name
-		}
-	}
+	// 2. check the system namespace labels
+	//if nw := c.networkFromSystemNamespace(); nw != "" {
+	//	return nw
+	//}
+
+	// 3. check the meshNetworks config
+	//if nw := c.networkFromMeshNetworks(endpointIP); nw != "" {
+	//	return nw
+	//}
+
 	return ""
 }
 
@@ -144,332 +126,10 @@ func (n namedRangerEntry) Network() net.IPNet {
 	return n.network
 }
 
-// onNetworkChange is fired if the default network is changed either via the namespace label or mesh-networks
-func (c *Controller) onNetworkChange() {
-	// the network for endpoints are computed when we process the events; this will fix the cache
-	// NOTE: this must run before the other network watcher handler that creates a force push
-	if err := c.syncPods(); err != nil {
-		log.Errorf("one or more errors force-syncing pods: %v", err)
-	}
-	if err := c.endpoints.initializeNamespace(metav1.NamespaceAll, true); err != nil {
-		log.Errorf("one or more errors force-syncing endpoints: %v", err)
-	}
-	if c.reloadNetworkGateways() {
-		c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{Full: true, Reason: model.NewReasonStats(model.NetworksTrigger)})
-	}
-	c.NotifyGatewayHandlers()
-}
-
-// reloadMeshNetworks will read the mesh networks configuration to setup
-// fromRegistry and cidr based network lookups for this registry
-func (n *networkManager) reloadMeshNetworks() {
-	n.Lock()
-	defer n.Unlock()
-	ranger := cidranger.NewPCTrieRanger()
-
-	n.networkFromMeshConfig = ""
-	n.registryServiceNameGateways = make(map[host.Name][]model.NetworkGateway)
-
-	meshNetworks := n.meshNetworksWatcher.Networks()
-	if meshNetworks == nil || len(meshNetworks.Networks) == 0 {
-		return
-	}
-	for id, v := range meshNetworks.Networks {
-		// track endpoints items from this registry are a part of this network
-		fromRegistry := false
-		for _, ep := range v.Endpoints {
-			if ep.GetFromCidr() != "" {
-				_, nw, err := net.ParseCIDR(ep.GetFromCidr())
-				if err != nil {
-					log.Warnf("unable to parse CIDR %q for network %s", ep.GetFromCidr(), id)
-					continue
-				}
-				rangerEntry := namedRangerEntry{
-					name:    network.ID(id),
-					network: *nw,
-				}
-				_ = ranger.Insert(rangerEntry)
-			}
-			if ep.GetFromRegistry() != "" && cluster.ID(ep.GetFromRegistry()) == n.clusterID {
-				fromRegistry = true
-			}
-		}
-
-		// fromRegistry field specified this cluster
-		if fromRegistry {
-			// treat endpoints in this cluster as part of this network
-			if n.networkFromMeshConfig != "" {
-				log.Warnf("multiple networks specify %s in fromRegistry; endpoints from %s will continue to be treated as part of %s",
-					n.clusterID, n.clusterID, n.networkFromMeshConfig)
-			} else {
-				n.networkFromMeshConfig = network.ID(id)
-			}
-
-			// services in this registry matching the registryServiceName and port are part of this network
-			for _, gw := range v.Gateways {
-				if gwSvcName := gw.GetRegistryServiceName(); gwSvcName != "" {
-					svc := host.Name(gwSvcName)
-					n.registryServiceNameGateways[svc] = append(n.registryServiceNameGateways[svc], model.NetworkGateway{
-						Network: network.ID(id),
-						Cluster: n.clusterID,
-						Port:    gw.GetPort(),
-					})
-				}
-			}
-		}
-
-	}
-	n.ranger = ranger
-}
-
 func (c *Controller) NetworkGateways() []model.NetworkGateway {
-	c.networkManager.RLock()
-	defer c.networkManager.RUnlock()
-
-	// Merge all the gateways into a single set to eliminate duplicates.
-	out := make(model.NetworkGatewaySet)
-	for _, gateways := range c.networkGatewaysBySvc {
-		out.Merge(gateways)
-	}
-	for _, gateways := range c.gatewaysFromResource {
-		out.Merge(gateways)
-	}
-
-	unsorted := out.UnsortedList()
-	return model.SortGateways(unsorted)
-}
-
-// extractGatewaysFromService checks if the service is a cross-network gateway
-// and if it is, updates the controller's gateways.
-func (c *Controller) extractGatewaysFromService(svc *model.Service) bool {
-	changed := c.networkManager.extractGatewaysInner(svc)
-	if changed {
-		c.NotifyGatewayHandlers()
-	}
-	return changed
-}
-
-// reloadNetworkGateways performs extractGatewaysFromService for all services registered with the controller.
-// It returns whether there is a gateway changed.
-// It is called only by `onNetworkChange`.
-// It iterates over all services, because mesh networks can be set with a service name.
-func (c *Controller) reloadNetworkGateways() bool {
-	c.Lock()
-	defer c.Unlock()
-	gwChanged := false
-	for _, svc := range c.servicesMap {
-		if c.extractGatewaysInner(svc) {
-			gwChanged = true
-		}
-	}
-	return gwChanged
-}
-
-// extractGatewaysInner updates the gateway address inferred from the service.
-// Returns true if any gateway address changed.
-func (n *networkManager) extractGatewaysInner(svc *model.Service) bool {
-	n.Lock()
-	defer n.Unlock()
-	previousGateways := n.networkGatewaysBySvc[svc.Hostname]
-	gateways := n.getGatewayDetails(svc)
-	// short circuit for most services.
-	if len(previousGateways) == 0 && len(gateways) == 0 {
-		return false
-	}
-
-	newGateways := make(model.NetworkGatewaySet)
-	// check if we have node port mappings
-	nodePortMap := make(map[uint32]uint32)
-	if svc.Attributes.ClusterExternalPorts != nil {
-		if npm, exists := svc.Attributes.ClusterExternalPorts[n.clusterID]; exists {
-			nodePortMap = npm
-		}
-	}
-
-	for _, addr := range svc.Attributes.ClusterExternalAddresses.GetAddressesFor(n.clusterID) {
-		for _, gw := range gateways {
-			// what we now have is a service port. If there is a mapping for cluster external ports,
-			// look it up and get the node port for the remote port
-			if nodePort, exists := nodePortMap[gw.Port]; exists {
-				gw.Port = nodePort
-			}
-
-			gw.Cluster = n.clusterID
-			gw.Addr = addr
-			newGateways.Insert(gw)
-		}
-	}
-
-	gatewaysChanged := !newGateways.Equals(previousGateways)
-	if len(newGateways) > 0 {
-		n.networkGatewaysBySvc[svc.Hostname] = newGateways
-	} else {
-		delete(n.networkGatewaysBySvc, svc.Hostname)
-	}
-
-	return gatewaysChanged
-}
-
-// getGatewayDetails returns gateways without the address populated, only the network and (unmapped) port for a given service.
-func (n *networkManager) getGatewayDetails(svc *model.Service) []model.NetworkGateway {
-	// TODO should we start checking if svc's Ports contain the gateway port?
-
-	// label based gateways
-	// TODO label based gateways could support being the gateway for multiple networks
-	if nw := svc.Attributes.Labels[label.TopologyNetwork.Name]; nw != "" {
-		if gwPortStr := svc.Attributes.Labels[label.NetworkingGatewayPort.Name]; gwPortStr != "" {
-			if gwPort, err := strconv.Atoi(gwPortStr); err == nil {
-				return []model.NetworkGateway{{Port: uint32(gwPort), Network: network.ID(nw)}}
-			}
-			log.Warnf("could not parse %q for %s on %s/%s; defaulting to %d",
-				gwPortStr, label.NetworkingGatewayPort.Name, svc.Attributes.Namespace, svc.Attributes.Name, DefaultNetworkGatewayPort)
-		}
-		return []model.NetworkGateway{{Port: DefaultNetworkGatewayPort, Network: network.ID(nw)}}
-	}
-
-	// meshNetworks registryServiceName+fromRegistry
-	if gws, ok := n.registryServiceNameGateways[svc.Hostname]; ok {
-		out := append(make([]model.NetworkGateway, 0, len(gws)), gws...)
-		return out
-	}
-
-	return nil
-}
-
-// handleGateway resource adds a NetworkGateway for each combination of address and auto-passthrough listener
-// discovering duplicates from the generated Service is not a huge concern as we de-duplicate in NetworkGateways
-// which returns a set, although it's not totally efficient.
-func (n *networkManager) handleGatewayResource(_ *v1beta1.Gateway, gw *v1beta1.Gateway, event model.Event) error {
-	if nw := gw.GetLabels()[label.TopologyNetwork.Name]; nw == "" {
-		return nil
-	}
-
-	// Gateway with istio-remote: only discover this from the config cluster
-	// this is a way to reference a gateway that lives in a place that this control plane
-	// won't have API server access. Nothing will be deployed for these Gateway resources.
-	if !n.discoverRemoteGatewayResources && gw.Spec.GatewayClassName == constants.RemoteGatewayClassName {
-		return nil
-	}
-
-	gatewaysChanged := false
-	n.Lock()
-	defer func() {
-		n.Unlock()
-		if gatewaysChanged {
-			n.NotifyGatewayHandlers()
-		}
-	}()
-
-	previousGateways := n.gatewaysFromResource[gw.UID]
-
-	if event == model.EventDelete {
-		gatewaysChanged = len(previousGateways) > 0
-		delete(n.gatewaysFromResource, gw.UID)
-		return nil
-	}
-
-	autoPassthrough := func(l v1beta1.Listener) bool {
-		return kube.IsAutoPassthrough(gw.GetLabels(), l)
-	}
-
-	base := model.NetworkGateway{
-		Network: network.ID(gw.GetLabels()[label.TopologyNetwork.Name]),
-		Cluster: n.clusterID,
-		ServiceAccount: types.NamespacedName{
-			Namespace: gw.Namespace,
-			Name:      kube.GatewaySA(gw),
-		},
-	}
-	newGateways := model.NetworkGatewaySet{}
-	for _, addr := range gw.Spec.Addresses {
-		if addr.Type == nil {
-			continue
-		}
-		if addrType := *addr.Type; addrType != v1beta1.IPAddressType && addrType != v1beta1.HostnameAddressType {
-			continue
-		}
-		for _, l := range slices.Filter(gw.Spec.Listeners, autoPassthrough) {
-			networkGateway := base
-			networkGateway.Addr = addr.Value
-			networkGateway.Port = uint32(l.Port)
-			newGateways.Insert(networkGateway)
-		}
-		for _, l := range gw.Spec.Listeners {
-			if l.Protocol == "HBONE" {
-				networkGateway := base
-				networkGateway.Addr = addr.Value
-				networkGateway.Port = uint32(l.Port)
-				networkGateway.HBONEPort = uint32(l.Port)
-				newGateways.Insert(networkGateway)
-			}
-		}
-	}
-	n.gatewaysFromResource[gw.UID] = newGateways
-
-	if len(previousGateways) != len(newGateways) {
-		gatewaysChanged = true
-		return nil
-	}
-
-	gatewaysChanged = !newGateways.Equals(previousGateways)
-	if len(newGateways) > 0 {
-		n.gatewaysFromResource[gw.UID] = newGateways
-	} else {
-		delete(n.gatewaysFromResource, gw.UID)
-	}
-
 	return nil
 }
 
 func (n *networkManager) HasSynced() bool {
-	if n.gatewayResourceClient == nil {
-		return true
-	}
-	return n.gatewayResourceClient.HasSynced()
-}
-
-// updateServiceNodePortAddresses updates ClusterExternalAddresses for Services of nodePort type
-func (c *Controller) updateServiceNodePortAddresses(svcs ...*model.Service) bool {
-	// node event, update all nodePort gateway services
-	if len(svcs) == 0 {
-		svcs = c.getNodePortGatewayServices()
-	}
-	// no nodePort gateway service found, no update
-	if len(svcs) == 0 {
-		return false
-	}
-	for _, svc := range svcs {
-		c.RLock()
-		nodeSelector := c.nodeSelectorsForServices[svc.Hostname]
-		c.RUnlock()
-		// update external address
-		var nodeAddresses []string
-		for _, n := range c.nodeInfoMap {
-			if nodeSelector.SubsetOf(n.labels) {
-				nodeAddresses = append(nodeAddresses, n.address)
-			}
-		}
-		if svc.Attributes.ClusterExternalAddresses == nil {
-			svc.Attributes.ClusterExternalAddresses = &model.AddressMap{}
-		}
-		svc.Attributes.ClusterExternalAddresses.SetAddressesFor(c.Cluster(), nodeAddresses)
-		// update gateways that use the service
-		c.extractGatewaysFromService(svc)
-	}
-	return true
-}
-
-// getNodePortServices returns nodePort type gateway service
-func (c *Controller) getNodePortGatewayServices() []*model.Service {
-	c.RLock()
-	defer c.RUnlock()
-	out := make([]*model.Service, 0, len(c.nodeSelectorsForServices))
-	for hostname := range c.nodeSelectorsForServices {
-		svc := c.servicesMap[hostname]
-		if svc != nil {
-			out = append(out, svc)
-		}
-	}
-
-	return out
+	return false
 }

--- a/pilot/pkg/serviceregistry/kube/controller/network.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network.go
@@ -15,6 +15,18 @@
 package controller
 
 import (
+	"github.com/yl2chen/cidranger"
+	"istio.io/istio/pilot/pkg/serviceregistry/kube"
+	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/config/schema/gvr"
+	"istio.io/istio/pkg/kube/kubetypes"
+	"istio.io/istio/pkg/slices"
+	"k8s.io/apimachinery/pkg/types"
+	"net"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	v1 "k8s.io/api/core/v1"
+
 	"istio.io/api/label"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller/ambient"
@@ -24,8 +36,7 @@ import (
 	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/network"
-	v1 "k8s.io/api/core/v1"
-	"net"
+	"istio.io/istio/pkg/ptr"
 )
 
 // nodeAddresses represents a kubernetes node that is reachable externally
@@ -39,14 +50,27 @@ func (n nodeAddresses) Equals(other nodeAddresses) bool {
 }
 
 type networkManager struct {
-	clusterID cluster.ID
-	stop chan struct{}
+	clusterID                      cluster.ID
+	stop                           chan struct{}
+	discoverRemoteGatewayResources bool
+
+	RecomputeTrigger         *krt.RecomputeTrigger
+	SystemNamespaceNetwork   krt.Singleton[string]
+	NetworkGateways          krt.Collection[model.NetworkGateway]
+	NetworkGatewaysByNetwork krt.Index[network.ID, model.NetworkGateway]
+	ParsedMeshNetworks       krt.Singleton[meshNetworks]
+}
+
+type meshNetworks struct {
+	ranger  cidranger.Ranger
+	network network.ID
 }
 
 func initNetworkManager(c *Controller, options Options) *networkManager {
 	n := &networkManager{
-		stop: make(chan struct{}),
-		clusterID: c.clusterID,
+		stop:                           make(chan struct{}),
+		clusterID:                      options.ClusterID,
+		discoverRemoteGatewayResources: options.ConfigCluster,
 	}
 	opts := ambient.KrtOptions{
 		Stop:     n.stop,
@@ -57,8 +81,94 @@ func initNetworkManager(c *Controller, options Options) *networkManager {
 	}
 	ConfigMaps := krt.NewInformerFiltered[*v1.ConfigMap](c.client, filter, opts.WithName("ConfigMaps")...)
 
+	RecomputeTrigger := krt.NewRecomputeTrigger(false, krt.WithName("NetworkTrigger"))
 	ambOpts := ambient.Options{Revision: options.Revision, SystemNamespace: options.SystemNamespace}
+	Namespaces := krt.NewInformer[*v1.Namespace](c.client, opts.WithName("Namespaces")...)
+	SystemNamespaceNetwork := krt.NewSingleton[string](func(ctx krt.HandlerContext) *string {
+		ns := ptr.Flatten(krt.FetchOne(ctx, Namespaces, krt.FilterKey(options.SystemNamespace)))
+		if ns == nil {
+			return nil
+		}
+		nw, f := ns.Labels[label.TopologyNetwork.Name]
+		if !f {
+			return nil
+		}
+		return &nw
+	})
 	MeshNetworks := ambient.MeshNetworksCollection(ConfigMaps, ambOpts, opts)
+	ParsedMeshNetworks := krt.NewSingleton(func(ctx krt.HandlerContext) *meshNetworks {
+		mn := krt.FetchOne(ctx, MeshNetworks.AsCollection())
+		ranger := cidranger.NewPCTrieRanger()
+		res := meshNetworks{}
+
+		if len(mn.Networks) == 0 {
+			return nil
+		}
+		for id, v := range mn.Networks {
+			// track endpoints items from this registry are a part of this network
+			fromRegistry := false
+			for _, ep := range v.Endpoints {
+				if ep.GetFromCidr() != "" {
+					_, nw, err := net.ParseCIDR(ep.GetFromCidr())
+					if err != nil {
+						log.Warnf("unable to parse CIDR %q for network %s", ep.GetFromCidr(), id)
+						continue
+					}
+					rangerEntry := namedRangerEntry{
+						name:    network.ID(id),
+						network: *nw,
+					}
+					_ = ranger.Insert(rangerEntry)
+				}
+				if ep.GetFromRegistry() != "" && cluster.ID(ep.GetFromRegistry()) == n.clusterID {
+					fromRegistry = true
+				}
+			}
+
+			// fromRegistry field specified this cluster
+			if fromRegistry {
+				// treat endpoints in this cluster as part of this network
+				if res.network != "" {
+					log.Warnf("multiple networks specify %s in fromRegistry; endpoints from %s will continue to be treated as part of %s",
+						n.clusterID, n.clusterID, res.network)
+				} else {
+					res.network = network.ID(id)
+				}
+			}
+		}
+		res.ranger = ranger
+		return &res
+	})
+	FromMeshNetworks := krt.NewManyCollection(MeshNetworks.AsCollection(), func(ctx krt.HandlerContext, mn ambient.MeshNetworks) []model.NetworkGateway {
+		res := []model.NetworkGateway{}
+		if len(mn.Networks) == 0 {
+			return nil
+		}
+		for id, v := range mn.Networks {
+			// track endpoints items from this registry are a part of this network
+			fromRegistry := false
+			for _, ep := range v.Endpoints {
+				if ep.GetFromRegistry() != "" && cluster.ID(ep.GetFromRegistry()) == n.clusterID {
+					fromRegistry = true
+				}
+			}
+
+			// fromRegistry field specified this cluster
+			if fromRegistry {
+				// services in this registry matching the registryServiceName and port are part of this network
+				for _, gw := range v.Gateways {
+					if gwSvcName := gw.GetRegistryServiceName(); gwSvcName != "" {
+						res = append(res, model.NetworkGateway{
+							Network: network.ID(id),
+							Cluster: n.clusterID,
+							Port:    gw.GetPort(),
+						})
+					}
+				}
+			}
+		}
+		return res
+	})
 	Nodes := krt.NewInformerFiltered[*v1.Node](c.client, kclient.Filter{
 		ObjectFilter:    c.client.ObjectFilter(),
 		ObjectTransform: kubeclient.StripNodeUnusedFields,
@@ -68,16 +178,40 @@ func initNetworkManager(c *Controller, options Options) *networkManager {
 		n.nodeAddressesBuilder(),
 		opts.WithName("NodeAddresses")...,
 	)
+	gatewayClient := kclient.NewDelayedInformer[*v1beta1.Gateway](c.client, gvr.KubernetesGateway, kubetypes.StandardInformer, filter)
+	Gateways := krt.WrapClient[*v1beta1.Gateway](gatewayClient, opts.WithName("Gateways")...)
+	FromGateway := krt.NewManyCollection(
+		Gateways,
+		n.fromGatewayBuilder(),
+		opts.WithName("FromGateway")...,
+	)
+
+	NetworkGateways := krt.JoinCollection([]krt.Collection[model.NetworkGateway]{FromGateway, FromMeshNetworks}, opts.WithName("NetworkGateways")...)
+	NetworkGatewaysByNetwork := krt.NewIndex(NetworkGateways, func(o model.NetworkGateway) []network.ID {
+		return []network.ID{o.Network}
+	})
+	ParsedMeshNetworks.Register(func(o krt.Event[meshNetworks]) {
+		RecomputeTrigger.TriggerRecomputation()
+	})
+
+	// TODO make this proper
+	RecomputeTrigger.MarkSynced()
+	n.NetworkGateways = NetworkGateways
+	n.NetworkGatewaysByNetwork = NetworkGatewaysByNetwork
+	n.SystemNamespaceNetwork = SystemNamespaceNetwork
+	n.RecomputeTrigger = RecomputeTrigger
+	n.ParsedMeshNetworks = ParsedMeshNetworks
 	_ = NodeAddresses
 	_ = MeshNetworks
+	_ = SystemNamespaceNetwork
 	// TODO event handlers for this
 	return n
 }
 
-
 func (c *Controller) AppendNetworkGatewayHandler(h func()) {
-	//TODO implement me
-	panic("implement me")
+	c.networkManager.NetworkGateways.RegisterBatch(func(o []krt.Event[model.NetworkGateway], initialSync bool) {
+		h()
+	}, false)
 }
 
 func (n *networkManager) nodeAddressesBuilder() krt.TransformationSingle[*v1.Node, nodeAddresses] {
@@ -96,22 +230,87 @@ func (n *networkManager) nodeAddressesBuilder() krt.TransformationSingle[*v1.Nod
 	}
 }
 
+func (n *networkManager) fromGatewayBuilder() krt.TransformationMulti[*v1beta1.Gateway, model.NetworkGateway] {
+	return func(ctx krt.HandlerContext, gw *v1beta1.Gateway) []model.NetworkGateway {
+		if nw := gw.GetLabels()[label.TopologyNetwork.Name]; nw == "" {
+			return nil
+		}
+
+		// Gateway with istio-remote: only discover this from the config cluster
+		// this is a way to reference a gateway that lives in a place that this control plane
+		// won't have API server access. Nothing will be deployed for these Gateway resources.
+		if !n.discoverRemoteGatewayResources && gw.Spec.GatewayClassName == constants.RemoteGatewayClassName {
+			return nil
+		}
+
+		autoPassthrough := func(l v1beta1.Listener) bool {
+			return kube.IsAutoPassthrough(gw.GetLabels(), l)
+		}
+
+		base := model.NetworkGateway{
+			Network: network.ID(gw.GetLabels()[label.TopologyNetwork.Name]),
+			Cluster: n.clusterID,
+			ServiceAccount: types.NamespacedName{
+				Namespace: gw.Namespace,
+				Name:      kube.GatewaySA(gw),
+			},
+		}
+		gateways := []model.NetworkGateway{}
+		for _, addr := range gw.Spec.Addresses {
+			if addr.Type == nil {
+				continue
+			}
+			if addrType := *addr.Type; addrType != v1beta1.IPAddressType && addrType != v1beta1.HostnameAddressType {
+				continue
+			}
+			for _, l := range slices.Filter(gw.Spec.Listeners, autoPassthrough) {
+				networkGateway := base
+				networkGateway.Addr = addr.Value
+				networkGateway.Port = uint32(l.Port)
+				gateways = append(gateways, networkGateway)
+			}
+			for _, l := range gw.Spec.Listeners {
+				if l.Protocol == "HBONE" {
+					networkGateway := base
+					networkGateway.Addr = addr.Value
+					networkGateway.Port = uint32(l.Port)
+					networkGateway.HBONEPort = uint32(l.Port)
+					gateways = append(gateways, networkGateway)
+				}
+			}
+		}
+		return gateways
+	}
+}
+
 func (n *networkManager) Network(endpointIP string, labels labels.Instance) network.ID {
 	// 1. check the pod/workloadEntry label
 	if nw := labels[label.TopologyNetwork.Name]; nw != "" {
 		return network.ID(nw)
 	}
+	if nw := n.SystemNamespaceNetwork.Get(); nw != nil {
+		return network.ID(*nw)
+	}
+	if nw := n.networkFromMeshNetworks(endpointIP); nw != "" {
+		return nw
+	}
+	return ""
+}
 
-	// 2. check the system namespace labels
-	//if nw := c.networkFromSystemNamespace(); nw != "" {
-	//	return nw
-	//}
+func (n *networkManager) FetchNetwork(ctx krt.HandlerContext, endpointIP string, labels labels.Instance) network.ID {
+	// 1. check the pod/workloadEntry label
+	if nw := labels[label.TopologyNetwork.Name]; nw != "" {
+		return network.ID(nw)
+	}
 
-	// 3. check the meshNetworks config
-	//if nw := c.networkFromMeshNetworks(endpointIP); nw != "" {
-	//	return nw
-	//}
-
+	if nw := krt.FetchOne(ctx, n.SystemNamespaceNetwork.AsCollection()); nw != nil {
+		return network.ID(*nw)
+	}
+	if nw := n.networkFromMeshNetworks(endpointIP); nw != "" {
+		// Mesh networks is out of scope of our dependency tracking, so any change to mesh networks we recompute.
+		n.RecomputeTrigger.MarkDependant(ctx)
+		return nw
+	}
 	return ""
 }
 
@@ -131,5 +330,36 @@ func (c *Controller) NetworkGateways() []model.NetworkGateway {
 }
 
 func (n *networkManager) HasSynced() bool {
-	return false
+	return n.SystemNamespaceNetwork.AsCollection().Synced().HasSynced() &&
+		n.NetworkGateways.Synced().HasSynced() &&
+		n.ParsedMeshNetworks.AsCollection().Synced().HasSynced()
+}
+
+func (n *networkManager) networkFromMeshNetworks(endpointIP string) network.ID {
+	mn := n.ParsedMeshNetworks.Get()
+	if mn == nil {
+		return ""
+	}
+	if mn.network != "" {
+		return mn.network
+	}
+
+	if mn.ranger != nil {
+		ip := net.ParseIP(endpointIP)
+		if ip == nil {
+			return ""
+		}
+		entries, err := mn.ranger.ContainingNetworks(ip)
+		if err != nil {
+			log.Errorf("error getting cidr ranger entry from endpoint ip %s", endpointIP)
+			return ""
+		}
+		if len(entries) > 1 {
+			log.Warnf("Found multiple networks CIDRs matching the endpoint IP: %s. Using the first match.", endpointIP)
+		}
+		if len(entries) > 0 {
+			return (entries[0].(namedRangerEntry)).name
+		}
+	}
+	return ""
 }

--- a/pilot/pkg/serviceregistry/kube/controller/network_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network_test.go
@@ -272,9 +272,6 @@ func TestAmbientSystemNamespaceNetworkChange(t *testing.T) {
 		t.Helper()
 		retry.UntilSuccessOrFail(t, func() error {
 			t.Helper()
-			if c.networkFromSystemNamespace().String() != network {
-				return fmt.Errorf("no network system notify")
-			}
 			podNames := sets.New[string]("pod1", "pod2")
 			svcNames := sets.New[string]("svc1")
 			addresses := c.ambientIndex.All()
@@ -337,21 +334,6 @@ func TestAmbientSystemNamespaceNetworkChange(t *testing.T) {
 		createOrUpdateNamespace(t, s, systemNS, "nw2")
 		tracker.WaitOrdered(systemNS)
 		expectNetwork(t, s, "nw2")
-	})
-
-	t.Run("manually change namespace network to nw3, and update meshNetworks", func(t *testing.T) {
-		s.setNetworkFromNamespace(&corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: systemNS,
-				Labels: map[string]string{
-					label.TopologyNetwork.Name: "nw3",
-				},
-			},
-		})
-		createOrUpdateNamespace(t, s, systemNS, "nw3")
-		tracker.WaitOrdered(systemNS)
-		addMeshNetworksFromRegistryGateway(t, s, s.meshNetworksWatcher)
-		expectNetwork(t, s, "nw3")
 	})
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/util.go
+++ b/pilot/pkg/serviceregistry/kube/controller/util.go
@@ -136,17 +136,6 @@ func getNodeSelectorsForService(svc *v1.Service) labels.Instance {
 	return nil
 }
 
-func nodeEquals(a, b kubernetesNode) bool {
-	return a.address == b.address && a.labels.Equals(b.labels)
-}
-
-func isNodePortGatewayService(svc *v1.Service) bool {
-	if svc == nil {
-		return false
-	}
-	_, ok := svc.Annotations[annotation.TrafficNodeSelector.Name]
-	return ok && svc.Spec.Type == v1.ServiceTypeNodePort
-}
 
 // Get the pod key of the proxy which can be used to get pod from the informer cache
 func podKeyByProxy(proxy *model.Proxy) types.NamespacedName {


### PR DESCRIPTION
The primary motivation for tackling this code vs anything else is that we currently are referencing this from the ambient code, which is awkward since its not in krt. 

Some things found along the way...
* I do think this makes the code quite a bit simpler and more performant
* We have some awkward edges still around integration from non-krt -> krt. Its easy to bridge the other direction. Specifically, MeshNetworks today uses a `mesh.NetworksHolder` interface to pass around mesh networks. We want a `krt.Singleton[MeshNetworks]`, which I built here.. but all the code expects a NetworksHolder to be passed in + used. It also has a few more features there (like read from file, etc - one big one is "retain last state" which krt cannot do today!). We will likely need to move some of these core parts to krt to make this unified