### PR TITLE
Gateway API: add an annotation to control the 15021 status port in the generated Service

### DIFF
--- a/pilot/pkg/config/kube/gateway/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller.go
@@ -651,12 +651,21 @@ type TemplateInput struct {
 
 func extractServicePorts(gw gateway.Gateway) []corev1.ServicePort {
 	tcp := strings.ToLower(string(protocol.TCP))
-	svcPorts := make([]corev1.ServicePort, 0, len(gw.Spec.Listeners)+1)
-	svcPorts = append(svcPorts, corev1.ServicePort{
-		Name:        "status-port",
-		Port:        int32(15021),
-		AppProtocol: &tcp,
-	})
+
+	svcPortsSize := len(gw.Spec.Listeners)
+	if gw.Annotations[annotation.NetworkingServiceExposeStatusPort.Name] != "false" {
+		svcPortsSize++
+	}
+	svcPorts := make([]corev1.ServicePort, 0, svcPortsSize)
+
+	if gw.Annotations[annotation.NetworkingServiceExposeStatusPort.Name] != "false" {
+		svcPorts = append(svcPorts, corev1.ServicePort{
+			Name:        "status-port",
+			Port:        int32(15021),
+			AppProtocol: &tcp,
+		})
+	}
+
 	portNums := sets.New[int32]()
 	for i, l := range gw.Spec.Listeners {
 		if portNums.Contains(int32(l.Port)) {

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
@@ -396,6 +396,44 @@ func TestConfigureIstioGateway(t *testing.T) {
   tag: test
   network: network-1`,
 		},
+		{
+			name: "service-status-port-enable-explicitly",
+			gw: k8sbeta.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "default",
+					Namespace: "default",
+					Annotations: map[string]string{annotation.NetworkingServiceExposeStatusPort.Name: "true"},
+				},
+				Spec: k8s.GatewaySpec{
+					GatewayClassName: k8s.ObjectName(features.GatewayAPIDefaultGatewayClass),
+					Listeners: []k8s.Listener{{
+						Name:     "http",
+						Port:     k8s.PortNumber(80),
+						Protocol: k8s.HTTPProtocolType,
+					}},
+				},
+			},
+			objects: defaultObjects,
+		},
+		{
+			name: "service-status-port-disable",
+			gw: k8sbeta.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "default",
+					Namespace: "default",
+					Annotations: map[string]string{annotation.NetworkingServiceExposeStatusPort.Name: "false"},
+				},
+				Spec: k8s.GatewaySpec{
+					GatewayClassName: k8s.ObjectName(features.GatewayAPIDefaultGatewayClass),
+					Listeners: []k8s.Listener{{
+						Name:     "http",
+						Port:     k8s.PortNumber(80),
+						Protocol: k8s.HTTPProtocolType,
+					}},
+				},
+			},
+			objects: defaultObjects,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/service-status-port-disable.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/service-status-port-disable.yaml
@@ -1,0 +1,249 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.istio.io/controller-version: "5"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    networking.istio.io/service-expose-status-port: "false"
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
+  name: default-istio
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    name: default
+    uid: ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    networking.istio.io/service-expose-status-port: "false"
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
+  name: default-istio
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    name: default
+    uid: ""
+spec:
+  selector:
+    matchLabels:
+      gateway.networking.k8s.io/gateway-name: default
+  template:
+    metadata:
+      annotations:
+        istio.io/rev: default
+        networking.istio.io/service-expose-status-port: "false"
+        prometheus.io/path: /stats/prometheus
+        prometheus.io/port: "15020"
+        prometheus.io/scrape: "true"
+      labels:
+        gateway.istio.io/managed: istio.io-gateway-controller
+        gateway.networking.k8s.io/gateway-name: default
+        istio.io/dataplane-mode: none
+        service.istio.io/canonical-name: default-istio
+        service.istio.io/canonical-revision: latest
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - args:
+        - proxy
+        - router
+        - --domain
+        - $(POD_NAMESPACE).svc.<no value>
+        - --proxyLogLevel
+        - <nil>
+        - --proxyComponentLogLevel
+        - <nil>
+        - --log_output_level
+        - <nil>
+        env:
+        - name: PILOT_CERT_PROVIDER
+          value: <no value>
+        - name: CA_ADDR
+          value: istiod-<no value>.<no value>.svc:15012
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_CPU_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: PROXY_CONFIG
+          value: |
+            {}
+        - name: ISTIO_META_POD_PORTS
+          value: '[]'
+        - name: ISTIO_META_APP_CONTAINERS
+          value: ""
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
+        - name: ISTIO_META_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: default-istio
+        - name: ISTIO_META_OWNER
+          value: kubernetes://apis/apps/v1/namespaces/default/deployments/default-istio
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        - name: TRUST_DOMAIN
+          value: cluster.local
+        image: test/proxyv2:test
+        name: istio-proxy
+        ports:
+        - containerPort: 15020
+          name: metrics
+          protocol: TCP
+        - containerPort: 15021
+          name: status-port
+          protocol: TCP
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 4
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          initialDelaySeconds: 0
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
+        startupProbe:
+          failureThreshold: 30
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          initialDelaySeconds: 1
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 1
+        volumeMounts:
+        - mountPath: /var/run/secrets/workload-spiffe-uds
+          name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
+        - mountPath: /var/run/secrets/workload-spiffe-credentials
+          name: workload-certs
+        - mountPath: /var/lib/istio/data
+          name: istio-data
+        - mountPath: /etc/istio/proxy
+          name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
+        - mountPath: /etc/istio/pod
+          name: istio-podinfo
+      securityContext:
+        sysctls:
+        - name: net.ipv4.ip_unprivileged_port_start
+          value: "0"
+      serviceAccountName: default-istio
+      volumes:
+      - emptyDir: {}
+        name: workload-socket
+      - emptyDir: {}
+        name: credential-socket
+      - emptyDir: {}
+        name: workload-certs
+      - emptyDir:
+          medium: Memory
+        name: istio-envoy
+      - emptyDir: {}
+        name: istio-data
+      - downwardAPI:
+          items:
+          - fieldRef:
+              fieldPath: metadata.labels
+            path: labels
+          - fieldRef:
+              fieldPath: metadata.annotations
+            path: annotations
+        name: istio-podinfo
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: <no value>
+              expirationSeconds: 43200
+              path: istio-token
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    networking.istio.io/service-expose-status-port: "false"
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
+  name: default-istio
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    name: default
+    uid: null
+spec:
+  ipFamilyPolicy: PreferDualStack
+  ports:
+  - appProtocol: http
+    name: http
+    port: 80
+    protocol: TCP
+  selector:
+    gateway.networking.k8s.io/gateway-name: default
+  type: LoadBalancer
+---

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/service-status-port-enable-explicitly.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/service-status-port-enable-explicitly.yaml
@@ -1,0 +1,253 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.istio.io/controller-version: "5"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    networking.istio.io/service-expose-status-port: "true"
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
+  name: default-istio
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    name: default
+    uid: ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    networking.istio.io/service-expose-status-port: "true"
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
+  name: default-istio
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    name: default
+    uid: ""
+spec:
+  selector:
+    matchLabels:
+      gateway.networking.k8s.io/gateway-name: default
+  template:
+    metadata:
+      annotations:
+        istio.io/rev: default
+        networking.istio.io/service-expose-status-port: "true"
+        prometheus.io/path: /stats/prometheus
+        prometheus.io/port: "15020"
+        prometheus.io/scrape: "true"
+      labels:
+        gateway.istio.io/managed: istio.io-gateway-controller
+        gateway.networking.k8s.io/gateway-name: default
+        istio.io/dataplane-mode: none
+        service.istio.io/canonical-name: default-istio
+        service.istio.io/canonical-revision: latest
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - args:
+        - proxy
+        - router
+        - --domain
+        - $(POD_NAMESPACE).svc.<no value>
+        - --proxyLogLevel
+        - <nil>
+        - --proxyComponentLogLevel
+        - <nil>
+        - --log_output_level
+        - <nil>
+        env:
+        - name: PILOT_CERT_PROVIDER
+          value: <no value>
+        - name: CA_ADDR
+          value: istiod-<no value>.<no value>.svc:15012
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_CPU_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: PROXY_CONFIG
+          value: |
+            {}
+        - name: ISTIO_META_POD_PORTS
+          value: '[]'
+        - name: ISTIO_META_APP_CONTAINERS
+          value: ""
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
+        - name: ISTIO_META_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: default-istio
+        - name: ISTIO_META_OWNER
+          value: kubernetes://apis/apps/v1/namespaces/default/deployments/default-istio
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        - name: TRUST_DOMAIN
+          value: cluster.local
+        image: test/proxyv2:test
+        name: istio-proxy
+        ports:
+        - containerPort: 15020
+          name: metrics
+          protocol: TCP
+        - containerPort: 15021
+          name: status-port
+          protocol: TCP
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 4
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          initialDelaySeconds: 0
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
+        startupProbe:
+          failureThreshold: 30
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          initialDelaySeconds: 1
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 1
+        volumeMounts:
+        - mountPath: /var/run/secrets/workload-spiffe-uds
+          name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
+        - mountPath: /var/run/secrets/workload-spiffe-credentials
+          name: workload-certs
+        - mountPath: /var/lib/istio/data
+          name: istio-data
+        - mountPath: /etc/istio/proxy
+          name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
+        - mountPath: /etc/istio/pod
+          name: istio-podinfo
+      securityContext:
+        sysctls:
+        - name: net.ipv4.ip_unprivileged_port_start
+          value: "0"
+      serviceAccountName: default-istio
+      volumes:
+      - emptyDir: {}
+        name: workload-socket
+      - emptyDir: {}
+        name: credential-socket
+      - emptyDir: {}
+        name: workload-certs
+      - emptyDir:
+          medium: Memory
+        name: istio-envoy
+      - emptyDir: {}
+        name: istio-data
+      - downwardAPI:
+          items:
+          - fieldRef:
+              fieldPath: metadata.labels
+            path: labels
+          - fieldRef:
+              fieldPath: metadata.annotations
+            path: annotations
+        name: istio-podinfo
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: <no value>
+              expirationSeconds: 43200
+              path: istio-token
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    networking.istio.io/service-expose-status-port: "true"
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
+  name: default-istio
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    name: default
+    uid: null
+spec:
+  ipFamilyPolicy: PreferDualStack
+  ports:
+  - appProtocol: tcp
+    name: status-port
+    port: 15021
+    protocol: TCP
+  - appProtocol: http
+    name: http
+    port: 80
+    protocol: TCP
+  selector:
+    gateway.networking.k8s.io/gateway-name: default
+  type: LoadBalancer
+---

--- a/releasenotes/notes/gateway-api-service-health-port.yaml
+++ b/releasenotes/notes/gateway-api-service-health-port.yaml
@@ -1,0 +1,21 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+issue:
+  - 54453
+
+releaseNotes:
+- |
+  **Added** a new `Gateway` annotation to control whether its auto-generated `Service` exposes the `15021` health status port. The default
+  behavior is to expose the port, and this remains unchanged.
+
+  Now, it can be disabled by setting the `networking.istio.io/service-expose-status-port` annotation to `false`, e.g.:
+  ```yaml
+  apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    name: default
+    annotations:
+      networking.istio.io/service-expose-status-port: "false"
+  ```


### PR DESCRIPTION
**Please provide a description of this PR:**

Closes #54453. Depends on https://github.com/istio/api/pull/3400.

This PR adds an option to disable the exposure of the `15021` port in the auto-generated `Service` behind a created `Gateway`. As described in the original issue, unconditionally exposing this port for every Gateway might cause conflicts in GCP (GKE) environments.

The new `networking.istio.io/service-expose-status-port` annotation allows disabling this default behavior, exposing only the ports listed in `spec.listeners`.

Tasks:
- [x] Change the API repo - https://github.com/istio/api/pull/3400
- [ ] Change the docs repo - TODO