### PR TITLE
serverca: expand signed cert and cert chain PEMs with multiple cert blocks inside

### DIFF
--- a/releasenotes/notes/serverca-expand-certs.yaml
+++ b/releasenotes/notes/serverca-expand-certs.yaml
@@ -1,0 +1,12 @@
+apiVersion: release-notes/v2
+
+kind: bug-fix
+
+area: security
+
+issue:
+- https://github.com/istio/ztunnel/issues/1061
+
+releaseNotes:
+- |
+  **Fixed** `IstioCertificateService` to ensure `IstioCertificateResponse.CertChain` contains only a single cert per element in the array.

--- a/security/pkg/server/ca/server_test.go
+++ b/security/pkg/server/ca/server_test.go
@@ -243,6 +243,18 @@ func TestCreateCertificate(t *testing.T) {
 			certChain: []string{"cert", "cert_chain", "root_cert"},
 			code:      codes.OK,
 		},
+		"Successful signing w/ multi-cert chain": {
+			authenticators: []security.Authenticator{&mockAuthenticator{identities: []string{"test-identity"}}},
+			ca: &mockca.FakeCA{
+				SignedCert: []byte("cert"),
+				KeyCertBundle: util.NewKeyCertBundleFromPem(nil, nil,
+					[]byte("cert_chain1-----END CERTIFICATE-----\ncert_chain2-----END CERTIFICATE-----\n"),
+					[]byte("root_cert"),
+				),
+			},
+			certChain: []string{"cert", "cert_chain1-----END CERTIFICATE-----\n", "cert_chain2-----END CERTIFICATE-----\n", "root_cert"},
+			code:      codes.OK,
+		},
 	}
 
 	p := &peer.Peer{Addr: &net.IPAddr{IP: net.IPv4(192, 168, 1, 1)}, AuthInfo: credentials.TLSInfo{}}


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes https://github.com/istio/ztunnel/issues/1061

In multiple places such as the cert chain from CA bundle, or returned singed certs, there could be a single `string` representing a PEM with multiple blocks/certs.

Since `IstioCertificateResponse`'s signature is `[]string`, we should semantically expand those multi-cert PEMs.

See detailed analysis on how this is causing issues with `ztunnel` in particular https://github.com/istio/ztunnel/issues/1061#issuecomment-2542545936