### PR TITLE
match vhost on domain in envoyfilter

### DIFF
--- a/pilot/pkg/networking/core/envoyfilter/rc_patch.go
+++ b/pilot/pkg/networking/core/envoyfilter/rc_patch.go
@@ -340,14 +340,21 @@ func virtualHostMatch(vh *route.VirtualHost, rp *model.EnvoyFilterConfigPatchWra
 		// we do not have a virtual host to match.
 		return false
 	}
+
+	if match.DomainName == "" {
+		// check if virtual host names match
+		return match.Name == "" || match.Name == vh.Name
+	}
+	
 	// check if a domain of the virtual host matches
 	for _, domain := range vh.Domains {
 		if match.DomainName == domain {
-			return true
+			// check if virtual host names match
+			return match.Name == "" || match.Name == vh.Name
 		}
 	}
-	// check if virtual host names match
-	return match.Name == "" || match.Name == vh.Name
+
+	return false
 }
 
 func routeMatch(httpRoute *route.Route, rp *model.EnvoyFilterConfigPatchWrapper) bool {

--- a/pilot/pkg/networking/core/envoyfilter/rc_patch.go
+++ b/pilot/pkg/networking/core/envoyfilter/rc_patch.go
@@ -341,20 +341,9 @@ func virtualHostMatch(vh *route.VirtualHost, rp *model.EnvoyFilterConfigPatchWra
 		return false
 	}
 
-	if match.DomainName == "" {
-		// check if virtual host names match
-		return match.Name == "" || match.Name == vh.Name
-	}
-
-	// check if a domain of the virtual host matches
-	for _, domain := range vh.Domains {
-		if match.DomainName == domain {
-			// check if virtual host names match
-			return match.Name == "" || match.Name == vh.Name
-		}
-	}
-
-	return false
+	// check if virtual host name and a domain name matches
+	return (match.Name == "" || match.Name == vh.Name) &&
+		(match.DomainName == "" || slices.Contains(vh.Domains, match.DomainName))
 }
 
 func routeMatch(httpRoute *route.Route, rp *model.EnvoyFilterConfigPatchWrapper) bool {

--- a/pilot/pkg/networking/core/envoyfilter/rc_patch.go
+++ b/pilot/pkg/networking/core/envoyfilter/rc_patch.go
@@ -345,7 +345,7 @@ func virtualHostMatch(vh *route.VirtualHost, rp *model.EnvoyFilterConfigPatchWra
 		// check if virtual host names match
 		return match.Name == "" || match.Name == vh.Name
 	}
-	
+
 	// check if a domain of the virtual host matches
 	for _, domain := range vh.Domains {
 		if match.DomainName == domain {

--- a/pilot/pkg/networking/core/envoyfilter/rc_patch.go
+++ b/pilot/pkg/networking/core/envoyfilter/rc_patch.go
@@ -340,6 +340,12 @@ func virtualHostMatch(vh *route.VirtualHost, rp *model.EnvoyFilterConfigPatchWra
 		// we do not have a virtual host to match.
 		return false
 	}
+	// check if a domain of the virtual host matches
+	for _, domain := range vh.Domains {
+		if match.DomainName == domain {
+			return true
+		}
+	}
 	// check if virtual host names match
 	return match.Name == "" || match.Name == vh.Name
 }

--- a/pilot/pkg/networking/core/envoyfilter/rc_patch_test.go
+++ b/pilot/pkg/networking/core/envoyfilter/rc_patch_test.go
@@ -133,7 +133,7 @@ func Test_virtualHostMatch(t *testing.T) {
 							RouteConfiguration: &networking.EnvoyFilter_RouteConfigurationMatch{
 								Vhost: &networking.EnvoyFilter_RouteConfigurationMatch_VirtualHostMatch{
 									DomainName: "*.scooby",
-									Name: "scoobydoo",
+									Name:       "scoobydoo",
 								},
 							},
 						},
@@ -181,7 +181,7 @@ func Test_virtualHostMatch(t *testing.T) {
 							RouteConfiguration: &networking.EnvoyFilter_RouteConfigurationMatch{
 								Vhost: &networking.EnvoyFilter_RouteConfigurationMatch_VirtualHostMatch{
 									DomainName: "*.scooby",
-									Name: "scooby",
+									Name:       "scooby",
 								},
 							},
 						},
@@ -206,7 +206,7 @@ func Test_virtualHostMatch(t *testing.T) {
 							RouteConfiguration: &networking.EnvoyFilter_RouteConfigurationMatch{
 								Vhost: &networking.EnvoyFilter_RouteConfigurationMatch_VirtualHostMatch{
 									DomainName: "*.in",
-									Name: "scoobydoo",
+									Name:       "scoobydoo",
 								},
 							},
 						},

--- a/pilot/pkg/networking/core/envoyfilter/rc_patch_test.go
+++ b/pilot/pkg/networking/core/envoyfilter/rc_patch_test.go
@@ -94,6 +94,127 @@ func Test_virtualHostMatch(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "domain name match",
+			args: args{
+				vh: &route.VirtualHost{
+					Domains: []string{
+						"*.scooby",
+						"*.com",
+					},
+				},
+				cp: &model.EnvoyFilterConfigPatchWrapper{
+					Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
+						ObjectTypes: &networking.EnvoyFilter_EnvoyConfigObjectMatch_RouteConfiguration{
+							RouteConfiguration: &networking.EnvoyFilter_RouteConfigurationMatch{
+								Vhost: &networking.EnvoyFilter_RouteConfigurationMatch_VirtualHostMatch{
+									DomainName: "*.scooby",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "vhost name match and domain name match",
+			args: args{
+				vh: &route.VirtualHost{
+					Domains: []string{
+						"*.scooby",
+						"*.com",
+					},
+					Name: "scoobydoo",
+				},
+				cp: &model.EnvoyFilterConfigPatchWrapper{
+					Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
+						ObjectTypes: &networking.EnvoyFilter_EnvoyConfigObjectMatch_RouteConfiguration{
+							RouteConfiguration: &networking.EnvoyFilter_RouteConfigurationMatch{
+								Vhost: &networking.EnvoyFilter_RouteConfigurationMatch_VirtualHostMatch{
+									DomainName: "*.scooby",
+									Name: "scoobydoo",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "domain name mismatch",
+			args: args{
+				vh: &route.VirtualHost{
+					Domains: []string{
+						"*.scooby",
+						"*.com",
+					},
+				},
+				cp: &model.EnvoyFilterConfigPatchWrapper{
+					Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
+						ObjectTypes: &networking.EnvoyFilter_EnvoyConfigObjectMatch_RouteConfiguration{
+							RouteConfiguration: &networking.EnvoyFilter_RouteConfigurationMatch{
+								Vhost: &networking.EnvoyFilter_RouteConfigurationMatch_VirtualHostMatch{
+									DomainName: "*.in",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "vhost name mismatch and domain name match",
+			args: args{
+				vh: &route.VirtualHost{
+					Domains: []string{
+						"*.scooby",
+						"*.com",
+					},
+					Name: "scoobydoo",
+				},
+				cp: &model.EnvoyFilterConfigPatchWrapper{
+					Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
+						ObjectTypes: &networking.EnvoyFilter_EnvoyConfigObjectMatch_RouteConfiguration{
+							RouteConfiguration: &networking.EnvoyFilter_RouteConfigurationMatch{
+								Vhost: &networking.EnvoyFilter_RouteConfigurationMatch_VirtualHostMatch{
+									DomainName: "*.scooby",
+									Name: "scooby",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "vhost name match but domain name mismatch",
+			args: args{
+				vh: &route.VirtualHost{
+					Domains: []string{
+						"*.scooby",
+						"*.com",
+					},
+					Name: "scoobydoo",
+				},
+				cp: &model.EnvoyFilterConfigPatchWrapper{
+					Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
+						ObjectTypes: &networking.EnvoyFilter_EnvoyConfigObjectMatch_RouteConfiguration{
+							RouteConfiguration: &networking.EnvoyFilter_RouteConfigurationMatch{
+								Vhost: &networking.EnvoyFilter_RouteConfigurationMatch_VirtualHostMatch{
+									DomainName: "*.in",
+									Name: "scoobydoo",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pilot/pkg/networking/core/envoyfilter/rc_patch_test.go
+++ b/pilot/pkg/networking/core/envoyfilter/rc_patch_test.go
@@ -102,6 +102,7 @@ func Test_virtualHostMatch(t *testing.T) {
 						"*.scooby",
 						"*.com",
 					},
+					Name: "scoobydoo",
 				},
 				cp: &model.EnvoyFilterConfigPatchWrapper{
 					Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
@@ -150,6 +151,7 @@ func Test_virtualHostMatch(t *testing.T) {
 						"*.scooby",
 						"*.com",
 					},
+					Name: "scoobydoo",
 				},
 				cp: &model.EnvoyFilterConfigPatchWrapper{
 					Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{

--- a/releasenotes/notes/54892.yaml
+++ b/releasenotes/notes/54892.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: feature
-area: istioctl
+area: networking
 
 releaseNotes:
 - |

--- a/releasenotes/notes/54892.yaml
+++ b/releasenotes/notes/54892.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: feature
-area: extensibility
+area: traffic-management
 
 releaseNotes:
 - |

--- a/releasenotes/notes/54892.yaml
+++ b/releasenotes/notes/54892.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: feature
-area: networking
+area: extensibility
 
 releaseNotes:
 - |

--- a/releasenotes/notes/54892.yaml
+++ b/releasenotes/notes/54892.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+
+releaseNotes:
+- |
+  **Added** support for envoyfilter to match a virtualhost on domain name as well.


### PR DESCRIPTION
allow envoyfilter to match a virtualhost on domain name as well
https://github.com/istio/api/pull/3376

it is backward compatible and handles all cases:
1. name match
2. name and domain match
3. domain match