### PR TITLE
kube/controller: Prevent leaking stale endpoints

### DIFF
--- a/releasenotes/notes/eviction-bug.yaml
+++ b/releasenotes/notes/eviction-bug.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 54997
+releaseNotes:
+- |
+  **Fixed** an issue where ServiceEntry endpoints are leaked when a pod is evicted.


### PR DESCRIPTION
**Please provide a description of this PR:**
When selecting pods via a ServiceEntry, there are times when the pod may not have an IP address:
1. When it is first created
2. When it is Evicted/Failed.

The code today handles (1), however there exists a case when the IP is removed from the Pod in the same event that marks it with a terminal (Failed) status. Due to the cross-controller interaction (between the kube registry and serviceentry registry), the WorkloadInstance needs to have a valid IP, as the podCache and endpointShards are both keyed by address. This PR adds logic to fetch the oldIP from the ipByPods cache, and uses that when building the WorkloadInstance.

Fixes https://github.com/istio/istio/issues/54997