### PR TITLE
krt: optimize lookups in Join

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
@@ -113,13 +113,17 @@ func (a *index) WorkloadsCollection(
 		return slices.Map(a.LookupAllNetworkGateway(), convertGateway)
 	}, opts.WithName("NetworkGatewayWorkloads")...)
 
-	Workloads := krt.JoinCollection([]krt.Collection[model.WorkloadInfo]{
-		PodWorkloads,
-		WorkloadEntryWorkloads,
-		ServiceEntryWorkloads,
-		EndpointSliceWorkloads,
-		NetworkGatewayWorkloads,
-	}, opts.WithName("Workloads")...)
+	Workloads := krt.JoinCollection(
+		[]krt.Collection[model.WorkloadInfo]{
+			PodWorkloads,
+			WorkloadEntryWorkloads,
+			ServiceEntryWorkloads,
+			EndpointSliceWorkloads,
+			NetworkGatewayWorkloads,
+		},
+		// Each collection has its own unique UID as the key. This guarantees an object can exist in only a single collection
+		// This enables us to use the JoinUnchecked optimization.
+		append(opts.WithName("Workloads"), krt.WithJoinUnchecked())...)
 	return Workloads
 }
 

--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -483,6 +483,14 @@ func WithDebugging(handler *DebugHandler) CollectionOption {
 	}
 }
 
+// WithJoinUnchecked enables an optimization for join collections, where keys are not deduplicated across collections.
+// This option can only be used when joined collections are disjoint: keys overlapping between collections is undefined behavior
+func WithJoinUnchecked() CollectionOption {
+	return func(c *collectionOptions) {
+		c.joinUnchecked = true
+	}
+}
+
 // NewCollection transforms a Collection[I] to a Collection[O] by applying the provided transformation function.
 // This applies for one-to-one relationships between I and O.
 // For zero-to-one, use NewSingleton. For one-to-many, use NewManyCollection.

--- a/pkg/kube/krt/internal.go
+++ b/pkg/kube/krt/internal.go
@@ -66,10 +66,11 @@ func buildCollectionOptions(opts ...CollectionOption) collectionOptions {
 
 // collectionOptions tracks options for a collection
 type collectionOptions struct {
-	name         string
-	augmentation func(o any) any
-	stop         <-chan struct{}
-	debugger     *DebugHandler
+	name          string
+	augmentation  func(o any) any
+	stop          <-chan struct{}
+	debugger      *DebugHandler
+	joinUnchecked bool
 }
 
 type indexedDependency struct {


### PR DESCRIPTION
```
cpu: AMD Ryzen 7 PRO 7840U w/ Radeon 780M Graphics
                                                           │  baseline2  │                join2                │
                                                           │   sec/op    │   sec/op     vs base                │
AddressFullGeneration/serviceentry-workloadentry-16          1.377m ± 4%   1.115m ± 3%  -19.05% (p=0.000 n=10)
AddressIncrementalGeneration/serviceentry-workloadentry-16   1.410µ ± 7%   1.411µ ± 3%        ~ (p=0.869 n=10)
geomean                                                      44.06µ        39.66µ        -9.99%

                                                           │   baseline2   │                 join2                  │
                                                           │     B/op      │     B/op      vs base                  │
AddressFullGeneration/serviceentry-workloadentry-16          1254.2Ki ± 0%   995.8Ki ± 0%  -20.61% (p=0.000 n=10)
AddressIncrementalGeneration/serviceentry-workloadentry-16    1.250Ki ± 0%   1.250Ki ± 0%        ~ (p=1.000 n=10) ¹
geomean                                                       39.59Ki        35.28Ki       -10.90%
¹ all samples are equal

                                                           │  baseline2  │                 join2                 │
                                                           │  allocs/op  │  allocs/op   vs base                  │
AddressFullGeneration/serviceentry-workloadentry-16          9.182k ± 0%   7.124k ± 0%  -22.41% (p=0.000 n=10)
AddressIncrementalGeneration/serviceentry-workloadentry-16    18.00 ± 0%    18.00 ± 0%        ~ (p=1.000 n=10) ¹
geomean                                                       406.5         358.1       -11.92%
¹ all samples are equal
```