### PR TITLE
fix(virtualservice): Ensure hostnames are not resolved as shortnames for Ingress, Gateway API converted VirtualServices

### DIFF
--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -114,8 +114,9 @@ func SelectVirtualServices(vsidx virtualServiceIndex, configNamespace string, ho
 }
 
 func resolveVirtualServiceShortnames(rule *networking.VirtualService, meta config.Meta) {
-	// Kubernetes Gateway API semantics support shortnames
-	if UseGatewaySemantics(config.Config{Meta: meta}) {
+	// If this VirtualService was generated (Ingress, Gateway API, etc.) rather than internal, don't resolve shortnames
+	cfg := config.Config{Meta: meta}
+	if UseIngressSemantics(cfg) || UseGatewaySemantics(cfg) {
 		return
 	}
 


### PR DESCRIPTION
**Please provide a description of this PR:**
Fixes Ingress to VirtualService conversion where VirtualService(s) with IngressSemantics were not being skipped in shortname resolver function, leading to all Ingress _short_ hostnames being converted to Kubernetes internal FQDNs. This VirtualService would then not match any Gateways on key `host` resulting in:
1. http routes to target an invalid external domain (the K8s FQDN instead)
2. https routes to target the blackhole catchall [case here](https://github.com/istio/istio/blob/3efe4036f25e00f9aa26b7c1b857f6344c127871/pilot/pkg/networking/core/gateway.go#L522-L530)

This _might_ be the cause of https://github.com/istio/istio/issues/42985 and https://github.com/istio/istio/issues/54757 due to mangling of route domain running those through the resolve shortnames function but I am not 100% sure.