### PR TITLE
Initial implementation of L4 policies for waypoints

### DIFF
--- a/pilot/pkg/features/ambient.go
+++ b/pilot/pkg/features/ambient.go
@@ -65,7 +65,7 @@ var (
 
 	WaypointLayeredAuthorizationPolicies = env.Register(
 		"ENABLE_LAYERED_WAYPOINT_AUTHORIZATION_POLICIES",
-		true,
+		false,
 		"If enabled, selector based authorization policies will be enforced as L4 policies in front of the waypoint.").Get()
 )
 

--- a/pilot/pkg/features/ambient.go
+++ b/pilot/pkg/features/ambient.go
@@ -62,6 +62,11 @@ var (
 
 	EnableAmbientMultiNetwork = registerAmbient("AMBIENT_ENABLE_MULTI_NETWORK", false, false,
 		"If true, the multi-network functionality will be enabled.")
+
+	WaypointLayeredAuthorizationPolicies = env.Register(
+		"ENABLE_LAYERED_WAYPOINT_AUTHORIZATION_POLICIES",
+		true,
+		"If enabled, selector based authorization policies will be enforced as L4 policies in front of the waypoint.").Get()
 )
 
 // registerAmbient registers a variable that is allowed only if EnableAmbient is set

--- a/pilot/pkg/networking/plugin/authz/authorization.go
+++ b/pilot/pkg/networking/plugin/authz/authorization.go
@@ -55,7 +55,14 @@ func NewWaypointTerminationBuilder(actionType ActionType, push *model.PushContex
 	return newBuilder(actionType, push, proxy, false, nil, true)
 }
 
