### PR TITLE
Fix crash when starting pilot without kubeClient

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1162,6 +1162,9 @@ func (s *Server) initControllers(args *PilotArgs) error {
 }
 
 func (s *Server) initNodeUntaintController(args *PilotArgs) {
+	if s.kubeClient == nil {
+		return
+	}
 	s.addStartFunc("nodeUntainter controller", func(stop <-chan struct{}) error {
 		go leaderelection.
 			NewLeaderElection(args.Namespace, args.PodName, leaderelection.NodeUntaintController, args.Revision, s.kubeClient).
@@ -1174,6 +1177,9 @@ func (s *Server) initNodeUntaintController(args *PilotArgs) {
 }
 
 func (s *Server) initIPAutoallocateController(args *PilotArgs) {
+	if s.kubeClient == nil {
+		return
+	}
 	s.addStartFunc("ip autoallocate controller", func(stop <-chan struct{}) error {
 		go leaderelection.
 			NewLeaderElection(args.Namespace, args.PodName, leaderelection.IPAutoallocateController, args.Revision, s.kubeClient).


### PR DESCRIPTION
Clearly no one does this, and we don't have tests, which is maybe a sign
we should do something besides just adding these `if`s... but for now
might as well make it work
