### PR TITLE
AuthorizationPolicy serviceAccount: allow same namespace

### DIFF
--- a/pilot/pkg/networking/grpcgen/lds.go
+++ b/pilot/pkg/networking/grpcgen/lds.go
@@ -179,7 +179,7 @@ func buildInboundFilterChain(node *model.Proxy, push *model.PushContext, nameSuf
 	selectionOpts := model.PolicyMatcherForProxy(node)
 	policies := push.AuthzPolicies.ListAuthorizationPolicies(selectionOpts)
 	if len(policies.Deny)+len(policies.Allow) > 0 {
-		rules := buildRBAC(node, push, nameSuffix, tlsContext, rbacpb.RBAC_DENY, policies.Deny)
+		rules := buildRBAC(rbacpb.RBAC_DENY, policies.Deny)
 		if rules != nil && len(rules.Policies) > 0 {
 			rbac := &rbachttp.RBAC{
 				Rules: rules,
@@ -190,7 +190,7 @@ func buildInboundFilterChain(node *model.Proxy, push *model.PushContext, nameSuf
 					ConfigType: &hcm.HttpFilter_TypedConfig{TypedConfig: protoconv.MessageToAny(rbac)},
 				})
 		}
-		arules := buildRBAC(node, push, nameSuffix, tlsContext, rbacpb.RBAC_ALLOW, policies.Allow)
+		arules := buildRBAC(rbacpb.RBAC_ALLOW, policies.Allow)
 		if arules != nil && len(arules.Policies) > 0 {
 			rbac := &rbachttp.RBAC{
 				Rules: arules,
@@ -254,11 +254,7 @@ func buildInboundFilterChain(node *model.Proxy, push *model.PushContext, nameSuf
 //
 // For gateways it would make a lot of sense to use this concept, same for moving path prefix at top level ( more scalable, easier for users)
 // This should probably be done for the v2 API.
-//
-// nolint: unparam
-func buildRBAC(node *model.Proxy, push *model.PushContext, suffix string, context *tls.DownstreamTlsContext,
-	a rbacpb.RBAC_Action, policies []model.AuthorizationPolicy,
-) *rbacpb.RBAC {
+func buildRBAC(a rbacpb.RBAC_Action, policies []model.AuthorizationPolicy) *rbacpb.RBAC {
 	rules := &rbacpb.RBAC{
 		Action:   a,
 		Policies: map[string]*rbacpb.Policy{},
@@ -266,7 +262,7 @@ func buildRBAC(node *model.Proxy, push *model.PushContext, suffix string, contex
 	for _, policy := range policies {
 		for i, rule := range policy.Spec.Rules {
 			name := fmt.Sprintf("%s-%s-%d", policy.Namespace, policy.Name, i)
-			m, err := authzmodel.New(rule)
+			m, err := authzmodel.New(policy.NamespacedName(), rule)
 			if err != nil {
 				log.Warnf("Invalid rule %v: %v", rule, err)
 				continue

--- a/pilot/pkg/security/authz/builder/builder.go
+++ b/pilot/pkg/security/authz/builder/builder.go
@@ -218,7 +218,7 @@ func (b Builder) build(policies []model.AuthorizationPolicy, action rbacpb.RBAC_
 				b.logger.AppendError(fmt.Errorf("skipped nil rule %s", name))
 				continue
 			}
-			m, err := authzmodel.New(rule)
+			m, err := authzmodel.New(policy.NamespacedName(), rule)
 			if err != nil {
 				b.logger.AppendError(multierror.Prefix(err, fmt.Sprintf("skipped invalid rule %s:", name)))
 				continue

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-in.yaml
@@ -11,8 +11,8 @@ spec:
   rules:
     - from:
         - source:
-            serviceAccounts: [ "my-ns/my-sa" ]
-            notServiceAccounts: [ "my-ns/my-sa-not" ]
+            serviceAccounts: [ "my-ns/my-sa", "sa-only" ]
+            notServiceAccounts: [ "my-ns/my-sa-not", "sa-not-only" ]
     - from:
         - source:
             principals: ["principal", "principal-prefix-*", "*-suffix-principal", "*"]

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
@@ -17,6 +17,10 @@ typedConfig:
                     principalName:
                       safeRegex:
                         regex: spiffe://.+/ns/my-ns/(.+/|)sa/my-sa(/.+)?
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        regex: spiffe://.+/ns/foo/(.+/|)sa/sa-only(/.+)?
             - notId:
                 orIds:
                   ids:
@@ -24,6 +28,10 @@ typedConfig:
                       principalName:
                         safeRegex:
                           regex: spiffe://.+/ns/my-ns/(.+/|)sa/my-sa-not(/.+)?
+                  - authenticated:
+                      principalName:
+                        safeRegex:
+                          regex: spiffe://.+/ns/foo/(.+/|)sa/sa-not-only(/.+)?
       ns[foo]-policy[httpbin-1]-rule[1]:
         permissions:
         - andRules:

--- a/pilot/pkg/security/authz/builder/testdata/http/extended-allow-full-rule-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/extended-allow-full-rule-out.yaml
@@ -17,6 +17,10 @@ typedConfig:
                     principalName:
                       safeRegex:
                         regex: spiffe://.+/ns/my-ns/(.+/|)sa/my-sa(/.+)?
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        regex: spiffe://.+/ns/foo/(.+/|)sa/sa-only(/.+)?
             - notId:
                 orIds:
                   ids:
@@ -24,6 +28,10 @@ typedConfig:
                       principalName:
                         safeRegex:
                           regex: spiffe://.+/ns/my-ns/(.+/|)sa/my-sa-not(/.+)?
+                  - authenticated:
+                      principalName:
+                        safeRegex:
+                          regex: spiffe://.+/ns/foo/(.+/|)sa/sa-not-only(/.+)?
       ns[foo]-policy[httpbin-1]-rule[1]:
         permissions:
         - andRules:

--- a/pilot/pkg/security/authz/model/generator.go
+++ b/pilot/pkg/security/authz/model/generator.go
@@ -195,6 +195,8 @@ func (g srcServiceAccountGenerator) principal(_, value string, _ bool, useAuthen
 	return principalAuthenticated(m, useAuthenticated), nil
 }
 
+// serviceAccountRegex builds a regex that will match the SA specifier.
+// The specifier takes a `<name>` or `<namespace>/<name>` value. If namespace is elided, defaultNamespace is used.
 func serviceAccountRegex(defaultNamespace string, value string) string {
 	ns, sa, ok := strings.Cut(value, "/")
 	if !ok {

--- a/pilot/pkg/security/authz/model/generator.go
+++ b/pilot/pkg/security/authz/model/generator.go
@@ -20,6 +20,7 @@ import (
 
 	rbacpb "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
 	matcherpb "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	"k8s.io/apimachinery/pkg/types"
 
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/security/authz/matcher"
@@ -180,25 +181,25 @@ func (srcNamespaceGenerator) principal(_, value string, _ bool, useAuthenticated
 	return principalAuthenticated(m, useAuthenticated), nil
 }
 
-type srcServiceAccountGenerator struct{}
+type srcServiceAccountGenerator struct {
+	policyName types.NamespacedName
+}
 
-func (srcServiceAccountGenerator) permission(_, _ string, _ bool) (*rbacpb.Permission, error) {
+func (g srcServiceAccountGenerator) permission(_, _ string, _ bool) (*rbacpb.Permission, error) {
 	return nil, fmt.Errorf("unimplemented")
 }
 
-func (srcServiceAccountGenerator) principal(_, value string, _ bool, useAuthenticated bool) (*rbacpb.Principal, error) {
-	regex, err := serviceAccountRegex(value)
-	if err != nil {
-		return nil, err
-	}
+func (g srcServiceAccountGenerator) principal(_, value string, _ bool, useAuthenticated bool) (*rbacpb.Principal, error) {
+	regex := serviceAccountRegex(g.policyName.Namespace, value)
 	m := matcher.StringMatcherRegex(regex)
 	return principalAuthenticated(m, useAuthenticated), nil
 }
 
-func serviceAccountRegex(value string) (string, error) {
+func serviceAccountRegex(defaultNamespace string, value string) string {
 	ns, sa, ok := strings.Cut(value, "/")
 	if !ok {
-		return "", fmt.Errorf("invalid value: %v", value)
+		ns = defaultNamespace
+		sa = value
 	}
 	// Format should follow...
 	// 'spiffe://' then a trust domain + arbitrary k/v pairs
@@ -206,7 +207,7 @@ func serviceAccountRegex(value string) (string, error) {
 	// optional arbitrary k/v pairs
 	// '/sa/<serviceAccount>'
 	// Either end of string OR / + arbitrary k/v pairs (the / ensures we do not match <service account>-some-junk)
-	return fmt.Sprintf("spiffe://.+/ns/%s/(.+/|)sa/%s(/.+)?", ns, sa), nil
+	return fmt.Sprintf("spiffe://.+/ns/%s/(.+/|)sa/%s(/.+)?", ns, sa)
 }
 
 type srcPrincipalGenerator struct{}

--- a/pilot/pkg/security/authz/model/generator_test.go
+++ b/pilot/pkg/security/authz/model/generator_test.go
@@ -542,7 +542,7 @@ func TestServiceAccount(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
-			r, _ := serviceAccountRegex(input)
+			r := serviceAccountRegex("", input)
 			// Parse as regex. Envoy does a full string match, so handle that
 			rgx, err := regexp.Compile("^" + r + "$")
 			if err != nil {

--- a/pilot/pkg/security/authz/model/generator_test.go
+++ b/pilot/pkg/security/authz/model/generator_test.go
@@ -570,3 +570,8 @@ func yamlPrincipal(t *testing.T, yaml string) *rbacpb.Principal {
 	}
 	return p
 }
+
+func TestServiceAccountRegex(t *testing.T) {
+	assert.Equal(t, serviceAccountRegex("", "my-ns/my-sa"), `spiffe://.+/ns/my-ns/(.+/|)sa/my-sa(/.+)?`)
+	assert.Equal(t, serviceAccountRegex("my-ns", "my-sa"), `spiffe://.+/ns/my-ns/(.+/|)sa/my-sa(/.+)?`)
+}

--- a/pilot/pkg/security/authz/model/model_test.go
+++ b/pilot/pkg/security/authz/model/model_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	rbacpb "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
 	matcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	"k8s.io/apimachinery/pkg/types"
 
 	authzpb "istio.io/api/security/v1beta1"
 	"istio.io/istio/pilot/pkg/security/trustdomain"
@@ -81,7 +82,7 @@ when:
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := New(tc.rule)
+			got, err := New(types.NamespacedName{}, tc.rule)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -259,7 +260,7 @@ when:
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			m, err := New(tc.rule)
+			m, err := New(types.NamespacedName{}, tc.rule)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/testdata/allow-full-in.yaml
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/testdata/allow-full-in.yaml
@@ -2,6 +2,7 @@ apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: allow
+  namespace: cfg
 spec:
   action: ALLOW
   rules:
@@ -11,8 +12,8 @@ spec:
         notPrincipals: [ "not-principal", "not-principal-prefix-*", "*-suffix-not-principal", "*" ]
   - from:
     - source:
-        serviceAccounts: [ "ns/sa" ]
-        notServiceAccounts: [ "ns/sa-not" ]
+        serviceAccounts: [ "ns/sa", "sa-only" ]
+        notServiceAccounts: [ "ns/sa-not", "sa-not-only" ]
   - from:
     - source:
         requestPrincipals: [ "requestPrincipals", "requestPrincipals-prefix-*", "*-suffix-requestPrincipals", "*" ]

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/testdata/allow-full.yaml
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/testdata/allow-full.yaml
@@ -16,9 +16,13 @@ groups:
     - notServiceAccounts:
       - namespace: ns
         serviceAccount: sa-not
+      - namespace: cfg
+        serviceAccount: sa-not-only
       serviceAccounts:
       - namespace: ns
         serviceAccount: sa
+      - namespace: cfg
+        serviceAccount: sa-only
 - rules:
   - matches:
     - namespaces:
@@ -108,4 +112,5 @@ groups:
       - 9001
       - 9002
 name: allow
+namespace: cfg
 scope: NAMESPACE

--- a/pkg/config/security/security_test.go
+++ b/pkg/config/security/security_test.go
@@ -141,12 +141,16 @@ func TestValidateCondition(t *testing.T) {
 		},
 		{
 			key:       "source.serviceAccount",
-			values:    []string{"bad"},
+			values:    []string{"too/many/slashes"},
 			wantError: true,
 		},
 		{
 			key:    "source.serviceAccount",
 			values: []string{"ns/sa"},
+		},
+		{
+			key:    "source.serviceAccount",
+			values: []string{"sa"},
 		},
 		{
 			key:    "request.auth.principal",

--- a/pkg/config/security/security_test.go
+++ b/pkg/config/security/security_test.go
@@ -145,6 +145,16 @@ func TestValidateCondition(t *testing.T) {
 			wantError: true,
 		},
 		{
+			key:       "source.serviceAccount",
+			values:    []string{"/emptyns"},
+			wantError: true,
+		},
+		{
+			key:       "source.serviceAccount",
+			values:    []string{"emptysa/"},
+			wantError: true,
+		},
+		{
 			key:    "source.serviceAccount",
 			values: []string{"ns/sa"},
 		},


### PR DESCRIPTION
This allows applying a policy like

```yaml
apiVersion: security.istio.io/v1
kind: AuthorizationPolicy
metadata:
 name: allow-waypoint
spec:
  selector:
    matchLabels:
      app: echo
  action: ALLOW
  rules:
  - from:
    - source:
        serviceAccounts: ["waypoint"]
```

To get the semantics of "allow the waypoint in the same namespace". 

It is common in k8s to allow configurations to be written without a namespace specified and have the namespace of references implied by the namespace it is eventually written to. This allows taking the same policy and applying it to many places without the need for modification/templating. As far as I know, this is allowed with virtually every k8s core type and Istio type today.

No changes are needed to the dataplane to support this, as it is entirely control plane logic changing

Note: a release note is skipped since we have not shipped this feature