### PR TITLE
krt: make collections implement Syncer

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -690,10 +690,10 @@ func (a *index) Run(stop <-chan struct{}) {
 }
 
 func (a *index) HasSynced() bool {
-	return a.services.Synced().HasSynced() &&
-		a.workloads.Synced().HasSynced() &&
-		a.waypoints.Synced().HasSynced() &&
-		a.authorizationPolicies.Synced().HasSynced()
+	return a.services.HasSynced() &&
+		a.workloads.HasSynced() &&
+		a.waypoints.HasSynced() &&
+		a.authorizationPolicies.HasSynced()
 }
 
 type (

--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -164,6 +164,8 @@ type manyCollection[I, O any] struct {
 	synced       chan struct{}
 	stop         <-chan struct{}
 	queue        queue.Instance
+
+	syncer Syncer
 }
 
 type collectionIndex[I, O any] struct {
@@ -244,11 +246,12 @@ type multiIndex[I, O any] struct {
 	mappings map[Key[I]]sets.Set[Key[O]]
 }
 
-func (h *manyCollection[I, O]) Synced() Syncer {
-	return channelSyncer{
-		name:   h.collectionName,
-		synced: h.synced,
-	}
+func (h *manyCollection[I, O]) HasSynced() bool {
+	return h.syncer.HasSynced()
+}
+
+func (h *manyCollection[I, O]) WaitUntilSynced(stop <-chan struct{}) bool {
+	return h.syncer.WaitUntilSynced(stop)
 }
 
 // nolint: unused // (not true, its to implement an interface)
@@ -515,6 +518,7 @@ func NewManyCollection[I, O any](c Collection[I], hf TransformationMulti[I, O], 
 
 func newManyCollection[I, O any](cc Collection[I], hf TransformationMulti[I, O], opts collectionOptions) Collection[O] {
 	c := cc.(internalCollection[I])
+
 	h := &manyCollection[I, O]{
 		transformation: hf,
 		collectionName: opts.name,
@@ -537,6 +541,10 @@ func newManyCollection[I, O any](cc Collection[I], hf TransformationMulti[I, O],
 		synced:        make(chan struct{}),
 		stop:          opts.stop,
 	}
+	h.syncer = channelSyncer{
+		name:   h.collectionName,
+		synced: h.synced,
+	}
 	maybeRegisterCollectionForDebugging(h, opts.debugger)
 
 	// Create our queue. When it syncs (that is, all items that were present when Run() was called), we mark ourselves as synced.
@@ -556,7 +564,7 @@ func newManyCollection[I, O any](cc Collection[I], hf TransformationMulti[I, O],
 func (h *manyCollection[I, O]) runQueue() {
 	c := h.parent
 	// Wait for primary dependency to be ready
-	if !c.Synced().WaitUntilSynced(h.stop) {
+	if !c.WaitUntilSynced(h.stop) {
 		return
 	}
 	// Now register to our primary collection. On any event, we will enqueue the update.
@@ -641,7 +649,7 @@ func (h *manyCollection[I, O]) Register(f func(o Event[O])) Syncer {
 func (h *manyCollection[I, O]) RegisterBatch(f func(o []Event[O], initialSync bool), runExistingState bool) Syncer {
 	if !runExistingState {
 		// If we don't to run the initial state this is simple, we just register the handler.
-		return h.eventHandlers.Insert(f, h.Synced(), nil, h.stop)
+		return h.eventHandlers.Insert(f, h, nil, h.stop)
 	}
 	// We need to run the initial state, but we don't want to get duplicate events.
 	// We should get "ADD initialObject1, ADD initialObjectN, UPDATE someLaterUpdate" without mixing the initial ADDs
@@ -659,7 +667,7 @@ func (h *manyCollection[I, O]) RegisterBatch(f func(o []Event[O], initialSync bo
 	}
 
 	// Send out all the initial objects to the handler. We will then unlock the new events so it gets the future updates.
-	return h.eventHandlers.Insert(f, h.Synced(), events, h.stop)
+	return h.eventHandlers.Insert(f, h, events, h.stop)
 }
 
 func (h *manyCollection[I, O]) name() string {

--- a/pkg/kube/krt/collection_test.go
+++ b/pkg/kube/krt/collection_test.go
@@ -229,7 +229,7 @@ func TestCollectionInitialState(t *testing.T) {
 	SimplePods := SimplePodCollection(pods, opts)
 	SimpleServices := SimpleServiceCollection(services, opts)
 	SimpleEndpoints := SimpleEndpointsCollection(SimplePods, SimpleServices, opts)
-	assert.Equal(t, SimpleEndpoints.Synced().WaitUntilSynced(stop), true)
+	assert.Equal(t, SimpleEndpoints.WaitUntilSynced(stop), true)
 	// Assert Equal -- not EventuallyEqual -- to ensure our WaitForCacheSync is proper
 	assert.Equal(t, fetcherSorted(SimpleEndpoints)(), []SimpleEndpoint{{"pod", "svc", "namespace", "1.2.3.4"}})
 }

--- a/pkg/kube/krt/conformance_test.go
+++ b/pkg/kube/krt/conformance_test.go
@@ -147,7 +147,7 @@ func runConformance[T any](t *testing.T, collection Rig[T]) {
 	earlyHandlerSynced := collection.Register(TrackerHandler[T](earlyHandler))
 
 	// Ensure the collection and handler are synced
-	assert.Equal(t, collection.Synced().WaitUntilSynced(stop), true)
+	assert.Equal(t, collection.WaitUntilSynced(stop), true)
 	assert.Equal(t, earlyHandlerSynced.WaitUntilSynced(stop), true)
 
 	// Create an object

--- a/pkg/kube/krt/core.go
+++ b/pkg/kube/krt/core.go
@@ -44,6 +44,8 @@ type Collection[T any] interface {
 // On initial sync, events will be published to registered clients
 // as the Collection is populated.
 type EventStream[T any] interface {
+	Syncer
+
 	// Register adds an event watcher to the collection. Any time an item in the collection changes, the handler will be
 	// called. Typically, usage of Register is done internally in krt via composition of Collections with Transformations
 	// (NewCollection, NewManyCollection, NewSingleton); however, at boundaries of the system (connecting to something not
@@ -54,10 +56,6 @@ type EventStream[T any] interface {
 	//   other handlers.
 	// * Events will be sent in order, and will not be dropped or deduplicated.
 	Register(f func(o Event[T])) Syncer
-
-	// Synced returns a Syncer which can be used to determine if the collection has synced. Once its synced, all dependencies have
-	// been processed, and all handlers have been called with the results.
-	Synced() Syncer
 
 	// RegisterBatch registers a handler that accepts multiple events at once. This can be useful as an optimization.
 	// Otherwise, behaves the same as Register.

--- a/pkg/kube/krt/fetch.go
+++ b/pkg/kube/krt/fetch.go
@@ -42,7 +42,7 @@ func Fetch[T any](ctx HandlerContext, cc Collection[T], opts ...FetchOption) []T
 		o(d)
 	}
 	// Important: register before we List(), so we cannot miss any events
-	h.registerDependency(d, c.Synced(), func(f erasedEventHandler) Syncer {
+	h.registerDependency(d, c, func(f erasedEventHandler) Syncer {
 		ff := func(o []Event[T], initialSync bool) {
 			f(slices.Map(o, castEvent[T, any]), initialSync)
 		}

--- a/pkg/kube/krt/index_test.go
+++ b/pkg/kube/krt/index_test.go
@@ -107,7 +107,7 @@ func TestIndexCollection(t *testing.T) {
 		names := slices.Sort(slices.Map(pods, SimplePod.ResourceName))
 		return ptr.Of(strings.Join(names, ","))
 	}, opts.WithName("Collection")...)
-	Collection.AsCollection().Synced().WaitUntilSynced(stop)
+	Collection.AsCollection().WaitUntilSynced(stop)
 	fetchSorted := func(ip string) []SimplePod {
 		return slices.SortBy(IPIndex.Lookup(ip), func(t SimplePod) string {
 			return t.ResourceName()

--- a/pkg/kube/krt/join_test.go
+++ b/pkg/kube/krt/join_test.go
@@ -186,7 +186,7 @@ func TestCollectionJoinSync(t *testing.T) {
 		IP:      "9.9.9.9",
 	}, true)
 	AllPods := krt.JoinCollection([]krt.Collection[SimplePod]{SimplePods, ExtraSimplePods.AsCollection()})
-	assert.Equal(t, AllPods.Synced().WaitUntilSynced(stop), true)
+	assert.Equal(t, AllPods.WaitUntilSynced(stop), true)
 	// Assert Equal -- not EventuallyEqual -- to ensure our WaitForCacheSync is proper
 	assert.Equal(t, fetcherSorted(AllPods)(), []SimplePod{
 		{Named{"namespace", "name"}, NewLabeled(map[string]string{"app": "foo"}), "1.2.3.4"},

--- a/pkg/kube/krt/recomputetrigger_test.go
+++ b/pkg/kube/krt/recomputetrigger_test.go
@@ -34,9 +34,9 @@ func TestRecomputeTrigger(t *testing.T) {
 		return ptr.Of(response.Load())
 	}, krt.WithStop(test.NewStop(t)))
 
-	assert.Equal(t, col2.Synced().HasSynced(), false)
+	assert.Equal(t, col2.HasSynced(), false)
 	rt.MarkSynced()
-	assert.Equal(t, col2.Synced().WaitUntilSynced(test.NewStop(t)), true)
+	assert.Equal(t, col2.WaitUntilSynced(test.NewStop(t)), true)
 
 	tt := assert.NewTracker[string](t)
 	col2.Register(TrackerHandler[string](tt))

--- a/pkg/kube/krt/singleton_test.go
+++ b/pkg/kube/krt/singleton_test.go
@@ -45,7 +45,7 @@ func TestSingleton(t *testing.T) {
 			})...))
 		}, krt.WithStop(stop),
 	)
-	ConfigMapNames.AsCollection().Synced().WaitUntilSynced(stop)
+	ConfigMapNames.AsCollection().WaitUntilSynced(stop)
 	tt := assert.NewTracker[string](t)
 	ConfigMapNames.Register(TrackerHandler[string](tt))
 	tt.WaitOrdered("add/")

--- a/pkg/kube/krt/static.go
+++ b/pkg/kube/krt/static.go
@@ -36,6 +36,7 @@ type staticList[T any] struct {
 	id             collectionUID
 	stop           <-chan struct{}
 	collectionName string
+	syncer         Syncer
 }
 
 func NewStaticCollection[T any](vals []T, opts ...CollectionOption) StaticCollection[T] {
@@ -55,6 +56,7 @@ func NewStaticCollection[T any](vals []T, opts ...CollectionOption) StaticCollec
 		id:             nextUID(),
 		stop:           o.stop,
 		collectionName: o.name,
+		syncer:         alwaysSynced{},
 	}
 
 	return StaticCollection[T]{
@@ -183,6 +185,14 @@ func (s *staticList[T]) List() []T {
 
 func (s *staticList[T]) Register(f func(o Event[T])) Syncer {
 	return registerHandlerAsBatched(s, f)
+}
+
+func (s *staticList[T]) HasSynced() bool {
+	return s.syncer.HasSynced()
+}
+
+func (s *staticList[T]) WaitUntilSynced(stop <-chan struct{}) bool {
+	return s.syncer.WaitUntilSynced(stop)
 }
 
 func (s *staticList[T]) Synced() Syncer {


### PR DESCRIPTION
Make collections implement `Syncer` so that we do not have indirect redirection of calling Synced() and then calling Syncer's methods. 



- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
