### PR TITLE
PILOT_SEND_UNHEALTHY_ENDPOINTS: exclude terminating endpoints

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -467,6 +467,7 @@ const (
 	// Without persistent sessions, an endpoint that is shutting down will be marked as Terminating.
 	Draining HealthStatus = 3
 	// Terminating marks an endpoint as shutting down. Similar to "unhealthy", this means we should not send it traffic.
+	// But unlike "unhealthy", this means we do not consider it when calculating failover.
 	Terminating HealthStatus = 4
 )
 

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -454,16 +454,20 @@ type Locality struct {
 	ClusterID cluster.ID
 }
 
-// Endpoint health status.
+// HealthStatus indicates the status of the Endpoint.
 type HealthStatus int32
 
 const (
-	// Healthy.
+	// Healthy indicates an endpoint is ready to accept traffic
 	Healthy HealthStatus = 1
-	// Unhealthy.
+	// UnHealthy indicates an endpoint is not ready to accept traffic
 	UnHealthy HealthStatus = 2
-	// Draining - the constant matches envoy
+	// Draining is a special case, which is used only when persistent sessions are enabled. This indicates an endpoint
+	// was previously healthy, but is now shutting down.
+	// Without persistent sessions, an endpoint that is shutting down will be marked as Terminating.
 	Draining HealthStatus = 3
+	// Terminating marks an endpoint as shutting down. Similar to "unhealthy", this means we should not send it traffic.
+	Terminating HealthStatus = 4
 )
 
 // IstioEndpoint defines a network address (IP:port) associated with an instance of the

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -244,10 +244,17 @@ func endpointHealthStatus(svc *model.Service, e v1.Endpoint) model.HealthStatus 
 		return model.Healthy
 	}
 
+	// An endpoint is draining only if it was previously ready (serving == true) and persistent sessions is enabled
 	if svc != nil && svc.SupportsDrainingEndpoints() &&
 		(e.Conditions.Serving == nil || *e.Conditions.Serving) &&
 		(e.Conditions.Terminating == nil || *e.Conditions.Terminating) {
 		return model.Draining
+	}
+
+	// If it is shutting down, mark it as terminating. This occurs regardless of whether it was previously healthy or not.
+	if svc != nil &&
+		(e.Conditions.Terminating == nil || *e.Conditions.Terminating) {
+		return model.Terminating
 	}
 
 	return model.UnHealthy

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -589,6 +589,26 @@ func TestEDSUnhealthyEndpoints(t *testing.T) {
 			// Validate that endpoints are pushed.
 			validateEndpoints(true, []string{"10.0.0.53:53", "10.0.0.54:53"}, nil)
 
+			// Mark an endpoint as terminating, it should be removed
+			s.MemRegistry.SetEndpoints("unhealthy.svc.cluster.local", "",
+				[]*model.IstioEndpoint{
+					{
+						Addresses:       []string{"10.0.0.53"},
+						EndpointPort:    53,
+						ServicePortName: "tcp-dns",
+						HealthStatus:    model.Healthy,
+					},
+					{
+						Addresses:       []string{"10.0.0.54"},
+						EndpointPort:    53,
+						ServicePortName: "tcp-dns",
+						HealthStatus:    model.Terminating,
+					},
+				})
+
+			// Validate that endpoints are pushed.
+			validateEndpoints(true, []string{"10.0.0.53:53"}, nil)
+
 			// Remove last healthy endpoints
 			s.MemRegistry.SetEndpoints("unhealthy.svc.cluster.local", "", []*model.IstioEndpoint{})
 			validateEndpoints(true, nil, nil)

--- a/pkg/dns/server/name_table.go
+++ b/pkg/dns/server/name_table.go
@@ -72,7 +72,7 @@ func BuildNameTable(cfg Config) *dnsProto.NameTable {
 							}
 						}
 						if len(instance.Addresses) == 0 || !isValidInstance ||
