### PR TITLE
Support simple TLS for MCP

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -15,13 +15,19 @@
 package bootstrap
 
 import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net/url"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/autoregistration"
 	configaggregate "istio.io/istio/pilot/pkg/config/aggregate"
 	"istio.io/istio/pilot/pkg/config/kube/crdclient"
@@ -29,6 +35,8 @@ import (
 	ingress "istio.io/istio/pilot/pkg/config/kube/ingress"
 	"istio.io/istio/pilot/pkg/config/memory"
 	configmonitor "istio.io/istio/pilot/pkg/config/monitor"
+	istioCredentials "istio.io/istio/pilot/pkg/credentials"
+	"istio.io/istio/pilot/pkg/credentials/kube"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/leaderelection"
 	"istio.io/istio/pilot/pkg/model"
@@ -244,6 +252,10 @@ func (s *Server) initConfigSources(args *PilotArgs) (err error) {
 			s.ConfigStores = append(s.ConfigStores, configController)
 			log.Infof("Started File configSource %s", configSource.Address)
 		case XDS:
+			transportCredentials, err := s.getTransportCredentials(args, configSource.TlsSettings)
+			if err != nil {
+				return fmt.Errorf("failed to read transport credentials from config: %v", err)
+			}
 			xdsMCP, err := adsc.New(srcAddress.Host, &adsc.ADSConfig{
 				InitialDiscoveryRequests: adsc.ConfigInitialRequests(),
 				Config: adsc.Config{
@@ -257,11 +269,7 @@ func (s *Server) initConfigSources(args *PilotArgs) (err error) {
 					}.ToStruct(),
 					GrpcOpts: []grpc.DialOption{
 						args.KeepaliveOptions.ConvertToClientOption(),
-						// Because we use the custom grpc options for adsc, here we should
-						// explicitly set transport credentials.
-						// TODO: maybe we should use the tls settings within ConfigSource
-						// to secure the connection between istiod and remote xds server.
-						grpc.WithTransportCredentials(insecure.NewCredentials()),
+						grpc.WithTransportCredentials(transportCredentials),
 					},
 				},
 			})
@@ -342,4 +350,52 @@ func (s *Server) makeFileMonitor(fileDir string, domainSuffix string, configCont
 	})
 
 	return nil
+}
+
+// getTransportCredentials attempts to create credentials.TransportCredentials from ClientTLSSettings in mesh config
+// Implemented only for SIMPLE_TLS mode
+// TODO:
+//
+//	Implement CRL and SANs override for cert verification
+//	Implement for MUTUAL_TLS/ISTIO_MUTUAL_TLS modes
+func (s *Server) getTransportCredentials(args *PilotArgs, tlsSettings *v1alpha3.ClientTLSSettings) (credentials.TransportCredentials, error) {
+	switch tlsSettings.GetMode() {
+	case v1alpha3.ClientTLSSettings_SIMPLE:
+		if len(tlsSettings.GetCredentialName()) > 0 {
+			if len(tlsSettings.GetCaCertificates()) > 0 {
+				return nil, fmt.Errorf("only one of caCertificates or credentialName can be specified")
+			}
+			rootCert, err := s.getRootCertFromSecret(tlsSettings.GetCredentialName(), args.Namespace)
+			if err != nil {
+				return nil, err
+			}
+			tlsSettings.CaCertificates = string(rootCert.Cert)
+		}
+		if tlsSettings.GetInsecureSkipVerify().GetValue() || len(tlsSettings.GetCaCertificates()) == 0 {
+			return credentials.NewTLS(&tls.Config{
+				ServerName:         tlsSettings.GetSni(),
+				InsecureSkipVerify: tlsSettings.GetInsecureSkipVerify().GetValue(), //nolint
+			}), nil
+		}
+		certPool := x509.NewCertPool()
+		if !certPool.AppendCertsFromPEM([]byte(tlsSettings.GetCaCertificates())) {
+			return nil, fmt.Errorf("failed to add ca certificate from configSource.tlsSettings to pool")
+		}
+		return credentials.NewTLS(&tls.Config{
+			ServerName:         tlsSettings.GetSni(),
+			InsecureSkipVerify: tlsSettings.GetInsecureSkipVerify().GetValue(), //nolint
+			RootCAs:            certPool,
+		}), nil
+	default:
+		return insecure.NewCredentials(), nil
+	}
+}
+
+// getRootCertFromSecret fetches a map of keys and values from a secret with name in namespace
+func (s *Server) getRootCertFromSecret(name, namespace string) (*istioCredentials.CertInfo, error) {
+	secret, err := s.kubeClient.Kube().CoreV1().Secrets(namespace).Get(context.Background(), name, v1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get credential with name %v: %v", name, err)
+	}
+	return kube.ExtractRoot(secret)
 }

