### PR TITLE
ambient: Properly support add/remove retries

### DIFF
--- a/cni/pkg/cmd/root.go
+++ b/cni/pkg/cmd/root.go
@@ -160,6 +160,9 @@ var rootCmd = &cobra.Command{
 		// repair will (necessarily) be unavailable.
 		repair.StartRepair(ctx, cfg.RepairConfig)
 
+		// Note that even though we "install" the CNI plugin here *after* we start the node agent,
+		// it will block ambient-enabled pods from starting until `watchServerReady` == true
+		// (that is, the node agent is ready to respond to plugin events)
 		log.Info("initialization complete, watching node CNI dir")
 		// installer.Run() will block indefinitely, and attempt to permanently "keep"
 		// the CNI binary installed.

--- a/cni/pkg/nodeagent/error.go
+++ b/cni/pkg/nodeagent/error.go
@@ -19,22 +19,24 @@ import (
 	"fmt"
 )
 
-var ErrRetryablePartialAdd = errors.New("partial add error")
+// An error on pod add that the ambient informer should not
+// attempt to retry
+var ErrNonRetryableAdd = errors.New("pod add cannot be retried")
 
-type RetryablePartialAddError struct {
+type NonRetryableAddError struct {
 	inner error
 }
 
-func (e *RetryablePartialAddError) Error() string {
-	return fmt.Sprintf("%s: %v", ErrRetryablePartialAdd.Error(), e.inner)
+func (e *NonRetryableAddError) Error() string {
+	return fmt.Sprintf("%s: %v", ErrNonRetryableAdd.Error(), e.inner)
 }
 
-func (e *RetryablePartialAddError) Unwrap() []error {
-	return []error{ErrRetryablePartialAdd, e.inner}
+func (e *NonRetryableAddError) Unwrap() []error {
+	return []error{ErrNonRetryableAdd, e.inner}
 }
 
-func NewErrRetryablePartialAdd(err error) *RetryablePartialAddError {
-	return &RetryablePartialAddError{
+func NewErrNonRetryableAdd(err error) *NonRetryableAddError {
+	return &NonRetryableAddError{
 		inner: err,
 	}
 }

--- a/cni/pkg/nodeagent/error.go
+++ b/cni/pkg/nodeagent/error.go
@@ -19,22 +19,22 @@ import (
 	"fmt"
 )
 
-var ErrPartialAdd = errors.New("partial add error")
+var ErrRetryablePartialAdd = errors.New("partial add error")
 
-type PartialAddError struct {
+type RetryablePartialAddError struct {
 	inner error
 }
 
-func (e *PartialAddError) Error() string {
-	return fmt.Sprintf("%s: %v", ErrPartialAdd.Error(), e.inner)
+func (e *RetryablePartialAddError) Error() string {
+	return fmt.Sprintf("%s: %v", ErrRetryablePartialAdd.Error(), e.inner)
 }
 
-func (e *PartialAddError) Unwrap() []error {
-	return []error{ErrPartialAdd, e.inner}
+func (e *RetryablePartialAddError) Unwrap() []error {
+	return []error{ErrRetryablePartialAdd, e.inner}
 }
 
-func NewErrPartialAdd(err error) *PartialAddError {
-	return &PartialAddError{
+func NewErrRetryablePartialAdd(err error) *RetryablePartialAddError {
+	return &RetryablePartialAddError{
 		inner: err,
 	}
 }

--- a/cni/pkg/nodeagent/informers.go
+++ b/cni/pkg/nodeagent/informers.go
@@ -103,11 +103,8 @@ func (s *InformerHandlers) GetPodIfAmbientEnabled(podName, podNamespace string) 
 }
 
 func (s *InformerHandlers) Start() {
-	// Wait for all (pod|namespace) events to be enqueued.
 	kube.WaitForCacheSync("informer", s.ctx.Done(), s.pods.HasSynced, s.namespaces.HasSynced)
 	go s.queue.Run(s.ctx.Done())
-	// Wait for all enqueued (pod|namespace) events in queue to be processed
-	kube.WaitForCacheSync("informer queue", s.ctx.Done(), s.queue.HasSynced)
 }
 
 // Gets a point-in-time snapshot of all pods that are CURRENTLY ambient enabled

--- a/cni/pkg/nodeagent/informers.go
+++ b/cni/pkg/nodeagent/informers.go
@@ -103,8 +103,11 @@ func (s *InformerHandlers) GetPodIfAmbientEnabled(podName, podNamespace string) 
 }
 
 func (s *InformerHandlers) Start() {
+	// Wait for all (pod|namespace) events to be enqueued.
 	kube.WaitForCacheSync("informer", s.ctx.Done(), s.pods.HasSynced, s.namespaces.HasSynced)
 	go s.queue.Run(s.ctx.Done())
+	// Wait for all enqueued (pod|namespace) events in queue to be processed
+	kube.WaitForCacheSync("informer queue", s.ctx.Done(), s.queue.HasSynced)
 }
 
 // Gets a point-in-time snapshot of all pods that are CURRENTLY ambient enabled

--- a/cni/pkg/nodeagent/informers.go
+++ b/cni/pkg/nodeagent/informers.go
@@ -103,8 +103,12 @@ func (s *InformerHandlers) GetPodIfAmbientEnabled(podName, podNamespace string) 
 }
 
 func (s *InformerHandlers) Start() {
+	// Wait for all events to be queued
 	kube.WaitForCacheSync("informer", s.ctx.Done(), s.pods.HasSynced, s.namespaces.HasSynced)
 	go s.queue.Run(s.ctx.Done())
+	// Note that we are explicitly *not* doing
+	// 'kube.WaitForCacheSync("informer queue", s.ctx.Done(), s.queue.HasSynced)'
+	// here, because we cannot successfully process the event queue until a ztunnel connects.
 }
 
 // Gets a point-in-time snapshot of all pods that are CURRENTLY ambient enabled

--- a/cni/pkg/nodeagent/informers_test.go
+++ b/cni/pkg/nodeagent/informers_test.go
@@ -16,6 +16,7 @@ package nodeagent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -76,6 +77,120 @@ func TestInformerExistingPodAddedWhenNsLabeled(t *testing.T) {
 	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.Exactly(4))
 
 	assertPodAnnotated(t, client, pod)
+
+	// Assert expected calls actually made
+	fs.AssertExpectations(t)
+}
+
+func TestInformerExistingPodAddErrorRetriesIfRetryable(t *testing.T) {
+	setupLogging()
+	NodeName = "testnode"
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: NodeName,
+		},
+		Status: corev1.PodStatus{
+			PodIP: "11.1.1.12",
+		},
+	}
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
+	client := kube.NewFakeClient(ns, pod)
+	fs := &fakeServer{}
+
+	fs.On("AddPodToMesh",
+		ctx,
+		mock.IsType(pod),
+		util.GetPodIPsIfPresent(pod),
+		"",
+	).Once().Return(ErrRetryablePartialAdd)
+
+	fs.On("AddPodToMesh",
+		ctx,
+		mock.IsType(pod),
+		util.GetPodIPsIfPresent(pod),
+		"",
+	).Once().Return(ErrRetryablePartialAdd)
+
+	fs.On("AddPodToMesh",
+		ctx,
+		mock.IsType(pod),
+		util.GetPodIPsIfPresent(pod),
+		"",
+	).Once().Return(nil)
+
+	_, mt := populateClientAndWaitForInformer(ctx, t, client, fs, 2, 1)
+
+	// label the namespace
+	labelsPatch := []byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":"%s"}}}`,
+		label.IoIstioDataplaneMode.Name, constants.DataplaneModeAmbient))
+	_, err := client.Kube().CoreV1().Namespaces().Patch(ctx, ns.Name,
+		types.MergePatchType, labelsPatch, metav1.PatchOptions{})
+	assert.NoError(t, err)
+
+	// wait for all update events to settle
+	// for all that tho, we should only get 3 ADD attempts (2 failed, one succeed), as enforced by mock
+	// total 8:
+	// 1. init ns reconcile 2. ns label reconcile 3. pod reconcile 4. pod partial anno
+	// 5. retry 6. retry 7. success 8. pod full anno
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.Exactly(8))
+
+	assertPodAnnotated(t, client, pod)
+
+	// Assert expected calls actually made
+	fs.AssertExpectations(t)
+}
+
+func TestInformerExistingPodAddErrorDoesNotRetryIfNotRetryable(t *testing.T) {
+	setupLogging()
+	NodeName = "testnode"
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: NodeName,
+		},
+		Status: corev1.PodStatus{
+			PodIP: "11.1.1.12",
+		},
+	}
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
+	client := kube.NewFakeClient(ns, pod)
+	fs := &fakeServer{}
+
+	fs.On("AddPodToMesh",
+		ctx,
+		mock.IsType(pod),
+		util.GetPodIPsIfPresent(pod),
+		"",
+	).Once().Return(errors.New("SOMETHING ELSE BAD"))
+
+	_, mt := populateClientAndWaitForInformer(ctx, t, client, fs, 2, 1)
+
+	// label the namespace
+	labelsPatch := []byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":"%s"}}}`,
+		label.IoIstioDataplaneMode.Name, constants.DataplaneModeAmbient))
+	_, err := client.Kube().CoreV1().Namespaces().Patch(ctx, ns.Name,
+		types.MergePatchType, labelsPatch, metav1.PatchOptions{})
+	assert.NoError(t, err)
+
+	// wait for all update events to settle
+	// total 3:
+	// 1. init ns reconcile 2. ns label reconcile 3. pod reconcile (fail)
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.Exactly(3))
+
+	assertPodNotAnnotated(t, client, pod)
 
 	// Assert expected calls actually made
 	fs.AssertExpectations(t)
