### PR TITLE
Updated queries to support longer scrape intervals in Control Plane Dashboard

### DIFF
--- a/manifests/addons/dashboards/lib/queries.libsonnet
+++ b/manifests/addons/dashboards/lib/queries.libsonnet
@@ -165,7 +165,7 @@ local variables = import './variables.libsonnet';
         self.query(
           '{{le}}',
           |||
-            sum(rate(pilot_xds_push_time_bucket{}[1m])) by (le)
+            sum(rate(pilot_xds_push_time_bucket{}[$__rate_interval])) by (le)
           |||
         ) + q.withFormat('heatmap'),
 
@@ -173,7 +173,7 @@ local variables = import './variables.libsonnet';
         self.query(
           '{{le}}',
           |||
-            sum(rate(pilot_xds_config_size_bytes_bucket{}[1m])) by (le)
+            sum(rate(pilot_xds_config_size_bytes_bucket{}[$__rate_interval])) by (le)
           |||
         ) + q.withFormat('heatmap'),
 


### PR DESCRIPTION
**Please provide a description of this PR:**
Hi team, we noticed some of the queries in the Istio Grafana dashboards that may cause visualization issues for metric scrape intervals longer than 30 seconds. For example, scrapes every 60 seconds or less frequent. The dashboard PromQL queries seem to mostly use [$__rate_interval] to automatically calculation rate() interval in queries. However some of the queries instead use [1m] instead. The concern is when evaluating at a 1 minute interval while receiving a datapoint every 1 minute, it will be difficult to calculate a rate. We’d like to propose these changes to automatically determine the interval. The values modified appear to belong to the script that creates the Istio Control Plane Dashboard.

It appears that the **queries.libsonnet** file is used to generate the control plane dashboard: https://github.com/istio/istio/blob/master/manifests/addons/dashboards/README.md

The dashboards are hosted here:
https://grafana.com/grafana/dashboards/7645-istio-control-plane-dashboard/ https://grafana.com/orgs/istio/dashboards

Can you please validate this change in your pipeline used to create the hosted Istio dashboards to confirm the change is acceptable, your dashboards continue to work as expected and this does not introduce any other issues? Thank you.