### PR TITLE
Handle out-of-order ztunnel connection removals correctly.

### DIFF
--- a/cni/pkg/nodeagent/server.go
+++ b/cni/pkg/nodeagent/server.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync/atomic"
+	"time"
 
 	"golang.org/x/sys/unix"
 	corev1 "k8s.io/api/core/v1"
@@ -37,6 +38,8 @@ import (
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/util/sets"
 )
+
+const defaultZTunnelKeepAliveCheckInterval = 5 * time.Second
 
 var log = scopes.CNIAgent
 
@@ -91,7 +94,7 @@ func NewServer(ctx context.Context, ready *atomic.Value, pluginSocket string, ar
 	}
 
 	podNsMap := newPodNetnsCache(openNetnsInRoot(pconstants.HostMountsPath))
-	ztunnelServer, err := newZtunnelServer(args.ServerSocket, podNsMap)
+	ztunnelServer, err := newZtunnelServer(args.ServerSocket, podNsMap, defaultZTunnelKeepAliveCheckInterval)
 	if err != nil {
 		return nil, fmt.Errorf("error initializing the ztunnel server: %w", err)
 	}

--- a/cni/pkg/nodeagent/ztunnelserver.go
+++ b/cni/pkg/nodeagent/ztunnelserver.go
@@ -62,7 +62,6 @@ To clean up stale ztunnels
 
 type connMgr struct {
 	connectionSet []*ZtunnelConnection
-	latestConn    *ZtunnelConnection
 	mu            sync.Mutex
 }
 
@@ -71,14 +70,16 @@ func (c *connMgr) addConn(conn *ZtunnelConnection) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.connectionSet = append(c.connectionSet, conn)
-	c.latestConn = conn
 	ztunnelConnected.RecordInt(int64(len(c.connectionSet)))
 }
 
 func (c *connMgr) LatestConn() *ZtunnelConnection {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.latestConn
+	if len(c.connectionSet) == 0 {
+		return nil
+	}
+	return c.connectionSet[len(c.connectionSet)-1]
 }
 
 func (c *connMgr) deleteConn(conn *ZtunnelConnection) {
@@ -96,12 +97,6 @@ func (c *connMgr) deleteConn(conn *ZtunnelConnection) {
 		}
 	}
 	c.connectionSet = retainedConns
-	newSize := len(c.connectionSet)
-	if newSize == 0 {
-		c.latestConn = nil
-	} else {
-		c.latestConn = c.connectionSet[newSize-1]
-	}
 	ztunnelConnected.RecordInt(int64(len(c.connectionSet)))
 }
 
