### PR TITLE
ambient: fix aggregation logic for removed address set in AddressInormation function

### DIFF
--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -128,16 +128,13 @@ func (c *Controller) AddressInformation(addresses sets.String) ([]model.AddressI
 			i = wis
 		} else {
 			i = append(i, wis...)
-			removed.Merge(r)
-		}
-	}
-	if foundRegistryCount > 1 {
-		// We may have 'removed' it in one registry but found it in another
-		// As an optimization, we skip this in the common case of only one registry
-		for _, wl := range i {
-			// TODO(@hzxuzhonghu) This is not right for workload, we may search workload by ip, but the resource name is uid.
-			if removed.Contains(wl.ResourceName()) {
-				removed.Delete(wl.ResourceName())
+			// Each value in the removed set means an address that is
+			// not found in any registry above. So we should compute the
+			// intersection of these sets.
+			if removed == nil || r == nil {
+				removed = nil
+			} else {
+				removed = removed.Intersection(r)
 			}
 		}
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**
I'm trying to deploy the single network multi-cluster and a logic error triggers an occasional problem: the services in different k8s clusters are conflicting.

I have the comment in my code:

```
// Each value in the removed set means an address that is
// not found in any registry above. So we should compute the
// intersection of these sets.
```