### PR TITLE
Fix TestTlsGatewaysWithQUIC security test on Openshift

### DIFF
--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -80,6 +80,12 @@ const (
 	imagePullPolicyValuesKey = "global.imagePullPolicy"
 
 	// DefaultEgressGatewayLabel is the default Istio label for the egress gateway.
+	DefaultIngressGatewayIstioLabel = "ingressgateway"
+
+	// DefaultEgressGatewayServiceName is the default service name for the egress gateway.
+	DefaultIngressGatewayServiceName = "istio-ingressgateway"
+
+	// DefaultEgressGatewayLabel is the default Istio label for the egress gateway.
 	DefaultEgressGatewayIstioLabel = "egressgateway"
 
 	// DefaultEgressGatewayServiceName is the default service name for the egress gateway.
@@ -91,20 +97,23 @@ var (
 	operatorOptions string
 
 	settingsFromCommandline = &Config{
-		SystemNamespace:               DefaultSystemNamespace,
-		TelemetryNamespace:            DefaultSystemNamespace,
-		DeployIstio:                   true,
-		PrimaryClusterIOPFile:         IntegrationTestDefaultsIOP,
-		ConfigClusterIOPFile:          IntegrationTestDefaultsIOP,
-		RemoteClusterIOPFile:          IntegrationTestRemoteDefaultsIOP,
-		BaseIOPFile:                   BaseIOP,
-		DeployEastWestGW:              true,
-		DumpKubernetesManifests:       false,
-		IstiodlessRemotes:             true,
-		EnableCNI:                     false,
-		EgressGatewayServiceNamespace: DefaultSystemNamespace,
-		EgressGatewayServiceName:      DefaultEgressGatewayServiceName,
-		EgressGatewayIstioLabel:       DefaultEgressGatewayIstioLabel,
+		SystemNamespace:                DefaultSystemNamespace,
+		TelemetryNamespace:             DefaultSystemNamespace,
+		DeployIstio:                    true,
+		PrimaryClusterIOPFile:          IntegrationTestDefaultsIOP,
+		ConfigClusterIOPFile:           IntegrationTestDefaultsIOP,
+		RemoteClusterIOPFile:           IntegrationTestRemoteDefaultsIOP,
+		BaseIOPFile:                    BaseIOP,
+		DeployEastWestGW:               true,
+		DumpKubernetesManifests:        false,
+		IstiodlessRemotes:              true,
+		EnableCNI:                      false,
+		IngressGatewayServiceNamespace: DefaultSystemNamespace,
+		IngressGatewayServiceName:      DefaultIngressGatewayServiceName,
+		IngressGatewayIstioLabel:       DefaultIngressGatewayIstioLabel,
+		EgressGatewayServiceNamespace:  DefaultSystemNamespace,
+		EgressGatewayServiceName:       DefaultEgressGatewayServiceName,
+		EgressGatewayIstioLabel:        DefaultEgressGatewayIstioLabel,
 	}
 )
 

--- a/tests/integration/iop-integration-test-defaults-with-quic.yaml
+++ b/tests/integration/iop-integration-test-defaults-with-quic.yaml
@@ -21,10 +21,27 @@ spec:
           - port: 443
             targetPort: 8443
             name: https
+    - name: istio-ingressgateway-quic
+      enabled: true
+      k8s:
+        service:
+          ports:
           - port: 443
             targetPort: 8443
             name: http3
             protocol: UDP
+        serviceAnnotations:
+          # This annotation is required for aws platform clusters.
+          # Otherwise, the service will stuck in the "pending" state.
+          # The annotation creates the load balancer and "Network LB"
+          # instead of the default "Application LB".
+          service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+        overlays:
+        - kind: Service
+          name: istio-ingressgateway-quic
+          patches:
+          - path: metadata.labels.istio-quic-svc
+            value: "true"
   values:
     pilot:
       env:

--- a/tests/integration/security/sds_ingress/util/util.go
+++ b/tests/integration/security/sds_ingress/util/util.go
@@ -28,6 +28,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/pkg/config/protocol"
@@ -608,7 +609,8 @@ func RunTestMultiQUICGateways(t framework.TestContext, inst istio.Instance, call
 					CreateIngressKubeSecret(t, cn, TLS, IngressCredentialA, false)
 				}
 
-				ing := inst.IngressFor(fromCluster)
+				serviceName := types.NamespacedName{Name: inst.Settings().IngressGatewayServiceName + "-quic", Namespace: inst.Settings().SystemNamespace}
+				ing := inst.CustomIngressFor(fromCluster, serviceName, inst.Settings().IngressGatewayServiceName+"-quic")
 				if ing == nil {
 					t.Skip()
 				}


### PR DESCRIPTION
**Please provide a description of this PR:**

During execution of the TestTlsGatewaysWithQUIC security test, as part of the tear up setup, an "istio-ingressgateway" service being created with both TCP and UDP (for QUIC) running on the same 443 port.

While in Kind based environment is works, in Openshift cluster running on AWS platform, creation of the service stuck in the "pending" state with the following error:

"Error syncing load balancer: failed to ensure load balancer: mixed protocol is not supported for LoadBalancer"

In order to solve the error in creation of the "istio-ingressgateway" service, need to perform two steps:

* Separate protocols from being mixed by moving the QUIC UDP 443 to a separate service - "istio-ingressgateway-quic"
* Add annotation to the "istio-ingressgateway-quic" service to create the aws load balanced from type "nlb" - Network LB.

By default, aws platform creates the load balancer from type "Application LB", which fails creation of the service.