### PR TITLE
Benchmark WDS

### DIFF
--- a/pilot/pkg/xds/testdata/benchmarks/serviceentry-workloadentry.yaml
+++ b/pilot/pkg/xds/testdata/benchmarks/serviceentry-workloadentry.yaml
@@ -64,7 +64,7 @@ metadata:
   name: random-{{$j}}
 spec:
   serviceAccount: random
-  address: 10.10.10.10
+  address: 240.241.{{div $j 255 }}.{{mod $j 255 }}
   labels:
     app: random-{{mod $j $.Services}}
 ---


### PR DESCRIPTION
Running this on a few PRs...

```
                                                           │   baseline    │               master                │
                                                           │    sec/op     │    sec/op     vs base               │
AddressFullGeneration/serviceentry-workloadentry-16            2.642m ± 9%   1.323m ± 17%  -49.92% (p=0.002 n=6)
AddressIncrementalGeneration/serviceentry-workloadentry-16   136.429µ ± 3%   1.452µ ±  7%  -98.94% (p=0.002 n=6)
geomean                                                        600.4µ        43.83µ        -92.70%

                                                           │    baseline    │               master                │
                                                           │      B/op      │     B/op      vs base               │
AddressFullGeneration/serviceentry-workloadentry-16            1.631Mi ± 0%   1.225Mi ± 0%  -24.91% (p=0.002 n=6)
AddressIncrementalGeneration/serviceentry-workloadentry-16   143.185Ki ± 0%   1.250Ki ± 0%  -99.13% (p=0.002 n=6)
geomean                                                        489.0Ki        39.60Ki       -91.90%

                                                           │   baseline   │               master               │
                                                           │  allocs/op   │  allocs/op   vs base               │
AddressFullGeneration/serviceentry-workloadentry-16          17.366k ± 0%   9.183k ± 0%  -47.12% (p=0.002 n=6)
AddressIncrementalGeneration/serviceentry-workloadentry-16     66.00 ± 0%    18.00 ± 0%  -72.73% (p=0.002 n=6)
geomean                                                       1.071k         406.6       -62.02%
```
a few days ago vs master today



```
                                                           │    master     │                full                │
                                                           │    sec/op     │   sec/op     vs base               │
AddressFullGeneration/serviceentry-workloadentry-16          1323.0µ ± 17%   221.8µ ± 2%  -83.24% (p=0.002 n=6)
AddressIncrementalGeneration/serviceentry-workloadentry-16   1452.0n ±  7%   823.7n ± 3%  -43.27% (p=0.002 n=6)
geomean                                                       43.83µ         13.52µ       -69.16%


                                                           │    master     │                full                 │
                                                           │     B/op      │     B/op      vs base               │
AddressFullGeneration/serviceentry-workloadentry-16          1254.2Ki ± 0%   430.3Ki ± 0%  -65.70% (p=0.002 n=6)
AddressIncrementalGeneration/serviceentry-workloadentry-16     1280.0 ± 0%     968.0 ± 0%  -24.38% (p=0.002 n=6)
geomean                                                       39.60Ki        20.17Ki       -49.07%

                                                           │   master    │                full                │
                                                           │  allocs/op  │  allocs/op   vs base               │
AddressFullGeneration/serviceentry-workloadentry-16          9.183k ± 0%   1.725k ± 0%  -81.22% (p=0.002 n=6)
AddressIncrementalGeneration/serviceentry-workloadentry-16    18.00 ± 0%    13.00 ± 0%  -27.78% (p=0.002 n=6)
geomean                                                       406.6         149.7       -63.17%
```
master vs remaining optimizations to make (in local branch, not yet pushed)