### PR TITLE
Use the commmon label 'pod' instead of 'pod_name' as label in PodMonitor

### DIFF
--- a/samples/addons/extras/prometheus-operator.yaml
+++ b/samples/addons/extras/prometheus-operator.yaml
@@ -43,7 +43,7 @@ spec:
       targetLabel: namespace
     - sourceLabels: [__meta_kubernetes_pod_name]
       action: replace
-      targetLabel: pod_name
+      targetLabel: pod
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor


### PR DESCRIPTION
**Please provide a description of this PR:**

By default (https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/running-exporters.md#default-labels) the Prometheus Operator will apply common labels, such as the pod name and the namespace to targets from PodMonitors. Currently the example Podmonitor provided by Istio to collect the Envoy stats from all sidecars uses `pod_name` instead of `pod` which is used by kubelet, [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/metrics/workload/pod-metrics.md) and other exporters. This different label was likely not intentional, but since the Podmonitor contains relabeling, the defaults are not applied.

By aligning this label it becomes much easier to join metrics from various exporters (e.g. kube-state-metrics) without any error-prone, complex and expensive label_replacing users would have to do.