### PR TITLE
Ambient: Add pre-marshalling of xds

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -23,6 +23,7 @@
 package model
 
 import (
+	"bytes"
 	"fmt"
 	"net/netip"
 	"sort"
@@ -32,6 +33,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 	"k8s.io/apimachinery/pkg/types"
 
 	"istio.io/api/label"
@@ -958,6 +961,11 @@ var _ AmbientIndexes = NoopAmbientIndexes{}
 
 type AddressInfo struct {
 	*workloadapi.Address
+	Marshalled *anypb.Any
+}
+
+func (i AddressInfo) Equals(other AddressInfo) bool {
+	return protoconv.Equals(i.Address, other.Address)
 }
 
 func (i AddressInfo) Aliases() []string {
@@ -1016,6 +1024,12 @@ type ServiceInfo struct {
 	// Source is the type that introduced this service.
 	Source   TypedObject
 	Waypoint WaypointBindingStatus
+	// MarshalledAddress contains the pre-marshalled representation.
+	// Note: this is an Address -- not a Service.
+	MarshalledAddress *anypb.Any
+	// AsAddress contains a pre-created AddressInfo representation. This ensures we do not need repeated conversions on
+	// the hotpath
+	AsAddress AddressInfo
 }
 
 func (i ServiceInfo) GetLabelSelector() map[string]string {
@@ -1113,7 +1127,7 @@ func (i ServiceInfo) GetNamespace() string {
 }
 
 func (i ServiceInfo) Equals(other ServiceInfo) bool {
-	return protoconv.Equals(i.Service, other.Service) &&
+	return EqualUsingPremarshalled(i.Service, i.MarshalledAddress, other.Service, other.MarshalledAddress) &&
 		maps.Equal(i.LabelSelector.Labels, other.LabelSelector.Labels) &&
 		maps.Equal(i.PortNames, other.PortNames) &&
 		i.Source == other.Source &&
@@ -1136,10 +1150,16 @@ type WorkloadInfo struct {
 	Source kind.Kind
 	// CreationTime is the time when the workload was created. Note this is used internally only.
 	CreationTime time.Time
+	// MarshalledAddress contains the pre-marshalled representation.
+	// Note: this is an Address -- not a Workload.
+	MarshalledAddress *anypb.Any
+	// AsAddress contains a pre-created AddressInfo representation. This ensures we do not need repeated conversions on
+	// the hotpath
+	AsAddress AddressInfo
 }
 
 func (i WorkloadInfo) Equals(other WorkloadInfo) bool {
-	return protoconv.Equals(i.Workload, other.Workload) &&
+	return EqualUsingPremarshalled(i.Workload, i.MarshalledAddress, other.Workload, other.MarshalledAddress) &&
 		maps.Equal(i.Labels, other.Labels) &&
 		i.Source == other.Source &&
 		i.CreationTime == other.CreationTime
@@ -1767,4 +1787,14 @@ func (ep *IstioEndpoint) Equals(other *IstioEndpoint) bool {
 	}
 
 	return true
+}
+
+func EqualUsingPremarshalled[T proto.Message](a T, am *anypb.Any, b T, bm *anypb.Any) bool {
+	// If they are both pre-marshalled, use the marshalled representation. This is orders of magnitude faster
+	if am != nil && bm != nil {
+		return bytes.Equal(am.Value, bm.Value)
+	}
+
+	// Fallback to equals
+	return protoconv.Equals(a, b)
 }

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1790,7 +1790,7 @@ func (ep *IstioEndpoint) Equals(other *IstioEndpoint) bool {
 }
 
 func EqualUsingPremarshaled[T proto.Message](a T, am *anypb.Any, b T, bm *anypb.Any) bool {
-	// If they are both pre-marshaled, use the marshalled representation. This is orders of magnitude faster
+	// If they are both pre-marshaled, use the marshaled representation. This is orders of magnitude faster
 	if am != nil && bm != nil {
 		return bytes.Equal(am.Value, bm.Value)
 	}

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -961,7 +961,7 @@ var _ AmbientIndexes = NoopAmbientIndexes{}
 
 type AddressInfo struct {
 	*workloadapi.Address
-	Marshalled *anypb.Any
+	Marshaled *anypb.Any
 }
 
 func (i AddressInfo) Equals(other AddressInfo) bool {
@@ -1024,9 +1024,9 @@ type ServiceInfo struct {
 	// Source is the type that introduced this service.
 	Source   TypedObject
 	Waypoint WaypointBindingStatus
-	// MarshalledAddress contains the pre-marshalled representation.
+	// MarshaledAddress contains the pre-marshaled representation.
 	// Note: this is an Address -- not a Service.
-	MarshalledAddress *anypb.Any
+	MarshaledAddress *anypb.Any
 	// AsAddress contains a pre-created AddressInfo representation. This ensures we do not need repeated conversions on
 	// the hotpath
 	AsAddress AddressInfo
@@ -1127,7 +1127,7 @@ func (i ServiceInfo) GetNamespace() string {
 }
 
 func (i ServiceInfo) Equals(other ServiceInfo) bool {
-	return EqualUsingPremarshalled(i.Service, i.MarshalledAddress, other.Service, other.MarshalledAddress) &&
+	return EqualUsingPremarshaled(i.Service, i.MarshaledAddress, other.Service, other.MarshaledAddress) &&
 		maps.Equal(i.LabelSelector.Labels, other.LabelSelector.Labels) &&
 		maps.Equal(i.PortNames, other.PortNames) &&
 		i.Source == other.Source &&
@@ -1150,16 +1150,16 @@ type WorkloadInfo struct {
 	Source kind.Kind
 	// CreationTime is the time when the workload was created. Note this is used internally only.
 	CreationTime time.Time
-	// MarshalledAddress contains the pre-marshalled representation.
+	// MarshaledAddress contains the pre-marshaled representation.
 	// Note: this is an Address -- not a Workload.
-	MarshalledAddress *anypb.Any
+	MarshaledAddress *anypb.Any
 	// AsAddress contains a pre-created AddressInfo representation. This ensures we do not need repeated conversions on
 	// the hotpath
 	AsAddress AddressInfo
 }
 
 func (i WorkloadInfo) Equals(other WorkloadInfo) bool {
-	return EqualUsingPremarshalled(i.Workload, i.MarshalledAddress, other.Workload, other.MarshalledAddress) &&
+	return EqualUsingPremarshaled(i.Workload, i.MarshaledAddress, other.Workload, other.MarshaledAddress) &&
 		maps.Equal(i.Labels, other.Labels) &&
 		i.Source == other.Source &&
 		i.CreationTime == other.CreationTime
@@ -1789,8 +1789,8 @@ func (ep *IstioEndpoint) Equals(other *IstioEndpoint) bool {
 	return true
 }
 
-func EqualUsingPremarshalled[T proto.Message](a T, am *anypb.Any, b T, bm *anypb.Any) bool {
-	// If they are both pre-marshalled, use the marshalled representation. This is orders of magnitude faster
+func EqualUsingPremarshaled[T proto.Message](a T, am *anypb.Any, b T, bm *anypb.Any) bool {
+	// If they are both pre-marshaled, use the marshalled representation. This is orders of magnitude faster
 	if am != nil && bm != nil {
 		return bytes.Equal(am.Value, bm.Value)
 	}

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1127,7 +1127,7 @@ func (i ServiceInfo) GetNamespace() string {
 }
 
 func (i ServiceInfo) Equals(other ServiceInfo) bool {
-	return EqualUsingPremarshaled(i.Service, i.MarshaledAddress, other.Service, other.MarshaledAddress) &&
+	return equalUsingPremarshaled(i.Service, i.MarshaledAddress, other.Service, other.MarshaledAddress) &&
 		maps.Equal(i.LabelSelector.Labels, other.LabelSelector.Labels) &&
 		maps.Equal(i.PortNames, other.PortNames) &&
 		i.Source == other.Source &&
@@ -1159,7 +1159,7 @@ type WorkloadInfo struct {
 }
 
 func (i WorkloadInfo) Equals(other WorkloadInfo) bool {
-	return EqualUsingPremarshaled(i.Workload, i.MarshaledAddress, other.Workload, other.MarshaledAddress) &&
+	return equalUsingPremarshaled(i.Workload, i.MarshaledAddress, other.Workload, other.MarshaledAddress) &&
 		maps.Equal(i.Labels, other.Labels) &&
 		i.Source == other.Source &&
 		i.CreationTime == other.CreationTime
@@ -1789,7 +1789,7 @@ func (ep *IstioEndpoint) Equals(other *IstioEndpoint) bool {
 	return true
 }
 
-func EqualUsingPremarshaled[T proto.Message](a T, am *anypb.Any, b T, bm *anypb.Any) bool {
+func equalUsingPremarshaled[T proto.Message](a T, am *anypb.Any, b T, bm *anypb.Any) bool {
 	// If they are both pre-marshaled, use the marshaled representation. This is orders of magnitude faster
 	if am != nil && bm != nil {
 		return bytes.Equal(am.Value, bm.Value)

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -470,7 +470,7 @@ func translateKubernetesCondition(conds []metav1.Condition) map[string]model.Con
 func (a *index) Lookup(key string) []model.AddressInfo {
 	// 1. Workload UID
 	if w := a.workloads.GetKey(key); w != nil {
-		return []model.AddressInfo{workloadToAddressInfo(w.Workload)}
+		return []model.AddressInfo{w.AsAddress}
 	}
 
 	network, ip, found := strings.Cut(key, "/")
@@ -487,9 +487,9 @@ func (a *index) Lookup(key string) []model.AddressInfo {
 
 	// 3. Service
 	if svc := a.lookupService(key); svc != nil {
-		res := []model.AddressInfo{serviceToAddressInfo(svc.Service)}
+		res := []model.AddressInfo{svc.AsAddress}
 		for _, w := range a.workloads.ByServiceKey.Lookup(svc.ResourceName()) {
-			res = append(res, workloadToAddressInfo(w.Workload))
+			res = append(res, w.AsAddress)
 		}
 		return res
 	}
@@ -516,7 +516,7 @@ func (a *index) lookupService(key string) *model.ServiceInfo {
 func (a *index) All() []model.AddressInfo {
 	res := dedupeWorkloads(a.workloads.List())
 	for _, s := range a.services.List() {
-		res = append(res, serviceToAddressInfo(s.Service))
+		res = append(res, s.AsAddress)
 	}
 	return res
 }
@@ -545,7 +545,7 @@ func dedupeWorkloads(workloads []model.WorkloadInfo) []model.AddressInfo {
 			}
 		}
 		if write {
-			res = append(res, workloadToAddressInfo(wl.Workload))
+			res = append(res, wl.AsAddress)
 		}
 	}
 	return res

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -1925,6 +1925,8 @@ func (s *ambientTestServer) assertAddresses(t *testing.T, lookup string, names .
 		addresses := s.lookup(lookup)
 		have := sets.New[string]()
 		for _, address := range addresses {
+			// Validate we pre-marshal everything
+			assert.Equal(t, address.Marshaled != nil, true)
 			switch addr := address.Address.Type.(type) {
 			case *workloadapi.Address_Workload:
 				have.Insert(addr.Workload.Name)

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/helpers.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/helpers.go
@@ -43,26 +43,22 @@ func (a *index) generateServiceEntryUID(svcEntryNamespace, svcEntryName, addr st
 	return a.ClusterID.String() + "/networking.istio.io/ServiceEntry/" + svcEntryNamespace + "/" + svcEntryName + "/" + addr
 }
 
-func workloadToAddressInfo(w *workloadapi.Workload) model.AddressInfo {
-	return model.AddressInfo{
-		Address: &workloadapi.Address{
-			Type: &workloadapi.Address_Workload{
-				Workload: w,
-			},
+func workloadToAddress(w *workloadapi.Workload) *workloadapi.Address {
+	return &workloadapi.Address{
+		Type: &workloadapi.Address_Workload{
+			Workload: w,
 		},
 	}
 }
 
 func modelWorkloadToAddressInfo(w model.WorkloadInfo) model.AddressInfo {
-	return workloadToAddressInfo(w.Workload)
+	return w.AsAddress
 }
 
-func serviceToAddressInfo(s *workloadapi.Service) model.AddressInfo {
-	return model.AddressInfo{
-		Address: &workloadapi.Address{
-			Type: &workloadapi.Address_Service{
-				Service: s,
-			},
+func serviceToAddress(s *workloadapi.Service) *workloadapi.Address {
+	return &workloadapi.Address{
+		Type: &workloadapi.Address_Service{
+			Service: s,
 		},
 	}
 }

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
@@ -27,6 +27,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/serviceentry"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
+	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/schema/kind"
@@ -34,6 +35,7 @@ import (
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/workloadapi"
 )
@@ -87,13 +89,14 @@ func (a *index) serviceServiceBuilder(
 		waypointStatus.Error = wperr
 
 		a.networkUpdateTrigger.MarkDependant(ctx) // Mark we depend on out of band a.Network
-		return &model.ServiceInfo{
-			Service:       a.constructService(s, waypoint),
+		svc := a.constructService(s, waypoint)
+		return precomputeServicePtr(&model.ServiceInfo{
+			Service:       svc,
 			PortNames:     portNames,
 			LabelSelector: model.NewSelector(s.Spec.Selector),
 			Source:        MakeSource(s),
 			Waypoint:      waypointStatus,
-		}
+		})
 	}
 }
 
@@ -133,13 +136,13 @@ func (a *index) serviceEntriesInfo(s *networkingclient.ServiceEntry, w *Waypoint
 		waypoint.Error = wperr
 	}
 	return slices.Map(a.constructServiceEntries(s, w), func(e *workloadapi.Service) model.ServiceInfo {
-		return model.ServiceInfo{
+		return precomputeService(model.ServiceInfo{
 			Service:       e,
 			PortNames:     portNames,
 			LabelSelector: sel,
 			Source:        MakeSource(s),
 			Waypoint:      waypoint,
-		}
+		})
 	})
 }
 
@@ -285,4 +288,18 @@ func getVIPs(svc *v1.Service) []string {
 		}
 	}
 	return res
+}
+
+func precomputeServicePtr(w *model.ServiceInfo) *model.ServiceInfo {
+	return ptr.Of(precomputeService(*w))
+}
+
+func precomputeService(w model.ServiceInfo) model.ServiceInfo {
+	addr := serviceToAddress(w.Service)
+	w.MarshalledAddress = protoconv.MessageToAny(addr)
+	w.AsAddress = model.AddressInfo{
+		Address:    addr,
+		Marshalled: w.MarshalledAddress,
+	}
+	return w
 }

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
@@ -296,10 +296,10 @@ func precomputeServicePtr(w *model.ServiceInfo) *model.ServiceInfo {
 
 func precomputeService(w model.ServiceInfo) model.ServiceInfo {
 	addr := serviceToAddress(w.Service)
-	w.MarshalledAddress = protoconv.MessageToAny(addr)
+	w.MarshaledAddress = protoconv.MessageToAny(addr)
 	w.AsAddress = model.AddressInfo{
-		Address:    addr,
-		Marshalled: w.MarshalledAddress,
+		Address:   addr,
+		Marshaled: w.MarshaledAddress,
 	}
 	return w
 }

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
@@ -34,6 +34,7 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
 	labelutil "istio.io/istio/pilot/pkg/serviceregistry/util/label"
+	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/schema/gvk"
@@ -184,7 +185,12 @@ func (a *index) workloadEntryWorkloadBuilder(
 		w.CanonicalName, w.CanonicalRevision = kubelabels.CanonicalService(wle.Labels, w.WorkloadName)
 
 		setTunnelProtocol(wle.Labels, wle.Annotations, w)
-		return &model.WorkloadInfo{Workload: w, Labels: wle.Labels, Source: kind.WorkloadEntry, CreationTime: wle.CreationTimestamp.Time}
+		return precomputeWorkloadPtr(&model.WorkloadInfo{
+			Workload:     w,
+			Labels:       wle.Labels,
+			Source:       kind.WorkloadEntry,
+			CreationTime: wle.CreationTimestamp.Time,
+		})
 	}
 }
 
@@ -298,7 +304,12 @@ func (a *index) podWorkloadBuilder(
 		w.CanonicalName, w.CanonicalRevision = kubelabels.CanonicalService(p.Labels, w.WorkloadName)
 
 		setTunnelProtocol(p.Labels, p.Annotations, w)
-		return &model.WorkloadInfo{Workload: w, Labels: p.Labels, Source: kind.Pod, CreationTime: p.CreationTimestamp.Time}
+		return precomputeWorkloadPtr(&model.WorkloadInfo{
+			Workload:     w,
+			Labels:       p.Labels,
+			Source:       kind.Pod,
+			CreationTime: p.CreationTimestamp.Time,
+		})
 	}
 }
 
@@ -489,7 +500,12 @@ func (a *index) serviceEntryWorkloadBuilder(
 			w.CanonicalName, w.CanonicalRevision = kubelabels.CanonicalService(se.Labels, w.WorkloadName)
 
 			setTunnelProtocol(se.Labels, se.Annotations, w)
-			res = append(res, model.WorkloadInfo{Workload: w, Labels: se.Labels, Source: kind.WorkloadEntry, CreationTime: se.CreationTimestamp.Time})
+			res = append(res, precomputeWorkload(model.WorkloadInfo{
+				Workload:     w,
+				Labels:       se.Labels,
+				Source:       kind.WorkloadEntry,
+				CreationTime: se.CreationTimestamp.Time,
+			}))
 		}
 		return res
 	}
@@ -617,12 +633,12 @@ func (a *index) endpointSlicesBuilder(
 				Waypoint:              nil, // Not supported. In theory, we could allow it as an EndpointSlice label, but there is no real use case.
 				Locality:              nil, // Not supported. We could maybe, there is a "zone", but it doesn't seem to be well supported
 			}
-			res = append(res, model.WorkloadInfo{
+			res = append(res, precomputeWorkload(model.WorkloadInfo{
 				Workload:     w,
 				Labels:       nil,
 				Source:       kind.EndpointSlice,
 				CreationTime: es.CreationTimestamp.Time,
-			})
+			}))
 		}
 
 		return res
@@ -937,4 +953,18 @@ func endpointSliceAddressIndex(EndpointSlices krt.Collection[*discovery.Endpoint
 		}
 		return res
 	})
+}
+
+func precomputeWorkloadPtr(w *model.WorkloadInfo) *model.WorkloadInfo {
+	return ptr.Of(precomputeWorkload(*w))
+}
+
+func precomputeWorkload(w model.WorkloadInfo) model.WorkloadInfo {
+	addr := workloadToAddress(w.Workload)
+	w.MarshalledAddress = protoconv.MessageToAny(addr)
+	w.AsAddress = model.AddressInfo{
+		Address:    addr,
+		Marshalled: w.MarshalledAddress,
+	}
+	return w
 }

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
@@ -961,10 +961,10 @@ func precomputeWorkloadPtr(w *model.WorkloadInfo) *model.WorkloadInfo {
 
 func precomputeWorkload(w model.WorkloadInfo) model.WorkloadInfo {
 	addr := workloadToAddress(w.Workload)
-	w.MarshalledAddress = protoconv.MessageToAny(addr)
+	w.MarshaledAddress = protoconv.MessageToAny(addr)
 	w.AsAddress = model.AddressInfo{
-		Address:    addr,
-		Marshalled: w.MarshalledAddress,
+		Address:   addr,
+		Marshaled: w.MarshaledAddress,
 	}
 	return w
 }

--- a/pilot/pkg/xds/workload.go
+++ b/pilot/pkg/xds/workload.go
@@ -129,7 +129,7 @@ func (e WorkloadGenerator) GenerateDeltas(
 				})
 			}
 		case v3.AddressType:
-			proto := addr.Marshalled
+			proto := addr.Marshaled
 			if proto == nil {
 				proto = protoconv.MessageToAny(addr)
 			}

--- a/pilot/pkg/xds/workload.go
+++ b/pilot/pkg/xds/workload.go
@@ -129,10 +129,15 @@ func (e WorkloadGenerator) GenerateDeltas(
 				})
 			}
 		case v3.AddressType:
+			proto := addr.Marshalled
+			if proto == nil {
+				proto = protoconv.MessageToAny(addr)
+			}
+
 			resources = append(resources, &discovery.Resource{
 				Name:     n,
 				Aliases:  aliases,
-				Resource: protoconv.MessageToAny(addr), // TODO: pre-marshal
+				Resource: proto,
 			})
 		}
 	}


### PR DESCRIPTION
This implements a long-standing TODO in the ambient code path, greatly improving performance.

In WDS, we (intentionally) do not have client-specific configuration. As such, we can pre-marshal all our resources, rather than marshalling them for each client. This dramatically reduces the number of times we need to marshal config.

For example, consider a large cluster with 25k pods and 500 ztunnel connections. Today, each workload change would be marshalled 500x. A full push (which can be improved - https://github.com/istio/istio/issues/54499) would require 12.5M marshals.

With this change, a workload change is marshalled 1x. Additional full pushes required 0 marshals!

There is a small cost to this -- the memory overhead of storing the pre-marshaled bytes. However, this is negligible. With 25k pods (a large cluster!), this is roughly 4mb of data total - the garbage created by re-marshalling everything will bloat memory orders of magnitude more.

I don't have concrete numbers (I was making too many changes at once and did a bad job recording the impact of each) of the delta of performance here but its quite good -- on the order of 2x improvements in a typical case (and WAY better if we trigger full pushes). but I can get some data if desired.

One cool thing is we can use the pre-marshalling for Equals impl. This is 80x-4000x faster (depending on vtproto equals or golang equals)