### PR TITLE
Support TrafficDistribution for Envoy

### DIFF
--- a/pilot/pkg/features/experimental.go
+++ b/pilot/pkg/features/experimental.go
@@ -29,8 +29,8 @@ var (
 	FilterGatewayClusterConfig = env.Register("PILOT_FILTER_GATEWAY_CLUSTER_CONFIG", false,
 		"If enabled, Pilot will send only clusters that referenced in gateway virtual services attached to gateway").Get()
 
-	// RawSendUnhealthyEndpoints contains the raw setting on RawSendUnhealthyEndpoints. This should be checked per-service
-	RawSendUnhealthyEndpoints = atomic.NewBool(env.Register(
+	// GlobalSendUnhealthyEndpoints contains the raw setting on GlobalSendUnhealthyEndpoints. This should be checked per-service
+	GlobalSendUnhealthyEndpoints = atomic.NewBool(env.Register(
 		"PILOT_SEND_UNHEALTHY_ENDPOINTS",
 		false,
 		"If enabled, Pilot will include unhealthy endpoints in EDS pushes and even if they are sent Envoy does not use them for load balancing."+

--- a/pilot/pkg/features/experimental.go
+++ b/pilot/pkg/features/experimental.go
@@ -29,7 +29,8 @@ var (
 	FilterGatewayClusterConfig = env.Register("PILOT_FILTER_GATEWAY_CLUSTER_CONFIG", false,
 		"If enabled, Pilot will send only clusters that referenced in gateway virtual services attached to gateway").Get()
 
-	SendUnhealthyEndpoints = atomic.NewBool(env.Register(
+	// RawSendUnhealthyEndpoints contains the raw setting on RawSendUnhealthyEndpoints. This should be checked per-service
+	RawSendUnhealthyEndpoints = atomic.NewBool(env.Register(
 		"PILOT_SEND_UNHEALTHY_ENDPOINTS",
 		false,
 		"If enabled, Pilot will include unhealthy endpoints in EDS pushes and even if they are sent Envoy does not use them for load balancing."+

--- a/pilot/pkg/model/endpointshards.go
+++ b/pilot/pkg/model/endpointshards.go
@@ -18,7 +18,6 @@ import (
 	"sort"
 	"sync"
 
-	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/schema/kind"
@@ -374,7 +373,7 @@ func endpointUpdateRequiresPush(oldIstioEndpoints []*IstioEndpoint, incomingEndp
 			// new endpoint. Always send new healthy endpoints.
 			// Also send new unhealthy endpoints when SendUnhealthyEndpoints is enabled.
 			// This is OK since we disable panic threshold when SendUnhealthyEndpoints is enabled.
-			if nie.HealthStatus != UnHealthy || features.SendUnhealthyEndpoints.Load() {
+			if nie.HealthStatus != UnHealthy || nie.SendUnhealthyEndpoints {
 				needPush = true
 			}
 			newIstioEndpoints = append(newIstioEndpoints, nie)

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -148,6 +148,23 @@ func (s *Service) SupportsDrainingEndpoints() bool {
 		(features.PersistentSessionHeaderLabel != "" && s.Attributes.Labels[features.PersistentSessionHeaderLabel] != "")
 }
 
+// SupportsUnhealthyEndpoints marks if this service should send unhealthy endpoints
+func (s *Service) SupportsUnhealthyEndpoints() bool {
+	if features.RawSendUnhealthyEndpoints.Load() {
+		// Enable process-wide
+		return true
+	}
+	if s != nil && s.Attributes.TrafficDistribution != TrafficDistributionAny {
+		// When we are doing location aware routing, we need some way to indicate if endpoints are healthy, otherwise we don't
+		// know when to spill over to other zones.
+		// For the older DestinationRule localityLB, we do this by requiring outlier detection.
+		// If they use the newer Kubernetes-native TrafficDistribution we don't want to require an Istio-specific outlier rule,
+		// and instead will use endpoint health which requires sending unhealthy endpoints.
+		return true
+	}
+	return false
+}
+
 // Resolution indicates how the service instances need to be resolved before routing traffic.
 type Resolution int
 
@@ -554,6 +571,11 @@ type IstioEndpoint struct {
 	// Indicates the endpoint health status.
 	HealthStatus HealthStatus
 
+	// SendUnhealthyEndpoints indicates whether this endpoint should be sent when it is unhealthy
+	// Note: this is more appropriate at the Service level, but some codepaths require this in areas without the service
+	// object present.
+	SendUnhealthyEndpoints bool
+
 	// If in k8s, the node where the pod resides
 	NodeName string
 }
@@ -753,12 +775,25 @@ type K8sAttributes struct {
 	// spec.InternalTrafficPolicy == Local
 	NodeLocal bool
 
+	// TrafficDistribution determines the service-level traffic distribution.
+	// This may be overridden by locality load balancing settings.
+	TrafficDistribution TrafficDistribution
+
 	// ObjectName is the object name of the underlying object. This may differ from the Service.Attributes.Name for legacy semantics.
 	ObjectName string
 
 	// spec.PublishNotReadyAddresses
 	PublishNotReadyAddresses bool
 }
+
+type TrafficDistribution int
+
+const (
+	// TrafficDistributionAny allows any destination
+	TrafficDistributionAny TrafficDistribution = iota
+	// TrafficDistributionPreferClose prefers traffic in same region/zone/network if possible, with failover allowed.
+	TrafficDistributionPreferClose TrafficDistribution = iota
+)
 
 // DeepCopy creates a deep copy of ServiceAttributes, but skips internal mutexes.
 func (s *ServiceAttributes) DeepCopy() ServiceAttributes {
@@ -1765,6 +1800,7 @@ func (ep *IstioEndpoint) Equals(other *IstioEndpoint) bool {
 		ep.HostName == other.HostName &&
 		ep.SubDomain == other.SubDomain &&
 		ep.HealthStatus == other.HealthStatus &&
+		ep.SendUnhealthyEndpoints == other.SendUnhealthyEndpoints &&
 		ep.NodeName == other.NodeName
 	if !eq {
 		return false

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -150,7 +150,7 @@ func (s *Service) SupportsDrainingEndpoints() bool {
 
 // SupportsUnhealthyEndpoints marks if this service should send unhealthy endpoints
 func (s *Service) SupportsUnhealthyEndpoints() bool {
-	if features.RawSendUnhealthyEndpoints.Load() {
+	if features.GlobalSendUnhealthyEndpoints.Load() {
 		// Enable process-wide
 		return true
 	}

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -218,7 +218,7 @@ func (cb *ClusterBuilder) buildSubsetCluster(
 		opts.isDrWithSelector = destinationRule.GetWorkloadSelector() != nil
 	}
 	// Apply traffic policy for the subset cluster.
-	cb.applyTrafficPolicy(opts)
+	cb.applyTrafficPolicy(service, opts)
 
 	maybeApplyEdsConfig(subsetCluster.cluster)
 
@@ -263,7 +263,7 @@ func (cb *ClusterBuilder) applyDestinationRule(mc *clusterWrapper, clusterMode C
 		opts.isDrWithSelector = destinationRule.GetWorkloadSelector() != nil
 	}
 	// Apply traffic policy for the main default cluster.
-	cb.applyTrafficPolicy(opts)
+	cb.applyTrafficPolicy(service, opts)
 
 	// Apply EdsConfig if needed. This should be called after traffic policy is applied because, traffic policy might change
 	// discovery type.
@@ -465,7 +465,7 @@ func (cb *ClusterBuilder) buildInboundCluster(clusterPort int, bind string,
 		}
 		opts.policy.ConnectionPool = sidecarConnPool
 	}
-	cb.applyTrafficPolicy(opts)
+	cb.applyTrafficPolicy(nil, opts)
 
 	if bind != LocalhostAddress && bind != LocalhostIPv6Address {
 		// iptables will redirect our own traffic to localhost back to us if we do not use the "magic" upstream bind

--- a/pilot/pkg/networking/core/cluster_test.go
+++ b/pilot/pkg/networking/core/cluster_test.go
@@ -2463,7 +2463,7 @@ func TestApplyLoadBalancer(t *testing.T) {
 
 	for _, tt := range testcases {
 		t.Run(tt.name, func(t *testing.T) {
-			test.SetAtomicBoolForTest(t, features.SendUnhealthyEndpoints, tt.sendUnhealthyEndpoints)
+			test.SetAtomicBoolForTest(t, features.RawSendUnhealthyEndpoints, tt.sendUnhealthyEndpoints)
 			c := &cluster.Cluster{
 				ClusterDiscoveryType: &cluster.Cluster_Type{Type: tt.discoveryType},
 				LoadAssignment:       &endpoint.ClusterLoadAssignment{},
@@ -2478,7 +2478,7 @@ func TestApplyLoadBalancer(t *testing.T) {
 				test.SetForTest(t, &features.EnableRedisFilter, true)
 			}
 
-			applyLoadBalancer(c, tt.lbSettings, tt.port, proxy.Locality, nil, &meshconfig.MeshConfig{})
+			applyLoadBalancer(nil, c, tt.lbSettings, tt.port, proxy.Locality, nil, &meshconfig.MeshConfig{})
 
 			if c.LbPolicy != tt.expectedLbPolicy {
 				t.Errorf("cluster LbPolicy %s != expected %s", c.LbPolicy, tt.expectedLbPolicy)

--- a/pilot/pkg/networking/core/cluster_test.go
+++ b/pilot/pkg/networking/core/cluster_test.go
@@ -2463,7 +2463,7 @@ func TestApplyLoadBalancer(t *testing.T) {
 
 	for _, tt := range testcases {
 		t.Run(tt.name, func(t *testing.T) {
-			test.SetAtomicBoolForTest(t, features.RawSendUnhealthyEndpoints, tt.sendUnhealthyEndpoints)
+			test.SetAtomicBoolForTest(t, features.GlobalSendUnhealthyEndpoints, tt.sendUnhealthyEndpoints)
 			c := &cluster.Cluster{
 				ClusterDiscoveryType: &cluster.Cluster_Type{Type: tt.discoveryType},
 				LoadAssignment:       &endpoint.ClusterLoadAssignment{},

--- a/pilot/pkg/networking/core/cluster_waypoint.go
+++ b/pilot/pkg/networking/core/cluster_waypoint.go
@@ -158,8 +158,8 @@ func (cb *ClusterBuilder) buildWaypointInboundVIPCluster(
 	// For these policies, we have the standard logic apply
 	cb.applyConnectionPool(mesh, localCluster, connectionPool)
 	cb.applyH2Upgrade(localCluster, &port, mesh, connectionPool)
-	applyOutlierDetection(localCluster.cluster, outlierDetection)
-	applyLoadBalancer(localCluster.cluster, loadBalancer, &port, cb.locality, cb.proxyLabels, mesh)
+	applyOutlierDetection(nil, localCluster.cluster, outlierDetection)
+	applyLoadBalancer(svc, localCluster.cluster, loadBalancer, &port, cb.locality, cb.proxyLabels, mesh)
 
 	// Setup EDS config after apply LoadBalancer, since it can impact the result
 	if localCluster.cluster.GetType() == cluster.Cluster_ORIGINAL_DST {

--- a/pilot/pkg/networking/core/loadbalancer/loadbalancer_test.go
+++ b/pilot/pkg/networking/core/loadbalancer/loadbalancer_test.go
@@ -992,15 +992,20 @@ func TestApplyLocalitySetting(t *testing.T) {
 
 func TestGetLocalityLbSetting(t *testing.T) {
 	// dummy config for test
+	preferCloseService := &model.Service{Attributes: model.ServiceAttributes{K8sAttributes: model.K8sAttributes{
+		TrafficDistribution: model.TrafficDistributionPreferClose,
+	}}}
 	failover := []*networking.LocalityLoadBalancerSetting_Failover{nil}
 	cases := []struct {
 		name     string
 		mesh     *networking.LocalityLoadBalancerSetting
 		dr       *networking.LocalityLoadBalancerSetting
+		svc      *model.Service
 		expected *networking.LocalityLoadBalancerSetting
 	}{
 		{
 			"all disabled",
+			nil,
 			nil,
 			nil,
 			nil,
@@ -1009,29 +1014,48 @@ func TestGetLocalityLbSetting(t *testing.T) {
 			"mesh only",
 			&networking.LocalityLoadBalancerSetting{},
 			nil,
+			nil,
 			&networking.LocalityLoadBalancerSetting{},
 		},
 		{
 			"dr only",
 			nil,
 			&networking.LocalityLoadBalancerSetting{},
+			nil,
 			&networking.LocalityLoadBalancerSetting{},
 		},
 		{
 			"dr only override",
 			nil,
 			&networking.LocalityLoadBalancerSetting{Enabled: &wrappers.BoolValue{Value: true}},
+			nil,
 			&networking.LocalityLoadBalancerSetting{Enabled: &wrappers.BoolValue{Value: true}},
 		},
 		{
-			"both",
+			"dr and mesh",
 			&networking.LocalityLoadBalancerSetting{},
 			&networking.LocalityLoadBalancerSetting{Failover: failover},
+			nil,
 			&networking.LocalityLoadBalancerSetting{Failover: failover},
+		},
+		{
+			"all",
+			&networking.LocalityLoadBalancerSetting{},
+			&networking.LocalityLoadBalancerSetting{Failover: failover},
+			preferCloseService,
+			&networking.LocalityLoadBalancerSetting{Failover: failover},
+		},
+		{
+			"service and mesh",
+			&networking.LocalityLoadBalancerSetting{},
+			nil,
+			preferCloseService,
+			&networking.LocalityLoadBalancerSetting{Enabled: &wrappers.BoolValue{Value: true}},
 		},
 		{
 			"mesh disabled",
 			&networking.LocalityLoadBalancerSetting{Enabled: &wrappers.BoolValue{Value: false}},
+			nil,
 			nil,
 			nil,
 		},
@@ -1040,17 +1064,19 @@ func TestGetLocalityLbSetting(t *testing.T) {
 			&networking.LocalityLoadBalancerSetting{Enabled: &wrappers.BoolValue{Value: true}},
 			&networking.LocalityLoadBalancerSetting{Enabled: &wrappers.BoolValue{Value: false}},
 			nil,
+			nil,
 		},
 		{
 			"dr enabled override mesh disabled",
 			&networking.LocalityLoadBalancerSetting{Enabled: &wrappers.BoolValue{Value: false}},
 			&networking.LocalityLoadBalancerSetting{Enabled: &wrappers.BoolValue{Value: true}},
+			nil,
 			&networking.LocalityLoadBalancerSetting{Enabled: &wrappers.BoolValue{Value: true}},
 		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			got, _ := GetLocalityLbSetting(tt.mesh, tt.dr, nil)
+			got, _ := GetLocalityLbSetting(tt.mesh, tt.dr, tt.svc)
 			if !reflect.DeepEqual(tt.expected, got) {
 				t.Fatalf("Expected: %v, got: %v", tt.expected, got)
 			}

--- a/pilot/pkg/networking/core/loadbalancer/loadbalancer_test.go
+++ b/pilot/pkg/networking/core/loadbalancer/loadbalancer_test.go
@@ -1050,7 +1050,7 @@ func TestGetLocalityLbSetting(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GetLocalityLbSetting(tt.mesh, tt.dr, nil)
+			got, _ := GetLocalityLbSetting(tt.mesh, tt.dr, nil)
 			if !reflect.DeepEqual(tt.expected, got) {
 				t.Fatalf("Expected: %v, got: %v", tt.expected, got)
 			}

--- a/pilot/pkg/networking/core/loadbalancer/loadbalancer_test.go
+++ b/pilot/pkg/networking/core/loadbalancer/loadbalancer_test.go
@@ -1050,7 +1050,7 @@ func TestGetLocalityLbSetting(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GetLocalityLbSetting(tt.mesh, tt.dr)
+			got := GetLocalityLbSetting(tt.mesh, tt.dr, nil)
 			if !reflect.DeepEqual(tt.expected, got) {
 				t.Fatalf("Expected: %v, got: %v", tt.expected, got)
 			}

--- a/pilot/pkg/serviceregistry/kube/controller/endpoint_builder.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoint_builder.go
@@ -92,6 +92,7 @@ func (b *EndpointBuilder) buildIstioEndpoint(
 	svcPortName string,
 	discoverabilityPolicy model.EndpointDiscoverabilityPolicy,
 	healthStatus model.HealthStatus,
+	sendUnhealthy bool,
 ) *model.IstioEndpoint {
 	if b == nil {
 		return nil
@@ -105,21 +106,22 @@ func (b *EndpointBuilder) buildIstioEndpoint(
 	}
 
 	return &model.IstioEndpoint{
-		Labels:                b.labels,
-		ServiceAccount:        b.serviceAccount,
-		Locality:              b.locality,
-		TLSMode:               b.tlsMode,
-		Addresses:             []string{endpointAddress},
-		EndpointPort:          uint32(endpointPort),
-		ServicePortName:       svcPortName,
-		Network:               networkID,
-		WorkloadName:          b.workloadName,
-		Namespace:             b.namespace,
-		HostName:              b.hostname,
-		SubDomain:             b.subDomain,
-		DiscoverabilityPolicy: discoverabilityPolicy,
-		HealthStatus:          healthStatus,
-		NodeName:              b.nodeName,
+		Labels:                 b.labels,
+		ServiceAccount:         b.serviceAccount,
+		Locality:               b.locality,
+		TLSMode:                b.tlsMode,
+		Addresses:              []string{endpointAddress},
+		EndpointPort:           uint32(endpointPort),
+		ServicePortName:        svcPortName,
+		Network:                networkID,
+		WorkloadName:           b.workloadName,
+		Namespace:              b.namespace,
+		HostName:               b.hostname,
+		SubDomain:              b.subDomain,
+		DiscoverabilityPolicy:  discoverabilityPolicy,
+		HealthStatus:           healthStatus,
+		SendUnhealthyEndpoints: sendUnhealthy,
+		NodeName:               b.nodeName,
 	}
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -312,7 +312,7 @@ func (esc *endpointSliceController) updateEndpointCacheForSlice(hostName host.Na
 					portName = *port.Name
 				}
 
-				istioEndpoint := builder.buildIstioEndpoint(a, portNum, portName, discoverabilityPolicy, healthStatus)
+				istioEndpoint := builder.buildIstioEndpoint(a, portNum, portName, discoverabilityPolicy, healthStatus, svc.SupportsUnhealthyEndpoints())
 				if len(overrideAddresses) > 1 {
 					istioEndpoint.Addresses = overrideAddresses
 				}

--- a/pilot/pkg/serviceregistry/kube/controller/pod.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod.go
@@ -197,7 +197,7 @@ func (pc *PodCache) notifyWorkloadHandlers(pod *v1.Pod, ev model.Event) {
 		"",
 		model.AlwaysDiscoverable,
 		model.Healthy,
-		features.RawSendUnhealthyEndpoints.Load(),
+		features.GlobalSendUnhealthyEndpoints.Load(),
 	)
 	// If pod is dual stack, handle all IPs
 	if features.EnableDualStack && len(pod.Status.PodIPs) > 1 {

--- a/pilot/pkg/serviceregistry/kube/controller/pod.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod.go
@@ -191,7 +191,14 @@ func (pc *PodCache) notifyWorkloadHandlers(pod *v1.Pod, ev model.Event) {
 		return
 	}
 	// fire instance handles for workload
-	ep := pc.c.NewEndpointBuilder(pod).buildIstioEndpoint(pod.Status.PodIP, 0, "", model.AlwaysDiscoverable, model.Healthy)
+	ep := pc.c.NewEndpointBuilder(pod).buildIstioEndpoint(
+		pod.Status.PodIP,
+		0,
+		"",
+		model.AlwaysDiscoverable,
+		model.Healthy,
+		features.RawSendUnhealthyEndpoints.Load(),
+	)
 	// If pod is dual stack, handle all IPs
 	if features.EnableDualStack && len(pod.Status.PodIPs) > 1 {
 		ep.Addresses = slices.Map(pod.Status.PodIPs, func(e v1.PodIP) string {

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -154,6 +154,14 @@ func ConvertService(svc corev1.Service, domainSuffix string, clusterID cluster.I
 
 	istioService.Attributes.Type = string(svc.Spec.Type)
 	istioService.Attributes.ExternalName = externalName
+
+	preferClose := strings.EqualFold(svc.Annotations[annotation.NetworkingTrafficDistribution.Name], corev1.ServiceTrafficDistributionPreferClose)
+	if svc.Spec.TrafficDistribution != nil {
+		preferClose = *svc.Spec.TrafficDistribution == corev1.ServiceTrafficDistributionPreferClose
+	}
+	if preferClose {
+		istioService.Attributes.TrafficDistribution = model.TrafficDistributionPreferClose
+	}
 	istioService.Attributes.NodeLocal = nodeLocal
 	istioService.Attributes.PublishNotReadyAddresses = svc.Spec.PublishNotReadyAddresses
 	if len(svc.Spec.ExternalIPs) > 0 {

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -165,7 +165,7 @@ func TestIncrementalPush(t *testing.T) {
 
 // Regression test for https://github.com/istio/istio/issues/38709
 func TestSAUpdate(t *testing.T) {
-	test.SetAtomicBoolForTest(t, features.RawSendUnhealthyEndpoints, false)
+	test.SetAtomicBoolForTest(t, features.GlobalSendUnhealthyEndpoints, false)
 	s := xdsfake.NewFakeDiscoveryServer(t, xdsfake.FakeOptions{})
 	ads := s.Connect(s.SetupProxy(nil), nil, []string{v3.ClusterType})
 
@@ -207,7 +207,7 @@ func TestSAUpdate(t *testing.T) {
 
 // Regression test for https://github.com/istio/istio/issues/38709
 func TestSAUpdateWithMulAddrsInstance(t *testing.T) {
-	test.SetAtomicBoolForTest(t, features.RawSendUnhealthyEndpoints, false)
+	test.SetAtomicBoolForTest(t, features.GlobalSendUnhealthyEndpoints, false)
 	s := xdsfake.NewFakeDiscoveryServer(t, xdsfake.FakeOptions{})
 	ads := s.Connect(s.SetupProxy(nil), nil, []string{v3.ClusterType})
 
@@ -398,7 +398,7 @@ func TestEDSOverlapping(t *testing.T) {
 func TestEDSUnhealthyEndpoints(t *testing.T) {
 	for _, sendUnhealthy := range []bool{true, false} {
 		t.Run(fmt.Sprint(sendUnhealthy), func(t *testing.T) {
-			test.SetAtomicBoolForTest(t, features.RawSendUnhealthyEndpoints, sendUnhealthy)
+			test.SetAtomicBoolForTest(t, features.GlobalSendUnhealthyEndpoints, sendUnhealthy)
 			s := xdsfake.NewFakeDiscoveryServer(t, xdsfake.FakeOptions{})
 			addUnhealthyCluster(s, sendUnhealthy)
 			s.EnsureSynced(t)

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -165,7 +165,7 @@ func TestIncrementalPush(t *testing.T) {
 
 // Regression test for https://github.com/istio/istio/issues/38709
 func TestSAUpdate(t *testing.T) {
-	test.SetAtomicBoolForTest(t, features.SendUnhealthyEndpoints, false)
+	test.SetAtomicBoolForTest(t, features.RawSendUnhealthyEndpoints, false)
 	s := xdsfake.NewFakeDiscoveryServer(t, xdsfake.FakeOptions{})
 	ads := s.Connect(s.SetupProxy(nil), nil, []string{v3.ClusterType})
 
@@ -207,7 +207,7 @@ func TestSAUpdate(t *testing.T) {
 
 // Regression test for https://github.com/istio/istio/issues/38709
 func TestSAUpdateWithMulAddrsInstance(t *testing.T) {
-	test.SetAtomicBoolForTest(t, features.SendUnhealthyEndpoints, false)
+	test.SetAtomicBoolForTest(t, features.RawSendUnhealthyEndpoints, false)
 	s := xdsfake.NewFakeDiscoveryServer(t, xdsfake.FakeOptions{})
 	ads := s.Connect(s.SetupProxy(nil), nil, []string{v3.ClusterType})
 
@@ -398,9 +398,9 @@ func TestEDSOverlapping(t *testing.T) {
 func TestEDSUnhealthyEndpoints(t *testing.T) {
 	for _, sendUnhealthy := range []bool{true, false} {
 		t.Run(fmt.Sprint(sendUnhealthy), func(t *testing.T) {
-			test.SetAtomicBoolForTest(t, features.SendUnhealthyEndpoints, sendUnhealthy)
+			test.SetAtomicBoolForTest(t, features.RawSendUnhealthyEndpoints, sendUnhealthy)
 			s := xdsfake.NewFakeDiscoveryServer(t, xdsfake.FakeOptions{})
-			addUnhealthyCluster(s)
+			addUnhealthyCluster(s, sendUnhealthy)
 			s.EnsureSynced(t)
 			adscon := s.Connect(nil, nil, watchEds)
 
@@ -454,16 +454,18 @@ func TestEDSUnhealthyEndpoints(t *testing.T) {
 			s.MemRegistry.SetEndpoints("unhealthy.svc.cluster.local", "",
 				[]*model.IstioEndpoint{
 					{
-						Addresses:       []string{"10.0.0.53"},
-						EndpointPort:    53,
-						ServicePortName: "tcp-dns",
-						HealthStatus:    model.UnHealthy,
+						Addresses:              []string{"10.0.0.53"},
+						EndpointPort:           53,
+						ServicePortName:        "tcp-dns",
+						HealthStatus:           model.UnHealthy,
+						SendUnhealthyEndpoints: sendUnhealthy,
 					},
 					{
-						Addresses:       []string{"10.0.0.54"},
-						EndpointPort:    53,
-						ServicePortName: "tcp-dns",
-						HealthStatus:    model.UnHealthy,
+						Addresses:              []string{"10.0.0.54"},
+						EndpointPort:           53,
+						ServicePortName:        "tcp-dns",
+						HealthStatus:           model.UnHealthy,
+						SendUnhealthyEndpoints: sendUnhealthy,
 					},
 				})
 
@@ -478,16 +480,18 @@ func TestEDSUnhealthyEndpoints(t *testing.T) {
 			s.MemRegistry.SetEndpoints("unhealthy.svc.cluster.local", "",
 				[]*model.IstioEndpoint{
 					{
-						Addresses:       []string{"10.0.0.53"},
-						EndpointPort:    53,
-						ServicePortName: "tcp-dns",
-						HealthStatus:    model.Healthy,
+						Addresses:              []string{"10.0.0.53"},
+						EndpointPort:           53,
+						ServicePortName:        "tcp-dns",
+						HealthStatus:           model.Healthy,
+						SendUnhealthyEndpoints: sendUnhealthy,
 					},
 					{
-						Addresses:       []string{"10.0.0.54"},
-						EndpointPort:    53,
-						ServicePortName: "tcp-dns",
-						HealthStatus:    model.Healthy,
+						Addresses:              []string{"10.0.0.54"},
+						EndpointPort:           53,
+						ServicePortName:        "tcp-dns",
+						HealthStatus:           model.Healthy,
+						SendUnhealthyEndpoints: sendUnhealthy,
 					},
 				})
 
@@ -498,16 +502,18 @@ func TestEDSUnhealthyEndpoints(t *testing.T) {
 			s.MemRegistry.SetEndpoints("unhealthy.svc.cluster.local", "",
 				[]*model.IstioEndpoint{
 					{
-						Addresses:       []string{"10.0.0.53"},
-						EndpointPort:    53,
-						ServicePortName: "tcp-dns",
-						HealthStatus:    model.Healthy,
+						Addresses:              []string{"10.0.0.53"},
+						EndpointPort:           53,
+						ServicePortName:        "tcp-dns",
+						HealthStatus:           model.Healthy,
+						SendUnhealthyEndpoints: sendUnhealthy,
 					},
 					{
-						Addresses:       []string{"10.0.0.54"},
-						EndpointPort:    53,
-						ServicePortName: "tcp-dns",
-						HealthStatus:    model.Healthy,
+						Addresses:              []string{"10.0.0.54"},
+						EndpointPort:           53,
+						ServicePortName:        "tcp-dns",
+						HealthStatus:           model.Healthy,
+						SendUnhealthyEndpoints: sendUnhealthy,
 					},
 				})
 			// Validate that endpoint is not pushed.
@@ -517,16 +523,18 @@ func TestEDSUnhealthyEndpoints(t *testing.T) {
 			s.MemRegistry.SetEndpoints("unhealthy.svc.cluster.local", "",
 				[]*model.IstioEndpoint{
 					{
-						Addresses:       []string{"10.0.0.53"},
-						EndpointPort:    53,
-						ServicePortName: "tcp-dns",
-						HealthStatus:    model.UnHealthy,
+						Addresses:              []string{"10.0.0.53"},
+						EndpointPort:           53,
+						ServicePortName:        "tcp-dns",
+						HealthStatus:           model.UnHealthy,
+						SendUnhealthyEndpoints: sendUnhealthy,
 					},
 					{
-						Addresses:       []string{"10.0.0.54"},
-						EndpointPort:    53,
-						ServicePortName: "tcp-dns",
-						HealthStatus:    model.Healthy,
+						Addresses:              []string{"10.0.0.54"},
+						EndpointPort:           53,
+						ServicePortName:        "tcp-dns",
+						HealthStatus:           model.Healthy,
+						SendUnhealthyEndpoints: sendUnhealthy,
 					},
 				})
 
@@ -541,16 +549,18 @@ func TestEDSUnhealthyEndpoints(t *testing.T) {
 			s.MemRegistry.SetEndpoints("unhealthy.svc.cluster.local", "",
 				[]*model.IstioEndpoint{
 					{
-						Addresses:       []string{"10.0.0.53"},
-						EndpointPort:    53,
-						ServicePortName: "tcp-dns",
-						HealthStatus:    model.Healthy,
+						Addresses:              []string{"10.0.0.53"},
+						EndpointPort:           53,
+						ServicePortName:        "tcp-dns",
+						HealthStatus:           model.Healthy,
+						SendUnhealthyEndpoints: sendUnhealthy,
 					},
 					{
-						Addresses:       []string{"10.0.0.54"},
-						EndpointPort:    53,
-						ServicePortName: "tcp-dns",
-						HealthStatus:    model.Healthy,
+						Addresses:              []string{"10.0.0.54"},
+						EndpointPort:           53,
+						ServicePortName:        "tcp-dns",
+						HealthStatus:           model.Healthy,
+						SendUnhealthyEndpoints: sendUnhealthy,
 					},
 				})
 
@@ -560,10 +570,11 @@ func TestEDSUnhealthyEndpoints(t *testing.T) {
 			s.MemRegistry.SetEndpoints("unhealthy.svc.cluster.local", "",
 				[]*model.IstioEndpoint{
 					{
-						Addresses:       []string{"10.0.0.53"},
-						EndpointPort:    53,
-						ServicePortName: "tcp-dns",
-						HealthStatus:    model.Healthy,
+						Addresses:              []string{"10.0.0.53"},
+						EndpointPort:           53,
+						ServicePortName:        "tcp-dns",
+						HealthStatus:           model.Healthy,
+						SendUnhealthyEndpoints: sendUnhealthy,
 					},
 				})
 
@@ -573,16 +584,18 @@ func TestEDSUnhealthyEndpoints(t *testing.T) {
 			s.MemRegistry.SetEndpoints("unhealthy.svc.cluster.local", "",
 				[]*model.IstioEndpoint{
 					{
-						Addresses:       []string{"10.0.0.53"},
-						EndpointPort:    53,
-						ServicePortName: "tcp-dns",
-						HealthStatus:    model.Healthy,
+						Addresses:              []string{"10.0.0.53"},
+						EndpointPort:           53,
+						ServicePortName:        "tcp-dns",
+						HealthStatus:           model.Healthy,
+						SendUnhealthyEndpoints: sendUnhealthy,
 					},
 					{
-						Addresses:       []string{"10.0.0.54"},
-						EndpointPort:    53,
-						ServicePortName: "tcp-dns",
-						HealthStatus:    model.Healthy,
+						Addresses:              []string{"10.0.0.54"},
+						EndpointPort:           53,
+						ServicePortName:        "tcp-dns",
+						HealthStatus:           model.Healthy,
+						SendUnhealthyEndpoints: sendUnhealthy,
 					},
 				})
 
@@ -1325,7 +1338,7 @@ func addOverlappingEndpoints(s *xdsfake.FakeDiscoveryServer) {
 	fullPush(s)
 }
 
-func addUnhealthyCluster(s *xdsfake.FakeDiscoveryServer) {
+func addUnhealthyCluster(s *xdsfake.FakeDiscoveryServer, sendUnhealthy bool) {
 	svc := &model.Service{
 		DefaultAddress: constants.UnspecifiedIP,
 		Hostname:       "unhealthy.svc.cluster.local",
@@ -1341,10 +1354,11 @@ func addUnhealthyCluster(s *xdsfake.FakeDiscoveryServer) {
 	s.MemRegistry.AddInstance(&model.ServiceInstance{
 		Service: svc,
 		Endpoint: &model.IstioEndpoint{
-			Addresses:       []string{"10.0.0.53"},
-			EndpointPort:    53,
-			ServicePortName: "tcp-dns",
-			HealthStatus:    model.UnHealthy,
+			Addresses:              []string{"10.0.0.53"},
+			EndpointPort:           53,
+			ServicePortName:        "tcp-dns",
+			HealthStatus:           model.UnHealthy,
+			SendUnhealthyEndpoints: sendUnhealthy,
 		},
 		ServicePort: &model.Port{
 			Name:     "tcp-dns",

--- a/releasenotes/notes/traffic-distribution.yaml
+++ b/releasenotes/notes/traffic-distribution.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+  - |
+    **Added** support for the `Service.spec.trafficDistribution` field, allowing a simpler mechanism to make traffic prefer geographically close endpoints.
+    Note: this feature previously existed only for ztunnel, but is now supported across all data planes.

--- a/releasenotes/notes/traffic-distribution.yaml
+++ b/releasenotes/notes/traffic-distribution.yaml
@@ -3,5 +3,5 @@ kind: feature
 area: traffic-management
 releaseNotes:
   - |
-    **Added** support for the `Service.spec.trafficDistribution` field, allowing a simpler mechanism to make traffic prefer geographically close endpoints.
+    **Added** support for the `Service.spec.trafficDistribution` field and `networking.istio.io/traffic-distribution` annotation, allowing a simpler mechanism to make traffic prefer geographically close endpoints.
     Note: this feature previously existed only for ztunnel, but is now supported across all data planes.


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/53055

This enables TrafficDistribution to work with Envoy. Today, this is implemented only for ztunnel. That leads to some awkward behavior where I can control the distribution with native k8s APIs (that are much simpler than ours) with ztunnel, but if I add a waypoint it is ignored. With this change, you can just set preferClose on the service and everything will respect it.

The implementation is _mostly_ straightforward. We follow this ordering of precedence: DR locality LB > prefer close > mesh config locality LB. if they have preferclose, we setup a default `failover` locality LB policy.

The more complicated aspect is around failover/outlier detection. In locality LB, we only allow failover if locality LB is configured. The intent for this was that if there is no way to mark endpoints as unhealthy, we never failover at all. However, this is problematic for TrafficDistribution: ztunnel cannot do outlier detection, and we don't want users to need to configure a (complex!) Istio API to enable a K8s core feature.

We already have a solution for this -- PILOT_SEND_UNHEALTHY_ENDPOINTS -- but its a global flag. This PR enables that feature on a per-service basis if TrafficDistribution is set. 

Works better with https://github.com/istio/istio/pull/54711 but not dependent on it
