### PR TITLE
istiod ca: custom ConfigMap/ClusterTrustBundle name for CA root cert

### DIFF
--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -274,11 +274,11 @@ spec:
         projected:
           sources:
           - clusterTrustBundle:
-              name: istio.io:istiod-ca:root-cert
+              name: istio.io:istiod-ca:{{ .Values.global.trustBundleName | default "root-cert" }}
               path: root-cert.pem
 {{- else }}
         configMap:
-          name: istio-ca-root-cert
+          name: {{ .Values.global.trustBundleName | default "istio-ca-root-cert" }}
 {{- end }}
 {{- end }}
       - name: podinfo

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -274,11 +274,11 @@ spec:
         projected:
           sources:
           - clusterTrustBundle:
-              name: istio.io:istiod-ca:root-cert
+              name: istio.io:istiod-ca:{{ .Values.global.trustBundleName | default "root-cert" }}
               path: root-cert.pem
 {{- else }}
         configMap:
-          name: istio-ca-root-cert
+          name: {{ .Values.global.trustBundleName | default "istio-ca-root-cert" }}
 {{- end }}
 {{- end }}
       - name: podinfo

--- a/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
@@ -235,11 +235,11 @@ spec:
     projected:
       sources:
       - clusterTrustBundle:
-        name: istio.io:istiod-ca:root-cert
+        name: istio.io:istiod-ca:{{ .Values.global.trustBundleName | default "root-cert" }}
         path: root-cert.pem
   {{- else }}
     configMap:
-      name: istio-ca-root-cert
+      name: {{ .Values.global.trustBundleName | default "istio-ca-root-cert" }}
   {{- end }}
   {{- end }}
   {{- if .Values.global.mountMtlsCerts }}

--- a/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
@@ -286,11 +286,11 @@ spec:
     projected:
       sources:
       - clusterTrustBundle:
-        name: istio.io:istiod-ca:root-cert
+        name: istio.io:istiod-ca:{{ .Values.global.trustBundleName | default "root-cert" }}
         path: root-cert.pem
   {{- else }}
     configMap:
-      name: istio-ca-root-cert
+      name: {{ .Values.global.trustBundleName | default "istio-ca-root-cert" }}
   {{- end }}
   {{- end }}
   {{- if .Values.global.mountMtlsCerts }}

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -492,11 +492,11 @@ spec:
     projected:
       sources:
       - clusterTrustBundle:
-        name: istio.io:istiod-ca:root-cert
+        name: istio.io:istiod-ca:{{ .Values.global.trustBundleName | default "root-cert" }}
         path: root-cert.pem
   {{- else }}
     configMap:
-      name: istio-ca-root-cert
+      name: {{ .Values.global.trustBundleName | default "istio-ca-root-cert" }}
   {{- end }}
   {{- end }}
   {{- if .Values.global.mountMtlsCerts }}

--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -303,11 +303,11 @@ spec:
         projected:
           sources:
           - clusterTrustBundle:
-              name: istio.io:istiod-ca:root-cert
+              name: istio.io:istiod-ca:{{ .Values.global.trustBundleName | default "root-cert" }}
               path: root-cert.pem
       {{- else }}
         configMap:
-          name: istio-ca-root-cert
+          name: {{ .Values.global.trustBundleName | default "istio-ca-root-cert" }}
       {{- end }}
       {{- end }}
       {{- if .Values.global.imagePullSecrets }}

--- a/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
@@ -292,11 +292,11 @@ spec:
         projected:
           sources:
           - clusterTrustBundle:
-              name: istio.io:istiod-ca:root-cert
+              name: istio.io:istiod-ca:{{ .Values.global.trustBundleName | default "root-cert" }}
               path: root-cert.pem
       {{- else }}
         configMap:
-          name: istio-ca-root-cert
+          name: {{ .Values.global.trustBundleName | default "istio-ca-root-cert" }}
       {{- end }}
       {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -194,6 +194,10 @@ spec:
           - name: EXTERNAL_ISTIOD
             value: "{{ .Values.global.externalIstiod }}"
 {{- end }}
+{{- if .Values.global.trustBundleName }}
+          - name: PILOT_CA_CERT_CONFIGMAP
+            value: "{{ .Values.global.trustBundleName }}"
+{{- end }}
           - name: PILOT_ENABLE_ANALYSIS
             value: "{{ .Values.global.istiod.enableAnalysis }}"
           - name: CLUSTER_ID
@@ -284,12 +288,12 @@ spec:
         projected:
           sources:
           - clusterTrustBundle:
-              name: istio.io:istiod-ca:root-cert
+              name: istio.io:istiod-ca:{{ .Values.global.trustBundleName | default "root-cert" }}
               path: root-cert.pem
               optional: true
   {{- else }}
         configMap:
-          name: istio-ca-root-cert
+          name: {{ .Values.global.trustBundleName | default "istio-ca-root-cert" }}
           defaultMode: 420
           optional: true
   {{- end }}

--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -191,11 +191,11 @@ spec:
         projected:
           sources:
           - clusterTrustBundle:
-              name: istio.io:istiod-ca:root-cert
+              name: istio.io:istiod-ca:{{ .Values.global.trustBundleName | default "root-cert" }}
               path: root-cert.pem
         {{- else }}
         configMap:
-          name: istio-ca-root-cert
+          name: {{ .Values.trustBundleName | default "istio-ca-root-cert" }}
         {{- end }}
       - name: cni-ztunnel-sock-dir
         hostPath:

--- a/operator/pkg/apis/values_types.pb.go
+++ b/operator/pkg/apis/values_types.pb.go
@@ -1795,9 +1795,11 @@ type GlobalConfig struct {
 	// More info: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services
 	IpFamilyPolicy string `protobuf:"bytes,71,opt,name=ipFamilyPolicy,proto3" json:"ipFamilyPolicy,omitempty"`
 	// Specifies how waypoints are configured within Istio.
-	Waypoint      *WaypointConfig `protobuf:"bytes,72,opt,name=waypoint,proto3" json:"waypoint,omitempty"` // The next available key is 73
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Waypoint *WaypointConfig `protobuf:"bytes,72,opt,name=waypoint,proto3" json:"waypoint,omitempty"`
+	// Select a custom name for istiod's CA Root Cert ConfigMap.
+	TrustBundleName string `protobuf:"bytes,73,opt,name=trustBundleName,proto3" json:"trustBundleName,omitempty"` // The next available key is 74
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *GlobalConfig) Reset() {
@@ -2128,6 +2130,13 @@ func (x *GlobalConfig) GetWaypoint() *WaypointConfig {
 		return x.Waypoint
 	}
 	return nil
+}
+
+func (x *GlobalConfig) GetTrustBundleName() string {
+	if x != nil {
+		return x.TrustBundleName
+	}
+	return ""
 }
 
 // Configuration for Security Token Service (STS) server.
@@ -5424,7 +5433,7 @@ const file_pkg_apis_values_types_proto_rawDesc = "" +
 	"\x14istio_ingressgateway\x18\x04 \x01(\v2-.istio.operator.v1alpha1.IngressGatewayConfigR\x14istio-ingressgateway\x12@\n" +
 	"\x0fsecurityContext\x18\n" +
 	" \x01(\v2\x16.google.protobuf.ValueR\x0fsecurityContext\x12>\n" +
-	"\x0eseccompProfile\x18\f \x01(\v2\x16.google.protobuf.ValueR\x0eseccompProfile\"\x9d\x12\n" +
+	"\x0eseccompProfile\x18\f \x01(\v2\x16.google.protobuf.ValueR\x0eseccompProfile\"\xc7\x12\n" +
 	"\fGlobalConfig\x12;\n" +
 	"\x04arch\x18\x01 \x01(\v2#.istio.operator.v1alpha1.ArchConfigB\x02\x18\x01R\x04arch\x12 \n" +
 	"\vcertSigners\x18D \x03(\tR\vcertSigners\x12F\n" +
@@ -5471,7 +5480,8 @@ const file_pkg_apis_values_types_proto_rawDesc = "" +
 	"ipFamilies\x18F \x03(\tR\n" +
 	"ipFamilies\x12&\n" +
 	"\x0eipFamilyPolicy\x18G \x01(\tR\x0eipFamilyPolicy\x12C\n" +
-	"\bwaypoint\x18H \x01(\v2'.istio.operator.v1alpha1.WaypointConfigR\bwaypoint\"-\n" +
+	"\bwaypoint\x18H \x01(\v2'.istio.operator.v1alpha1.WaypointConfigR\bwaypoint\x12(\n" +
+	"\x0ftrustBundleName\x18I \x01(\tR\x0ftrustBundleName\"-\n" +
 	"\tSTSConfig\x12 \n" +
 	"\vservicePort\x18\x01 \x01(\rR\vservicePort\"R\n" +
 	"\fIstiodConfig\x12B\n" +

--- a/operator/pkg/apis/values_types.proto
+++ b/operator/pkg/apis/values_types.proto
@@ -617,7 +617,10 @@ message GlobalConfig {
 
   // Specifies how waypoints are configured within Istio.
   WaypointConfig waypoint = 72;
-  // The next available key is 73
+
+  // Select a custom name for istiod's CA Root Cert ConfigMap.
+  string trustBundleName = 73;
+  // The next available key is 74
 }
 
 // Configuration for Security Token Service (STS) server.

--- a/pilot/pkg/features/experimental.go
+++ b/pilot/pkg/features/experimental.go
@@ -198,4 +198,7 @@ var (
 
 	UnifiedSidecarScoping = env.Register("PILOT_UNIFIED_SIDECAR_SCOPE", true,
 		"If true, unified SidecarScope creation will be used. This is only intended as a temporary feature flag for backwards compatibility.").Get()
+
+	CACertConfigMapName = env.Register("PILOT_CA_CERT_CONFIGMAP", "istio-ca-root-cert",
+		"The name of the ConfigMap that stores the Root CA Certificate that is used by istiod").Get()
 )

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
@@ -32,9 +32,6 @@ import (
 )
 
 const (
-	// CACertNamespaceConfigMap is the name of the ConfigMap in each namespace storing the root cert of non-Kube CA.
-	CACertNamespaceConfigMap = "istio-ca-root-cert"
-
 	// maxRetries is the number of times a namespace will be retried before it is dropped out of the queue.
 	// With the current rate-limiter in use (5ms*2^(maxRetries-1)) the following numbers represent the
 	// sequence of delays between successive queuing of a namespace.
@@ -43,7 +40,12 @@ const (
 	maxRetries = 5
 )
 
-var configMapLabel = map[string]string{"istio.io/config": "true"}
+var (
+	// CACertNamespaceConfigMap is the name of the ConfigMap in each namespace storing the root cert of non-Kube CA.
+	CACertNamespaceConfigMap = features.CACertConfigMapName
+
+	configMapLabel = map[string]string{"istio.io/config": "true"}
+)
 
 // NamespaceController manages reconciles a configmap in each namespace with a desired set of data.
 type NamespaceController struct {

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
@@ -278,6 +278,6 @@ func expectConfigMapNotExist(t *testing.T, configmaps kclient.Client[*v1.ConfigM
 	}, retry.Timeout(time.Millisecond*25))
 
 	if err == nil {
-		t.Fatalf("%s namespace should not have istio-ca-root-cert configmap.", ns)
+		t.Fatalf("%s namespace should not have %s configmap.", ns, CACertNamespaceConfigMap)
 	}
 }

--- a/pkg/test/framework/components/echo/common/deployment/namespace.go
+++ b/pkg/test/framework/components/echo/common/deployment/namespace.go
@@ -74,6 +74,9 @@ type EchoNamespace struct {
 	Sotw echo.Instances
 	// All echo apps in this namespace
 	All echo.Services
+
+	// Common prefix for Service names
+	ServiceNamePrefix string
 }
 
 func (n EchoNamespace) build(b deployment.Builder, cfg Config) deployment.Builder {
@@ -92,23 +95,23 @@ func (n *EchoNamespace) loadValues(t resource.Context, echos echo.Instances, d *
 	ns := n.Namespace
 	n.All = match.Namespace(ns).GetMatches(echos).Services()
 
-	n.A = match.ServiceName(echo.NamespacedName{Name: ASvc, Namespace: ns}).GetMatches(echos)
-	n.B = match.ServiceName(echo.NamespacedName{Name: BSvc, Namespace: ns}).GetMatches(echos)
-	n.C = match.ServiceName(echo.NamespacedName{Name: CSvc, Namespace: ns}).GetMatches(echos)
+	n.A = match.ServiceName(echo.NamespacedName{Name: n.ServiceNamePrefix + ASvc, Namespace: ns}).GetMatches(echos)
+	n.B = match.ServiceName(echo.NamespacedName{Name: n.ServiceNamePrefix + BSvc, Namespace: ns}).GetMatches(echos)
+	n.C = match.ServiceName(echo.NamespacedName{Name: n.ServiceNamePrefix + CSvc, Namespace: ns}).GetMatches(echos)
 	if len(t.Settings().IPFamilies) > 1 {
-		n.D = match.ServiceName(echo.NamespacedName{Name: DSvc, Namespace: ns}).GetMatches(echos)
-		n.E = match.ServiceName(echo.NamespacedName{Name: ESvc, Namespace: ns}).GetMatches(echos)
+		n.D = match.ServiceName(echo.NamespacedName{Name: n.ServiceNamePrefix + DSvc, Namespace: ns}).GetMatches(echos)
+		n.E = match.ServiceName(echo.NamespacedName{Name: n.ServiceNamePrefix + ESvc, Namespace: ns}).GetMatches(echos)
 	}
-	n.Tproxy = match.ServiceName(echo.NamespacedName{Name: TproxySvc, Namespace: ns}).GetMatches(echos)
-	n.Headless = match.ServiceName(echo.NamespacedName{Name: HeadlessSvc, Namespace: ns}).GetMatches(echos)
-	n.StatefulSet = match.ServiceName(echo.NamespacedName{Name: StatefulSetSvc, Namespace: ns}).GetMatches(echos)
-	n.Naked = match.ServiceName(echo.NamespacedName{Name: NakedSvc, Namespace: ns}).GetMatches(echos)
-	n.ProxylessGRPC = match.ServiceName(echo.NamespacedName{Name: ProxylessGRPCSvc, Namespace: ns}).GetMatches(echos)
+	n.Tproxy = match.ServiceName(echo.NamespacedName{Name: n.ServiceNamePrefix + TproxySvc, Namespace: ns}).GetMatches(echos)
+	n.Headless = match.ServiceName(echo.NamespacedName{Name: n.ServiceNamePrefix + HeadlessSvc, Namespace: ns}).GetMatches(echos)
+	n.StatefulSet = match.ServiceName(echo.NamespacedName{Name: n.ServiceNamePrefix + StatefulSetSvc, Namespace: ns}).GetMatches(echos)
+	n.Naked = match.ServiceName(echo.NamespacedName{Name: n.ServiceNamePrefix + NakedSvc, Namespace: ns}).GetMatches(echos)
+	n.ProxylessGRPC = match.ServiceName(echo.NamespacedName{Name: n.ServiceNamePrefix + ProxylessGRPCSvc, Namespace: ns}).GetMatches(echos)
 	if !t.Settings().Skip(echo.VM) {
-		n.VM = match.ServiceName(echo.NamespacedName{Name: VMSvc, Namespace: ns}).GetMatches(echos)
+		n.VM = match.ServiceName(echo.NamespacedName{Name: n.ServiceNamePrefix + VMSvc, Namespace: ns}).GetMatches(echos)
 	}
 	if !t.Settings().Skip(echo.Sotw) {
-		n.Sotw = match.ServiceName(echo.NamespacedName{Name: SotwSvc, Namespace: ns}).GetMatches(echos)
+		n.Sotw = match.ServiceName(echo.NamespacedName{Name: n.ServiceNamePrefix + SotwSvc, Namespace: ns}).GetMatches(echos)
 	}
 
 	namespaces, err := namespace.GetAll(t)

--- a/releasenotes/notes/53385.yaml
+++ b/releasenotes/notes/53385.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+
+releaseNotes:
+- |
+  **Added** a setting values.global.trustBundleName that allows configuring the name of the ConfigMap that istiod uses to propagate its root CA certificate in the cluster. This allows running multiple control planes with overlapping namespaces in the same cluster.

--- a/tests/integration/pilot/multiplecontrolplanes/main_test.go
+++ b/tests/integration/pilot/multiplecontrolplanes/main_test.go
@@ -136,6 +136,7 @@ values:
 					namespace.Future(&sharedNS),
 				},
 				ExternalNamespace: namespace.Future(&externalNS),
+				// we're using the ServiceNamePrefix field to prefix service names, as we deploy two echo instances to the sharedNS namespace
 				ServiceNamePrefix: "usergroup-1-",
 			})).
 		Setup(func(ctx resource.Context) error {
@@ -149,6 +150,7 @@ values:
 					namespace.Future(&sharedNS),
 				},
 				ExternalNamespace: namespace.Future(&externalNS),
+				// we're using the ServiceNamePrefix field to prefix service names, as we deploy two echo instances to the sharedNS namespace
 				ServiceNamePrefix: "usergroup-2-",
 			})(ctx)
 		}).

