### PR TITLE
Ambient - Send on response channel to prevent deadlock if ztunnel disconnects during event process

### DIFF
--- a/cni/pkg/nodeagent/ztunnelserver.go
+++ b/cni/pkg/nodeagent/ztunnelserver.go
@@ -67,7 +67,7 @@ type connMgr struct {
 func (c *connMgr) addConn(conn ZtunnelConnection) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	log := log.WithLabels("conn_uuid", conn.uuid)
+	log := log.WithLabels("conn_uuid", conn.UUID())
 	c.connectionSet = append(c.connectionSet, conn)
 	log.Infof("new ztunnel connected, total connected %s", len(c.connectionSet))
 	ztunnelConnected.RecordInt(int64(len(c.connectionSet)))
@@ -77,17 +77,17 @@ func (c *connMgr) LatestConn() (ZtunnelConnection, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if len(c.connectionSet) == 0 {
-		return ZtunnelConnection{}, fmt.Errorf("no connection")
+		return nil, fmt.Errorf("no connection")
 	}
 	lConn := c.connectionSet[len(c.connectionSet)-1]
-	log.Debugf("latest ztunnel connection is %s, total connected %s", lConn.uuid, len(c.connectionSet))
+	log.Debugf("latest ztunnel connection is %s, total connected %s", lConn.UUID(), len(c.connectionSet))
 	return lConn, nil
 }
 
 func (c *connMgr) deleteConn(conn ZtunnelConnection) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	log := log.WithLabels("conn_uuid", conn.uuid)
+	log := log.WithLabels("conn_uuid", conn.UUID())
 
 	// Loop over the slice, keeping non-deleted conn but
 	// filtering out the deleted one.
@@ -184,7 +184,7 @@ func (z *ztunnelServer) Run(ctx context.Context) {
 		}
 		log.Debug("connection accepted")
 		go func() {
-			log := log.WithLabels("conn_uuid", conn.uuid)
+			log := log.WithLabels("conn_uuid", conn.UUID())
 			log.Debug("handling conn")
 			if err := z.handleConn(ctx, conn); err != nil {
 				log.Errorf("failed to handle conn: %v", err)
@@ -201,22 +201,17 @@ func (z *ztunnelServer) Run(ctx context.Context) {
 func (z *ztunnelServer) handleConn(ctx context.Context, conn ZtunnelConnection) error {
 	defer conn.Close()
 
-	context.AfterFunc(ctx, func() {
-		log.Debug("context cancelled, closing ztunnel server")
-		conn.Close()
-	})
-
 	// before doing anything, add the connection to the list of active connections
 	z.conns.addConn(conn)
 	defer z.conns.deleteConn(conn)
 
-	log := log.WithLabels("conn_uuid", conn.uuid)
+	log := log.WithLabels("conn_uuid", conn.UUID())
 
-	// get hello message from ztunnel
-	m, _, err := readProto[zdsapi.ZdsHello](conn.u, readWriteDeadline, nil)
+	m, err := conn.ReadHello()
 	if err != nil {
 		return err
 	}
+
 	log.WithLabels("version", m.Version).Infof("received hello from ztunnel")
 	log.Debug("sending snapshot to ztunnel")
 	if err := z.sendSnapshot(ctx, conn); err != nil {
@@ -225,13 +220,13 @@ func (z *ztunnelServer) handleConn(ctx context.Context, conn ZtunnelConnection) 
 	for {
 		// listen for updates:
 		select {
-		case update, ok := <-conn.Updates:
+		case update, ok := <-conn.Updates():
 			if !ok {
 				log.Debug("update channel closed - returning")
 				return nil
 			}
 			log.Debugf("got update to send to ztunnel")
-			resp, err := conn.sendDataAndWaitForAck(update.Update, update.Fd)
+			resp, err := conn.SendMsgAndWaitForAck(update.Update, update.Fd)
 			if err != nil {
 				// Two possibilities
 				// - we couldn't _write_ to the connection (in which case, this conn is dead)
@@ -265,7 +260,7 @@ func (z *ztunnelServer) handleConn(ctx context.Context, conn ZtunnelConnection) 
 			// something first, we expect to get an os.ErrDeadlineExceeded error
 			// here if the connection is still alive.
 			// note that unlike tcp connections, reading is a good enough test here.
-			_, err := conn.readMessage(time.Second / 100)
+			err := conn.CheckAlive(time.Second / 100)
 			switch {
 			case !errors.Is(err, os.ErrDeadlineExceeded):
 				log.Debugf("ztunnel keepalive failed: %v", err)
@@ -301,10 +296,6 @@ func (z *ztunnelServer) PodDeleted(ctx context.Context, uid string) error {
 			},
 		},
 	}
-	data, err := proto.Marshal(r)
-	if err != nil {
-		return err
-	}
 
 	log.Debugf("sending delete pod to all ztunnels: %s %v", uid, r)
 
@@ -313,9 +304,9 @@ func (z *ztunnelServer) PodDeleted(ctx context.Context, uid string) error {
 	z.conns.mu.Lock()
 	defer z.conns.mu.Unlock()
 	for _, conn := range z.conns.connectionSet {
-		log := log.WithLabels("conn_uuid", conn.uuid)
+		log := log.WithLabels("conn_uuid", conn.UUID())
 		log.Debug("sending msg to connected ztunnel")
-		_, err := conn.send(ctx, data, nil)
+		_, err := conn.Send(ctx, r, nil)
 		if err != nil {
 			delErr = append(delErr, err)
 		}
@@ -356,17 +347,13 @@ func (z *ztunnelServer) PodAdded(ctx context.Context, pod *v1.Pod, netns Netns) 
 		"name", add.WorkloadInfo.Name,
 		"namespace", add.WorkloadInfo.Namespace,
 		"serviceAccount", add.WorkloadInfo.ServiceAccount,
-		"conn_uuid", latestConn.uuid,
+		"conn_uuid", latestConn.UUID(),
 	)
 
 	log.Infof("sending pod add to ztunnel")
-	data, err := proto.Marshal(r)
-	if err != nil {
-		return err
-	}
 
 	fd := int(netns.Fd())
-	resp, err := latestConn.send(ctx, data, &fd)
+	resp, err := latestConn.Send(ctx, r, &fd)
 	if err != nil {
 		return err
 	}
@@ -396,7 +383,7 @@ func (z *ztunnelServer) sendSnapshot(ctx context.Context, conn ZtunnelConnection
 		if wl.Netns != nil {
 			fd := int(wl.Netns.Fd())
 			log.Infof("sending pod to ztunnel as part of snapshot")
-			resp, err = conn.sendMsgAndWaitForAck(&zdsapi.WorkloadRequest{
+			resp, err = conn.SendMsgAndWaitForAck(&zdsapi.WorkloadRequest{
 				Payload: &zdsapi.WorkloadRequest_Add{
 					Add: &zdsapi.AddWorkload{
 						Uid:          uid,
@@ -406,7 +393,7 @@ func (z *ztunnelServer) sendSnapshot(ctx context.Context, conn ZtunnelConnection
 			}, &fd)
 		} else {
 			log.Infof("netns is not available for pod, sending 'keep' to ztunnel")
-			resp, err = conn.sendMsgAndWaitForAck(&zdsapi.WorkloadRequest{
+			resp, err = conn.SendMsgAndWaitForAck(&zdsapi.WorkloadRequest{
 				Payload: &zdsapi.WorkloadRequest_Keep{
 					Keep: &zdsapi.KeepWorkload{
 						Uid: uid,
@@ -421,7 +408,7 @@ func (z *ztunnelServer) sendSnapshot(ctx context.Context, conn ZtunnelConnection
 			log.Errorf("add-workload: got ack error: %s", resp.GetAck().GetError())
 		}
 	}
-	resp, err := conn.sendMsgAndWaitForAck(&zdsapi.WorkloadRequest{
+	resp, err := conn.SendMsgAndWaitForAck(&zdsapi.WorkloadRequest{
 		Payload: &zdsapi.WorkloadRequest_SnapshotSent{
 			SnapshotSent: &zdsapi.SnapshotSent{},
 		},
@@ -441,7 +428,7 @@ func (z *ztunnelServer) accept() (ZtunnelConnection, error) {
 	log.Debug("accepting unix conn")
 	conn, err := z.listener.AcceptUnix()
 	if err != nil {
-		return ZtunnelConnection{}, fmt.Errorf("failed to accept unix: %w", err)
+		return nil, fmt.Errorf("failed to accept unix: %w", err)
 	}
 	log.Debug("accepted conn")
 	return newZtunnelConnection(conn), nil
@@ -453,27 +440,61 @@ type updateResponse struct {
 }
 
 type updateRequest struct {
-	Update []byte
+	Update *zdsapi.WorkloadRequest
 	Fd     *int
 
 	Resp chan updateResponse
 }
 
-type ZtunnelConnection struct {
+type ZtunnelConnection interface {
+	Close()
+	UUID() uuid.UUID
+	Updates() <-chan updateRequest
+	CheckAlive(timeout time.Duration) error
+	ReadHello() (*zdsapi.ZdsHello, error)
+	Send(ctx context.Context, data *zdsapi.WorkloadRequest, fd *int) (*zdsapi.WorkloadResponse, error)
+	SendMsgAndWaitForAck(msg *zdsapi.WorkloadRequest, fd *int) (*zdsapi.WorkloadResponse, error)
+}
+
+type ZtunnelUDSConnection struct {
 	uuid    uuid.UUID
 	u       *net.UnixConn
-	Updates chan updateRequest
+	updates chan updateRequest
 }
 
 func newZtunnelConnection(u *net.UnixConn) ZtunnelConnection {
-	return ZtunnelConnection{uuid: uuid.New(), u: u, Updates: make(chan updateRequest, 100)}
+	return ZtunnelUDSConnection{uuid: uuid.New(), u: u, updates: make(chan updateRequest, 100)}
 }
 
-func (z *ZtunnelConnection) Close() {
+func (z ZtunnelUDSConnection) Close() {
 	z.u.Close()
 }
 
-func (z *ZtunnelConnection) send(ctx context.Context, data []byte, fd *int) (*zdsapi.WorkloadResponse, error) {
+func (z ZtunnelUDSConnection) UUID() uuid.UUID {
+	return z.uuid
+}
+
+func (z ZtunnelUDSConnection) Updates() <-chan updateRequest {
+	return z.updates
+}
+
+// do a short read, just to see if the connection to ztunnel is
+// still alive. As ztunnel shouldn't send anything unless we send
+// something first, we expect to get an os.ErrDeadlineExceeded error
+// here if the connection is still alive.
+// note that unlike tcp connections, reading is a good enough test here.
+func (z ZtunnelUDSConnection) CheckAlive(timeout time.Duration) error {
+	_, err := z.readMessage(timeout)
+	return err
+}
+
+func (z ZtunnelUDSConnection) ReadHello() (*zdsapi.ZdsHello, error) {
+	// get hello message from ztunnel
+	m, _, err := readProto[zdsapi.ZdsHello](z.u, readWriteDeadline, nil)
+	return m, err
+}
+
+func (z ZtunnelUDSConnection) Send(ctx context.Context, data *zdsapi.WorkloadRequest, fd *int) (*zdsapi.WorkloadResponse, error) {
 	ret := make(chan updateResponse, 1)
 	req := updateRequest{
 		Update: data,
@@ -481,7 +502,7 @@ func (z *ZtunnelConnection) send(ctx context.Context, data []byte, fd *int) (*zd
 		Resp:   ret,
 	}
 	select {
-	case z.Updates <- req:
+	case z.updates <- req:
 	case <-ctx.Done():
 		return nil, fmt.Errorf("context expired before request sent: %v", ctx.Err())
 	}
@@ -494,7 +515,7 @@ func (z *ZtunnelConnection) send(ctx context.Context, data []byte, fd *int) (*zd
 	}
 }
 
-func (z *ZtunnelConnection) sendMsgAndWaitForAck(msg *zdsapi.WorkloadRequest, fd *int) (*zdsapi.WorkloadResponse, error) {
+func (z ZtunnelUDSConnection) SendMsgAndWaitForAck(msg *zdsapi.WorkloadRequest, fd *int) (*zdsapi.WorkloadResponse, error) {
 	data, err := proto.Marshal(msg)
 	if err != nil {
 		return nil, err
@@ -502,7 +523,7 @@ func (z *ZtunnelConnection) sendMsgAndWaitForAck(msg *zdsapi.WorkloadRequest, fd
 	return z.sendDataAndWaitForAck(data, fd)
 }
 
-func (z *ZtunnelConnection) sendDataAndWaitForAck(data []byte, fd *int) (*zdsapi.WorkloadResponse, error) {
+func (z ZtunnelUDSConnection) sendDataAndWaitForAck(data []byte, fd *int) (*zdsapi.WorkloadResponse, error) {
 	var rights []byte
 	if fd != nil {
 		rights = unix.UnixRights(*fd)
@@ -521,7 +542,7 @@ func (z *ZtunnelConnection) sendDataAndWaitForAck(data []byte, fd *int) (*zdsapi
 	return z.readMessage(readWriteDeadline)
 }
 
-func (z *ZtunnelConnection) readMessage(timeout time.Duration) (*zdsapi.WorkloadResponse, error) {
+func (z ZtunnelUDSConnection) readMessage(timeout time.Duration) (*zdsapi.WorkloadResponse, error) {
 	m, _, err := readProto[zdsapi.WorkloadResponse](z.u, timeout, nil)
 	return m, err
 }

--- a/cni/pkg/nodeagent/ztunnelserver.go
+++ b/cni/pkg/nodeagent/ztunnelserver.go
@@ -439,7 +439,7 @@ type updateResponse struct {
 	resp *zdsapi.WorkloadResponse
 }
 
-type updateRequest struct {
+type UpdateRequest struct {
 	Update *zdsapi.WorkloadRequest
 	Fd     *int
 
@@ -449,7 +449,7 @@ type updateRequest struct {
 type ZtunnelConnection interface {
 	Close()
 	UUID() uuid.UUID
-	Updates() <-chan updateRequest
+	Updates() <-chan UpdateRequest
 	CheckAlive(timeout time.Duration) error
 	ReadHello() (*zdsapi.ZdsHello, error)
 	Send(ctx context.Context, data *zdsapi.WorkloadRequest, fd *int) (*zdsapi.WorkloadResponse, error)
@@ -459,11 +459,11 @@ type ZtunnelConnection interface {
 type ZtunnelUDSConnection struct {
 	uuid    uuid.UUID
 	u       *net.UnixConn
-	updates chan updateRequest
+	updates chan UpdateRequest
 }
 
 func newZtunnelConnection(u *net.UnixConn) ZtunnelConnection {
-	return ZtunnelUDSConnection{uuid: uuid.New(), u: u, updates: make(chan updateRequest, 100)}
+	return ZtunnelUDSConnection{uuid: uuid.New(), u: u, updates: make(chan UpdateRequest, 100)}
 }
 
 func (z ZtunnelUDSConnection) Close() {
@@ -474,7 +474,7 @@ func (z ZtunnelUDSConnection) UUID() uuid.UUID {
 	return z.uuid
 }
 
-func (z ZtunnelUDSConnection) Updates() <-chan updateRequest {
+func (z ZtunnelUDSConnection) Updates() <-chan UpdateRequest {
 	return z.updates
 }
 
@@ -496,7 +496,7 @@ func (z ZtunnelUDSConnection) ReadHello() (*zdsapi.ZdsHello, error) {
 
 func (z ZtunnelUDSConnection) Send(ctx context.Context, data *zdsapi.WorkloadRequest, fd *int) (*zdsapi.WorkloadResponse, error) {
 	ret := make(chan updateResponse, 1)
-	req := updateRequest{
+	req := UpdateRequest{
 		Update: data,
 		Fd:     fd,
 		Resp:   ret,

--- a/cni/pkg/nodeagent/ztunnelserver_mocks.go
+++ b/cni/pkg/nodeagent/ztunnelserver_mocks.go
@@ -41,9 +41,9 @@ func (m *MockedZtunnelConnection) UUID() uuid.UUID {
 	return args.Get(0).(uuid.UUID)
 }
 
-func (m *MockedZtunnelConnection) Updates() <-chan updateRequest {
+func (m *MockedZtunnelConnection) Updates() <-chan UpdateRequest {
 	args := m.Called()
-	return args.Get(0).(<-chan updateRequest)
+	return args.Get(0).(<-chan UpdateRequest)
 }
 
 func (m *MockedZtunnelConnection) CheckAlive(timeout time.Duration) error {

--- a/cni/pkg/nodeagent/ztunnelserver_mocks.go
+++ b/cni/pkg/nodeagent/ztunnelserver_mocks.go
@@ -1,0 +1,76 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodeagent
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/mock"
+
+	"istio.io/istio/pkg/zdsapi"
+)
+
+type MockedZtunnelConnection struct {
+	mock.Mock
+}
+
+func FakeZtunnelConnection() *MockedZtunnelConnection {
+	return &MockedZtunnelConnection{}
+}
+
+func (m *MockedZtunnelConnection) Close() {
+	m.Called()
+}
+
+func (m *MockedZtunnelConnection) UUID() uuid.UUID {
+	args := m.Called()
+	return args.Get(0).(uuid.UUID)
+}
+
+func (m *MockedZtunnelConnection) Updates() <-chan updateRequest {
+	args := m.Called()
+	return args.Get(0).(<-chan updateRequest)
+}
+
+func (m *MockedZtunnelConnection) CheckAlive(timeout time.Duration) error {
+	args := m.Called(timeout)
+	return args.Error(0)
+}
+
+func (m *MockedZtunnelConnection) ReadHello() (*zdsapi.ZdsHello, error) {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*zdsapi.ZdsHello), args.Error(1)
+}
+
+func (m *MockedZtunnelConnection) Send(ctx context.Context, data *zdsapi.WorkloadRequest, fd *int) (*zdsapi.WorkloadResponse, error) {
+	args := m.Called(ctx, data, fd)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*zdsapi.WorkloadResponse), args.Error(1)
+}
+
+func (m *MockedZtunnelConnection) SendMsgAndWaitForAck(msg *zdsapi.WorkloadRequest, fd *int) (*zdsapi.WorkloadResponse, error) {
+	args := m.Called(msg, fd)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*zdsapi.WorkloadResponse), args.Error(1)
+}


### PR DESCRIPTION
**Please provide a description of this PR:**
Followup to https://github.com/istio/istio/pull/55085

Should fix: https://github.com/istio/istio/issues/54645 and the flakes.


Context - failures like: https://prow.istio.io/view/gs/istio-prow/logs/integ-ambient-dual_istio_postsubmit/1890443585262718976

(on one node, the conn failure happened during an update, and the others it happened after/before)

tl;dr because in the case of the connection failing with a broken pipe *during* an update handling, we were returning _without_ pushing a response back thru the response channel, this was causing `PodDeleted` to deadlock and never send the second delete, causing the ztunnel that should have gotten the delete message to never get it (thus failing the test).

Should _not_ have taken me this long to see the cause here, but whatever.

This also adds a bit more connection-related logging, and reworks things so it's easier to mock/test conn failures.