### PR TITLE
Refactor RunX cmds for istio-iptables into a single API

### DIFF
--- a/cni/pkg/iptables/iptables.go
+++ b/cni/pkg/iptables/iptables.go
@@ -465,8 +465,8 @@ func (cfg *IptablesConfigurator) executeCommands(log *istiolog.Scope, iptablesBu
 		if guardrails {
 			log.Info("Removing guardrails")
 			guardrailsCleanup := iptablesBuilder.BuildCleanupGuardrails()
-			_ = cfg.executeIptablesCommands(log, &cfg.iptV, guardrailsCleanup)
-			_ = cfg.executeIptablesCommands(log, &cfg.ipt6V, guardrailsCleanup)
+			cfg.tryExecuteIptablesCommands(log, &cfg.iptV, guardrailsCleanup)
+			cfg.tryExecuteIptablesCommands(log, &cfg.ipt6V, guardrailsCleanup)
 		}
 	}()
 	residueExists, deltaExists := iptablescapture.VerifyIptablesState(log, cfg.ext, iptablesBuilder, &cfg.iptV, &cfg.ipt6V)

--- a/cni/pkg/iptables/iptables.go
+++ b/cni/pkg/iptables/iptables.go
@@ -465,8 +465,8 @@ func (cfg *IptablesConfigurator) executeCommands(log *istiolog.Scope, iptablesBu
 		if guardrails {
 			log.Info("Removing guardrails")
 			guardrailsCleanup := iptablesBuilder.BuildCleanupGuardrails()
-			cfg.tryExecuteIptablesCommands(log, &cfg.iptV, guardrailsCleanup)
-			cfg.tryExecuteIptablesCommands(log, &cfg.ipt6V, guardrailsCleanup)
+			_ = cfg.executeIptablesCommands(log, &cfg.iptV, guardrailsCleanup)
+			_ = cfg.executeIptablesCommands(log, &cfg.ipt6V, guardrailsCleanup)
 		}
 	}()
 	residueExists, deltaExists := iptablescapture.VerifyIptablesState(log, cfg.ext, iptablesBuilder, &cfg.iptV, &cfg.ipt6V)

--- a/releasenotes/notes/54644.yaml
+++ b/releasenotes/notes/54644.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 54644
+releaseNotes:
+- |
+  **Reduced** the amount of iptables logs related to rule checks and deletions.

--- a/releasenotes/notes/54644.yaml
+++ b/releasenotes/notes/54644.yaml
@@ -6,3 +6,4 @@ issue:
 releaseNotes:
 - |
   **Fixed** excessive iptables info-level log entries for rule checks and deletions.
+  Detailed logging can be re-enabled by switching to debug-level logs if necessary.

--- a/releasenotes/notes/54644.yaml
+++ b/releasenotes/notes/54644.yaml
@@ -5,4 +5,4 @@ issue:
   - 54644
 releaseNotes:
 - |
-  **Reduced** the amount of iptables logs related to rule checks and deletions.
+  **Fixed** excessive iptables info-level log entries for rule checks and deletions.

--- a/tools/istio-iptables/pkg/capture/helper.go
+++ b/tools/istio-iptables/pkg/capture/helper.go
@@ -68,7 +68,7 @@ check_loop:
 		if ipCfg.ver == nil {
 			continue
 		}
