### PR TITLE
Documentation fix - `OUTPUT_CERT` should be `OUTPUT_CERTS`

### DIFF
--- a/architecture/security/istio-agent.md
+++ b/architecture/security/istio-agent.md
@@ -84,7 +84,7 @@ a new one will be generated on demand.
 |CA_ADDR|Address of CA, defaults to discoveryAddress|
 |CA_PROVIDER|Type of CA; supported values are GoogleCA or Citadel (although anything but GoogleCA will use Citadel); defaults to Citadel|
 |PROV_CERT|certificates to be used for mTLS communication with control plane only; NOT for workload mTLS|
-|OUTPUT_CERT|write all fetched certificates to some directory. Used to support applications that need certificates (Prometheus) as well as rotating mTLS control plane authentication.|
+|OUTPUT_CERTS|write all fetched certificates to some directory. Used to support applications that need certificates (Prometheus) as well as rotating mTLS control plane authentication.|
 |FILE_MOUNTED_CERTS|completely disable CA path, exclusively use certs mounted into the pod with set certificate file locations|
 |CREDENTIAL_FETCHER_TYPE|allows using custom credential fetcher, for VMs with existing identity|
 |CREDENTIAL_IDENTITY_PROVIDER|just used to control the audience for VMs with existing identity|


### PR DESCRIPTION
`OUTPUT_CERT` should be `OUTPUT_CERTS`

**Please provide a description of this PR:**

Fix for a small typo in the Istio Agent configuration documentation where the configuration variable should be `OUTPUT_CERTS`. 

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
