### PR TITLE
multus: fix behavior when the value of `k8s.v1.cni.cncf.io/networks` annotation is a JSON array

### DIFF
--- a/pkg/kube/inject/template.go
+++ b/pkg/kube/inject/template.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kstrings "k8s.io/utils/strings"
 	"sigs.k8s.io/yaml"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -195,12 +196,25 @@ func appendMultusNetwork(existingValue, istioCniNetwork string) string {
 			log.Warnf("Unable to unmarshal Multus Network annotation JSON value: %v", err)
 			return existingValue
 		}
+		istioCniNetworkNs, istioCniNetworkName := kstrings.SplitQualifiedName(istioCniNetwork)
 		for _, net := range networks {
-			if net["name"] == istioCniNetwork {
-				return existingValue
+			if net["name"] == istioCniNetworkName {
+				ns := net["namespace"]
+				if ns == nil {
+					ns = ""
+				}
+				if ns == istioCniNetworkNs {
+					return existingValue
+				}
 			}
 		}
-		return existingValue[0:i] + fmt.Sprintf(`, {"name": "%s"}`, istioCniNetwork) + existingValue[i:]
+		var istioCniNetworkJSON string
+		if istioCniNetworkNs == "" {
+			istioCniNetworkJSON = fmt.Sprintf(`, {"name": "%s"}`, istioCniNetworkName)
+		} else {
+			istioCniNetworkJSON = fmt.Sprintf(`, {"name": "%s", "namespace": "%s"}`, istioCniNetworkName, istioCniNetworkNs)
+		}
+		return existingValue[0:i] + istioCniNetworkJSON + existingValue[i:]
 	}
 	for _, net := range strings.Split(existingValue, ",") {
 		if strings.TrimSpace(net) == istioCniNetwork {

--- a/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks-json.yaml
+++ b/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks-json.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       annotations:
-        k8s.v1.cni.cncf.io/networks: '[{"name": "alt_cni"}]'
+        k8s.v1.cni.cncf.io/networks: '[{"name": "alt_cni"}, {"name": "more_cni", "namespace": "kube-system"}]'
       labels:
         app: hello
         tier: backend

--- a/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks-json.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks-json.yaml.injected
@@ -15,7 +15,8 @@ spec:
     metadata:
       annotations:
         istio.io/rev: default
-        k8s.v1.cni.cncf.io/networks: '[{"name": "alt_cni"}, {"name": "default/istio-cni"}]'
+        k8s.v1.cni.cncf.io/networks: '[{"name": "alt_cni"}, {"name": "istio-cni",
+          "namespace": "default"}]'
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello
         prometheus.io/path: /stats/prometheus

--- a/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks-json.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks-json.yaml.injected
@@ -15,8 +15,8 @@ spec:
     metadata:
       annotations:
         istio.io/rev: default
-        k8s.v1.cni.cncf.io/networks: '[{"name": "alt_cni"}, {"name": "istio-cni",
-          "namespace": "default"}]'
+        k8s.v1.cni.cncf.io/networks: '[{"name": "alt_cni"}, {"name": "more_cni", "namespace":
+          "kube-system"}, {"name": "istio-cni", "namespace": "default"}]'
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello
         prometheus.io/path: /stats/prometheus


### PR DESCRIPTION
Fixes #54820

**Please provide a description of this PR:**

Fix behavior when the value of `k8s.v1.cni.cncf.io/networks` annotation is a JSON array.