### PR TITLE
ambient: do not put circuit breakers on internal clusters

### DIFF
--- a/pilot/pkg/networking/core/cluster_waypoint.go
+++ b/pilot/pkg/networking/core/cluster_waypoint.go
@@ -52,6 +52,7 @@ func buildInternalUpstreamCluster(name string, internalListener string) *cluster
 	c := &cluster.Cluster{
 		Name:                 name,
 		ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_STATIC},
+		CircuitBreakers:      &cluster.CircuitBreakers{Thresholds: []*cluster.CircuitBreakers_Thresholds{getDefaultCircuitBreakerThresholds()}},
 		LoadAssignment: &endpoint.ClusterLoadAssignment{
 			ClusterName: name,
 			Endpoints:   util.BuildInternalEndpoint(internalListener, nil),


### PR DESCRIPTION
Now:

```
$ istioctl pc c gtw/waypoint -ojson | jq '.[] | select(.circuitBreakers == null).name' -r
agent
prometheus_stats
sds-grpc
```

Fixes https://github.com/istio/istio/issues/55076
