### PR TITLE
Allow customization of reinvocationPolicy for revision-tag webhook

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags.yaml
@@ -29,6 +29,7 @@ a unique prefix to each. */}}
     apiVersions: ["v1"]
     resources: ["pods"]
   failurePolicy: Fail
+  reinvocationPolicy: "{{ .reinvocationPolicy }}"
   admissionReviewVersions: ["v1"]
 {{- end }}
 # Not created if istiod is running remotely

--- a/releasenotes/notes/54575.yaml
+++ b/releasenotes/notes/54575.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+
+releaseNotes:
+  - |
+    **Added** support to set reinvocationPolicy for the revision-tag webhook when installing Istio with istioctl or Helm.


### PR DESCRIPTION
**Please provide a description of this PR:**

This PR adds a feature to set the `reinvocationPolicy` for revision-tag when installing Istio using istioctl or helm. Currently, the policy is fixed to `Never`. When multiple sidecar injector webhooks compete for the first position in initContainers. Enabling `reinvocationPolicy` to be set to `IfNeeded` resolves this issue.

Changes:

- Updated the code in istioctl/pkg/tag/generate.go to copy ReinvocationPolicy from the existing non-tag webhook.
- Modified the corresponding templates in the Helm chart.

This change tries to keep backward compatibility. If `reinvocationPolicy` is not set, it remains `Never`.