### PR TITLE
[Dual-stack] Introduce IP_FAMILIES for integration tests

### DIFF
--- a/common/scripts/kind_provisioner.sh
+++ b/common/scripts/kind_provisioner.sh
@@ -35,7 +35,8 @@ set -x
 DEFAULT_KIND_IMAGE="gcr.io/istio-testing/kind-node:v1.32.0"
 
 # the default kind cluster should be ipv4 if not otherwise specified
-IP_FAMILY="${IP_FAMILY:-ipv4}"
+# Default IP family of the cluster is IPv4
+KIND_IP_FAMILY="${KIND_IP_FAMILY:-ipv4}"
 
 # COMMON_SCRIPTS contains the directory this file is in.
 COMMON_SCRIPTS=$(dirname "${BASH_SOURCE:-$0}")
@@ -147,7 +148,7 @@ function setup_kind_cluster_retry() {
 # 1. NAME: Name of the Kind cluster (optional)
 # 2. IMAGE: Node image used by KinD (optional)
 # 3. CONFIG: KinD cluster configuration YAML file. If not specified then DEFAULT_CLUSTER_YAML is used
-# 4. NOMETALBINSTALL: Dont install matllb if set.
+# 4. NOMETALBINSTALL: Dont install metalb if set.
 # This function returns 0 when everything goes well, or 1 otherwise
 # If Kind cluster was already created then it would be cleaned up in case of errors
 function setup_kind_cluster() {
@@ -186,7 +187,7 @@ function setup_kind_cluster() {
 
   # Create KinD cluster
   if ! (yq eval "${CONFIG}" --expression ".networking.disableDefaultCNI = ${KIND_DISABLE_CNI}" \
-    --expression ".networking.ipFamily = \"${IP_FAMILY}\"" | \
+    --expression ".networking.ipFamily = \"${KIND_IP_FAMILY}\"" | \
     kind create cluster --name="${NAME}" -v4 --retain --image "${IMAGE}" ${KIND_WAIT_FLAG:+"$KIND_WAIT_FLAG"} --config -); then
     echo "Could not setup KinD environment. Something wrong with KinD setup. Exporting logs."
     return 9
@@ -230,7 +231,7 @@ function setup_kind_cluster() {
   # https://github.com/coredns/coredns/issues/2494#issuecomment-457215452
   # CoreDNS should handle those domains and answer with NXDOMAIN instead of SERVFAIL
   # otherwise pods stops trying to resolve the domain.
-  if [ "${IP_FAMILY}" = "ipv6" ] || [ "${IP_FAMILY}" = "dual" ]; then
+  if [ "${KIND_IP_FAMILY}" = "ipv6" ] || [ "${KIND_IP_FAMILY}" = "dual" ]; then
     # Get the current config
     original_coredns=$(kubectl get -oyaml -n=kube-system configmap/coredns)
     echo "Original CoreDNS config:"
@@ -267,14 +268,14 @@ function cleanup_kind_clusters() {
 # setup_kind_clusters sets up a given number of kind clusters with given topology
 # as specified in cluster topology configuration file.
 # 1. IMAGE = docker image used as node by KinD
-# 2. IP_FAMILY = either ipv4 or ipv6
+# 2. KIND_IP_FAMILY = either ipv4 or ipv6 or dual
 #
 # NOTE: Please call load_cluster_topology before calling this method as it expects
 # cluster topology information to be loaded in advance
 function setup_kind_clusters() {
   IMAGE="${1:-"${DEFAULT_KIND_IMAGE}"}"
   KUBECONFIG_DIR="${ARTIFACTS:-$(mktemp -d)}/kubeconfig"
-  IP_FAMILY="${2:-ipv4}"
+  KIND_IP_FAMILY="${2:-ipv4}"
 
   check_default_cluster_yaml
 

--- a/pkg/test/framework/components/echo/common/deployment/echos.go
+++ b/pkg/test/framework/components/echo/common/deployment/echos.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"golang.org/x/sync/errgroup"
-	corev1 "k8s.io/api/core/v1"
 
 	"istio.io/api/annotation"
 	"istio.io/api/label"
@@ -281,8 +280,7 @@ func (c *Config) DefaultEchoConfigs(t resource.Context) []echo.Config {
 			Ports:           ports.All(),
 			Subsets:         []echo.SubsetConfig{{}},
 			IncludeExtAuthz: c.IncludeExtAuthz,
-			IPFamilies:      "IPv6, IPv4",
-			IPFamilyPolicy:  string(corev1.IPFamilyPolicyRequireDualStack),
+			IPFamilies:      "IPv4",
 			DualStack:       true,
 		}
 		eSvc := echo.Config{
@@ -292,7 +290,6 @@ func (c *Config) DefaultEchoConfigs(t resource.Context) []echo.Config {
 			Subsets:         []echo.SubsetConfig{{}},
 			IncludeExtAuthz: c.IncludeExtAuthz,
 			IPFamilies:      "IPv6",
-			IPFamilyPolicy:  string(corev1.IPFamilyPolicySingleStack),
 			DualStack:       true,
 		}
 		defaultConfigs = append(defaultConfigs, dSvc, eSvc)

--- a/pkg/test/framework/components/echo/common/deployment/echos.go
+++ b/pkg/test/framework/components/echo/common/deployment/echos.go
@@ -273,14 +273,14 @@ func (c *Config) DefaultEchoConfigs(t resource.Context) []echo.Config {
 
 	defaultConfigs = append(defaultConfigs, a, b, cSvc, headless, stateful, naked, tProxy, vmSvc)
 
-	if t.Settings().EnableDualStack {
+	if len(t.Settings().IPFamilies) > 1 {
 		dSvc := echo.Config{
 			Service:         DSvc,
 			ServiceAccount:  true,
 			Ports:           ports.All(),
 			Subsets:         []echo.SubsetConfig{{}},
 			IncludeExtAuthz: c.IncludeExtAuthz,
-			IPFamilies:      "IPv4",
+			IPFamilies:      t.Settings().IPFamilies[0],
 			DualStack:       true,
 		}
 		eSvc := echo.Config{
@@ -289,7 +289,7 @@ func (c *Config) DefaultEchoConfigs(t resource.Context) []echo.Config {
 			Ports:           ports.All(),
 			Subsets:         []echo.SubsetConfig{{}},
 			IncludeExtAuthz: c.IncludeExtAuthz,
-			IPFamilies:      "IPv6",
+			IPFamilies:      t.Settings().IPFamilies[1],
 			DualStack:       true,
 		}
 		defaultConfigs = append(defaultConfigs, dSvc, eSvc)

--- a/pkg/test/framework/components/echo/common/deployment/external.go
+++ b/pkg/test/framework/components/echo/common/deployment/external.go
@@ -17,8 +17,6 @@ package deployment
 import (
 	"path"
 
-	corev1 "k8s.io/api/core/v1"
-
 	"istio.io/api/annotation"
 	"istio.io/istio/pkg/test/echo/common"
 	"istio.io/istio/pkg/test/env"
@@ -66,12 +64,6 @@ func (e External) Build(t resource.Context, b deployment.Builder) deployment.Bui
 				Annotations: map[string]string{annotation.SidecarInject.Name: "false"},
 			},
 		},
-	}
-	if t.Settings().EnableDualStack {
-		config.IPFamilies = "IPv6, IPv4"
-		config.IPFamilyPolicy = string(corev1.IPFamilyPolicyRequireDualStack)
-	} else {
-		config.IPFamilyPolicy = string(corev1.IPFamilyPolicyPreferDualStack)
 	}
 	return b.WithConfig(config)
 }

--- a/pkg/test/framework/components/echo/common/deployment/namespace.go
+++ b/pkg/test/framework/components/echo/common/deployment/namespace.go
@@ -95,7 +95,7 @@ func (n *EchoNamespace) loadValues(t resource.Context, echos echo.Instances, d *
 	n.A = match.ServiceName(echo.NamespacedName{Name: ASvc, Namespace: ns}).GetMatches(echos)
 	n.B = match.ServiceName(echo.NamespacedName{Name: BSvc, Namespace: ns}).GetMatches(echos)
 	n.C = match.ServiceName(echo.NamespacedName{Name: CSvc, Namespace: ns}).GetMatches(echos)
-	if t.Settings().EnableDualStack {
+	if len(t.Settings().IPFamilies) > 1 {
 		n.D = match.ServiceName(echo.NamespacedName{Name: DSvc, Namespace: ns}).GetMatches(echos)
 		n.E = match.ServiceName(echo.NamespacedName{Name: ESvc, Namespace: ns}).GetMatches(echos)
 	}

--- a/pkg/test/framework/components/echo/common/deployment/namespace.go
+++ b/pkg/test/framework/components/echo/common/deployment/namespace.go
@@ -54,7 +54,7 @@ type EchoNamespace struct {
 	B echo.Instances
 	// Standard echo app to be used by tests
 	C echo.Instances
-	// Dual-stack echo app to be used by tests if running in dual-stack mode
+	// IPv4 only echo app to be used by tests if running in dual-stack mode
 	D echo.Instances
 	// IPv6 only echo app to be used by tests if running in dual-stack mode
 	E echo.Instances

--- a/pkg/test/framework/components/echo/deployment/builder.go
+++ b/pkg/test/framework/components/echo/deployment/builder.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-multierror"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/api/annotation"
@@ -302,6 +303,14 @@ func (b *builder) getOrCreateNamespace(prefix string) (*builder, namespace.Insta
 func (b *builder) deployServices() (err error) {
 	services := make(map[string]string)
 	for _, cfg := range b.configs {
+		if cfg.IPFamilies == "" {
+			cfg.IPFamilies = b.ctx.Settings().IPFamilies
+		}
+		if len(strings.Split(cfg.IPFamilies, ",")) == 1 {
+			cfg.IPFamilyPolicy = string(corev1.IPFamilyPolicySingleStack)
+		} else {
+			cfg.IPFamilyPolicy = string(corev1.IPFamilyPolicyRequireDualStack)
+		}
 		svc, err := kube.GenerateService(cfg)
 		if err != nil {
 			return err

--- a/pkg/test/framework/components/echo/deployment/builder.go
+++ b/pkg/test/framework/components/echo/deployment/builder.go
@@ -304,7 +304,7 @@ func (b *builder) deployServices() (err error) {
 	services := make(map[string]string)
 	for _, cfg := range b.configs {
 		if cfg.IPFamilies == "" {
-			cfg.IPFamilies = b.ctx.Settings().IPFamilies
+			cfg.IPFamilies = strings.Join(b.ctx.Settings().IPFamilies, ",")
 		}
 		if len(strings.Split(cfg.IPFamilies, ",")) == 1 {
 			cfg.IPFamilyPolicy = string(corev1.IPFamilyPolicySingleStack)

--- a/pkg/test/framework/components/istio/kube.go
+++ b/pkg/test/framework/components/istio/kube.go
@@ -597,7 +597,7 @@ func commonInstallArgs(ctx resource.Context, cfg Config, c cluster.Cluster, defa
 		args.AppendSet("components.cni.enabled", "true")
 	}
 
-	if ctx.Settings().EnableDualStack {
+	if len(ctx.Settings().IPFamilies) > 1 {
 		args.AppendSet("values.pilot.env.ISTIO_DUAL_STACK", "true")
 		args.AppendSet("values.pilot.ipFamilyPolicy", string(corev1.IPFamilyPolicyRequireDualStack))
 		args.AppendSet("meshConfig.defaultConfig.proxyMetadata.ISTIO_DUAL_STACK", "true")

--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -91,6 +91,9 @@ func SettingsFromCommandLine(testID string) (*Settings, error) {
 		s.HelmRepo = "https://istio-release.storage.googleapis.com/charts"
 	}
 
+	// set dual-stack mode for tests based on the specified ip families
+	s.SetDualStack()
+
 	if err = validate(s); err != nil {
 		return nil, err
 	}
@@ -202,9 +205,8 @@ func init() {
 			"Secret should already exist when used with istio.test.stableNamespaces.")
 	flag.Uint64Var(&settingsFromCommandLine.MaxDumps, "istio.test.maxDumps", settingsFromCommandLine.MaxDumps,
 		"Maximum number of full test dumps that are allowed to occur within a test suite.")
-	flag.BoolVar(&settingsFromCommandLine.EnableDualStack, "istio.test.enableDualStack", settingsFromCommandLine.EnableDualStack,
-		"Deploy Istio with Dual Stack enabled.")
 	flag.StringVar(&settingsFromCommandLine.HelmRepo, "istio.test.helmRepo", settingsFromCommandLine.HelmRepo, "Helm repo to use to pull the charts.")
+	flag.StringVar(&settingsFromCommandLine.IPFamilies, "istio.test.IPFamilies", settingsFromCommandLine.IPFamilies, "The order of IP families for dual-stack")
 	flag.BoolVar(&settingsFromCommandLine.GatewayConformanceStandardOnly, "istio.test.gatewayConformanceStandardOnly",
 		settingsFromCommandLine.GatewayConformanceStandardOnly,
 		"If set, only the standard gateway conformance tests will be run; tests relying on experimental resources will be skipped.")

--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -133,6 +133,11 @@ func validate(s *Settings) error {
 		return fmt.Errorf("values for Hub & Tag are not detected. Please supply them through command-line or via environment")
 	}
 
+	for _, ipFamily := range s.IPFamilies {
+		if ipFamily != "IPv4" && ipFamily != "IPv6" {
+			return fmt.Errorf("supported values for --istio.test.IPFamilies are `IPv4`, `IPv6`, `IPv4,IPv6` or `IPv6,IPv4`")
+		}
+	}
 	return nil
 }
 

--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -63,6 +63,12 @@ func SettingsFromCommandLine(testID string) (*Settings, error) {
 	}
 	s.SkipWorkloadClasses = normalized
 
+	normalizedIPFamilies := make(ArrayFlags, 0)
+	for _, ipFamily := range s.IPFamilies {
+		normalizedIPFamilies = append(normalizedIPFamilies, strings.Split(ipFamily, ",")...)
+	}
+	s.IPFamilies = normalizedIPFamilies
+
 	if s.Image.Hub == "" {
 		s.Image.Hub = env.HUB.ValueOrDefault("gcr.io/istio-testing")
 	}
@@ -90,9 +96,6 @@ func SettingsFromCommandLine(testID string) (*Settings, error) {
 	if s.HelmRepo == "" {
 		s.HelmRepo = "https://istio-release.storage.googleapis.com/charts"
 	}
-
-	// set dual-stack mode for tests based on the specified ip families
-	s.SetDualStack()
 
 	if err = validate(s); err != nil {
 		return nil, err
@@ -206,7 +209,8 @@ func init() {
 	flag.Uint64Var(&settingsFromCommandLine.MaxDumps, "istio.test.maxDumps", settingsFromCommandLine.MaxDumps,
 		"Maximum number of full test dumps that are allowed to occur within a test suite.")
 	flag.StringVar(&settingsFromCommandLine.HelmRepo, "istio.test.helmRepo", settingsFromCommandLine.HelmRepo, "Helm repo to use to pull the charts.")
-	flag.StringVar(&settingsFromCommandLine.IPFamilies, "istio.test.IPFamilies", settingsFromCommandLine.IPFamilies, "The order of IP families for dual-stack")
+	flag.Var(&settingsFromCommandLine.IPFamilies, "istio.test.IPFamilies",
+		"IP families (IPv6, IPv4) to test with. If both specified, dualstack config will be used. The order the families are defined indicates precedence.")
 	flag.BoolVar(&settingsFromCommandLine.GatewayConformanceStandardOnly, "istio.test.gatewayConformanceStandardOnly",
 		settingsFromCommandLine.GatewayConformanceStandardOnly,
 		"If set, only the standard gateway conformance tests will be run; tests relying on experimental resources will be skipped.")

--- a/pkg/test/framework/resource/settings.go
+++ b/pkg/test/framework/resource/settings.go
@@ -173,6 +173,8 @@ type Settings struct {
 	// EnableDualStack indicates the test should have dual stack enabled or not.
 	EnableDualStack bool
 
+	IPFamilies string
+
 	// Helm repo to be used for tests
 	HelmRepo string
 
@@ -193,6 +195,13 @@ type Settings struct {
 func (s *Settings) SkipVMs() {
 	s.SkipVM = true
 	s.SkipWorkloadClasses = append(s.SkipWorkloadClasses, "vm")
+}
+
+// Checks if dual-stack mode is to be enabled for tests based on the IpFamilies
+func (s *Settings) SetDualStack() {
+	if len(strings.Split(s.IPFamilies, ",")) > 1 {
+		s.EnableDualStack = true
+	}
 }
 
 // Skip checks whether a given class is skipped
@@ -266,6 +275,8 @@ func (s *Settings) String() string {
 	result += fmt.Sprintf("PullSecret:        						 %s\n", s.Image.PullSecret)
 	result += fmt.Sprintf("MaxDumps:          						 %d\n", s.MaxDumps)
 	result += fmt.Sprintf("HelmRepo:          						 %v\n", s.HelmRepo)
+	result += fmt.Sprintf("EnableDualStack:							 %v\n", s.EnableDualStack)
+	result += fmt.Sprintf("IPFamilies:							 %v\n", s.IPFamilies)
 	result += fmt.Sprintf("GatewayConformanceStandardOnly: %v\n", s.GatewayConformanceStandardOnly)
 	return result
 }

--- a/pkg/test/framework/resource/settings.go
+++ b/pkg/test/framework/resource/settings.go
@@ -170,10 +170,8 @@ type Settings struct {
 	// MaxDumps is the maximum number of full test dumps that are allowed to occur within a test suite.
 	MaxDumps uint64
 
-	// EnableDualStack indicates the test should have dual stack enabled or not.
-	EnableDualStack bool
-
-	IPFamilies string
+	// IP Families (IPv6, IPv4) to test with. The order indicates precedence.
+	IPFamilies ArrayFlags
 
 	// Helm repo to be used for tests
 	HelmRepo string
@@ -195,13 +193,6 @@ type Settings struct {
 func (s *Settings) SkipVMs() {
 	s.SkipVM = true
 	s.SkipWorkloadClasses = append(s.SkipWorkloadClasses, "vm")
-}
-
-// Checks if dual-stack mode is to be enabled for tests based on the IpFamilies
-func (s *Settings) SetDualStack() {
-	if len(strings.Split(s.IPFamilies, ",")) > 1 {
-		s.EnableDualStack = true
-	}
 }
 
 // Skip checks whether a given class is skipped
@@ -275,7 +266,6 @@ func (s *Settings) String() string {
 	result += fmt.Sprintf("PullSecret:        						 %s\n", s.Image.PullSecret)
 	result += fmt.Sprintf("MaxDumps:          						 %d\n", s.MaxDumps)
 	result += fmt.Sprintf("HelmRepo:          						 %v\n", s.HelmRepo)
-	result += fmt.Sprintf("EnableDualStack:							 %v\n", s.EnableDualStack)
 	result += fmt.Sprintf("IPFamilies:							 %v\n", s.IPFamilies)
 	result += fmt.Sprintf("GatewayConformanceStandardOnly: %v\n", s.GatewayConformanceStandardOnly)
 	return result

--- a/pkg/test/framework/suite.go
+++ b/pkg/test/framework/suite.go
@@ -320,7 +320,7 @@ func (s *suiteImpl) RequireMinVersion(minorVersion uint) Suite {
 
 func (s *suiteImpl) RequireDualStack() Suite {
 	fn := func(ctx resource.Context) error {
-		if len(ctx.Settings().IPFamilies) <= 1 {
+		if len(ctx.Settings().IPFamilies) < 2 {
 			s.Skip("Required DualStack condition is not satisfied")
 		}
 		return nil

--- a/pkg/test/framework/suite.go
+++ b/pkg/test/framework/suite.go
@@ -320,7 +320,7 @@ func (s *suiteImpl) RequireMinVersion(minorVersion uint) Suite {
 
 func (s *suiteImpl) RequireDualStack() Suite {
 	fn := func(ctx resource.Context) error {
-		if !ctx.Settings().EnableDualStack {
+		if len(ctx.Settings().IPFamilies) <= 1 {
 			s.Skip("Required DualStack condition is not satisfied")
 		}
 		return nil

--- a/pkg/test/framework/test.go
+++ b/pkg/test/framework/test.go
@@ -254,7 +254,7 @@ func (t *testImpl) doRun(ctx *testContext, fn func(ctx TestContext), parallel bo
 		return
 	}
 
-	if t.requiredDualstack && len(t.ctx.Settings().IPFamilies) <= 1 {
+	if t.requiredDualstack && len(t.ctx.Settings().IPFamilies) < 2 {
 		t.goTest.Skipf("Skipping %q: context does not have DualStack configuration",
 			t.goTest.Name())
 	}

--- a/pkg/test/framework/test.go
+++ b/pkg/test/framework/test.go
@@ -254,7 +254,7 @@ func (t *testImpl) doRun(ctx *testContext, fn func(ctx TestContext), parallel bo
 		return
 	}
 
-	if t.requiredDualstack && !t.ctx.Settings().EnableDualStack {
+	if t.requiredDualstack && len(t.ctx.Settings().IPFamilies) <= 1 {
 		t.goTest.Skipf("Skipping %q: context does not have DualStack configuration",
 			t.goTest.Name())
 	}

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -115,7 +115,7 @@ function build_images() {
   SELECT_TEST="${1}"
 
   # Build just the images needed for tests
-  targets="docker.pilot docker.proxyv2 "
+  targets="docker.pilot docker.proxyv2 docker.ztunnel "
 
   # use ubuntu:jammy to test vms by default
   nonDistrolessTargets="docker.app docker.app_sidecar_ubuntu_noble docker.ext-authz "

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -115,7 +115,7 @@ function build_images() {
   SELECT_TEST="${1}"
 
   # Build just the images needed for tests
-  targets="docker.pilot docker.proxyv2 docker.ztunnel "
+  targets="docker.pilot docker.proxyv2 "
 
   # use ubuntu:jammy to test vms by default
   nonDistrolessTargets="docker.app docker.app_sidecar_ubuntu_noble docker.ext-authz "

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -3718,7 +3718,7 @@ spec:
 			if tt.server != "" {
 				address += "&server=" + tt.server
 			}
-			expected := aInCluster[0].Address()
+			expected := aInCluster[0].Addresses()
 			t.RunTraffic(TrafficTestCase{
 				name: fmt.Sprintf("svc/%s/%s/%s", client.Config().Service, client.Config().Cluster.StableName(), tt.name),
 				call: client.CallOrFail,
@@ -3729,10 +3729,9 @@ spec:
 					Check: func(result echo.CallResult, _ error) error {
 						for _, r := range result.Responses {
 							ips := r.Body()
-							sort.Strings(ips)
-							exp := []string{expected}
-							if !reflect.DeepEqual(ips, exp) {
-								return fmt.Errorf("unexpected dns response: wanted %v, got %v", exp, ips)
+							sort.Strings(expected)
+							if !reflect.DeepEqual(ips, expected) {
+								return fmt.Errorf("unexpected dns response: wanted %v, got %v", expected, ips)
 							}
 						}
 						return nil

--- a/tests/integration/pilot/gateway_test.go
+++ b/tests/integration/pilot/gateway_test.go
@@ -197,7 +197,8 @@ spec:
 			host:  "bar",
 		},
 	}
-	if t.Settings().EnableDualStack {
+	// additional tests for dual-stack scenario
+	if len(t.Settings().IPFamilies) > 1 {
 		additionalTestCases := []struct {
 			check echo.Checker
 			from  echo.Instances

--- a/tests/integration/pilot/gateway_test.go
+++ b/tests/integration/pilot/gateway_test.go
@@ -203,9 +203,9 @@ spec:
 			from  echo.Instances
 			host  string
 		}{
-			// apps.D hosts a dual-stack service,
+			// apps.D hosts an ipv4 service,
 			// apps.E hosts an ipv6 only service and
-			// apps.B hosts an ipv4 only service
+			// apps.B hosts a dual-stack service service
 			{
 				check: check.OK(),
 				from:  apps.D,

--- a/tests/integration/pilot/gateway_test.go
+++ b/tests/integration/pilot/gateway_test.go
@@ -204,9 +204,8 @@ spec:
 			from  echo.Instances
 			host  string
 		}{
-			// apps.D hosts an ipv4 service,
-			// apps.E hosts an ipv6 only service and
-			// apps.B hosts a dual-stack service service
+			// apps.D and apps.E host single-stack services
+			// apps.B hosts a dual-stack service
 			{
 				check: check.OK(),
 				from:  apps.D,

--- a/tests/integration/security/policy_attachment_only/main_test.go
+++ b/tests/integration/security/policy_attachment_only/main_test.go
@@ -49,7 +49,7 @@ func TestMain(m *testing.M) {
 		NewSuite(m).
 		Label(label.CustomSetup).
 		Setup(istio.Setup(&i, func(c resource.Context, cfg *istio.Config) {
-			if len(c.Settings().IPFamilies) <= 1 {
+			if len(c.Settings().IPFamilies) < 2 {
 				cfg.ControlPlaneValues = `
 values:
   pilot: 

--- a/tests/integration/security/policy_attachment_only/main_test.go
+++ b/tests/integration/security/policy_attachment_only/main_test.go
@@ -49,7 +49,7 @@ func TestMain(m *testing.M) {
 		NewSuite(m).
 		Label(label.CustomSetup).
 		Setup(istio.Setup(&i, func(c resource.Context, cfg *istio.Config) {
-			if !c.Settings().EnableDualStack {
+			if len(c.Settings().IPFamilies) <= 1 {
 				cfg.ControlPlaneValues = `
 values:
   pilot: 

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -18,6 +18,7 @@
 package security
 
 import (
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -60,7 +61,7 @@ func TestReachability(t *testing.T) {
 			integIstioVersion := cMinIstioVersion
 			var migrationApp echo.Instances
 			// if dual stack is enabled, a dual stack echo config should be added
-			if !t.Settings().EnableDualStack {
+			if len(t.Settings().IPFamilies) <= 1 {
 				// Create a custom echo deployment in NS1 with subsets that allows us to test the
 				// migration of a workload to istio (from no sidecar to sidecar).
 				migrationApp = deployment.New(t).
@@ -105,7 +106,7 @@ func TestReachability(t *testing.T) {
 							Annotations: map[string]string{annotation.SidecarInject.Name: "false"},
 						},
 					},
-					IPFamilies:     "IPv4, IPv6",
+					IPFamilies:     strings.Join(t.Settings().IPFamilies, ","),
 					IPFamilyPolicy: string(corev1.IPFamilyPolicyRequireDualStack),
 				}).BuildOrFail(t)
 			}

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -18,10 +18,7 @@
 package security
 
 import (
-	"strings"
 	"testing"
-
-	corev1 "k8s.io/api/core/v1"
 
 	"istio.io/api/annotation"
 	"istio.io/istio/pilot/pkg/model"
@@ -60,56 +57,27 @@ func TestReachability(t *testing.T) {
 
 			integIstioVersion := cMinIstioVersion
 			var migrationApp echo.Instances
-			// if dual stack is enabled, a dual stack echo config should be added
-			if len(t.Settings().IPFamilies) <= 1 {
-				// Create a custom echo deployment in NS1 with subsets that allows us to test the
-				// migration of a workload to istio (from no sidecar to sidecar).
-				migrationApp = deployment.New(t).
-					WithClusters(t.Clusters()...).WithConfig(echo.Config{
-					Namespace:      echo1NS,
-					Service:        migrationServiceName,
-					ServiceAccount: true,
-					Ports:          ports.All(),
-					Subsets: []echo.SubsetConfig{
-						{
-							// Istio deployment, with sidecar.
-							Version:     migrationVersionIstio,
-							Annotations: map[string]string{annotation.SidecarInject.Name: "true"},
-						},
-						{
-							// Legacy (non-Istio) deployment subset, does not have sidecar injected.
-							Version:     migrationVersionNonIstio,
-							Annotations: map[string]string{annotation.SidecarInject.Name: "false"},
-						},
+			// Create a custom echo deployment in NS1 with subsets that allows us to test the
+			// migration of a workload to istio (from no sidecar to sidecar).
+			migrationApp = deployment.New(t).
+				WithClusters(t.Clusters()...).WithConfig(echo.Config{
+				Namespace:      echo1NS,
+				Service:        migrationServiceName,
+				ServiceAccount: true,
+				Ports:          ports.All(),
+				Subsets: []echo.SubsetConfig{
+					{
+						// Istio deployment, with sidecar.
+						Version:     migrationVersionIstio,
+						Annotations: map[string]string{annotation.SidecarInject.Name: "true"},
 					},
-				}).BuildOrFail(t)
-			} else {
-				// TODO: remove the MinIstioVersion setting for dual stack integration test for next line
-				// integIstioVersion = cMinIstioVersionDS
-				// Create a custom echo deployment in NS1 with subsets that allows us to test the
-				// migration of a workload to istio (from no sidecar to sidecar).
-				migrationApp = deployment.New(t).
-					WithClusters(t.Clusters()...).WithConfig(echo.Config{
-					Namespace:      echo1NS,
-					Service:        migrationServiceName,
-					ServiceAccount: true,
-					Ports:          ports.All(),
-					Subsets: []echo.SubsetConfig{
-						{
-							// Istio deployment, with sidecar.
-							Version:     migrationVersionIstio,
-							Annotations: map[string]string{annotation.SidecarInject.Name: "true"},
-						},
-						{
-							// Legacy (non-Istio) deployment subset, does not have sidecar injected.
-							Version:     migrationVersionNonIstio,
-							Annotations: map[string]string{annotation.SidecarInject.Name: "false"},
-						},
+					{
+						// Legacy (non-Istio) deployment subset, does not have sidecar injected.
+						Version:     migrationVersionNonIstio,
+						Annotations: map[string]string{annotation.SidecarInject.Name: "false"},
 					},
-					IPFamilies:     strings.Join(t.Settings().IPFamilies, ","),
-					IPFamilyPolicy: string(corev1.IPFamilyPolicyRequireDualStack),
-				}).BuildOrFail(t)
-			}
+				},
+			}).BuildOrFail(t)
 
 			// Add the migration app to the full list of services.
 			allServices := apps.Ns1.All.Append(migrationApp.Services())

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -56,10 +56,9 @@ func TestReachability(t *testing.T) {
 			systemNS := istio.ClaimSystemNamespaceOrFail(t, t)
 
 			integIstioVersion := cMinIstioVersion
-			var migrationApp echo.Instances
 			// Create a custom echo deployment in NS1 with subsets that allows us to test the
 			// migration of a workload to istio (from no sidecar to sidecar).
-			migrationApp = deployment.New(t).
+			migrationApp := deployment.New(t).
 				WithClusters(t.Clusters()...).WithConfig(echo.Config{
 				Namespace:      echo1NS,
 				Service:        migrationServiceName,

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -36,6 +36,10 @@ ifneq ($(VARIANT),)
     _INTEGRATION_TEST_FLAGS += --istio.test.variant=$(VARIANT)
 endif
 
+ifneq ($(IP_FAMILIES),)
+   _INTEGRATION_TEST_FLAGS += --istio.test.IPFamilies=$(IP_FAMILIES)
+endif
+
 _INTEGRATION_TEST_SELECT_FLAGS ?= --istio.test.select=$(TEST_SELECT)
 ifneq ($(JOB_TYPE),postsubmit)
 	_INTEGRATION_TEST_SELECT_FLAGS:="$(_INTEGRATION_TEST_SELECT_FLAGS),-postsubmit"
@@ -43,11 +47,10 @@ endif
 
 # both ipv6 only and dual stack support ipv6
 support_ipv6 =
-ifeq ($(IP_FAMILY),ipv6)
+ifeq ($(KIND_IP_FAMILY),ipv6)
 	support_ipv6 = yes
-else ifeq ($(IP_FAMILY),dual)
+else ifeq ($(KIND_IP_FAMILY),dual)
 	support_ipv6 = yes
-	_INTEGRATION_TEST_FLAGS += --istio.test.enableDualStack
 endif
 ifdef support_ipv6
 	_INTEGRATION_TEST_SELECT_FLAGS:="$(_INTEGRATION_TEST_SELECT_FLAGS),-ipv4"

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -125,5 +125,5 @@ test.integration.kube.environment: | $(JUNIT_REPORT) check-go-tag
 ifeq (${JOB_TYPE},postsubmit)
 	$(call run-test,./tests/integration/...)
 else
-	$(call run-test,./tests/integration/...)
+	$(call run-test,./tests/integration/security/ ./tests/integration/pilot,-run="TestReachability|TestTraffic|TestGatewayConformance")
 endif

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -125,5 +125,5 @@ test.integration.kube.environment: | $(JUNIT_REPORT) check-go-tag
 ifeq (${JOB_TYPE},postsubmit)
 	$(call run-test,./tests/integration/...)
 else
-	$(call run-test,./tests/integration/security/ ./tests/integration/pilot,-run="TestReachability|TestTraffic|TestGatewayConformance")
+	$(call run-test,./tests/integration/...)
 endif


### PR DESCRIPTION
**Please provide a description of this PR:**

This PR tries to address the comment as mentioned in https://github.com/istio/istio/pull/51914#discussion_r1668094067
Fixes https://github.com/istio/istio/issues/53704
Currently this includes kind_provisioner.sh too just for testing purpose and review. Once finalized the respective changes will move to istio/common-files repo

Right now we have IP_FAMILIES which can be

"V4"
"V6"
"dual"
This PR suggests we simply pass a list of families to the test as a test arg and drop "dual". Whatever ipfamily order the tests are passed is the order that will be used in the test, and if more than one family (regardless of order) is provided we always use IPFamilyPolicyRequireDualStack for the policy.

This simplifies things, as the only test knob is IP_FAMILIES which can be V4, or V6, or both, in your choice of order/preference.

That also makes it easy to run a suite with IP_FAMILIES=[v4, v6] while we sort out why IP_FAMILIES=[v6, v4] doesn't work, as a separate concern - we can then run it both ways, if we want.