### PR TITLE
Drop clearly wrong goroutine spawn in test code

### DIFF
--- a/cni/pkg/nodeagent/informers_test.go
+++ b/cni/pkg/nodeagent/informers_test.go
@@ -1285,7 +1285,7 @@ func populateClientAndWaitForInformer(ctx context.Context, t *testing.T, client 
 
 	handlers := setupHandlers(ctx, client, server, "istio-system")
 	client.RunAndWait(ctx.Done())
-	go handlers.Start()
+	handlers.Start()
 
 	// Unfortunately mt asserts cannot assert on 0 events (which makes a certain amount of sense)
 	if expectAddEvents > 0 {


### PR DESCRIPTION
**Please provide a description of this PR:**

This is probably something that got missed in a past refactoring, but we don't need to double-`goroutine` in test code, and in fact it defeats the "wait for informer sync" stuff.

This is likely the cause of https://prow.istio.io/view/gs/istio-prow/logs/unit-tests-arm64_istio_postsubmit/1882560216436838400 and similar.