### PR TITLE
Adding the environment dns resolvers config. Its priority is lower th…

### DIFF
--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -117,6 +117,9 @@ func bindCmdlineFlags(cfg *config.Config, cmd *cobra.Command) {
 	// Allow binding to a different var, for consistency with other components
 	flag.AdditionalEnv(fs, constants.RedirectDNS, "ISTIO_META_DNS_CAPTURE")
 
+	flag.BindEnv(fs, constants.DNSResolverIPPort, "", "Specified environment DNS resolver.", &cfg.DNSResolverIPPort)
+	flag.AdditionalEnv(fs, constants.DNSResolverIPPort, "ISTIO_META_DNS_RESOLVER_IP_PORT")
+
 	flag.BindEnv(fs, constants.DropInvalid, "", "Enable invalid drop in the iptables rules.", &cfg.DropInvalid)
 	// This could have just used the default but for backwards compat we support the old env.
 	flag.AdditionalEnv(fs, constants.DropInvalid, InvalidDropByIptables)

--- a/tools/istio-iptables/pkg/config/config.go
+++ b/tools/istio-iptables/pkg/config/config.go
@@ -74,6 +74,7 @@ type Config struct {
 	SkipRuleApply            bool          `json:"SKIP_RULE_APPLY"`
 	RunValidation            bool          `json:"RUN_VALIDATION"`
 	RedirectDNS              bool          `json:"REDIRECT_DNS"`
+	DNSResolverIPPort        string        `json:"DNS_RESOLVER_IP_PORT"`
 	DropInvalid              bool          `json:"DROP_INVALID"`
 	CaptureAllDNS            bool          `json:"CAPTURE_ALL_DNS"`
 	EnableIPv6               bool          `json:"ENABLE_INBOUND_IPV6"`
@@ -130,6 +131,7 @@ func (c *Config) Print() {
 	b.WriteString(fmt.Sprintf("DNS_CAPTURE=%t\n", c.RedirectDNS))
 	b.WriteString(fmt.Sprintf("DROP_INVALID=%t\n", c.DropInvalid))
 	b.WriteString(fmt.Sprintf("CAPTURE_ALL_DNS=%t\n", c.CaptureAllDNS))
+	b.WriteString(fmt.Sprintf("DNS_RESOLVER_IP_PORT=%s\n", c.DNSResolverIPPort))
 	b.WriteString(fmt.Sprintf("DNS_SERVERS=%s,%s\n", c.DNSServersV4, c.DNSServersV6))
 	b.WriteString(fmt.Sprintf("NETWORK_NAMESPACE=%s\n", c.NetworkNamespace))
 	b.WriteString(fmt.Sprintf("CNI_MODE=%s\n", strconv.FormatBool(c.HostFilesystemPodNetwork)))
@@ -187,7 +189,7 @@ func (c *Config) FillConfigFromEnvironment() error {
 	// case where reading /etc/resolv.conf could fail.
 	// If capture all DNS option is enabled, we don't need to read from the dns resolve conf. All
 	// traffic to port 53 will be captured.
-	if c.RedirectDNS && !c.CaptureAllDNS {
+	if (c.RedirectDNS && !c.CaptureAllDNS) || len(c.DNSResolverIPPort) > 0 {
 		dnsConfig, err := dns.ClientConfigFromFile("/etc/resolv.conf")
 		if err != nil {
 			return fmt.Errorf("failed to load /etc/resolv.conf: %v", err)

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -44,14 +44,15 @@ const OutboundMark = "1338"
 
 // iptables chains
 const (
-	ISTIOOUTPUT     = "ISTIO_OUTPUT"
-	ISTIOOUTPUTDNS  = "ISTIO_OUTPUT_DNS"
-	ISTIOINBOUND    = "ISTIO_INBOUND"
-	ISTIODIVERT     = "ISTIO_DIVERT"
-	ISTIOTPROXY     = "ISTIO_TPROXY"
-	ISTIOREDIRECT   = "ISTIO_REDIRECT"
-	ISTIOINREDIRECT = "ISTIO_IN_REDIRECT"
-	ISTIODROP       = "ISTIO_DROP"
+	ISTIOOUTPUT            = "ISTIO_OUTPUT"
+	ISTIOOUTPUTDNS         = "ISTIO_OUTPUT_DNS"
+	ISTIOOUTPUTDNSRESOLVER = "ISTIO_OUTPUT_DNS_RESOLVER"
+	ISTIOINBOUND           = "ISTIO_INBOUND"
+	ISTIODIVERT            = "ISTIO_DIVERT"
+	ISTIOTPROXY            = "ISTIO_TPROXY"
+	ISTIOREDIRECT          = "ISTIO_REDIRECT"
+	ISTIOINREDIRECT        = "ISTIO_IN_REDIRECT"
+	ISTIODROP              = "ISTIO_DROP"
 )
 
 // Constants used in cobra/viper CLI
@@ -79,6 +80,7 @@ const (
 	IptablesProbePort         = "iptables-probe-port"
 	ProbeTimeout              = "probe-timeout"
 	RedirectDNS               = "redirect-dns"
+	DNSResolverIPPort         = "dns-resolver-ip-port"
 	DropInvalid               = "drop-invalid"
 	DualStack                 = "dual-stack"
 	CaptureAllDNS             = "capture-all-dns"


### PR DESCRIPTION
…an dns proxying/service entry, and higher than local resolv.conf resolvers.

**Please provide a description of this PR:**

_Objective_
Istio provide the DNS proxying to capture the DNS query and customize the fqdn IP mapping in service entry. But it dose not has the mechanism to control the DNS resolvers. The proxy's resolv.conf can be overwritten by user deployment with dnsConfig setting.

_Background_
Our  application can't rely on the dns resolver configured in local resolv.conf file. For some platform, like serverless or VM, it may need extra effort to configure a DNS proxy (like coreDNS in k8s). We need a configuration in istio to specify and control the dns resolvers.

_Requirements_
This feature is useful when we need to specify the DNS resolver. A company has its internal DNS server which will map the fqdn to specific IP. The engineer don't know how many customized fqdn their organization has or what is the customized the fqdn their application may visit. Those customized fqdns are maintained by platform team. So they can't configure those customized fqdn in istio Service Entry. It is also useful when the public DNS server cached incorrect fqdn mapping, e.g. dns poisoning. 

_Design Ideas_
This new environment dns resolver should not impact the current dns proxying. Only when the dns proxying not enabled, we will redirect the dns requests to the environment dns resolver. And if the dns proxying is enabled, the environment dns resolver will be act as a kind of backup resolvers. Its priority is lower than service entry record and higher than local resolv.conf resolvers.
Below is the implemention design:
- The extra mesh configuration of proxy metadata been created, like ISTIO_META_DNS_CAPTURE, we named it as ISTIO_META_DNS_RESOLVER_IP_PORT. Its value format will be "resolverIP:port,resolver2IP:port,…"
- If the dns capture is not enabled, we will add iptables to dnat the dns query from resolver in resolv.conf file to  the resolvers specified in environment ISTIO_META_DNS_CAPTURE. The random or round robin load balancer will be configured for those environment dns resolvers query.
- And if the dns capture is enabled, the dns query priority will be: ServiceEntry config > resolver in ISTIO_META_DNS_CAPTURE > local resolv.conf resolvers

_Alternatives Considered_
The initial consideration is the dnsConfig of proxy deployment. But it can be overwritten if user specify the dns config setting in their app deployment. So we still can't take fully control of the dns resolver setting. We don't want such user deployment overwritten causing random connection issue.
We also consider envoy filter. It may increase the complexity of service mesh configuration. Such filter bypass istio and is difficult for maintenance. We also need to consider its compatible with istio dns proxying. We do not make more test with envoy filter.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