@@ -257,6 +372,91 @@ func TestInformerExistingPodRemovedWhenNsUnlabeled(t *testing.T) {
 	fs.AssertExpectations(t)
 }
 
+func TestInformerExistingPodRemovalRetriesOnFailure(t *testing.T) {
+	setupLogging()
+	NodeName = "testnode"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: NodeName,
+		},
+		Status: corev1.PodStatus{
+			PodIP: "11.1.1.12",
+		},
+	}
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+		// TODO: once we if the add pod bug, re-enable this and remove the patch below
+		//		Labels: map[string]string{label.IoIstioDataplaneMode.Name: constants.DataplaneModeAmbient},
+
+	}
+
+	client := kube.NewFakeClient(ns, pod)
+
+	fs := &fakeServer{}
+
+	fs.On("AddPodToMesh",
+		ctx,
+		mock.IsType(pod),
+		util.GetPodIPsIfPresent(pod),
+		"",
+	).Once().Return(nil)
+
+	_, mt := populateClientAndWaitForInformer(ctx, t, client, fs, 2, 1)
+
+	log.Debug("labeling namespace")
+	_, err := client.Kube().CoreV1().Namespaces().Patch(ctx, ns.Name,
+		types.MergePatchType, []byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":"%s"}}}`,
+			label.IoIstioDataplaneMode.Name, constants.DataplaneModeAmbient)), metav1.PatchOptions{})
+	assert.NoError(t, err)
+
+	// wait for all update events to settle
+	// total 3: 1. init ns reconcile 2. ns label reconcile 3. pod reconcile 4. pod annotate
+	// for all that tho, we should only get 1 ADD, as enforced by mock
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.Exactly(4))
+
+	// wait for the pod to be annotated
+	// after Pod annotated, another update event will be triggered.
+	assertPodAnnotated(t, client, pod)
+
+	// Assert expected calls actually made
+	fs.AssertExpectations(t)
+
+	// Failure should cause a retry
+	fs.On("RemovePodFromMesh",
+		ctx,
+		mock.Anything,
+		false,
+	).Once().Return(errors.New("SOME ERR"))
+
+	fs.On("RemovePodFromMesh",
+		ctx,
+		mock.Anything,
+		false,
+	).Once().Return(nil)
+
+	// unlabel the namespace
+	labelsPatch := []byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":null}}}`,
+		label.IoIstioDataplaneMode.Name))
+	_, err = client.Kube().CoreV1().Namespaces().Patch(ctx, ns.Name,
+		types.MergePatchType, labelsPatch, metav1.PatchOptions{})
+	assert.NoError(t, err)
+
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.Exactly(8))
+
+	assertPodNotAnnotated(t, client, pod)
+
+	// Assert expected calls actually made
+	fs.AssertExpectations(t)
+}
+
 func TestInformerExistingPodRemovedWhenPodLabelRemoved(t *testing.T) {
 	setupLogging()
 	NodeName = "testnode"
@@ -300,7 +500,7 @@ func TestInformerExistingPodRemovedWhenPodLabelRemoved(t *testing.T) {
 	assert.NoError(t, err)
 
 	// wait for all update events to settle
-	// total 3: 1. init ns reconcile 2. ns label reconcile 3. pod reconcile 4. pod annotate
+	// total 4: 1. init ns reconcile 2. ns label reconcile 3. pod reconcile 4. pod annotate
 	// for all that tho, we should only get 1 ADD, as enforced by mock
 	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.Exactly(4))
 
@@ -337,6 +537,90 @@ func TestInformerExistingPodRemovedWhenPodLabelRemoved(t *testing.T) {
 	assert.NoError(t, err)
 
 	// wait for an update event
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.Exactly(7))
+
+	assertPodNotAnnotated(t, client, pod)
+
+	// Assert expected calls actually made
+	fs.AssertExpectations(t)
+}
+
+func TestInformerJobPodRemovalRetriesOnErrorEvenIfPodTerminal(t *testing.T) {
+	setupLogging()
+	NodeName = "testnode"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: NodeName,
+		},
+		Status: corev1.PodStatus{
+			PodIP: "11.1.1.12",
+		},
+	}
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+		// TODO: once we if the add pod bug, re-enable this and remove the patch below
+		//		Labels: map[string]string{label.IoIstioDataplaneMode.Name: constants.DataplaneModeAmbient},
+
+	}
+
+	client := kube.NewFakeClient(ns, pod)
+
+	fs := &fakeServer{}
+
+	fs.On("AddPodToMesh",
+		ctx,
+		mock.IsType(pod),
+		util.GetPodIPsIfPresent(pod),
+		"",
+	).Once().Return(nil)
+
+	_, mt := populateClientAndWaitForInformer(ctx, t, client, fs, 2, 1)
+
+	log.Debug("labeling namespace")
+	_, err := client.Kube().CoreV1().Namespaces().Patch(ctx, ns.Name,
+		types.MergePatchType, []byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":"%s"}}}`,
+			label.IoIstioDataplaneMode.Name, constants.DataplaneModeAmbient)), metav1.PatchOptions{})
+	assert.NoError(t, err)
+
+	// wait for all update events to settle
+	// total 3: 1. init ns reconcile 2. ns label reconcile 3. pod reconcile 4. Pod annotate.
+	// for all that tho, we should only get 1 ADD, as enforced by mock
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.Exactly(4))
+
+	// wait for the pod to be annotated
+	// after Pod annotated, another update event will be triggered.
+	assertPodAnnotated(t, client, pod)
+
+	// Assert expected calls actually made
+	fs.AssertExpectations(t)
+
+	fs.On("RemovePodFromMesh",
+		ctx,
+		mock.Anything,
+		true,
+	).Once().Return(errors.New("SOME REMOVE ERR"))
+
+	fs.On("RemovePodFromMesh",
+		ctx,
+		mock.Anything,
+		true,
+	).Once().Return(nil)
+
+	// Patch the pod to a succeeded status
+	phasePatch := []byte(`{"status":{"phase":"Succeeded"}}`)
+	_, err = client.Kube().CoreV1().Pods(pod.Namespace).Patch(ctx, pod.Name,
+		types.MergePatchType, phasePatch, metav1.PatchOptions{})
+	assert.NoError(t, err)
+
+	// wait for 2 more update events (status change + un-annotate)
 	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.Exactly(7))
 
 	assertPodNotAnnotated(t, client, pod)
