### PR TITLE
ambient: do not full push for WDS when we don't need to

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -371,6 +371,8 @@ type PushRequest struct {
 	// The kind of resources are defined in pkg/config/schemas.
 	ConfigsUpdated sets.Set[ConfigKey]
 
+	AddressesUpdated sets.Set[string]
+
 	// Push stores the push context to use for the update. This may initially be nil, as we will
 	// debounce changes before a PushContext is eventually created.
 	Push *PushContext
@@ -506,7 +508,6 @@ func (pr *PushRequest) Merge(other *PushRequest) *PushRequest {
 	if other.Push != nil {
 		pr.Push = other.Push
 	}
-
 	// Do not merge when any one is empty
 	if len(pr.ConfigsUpdated) == 0 || len(other.ConfigsUpdated) == 0 {
 		pr.ConfigsUpdated = nil
@@ -514,6 +515,12 @@ func (pr *PushRequest) Merge(other *PushRequest) *PushRequest {
 		for conf := range other.ConfigsUpdated {
 			pr.ConfigsUpdated.Insert(conf)
 		}
+	}
+
+	if pr.AddressesUpdated == nil {
+		pr.AddressesUpdated = other.AddressesUpdated
+	} else {
+		pr.AddressesUpdated.Merge(other.AddressesUpdated)
 	}
 
 	return pr
@@ -555,6 +562,12 @@ func (pr *PushRequest) CopyMerge(other *PushRequest) *PushRequest {
 		merged.ConfigsUpdated = make(sets.Set[ConfigKey], len(pr.ConfigsUpdated)+len(other.ConfigsUpdated))
 		merged.ConfigsUpdated.Merge(pr.ConfigsUpdated)
 		merged.ConfigsUpdated.Merge(other.ConfigsUpdated)
+	}
+
+	if len(pr.AddressesUpdated) > 0 || len(other.AddressesUpdated) > 0 {
+		merged.AddressesUpdated = make(sets.Set[string], len(pr.AddressesUpdated)+len(other.AddressesUpdated))
+		merged.AddressesUpdated.Merge(pr.AddressesUpdated)
+		merged.AddressesUpdated.Merge(other.AddressesUpdated)
 	}
 
 	return merged

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -47,7 +47,6 @@ import (
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/gvk"
-	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/env"
 	istiolog "istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/slices"
@@ -260,6 +259,9 @@ var wdsCases = []ConfigInput{
 		Services:         100,
 		Instances:        1000,
 		KubernetesClient: true,
+		PushRequest: &model.PushRequest{
+			Reason: model.NewReasonStats(model.ProxyRequest),
+		},
 	},
 }
 
@@ -275,10 +277,7 @@ var wdsIncrementalCases = func() []ConfigInput {
 	cases := slices.Clone(wdsCases)
 	// Request a single resource
 	cases[0].PushRequest = &model.PushRequest{
-		ConfigsUpdated: sets.New(model.ConfigKey{
-			Kind: kind.Address,
-			Name: "Kubernetes/networking.istio.io/WorkloadEntry//random-0",
-		}),
+		AddressesUpdated: sets.New("Kubernetes/networking.istio.io/WorkloadEntry//random-0"),
 	}
 	return cases
 }()

--- a/pilot/pkg/xds/delta_test.go
+++ b/pilot/pkg/xds/delta_test.go
@@ -398,9 +398,7 @@ func TestDeltaWDS(t *testing.T) {
 
 	// simulate a svc update
 	s.XdsUpdater.ConfigUpdate(&model.PushRequest{
-		ConfigsUpdated: sets.New(model.ConfigKey{
-			Kind: kind.Address, Name: svcA.ResourceName(), Namespace: svcA.Service.Namespace,
-		}),
+		AddressesUpdated: sets.New(svcA.ResourceName()),
 	})
 
 	resp = ads.ExpectResponse()
@@ -414,9 +412,7 @@ func TestDeltaWDS(t *testing.T) {
 	// simulate a svc delete
 	s.MemRegistry.RemoveServiceInfo(svcA)
 	s.XdsUpdater.ConfigUpdate(&model.PushRequest{
-		ConfigsUpdated: sets.New(model.ConfigKey{
-			Kind: kind.Address, Name: svcA.ResourceName(), Namespace: svcA.Service.Namespace,
-		}),
+		AddressesUpdated: sets.New(svcA.ResourceName()),
 	})
 
 	resp = ads.ExpectResponse()
@@ -429,18 +425,17 @@ func TestDeltaWDS(t *testing.T) {
 
 	// delete workload
 	s.MemRegistry.RemoveWorkloadInfo(wlA)
-	// a full push and a pod delete event
-	// This is a merged push request
+	// a pod delete event
 	s.XdsUpdater.ConfigUpdate(&model.PushRequest{
-		Full: true,
+		AddressesUpdated: sets.New(wlA.ResourceName()),
 	})
 
 	resp = ads.ExpectResponse()
 	if len(resp.RemovedResources) != 1 || resp.RemovedResources[0] != wlA.ResourceName() {
-		t.Fatalf("received unexpected removed eds resource %v", resp.RemovedResources)
+		t.Fatalf("received unexpected removed wds resource %v", resp.RemovedResources)
 	}
-	if len(resp.Resources) != 4 {
-		t.Fatalf("received unexpected eds resource %v", resp.Resources)
+	if len(resp.Resources) != 0 {
+		t.Fatalf("received unexpected wds resource %v", resp.Resources)
 	}
 }
 

--- a/pilot/pkg/xds/workload.go
+++ b/pilot/pkg/xds/workload.go
@@ -117,7 +117,11 @@ func (e WorkloadGenerator) Generate(proxy *model.Proxy, w *model.WatchedResource
 	return resources, details, err
 }
 
-func (e WorkloadGenerator) generateDeltasOndemand(proxy *model.Proxy, req *model.PushRequest, w *model.WatchedResource) (model.Resources, model.DeletedResources, model.XdsLogDetails, bool, error) {
+func (e WorkloadGenerator) generateDeltasOndemand(
+	proxy *model.Proxy,
+	req *model.PushRequest,
+	w *model.WatchedResource,
+) (model.Resources, model.DeletedResources, model.XdsLogDetails, bool, error) {
 	isReq := req.IsRequest()
 	subs := w.ResourceNames
 

--- a/pilot/pkg/xds/workload.go
+++ b/pilot/pkg/xds/workload.go
@@ -45,14 +45,82 @@ func (e WorkloadGenerator) GenerateDeltas(
 	req *model.PushRequest,
 	w *model.WatchedResource,
 ) (model.Resources, model.DeletedResources, model.XdsLogDetails, bool, error) {
-	updatedAddresses := model.ConfigNamesOfKind(req.ConfigsUpdated, kind.Address)
+	addresses := req.AddressesUpdated
 	isReq := req.IsRequest()
-	if len(updatedAddresses) == 0 && len(req.ConfigsUpdated) > 0 {
-		// Nothing changed..
+	if !isReq && len(addresses) == 0 {
+		// Nothing changed...
 		return nil, nil, model.XdsLogDetails{}, false, nil
 	}
 
+	if !w.Wildcard {
+		return e.generateDeltasOndemand(proxy, req, w)
+	}
+
 	subs := w.ResourceNames
+
+	reqAddresses := addresses
+	if isReq {
+		reqAddresses = nil
+	}
+	addrs, removed := e.Server.Env.ServiceDiscovery.AddressInformation(reqAddresses)
+	// Note: while "removed" is a weird name for a resource that never existed, this is how the spec works:
+	// https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#id2
+	have := sets.New[string]()
+	resources := make(model.Resources, 0, len(addrs))
+	for _, addr := range addrs {
+		resources = appendAddress(addr, w.TypeUrl, nil, have, resources)
+	}
+
+	if isReq {
+		// If it's a full push, AddressInformation won't have info to compute the full set of removals.
+		// Instead, we need can see what resources are missing that we were subscribe to; those were removed.
+		removed = subs.Difference(have).Merge(removed)
+	}
+
+	proxy.Lock()
+	defer proxy.Unlock()
+	// For wildcard, we record all resources that have been pushed and not removed
+	// It was to correctly calculate removed resources during full push alongside with specific address removed.
+	w.ResourceNames = subs.Merge(have).DeleteAllSet(removed)
+	return resources, removed.UnsortedList(), model.XdsLogDetails{}, true, nil
+}
+
+func appendAddress(addr model.AddressInfo, requestedType string, aliases []string, have sets.Set[string], resources model.Resources) model.Resources {
+	n := addr.ResourceName()
+	have.Insert(n)
+	switch requestedType {
+	case v3.WorkloadType:
+		if addr.GetWorkload() != nil {
+			resources = append(resources, &discovery.Resource{
+				Name:     n,
+				Aliases:  aliases,
+				Resource: protoconv.MessageToAny(addr.GetWorkload()), // TODO: pre-marshal
+			})
+		}
+	case v3.AddressType:
+		proto := addr.Marshaled
+		if proto == nil {
+			proto = protoconv.MessageToAny(addr)
+		}
+
+		resources = append(resources, &discovery.Resource{
+			Name:     n,
+			Aliases:  aliases,
+			Resource: proto,
+		})
+	}
+	return resources
+}
+
+func (e WorkloadGenerator) Generate(proxy *model.Proxy, w *model.WatchedResource, req *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
+	resources, _, details, _, err := e.GenerateDeltas(proxy, req, w)
+	return resources, details, err
+}
+
+func (e WorkloadGenerator) generateDeltasOndemand(proxy *model.Proxy, req *model.PushRequest, w *model.WatchedResource) (model.Resources, model.DeletedResources, model.XdsLogDetails, bool, error) {
+	isReq := req.IsRequest()
+	subs := w.ResourceNames
+
 	var addresses sets.String
 	if isReq {
 		// this is from request, we only send response for the subscribed address
@@ -60,35 +128,22 @@ func (e WorkloadGenerator) GenerateDeltas(
 		// At t1, a client request B, we only send B and additional resources back to the client, no A here.
 		addresses = req.Delta.Subscribed
 	} else {
-		if w.Wildcard {
-			addresses = updatedAddresses
-		} else {
-			// this is from the external triggers instead of request
-			// send response for all the subscribed intersect with the updated
-			addresses = updatedAddresses.IntersectInPlace(subs)
-		}
+		// this is from the external triggers instead of request
+		// send response for all the subscribed intersect with the updated
+		addresses = req.AddressesUpdated.Intersection(subs)
 	}
 
-	if !w.Wildcard {
-		// We only need this for on-demand. This allows us to subscribe the client to resources they
-		// didn't explicitly request.
-		// For wildcard, they subscribe to everything already.
-		additional := e.Server.Env.ServiceDiscovery.AdditionalPodSubscriptions(proxy, addresses, subs)
-		if addresses == nil {
-			addresses = sets.New[string]()
-		}
+	// We only need this for on-demand. This allows us to subscribe the client to resources they
+	// didn't explicitly request.
+	// For wildcard, they subscribe to everything already.
+	additional := e.Server.Env.ServiceDiscovery.AdditionalPodSubscriptions(proxy, addresses, subs)
+	if addresses == nil {
+		addresses = additional
+	} else {
 		addresses.Merge(additional)
 	}
 
-	// TODO: it is needlessly wasteful to do a full sync just because the rest of Istio thought it was "full"
-	// The rest of Istio xDS types would treat `req.Full && len(req.ConfigsUpdated) == 0` as a need to trigger a "full" push.
-	// This is only an escape hatch for a lack of complete mapping of "Input changed -> Output changed".
-	// WDS does not suffer this limitation, so we could almost safely ignore these.
-	// However, other code will merge "Partial push + Full push -> Full push", so skipping full pushes isn't viable.
-	full := (isReq && w.Wildcard) || (!isReq && req.Full && len(req.ConfigsUpdated) == 0)
-
-	// Nothing to do
-	if len(addresses) == 0 && !full {
+	if len(addresses) == 0 {
 		if isReq {
 			// We need to respond for requests, even if we have nothing to respond with
 			return make(model.Resources, 0), nil, model.XdsLogDetails{}, false, nil
@@ -96,75 +151,23 @@ func (e WorkloadGenerator) GenerateDeltas(
 		// For NOP pushes, no need
 		return nil, nil, model.XdsLogDetails{}, false, nil
 	}
-	resources := make(model.Resources, 0)
-	reqAddresses := addresses
-	if full {
-		reqAddresses = nil
-	}
-	addrs, removed := e.Server.Env.ServiceDiscovery.AddressInformation(reqAddresses)
+	addrs, removed := e.Server.Env.ServiceDiscovery.AddressInformation(addresses)
 	// Note: while "removed" is a weird name for a resource that never existed, this is how the spec works:
 	// https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#id2
 	have := sets.New[string]()
-	haveAliases := sets.New[string]()
+	resources := make(model.Resources, 0, len(addrs))
 	for _, addr := range addrs {
-		// TODO(@hzxuzhonghu): calculate removed with aliases in `AddressInformation`
-		var aliases []string
-		if !w.Wildcard {
-			// For on-demand, a client may request by an alias, so we need to compute things.
-			// For wildcard subscriptions, alias is not needed and we always use the canonical resource name.
-			// Avoid Alias computation in these situations
-			aliases := addr.Aliases()
-			removed.DeleteAll(aliases...)
-			haveAliases.InsertAll(aliases...)
-		}
-		n := addr.ResourceName()
-		have.Insert(n)
-		switch w.TypeUrl {
-		case v3.WorkloadType:
-			if addr.GetWorkload() != nil {
-				resources = append(resources, &discovery.Resource{
-					Name:     n,
-					Aliases:  aliases,
-					Resource: protoconv.MessageToAny(addr.GetWorkload()), // TODO: pre-marshal
-				})
-			}
-		case v3.AddressType:
-			proto := addr.Marshaled
-			if proto == nil {
-				proto = protoconv.MessageToAny(addr)
-			}
-
-			resources = append(resources, &discovery.Resource{
-				Name:     n,
-				Aliases:  aliases,
-				Resource: proto,
-			})
-		}
-	}
-
-	if full {
-		// If it's a full push, AddressInformation won't have info to compute the full set of removals.
-		// Instead, we need can see what resources are missing that we were subscribe to; those were removed.
-		removed = subs.Difference(have).Difference(haveAliases).Merge(removed)
+		aliases := addr.Aliases()
+		removed.DeleteAll(aliases...)
+		resources = appendAddress(addr, w.TypeUrl, aliases, have, resources)
 	}
 
 	proxy.Lock()
 	defer proxy.Unlock()
-	if !w.Wildcard {
-		// For on-demand, we may have requested a VIP but gotten Pod IPs back. We need to update
-		// the internal book-keeping to subscribe to the Pods, so that we push updates to those Pods.
-		w.ResourceNames = subs.Merge(have)
-	} else {
-		// For wildcard, we record all resources that have been pushed and not removed
-		// It was to correctly calculate removed resources during full push alongside with specific address removed.
-		w.ResourceNames = subs.Merge(have).DeleteAllSet(removed)
-	}
+	// For on-demand, we may have requested a VIP but gotten Pod IPs back. We need to update
+	// the internal book-keeping to subscribe to the Pods, so that we push updates to those Pods.
+	w.ResourceNames = subs.Merge(have)
 	return resources, removed.UnsortedList(), model.XdsLogDetails{}, true, nil
-}
-
-func (e WorkloadGenerator) Generate(proxy *model.Proxy, w *model.WatchedResource, req *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
-	resources, _, details, _, err := e.GenerateDeltas(proxy, req, w)
-	return resources, details, err
 }
 
 type WorkloadRBACGenerator struct {


### PR DESCRIPTION
Solves part 1 of https://github.com/istio/istio/issues/54499.

The idea here is that we use ConfigsUpdate which is lossy - at some points we wipe the configs, and the only choice is to push everything. At large scale, these full pushes cause dramatic spikes in Istio CPU utilization. For instance, imagine I have a massive scale of 100k pods and 1k ztunnels connected. At steady state, even with a crazy 10 pods/s changing, I need to push 10 workloads * 1k ztunnels = 10k workloads/s. If a full push is triggered, it will instantly need to push 100M workloads - a 10000x increase.

This fixes things by putting Addresses in a separate object. This _probably_ should not actually be specialized to Addresses and instead should also allow WADS resources maybe, to apply the same optimization there. However, in WADS we are using AuthorizationPolicy as the trigger kind so that may be awkward. Maybe we can make that its own type, too. Then instead of AddressesUpdated, this becomes more like `ConfigsThatHavePerfectDiffing` (we can pick a better name :-) ).

We still place objects into ConfigsUpdate. The reason is to avoid accidentally triggering a full push for the _other_ types; if we just sent a `Request{addressUpdated: [foo]}`, the other types will see `ConfigsUpdated=nil` and do a full push. We can likely improve this in the future, but for now this offers the best compatibility

Benchmark doesn't really capture this appropriately since we measure for fast a full/incremental push is; this fix makes full pushes less likely, so its not covered.
```
                                                           │  /tmp/master  │              /tmp/now              │
                                                           │    sec/op     │   sec/op     vs base               │
AddressFullGeneration/serviceentry-workloadentry-16           703.0µ ± 19%   698.3µ ± 7%        ~ (p=1.000 n=6)
AddressIncrementalGeneration/serviceentry-workloadentry-16   1035.0n ±  4%   856.4n ± 6%  -17.26% (p=0.002 n=6)
geomean                                                       26.97µ         24.45µ        -9.35%


                                                           │ /tmp/master  │              /tmp/now               │
                                                           │     B/op     │     B/op      vs base               │
AddressFullGeneration/serviceentry-workloadentry-16          869.0Ki ± 0%   849.1Ki ± 0%   -2.29% (p=0.002 n=6)
AddressIncrementalGeneration/serviceentry-workloadentry-16     968.0 ± 0%     776.0 ± 0%  -19.83% (p=0.002 n=6)
geomean                                                      28.66Ki        25.37Ki       -11.50%

                                                           │ /tmp/master │              /tmp/now              │
                                                           │  allocs/op  │  allocs/op   vs base               │
AddressFullGeneration/serviceentry-workloadentry-16          3.623k ± 0%   3.610k ± 0%   -0.36% (p=0.002 n=6)
AddressIncrementalGeneration/serviceentry-workloadentry-16    13.00 ± 0%    11.00 ± 0%  -15.38% (p=0.002 n=6)
geomean                                                       217.0         199.3        -8.18%
```

As part of this implementation, I have split out the on-demand vs wildcard code for WDS generator. I feel its much simpler to have 2 split codepaths vs having `ifs` all over the place. Actually, as part of this, I found some minor issues caused by the complexity of the `ifs` - not a meaningful bug, but `haveAliases` can never be used for instance.