### PR TITLE
move Envoy go-control-plane DNS lint rules to local overrides

### DIFF
--- a/common/config/.golangci.yml
+++ b/common/config/.golangci.yml
@@ -316,10 +316,10 @@ issues:
     # This is not helpful. The new function is not very usable and the current function will not be removed
     - linters:
         - staticcheck
-      text: 'SA1019: grpc.Dial is deprecated: use NewClient instead'
+      text: "SA1019: grpc.Dial is deprecated: use NewClient instead"
     - linters:
         - staticcheck
-      text: 'SA1019: grpc.DialContext is deprecated: use NewClient instead'
+      text: "SA1019: grpc.DialContext is deprecated: use NewClient instead"
     - linters:
         - staticcheck
       text: "SA1019: grpc.WithBlock is deprecated"
@@ -329,15 +329,6 @@ issues:
     - linters:
         - staticcheck
       text: "SA1019: grpc.WithReturnConnectionError"
-    - linters:
-        - staticcheck
-      text: 'SA1019: c.DnsJitter is deprecated: Marked as deprecated in envoy/config/cluster/v3/cluster.proto.'
-    - linters:
-        - staticcheck
-      text: 'SA1019: c.DnsRefreshRate is deprecated: Marked as deprecated in envoy/config/cluster/v3/cluster.proto.'
-    - linters:
-        - staticcheck
-      text: 'SA1019: c.RespectDnsTtl is deprecated: Marked as deprecated in envoy/config/cluster/v3/cluster.proto.'
   # Independently from option `exclude` we use default exclude patterns,
   # it can be disabled by this option. To list all
   # excluded by default patterns execute `golangci-lint run --help`.

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -352,9 +352,9 @@ func (cb *ClusterBuilder) buildCluster(name string, discoveryType cluster.Cluste
 			}
 		}
 		// 0 disables jitter.
-		c.DnsJitter = durationpb.New(features.PilotDNSJitterDurationEnv)
-		c.DnsRefreshRate = cb.req.Push.Mesh.DnsRefreshRate
-		c.RespectDnsTtl = true
+		c.DnsJitter = durationpb.New(features.PilotDNSJitterDurationEnv) //nolint:staticcheck // DnsJitter is deprecated
+		c.DnsRefreshRate = cb.req.Push.Mesh.DnsRefreshRate               //nolint:staticcheck // DnsRefreshRate is deprecated
+		c.RespectDnsTtl = true                                           //nolint:staticcheck // RespectDnsTtl is deprecated
 		// we want to run all the STATIC parts as well to build the load assignment
 		fallthrough
 	case cluster.Cluster_STATIC:

--- a/pilot/pkg/networking/core/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/cluster_builder_test.go
@@ -1384,6 +1384,7 @@ func TestClusterDnsConfig(t *testing.T) {
 			if dnsConfig.UdpMaxQueries.Value != tt.udpMaxQueries {
 				t.Errorf("Unexpected UdpMaxQueries, expected : %v, got: %v", tt.udpMaxQueries, dnsConfig.UdpMaxQueries.Value)
 			}
+			//nolint:staticcheck // DnsJitter is deprecated
 			if c.DnsJitter.AsDuration() != tt.dnsJitter {
 				t.Errorf("Unexpected dnsJitter, expected : %v, got: %v", tt.dnsJitter, c.DnsJitter.AsDuration())
 			}

--- a/tools/golangci-override.yaml
+++ b/tools/golangci-override.yaml
@@ -40,12 +40,6 @@ linters-settings:
             desc: "do not use gopkg.in/yaml.v3; use sigs.k8s.io/yaml instead"
           - pkg: github.com/ghodss/yaml
             desc: "do not use github.com/ghodss/yaml; use sigs.k8s.io/yaml instead"
-          - pkg: github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3
-            desc: "DnsJitter is deprecated: Marked as deprecated in envoy/config/cluster/v3/cluster.proto"
-          - pkg: github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3
-            desc: "DnsRefreshRate is deprecated: Marked as deprecated in envoy/config/cluster/v3/cluster.proto"
-          - pkg: github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3
-            desc: "RespectDnsTtl is deprecated: Marked as deprecated in envoy/config/cluster/v3/cluster.proto"
       DenyOperatorAndIstioctl:
         files:
           # Tests can do anything

--- a/tools/golangci-override.yaml
+++ b/tools/golangci-override.yaml
@@ -40,6 +40,12 @@ linters-settings:
             desc: "do not use gopkg.in/yaml.v3; use sigs.k8s.io/yaml instead"
           - pkg: github.com/ghodss/yaml
             desc: "do not use github.com/ghodss/yaml; use sigs.k8s.io/yaml instead"
+          - pkg: github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3
+            desc: "DnsJitter is deprecated: Marked as deprecated in envoy/config/cluster/v3/cluster.proto"
+          - pkg: github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3
+            desc: "DnsRefreshRate is deprecated: Marked as deprecated in envoy/config/cluster/v3/cluster.proto"
+          - pkg: github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3
+            desc: "RespectDnsTtl is deprecated: Marked as deprecated in envoy/config/cluster/v3/cluster.proto"
       DenyOperatorAndIstioctl:
         files:
           # Tests can do anything


### PR DESCRIPTION
**Please provide a description of this PR:**
Remove lint rules from copied file which will be overwritten during common-files sync, add to overrides.

Refs https://github.com/istio/istio/pull/54803, https://github.com/istio/common-files/pull/1141

Couldn't get exclude rules as documented at https://golangci-lint.run/usage/false-positives/#exclude-or-skip working properly, so opting for granular nolint comments for now.