### PR TITLE
EnvoyFilter: allow referencing services as annotation

### DIFF
--- a/pilot/pkg/model/envoyfilter.go
+++ b/pilot/pkg/model/envoyfilter.go
@@ -92,6 +92,9 @@ func convertToEnvoyFilterWrapper(local *config.Config) *EnvoyFilterWrapper {
 		out.workloadSelector = localEnvoyFilter.WorkloadSelector.Labels
 	}
 
+	// For Waypoint/Gateway with filtering, we need to explicitly opt-in to included services.
+	// This annotation allows doing so.
+	// Note: sidecar use cases should make sure to use Sidecar to include them; this will not override exclusions by sidecar
 	svcRefs := local.Annotations["envoyfilter.istio.io/referenced-services"]
 	for _, ref := range strings.Split(svcRefs, ",") {
 		ns, h, ok := strings.Cut(ref, "/")

--- a/pilot/pkg/model/envoyfilter.go
+++ b/pilot/pkg/model/envoyfilter.go
@@ -23,6 +23,7 @@ import (
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/xds"
 	"istio.io/istio/pkg/util/sets"
@@ -30,12 +31,14 @@ import (
 
 // EnvoyFilterWrapper is a wrapper for the EnvoyFilter api object with pre-processed data
 type EnvoyFilterWrapper struct {
-	Name             string
-	Namespace        string
-	workloadSelector labels.Instance
-	Patches          map[networking.EnvoyFilter_ApplyTo][]*EnvoyFilterConfigPatchWrapper
-	Priority         int32
-	creationTime     time.Time
+	Name                         string
+	Namespace                    string
+	ReferencedNamespacedServices sets.Set[NamespacedHostname]
+	ReferencedServices           sets.String
+	workloadSelector             labels.Instance
+	Patches                      map[networking.EnvoyFilter_ApplyTo][]*EnvoyFilterConfigPatchWrapper
+	Priority                     int32
+	creationTime                 time.Time
 }
 
 // EnvoyFilterConfigPatchWrapper is a wrapper over the EnvoyFilter ConfigPatch api object
@@ -75,9 +78,34 @@ var wellKnownVersions = map[string]string{
 func convertToEnvoyFilterWrapper(local *config.Config) *EnvoyFilterWrapper {
 	localEnvoyFilter := local.Spec.(*networking.EnvoyFilter)
 
-	out := &EnvoyFilterWrapper{Name: local.Name, Namespace: local.Namespace, Priority: localEnvoyFilter.Priority, creationTime: local.CreationTimestamp}
+	out := &EnvoyFilterWrapper{
+		Name:                         local.Name,
+		Namespace:                    local.Namespace,
+		ReferencedNamespacedServices: nil,
+		ReferencedServices:           nil,
+		workloadSelector:             nil,
+		Patches:                      nil,
+		Priority:                     localEnvoyFilter.Priority,
+		creationTime:                 local.CreationTimestamp,
+	}
 	if localEnvoyFilter.WorkloadSelector != nil {
 		out.workloadSelector = localEnvoyFilter.WorkloadSelector.Labels
+	}
+
+	svcRefs := local.Annotations["envoyfilter.istio.io/referenced-services"]
+	for _, ref := range strings.Split(svcRefs, ",") {
+		ns, h, ok := strings.Cut(ref, "/")
+		if ok {
+			if out.ReferencedNamespacedServices == nil {
+				out.ReferencedNamespacedServices = sets.New[NamespacedHostname]()
+			}
+			out.ReferencedNamespacedServices.Insert(NamespacedHostname{Hostname: host.Name(h), Namespace: ns})
+		} else {
+			if out.ReferencedServices == nil {
+				out.ReferencedServices = sets.New[string]()
+			}
+			out.ReferencedServices.Insert(ref)
+		}
 	}
 	out.Patches = make(map[networking.EnvoyFilter_ApplyTo][]*EnvoyFilterConfigPatchWrapper)
 	for _, cp := range localEnvoyFilter.ConfigPatches {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1012,8 +1012,10 @@ func (ps *PushContext) extraServicesForProxy(proxy *Proxy, patches *EnvoyFilterW
 		}
 	}
 
-	namespaceScoped.Merge(patches.ReferencedNamespacedServices)
-	hosts.Merge(patches.ReferencedServices)
+	if patches != nil {
+		namespaceScoped.Merge(patches.ReferencedNamespacedServices)
+		hosts.Merge(patches.ReferencedServices)
+	}
 	return namespaceScoped, hosts
 }
 

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -3280,8 +3280,17 @@ func TestGetHostsFromMeshConfig(t *testing.T) {
 			},
 		},
 	}
+	ef := config.Config{
+		Meta: config.Meta{
+			GroupVersionKind: gvk.EnvoyFilter,
+			Annotations:      map[string]string{"envoyfilter.istio.io/referenced-services": "envoyfilter.example.com"},
+			Name:             "ef",
+			Namespace:        "istio-system",
+		},
+		Spec: &networking.EnvoyFilter{},
+	}
 
-	for _, c := range []config.Config{vs1, vs2} {
+	for _, c := range []config.Config{vs1, vs2, ef} {
 		if _, err := configStore.Create(c); err != nil {
 			t.Fatalf("could not create %v", c.Name)
 		}
@@ -3306,18 +3315,24 @@ func TestGetHostsFromMeshConfig(t *testing.T) {
 				Hostname:   "otel-wrong.example.com",
 				Attributes: ServiceAttributes{Namespace: "some-ns"},
 			},
+			{
+				Hostname:   "envoyfilter.example.com",
+				Attributes: ServiceAttributes{Namespace: "some-ns"},
+			},
 		},
 	}
 	ps.initDefaultExportMaps()
+	ps.initEnvoyFilters(env, nil, nil)
 	ps.initServiceRegistry(env, nil)
 	proxy := &Proxy{Type: Router}
 	proxy.SetSidecarScope(ps)
 	proxy.SetGatewaysForProxy(ps)
-	got := sets.New(slices.Map(ps.GatewayServices(proxy, nil), func(e *Service) string {
+	patches := ps.EnvoyFilters(proxy)
+	got := sets.New(slices.Map(ps.GatewayServices(proxy, patches), func(e *Service) string {
 		return e.Hostname.String()
 	})...)
 	// Should match 2 of the 3 providers; one has a mismatched namespace though
-	assert.Equal(t, got, sets.New("otel.foo.svc.cluster.local", "otel.example.com"))
+	assert.Equal(t, got, sets.New("otel.foo.svc.cluster.local", "otel.example.com", "envoyfilter.example.com"))
 }
 
 func TestWellKnownProvidersCount(t *testing.T) {

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -3313,7 +3313,7 @@ func TestGetHostsFromMeshConfig(t *testing.T) {
 	proxy := &Proxy{Type: Router}
 	proxy.SetSidecarScope(ps)
 	proxy.SetGatewaysForProxy(ps)
-	got := sets.New(slices.Map(ps.GatewayServices(proxy), func(e *Service) string {
+	got := sets.New(slices.Map(ps.GatewayServices(proxy, nil), func(e *Service) string {
 		return e.Hostname.String()
 	})...)
 	// Should match 2 of the 3 providers; one has a mismatched namespace though

--- a/pilot/pkg/networking/core/cluster.go
+++ b/pilot/pkg/networking/core/cluster.go
@@ -211,7 +211,7 @@ func (configgen *ConfigGeneratorImpl) deltaFromDestinationRules(updatedDr model.
 
 // buildClusters builds clusters for the proxy with the services passed.
 func (configgen *ConfigGeneratorImpl) buildClusters(proxy *model.Proxy, req *model.PushRequest,
-	services []*model.Service, envoyFilterPatches *model.EnvoyFilterWrapper,
+	services []*model.Service, envoyFilterPatches *model.MergedEnvoyFilterWrapper,
 ) ([]*discovery.Resource, model.XdsLogDetails) {
 	clusters := make([]*cluster.Cluster, 0)
 	resources := model.Resources{}

--- a/pilot/pkg/networking/core/cluster.go
+++ b/pilot/pkg/networking/core/cluster.go
@@ -54,14 +54,15 @@ var deltaConfigTypes = sets.New(kind.ServiceEntry.String(), kind.DestinationRule
 // Cluster type based on resolution
 // For inbound (sidecar only): Cluster for each inbound endpoint port and for each service port
 func (configgen *ConfigGeneratorImpl) BuildClusters(proxy *model.Proxy, req *model.PushRequest) ([]*discovery.Resource, model.XdsLogDetails) {
+	envoyFilterPatches := req.Push.EnvoyFilters(proxy)
 	// In Sotw, we care about all services.
 	var services []*model.Service
 	if features.FilterGatewayClusterConfig && proxy.Type == model.Router {
-		services = req.Push.GatewayServices(proxy)
+		services = req.Push.GatewayServices(proxy, envoyFilterPatches)
 	} else {
 		services = proxy.SidecarScope.Services()
 	}
-	return configgen.buildClusters(proxy, req, services)
+	return configgen.buildClusters(proxy, req, services, envoyFilterPatches)
 }
 
 // BuildDeltaClusters generates the deltas (add and delete) for a given proxy. Currently, only service changes are reflected with deltas.
@@ -128,7 +129,8 @@ func (configgen *ConfigGeneratorImpl) BuildDeltaClusters(proxy *model.Proxy, upd
 
 		deletedClusters.InsertAll(deleted...)
 	}
-	clusters, log := configgen.buildClusters(proxy, updates, services)
+	envoyFilterPatches := updates.Push.EnvoyFilters(proxy)
+	clusters, log := configgen.buildClusters(proxy, updates, services, envoyFilterPatches)
 	// DeletedClusters contains list of all subset clusters for the deleted DR or updated DR.
 	// When clusters are rebuilt, we rebuild the subset clusters as well. So, we know what
 	// subset clusters are really needed. So if deleted cluster is not rebuilt, then it is really deleted.
@@ -209,11 +211,10 @@ func (configgen *ConfigGeneratorImpl) deltaFromDestinationRules(updatedDr model.
 
 // buildClusters builds clusters for the proxy with the services passed.
 func (configgen *ConfigGeneratorImpl) buildClusters(proxy *model.Proxy, req *model.PushRequest,
-	services []*model.Service,
+	services []*model.Service, envoyFilterPatches *model.EnvoyFilterWrapper,
 ) ([]*discovery.Resource, model.XdsLogDetails) {
 	clusters := make([]*cluster.Cluster, 0)
 	resources := model.Resources{}
-	envoyFilterPatches := req.Push.EnvoyFilters(proxy)
 	cb := NewClusterBuilder(proxy, req, configgen.Cache)
 	instances := proxy.ServiceTargets
 	cacheStats := cacheStats{}
@@ -240,7 +241,7 @@ func (configgen *ConfigGeneratorImpl) buildClusters(proxy *model.Proxy, req *mod
 		_, wps := findWaypointResources(proxy, req.Push)
 		// Waypoint proxies do not need outbound clusters in most cases, unless we have a route pointing to something
 		outboundPatcher := clusterPatcher{efw: envoyFilterPatches, pctx: networking.EnvoyFilter_SIDECAR_OUTBOUND}
-		extraNamespacedHosts, extraHosts := req.Push.ExtraWaypointServices(proxy)
+		extraNamespacedHosts, extraHosts := req.Push.ExtraWaypointServices(proxy, envoyFilterPatches)
 		ob, cs := configgen.buildOutboundClusters(cb, proxy, outboundPatcher, filterWaypointOutboundServices(
 			req.Push.ServicesAttachedToMesh(), wps.services, extraNamespacedHosts, extraHosts, services))
 		cacheStats = cacheStats.merge(cs)


### PR DESCRIPTION
This solves the issues I was aiming for in https://github.com/istio/istio/pull/54895 but in a better way.

Instead of saying "This service is needed", the envoyfilter itself declares what it needs.