### PR TITLE
Implement ambient pod-level DNS inclusion/exclusion

### DIFF
--- a/cni/pkg/iptables/common_test.go
+++ b/cni/pkg/iptables/common_test.go
@@ -54,6 +54,34 @@ func GetCommonInPodTestCases() []struct {
 				VirtualInterfaces: []string{"fake1s0f0", "fake1s0f1"},
 			},
 		},
+		{
+			name: "dns_pod_enabled_and_off_globally",
+			config: func(cfg *IptablesConfig) {
+				cfg.RedirectDNS = false
+			},
+			podOverrides: PodLevelOverrides{DNSProxy: PodDNSEnabled},
+		},
+		{
+			name: "dns_pod_disabled_and_on_globally",
+			config: func(cfg *IptablesConfig) {
+				cfg.RedirectDNS = true
+			},
+			podOverrides: PodLevelOverrides{DNSProxy: PodDNSDisabled},
+		},
+		{
+			name: "dns_pod_not_present_and_on_globally",
+			config: func(cfg *IptablesConfig) {
+				cfg.RedirectDNS = true
+			},
+			podOverrides: PodLevelOverrides{DNSProxy: PodDNSUnset},
+		},
+		{
+			name: "dns_pod_not_present_and_off_globally",
+			config: func(cfg *IptablesConfig) {
+				cfg.RedirectDNS = false
+			},
+			podOverrides: PodLevelOverrides{DNSProxy: PodDNSUnset},
+		},
 	}
 }
 

--- a/cni/pkg/iptables/common_test.go
+++ b/cni/pkg/iptables/common_test.go
@@ -68,20 +68,6 @@ func GetCommonInPodTestCases() []struct {
 			},
 			podOverrides: PodLevelOverrides{DNSProxy: PodDNSDisabled},
 		},
-		{
-			name: "dns_pod_not_present_and_on_globally",
-			config: func(cfg *IptablesConfig) {
-				cfg.RedirectDNS = true
-			},
-			podOverrides: PodLevelOverrides{DNSProxy: PodDNSUnset},
-		},
-		{
-			name: "dns_pod_not_present_and_off_globally",
-			config: func(cfg *IptablesConfig) {
-				cfg.RedirectDNS = false
-			},
-			podOverrides: PodLevelOverrides{DNSProxy: PodDNSUnset},
-		},
 	}
 }
 

--- a/cni/pkg/iptables/testdata/dns_pod_disabled_and_on_globally.golden
+++ b/cni/pkg/iptables/testdata/dns_pod_disabled_and_on_globally.golden
@@ -1,0 +1,22 @@
+iptables-save
+ip6tables-save
+* mangle
+-N ISTIO_PRERT
+-N ISTIO_OUTPUT
+-A PREROUTING -j ISTIO_PRERT
+-A OUTPUT -j ISTIO_OUTPUT
+-A ISTIO_PRERT -m mark --mark 0x539/0xfff -j CONNMARK --set-xmark 0x111/0xfff
+-A ISTIO_OUTPUT -m connmark --mark 0x111/0xfff -j CONNMARK --restore-mark --nfmask 0xffffffff --ctmask 0xffffffff
+COMMIT
+* nat
+-N ISTIO_PRERT
+-N ISTIO_OUTPUT
+-A OUTPUT -j ISTIO_OUTPUT
+-A PREROUTING -j ISTIO_PRERT
+-A ISTIO_PRERT -s 169.254.7.127 -p tcp -m tcp -j ACCEPT
+-A ISTIO_OUTPUT -d 169.254.7.127 -p tcp -m tcp -j ACCEPT
+-A ISTIO_PRERT ! -d 127.0.0.1/32 -p tcp ! --dport 15008 -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15006
+-A ISTIO_OUTPUT -p tcp -m mark --mark 0x111/0xfff -j ACCEPT
+-A ISTIO_OUTPUT ! -d 127.0.0.1/32 -o lo -j ACCEPT
+-A ISTIO_OUTPUT ! -d 127.0.0.1/32 -p tcp -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15001
+COMMIT

