### PR TITLE
Modify telemetry test "cluster type detection" function

### DIFF
--- a/tests/integration/telemetry/api/setup_test.go
+++ b/tests/integration/telemetry/api/setup_test.go
@@ -20,6 +20,7 @@ package api
 import (
 	"encoding/base64"
 	"fmt"
+	"os"
 	"testing"
 
 	"k8s.io/client-go/tools/clientcmd"
@@ -161,8 +162,16 @@ proxyMetadata:
 // By looking into a context name. Expects "kind-" prefix.
 // That is required by some tests for specific actions on "Kind".
 func IsKindCluster() (bool, error) {
-	config, err := clientcmd.LoadFromFile(clientcmd.RecommendedHomeFile)
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		kubeconfig = clientcmd.RecommendedHomeFile
+	}
+
+	config, err := clientcmd.LoadFromFile(kubeconfig)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return false, fmt.Errorf("kubeconfig file not found: %s", kubeconfig)
+		}
 		return false, err
 	}
 	currentContext := config.CurrentContext


### PR DESCRIPTION
**Please provide a description of this PR:**
This is a followup PR for https://github.com/istio/istio/pull/54348

When "Image-regirector" deployment is created on Openshift cluster and kubeconfig file provided via KUBECONFIG environment variable and the "~/.kube/config" file does not exist, the "IsKindCluster" function fails to allocate the kubeconfig file from the env var.

Modify the function to check the "KUBECONFIG" env var and check the kubeconfig file path from it.