### PR TITLE
Fix *possible* pointer mismatch (re-introduced) by #54565

### DIFF
--- a/cni/pkg/nodeagent/ztunnelserver.go
+++ b/cni/pkg/nodeagent/ztunnelserver.go
@@ -88,8 +88,8 @@ func (c *connMgr) deleteConn(conn ZtunnelConnection) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// Loop over the slice, keeping non-deleted conn pointers
-	// but filtering out the deleted one.
+	// Loop over the slice, keeping non-deleted conn but
+	// filtering out the deleted one.
 	var retainedConns []ZtunnelConnection
 	for _, existingConn := range c.connectionSet {
 		// Not conn that was deleted? Keep it.
@@ -180,11 +180,11 @@ func (z *ztunnelServer) Run(ctx context.Context) {
 			log.Errorf("failed to accept conn: %v", err)
 			continue
 		}
-		log.Debugf("connection accepted: %v", conn.uuid)
+		log.Debug("connection accepted")
 		go func() {
-			log.Debugf("handling conn %v", conn.uuid)
+			log.Debug("handling conn")
 			if err := z.handleConn(ctx, conn); err != nil {
-				log.Errorf("failed to handle conn: %v, %+v", err, conn)
+				log.Errorf("failed to handle conn: %v", err)
 			}
 		}()
 	}
@@ -346,7 +346,7 @@ func (z *ztunnelServer) PodAdded(ctx context.Context, pod *v1.Pod, netns Netns) 
 		"name", add.WorkloadInfo.Name,
 		"namespace", add.WorkloadInfo.Namespace,
 		"serviceAccount", add.WorkloadInfo.ServiceAccount,
-		"con_uuid", latestConn.uuid,
+		"conn_uuid", latestConn.uuid,
 	)
 
 	log.Infof("sending pod add to ztunnel")