--- a/cni/pkg/iptables/testdata/dns_pod_disabled_and_on_globally_ipv6.golden
+++ b/cni/pkg/iptables/testdata/dns_pod_disabled_and_on_globally_ipv6.golden
@@ -1,0 +1,42 @@
+iptables-save
+ip6tables-save
+* mangle
+-N ISTIO_PRERT
+-N ISTIO_OUTPUT
+-A PREROUTING -j ISTIO_PRERT
+-A OUTPUT -j ISTIO_OUTPUT
+-A ISTIO_PRERT -m mark --mark 0x539/0xfff -j CONNMARK --set-xmark 0x111/0xfff
+-A ISTIO_OUTPUT -m connmark --mark 0x111/0xfff -j CONNMARK --restore-mark --nfmask 0xffffffff --ctmask 0xffffffff
+COMMIT
+* nat
+-N ISTIO_PRERT
+-N ISTIO_OUTPUT
+-A OUTPUT -j ISTIO_OUTPUT
+-A PREROUTING -j ISTIO_PRERT
+-A ISTIO_PRERT -s 169.254.7.127 -p tcp -m tcp -j ACCEPT
+-A ISTIO_OUTPUT -d 169.254.7.127 -p tcp -m tcp -j ACCEPT
+-A ISTIO_PRERT ! -d 127.0.0.1/32 -p tcp ! --dport 15008 -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15006
+-A ISTIO_OUTPUT -p tcp -m mark --mark 0x111/0xfff -j ACCEPT
+-A ISTIO_OUTPUT ! -d 127.0.0.1/32 -o lo -j ACCEPT
+-A ISTIO_OUTPUT ! -d 127.0.0.1/32 -p tcp -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15001
+COMMIT
+* mangle
+-N ISTIO_PRERT
+-N ISTIO_OUTPUT
+-A PREROUTING -j ISTIO_PRERT
+-A OUTPUT -j ISTIO_OUTPUT
+-A ISTIO_PRERT -m mark --mark 0x539/0xfff -j CONNMARK --set-xmark 0x111/0xfff
+-A ISTIO_OUTPUT -m connmark --mark 0x111/0xfff -j CONNMARK --restore-mark --nfmask 0xffffffff --ctmask 0xffffffff
+COMMIT
+* nat
+-N ISTIO_PRERT
+-N ISTIO_OUTPUT
+-A OUTPUT -j ISTIO_OUTPUT
+-A PREROUTING -j ISTIO_PRERT
+-A ISTIO_PRERT -s e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 -p tcp -m tcp -j ACCEPT
+-A ISTIO_OUTPUT -d e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 -p tcp -m tcp -j ACCEPT
+-A ISTIO_PRERT ! -d ::1/128 -p tcp ! --dport 15008 -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15006
+-A ISTIO_OUTPUT -p tcp -m mark --mark 0x111/0xfff -j ACCEPT
+-A ISTIO_OUTPUT ! -d ::1/128 -o lo -j ACCEPT
+-A ISTIO_OUTPUT ! -d ::1/128 -p tcp -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15001
+COMMIT

--- a/cni/pkg/iptables/testdata/dns_pod_enabled_and_off_globally.golden
+++ b/cni/pkg/iptables/testdata/dns_pod_enabled_and_off_globally.golden
@@ -1,0 +1,32 @@
+iptables-save
+ip6tables-save
+* mangle
+-N ISTIO_PRERT
+-N ISTIO_OUTPUT
+-A PREROUTING -j ISTIO_PRERT
+-A OUTPUT -j ISTIO_OUTPUT
+-A ISTIO_PRERT -m mark --mark 0x539/0xfff -j CONNMARK --set-xmark 0x111/0xfff
+-A ISTIO_OUTPUT -m connmark --mark 0x111/0xfff -j CONNMARK --restore-mark --nfmask 0xffffffff --ctmask 0xffffffff
+COMMIT
+* nat
+-N ISTIO_PRERT
+-N ISTIO_OUTPUT
+-A OUTPUT -j ISTIO_OUTPUT
+-A PREROUTING -j ISTIO_PRERT
+-A ISTIO_PRERT -s 169.254.7.127 -p tcp -m tcp -j ACCEPT
+-A ISTIO_OUTPUT -d 169.254.7.127 -p tcp -m tcp -j ACCEPT
+-A ISTIO_PRERT ! -d 127.0.0.1/32 -p tcp ! --dport 15008 -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15006
+-A ISTIO_OUTPUT ! -o lo -p udp -m mark ! --mark 0x539/0xfff -m udp --dport 53 -j REDIRECT --to-port 15053
+-A ISTIO_OUTPUT ! -d 127.0.0.1/32 -p tcp --dport 53 -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15053
+-A ISTIO_OUTPUT -p tcp -m mark --mark 0x111/0xfff -j ACCEPT
+-A ISTIO_OUTPUT ! -d 127.0.0.1/32 -o lo -j ACCEPT
+-A ISTIO_OUTPUT ! -d 127.0.0.1/32 -p tcp -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15001
+COMMIT
+* raw
+-N ISTIO_OUTPUT
+-N ISTIO_PRERT
+-A PREROUTING -j ISTIO_PRERT
+-A OUTPUT -j ISTIO_OUTPUT
+-A ISTIO_OUTPUT -p udp -m mark --mark 0x539/0xfff -m udp --dport 53 -j CT --zone 1
+-A ISTIO_PRERT -p udp -m mark ! --mark 0x539/0xfff -m udp --sport 53 -j CT --zone 1
+COMMIT

