### PR TITLE
Increase timeout on benchmark test

### DIFF
--- a/prow/benchtest.sh
+++ b/prow/benchtest.sh
@@ -43,7 +43,7 @@ case "${1}" in
       --test-arg "--benchmem" \
       --test-arg "--count=${BENCHMARK_COUNT}" \
       --test-arg "--cpu=${BENCHMARK_CPUS}" \
-      --test-arg "--test.timeout=30m" \
+      --test-arg "--test.timeout=60m" \
       --test-arg "-tags=vtprotobuf"
     # Print out the results as well for ease of debugging, so they are in the logs instead of just output
     cat "${REPORT_PLAINTEXT}"


### PR DESCRIPTION
We keep hitting this. We should probably find a way to make the tst
shorter, but for now bump the time
