### PR TITLE
samples: do not inject ext-authz demo

### DIFF
--- a/samples/extauthz/ext-authz.yaml
+++ b/samples/extauthz/ext-authz.yaml
@@ -44,6 +44,7 @@ spec:
     metadata:
       labels:
         app: ext-authz
+        sidecar.istio.io/inject: "false" # do not inject the sidecar
     spec:
       containers:
       - image: gcr.io/istio-testing/ext-authz:latest


### PR DESCRIPTION
**Please provide a description of this PR:**

If we are not supposed to inject the ext authz server, this can lead to unexpected behavior when you apply authz rules in root namespace.