### PR TITLE
Telemetry test: handle multiple paths in KUBECONFIG 

### DIFF
--- a/tests/integration/telemetry/api/setup_test.go
+++ b/tests/integration/telemetry/api/setup_test.go
@@ -172,7 +172,7 @@ func IsKindCluster() (bool, error) {
 		config, err := clientcmd.LoadFromFile(kc)
 		if err != nil {
 			if os.IsNotExist(err) {
-				fmt.Print("kubeconfig file not found: %s", kc)
+				fmt.Printf("kubeconfig file not found: %s", kc)
 				continue
 			}
 			return false, err

--- a/tests/integration/telemetry/api/setup_test.go
+++ b/tests/integration/telemetry/api/setup_test.go
@@ -172,7 +172,7 @@ func IsKindCluster() (bool, error) {
 		config, err := clientcmd.LoadFromFile(kc)
 		if err != nil {
 			if os.IsNotExist(err) {
-				fmt.Errorf("kubeconfig file not found: %s", kubeconfig)
+				fmt.Print("kubeconfig file not found: %s", kc)
 				continue
 			}
 			return false, err


### PR DESCRIPTION
**Please provide a description of this PR:**

Follow up for #54392

Handle multiple paths in KUBECONFIG - https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/#set-the-kubeconfig-environment-variable