### PR TITLE
ambient: support `istio.io/ingress-use-waypoint` at the namespace level

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1001,8 +1001,9 @@ func (i AddressInfo) ResourceName() string {
 }
 
 type ServiceWaypointInfo struct {
-	Service          *workloadapi.Service
-	WaypointHostname string
+	Service            *workloadapi.Service
+	IngressUseWaypoint bool
+	WaypointHostname   string
 }
 
 type TypedObject struct {
@@ -1115,7 +1116,10 @@ type StatusMessage struct {
 }
 
 func (i WaypointBindingStatus) Equals(other WaypointBindingStatus) bool {
-	return i.ResourceName == other.ResourceName && i.IngressUseWaypoint == other.IngressUseWaypoint && ptr.Equal(i.Error, other.Error)
+	return i.ResourceName == other.ResourceName &&
+		i.IngressUseWaypoint == other.IngressUseWaypoint &&
+		i.IngressLabelPresent == other.IngressLabelPresent &&
+		ptr.Equal(i.Error, other.Error)
 }
 
 func (i ServiceInfo) NamespacedName() types.NamespacedName {
@@ -1368,6 +1372,19 @@ func SortWorkloadsByCreationTime(workloads []WorkloadInfo) []WorkloadInfo {
 		return workloads[i].CreationTime.Before(workloads[j].CreationTime)
 	})
 	return workloads
+}
+
+type NamespaceInfo struct {
+	Name               string
+	IngressUseWaypoint bool
+}
+
+func (i NamespaceInfo) ResourceName() string {
+	return i.Name
+}
+
+func (i NamespaceInfo) Equals(other NamespaceInfo) bool {
+	return i == other
 }
 
 // MCSServiceInfo combines the name of a service with a particular Kubernetes cluster. This

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/sidecar_interop.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/sidecar_interop.go
@@ -58,7 +58,7 @@ func RegisterEdsShim(
 	ServiceEds := krt.NewCollection(
 		Services,
 		func(ctx krt.HandlerContext, svc model.ServiceInfo) *serviceEDS {
-			useWaypoint := ingressUseWaypoint(svc, krt.FetchOne(ctx, Namespaces, krt.FilterKey(svc.Namespace)))
+			useWaypoint := ingressUseWaypoint(svc, krt.FetchOne(ctx, Namespaces, krt.FilterKey(svc.Service.Namespace)))
 			if !useWaypoint {
 				// Currently, we only need this for ingres -> waypoint usage
 				// If we extend this to sidecars, etc we can drop this.
@@ -114,7 +114,7 @@ func (a *index) ServicesWithWaypoint(key string) []model.ServiceWaypointInfo {
 	}
 	for _, s := range svcs {
 		wp := s.Service.GetWaypoint()
-		useWaypoint := ingressUseWaypoint(s, a.namespaces.GetKey(s.Namespace))
+		useWaypoint := ingressUseWaypoint(s, a.namespaces.GetKey(s.Service.Namespace))
 		wi := model.ServiceWaypointInfo{
 			Service:            s.Service,
 			IngressUseWaypoint: useWaypoint,

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/sidecar_interop.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/sidecar_interop.go
@@ -33,6 +33,7 @@ import (
 type serviceEDS struct {
 	ServiceKey       string
 	WaypointInstance []*workloadapi.Workload
+	UseWaypoint      bool
 }
 
 func (w serviceEDS) ResourceName() string {
@@ -48,6 +49,7 @@ func (w serviceEDS) ResourceName() string {
 func RegisterEdsShim(
 	xdsUpdater model.XDSUpdater,
 	Workloads krt.Collection[model.WorkloadInfo],
+	Namespaces krt.Collection[model.NamespaceInfo],
 	WorkloadsByServiceKey krt.Index[string, model.WorkloadInfo],
 	Services krt.Collection[model.ServiceInfo],
 	ServicesByAddress krt.Index[networkAddress, model.ServiceInfo],
@@ -56,7 +58,8 @@ func RegisterEdsShim(
 	ServiceEds := krt.NewCollection(
 		Services,
 		func(ctx krt.HandlerContext, svc model.ServiceInfo) *serviceEDS {
-			if !svc.Waypoint.IngressUseWaypoint {
+			useWaypoint := ingressUseWaypoint(svc, krt.FetchOne(ctx, Namespaces, krt.FilterKey(svc.Namespace)))
+			if !useWaypoint {
 				// Currently, we only need this for ingres -> waypoint usage
 				// If we extend this to sidecars, etc we can drop this.
 				return nil
@@ -86,7 +89,8 @@ func RegisterEdsShim(
 			}
 			workloads := krt.Fetch(ctx, Workloads, krt.FilterIndex(WorkloadsByServiceKey, waypointServiceKey))
 			return &serviceEDS{
-				ServiceKey: svc.ResourceName(),
+				ServiceKey:  svc.ResourceName(),
+				UseWaypoint: useWaypoint,
 				WaypointInstance: slices.Map(workloads, func(e model.WorkloadInfo) *workloadapi.Workload {
 					return e.Workload
 				}),
@@ -110,8 +114,10 @@ func (a *index) ServicesWithWaypoint(key string) []model.ServiceWaypointInfo {
 	}
 	for _, s := range svcs {
 		wp := s.Service.GetWaypoint()
+		useWaypoint := ingressUseWaypoint(s, a.namespaces.GetKey(s.Namespace))
 		wi := model.ServiceWaypointInfo{
-			Service: s.Service,
+			Service:            s.Service,
+			IngressUseWaypoint: useWaypoint,
 		}
 		if wp == nil {
 			continue
@@ -137,4 +143,14 @@ func (a *index) ServicesWithWaypoint(key string) []model.ServiceWaypointInfo {
 		res = append(res, wi)
 	}
 	return res
+}
+
+func ingressUseWaypoint(s model.ServiceInfo, ns *model.NamespaceInfo) bool {
+	if s.Waypoint.IngressLabelPresent {
+		return s.Waypoint.IngressUseWaypoint
+	}
+	if ns != nil {
+		return ns.IngressUseWaypoint
+	}
+	return false
 }

--- a/pilot/pkg/xds/endpoints/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder.go
@@ -830,14 +830,11 @@ func getSubSetLabels(dr *v1alpha3.DestinationRule, subsetName string) labels.Ins
 }
 
 // For services that have a waypoint, we want to send to the waypoints rather than the service endpoints.
-// Lookup the
+// Lookup the service, find its waypoint, then find the waypoint's endpoints.
 func (b *EndpointBuilder) findServiceWaypoint(endpointIndex *model.EndpointIndex) ([]*model.IstioEndpoint, bool) {
+	// Currently we only support routers (gateways)
 	if b.nodeType != model.Router {
 		// Currently only ingress will call waypoints
-		return nil, false
-	}
-	// ...and they must explicitly opt in
-	if b.service.Attributes.Labels["istio.io/ingress-use-waypoint"] != "true" {
 		return nil, false
 	}
 	if b.service.GetAddressForProxy(b.proxy) == constants.UnspecifiedIP {
@@ -854,6 +851,10 @@ func (b *EndpointBuilder) findServiceWaypoint(endpointIndex *model.EndpointIndex
 		log.Warnf("unexpected multiple waypoint services for %v", b.clusterName)
 	}
 	svc := svcs[0]
+	// They need to explicitly opt-in on the service to send from ingress -> waypoint
+	if !svc.IngressUseWaypoint {
+		return nil, false
+	}
 	waypointClusterName := model.BuildSubsetKey(
 		model.TrafficDirectionOutbound,
 		"",

--- a/releasenotes/notes/ingress-use-waypoint-namespace.yaml
+++ b/releasenotes/notes/ingress-use-waypoint-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+  - |
+    **Added** support for configuring the `istio.io/ingress-use-waypoint` label at the namespace level.


### PR DESCRIPTION
This adds consistency between `use-waypoint` and `ingress-use-waypoint`
