### PR TITLE
1.24 cherrypick: krt: move event processing to queue

### DIFF
--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -23,6 +23,7 @@ import (
 	istiolog "istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/ptr"
+	"istio.io/istio/pkg/queue"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/sets"
 )
@@ -44,13 +45,9 @@ type manyCollection[I, O any] struct {
 
 	// log is a logger for the collection, with additional labels already added to identify it.
 	log *istiolog.Scope
-
-	// recomputeMu blocks a recomputation of I->O.
-	recomputeMu sync.Mutex
-
+	// This can be acquired with blockNewEvents held, but only with strict ordering (mu inside blockNewEvents)
 	// mu protects all items grouped below.
 	// This is acquired for reads and writes of data.
-	// This can be acquired with recomputeMu held, but only with strict ordering (mu inside recomputeMu)
 	mu              sync.Mutex
 	collectionState multiIndex[I, O]
 	// collectionDependencies specifies the set of collections we depend on from within the transformation functions (via Fetch).
@@ -63,7 +60,7 @@ type manyCollection[I, O any] struct {
 	indexes []collectionIndex[I, O]
 
 	// eventHandlers is a list of event handlers registered for the collection. On any changes, each will be notified.
-	eventHandlers *handlers[O]
+	eventHandlers *handlerSet[O]
 
 	transformation TransformationMulti[I, O]
 
@@ -71,6 +68,7 @@ type manyCollection[I, O any] struct {
 	augmentation func(a any) any
 	synced       chan struct{}
 	stop         <-chan struct{}
+	queue        queue.Instance
 }
 
 type collectionIndex[I, O any] struct {
@@ -160,8 +158,6 @@ func (h *manyCollection[I, O]) Synced() Syncer {
 
 // nolint: unused // (not true, its to implement an interface)
 func (h *manyCollection[I, O]) dump() {
-	h.recomputeMu.Lock()
-	defer h.recomputeMu.Unlock()
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.log.Errorf(">>> BEGIN DUMP")
@@ -210,13 +206,9 @@ func (h *manyCollection[I, O]) index(extract func(o O) []string) kclient.RawInde
 // onPrimaryInputEvent takes a list of I's that changed and reruns the handler over them.
 // This is called either when I directly changes, or if a secondary dependency changed. In this case, we compute which I's depended
 // on the secondary dependency, and call onPrimaryInputEvent with them
-func (h *manyCollection[I, O]) onPrimaryInputEvent(items []Event[I], lock bool) {
-	if lock {
-		h.recomputeMu.Lock()
-		defer h.recomputeMu.Unlock()
-	}
+func (h *manyCollection[I, O]) onPrimaryInputEvent(items []Event[I]) {
 	// Between the events being enqueued and now, the input may have changed. Update with latest info.
-	// Note we now have the recomputeMu so this is safe; any futures calls will do the same so always have up-to-date information.
+	// Note we now have the `blockNewEvents` lock so this is safe; any futures calls will do the same so always have up-to-date information.
 	for idx, ev := range items {
 		iKey := GetKey(ev.Latest())
 		iObj := h.parent.GetKey(iKey)
@@ -257,6 +249,7 @@ func (h *manyCollection[I, O]) onPrimaryInputEventLocked(items []Event[I]) {
 
 	// Now acquire the full lock. Note we still have recomputeMu held!
 	h.mu.Lock()
+	defer h.mu.Unlock()
 	for idx, a := range items {
 		i := a.Latest()
 		iKey := GetKey(i)
@@ -328,20 +321,15 @@ func (h *manyCollection[I, O]) onPrimaryInputEventLocked(items []Event[I]) {
 			}
 		}
 	}
-	h.mu.Unlock()
 
 	// Short circuit if we have nothing to do
 	if len(events) == 0 {
 		return
 	}
-	handlers := h.eventHandlers.Get()
-
 	if h.log.DebugEnabled() {
-		h.log.WithLabels("events", len(events), "handlers", len(handlers)).Debugf("calling handlers")
+		h.log.WithLabels("events", len(events)).Debugf("calling handlers")
 	}
-	for _, handler := range handlers {
-		handler(slices.Clone(events), false)
-	}
+	h.eventHandlers.Distribute(events, false)
 }
 
 // WithName allows explicitly naming a controller. This is a best practice to make debugging easier.
@@ -419,49 +407,49 @@ func newManyCollection[I, O any](cc Collection[I], hf TransformationMulti[I, O],
 			outputs:  map[Key[O]]O{},
 			mappings: map[Key[I]]sets.Set[Key[O]]{},
 		},
-		eventHandlers: &handlers[O]{},
+		eventHandlers: &handlerSet[O]{},
 		augmentation:  opts.augmentation,
 		synced:        make(chan struct{}),
 		stop:          opts.stop,
 	}
-	go func() {
-		// Wait for primary dependency to be ready
-		if !c.Synced().WaitUntilSynced(h.stop) {
-			return
-		}
-		// Now, register our handler. This will call Add() for the initial state
-		// Locking here is tricky. We want to make sure we don't get duplicate events.
-		// When we run RegisterBatch, it will trigger events for the initial state. However, other events could trigger
-		// while we are processing these.
-		// By holding the lock, we ensure we have exclusive access during this time.
-		h.recomputeMu.Lock()
-		h.eventHandlers.MarkInitialized()
-		handlerReg := c.RegisterBatch(func(events []Event[I], initialSync bool) {
-			if log.DebugEnabled() {
-				h.log.WithLabels("dep", "primary", "batch", len(events)).
-					Debugf("got event")
-			}
-			// Lock after the initial sync only
-			// For initial sync we explicitly hold the lock ourselves to ensure we have a broad enough critical section.
-			lock := !initialSync
-			h.onPrimaryInputEvent(events, lock)
-		}, true)
-		if !handlerReg.WaitUntilSynced(h.stop) {
-			h.recomputeMu.Unlock()
-			return
-		}
-		h.recomputeMu.Unlock()
+
+	// Create our queue. When it syncs (that is, all items that were present when Run() was called), we mark ourselves as synced.
+	h.queue = queue.NewWithSync(func() {
 		close(h.synced)
 		h.log.Infof("%v synced", h.name())
-	}()
+	}, h.collectionName)
+
+	// Finally, async wait for the primary to be synced. Once it has, we know it has enqueued the initial state.
+	// After this, we can run our queue.
+	// The queue will process the initial state and mark ourselves as synced (from the NewWithSync callback)
+	go h.runQueue()
+
 	return h
+}
+
+func (h *manyCollection[I, O]) runQueue() {
+	c := h.parent
+	// Wait for primary dependency to be ready
+	if !c.Synced().WaitUntilSynced(h.stop) {
+		return
+	}
+	// Now register to our primary collection. On any event, we will enqueue the update.
+	syncer := c.RegisterBatch(func(o []Event[I], initialSync bool) {
+		h.queue.Push(func() error {
+			h.onPrimaryInputEvent(o)
+			return nil
+		})
+	}, true)
+	// Wait for everything initial state to be enqueued
+	if !syncer.WaitUntilSynced(h.stop) {
+		return
+	}
+	h.queue.Run(h.stop)
 }
 
 // Handler is called when a dependency changes. We will take as inputs the item that changed.
 // Then we find all of our own values (I) that changed and onPrimaryInputEvent() them
 func (h *manyCollection[I, O]) onSecondaryDependencyEvent(sourceCollection collectionUID, events []Event[any]) {
-	h.recomputeMu.Lock()
-	defer h.recomputeMu.Unlock()
 	// A secondary dependency changed...
 	// Got an event. Now we need to find out who depends on it..
 	changedInputKeys := sets.Set[Key[I]]{}
@@ -558,36 +546,29 @@ func (h *manyCollection[I, O]) Register(f func(o Event[O])) Syncer {
 }
 
 func (h *manyCollection[I, O]) RegisterBatch(f func(o []Event[O], initialSync bool), runExistingState bool) Syncer {
-	if runExistingState {
-		h.recomputeMu.Lock()
-		defer h.recomputeMu.Unlock()
+	if !runExistingState {
+		// If we don't to run the initial state this is simple, we just register the handler.
+		return h.eventHandlers.Insert(f, h.Synced(), nil, h.stop)
 	}
-	initialized := !h.eventHandlers.Insert(f)
-	if initialized && runExistingState {
-		// Already started. Pause everything, and run through the handler.
-		h.mu.Lock()
-		events := make([]Event[O], 0, len(h.collectionState.outputs))
-		for _, o := range h.collectionState.outputs {
-			o := o
-			events = append(events, Event[O]{
-				New:   &o,
-				Event: controllers.EventAdd,
-			})
-		}
-		h.mu.Unlock()
-		if len(events) > 0 {
-			if log.DebugEnabled() {
-				h.log.WithLabels("items", len(events)).Debugf("call handler with initial state")
-			}
-			f(events, true)
-		}
-		// We handle events in sequence here, so its always synced at this point/
-		return alwaysSynced{}
+	// We need to run the initial state, but we don't want to get duplicate events.
+	// We should get "ADD initialObject1, ADD initialObjectN, UPDATE someLaterUpdate" without mixing the initial ADDs
+	// To do this we block any new event processing
+	// Get initial state
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	events := make([]Event[O], 0, len(h.collectionState.outputs))
+	for _, o := range h.collectionState.outputs {
+		o := o
+		events = append(events, Event[O]{
+			New:   &o,
+			Event: controllers.EventAdd,
+		})
+
 	}
-	return channelSyncer{
-		name:   h.collectionName + " handler",
-		synced: h.synced,
-	}
+
+	// Send out all the initial objects to the handler. We will then unlock the new events so it gets the future updates.
+	return h.eventHandlers.Insert(f, h.Synced(), events, h.stop)
 }
 
 func (h *manyCollection[I, O]) name() string {
@@ -621,7 +602,7 @@ func (i *collectionDependencyTracker[I, O]) name() string {
 func (i *collectionDependencyTracker[I, O]) registerDependency(
 	d *dependency,
 	syncer Syncer,
-	register func(f erasedEventHandler),
+	register func(f erasedEventHandler) Syncer,
 ) {
 	i.d = append(i.d, d)
 
@@ -630,8 +611,11 @@ func (i *collectionDependencyTracker[I, O]) registerDependency(
 		i.log.WithLabels("collection", d.collectionName).Debugf("register new dependency")
 		syncer.WaitUntilSynced(i.stop)
 		register(func(o []Event[any], initialSync bool) {
-			i.onSecondaryDependencyEvent(d.id, o)
-		})
+			i.queue.Push(func() error {
+				i.onSecondaryDependencyEvent(d.id, o)
+				return nil
+			})
+		}).WaitUntilSynced(i.stop)
 	}
 }
 

--- a/pkg/kube/krt/conformance_test.go
+++ b/pkg/kube/krt/conformance_test.go
@@ -1,0 +1,147 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package krt_test
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/kclient"
+	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/assert"
+)
+
+type Rig[T any] interface {
+	krt.Collection[T]
+	CreateObject(key string)
+}
+
+type informerRig struct {
+	krt.Collection[*corev1.ConfigMap]
+	client kclient.Client[*corev1.ConfigMap]
+}
+
+func (r *informerRig) CreateObject(key string) {
+	ns, name, _ := strings.Cut(key, "/")
+	_, _ = r.client.Create(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+	})
+}
+
+// TestConformance aims to provide a 'conformance' suite for Collection implementations to ensure each collection behaves
+// the same way.
+// This is done by having each collection implement a small test rig that can be used to exercise various standardized paths.
+// The test assumes a collection with items of any type, but with keys in the form of '<string>/<string>'; all current
+// collection types can handle some type with this key.
+func TestConformance(t *testing.T) {
+	t.Run("informer", func(t *testing.T) {
+		fc := kube.NewFakeClient()
+		kc := kclient.New[*corev1.ConfigMap](fc)
+		col := krt.WrapClient(kc, krt.WithStop(test.NewStop(t)))
+		rig := &informerRig{
+			Collection: col,
+			client:     kc,
+		}
+		fc.RunAndWait(test.NewStop(t))
+		runConformance[*corev1.ConfigMap](t, rig)
+	})
+}
+
+func runConformance[T any](t *testing.T, collection Rig[T]) {
+	stop := test.NewStop(t)
+	// Collection should start empty...
+	assert.Equal(t, len(collection.List()), 0)
+
+	// Register a handler at the start of the collection
+	earlyHandler := assert.NewTracker[string](t)
+	earlyHandlerSynced := collection.Register(TrackerHandler[T](earlyHandler))
+
+	// Ensure the collection and handler are synced
+	assert.Equal(t, collection.Synced().WaitUntilSynced(stop), true)
+	assert.Equal(t, earlyHandlerSynced.WaitUntilSynced(stop), true)
+
+	// Create an object
+	collection.CreateObject("a/b")
+	earlyHandler.WaitOrdered("add/a/b")
+	assert.Equal(t, len(collection.List()), 1)
+	assert.Equal(t, collection.GetKey("a/b") != nil, true)
+
+	// Now register one later
+	lateHandler := assert.NewTracker[string](t)
+	assert.Equal(t, collection.Register(TrackerHandler[T](lateHandler)).WaitUntilSynced(stop), true)
+	// It should get the initial state
+	lateHandler.WaitOrdered("add/a/b")
+
+	// Add a new handler that blocks events. This should not block the other handlers
+	delayedSynced := collection.Register(func(o krt.Event[T]) {
+		<-stop
+	})
+	// This should never be synced
+	assert.Equal(t, delayedSynced.HasSynced(), false)
+
+	// add another object. We should get it from both handlers
+	collection.CreateObject("a/c")
+	earlyHandler.WaitOrdered("add/a/c")
+	lateHandler.WaitOrdered("add/a/c")
+	assert.Equal(t, len(collection.List()), 2)
+	assert.Equal(t, collection.GetKey("a/b") != nil, true)
+	assert.Equal(t, collection.GetKey("a/c") != nil, true)
+
+	// Add another object. Some bad implementations could handle 1 event with a blocked handler, but not >1, so make sure we catch that
+	collection.CreateObject("a/d")
+	earlyHandler.WaitOrdered("add/a/d")
+	lateHandler.WaitOrdered("add/a/d")
+	assert.Equal(t, len(collection.List()), 3)
+
+	// Test another handler can be added even though one is blocked
+	endHandler := assert.NewTracker[string](t)
+	endHandlerSynced := collection.Register(TrackerHandler[T](endHandler))
+	assert.Equal(t, endHandlerSynced.WaitUntilSynced(stop), true)
+	endHandler.WaitUnordered("add/a/b", "add/a/c", "add/a/d")
+
+	// Now, we want to test some race conditions.
+	// We will trigger a bunch of ADD operations, and register a handler sometime in-between
+	// The handler should not get any duplicates or missed events.
+	keys := []string{}
+	for n := range 20 {
+		keys = append(keys, fmt.Sprintf("a/%v", n))
+	}
+	raceHandler := assert.NewTracker[string](t)
+	go func() {
+		for _, k := range keys {
+			collection.CreateObject(k)
+		}
+	}()
+	// Introduce some small jitter to help ensure we don't always just register first
+	// nolint: gosec // just for testing
+	time.Sleep(time.Microsecond * time.Duration(rand.Int31n(100)))
+	raceHandlerSynced := collection.Register(TrackerHandler[T](raceHandler))
+	assert.Equal(t, raceHandlerSynced.WaitUntilSynced(stop), true)
+	want := []string{"add/a/b", "add/a/c", "add/a/d"}
+	for _, k := range keys {
+		want = append(want, fmt.Sprintf("add/%v", k))
+	}
+	// We should get every event exactly one time
+	raceHandler.WaitUnordered(want...)
+	raceHandler.Empty()
+}

--- a/pkg/kube/krt/core.go
+++ b/pkg/kube/krt/core.go
@@ -48,6 +48,11 @@ type EventStream[T any] interface {
 	// called. Typically, usage of Register is done internally in krt via composition of Collections with Transformations
 	// (NewCollection, NewManyCollection, NewSingleton); however, at boundaries of the system (connecting to something not
 	// using krt), registering directly is expected.
+	// Handlers have the following semantics:
+	// * On each event, all handlers are called.
+	// * Each handler has its own unbounded event queue. Slow handlers will cause this queue to accumulate, but will not block
+	//   other handlers.
+	// * Events will be sent in order, and will not be dropped or deduplicated.
 	Register(f func(o Event[T])) Syncer
 
 	// Synced returns a Syncer which can be used to determine if the collection has synced. Once its synced, all dependencies have

--- a/pkg/kube/krt/fetch.go
+++ b/pkg/kube/krt/fetch.go
@@ -42,13 +42,13 @@ func Fetch[T any](ctx HandlerContext, cc Collection[T], opts ...FetchOption) []T
 		o(d)
 	}
 	// Important: register before we List(), so we cannot miss any events
-	h.registerDependency(d, c.Synced(), func(f erasedEventHandler) {
+	h.registerDependency(d, c.Synced(), func(f erasedEventHandler) Syncer {
 		ff := func(o []Event[T], initialSync bool) {
 			f(slices.Map(o, castEvent[T, any]), initialSync)
 		}
 		// Skip calling all the existing state for secondary dependencies, otherwise we end up with a deadlock due to
 		// rerunning the same collection's recomputation at the same time (once for the initial event, then for the initial registration).
-		c.RegisterBatch(ff, false)
+		return c.RegisterBatch(ff, false)
 	})
 
 	// Now we can do the real fetching

--- a/pkg/kube/krt/informer.go
+++ b/pkg/kube/krt/informer.go
@@ -103,15 +103,15 @@ func (i *informer[I]) RegisterBatch(f func(o []Event[I], initialSync bool), runE
 	// Informer doesn't expose a way to do that. However, due to the runtime model of informers, this isn't a dealbreaker;
 	// the handlers are all called async, so we don't end up with the same deadlocks we would have in the other collection types.
 	// While this is quite kludgy, this is an internal interface so its not too bad.
-	if !i.eventHandlers.Insert(f) {
-		i.inf.AddEventHandler(informerEventHandler[I](func(o Event[I], initialSync bool) {
-			f([]Event[I]{o}, initialSync)
-		}))
-	}
-	return pollSyncer{
+	synced := i.inf.AddEventHandler(informerEventHandler[I](func(o Event[I], initialSync bool) {
+		f([]Event[I]{o}, initialSync)
+	}))
+	base := i.Synced()
+	handler := pollSyncer{
 		name: fmt.Sprintf("%v handler", i.name()),
-		f:    i.inf.HasSynced,
+		f:    synced.HasSynced,
 	}
+	return multiSyncer{syncers: []Syncer{base, handler}}
 }
 
 // nolint: unused // (not true)
@@ -152,7 +152,7 @@ func informerEventHandler[I controllers.ComparableObject](handler func(o Event[I
 func WrapClient[I controllers.ComparableObject](c kclient.Informer[I], opts ...CollectionOption) Collection[I] {
 	o := buildCollectionOptions(opts...)
 	if o.name == "" {
-		o.name = fmt.Sprintf("NewInformer[%v]", ptr.TypeName[I]())
+		o.name = fmt.Sprintf("Informer[%v]", ptr.TypeName[I]())
 	}
 	h := &informer[I]{
 		inf:            c,
@@ -165,24 +165,15 @@ func WrapClient[I controllers.ComparableObject](c kclient.Informer[I], opts ...C
 	}
 
 	go func() {
-		// First, wait for the informer to populate
-		if !kube.WaitForCacheSync(o.name, o.stop, c.HasSynced) {
-			return
-		}
-		// Now, take all our handlers we have built up and register them...
-		handlers := h.eventHandlers.MarkInitialized()
-		for _, h := range handlers {
-			c.AddEventHandler(informerEventHandler[I](func(o Event[I], initialSync bool) {
-				h([]Event[I]{o}, initialSync)
-			}))
-		}
-		// Now wait for handlers to sync
-		if !kube.WaitForCacheSync(o.name+" handlers", o.stop, c.HasSynced) {
-			c.ShutdownHandlers()
+		defer c.ShutdownHandlers()
+		// First, wait for the informer to populate. We ignore handlers which have their own syncing
+		if !kube.WaitForCacheSync(o.name, o.stop, c.HasSyncedIgnoringHandlers) {
 			return
 		}
 		close(h.synced)
 		h.log.Infof("%v synced", h.name())
+
+		<-o.stop
 	}()
 	return h
 }

--- a/pkg/kube/krt/internal.go
+++ b/pkg/kube/krt/internal.go
@@ -87,7 +87,7 @@ type erasedEventHandler = func(o []Event[any], initialSync bool)
 // This is called from Fetch to Collections, generally.
 type registerDependency interface {
 	// Registers a dependency, returning true if it is finalized
-	registerDependency(*dependency, Syncer, func(f erasedEventHandler))
+	registerDependency(*dependency, Syncer, func(f erasedEventHandler) Syncer)
 	name() string
 }
 

--- a/pkg/kube/krt/processor.go
+++ b/pkg/kube/krt/processor.go
@@ -1,0 +1,235 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package krt
+
+import (
+	"sync"
+	"sync/atomic"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/buffer"
+
+	"istio.io/istio/pkg/slices"
+)
+
+// handlerSet tracks a set of handlers. Handlers can be added at any time.
+type handlerSet[O any] struct {
+	mu       sync.RWMutex
+	handlers []*processorListener[O]
+	wg       wait.Group
+}
+
+func (o *handlerSet[O]) Insert(f func(o []Event[O], initialSync bool), parentSynced Syncer, initialEvents []Event[O], stopCh <-chan struct{}) Syncer {
+	o.mu.Lock()
+	l := newProcessListener(f, parentSynced, stopCh)
+	o.handlers = append(o.handlers, l)
+	o.wg.Start(l.run)
+	o.wg.Start(l.pop)
+	o.mu.Unlock()
+	l.send(initialEvents, true)
+	return l.Synced()
+}
+
+func (o *handlerSet[O]) Distribute(events []Event[O], initialSync bool) {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	for _, listener := range o.handlers {
+		listener.send(slices.Clone(events), initialSync)
+	}
+}
+
+// Synced returns a Syncer that will wait for all registered handlers (at the time of the call!) are synced.
+func (o *handlerSet[O]) Synced() Syncer {
+	o.mu.RLock()
+	syncer := multiSyncer{syncers: make([]Syncer, 0, len(o.handlers))}
+	for _, listener := range o.handlers {
+		syncer.syncers = append(syncer.syncers, listener.Synced())
+	}
+	o.mu.RUnlock()
+	return syncer
+}
+
+// processorListener is a fork of the upstream Kubernetes one. It has minimal tweaks to fit into
+// our use case better, but the most important one being that processorListener is private in Kubernetes.
+//
+// processorListener relays notifications from a sharedProcessor to
+// one ResourceEventHandler --- using two goroutines, two unbuffered
+// channels, and an unbounded ring buffer.  The `add(notification)`
+// function sends the given notification to `addCh`.  One goroutine
+// runs `pop()`, which pumps notifications from `addCh` to `nextCh`
+// using storage in the ring buffer while `nextCh` is not keeping up.
+// Another goroutine runs `run()`, which receives notifications from
+// `nextCh` and synchronously invokes the appropriate handler method.
+//
+// processorListener also keeps track of the adjusted requested resync
+// period of the listener.
+type processorListener[O any] struct {
+	nextCh chan any
+	addCh  chan eventSet[O]
+	stop   <-chan struct{}
+
+	handler func(o []Event[O], initialSync bool)
+
+	syncTracker *countingTracker
+
+	// pendingNotifications is an unbounded ring buffer that holds all notifications not yet distributed.
+	// There is one per listener, but a failing/stalled listener will have infinite pendingNotifications
+	// added until we OOM.
+	// TODO: This is no worse than before, since reflectors were backed by unbounded DeltaFIFOs, but
+	// we should try to do something better.
+	pendingNotifications buffer.RingGrowing
+}
+
+func newProcessListener[O any](
+	handler func(o []Event[O], initialSync bool),
+	upstreamSyncer Syncer,
+	stop <-chan struct{},
+) *processorListener[O] {
+	bufferSize := 1024
+	ret := &processorListener[O]{
+		nextCh:               make(chan any),
+		addCh:                make(chan eventSet[O]),
+		stop:                 stop,
+		handler:              handler,
+		syncTracker:          &countingTracker{upstreamHasSynced: upstreamSyncer, synced: make(chan struct{})},
+		pendingNotifications: *buffer.NewRingGrowing(bufferSize),
+	}
+
+	return ret
+}
+
+type eventSet[O any] struct {
+	event           []Event[O]
+	isInInitialList bool
+}
+
+func (p *processorListener[O]) send(event []Event[O], isInInitialList bool) {
+	if isInInitialList {
+		// The initial sync had no items to process, so we would never call syncTracker.Finish().
+		// Just directly mark it as done here
+		if len(event) == 0 {
+			close(p.syncTracker.synced)
+			return
+		}
+		// Otherwise, mark how many items we have left to process
+		p.syncTracker.Start(len(event))
+	}
+	select {
+	case <-p.stop:
+		return
+	case p.addCh <- eventSet[O]{event: event, isInInitialList: isInInitialList}:
+	}
+}
+
+func (p *processorListener[O]) pop() {
+	defer utilruntime.HandleCrash()
+	defer close(p.nextCh) // Tell .run() to stop
+
+	var nextCh chan<- any
+	var notification any
+	for {
+		select {
+		case <-p.stop:
+			return
+		case nextCh <- notification:
+			// Notification dispatched
+			var ok bool
+			notification, ok = p.pendingNotifications.ReadOne()
+			if !ok { // Nothing to pop
+				nextCh = nil // Disable this select case
+			}
+		case notificationToAdd, ok := <-p.addCh:
+			if !ok {
+				return
+			}
+			if notification == nil { // No notification to pop (and pendingNotifications is empty)
+				// Optimize the case - skip adding to pendingNotifications
+				notification = notificationToAdd
+				nextCh = p.nextCh
+			} else { // There is already a notification waiting to be dispatched
+				p.pendingNotifications.WriteOne(notificationToAdd)
+			}
+		}
+	}
+}
+
+func (p *processorListener[O]) run() {
+	for {
+		select {
+		case <-p.stop:
+			return
+		case nextr, ok := <-p.nextCh:
+			if !ok {
+				return
+			}
+			next := nextr.(eventSet[O])
+			p.handler(next.event, next.isInInitialList)
+			if next.isInInitialList {
+				p.syncTracker.Finished(len(next.event))
+			}
+		}
+	}
+}
+
+func (p *processorListener[O]) Synced() Syncer {
+	return p.syncTracker.Synced()
+}
+
+// countingTracker helps propagate HasSynced when events are processed in
+// order (i.e. via a queue).
+type countingTracker struct {
+	count int64
+
+	upstreamHasSynced Syncer
+	synced            chan struct{}
+}
+
+// Start should be called prior to processing each key which is part of the
+// initial list.
+func (t *countingTracker) Start(count int) {
+	atomic.AddInt64(&t.count, int64(count))
+}
+
+// Finished should be called when finished processing a key which was part of
+// the initial list. You must never call Finished() before (or without) its
+// corresponding Start(), that is a logic error that could cause HasSynced to
+// return a wrong value. To help you notice this should it happen, Finished()
+// will panic if the internal counter goes negative.
+func (t *countingTracker) Finished(count int) {
+	result := atomic.AddInt64(&t.count, -int64(count))
+	if result < 0 {
+		panic("synctrack: negative counter; this logic error means HasSynced may return incorrect value")
+	}
+	if result == 0 {
+		close(t.synced)
+	}
+}
+
+// Synced returns a syncer that responds as "Synced" when the underlying collection is synced, and the
+// initial list has been processed. This relies on the source not considering
+// itself synced until *after* it has delivered the notification for the last
+// key, and that notification handler must have called Start.
+func (t *countingTracker) Synced() Syncer {
+	// Call UpstreamHasSynced first: it might take a lock, which might take
+	// a significant amount of time, and we don't want to then act on a
+	// stale count value.
+	return multiSyncer{
+		syncers: []Syncer{
+			t.upstreamHasSynced,
+			channelSyncer{synced: t.synced, name: "tracker"},
+		},
+	}
+}

--- a/pkg/kube/krt/static_test.go
+++ b/pkg/kube/krt/static_test.go
@@ -1,0 +1,38 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package krt_test
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/assert"
+)
+
+func TestStaticCollection(t *testing.T) {
+	stop := test.NewStop(t)
+	c := krt.NewStaticCollection[Named]([]Named{{"ns", "a"}}, krt.WithStop(stop))
+	assert.Equal(t, c.Synced().HasSynced(), true, "should start synced")
+	assert.Equal(t, c.List(), []Named{{"ns", "a"}})
+
+	tracker := assert.NewTracker[string](t)
+	c.RegisterBatch(BatchedTrackerHandler[Named](tracker), true)
+	tracker.WaitOrdered("add/ns/a")
+
+	tracker2 := assert.NewTracker[string](t)
+	c.RegisterBatch(BatchedTrackerHandler[Named](tracker2), true)
+	tracker2.WaitCompare(CompareUnordered("add/ns/a"))
+}

--- a/pkg/kube/krt/testing.go
+++ b/pkg/kube/krt/testing.go
@@ -24,7 +24,7 @@ type TestingDummyContext struct{}
 func (t TestingDummyContext) _internalHandler() {
 }
 
-func (t TestingDummyContext) registerDependency(d *dependency, s Syncer, f func(f erasedEventHandler)) {
+func (t TestingDummyContext) registerDependency(d *dependency, s Syncer, f func(f erasedEventHandler) Syncer) {
 }
 
 func (t TestingDummyContext) name() string {


### PR DESCRIPTION
cherrypick of https://github.com/istio/istio/pull/53994/files

Part of this was already cherrypicked in
https://github.com/istio/istio/pull/54369. This finishes it.

This is based on discussion in the WG meeting on 12/18 - the concern was that this deadlock was easy to trigger in real world environments. We were a bit worried about the risk of the backport, but ultimately decided that the pros outweighed the cons. A feature flag was seriously considered but ultimately decided against, due to the complexity to implement such a flag -- we felt the risk of imlementing the flag incorrectly was higher than the risk of not having the flag at all.

**Please provide a description of this PR:**