### PR TITLE
ambient: drop dedupe of workloads

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_serviceentry_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_serviceentry_test.go
@@ -33,7 +33,7 @@ func TestAmbientIndexDuplicates(t *testing.T) {
 	s.addWorkloadEntries(t, "140.140.0.10", "name1", "sa1", map[string]string{"app": "a"})
 	s.addPods(t, "140.140.0.10", "pod1", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
 	s.assertEvent(t, s.wleXdsName("name0"), s.wleXdsName("name1"), s.podXdsName("pod0"), s.podXdsName("pod1"))
-	s.assertAddresses(t, "", "pod0")
+	s.assertAddresses(t, "", "pod0", "pod1", "name0", "name1")
 }
 
 func TestAmbientIndex_ServiceEntry(t *testing.T) {
@@ -85,7 +85,7 @@ func TestAmbientIndex_ServiceEntry(t *testing.T) {
 	// workload entry is included in the result until pod1 with the same address below is added
 	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "name0")
 	// lookup by address should return the workload entry's address info
-	assert.Equal(t, s.lookup(s.addrXdsName("140.140.0.10")), []model.AddressInfo{{
+	we := model.AddressInfo{
 		Address: &workloadapi.Address{
 			Type: &workloadapi.Address_Workload{
 				Workload: &workloadapi.Workload{
@@ -103,14 +103,15 @@ func TestAmbientIndex_ServiceEntry(t *testing.T) {
 				},
 			},
 		},
-	}})
+	}
+	assert.Equal(t, s.lookup(s.addrXdsName("140.140.0.10")), []model.AddressInfo{we})
 
 	// test code path where service entry selects workloads via `ServiceEntry.workloadSelector`
 	s.addPods(t, "140.140.0.10", "pod1", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
 	s.assertEvent(t, s.podXdsName("pod1"))
 
-	// lookup by address should return the pod's address info (ignore the workload entry with similar address)
-	assert.Equal(t, s.lookup(s.addrXdsName("140.140.0.10")), []model.AddressInfo{{
+	// lookup by address should return the pod and workload entry address info
+	pod := model.AddressInfo{
 		Address: &workloadapi.Address{
 			Type: &workloadapi.Address_Workload{
 				Workload: &workloadapi.Workload{
@@ -129,45 +130,49 @@ func TestAmbientIndex_ServiceEntry(t *testing.T) {
 				},
 			},
 		},
-	}})
+	}
+	assert.Equal(t, s.lookup(s.addrXdsName("140.140.0.10")), []model.AddressInfo{pod, we})
 
 	s.addPods(t, "140.140.0.11", "pod2", "sa1", map[string]string{"app": "other"}, nil, true, corev1.PodRunning)
 	s.assertEvent(t, s.podXdsName("pod2"))
-	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "pod1", "pod2")
+	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "pod1", "pod2", "name0")
 	s.addWorkloadEntries(t, "240.240.34.56", "name1", "sa1", map[string]string{"app": "a"})
 	s.assertEvent(t, s.wleXdsName("name1"))
 	s.addWorkloadEntries(t, "240.240.34.57", "name2", "sa1", map[string]string{"app": "other"})
 	s.assertEvent(t, s.wleXdsName("name2"))
-	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "pod1", "pod2", "name1", "name2")
+	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "pod1", "pod2", "name0", "name1", "name2")
 
 	s.addWorkloadEntries(t, "140.140.0.11", "name3", "sa1", map[string]string{"app": "other"})
 	s.assertEvent(t, s.wleXdsName("name3"))
-	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "pod1", "pod2", "name1", "name2")
+	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "pod1", "pod2", "name0", "name1", "name2", "name3")
 
 	// a service entry should not be able to select across namespaces
 	s.addServiceEntry(t, "mismatched.istio.io", []string{"240.240.23.45"}, "name1", "mismatched-ns", map[string]string{"app": "a"}, nil)
 	s.assertEvent(t, "mismatched-ns/mismatched.istio.io")
