### PR TITLE
Push authorization before workload

### DIFF
--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -503,9 +503,9 @@ var PushOrder = []string{
 	v3.ListenerType,
 	v3.RouteType,
 	v3.SecretType,
+	v3.WorkloadAuthorizationType,
 	v3.AddressType,
 	v3.WorkloadType,
-	v3.WorkloadAuthorizationType,
 }
 
 // KnownOrderedTypeUrls has typeUrls for which we know the order of push.


### PR DESCRIPTION
**Please provide a description of this PR:**


Suggest Push authorization before workload, because authz is referenced by workload.  if workload is pushed later, ztunnel may not get it when workload is received, especially at the initial time.

So the initial request to a workload may miss the authz policy, that is dangerous
