### PR TITLE
Fix shared state access causing test flakes

### DIFF
--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -679,7 +679,7 @@ spec:
       version: v2
 `).ApplyOrFail(t)
 			t.NewSubTest("v1").Run(func(t framework.TestContext) {
-				opt = opt.DeepCopy()
+				opt := opt.DeepCopy()
 				opt.Count = 5
 				opt.Timeout = time.Second * 10
 				opt.Check = check.And(
@@ -696,7 +696,7 @@ spec:
 			})
 
 			t.NewSubTest("v2").Run(func(t framework.TestContext) {
-				opt = opt.DeepCopy()
+				opt := opt.DeepCopy()
 				opt.Count = 5
 				opt.Timeout = time.Second * 10
 				if opt.HTTP.Headers == nil {
@@ -741,7 +741,7 @@ spec:
   mtls:
     mode: PERMISSIVE
 `).ApplyOrFail(t)
-				opt = opt.DeepCopy()
+				opt := opt.DeepCopy()
 				src.CallOrFail(t, opt)
 			})
 			t.NewSubTest("strict").Run(func(t framework.TestContext) {
@@ -758,7 +758,7 @@ spec:
   mtls:
     mode: STRICT
 				`).ApplyOrFail(t)
-				opt = opt.DeepCopy()
+				opt := opt.DeepCopy()
 				if !src.Config().HasProxyCapabilities() && dst.Config().HasProxyCapabilities() {
 					// Expect deny if the dest is in the mesh (enforcing mTLS) but src is not (not sending mTLS)
 					opt.Check = CheckDeny
@@ -788,7 +788,7 @@ spec:
     18080:
       mode: PERMISSIVE
 				`).ApplyOrFail(t)
-				opt = opt.DeepCopy()
+				opt := opt.DeepCopy()
 				// Should pass for all workloads, in or out of mesh, targeting this port
 				src.CallOrFail(t, opt)
 			})
@@ -823,7 +823,7 @@ spec:
     19090:
       mode: PERMISSIVE
         `).ApplyOrFail(t)
-				opt = opt.DeepCopy()
+				opt := opt.DeepCopy()
 				// Should pass for all workloads, in or out of mesh, targeting this port
 				src.CallOrFail(t, opt)
 			})
@@ -856,7 +856,7 @@ spec:
     19090:
       mode: STRICT
         `).ApplyOrFail(t)
-				opt = opt.DeepCopy()
+				opt := opt.DeepCopy()
 				if !src.Config().HasProxyCapabilities() && dst.Config().HasProxyCapabilities() {
 					// Expect deny if the dest is in the mesh (enforcing mTLS) but src is not (not sending mTLS)
 					opt.Check = CheckDeny
@@ -1124,14 +1124,14 @@ spec:
 				}
 			}
 			t.NewSubTest("simple deny").Run(func(t framework.TestContext) {
-				opt = opt.DeepCopy()
+				opt := opt.DeepCopy()
 				opt.HTTP.Path = "/deny"
 				opt.Check = CheckDeny
 				overrideCheck(&opt)
 				src.CallOrFail(t, opt)
 			})
 			t.NewSubTest("simple allow").Run(func(t framework.TestContext) {
-				opt = opt.DeepCopy()
+				opt := opt.DeepCopy()
 				opt.HTTP.Path = "/allowed"
 				opt.Check = check.OK()
 				overrideCheck(&opt)
@@ -2302,7 +2302,7 @@ func RunReachability(testCases []reachability.TestCase, t framework.TestContext)
 					t.NewSubTestf("to %v", dst.Config().Service).RunParallel(func(t framework.TestContext) {
 						for _, opt := range callOptions {
 							t.NewSubTestf("%v", opt.Scheme).RunParallel(func(t framework.TestContext) {
-								opt = opt.DeepCopy()
+								opt := opt.DeepCopy()
 								opt.To = dst
 								opt.Check = check.OK()
 								f(t, src, dst, opt)
@@ -2500,7 +2500,7 @@ func runTestContext(t framework.TestContext, f func(t framework.TestContext, src
 				t.NewSubTestf("to %v", dst.Config().Service).Run(func(t framework.TestContext) {
 					for _, opt := range callOptions {
 						t.NewSubTestf("%v", opt.Scheme).Run(func(t framework.TestContext) {
-							opt = opt.DeepCopy()
+							opt := opt.DeepCopy()
 							opt.To = dst
 							opt.Check = check.OK()
 							f(t, src, dst, opt)

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -787,7 +787,7 @@ spec:
   portLevelMtls:
     18080:
       mode: PERMISSIVE
-		19090:
+    19090:
       mode: PERMISSIVE
 				`).ApplyOrFail(t)
 				opt := opt.DeepCopy()

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -787,6 +787,8 @@ spec:
   portLevelMtls:
     18080:
       mode: PERMISSIVE
+		19090:
+      mode: PERMISSIVE
 				`).ApplyOrFail(t)
 				opt := opt.DeepCopy()
 				// Should pass for all workloads, in or out of mesh, targeting this port


### PR DESCRIPTION
**Please provide a description of this PR:**
This has been a pain for awhile, and the true source of some of the ambient test flakes (finding #54566 was just a coincidence apparently). Our test code makes deep copies of opt, but assigns it to a shared variable, meaning that the evaluation criteria for echo tests was changing in between requests. This is why in failures like https://prow.istio.io/view/gs/istio-prow/logs/integ-assertion_istio_postsubmit/1877054177264275456, we see different reasons why the test failed even though the response status code is consistent (always a 200). What made me notice this is that the above test was failing because it expected an error even though the code as written always expects a 200. This can only happen if state is being changed from multiple goroutines, so I've made new variables every time opt is deep-copied.