### PR TITLE
Allow SIMPLE TLS origination without secret read acces

### DIFF
--- a/pilot/pkg/xds/sds.go
+++ b/pilot/pkg/xds/sds.go
@@ -270,9 +270,12 @@ func filterAuthorizedResources(resources []SecretResource, proxy *model.Proxy, s
 				deniedResources = append(deniedResources, r.Name)
 			}
 		case credentials.KubernetesSecretType:
+			// CA Certs are public information, so we allows allow these to be accessed (from the same namespace)
+			isCAOnlySecret := strings.HasSuffix(r.Name, securitymodel.SdsCaSuffix)
 			// For Kubernetes, we require the secret to be in the same namespace as the proxy and for it to be
 			// authorized for access.
-			if sameNamespace && isAuthorized() {
+			if sameNamespace && (isCAOnlySecret || isAuthorized()) {
+				// if sameNamespace && isAuthorized() {
 				allowedResources = append(allowedResources, r)
 			} else {
 				deniedResources = append(deniedResources, r.Name)

--- a/pilot/pkg/xds/sds_test.go
+++ b/pilot/pkg/xds/sds_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/types/known/durationpb"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,6 +39,7 @@ import (
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/test/env"
+	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/util/sets"
 	xdsserver "istio.io/istio/pkg/xds"
 )
@@ -59,7 +59,10 @@ func makeSecret(name string, data map[string]string) *corev1.Secret {
 }
 
 var (
-	certDir     = filepath.Join(env.IstioSrc, "./tests/testdata/certs")
+	certDir      = filepath.Join(env.IstioSrc, "./tests/testdata/certs")
+	simpleCaCert = makeSecret("ca-only", map[string]string{
+		credentials.GenericScrtCaCert: readFile(filepath.Join(certDir, "dns/root-cert.pem")),
+	})
 	genericCert = makeSecret("generic", map[string]string{
 		credentials.GenericScrtCert: readFile(filepath.Join(certDir, "default/cert-chain.pem")),
 		credentials.GenericScrtKey:  readFile(filepath.Join(certDir, "default/key.pem")),
@@ -97,7 +100,7 @@ func TestGenerateSDS(t *testing.T) {
 		CaCrl  string
 	}
 	allResources := []string{
-		"kubernetes://generic", "kubernetes://generic-mtls", "kubernetes://generic-mtls-cacert",
+		"kubernetes://generic", "kubernetes://generic-mtls", "kubernetes://generic-mtls-cacert", "kubernetes://ca-only-cacert",
 		"kubernetes://generic-mtls-split", "kubernetes://generic-mtls-split-cacert", "kubernetes://generic-mtls-crl",
 		"kubernetes://generic-mtls-crl-cacert",
 	}
@@ -153,6 +156,9 @@ func TestGenerateSDS(t *testing.T) {
 				"kubernetes://generic-mtls": {
 					Key:  string(genericMtlsCert.Data[credentials.GenericScrtKey]),
 					Cert: string(genericMtlsCert.Data[credentials.GenericScrtCert]),
+				},
+				"kubernetes://ca-only-cacert": {
+					CaCert: string(simpleCaCert.Data[credentials.GenericScrtCaCert]),
 				},
 				"kubernetes://generic-mtls-cacert": {
 					CaCert: string(genericMtlsCert.Data[credentials.GenericScrtCaCert]),
@@ -307,6 +313,35 @@ func TestGenerateSDS(t *testing.T) {
 				return true, nil, errors.New("not authorized")
 			},
 		},
+		{
+			// proxy without authorization -- can get CA certs only
+			name:      "partially unauthorized",
+			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, Type: model.Router},
+			resources: allResources,
+			request:   &model.PushRequest{Full: true},
+			// Should get a response, but it will be empty
+			expect: map[string]Expected{
+				"kubernetes://ca-only-cacert": {
+					CaCert: string(simpleCaCert.Data[credentials.GenericScrtCaCert]),
+				},
+				// Note: below are a little strange, since we split a mTLS secret (with 3 parts) into 2 resources
+				// We allow only the public part.
+				// Ultimately it doesn't matter that we allow this; the client will need both parts to do anything
+				"kubernetes://generic-mtls-split-cacert": {
+					CaCert: string(genericMtlsCertSplitCa.Data[credentials.GenericScrtCaCert]),
+				},
+				"kubernetes://generic-mtls-crl-cacert": {
+					CaCert: string(genericMtlsCertCrl.Data[credentials.GenericScrtCaCert]),
+					CaCrl:  string(genericMtlsCertCrl.Data[credentials.GenericScrtCRL]),
+				},
+				"kubernetes://generic-mtls-cacert": {
+					CaCert: string(genericMtlsCert.Data[credentials.GenericScrtCaCert]),
+				},
+			},
+			accessReviewResponse: func(action k8stesting.Action) (bool, runtime.Object, error) {
+				return true, nil, errors.New("not authorized")
+			},
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
@@ -315,7 +350,14 @@ func TestGenerateSDS(t *testing.T) {
 			}
 			tt.proxy.Metadata.ClusterID = constants.DefaultClusterName
 			s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
-				KubernetesObjects: []runtime.Object{genericCert, genericMtlsCert, genericMtlsCertCrl, genericMtlsCertSplit, genericMtlsCertSplitCa},
+				KubernetesObjects: []runtime.Object{
+					genericCert,
+					genericMtlsCert,
+					simpleCaCert,
+					genericMtlsCertCrl,
+					genericMtlsCertSplit,
+					genericMtlsCertSplitCa,
+				},
 			})
 			cc := s.KubeClient().Kube().(*fake.Clientset)
 
@@ -341,9 +383,7 @@ func TestGenerateSDS(t *testing.T) {
 					CaCrl:  string(scrt.GetValidationContext().GetCrl().GetInlineBytes()),
 				}
 			}
-			if diff := cmp.Diff(got, tt.expect); diff != "" {
-				t.Fatal(diff)
-			}
+			assert.Equal(t, got, tt.expect)
 		})
 	}
 }


### PR DESCRIPTION
This allows a config like this:

```yaml
apiVersion: networking.istio.io/v1
kind: DestinationRule
metadata:
  name: originate-tls
spec:
  host: example.com
  trafficPolicy:
    tls:
      mode: SIMPLE
      credentialName: root-cert
  workloadSelector:
    matchLabels:
      app: shell
---
apiVersion: v1
data:
  ca.crt: xxx
kind: Secret
metadata:
  name: root-cert
```

to work without `shell` having secret LIST RBAC privilege

Fixes https://github.com/istio/istio/issues/54710
Related to https://github.com/istio/istio/issues/52728 (but doesn't
solve it, that one was doing mTLS which is legitimately secret).
