### PR TITLE
HBONE: properly use HBONE when ISTIO_MUTUAL is explicitly set

### DIFF
--- a/pilot/pkg/networking/core/cluster_tls.go
+++ b/pilot/pkg/networking/core/cluster_tls.go
@@ -324,7 +324,7 @@ func (cb *ClusterBuilder) applyHBONETransportSocketMatches(c *cluster.Cluster, t
 				if tls.Mode == networking.ClientTLSSettings_ISTIO_MUTUAL {
 					// If a user sets ISTIO_MUTUAL, then HBONE is replacing it. So we will do HBONE or mTLS, depending on backend support.
 					c.TransportSocketMatches = []*cluster.Cluster_TransportSocketMatch{
-						hboneTransportSocket(ts),
+						hboneTransportSocket(xdsfilters.RawBufferTransportSocket),
 						{
 							Name:            "tlsMode-" + model.IstioMutualTLSModeLabel,
 							TransportSocket: ts,

--- a/pilot/pkg/xds/endpoints/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder.go
@@ -661,7 +661,8 @@ func buildEnvoyLbEndpoint(b *EndpointBuilder, e *model.IstioEndpoint, mtlsEnable
 	tunnel := supportTunnel(b, e)
 	// Only send HBONE if its necessary. If they support legacy mTLS and do not explicitly PreferHBONE, we will use legacy mTLS.
 	// However, waypoints (TrafficDirectionInboundVIP) do not support legacy mTLS, so do not allow opting out of that case.
-	if mtlsEnabled && !features.PreferHBONESend && b.dir != model.TrafficDirectionInboundVIP {
+	supportsMtls := e.TLSMode == model.IstioMutualTLSModeLabel
+	if supportsMtls && !features.PreferHBONESend && b.dir != model.TrafficDirectionInboundVIP {
 		tunnel = false
 	}
 	if b.proxy.Metadata.DisableHBONESend {

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -1658,6 +1658,45 @@ spec:
 				Scheme: scheme.HTTP,
 			},
 		},
+		{
+			name: "ISTIO_MUTUAL",
+			config: `
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: "{{.Host}}"
+spec:
+  host: "{{.Host}}"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+`,
+			call: echo.CallOptions{
+				// Should just do HBONE
+				Port:   ports.HTTP,
+				Scheme: scheme.HTTP,
+			},
+		},
+		{
+			name: "ISTIO_MUTUAL and PROXY",
+			config: `
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: "{{.Host}}"
+spec:
+  host: "{{.Host}}"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+    proxyProtocol:
+      version: V1
+`,
+			call: echo.CallOptions{
+				Port:   ports.HTTPWithProxy,
+				Scheme: scheme.HTTP,
+			},
+		},
 	}
 	framework.NewTest(t).Run(func(t framework.TestContext) {
 		for _, tt := range cases {
@@ -1667,16 +1706,18 @@ spec:
 						continue
 					}
 					t.NewSubTestf("from %v", src.Config().Service).Run(func(t framework.TestContext) {
+						dst := dst
 						if src.Config().HasSidecar() && dst.Config().HasAnyWaypointProxy() {
-							// TODO: sidecar -> workload waypoint support
-							t.Skip("https://github.com/istio/istio/issues/51445")
+							// Let the DR be enforced by the client
+							// TODO(https://github.com/istio/istio/issues/51445): sidecar -> workload waypoint support
+							dst = apps.Captured
 						}
 						t.ConfigIstio().Eval(apps.Namespace.Name(), map[string]string{
 							"Host": dst.Config().Service,
 						}, tt.config).ApplyOrFail(t)
 						call := tt.call
 						call.To = dst
-						t.Log(src.CallOrFail(t, call))
+						src.CallOrFail(t, call)
 					})
 				}
 			})


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/53526.

Two flaws in the code:
* In CDS, we accidentally wrapped HBONE on top of mTLS. It should be on raw_buffer. Note this never triggered, due to the next issue, so went unnoticed.
* In EDS, we disable HBONE if mTLS is explicitly enabled. The intent was to make it so we prefer to use mTLS. But this means we would use it even when we should use HBONE. Loosen the check to make it only apply if the backend supports mTLS.