### PR TITLE
fix missing wasm convert error logs

### DIFF
--- a/pkg/wasm/convert.go
+++ b/pkg/wasm/convert.go
@@ -123,16 +123,19 @@ func MaybeConvertWasmExtensionConfig(resources []*anypb.Any, cache Cache) error 
 			if wasmHTTPConfig != nil {
 				newExtensionConfig, err := convertHTTPWasmConfigFromRemoteToLocal(extConfig, wasmHTTPConfig, cache)
 				if err != nil {
-					// Store the conversion error.
-					convertErrs[i] = err
+					failOpen := httpWasmFailOpen(wasmHTTPConfig)
+					rbacFilter := "deny"
+					if failOpen {
+						rbacFilter = "allow"
+					}
+					wasmLog.Errorf("error in converting the wasm config to local: %v. applying %s RBAC filter", err, rbacFilter)
 					// Use NOOP filter because the download failed.
 					// nolint: staticcheck // FailOpen deprecated
-					newExtensionConfig, err = createHTTPDefaultFilter(extConfig.GetName(), httpWasmFailOpen(wasmHTTPConfig))
+					newExtensionConfig, err = createHTTPDefaultFilter(extConfig.GetName(), failOpen)
 					if err != nil {
 						// If the fallback is failing, send the Nack regardless of fail_open.
-						me := multierror.Append(istiomultierror.New(), convertErrs[i],
-							fmt.Errorf("failed to create allow-all filter as a fallback of %s Wasm Module: %w", extConfig.GetName(), err))
-						convertErrs[i] = me.ErrorOrNil()
+						err = fmt.Errorf("failed to create allow-all filter as a fallback of %s Wasm Module: %w", extConfig.GetName(), err)
+						convertErrs[i] = err
 						return
 					}
 				}
@@ -140,15 +143,19 @@ func MaybeConvertWasmExtensionConfig(resources []*anypb.Any, cache Cache) error 
 			} else {
 				newExtensionConfig, err := convertNetworkWasmConfigFromRemoteToLocal(extConfig, wasmNetworkConfig, cache)
 				if err != nil {
-					// Store the conversion error.
-					convertErrs[i] = err
+					failOpen := networkWasmFailOpen(wasmNetworkConfig)
+					rbacFilter := "deny"
+					if failOpen {
+						rbacFilter = "allow"
+					}
+					wasmLog.Errorf("error in converting the wasm config to local: %v. applying %s RBAC filter", err, rbacFilter)
+
 					// Use NOOP filter because the download failed.
-					newExtensionConfig, err = createNetworkDefaultFilter(extConfig.GetName(), networkWasmFailOpen(wasmNetworkConfig))
+					newExtensionConfig, err = createNetworkDefaultFilter(extConfig.GetName(), failOpen)
 					if err != nil {
 						// If the fallback is failing, send the Nack regardless of fail_open.
-						me := multierror.Append(istiomultierror.New(), convertErrs[i],
-							fmt.Errorf("failed to create allow-all filter as a fallback of %s Wasm Module: %w", extConfig.GetName(), err))
-						convertErrs[i] = me.ErrorOrNil()
+						err = fmt.Errorf("failed to create allow-all filter as a fallback of %s Wasm Module: %w", extConfig.GetName(), err)
+						convertErrs[i] = err
 						return
 					}
 				}
@@ -160,7 +167,7 @@ func MaybeConvertWasmExtensionConfig(resources []*anypb.Any, cache Cache) error 
 	wg.Wait()
 	err := multierror.Append(istiomultierror.New(), convertErrs...).ErrorOrNil()
 	if err != nil {
-		wasmLog.Errorf("convert the wasm config: %v", err)
+		wasmLog.Errorf("error in applying failopen rbac config: %v", err)
 	}
 	return err
 }


### PR DESCRIPTION
wasm convert error message is now not logged correct incase of conversion errors. Broken  in https://github.com/istio/istio/pull/53363. The createDefaultxxx now overwrites the original error that gets copied to convertErrs

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions