### PR TITLE
fix missing analysis messages in multi-cluster scenario

### DIFF
--- a/istioctl/pkg/util/formatting/formatter.go
+++ b/istioctl/pkg/util/formatting/formatter.go
@@ -47,41 +47,8 @@ func init() {
 	}
 }
 
-// shouldPrintCluster set PrintCluster to true for messages
-// by checking if there are multiple clusters in the messages.
-//
-// Messages are sorted by cluster name, so we can simply check if
-// the cluster name of first message equal to the last one.
-func shouldPrintCluster(ms diag.Messages) diag.Messages {
-	firstCluster, lastCluster := "", ""
-	for _, m := range ms {
-		if m.Resource != nil && m.Resource.Origin.ClusterName() != "" {
-			firstCluster = m.Resource.Origin.ClusterName().String()
-			break
-		}
-	}
-
-	for i := len(ms) - 1; i >= 0; i-- {
-		m := ms[i]
-		if m.Resource != nil && m.Resource.Origin.ClusterName() != "" {
-			lastCluster = m.Resource.Origin.ClusterName().String()
-			break
-		}
-	}
-	if firstCluster != lastCluster {
-		for i := range ms {
-			m := &ms[i]
-			if m.Resource != nil && m.Resource.Origin.ClusterName() != "" {
-				m.PrintCluster = true
-			}
-		}
-	}
-	return ms
-}
-
 // Print output messages in the specified format with color options
 func Print(ms diag.Messages, format string, colorize bool) (string, error) {
-	ms = shouldPrintCluster(ms)
 	switch format {
 	case LogFormat:
 		return printLog(ms, colorize), nil

--- a/istioctl/pkg/util/formatting/formatter.go
+++ b/istioctl/pkg/util/formatting/formatter.go
@@ -47,8 +47,41 @@ func init() {
 	}
 }
 
+// shouldPrintCluster set PrintCluster to true for messages
+// by checking if there are multiple clusters in the messages.
+//
+// Messages are sorted by cluster name, so we can simply check if
+// the cluster name of first message equal to the last one.
+func shouldPrintCluster(ms diag.Messages) diag.Messages {
+	firstCluster, lastCluster := "", ""
+	for _, m := range ms {
+		if m.Resource != nil && m.Resource.Origin.ClusterName() != "" {
+			firstCluster = m.Resource.Origin.ClusterName().String()
+			break
+		}
+	}
+
+	for i := len(ms) - 1; i >= 0; i-- {
+		m := ms[i]
+		if m.Resource != nil && m.Resource.Origin.ClusterName() != "" {
+			lastCluster = m.Resource.Origin.ClusterName().String()
+			break
+		}
+	}
+	if firstCluster != lastCluster {
+		for i := range ms {
+			m := &ms[i]
+			if m.Resource != nil && m.Resource.Origin.ClusterName() != "" {
+				m.PrintCluster = true
+			}
+		}
+	}
+	return ms
+}
+
 // Print output messages in the specified format with color options
 func Print(ms diag.Messages, format string, colorize bool) (string, error) {
+	ms = shouldPrintCluster(ms)
 	switch format {
 	case LogFormat:
 		return printLog(ms, colorize), nil

--- a/istioctl/pkg/util/formatting/formatter_test.go
+++ b/istioctl/pkg/util/formatting/formatter_test.go
@@ -166,6 +166,8 @@ func TestFormatter_PintLogForMultiCluster(t *testing.T) {
 		diag.MockResourceMultiCluster("GrandCastle"),
 		"the castle is too old",
 	)
+	firstMsg.PrintCluster = true
+	secondMsg.PrintCluster = true
 
 	msgs := diag.Messages{firstMsg, secondMsg}
 	output, _ := Print(msgs, LogFormat, true)

--- a/istioctl/pkg/util/formatting/formatter_test.go
+++ b/istioctl/pkg/util/formatting/formatter_test.go
@@ -41,8 +41,8 @@ func TestFormatter_PrintLog(t *testing.T) {
 	output, _ := Print(msgs, LogFormat, false)
 
 	g.Expect(output).To(Equal(
-		"Error [B1] ([cluster-default] SoapBubble) Explosion accident: the bubble is too big\n" +
-			"Warning [C1] ([cluster-default] GrandCastle) Collapse danger: the castle is too old",
+		"Error [B1] (SoapBubble) Explosion accident: the bubble is too big\n" +
+			"Warning [C1] (GrandCastle) Collapse danger: the castle is too old",
 	))
 }
 
@@ -64,8 +64,8 @@ func TestFormatter_PrintLogWithColor(t *testing.T) {
 	output, _ := Print(msgs, LogFormat, true)
 
 	g.Expect(output).To(Equal(
-		"\033[1;31mError\033[0m [B1] ([cluster-default] SoapBubble) Explosion accident: the bubble is too big\n" +
-			"\033[33mWarning\033[0m [C1] ([cluster-default] GrandCastle) Collapse danger: the castle is too old",
+		"\033[1;31mError\033[0m [B1] (SoapBubble) Explosion accident: the bubble is too big\n" +
+			"\033[33mWarning\033[0m [C1] (GrandCastle) Collapse danger: the castle is too old",
 	))
 }
 
@@ -151,4 +151,27 @@ func TestFormatter_PrintEmpty(t *testing.T) {
 
 	yamlOutput, _ := Print(msgs, YAMLFormat, false)
 	g.Expect(yamlOutput).To(Equal("[]\n"))
+}
+
+func TestFormatter_PintLogForMultiCluster(t *testing.T) {
+	g := NewWithT(t)
+
+	firstMsg := diag.NewMessage(
+		diag.NewMessageType(diag.Error, "B1", "Explosion accident: %v"),
+		diag.MockResource("SoapBubble"),
+		"the bubble is too big",
+	)
+	secondMsg := diag.NewMessage(
+		diag.NewMessageType(diag.Warning, "C1", "Collapse danger: %v"),
+		diag.MockResourceMultiCluster("GrandCastle"),
+		"the castle is too old",
+	)
+
+	msgs := diag.Messages{firstMsg, secondMsg}
+	output, _ := Print(msgs, LogFormat, true)
+
+	g.Expect(output).To(Equal(
+		"\033[1;31mError\033[0m [B1] [cluster-default] (SoapBubble) Explosion accident: the bubble is too big\n" +
+			"\033[33mWarning\033[0m [C1] [cluster-another] (GrandCastle) Collapse danger: the castle is too old",
+	))
 }

--- a/istioctl/pkg/util/formatting/formatter_test.go
+++ b/istioctl/pkg/util/formatting/formatter_test.go
@@ -41,8 +41,8 @@ func TestFormatter_PrintLog(t *testing.T) {
 	output, _ := Print(msgs, LogFormat, false)
 
 	g.Expect(output).To(Equal(
-		"Error [B1] (SoapBubble) Explosion accident: the bubble is too big\n" +
-			"Warning [C1] (GrandCastle) Collapse danger: the castle is too old",
+		"Error [B1] ([cluster-default] SoapBubble) Explosion accident: the bubble is too big\n" +
+			"Warning [C1] ([cluster-default] GrandCastle) Collapse danger: the castle is too old",
 	))
 }
 
@@ -64,8 +64,8 @@ func TestFormatter_PrintLogWithColor(t *testing.T) {
 	output, _ := Print(msgs, LogFormat, true)
 
 	g.Expect(output).To(Equal(
-		"\033[1;31mError\033[0m [B1] (SoapBubble) Explosion accident: the bubble is too big\n" +
-			"\033[33mWarning\033[0m [C1] (GrandCastle) Collapse danger: the castle is too old",
+		"\033[1;31mError\033[0m [B1] ([cluster-default] SoapBubble) Explosion accident: the bubble is too big\n" +
+			"\033[33mWarning\033[0m [C1] ([cluster-default] GrandCastle) Collapse danger: the castle is too old",
 	))
 }
 

--- a/pkg/config/analysis/diag/helper.go
+++ b/pkg/config/analysis/diag/helper.go
@@ -71,3 +71,12 @@ func MockResource(name string) *resource.Instance {
 		Origin: testOrigin{name: name, cluster: "default"},
 	}
 }
+
+func MockResourceMultiCluster(name string) *resource.Instance {
+	return &resource.Instance{
+		Metadata: resource.Metadata{
+			FullName: resource.NewShortOrFullName("default", name),
+		},
+		Origin: testOrigin{name: name, cluster: "another"},
+	}
+}

--- a/pkg/config/analysis/diag/helper.go
+++ b/pkg/config/analysis/diag/helper.go
@@ -68,6 +68,6 @@ func MockResource(name string) *resource.Instance {
 		Metadata: resource.Metadata{
 			FullName: resource.NewShortOrFullName("default", name),
 		},
-		Origin: testOrigin{name: name},
+		Origin: testOrigin{name: name, cluster: "default"},
 	}
 }

--- a/pkg/config/analysis/diag/message.go
+++ b/pkg/config/analysis/diag/message.go
@@ -135,7 +135,7 @@ func (m *Message) Origin() string {
 				loc = m.ReplaceLine(loc)
 			}
 		}
