### PR TITLE
Set topology.istio.io/network label on networkGateway pods

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -41,6 +41,9 @@ spec:
         {{ $key | quote }}: {{ $val | quote }}
         {{- end }}
         {{- end }}
+        {{- with .Values.networkGateway }}
+        topology.istio.io/network: "{{.}}"
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/releasenotes/notes/54909.yaml
+++ b/releasenotes/notes/54909.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue: [54909]
+releaseNotes:
+  - |
+    **Fixed** missing `topology.istio.io/network` label on gateway pods when `--set networkGateway` is used.


### PR DESCRIPTION
**Please provide a description of this PR:**

I am migrating from `istioctl manifest generate` to `helm template` and noticed that the `topology.istio.io/network` label is missing from the templated pod when `networkGateway` is defined. I am creating this PR as a reference for when I ask questions about it, though I am not entirely sure if this is the right approach. However, the [same approach](https://github.com/istio/istio/blob/5251e48363e636d922d8d25adc22db9085bf38f8/manifests/charts/gateway/templates/service.yaml#L11-L13) I am proposing here is already applied in `service.yaml`.

Tested like this:
```console
$ helm template manifests/charts/gateway -s templates/deployment.yaml --set networkGateway=foo | grep -B3 -A3 foo
        app.kubernetes.io/version: "1.0.0"
        helm.sh/chart: gateway-1.0.0
        "istio.io/dataplane-mode": "none"
        topology.istio.io/network: "foo"
    spec:
      serviceAccountName: release-name
      securityContext:
--
            runAsNonRoot: true
          env:
          - name: ISTIO_META_REQUESTED_NETWORK_VIEW
            value: "foo"
          ports:
          - containerPort: 15090
            protocol: TCP
```