### PR TITLE
Skip pilot revisions tests when Istioctl produced by Openshift Service Mesh is used

### DIFF
--- a/tests/integration/pilot/revisions/revision_tag_test.go
+++ b/tests/integration/pilot/revisions/revision_tag_test.go
@@ -76,6 +76,7 @@ func TestRevisionTags(t *testing.T) {
 			}
 
 			istioCtl := istioctl.NewOrFail(t, istioctl.Config{Cluster: t.Clusters().Default()})
+			skipIfIstioctlProducedByOpenShiftServiceMesh(t, istioCtl, "tag")
 			baseArgs := []string{"tag"}
 			for _, tc := range tcs {
 				t.NewSubTest(tc.name).Run(func(t framework.TestContext) {

--- a/tests/integration/pilot/revisions/uninstall_test.go
+++ b/tests/integration/pilot/revisions/uninstall_test.go
@@ -60,6 +60,9 @@ func TestUninstallByRevision(t *testing.T) {
 		Run(func(t framework.TestContext) {
 			t.NewSubTest("uninstall_revision").Run(func(t framework.TestContext) {
 				istioCtl := istioctl.NewOrFail(t, istioctl.Config{})
+
+				skipIfIstioctlProducedByOpenShiftServiceMesh(t, istioCtl, "uninstall")
+
 				uninstallCmd := []string{
 					"uninstall",
 					"--revision=" + stableRevision, "--skip-confirmation",
@@ -81,6 +84,9 @@ func TestUninstallByNotFoundRevision(t *testing.T) {
 		Run(func(t framework.TestContext) {
 			t.NewSubTest("uninstall_revision_notfound").Run(func(t framework.TestContext) {
 				istioCtl := istioctl.NewOrFail(t, istioctl.Config{})
+
+				skipIfIstioctlProducedByOpenShiftServiceMesh(t, istioCtl, "uninstall")
+
 				uninstallCmd := []string{
 					"uninstall",
 					"--revision=" + notFoundRevision, "--dry-run",
@@ -99,6 +105,9 @@ func TestUninstallWithSetFlag(t *testing.T) {
 		Run(func(t framework.TestContext) {
 			t.NewSubTest("uninstall_revision").Run(func(t framework.TestContext) {
 				istioCtl := istioctl.NewOrFail(t, istioctl.Config{})
+
+				skipIfIstioctlProducedByOpenShiftServiceMesh(t, istioCtl, "uninstall")
+
 				uninstallCmd := []string{
 					"uninstall", "--set",
 					"revision=" + stableRevision, "--skip-confirmation",
@@ -118,6 +127,8 @@ func TestUninstallCustomFile(t *testing.T) {
 	framework.NewTest(t).
 		Run(func(t framework.TestContext) {
 			istioCtl := istioctl.NewOrFail(t, istioctl.Config{})
+
+			skipIfIstioctlProducedByOpenShiftServiceMesh(t, istioCtl, "uninstall")
 
 			createIstioOperatorTempFile := func(name, revision string) (fileName string) {
 				tempFile, err := os.CreateTemp("", name)
@@ -179,6 +190,9 @@ func TestUninstallPurge(t *testing.T) {
 		NewTest(t).
 		Run(func(t framework.TestContext) {
 			istioCtl := istioctl.NewOrFail(t, istioctl.Config{})
+
+			skipIfIstioctlProducedByOpenShiftServiceMesh(t, istioCtl, "uninstall")
+
 			uninstallCmd := []string{
 				"uninstall",
 				"--purge", "--skip-confirmation",


### PR DESCRIPTION
**Please provide a description of this PR:**
Fixes: https://github.com/istio/istio/issues/54493

When during the pilot "revisions" tests, the Istioctl binary produced
by Openshift Service Mesh is used, the test fails with the following errors:
- "istioctl error: Error: unknown flag: --revision"
- "istioctl error: Error: unknown flag: -f"

That happens because the istioctl binary produced by Openshift Service Mesh
does not support "uninstall" or "set" parameters.

Added "skipIfIstioctlProducedByOpenShiftServiceMesh" function that will check
the istioctl binary and will skip the "revisions" tests in case
the istioctl binary that is used, produced by Openshift Service Mesh.