### PR TITLE
Switch this back so we don't create it unless remotePilotAddress is set

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/remote-istiod-service.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/remote-istiod-service.yaml
@@ -1,5 +1,5 @@
 # This file is only used for remote `istiod` installs.
-{{- if .Values.istiodRemote.enabled }}
+{{- if .Values.global.remotePilotAddress }}
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
**Please provide a description of this PR:**

https://github.com/istio/istio/issues/54679

This is how it used to be, but I seem to  recall there was some corner case in test code that made me change it. I might be misremembering. Proof in the tests.