### PR TITLE
spire: fixup sample

### DIFF
--- a/samples/security/spire/istio-spire-config.yaml
+++ b/samples/security/spire/istio-spire-config.yaml
@@ -7,7 +7,6 @@ spec:
   meshConfig:
     trustDomain: example.org
   values:
-    global:
     # This is used to customize the sidecar template
     sidecarInjectorWebhook:
       templates:


### PR DESCRIPTION
This is setting `global` to null which is not valid
