### PR TITLE
doc: fix typo in accesslog test

### DIFF
--- a/pilot/pkg/networking/core/accesslog_test.go
+++ b/pilot/pkg/networking/core/accesslog_test.go
@@ -225,7 +225,7 @@ spec:
 	}
 }
 
-func newTestEnviroment() *model.Environment {
+func newTestEnvironment() *model.Environment {
 	serviceDiscovery := memregistry.NewServiceDiscovery(&model.Service{
 		Hostname:       "test.example.org",
 		DefaultAddress: "1.1.1.1",
@@ -372,7 +372,7 @@ var (
 func TestSetTCPAccessLog(t *testing.T) {
 	b := newAccessLogBuilder()
 
-	env := newTestEnviroment()
+	env := newTestEnvironment()
 
 	cases := []struct {
 		name     string
@@ -464,7 +464,7 @@ func TestSetTCPAccessLog(t *testing.T) {
 func TestSetHttpAccessLog(t *testing.T) {
 	b := newAccessLogBuilder()
 
-	env := newTestEnviroment()
+	env := newTestEnvironment()
 
 	cases := []struct {
 		name     string
@@ -556,7 +556,7 @@ func TestSetHttpAccessLog(t *testing.T) {
 func TestSetListenerAccessLog(t *testing.T) {
 	b := newAccessLogBuilder()
 
-	env := newTestEnviroment()
+	env := newTestEnvironment()
 
 	cases := []struct {
 		name     string


### PR DESCRIPTION
**Please provide a description of this PR:**
In `pilot/pkg/networking/core/accesslog_test.go` file, `newTestEnviroment` should be named as `newTestEnvironment`.