--- a/pilot/pkg/bootstrap/configcontroller_test.go
+++ b/pilot/pkg/bootstrap/configcontroller_test.go
@@ -1,0 +1,205 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bootstrap
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/test"
+)
+
+func TestGetTransportCredentials(t *testing.T) {
+	cases := []struct {
+		name                       string
+		args                       *PilotArgs
+		tlsSettings                *v1alpha3.ClientTLSSettings
+		secret                     *corev1.Secret
+		credentialSecurityProtocol string
+		expectedError              error
+	}{
+		{
+			name:                       "No TLS Setting",
+			args:                       &PilotArgs{Namespace: testNamespace},
+			credentialSecurityProtocol: "insecure",
+			expectedError:              nil,
+		},
+		{
+			name: "SIMPLE TLS",
+			args: &PilotArgs{Namespace: testNamespace},
+			tlsSettings: &v1alpha3.ClientTLSSettings{
+				Mode:           v1alpha3.ClientTLSSettings_SIMPLE,
+				CaCertificates: testCert(),
+			},
+			credentialSecurityProtocol: "tls",
+			expectedError:              nil,
+		},
+		{
+			name: "Fail SIMPLE TLS with InsecureSkipVerify",
+			args: &PilotArgs{Namespace: testNamespace},
+			tlsSettings: &v1alpha3.ClientTLSSettings{
+				Mode:               v1alpha3.ClientTLSSettings_SIMPLE,
+				InsecureSkipVerify: &wrappers.BoolValue{Value: true},
+			},
+			credentialSecurityProtocol: "tls",
+			expectedError:              nil,
+		},
+		{
+			name: "SIMPLE TLS from secrets",
+			args: &PilotArgs{Namespace: testNamespace},
+			tlsSettings: &v1alpha3.ClientTLSSettings{
+				Mode:           v1alpha3.ClientTLSSettings_SIMPLE,
+				CredentialName: "test-secret",
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret",
+					Namespace: testNamespace,
+				},
+				Data: map[string][]byte{
+					"cacert": []byte(testCert()),
+				},
+				Type: corev1.SecretTypeOpaque,
+			},
+			credentialSecurityProtocol: "tls",
+			expectedError:              nil,
+		},
+		{
+			name: "SIMPLE TLS from secrets ca.crt",
+			args: &PilotArgs{Namespace: testNamespace},
+			tlsSettings: &v1alpha3.ClientTLSSettings{
+				Mode:           v1alpha3.ClientTLSSettings_SIMPLE,
+				CredentialName: "test-secret",
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret",
+					Namespace: testNamespace,
+				},
+				Data: map[string][]byte{
+					"ca.crt": []byte(testCert()),
+				},
+				Type: corev1.SecretTypeOpaque,
+			},
+			credentialSecurityProtocol: "tls",
+			expectedError:              nil,
+		},
+		{
+			name: "Fail SIMPLE TLS from secrets not in cluster",
+			args: &PilotArgs{Namespace: testNamespace},
+			tlsSettings: &v1alpha3.ClientTLSSettings{
+				Mode:           v1alpha3.ClientTLSSettings_SIMPLE,
+				CredentialName: "test-secret",
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "not-test-secret",
+					Namespace: testNamespace,
+				},
+				Data: map[string][]byte{},
+				Type: corev1.SecretTypeOpaque,
+			},
+			credentialSecurityProtocol: "tls",
+			expectedError:              errors.New("failed to get credential with name test-secret: secrets \"test-secret\" not found"),
+		},
+		{
+			name: "Fail SIMPLE TLS from secrets but caCert is also configured",
+			args: &PilotArgs{Namespace: testNamespace},
+			tlsSettings: &v1alpha3.ClientTLSSettings{
+				Mode:           v1alpha3.ClientTLSSettings_SIMPLE,
+				CredentialName: "test-secret",
+				CaCertificates: testCert(),
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret",
+					Namespace: testNamespace,
+				},
+				Data: map[string][]byte{
+					"cacert": []byte(base64.StdEncoding.EncodeToString([]byte(testCert()))),
+				},
+				Type: corev1.SecretTypeOpaque,
+			},
+			credentialSecurityProtocol: "tls",
+			expectedError:              errors.New("only one of caCertificates or credentialName can be specified"),
+		},
+		{
+			name: "MUTUAL TLS",
+			args: &PilotArgs{Namespace: testNamespace},
+			tlsSettings: &v1alpha3.ClientTLSSettings{
+				Mode: v1alpha3.ClientTLSSettings_MUTUAL,
+			},
+			credentialSecurityProtocol: "insecure",
+			expectedError:              nil,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := &Server{}
+			if c.secret != nil {
+				client := kube.NewFakeClient(c.secret)
+				stop := test.NewStop(t)
+				client.RunAndWait(stop)
+				s = &Server{kubeClient: client}
+			}
+			if creds, err := s.getTransportCredentials(c.args, c.tlsSettings); err != nil {
+				if c.expectedError == nil {
+					t.Errorf("unexpected getTransportCredentials error: %v", err)
+				} else if c.expectedError.Error() != err.Error() {
+					t.Errorf("expected getTransportCredentials error: %v got: %v", c.expectedError.Error(), err.Error())
+				}
+			} else if c.expectedError != nil {
+				t.Errorf("got not error but expected getTransportCredentials error: %v", c.expectedError.Error())
+			} else if creds.Info().SecurityProtocol != c.credentialSecurityProtocol {
+				t.Errorf("expected credential security protocol %v got: %v", c.credentialSecurityProtocol, creds.Info().SecurityProtocol)
+			}
+		})
+	}
+}
+
+func testCert() string {
+	priv, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Test Organization"},
+			CommonName:   "localhost",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{"example.com"},
+	}
+	certDER, _ := x509.CreateCertificate(rand.Reader, cert, cert, &priv.PublicKey, priv)
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	return string(certPEM)
+}

