### PR TITLE
Do not record resource names for WDS

### DIFF
--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -390,6 +390,10 @@ func shouldRespondDelta(con *Connection, request *discovery.DeltaDiscoveryReques
 		}
 
 		res, wildcard, _ := deltaWatchedResources(nil, request)
+		skip := request.TypeUrl == v3.AddressType && wildcard
+		if skip {
+			res = nil
+		}
 		con.proxy.WatchedResources[request.TypeUrl] = &model.WatchedResource{
 			TypeUrl:       request.TypeUrl,
 			ResourceNames: res,

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -392,6 +392,8 @@ func shouldRespondDelta(con *Connection, request *discovery.DeltaDiscoveryReques
 		res, wildcard, _ := deltaWatchedResources(nil, request)
 		skip := request.TypeUrl == v3.AddressType && wildcard
 		if skip {
+			// Due to the high resource count in WDS at scale, we do not store ResourceName.
+			// See the workload generator for more information on why we don't use this.
 			res = nil
 		}
 		con.proxy.WatchedResources[request.TypeUrl] = &model.WatchedResource{

--- a/pilot/pkg/xds/workload.go
+++ b/pilot/pkg/xds/workload.go
@@ -56,8 +56,6 @@ func (e WorkloadGenerator) GenerateDeltas(
 		return e.generateDeltasOndemand(proxy, req, w)
 	}
 
-	subs := req.Delta.Subscribed
-
 	reqAddresses := addresses
 	if isReq {
 		reqAddresses = nil
@@ -74,8 +72,15 @@ func (e WorkloadGenerator) GenerateDeltas(
 	if isReq {
 		// If it's a full push, AddressInformation won't have info to compute the full set of removals.
 		// Instead, we need can see what resources are missing that we were subscribe to; those were removed.
-		removed = subs.Difference(have).Merge(removed)
+		// During a request, a client will send a subscription request with its current state, so our removals will be:
+		// ZtunnelCurrentResources - IstiodCurrentResources (+ empty `removed`).
+		removed = req.Delta.Subscribed.Difference(have).Merge(removed)
 	}
+
+	// Due to the high resource count in WDS at scale, we elide updating ResourceNames here.
+	// A name will be ~50-100 bytes. So 50k pods would be 5MB per XDS client (plus overheads around GC, sets, fragmentation, etc).
+	// Fortunately, we do not actually need this: the only time we need to know the state in Ztunnel is on reconnection which we handle from
+	// `req.Delta.Subscribed`.
 
 	return resources, removed.UnsortedList(), model.XdsLogDetails{}, true, nil
 }

--- a/pilot/pkg/xds/workload.go
+++ b/pilot/pkg/xds/workload.go
@@ -56,7 +56,7 @@ func (e WorkloadGenerator) GenerateDeltas(
 		return e.generateDeltasOndemand(proxy, req, w)
 	}
 
-	subs := w.ResourceNames
+	subs := req.Delta.Subscribed
 
 	reqAddresses := addresses
 	if isReq {
@@ -77,11 +77,6 @@ func (e WorkloadGenerator) GenerateDeltas(
 		removed = subs.Difference(have).Merge(removed)
 	}
 
-	proxy.Lock()
-	defer proxy.Unlock()
-	// For wildcard, we record all resources that have been pushed and not removed
-	// It was to correctly calculate removed resources during full push alongside with specific address removed.
-	w.ResourceNames = subs.Merge(have).DeleteAllSet(removed)
 	return resources, removed.UnsortedList(), model.XdsLogDetails{}, true, nil
 }
 


### PR DESCRIPTION
This is a further optimization on https://github.com/istio/istio/pull/54464, to avoid storing the resource name entirely in some scenarios where its not needed.

I've somehow lost my test results around this but at large scale this accounts for about 35% of Istiod memory usage, ~1GB in the test I had setup