@@ -905,6 +1189,20 @@ func assertPodAnnotated(t *testing.T, client kube.Client, pod *corev1.Pod) {
 		time.Sleep(1 * time.Second)
 	}
 	t.Fatal("Pod not annotated")
+}
+
+func assertPodAnnotatedPending(t *testing.T, client kube.Client, pod *corev1.Pod) {
+	for i := 0; i < 5; i++ {
+		p, err := client.Kube().CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if p.Annotations[annotation.AmbientRedirection.Name] == constants.AmbientRedirectionPending {
+			return
+		}
+		time.Sleep(1 * time.Second)
+	}
+	t.Fatal("Pod not annotated with pending status")
 }
 
 func assertPodNotAnnotated(t *testing.T, client kube.Client, pod *corev1.Pod) {

--- a/cni/pkg/nodeagent/informers_test.go
+++ b/cni/pkg/nodeagent/informers_test.go
@@ -109,14 +109,14 @@ func TestInformerExistingPodAddErrorRetriesIfRetryable(t *testing.T) {
 		mock.IsType(pod),
 		util.GetPodIPsIfPresent(pod),
 		"",
-	).Once().Return(ErrRetryablePartialAdd)
+	).Once().Return(errors.New("something failed"))
 
 	fs.On("AddPodToMesh",
 		ctx,
 		mock.IsType(pod),
 		util.GetPodIPsIfPresent(pod),
 		"",
-	).Once().Return(ErrRetryablePartialAdd)
+	).Once().Return(errors.New("something failed"))
 
 	fs.On("AddPodToMesh",
 		ctx,
@@ -136,7 +136,7 @@ func TestInformerExistingPodAddErrorRetriesIfRetryable(t *testing.T) {
 
 	// wait for all update events to settle
 	// for all that tho, we should only get 3 ADD attempts (2 failed, one succeed), as enforced by mock
-	// total 8:
+	// total 8 update events:
 	// 1. init ns reconcile 2. ns label reconcile 3. pod reconcile 4. pod partial anno
 	// 5. retry 6. retry 7. success 8. pod full anno
 	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.Exactly(8))
@@ -174,7 +174,7 @@ func TestInformerExistingPodAddErrorAnnotatesWithPartialStatusOnRetry(t *testing
 		mock.IsType(pod),
 		util.GetPodIPsIfPresent(pod),
 		"",
-	).Return(ErrRetryablePartialAdd)
+	).Return(errors.New("something failed"))
 
 	_, mt := populateClientAndWaitForInformer(ctx, t, client, fs, 2, 1)
 