--- a/cni/pkg/iptables/testdata/dns_pod_enabled_and_off_globally_ipv6.golden
+++ b/cni/pkg/iptables/testdata/dns_pod_enabled_and_off_globally_ipv6.golden
@@ -1,0 +1,62 @@
+iptables-save
+ip6tables-save
+* mangle
+-N ISTIO_PRERT
+-N ISTIO_OUTPUT
+-A PREROUTING -j ISTIO_PRERT
+-A OUTPUT -j ISTIO_OUTPUT
+-A ISTIO_PRERT -m mark --mark 0x539/0xfff -j CONNMARK --set-xmark 0x111/0xfff
+-A ISTIO_OUTPUT -m connmark --mark 0x111/0xfff -j CONNMARK --restore-mark --nfmask 0xffffffff --ctmask 0xffffffff
+COMMIT
+* nat
+-N ISTIO_PRERT
+-N ISTIO_OUTPUT
+-A OUTPUT -j ISTIO_OUTPUT
+-A PREROUTING -j ISTIO_PRERT
+-A ISTIO_PRERT -s 169.254.7.127 -p tcp -m tcp -j ACCEPT
+-A ISTIO_OUTPUT -d 169.254.7.127 -p tcp -m tcp -j ACCEPT
+-A ISTIO_PRERT ! -d 127.0.0.1/32 -p tcp ! --dport 15008 -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15006
+-A ISTIO_OUTPUT ! -o lo -p udp -m mark ! --mark 0x539/0xfff -m udp --dport 53 -j REDIRECT --to-port 15053
+-A ISTIO_OUTPUT ! -d 127.0.0.1/32 -p tcp --dport 53 -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15053
+-A ISTIO_OUTPUT -p tcp -m mark --mark 0x111/0xfff -j ACCEPT
+-A ISTIO_OUTPUT ! -d 127.0.0.1/32 -o lo -j ACCEPT
+-A ISTIO_OUTPUT ! -d 127.0.0.1/32 -p tcp -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15001
+COMMIT
+* raw
+-N ISTIO_OUTPUT
+-N ISTIO_PRERT
+-A PREROUTING -j ISTIO_PRERT
+-A OUTPUT -j ISTIO_OUTPUT
+-A ISTIO_OUTPUT -p udp -m mark --mark 0x539/0xfff -m udp --dport 53 -j CT --zone 1
+-A ISTIO_PRERT -p udp -m mark ! --mark 0x539/0xfff -m udp --sport 53 -j CT --zone 1
+COMMIT
+* mangle
+-N ISTIO_PRERT
+-N ISTIO_OUTPUT
+-A PREROUTING -j ISTIO_PRERT
+-A OUTPUT -j ISTIO_OUTPUT
+-A ISTIO_PRERT -m mark --mark 0x539/0xfff -j CONNMARK --set-xmark 0x111/0xfff
+-A ISTIO_OUTPUT -m connmark --mark 0x111/0xfff -j CONNMARK --restore-mark --nfmask 0xffffffff --ctmask 0xffffffff
+COMMIT
+* nat
+-N ISTIO_PRERT
+-N ISTIO_OUTPUT
+-A OUTPUT -j ISTIO_OUTPUT
+-A PREROUTING -j ISTIO_PRERT
+-A ISTIO_PRERT -s e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 -p tcp -m tcp -j ACCEPT
+-A ISTIO_OUTPUT -d e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 -p tcp -m tcp -j ACCEPT
+-A ISTIO_PRERT ! -d ::1/128 -p tcp ! --dport 15008 -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15006
+-A ISTIO_OUTPUT ! -o lo -p udp -m mark ! --mark 0x539/0xfff -m udp --dport 53 -j REDIRECT --to-port 15053
+-A ISTIO_OUTPUT ! -d ::1/128 -p tcp --dport 53 -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15053
+-A ISTIO_OUTPUT -p tcp -m mark --mark 0x111/0xfff -j ACCEPT
+-A ISTIO_OUTPUT ! -d ::1/128 -o lo -j ACCEPT
+-A ISTIO_OUTPUT ! -d ::1/128 -p tcp -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15001
+COMMIT
+* raw
+-N ISTIO_OUTPUT
+-N ISTIO_PRERT
+-A PREROUTING -j ISTIO_PRERT
+-A OUTPUT -j ISTIO_OUTPUT
+-A ISTIO_OUTPUT -p udp -m mark --mark 0x539/0xfff -m udp --dport 53 -j CT --zone 1
+-A ISTIO_PRERT -p udp -m mark ! --mark 0x539/0xfff -m udp --sport 53 -j CT --zone 1
+COMMIT

--- a/cni/pkg/nodeagent/net_test.go
+++ b/cni/pkg/nodeagent/net_test.go
@@ -17,6 +17,7 @@ package nodeagent
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/netip"
 	"runtime"
 	"sync/atomic"
