### PR TITLE
ambient: fix ingress-use-waypoint with ServiceEntry

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1592,6 +1592,9 @@ func (s *Service) HasAddressOrAssigned(id cluster.ID) bool {
 			return true
 		}
 	}
+	if s.DefaultAddress != constants.UnspecifiedIP {
+		return true
+	}
 	if s.AutoAllocatedIPv4Address != "" {
 		return true
 	}

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1583,6 +1583,24 @@ func (s *Service) GetExtraAddressesForProxy(node *Proxy) []string {
 	return nil
 }
 
+// HasAddressOrAssigned returns whether the service has an IP address.
+// This includes auto-allocated IP addresses. Note that not all proxies support auto-allocated IP addresses;
+// typically GetAllAddressesForProxy should be used which automatically filters addresses to account for that.
+func (s *Service) HasAddressOrAssigned(id cluster.ID) bool {
+	if id != "" {
+		if len(s.ClusterVIPs.GetAddressesFor(id)) > 0 {
+			return true
+		}
+	}
+	if s.AutoAllocatedIPv4Address != "" {
+		return true
+	}
+	if s.AutoAllocatedIPv6Address != "" {
+		return true
+	}
+	return false
+}
+
 // GetAllAddressesForProxy returns a k8s service's all addresses to the cluster where the node resides.
 // Especially for dual stack k8s service to get other IP family addresses.
 func (s *Service) GetAllAddressesForProxy(node *Proxy) []string {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -311,7 +311,7 @@ func New(options Options) Index {
 	NamespacesInfo := krt.NewCollection(Namespaces, func(ctx krt.HandlerContext, i *v1.Namespace) *model.NamespaceInfo {
 		return &model.NamespaceInfo{
 			Name:               i.Name,
-			IngressUseWaypoint: i.Labels["istio.io/ingress-use-waypoint"] == "true",
+			IngressUseWaypoint: strings.EqualFold(i.Labels["istio.io/ingress-use-waypoint"], "true"),
 		}
 	}, opts.WithName("NamespacesInfo")...)
 

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
@@ -128,7 +128,10 @@ func (a *index) serviceEntriesInfo(ctx krt.HandlerContext, s *networkingclient.S
 	waypoint := model.WaypointBindingStatus{}
 	if w != nil {
 		waypoint.ResourceName = w.ResourceName()
-		waypoint.IngressUseWaypoint = s.Labels["istio.io/ingress-use-waypoint"] == "true"
+		if val, ok := s.Labels["istio.io/ingress-use-waypoint"]; ok {
+			waypoint.IngressLabelPresent = true
+			waypoint.IngressUseWaypoint = strings.EqualFold(val, "true")
+		}
 	}
 	if wperr != nil {
 		waypoint.Error = wperr

--- a/pilot/pkg/xds/endpoints/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder.go
@@ -845,7 +845,7 @@ func (b *EndpointBuilder) findServiceWaypoint(endpointIndex *model.EndpointIndex
 		// Currently only ingress will call waypoints
 		return nil, false
 	}
-	if b.service.GetAddressForProxy(b.proxy) == constants.UnspecifiedIP {
+	if !b.service.HasAddressOrAssigned(b.proxy.Metadata.ClusterID) {
 		// No VIP, so skip this. Currently, waypoints can only accept VIP traffic
 		return nil, false
 	}


### PR DESCRIPTION
Two different bugs leading to the same breakage

1. We just incorrectly assigned the IngressUseWaypoint option in the SE
   codepath
2. We ignore auto-allocated IPs and prematurely filter out services from
   waypoint support
