### PR TITLE
Do not impersonate empty group

### DIFF
--- a/istioctl/pkg/cli/option.go
+++ b/istioctl/pkg/cli/option.go
@@ -51,7 +51,7 @@ func AddRootFlags(flags *pflag.FlagSet) *RootFlags {
 		configContext:    ptr.Of[string](""),
 		impersonate:      ptr.Of[string](""),
 		impersonateUID:   ptr.Of[string](""),
-		impersonateGroup: ptr.Of[[]string]([]string{""}),
+		impersonateGroup: ptr.Of[[]string](nil),
 		namespace:        ptr.Of[string](""),
 		istioNamespace:   ptr.Of[string](""),
 	}

--- a/istioctl/pkg/cli/option_test.go
+++ b/istioctl/pkg/cli/option_test.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cli
 
 import (

--- a/istioctl/pkg/cli/option_test.go
+++ b/istioctl/pkg/cli/option_test.go
@@ -18,8 +18,9 @@ import (
 	"testing"
 
 	"github.com/spf13/pflag"
-	"istio.io/istio/pkg/test/util/assert"
 	"k8s.io/client-go/rest"
+
+	"istio.io/istio/pkg/test/util/assert"
 )
 
 func Test_AddRootFlags(t *testing.T) {

--- a/istioctl/pkg/cli/option_test.go
+++ b/istioctl/pkg/cli/option_test.go
@@ -1,0 +1,18 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"istio.io/istio/pkg/test/util/assert"
+	"k8s.io/client-go/rest"
+)
+
+func Test_AddRootFlags(t *testing.T) {
+	flags := &pflag.FlagSet{}
+	r := AddRootFlags(flags)
+	impersonateConfig := rest.ImpersonationConfig{}
+	assert.Equal(t, *r.impersonate, impersonateConfig.UserName)
+	assert.Equal(t, *r.impersonateUID, impersonateConfig.UID)
+	assert.Equal(t, *r.impersonateGroup, impersonateConfig.Groups)
+}

--- a/releasenotes/notes/54667.yaml
+++ b/releasenotes/notes/54667.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+    - |
+        **Fixed** 'istioctl --as' implicitly sets `--as-group=""` when `--as` is used without `--as-group`.


### PR DESCRIPTION
Do not impersonate empty group when group not set in flags

When `--as` flag is passed to `istioctl`, it overwrites `UserName`, `UID`, and `Groups` in `rest.ImpersonationConfig` from default (empty) values using the corresponding values from `RootFlags`. If a parameter is not set in flags, then custom default values are used. The default value for `impersonateGroup` is not `nil`, but a slice with a single empty string. This breaks impersonalisation when only username (i.e. `--as` is used).

**Example**
When permissions are missing, `istioctl` fails _as expected_:
```
❯ k auth can-i create pods/portforward
no - User does not have access to the resource in Azure. Update role assignment to allow access.
❯ istioctl pc log --level 'http:warn' mypod
2025-01-13T17:11:18.447037Z	error	port forward failed: error upgrading connection: pods "mypod" is forbidden: User "maxim.nazarenko@hostname.com" cannot create resource "pods/portforward" in API group "" in the namespace "mynamespace": User does not have access to the resource in Azure. Update role assignment to allow access.
```
However, `istioctl`@1.24.2 also fails when using correct impersonalisation, this is NOT expected:
```
❯ k auth can-i create pods/portforward --as superadmin
yes
❯ istioctl pc log --level 'http:warn' mypods --as superadmin
Error: failed to execute command on Envoy: failure running port forward process: failure running port forward process: building port forwarded: failed retrieving: groups is forbidden: User "maxim.nazarenko@hostname.com" cannot impersonate resource "groups" in API group "" at the cluster scope: User does not have access to the resource in Azure. Update role assignment to allow access. in the "mynamespace" namespace
```
This happens because call at https://github.com/istio/istio/blob/240bde4689a037b5d39d24b6061376f8ab1df0fe/pkg/kube/portforwarder.go#L186 tries to impersonate an empty group, and fails.

This PR changes the default value for `impersonateGroup` in `RootFlags` to `nil`, so when `--as` is set but `--as-group` is not set, the value for `impersonateConfig.Groups` is the same (`nil`) as when `--as` is not set. Example output after the fix:
```
mypod.mynamespace:
active loggers:
  admin: warning
  alternate_protocols_cache: warning
  aws: warning
  assert: warning
  backtrace: warning
  basic_auth: warning
  cache_filter: warning
  client: warning
  config: warning
  connection: warning
  conn_handler: warning
  decompression: warning
  dns: warning
  dubbo: warning
  envoy_bug: warning
  ext_authz: warning
  ext_proc: warning
  rocketmq: warning
  file: warning
  filter: warning
  forward_proxy: warning
  geolocation: warning
  grpc: warning
  happy_eyeballs: warning
  hc: warning
  health_checker: warning
  http: warning
  http2: warning
  hystrix: warning
  init: warning
  io: warning
  jwt: warning
  kafka: warning
  key_value_store: warning
  lua: warning
  main: warning
  matcher: warning
  misc: error
  mongo: warning
  multi_connection: warning
  oauth2: warning
  quic: warning
  quic_stream: warning
  pool: warning
  rate_limit_quota: warning
  rbac: warning
  rds: warning
  redis: warning
  router: warning
  runtime: warning
  stats: warning
  secret: warning
  tap: warning
  testing: warning
  thrift: warning
  tracing: warning
  upstream: warning
  udp: warning
  wasm: warning
  websocket: warning
  golang: warning
```