-							(!svc.Attributes.PublishNotReadyAddresses && instance.HealthStatus == model.UnHealthy) {
+							(!svc.Attributes.PublishNotReadyAddresses && instance.HealthStatus != model.Healthy) {
 							continue
 						}
 						// TODO(stevenctl): headless across-networks https://github.com/istio/istio/issues/38327

--- a/pkg/dns/server/name_table_test.go
+++ b/pkg/dns/server/name_table_test.go
@@ -249,6 +249,8 @@ func TestNameTable(t *testing.T) {
 		makeServiceInstances(pod1, headlessService, "pod1", "headless-svc", model.Healthy))
 	uhpush.AddServiceInstances(headlessService,
 		makeServiceInstances(pod2, headlessService, "pod2", "headless-svc", model.UnHealthy))
+	uhpush.AddServiceInstances(headlessService,
+		makeServiceInstances(pod3, headlessService, "pod3", "headless-svc", model.Terminating))
 
 	uhreadypush := model.NewPushContext()
 	uhreadypush.Mesh = mesh
@@ -257,6 +259,8 @@ func TestNameTable(t *testing.T) {
 		makeServiceInstances(pod1, headlessService, "pod1", "headless-svc", model.Healthy))
 	uhreadypush.AddServiceInstances(headlessService,
 		makeServiceInstances(pod2, headlessService, "pod2", "headless-svc", model.UnHealthy))
+	uhreadypush.AddServiceInstances(headlessService,
+		makeServiceInstances(pod3, headlessService, "pod3", "headless-svc", model.Terminating))
 
 	wpush := model.NewPushContext()
 	wpush.Mesh = mesh
@@ -492,8 +496,14 @@ func TestNameTable(t *testing.T) {
 						Shortname: "pod2.headless-svc",
 						Namespace: "testns",
 					},
+					"pod3.headless-svc.testns.svc.cluster.local": {
+						Ips:       []string{"19.6.7.8"},
+						Registry:  "Kubernetes",
+						Shortname: "pod3.headless-svc",
+						Namespace: "testns",
+					},
 					"headless-svc.testns.svc.cluster.local": {
-						Ips:       []string{"1.2.3.4", "9.6.7.8"},
+						Ips:       []string{"1.2.3.4", "9.6.7.8", "19.6.7.8"},
 						Registry:  "Kubernetes",
 						Shortname: "headless-svc",
 						Namespace: "testns",

--- a/releasenotes/notes/endpoint-termination.yaml
+++ b/releasenotes/notes/endpoint-termination.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+releaseNotes:
+  - |
+    **Updated** the `PILOT_SEND_UNHEALTHY_ENDPOINTS` feature (which is off by default) to not include terminating endpoints.
+    This ensures a service is not considered unhealthy during scale down or rollout events.


### PR DESCRIPTION
The purpose of PILOT_SEND_UNHEALTHY_ENDPOINTS is to let envoy know about
the count of health and unhealth endpoints as a factor into its failover
decisions. For instance, if we have 5/10 pods health, it would failover.

This has problematic behavior during scaling up/down. For instance, if I
just have a single pod and then make a change, I will temporarily have 2
pods (the new one, and the old one terminating). Envoy will now see this
as 50% health and failover. This is bad -- its not actually unhealthy at
all!

Additionally, when pods are scaling down we end up keeping them as
unhealthy. Consider I have 1/2 pods healthy, and shut down the unhealthy
one but it takes a few minutes to fully terminate. During that time,
envoy will consider us 50% healthy. However, because we requested 1 pod
and have 1 pod, I would consider that 100% healthy.

----

This PR adds a new health mode, "terminating".
* When the feature flag is false, terminating and unhealthy mean the
  same thing -- do not send the endpoint to envoy. This has no impact.
* When the feature flag is true, we will not sending terminating
  endpoints. This means a terminating endpoint is not taken into account
for the health calculations.

This change does not impact whether we send traffic to the terminating
pods or not -- both before and after, we never do this.

Note: there is another status, 'draining', which is a very specialized
mode that is only used when session persistence is enabled on a service
&& the endpoint is terminating && it used to be healthy. Comments in the
code clarify the differences between these two similar states. These
endpoints *are* sent to envoy and traffic is sent to them, so its
fundamentally different than Terminating.
