### PR TITLE
ambient: move networks logic to native krt

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -1660,7 +1660,6 @@ func newAmbientTestServerWithFlags(t *testing.T, clusterID cluster.ID, networkID
 		Debugger:       debugger,
 		Flags:          flags,
 	})
-	cl.RunAndWait(test.NewStop(t))
 
 	dumpOnFailure(t, debugger)
 	a := &ambientTestServer{
@@ -1705,6 +1704,7 @@ func newAmbientTestServerWithFlags(t *testing.T, clusterID cluster.ID, networkID
 		},
 	})
 
+	cl.RunAndWait(test.NewStop(t))
 	return a
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -1660,7 +1660,6 @@ func newAmbientTestServerWithFlags(t *testing.T, clusterID cluster.ID, networkID
 		Debugger:       debugger,
 		Flags:          flags,
 	})
-	idx.NetworksSynced()
 	cl.RunAndWait(test.NewStop(t))
 
 	dumpOnFailure(t, debugger)
@@ -1696,7 +1695,13 @@ func newAmbientTestServerWithFlags(t *testing.T, clusterID cluster.ID, networkID
 	a.ns.Create(&corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   testNS,
-			Labels: map[string]string{"istio.io/dataplane-mode": "ambient"},
+			Labels: map[string]string{label.IoIstioDataplaneMode.Name: "ambient"},
+		},
+	})
+	a.ns.Create(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   systemNS,
+			Labels: map[string]string{label.TopologyNetwork.Name: string(networkID)},
 		},
 	})
 

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/helpers.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/helpers.go
@@ -22,7 +22,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pkg/config/labels"
+	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/workloadapi"
 )
 
@@ -68,31 +68,31 @@ func mustByteIPToString(b []byte) string {
 	return ip.String()
 }
 
