### PR TITLE
Check equality of ports in Gateway conflict check

### DIFF
--- a/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/pkg/config/analysis/analyzers/analyzers_test.go
@@ -251,6 +251,23 @@ var testGrid = []testCase{
 		},
 	},
 	{
+		name:       "gateways with different port are non-conflicting",
+		inputFiles: []string{"testdata/gateway-different-port.yaml"},
+		analyzer:   &gateway.ConflictingGatewayAnalyzer{},
+		expected:   []message{
+			// no conflict expected, verify that no false-positive conflict is returned
+		},
+	},
+	{
+		name:       "conflicting gateways with multiple port declarations",
+		inputFiles: []string{"testdata/conflicting-gateways-multiple-ports.yaml"},
+		analyzer:   &gateway.ConflictingGatewayAnalyzer{},
+		expected: []message{
+			{msg.ConflictingGateways, "Gateway alpha"},
+			{msg.ConflictingGateways, "Gateway beta"},
+		},
+	},
+	{
 		name:       "conflicting gateways detect by sub selector",
 		inputFiles: []string{"testdata/conflicting-gateways-subSelector.yaml"},
 		analyzer:   &gateway.ConflictingGatewayAnalyzer{},

--- a/pkg/config/analysis/analyzers/gateway/conflictinggateway.go
+++ b/pkg/config/analysis/analyzers/gateway/conflictinggateway.go
@@ -111,7 +111,11 @@ func (*ConflictingGatewayAnalyzer) analyzeGateway(r *resource.Instance, c analys
 		var gateways []string
 		conflictingGWMatch := 0
 		sPortNumber := strconv.Itoa(int(server.GetPort().GetNumber()))
-		for _, values := range hitSameGateways {
+		for key, values := range hitSameGateways {
+			if _, port := parseFromGatewayMapKey(key); port != sPortNumber {
+				continue
+			}
+
 			for gwNameKey, gwHostsBind := range values {
 				// both selector and port number are the same, then check hosts and bind
 				if gwName != gwNameKey && isGWConflict(server, gwHostsBind) {

--- a/pkg/config/analysis/analyzers/testdata/conflicting-gateways-multiple-ports.yaml
+++ b/pkg/config/analysis/analyzers/testdata/conflicting-gateways-multiple-ports.yaml
@@ -1,0 +1,41 @@
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: beta
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 80
+      name: tcp
+      protocol: TCP
+    hosts:
+    - "foo.bar"
+  - port:
+      number: 90
+      name: tcp
+      protocol: TCP
+    hosts:
+    - "foo.bar"
+---
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: alpha
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 70
+      name: http
+      protocol: HTTP
+    hosts:
+    - "foo.bar"
+  - port:
+      number: 90
+      name: http
+      protocol: HTTP
+    hosts:
+    - "foo.bar"

--- a/pkg/config/analysis/analyzers/testdata/gateway-different-port.yaml
+++ b/pkg/config/analysis/analyzers/testdata/gateway-different-port.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: beta
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 443
+      name: tcp
+      protocol: TCP
+    hosts:
+    - "foo.bar"
+---
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: alpha
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "foo.bar"

--- a/releasenotes/notes/54643.yaml
+++ b/releasenotes/notes/54643.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+issue:
+  - 54643
+releaseNotes:
+  - |
+    **Fixed** 'istioctl analyze' reports IST0145 error when using the same host with different ports and multiple gateways.


### PR DESCRIPTION
Fixes #54643.

This PR fixes the conflict check for Gateways, when different ports are used for the same hosts.