### PR TITLE
Improvements to PILOT_FILTER_GATEWAY_CLUSTER_CONFIG

### DIFF
--- a/pilot/pkg/networking/core/cluster.go
+++ b/pilot/pkg/networking/core/cluster.go
@@ -240,8 +240,9 @@ func (configgen *ConfigGeneratorImpl) buildClusters(proxy *model.Proxy, req *mod
 		_, wps := findWaypointResources(proxy, req.Push)
 		// Waypoint proxies do not need outbound clusters in most cases, unless we have a route pointing to something
 		outboundPatcher := clusterPatcher{efw: envoyFilterPatches, pctx: networking.EnvoyFilter_SIDECAR_OUTBOUND}
+		extraNamespacedHosts, extraHosts := req.Push.ExtraWaypointServices(proxy)
 		ob, cs := configgen.buildOutboundClusters(cb, proxy, outboundPatcher, filterWaypointOutboundServices(
-			req.Push.ServicesAttachedToMesh(), wps.services, req.Push.ExtraWaypointServices(proxy), services))
+			req.Push.ServicesAttachedToMesh(), wps.services, extraNamespacedHosts, extraHosts, services))
 		cacheStats = cacheStats.merge(cs)
 		resources = append(resources, ob...)
 		// Setup inbound clusters

--- a/pilot/pkg/networking/core/waypoint.go
+++ b/pilot/pkg/networking/core/waypoint.go
@@ -81,7 +81,8 @@ func findWaypointResources(node *model.Proxy, push *model.PushContext) ([]model.
 func filterWaypointOutboundServices(
 	referencedServices map[string]sets.String,
 	waypointServices map[host.Name]*model.Service,
-	extraServices sets.String,
+	extraNamespacedHostnames sets.Set[model.NamespacedHostname],
+	extraHostnames sets.String,
 	services []*model.Service,
 ) []*model.Service {
 	outboundServices := sets.New[string]()
@@ -97,7 +98,12 @@ func filterWaypointOutboundServices(
 	}
 	res := make([]*model.Service, 0, len(outboundServices))
 	for _, s := range services {
-		if outboundServices.Contains(s.Hostname.String()) || extraServices.Contains(s.Hostname.String()) {
+		if outboundServices.Contains(s.Hostname.String()) ||
+			extraHostnames.Contains(s.Hostname.String()) ||
+			extraNamespacedHostnames.Contains(model.NamespacedHostname{
+				Hostname:  s.Hostname,
+				Namespace: s.Attributes.Namespace,
+			}) {
 			res = append(res, s)
 		}
 	}

--- a/pilot/pkg/xds/proxy_dependencies.go
+++ b/pilot/pkg/xds/proxy_dependencies.go
@@ -68,7 +68,7 @@ func proxyDependentOnConfig(proxy *model.Proxy, config model.ConfigKey, push *mo
 	case model.Router:
 		if config.Kind == kind.ServiceEntry {
 			// If config is ServiceEntry, name of the config is service's FQDN
-			if features.FilterGatewayClusterConfig && !push.ServiceAttachedToGateway(config.Name, proxy) {
+			if features.FilterGatewayClusterConfig && !push.ServiceAttachedToGateway(config.Name, config.Namespace, proxy) {
 				return false
 			}
 


### PR DESCRIPTION
Two improvements:
* Add an explicit annotation to services to include them. This allows
  reference from unknown usage like EnvoyFilter
* Bug fix: PILOT_FILTER_GATEWAY_CLUSTER_CONFIG needs to respect the
  `namespace/hostname` format of extension providers
