### PR TITLE
hbone: disable metadata exchange to the upstream HBONEs

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -2421,7 +2421,11 @@ func (ps *PushContext) NetworkManager() *NetworkManager {
 	return ps.networkMgr
 }
 
-func (ps *PushContext) BestEffortInferHBONE(service *Service, port *Port) bool {
+// AllInstancesSupportHBONE checks whether all instances of a service support HBONE. This is used in cases where we need
+// to decide if we are always going to send HBONE, so we can set service-level properties.
+// Mostly this works around limitations in the dataplane that don't support per-endpoint properties we would want to be
+// per-endpoint.
+func (ps *PushContext) AllInstancesSupportHBONE(service *Service, port *Port) bool {
 	instances := ps.ServiceEndpointsByPort(service, port.Port, nil)
 	if len(instances) == 0 {
 		return false

--- a/pilot/pkg/networking/core/cluster.go
+++ b/pilot/pkg/networking/core/cluster.go
@@ -731,11 +731,12 @@ type buildClusterOpts struct {
 	// Used for traffic across multiple network clusters
 	// the east-west gateway in a remote cluster will use this value to route
 	// traffic to the appropriate service
-	istioMtlsSni    string
-	clusterMode     ClusterMode
-	direction       model.TrafficDirection
-	meshExternal    bool
-	serviceMTLSMode model.MutualTLSMode
+	istioMtlsSni      string
+	clusterMode       ClusterMode
+	direction         model.TrafficDirection
+	meshExternal      bool
+	serviceMTLSMode   model.MutualTLSMode
+	allInstancesHBONE bool
 	// Indicates the service registry of the cluster being built.
 	serviceRegistry provider.ID
 	// Indicates if the destinationRule has a workloadSelector

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -257,6 +257,7 @@ func (cb *ClusterBuilder) applyDestinationRule(mc *clusterWrapper, clusterMode C
 		opts.meshExternal = service.MeshExternal
 		opts.serviceRegistry = service.Attributes.ServiceRegistry
 		opts.serviceMTLSMode = cb.req.Push.BestEffortInferServiceMTLSMode(destinationRule.GetTrafficPolicy(), service, port)
+		opts.allInstancesHBONE = cb.req.Push.BestEffortInferHBONE(service, port)
 	}
 
 	if destRule != nil {
@@ -271,7 +272,7 @@ func (cb *ClusterBuilder) applyDestinationRule(mc *clusterWrapper, clusterMode C
 
 	cb.applyMetadataExchange(opts.mutable.cluster)
 
-	if service.MeshExternal {
+	if service.MeshExternal || opts.allInstancesHBONE {
 		im := getOrCreateIstioMetadata(mc.cluster)
 		im.Fields["external"] = &structpb.Value{
 			Kind: &structpb.Value_BoolValue{

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -257,7 +257,7 @@ func (cb *ClusterBuilder) applyDestinationRule(mc *clusterWrapper, clusterMode C
 		opts.meshExternal = service.MeshExternal
 		opts.serviceRegistry = service.Attributes.ServiceRegistry
 		opts.serviceMTLSMode = cb.req.Push.BestEffortInferServiceMTLSMode(destinationRule.GetTrafficPolicy(), service, port)
-		opts.allInstancesHBONE = cb.req.Push.BestEffortInferHBONE(service, port)
+		opts.allInstancesHBONE = cb.req.Push.AllInstancesSupportHBONE(service, port)
 	}
 
 	if destRule != nil {

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -273,8 +273,14 @@ func (cb *ClusterBuilder) applyDestinationRule(mc *clusterWrapper, clusterMode C
 	cb.applyMetadataExchange(opts.mutable.cluster)
 
 	if service.MeshExternal || opts.allInstancesHBONE {
+		// Conditionally skips based on config
+		key := "external"
+		if opts.allInstancesHBONE {
+			// Unconditionally skips
+			key = "disable_mx"
+		}
 		im := getOrCreateIstioMetadata(mc.cluster)
-		im.Fields["external"] = &structpb.Value{
+		im.Fields[key] = &structpb.Value{
 			Kind: &structpb.Value_BoolValue{
 				BoolValue: true,
 			},

--- a/pilot/pkg/networking/core/httproute.go
+++ b/pilot/pkg/networking/core/httproute.go
@@ -314,7 +314,7 @@ func GetProxyHeadersFromProxyConfig(pc *meshconfig.ProxyConfig, class istionetwo
 		ForwardedClientCert:        hcm.HttpConnectionManager_APPEND_FORWARD,
 		IncludeRequestAttemptCount: true,
 		SuppressDebugHeaders:       false,
-		GenerateRequestID:          nil,  // Envoy default is to enable them, so set nil
+		GenerateRequestID:          nil, // Envoy default is to enable them, so set nil
 		SkipIstioMXHeaders:         false,
 	}
 	if class == istionetworking.ListenerClassSidecarOutbound {

--- a/pilot/pkg/networking/core/httproute.go
+++ b/pilot/pkg/networking/core/httproute.go
@@ -314,8 +314,8 @@ func GetProxyHeadersFromProxyConfig(pc *meshconfig.ProxyConfig, class istionetwo
 		ForwardedClientCert:        hcm.HttpConnectionManager_APPEND_FORWARD,
 		IncludeRequestAttemptCount: true,
 		SuppressDebugHeaders:       false,
-		GenerateRequestID:          nil, // Envoy default is to enable them, so set nil
-		SkipIstioMXHeaders:         false,
+		GenerateRequestID:          nil,  // Envoy default is to enable them, so set nil
+		SkipIstioMXHeaders:         true, // TODO: do not merge
 	}
 	if class == istionetworking.ListenerClassSidecarOutbound {
 		// Likely due to a mistake, outbound uses "envoy" while inbound uses "istio-envoy". Bummer.

--- a/pilot/pkg/networking/core/httproute.go
+++ b/pilot/pkg/networking/core/httproute.go
@@ -315,7 +315,7 @@ func GetProxyHeadersFromProxyConfig(pc *meshconfig.ProxyConfig, class istionetwo
 		IncludeRequestAttemptCount: true,
 		SuppressDebugHeaders:       false,
 		GenerateRequestID:          nil,  // Envoy default is to enable them, so set nil
-		SkipIstioMXHeaders:         true, // TODO: do not merge
+		SkipIstioMXHeaders:         false,
 	}
 	if class == istionetworking.ListenerClassSidecarOutbound {
 		// Likely due to a mistake, outbound uses "envoy" while inbound uses "istio-envoy". Bummer.

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -198,8 +198,9 @@ func TestServices(t *testing.T) {
 		}
 
 		// Ensure we are not leaking metadata exchange headers
+		// We skip uncaptured workloads, as there is a pre-existing issue around Sidecar-->Uncaptured leaking the headers.
+		// Since this is not really related to ambient we just skip this for now; the case we really care about is Sidecar-->Ztunnel.
 		if !dst.Config().IsUncaptured() {
-			// Probably we shouldn't do it to uncaptured workloads either but ... not an ambient problem.
 			opt.Check = check.And(opt.Check, check.RequestHeader("X-Envoy-Peer-Metadata", ""))
 		}
 

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -197,6 +197,12 @@ func TestServices(t *testing.T) {
 			t.Skip("https://github.com/istio/istio/pull/50182")
 		}
 
+		// Ensure we are not leaking metadata exchange headers
+		if !dst.Config().IsUncaptured() {
+			// Probably we shouldn't do it to uncaptured workloads either but ... not an ambient problem.
+			opt.Check = check.And(opt.Check, check.RequestHeader("X-Envoy-Peer-Metadata", ""))
+		}
+
 		// TODO test from all source workloads as well
 		src.CallOrFail(t, opt)
 	})


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/54913

This is a control plane hack for a limitation in the filter. The MX filter is currently a HCM-level filter, which can access cluster metadata but not **host metadata**. This means we cannot just check `if the endpoint is hbone, do not send MX`.

There are two routes here:
(1) Move MX filter to an upstream filter. Probably more correct overall, but a big effort
(2) Infer that all instances are hbone, and stop sending MX in this case. This leaves some edge cases of a mixed service, but these are niche

Note that (2) is already used for enabling mTLS for headless services, so the same concept has proven to be ok-enough.

This PR is a WIP since it requires some envoy changes as well. We currently let us skip MX if the filter has `skip_external_clusters` set **which is off by default** and the cluster metadata has `external=true`. I have hacked this in the PR for testing by always setting this to `true`, and marking `external=true` when we have HBONE. A more realistic approach would be to set a new metadata `hbone=true` and unconditionally check that.