-func newBuilder(actionType ActionType, push *model.PushContext, proxy *model.Proxy, useFilterState bool, svc *model.Service, alwaysTreatAsNonWaypoint bool) *Builder {
+func newBuilder(
+	actionType ActionType,
+	push *model.PushContext,
+	proxy *model.Proxy,
+	useFilterState bool,
+	svc *model.Service,
+	alwaysTreatAsNonWaypoint bool,
+) *Builder {
 	tdBundle := trustdomain.NewBundle(push.Mesh.TrustDomain, push.Mesh.TrustDomainAliases)
 	option := builder.Option{
 		IsCustomBuilder: actionType == Custom,

--- a/pilot/pkg/networking/plugin/authz/authorization.go
+++ b/pilot/pkg/networking/plugin/authz/authorization.go
@@ -70,6 +70,9 @@ func newBuilder(
 	}
 	selectionOpts := model.PolicyMatcherForProxy(proxy).WithService(svc).WithRootNamespace(push.AuthzPolicies.RootNamespace)
 	if alwaysTreatAsNonWaypoint {
+		// The intention here is to apply authz rules to the waypoint, but using the standard workload selector policy semantics,
+		// rather than the per-service rules.
+		// This gives us two layers of authorization policy applied.
 		selectionOpts.IsWaypoint = false
 	}
 	policies := push.AuthzPolicies.ListAuthorizationPolicies(selectionOpts)

--- a/pilot/pkg/security/authz/builder/builder.go
+++ b/pilot/pkg/security/authz/builder/builder.go
@@ -101,7 +101,7 @@ func (b Builder) BuildTCP() []*listener.Filter {
 	return build(b, b.buildTCP, "TCP", true)
 }
 
-// BuildTCPRulesAsHTTPFilter returns the TCP filters built from the authorization policy.
+// BuildTCPRulesAsHTTPFilter returns the HTTP filters built from TCP authorization policy.
 func (b Builder) BuildTCPRulesAsHTTPFilter() []*hcm.HttpFilter {
 	return build(b, b.buildHTTP, "HTTP for TCP", true)
 }

--- a/pilot/pkg/security/authz/builder/builder.go
+++ b/pilot/pkg/security/authz/builder/builder.go
@@ -62,9 +62,6 @@ type Builder struct {
 	denyPolicies  []model.AuthorizationPolicy
 	allowPolicies []model.AuthorizationPolicy
 	auditPolicies []model.AuthorizationPolicy
-
-	// logger emits logs about policies
-	logger *AuthzLogger
 }
 
 // New returns a new builder for the given workload with the authorization policy.
@@ -109,32 +106,33 @@ func (b Builder) BuildTCPRulesAsHTTPFilter() []*hcm.HttpFilter {
 	return build(b, b.buildHTTP, "HTTP for TCP", true)
 }
 
-func build[T any](b Builder, build func(rule *builtRule) []T, logType string, forTCP bool) []T {
-	b.logger = &AuthzLogger{}
-	defer b.logger.Report()
+// build computes the rules and transforms them to the appropriate type (via translateFn)
+func build[T any](b Builder, translateFn func(rule *builtRule, logger *AuthzLogger) []T, logType string, forTCP bool) []T {
+	logger := &AuthzLogger{}
+	defer logger.Report()
 	if b.option.IsCustomBuilder {
-		if configs := b.build(b.customPolicies, rbacpb.RBAC_DENY, forTCP); configs != nil {
-			t := build(configs)
-			b.logger.AppendDebugf("built %d %s filters for CUSTOM action", len(t), logType)
+		if configs := b.build(b.customPolicies, rbacpb.RBAC_DENY, forTCP, logger); configs != nil {
+			t := translateFn(configs, logger)
+			logger.AppendDebugf("built %d %s filters for CUSTOM action", len(t), logType)
 			return t
 		}
 		return nil
 	}
 
 	var filters []T
-	if configs := b.build(b.auditPolicies, rbacpb.RBAC_LOG, forTCP); configs != nil {
-		t := build(configs)
-		b.logger.AppendDebugf("built %d %s filters for AUDIT action", len(t), logType)
+	if configs := b.build(b.auditPolicies, rbacpb.RBAC_LOG, forTCP, logger); configs != nil {
+		t := translateFn(configs, logger)
+		logger.AppendDebugf("built %d %s filters for AUDIT action", len(t), logType)
 		filters = append(filters, t...)
 	}
-	if configs := b.build(b.denyPolicies, rbacpb.RBAC_DENY, forTCP); configs != nil {
-		t := build(configs)
-		b.logger.AppendDebugf("built %d %s filters for DENY action", len(t), logType)
+	if configs := b.build(b.denyPolicies, rbacpb.RBAC_DENY, forTCP, logger); configs != nil {
+		t := translateFn(configs, logger)
+		logger.AppendDebugf("built %d %s filters for DENY action", len(t), logType)
 		filters = append(filters, t...)
 	}
-	if configs := b.build(b.allowPolicies, rbacpb.RBAC_ALLOW, forTCP); configs != nil {
-		t := build(configs)
-		b.logger.AppendDebugf("built %d %s filters for ALLOW action", len(t), logType)
+	if configs := b.build(b.allowPolicies, rbacpb.RBAC_ALLOW, forTCP, logger); configs != nil {
+		t := translateFn(configs, logger)
+		logger.AppendDebugf("built %d %s filters for ALLOW action", len(t), logType)
 		filters = append(filters, t...)
 	}
 	return filters
@@ -146,13 +144,13 @@ type builtRule struct {
 	providers   []string
 }
 
-func (b Builder) isDryRun(policy model.AuthorizationPolicy) bool {
+func isDryRun(policy model.AuthorizationPolicy, logger *AuthzLogger) bool {
 	dryRun := false
 	if val, ok := policy.Annotations[annotation.IoIstioDryRun.Name]; ok {
 		var err error
 		dryRun, err = strconv.ParseBool(val)
 		if err != nil {
-			b.logger.AppendError(fmt.Errorf("failed to parse the value of %s: %v", annotation.IoIstioDryRun.Name, err))
+			logger.AppendError(fmt.Errorf("failed to parse the value of %s: %v", annotation.IoIstioDryRun.Name, err))
 		}
 	}
 	return dryRun
@@ -169,7 +167,7 @@ func shadowRuleStatPrefix(rule *rbacpb.RBAC) string {
 	}
 }
 
-func (b Builder) build(policies []model.AuthorizationPolicy, action rbacpb.RBAC_Action, forTCP bool) *builtRule {
+func (b Builder) build(policies []model.AuthorizationPolicy, action rbacpb.RBAC_Action, forTCP bool, logger *AuthzLogger) *builtRule {
 	if len(policies) == 0 {
 		return nil
 	}
@@ -191,7 +189,7 @@ func (b Builder) build(policies []model.AuthorizationPolicy, action rbacpb.RBAC_
 	hasEnforcePolicy, hasDryRunPolicy := false, false
 	for _, policy := range policies {
 		var currentRule *rbacpb.RBAC
-		if b.isDryRun(policy) {
+		if isDryRun(policy, logger) {
 			currentRule = shadowRules
 			hasDryRunPolicy = true
 		} else {
@@ -205,32 +203,32 @@ func (b Builder) build(policies []model.AuthorizationPolicy, action rbacpb.RBAC_
 			// The name will later be used by ext_authz filter to get the evaluation result from dynamic metadata.
 			name := policyName(policy.Namespace, policy.Name, i, b.option)
 			if rule == nil {
-				b.logger.AppendError(fmt.Errorf("skipped nil rule %s", name))
+				logger.AppendError(fmt.Errorf("skipped nil rule %s", name))
 				continue
 			}
 			m, err := authzmodel.New(policy.NamespacedName(), rule)
 			if err != nil {
-				b.logger.AppendError(multierror.Prefix(err, fmt.Sprintf("skipped invalid rule %s:", name)))
+				logger.AppendError(multierror.Prefix(err, fmt.Sprintf("skipped invalid rule %s:", name)))
 				continue
 			}
 			m.MigrateTrustDomain(b.trustDomainBundle)
 			if len(b.trustDomainBundle.TrustDomains) > 1 {
-				b.logger.AppendDebugf("patched source principal with trust domain aliases %v", b.trustDomainBundle.TrustDomains)
+				logger.AppendDebugf("patched source principal with trust domain aliases %v", b.trustDomainBundle.TrustDomains)
 			}
 			generated, err := m.Generate(forTCP, !b.option.UseFilterState, action)
 			if err != nil {
-				b.logger.AppendDebugf("skipped rule %s on TCP filter chain: %v", name, err)
+				logger.AppendDebugf("skipped rule %s on TCP filter chain: %v", name, err)
 				continue
 			}
 			if generated != nil {
 				currentRule.Policies[name] = generated
-				b.logger.AppendDebugf("generated config from rule %s on %s filter chain successfully", name, filterType)
+				logger.AppendDebugf("generated config from rule %s on %s filter chain successfully", name, filterType)
 			}
 		}
 		if len(policy.Spec.Rules) == 0 {
 			// Generate an explicit policy that never matches.
 			name := policyName(policy.Namespace, policy.Name, 0, b.option)
-			b.logger.AppendDebugf("generated config from policy %s on %s filter chain successfully", name, filterType)
+			logger.AppendDebugf("generated config from policy %s on %s filter chain successfully", name, filterType)
 			currentRule.Policies[name] = rbacPolicyMatchNever
 		}
 	}
@@ -248,7 +246,7 @@ func (b Builder) build(policies []model.AuthorizationPolicy, action rbacpb.RBAC_
 	}
 }
 
-func (b Builder) buildHTTP(rule *builtRule) []*hcm.HttpFilter {
+func (b Builder) buildHTTP(rule *builtRule, logger *AuthzLogger) []*hcm.HttpFilter {
 	rules := rule.rules
 	shadowRules := rule.shadowRules
 	providers := rule.providers
@@ -268,7 +266,7 @@ func (b Builder) buildHTTP(rule *builtRule) []*hcm.HttpFilter {
 
 	extauthz, err := getExtAuthz(b.extensions, providers)
 	if err != nil {
-		b.logger.AppendError(multierror.Prefix(err, "failed to process CUSTOM action, will generate deny configs for the specified rules:"))
+		logger.AppendError(multierror.Prefix(err, "failed to process CUSTOM action, will generate deny configs for the specified rules:"))
 		rbac := &rbachttp.RBAC{Rules: getBadCustomDenyRules(rules)}
 		return []*hcm.HttpFilter{
 			{
@@ -298,7 +296,7 @@ func (b Builder) buildHTTP(rule *builtRule) []*hcm.HttpFilter {
 	}
 }
 
-func (b Builder) buildTCP(rule *builtRule) []*listener.Filter {
+func (b Builder) buildTCP(rule *builtRule, logger *AuthzLogger) []*listener.Filter {
 	rules := rule.rules
 	shadowRules := rule.shadowRules
 	providers := rule.providers
@@ -319,7 +317,7 @@ func (b Builder) buildTCP(rule *builtRule) []*listener.Filter {
 
 	extauthz, err := getExtAuthz(b.extensions, providers)
 	if err != nil {
-		b.logger.AppendError(multierror.Prefix(err, "failed to process CUSTOM action, will generate deny configs for the specified rules:"))
+		logger.AppendError(multierror.Prefix(err, "failed to process CUSTOM action, will generate deny configs for the specified rules:"))
 		rbac := &rbactcp.RBAC{
 			Rules:      getBadCustomDenyRules(rules),
 			StatPrefix: authzmodel.RBACTCPFilterStatPrefix,
@@ -331,7 +329,7 @@ func (b Builder) buildTCP(rule *builtRule) []*listener.Filter {
 			},
 		}
 	} else if extauthz.tcp == nil {
-		b.logger.AppendDebugf("ignored CUSTOM action with HTTP provider on TCP filter chain")
+		logger.AppendDebugf("ignored CUSTOM action with HTTP provider on TCP filter chain")
 		return nil
 	}
 


### PR DESCRIPTION
Waypoints are logically two parts merged into one component for operational reasons:
* An HBONE termination and encapsulation phase, for inbound/outbound traffic, equivalent to having Ztunnel in front of the waypoint
* The inner waypoint logic

However, we behave different from Ztunnel in one key way -- we don't apply any policies on the HBONE termination layer. This adds a feature flag (off by default while we evaluate it) to apply these policies like Ztunnel would.

See https://github.com/istio/istio/issues/54696 for some previous discussion

Fixes https://github.com/istio/istio/issues/54718