@@ -450,9 +450,9 @@ type updateRequest struct {
 }
 
 type ZtunnelConnection struct {
-	uuid uuid.UUID
-	u         *net.UnixConn
-	Updates   chan updateRequest
+	uuid    uuid.UUID
+	u       *net.UnixConn
+	Updates chan updateRequest
 }
 
 func newZtunnelConnection(u *net.UnixConn) ZtunnelConnection {

--- a/cni/pkg/nodeagent/ztunnelserver.go
+++ b/cni/pkg/nodeagent/ztunnelserver.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"golang.org/x/sys/unix"
 	"golang.org/x/time/rate"
 	"google.golang.org/protobuf/proto"
@@ -59,11 +60,12 @@ To clean up stale ztunnels
 */
 
 type connMgr struct {
-	connectionSet []*ZtunnelConnection
+	connectionSet []ZtunnelConnection
 	mu            sync.Mutex
 }
 
-func (c *connMgr) addConn(conn *ZtunnelConnection) {
+func (c *connMgr) addConn(conn ZtunnelConnection) {
+	log := log.WithLabels("conn_uuid", conn.conn_uuid)
 	log.Info("ztunnel connected")
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -71,25 +73,26 @@ func (c *connMgr) addConn(conn *ZtunnelConnection) {
 	ztunnelConnected.RecordInt(int64(len(c.connectionSet)))
 }
 
-func (c *connMgr) LatestConn() *ZtunnelConnection {
+func (c *connMgr) LatestConn() (ZtunnelConnection, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if len(c.connectionSet) == 0 {
-		return nil
+		return ZtunnelConnection{}, fmt.Errorf("no connection")
 	}
-	return c.connectionSet[len(c.connectionSet)-1]
+	return c.connectionSet[len(c.connectionSet)-1], nil
 }
 
-func (c *connMgr) deleteConn(conn *ZtunnelConnection) {
+func (c *connMgr) deleteConn(conn ZtunnelConnection) {
+	log := log.WithLabels("conn_uuid", conn.conn_uuid)
 	log.Info("ztunnel disconnected")
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	// Loop over the slice, keeping non-deleted conn pointers
 	// but filtering out the deleted one.
-	var retainedConns []*ZtunnelConnection
+	var retainedConns []ZtunnelConnection
 	for _, existingConn := range c.connectionSet {
-		// Not conn-by-pointer that was deleted? Keep it.
+		// Not conn that was deleted? Keep it.
 		if existingConn != conn {
 			retainedConns = append(retainedConns, existingConn)
 		}
@@ -143,7 +146,7 @@ func newZtunnelServer(addr string, pods PodNetnsCache, keepaliveInterval time.Du
 	return &ztunnelServer{
 		listener: l,
 		conns: &connMgr{
-			connectionSet: []*ZtunnelConnection{},
+			connectionSet: []ZtunnelConnection{},
 		},
 		pods:              pods,
 		keepaliveInterval: keepaliveInterval,
@@ -177,11 +180,11 @@ func (z *ztunnelServer) Run(ctx context.Context) {
 			log.Errorf("failed to accept conn: %v", err)
 			continue
 		}
-		log.Debug("connection accepted")
+		log.Debugf("connection accepted: %v", conn.conn_uuid)
 		go func() {
-			log.Debug("handling conn")
+			log.Debugf("handling conn %v", conn.conn_uuid)
 			if err := z.handleConn(ctx, conn); err != nil {
-				log.Errorf("failed to handle conn: %v", err)
+				log.Errorf("failed to handle conn: %v, %+v", err, conn)
 			}
 		}()
 	}
@@ -192,7 +195,7 @@ func (z *ztunnelServer) Run(ctx context.Context) {
 // All this to say, that we want to make sure that message to ztunnel are sent from a single goroutine
 // so we don't mix messages and acks.
 // nolint: unparam
-func (z *ztunnelServer) handleConn(ctx context.Context, conn *ZtunnelConnection) error {
+func (z *ztunnelServer) handleConn(ctx context.Context, conn ZtunnelConnection) error {
 	defer conn.Close()
 
 	context.AfterFunc(ctx, func() {
@@ -203,6 +206,8 @@ func (z *ztunnelServer) handleConn(ctx context.Context, conn *ZtunnelConnection)
 	// before doing anything, add the connection to the list of active connections
 	z.conns.addConn(conn)
 	defer z.conns.deleteConn(conn)
+
+	log := log.WithLabels("conn_uuid", conn.conn_uuid)
 
 	// get hello message from ztunnel
 	m, _, err := readProto[zdsapi.ZdsHello](conn.u, readWriteDeadline, nil)
@@ -294,7 +299,7 @@ func (z *ztunnelServer) PodDeleted(ctx context.Context, uid string) error {
 		return err
 	}
 
-	log.Debugf("sending delete pod to ztunnel: %s %v", uid, r)
+	log.Debugf("sending delete pod to all ztunnels: %s %v", uid, r)
 
 	var delErr []error
 
@@ -321,8 +326,8 @@ func podToWorkload(pod *v1.Pod) *zdsapi.WorkloadInfo {
 }
 
 func (z *ztunnelServer) PodAdded(ctx context.Context, pod *v1.Pod, netns Netns) error {
-	latestConn := z.conns.LatestConn()
-	if latestConn == nil {
+	latestConn, err := z.conns.LatestConn()
+	if err != nil {
 		return fmt.Errorf("no ztunnel connection")
 	}
 	uid := string(pod.ObjectMeta.UID)
@@ -341,6 +346,7 @@ func (z *ztunnelServer) PodAdded(ctx context.Context, pod *v1.Pod, netns Netns) 
 		"name", add.WorkloadInfo.Name,
 		"namespace", add.WorkloadInfo.Namespace,
 		"serviceAccount", add.WorkloadInfo.ServiceAccount,
+		"con_uuid", latestConn.conn_uuid,
 	)
 
 	log.Infof("sending pod add to ztunnel")
@@ -365,7 +371,7 @@ func (z *ztunnelServer) PodAdded(ctx context.Context, pod *v1.Pod, netns Netns) 
 
 // TODO ctx is unused here
 // nolint: unparam
-func (z *ztunnelServer) sendSnapshot(ctx context.Context, conn *ZtunnelConnection) error {
+func (z *ztunnelServer) sendSnapshot(ctx context.Context, conn ZtunnelConnection) error {
 	snap := z.pods.ReadCurrentPodSnapshot()
 	for uid, wl := range snap {
 		var resp *zdsapi.WorkloadResponse
@@ -421,11 +427,11 @@ func (z *ztunnelServer) sendSnapshot(ctx context.Context, conn *ZtunnelConnectio
 	return nil
 }
 
-func (z *ztunnelServer) accept() (*ZtunnelConnection, error) {
+func (z *ztunnelServer) accept() (ZtunnelConnection, error) {
 	log.Debug("accepting unix conn")
 	conn, err := z.listener.AcceptUnix()
 	if err != nil {
-		return nil, fmt.Errorf("failed to accept unix: %w", err)
+		return ZtunnelConnection{}, fmt.Errorf("failed to accept unix: %w", err)
 	}
 	log.Debug("accepted conn")
 	return newZtunnelConnection(conn), nil
@@ -444,12 +450,13 @@ type updateRequest struct {
 }
 
 type ZtunnelConnection struct {
-	u       *net.UnixConn
-	Updates chan updateRequest
+	conn_uuid uuid.UUID
+	u         *net.UnixConn
+	Updates   chan updateRequest
 }
 
-func newZtunnelConnection(u *net.UnixConn) *ZtunnelConnection {
-	return &ZtunnelConnection{u: u, Updates: make(chan updateRequest, 100)}
+func newZtunnelConnection(u *net.UnixConn) ZtunnelConnection {
+	return ZtunnelConnection{conn_uuid: uuid.New(), u: u, Updates: make(chan updateRequest, 100)}
 }
 
 func (z *ZtunnelConnection) Close() {

--- a/cni/pkg/nodeagent/ztunnelserver_test.go
+++ b/cni/pkg/nodeagent/ztunnelserver_test.go
@@ -268,8 +268,8 @@ func TestZtunnelLatestConnFallsBackToPreviousIfNewestDisconnects(t *testing.T) {
 
 	// this will retry for a bit, so shouldn't flake
 	mt.Assert(ztunnelConnected.Name(), nil, monitortest.Exactly(1))
-
-	assert.Equal(t, (srv.ztunServer.conns.LatestConn() != nil), true)
+	_, err := srv.ztunServer.conns.LatestConn()
+	assert.Equal(t, (err == nil), true)
 
 	// Now, add a new pod. Since client2 already disconnected, this should go to client 1
 	errChan := make(chan error)


### PR DESCRIPTION
ref: #54645

**Please provide a description of this PR:**

In #54645, we are pretty clearly getting "the wrong" connection - we try to send a delete on a connection when we should only have one ztunnel connected, and the connection is trashed - the ztunnel never gets it (but continues on with no error) - and this happens right after the previous ztunnel disconnects.

In https://github.com/istio/istio/pull/54565/files#diff-9873062ab6cdec1c9e1829c5cad625c4ef9d878a05b8b96ee3449623ea50f442L64 because we needed to order connections temporally, I dropped the `map[pointer]` approach for a slice, but this creates a possible (unlikely but possible, I think) pointer mixup in some cases which may be what is triggering https://github.com/istio/istio/issues/54645

This drops pointers for the collection type so we don't have to worry about that (at-most we will have 2x connections, so we don't need to worry about efficiency here) and also adds a UUID to accepted connections for logging purposes, so connection-related logs in `istio-cni` are easier to correlate to specific ztunnel connections (even if the same ztunnel re-connects, for some reason).

_Ideally_ ztunnel itself should send (and log) the UUID in the HELLO message it sends for each new connection it initiates, so correlating connections between the two components would be completely unambiguous, but that's a more invasive change so this is all `istio-cni`-side for now.