### PR TITLE
ambient: refactor internal transports

### DIFF
--- a/pilot/pkg/networking/core/cluster_waypoint.go
+++ b/pilot/pkg/networking/core/cluster_waypoint.go
@@ -200,7 +200,7 @@ func (cb *ClusterBuilder) buildWaypointInboundVIPCluster(
 	// no TLS, we are just going to internal address
 	localCluster.cluster.TransportSocketMatches = nil
 	// Wrap the transportSocket with internal listener upstream. Note this could be a raw buffer, PROXY, TLS, etc
-	localCluster.cluster.TransportSocket = util.TunnelHostInternalUpstreamTransportSocket(transportSocket)
+	localCluster.cluster.TransportSocket = util.WaypointInternalUpstreamTransportSocket(transportSocket)
 
 	return localCluster.build()
 }


### PR DESCRIPTION
This is pure refactor, no behavior changes.

Currently we have 3 usage of internal upstream, and they are all named
similarly but used for different purposes.

Trying to move these to a centralized place + explain when they are
used.

We still probably should comment WHY but I honestly don't really know
myself...
