### PR TITLE
feat: ability override namespace for the istio-cni chart

### DIFF
--- a/manifests/charts/istio-cni/templates/clusterrolebinding.yaml
+++ b/manifests/charts/istio-cni/templates/clusterrolebinding.yaml
@@ -17,7 +17,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "name" . }}
-  namespace: {{ if .Values.namespaceOverride }}{{ .Values.namespaceOverride }}{{ else }}{{ .Release.Namespace }}{{ end }}
+  namespace: {{ coalesce .Values.namespace .Release.Namespace }}
 ---
 {{- if .Values.repair.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -35,7 +35,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ template "name" . }}
-  namespace: {{ if .Values.namespaceOverride }}{{ .Values.namespaceOverride }}{{ else }}{{ .Release.Namespace }}{{ end }}
+  namespace: {{ coalesce .Values.namespace .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -58,7 +58,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "name" . }}
-    namespace: {{ if .Values.namespaceOverride }}{{ .Values.namespaceOverride }}{{ else }}{{ .Release.Namespace }}{{ end }}
+    namespace: {{ coalesce .Values.namespace .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/charts/istio-cni/templates/clusterrolebinding.yaml
+++ b/manifests/charts/istio-cni/templates/clusterrolebinding.yaml
@@ -17,7 +17,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ if .Values.namespaceOverride }}{{ .Values.namespaceOverride }}{{ else }}{{ .Release.Namespace }}{{ end }}
 ---
 {{- if .Values.repair.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -35,7 +35,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ template "name" . }}
-  namespace: {{ .Release.Namespace}}
+  namespace: {{ if .Values.namespaceOverride }}{{ .Values.namespaceOverride }}{{ else }}{{ .Release.Namespace }}{{ end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -58,7 +58,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "name" . }}
-    namespace: {{ .Release.Namespace}}
+    namespace: {{ if .Values.namespaceOverride }}{{ .Values.namespaceOverride }}{{ else }}{{ .Release.Namespace }}{{ end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/charts/istio-cni/templates/configmap-cni.yaml
+++ b/manifests/charts/istio-cni/templates/configmap-cni.yaml
@@ -2,7 +2,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: {{ template "name" . }}-config
-  namespace: {{ if .Values.namespaceOverride }}{{ .Values.namespaceOverride }}{{ else }}{{ .Release.Namespace }}{{ end }}
+  namespace: {{ coalesce .Values.namespace .Release.Namespace }}
   labels:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}

--- a/manifests/charts/istio-cni/templates/configmap-cni.yaml
+++ b/manifests/charts/istio-cni/templates/configmap-cni.yaml
@@ -2,7 +2,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: {{ template "name" . }}-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ if .Values.namespaceOverride }}{{ .Values.namespaceOverride }}{{ else }}{{ .Release.Namespace }}{{ end }}
   labels:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -13,7 +13,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: {{ template "name" . }}-node
-  namespace: {{ if .Values.namespaceOverride }}{{ .Values.namespaceOverride }}{{ else }}{{ .Release.Namespace }}{{ end }}
+  namespace: {{ coalesce .Values.namespace .Release.Namespace }}
   labels:
     k8s-app: {{ template "name" . }}-node
     release: {{ .Release.Name }}

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -13,7 +13,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: {{ template "name" . }}-node
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ if .Values.namespaceOverride }}{{ .Values.namespaceOverride }}{{ else }}{{ .Release.Namespace }}{{ end }}
   labels:
     k8s-app: {{ template "name" . }}-node
     release: {{ .Release.Name }}

--- a/manifests/charts/istio-cni/templates/resourcequota.yaml
+++ b/manifests/charts/istio-cni/templates/resourcequota.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ResourceQuota
 metadata:
   name: {{ template "name" . }}-resource-quota
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ if .Values.namespaceOverride }}{{ .Values.namespaceOverride }}{{ else }}{{ .Release.Namespace }}{{ end }}
   labels:
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/manifests/charts/istio-cni/templates/resourcequota.yaml
+++ b/manifests/charts/istio-cni/templates/resourcequota.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ResourceQuota
 metadata:
   name: {{ template "name" . }}-resource-quota
-  namespace: {{ if .Values.namespaceOverride }}{{ .Values.namespaceOverride }}{{ else }}{{ .Release.Namespace }}{{ end }}
+  namespace: {{ coalesce .Values.namespace .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/manifests/charts/istio-cni/templates/serviceaccount.yaml
+++ b/manifests/charts/istio-cni/templates/serviceaccount.yaml
@@ -8,7 +8,7 @@ imagePullSecrets:
 {{- end }}
 metadata:
   name: {{ template "name" . }}
-  namespace: {{ if .Values.namespaceOverride }}{{ .Values.namespaceOverride }}{{ else }}{{ .Release.Namespace }}{{ end }}
+  namespace: {{ coalesce .Values.namespace .Release.Namespace }}
   labels:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}

--- a/manifests/charts/istio-cni/templates/serviceaccount.yaml
+++ b/manifests/charts/istio-cni/templates/serviceaccount.yaml
@@ -8,7 +8,7 @@ imagePullSecrets:
 {{- end }}
 metadata:
   name: {{ template "name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ if .Values.namespaceOverride }}{{ .Values.namespaceOverride }}{{ else }}{{ .Release.Namespace }}{{ end }}
   labels:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -1,6 +1,8 @@
 # "_internal_defaults_do_not_set" is a workaround for Helm limitations. Users should NOT set "._internal_defaults_do_not_set" explicitly, but rather directly set the fields internally.
 # For instance, instead of `--set _internal_defaults_do_not_set.foo=bar``, just set `--set foo=bar`.
 _internal_defaults_do_not_set:
+  # This will override the namespace of resources created by this chart
+  namespaceOverride: ""
   hub: ""
   tag: ""
   variant: ""

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -2,7 +2,7 @@
 # For instance, instead of `--set _internal_defaults_do_not_set.foo=bar``, just set `--set foo=bar`.
 _internal_defaults_do_not_set:
   # This will override the namespace of resources created by this chart
-  namespaceOverride: ""
+  namespace: ""
   hub: ""
   tag: ""
   variant: ""

--- a/releasenotes/notes/54954.yaml
+++ b/releasenotes/notes/54954.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+
+releaseNotes:
+- |
+  **Added** ability to override namespace in the istio-cni chart.


### PR DESCRIPTION
**Please provide a description of this PR:**

This gives the ability to override the namespace for the istio-cni chart.

Use-case: We're currently migrating clusters still using the Istio operator. We plan to deploy Istio Helm charts using an umbrella-chart, and would like to have istio-cni installed in a separate namespace than istiod to match our current setup.