--- a/pilot/pkg/credentials/kube/secrets.go
+++ b/pilot/pkg/credentials/kube/secrets.go
@@ -204,9 +204,9 @@ func (s *CredentialsController) GetCaCert(name, namespace string) (certInfo *cre
 		if k8sSecret == nil {
 			return nil, fmt.Errorf("secret %v/%v not found", namespace, strippedName)
 		}
-		return extractRoot(k8sSecret)
+		return ExtractRoot(k8sSecret)
 	}
-	return extractRoot(k8sSecret)
+	return ExtractRoot(k8sSecret)
 }
 
 func (s *CredentialsController) GetDockerCredential(name, namespace string) ([]byte, error) {
@@ -283,8 +283,8 @@ func truncatedKeysMessage(data map[string][]byte) string {
 	return fmt.Sprintf("%s, and %d more...", strings.Join(keys[:3], ", "), len(keys)-3)
 }
 
-// extractRoot extracts the root certificate
-func extractRoot(scrt *v1.Secret) (certInfo *credentials.CertInfo, err error) {
+// ExtractRoot extracts the root certificate
+func ExtractRoot(scrt *v1.Secret) (certInfo *credentials.CertInfo, err error) {
 	ret := &credentials.CertInfo{}
 	if hasValue(scrt.Data, GenericScrtCaCert) {
 		ret.Cert = scrt.Data[GenericScrtCaCert]


### PR DESCRIPTION
**Please provide a description of this PR:**





- [x] Changes behaviour if `ConfigSource.TlsSetting.Mode` has been explicitly set to `SIMPLE`. 

Related #33143 