--- a/tests/integration/pilot/multiplecontrolplanes/main_test.go
+++ b/tests/integration/pilot/multiplecontrolplanes/main_test.go
@@ -46,8 +46,10 @@ var (
 	echo1NS    namespace.Instance
 	echo2NS    namespace.Instance
 	echo3NS    namespace.Instance
+	sharedNS   namespace.Instance
 	externalNS namespace.Instance
-	apps       deployment.Echos
+	apps1      deployment.Echos
+	apps2      deployment.Echos
 )
 
 // TestMain defines the entrypoint for multiple controlplane tests using revisions and discoverySelectors.
@@ -86,6 +88,8 @@ meshConfig:
   discoverySelectors:
     - matchLabels:
         usergroup: usergroup-1
+    - matchLabels:
+        usergroup: shared
 values:
   global:
     istioNamespace: %s`,
@@ -98,6 +102,11 @@ values:
 
 			cfg.Values["global.istioNamespace"] = userGroup2NS.Name()
 			cfg.SystemNamespace = userGroup2NS.Name()
+			cfg.EastWestGatewayValues = `
+values:
+  global:
+    trustBundleName: usergroup-2-ca-root-cert
+`
 			cfg.ControlPlaneValues = fmt.Sprintf(`
 namespace: %s
 revision: usergroup-2
