### PR TITLE
leaderelection: actually respect useLeaseLock

### DIFF
--- a/pilot/pkg/leaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/leaderelection.go
@@ -162,7 +162,7 @@ func (l *LeaderElection) create() (*k8sleaderelection.LeaderElector, error) {
 			Key:      key,
 		},
 	}
-	if l.perRevision {
+	if l.perRevision || l.useLeaseLock {
 		lock = &k8sresourcelock.LeaseLock{
 			LeaseMeta: metav1.ObjectMeta{Namespace: l.namespace, Name: l.electionID},
 			Client:    l.client.CoordinationV1(),


### PR DESCRIPTION
This var did nothing, making usage fall back to the legacy usage
