### PR TITLE
fix regex max program size validation

### DIFF
--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -332,7 +332,7 @@ func extractRuntimeFlags(cfg *model.NodeMetaProxyConfig, policy string) map[stri
 	// Setup defaults
 	runtimeFlags := map[string]any{
 		"overload.global_downstream_max_connections": "2147483647",
-		"re2.max_program_size.error_level":           "32768",
+		"re2.max_program_size.error_level":           strconv.Itoa(constants.Re2MaxProgramSizeErorLevel),
 		"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
 		"envoy.reloadable_features.http_reject_path_with_fragment":                                             false,
 	}

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -189,4 +189,7 @@ const (
 	AllTraffic = "all"
 	// NoTraffic indicates that no traffic should go through the intended waypoint.
 	NoTraffic = "none"
+
+	// Limit that Envoy enforces on the MaxProgramSize of RE2 regular expressions.
+	Re2MaxProgramSizeErorLevel = 32768
 )

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -2197,13 +2197,13 @@ func validateStringMatchRegexp(sm *networking.StringMatch, where string) error {
 func validateStringRegexp(re string, where string) error {
 	// Envoy enforces a re2.max_program_size.error_level re2 program size is not the same as length,
 	// but it is always *larger* than length. Because goland does not have a way to evaluate the
-	// program size, we approximate by the length. To ensure that a program that is smaller than 1024
-	// length but larger than 1024 size does not enter the system, we program Envoy to allow very large
+	// program size, we approximate by the length. To ensure that a program that is smaller than 32768
+	// length but larger than 32768 size does not enter the system, we program Envoy to allow very large
 	// regexs to avoid NACKs. See
 	// https://github.com/jpeach/snippets/blob/889fda84cc8713af09205438b33553eb69dd5355/re2sz.cc to
 	// evaluate program size.
-	if len(re) > 1024 {
-		return fmt.Errorf("%q: regex is too large, max length allowed is 1024", where)
+	if len(re) > constants.Re2MaxProgramSizeErorLevel {
+		return fmt.Errorf("%q: regex is too large, max length allowed is %d", where, constants.Re2MaxProgramSizeErorLevel)
 	}
 
 	_, err := regexp.Compile(re)


### PR DESCRIPTION
We have changed this value to 32768 but validation still enforces 1024

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions