### PR TITLE
remove duplicate INTEGRATION_TEST_FLAGS in CI runs

### DIFF
--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -102,8 +102,8 @@ test.integration-fuzz.%.kube: | $(JUNIT_REPORT) check-go-tag
 	$(call run-test,./tests/integration/$(subst .,/,$*)/...,-tags="integfuzz integ")
 
 # Generate presubmit integration test targets for each component in kubernetes environment
-test.integration.%.kube.presubmit:
-	@make test.integration.$*.kube
+test.integration.%.kube.presubmit: test.integration.$*.kube
+	@:
 
 # Run all tests
 .PHONY: test.integration.kube


### PR DESCRIPTION
some of the tests in CI appends INTEGRATION_TEST_FLAGS twice, see : https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/54604/integ-cni_istio/1877125321656897536

```
go test -p 1 -v -count=1 -tags=integ -vet=off -timeout 30m  ./tests/integration/pilot/...  --istio.test.istio.enableCNI=true  --istio.test.ci --istio.test.pullpolicy=IfNotPresent --istio.test.work_dir=/logs/artifacts --istio.test.hub=localhost:5000 --istio.test.tag=istio-testing --istio.test.kube.config=/home/.kube/config --istio.test.ci --istio.test.pullpolicy=IfNotPresent --istio.test.work_dir=/logs/artifacts --istio.test.hub=localhost:5000 --istio.test.tag=istio-testing --istio.test.kube.config=/home/.kube/config ""--istio.test.select=,-postsubmit",-postsubmit" 2>&1 | tee >(/usr/bin/go-junit-report > /logs/artifacts/junit.xml)
```

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
