### PR TITLE
ambient: support direct usage of ReplicaSet

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
@@ -136,6 +136,44 @@ func TestPodWorkloads(t *testing.T) {
 			},
 		},
 		{
+			name:   "pod from replicaset",
+			inputs: []any{},
+			pod: &v1.Pod{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:         "rs-xvnqd",
+					Namespace:    "ns",
+					GenerateName: "rs-",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:       "ReplicaSet",
+							APIVersion: "apps/v1",
+							Name:       "rs",
+							Controller: ptr.Of(true),
+						},
+					},
+				},
+				Spec: v1.PodSpec{},
+				Status: v1.PodStatus{
+					Phase: v1.PodRunning,
+					PodIP: "1.2.3.4",
+				},
+			},
+			result: &workloadapi.Workload{
+				Uid:               "cluster0//Pod/ns/rs-xvnqd",
+				Name:              "rs-xvnqd",
+				Namespace:         "ns",
+				Addresses:         [][]byte{netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice()},
+				Network:           testNW,
+				CanonicalName:     "rs",
+				CanonicalRevision: "latest",
+				WorkloadType:      workloadapi.WorkloadType_POD,
+				WorkloadName:      "rs",
+				Status:            workloadapi.WorkloadStatus_UNHEALTHY,
+				ClusterId:         testC,
+			},
+		},
+		{
 			name: "pod with service",
 			inputs: []any{
 				model.ServiceInfo{


### PR DESCRIPTION
See https://istio.slack.com/archives/C06M609UE11/p1738680394797249

This PR makes us support any controller kind (well, any that is already supported in the shared-with-sidecars heuristics).

As part of this, it removes any setting of "workload type". This field is inaccurate and not useful; we do not use it anywhere in ztunnel except to plug into baggage. I propose we hardcode this for all resource types. Otherwise, we will need to continually update it with all sorts of types we may want to include which seems of limited value

**Please provide a description of this PR:**