### PR TITLE
xds: move ResourceNames to a set

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -979,7 +979,7 @@ func (node *Proxy) Clusters() []string {
 	defer node.RUnlock()
 	wr := node.WatchedResources[v3.EndpointType]
 	if wr != nil {
-		return wr.ResourceNames
+		return wr.ResourceNames.UnsortedList()
 	}
 	return nil
 }
@@ -988,7 +988,7 @@ func (node *Proxy) NewWatchedResource(typeURL string, names []string) {
 	node.Lock()
 	defer node.Unlock()
 
-	node.WatchedResources[typeURL] = &WatchedResource{TypeUrl: typeURL, ResourceNames: names}
+	node.WatchedResources[typeURL] = &WatchedResource{TypeUrl: typeURL, ResourceNames: sets.New(names...)}
 	// For all EDS requests that we have already responded with in the same stream let us
 	// force the response. It is important to respond to those requests for Envoy to finish
 	// warming of those resources(Clusters).

--- a/pilot/pkg/networking/core/cluster.go
+++ b/pilot/pkg/networking/core/cluster.go
@@ -85,7 +85,7 @@ func (configgen *ConfigGeneratorImpl) BuildDeltaClusters(proxy *model.Proxy, upd
 	// Holds subset clusters per service, keyed by hostname.
 	subsetClusters := make(map[string]sets.String)
 
-	for _, cluster := range watched.ResourceNames {
+	for cluster := range watched.ResourceNames {
 		// WatchedResources.ResourceNames will contain the names of the clusters it is subscribed to. We can
 		// check with the name of our service (cluster names are in the format outbound|<port>|<subset>|<hostname>).
 		dir, subset, svcHost, port := model.ParseSubsetKey(cluster)

--- a/pilot/pkg/networking/core/cluster_test.go
+++ b/pilot/pkg/networking/core/cluster_test.go
@@ -3624,7 +3624,7 @@ func TestBuildDeltaClusters(t *testing.T) {
 				proxy.PrevSidecarScope.SetDestinationRulesForTesting(tc.prevConfigs)
 			}
 			clusters, removed, delta := cg.DeltaClusters(proxy, tc.configUpdated,
-				&model.WatchedResource{ResourceNames: tc.watchedResourceNames})
+				&model.WatchedResource{ResourceNames: sets.New(tc.watchedResourceNames...)})
 			if delta != tc.usedDelta {
 				t.Errorf("un expected delta, want %v got %v", tc.usedDelta, delta)
 			}

--- a/pilot/pkg/networking/grpcgen/grpcgen.go
+++ b/pilot/pkg/networking/grpcgen/grpcgen.go
@@ -56,11 +56,11 @@ func subsetClusterKey(subset, hostname string, port int) string {
 func (g *GrpcConfigGenerator) Generate(proxy *model.Proxy, w *model.WatchedResource, req *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
 	switch w.TypeUrl {
 	case v3.ListenerType:
-		return g.BuildListeners(proxy, req.Push, w.ResourceNames), model.DefaultXdsLogDetails, nil
+		return g.BuildListeners(proxy, req.Push, w.ResourceNames.UnsortedList()), model.DefaultXdsLogDetails, nil
 	case v3.ClusterType:
-		return g.BuildClusters(proxy, req.Push, w.ResourceNames), model.DefaultXdsLogDetails, nil
+		return g.BuildClusters(proxy, req.Push, w.ResourceNames.UnsortedList()), model.DefaultXdsLogDetails, nil
 	case v3.RouteType:
-		return g.BuildHTTPRoutes(proxy, req.Push, w.ResourceNames), model.DefaultXdsLogDetails, nil
+		return g.BuildHTTPRoutes(proxy, req.Push, w.ResourceNames.UnsortedList()), model.DefaultXdsLogDetails, nil
 	}
 
 	return nil, model.DefaultXdsLogDetails, nil

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -147,7 +147,7 @@ func (s *DiscoveryServer) processRequest(req *discovery.DiscoveryRequest, con *C
 	// For now, don't let xDS piggyback debug requests start watchers.
 	if strings.HasPrefix(req.TypeUrl, v3.DebugType) {
 		return s.pushXds(con,
-			&model.WatchedResource{TypeUrl: req.TypeUrl, ResourceNames: req.ResourceNames},
+			&model.WatchedResource{TypeUrl: req.TypeUrl, ResourceNames: sets.New(req.ResourceNames...)},
 			&model.PushRequest{Full: true, Push: con.proxy.LastPushContext})
 	}
 

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -520,11 +520,7 @@ func (s *DiscoveryServer) adsz(w http.ResponseWriter, req *http.Request) {
 		}
 		c.proxy.RLock()
 		for k, wr := range c.proxy.WatchedResources {
-			r := wr.ResourceNames
-			if r == nil {
-				r = []string{}
-			}
-			adsClient.Watches[k] = r
+			adsClient.Watches[k] = wr.ResourceNames.UnsortedList()
 		}
 		c.proxy.RUnlock()
 		adsClients.Connected = append(adsClients.Connected, adsClient)
@@ -948,6 +944,7 @@ func cloneProxy(proxy *model.Proxy) *model.Proxy {
 	for k, v := range proxy.WatchedResources {
 		// nolint: govet
 		v := *v
+		v.ResourceNames = v.ResourceNames.Copy()
 		out.WatchedResources[k] = &v
 	}
 	return out

--- a/pilot/pkg/xds/debuggen.go
+++ b/pilot/pkg/xds/debuggen.go
@@ -143,7 +143,7 @@ func validateProxyAuthentication(proxy *model.Proxy, w *model.WatchedResource) e
 }
 
 func parseAndValidateDebugRequest(proxy *model.Proxy, w *model.WatchedResource, dg *DebugGen) (string, error) {
-	resourceName := w.ResourceNames[0]
+	resourceName := w.ResourceNames.UnsortedList()[0]
 	u, _ := url.Parse(resourceName)
 	debugType := u.Path
 	identity := proxy.VerifiedIdentity

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -231,7 +231,7 @@ func (s *DiscoveryServer) receiveDelta(con *Connection, identities []string) {
 	}
 }
 
-func (conn *Connection) sendDelta(res *discovery.DeltaDiscoveryResponse, newResourceNames []string) error {
+func (conn *Connection) sendDelta(res *discovery.DeltaDiscoveryResponse, newResourceNames sets.String) error {
 	sendResonse := func() error {
 		start := time.Now()
 		defer func() { xds.RecordSendTime(time.Since(start)) }()
@@ -277,7 +277,7 @@ func (s *DiscoveryServer) processDeltaRequest(req *discovery.DeltaDiscoveryReque
 	}
 	if strings.HasPrefix(req.TypeUrl, v3.DebugType) {
 		return s.pushDeltaXds(con,
-			&model.WatchedResource{TypeUrl: req.TypeUrl, ResourceNames: req.ResourceNamesSubscribe},
+			&model.WatchedResource{TypeUrl: req.TypeUrl, ResourceNames: sets.New(req.ResourceNamesSubscribe...)},
 			&model.PushRequest{Full: true, Push: con.proxy.LastPushContext})
 	}
 
@@ -286,7 +286,7 @@ func (s *DiscoveryServer) processDeltaRequest(req *discovery.DeltaDiscoveryReque
 		return nil
 	}
 
-	subs, _ := deltaWatchedResources(nil, req)
+	subs, _, _ := deltaWatchedResources(nil, req)
 	request := &model.PushRequest{
 		Full:   true,
 		Push:   con.proxy.LastPushContext,
@@ -298,7 +298,7 @@ func (s *DiscoveryServer) processDeltaRequest(req *discovery.DeltaDiscoveryReque
 		Start: con.proxy.LastPushTime,
 		Delta: model.ResourceDelta{
 			// Record sub/unsub, but drop synthetic wildcard info
-			Subscribed:   sets.New(subs...),
+			Subscribed:   subs,
 			Unsubscribed: sets.New(req.ResourceNamesUnsubscribe...).Delete("*"),
 		},
 	}
@@ -388,7 +388,7 @@ func (s *DiscoveryServer) shouldRespondDelta(con *Connection, request *discovery
 			deltaLog.Debugf("ADS:%s: INIT %s %s", stype, con.ID(), request.ResponseNonce)
 		}
 
-		res, wildcard := deltaWatchedResources(nil, request)
+		res, wildcard, _ := deltaWatchedResources(nil, request)
 		con.proxy.WatchedResources[request.TypeUrl] = &model.WatchedResource{
 			TypeUrl:       request.TypeUrl,
 			ResourceNames: res,
@@ -411,26 +411,23 @@ func (s *DiscoveryServer) shouldRespondDelta(con *Connection, request *discovery
 	// In this case response_nonce is empty.
 	spontaneousReq := request.ResponseNonce == ""
 
-	var previousResources, currentResources []string
 	var alwaysRespond bool
+	var subChanged bool
 
 	// Update resource names, and record ACK if required.
 	con.proxy.UpdateWatchedResource(request.TypeUrl, func(wr *model.WatchedResource) *model.WatchedResource {
-		previousResources = wr.ResourceNames
-		currentResources, _ = deltaWatchedResources(previousResources, request)
+		wr.ResourceNames, _, subChanged = deltaWatchedResources(wr.ResourceNames, request)
 		if !spontaneousReq {
 			// Clear last error, we got an ACK.
 			// Otherwise, this is just a change in resource subscription, so leave the last ACK info in place.
 			wr.LastError = ""
 			wr.NonceAcked = request.ResponseNonce
 		}
-		wr.ResourceNames = currentResources
 		alwaysRespond = wr.AlwaysRespond
 		wr.AlwaysRespond = false
 		return wr
 	})
 
-	subChanged := !slices.EqualUnordered(previousResources, currentResources)
 	// It is invalid in the below two cases:
 	// 1. no subscribed resources change from spontaneous delta request.
 	// 2. subscribed resources changes from ACK.
@@ -454,8 +451,7 @@ func (s *DiscoveryServer) shouldRespondDelta(con *Connection, request *discovery
 		deltaLog.Debugf("ADS:%s: ACK %s %s", stype, con.ID(), request.ResponseNonce)
 		return false
 	}
-	deltaLog.Debugf("ADS:%s: RESOURCE CHANGE previous resources: %v, new resources: %v %s %s", stype,
-		previousResources, currentResources, con.ID(), request.ResponseNonce)
+	deltaLog.Debugf("ADS:%s: RESOURCE CHANGE %s %s", stype, con.ID(), request.ResponseNonce)
 
 	return true
 }
@@ -483,7 +479,7 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection, w *model.WatchedResource
 		logFiltered = " filtered:" + strconv.Itoa(len(w.ResourceNames)-len(req.Delta.Subscribed))
 		w = &model.WatchedResource{
 			TypeUrl:       w.TypeUrl,
-			ResourceNames: req.Delta.Subscribed.UnsortedList(),
+			ResourceNames: req.Delta.Subscribed,
 		}
 	}
 
@@ -514,27 +510,28 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection, w *model.WatchedResource
 		Nonce:             nonce(req.Push.PushVersion),
 		Resources:         res,
 	}
-	currentResources := slices.Map(res, func(r *discovery.Resource) string {
-		return r.Name
-	})
 	if usedDelta {
 		resp.RemovedResources = deletedRes
 	} else if req.Full {
 		// similar to sotw
-		subscribed := sets.New(w.ResourceNames...)
-		removed := subscribed.DeleteAll(currentResources...)
+		removed := w.ResourceNames.Copy()
+		for _, r := range res {
+			removed.Delete(r.Name)
+		}
 		resp.RemovedResources = sets.SortedList(removed)
 	}
-	var newResourceNames []string
+	var newResourceNames sets.String
 	if shouldSetWatchedResources(w) {
 		// Set the new watched resources. Do not write to w directly, as it can be a copy from the 'filtered' logic above
 		if usedDelta {
 			// Apply the delta
-			newResourceNames = sets.SortedList(sets.New(w.ResourceNames...).
-				DeleteAll(resp.RemovedResources...).
-				InsertAll(currentResources...))
+			newResourceNames = w.ResourceNames.Copy().
+				DeleteAll(resp.RemovedResources...)
+			for _, r := range res {
+				newResourceNames.Insert(r.Name)
+			}
 		} else {
-			newResourceNames = currentResources
+			newResourceNames = resourceNamesSet(res)
 		}
 	}
 	if neverRemoveDelta(w.TypeUrl) {
@@ -591,6 +588,12 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection, w *model.WatchedResource
 	return nil
 }
 
+func resourceNamesSet(res model.Resources) sets.Set[string] {
+	return sets.New(slices.Map(res, func(r *discovery.Resource) string {
+		return r.Name
+	})...)
+}
+
 // requiresResourceNamesModification checks if a generator needs mutable access to w.ResourceNames.
 // This is used when resources are spontaneously pushed during Delta XDS
 func requiresResourceNamesModification(url string) bool {
@@ -635,15 +638,29 @@ func deltaToSotwRequest(request *discovery.DeltaDiscoveryRequest) *discovery.Dis
 }
 
 // deltaWatchedResources returns current watched resources of delta xds
-func deltaWatchedResources(existing []string, request *discovery.DeltaDiscoveryRequest) ([]string, bool) {
-	res := sets.New(existing...)
-	res.InsertAll(request.ResourceNamesSubscribe...)
+func deltaWatchedResources(existing sets.String, request *discovery.DeltaDiscoveryRequest) (sets.String, bool, bool) {
+	res := existing
+	if res == nil {
+		res = sets.New[string]()
+	}
+	changed := false
+	for _, r := range request.ResourceNamesSubscribe {
+		if !res.InsertContains(r) {
+			changed = true
+		}
+	}
 	// This is set by Envoy on first request on reconnection so that we are aware of what Envoy knows
 	// and can continue the xDS session properly.
-	for k := range request.InitialResourceVersions {
-		res.Insert(k)
+	for r := range request.InitialResourceVersions {
+		if !res.InsertContains(r) {
+			changed = true
+		}
 	}
-	res.DeleteAll(request.ResourceNamesUnsubscribe...)
+	for _, r := range request.ResourceNamesUnsubscribe {
+		if !res.DeleteContains(r) {
+			changed = true
+		}
+	}
 	wildcard := false
 	// A request is wildcard if they explicitly subscribe to "*" or subscribe to nothing
 	if res.Contains("*") {
@@ -658,5 +675,5 @@ func deltaWatchedResources(existing []string, request *discovery.DeltaDiscoveryR
 	if len(request.ResourceNamesSubscribe) == 0 {
 		wildcard = true
 	}
-	return res.UnsortedList(), wildcard
+	return res, wildcard, changed
 }

--- a/pilot/pkg/xds/delta_test.go
+++ b/pilot/pkg/xds/delta_test.go
@@ -21,6 +21,7 @@ import (
 
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pilot/test/xds"
@@ -327,6 +328,10 @@ func TestDeltaReconnectRequests(t *testing.T) {
 	if resn := sets.New(res.RemovedResources...); !resn.Contains(updateCluster) {
 		t.Fatalf("unexpected remove resources: %v", resn)
 	}
+}
+
+func init() {
+	features.EnableAmbient = true
 }
 
 func TestDeltaWDS(t *testing.T) {

--- a/pilot/pkg/xds/deltatest.go
+++ b/pilot/pkg/xds/deltatest.go
@@ -59,7 +59,7 @@ func (s *DiscoveryServer) compareDiff(
 	newByName := slices.GroupUnique(sotwRes, (*discovery.Resource).GetName)
 	curByName := slices.GroupUnique(current, (*discovery.Resource).GetName)
 
-	watched := sets.New(w.ResourceNames...)
+	watched := w.ResourceNames
 
 	details := fmt.Sprintf("last:%v sotw:%v delta:%v-%v", len(current), len(sotwRes), len(deltaRes), len(deleted))
 	wantDeleted := sets.New[string]()

--- a/pilot/pkg/xds/ecds.go
+++ b/pilot/pkg/xds/ecds.go
@@ -123,7 +123,7 @@ func (e *EcdsGenerator) Generate(proxy *model.Proxy, w *model.WatchedResource, r
 		}
 	}
 
-	ec := e.ConfigGenerator.BuildExtensionConfiguration(proxy, req.Push, w.ResourceNames, secrets)
+	ec := e.ConfigGenerator.BuildExtensionConfiguration(proxy, req.Push, w.ResourceNames.UnsortedList(), secrets)
 
 	if ec == nil {
 		return nil, model.DefaultXdsLogDetails, nil
@@ -164,13 +164,12 @@ func (e *EcdsGenerator) SetCredController(creds credscontroller.MulticlusterCont
 	e.secretController = creds
 }
 
-func referencedSecrets(proxy *model.Proxy, push *model.PushContext, resourceNames []string) []SecretResource {
+func referencedSecrets(proxy *model.Proxy, push *model.PushContext, watched sets.String) []SecretResource {
 	// The requirement for the Wasm pull secret:
 	// * Wasm pull secrets must be of type `kubernetes.io/dockerconfigjson`.
 	// * Secret are referenced by a WasmPlugin which applies to this proxy.
 	// TODO: we get the WasmPlugins here to get the secrets reference in order to decide whether ECDS push is needed,
 	//       and we will get it again at extension config build. Avoid getting it twice if this becomes a problem.
-	watched := sets.New(resourceNames...)
 	wasmPlugins := push.WasmPlugins(proxy)
 	referencedSecrets := sets.String{}
 	for _, wps := range wasmPlugins {

--- a/pilot/pkg/xds/ecds_test.go
+++ b/pilot/pkg/xds/ecds_test.go
@@ -286,7 +286,7 @@ func TestECDSGenerate(t *testing.T) {
 			tt.request.Push = s.PushContext()
 			tt.request.Push.Mesh.RootNamespace = "istio-system"
 			resources, _, _ := gen.Generate(s.SetupProxy(proxy),
-				&model.WatchedResource{ResourceNames: tt.watchedResources}, tt.request)
+				&model.WatchedResource{ResourceNames: sets.New(tt.watchedResources...)}, tt.request)
 			gotExtensions := sets.String{}
 			gotSecrets := sets.String{}
 			for _, res := range resources {

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -193,7 +193,7 @@ func (eds *EdsGenerator) buildEndpoints(proxy *model.Proxy,
 	empty := 0
 	cached := 0
 	regenerated := 0
-	for _, clusterName := range w.ResourceNames {
+	for clusterName := range w.ResourceNames {
 		if edsUpdatedServices != nil {
 			if _, ok := edsUpdatedServices[model.ParseSubsetKeyHostname(clusterName)]; !ok {
 				// Cluster was not updated, skip recomputing. This happens when we get an incremental update for a
@@ -250,7 +250,7 @@ func (eds *EdsGenerator) buildDeltaEndpoints(proxy *model.Proxy,
 	cached := 0
 	regenerated := 0
 
-	for _, clusterName := range w.ResourceNames {
+	for clusterName := range w.ResourceNames {
 		// filter out eds that are not updated for clusters
 		if _, ok := edsUpdatedServices[model.ParseSubsetKeyHostname(clusterName)]; !ok {
 			continue

--- a/pilot/pkg/xds/nds_test.go
+++ b/pilot/pkg/xds/nds_test.go
@@ -31,6 +31,7 @@ import (
 	"istio.io/istio/pkg/config/constants"
 	dnsProto "istio.io/istio/pkg/dns/proto"
 	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/util/sets"
 )
 
 func TestNDS(t *testing.T) {
@@ -152,7 +153,7 @@ func TestGenerate(t *testing.T) {
 
 			gen := s.Discovery.Generators[v3.NameTableType]
 			tt.request.Start = time.Now()
-			nametable, _, _ := gen.Generate(s.SetupProxy(tt.proxy), &model.WatchedResource{ResourceNames: tt.resources}, tt.request)
+			nametable, _, _ := gen.Generate(s.SetupProxy(tt.proxy), &model.WatchedResource{ResourceNames: sets.New(tt.resources...)}, tt.request)
 			if len(tt.nameTable) == 0 {
 				if len(nametable) != 0 {
 					t.Errorf("unexpected nametable. want: %v, got: %v", tt.nameTable, nametable)

--- a/pilot/pkg/xds/rds.go
+++ b/pilot/pkg/xds/rds.go
@@ -69,6 +69,6 @@ func (c RdsGenerator) Generate(proxy *model.Proxy, w *model.WatchedResource, req
 	if !rdsNeedsPush(req, proxy) {
 		return nil, model.DefaultXdsLogDetails, nil
 	}
-	resources, logDetails := c.ConfigGenerator.BuildHTTPRoutes(proxy, req, w.ResourceNames)
+	resources, logDetails := c.ConfigGenerator.BuildHTTPRoutes(proxy, req, w.ResourceNames.UnsortedList())
 	return resources, logDetails, nil
 }

--- a/pilot/pkg/xds/sds.go
+++ b/pilot/pkg/xds/sds.go
@@ -136,7 +136,7 @@ func (s *SecretGen) Generate(proxy *model.Proxy, w *model.WatchedResource, req *
 	// Filter down to resources we can access. We do not return an error if they attempt to access a Secret
 	// they cannot; instead we just exclude it. This ensures that a single bad reference does not break the whole
 	// SDS flow. The pilotSDSCertificateErrors metric and logs handle visibility into invalid references.
-	resources := filterAuthorizedResources(s.parseResources(w.ResourceNames, proxy), proxy, proxyClusterSecrets)
+	resources := filterAuthorizedResources(s.parseResources(w.ResourceNames.UnsortedList(), proxy), proxy, proxyClusterSecrets)
 
 	var results model.Resources
 	cached, regenerated := 0, 0

--- a/pilot/pkg/xds/statusgen.go
+++ b/pilot/pkg/xds/statusgen.go
@@ -89,7 +89,7 @@ func (sg *StatusGen) handleInternalRequest(_ *model.Proxy, w *model.WatchedResou
 			break
 		}
 		var err error
-		dumpRes, err := sg.debugConfigDump(w.ResourceNames[0])
+		dumpRes, err := sg.debugConfigDump(w.ResourceNames.UnsortedList()[0])
 		if err != nil {
 			log.Infof("%s failed: %v", TypeDebugConfigDump, err)
 			break

--- a/pilot/pkg/xds/workload.go
+++ b/pilot/pkg/xds/workload.go
@@ -52,7 +52,7 @@ func (e WorkloadGenerator) GenerateDeltas(
 		return nil, nil, model.XdsLogDetails{}, false, nil
 	}
 
-	subs := sets.New(w.ResourceNames...)
+	subs := w.ResourceNames
 	var addresses sets.String
 	if isReq {
 		// this is from request, we only send response for the subscribed address
@@ -142,11 +142,11 @@ func (e WorkloadGenerator) GenerateDeltas(
 	if !w.Wildcard {
 		// For on-demand, we may have requested a VIP but gotten Pod IPs back. We need to update
 		// the internal book-keeping to subscribe to the Pods, so that we push updates to those Pods.
-		w.ResourceNames = subs.Merge(have).UnsortedList()
+		w.ResourceNames = subs.Merge(have)
 	} else {
 		// For wildcard, we record all resources that have been pushed and not removed
 		// It was to correctly calculate removed resources during full push alongside with specific address removed.
-		w.ResourceNames = subs.Merge(have).Difference(removed).UnsortedList()
+		w.ResourceNames = subs.Merge(have).DeleteAllSet(removed)
 	}
 	return resources, removed.UnsortedList(), model.XdsLogDetails{}, true, nil
 }
@@ -184,7 +184,7 @@ func (e WorkloadRBACGenerator) GenerateDeltas(
 		}
 	} else {
 		// Full update, expect everything
-		expected.InsertAll(w.ResourceNames...)
+		expected.Merge(w.ResourceNames)
 	}
 
 	resources := make(model.Resources, 0)

--- a/pilot/pkg/xds/workload_test.go
+++ b/pilot/pkg/xds/workload_test.go
@@ -253,6 +253,7 @@ func TestWorkload(t *testing.T) {
 		expect(ads.ExpectResponse(), "Kubernetes//Pod/default/pod4")
 	})
 	t.Run("wildcard", func(t *testing.T) {
+		log.FindScope("delta").SetOutputLevel(log.DebugLevel)
 		expect := buildExpect(t)
 		expectRemoved := buildExpectExpectRemoved(t)
 		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{

--- a/pilot/pkg/xds/xdsgen.go
+++ b/pilot/pkg/xds/xdsgen.go
@@ -114,7 +114,7 @@ func (s *DiscoveryServer) pushXds(con *Connection, w *model.WatchedResource, req
 		logFiltered = " filtered:" + strconv.Itoa(len(w.ResourceNames)-len(req.Delta.Subscribed))
 		w = &model.WatchedResource{
 			TypeUrl:       w.TypeUrl,
-			ResourceNames: req.Delta.Subscribed.UnsortedList(),
+			ResourceNames: req.Delta.Subscribed,
 		}
 	}
 	res, logdata, err := gen.Generate(con.proxy, w, req)

--- a/pkg/util/sets/set.go
+++ b/pkg/util/sets/set.go
@@ -65,6 +65,15 @@ func (s Set[T]) DeleteAll(items ...T) Set[T] {
 	return s
 }
 
+// DeleteAllSet removes items from the set.
+// Note: this differs from Difference() as this is in-place
+func (s Set[T]) DeleteAllSet(other Set[T]) Set[T] {
+	for item := range other {
+		delete(s, item)
+	}
+	return s
+}
+
 // Merge a set of objects that are in s2 into s
 // For example:
 // s = {a1, a2, a3}
@@ -217,6 +226,20 @@ func (s Set[T]) InsertContains(item T) bool {
 	}
 	s[item] = struct{}{}
 	return false
+}
+
+// DeleteContains deletes the item from the set and returns if it was already present.
+// Example:
+//
+//	if !set.DeleteContains(item) {
+//		fmt.Println("item was not in the set", item)
+//	}
+func (s Set[T]) DeleteContains(item T) bool {
+	if !s.Contains(item) {
+		return false
+	}
+	delete(s, item)
+	return true
 }
 
 // Contains returns whether the given item is in the set.

--- a/pkg/xds/server_test.go
+++ b/pkg/xds/server_test.go
@@ -20,6 +20,7 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
 	"istio.io/istio/pkg/model"
+	"istio.io/istio/pkg/util/sets"
 )
 
 type TestProxy struct {
@@ -35,7 +36,7 @@ func (p *TestProxy) GetWatchedResource(url string) *WatchedResource {
 }
 
 func (p *TestProxy) NewWatchedResource(url string, names []string) {
-	p.WatchedResources[url] = &WatchedResource{ResourceNames: names}
+	p.WatchedResources[url] = &WatchedResource{ResourceNames: sets.New(names...)}
 }
 
 func (p *TestProxy) UpdateWatchedResource(url string, f func(*WatchedResource) *WatchedResource) {
@@ -86,7 +87,7 @@ func TestShouldRespond(t *testing.T) {
 					model.EndpointType: {
 						NonceSent:     "nonce",
 						AlwaysRespond: true,
-						ResourceNames: []string{"my-resource"},
+						ResourceNames: sets.New("my-resource"),
 					},
 				},
 			},
@@ -132,7 +133,7 @@ func TestShouldRespond(t *testing.T) {
 				WatchedResources: map[string]*WatchedResource{
 					model.EndpointType: {
 						NonceSent:     "nonce",
-						ResourceNames: []string{"cluster1"},
+						ResourceNames: sets.New("cluster1"),
 					},
 				},
 			},
@@ -150,7 +151,7 @@ func TestShouldRespond(t *testing.T) {
 				WatchedResources: map[string]*WatchedResource{
 					model.EndpointType: {
 						NonceSent:     "nonce",
-						ResourceNames: []string{"cluster2", "cluster1"},
+						ResourceNames: sets.New("cluster2", "cluster1"),
 					},
 				},
 			},
@@ -168,7 +169,7 @@ func TestShouldRespond(t *testing.T) {
 				WatchedResources: map[string]*WatchedResource{
 					model.EndpointType: {
 						NonceSent:     "nonce",
-						ResourceNames: []string{"cluster2", "cluster1"},
+						ResourceNames: sets.New("cluster2", "cluster1"),
 					},
 				},
 			},

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -42,6 +42,7 @@ import (
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/model"
 	"istio.io/istio/pkg/security"
+	"istio.io/istio/pkg/util/sets"
 	"istio.io/istio/pkg/xds"
 )
 
@@ -213,7 +214,7 @@ func (w *Watch) GetWatchedResource(string) *xds.WatchedResource {
 func (w *Watch) NewWatchedResource(typeURL string, names []string) {
 	w.Lock()
 	defer w.Unlock()
-	w.watch = &xds.WatchedResource{TypeUrl: typeURL, ResourceNames: names}
+	w.watch = &xds.WatchedResource{TypeUrl: typeURL, ResourceNames: sets.New(names...)}
 }
 
 func (w *Watch) UpdateWatchedResource(_ string, f func(*xds.WatchedResource) *xds.WatchedResource) {
@@ -231,11 +232,7 @@ func (w *Watch) requested(secretName string) bool {
 	w.Lock()
 	defer w.Unlock()
 	if w.watch != nil {
-		for _, res := range w.watch.ResourceNames {
-			if res == secretName {
-				return true
-			}
-		}
+		return w.watch.ResourceNames.Contains(secretName)
 	}
 	return false
 }


### PR DESCRIPTION
The `watchedResource.ResourceNames` field contains the set of all resources watched by a proxy. Today, this is stored as a `[]string`.

This field is used exclusively as a set through Istio. It has no ordering semantics, and is regularly converting into a set (and from a set), in a variety of places, such as `slices.EqualUnordered` and various places where we try to insert/delete resources by name, do merge/union/difference operations, and more.

This PR officially moves the usage over to actually be a set.

Primary changes beyond the superficial compilation fixes:
* `deltaWatchedResources` - before, we build a new resource set and then diff it. Now, we modify-in-place the resource set, and mark if we ever changed it.
* Workload generator -- massive performance wins by modifying set in place vs copy-modify-serialize
* Race conditions with a map vs a list are more serious. **Its a bug in either case** but can panic for maps. This PR builds on https://github.com/istio/istio/pull/54463 which fixes a variety of pre-existing race conditions and adds tests.

Below is a picture of a test of 10k pods in ambient mode. Before vs after this PR:

![2024-12-20_13-21-13](https://github.com/user-attachments/assets/92ae6a38-96c6-4fbf-b7ce-1bcab10385e1)

(Note: while above is a simulated test I setup, the pprof from my test and a real users production report are ~identical, so I think its very realistic)