### PR TITLE
Collect more integ flake info + fix potential nil panic

### DIFF
--- a/cni/pkg/cmd/root.go
+++ b/cni/pkg/cmd/root.go
@@ -96,7 +96,7 @@ var rootCmd = &cobra.Command{
 		// to cleanup the node plugin ONLY IF anything (including other defer funcs) panic.
 		defer func() {
 			if r := recover(); r != nil {
-				fmt.Println("CNI node agent panicked: %s, doing emergency failsafe cleanup", r)
+				fmt.Printf("CNI node agent panicked: %s, doing emergency failsafe cleanup\n", r)
 				if cleanErr := installer.Cleanup(); cleanErr != nil {
 					fmt.Printf(cleanErr.Error())
 				}

--- a/cni/pkg/cmd/root.go
+++ b/cni/pkg/cmd/root.go
@@ -92,17 +92,6 @@ var rootCmd = &cobra.Command{
 
 		installer := install.NewInstaller(&cfg.InstallConfig, installDaemonReady)
 
-		// Before starting anything below, set up a failsafe defer func that will try
-		// to cleanup the node plugin ONLY IF anything (including other defer funcs) panic.
-		defer func() {
-			if r := recover(); r != nil {
-				fmt.Printf("CNI node agent panicked: %s, doing emergency failsafe cleanup\n", r)
-				if cleanErr := installer.Cleanup(); cleanErr != nil {
-					fmt.Println(cleanErr.Error())
-				}
-			}
-		}()
-
 		if cfg.InstallConfig.AmbientEnabled {
 			// Start ambient controller
 

--- a/cni/pkg/cmd/root.go
+++ b/cni/pkg/cmd/root.go
@@ -111,7 +111,6 @@ var rootCmd = &cobra.Command{
 				return fmt.Errorf("failed to create ambient nodeagent service: %v", err)
 			}
 
-			ambientAgent.Start()
 			// Ambient watch server IS enabled - on shutdown
 			// we need to check and see if this is an upgrade.
 			//
@@ -138,6 +137,8 @@ var rootCmd = &cobra.Command{
 				}
 				ambientAgent.Stop(isUpgrade)
 			}()
+
+			ambientAgent.Start()
 
 			log.Info("Ambient node agent started, starting installer...")
 

--- a/cni/pkg/cmd/root.go
+++ b/cni/pkg/cmd/root.go
@@ -132,7 +132,7 @@ var rootCmd = &cobra.Command{
 				// new ambient-enabled pods while our replacement spins up.
 				if !isUpgrade {
 					if cleanErr := installer.Cleanup(); cleanErr != nil {
-						fmt.Println(cleanErr.Error())
+						log.Error(cleanErr.Error())
 					}
 				}
 				ambientAgent.Stop(isUpgrade)
@@ -151,7 +151,7 @@ var rootCmd = &cobra.Command{
 			defer func() {
 				log.Infof("CNI node agent shutting down")
 				if cleanErr := installer.Cleanup(); cleanErr != nil {
-					fmt.Println(cleanErr.Error())
+					log.Error(cleanErr.Error())
 				}
 			}()
 		}

--- a/cni/pkg/cmd/root.go
+++ b/cni/pkg/cmd/root.go
@@ -98,7 +98,7 @@ var rootCmd = &cobra.Command{
 			if r := recover(); r != nil {
 				fmt.Printf("CNI node agent panicked: %s, doing emergency failsafe cleanup\n", r)
 				if cleanErr := installer.Cleanup(); cleanErr != nil {
-					fmt.Printf(cleanErr.Error())
+					fmt.Println(cleanErr.Error())
 				}
 			}
 		}()
@@ -144,7 +144,7 @@ var rootCmd = &cobra.Command{
 				// new ambient-enabled pods while our replacement spins up.
 				if !isUpgrade {
 					if cleanErr := installer.Cleanup(); cleanErr != nil {
-						fmt.Printf(cleanErr.Error())
+						fmt.Println(cleanErr.Error())
 					}
 				}
 				ambientAgent.Stop(isUpgrade)
@@ -161,7 +161,7 @@ var rootCmd = &cobra.Command{
 			defer func() {
 				log.Infof("CNI node agent shutting down")
 				if cleanErr := installer.Cleanup(); cleanErr != nil {
-					fmt.Printf(cleanErr.Error())
+					fmt.Println(cleanErr.Error())
 				}
 			}()
 		}

--- a/cni/pkg/nodeagent/informers.go
+++ b/cni/pkg/nodeagent/informers.go
@@ -227,9 +227,9 @@ func (s *InformerHandlers) reconcilePod(input any) error {
 
 	case controllers.EventUpdate:
 		// if the pod we get an Update event for no longer actually exists in the cluster,
-		// we shoud just skip handling the update event - we (probably) will get a Delete event.
+		// we should just skip handling the update event - we (probably) will get a Delete event.
 		if currentPod == nil {
-			log.Warnf("update event - pod no longer exists")
+			log.Warnf("update event skipped - pod no longer exists")
 			return nil
 		}
 		// NOTE that we *do not* consult the old pod state here, and that is intentional,

--- a/cni/pkg/nodeagent/informers.go
+++ b/cni/pkg/nodeagent/informers.go
@@ -201,22 +201,18 @@ func getModeLabel(m map[string]string) string {
 
 func (s *InformerHandlers) reconcilePod(input any) error {
 	event := input.(controllers.Event)
-	pod := event.Latest().(*corev1.Pod)
-	if pod == nil {
-		log.Warnf("pod update event skipped: got stale event for pod that no longer exists")
-		return nil
-	}
+	latestEventPod := event.Latest().(*corev1.Pod)
 
-	log := log.WithLabels("ns", pod.Namespace, "name", pod.Name)
+	log := log.WithLabels("ns", latestEventPod.Namespace, "name", latestEventPod.Name)
 
-	ns := s.namespaces.Get(pod.Namespace, "")
+	ns := s.namespaces.Get(latestEventPod.Namespace, "")
 	if ns == nil {
 		return fmt.Errorf("failed to find namespace %v", ns)
 	}
 
 	// The pod data in the event may be stale, and we always want to operate on the most recent
 	// instance of the pod data in the former cache, so fetch it here.
-	newPod := s.pods.Get(pod.Name, ns.Name)
+	currentPod := s.pods.Get(latestEventPod.Name, ns.Name)
 
 	switch event.Event {
 	case controllers.EventAdd:
@@ -230,20 +226,26 @@ func (s *InformerHandlers) reconcilePod(input any) error {
 		// and the initial enqueueNamespace, and new pods will be handled by the CNI.
 
 	case controllers.EventUpdate:
+		// if the pod we get an Update event for no longer actually exists in the cluster,
+		// we shoud just skip handling the update event - we (probably) will get a Delete event.
+		if currentPod == nil {
+			log.Warnf("update event - pod no longer exists")
+			return nil
+		}
 		// NOTE that we *do not* consult the old pod state here, and that is intentional,
 		// with 2 exceptions:
 		// 1. Logging (so the change event diff is more obvious)
 		// 2. To work around a potential k8s pod removal bug
 		oldPod := event.Old.(*corev1.Pod)
-		isAnnotated := util.PodRedirectionActive(newPod)
-		shouldBeEnabled := util.PodRedirectionEnabled(ns, newPod)
-		isTerminated := kube.CheckPodTerminal(newPod)
+		isAnnotated := util.PodRedirectionActive(currentPod)
+		shouldBeEnabled := util.PodRedirectionEnabled(ns, currentPod)
+		isTerminated := kube.CheckPodTerminal(currentPod)
 		// Check intent (labels) versus status (annotation) - is there a delta we need to fix?
 		changeNeeded := (isAnnotated != shouldBeEnabled) && !isTerminated
 
 		// nolint: lll
 		log.Debugf("pod update: annotation=%v shouldBeEnabled=%v changeNeeded=%v isTerminated=%v, oldPod=%+v, newPod=%+v",
-			isAnnotated, shouldBeEnabled, changeNeeded, isTerminated, oldPod.ObjectMeta, newPod.ObjectMeta)
+			isAnnotated, shouldBeEnabled, changeNeeded, isTerminated, oldPod.ObjectMeta, currentPod.ObjectMeta)
 
 		// If it was a job pod that (a) we captured and (b) just terminated (successfully or otherwise)
 		// remove it (the pod process is gone, but kube will keep the Pods around in
@@ -271,7 +273,7 @@ func (s *InformerHandlers) reconcilePod(input any) error {
 		// Pod is not terminated, and has changed in a way we care about - so reconcile
 		if !shouldBeEnabled {
 			log.Debugf("removing pod from mesh: no longer should be enabled")
-			err := s.dataplane.RemovePodFromMesh(s.ctx, newPod, false)
+			err := s.dataplane.RemovePodFromMesh(s.ctx, currentPod, false)
 			log.Debugf("RemovePodFromMesh returned: %v", err)
 			return err
 			// we ignore errors here as we don't want this event to be retried by the queue.
@@ -289,14 +291,14 @@ func (s *InformerHandlers) reconcilePod(input any) error {
 		//
 		// If we get to this point and have a pod that really and truly has no IP in either of those,
 		// it's not routable at this point and something is wrong/we should discard this event.
-		podIPs := util.GetPodIPsIfPresent(newPod)
+		podIPs := util.GetPodIPsIfPresent(currentPod)
 		if len(podIPs) == 0 {
 			log.Debugf("pod update event skipped: no IP assigned yet")
 			return nil
 		}
 
 		log.Debugf("pod is now enrolled, adding to mesh")
-		err := s.dataplane.AddPodToMesh(s.ctx, newPod, podIPs, "")
+		err := s.dataplane.AddPodToMesh(s.ctx, currentPod, podIPs, "")
 		if err != nil {
 			log.Warnf("AddPodToMesh returned: %v", err)
 		}
@@ -306,9 +308,9 @@ func (s *InformerHandlers) reconcilePod(input any) error {
 		// we *do not* want to check the cache for the pod - because it (probably)
 		// won't be there anymore. So for this case *alone*, we check the most recent
 		// pod information from the triggering event.
-		if util.PodRedirectionActive(pod) {
+		if util.PodRedirectionActive(latestEventPod) {
 			log.Debugf("pod is deleted and was captured, removing from ztunnel")
-			err := s.dataplane.RemovePodFromMesh(s.ctx, pod, true)
+			err := s.dataplane.RemovePodFromMesh(s.ctx, latestEventPod, true)
 			if err != nil {
 				log.Warnf("DelPodFromMesh returned: %v", err)
 			}

--- a/cni/pkg/nodeagent/informers_test.go
+++ b/cni/pkg/nodeagent/informers_test.go
@@ -876,8 +876,7 @@ func TestInformerStillHandlesDeleteEventIfPodNotActuallyPresentAnymore(t *testin
 
 	handlers, mt := populateClientAndWaitForInformer(ctx, t, client, fs, 1, 0)
 
-	// Now, force thru a stale pod update event that would normally trigger add/remove
-	// in the informer if the pod existed
+	// Now, force thru a pod delete
 	fakePodNew := fakePod.DeepCopy()
 	fakePodNew.ObjectMeta.Annotations = map[string]string{}
 	// We've started the informer, but there is no pod in the cluster.

--- a/cni/pkg/nodeagent/informers_test.go
+++ b/cni/pkg/nodeagent/informers_test.go
@@ -923,7 +923,7 @@ func assertPodNotAnnotated(t *testing.T, client kube.Client, pod *corev1.Pod) {
 	t.Fatal("Pod annotated")
 }
 
-// nolint: lll, unparam
+// nolint: lll
 func populateClientAndWaitForInformer(ctx context.Context, t *testing.T, client kube.Client, fs *fakeServer, expectAddEvents, expectUpdateEvents int) (*InformerHandlers, *monitortest.MetricsTest) {
 	mt := monitortest.New(t)
 
@@ -932,7 +932,6 @@ func populateClientAndWaitForInformer(ctx context.Context, t *testing.T, client 
 	handlers := setupHandlers(ctx, client, server, "istio-system")
 	client.RunAndWait(ctx.Done())
 	go handlers.Start()
-
 
 	// Unfortunately mt asserts cannot assert on 0 events (which makes a certain amount of sense)
 	if expectAddEvents > 0 {

--- a/cni/pkg/nodeagent/informers_test.go
+++ b/cni/pkg/nodeagent/informers_test.go
@@ -890,7 +890,6 @@ func TestInformerStillHandlesDeleteEventIfPodNotActuallyPresentAnymore(t *testin
 
 	mt.Assert(EventTotals.Name(), map[string]string{"type": "delete"}, monitortest.Exactly(1))
 
-	// None of our remove or add mocks should have been called
 	fs.AssertExpectations(t)
 }
 

--- a/cni/pkg/nodeagent/informers_test.go
+++ b/cni/pkg/nodeagent/informers_test.go
@@ -784,6 +784,117 @@ func TestInformerPendingPodSkippedIfAlreadyLabeledAndEventStale(t *testing.T) {
 	fs.AssertExpectations(t)
 }
 
+func TestInformerSkipsUpdateEventIfPodNotActuallyPresentAnymore(t *testing.T) {
+	setupLogging()
+	NodeName = "testnode"
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	fakePod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test",
+			Namespace:   "test",
+			Annotations: map[string]string{annotation.AmbientRedirection.Name: constants.AmbientRedirectionEnabled},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: NodeName,
+		},
+		Status: corev1.PodStatus{
+			PodIP: "11.1.1.12",
+			Phase: corev1.PodPending,
+		},
+	}
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test",
+			Labels: map[string]string{label.IoIstioDataplaneMode.Name: constants.DataplaneModeAmbient},
+		},
+	}
+
+	client := kube.NewFakeClient(ns)
+
+	fs := &fakeServer{}
+
+	handlers, mt := populateClientAndWaitForInformer(ctx, t, client, fs, 1, 0)
+
+	// Now, force thru a stale pod update event that would normally trigger add/remove
+	// in the informer if the pod existed
+	fakePodNew := fakePod.DeepCopy()
+	fakePodNew.ObjectMeta.Annotations = map[string]string{}
+	// We've started the informer, but there is no pod in the cluster.
+	// Now force thru a "stale" event for an enrolled pod no longer in the cluster.
+	fakeEvent := controllers.Event{
+		Event: controllers.EventUpdate,
+		Old:   fakePod,
+		New:   fakePodNew,
+	}
+	handlers.reconcile(fakeEvent)
+
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.Exactly(1))
+
+	// None of our remove or add mocks should have been called
+	fs.AssertExpectations(t)
+}
+
+func TestInformerStillHandlesDeleteEventIfPodNotActuallyPresentAnymore(t *testing.T) {
+	setupLogging()
+	NodeName = "testnode"
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	fakePod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test",
+			Namespace:   "test",
+			Annotations: map[string]string{annotation.AmbientRedirection.Name: constants.AmbientRedirectionEnabled},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: NodeName,
+		},
+		Status: corev1.PodStatus{
+			PodIP: "11.1.1.12",
+			Phase: corev1.PodPending,
+		},
+	}
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test",
+			Labels: map[string]string{label.IoIstioDataplaneMode.Name: constants.DataplaneModeAmbient},
+		},
+	}
+
+	client := kube.NewFakeClient(ns)
+
+	fs := &fakeServer{}
+
+	// Pod deletion event should trigger one RemovePodFromMesh, even if the pod doesn't exist anymore
+	fs.On("RemovePodFromMesh",
+		ctx,
+		mock.Anything,
+		true,
+	).Once().Return(nil)
+
+	handlers, mt := populateClientAndWaitForInformer(ctx, t, client, fs, 1, 0)
+
+	// Now, force thru a stale pod update event that would normally trigger add/remove
+	// in the informer if the pod existed
+	fakePodNew := fakePod.DeepCopy()
+	fakePodNew.ObjectMeta.Annotations = map[string]string{}
+	// We've started the informer, but there is no pod in the cluster.
+	// Now force thru a "stale" event for an enrolled pod no longer in the cluster.
+	fakeEvent := controllers.Event{
+		Event: controllers.EventDelete,
+		Old:   fakePod,
+		New:   nil,
+	}
+	handlers.reconcile(fakeEvent)
+
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "delete"}, monitortest.Exactly(1))
+
+	// None of our remove or add mocks should have been called
+	fs.AssertExpectations(t)
+}
+
 func assertPodAnnotated(t *testing.T, client kube.Client, pod *corev1.Pod) {
 	for i := 0; i < 5; i++ {
 		p, err := client.Kube().CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
@@ -822,8 +933,14 @@ func populateClientAndWaitForInformer(ctx context.Context, t *testing.T, client 
 	client.RunAndWait(ctx.Done())
 	go handlers.Start()
 
-	mt.Assert(EventTotals.Name(), map[string]string{"type": "add"}, monitortest.Exactly(float64(expectAddEvents)))
-	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.Exactly(float64(expectUpdateEvents)))
+
+	// Unfortunately mt asserts cannot assert on 0 events (which makes a certain amount of sense)
+	if expectAddEvents > 0 {
+		mt.Assert(EventTotals.Name(), map[string]string{"type": "add"}, monitortest.Exactly(float64(expectAddEvents)))
+	}
+	if expectUpdateEvents > 0 {
+		mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.Exactly(float64(expectUpdateEvents)))
+	}
 
 	return handlers, mt
 }

--- a/pkg/test/framework/components/istio/cleanup.go
+++ b/pkg/test/framework/components/istio/cleanup.go
@@ -28,7 +28,6 @@ import (
 	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/resource"
 	kube2 "istio.io/istio/pkg/test/kube"
-	kubetest "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/test/util/yml"
@@ -146,7 +145,7 @@ func (i *istioImpl) cleanupCluster(c cluster.Cluster, errG *multierror.Group) {
 		cleanErr := retry.UntilSuccess(func() error {
 			label := "app.kubernetes.io/part-of=istio"
 
-			fetchFunc := kubetest.NewPodFetch(c, i.cfg.SystemNamespace, label)
+			fetchFunc := kube2.NewPodFetch(c, i.cfg.SystemNamespace, label)
 
 			fetched, e := fetchFunc()
 			if e != nil {
@@ -155,11 +154,10 @@ func (i *istioImpl) cleanupCluster(c cluster.Cluster, errG *multierror.Group) {
 
 			if len(fetched) == 0 {
 				return nil
-			} else {
-				res := fmt.Sprintf("Still waiting for %d pods to terminate in %s ", len(fetched), i.cfg.SystemNamespace)
-				scopes.Framework.Infof(res)
-				return errors.New(res)
 			}
+			res := fmt.Sprintf("Still waiting for %d pods to terminate in %s ", len(fetched), i.cfg.SystemNamespace)
+			scopes.Framework.Infof(res)
+			return errors.New(res)
 		}, retry.Timeout(RetryTimeOut), retry.Delay(RetryDelay))
 
 		err = multierror.Append(err, cleanErr)

--- a/tests/integration/ambient/cni/main_test.go
+++ b/tests/integration/ambient/cni/main_test.go
@@ -211,8 +211,6 @@ func TestCNIMisconfigHealsOnRestart(t *testing.T) {
 	framework.NewTest(t).
 		TopLevel().
 		Run(func(t framework.TestContext) {
-			// TODO BML I have no solid reason to think this is causing test flakes yet
-			t.Skip("suspected flaky: https://github.com/istio/istio/issues/54303")
 			c := t.Clusters().Default()
 			t.Log("Updating CNI Daemonset config")
 


### PR DESCRIPTION
**Please provide a description of this PR:**
Still seeing flakes for integ: https://prow.istio.io/view/gs/istio-prow/logs/integ-k8s-128_istio_postsubmit/1869099513055023104

More hypothesis-es:

1.  Create a failsafe-cleanup `defer` that only runs under node agent panic, on the hypothesis that the agent could be panicking on shutdown somehow ~(haven't figured out a reasonable way to capture shutdown logs on uninstall in the integ tests yet)~.

2. Change integ test cleanup to wait for pods to go away in `istio-system` before considering cleanup "done" (I don't see how this could have caused the problem but in general it's a bit more robust).

3. Add a way to follow pod logs until stream interrupted in integ test cleanup - doing this for any CNI pods that are present during cluster cleanup ATM to get a good log (hopefully).

Also this unskips the test in https://github.com/istio/istio/pull/54322 - obviously it's not the culprit.

EDIT:

Since we got a `previous` log here for a CNI restart that has a `nil` panic: https://storage.googleapis.com/istio-prow/pr-logs/pull/istio_istio/54380/integ-ambient_istio/1869391778713440256/artifacts/ambient-7f256e09143e49b1901c519/_suite_context/istio-state-3665008920/primary-0/istio-cni-node-5ft9x_install-cni.previous.log

also added a fix + tests for that and _removed_ the failsafe cleanup, so we can verify that is the culprit.

I'm leaving in the integ test changes tho as they would make finding this kind of problem much faster in the future, without waiting to get lucky with a `previous` log from a random crash elsewhere.