### PR TITLE
ambient: fix caching of HBONE access log filter

### DIFF
--- a/pilot/pkg/networking/core/accesslog.go
+++ b/pilot/pkg/networking/core/accesslog.go
@@ -378,5 +378,6 @@ func (b *AccessLogBuilder) reset() {
 	b.mutex.Lock()
 	b.fileAccesslog = nil
 	b.listenerFileAccessLog = nil
+	b.hboneFileAccessLog = nil
 	b.mutex.Unlock()
 }


### PR DESCRIPTION
Really niche bug. We log for only UF, but we don't clear the cache so we
don't get formatting changes if someone changes mesh config
