### PR TITLE
Fix tests resources cleanup for Openshift

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -194,6 +194,9 @@ type CLIClient interface {
 	// PodLogsFollow retrieves the logs for the given pod, following until the pod log stream is interrupted
 	PodLogsFollow(ctx context.Context, podName string, podNamespace string, container string) (string, error)
 
+	// ServicesForSelector finds services matching selector.
+	ServicesForSelector(ctx context.Context, namespace string, labelSelectors ...string) (*v1.ServiceList, error)
+
 	// NewPortForwarder creates a new PortForwarder configured for the given pod. If localPort=0, a port will be
 	// dynamically selected. If localAddress is empty, "localhost" is used.
 	NewPortForwarder(podName string, ns string, localAddress string, localPort int, podPort int) (PortForwarder, error)
@@ -1022,6 +1025,12 @@ func (c *client) NewPortForwarder(podName, ns, localAddress string, localPort in
 
 func (c *client) PodsForSelector(ctx context.Context, namespace string, labelSelectors ...string) (*v1.PodList, error) {
 	return c.kube.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: strings.Join(labelSelectors, ","),
+	})
+}
+
+func (c *client) ServicesForSelector(ctx context.Context, namespace string, labelSelectors ...string) (*v1.ServiceList, error) {
+	return c.kube.CoreV1().Services(namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: strings.Join(labelSelectors, ","),
 	})
 }

--- a/pkg/test/kube/util.go
+++ b/pkg/test/kube/util.go
@@ -39,8 +39,13 @@ var (
 	ErrNoPodsFetched = fmt.Errorf("no pods fetched")
 )
 
-// PodFetchFunc fetches pods from a k8s Client.
-type PodFetchFunc func() ([]corev1.Pod, error)
+type (
+	// PodFetchFunc fetches pods from a k8s Client.
+	PodFetchFunc func() ([]corev1.Pod, error)
+
+	// SvcFetchFunc fetches services from a k8s Client.
+	SvcFetchFunc func() ([]corev1.Service, error)
+)
 
 // NewPodFetch creates a new PodFetchFunction that fetches all pods matching the namespace and label selectors.
 func NewPodFetch(a istioKube.CLIClient, namespace string, selectors ...string) PodFetchFunc {
@@ -117,6 +122,17 @@ func CheckPodsAreReady(fetchFunc PodFetchFunc) ([]corev1.Pod, error) {
 	}
 
 	return fetched, nil
+}
+
+// NewServiceFetch creates a new ServiceFetchFunction that fetches all services matching the namespace and label selectors.
+func NewServiceFetch(a istioKube.CLIClient, namespace string, selectors ...string) SvcFetchFunc {
+	return func() ([]corev1.Service, error) {
+		services, err := a.ServicesForSelector(context.TODO(), namespace, selectors...)
+		if err != nil {
+			return nil, err
+		}
+		return services.Items, nil
+	}
 }
 
 // DeleteOptionsForeground creates new delete options that will block until the operation completes.


### PR DESCRIPTION
**Please provide a description of this PR:**
Fixes: https://github.com/istio/istio/issues/54446

When test resources cleaned up in Openshift, it takes time for the "istio-ingressgateway" and "istio-egressgateway" services to be deleted.

As a result, when the resources are cleaned after one test and the next test starts, ittend to fail because the services are in deletion state and failed to be used by the next test.

Check for the services to be deleted completely before ending the test.