### PR TITLE
Add support for hostnetwork in istiod helm chart

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -88,11 +88,11 @@ spec:
       initContainers:
         {{- tpl (toYaml .) $ | nindent 8 }}
 {{- end }}
-    {{- if .Values.global.hostNetwork }}
+    {{- if .Values.hostNetwork }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
     {{- else }}
-      dnsPolicy: {{ .Values.global.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
     {{- end }}
       containers:
         - name: discovery

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -88,6 +88,12 @@ spec:
       initContainers:
         {{- tpl (toYaml .) $ | nindent 8 }}
 {{- end }}
+    {{- if .Values.global.hostNetwork }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+    {{- else }}
+      dnsPolicy: {{ .Values.global.dnsPolicy }}
+    {{- end }}
       containers:
         - name: discovery
 {{- if contains "/" .Values.image }}

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -63,6 +63,14 @@ _internal_defaults_do_not_set:
   # Inject initContainers into the istiod pod
   initContainers: []
 
+  # Required for use in managed kubernetes clusters (such as AWS EKS) with custom CNI (such as calico),
+  # because control-plane managed by AWS cannot communicate with pods' IP CIDR and admission webhooks are not working
+  ##
+  hostNetwork: true
+
+  # When hostNetwork is enabled, this will set to ClusterFirstWithHostNet automatically
+  dnsPolicy: ClusterFirst    
+
   nodeSelector: {}
   podAnnotations: {}
   serviceAnnotations: {}
@@ -299,14 +307,6 @@ _internal_defaults_do_not_set:
     # Refer to https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
     # for more detail.
     priorityClassName: ""
-
-    # Required for use in managed kubernetes clusters (such as AWS EKS) with custom CNI (such as calico),
-    # because control-plane managed by AWS cannot communicate with pods' IP CIDR and admission webhooks are not working
-    ##
-    hostNetwork: false
-
-    # When hostNetwork is enabled, this will set to ClusterFirstWithHostNet automatically
-    dnsPolicy: ClusterFirst    
 
     proxy:
       image: proxyv2

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -300,6 +300,14 @@ _internal_defaults_do_not_set:
     # for more detail.
     priorityClassName: ""
 
+    # Required for use in managed kubernetes clusters (such as AWS EKS) with custom CNI (such as calico),
+    # because control-plane managed by AWS cannot communicate with pods' IP CIDR and admission webhooks are not working
+    ##
+    hostNetwork: false
+
+    # When hostNetwork is enabled, this will set to ClusterFirstWithHostNet automatically
+    dnsPolicy: ClusterFirst    
+
     proxy:
       image: proxyv2
 


### PR DESCRIPTION
When using managed kubernetes clusters (such as AWS EKS) with custom CNI (such as calico), control-planes cannot communicate with pods' IP CIDR and admission webhooks are not working. 

Related to : https://github.com/istio/istio/issues/47932

Calico documentation: https://docs.tigera.io/calico/latest/getting-started/kubernetes/managed-public-cloud/eks#install-eks-with-calico-networking

This PR adds the ability to set `hostnetwork` in the helm chart of `istiod`