### PR TITLE
remove wrong example for waypoint delete

### DIFF
--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -313,10 +313,7 @@ func Cmd(ctx cli.Context) *cobra.Command {
 		Use:   "delete",
 		Short: "Delete a waypoint configuration",
 		Long:  "Delete a waypoint configuration from the cluster",
-		Example: `  # Delete a waypoint from the default namespace
-  istioctl waypoint delete
-
-  # Delete a waypoint by name, which can obtain from istioctl waypoint list
+		Example: `# Delete a waypoint by name, which can obtain from istioctl waypoint list
   istioctl waypoint delete waypoint-name --namespace default
 
   # Delete several waypoints by name


### PR DESCRIPTION
**Please provide a description of this PR:**

The current code logic requires that waypoints must be specified, so this part of the example cannot be executed:

```
if !(deleteAll || revision != "") && len(args) == 0 {
    return fmt.Errorf("must specify a waypoint name or delete all using --all or delete specific revision using --revision")
```