### PR TITLE
xds: do not send ControlPlane identifier when it is not needed

### DIFF
--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -504,7 +504,7 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection, w *model.WatchedResource
 	}
 	defer func() { recordPushTime(w.TypeUrl, time.Since(t0)) }()
 	resp := &discovery.DeltaDiscoveryResponse{
-		ControlPlane: ControlPlane(),
+		ControlPlane: ControlPlane(w.TypeUrl),
 		TypeUrl:      w.TypeUrl,
 		// TODO: send different version for incremental eds
 		SystemVersionInfo: req.Push.PushVersion,

--- a/pilot/pkg/xds/xdsgen.go
+++ b/pilot/pkg/xds/xdsgen.go
@@ -58,8 +58,12 @@ var controlPlane = lazy.New(func() (*core.ControlPlane, error) {
 	return &core.ControlPlane{Identifier: string(byVersion)}, nil
 })
 
-// ControlPlane identifies the instance and Istio version.
-func ControlPlane() *core.ControlPlane {
+// ControlPlane identifies the instance and Istio version, based on the requested type URL
+func ControlPlane(typ string) *core.ControlPlane {
+	if typ != TypeDebugSyncronization {
+		// Currently only TypeDebugSyncronization utilizes this so don't both sending otherwise
+		return nil
+	}
 	// Error will never happen because the getter of lazy does not return error.
 	cp, _ := controlPlane.Get()
 	return cp
@@ -136,7 +140,7 @@ func (s *DiscoveryServer) pushXds(con *Connection, w *model.WatchedResource, req
 	defer func() { recordPushTime(w.TypeUrl, time.Since(t0)) }()
 
 	resp := &discovery.DiscoveryResponse{
-		ControlPlane: ControlPlane(),
+		ControlPlane: ControlPlane(w.TypeUrl),
 		TypeUrl:      w.TypeUrl,
 		// TODO: send different version for incremental eds
 		VersionInfo: req.Push.PushVersion,


### PR DESCRIPTION
```
                                                           │ /tmp/with-cp │           /tmp/with-nocp           │
                                                           │    sec/op    │   sec/op     vs base               │
AddressFullGeneration/serviceentry-workloadentry-16           876.0µ ± 2%   854.5µ ± 3%  -2.45% (p=0.035 n=10)
AddressIncrementalGeneration/serviceentry-workloadentry-16    1.327µ ± 3%   1.259µ ± 4%  -5.12% (p=0.001 n=10)
geomean                                                       34.09µ        32.80µ       -3.80%

                                                           │ /tmp/with-cp │           /tmp/with-nocp            │
                                                           │   kb/msg    │   kb/msg    vs base                │
AddressFullGeneration/serviceentry-workloadentry-16            319.4 ± 0%    319.3 ± 0%   -0.03% (p=0.000 n=10)
AddressIncrementalGeneration/serviceentry-workloadentry-16    488.0m ± 0%   339.0m ± 0%  -30.53% (p=0.000 n=10)
geomean                                                        12.48         10.40       -16.67%

                                                           │ /tmp/with-cp │           /tmp/with-nocp            │
                                                           │     B/op     │     B/op      vs base               │
AddressFullGeneration/serviceentry-workloadentry-16          1.849Mi ± 0%   1.849Mi ± 0%       ~ (p=0.699 n=10)
AddressIncrementalGeneration/serviceentry-workloadentry-16   1.719Ki ± 0%   1.562Ki ± 0%  -9.09% (p=0.000 n=10)
geomean                                                      57.05Ki        54.39Ki       -4.65%
```