@@ -28,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"istio.io/api/annotation"
 	"istio.io/istio/cni/pkg/iptables"
 	istiolog "istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/test/util/assert"
@@ -502,6 +504,107 @@ func TestReconcilePodReturnsNoErrorIfPodReconciles(t *testing.T) {
 	// If no error, we should have executed some iptables rule insertions
 	// on this pod (since it is a faked pod, it had none to start with)
 	assert.Equal(t, (len(fakeDeps.ExecutedAll) != 0), true)
+}
+
+var overrideTests = map[string]struct {
+	in  corev1.Pod
+	out iptables.PodLevelOverrides
+}{
+	"pod dns override": {
+		in: corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test",
+				Namespace:   "test",
+				UID:         "12345",
+				Annotations: map[string]string{annotation.AmbientDnsCapture.Name: "true"},
+			},
+		},
+		out: iptables.PodLevelOverrides{
+			VirtualInterfaces: []string{},
+			IngressMode:       false,
+			DNSProxy:          iptables.PodDNSEnabled,
+		},
+	},
+
+	"no pod dns set": {
+		in: corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test",
+				UID:       "12345",
+			},
+		},
+		out: iptables.PodLevelOverrides{
+			VirtualInterfaces: []string{},
+			IngressMode:       false,
+			DNSProxy:          iptables.PodDNSUnset,
+		},
+	},
+
+	"pod dns disabled": {
+		in: corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test",
+				Namespace:   "test",
+				UID:         "12345",
+				Annotations: map[string]string{annotation.AmbientDnsCapture.Name: "false"},
+			},
+		},
+		out: iptables.PodLevelOverrides{
+			VirtualInterfaces: []string{},
+			IngressMode:       false,
+			DNSProxy:          iptables.PodDNSDisabled,
+		},
+	},
+
+	"pod dns disabled, ingress mode enabled, two virt interfaces": {
+		in: corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test",
+				UID:       "12345",
+				Annotations: map[string]string{
+					annotation.AmbientDnsCapture.Name:               "true",
+					annotation.AmbientBypassInboundCapture.Name:     "true",
+					annotation.IoIstioRerouteVirtualInterfaces.Name: "en0ps1, en1ps1",
+				},
+			},
+		},
+		out: iptables.PodLevelOverrides{
+			VirtualInterfaces: []string{"en0ps1", "en1ps1"},
+			IngressMode:       true,
+			DNSProxy:          iptables.PodDNSEnabled,
+		},
+	},
+
+	"various manglings": {
+		in: corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test",
+				UID:       "12345",
+				Annotations: map[string]string{
+					annotation.AmbientDnsCapture.Name:               "tweedledum",
+					annotation.AmbientBypassInboundCapture.Name:     "tweedledee",
+					annotation.IoIstioRerouteVirtualInterfaces.Name: "asd^&&*$&*(#$&*(#&$*())),   ",
+				},
+			},
+		},
+		out: iptables.PodLevelOverrides{
+			VirtualInterfaces: []string{"asd^&&*$&*(#$&*(#&$*()))"},
+			IngressMode:       false,
+			DNSProxy:          iptables.PodDNSUnset,
+		},
+	},
+}
+
+func TestGetPodLevelOverrides(t *testing.T) {
+	for name, test := range overrideTests {
+		t.Run(name, func(t *testing.T) {
+			res := getPodLevelTrafficOverrides(&test.in)
+			assert.Equal(t, res, test.out, fmt.Sprintf("test '%s' failed", name))
+		})
+	}
 }
 
 // for tests that call `runtime.GC()` - we have no control over when the GC is actually scheduled,

--- a/releasenotes/notes/54935.yaml
+++ b/releasenotes/notes/54935.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+- 49829
+releaseNotes:
+- |
+    **Added** `ambient.istio.io/dns-capture` annotation. May be unset, or set to `true` or `false`.
+    When specified on a `Pod` enrolled in ambient mesh, controls whether DNS traffic (TCP and UDP on port 53) will be captured and proxied in ambient.
+    This pod-level annotation, if present on a pod, will override the global `istio-cni` `AMBIENT_DNS_CAPTURE` setting, which as of 1.25 defaults to `true`.
+    Note that setting this to `false` will break some Istio features, such as ServiceEntries and egress waypoints, but may be desirable for workloads that interact poorly with DNS proxies.


### PR DESCRIPTION
**Please provide a description of this PR:**

Impl side of https://github.com/istio/api/pull/3361 (which I had forgotten about - my bad).

Since Ambient DNS capture is newly opt-in by default in 1.25, there's a case to be made for backporting this (and https://github.com/istio/api/pull/3361).

I've raised an API backport PR here: https://github.com/istio/api/pull/3427, if that merges I will tag this for 1.25 backport as well.