### PR TITLE
feat: introduce matchExpression syntax subset filtering

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module istio.io/istio
 
 go 1.23.0
 
+replace istio.io/api v1.24.0-alpha.0.0.20241217180900-c363ca75e894 => /Users/shulin/Development/api
+
 require (
 	cloud.google.com/go/compute/metadata v0.6.0
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6

--- a/pilot/pkg/config/kube/gateway/context.go
+++ b/pilot/pkg/config/kube/gateway/context.go
@@ -85,7 +85,7 @@ func (gc GatewayContext) ResolveGatewayInstances(
 		}
 		svcKey := svc.Key()
 		for port := range ports {
-			instances := gc.ps.ServiceEndpointsByPort(svc, port, nil)
+			instances := gc.ps.ServiceEndpointsByPort(svc, port, nil, nil)
 			if len(instances) > 0 {
 				foundInternal.Insert(fmt.Sprintf("%s:%d", g, port))
 				dummyProxy := &model.Proxy{Metadata: &model.NodeMetadata{ClusterID: gc.cluster}}

--- a/pilot/pkg/networking/core/listener.go
+++ b/pilot/pkg/networking/core/listener.go
@@ -484,7 +484,7 @@ func (lb *ListenerBuilder) buildSidecarOutboundListeners(node *model.Proxy,
 					// wildcard route match to get to the appropriate IP through original dst clusters.
 					if bind.Primary() == "" && service.Resolution == model.Passthrough &&
 						saddress == constants.UnspecifiedIP && (servicePort.Protocol.IsTCP() || servicePort.Protocol.IsUnsupported()) {
-						instances := push.ServiceEndpointsByPort(service, servicePort.Port, nil)
+						instances := push.ServiceEndpointsByPort(service, servicePort.Port, nil, nil)
 						if service.Attributes.ServiceRegistry != provider.Kubernetes && len(instances) == 0 && service.Attributes.LabelSelectors == nil {
 							// A Kubernetes service with no endpoints means there are no endpoints at
 							// all, so don't bother sending, as traffic will never work. If we did

--- a/pkg/config/labels/instance.go
+++ b/pkg/config/labels/instance.go
@@ -56,6 +56,17 @@ var (
 // have labels name=kittyCat,region=us-east.
 type Instance map[string]string
 
+// Has returns whether the provided label exists in the map.
+func (i Instance) Has(label string) bool {
+	_, exists := i[label]
+	return exists
+}
+
+// Get returns the value in the map for the provided label.
+func (i Instance) Get(label string) string {
+	return i[label]
+}
+
 // SubsetOf is true if the label has same values for the keys
 func (i Instance) SubsetOf(that Instance) bool {
 	if len(i) == 0 {

--- a/pkg/dns/server/name_table.go
+++ b/pkg/dns/server/name_table.go
@@ -62,7 +62,7 @@ func BuildNameTable(cfg Config) *dnsProto.NameTable {
 				// The IP will be unspecified here if its headless service or if the auto
 				// IP allocation logic for service entry was unable to allocate an IP.
 				if svc.Resolution == model.Passthrough && len(svc.Ports) > 0 {
-					for _, instance := range cfg.Push.ServiceEndpointsByPort(svc, svc.Ports[0].Port, nil) {
+					for _, instance := range cfg.Push.ServiceEndpointsByPort(svc, svc.Ports[0].Port, nil, nil) {
 						// addresses may be empty or invalid here
 						isValidInstance := true
 						for _, addr := range instance.Addresses {

--- a/pkg/kube/namespace/filter.go
+++ b/pkg/kube/namespace/filter.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"sync"
 
+	selectorpb "istio.io/api/type/v1beta1"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -150,6 +152,47 @@ func extractObjectNamespace(obj any) (string, bool) {
 }
 
 func LabelSelectorAsSelector(ps *meshapi.LabelSelector) (labels.Selector, error) {
+	if ps == nil {
+		return labels.Nothing(), nil
+	}
+	if len(ps.MatchLabels)+len(ps.MatchExpressions) == 0 {
+		return labels.Everything(), nil
+	}
+	requirements := make([]labels.Requirement, 0, len(ps.MatchLabels)+len(ps.MatchExpressions))
+	for k, v := range ps.MatchLabels {
+		r, err := labels.NewRequirement(k, selection.Equals, []string{v})
+		if err != nil {
+			return nil, err
+		}
+		requirements = append(requirements, *r)
+	}
+	for _, expr := range ps.MatchExpressions {
+		var op selection.Operator
+		switch metav1.LabelSelectorOperator(expr.Operator) {
+		case metav1.LabelSelectorOpIn:
+			op = selection.In
+		case metav1.LabelSelectorOpNotIn:
+			op = selection.NotIn
+		case metav1.LabelSelectorOpExists:
+			op = selection.Exists
+		case metav1.LabelSelectorOpDoesNotExist:
+			op = selection.DoesNotExist
+		default:
+			return nil, fmt.Errorf("%q is not a valid label selector operator", expr.Operator)
+		}
+		r, err := labels.NewRequirement(expr.Key, op, append([]string(nil), expr.Values...))
+		if err != nil {
+			return nil, err
+		}
+		requirements = append(requirements, *r)
+	}
+	selector := labels.NewSelector()
+	selector = selector.Add(requirements...)
+	return selector, nil
+}
+
+// same as above, pre-merge of the LabelSelector proto
+func LabelSelectorSelectorPbAsSelector(ps *selectorpb.LabelSelector) (labels.Selector, error) {
 	if ps == nil {
 		return labels.Nothing(), nil
 	}

--- a/tests/testdata/config/destination-rule-subsets.yaml
+++ b/tests/testdata/config/destination-rule-subsets.yaml
@@ -1,0 +1,59 @@
+# Attempt to use all possible fields in DestinationRule
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: subset
+  namespace: testns
+spec:
+  hosts:
+    - subset.default.svc.cluster.local
+  ports:
+    - number: 81
+      name: http
+      protocol: HTTP
+  resolution: STATIC
+  endpoints:
+    - address: 127.0.0.2
+      labels:
+        numtype: even
+        version: a
+      ports:
+        http: 7072
+    - address: 127.0.0.3
+      labels:
+        numtype: odd
+        version: a
+      ports:
+        http: 7072
+    - address: 127.0.0.4
+      labels:
+        numtype: even
+        version: b
+      ports:
+        http: 7072
+---
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: subset
+  namespace: testns
+spec:
+  host: subset.default.svc.cluster.local
+  trafficPolicy:
+    loadBalancer:
+      simple: ROUND_ROBIN
+    tls:
+      mode: DISABLE
+  subsets:
+    - name: evens
+      labels:
+        numtype: even
+    - name: odds
+      labels:
+        numtype: odd
+    - name: notodds
+      selector:
+        matchExpressions:
+          - { key: numtype, operator: NotIn, values: [ odd ] }
+          - { key: version, operator: In, values: [ a ] }
+---


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR implements the feature proposed in https://docs.google.com/document/d/1ai7uMAx4xd6mevtzrbMgkI4x9Zwqjb50zu_68pXNz_k/edit?tab=t.0

I have initially marked this PR as a draft because I have a few questions
- currently there already exists a matchExpression in the mesh proto (config.proto) but depending on it in the DestinationRule proto will introduce a cycle. Should I refactor everything and move that matchExpression somewhere more sharable? if so, is there a location that is preferred? There's also a helper function `labelSelectorAsSelector` that can be shared if the proto is the same.
- I know there's a few other places where subset is used, for example istioctl. Should I make non-endpoint builder specific  changes part of this PR or a separate one?

```
☁  api [master] ⚡  make gen
./clean.sh
./gen.sh
mesh/v1alpha1/config.proto:21:8:cycle found in imports: "mesh/v1alpha1/config.proto" -> "networking/v1alpha3/destination_rule.proto" -> "mesh/v1alpha1/config.proto"
mesh/v1alpha1/proxy.proto:19:8:cycle found in imports: "mesh/v1alpha1/proxy.proto" -> "networking/v1alpha3/destination_rule.proto" -> "mesh/v1alpha1/config.proto" -> "mesh/v1alpha1/proxy.proto"
make[1]: *** [Makefile.core.mk:34: gen-proto] Error 100
make: *** [gen] Error 2
```
Some design decisions, please feel free to challenge:
- existing labels selector will override match expression. So if label: is defined, then selector: will be ignored. Currently there's no error for this, would an error or warning be preferred?
- to keep existing behavior in kubernetes matchexpression, the label matching portion of that config is still kept, so the user might have the option to either use `labels:` or use `selector:`

related api change: https://github.com/istio/api/pull/3397

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