-		origin = fmt.Sprintf(" ([cluster-%s] %s%s) ",
+		origin = fmt.Sprintf(" ([cluster-%s] %s%s)",
 			m.Resource.Origin.ClusterName().String(), m.Resource.Origin.FriendlyName(), loc)
 	}
 	return origin

--- a/pkg/config/analysis/diag/message.go
+++ b/pkg/config/analysis/diag/message.go
@@ -135,7 +135,8 @@ func (m *Message) Origin() string {
 				loc = m.ReplaceLine(loc)
 			}
 		}
-		origin = " (" + m.Resource.Origin.FriendlyName() + loc + ")"
+		origin = fmt.Sprintf(" ([cluster-%s] %s%s) ",
+			m.Resource.Origin.ClusterName().String(), m.Resource.Origin.FriendlyName(), loc)
 	}
 	return origin
 }

--- a/pkg/config/analysis/diag/message.go
+++ b/pkg/config/analysis/diag/message.go
@@ -63,6 +63,9 @@ type Message struct {
 
 	// Line is the line number of the error place in the message
 	Line int
+
+	// PintCluster indicates whether to add cluster info when printing the message
+	PrintCluster bool
 }
 
 // Unstructured returns this message as a JSON-style unstructured map
@@ -135,8 +138,10 @@ func (m *Message) Origin() string {
 				loc = m.ReplaceLine(loc)
 			}
 		}
