### PR TITLE
Fix accesslog format incompatibility between 1.23 istiod and <1.23 proxies

### DIFF
--- a/pilot/pkg/networking/core/accesslog.go
+++ b/pilot/pkg/networking/core/accesslog.go
@@ -249,6 +249,13 @@ func buildAccessLogFilter(f ...*accesslog.AccessLogFilter) *accesslog.AccessLogF
 }
 
 func (b *AccessLogBuilder) buildListenerFileAccessLog(mesh *meshconfig.MeshConfig, proxyVersion *model.IstioVersion) *accesslog.AccessLog {
+	// Calculate access log config on-the-flay for proxy versions <1.23
+	if !util.IsIstioVersionGE123(proxyVersion) {
+		lal := model.FileAccessLogFromMeshConfig(mesh.AccessLogFile, mesh, proxyVersion)
+		lal.Filter = addAccessLogFilter()
+		return lal
+	}
+
 	if cal := b.cachedListenerFileAccessLog(); cal != nil {
 		return cal
 	}

--- a/releasenotes/notes/54795.yaml
+++ b/releasenotes/notes/54795.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 54795
+releaseNotes:
+- |
+  **Fixed** Istiod sending an incompatible access log format to <1.23 proxies.


### PR DESCRIPTION
**Please provide a description of this PR:**

This change is specific to Istio 1.23 (other releases are not affected since support for this upgrade scenario is absent in 1.24).

Currently, a 1.23 controller encounters issues when sending configuration for access logs to proxies running versions earlier than 1.23 for two reasons:
- It uses the UPSTREAM_CLUSTER_RAW field in the JSON access log format, which older proxies do not recognize.
- The access log format for listeners is cached, which may result in a 1.23 configuration being sent to <1.23 sidecars (and potentially vice versa).

This issue could prevent new proxies with 1.22 from going in a ready state or prevent existing ones to receive LDS updates.
```
envoy config\tgRPC config for type.googleapis.com/envoy.config.listener.v3.Listener rejected: Error adding/updating listener(s) ::_8080: Not supported field in StreamInfo: UPSTREAM_CLUSTER_RAW
```
These changes extend the modifications made in [PR #52384]
(https://github.com/istio/istio/pull/52384) to support compatibility with older proxies.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [x] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