@@ -106,26 +115,43 @@ meshConfig:
   discoverySelectors:
     - matchLabels:
         usergroup: usergroup-2
+    - matchLabels:
+        usergroup: shared
 values:
   global:
-    istioNamespace: %s`,
-				userGroup2NS.Name(), userGroup2NS.Name())
+    trustBundleName: usergroup-2-ca-root-cert
+    istioNamespace: %s`, userGroup2NS.Name(), userGroup2NS.Name())
 		})).
 		SetupParallel(
 			// application namespaces are labeled according to the required control plane ownership.
 			namespace.Setup(&echo1NS, namespace.Config{Prefix: "echo1", Inject: true, Revision: "usergroup-1", Labels: map[string]string{"usergroup": "usergroup-1"}}),
 			namespace.Setup(&echo2NS, namespace.Config{Prefix: "echo2", Inject: true, Revision: "usergroup-2", Labels: map[string]string{"usergroup": "usergroup-2"}}),
 			namespace.Setup(&echo3NS, namespace.Config{Prefix: "echo3", Inject: true, Revision: "usergroup-2", Labels: map[string]string{"usergroup": "usergroup-2"}}),
+			namespace.Setup(&sharedNS, namespace.Config{Prefix: "echo-shared", Inject: true, Revision: "usergroup-1", Labels: map[string]string{"usergroup": "shared"}}),
 			namespace.Setup(&externalNS, namespace.Config{Prefix: "external", Inject: false})).
 		SetupParallel(
-			deployment.Setup(&apps, deployment.Config{
+			deployment.Setup(&apps1, deployment.Config{
 				Namespaces: []namespace.Getter{
 					namespace.Future(&echo1NS),
-					namespace.Future(&echo2NS),
-					namespace.Future(&echo3NS),
+					namespace.Future(&sharedNS),
 				},
 				ExternalNamespace: namespace.Future(&externalNS),
+				ServiceNamePrefix: "usergroup-1-",
 			})).
+		Setup(func(ctx resource.Context) error {
+			return sharedNS.SetLabel("istio.io/rev", "usergroup-2")
+		}).
+		Setup(func(ctx resource.Context) error {
+			return deployment.Setup(&apps2, deployment.Config{
+				Namespaces: []namespace.Getter{
+					namespace.Future(&echo2NS),
+					namespace.Future(&echo3NS),
+					namespace.Future(&sharedNS),
+				},
+				ExternalNamespace: namespace.Future(&externalNS),
+				ServiceNamePrefix: "usergroup-2-",
+			})(ctx)
+		}).
 		Run()
 }
 
@@ -145,26 +171,44 @@ func TestMultiControlPlane(t *testing.T) {
 				{
 					name:       "workloads within same usergroup can communicate, same namespace",
 					statusCode: http.StatusOK,
-					from:       apps.NS[0].A,
-					to:         apps.NS[0].B,
+					from:       apps1.NS[0].A,
+					to:         apps1.NS[0].B,
 				},
 				{
 					name:       "workloads within same usergroup can communicate, different namespaces",
 					statusCode: http.StatusOK,
-					from:       apps.NS[1].A,
-					to:         apps.NS[2].B,
+					from:       apps2.NS[0].A,
+					to:         apps2.NS[1].B,
+				},
+				{
+					name:       "workloads within same usergroup can communicate, different namespaces, one of them shared",
+					statusCode: http.StatusOK,
+					from:       apps2.NS[0].A,
+					to:         apps2.NS[2].B,
+				},
+				{
+					name:       "workloads within same usergroup can communicate, shared namespace",
+					statusCode: http.StatusOK,
+					from:       apps1.NS[1].A,
+					to:         apps1.NS[1].B,
 				},
 				{
 					name:       "workloads within different usergroups cannot communicate, registry only",
 					statusCode: http.StatusBadGateway,
-					from:       apps.NS[0].A,
-					to:         apps.NS[1].B,
+					from:       apps1.NS[0].A,
+					to:         apps2.NS[0].B,
 				},
 				{
 					name:       "workloads within different usergroups cannot communicate, default passthrough",
 					statusCode: http.StatusServiceUnavailable,
-					from:       apps.NS[2].B,
-					to:         apps.NS[0].B,
+					from:       apps2.NS[1].B,
+					to:         apps1.NS[0].B,
+				},
+				{
+					name:       "workloads within different usergroups cannot communicate, shared namespace",
+					statusCode: http.StatusServiceUnavailable,
+					from:       apps2.NS[2].B,
+					to:         apps1.NS[1].B,
 				},
 			}
 
@@ -190,7 +234,7 @@ func TestCustomResourceScoping(t *testing.T) {
 	framework.NewTest(t).
 		Run(func(t framework.TestContext) {
 			// allow access to external service only for app-ns-2 namespace which is under usergroup-2
-			allowExternalService(t, apps.NS[1].Namespace.Name(), externalNS.Name(), "usergroup-2")
+			allowExternalService(t, apps2.NS[0].Namespace.Name(), externalNS.Name(), "usergroup-2")
 
 			testCases := []struct {
 				name       string
@@ -200,25 +244,25 @@ func TestCustomResourceScoping(t *testing.T) {
 				{
 					name:       "workloads in SE configured namespace can reach external service",
 					statusCode: http.StatusOK,
-					from:       apps.NS[1].A,
+					from:       apps2.NS[0].A,
 				},
 				{
 					name:       "workloads in non-SE configured namespace, but same usergroup can reach external service",
 					statusCode: http.StatusOK,
-					from:       apps.NS[2].A,
+					from:       apps2.NS[1].A,
 				},
 				{
 					name:       "workloads in non-SE configured usergroup cannot reach external service",
 					statusCode: http.StatusBadGateway,
-					from:       apps.NS[0].A,
+					from:       apps1.NS[0].A,
 				},
 			}
 			for _, tc := range testCases {
 				t.NewSubTestf(tc.name).Run(func(t framework.TestContext) {
 					tc.from[0].CallOrFail(t, echo.CallOptions{
-						Address: apps.External.All[0].Address(),
+						Address: apps1.External.All[0].Address(),
 						HTTP: echo.HTTP{
-							Headers: HostHeader(apps.External.All[0].Config().DefaultHostHeader),
+							Headers: HostHeader(apps1.External.All[0].Config().DefaultHostHeader),
 						},
 						Port:   echo.Port{Name: "http", ServicePort: 80},
 						Scheme: scheme.HTTP,


### PR DESCRIPTION
**Please provide a description of this PR:**
Another shot, precursor was https://github.com/istio/istio/pull/53386.

To extend our current multi controlplane support, this PR adds support for a custom CACert ConfigMap name, different than the default istio-ca-root-cert. This is currently the only thing stopping us from running control planes where the discoverySelectors overlap.

Part of https://github.com/istio/istio/issues/53385