### PR TITLE
trafficDistribution: align Envoy behavior with ambient

### DIFF
--- a/pilot/pkg/networking/core/loadbalancer/loadbalancer_test.go
+++ b/pilot/pkg/networking/core/loadbalancer/loadbalancer_test.go
@@ -25,11 +25,13 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
+	"istio.io/api/label"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/model"
 	memregistry "istio.io/istio/pilot/pkg/serviceregistry/memory"
+	registrylabel "istio.io/istio/pilot/pkg/serviceregistry/util/label"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/mesh/meshwatcher"
 	"istio.io/istio/pkg/config/protocol"
@@ -1050,7 +1052,15 @@ func TestGetLocalityLbSetting(t *testing.T) {
 			&networking.LocalityLoadBalancerSetting{},
 			nil,
 			preferCloseService,
-			&networking.LocalityLoadBalancerSetting{Enabled: &wrappers.BoolValue{Value: true}},
+			&networking.LocalityLoadBalancerSetting{
+				FailoverPriority: []string{
+					label.TopologyNetwork.Name,
+					registrylabel.LabelTopologyRegion,
+					registrylabel.LabelTopologyZone,
+					label.TopologySubzone.Name,
+				},
+				Enabled: &wrappers.BoolValue{Value: true},
+			},
 		},
 		{
 			"mesh disabled",

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -154,14 +154,7 @@ func ConvertService(svc corev1.Service, domainSuffix string, clusterID cluster.I
 
 	istioService.Attributes.Type = string(svc.Spec.Type)
 	istioService.Attributes.ExternalName = externalName
-
-	preferClose := strings.EqualFold(svc.Annotations[annotation.NetworkingTrafficDistribution.Name], corev1.ServiceTrafficDistributionPreferClose)
-	if svc.Spec.TrafficDistribution != nil {
-		preferClose = *svc.Spec.TrafficDistribution == corev1.ServiceTrafficDistributionPreferClose
-	}
-	if preferClose {
-		istioService.Attributes.TrafficDistribution = model.TrafficDistributionPreferClose
-	}
+	istioService.Attributes.TrafficDistribution = GetTrafficDistribution(svc.Spec.TrafficDistribution, svc.Annotations)
 	istioService.Attributes.NodeLocal = nodeLocal
 	istioService.Attributes.PublishNotReadyAddresses = svc.Spec.PublishNotReadyAddresses
 	if len(svc.Spec.ExternalIPs) > 0 {
@@ -235,4 +228,21 @@ func hasListenerMode(l v1beta1.Listener, mode string) bool {
 
 func GatewaySA(gw *v1beta1.Gateway) string {
 	return model.GetOrDefault(gw.GetAnnotations()[annotation.GatewayServiceAccount.Name], fmt.Sprintf("%s-%s", gw.Name, gw.Spec.GatewayClassName))
+}
+
+func GetTrafficDistribution(specValue *string, annotations map[string]string) model.TrafficDistribution {
+	if specValue != nil {
+		preferClose := *specValue == corev1.ServiceTrafficDistributionPreferClose
+		if preferClose {
+			return model.TrafficDistributionPreferClose
+		}
+	}
+	// The TrafficDistribution field is quite new, so we allow a legacy annotation option as well
+	// This also has some custom types
+	switch strings.ToLower(annotations[annotation.NetworkingTrafficDistribution.Name]) {
+	case strings.ToLower(corev1.ServiceTrafficDistributionPreferClose):
+		return model.TrafficDistributionPreferClose
+	default:
+		return model.TrafficDistributionAny
+	}
 }

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -18,14 +18,12 @@ import (
 	"net/netip"
 	"strings"
 
-	corev1 "k8s.io/api/core/v1"
-
-	"istio.io/api/annotation"
 	"istio.io/api/label"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/serviceentry"
+	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
 	labelutil "istio.io/istio/pilot/pkg/serviceregistry/util/label"
 	"istio.io/istio/pkg/cluster"
@@ -181,10 +179,7 @@ func convertServices(cfg config.Config) []*model.Service {
 		resolution = model.ClientSideLB
 	}
 
-	trafficDistribution := model.TrafficDistributionAny
-	if strings.EqualFold(cfg.Annotations[annotation.NetworkingTrafficDistribution.Name], corev1.ServiceTrafficDistributionPreferClose) {
-		trafficDistribution = model.TrafficDistributionPreferClose
-	}
+	trafficDistribution := kube.GetTrafficDistribution(nil, cfg.Annotations)
 
 	svcPorts := make(model.PortList, 0, len(serviceEntry.Ports))
 	var portOverrides map[uint32]uint32

--- a/tests/integration/pilot/locality_test.go
+++ b/tests/integration/pilot/locality_test.go
@@ -50,8 +50,14 @@ spec:
   endpoints:
   - address: {{.Local}}
     locality: region/zone/subzone
+{{with .Network}}
+    network: {{.}}
+{{end}}
   - address: {{.Remote}}
     locality: notregion/notzone/notsubzone
+{{with .Network}}
+    network: {{.}}
+{{end}}
   {{ if ne .NearLocal "" }}
   - address: {{.NearLocal}}
     locality: "nearregion/zone/subzone"
@@ -86,6 +92,7 @@ type LocalityInput struct {
 	Local               string
 	NearLocal           string
 	Remote              string
+	Network             string
 }
 
 const localityFailover = `
@@ -120,6 +127,10 @@ func TestLocality(t *testing.T) {
 				destC = apps.VM[0]
 			}
 
+			var network string
+			if len(t.Clusters()) == 1 {
+				network = t.Clusters()[0].NetworkName()
+			}
 			cases := []struct {
 				name     string
 				input    LocalityInput
@@ -213,6 +224,7 @@ func TestLocality(t *testing.T) {
 						Resolution:          "STATIC",
 						Local:               destB.Address(),
 						Remote:              destA.Address(),
+						Network:             network,
 					},
 					expectAllTrafficTo(destB.Config().Service),
 				},


### PR DESCRIPTION
Before, we only consider region/zone. Now we also consider network,
mirroring the ztunnel path/desired state