-	assert.Equal(t, s.lookup(s.addrXdsName("140.140.0.10")), []model.AddressInfo{{
-		Address: &workloadapi.Address{
-			Type: &workloadapi.Address_Workload{
-				Workload: &workloadapi.Workload{
-					Uid:               s.podXdsName("pod1"),
-					Name:              "pod1",
-					Namespace:         testNS,
-					Addresses:         [][]byte{parseIP("140.140.0.10")},
-					Node:              "node1",
-					Network:           testNW,
-					CanonicalName:     "a",
-					CanonicalRevision: "latest",
-					ServiceAccount:    "sa1",
-					WorkloadType:      workloadapi.WorkloadType_POD,
-					WorkloadName:      "pod1",
-					Services:          nil, // should not be selected by the mismatched service entry
-					ClusterId:         testC,
+	assert.Equal(t, s.lookup(s.addrXdsName("140.140.0.10")), []model.AddressInfo{
+		pod,
+		{
+			Address: &workloadapi.Address{
+				Type: &workloadapi.Address_Workload{
+					Workload: &workloadapi.Workload{
+						Uid:               s.wleXdsName("name0"),
+						Name:              "name0",
+						Namespace:         testNS,
+						Addresses:         [][]byte{parseIP("140.140.0.10")},
+						Node:              "",
+						Network:           testNW,
+						CanonicalName:     "a",
+						CanonicalRevision: "latest",
+						ServiceAccount:    "sa1",
+						WorkloadType:      workloadapi.WorkloadType_POD,
+						WorkloadName:      "name0",
+						Services:          nil, // should not be selected by the mismatched service entry
+						ClusterId:         testC,
+					},
 				},
 			},
 		},
-	}})
+	})
 	assert.Equal(t, s.lookup(s.addrXdsName("240.240.34.56")), []model.AddressInfo{{
 		Address: &workloadapi.Address{
 			Type: &workloadapi.Address_Workload{
@@ -191,63 +196,118 @@ func TestAmbientIndex_ServiceEntry(t *testing.T) {
 	}})
 
 	s.addServiceEntry(t, "se.istio.io", []string{"240.240.23.45"}, "name1", testNS, map[string]string{"app": "a"}, nil)
-	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "pod1", "pod2", "name1", "name2")
+	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "pod1", "pod2", "name0", "name1", "name2", "name3")
 	// we should see an update for the workloads selected by the service entry
 	// do not expect event for pod2 since it is not selected by the service entry
 	s.assertEvent(t, s.podXdsName("pod1"), s.wleXdsName("name0"), s.wleXdsName("name1"), "ns1/se.istio.io")
 
-	assert.Equal(t, s.lookup(s.addrXdsName("140.140.0.10")), []model.AddressInfo{{
-		Address: &workloadapi.Address{
-			Type: &workloadapi.Address_Workload{
-				Workload: &workloadapi.Workload{
-					Uid:               s.podXdsName("pod1"),
-					Name:              "pod1",
-					Namespace:         testNS,
-					Addresses:         [][]byte{parseIP("140.140.0.10")},
-					Node:              "node1",
-					Network:           testNW,
-					CanonicalName:     "a",
-					CanonicalRevision: "latest",
-					ServiceAccount:    "sa1",
-					WorkloadType:      workloadapi.WorkloadType_POD,
-					WorkloadName:      "pod1",
-					Services: map[string]*workloadapi.PortList{
-						"ns1/se.istio.io": {
-							Ports: []*workloadapi.Port{
-								{
-									ServicePort: 80,
-									TargetPort:  8080,
+	assert.Equal(t, s.lookup(s.addrXdsName("140.140.0.10")), []model.AddressInfo{
+		{
+			Address: &workloadapi.Address{
+				Type: &workloadapi.Address_Workload{
+					Workload: &workloadapi.Workload{
+						Uid:               s.podXdsName("pod1"),
+						Name:              "pod1",
+						Namespace:         testNS,
+						Addresses:         [][]byte{parseIP("140.140.0.10")},
+						Node:              "node1",
+						Network:           testNW,
+						CanonicalName:     "a",
+						CanonicalRevision: "latest",
+						ServiceAccount:    "sa1",
+						WorkloadType:      workloadapi.WorkloadType_POD,
+						WorkloadName:      "pod1",
+						Services: map[string]*workloadapi.PortList{
+							"ns1/se.istio.io": {
+								Ports: []*workloadapi.Port{
+									{
+										ServicePort: 80,
+										TargetPort:  8080,
+									},
+								},
+							},
+						},
+						ClusterId: testC,
+					},
+				},
+			},
+		},
+		{
+			Address: &workloadapi.Address{
+				Type: &workloadapi.Address_Workload{
+					Workload: &workloadapi.Workload{
+						Uid:               s.wleXdsName("name0"),
+						Name:              "name0",
+						Namespace:         testNS,
+						Addresses:         [][]byte{parseIP("140.140.0.10")},
+						Node:              "",
+						Network:           testNW,
+						CanonicalName:     "a",
+						CanonicalRevision: "latest",
+						ServiceAccount:    "sa1",
+						WorkloadType:      workloadapi.WorkloadType_POD,
+						WorkloadName:      "name0",
+						ClusterId:         testC,
+						Services: map[string]*workloadapi.PortList{
+							"ns1/se.istio.io": {
+								Ports: []*workloadapi.Port{
+									{
+										ServicePort: 80,
+										TargetPort:  8080,
+									},
 								},
 							},
 						},
 					},
-					ClusterId: testC,
 				},
 			},
 		},
-	}})
+	})
 
-	assert.Equal(t, s.lookup(s.addrXdsName("140.140.0.11")), []model.AddressInfo{{
-		Address: &workloadapi.Address{
-			Type: &workloadapi.Address_Workload{
-				Workload: &workloadapi.Workload{
-					Uid:               s.podXdsName("pod2"),
-					Name:              "pod2",
-					Namespace:         testNS,
-					Addresses:         [][]byte{parseIP("140.140.0.11")},
-					Node:              "node1",
-					Network:           testNW,
-					ClusterId:         testC,
-					CanonicalName:     "other",
-					CanonicalRevision: "latest",
-					ServiceAccount:    "sa1",
-					WorkloadType:      workloadapi.WorkloadType_POD,
-					WorkloadName:      "pod2",
-					Services:          nil, // labels don't match workloadSelector, this should be nil
+	assert.Equal(t, s.lookup(s.addrXdsName("140.140.0.11")), []model.AddressInfo{
+		{
+			Address: &workloadapi.Address{
+				Type: &workloadapi.Address_Workload{
+					Workload: &workloadapi.Workload{
+						Uid:               s.podXdsName("pod2"),
+						Name:              "pod2",
+						Namespace:         testNS,
+						Addresses:         [][]byte{parseIP("140.140.0.11")},
+						Node:              "node1",
+						Network:           testNW,
+						ClusterId:         testC,
+						CanonicalName:     "other",
+						CanonicalRevision: "latest",
+						ServiceAccount:    "sa1",
+						WorkloadType:      workloadapi.WorkloadType_POD,
+						WorkloadName:      "pod2",
+						Services:          nil, // labels don't match workloadSelector, this should be nil
+					},
 				},
 			},
 		},
-	}})
+		{
+			Address: &workloadapi.Address{
+				Type: &workloadapi.Address_Workload{
+					Workload: &workloadapi.Workload{
+						Uid:               s.wleXdsName("name3"),
+						Name:              "name3",
+						Namespace:         testNS,
+						Addresses:         [][]byte{parseIP("140.140.0.11")},
+						Node:              "",
+						Network:           testNW,
+						CanonicalName:     "other",
+						CanonicalRevision: "latest",
+						ServiceAccount:    "sa1",
+						WorkloadType:      workloadapi.WorkloadType_POD,
+						WorkloadName:      "name3",
+						Services:          nil, // labels don't match workloadSelector, this should be nil
+						ClusterId:         testC,
+					},
+				},
+			},
+		},
+	})
 
 	assert.Equal(t, s.lookup(s.addrXdsName("240.240.34.56")), []model.AddressInfo{{
 		Address: &workloadapi.Address{
@@ -281,31 +341,54 @@ func TestAmbientIndex_ServiceEntry(t *testing.T) {
 	}})
 
 	s.deleteServiceEntry(t, "name1", testNS)
-	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "pod1", "pod2", "name1", "name2")
+	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "pod1", "pod2", "name0", "name1", "name2", "name3")
 	s.assertUniqueWorkloads(t)
 	// we should see an update for the workloads selected by the service entry
 	s.assertEvent(t, s.podXdsName("pod1"), s.wleXdsName("name0"), s.wleXdsName("name1"), "ns1/se.istio.io")
-	assert.Equal(t, s.lookup(s.addrXdsName("140.140.0.10")), []model.AddressInfo{{
-		Address: &workloadapi.Address{
-			Type: &workloadapi.Address_Workload{
-				Workload: &workloadapi.Workload{
-					Uid:               s.podXdsName("pod1"),
-					Name:              "pod1",
-					Namespace:         testNS,
-					Addresses:         [][]byte{parseIP("140.140.0.10")},
-					Node:              "node1",
-					Network:           testNW,
-					ClusterId:         testC,
-					CanonicalName:     "a",
-					CanonicalRevision: "latest",
-					ServiceAccount:    "sa1",
-					WorkloadType:      workloadapi.WorkloadType_POD,
-					WorkloadName:      "pod1",
-					Services:          nil, // vips for pod1 should be gone now
+	assert.Equal(t, s.lookup(s.addrXdsName("140.140.0.10")), []model.AddressInfo{
+		{
+			Address: &workloadapi.Address{
+				Type: &workloadapi.Address_Workload{
+					Workload: &workloadapi.Workload{
+						Uid:               s.podXdsName("pod1"),
+						Name:              "pod1",
+						Namespace:         testNS,
+						Addresses:         [][]byte{parseIP("140.140.0.10")},
+						Node:              "node1",
+						Network:           testNW,
+						ClusterId:         testC,
+						CanonicalName:     "a",
+						CanonicalRevision: "latest",
+						ServiceAccount:    "sa1",
+						WorkloadType:      workloadapi.WorkloadType_POD,
+						WorkloadName:      "pod1",
+						Services:          nil, // vips for pod1 should be gone now
+					},
 				},
 			},
 		},
-	}})
+		{
+			Address: &workloadapi.Address{
+				Type: &workloadapi.Address_Workload{
+					Workload: &workloadapi.Workload{
+						Uid:               s.wleXdsName("name0"),
+						Name:              "name0",
+						Namespace:         testNS,
+						Addresses:         [][]byte{parseIP("140.140.0.10")},
+						Node:              "",
+						Network:           testNW,
+						CanonicalName:     "a",
+						CanonicalRevision: "latest",
+						ServiceAccount:    "sa1",
+						WorkloadType:      workloadapi.WorkloadType_POD,
+						WorkloadName:      "name0",
+						ClusterId:         testC,
+						Services:          nil, // vips for pod1 should be gone now
+					},
+				},
+			},
+		},
+	})
 
 	assert.Equal(t, s.lookup(s.addrXdsName("240.240.34.56")), []model.AddressInfo{{
 		Address: &workloadapi.Address{

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/helpers.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/helpers.go
@@ -68,11 +68,6 @@ func mustByteIPToString(b []byte) string {
 	return ip.String()
 }
 
-func byteIPToAddr(b []byte) netip.Addr {
-	ip, _ := netip.AddrFromSlice(b) // Address only comes from objects we create, so it must be valid
-	return ip
-}
-
 func (a *index) toNetworkAddress(vip string) (*workloadapi.NetworkAddress, error) {
 	ip, err := netip.ParseAddr(vip)
 	if err != nil {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
@@ -873,7 +873,7 @@ func convertGateway(gw model.NetworkGateway) model.WorkloadInfo {
 		wl.Hostname = gw.Addr
 	}
 
-	return model.WorkloadInfo{Workload: wl}
+	return precomputeWorkload(model.WorkloadInfo{Workload: wl})
 }
 
 func (a *index) getNetworkGatewayAddress(n string) *workloadapi.GatewayAddress {

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -282,16 +282,20 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 
 	if features.EnableAmbient {
 		c.ambientIndex = ambient.New(ambient.Options{
-			Client:                kubeClient,
-			SystemNamespace:       options.SystemNamespace,
-			DomainSuffix:          options.DomainSuffix,
-			ClusterID:             options.ClusterID,
-			Revision:              options.Revision,
-			XDSUpdater:            options.XDSUpdater,
-			LookupNetwork:         c.Network,
-			LookupNetworkGateways: c.NetworkGateways,
-			StatusNotifier:        options.StatusWritingEnabled,
-			Debugger:              krt.GlobalDebugHandler,
+			Client:          kubeClient,
+			SystemNamespace: options.SystemNamespace,
+			DomainSuffix:    options.DomainSuffix,
+			ClusterID:       options.ClusterID,
+			Revision:        options.Revision,
+			XDSUpdater:      options.XDSUpdater,
+			LookupNetwork:   c.Network,
+			LookupNetworkGateways: func() []model.NetworkGateway {
+				return slices.Filter(c.NetworkGateways(), func(g model.NetworkGateway) bool {
+					return g.HBONEPort != 0
+				})
+			},
+			StatusNotifier: options.StatusWritingEnabled,
+			Debugger:       krt.GlobalDebugHandler,
 			Flags: ambient.FeatureFlags{
 				DefaultAllowFromWaypoint:              features.DefaultAllowFromWaypoint,
 				EnableK8SServiceSelectWorkloadEntries: features.EnableK8SServiceSelectWorkloadEntries,


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/54528

This removes the dedupe of workloads for WDS. This check is not correct (see https://github.com/istio/istio/issues/54528) and typically has no impact. Ztunnel has been updated to do the dedupe itself, where it can be done appropriately (https://github.com/istio/ztunnel/pull/1409)

```
                                                           │ /tmp/baseline │              /tmp/remove              │
                                                           │    sec/op     │   sec/op     vs base                  │
AddressFullGeneration/serviceentry-workloadentry-16          1223.3µ ± 60%   705.3µ ± 5%  -42.35% (p=0.000 n=10+6)
AddressIncrementalGeneration/serviceentry-workloadentry-16    1.583µ ± 34%   1.079µ ± 7%  -31.82% (p=0.000 n=10+6)
geomean                                                       44.00µ         27.59µ       -37.30%

                                                           │ /tmp/baseline │               /tmp/remove                │
                                                           │     B/op      │     B/op      vs base                    │
AddressFullGeneration/serviceentry-workloadentry-16          1006.7Ki ± 0%   869.0Ki ± 0%  -13.67% (p=0.000 n=10+6)
AddressIncrementalGeneration/serviceentry-workloadentry-16      968.0 ± 0%     968.0 ± 0%        ~ (p=1.000 n=10+6) ¹
geomean                                                       30.85Ki        28.66Ki        -7.09%

                                                           │ /tmp/baseline │              /tmp/remove               │
                                                           │   allocs/op   │  allocs/op   vs base                   │
AddressFullGeneration/serviceentry-workloadentry-16            3.672k ± 0%   3.623k ± 0%  -1.33% (n=10+6)
AddressIncrementalGeneration/serviceentry-workloadentry-16      13.00 ± 0%    13.00 ± 0%       ~ (p=1.000 n=10+6) ¹
geomean                                                         218.5         217.0       -0.67%
```
