### PR TITLE
(fix): align gateway condition key usage

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -2221,11 +2221,11 @@ func reportGatewayStatus(
 
 	if len(internal) > 0 {
 		msg := fmt.Sprintf("Resource programmed, assigned to service(s) %s", humanReadableJoin(internal))
-		gatewayConditions[string(k8s.GatewayReasonProgrammed)].message = msg
+		gatewayConditions[string(k8s.GatewayConditionProgrammed)].message = msg
 	}
 
 	if len(gatewayServices) == 0 {
-		gatewayConditions[string(k8s.GatewayReasonProgrammed)].error = &ConfigError{
+		gatewayConditions[string(k8s.GatewayConditionProgrammed)].error = &ConfigError{
 			Reason:  InvalidAddress,
 			Message: "Failed to assign to any requested addresses",
 		}


### PR DESCRIPTION

**Please provide a description of this PR:**

Minor update regarding keys used while populating Gateway (gateway.networking.k8s.io/v1) conditions

* gatewayConditions map uses `condition` type as a key. This PR updates assignments to `gatewayConditions` map using `reason` as the key.
* Although both GatewayReasonProgrammed and GatewayConditionProgrammed yield the same string, type diff might cause confusion. It helps prevent potential errors that could arise from mixing reason and condition types.