### PR TITLE
Fix Ambient Peer Authn flake

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/authorization.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/authorization.go
@@ -245,6 +245,7 @@ func convertPeerAuthentication(rootNamespace string, cfg, nsCfg, rootCfg *securi
 
 	action := security.Action_DENY
 	var rules []*security.Rules
+	var groups []*security.Group
 
 	if mode == v1beta1.PeerAuthentication_MutualTLS_STRICT {
 		rules = append(rules, &security.Rules{
@@ -268,15 +269,34 @@ func convertPeerAuthentication(rootNamespace string, cfg, nsCfg, rootCfg *securi
 	for port, mtls := range pa.PortLevelMtls {
 		switch portMtlsMode := mtls.GetMode(); {
 		case portMtlsMode == v1beta1.PeerAuthentication_MutualTLS_STRICT:
-			rules = append(rules, &security.Rules{
-				Matches: []*security.Match{
+			// If either:
+			// 1. The workload-level policy is STRICT
+			// 2. The workload level policy is nil/unset and the namespace-level policy is STRICT
+			// 3. The workload level policy is nil/unset and the namespace-level policy is nil/unset and the mesh-level policy is STRICT
+			// then we don't need to add a rule for this STRICT port since it will be enforced by the parent policy
+			if isMtlsModeStrict(pa.GetMtls()) || // #1
+				(isMtlsModeUnset(pa.GetMtls()) && // First condition for #2 and #3
+					(nsCfg != nil && isMtlsModeStrict(nsCfg.Spec.Mtls)) || // #2
+					// #3
+					((nsCfg == nil || isMtlsModeUnset(nsCfg.Spec.Mtls)) && rootCfg != nil && isMtlsModeStrict(rootCfg.Spec.Mtls))) {
+				log.Debugf("skipping port %s/%s for PeerAuthentication %s/%s for ambient since the parent mTLS mode is %s",
+					port, portMtlsMode, cfg.Namespace, cfg.Name, mode)
+				continue
+			}
+			// Groups are OR'd so we need to create one for each STRICT workload port
+			groups = append(groups, &security.Group{
+				Rules: []*security.Rules{
 					{
-						NotPrincipals: []*security.StringMatch{
+						Matches: []*security.Match{
 							{
-								MatchType: &security.StringMatch_Presence{},
+								NotPrincipals: []*security.StringMatch{
+									{
+										MatchType: &security.StringMatch_Presence{},
+									},
+								},
+								DestinationPorts: []uint32{port},
 							},
 						},
-						DestinationPorts: []uint32{port},
 					},
 				},
 			})
@@ -319,21 +339,9 @@ func convertPeerAuthentication(rootNamespace string, cfg, nsCfg, rootCfg *securi
 		return nil
 	}
 
-	if len(rules) == 0 {
-		// we never added any rules; return
+	if len(rules) == 0 && len(groups) == 0 {
+		// we never added any rules or groups; return
 		return nil
-	}
-
-	opol := &security.Authorization{
-		Name: model.GetAmbientPolicyConfigName(model.ConfigKey{
-			Name:      cfg.Name,
-			Kind:      kind.PeerAuthentication,
-			Namespace: cfg.Namespace,
-		}),
-		Namespace: cfg.Namespace,
-		Scope:     scope,
-		Action:    action,
-		Groups:    []*security.Group{{Rules: rules}},
 	}
 
 	// We only need to merge if the effective policy is STRICT, the workload policy's mode is unstrict, and we have a non-strict port level policy
@@ -346,9 +354,10 @@ func convertPeerAuthentication(rootNamespace string, cfg, nsCfg, rootCfg *securi
 	}
 
 	// If the effective policy (namespace or mesh) is STRICT and we have a non-strict port level policy,
-	// we need to merge that strictness into the workload policy so that the static strict policy
+	// we need to merge that strictness into the workload policy so that the static strict policy can be elided
+	// from the workload's policy list.
 	if shouldMergeStrict && foundNonStrictPortmTLS {
-		opol.Groups[0].Rules = append(opol.Groups[0].Rules, &security.Rules{
+		rules = append(rules, &security.Rules{
 			Matches: []*security.Match{
 				{
 					NotPrincipals: []*security.StringMatch{
@@ -359,6 +368,24 @@ func convertPeerAuthentication(rootNamespace string, cfg, nsCfg, rootCfg *securi
 				},
 			},
 		})
+	}
+
+	if len(rules) > 0 {
+		groups = append(groups, &security.Group{
+			Rules: rules,
+		})
+	}
+
+	opol := &security.Authorization{
+		Name: model.GetAmbientPolicyConfigName(model.ConfigKey{
+			Name:      cfg.Name,
+			Kind:      kind.PeerAuthentication,
+			Namespace: cfg.Namespace,
+		}),
+		Namespace: cfg.Namespace,
+		Scope:     scope,
+		Action:    action,
+		Groups:    groups,
 	}
 
 	return opol

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/testdata/peer-authn-permissive-port-mtls-strict-and-permissive-in.yaml
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/testdata/peer-authn-permissive-port-mtls-strict-and-permissive-in.yaml
@@ -1,0 +1,15 @@
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: permissive-strict-mtls
+spec:
+  selector:
+    matchLabels:
+      app: a
+  mtls:
+    mode: PERMISSIVE
+  portLevelMtls:
+    9090:
+      mode: STRICT
+    8080:
+      mode: PERMISSIVE

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/testdata/peer-authn-permissive-port-mtls-strict-and-permissive.yaml
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/testdata/peer-authn-permissive-port-mtls-strict-and-permissive.yaml
@@ -1,0 +1,10 @@
+action: DENY
+groups:
+- rules:
+  - matches:
+    - destinationPorts:
+      - 9090
+      notPrincipals:
+      - presence: {}
+name: converted_peer_authentication_permissive-strict-mtls
+scope: WORKLOAD_SELECTOR

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/testdata/peer-authn-permissive-root-permissive-namespace-strict-workload-ports-in.yaml
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/testdata/peer-authn-permissive-root-permissive-namespace-strict-workload-ports-in.yaml
@@ -1,0 +1,32 @@
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: default-mesh
+  namespace: istio-system
+spec:
+  mtls:
+    mode: PERMISSIVE
+---
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: default-foo
+  namespace: foo
+spec:
+  mtls:
+    mode: PERMISSIVE
+---
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: workload
+  namespace: foo
+spec:
+  selector:
+    matchLabels:
+      app: a
+  portLevelMtls:
+    9090:
+      mode: STRICT
+    8080:
+      mode: STRICT

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/testdata/peer-authn-permissive-root-permissive-namespace-strict-workload-ports.yaml
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/testdata/peer-authn-permissive-root-permissive-namespace-strict-workload-ports.yaml
@@ -1,0 +1,17 @@
+action: DENY
+groups:
+- rules:
+  - matches:
+    - destinationPorts:
+      - 8080
+      notPrincipals:
+      - presence: {}
+- rules:
+  - matches:
+    - destinationPorts:
+      - 9090
+      notPrincipals:
+      - presence: {}
+name: converted_peer_authentication_workload
+namespace: foo
+scope: WORKLOAD_SELECTOR

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/testdata/peer-authn-permissive-root-unset-namespace-mixed-workload-ports-in.yaml
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/testdata/peer-authn-permissive-root-unset-namespace-mixed-workload-ports-in.yaml
@@ -1,0 +1,32 @@
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: default-mesh
+  namespace: istio-system
+spec:
+  mtls:
+    mode: PERMISSIVE
+---
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: default-foo
+  namespace: foo
+spec:
+  mtls:
+    mode: UNSET
+---
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: workload
+  namespace: foo
+spec:
+  selector:
+    matchLabels:
+      app: a
+  portLevelMtls:
+    9090:
+      mode: STRICT
+    8080:
+      mode: PERMISSIVE

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/testdata/peer-authn-permissive-root-unset-namespace-mixed-workload-ports.yaml
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/testdata/peer-authn-permissive-root-unset-namespace-mixed-workload-ports.yaml
@@ -1,0 +1,11 @@
+action: DENY
+groups:
+- rules:
+  - matches:
+    - destinationPorts:
+      - 9090
+      notPrincipals:
+      - presence: {}
+name: converted_peer_authentication_workload
+namespace: foo
+scope: WORKLOAD_SELECTOR

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/testdata/peer-authn-strict-port-mtls-strict-and-permissive-in.yaml
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/testdata/peer-authn-strict-port-mtls-strict-and-permissive-in.yaml
@@ -1,0 +1,15 @@
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: permissive-strict-mtls
+spec:
+  selector:
+    matchLabels:
+      app: a
+  mtls:
+    mode: STRICT
+  portLevelMtls:
+    9090:
+      mode: STRICT
+    8080:
+      mode: PERMISSIVE

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/testdata/peer-authn-strict-port-mtls-strict-and-permissive.yaml
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/testdata/peer-authn-strict-port-mtls-strict-and-permissive.yaml
@@ -1,0 +1,11 @@
+action: DENY
+groups:
+- rules:
+  - matches:
+    - notPrincipals:
+      - presence: {}
+  - matches:
+    - notDestinationPorts:
+      - 8080
+name: converted_peer_authentication_permissive-strict-mtls
+scope: WORKLOAD_SELECTOR

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/testdata/peer-authn-strict-root-unset-workload-port-mtls-strict-and-permissive-in.yaml
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/testdata/peer-authn-strict-root-unset-workload-port-mtls-strict-and-permissive-in.yaml
@@ -1,0 +1,23 @@
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: default-mesh
+  namespace: istio-system
+spec:
+  mtls:
+    mode: STRICT
+---
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: workload
+  namespace: foo
+spec:
+  selector:
+    matchLabels:
+      app: a
+  portLevelMtls:
+    9090:
+      mode: PERMISSIVE
+    8080:
+      mode: STRICT

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/testdata/peer-authn-strict-root-unset-workload-port-mtls-strict-and-permissive.yaml
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/testdata/peer-authn-strict-root-unset-workload-port-mtls-strict-and-permissive.yaml
@@ -1,0 +1,12 @@
+action: DENY
+groups:
+- rules:
+  - matches:
+    - notDestinationPorts:
+      - 9090
+  - matches:
+    - notPrincipals:
+      - presence: {}
+name: converted_peer_authentication_workload
+namespace: foo
+scope: WORKLOAD_SELECTOR

--- a/releasenotes/notes/54146.yaml
+++ b/releasenotes/notes/54146.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+issue:
+  - 54146
+releaseNotes:
+- |
+  **Fixed** a bug in Ambient (only) where multiple STRICT port-level mTLS rules in a PeerAuthentication policy would effectively result
+  in a permissive policy due to incorrect evaluation logic (AND vs. OR).

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -723,9 +723,6 @@ func TestPeerAuthentication(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
 		applyDrainingWorkaround(t)
 		runTestContext(t, func(t framework.TestContext, src echo.Instance, dst echo.Instance, opt echo.CallOptions) {
-			if opt.Scheme != scheme.TCP {
-				return
-			}
 			// Ensure we don't get stuck on old connections with old RBAC rules. This causes 45s test times
 			// due to draining.
 			opt.NewConnectionPerRequest = true
@@ -824,7 +821,7 @@ spec:
     18080:
       mode: PERMISSIVE
     19090:
-      mode: STRICT
+      mode: PERMISSIVE
         `).ApplyOrFail(t)
 				opt = opt.DeepCopy()
 				// Should pass for all workloads, in or out of mesh, targeting this port
@@ -836,7 +833,7 @@ spec:
 apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
-  name: global-strict
+  name: global-permissive
 spec:
   mtls:
     mode: PERMISSIVE
@@ -858,7 +855,6 @@ spec:
       mode: STRICT
     19090:
       mode: STRICT
-
         `).ApplyOrFail(t)
 				opt = opt.DeepCopy()
 				if !src.Config().HasProxyCapabilities() && dst.Config().HasProxyCapabilities() {


### PR DESCRIPTION
**Please provide a description of this PR:**
Fixes #54146. I suspect that our test runners were too fast which is why this flaked instead of failing 100% of the time.

The ambient Peerauthn implementation is based on the on the WDS protobuf documentation for authorization; this exists here in istio as well as the ztunnel repo. #53938 and the subsequent PR revealed that the istio version of the documentation was incorrect; Group.Rules (in the istio version) are AND'd during evaluation, not OR'd (like the documentation says). This PR fixes that and adds tests for even more combinations of port-level overrides