### PR TITLE
Allow kind integ tests inside devcontainer

### DIFF
--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -44,6 +44,12 @@ CLUSTER_NAME="${CLUSTER_NAME:-istio-testing}"
 
 export FAST_VM_BUILDS=true
 export ISTIO_DOCKER_BUILDER="${ISTIO_DOCKER_BUILDER:-crane}"
+# DEVCONTAINER controls a set of features that allow this script to be run from
+# within a dev container using ghcr.io/devcontainers/features/docker-outside-of-docker
+export DEVCONTAINER="${DEVCONTAINER:-}"
+if [[ "${DEVCONTAINER}" ]]; then
+  export ISTIO_DOCKER_BUILDER=docker
+fi
 
 PARAMS=()
 
@@ -181,9 +187,9 @@ if [[ -z "${SKIP_BUILD:-}" ]]; then
   trace "build images" build_images "${PARAMS[*]}"
 
   # upload WASM plugins to kind-registry
-  crane copy gcr.io/istio-testing/wasm/attributegen:359dcd3a19f109c50e97517fe6b1e2676e870c4d localhost:5000/istio-testing/wasm/attributegen:0.0.1
-  crane copy gcr.io/istio-testing/wasm/header-injector:0.0.1 localhost:5000/istio-testing/wasm/header-injector:0.0.1
-  crane copy gcr.io/istio-testing/wasm/header-injector:0.0.2 localhost:5000/istio-testing/wasm/header-injector:0.0.2
+  crane copy gcr.io/istio-testing/wasm/attributegen:359dcd3a19f109c50e97517fe6b1e2676e870c4d kind-registry:5000/istio-testing/wasm/attributegen:0.0.1 --insecure
+  crane copy gcr.io/istio-testing/wasm/header-injector:0.0.1 kind-registry:5000/istio-testing/wasm/header-injector:0.0.1 --insecure
+  crane copy gcr.io/istio-testing/wasm/header-injector:0.0.2 kind-registry:5000/istio-testing/wasm/header-injector:0.0.2 --insecure
 
   # Make "kind-registry" resolvable in IPv6 cluster
   if [[ "$KIND_IP_FAMILY" == "ipv6" ]]; then

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -187,9 +187,10 @@ if [[ -z "${SKIP_BUILD:-}" ]]; then
   trace "build images" build_images "${PARAMS[*]}"
 
   # upload WASM plugins to kind-registry
-  crane copy gcr.io/istio-testing/wasm/attributegen:359dcd3a19f109c50e97517fe6b1e2676e870c4d kind-registry:5000/istio-testing/wasm/attributegen:0.0.1 --insecure
-  crane copy gcr.io/istio-testing/wasm/header-injector:0.0.1 kind-registry:5000/istio-testing/wasm/header-injector:0.0.1 --insecure
-  crane copy gcr.io/istio-testing/wasm/header-injector:0.0.2 kind-registry:5000/istio-testing/wasm/header-injector:0.0.2 --insecure
+  registry_url=$(if [ -z "$DEVCONTAINER" ]; then echo "localhost"; else echo $KIND_REGISTRY_NAME; fi):$KIND_REGISTRY_PORT
+  crane copy gcr.io/istio-testing/wasm/attributegen:359dcd3a19f109c50e97517fe6b1e2676e870c4d "$registry_url/istio-testing/wasm/attributegen:0.0.1" --insecure
+  crane copy gcr.io/istio-testing/wasm/header-injector:0.0.1 "$registry_url/istio-testing/wasm/header-injector:0.0.1" --insecure
+  crane copy gcr.io/istio-testing/wasm/header-injector:0.0.2 "$registry_url/istio-testing/wasm/header-injector:0.0.2" --insecure
 
   # Make "kind-registry" resolvable in IPv6 cluster
   if [[ "$KIND_IP_FAMILY" == "ipv6" ]]; then

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -156,9 +156,13 @@ function setup_kind_registry() {
   # https://docs.tilt.dev/choosing_clusters.html#discovering-the-registry
   for cluster in $(kind get clusters); do
     # TODO get context/config from existing variables
-    kind export kubeconfig --name="${cluster}"
+    if [[ "${DEVCONTAINER}" ]]; then
+      kind export kubeconfig --name="${cluster}" --internal
+    else
+      kind export kubeconfig --name="${cluster}"
+    fi
     for node in $(kind get nodes --name="${cluster}"); do
-      kubectl annotate node "${node}" "kind.x-k8s.io/registry=localhost:${KIND_REGISTRY_PORT}" --overwrite;
+      kubectl annotate node "${node}" "kind.x-k8s.io/registry=kind-registry:${KIND_REGISTRY_PORT}" --overwrite;
     done
   done
 }


### PR DESCRIPTION
Currently, it is very painful to run integ tests against kind from within a dev container, because our kind setup scripts rely on port-forwarding to the host machine, but the dev container does not have access to host ports.  This change adds an env var `DEVCONTAINER` which, if set, causes the script to run using docker network connections and hostnames, rather than ports on localhost.  This change depends on https://github.com/istio/common-files/pull/1138.