### PR TITLE
Prevent iptables GetStateFromSave from processing lines related to non-built-in tables

### DIFF
--- a/releasenotes/notes/fix-iptables-state-custom-table.yaml
+++ b/releasenotes/notes/fix-iptables-state-custom-table.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: bug-fix
-area: networking
+area: installation
 issue: []
 releaseNotes:
 - |

--- a/releasenotes/notes/fix-iptables-state-custom-table.yaml
+++ b/releasenotes/notes/fix-iptables-state-custom-table.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: networking
+issue: []
+releaseNotes:
+- |
+  **Fixed** an issue causing istio-iptables cmd to fail when a non-built-in table is present in the system.

--- a/tools/istio-iptables/pkg/builder/iptables_builder_impl.go
+++ b/tools/istio-iptables/pkg/builder/iptables_builder_impl.go
@@ -361,7 +361,7 @@ func (rb *IptablesRuleBuilder) GetStateFromSave(data string) map[string]map[stri
 			continue
 		}
 
-		// If we're not in a default table, skip processing line
+		// If we are in a non-built-in table, skip processing line
 		if _, exists := result[table]; !exists {
 			continue
 		}

--- a/tools/istio-iptables/pkg/builder/iptables_builder_impl.go
+++ b/tools/istio-iptables/pkg/builder/iptables_builder_impl.go
@@ -360,6 +360,12 @@ func (rb *IptablesRuleBuilder) GetStateFromSave(data string) map[string]map[stri
 			table = strings.TrimSpace(line[1:])
 			continue
 		}
+
+		// If we're not in a default table, skip processing line
+		if _, exists := result[table]; !exists {
+			continue
+		}
+
 		// Found chain, setup an empty list for the chain if it is an ISTIO one
 		if strings.HasPrefix(line, ":") {
 			if !strings.HasPrefix(line, ":ISTIO") {

--- a/tools/istio-iptables/pkg/builder/iptables_builder_test.go
+++ b/tools/istio-iptables/pkg/builder/iptables_builder_test.go
@@ -368,11 +368,13 @@ func TestStateFromRestoreFormat(t *testing.T) {
 				iptables.AppendRuleV4(iptableslog.UndefinedCommand, "chain", "raw", "-f", "foo", "-b", "baar")
 				iptables.AppendRuleV4(iptableslog.UndefinedCommand, "POSTROUTING", "nat", "-f", "foo", "-b", "bar", "-j", "ISTIO_TEST")
 				iptables.AppendRuleV4(iptableslog.UndefinedCommand, "ISTIO_TEST", "nat", "-f", "foo", "-b", "bar")
+				iptables.AppendRuleV4(iptableslog.UndefinedCommand, "chain", "filter", "-f", "foo", "-b", "bar")
 			},
 			map[string]map[string][]string{
 				"filter": {
 					"chain": {
 						"-A chain -f foo -b baaz",
+						"-A chain -f foo -b bar",
 					},
 				},
 				"mangle": {

--- a/tools/istio-iptables/pkg/builder/iptables_builder_test.go
+++ b/tools/istio-iptables/pkg/builder/iptables_builder_test.go
@@ -351,3 +351,94 @@ func TestCleanupRulesV4V6(t *testing.T) {
 		})
 	}
 }
+
+func TestStateFromRestoreFormat(t *testing.T) {
+	builderConfig := &config.Config{}
+	for _, tt := range []struct {
+		name      string
+		setupFunc func(iptables *IptablesRuleBuilder)
+		expected  map[string]map[string][]string
+	}{
+		{
+			"default",
+			func(iptables *IptablesRuleBuilder) {
+				iptables.InsertRuleV4(iptableslog.UndefinedCommand, "chain", "nat", 2, "-f", "foo", "-b", "bar")
+				iptables.AppendRuleV4(iptableslog.UndefinedCommand, "chain", "filter", "-f", "foo", "-b", "baaz")
+				iptables.AppendRuleV4(iptableslog.UndefinedCommand, "chain", "mangle", "-f", "fooo", "-b", "baz")
+				iptables.AppendRuleV4(iptableslog.UndefinedCommand, "chain", "raw", "-f", "foo", "-b", "baar")
+				iptables.AppendRuleV4(iptableslog.UndefinedCommand, "POSTROUTING", "nat", "-f", "foo", "-b", "bar", "-j", "ISTIO_TEST")
+				iptables.AppendRuleV4(iptableslog.UndefinedCommand, "ISTIO_TEST", "nat", "-f", "foo", "-b", "bar")
+			},
+			map[string]map[string][]string{
+				"filter": {
+					"chain": {
+						"-A chain -f foo -b baaz",
+					},
+				},
+				"mangle": {
+					"chain": {
+						"-A chain -f fooo -b baz",
+					},
+				},
+				"nat": {
+					"ISTIO_TEST": {
+						"-A ISTIO_TEST -f foo -b bar",
+					},
+					"POSTROUTING": {
+						"-A POSTROUTING -f foo -b bar -j ISTIO_TEST",
+					},
+					"chain": {
+						"-I chain 2 -f foo -b bar",
+					},
+				},
+				"raw": {
+					"chain": {
+						"-A chain -f foo -b baar",
+					},
+				},
+			},
+		},
+		{
+			"empty",
+			func(iptables *IptablesRuleBuilder) {
+			},
+			map[string]map[string][]string{
+				"filter": {},
+				"mangle": {},
+				"nat":    {},
+				"raw":    {},
+			},
+		},
+		{
+			"with-non-built-in-tables",
+			func(iptables *IptablesRuleBuilder) {
+				iptables.InsertRuleV4(iptableslog.UndefinedCommand, "chain", "nat", 2, "-f", "foo", "-b", "bar")
+				iptables.AppendRuleV4(iptableslog.UndefinedCommand, "chain2", "filter", "-f", "foo", "-b", "baz")
+				iptables.AppendRuleV4(iptableslog.UndefinedCommand, "chain2", "does-not-exist", "-f", "foo", "-b", "baz")
+			},
+			map[string]map[string][]string{
+				"filter": {
+					"chain2": {
+						"-A chain2 -f foo -b baz",
+					},
+				},
+				"mangle": {},
+				"nat": {
+					"chain": {
+						"-I chain 2 -f foo -b bar",
+					},
+				},
+				"raw": {},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			iptables := NewIptablesRuleBuilder(builderConfig)
+			tt.setupFunc(iptables)
+			actual := iptables.GetStateFromSave(iptables.BuildV4Restore())
+			if !reflect.DeepEqual(actual, tt.expected) {
+				t.Errorf("Actual and expected output mismatch; but instead got Actual: %#v ; Expected: %#v", actual, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Please provide a description of this PR:**

This addresses an issue where the user has a non-empty custom table beyond the built-in tables (RAW, NAT, FILTER, MANGLE).
Currently, the code panics when attempting to populate the state if a non-empty non-built-in table exists (e.g: SECURITY table from SELINUX). It was reported by an user on Slack and the PR was confirmed to fix the issue.

The new behavior will disregard chains, and rules from non-built-in tables.