@@ -225,7 +225,7 @@ func TestInformerExistingPodAddErrorDoesNotRetryIfNotRetryable(t *testing.T) {
 		mock.IsType(pod),
 		util.GetPodIPsIfPresent(pod),
 		"",
-	).Once().Return(errors.New("SOMETHING ELSE BAD"))
+	).Once().Return(ErrNonRetryableAdd)
 
 	_, mt := populateClientAndWaitForInformer(ctx, t, client, fs, 2, 1)
 

--- a/cni/pkg/nodeagent/net_test.go
+++ b/cni/pkg/nodeagent/net_test.go
@@ -308,7 +308,7 @@ func TestReturnsPartialErrorOnZtunnelFail(t *testing.T) {
 
 	err := netServer.AddPodToMesh(ctx, &corev1.Pod{ObjectMeta: podMeta}, podIPs, "faksens")
 	assert.Equal(t, ztunnelServer.addedPods.Load(), 1)
-	if !errors.Is(err, ErrPartialAdd) {
+	if !errors.Is(err, ErrRetryablePartialAdd) {
 		t.Fatal("expected partial error")
 	}
 }
@@ -336,7 +336,7 @@ func TestDoesntReturnPartialErrorOnIptablesFail(t *testing.T) {
 	assert.Equal(t, ztunnelServer.addedPods.Load(), 0)
 
 	// error is not partial error
-	if errors.Is(err, ErrPartialAdd) {
+	if errors.Is(err, ErrRetryablePartialAdd) {
 		t.Fatal("expected not a partial error")
 	}
 }

--- a/cni/pkg/nodeagent/server.go
+++ b/cni/pkg/nodeagent/server.go
@@ -249,10 +249,13 @@ func (s *meshDataplane) AddPodToMesh(ctx context.Context, pod *corev1.Pod, podIP
 	var retErr error
 	err := s.netServer.AddPodToMesh(ctx, pod, podIPs, netNs)
 	if err != nil {
-		log.Errorf("failed to add pod to ztunnel: %v", err)
+		// iptables failed, so don't bother annotating.
 		if !errors.Is(err, ErrPartialAdd) {
+			log.Errorf("failed capturing pod", err)
 			return err
 		}
+		// iptables succeeded, so even if we failed to send to ztunnel, must annotate
+		log.Errorf("failed to add pod to ztunnel: %v", err)
 		retErr = err
 	}
 

--- a/cni/pkg/nodeagent/server.go
+++ b/cni/pkg/nodeagent/server.go
@@ -157,11 +157,11 @@ func (s *Server) Start() {
 	log.Info("CNI ambient server starting")
 	s.kubeClient.RunAndWait(s.ctx.Done())
 	log.Info("CNI ambient server kubeclient started")
+	pods := s.handlers.GetActiveAmbientPodSnapshot()
+	err := s.dataplane.ConstructInitialSnapshot(pods)
 	// Start the informer handlers FIRST, before we snapshot.
 	// They will keep the (mutex'd) snapshot cache synced.
 	s.handlers.Start()
-	pods := s.handlers.GetActiveAmbientPodSnapshot()
-	err := s.dataplane.ConstructInitialSnapshot(pods)
 	if err != nil {
 		log.Warnf("failed to construct initial snapshot: %v", err)
 	}
@@ -239,6 +239,16 @@ func (s *meshDataplane) Stop(skipCleanup bool) {
 	s.netServer.Stop(skipCleanup)
 }
 
+// AddPodToMesh attempts to inject iptables rules into the pod, and sends the pod to ztunnel.
+// If this succeeds, it will add the pod to the node ipset, and finally annotate the pod
+// (indicating it has been mutated/captured) with a captured status.
+//
+// If anything fails *before* sending the pod to ztunnel, returns a nonrecoverable/nonretryable error.
+//
+// If the *last* step of sending the pod to ztunnel fails, or any subsequent step fails,
+// then the pod will still be annotated with a partially-captured status (indicating it has been
+// mutated/redirected, and thus potentially needs cleanup) and a RetryablePartialAdd error will be
+// returned, indicating that the function call can be retried.
 func (s *meshDataplane) AddPodToMesh(ctx context.Context, pod *corev1.Pod, podIPs []netip.Addr, netNs string) error {
 	// Ordering is important in this func:
 	//
@@ -246,87 +256,90 @@ func (s *meshDataplane) AddPodToMesh(ctx context.Context, pod *corev1.Pod, podIP
 	// - Annotate IF rule injection doesn't fail.
 	// - Add pod IP to ipset IF none of the above has failed, as a last step
 	log := log.WithLabels("ns", pod.Namespace, "name", pod.Name)
-	var retErr error
-	err := s.netServer.AddPodToMesh(ctx, pod, podIPs, netNs)
-	if err != nil {
-		// iptables failed, so don't bother annotating.
-		if !errors.Is(err, ErrPartialAdd) {
-			log.Errorf("failed capturing pod", err)
+	if err := s.netServer.AddPodToMesh(ctx, pod, podIPs, netNs); err != nil {
+		// iptables injection failed, this is not a "retryable partial add"
+		// this is a nonrecoverable/nonretryable error and we won't even bother to
+		// annotate the pod.
+		if !errors.Is(err, ErrRetryablePartialAdd) {
 			return err
 		}
-		// iptables succeeded, so even if we failed to send to ztunnel, must annotate
-		log.Errorf("failed to add pod to ztunnel: %v", err)
-		retErr = err
+		// Any other error is recoverable/retryable and means we just couldn't contact ztunnel.
+		// However, any other error also means iptables injection was successful, so
+		// we must annotate the pod with a partial status (so removal can undo iptables)
+		// regardless of ztunnel's current status.
+		// So annotate indicating that this pod was injected (and thus needs to be either retried
+		// or uninjected on removal) but is not fully captured yet.
+		log.Errorf("failed to add pod to ztunnel: %v, pod partially added, annotating with pending status")
+		if err := util.AnnotatePartiallyEnrolledPod(s.kubeClient, &pod.ObjectMeta); err != nil {
+			// If we have an error annotating the partial status - that is retryable.
+			return NewErrRetryablePartialAdd(err)
+		}
+		return err
 	}
 
+	// Handle node healthcheck probe rewrites
+	if _, err := s.addPodToHostNSIpset(pod, podIPs); err != nil {
+		log.Errorf("failed to add pod to ipset, pod will fail healthchecks: %v", err)
+		// If we have an error adding the pod to the ipset - that is retryable.
+		return NewErrRetryablePartialAdd(err)
+	}
+
+	// Once we successfully annotate the pod as fully captured,
+	// the informer can no longer retry events, and there's no going back.
+	// This should be the last step in all cases - once we do this, the CP (and the informer) will consider
+	// this pod "ambient" and successfully enrolled.
 	log.Debugf("annotating pod")
 	if err := util.AnnotateEnrolledPod(s.kubeClient, &pod.ObjectMeta); err != nil {
-		log.Errorf("failed to annotate pod enrollment: %v", err)
-		retErr = err
+		// If we have an error annotating the full status - that is retryable.
+		return NewErrRetryablePartialAdd(err)
 	}
 
-	// ipset is only relevant for pod healthchecks.
-	// therefore, if we had *any* error adding the pod to the mesh
-	// do not add the pod to the ipset, so that it will definitely *not* pass healthchecks,
-	// and the operator can investigate.
-	//
-	// This is also important to avoid ipset sync issues if we add the pod ip to the ipset, but
-	// enrolling fails because ztunnel (or the pod netns, or whatever) isn't ready yet,
-	// and the pod is rescheduled with a new IP. In that case we don't get
-	// a removal event, and so would never clean up the old IP that we eagerly-added.
-	//
-	// TODO one place this *can* fail is
-	// - if a CNI plugin after us in the chain fails (currently, we are explicitly the last in the chain by design)
-	// - the CmdAdd comes back thru here with a new IP
-	// - we will never clean up that old IP that we "lost"
-	// To fix this we probably need to impl CmdDel + manage our own podUID/IP mapping.
-	if retErr == nil {
-		// Handle node healthcheck probe rewrites
-		_, err = s.addPodToHostNSIpset(pod, podIPs)
-		if err != nil {
-			log.Errorf("failed to add pod to ipset: %v", err)
-			return err
-		}
-	} else {
-		log.Errorf("pod was not enrolled and is unhealthy: %v", retErr)
-	}
-
-	return retErr
+	return nil
 }
 
+// RemovePodFromMesh attempts to remove iptables rules from the pod (if it is not already terminating),
+// and sends the pod remove to ztunnel.
+//
+// If this succeeds, it will un-annotate the pod (indicating it is no longer captured) and remove the pod
+// from the node ipset.
+//
+// If anything fails, an error will be returned, indicating that the function call can be retried.
 func (s *meshDataplane) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod, isDelete bool) error {
 	log := log.WithLabels("ns", pod.Namespace, "name", pod.Name)
 	log.WithLabels("deleted", isDelete).Info("removing pod from mesh")
 
-	// Aggregate errors together, so that if part of the removal fails we still proceed with other steps.
-	var errs []error
-
 	// Remove the hostside ipset entry first, and unconditionally - if later failures happen, we never
-	// want to leave stale entries
+	// want to leave stale entries (and the pod healthchecks will start to fail, which is a good signal)
 	if err := removePodFromHostNSIpset(pod, &s.hostsideProbeIPSet); err != nil {
 		log.Errorf("failed to remove pod %s from host ipset, error was: %v", pod.Name, err)
-		errs = append(errs, err)
+		// if for some reason this fails, should be safe to retry
+		return err
 	}
 
 	// Specifically, at this time, we do _not_ want to un-annotate the pod if we cannot successfully remove it,
 	// as the pod is probably in a broken state and we don't want to let go of it from the CP perspective while that is true.
-	// So we will return if this fails.
+	// So we will return if this fails (for a potential retry).
 	if err := s.netServer.RemovePodFromMesh(ctx, pod, isDelete); err != nil {
 		log.Errorf("failed to remove pod from mesh: %v", err)
-		errs = append(errs, err)
-		return errors.Join(errs...)
+		return err
 	}
 
-	// This should be the last step in all cases - once we do this, the CP will no longer consider this pod "ambient",
-	// regardless of the state it is in
+	// This should be the last step in all cases - once we do this, the CP will no longer consider
+	// this pod "ambient" (and the informer will not be able to retry on removal errors),
+	// regardless of the state it is in.
 	log.Debug("removing annotation from pod")
 	if err := util.AnnotateUnenrollPod(s.kubeClient, &pod.ObjectMeta); err != nil {
 		log.Errorf("failed to annotate pod unenrollment: %v", err)
-		errs = append(errs, err)
-		return errors.Join(errs...)
+		// If the pod is already terminating anyway, we don't care if we can't remove the annotation,
+		// so only return a retryable error on annotation failure if it's not terminating.
+		if !isDelete {
+			// If we have an error annotating the partial status and the pod is not terminating
+			// - that is retryable.
+			return err
+		}
 	}
 
-	return errors.Join(errs...)
+	return nil
 }
 
 // syncHostIPSets is called after the host node ipset has been created (or found + flushed)
@@ -390,10 +403,6 @@ func (s *meshDataplane) addPodToHostNSIpset(pod *corev1.Pod, podIPs []netip.Addr
 	for _, pip := range podIPs {
 		// Add to host ipset
 		log.Debugf("adding probe ip %s to set", pip)
-		// Add IP/port combo to set. Note that we set Replace to false here - we _did_ previously
-		// set it to true, but in theory that could mask weird scenarios where K8S triggers events out of order ->
-		// an add(sameIPreused) then delete(originalIP).
-		// Which will result in the new pod starting to fail healthchecks.
 		if err := s.hostsideProbeIPSet.AddIP(pip, ipProto, podUID, true); err != nil {
 			ipsetAddrErrs = append(ipsetAddrErrs, err)
 			log.Errorf("failed adding ip %s to set, error was %s",

--- a/cni/pkg/nodeagent/server_test.go
+++ b/cni/pkg/nodeagent/server_test.go
@@ -97,12 +97,13 @@ func TestMeshDataplaneAddsAnnotationOnAddWithPartialError(t *testing.T) {
 		pod,
 		podIPs,
 		"",
-	).Return(ErrPartialAdd)
+	).Return(ErrRetryablePartialAdd)
 
 	server.Start(fakeCtx)
 	fakeClientSet := fake.NewClientset(pod)
 
 	fakeIPSetDeps := ipset.FakeNLDeps()
+
 	set := ipset.IPSet{V4Name: "foo-v4", Prefix: "foo", Deps: fakeIPSetDeps}
 
 	m := getFakeDPWithIPSet(server, fakeClientSet, set)
@@ -116,7 +117,7 @@ func TestMeshDataplaneAddsAnnotationOnAddWithPartialError(t *testing.T) {
 	pod, err = fakeClientSet.CoreV1().Pods("test").Get(fakeCtx, "test", metav1.GetOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, len(pod.Annotations), 1)
-	assert.Equal(t, pod.Annotations[annotation.AmbientRedirection.Name], constants.AmbientRedirectionEnabled)
+	assert.Equal(t, pod.Annotations[annotation.AmbientRedirection.Name], constants.AmbientRedirectionPending)
 }
 
 func TestMeshDataplaneDoesntAnnotateOnAddWithRealError(t *testing.T) {

--- a/cni/pkg/nodeagent/server_test.go
+++ b/cni/pkg/nodeagent/server_test.go
@@ -97,7 +97,7 @@ func TestMeshDataplaneAddsAnnotationOnAddWithPartialError(t *testing.T) {
 		pod,
 		podIPs,
 		"",
-	).Return(ErrRetryablePartialAdd)
+	).Return(errors.New("some retryable failure"))
 
 	server.Start(fakeCtx)
 	fakeClientSet := fake.NewClientset(pod)
@@ -120,7 +120,7 @@ func TestMeshDataplaneAddsAnnotationOnAddWithPartialError(t *testing.T) {
 	assert.Equal(t, pod.Annotations[annotation.AmbientRedirection.Name], constants.AmbientRedirectionPending)
 }
 
-func TestMeshDataplaneDoesntAnnotateOnAddWithRealError(t *testing.T) {
+func TestMeshDataplaneDoesntAnnotateOnAddWithNonretryableError(t *testing.T) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
@@ -139,7 +139,7 @@ func TestMeshDataplaneDoesntAnnotateOnAddWithRealError(t *testing.T) {
 		pod,
 		podIPs,
 		"",
-	).Return(errors.New("not partial error"))
+	).Return(ErrNonRetryableAdd)
 
 	server.Start(fakeCtx)
 	fakeClientSet := fake.NewClientset(pod)

--- a/cni/pkg/nodeagent/ztunnelserver.go
+++ b/cni/pkg/nodeagent/ztunnelserver.go
@@ -278,7 +278,9 @@ func (z *ztunnelServer) handleConn(ctx context.Context, conn *ZtunnelConnection)
 // PodDeleted sends a pod deletion notification to connected ztunnels.
 //
 // Note that unlike PodAdded, this deletion event is broadcast to *all*
-// currently-connected ztunnels - not just the latest. This is intentional.
+// currently-connected ztunnels - not just the latest.
+// This is intentional, and critical to handle proper shutdown/reconnect
+// cycles.
 func (z *ztunnelServer) PodDeleted(ctx context.Context, uid string) error {
 	r := &zdsapi.WorkloadRequest{
 		Payload: &zdsapi.WorkloadRequest_Del{

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -181,6 +181,11 @@ const (
 	// Anything else indicates it is not.
 	AmbientRedirectionEnabled = "enabled"
 
+	// The presence of this annotation with this specific value indicates the pod is
+	// *partially* captured but no ztunnel has accepted it for proxying yet.
+	// Pods in this state will not egress/ingress traffic until an active ztunnel begins proxying them.
+	AmbientRedirectionPending = "pending"
+
 	// ServiceTraffic indicates that service traffic should go through the intended waypoint.
 	ServiceTraffic = "service"
 	// WorkloadTraffic indicates that workload traffic should go through the intended waypoint.


### PR DESCRIPTION
**Please provide a description of this PR:**

Reworks how event handling and retries work in `istio-cni`, in an attempt to minimize the possibility of events being lost, and leverage the fact that `ztunnel` can now (https://github.com/istio/ztunnel/pull/1403 and others) handle pod ADD/DELETE properly during snapshot creation now, and also make partial adds/temp failures more recoverable/resilient.

## The goals:

- Make sure we don't accept ztunnel connections (start the ztunnel server) until both the informer and the podcache are ready.
- Make sure we don't mark `istio-cni` ready until the informer, the podcache, and the ztunnel server have started.
- Unconditionally log pod removals.
- Now that ztunnel can handle adds/deletes properly during snapshotting, make sure we *never* drop or lose any add or remove event out of the informer queue due to preceding failures, or lack of a current ztunnel connection.
- Do a pass on all `ADD` and `REMOVE` paths, making sure any errors in either always result in informer retries, so that we are guaranteed that every REMOVE is always handled no matter the connect flow.
  - With this change, the only two types of failures that will not be retried are: 
    - iptables capture failures on `ADD` (very little we can do about this ATM, reconcile might help in some cases).
    - iptables removal failure on `REMOVE` _if the pod is already terminating_.
    
## Changes
- Made it so the informer queue is able to retry pod add/removes that fail (rather than capping out at 5 attempts).
- Change the failed pod event retry in the informer from (5 retries) to (uncapped retries, but throttled intervals).
- Make sure all potentially transit add/remove errors (except the ones that can't be fully idempotent - namely iptables failures) are retry-able.
- `Partial Add Failures` are handled more explicitly now (and must be, with retries and the fact we only check the current pod state and not the event contents) - for cases where iptables injection succeeds, but later steps fail, annotate that partially-captured pod with `ambient.istio.io/redirection=pending` which means we have successfully mutated the pod rules, but ztunnel (or some other later step) has not yet succeeded, and so a retry is required. 
- Make sure that we don't begin accepting ztunnel connections until cache is populated with snapshot
- Make sure we don't begin accepting ztunnel connections until informer handlers are synced
- Do not self-mark `istio-cni` as ready until both of those are complete.


We've had several issues around events (remove events specifically) being dropped between CNI and ZT during connect and high-churn node scaling events, and this is an attempt to make those scenarios a little more resilient, and louder/more diagnose-able when they fail - specifically, cases where a pod `add` event clearly gets to `ztunnel`, but a corresponding `delete` never does, during connect/snapshotting.

Also fixes a few issues mentioned in https://github.com/istio/istio/issues/53371