### PR TITLE
ra: fix ztunnel CSR validation

### DIFF
--- a/security/pkg/pki/ra/common.go
+++ b/security/pkg/pki/ra/common.go
@@ -108,6 +108,10 @@ func ValidateCSR(csrPEM []byte, subjectIDs []string) bool {
 	if err != nil {
 		return false
 	}
+	// ztunnel CSRs do not have a Subject, fill in an empty "O=" to be consistent with `GenCSRTemplate`'s behavior
+	if len(csr.Subject.Organization) == 0 {
+		csr.Subject.Organization = []string{""}
+	}
 	if !compareCSRs(csr, genCSRTemplate) {
 		return false
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**

When operating in RA mode, Istiod fails validation of CSRs from `ztunnel`. This is due to a strict check on the CSR [having to have an empty `O=` in Subject](https://github.com/istio/istio/blob/aeb416ac10571de0570294792a84c2d023895064/security/pkg/pki/util/generate_csr.go#L89-L91).

This check is introduced in https://github.com/istio/istio/pull/51966 and seems to be very specific on asserting CSRs conform to the way Sidecar issues them.

This fix solves the issue with `ztunnel` but would like to tag @jaellio on the intention of the original check and if this fix is the most appropriate way to fix.