### PR TITLE
[release-1.24] enable configuration of global.proxy.outlierLogPath for waypoints

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
@@ -120,6 +120,9 @@ spec:
         {{- if .Values.global.logAsJson }}
         - --log_as_json
         {{- end }}
+        {{- if .Values.global.proxy.outlierLogPath }}
+        - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+        {{- end}}
         env:
         - name: ISTIO_META_SERVICE_ACCOUNT
           valueFrom:

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.43.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.43.template.gen.yaml
@@ -1270,6 +1270,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -1270,6 +1270,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.15.template.gen.yaml
@@ -1270,6 +1270,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.14.template.gen.yaml
@@ -1270,6 +1270,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.10.template.gen.yaml
@@ -1270,6 +1270,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello-openshift-custom-injection.yaml.51.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift-custom-injection.yaml.51.template.gen.yaml
@@ -1270,6 +1270,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.50.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.50.template.gen.yaml
@@ -1270,6 +1270,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.19.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.19.template.gen.yaml
@@ -1270,6 +1270,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.17.template.gen.yaml
@@ -1270,6 +1270,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -1270,6 +1270,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -1270,6 +1270,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.11.template.gen.yaml
@@ -1270,6 +1270,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -1270,6 +1270,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -1270,6 +1270,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.16.template.gen.yaml
@@ -1270,6 +1270,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -1270,6 +1270,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -1270,6 +1270,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.9.template.gen.yaml
@@ -1270,6 +1270,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.8.template.gen.yaml
@@ -1270,6 +1270,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.46.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.46.template.gen.yaml
@@ -1270,6 +1270,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.33.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.33.template.gen.yaml
@@ -1270,6 +1270,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.7.template.gen.yaml
@@ -1270,6 +1270,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.6.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.6.template.gen.yaml
@@ -1270,6 +1270,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:


### PR DESCRIPTION
**Please provide a description of this PR:**

fixes https://github.com/istio/istio/issues/54408

propagates helm configuration value outlierLogPath to waypoint template.

this PR is a cherry pick of this one that was merged into master last week (dec 12 2024): https://github.com/istio/istio/pull/54283