### PR TITLE
Ignore route matchers with sourceLabels in waypoints

### DIFF
--- a/releasenotes/notes/51565-waypoint-sourcelabels.yaml
+++ b/releasenotes/notes/51565-waypoint-sourcelabels.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+# issue is a list of GitHub issues resolved in this note.
+issue:
+  - https://github.com/istio/istio/issues/51565
+
+releaseNotes:
+- |
+  **Fixed** an issue where an HTTPRoute in a VirtualService with a matcher specifying sourceLabels would be applied to a waypoint.


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR resolves https://github.com/istio/istio/issues/51565 by ignoring matchers in `VirtualServices` that include `SourceLabels`. Client `SourceLabels` cannot be effectively translated to configuration for the waypoint and will not be supported in Ambient mode. 

I was unable to find tests covering listener generation specifically for Waypoints, but I've tested this end-to-end following the reproduction steps in the issue. If a reviewer can point me to appropriate tests, I'm happy to add some for this!

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
