### PR TITLE
EnvoyFilter: do not re-use struct where not appropriate

### DIFF
--- a/pilot/pkg/model/envoyfilter.go
+++ b/pilot/pkg/model/envoyfilter.go
@@ -185,7 +185,7 @@ func (efw *EnvoyFilterWrapper) Keys() []string {
 }
 
 // Returns the keys of all the wrapped envoyfilters.
-func (efw *EnvoyFilterWrapper) KeysApplyingTo(applyTo ...networking.EnvoyFilter_ApplyTo) []string {
+func (efw *MergedEnvoyFilterWrapper) KeysApplyingTo(applyTo ...networking.EnvoyFilter_ApplyTo) []string {
 	if efw == nil {
 		return nil
 	}

--- a/pilot/pkg/model/envoyfilter_test.go
+++ b/pilot/pkg/model/envoyfilter_test.go
@@ -179,7 +179,7 @@ func TestConvertEnvoyFilter(t *testing.T) {
 }
 
 func TestKeysApplyingTo(t *testing.T) {
-	e := &EnvoyFilterWrapper{
+	e := &MergedEnvoyFilterWrapper{
 		Patches: map[networking.EnvoyFilter_ApplyTo][]*EnvoyFilterConfigPatchWrapper{
 			networking.EnvoyFilter_HTTP_FILTER: {
 				{
@@ -214,7 +214,7 @@ func TestKeysApplyingTo(t *testing.T) {
 	}
 	tests := []struct {
 		name    string
-		efw     *EnvoyFilterWrapper
+		efw     *MergedEnvoyFilterWrapper
 		applyTo []networking.EnvoyFilter_ApplyTo
 		want    []string
 	}{

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -2247,8 +2247,12 @@ func (ps *PushContext) initEnvoyFilters(env *Environment, changed sets.Set[Confi
 	}
 }
 
+type MergedEnvoyFilterWrapper struct {
+	Patches map[networking.EnvoyFilter_ApplyTo][]*EnvoyFilterConfigPatchWrapper
+}
+
 // EnvoyFilters return the merged EnvoyFilterWrapper of a proxy
-func (ps *PushContext) EnvoyFilters(proxy *Proxy) *EnvoyFilterWrapper {
+func (ps *PushContext) EnvoyFilters(proxy *Proxy) *MergedEnvoyFilterWrapper {
 	// this should never happen
 	if proxy == nil {
 		return nil
@@ -2285,9 +2289,9 @@ func (ps *PushContext) EnvoyFilters(proxy *Proxy) *EnvoyFilterWrapper {
 		jn := jfilter.Name + "." + jfilter.Namespace
 		return in < jn
 	})
-	var out *EnvoyFilterWrapper
+	var out *MergedEnvoyFilterWrapper
 	if len(matchedEnvoyFilters) > 0 {
-		out = &EnvoyFilterWrapper{
+		out = &MergedEnvoyFilterWrapper{
 			// no need populate workloadSelector, as it is not used later.
 			Patches: make(map[networking.EnvoyFilter_ApplyTo][]*EnvoyFilterConfigPatchWrapper),
 		}

--- a/pilot/pkg/networking/core/cluster.go
+++ b/pilot/pkg/networking/core/cluster.go
@@ -377,7 +377,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(cb *ClusterBuilder, 
 }
 
 type clusterPatcher struct {
-	efw  *model.EnvoyFilterWrapper
+	efw  *model.MergedEnvoyFilterWrapper
 	pctx networking.EnvoyFilter_PatchContext
 }
 

--- a/pilot/pkg/networking/core/envoyfilter/cluster_patch.go
+++ b/pilot/pkg/networking/core/envoyfilter/cluster_patch.go
@@ -31,11 +31,11 @@ import (
 )
 
 // ApplyClusterMerge processes the MERGE operation and merges the supplied configuration to the matched clusters.
-func ApplyClusterMerge(pctx networking.EnvoyFilter_PatchContext, efw *model.EnvoyFilterWrapper,
+func ApplyClusterMerge(pctx networking.EnvoyFilter_PatchContext, efw *model.MergedEnvoyFilterWrapper,
 	c *cluster.Cluster, hosts []host.Name,
 ) (out *cluster.Cluster) {
 	defer runtime.HandleCrash(runtime.LogPanic, func(any) {
-		log.Errorf("clusters patch %s/%s caused panic, so the patches did not take effect", efw.Namespace, efw.Name)
+		log.Errorf("clusters patch caused panic, so the patches did not take effect")
 		IncrementEnvoyFilterErrorMetric(Cluster)
 	})
 	// In case the patches cause panic, use the clusters generated before to reduce the influence.
@@ -121,7 +121,7 @@ func mergeTransportSocketCluster(c *cluster.Cluster, cp *model.EnvoyFilterConfig
 }
 
 // ShouldKeepCluster checks if there is a REMOVE patch on the cluster, returns false if there is one so that it is removed.
-func ShouldKeepCluster(pctx networking.EnvoyFilter_PatchContext, efw *model.EnvoyFilterWrapper, c *cluster.Cluster, hosts []host.Name) bool {
+func ShouldKeepCluster(pctx networking.EnvoyFilter_PatchContext, efw *model.MergedEnvoyFilterWrapper, c *cluster.Cluster, hosts []host.Name) bool {
 	if efw == nil {
 		return true
 	}
@@ -137,7 +137,7 @@ func ShouldKeepCluster(pctx networking.EnvoyFilter_PatchContext, efw *model.Envo
 }
 
 // InsertedClusters collects all clusters that are added via ADD operation and match the patch context.
-func InsertedClusters(pctx networking.EnvoyFilter_PatchContext, efw *model.EnvoyFilterWrapper) []*cluster.Cluster {
+func InsertedClusters(pctx networking.EnvoyFilter_PatchContext, efw *model.MergedEnvoyFilterWrapper) []*cluster.Cluster {
 	if efw == nil {
 		return nil
 	}

--- a/pilot/pkg/networking/core/envoyfilter/extension_configuration_patch.go
+++ b/pilot/pkg/networking/core/envoyfilter/extension_configuration_patch.go
@@ -25,7 +25,7 @@ import (
 )
 
 // InsertedExtensionConfigurations returns extension configurations added via EnvoyFilter.
-func InsertedExtensionConfigurations(efw *model.EnvoyFilterWrapper, names []string) []*core.TypedExtensionConfig {
+func InsertedExtensionConfigurations(efw *model.MergedEnvoyFilterWrapper, names []string) []*core.TypedExtensionConfig {
 	result := make([]*core.TypedExtensionConfig, 0)
 	if efw == nil {
 		return result

--- a/pilot/pkg/networking/core/envoyfilter/listener_patch.go
+++ b/pilot/pkg/networking/core/envoyfilter/listener_patch.go
@@ -37,13 +37,13 @@ import (
 // ApplyListenerPatches applies patches to LDS output
 func ApplyListenerPatches(
 	patchContext networking.EnvoyFilter_PatchContext,
-	efw *model.EnvoyFilterWrapper,
+	efw *model.MergedEnvoyFilterWrapper,
 	lis []*listener.Listener,
 	skipAdds bool,
 ) (out []*listener.Listener) {
 	defer runtime.HandleCrash(runtime.LogPanic, func(any) {
 		IncrementEnvoyFilterErrorMetric(Listener)
-		log.Errorf("listeners patch %s/%s caused panic, so the patches did not take effect", efw.Namespace, efw.Name)
+		log.Errorf("listeners patch caused panic, so the patches did not take effect")
 	})
 	// In case the patches cause panic, use the listeners generated before to reduce the influence.
 	out = lis
@@ -57,7 +57,7 @@ func ApplyListenerPatches(
 
 func patchListeners(
 	patchContext networking.EnvoyFilter_PatchContext,
-	efw *model.EnvoyFilterWrapper,
+	efw *model.MergedEnvoyFilterWrapper,
 	listeners []*listener.Listener,
 	skipAdds bool,
 ) []*listener.Listener {

--- a/pilot/pkg/networking/core/envoyfilter/rc_patch.go
+++ b/pilot/pkg/networking/core/envoyfilter/rc_patch.go
@@ -34,12 +34,12 @@ import (
 func ApplyRouteConfigurationPatches(
 	patchContext networking.EnvoyFilter_PatchContext,
 	proxy *model.Proxy,
-	efw *model.EnvoyFilterWrapper,
+	efw *model.MergedEnvoyFilterWrapper,
 	routeConfiguration *route.RouteConfiguration,
 ) (out *route.RouteConfiguration) {
 	defer runtime.HandleCrash(runtime.LogPanic, func(any) {
 		IncrementEnvoyFilterErrorMetric(Route)
-		log.Errorf("route patch %s/%s caused panic, so the patches did not take effect", efw.Namespace, efw.Name)
+		log.Errorf("route patch caused panic, so the patches did not take effect")
 	})
 	// In case the patches cause panic, use the route generated before to reduce the influence.
 	out = routeConfiguration

--- a/pilot/pkg/networking/core/httproute.go
+++ b/pilot/pkg/networking/core/httproute.go
@@ -141,7 +141,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(
 	req *model.PushRequest,
 	routeName string,
 	vHostCache map[int][]*route.VirtualHost,
-	efw *model.EnvoyFilterWrapper,
+	efw *model.MergedEnvoyFilterWrapper,
 	efKeys []string,
 ) (*discovery.Resource, bool) {
 	listenerPort, useSniffing, err := extractListenerPort(routeName)

--- a/pilot/pkg/networking/core/listener_builder.go
+++ b/pilot/pkg/networking/core/listener_builder.go
@@ -61,7 +61,7 @@ type ListenerBuilder struct {
 	virtualOutboundListener *listener.Listener
 	virtualInboundListener  *listener.Listener
 
-	envoyFilterWrapper *model.EnvoyFilterWrapper
+	envoyFilterWrapper *model.MergedEnvoyFilterWrapper
 
 	// authnBuilder provides access to authn (mTLS) configuration for the given proxy.
 	authnBuilder *authn.Builder


### PR DESCRIPTION
We use EnvoyFilterWrapper for the per-config info, and for the merged
info. This is problematic since we just need to be careful not to
depend on fields we shouldn't use (which we have failed to do!).

This makes it clear which info is actually available.
