### PR TITLE
Use resolv.conf for getting the zone

### DIFF
--- a/pkg/bootstrap/platform/gcp.go
+++ b/pkg/bootstrap/platform/gcp.go
@@ -89,7 +89,7 @@ var GCPStaticMetadata = func() map[string]string {
 // GKE provides resolv.conf based on the Node(GCE)'s resolv.conf.
 // GCE's resolv.conf format can be found in:
 // https://cloud.google.com/compute/docs/internal-dns
-func zoneFromResolvConf() string {
+var zoneFromResolvConf = func() string {
 	b, err := os.ReadFile("/etc/resolv.conf")
 	if err != nil {
 		log.Warnf("Failed to read resolv.conf")

--- a/pkg/bootstrap/platform/gcp.go
+++ b/pkg/bootstrap/platform/gcp.go
@@ -98,8 +98,8 @@ var zoneInResolvRE = regexp.MustCompile(`^search.* ([^-]+-[^-]+-[^-]+)\.c\.[^.]+
 func zoneFromResolvConfData(s string) string {
 	ll := strings.Split(s, "\n")
 	for _, l := range ll {
-		if zone := zoneInResolvRE.FindString(l); zone != "" {
-			return zone
+		if m := zoneInResolvRE.FindStringSubmatch(l); len(m) == 2 {
+			return m[1]
 		}
 	}
 	log.Warnf("Failed to load the zone name of the pod from resolv.conf")

--- a/pkg/bootstrap/platform/gcp.go
+++ b/pkg/bootstrap/platform/gcp.go
@@ -98,7 +98,6 @@ var zoneInResolvRE = regexp.MustCompile(`^search.* ([^-]+-[^-]+-[^-]+)\.c\.[^.]+
 func zoneFromResolvConfData(s string) string {
 	ll := strings.Split(s, "\n")
 	for _, l := range ll {
-		log.Infof("%v", l)
 		if zone := zoneInResolvRE.FindString(l); zone != "" {
 			return zone
 		}

--- a/pkg/bootstrap/platform/gcp.go
+++ b/pkg/bootstrap/platform/gcp.go
@@ -83,6 +83,12 @@ var GCPStaticMetadata = func() map[string]string {
 	return md
 }()
 
+// zoneFromResolvConf extracts the zone from resolv.conf.
+// The doc which describes the format can be found in:
+// https://cloud.google.com/kubernetes-engine/docs/how-to/kube-dns
+// GKE provides resolv.conf based on the Node(GCE)'s resolv.conf.
+// GCE's resolv.conf format can be found in:
+// https://cloud.google.com/compute/docs/internal-dns
 func zoneFromResolvConf() string {
 	b, err := os.ReadFile("/etc/resolv.conf")
 	if err != nil {

--- a/pkg/bootstrap/platform/gcp_test.go
+++ b/pkg/bootstrap/platform/gcp_test.go
@@ -362,14 +362,16 @@ func TestDefaultPort(t *testing.T) {
 
 func TestLocality(t *testing.T) {
 	tests := []struct {
-		name   string
-		zoneFn func(context.Context) (string, error)
-		env    map[string]string
-		want   map[string]string
+		name     string
+		zoneFn   func(context.Context) (string, error)
+		resolvFn func() string
+		env      map[string]string
+		want     map[string]string
 	}{
 		{
 			"fill by env variable",
 			func(context.Context) (string, error) { return "us-east1-ir", nil },
+			func() string { return "us-central3-f" },
 			map[string]string{
 				GCPZone: "us-central2-ir",
 			},
@@ -378,12 +380,14 @@ func TestLocality(t *testing.T) {
 		{
 			"fill by metadata server",
 			func(context.Context) (string, error) { return "us-east1-ir", nil },
+			func() string { return "" },
 			map[string]string{},
 			map[string]string{"Zone": "us-east1-ir", "Region": "us-east1"},
 		},
 		{
 			"fill by env variable without compute metadata",
 			func(context.Context) (string, error) { return "", errors.New("error") },
+			func() string { return "" },
 			map[string]string{
 				GCPZone: "us-central2-ir",
 			},
@@ -392,12 +396,21 @@ func TestLocality(t *testing.T) {
 		{
 			"no env variable and unable to reach compute metadata",
 			func(context.Context) (string, error) { return "", errors.New("error") },
+			func() string { return "" },
 			map[string]string{},
 			map[string]string{},
+		},
+		{
+			"fill by resolv.conf",
+			func(context.Context) (string, error) { return "us-east1-ir", nil },
+			func() string { return "us-central3-f" },
+			map[string]string{},
+			map[string]string{"Zone": "us-central3-f", "Region": "us-central3"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			test.SetForTest(t, &zoneFromResolvConf, tt.resolvFn)
 			test.SetForTest(t, &GCPStaticMetadata, tt.env)
 			zoneFn = tt.zoneFn
 			e := NewGCP()


### PR DESCRIPTION
To avoid MDS query, this PR uses the /etc/resolv.conf configuration in GKE pod.

Currently GKE pod has resolv.conf has the entry like:
```
search ... [zone].c.[GCP-project].internal ...
```
Therefore we can extract the zone from the search clause in `resolv.conf` without using the GKE metadata server.
We had some issues on GKE metadata server, so I believe that it can help to get better stability.

This is basically a short-term approach. If https://github.com/istio/istio/issues/53859 is cleared, then we should use the zone from topology annotation.

Change-Id: I24f8da81a940703bab43c16eea6d079986fa2d52
