### PR TITLE
Refactor Telemetry tests "IsKindCluster" function

### DIFF
--- a/pkg/test/framework/components/cluster/clusters.go
+++ b/pkg/test/framework/components/cluster/clusters.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"sort"
 
+	"k8s.io/client-go/tools/clientcmd"
+
 	"istio.io/istio/pkg/util/sets"
 )
 
@@ -182,4 +184,13 @@ func (c Clusters) filterClusters(included func(Cluster) bool,
 
 func (c Clusters) String() string {
 	return fmt.Sprintf("%v", c.Names())
+}
+
+// The function validates if the cluster is a "Kind" cluster,
+// By looking into a context name. Expects "kind-" prefix.
+// That is required by some tests for specific actions on "Kind".
+func (c Clusters) IsKindCluster() bool {
+	config, _ := clientcmd.NewDefaultClientConfigLoadingRules().Load()
+	currentContext := config.CurrentContext
+	return currentContext == "kind-kind" || len(currentContext) > 5 && currentContext[:5] == "kind-"
 }

--- a/tests/integration/telemetry/api/customize_metrics_test.go
+++ b/tests/integration/telemetry/api/customize_metrics_test.go
@@ -111,10 +111,7 @@ spec:
 }
 
 func setupWasmExtension(t framework.TestContext) {
-	isKind, err := IsKindCluster()
-	if err != nil {
-		t.Errorf("failed to identify cluster type: %v", err)
-	}
+	isKind := t.Clusters().IsKindCluster()
 
 	// By default, for any platform, the test will pull the test image from public "gcr.io" registry.
 	// For "Kind" environment, it will pull the images from the "kind-registry".

--- a/tests/integration/telemetry/api/registry_setup_test.go
+++ b/tests/integration/telemetry/api/registry_setup_test.go
@@ -36,10 +36,7 @@ const (
 func testRegistrySetup(ctx resource.Context) (err error) {
 	var config registryredirector.Config
 
-	isKind, err := IsKindCluster()
-	if err != nil {
-		return
-	}
+	isKind := ctx.Clusters().IsKindCluster()
 
 	// By default, for any platform, the test will pull the test image from public "gcr.io" registry.
 	// For "Kind" environment, it will pull the images from the "kind-registry".

--- a/tests/integration/telemetry/api/setup_test.go
+++ b/tests/integration/telemetry/api/setup_test.go
@@ -20,10 +20,7 @@ package api
 import (
 	"encoding/base64"
 	"fmt"
-	"os"
 	"testing"
-
-	"k8s.io/client-go/tools/clientcmd"
 
 	"istio.io/api/annotation"
 	"istio.io/istio/pkg/test/echo/common"
@@ -156,24 +153,4 @@ proxyMetadata:
 		return err
 	}
 	return nil
-}
-
-// The function validates if the cluster is a "Kind" cluster,
-// By looking into a context name. Expects "kind-" prefix.
-// That is required by some tests for specific actions on "Kind".
-func IsKindCluster() (bool, error) {
-	kubeconfig := os.Getenv("KUBECONFIG")
-	if kubeconfig == "" {
-		kubeconfig = clientcmd.RecommendedHomeFile
-	}
-
-	config, err := clientcmd.LoadFromFile(kubeconfig)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false, fmt.Errorf("kubeconfig file not found: %s", kubeconfig)
-		}
-		return false, err
-	}
-	currentContext := config.CurrentContext
-	return currentContext == "kind-kind" || len(currentContext) > 5 && currentContext[:5] == "kind-", nil
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
Follow up for https://github.com/istio/istio/pull/54392 and https://github.com/istio/istio/pull/54488
Focusing on the following suggestion: https://github.com/istio/istio/pull/54392#discussion_r1890491152

The "isKindCluster" function used to detect if the cluster during the test is of "Kind" type or any other cluster type - vanilla Kubernetes or Openshift.

Move the "isKindCluster" function under the
"(resource.Context).Clusters()" to be available as "(resource.Context).Clusters().IsKindCluster()"