### PR TITLE
validation: loosen HTTP header validation which was accidentally made too strict

### DIFF
--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -826,8 +826,8 @@ func TestValidateHTTPHeaderName(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		if got := ValidateHTTPHeaderName(tc.name); (got == nil) != tc.valid {
-			t.Errorf("ValidateHTTPHeaderName(%q) => got valid=%v, want valid=%v",
+		if got := ValidateStrictHTTPHeaderName(tc.name); (got == nil) != tc.valid {
+			t.Errorf("ValidateStrictHTTPHeaderName(%q) => got valid=%v, want valid=%v",
 				tc.name, got == nil, tc.valid)
 		}
 	}


### PR DESCRIPTION
See https://github.com/istio/istio/pull/50315#issuecomment-2578291003

We used to allow this, now we are more strict than the RFCs