-func (a *index) toNetworkAddress(vip string) (*workloadapi.NetworkAddress, error) {
+func (a *index) toNetworkAddress(ctx krt.HandlerContext, vip string) (*workloadapi.NetworkAddress, error) {
 	ip, err := netip.ParseAddr(vip)
 	if err != nil {
 		return nil, fmt.Errorf("parse %v: %v", vip, err)
 	}
 	return &workloadapi.NetworkAddress{
-		Network: a.Network(vip, make(labels.Instance, 0)).String(),
+		Network: a.Network(ctx).String(),
 		Address: ip.AsSlice(),
 	}, nil
 }
 
-func (a *index) toNetworkAddressFromIP(ip netip.Addr) *workloadapi.NetworkAddress {
+func (a *index) toNetworkAddressFromIP(ctx krt.HandlerContext, ip netip.Addr) *workloadapi.NetworkAddress {
 	return &workloadapi.NetworkAddress{
-		Network: a.Network(ip.String(), make(labels.Instance, 0)).String(),
+		Network: a.Network(ctx).String(),
 		Address: ip.AsSlice(),
 	}
 }
 
-func (a *index) toNetworkAddressFromCidr(vip string) (*workloadapi.NetworkAddress, error) {
+func (a *index) toNetworkAddressFromCidr(ctx krt.HandlerContext, vip string) (*workloadapi.NetworkAddress, error) {
 	ip, err := parseCidrOrIP(vip)
 	if err != nil {
 		return nil, err
 	}
 	return &workloadapi.NetworkAddress{
-		Network: a.Network(vip, make(labels.Instance, 0)).String(),
+		Network: a.Network(ctx).String(),
 		Address: ip.AsSlice(),
 	}, nil
 }

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/networks.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/networks.go
@@ -47,8 +47,8 @@ type networkCollections struct {
 }
 
 func (c networkCollections) HasSynced() bool {
-	return c.SystemNamespace.AsCollection().Synced().HasSynced() &&
-		c.NetworkGateways.Synced().HasSynced()
+	return c.SystemNamespace.AsCollection().HasSynced() &&
+		c.NetworkGateways.HasSynced()
 }
 
 func buildNetworkCollections(

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/networks.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/networks.go
@@ -1,0 +1,131 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// nolint: gocritic
+package ambient
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"istio.io/api/label"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/serviceregistry/kube"
+	"istio.io/istio/pkg/cluster"
+	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/network"
+	"istio.io/istio/pkg/ptr"
+)
+
+type NetworkGateway struct {
+	model.NetworkGateway
+	Source types.NamespacedName
+}
+
+func (n NetworkGateway) ResourceName() string {
+	return n.Source.String() + "/" + n.Addr
+}
+
+type networkCollections struct {
+	SystemNamespace   krt.Singleton[string]
+	NetworkGateways   krt.Collection[NetworkGateway]
+	GatewaysByNetwork krt.Index[network.ID, NetworkGateway]
+}
+
+func (c networkCollections) HasSynced() bool {
+	return c.SystemNamespace.AsCollection().Synced().HasSynced() &&
+		c.NetworkGateways.Synced().HasSynced()
+}
+
+func buildNetworkCollections(
+	namespaces krt.Collection[*v1.Namespace],
+	gateways krt.Collection[*v1beta1.Gateway],
+	options Options,
+	opts KrtOptions,
+) networkCollections {
+	SystemNamespaceNetwork := krt.NewSingleton(func(ctx krt.HandlerContext) *string {
+		ns := ptr.Flatten(krt.FetchOne(ctx, namespaces, krt.FilterKey(options.SystemNamespace)))
+		if ns == nil {
+			return nil
+		}
+		nw, f := ns.Labels[label.TopologyNetwork.Name]
+		if !f {
+			return nil
+		}
+		return &nw
+	}, opts.WithName("SystemNamespaceNetwork")...)
+	NetworkGateways := krt.NewManyCollection(
+		gateways,
+		fromGatewayBuilder(options.ClusterID),
+		opts.WithName("NetworkGateways")...,
+	)
+	GatewaysByNetwork := krt.NewIndex(NetworkGateways, func(o NetworkGateway) []network.ID {
+		return []network.ID{o.Network}
+	})
+
+	return networkCollections{
+		SystemNamespace:   SystemNamespaceNetwork,
+		NetworkGateways:   NetworkGateways,
+		GatewaysByNetwork: GatewaysByNetwork,
+	}
+}
+
+func fromGatewayBuilder(clusterId cluster.ID) krt.TransformationMulti[*v1beta1.Gateway, NetworkGateway] {
+	return func(ctx krt.HandlerContext, gw *v1beta1.Gateway) []NetworkGateway {
+		netLabel := gw.GetLabels()[label.TopologyNetwork.Name]
+		if netLabel == "" {
+			return nil
+		}
+
+		if gw.Spec.GatewayClassName != constants.RemoteGatewayClassName {
+			return nil
+		}
+
+		base := model.NetworkGateway{
+			Network: network.ID(netLabel),
+			Cluster: clusterId,
+			ServiceAccount: types.NamespacedName{
+				Namespace: gw.Namespace,
+				Name:      kube.GatewaySA(gw),
+			},
+		}
+		gateways := []NetworkGateway{}
+		source := config.NamespacedName(gw)
+		for _, addr := range gw.Spec.Addresses {
+			if addr.Type == nil {
+				continue
+			}
+			if addrType := *addr.Type; addrType != v1beta1.IPAddressType && addrType != v1beta1.HostnameAddressType {
+				continue
+			}
+			for _, l := range gw.Spec.Listeners {
+				if l.Protocol == "HBONE" {
+					networkGateway := base
+					networkGateway.Addr = addr.Value
+					networkGateway.Port = uint32(l.Port)
+					networkGateway.HBONEPort = uint32(l.Port)
+					gateways = append(gateways, NetworkGateway{
+						NetworkGateway: networkGateway,
+						Source:         source,
+					})
+					break
+				}
+			}
+		}
+		return gateways
+	}
+}

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/networks.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/networks.go
@@ -84,7 +84,7 @@ func buildNetworkCollections(
 	}
 }
 
-func fromGatewayBuilder(clusterId cluster.ID) krt.TransformationMulti[*v1beta1.Gateway, NetworkGateway] {
+func fromGatewayBuilder(clusterID cluster.ID) krt.TransformationMulti[*v1beta1.Gateway, NetworkGateway] {
 	return func(ctx krt.HandlerContext, gw *v1beta1.Gateway) []NetworkGateway {
 		netLabel := gw.GetLabels()[label.TopologyNetwork.Name]
 		if netLabel == "" {
@@ -97,7 +97,7 @@ func fromGatewayBuilder(clusterId cluster.ID) krt.TransformationMulti[*v1beta1.G
 
 		base := model.NetworkGateway{
 			Network: network.ID(netLabel),
-			Cluster: clusterId,
+			Cluster: clusterID,
 			ServiceAccount: types.NamespacedName{
 				Namespace: gw.Namespace,
 				Name:      kube.GatewaySA(gw),

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/services_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/services_test.go
@@ -440,7 +440,7 @@ func TestServiceEntryServices(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := krttest.NewMock(t, tt.inputs)
-			a := newAmbientUnitTest()
+			a := newAmbientUnitTest(t)
 			builder := a.serviceEntryServiceBuilder(
 				krttest.GetMockCollection[Waypoint](mock),
 				krttest.GetMockCollection[*v1.Namespace](mock),
@@ -766,7 +766,7 @@ func TestServiceServices(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := krttest.NewMock(t, tt.inputs)
-			a := newAmbientUnitTest()
+			a := newAmbientUnitTest(t)
 			builder := a.serviceServiceBuilder(
 				krttest.GetMockCollection[Waypoint](mock),
 				krttest.GetMockCollection[*v1.Namespace](mock),
@@ -900,7 +900,7 @@ func TestServiceConditions(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := krttest.NewMock(t, tt.inputs)
-			a := newAmbientUnitTest()
+			a := newAmbientUnitTest(t)
 			builder := a.serviceServiceBuilder(
 				krttest.GetMockCollection[Waypoint](mock),
 				krttest.GetMockCollection[*v1.Namespace](mock),

--- a/pilot/pkg/serviceregistry/kube/controller/network_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network_test.go
@@ -366,20 +366,7 @@ func TestAmbientSync(t *testing.T) {
 		CRDs:            []schema.GroupVersionResource{gvr.KubernetesGateway},
 		ConfigCluster:   true,
 	})
-	done := make(chan struct{})
-	// We want to test that ambient is not marked synced until the Kube controller is synced, since it depends on it for network
-	// information.
-	// To simulate this, we intentionally slow down the syncing process (which is hard to make slow with the fake client).
-	s.queue.Push(func() error {
-		time.Sleep(time.Millisecond * 20)
-		close(done)
-		return nil
-	})
 	go s.Run(stop)
-	// We should start as not synced
-	assert.Equal(t, s.ambientIndex.HasSynced(), false)
-	<-done
-	// Once the queue is done, eventually we should sync.
 	assert.EventuallyEqual(t, s.ambientIndex.HasSynced, true)
 
 	gtw := clienttest.NewWriter[*v1beta1.Gateway](t, s.client)

--- a/tests/binary/binaries_test.go
+++ b/tests/binary/binaries_test.go
@@ -108,7 +108,7 @@ func TestBinarySizes(t *testing.T) {
 		// For now, having two small a range will result in lots of "merge conflicts"
 		"istioctl":        {60, 90},
 		"pilot-agent":     {20, 25},
-		"pilot-discovery": {60, 91},
+		"pilot-discovery": {60, 95},
 		"bug-report":      {60, 80},
 		"client":          {15, 30},
 		"server":          {15, 30},


### PR DESCRIPTION
Alternative to https://github.com/istio/istio/pull/54376/. In that PR,
I moved all the network logic to krt. This just makes ambient network
logic on krt, as its own copy.

This makes ambient's full state managed by krt! We can remove the hacks
around syncing, etc.

Note this only implements the system-namespace and Gateway driven
network logic, not the older MeshNetworks logic.
