### PR TITLE
Add the option to add secrets to the env of the gateway helm chart

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -93,7 +93,11 @@ spec:
           {{- end }}
           {{- range $key, $val := .Values.env }}
           - name: {{ $key }}
+            {{- if kindIs "map" $val }}
+            {{- toYaml $val | nindent 12 }}
+            {{- else }}
             value: {{ $val | quote }}
+            {{- end }}
           {{- end }}
           ports:
           - containerPort: 15090

--- a/releasenotes/notes/55141.yaml
+++ b/releasenotes/notes/55141.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue: [55141]
+releaseNotes:
+  - |
+    **Fixed** an issue where secrets references in the env of `istio/gateway` Helm chart incorrectly rendered as a string, instead of injected correctly.


### PR DESCRIPTION
#### Description

This PR enables support for using Kubernetes Secrets as environment variables in the Istio Gateway Helm Chart. The change ensures that valueFrom.secretKeyRef can be correctly rendered in env, allowing Secrets to be referenced in Gateway deployments.

#### Why is this needed?

In our setup, a secret is required inside a Lua script running in Envoy. Since the Istio Gateway does not natively support referencing secrets via environment variables, this modification ensures that secrets can be properly injected.

#### Changes

* Adjusted Helm template to support valueFrom.secretKeyRef in environment variables.
* Used toYaml with nindent to correctly format complex environment variable references.

Let me know if any further adjustments are needed!

#### More info

Before `valueFrom` in the env section was rendered wrong, e.g.:

```
        - name: TEST_SECRET
          value: map[valueFrom:map[secretKeyRef:map[key:test-key name:test-name]]]
```

#### Local test

Testfile with `valueFrom`:
```yaml
name: app-ingressgateway
labels:
  app: app-istio-ingressgateway
  istio: app-ingressgateway
service:
  ports:
    - port: 80
      targetPort: 15580
      name: http2
    - port: 443
      name: https
      targetPort: 15544
autoscaling:
  minReplicas: 5
  maxReplicas: 20
resources:
  requests:
    cpu: 100m
    memory: 128Mi
  limits:
    cpu: 2000m
    memory: 1024Mi
env:
  ABC_ENV: "abc"
  TEST_SECRET:
    valueFrom:
      secretKeyRef:
        name: test-name
        key: test-key

```
Now renders, correctly, to:

```yaml
# Source: gateway/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: app-ingressgateway
  namespace: default
  labels:
    app.kubernetes.io/name: app-ingressgateway
    app.kubernetes.io/managed-by: "Helm"
    app.kubernetes.io/instance: "my-release"
    app.kubernetes.io/part-of: "istio"
    app.kubernetes.io/version: "1.0.0"
    helm.sh/chart: gateway-1.0.0
    app: "app-istio-ingressgateway"
    istio: "app-ingressgateway"
    "istio.io/dataplane-mode": "none"
  annotations:
    {}
spec:
  selector:
    matchLabels:
      app: "app-istio-ingressgateway"
      istio: "app-ingressgateway"
  template:
    metadata:
      annotations:
        inject.istio.io/templates: gateway
        prometheus.io/path: /stats/prometheus
        prometheus.io/port: "15020"
        prometheus.io/scrape: "true"
        sidecar.istio.io/inject: "true"
      labels:
        sidecar.istio.io/inject: "true"
        app: "app-istio-ingressgateway"
        istio: "app-ingressgateway"
        app.kubernetes.io/name: app-ingressgateway
        app.kubernetes.io/managed-by: "Helm"
        app.kubernetes.io/instance: "my-release"
        app.kubernetes.io/part-of: "istio"
        app.kubernetes.io/version: "1.0.0"
        helm.sh/chart: gateway-1.0.0
        "istio.io/dataplane-mode": "none"
    spec:
      serviceAccountName: app-ingressgateway
      securityContext:
        # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
        sysctls:
        - name: net.ipv4.ip_unprivileged_port_start
          value: "0"
      containers:
        - name: istio-proxy
          # "auto" will be populated at runtime by the mutating webhook. See https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#customizing-injection
          image: auto
          securityContext:
            capabilities:
              drop:
              - ALL
            allowPrivilegeEscalation: false
            privileged: false
            readOnlyRootFilesystem: true
            runAsUser: 1337
            runAsGroup: 1337
            runAsNonRoot: true
          env:
          - name: ABC_ENV
            value: "abc"
          - name: TEST_SECRET
            valueFrom:
              secretKeyRef:
                key: test-key
                name: test-name
          ports:
          - containerPort: 15090
            protocol: TCP
            name: http-envoy-prom
          resources:
            limits:
              cpu: 2000m
              memory: 1024Mi
            requests:
              cpu: 100m
              memory: 128Mi
      terminationGracePeriodSeconds: 30
---

```

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Installation

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
