### PR TITLE
 [release-1.23] Backport release note for missed behavior change #54699 

### DIFF
--- a/releasenotes/notes/retroactive-note-for-53949.yaml
+++ b/releasenotes/notes/retroactive-note-for-53949.yaml
@@ -1,0 +1,13 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 53949
+releaseNotes:
+- |
+  **Fixed** DNS traffic (UDP and TCP) is now affected by traffic annotations like `traffic.sidecar.istio.io/excludeOutboundIPRanges` and `traffic.sidecar.istio.io/excludeOutboundPorts`. Before, UDP/DNS traffic would uniquely ignore these traffic annotations, even if a DNS port was specified, because of the rule structure. The behavior change actually happened in the 1.23 release series, but was left out of the release notes for 1.23.
+
+upgradeNotes:
+  - title: DNS traffic (TCP and UDP) now respects traffic exclusion annotations
+    content: |
+      DNS traffic (UDP and TCP) now respects pod-level traffic annotations like `traffic.sidecar.istio.io/excludeOutboundIPRanges` and `traffic.sidecar.istio.io/excludeOutboundPorts`. Before, UDP/DNS traffic would uniquely ignore these traffic annotations, even if a DNS port was specified, because of the rule structure. The behavior change actually happened in the 1.23 release series, but was left out of the release notes for 1.23.


### PR DESCRIPTION
**Please provide a description of this PR:**

As mentioned in https://github.com/istio/istio/issues/53949 this behavior changed in 1.23 but we didn't catch or relnote it, so might as well do it retroactively in the affected older branches for posterity's sake.