### PR TITLE
By default, exclude gateways from ambient mesh enrollment

### DIFF
--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -96,7 +96,9 @@ _internal_defaults_do_not_set:
   readinessProbe: {}
 
   # Labels to apply to all resources
-  labels: {}
+  labels:
+    # By default, don't enroll gateways into the ambient dataplane
+    "istio.io/dataplane-mode": none
 
   # Annotations to apply to all resources
   annotations: {}

--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -12,6 +12,10 @@ metadata:
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "EgressGateways"
     app.kubernetes.io/name: "istio-egressgateway"
+    # By default, don't enroll gateways into the ambient dataplane
+    # This is hardcoded and not a values override because these charts
+    # are deprecated versus the `gateway` chart and don't separate selectorLabels from labels.
+    istio.io/dataplane-mode: none
     {{- include "istio.labels" . | nindent 4 }}
 spec:
 {{- if not $gateway.autoscaleEnabled }}
@@ -42,6 +46,10 @@ spec:
         operator.istio.io/component: "EgressGateways"
         sidecar.istio.io/inject: "false"
         app.kubernetes.io/name: "istio-egressgateway"
+        # By default, don't enroll gateways into the ambient dataplane
+        # This is hardcoded and not a values override because these charts
+        # are deprecated versus the `gateway` chart and don't separate selectorLabels from labels.
+        istio.io/dataplane-mode: none
         {{- include "istio.labels" . | nindent 8 }}
       annotations:
         istio.io/rev: {{ .Values.revision | default "default" | quote }}

--- a/manifests/charts/gateways/istio-egress/values.yaml
+++ b/manifests/charts/gateways/istio-egress/values.yaml
@@ -16,11 +16,11 @@ _internal_defaults_do_not_set:
         targetPort: 8443
         protocol: TCP
 
+      # NOTE that these labels will get encoded implicitly into selectorLabels
+      # if this is a problem, consider using the `gateway` chart instead
       labels:
         app: istio-egressgateway
         istio: egressgateway
-        # By default, don't enroll gateways into the ambient dataplane
-        "istio.io/dataplane-mode": none
 
       # Scalability tuning
       # replicaCount: 1

--- a/manifests/charts/gateways/istio-egress/values.yaml
+++ b/manifests/charts/gateways/istio-egress/values.yaml
@@ -19,6 +19,8 @@ _internal_defaults_do_not_set:
       labels:
         app: istio-egressgateway
         istio: egressgateway
+        # By default, don't enroll gateways into the ambient dataplane
+        "istio.io/dataplane-mode": none
 
       # Scalability tuning
       # replicaCount: 1

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -12,6 +12,10 @@ metadata:
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "IngressGateways"
     app.kubernetes.io/name: "istio-ingressgateway"
+    # By default, don't enroll gateways into the ambient dataplane
+    # This is hardcoded and not a values override because these charts
+    # are deprecated versus the `gateway` chart and don't separate selectorLabels from labels.
+    istio.io/dataplane-mode: none
     {{- include "istio.labels" . | nindent 4 }}
 spec:
 {{- if not $gateway.autoscaleEnabled }}
@@ -42,6 +46,10 @@ spec:
         operator.istio.io/component: "IngressGateways"
         sidecar.istio.io/inject: "false"
         app.kubernetes.io/name: "istio-ingressgateway"
+        # By default, don't enroll gateways into the ambient dataplane
+        # This is hardcoded and not a values override because these charts
+        # are deprecated versus the `gateway` chart and don't separate selectorLabels from labels.
+        istio.io/dataplane-mode: none
         {{- include "istio.labels" . | nindent 8 }}
       annotations:
         istio.io/rev: {{ .Values.revision | default "default" | quote }}

--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -6,11 +6,11 @@ _internal_defaults_do_not_set:
   gateways:
     istio-ingressgateway:
       name: istio-ingressgateway
+      # NOTE that these labels will get encoded implicitly into selectorLabels
+      # if this is a problem, consider using the `gateway` chart instead
       labels:
         app: istio-ingressgateway
         istio: ingressgateway
-        # By default, don't enroll gateways into the ambient dataplane
-        "istio.io/dataplane-mode": none
       ports:
       ## You can add custom gateway ports in user values overrides, but it must include those ports since helm replaces.
       # Note that AWS ELB will by default perform health checks on the first port

--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -9,6 +9,8 @@ _internal_defaults_do_not_set:
       labels:
         app: istio-ingressgateway
         istio: ingressgateway
+        # By default, don't enroll gateways into the ambient dataplane
+        "istio.io/dataplane-mode": none
       ports:
       ## You can add custom gateway ports in user values overrides, but it must include those ports since helm replaces.
       # Note that AWS ELB will by default perform health checks on the first port

--- a/releasenotes/notes/54825.yaml
+++ b/releasenotes/notes/54825.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+- 54824
+releaseNotes:
+- |
+  **Added** ambient dataplane exclusion labels to Istio-shipped gateways by default, to avoid out-of-the-box confusing behavior if installing gateways outside of `istio-system`.


### PR DESCRIPTION
**Please provide a description of this PR:**

https://github.com/istio/istio/issues/54824

You can already do this today by installing gateways with this label override, and if you put your gateways in `istio-system` they won't be captured anyway, but we should default to explicit ignore of gateways by label. 