### PR TITLE
ambient: avoid slow lookup for network

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -17,6 +17,7 @@ package ambient
 import (
 	"net/netip"
 	"strings"
+	"sync/atomic"
 
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
@@ -45,6 +46,7 @@ import (
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/network"
+	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/sets"
 	"istio.io/istio/pkg/workloadapi"
@@ -101,6 +103,7 @@ type index struct {
 
 	authorizationPolicies krt.Collection[model.WorkloadAuthorization]
 	networkUpdateTrigger  *krt.RecomputeTrigger
+	networkGateways       *atomic.Pointer[map[network.ID][]model.NetworkGateway]
 
 	statusQueue *statusqueue.StatusQueue
 
@@ -110,9 +113,9 @@ type index struct {
 	XDSUpdater      model.XDSUpdater
 	// Network provides a way to lookup which network a given workload is running on
 	Network LookupNetwork
-	// LookupNetworkGateways provides a function to lookup all the known network gateways in the system.
-	LookupNetworkGateways LookupNetworkGateways
-	Flags                 FeatureFlags
+	// LookupNetworkGatewaysRaw provides a function to lookup all the known network gateways in the system.
+	LookupNetworkGatewaysRaw LookupNetworkGateways
+	Flags                    FeatureFlags
 
 	stop chan struct{}
 }
@@ -152,15 +155,16 @@ func (k KrtOptions) WithName(n string) []krt.CollectionOption {
 func New(options Options) Index {
 	a := &index{
 		networkUpdateTrigger: krt.NewRecomputeTrigger(false, krt.WithName("NetworkTrigger")),
+		networkGateways:      new(atomic.Pointer[map[network.ID][]model.NetworkGateway]),
 
-		SystemNamespace:       options.SystemNamespace,
-		DomainSuffix:          options.DomainSuffix,
-		ClusterID:             options.ClusterID,
-		XDSUpdater:            options.XDSUpdater,
-		Network:               options.LookupNetwork,
-		LookupNetworkGateways: options.LookupNetworkGateways,
-		Flags:                 options.Flags,
-		stop:                  make(chan struct{}),
+		SystemNamespace:          options.SystemNamespace,
+		DomainSuffix:             options.DomainSuffix,
+		ClusterID:                options.ClusterID,
+		XDSUpdater:               options.XDSUpdater,
+		Network:                  options.LookupNetwork,
+		LookupNetworkGatewaysRaw: options.LookupNetworkGateways,
+		Flags:                    options.Flags,
+		stop:                     make(chan struct{}),
 	}
 
 	filter := kclient.Filter{
@@ -637,7 +641,34 @@ func (a *index) AdditionalPodSubscriptions(
 }
 
 func (a *index) SyncAll() {
+	// Reload NetworkGateways, which is expensive to compute each time
+	raw := a.LookupNetworkGatewaysRaw()
+	grouped := slices.Group(raw, func(t model.NetworkGateway) network.ID {
+		return t.Network
+	})
+	a.networkGateways.Store(ptr.Of(grouped))
 	a.networkUpdateTrigger.TriggerRecomputation()
+}
+
+func (a *index) LookupNetworkGateway(id network.ID) []model.NetworkGateway {
+	n := a.networkGateways.Load()
+	if n == nil {
+		return nil
+	}
+	return (*n)[id]
+}
+
+func (a *index) LookupAllNetworkGateway() []model.NetworkGateway {
+	// Since computing the
+	n := a.networkGateways.Load()
+	if n == nil {
+		return nil
+	}
+	res := make([]model.NetworkGateway, 0, len(*n))
+	for _, v := range *n {
+		res = append(res, v...)
+	}
+	return res
 }
 
 func (a *index) NetworksSynced() {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
@@ -110,7 +110,7 @@ func (a *index) WorkloadsCollection(
 
 	NetworkGatewayWorkloads := krt.NewManyFromNothing[model.WorkloadInfo](func(ctx krt.HandlerContext) []model.WorkloadInfo {
 		a.networkUpdateTrigger.MarkDependant(ctx) // Mark we depend on out of band a.Network
-		return slices.Map(a.LookupNetworkGateways(), convertGateway)
+		return slices.Map(a.LookupAllNetworkGateway(), convertGateway)
 	}, opts.WithName("NetworkGatewayWorkloads")...)
 
 	Workloads := krt.JoinCollection([]krt.Collection[model.WorkloadInfo]{
@@ -859,16 +859,8 @@ func convertGateway(gw model.NetworkGateway) model.WorkloadInfo {
 	return model.WorkloadInfo{Workload: wl}
 }
 
-func (a *index) getNetworkGateway(id string) []model.NetworkGateway {
-	gtws := a.LookupNetworkGateways()
-	slices.FilterInPlace(gtws, func(gateway model.NetworkGateway) bool {
-		return gateway.Network == network.ID(id)
-	})
-	return gtws
-}
-
-func (a *index) getNetworkGatewayAddress(network string) *workloadapi.GatewayAddress {
-	if networks := a.getNetworkGateway(network); len(networks) > 0 {
+func (a *index) getNetworkGatewayAddress(n string) *workloadapi.GatewayAddress {
+	if networks := a.LookupNetworkGateway(network.ID(n)); len(networks) > 0 {
 		// Currently only support one, so find the first one that is valid
 		for _, net := range networks {
 			if net.HBONEPort == 0 {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
@@ -1593,7 +1593,7 @@ func newAmbientUnitTest() *index {
 			DefaultAllowFromWaypoint:              features.DefaultAllowFromWaypoint,
 			EnableK8SServiceSelectWorkloadEntries: features.EnableK8SServiceSelectWorkloadEntries,
 		},
-		LookupNetworkGatewaysRaw: func() []model.NetworkGateway {
+		LookupNetworkGatewaysExpensive: func() []model.NetworkGateway {
 			return []model.NetworkGateway{
 				{
 					Network:   "remote-network",

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
@@ -16,6 +16,7 @@ package ambient
 
 import (
 	"net/netip"
+	"sync/atomic"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -1580,8 +1581,9 @@ func kubernetesAPIServerEndpoint(ip string) *discovery.EndpointSlice {
 }
 
 func newAmbientUnitTest() *index {
-	return &index{
+	idx := &index{
 		networkUpdateTrigger: krt.NewRecomputeTrigger(true),
+		networkGateways:      new(atomic.Pointer[map[network.ID][]model.NetworkGateway]),
 		ClusterID:            testC,
 		DomainSuffix:         "domain.suffix",
 		Network: func(endpointIP string, labels labels.Instance) network.ID {
@@ -1591,7 +1593,7 @@ func newAmbientUnitTest() *index {
 			DefaultAllowFromWaypoint:              features.DefaultAllowFromWaypoint,
 			EnableK8SServiceSelectWorkloadEntries: features.EnableK8SServiceSelectWorkloadEntries,
 		},
-		LookupNetworkGateways: func() []model.NetworkGateway {
+		LookupNetworkGatewaysRaw: func() []model.NetworkGateway {
 			return []model.NetworkGateway{
 				{
 					Network:   "remote-network",
@@ -1618,6 +1620,8 @@ func newAmbientUnitTest() *index {
 			}
 		},
 	}
+	idx.SyncAll()
+	return idx
 }
 
 var podReady = []v1.PodCondition{


### PR DESCRIPTION
Today, the ambient hot-path is the workload constructors. These are the
highest scale + highest churn generally. Right now, we call
LookupNetworkGateway each time on this path. This call is not something
that was originally meant to be on a hot path, and is instead cached in
PushContext. Its very slow! We then use this and do an O(n) search which
is, again, pretty slow.

In some testing I was doing, while I was on a single cluster I had a
bunch of networks setup from previously, I found 30% of Istiod CPU on
this function. This is very simple to change into a cache O(1) lookup,
which is what I have done in this PR.
