### PR TITLE
xds: do not attempt to push resources to Ztunnel

### DIFF
--- a/pilot/pkg/xds/cds.go
+++ b/pilot/pkg/xds/cds.go
@@ -64,6 +64,10 @@ var pushCdsGatewayConfig = func() sets.Set[kind.Kind] {
 }()
 
 func cdsNeedsPush(req *model.PushRequest, proxy *model.Proxy) bool {
+	if proxy.Type == model.Ztunnel {
+		// Not supported for ztunnel
+		return false
+	}
 	if req == nil {
 		return true
 	}

--- a/pilot/pkg/xds/ecds.go
+++ b/pilot/pkg/xds/ecds.go
@@ -38,7 +38,11 @@ type EcdsGenerator struct {
 
 var _ model.XdsResourceGenerator = &EcdsGenerator{}
 
-func ecdsNeedsPush(req *model.PushRequest) bool {
+func ecdsNeedsPush(req *model.PushRequest, proxy *model.Proxy) bool {
+	if proxy.Type == model.Ztunnel {
+		// Not supported for ztunnel
+		return false
+	}
 	if req == nil {
 		return true
 	}
@@ -80,7 +84,7 @@ func onlyReferencedConfigsUpdated(req *model.PushRequest) bool {
 
 // Generate returns ECDS resources for a given proxy.
 func (e *EcdsGenerator) Generate(proxy *model.Proxy, w *model.WatchedResource, req *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
-	if !ecdsNeedsPush(req) {
+	if !ecdsNeedsPush(req, proxy) {
 		return nil, model.DefaultXdsLogDetails, nil
 	}
 

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -108,7 +108,11 @@ var skippedEdsConfigs = sets.New(
 	kind.GRPCRoute,
 )
 
-func edsNeedsPush(updates model.XdsUpdates) bool {
+func edsNeedsPush(updates model.XdsUpdates, proxy *model.Proxy) bool {
+	if proxy.Type == model.Ztunnel {
+		// Not supported for ztunnel
+		return false
+	}
 	// If none set, we will always push
 	if len(updates) == 0 {
 		return true
@@ -122,7 +126,7 @@ func edsNeedsPush(updates model.XdsUpdates) bool {
 }
 
 func (eds *EdsGenerator) Generate(proxy *model.Proxy, w *model.WatchedResource, req *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
-	if !edsNeedsPush(req.ConfigsUpdated) {
+	if !edsNeedsPush(req.ConfigsUpdated, proxy) {
 		return nil, model.DefaultXdsLogDetails, nil
 	}
 	resources, logDetails := eds.buildEndpoints(proxy, req, w)
@@ -132,7 +136,7 @@ func (eds *EdsGenerator) Generate(proxy *model.Proxy, w *model.WatchedResource, 
 func (eds *EdsGenerator) GenerateDeltas(proxy *model.Proxy, req *model.PushRequest,
 	w *model.WatchedResource,
 ) (model.Resources, model.DeletedResources, model.XdsLogDetails, bool, error) {
-	if !edsNeedsPush(req.ConfigsUpdated) {
+	if !edsNeedsPush(req.ConfigsUpdated, proxy) {
 		return nil, nil, model.DefaultXdsLogDetails, false, nil
 	}
 	if !shouldUseDeltaEds(req) {

--- a/pilot/pkg/xds/lds.go
+++ b/pilot/pkg/xds/lds.go
@@ -63,6 +63,10 @@ var skippedLdsConfigs = map[model.NodeType]sets.Set[kind.Kind]{
 }
 
 func ldsNeedsPush(proxy *model.Proxy, req *model.PushRequest) bool {
+	if proxy.Type == model.Ztunnel {
+		// Not supported for ztunnel
+		return false
+	}
 	if req == nil {
 		return true
 	}

--- a/pilot/pkg/xds/nds.go
+++ b/pilot/pkg/xds/nds.go
@@ -60,7 +60,11 @@ var skippedNdsConfigs = sets.New(
 	kind.GRPCRoute,
 )
 
-func ndsNeedsPush(req *model.PushRequest) bool {
+func ndsNeedsPush(req *model.PushRequest, proxy *model.Proxy) bool {
+	if proxy.Type == model.Ztunnel {
+		// Not supported for ztunnel
+		return false
+	}
 	if req == nil {
 		return true
 	}
@@ -85,7 +89,7 @@ func headlessEndpointsUpdated(req *model.PushRequest) bool {
 }
 
 func (n NdsGenerator) Generate(proxy *model.Proxy, _ *model.WatchedResource, req *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
-	if !ndsNeedsPush(req) {
+	if !ndsNeedsPush(req, proxy) {
 		return nil, model.DefaultXdsLogDetails, nil
 	}
 	nt := n.ConfigGenerator.BuildNameTable(proxy, req.Push)

--- a/pilot/pkg/xds/rds.go
+++ b/pilot/pkg/xds/rds.go
@@ -41,7 +41,11 @@ var skippedRdsConfigs = sets.New[kind.Kind](
 	kind.DNSName,
 )
 
-func rdsNeedsPush(req *model.PushRequest) bool {
+func rdsNeedsPush(req *model.PushRequest, proxy *model.Proxy) bool {
+	if proxy.Type == model.Ztunnel {
+		// Not supported for ztunnel
+		return false
+	}
 	if req == nil {
 		return true
 	}
@@ -62,7 +66,7 @@ func rdsNeedsPush(req *model.PushRequest) bool {
 }
 
 func (c RdsGenerator) Generate(proxy *model.Proxy, w *model.WatchedResource, req *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
-	if !rdsNeedsPush(req) {
+	if !rdsNeedsPush(req, proxy) {
 		return nil, model.DefaultXdsLogDetails, nil
 	}
 	resources, logDetails := c.ConfigGenerator.BuildHTTPRoutes(proxy, req, w.ResourceNames)


### PR DESCRIPTION
This is impossible in standard operations. However, a client can connect
to Istiod with arbitrary XDS info. If they declare themselves `ztunnel`,
we don't compute SidecarScope. Most of the generators make an assumption
SidecarScope is non-nil and don't check it. To handle this, we skip
these at the top level.
