### PR TITLE
mod: drop last `replace` directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,6 @@ module istio.io/istio
 
 go 1.23.0
 
-// Client-go does not handle different versions of mergo due to some breaking changes - use the matching version
-replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
-
 require (
 	cloud.google.com/go/compute/metadata v0.6.0
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6


### PR DESCRIPTION
Kubernetes no longer depends on this, yay.

The original failure was from 2020:
https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/23130/unit-tests_istio/12074.

This tests now passes since k8s moved off of it
