### PR TITLE
Fix multi-arch builds

### DIFF
--- a/pkg/test/echo/docker/Dockerfile.app_sidecar_centos_8
+++ b/pkg/test/echo/docker/Dockerfile.app_sidecar_centos_8
@@ -10,7 +10,8 @@ COPY certs/                           /var/lib/istio/
 COPY certs/default/                   /var/run/secrets/istio/
 
 # Install the sidecar components
-COPY istio-sidecar.rpm  /tmp/istio-sidecar.rpm
+ARG TARGETARCH
+COPY ${TARGETARCH:-amd64}/istio-sidecar.rpm  /tmp/istio-sidecar.rpm
 RUN rpm -vi /tmp/istio-sidecar.rpm && rm /tmp/istio-sidecar.rpm
 
 # Sudoers used to allow tcpdump and other debug utilities.
@@ -18,7 +19,6 @@ COPY sudoers /etc/sudoers
 
 # Install the Echo application
 COPY echo-start.sh /usr/local/bin/echo-start.sh
-ARG TARGETARCH
 COPY ${TARGETARCH:-amd64}/client /usr/local/bin/client
 COPY ${TARGETARCH:-amd64}/server /usr/local/bin/server
 

--- a/tools/docker-copy.sh
+++ b/tools/docker-copy.sh
@@ -29,6 +29,18 @@ function detect_arch() {
     arch="$(dpkg-deb --info "${FILE}" | grep Arch | cut -d: -f 2 | cut -c 2-)"
     echo "${arch}"
     return 0
+  elif [[ "${extension}" == "rpm" ]]; then
+    arch="$(rpm -qp --queryformat '%{arch}' "${FILE}" 2>/dev/null || true)"
+    case ${arch} in
+      "x86_64")
+        echo "amd64"
+        return 0
+        ;;
+      "aarch64")
+        echo "arm64"
+        return 0
+        ;;
+    esac
   fi
   FILE_INFO=$(file "${FILE}" || true)
   if [[ ${FILE_INFO} == *"ELF 64-bit LSB"* ]]; then


### PR DESCRIPTION
Setting DOCKER_ARCHITECUTRES=linux/amd64,linux/arm64 would
break the build.

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.