### PR TITLE
chiron: fix goroutine/memory leak of CSR watcher

### DIFF
--- a/security/pkg/k8s/chiron/utils.go
+++ b/security/pkg/k8s/chiron/utils.go
@@ -253,6 +253,7 @@ func readSignedCsr(client clientset.Interface, csr string, watchTimeout time.Dur
 	if err != nil {
 		return nil, fmt.Errorf("failed to watch CSR %v", csr)
 	}
+	defer watcher.Stop()
 
 	// Set a timeout
 	timer := time.After(watchTimeout)


### PR DESCRIPTION
**Please provide a description of this PR:**

We noticed memory leak over time after integrating with K8s CSR, heap profiling points this to chiron not `Stop`-ing on the watcher after the cert is signed or the wait times out.

Before:
<img width="633" alt="image" src="https://github.com/user-attachments/assets/3d81ee69-2c7e-4f84-a662-3d3935fb85af" />

<img width="1278" alt="image" src="https://github.com/user-attachments/assets/bd44c55d-4411-4790-a382-bd0a88ae7af4" />

After:
<img width="950" alt="image" src="https://github.com/user-attachments/assets/9d7102aa-bbb6-4a58-8c5b-f1ba36e72a40" />