-		output, err := ext.RunWithOutput(log, constants.IPTablesSave, ipCfg.ver, nil)
+		output, err := ext.Run(log, true, constants.IPTablesSave, ipCfg.ver, nil)
 		if err == nil {
 			currentState := ruleBuilder.GetStateFromSave(output.String())
 			log.Debugf("Current iptables state: %#v", currentState)
@@ -112,7 +112,7 @@ check_loop:
 				}
 			}
 			for _, cmd := range ipCfg.checkRules {
-				if err := ext.Run(log, constants.IPTables, ipCfg.ver, nil, cmd...); err != nil {
+				if _, err := ext.Run(log, true, constants.IPTables, ipCfg.ver, nil, cmd...); err != nil {
 					deltaExists = true
 					log.Debugf("iptables check rules failed")
 					break

--- a/tools/istio-iptables/pkg/capture/run.go
+++ b/tools/istio-iptables/pkg/capture/run.go
@@ -279,9 +279,13 @@ func (cfg *IptablesConfigurator) Run() error {
 
 	defer func() {
 		// Best effort since we don't know if the commands exist
-		_ = cfg.ext.Run(log.WithLabels(), constants.IPTablesSave, &iptVer, nil)
+		if state, err := cfg.ext.Run(log.WithLabels(), true, constants.IPTablesSave, &iptVer, nil); err != nil {
+			log.Infof("Final iptables state (IPv4):\n%s", state)
+		}
 		if cfg.cfg.EnableIPv6 {
-			_ = cfg.ext.Run(log.WithLabels(), constants.IPTablesSave, &ipt6Ver, nil)
+			if state, err := cfg.ext.Run(log.WithLabels(), true, constants.IPTablesSave, &ipt6Ver, nil); err != nil {
+				log.Infof("Final iptables state (IPv6):\n%s", state)
+			}
 		}
 	}()
 
@@ -692,7 +696,7 @@ func (cfg *IptablesConfigurator) handleCaptureByOwnerGroup(filter config.Interce
 
 func (cfg *IptablesConfigurator) executeIptablesCommands(iptVer *dep.IptablesVersion, commands [][]string) error {
 	for _, cmd := range commands {
-		if err := cfg.ext.Run(log.WithLabels(), constants.IPTables, iptVer, nil, cmd...); err != nil {
+		if _, err := cfg.ext.Run(log.WithLabels(), false, constants.IPTables, iptVer, nil, cmd...); err != nil {
 			return err
 		}
 	}
@@ -701,14 +705,15 @@ func (cfg *IptablesConfigurator) executeIptablesCommands(iptVer *dep.IptablesVer
 
 func (cfg *IptablesConfigurator) tryExecuteIptablesCommands(iptVer *dep.IptablesVersion, commands [][]string) {
 	for _, cmd := range commands {
-		cfg.ext.RunQuietlyAndIgnore(log.WithLabels(), constants.IPTables, iptVer, nil, cmd...)
+		_, _ = cfg.ext.Run(log.WithLabels(), true, constants.IPTables, iptVer, nil, cmd...)
 	}
 }
 
 func (cfg *IptablesConfigurator) executeIptablesRestoreCommand(iptVer *dep.IptablesVersion, data string) error {
 	log.Infof("Running iptables restore with: %s and the following input:\n%v", iptVer.CmdToString(constants.IPTablesRestore), strings.TrimSpace(data))
 	// --noflush to prevent flushing/deleting previous contents from table
-	return cfg.ext.Run(log.WithLabels(), constants.IPTablesRestore, iptVer, strings.NewReader(data), "--noflush")
+	_, err := cfg.ext.Run(log.WithLabels(), false, constants.IPTablesRestore, iptVer, strings.NewReader(data), "--noflush")
+	return err
 }
 
 func (cfg *IptablesConfigurator) executeCommands(iptVer, ipt6Ver *dep.IptablesVersion) error {

--- a/tools/istio-iptables/pkg/capture/run.go
+++ b/tools/istio-iptables/pkg/capture/run.go
@@ -279,11 +279,11 @@ func (cfg *IptablesConfigurator) Run() error {
 
 	defer func() {
 		// Best effort since we don't know if the commands exist
-		if state, err := cfg.ext.Run(log.WithLabels(), true, constants.IPTablesSave, &iptVer, nil); err != nil {
+		if state, err := cfg.ext.Run(log.WithLabels(), true, constants.IPTablesSave, &iptVer, nil); err == nil {
 			log.Infof("Final iptables state (IPv4):\n%s", state)
 		}
 		if cfg.cfg.EnableIPv6 {
-			if state, err := cfg.ext.Run(log.WithLabels(), true, constants.IPTablesSave, &ipt6Ver, nil); err != nil {
+			if state, err := cfg.ext.Run(log.WithLabels(), true, constants.IPTablesSave, &ipt6Ver, nil); err == nil {
 				log.Infof("Final iptables state (IPv6):\n%s", state)
 			}
 		}
@@ -722,8 +722,8 @@ func (cfg *IptablesConfigurator) executeCommands(iptVer, ipt6Ver *dep.IptablesVe
 		if guardrails {
 			log.Info("Removing guardrails")
 			guardrailsCleanup := cfg.ruleBuilder.BuildCleanupGuardrails()
-			_ = cfg.executeIptablesCommands(iptVer, guardrailsCleanup)
-			_ = cfg.executeIptablesCommands(ipt6Ver, guardrailsCleanup)
+			cfg.tryExecuteIptablesCommands(iptVer, guardrailsCleanup)
+			cfg.tryExecuteIptablesCommands(ipt6Ver, guardrailsCleanup)
 		}
 	}()
 

--- a/tools/istio-iptables/pkg/capture/run.go
+++ b/tools/istio-iptables/pkg/capture/run.go
@@ -722,8 +722,8 @@ func (cfg *IptablesConfigurator) executeCommands(iptVer, ipt6Ver *dep.IptablesVe
 		if guardrails {
 			log.Info("Removing guardrails")
 			guardrailsCleanup := cfg.ruleBuilder.BuildCleanupGuardrails()
-			cfg.tryExecuteIptablesCommands(iptVer, guardrailsCleanup)
-			cfg.tryExecuteIptablesCommands(ipt6Ver, guardrailsCleanup)
+			_ = cfg.executeIptablesCommands(iptVer, guardrailsCleanup)
+			_ = cfg.executeIptablesCommands(ipt6Ver, guardrailsCleanup)
 		}
 	}()
 

--- a/tools/istio-iptables/pkg/capture/run_test.go
+++ b/tools/istio-iptables/pkg/capture/run_test.go
@@ -413,6 +413,7 @@ func TestIdempotentEquivalentRerun(t *testing.T) {
 			cfg.ForceApply = true
 			iptConfigurator = NewIptablesConfigurator(cfg, ext)
 			assert.Error(t, iptConfigurator.Run())
+			cfg.ForceApply = false
 		})
 	}
 }

--- a/tools/istio-iptables/pkg/dependencies/implementation.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation.go
@@ -220,32 +220,11 @@ func transformToXTablesErrorMessage(stderr string, err error) string {
 // Run runs a command
 func (r *RealDependencies) Run(
 	logger *log.Scope,
-	cmd constants.IptablesCmd,
-	iptVer *IptablesVersion,
-	stdin io.ReadSeeker,
-	args ...string,
-) error {
-	return r.executeXTables(logger, cmd, iptVer, false, stdin, args...)
-}
-
-// Run runs a command and returns stdout
-func (r *RealDependencies) RunWithOutput(
-	logger *log.Scope,
+	quietLogging bool,
 	cmd constants.IptablesCmd,
 	iptVer *IptablesVersion,
 	stdin io.ReadSeeker,
 	args ...string,
 ) (*bytes.Buffer, error) {
-	return r.executeXTablesWithOutput(logger, cmd, iptVer, false, true, stdin, args...)
-}
-
-// RunQuietlyAndIgnore runs a command quietly and ignores errors
-func (r *RealDependencies) RunQuietlyAndIgnore(
-	logger *log.Scope,
-	cmd constants.IptablesCmd,
-	iptVer *IptablesVersion,
-	stdin io.ReadSeeker,
-	args ...string,
-) {
-	_ = r.executeXTables(logger, cmd, iptVer, true, stdin, args...)
+	return r.executeXTables(logger, cmd, iptVer, quietLogging, stdin, args...)
 }

--- a/tools/istio-iptables/pkg/dependencies/implementation_linux.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation_linux.go
@@ -204,7 +204,7 @@ func mount(src, dst string) error {
 }
 
 func (r *RealDependencies) executeXTables(log *log.Scope, cmd constants.IptablesCmd, iptVer *IptablesVersion,
-	silenceErrors bool, stdin io.ReadSeeker, args ...string,
+	quietLogging bool, stdin io.ReadSeeker, args ...string,
 ) (*bytes.Buffer, error) {
 	mode := "without lock"
 	stdout := &bytes.Buffer{}
@@ -261,7 +261,11 @@ func (r *RealDependencies) executeXTables(log *log.Scope, cmd constants.Iptables
 			c = exec.Command(cmdBin, args...)
 		}
 	}
-	log.Infof("Running command (%s): %s %s", mode, cmdBin, strings.Join(args, " "))
+	if quietLogging {
+		log.Debugf("Running command (%s): %s %s", mode, cmdBin, strings.Join(args, " "))
+	} else {
+		log.Infof("Running command (%s): %s %s", mode, cmdBin, strings.Join(args, " "))
+	}
 
 	c.Stdout = stdout
 	c.Stderr = stderr
@@ -272,7 +276,7 @@ func (r *RealDependencies) executeXTables(log *log.Scope, cmd constants.Iptables
 	}
 
 	// TODO Check naming and redirection logic
-	if (err != nil || len(stderr.String()) != 0) && !silenceErrors {
+	if (err != nil || len(stderr.String()) != 0) && !quietLogging {
 		stderrStr := stderr.String()
 
 		// Transform to xtables-specific error messages with more useful and actionable hints.
@@ -281,7 +285,7 @@ func (r *RealDependencies) executeXTables(log *log.Scope, cmd constants.Iptables
 		}
 
 		log.Errorf("Command error output: %v", stderrStr)
-	} else if err != nil && silenceErrors {
+	} else if err != nil && quietLogging {
 		// Log ignored errors for debugging purposes
 		log.Debugf("Ignoring iptables command error: %v", err)
 	}

--- a/tools/istio-iptables/pkg/dependencies/implementation_linux.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation_linux.go
@@ -284,7 +284,7 @@ func (r *RealDependencies) executeXTables(log *log.Scope, cmd constants.Iptables
 			// Log ignored errors for debugging purposes
 			log.Debugf("Ignoring iptables command error: %v", transformedErr)
 		}
-		err = errors.Join(err, fmt.Errorf(stderrStr))
+		err = errors.Join(err, errors.New(stderrStr))
 	} else if len(stderrStr) > 0 {
 		log.Debugf("Command stderr output: %s", stderrStr)
 	}

--- a/tools/istio-iptables/pkg/dependencies/implementation_linux.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation_linux.go
@@ -204,7 +204,7 @@ func mount(src, dst string) error {
 }
 
 func (r *RealDependencies) executeXTables(log *log.Scope, cmd constants.IptablesCmd, iptVer *IptablesVersion,
-	quietLogging bool, stdin io.ReadSeeker, args ...string,
+	silenceErrors bool, stdin io.ReadSeeker, args ...string,
 ) (*bytes.Buffer, error) {
 	mode := "without lock"
 	stdout := &bytes.Buffer{}
@@ -261,11 +261,7 @@ func (r *RealDependencies) executeXTables(log *log.Scope, cmd constants.Iptables
 			c = exec.Command(cmdBin, args...)
 		}
 	}
-	if quietLogging {
-		log.Debugf("Running command (%s): %s %s", mode, cmdBin, strings.Join(args, " "))
-	} else {
-		log.Infof("Running command (%s): %s %s", mode, cmdBin, strings.Join(args, " "))
-	}
+	log.Debugf("Running command (%s): %s %s", mode, cmdBin, strings.Join(args, " "))
 
 	c.Stdout = stdout
 	c.Stderr = stderr
@@ -276,7 +272,7 @@ func (r *RealDependencies) executeXTables(log *log.Scope, cmd constants.Iptables
 	}
 
 	// TODO Check naming and redirection logic
-	if (err != nil || len(stderr.String()) != 0) && !quietLogging {
+	if (err != nil || len(stderr.String()) != 0) && !silenceErrors {
 		stderrStr := stderr.String()
 
 		// Transform to xtables-specific error messages with more useful and actionable hints.
@@ -285,7 +281,7 @@ func (r *RealDependencies) executeXTables(log *log.Scope, cmd constants.Iptables
 		}
 
 		log.Errorf("Command error output: %v", stderrStr)
-	} else if err != nil && quietLogging {
+	} else if err != nil && silenceErrors {
 		// Log ignored errors for debugging purposes
 		log.Debugf("Ignoring iptables command error: %v", err)
 	}

--- a/tools/istio-iptables/pkg/dependencies/implementation_unspecified.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation_unspecified.go
@@ -29,13 +29,8 @@ import (
 // ErrNotImplemented is returned when a requested feature is not implemented.
 var ErrNotImplemented = errors.New("not implemented")
 
-func (r *RealDependencies) executeXTables(log *log.Scope, cmd constants.IptablesCmd, iptVer *IptablesVersion, ignoreErrors bool, stdin io.ReadSeeker, args ...string) error {
-	_, err := r.executeXTablesWithOutput(log, cmd, iptVer, ignoreErrors, false, stdin, args...)
-	return err
-}
-
-func (r *RealDependencies) executeXTablesWithOutput(log *log.Scope, cmd constants.IptablesCmd, iptVer *IptablesVersion,
-	ignoreErrors bool, silenceOutput bool, stdin io.ReadSeeker, args ...string,
+func (r *RealDependencies) executeXTables(log *log.Scope, cmd constants.IptablesCmd, iptVer *IptablesVersion,
+	silenceErrors bool, stdin io.ReadSeeker, args ...string,
 ) (*bytes.Buffer, error) {
 	return nil, ErrNotImplemented
 }

--- a/tools/istio-iptables/pkg/dependencies/implementation_unspecified.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation_unspecified.go
@@ -30,7 +30,7 @@ import (
 var ErrNotImplemented = errors.New("not implemented")
 
 func (r *RealDependencies) executeXTables(log *log.Scope, cmd constants.IptablesCmd, iptVer *IptablesVersion,
-	quietLogging bool, stdin io.ReadSeeker, args ...string,
+	silenceErrors bool, stdin io.ReadSeeker, args ...string,
 ) (*bytes.Buffer, error) {
 	return nil, ErrNotImplemented
 }

--- a/tools/istio-iptables/pkg/dependencies/implementation_unspecified.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation_unspecified.go
@@ -30,7 +30,7 @@ import (
 var ErrNotImplemented = errors.New("not implemented")
 
 func (r *RealDependencies) executeXTables(log *log.Scope, cmd constants.IptablesCmd, iptVer *IptablesVersion,
-	silenceErrors bool, stdin io.ReadSeeker, args ...string,
+	quietLogging bool, stdin io.ReadSeeker, args ...string,
 ) (*bytes.Buffer, error) {
 	return nil, ErrNotImplemented
 }

--- a/tools/istio-iptables/pkg/dependencies/interface.go
+++ b/tools/istio-iptables/pkg/dependencies/interface.go
@@ -25,13 +25,7 @@ import (
 // Dependencies is used as abstraction for the commands used from the operating system
 type Dependencies interface {
 	// Run runs a command
-	Run(log *istiolog.Scope, cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) error
-
-	// Run runs a command and get the output
-	RunWithOutput(log *istiolog.Scope, cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) (*bytes.Buffer, error)
-
-	// RunQuietlyAndIgnore runs a command quietly and ignores errors
-	RunQuietlyAndIgnore(log *istiolog.Scope, cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string)
+	Run(log *istiolog.Scope, quietLogging bool, cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) (*bytes.Buffer, error)
 
 	// DetectIptablesVersion consults the available binaries and in-use tables to determine
 	// which iptables variant (legacy, nft, v6, v4) we should use in the current context.

--- a/tools/istio-iptables/pkg/dependencies/stub.go
+++ b/tools/istio-iptables/pkg/dependencies/stub.go
@@ -44,7 +44,7 @@ func (s *DependenciesStub) Run(logger *log.Scope,
 	stdin io.ReadSeeker,
 	args ...string,
 ) (*bytes.Buffer, error) {
-	s.execute(quietLogging /*quietly*/, cmd, iptVer, stdin, args...)
+	s.execute(quietLogging, cmd, iptVer, stdin, args...)
 	_ = s.writeAllToDryRunPath()
 	return &bytes.Buffer{}, nil
 }

--- a/tools/istio-iptables/pkg/dependencies/stub.go
+++ b/tools/istio-iptables/pkg/dependencies/stub.go
@@ -37,33 +37,16 @@ type DependenciesStub struct {
 	ExecutedAll      []string
 }
 
-func (s *DependenciesStub) Run(logger *log.Scope, cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) error {
-	s.execute(false /*quietly*/, cmd, iptVer, stdin, args...)
-	_ = s.writeAllToDryRunPath()
-	return nil
-}
-
-func (s *DependenciesStub) RunWithOutput(
-	ogger *log.Scope,
+func (s *DependenciesStub) Run(logger *log.Scope,
+	quietLogging bool,
 	cmd constants.IptablesCmd,
 	iptVer *IptablesVersion,
 	stdin io.ReadSeeker,
 	args ...string,
 ) (*bytes.Buffer, error) {
-	s.execute(false /*quietly*/, cmd, iptVer, stdin, args...)
+	s.execute(quietLogging /*quietly*/, cmd, iptVer, stdin, args...)
 	_ = s.writeAllToDryRunPath()
 	return &bytes.Buffer{}, nil
-}
-
-func (s *DependenciesStub) RunQuietlyAndIgnore(
-	logger *log.Scope,
-	cmd constants.IptablesCmd,
-	iptVer *IptablesVersion,
-	stdin io.ReadSeeker,
-	args ...string,
-) {
-	s.execute(true /*quietly*/, cmd, iptVer, stdin, args...)
-	_ = s.writeAllToDryRunPath()
 }
 
 func (s *DependenciesStub) DetectIptablesVersion(ipV6 bool) (IptablesVersion, error) {


### PR DESCRIPTION
**Please provide a description of this PR:**

This PR refactor the iptables code to have a single Run() interface to execute iptables commands.
Previously, there were three Run functions:
- Run(): Did not return stdout, only an error. It logged the executed command, output, and error at the info level.
- RunWithOutput(): Returned both stdout and an error. It logged the executed command and error at the info level, with output logged at the debug level.
- RunQuietlyAndIgnore(): Returned nothing. It logged the executed command and output at the info level, with errors logged at the debug level.

The new Run() always returns both the command output and any error that occurs, it is up to the caller to decide which one to ignore. It now includes a flag to silence all errors (info->debug level).
A notable difference from the previous implementation is that the command and its output are now always logged at the debug level (this is relevant only for iptables-save cmds).

This PR also includes minor behavioral changes with respect to master: iptables check command, iptables delete commands, and the iptables-save command all use only debug-level logs. Guardrails-related cmds are no longer printed in the logs; however, messages indicating that they are being applied (or removed) are retained.
On top of this the err returned by the function is a wrapping of the error of the exec.Cmd.run() with stderr (on master stderr is ignored).

These changes fix #54644