-		origin = fmt.Sprintf(" ([cluster-%s] %s%s)",
-			m.Resource.Origin.ClusterName().String(), m.Resource.Origin.FriendlyName(), loc)
+		origin = " (" + m.Resource.Origin.FriendlyName() + loc + ")"
+		if m.PrintCluster {
+			origin = fmt.Sprintf(" [cluster-%s]", m.Resource.Origin.ClusterName()) + origin
+		}
 	}
 	return origin
 }

--- a/pkg/config/analysis/diag/message_test.go
+++ b/pkg/config/analysis/diag/message_test.go
@@ -36,9 +36,9 @@ func TestMessage_String(t *testing.T) {
 func TestMessageWithResource_String(t *testing.T) {
 	g := NewWithT(t)
 	mt := NewMessageType(Error, "IST-0042", "Cheese type not found: %q")
-	m := NewMessage(mt, &resource.Instance{Origin: testOrigin{name: "toppings/cheese", ref: testReference{"path/to/file"}}}, "Feta")
+	m := NewMessage(mt, &resource.Instance{Origin: testOrigin{name: "toppings/cheese", ref: testReference{"path/to/file"}, cluster: "default"}}, "Feta")
 
-	g.Expect(m.String()).To(Equal(`Error [IST-0042] (toppings/cheese path/to/file) Cheese type not found: "Feta"`))
+	g.Expect(m.String()).To(Equal(`Error [IST-0042] ([cluster-default] toppings/cheese path/to/file) Cheese type not found: "Feta"`))
 }
 
 func TestMessage_Unstructured(t *testing.T) {

--- a/pkg/config/analysis/diag/message_test.go
+++ b/pkg/config/analysis/diag/message_test.go
@@ -38,7 +38,15 @@ func TestMessageWithResource_String(t *testing.T) {
 	mt := NewMessageType(Error, "IST-0042", "Cheese type not found: %q")
 	m := NewMessage(mt, &resource.Instance{Origin: testOrigin{name: "toppings/cheese", ref: testReference{"path/to/file"}, cluster: "default"}}, "Feta")
 
-	g.Expect(m.String()).To(Equal(`Error [IST-0042] ([cluster-default] toppings/cheese path/to/file) Cheese type not found: "Feta"`))
+	g.Expect(m.String()).To(Equal(`Error [IST-0042] (toppings/cheese path/to/file) Cheese type not found: "Feta"`))
+}
+
+func TestMessageWithPrintCluster_String(t *testing.T) {
+	g := NewWithT(t)
+	mt := NewMessageType(Error, "IST-0042", "Cheese type not found: %q")
+	m := NewMessage(mt, &resource.Instance{Origin: testOrigin{name: "toppings/cheese", ref: testReference{"path/to/file"}, cluster: "default"}}, "Feta")
+	m.PrintCluster = true
+	g.Expect(m.String()).To(Equal(`Error [IST-0042] [cluster-default] (toppings/cheese path/to/file) Cheese type not found: "Feta"`))
 }
 
 func TestMessage_Unstructured(t *testing.T) {

--- a/pkg/config/analysis/diag/messages.go
+++ b/pkg/config/analysis/diag/messages.go
@@ -26,11 +26,14 @@ func (ms *Messages) Add(m ...Message) {
 	*ms = append(*ms, m...)
 }
 
-// Sort the message lexicographically by level, code, resource origin name, then string.
+// Sort the message lexicographically by cluster name, level, code, resource origin name, then string.
 func (ms *Messages) Sort() {
 	sort.Slice(*ms, func(i, j int) bool {
 		a, b := (*ms)[i], (*ms)[j]
 		switch {
+		case a.Resource != nil && b.Resource != nil &&
+			a.Resource.Origin.ClusterName().String() != b.Resource.Origin.ClusterName().String():
+			return a.Resource.Origin.ClusterName().String() < b.Resource.Origin.ClusterName().String()
 		case a.Type.Level() != b.Type.Level():
 			return a.Type.Level().sortOrder < b.Type.Level().sortOrder
 		case a.Type.Code() != b.Type.Code():


### PR DESCRIPTION
**Please provide a description of this PR:**
In multi-cluster scenario, when running `istioctl analyze`, if resources in different clusters have the same name, the analyze result messages will be filtered.

For example, if two services both named as `reviews-service` and have same issue, only one message will be printed since their messages are completely the same.

```go
func (ms *Messages) SortedDedupedCopy() Messages {
	newMs := append((*ms)[:0:0], *ms...)
	newMs.Sort()

	// Take advantage of the fact that the list is already sorted to dedupe
	// messages (any duplicates should be adjacent).
	var deduped Messages
	for _, m := range newMs {
		// Two messages are duplicates if they have the same string representation.
		if len(deduped) != 0 && deduped[len(deduped)-1].String() == m.String() {
			continue
		}
		deduped = append(deduped, m)
	}
	return deduped
}
```
(duplicated messages are filtered in here)

So to make this works in multi-cluster scenario, I added a tag to indicate which cluster the message is from like the example below.
```shell
[IST0135] ([cluster-clustername] Pod kube-system/istio-cni-node-z764q)  ...
```