### PR TITLE
ambient: disable accidental EnvoyFilter implementation

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -2328,6 +2328,11 @@ func (ps *PushContext) EnvoyFilters(proxy *Proxy) *MergedEnvoyFilterWrapper {
 func (ps *PushContext) getMatchedEnvoyFilters(proxy *Proxy, namespaces string) []*EnvoyFilterWrapper {
 	matchedEnvoyFilters := make([]*EnvoyFilterWrapper, 0)
 	for _, efw := range ps.envoyFiltersByNamespace[namespaces] {
+		if efw.GetTargetRefs() != nil {
+			// These are meant for a specific target, so we shouldn't treat these as "always match"
+			// In the future, targetRef for EnvoyFilter will likely be implemented -- but currently these would never match
+			continue
+		}
 		if efw.workloadSelector == nil || efw.workloadSelector.SubsetOf(proxy.Labels) {
 			matchedEnvoyFilters = append(matchedEnvoyFilters, efw)
 		}

--- a/pilot/pkg/networking/core/cluster.go
+++ b/pilot/pkg/networking/core/cluster.go
@@ -239,17 +239,14 @@ func (configgen *ConfigGeneratorImpl) buildClusters(proxy *model.Proxy, req *mod
 		clusters = append(clusters, inboundPatcher.insertedClusters()...)
 	case model.Waypoint:
 		_, wps := findWaypointResources(proxy, req.Push)
-		// Waypoint proxies do not need outbound clusters in most cases, unless we have a route pointing to something
-		outboundPatcher := clusterPatcher{efw: envoyFilterPatches, pctx: networking.EnvoyFilter_SIDECAR_OUTBOUND}
+		emptyPatcher := clusterPatcher{} // EnvoyFilter is not implemented for waypoints
 		extraNamespacedHosts, extraHosts := req.Push.ExtraWaypointServices(proxy, envoyFilterPatches)
-		ob, cs := configgen.buildOutboundClusters(cb, proxy, outboundPatcher, filterWaypointOutboundServices(
+		ob, cs := configgen.buildOutboundClusters(cb, proxy, emptyPatcher, filterWaypointOutboundServices(
 			req.Push.ServicesAttachedToMesh(), wps.services, extraNamespacedHosts, extraHosts, services))
 		cacheStats = cacheStats.merge(cs)
 		resources = append(resources, ob...)
 		// Setup inbound clusters
-		inboundPatcher := clusterPatcher{efw: envoyFilterPatches, pctx: networking.EnvoyFilter_SIDECAR_INBOUND}
 		clusters = append(clusters, configgen.buildWaypointInboundClusters(cb, proxy, req.Push, wps.services)...)
-		clusters = append(clusters, inboundPatcher.insertedClusters()...)
 	default: // Gateways
 		patcher := clusterPatcher{efw: envoyFilterPatches, pctx: networking.EnvoyFilter_GATEWAY}
 		ob, cs := configgen.buildOutboundClusters(cb, proxy, patcher, services)

--- a/pilot/pkg/networking/core/httproute.go
+++ b/pilot/pkg/networking/core/httproute.go
@@ -129,8 +129,10 @@ func buildSidecarInboundHTTPRouteConfig(lb *ListenerBuilder, cc inboundChainConf
 		VirtualHosts:     []*route.VirtualHost{inboundVHost},
 		ValidateClusters: proto.BoolFalse,
 	}
-	efw := lb.push.EnvoyFilters(lb.node)
-	r = envoyfilter.ApplyRouteConfigurationPatches(networking.EnvoyFilter_SIDECAR_INBOUND, lb.node, efw, r)
+	if !lb.node.IsWaypointProxy() {
+		efw := lb.push.EnvoyFilters(lb.node)
+		r = envoyfilter.ApplyRouteConfigurationPatches(networking.EnvoyFilter_SIDECAR_INBOUND, lb.node, efw, r)
+	}
 	return r
 }
 
@@ -201,7 +203,9 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(
 	}
 
 	// apply envoy filter patches
-	out = envoyfilter.ApplyRouteConfigurationPatches(networking.EnvoyFilter_SIDECAR_OUTBOUND, node, efw, out)
+	if !node.IsWaypointProxy() {
+		out = envoyfilter.ApplyRouteConfigurationPatches(networking.EnvoyFilter_SIDECAR_OUTBOUND, node, efw, out)
+	}
 
 	resource = &discovery.Resource{
 		Name:     out.Name,

--- a/pilot/pkg/networking/core/listener_builder.go
+++ b/pilot/pkg/networking/core/listener_builder.go
@@ -163,6 +163,10 @@ func (lb *ListenerBuilder) patchOneListener(l *listener.Listener, ctx networking
 }
 
 func (lb *ListenerBuilder) patchListeners() {
+	if lb.node.IsWaypointProxy() {
+		// EnvoyFilter is not implemented for waypoints
+		return
+	}
 	lb.envoyFilterWrapper = lb.push.EnvoyFilters(lb.node)
 	if lb.envoyFilterWrapper == nil {
 		return

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -628,11 +628,12 @@ spec:
 `).ApplyOrFail(t)
 			opt.Count = 5
 			opt.Timeout = time.Second * 10
+			// Test that we do NOT apply this envoyfilter, since EnvoyFilter is not implemented for waypoints
 			opt.Check = check.And(
 				check.OK(),
 				check.RequestHeaders(map[string]string{
-					"X-Lua-Inbound":   "hello world",
-					"X-Vhost-Inbound": "hello world",
+					"X-Lua-Inbound":   "",
+					"X-Vhost-Inbound": "",
 				}))
 			src.CallOrFail(t, opt)
 		})


### PR DESCRIPTION
EnvoyFilter is not implemented in waypoint, but due to code-reuse around
Istio we essentially accidentally implement some form of it.

Proper support is tracked in
https://github.com/istio/istio/issues/43720. This will require new logic
into Istio, likely around a new `WAYPOINT` context, `targetRef`
implementation, etc.

Until then, explicitly disable support to avoid accidental partial
attachment of filters to waypoints.
