### PR TITLE
Ensure `replicas: 0` is correctly rendered in the `istio/gateway` chart

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -11,8 +11,8 @@ metadata:
     {{- .Values.annotations | toYaml | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
-  {{- with .Values.replicaCount }}
-  replicas: {{ . }}
+  {{- if hasKey .Values "replicaCount" }}
+  replicas: {{ .Values.replicaCount }}
   {{- end }}
   {{- end }}
   {{- with .Values.strategy }}

--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- .Values.annotations | toYaml | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
-  {{- if and (hasKey .Values "replicaCount") (not (eq .Values.replicaCount nil)) }}
+  {{- if and (hasKey .Values "replicaCount") (ne .Values.replicaCount nil) }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   {{- end }}

--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- .Values.annotations | toYaml | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
-  {{- if hasKey .Values "replicaCount" }}
+  {{- if and (hasKey .Values "replicaCount") (not (eq .Values.replicaCount nil)) }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   {{- end }}

--- a/releasenotes/notes/55092.yaml
+++ b/releasenotes/notes/55092.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue: [55092]
+releaseNotes:
+  - |
+    **Fixed** an issue where setting `replicaCount=0` in the `istio/gateway` Helm chart incorrectly omitted the `replicas` field instead of explicitly setting it to `0`.


### PR DESCRIPTION
Closes: https://github.com/istio/istio/issues/55092

**Please provide a description of this PR:**

Ensures that the `replicas` field in the `istio/gateway` Helm chart is correctly handled when `replicaCount=0` and allows omitting replicas if the key is not set or set to `null`.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Installation

**Before**
```console
$ helm template manifests/charts/gateway --set autoscaling.enabled=false --set replicaCount=2 -s templates/deployment.yaml | grep 'replicas:'   
  replicas: 2
$ helm template manifests/charts/gateway --set autoscaling.enabled=false --set replicaCount=1 -s templates/deployment.yaml | grep 'replicas:'   
  replicas: 1
$ helm template manifests/charts/gateway --set autoscaling.enabled=false --set replicaCount=0 -s templates/deployment.yaml | grep 'replicas:'   
$ helm template manifests/charts/gateway --set autoscaling.enabled=false --set replicaCount=null -s templates/deployment.yaml | grep 'replicas:'
$ helm template manifests/charts/gateway --set autoscaling.enabled=false -s templates/deployment.yaml | grep 'replicas:' 
$ 
```

**After**
```console
$ helm template manifests/charts/gateway --set autoscaling.enabled=false --set replicaCount=2 -s templates/deployment.yaml | grep 'replicas:'   
  replicas: 2
$ helm template manifests/charts/gateway --set autoscaling.enabled=false --set replicaCount=1 -s templates/deployment.yaml | grep 'replicas:'   
  replicas: 1
$ helm template manifests/charts/gateway --set autoscaling.enabled=false --set replicaCount=0 -s templates/deployment.yaml | grep 'replicas:'   
  replicas: 0
$ helm template manifests/charts/gateway --set autoscaling.enabled=false --set replicaCount=null -s templates/deployment.yaml | grep 'replicas:'
$ helm template manifests/charts/gateway --set autoscaling.enabled=false -s templates/deployment.yaml | grep 'replicas:'
$
```