### PR TITLE
Gateway also needs global flattening

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -331,7 +331,7 @@ copy-templates:
 		for profile in manifests/helm-profiles/*.yaml ; do \
 			sed "1s|^|$${warning}\n\n|" $$profile > manifests/charts/$$chart/files/profile-$$(basename $$profile) ; \
 		done; \
-		[[ "$$chart" == "ztunnel" ]] && flatten="true" || flatten="false" ; \
+		[[ "$$chart" == "ztunnel" ]] || [[ "$$chart" == "gateway" ]] && flatten="true" || flatten="false" ; \
 		cat manifests/zzz_profile.yaml | \
 		  sed "s/FLATTEN_GLOBALS_REPLACEMENT/$${flatten}/g" \
 		  > manifests/charts/$$chart/templates/zzz_profile.yaml ; \

--- a/manifests/charts/gateway/templates/zzz_profile.yaml
+++ b/manifests/charts/gateway/templates/zzz_profile.yaml
@@ -49,7 +49,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- $a := mustMergeOverwrite $defaults $profile }}
 {{- end }}
 #  Flatten globals, if defined on a per-chart basis
-{{- if false }}
+{{- if true }}
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}

--- a/releasenotes/notes/54714.yamml
+++ b/releasenotes/notes/54714.yamml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+- |
+  **Fixed** an issue in the gateway chart where `--set platform` worked but `--set global.platform` did not.


### PR DESCRIPTION
**Please provide a description of this PR:**

Since:

- we do nonstandard things to `global` values across charts generally
- `gateway` chart doesn't treat globals-as-globals
- and `gateway` chart doesn't artificially flatten globals via `zzz_profile.yaml`

we get the following

`helm template manifests/charts/gateway --set global.platform=openshift` -> does not work
`helm template manifests/charts/gateway --set platform=openshift` -> works

Add `gateway` chart to the makefile-based "global flattening inclusion list" to fix this.

(we could also do `coalesce` like we do in the other charts but `makefile` tweak is probably more amenable in this case)

(I still think the way we special-case globals with machinery creates more problems than it solves - it would be simpler and less error prone to directly refer to globals-as-globals in charts - `platform` can **only** be a global value) 