@@ -403,7 +398,7 @@ func (z *ztunnelServer) sendSnapshot(ctx context.Context, conn *ZtunnelConnectio
 	if err != nil {
 		return err
 	}
-	log.Debugf("snaptshot sent to ztunnel")
+	log.Debugf("snapshot sent to ztunnel")
 	if resp.GetAck().GetError() != "" {
 		log.Errorf("snap-sent: got ack error: %s", resp.GetAck().GetError())
 	}

--- a/cni/pkg/nodeagent/ztunnelserver_test.go
+++ b/cni/pkg/nodeagent/ztunnelserver_test.go
@@ -38,7 +38,6 @@ import (
 var ztunnelTestCounter atomic.Uint32
 
 func TestZtunnelSendsPodSnapshot(t *testing.T) {
-	ztunnelKeepAliveCheckInterval = time.Second / 10
 	mt := monitortest.New(t)
 	setupLogging()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -80,7 +79,6 @@ func TestZtunnelSendsPodSnapshot(t *testing.T) {
 }
 
 func TestMultipleConnectedZtunnelsGetEvents(t *testing.T) {
-	ztunnelKeepAliveCheckInterval = time.Second / 10
 	mt := monitortest.New(t)
 	setupLogging()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -186,7 +184,6 @@ func TestMultipleConnectedZtunnelsGetEvents(t *testing.T) {
 }
 
 func TestZtunnelLatestConnFallsBackToPreviousIfNewestDisconnects(t *testing.T) {
-	ztunnelKeepAliveCheckInterval = time.Second / 10
 	mt := monitortest.New(t)
 	setupLogging()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -287,7 +284,6 @@ func TestZtunnelLatestConnFallsBackToPreviousIfNewestDisconnects(t *testing.T) {
 }
 
 func TestZtunnelRemovePod(t *testing.T) {
-	ztunnelKeepAliveCheckInterval = time.Second / 10
 	mt := monitortest.New(t)
 	setupLogging()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -310,6 +306,7 @@ func TestZtunnelRemovePod(t *testing.T) {
 
 	// now remove the pod
 	ztunnelServer := fixture.ztunServer
+	defer ztunnelServer.Close()
 	errChan := make(chan error)
 	go func() {
 		errChan <- ztunnelServer.PodDeleted(ctx, uid)
@@ -328,7 +325,6 @@ func TestZtunnelRemovePod(t *testing.T) {
 }
 
 func TestZtunnelPodAdded(t *testing.T) {
-	ztunnelKeepAliveCheckInterval = time.Second / 10
 	mt := monitortest.New(t)
 	setupLogging()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -350,6 +346,7 @@ func TestZtunnelPodAdded(t *testing.T) {
 
 	// now add the pod
 	ztunnelServer := fixture.ztunServer
+	defer ztunnelServer.Close()
 	errChan := make(chan error)
 	pod2, ns2, tmpFileToClose := podAndNetns()
 	defer tmpFileToClose.Close()
@@ -371,7 +368,6 @@ func TestZtunnelPodAdded(t *testing.T) {
 }
 
 func TestZtunnelPodKept(t *testing.T) {
-	ztunnelKeepAliveCheckInterval = time.Second / 10
 	mt := monitortest.New(t)
 	setupLogging()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -554,7 +550,7 @@ func startServerWithPodCache(ctx context.Context, podCache PodNetnsCache) struct
 } {
 	// go uses @ instead of \0 for abstract unix sockets
 	addr := fmt.Sprintf("@testaddr%d", ztunnelTestCounter.Add(1))
-	ztServ, err := newZtunnelServer(addr, podCache)
+	ztServ, err := newZtunnelServer(addr, podCache, time.Second/10)
 	if err != nil {
 		panic(err)
 	}

--- a/cni/pkg/nodeagent/ztunnelserver_test.go
+++ b/cni/pkg/nodeagent/ztunnelserver_test.go
@@ -79,7 +79,7 @@ func TestZtunnelSendsPodSnapshot(t *testing.T) {
 	mt.Assert(ztunnelConnected.Name(), nil, monitortest.Exactly(0))
 }
 
-func TestZtunnelConnectTwiceUpdatesLatest(t *testing.T) {
+func TestMultipleConnectedZtunnelsGetEvents(t *testing.T) {
 	ztunnelKeepAliveCheckInterval = time.Second / 10
 	mt := monitortest.New(t)
 	setupLogging()
@@ -251,6 +251,8 @@ func TestZtunnelLatestConnFallsBackToPreviousIfNewestDisconnects(t *testing.T) {
 
 	// this will retry for a bit, so shouldn't flake
 	mt.Assert(ztunnelConnected.Name(), nil, monitortest.Exactly(1))
+
+	assert.Equal(t, (srv.ztunServer.conns.LatestConn() != nil), true)
 
 	// Now, add a new pod. Since client2 already disconnected, this should go to client 1
 	errChan := make(chan error)

--- a/cni/pkg/nodeagent/ztunnelserver_test.go
+++ b/cni/pkg/nodeagent/ztunnelserver_test.go
@@ -25,10 +25,11 @@ import (
 
 	"golang.org/x/sys/unix"
 	"google.golang.org/protobuf/proto"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/monitoring/monitortest"
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/zdsapi"
@@ -44,12 +45,15 @@ func TestZtunnelSendsPodSnapshot(t *testing.T) {
 	defer cancel()
 
 	fixture := connect(ctx)
+	defer fixture.podCloser()
+
 	ztunClient := fixture.ztunClient
 	uid := fixture.uid
 
-	m, fds := readRequest(t, ztunClient)
-	// we got am essage from ztun, so it should have observed us being connected
+	// we got a message from ztun, so it should have observed us being connected
 	mt.Assert(ztunnelConnected.Name(), nil, monitortest.Exactly(1))
+
+	m, fds := readRequest(t, ztunClient)
 
 	// we should get the fd to dev null. note that we can't assert the fd number
 	// as the kernel may have given us a different number that refers to the same file.
@@ -69,7 +73,213 @@ func TestZtunnelSendsPodSnapshot(t *testing.T) {
 		panic("expected snapshot sent")
 	}
 	sendAck(ztunClient)
+
 	ztunClient.Close()
+	// this will retry for a bit, so shouldn't flake
+	mt.Assert(ztunnelConnected.Name(), nil, monitortest.Exactly(0))
+}
+
+func TestZtunnelConnectTwiceUpdatesLatest(t *testing.T) {
+	ztunnelKeepAliveCheckInterval = time.Second / 10
+	mt := monitortest.New(t)
+	setupLogging()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cache := &fakePodCache{}
+
+	cacheCloser := fillCacheWithFakePods(cache, 2)
+
+	defer cacheCloser()
+
+	srv := startServerWithPodCache(ctx, cache)
+	defer srv.ztunServer.Close()
+
+	// connect 1st zt client, and read snapshot
+	client1 := connectZtClientToServer(srv.addr)
+	sendHello(client1)
+	mt.Assert(ztunnelConnected.Name(), nil, monitortest.Exactly(1))
+
+	for i := 0; i < 2; i++ {
+		m1, fds1 := readRequest(t, client1)
+		_, ok := cache.pods[m1.Payload.(*zdsapi.WorkloadRequest_Add).Add.Uid]
+		assert.Equal(t, ok, true)
+		assert.Equal(t, len(fds1), 1)
+		sendAck(client1)
+	}
+
+	m, fds := readRequest(t, client1)
+	assert.Equal(t, len(fds), 0)
+
+	sent := m.Payload.(*zdsapi.WorkloadRequest_SnapshotSent).SnapshotSent
+	if sent == nil {
+		panic("expected snapshot sent")
+	}
+	sendAck(client1)
+
+	// Now, connect 2nd zt client, and read snapshot
+	client2 := connectZtClientToServer(srv.addr)
+	sendHello(client2)
+
+	for i := 0; i < 2; i++ {
+		m2, fds2 := readRequest(t, client2)
+		_, ok := cache.pods[m2.Payload.(*zdsapi.WorkloadRequest_Add).Add.Uid]
+		assert.Equal(t, ok, true)
+		assert.Equal(t, len(fds2), 1)
+		sendAck(client2)
+	}
+
+	m, fds = readRequest(t, client2)
+	assert.Equal(t, len(fds), 0)
+
+	sent = m.Payload.(*zdsapi.WorkloadRequest_SnapshotSent).SnapshotSent
+	if sent == nil {
+		panic("expected snapshot sent")
+	}
+	sendAck(client2)
+
+	mt.Assert(ztunnelConnected.Name(), nil, monitortest.Exactly(2))
+
+	// Now, add a new pod. It should only go to the second, most recent client.
+	errChan := make(chan error)
+	firstNewPod, ns, tmpFileToClose := podAndNetns()
+	defer tmpFileToClose.Close()
+
+	go func() {
+		errChan <- srv.ztunServer.PodAdded(ctx, firstNewPod, ns)
+	}()
+
+	// Synchronously process pod add for client2
+	m3, fds3 := readRequest(t, client2)
+	_, ok := cache.pods[m3.Payload.(*zdsapi.WorkloadRequest_Add).Add.Uid]
+	assert.Equal(t, ok, false)
+	assert.Equal(t, len(fds3), 1)
+	sendAck(client2)
+
+	// For delete, both should get the delete msg, even though only client2 got the add.
+
+	go func() {
+		errChan <- srv.ztunServer.PodDeleted(ctx, string(firstNewPod.ObjectMeta.UID))
+	}()
+	// Synchronously process pod delete for client1
+	m4, fds4 := readRequest(t, client1)
+	_, ok = cache.pods[m4.Payload.(*zdsapi.WorkloadRequest_Del).Del.Uid]
+	assert.Equal(t, ok, false)
+	assert.Equal(t, len(fds4), 0)
+	sendAck(client1)
+
+	// Synchronously process pod delete for client2
+	m4, fds4 = readRequest(t, client2)
+	_, ok = cache.pods[m4.Payload.(*zdsapi.WorkloadRequest_Del).Del.Uid]
+	assert.Equal(t, ok, false)
+	assert.Equal(t, len(fds4), 0)
+	sendAck(client2)
+
+	client1.Close()
+
+	// this will retry for a bit, so shouldn't flake
+	mt.Assert(ztunnelConnected.Name(), nil, monitortest.Exactly(1))
+
+	client2.Close()
+	// this will retry for a bit, so shouldn't flake
+	mt.Assert(ztunnelConnected.Name(), nil, monitortest.Exactly(0))
+}
+
+func TestZtunnelLatestConnFallsBackToPreviousIfNewestDisconnects(t *testing.T) {
+	ztunnelKeepAliveCheckInterval = time.Second / 10
+	mt := monitortest.New(t)
+	setupLogging()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cache := &fakePodCache{}
+
+	cacheCloser := fillCacheWithFakePods(cache, 2)
+
+	defer cacheCloser()
+
+	srv := startServerWithPodCache(ctx, cache)
+	defer srv.ztunServer.Close()
+
+	// connect 1st zt client, and read snapshot
+	client1 := connectZtClientToServer(srv.addr)
+	sendHello(client1)
+	mt.Assert(ztunnelConnected.Name(), nil, monitortest.Exactly(1))
+
+	for i := 0; i < 2; i++ {
+		m1, fds1 := readRequest(t, client1)
+		_, ok := cache.pods[m1.Payload.(*zdsapi.WorkloadRequest_Add).Add.Uid]
+		assert.Equal(t, ok, true)
+		assert.Equal(t, len(fds1), 1)
+		sendAck(client1)
+	}
+
+	m, fds := readRequest(t, client1)
+	assert.Equal(t, len(fds), 0)
+
+	sent := m.Payload.(*zdsapi.WorkloadRequest_SnapshotSent).SnapshotSent
+	if sent == nil {
+		panic("expected snapshot sent")
+	}
+	sendAck(client1)
+
+	// Now, connect 2nd zt client, and read snapshot
+	client2 := connectZtClientToServer(srv.addr)
+	sendHello(client2)
+
+	for i := 0; i < 2; i++ {
+		m2, fds2 := readRequest(t, client2)
+		_, ok := cache.pods[m2.Payload.(*zdsapi.WorkloadRequest_Add).Add.Uid]
+		assert.Equal(t, ok, true)
+		assert.Equal(t, len(fds2), 1)
+		sendAck(client2)
+	}
+
+	m, fds = readRequest(t, client2)
+	assert.Equal(t, len(fds), 0)
+
+	sent = m.Payload.(*zdsapi.WorkloadRequest_SnapshotSent).SnapshotSent
+	if sent == nil {
+		panic("expected snapshot sent")
+	}
+	sendAck(client2)
+
+	mt.Assert(ztunnelConnected.Name(), nil, monitortest.Exactly(2))
+
+	// Now disconnect the newest client
+	client2.Close()
+
+	// this will retry for a bit, so shouldn't flake
+	mt.Assert(ztunnelConnected.Name(), nil, monitortest.Exactly(1))
+
+	// Now, add a new pod. Since client2 already disconnected, this should go to client 1
+	errChan := make(chan error)
+	firstNewPod, ns, tmpFileToClose := podAndNetns()
+	defer tmpFileToClose.Close()
+
+	go func() {
+		errChan <- srv.ztunServer.PodAdded(ctx, firstNewPod, ns)
+	}()
+
+	// Synchronously process pod add for client2
+	m3, fds3 := readRequest(t, client1)
+	_, ok := cache.pods[m3.Payload.(*zdsapi.WorkloadRequest_Add).Add.Uid]
+	assert.Equal(t, ok, false)
+	assert.Equal(t, len(fds3), 1)
+	sendAck(client1)
+
+	go func() {
+		errChan <- srv.ztunServer.PodDeleted(ctx, string(firstNewPod.ObjectMeta.UID))
+	}()
+
+	// Synchronously process pod delete for client1
+	m4, fds4 := readRequest(t, client1)
+	_, ok = cache.pods[m4.Payload.(*zdsapi.WorkloadRequest_Del).Del.Uid]
+	assert.Equal(t, ok, false)
+	assert.Equal(t, len(fds4), 0)
+	sendAck(client1)
+
+	client1.Close()
 	// this will retry for a bit, so shouldn't flake
 	mt.Assert(ztunnelConnected.Name(), nil, monitortest.Exactly(0))
 }
@@ -112,7 +322,7 @@ func TestZtunnelRemovePod(t *testing.T) {
 
 	ztunClient.Close()
 	// this will retry for a bit, so shouldn't flake
-	mt.Assert(ztunnelConnected.Name(), nil, monitortest.Exactly(0))
+	mt.Assert(ztunnelConnected.Name(), nil, monitortest.Exactly(1))
 }
 
 func TestZtunnelPodAdded(t *testing.T) {
@@ -136,10 +346,12 @@ func TestZtunnelPodAdded(t *testing.T) {
 	}
 	sendAck(ztunClient)
 
-	// now remove the pod
+	// now add the pod
 	ztunnelServer := fixture.ztunServer
 	errChan := make(chan error)
-	pod2, ns2 := podAndNetns()
+	pod2, ns2, tmpFileToClose := podAndNetns()
+	defer tmpFileToClose.Close()
+
 	go func() {
 		errChan <- ztunnelServer.PodAdded(ctx, pod2, ns2)
 	}()
@@ -165,7 +377,9 @@ func TestZtunnelPodKept(t *testing.T) {
 
 	pods := &fakePodCache{}
 
-	pod, f := podAndNetns()
+	pod, f, tmpFileToClose := podAndNetns()
+	defer tmpFileToClose.Close()
+
 	f.Close()
 	pods.pods = map[string]WorkloadInfo{
 		string(pod.UID): {}, // simulate unknown netns
@@ -196,64 +410,162 @@ func TestZtunnelPodKept(t *testing.T) {
 	mt.Assert(ztunnelConnected.Name(), nil, monitortest.Exactly(0))
 }
 
-func podAndNetns() (*v1.Pod, *fakeNs) {
+// podAndNetns returns a ref to the file - Go will close FDs when the File object is GC'd,
+// so to prevent test glitches, we have to hang onto a reference for as long as we might need
+// the FD to remain valid, or there's a risk the FD will be closed underneath us in test due to a GC.
+//
+// callers should `Close()` the fileref when they are done with it.
+func podAndNetns() (*corev1.Pod, *fakeNs, *os.File) {
 	devNull, err := os.Open(os.DevNull)
 	if err != nil {
 		panic(err)
 	}
-	// we can't close this now, because we need to pass it from the ztunnel server to the client
-	// it would leak, but this is a test, so we don't care
-	//	defer devNull.Close()
-
 	id := ztunnelTestCounter.Add(1)
-	pod := &v1.Pod{
+	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("name-%d", id),
 			UID:  types.UID(fmt.Sprintf("uid-%d", id)),
 		},
-		Spec:   v1.PodSpec{},
-		Status: v1.PodStatus{},
+		Spec:   corev1.PodSpec{},
+		Status: corev1.PodStatus{},
 	}
-	return pod, newFakeNs(devNull.Fd())
+	return pod, newFakeNs(devNull.Fd()), devNull
 }
 
+func fillCacheWithFakePods(cache *fakePodCache, podCount int) func() {
+	if cache.pods == nil {
+		cache.pods = make(map[string]WorkloadInfo)
+	}
+	filesToClose := make([]*os.File, 0)
+	for i := 0; i < podCount; i++ {
+		uid, ns, closeFile := podAndNetns()
+		filesToClose = append(filesToClose, closeFile)
+		workload := WorkloadInfo{
+			Workload: podToWorkload(uid),
+			Netns:    ns,
+		}
+		cache.pods[string(uid.UID)] = workload
+	}
+
+	return func() {
+		for _, f := range filesToClose {
+			f.Close()
+		}
+	}
+}
+
+// func connect(ctx context.Context) struct {
+// 	ztunClient *net.UnixConn
+// 	ztunServer *ztunnelServer
+// 	uid        string
+// } {
+// 	pods := &fakePodCache{}
+
+// 	pod, ns := podAndNetns()
+// 	workload := WorkloadInfo{
+// 		Workload: podToWorkload(pod),
+// 		Netns:    ns,
+// 	}
+// 	pods.pods = map[string]WorkloadInfo{
+// 		string(pod.UID): workload,
+// 	}
+// 	ret := connectWithPods(ctx, pods)
+
+// 	return struct {
+// 		ztunClient *net.UnixConn
+// 		ztunServer *ztunnelServer
+// 		uid        string
+// 	}{ztunClient: ret.ztunClient, ztunServer: ret.ztunServer, uid: string(pod.UID)}
+// }
+
+// func connectWithPods(ctx context.Context, pods PodNetnsCache) struct {
+// 	ztunClient *net.UnixConn
+// 	ztunServer *ztunnelServer
+// } {
+// 	// go uses @ instead of \0 for abstract unix sockets
+// 	addr := fmt.Sprintf("@testaddr%d", ztunnelTestCounter.Add(1))
+// 	ztun, err := newZtunnelServer(addr, pods)
+// 	if err != nil {
+// 		panic(err)
+// 	}
+// 	go ztun.Run(ctx)
+
+// 	// now as a client connect confirm we and get snapshot
+// 	resolvedAddr, err := net.ResolveUnixAddr("unixpacket", addr)
+// 	if err != nil {
+// 		panic(err)
+// 	}
+// 	ztunClient, err := net.DialUnix("unixpacket", nil, resolvedAddr)
+// 	if err != nil {
+// 		panic(err)
+// 	}
+
+// 	// send hello
+// 	sendHello(ztunClient)
+
+// 	return struct {
+// 		ztunClient *net.UnixConn
+// 		ztunServer *ztunnelServer
+// 	}{ztunClient: ztunClient, ztunServer: ztun}
+// }
+
+// TODO
 func connect(ctx context.Context) struct {
 	ztunClient *net.UnixConn
 	ztunServer *ztunnelServer
 	uid        string
+	podCloser  func()
 } {
-	pods := &fakePodCache{}
+	cache := &fakePodCache{}
 
-	pod, ns := podAndNetns()
-	workload := WorkloadInfo{
-		Workload: podToWorkload(pod),
-		Netns:    ns,
-	}
-	pods.pods = map[string]WorkloadInfo{
-		string(pod.UID): workload,
-	}
-	ret := connectWithPods(ctx, pods)
+	podCloser := fillCacheWithFakePods(cache, 1)
 
+	ret := connectWithPods(ctx, cache)
 	return struct {
 		ztunClient *net.UnixConn
 		ztunServer *ztunnelServer
 		uid        string
-	}{ztunClient: ret.ztunClient, ztunServer: ret.ztunServer, uid: string(pod.UID)}
+		podCloser  func()
+	}{ztunClient: ret.ztunClient, ztunServer: ret.ztunServer, uid: maps.Keys(cache.pods)[0], podCloser: podCloser}
 }
 
 func connectWithPods(ctx context.Context, pods PodNetnsCache) struct {
 	ztunClient *net.UnixConn
 	ztunServer *ztunnelServer
 } {
+	server := startServerWithPodCache(ctx, pods)
+
+	client := connectZtClientToServer(server.addr)
+
+	// send hello
+	sendHello(client)
+
+	return struct {
+		ztunClient *net.UnixConn
+		ztunServer *ztunnelServer
+	}{ztunClient: client, ztunServer: server.ztunServer}
+}
+
+func startServerWithPodCache(ctx context.Context, podCache PodNetnsCache) struct {
+	ztunServer *ztunnelServer
+	addr       string
+} {
 	// go uses @ instead of \0 for abstract unix sockets
 	addr := fmt.Sprintf("@testaddr%d", ztunnelTestCounter.Add(1))
-	ztun, err := newZtunnelServer(addr, pods)
+	ztServ, err := newZtunnelServer(addr, podCache)
 	if err != nil {
 		panic(err)
 	}
-	go ztun.Run(ctx)
+	go ztServ.Run(ctx)
 
-	// now as a client connect confirm we and get snapshot
+	return struct {
+		ztunServer *ztunnelServer
+		addr       string
+	}{ztunServer: ztServ, addr: addr}
+}
+
+func connectZtClientToServer(addr string) *net.UnixConn {
+	// Now connect the fake client
 	resolvedAddr, err := net.ResolveUnixAddr("unixpacket", addr)
 	if err != nil {
 		panic(err)
@@ -263,13 +575,7 @@ func connectWithPods(ctx context.Context, pods PodNetnsCache) struct {
 		panic(err)
 	}
 
-	// send hello
-	sendHello(ztunClient)
-
-	return struct {
-		ztunClient *net.UnixConn
-		ztunServer *ztunnelServer
-	}{ztunClient: ztunClient, ztunServer: ztun}
+	return ztunClient
 }
 
 func readRequest(t *testing.T, c *net.UnixConn) (*zdsapi.WorkloadRequest, []int) {
@@ -338,5 +644,5 @@ type fakePodCache struct {
 }
 
 func (f fakePodCache) ReadCurrentPodSnapshot() map[string]WorkloadInfo {
-	return f.pods
+	return maps.Clone(f.pods)
 }

--- a/cni/pkg/nodeagent/ztunnelserver_test.go
+++ b/cni/pkg/nodeagent/ztunnelserver_test.go
@@ -452,62 +452,6 @@ func fillCacheWithFakePods(cache *fakePodCache, podCount int) func() {
 	}
 }
 
-// func connect(ctx context.Context) struct {
-// 	ztunClient *net.UnixConn
-// 	ztunServer *ztunnelServer
-// 	uid        string
-// } {
-// 	pods := &fakePodCache{}
-
-// 	pod, ns := podAndNetns()
-// 	workload := WorkloadInfo{
-// 		Workload: podToWorkload(pod),
-// 		Netns:    ns,
-// 	}
-// 	pods.pods = map[string]WorkloadInfo{
-// 		string(pod.UID): workload,
-// 	}
-// 	ret := connectWithPods(ctx, pods)
-
-// 	return struct {
-// 		ztunClient *net.UnixConn
-// 		ztunServer *ztunnelServer
-// 		uid        string
-// 	}{ztunClient: ret.ztunClient, ztunServer: ret.ztunServer, uid: string(pod.UID)}
-// }
-
-// func connectWithPods(ctx context.Context, pods PodNetnsCache) struct {
-// 	ztunClient *net.UnixConn
-// 	ztunServer *ztunnelServer
-// } {
-// 	// go uses @ instead of \0 for abstract unix sockets
-// 	addr := fmt.Sprintf("@testaddr%d", ztunnelTestCounter.Add(1))
-// 	ztun, err := newZtunnelServer(addr, pods)
-// 	if err != nil {
-// 		panic(err)
-// 	}
-// 	go ztun.Run(ctx)
-
-// 	// now as a client connect confirm we and get snapshot
-// 	resolvedAddr, err := net.ResolveUnixAddr("unixpacket", addr)
-// 	if err != nil {
-// 		panic(err)
-// 	}
-// 	ztunClient, err := net.DialUnix("unixpacket", nil, resolvedAddr)
-// 	if err != nil {
-// 		panic(err)
-// 	}
-
-// 	// send hello
-// 	sendHello(ztunClient)
-
-// 	return struct {
-// 		ztunClient *net.UnixConn
-// 		ztunServer *ztunnelServer
-// 	}{ztunClient: ztunClient, ztunServer: ztun}
-// }
-
-// TODO
 func connect(ctx context.Context) struct {
 	ztunClient *net.UnixConn
 	ztunServer *ztunnelServer

--- a/releasenotes/notes/54565.yaml
+++ b/releasenotes/notes/54565.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 54544
+  - 53843
+releaseNotes:
+- |
+  **Fixed** issue where out-of-order ztunnel disconnects could put `istio-cni` in a state where it believes it has no connections.


### PR DESCRIPTION
**Please provide a description of this PR:**

I had actually fixed this in passing ages ago in internal builds as part of unrelated work, but forgot to backport when that work was dropped.

Should fix https://github.com/istio/istio/issues/54544 and (I bet) https://github.com/istio/istio/issues/53843

Moves ztunnel conns to an ordered slice so we can keep track of what the "previous" connection was and revert back to that, if we happen to get out-of-order `deleteConn` calls due to restart timing variances.