### PR TITLE
[release-1.23] Fix compatibility with <1.23 proxies when meshConfig.accessLogEncoding is JSON

### DIFF
--- a/pilot/pkg/model/telemetry_logging.go
+++ b/pilot/pkg/model/telemetry_logging.go
@@ -463,6 +463,9 @@ func FileAccessLogFromMeshConfig(path string, mesh *meshconfig.MeshConfig, proxy
 		}
 	case meshconfig.MeshConfig_JSON:
 		jsonLogStruct := EnvoyJSONLogFormatIstio
+		if !versionGE123(proxyVersion) {
+			jsonLogStruct = LegacyEnvoyJSONLogFormatIstio
+		}
 		if len(mesh.AccessLogFormat) > 0 {
 			parsedJSONLogStruct := structpb.Struct{}
 			if err := protomarshal.UnmarshalAllowUnknown([]byte(mesh.AccessLogFormat), &parsedJSONLogStruct); err != nil {

--- a/releasenotes/notes/55116.yaml
+++ b/releasenotes/notes/55116.yaml
@@ -1,6 +1,8 @@
 apiVersion: release-notes/v2
 kind: bug-fix
 area: traffic-management
+issue:
+- 55116
 releaseNotes:
 - |
   **Fixed** Istiod sending an incompatible access log format to <1.23 proxies when meshConfig.accessLogEncoding is set to JSON

--- a/releasenotes/notes/fix-acccesslogencoding-json-1-23.yaml
+++ b/releasenotes/notes/fix-acccesslogencoding-json-1-23.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+- |
+  **Fixed** Istiod sending an incompatible access log format to <1.23 proxies when meshConfig.accessLogEncoding is set to JSON


### PR DESCRIPTION
Followup of #54795 ,
Fixes #55116
This cover a missed edge case where, in case meshConfig.accessLogEncoding is JSON but meshConfig.accessLogFormat is empty, the new format could be pushed to older proxies that do not support it.

As for the previous PR, this one is targeting release-1.23 exclusively. 1.24 and 1.25 are left unchanged since the conditional checks for retro-compatibility have been removed there.