### PR TITLE
remove settings from iop which should now default to enabled

### DIFF
--- a/tests/integration/iop-ambient-test-defaults.yaml
+++ b/tests/integration/iop-ambient-test-defaults.yaml
@@ -10,22 +10,12 @@ spec:
       - name: istio-ingressgateway
         enabled: true
   values:
-    cni:
-      ambient:
-        # Some of the tests require DNS capture
-        # For that, DNS capture must be enabled in the CNI
-        # and DNS proxying must be enabled in ztunnel
-        dnsCapture: true
-    ztunnel:
-      meshConfig:
-        defaultConfig:
-          proxyMetadata:
-            ISTIO_META_DNS_CAPTURE: "true"
     meshConfig:
-      defaultConfig:
-        proxyMetadata:
-          ISTIO_META_DNS_CAPTURE: "true"
-          DNS_PROXY_ADDR: "0.0.0.0:15053"
+      # maybe necessary for Sidecar interoperability testing
+      # defaultConfig:
+      #   proxyMetadata:
+      #     ISTIO_META_DNS_CAPTURE: "true"
+      #     DNS_PROXY_ADDR: "0.0.0.0:15053"
       accessLogFile: /dev/stdout
       # Just used to exclude for testing
       discoverySelectors:


### PR DESCRIPTION
**Please provide a description of this PR:**

Now that DNS capture and V2 Auto-allocation are enabled by default for ambient mode we should test it without specifically enabling these options to ensure the out-of-box UX for ambient mode functions as intended.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [X] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [X] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
