### PR TITLE
krt/kclient: Allow removing handlers

### DIFF
--- a/pkg/config/mesh/meshwatcher/mesh.go
+++ b/pkg/config/mesh/meshwatcher/mesh.go
@@ -15,7 +15,6 @@
 package meshwatcher
 
 import (
-	uatomic "go.uber.org/atomic"
 	"google.golang.org/protobuf/proto"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -54,15 +53,9 @@ func (a adapter) Mesh() *meshconfig.MeshConfig {
 // Usually a handler would then call .Mesh() to get the new state.
 // The returned WatcherHandlerRegistration can be used to un-register the handler at a later time.
 func (a adapter) AddMeshHandler(h func()) *mesh.WatcherHandlerRegistration {
-	active := uatomic.NewBool(true)
-	// The mesh.Watcher allows unregistering, while krt currently doesn't
-	// When we remove, mark this as "not active" so we skip events.
-
 	// Do not run initial state to match existing semantics
 	colReg := a.Singleton.AsCollection().RegisterBatch(func(o []krt.Event[MeshConfigResource], initialSync bool) {
-		if active.Load() {
-			h()
-		}
+		h()
 	}, false)
 	reg := mesh.NewWatcherHandlerRegistration(func() {
 		colReg.UnregisterHandler()

--- a/pkg/config/mesh/meshwatcher/networks.go
+++ b/pkg/config/mesh/meshwatcher/networks.go
@@ -15,8 +15,6 @@
 package meshwatcher
 
 import (
-	uatomic "go.uber.org/atomic"
-
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/kube/krt"
@@ -33,12 +31,8 @@ func (n networksAdapter) Networks() *meshconfig.MeshNetworks {
 
 // AddNetworksHandler registers a callback handler for changes to the networks config.
 func (n networksAdapter) AddNetworksHandler(h func()) *mesh.WatcherHandlerRegistration {
-	active := uatomic.NewBool(true)
-	// Do not run initial state to match existing semantics
 	colReg := n.Singleton.AsCollection().RegisterBatch(func(o []krt.Event[MeshNetworksResource], initialSync bool) {
-		if active.Load() {
-			h()
-		}
+		h()
 	}, false)
 
 	reg := mesh.NewWatcherHandlerRegistration(func() {

--- a/pkg/config/mesh/meshwatcher/networks.go
+++ b/pkg/config/mesh/meshwatcher/networks.go
@@ -34,15 +34,16 @@ func (n networksAdapter) Networks() *meshconfig.MeshNetworks {
 // AddNetworksHandler registers a callback handler for changes to the networks config.
 func (n networksAdapter) AddNetworksHandler(h func()) *mesh.WatcherHandlerRegistration {
 	active := uatomic.NewBool(true)
-	reg := mesh.NewWatcherHandlerRegistration(func() {
-		active.Store(false)
-	})
 	// Do not run initial state to match existing semantics
-	n.Singleton.AsCollection().RegisterBatch(func(o []krt.Event[MeshNetworksResource], initialSync bool) {
+	colReg := n.Singleton.AsCollection().RegisterBatch(func(o []krt.Event[MeshNetworksResource], initialSync bool) {
 		if active.Load() {
 			h()
 		}
 	}, false)
+
+	reg := mesh.NewWatcherHandlerRegistration(func() {
+		colReg.UnregisterHandler()
+	})
 	return reg
 }
 

--- a/pkg/kube/kclient/client.go
+++ b/pkg/kube/kclient/client.go
@@ -180,6 +180,16 @@ func (n *informerClient[T]) ShutdownHandlers() {
 	for _, c := range n.registeredHandlers {
 		_ = n.informer.RemoveEventHandler(c.registration)
 	}
+	n.registeredHandlers = nil
+}
+
+func (n *informerClient[T]) ShutdownHandler(registration cache.ResourceEventHandlerRegistration) {
+	n.handlerMu.Lock()
+	defer n.handlerMu.Unlock()
+	n.registeredHandlers = slices.FilterInPlace(n.registeredHandlers, func(h handlerRegistration) bool {
+		return h.registration != registration
+	})
+	_ = n.informer.RemoveEventHandler(registration)
 }
 
 type neverReady struct{}

--- a/pkg/kube/kclient/client_test.go
+++ b/pkg/kube/kclient/client_test.go
@@ -374,16 +374,16 @@ func TestShutdown(t *testing.T) {
 	// Shutdown one
 	deployments.ShutdownHandler(removeReg)
 
-	// Update object, should see the update...
+	// Update object, should see the update only one the active handler
 	obj1.Spec.MinReadySeconds = 2
 	tester.Update(obj1)
 	tracker.WaitOrdered("update/1")
 	removeTracker.Empty()
 
-	deployments.ShutdownHandler(removeReg)
+	deployments.ShutdownHandlers()
 
-	// Update object, should see the update...
-	obj1.Spec.MinReadySeconds = 2
+	// Update object, shouldn't see any updates since all handlers are removed
+	obj1.Spec.MinReadySeconds = 3
 	tester.Update(obj1)
 	tracker.Empty()
 	removeTracker.Empty()

--- a/pkg/kube/kclient/client_test.go
+++ b/pkg/kube/kclient/client_test.go
@@ -350,6 +350,45 @@ func TestClient(t *testing.T) {
 	assert.Equal(t, tester.Get(obj3.Name, obj3.Namespace), nil)
 }
 
+func TestShutdown(t *testing.T) {
+	tracker := assert.NewTracker[string](t)
+	removeTracker := assert.NewTracker[string](t)
+	c := kube.NewFakeClient()
+	deployments := kclient.NewFiltered[*appsv1.Deployment](c, kclient.Filter{})
+	deployments.AddEventHandler(clienttest.TrackerHandler(tracker))
+	removeReg := deployments.AddEventHandler(clienttest.TrackerHandler(removeTracker))
+	tester := clienttest.Wrap(t, deployments)
+
+	c.RunAndWait(test.NewStop(t))
+	obj1 := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "1", Namespace: "default"},
+		Spec:       appsv1.DeploymentSpec{MinReadySeconds: 1},
+	}
+
+	// Create object, make sure we can see it
+	tester.Create(obj1)
+	// Client is cached, so its only eventually consistent
+	tracker.WaitUnordered("add/1")
+	removeTracker.WaitUnordered("add/1")
+
+	// Shutdown one
+	deployments.ShutdownHandler(removeReg)
+
+	// Update object, should see the update...
+	obj1.Spec.MinReadySeconds = 2
+	tester.Update(obj1)
+	tracker.WaitOrdered("update/1")
+	removeTracker.Empty()
+
+	deployments.ShutdownHandler(removeReg)
+
+	// Update object, should see the update...
+	obj1.Spec.MinReadySeconds = 2
+	tester.Update(obj1)
+	tracker.Empty()
+	removeTracker.Empty()
+}
+
 func TestErrorHandler(t *testing.T) {
 	mt := monitortest.New(t)
 	c := kube.NewFakeClient()
@@ -456,6 +495,7 @@ func TestFilterNamespace(t *testing.T) {
 
 func TestFilter(t *testing.T) {
 	tracker := assert.NewTracker[string](t)
+	removeTracker := assert.NewTracker[string](t)
 	c := kube.NewFakeClient()
 	meshWatcher := meshwatcher.NewTestWatcher(&meshconfig.MeshConfig{})
 	testns := clienttest.NewWriter[*corev1.Namespace](t, c)
@@ -471,6 +511,7 @@ func TestFilter(t *testing.T) {
 		ObjectFilter: discoveryNamespacesFilter,
 	})
 	deployments.AddEventHandler(clienttest.TrackerHandler(tracker))
+	removeReg := deployments.AddEventHandler(clienttest.TrackerHandler(removeTracker))
 
 	// Create two dynamic informers: one with CRD initially ready, one later
 	// Ready now
@@ -498,6 +539,9 @@ func TestFilter(t *testing.T) {
 	}
 	tester.Create(obj1)
 	tracker.WaitOrdered("add/1")
+	removeTracker.WaitOrdered("add/1")
+	deployments.ShutdownHandler(removeReg)
+
 	obj2 := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "2", Namespace: "selected"},
 		Spec:       appsv1.DeploymentSpec{MinReadySeconds: 1},
@@ -529,6 +573,14 @@ func TestFilter(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "name4", Namespace: "selected"},
 	})
 	tracker.WaitOrdered("add/name4")
+
+	// Ensure we didn't get any events
+	removeTracker.Empty()
+	// Remove the other handler through ShutdownHandlers
+	deployments.ShutdownHandlers()
+	// We should get no event
+	meshWatcher.Set(&meshconfig.MeshConfig{DiscoverySelectors: []*meshconfig.LabelSelector{}})
+	tracker.Empty()
 }
 
 func TestFilterClusterScoped(t *testing.T) {

--- a/pkg/kube/kclient/interfaces.go
+++ b/pkg/kube/kclient/interfaces.go
@@ -53,6 +53,9 @@ type Informer[T controllers.Object] interface {
 	// Warning: this only applies to handlers called via AddEventHandler; any handlers directly added
 	// to the underlying informer are not touched
 	ShutdownHandlers()
+	// ShutdownHandler shuts down a single handler added by AddEventHandler.
+	// ShutdownHandlers can also be used to shutdown everything.
+	ShutdownHandler(registration cache.ResourceEventHandlerRegistration)
 	// Start starts just this informer. Typically, this is not used. Instead, the `kube.Client.Run()` is
 	// used to start all informers at once.
 	// However, in some cases we need to run individual informers directly.

--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -527,7 +527,7 @@ func newManyCollection[I, O any](
 			outputs:  map[Key[O]]O{},
 			mappings: map[Key[I]]sets.Set[Key[O]]{},
 		},
-		eventHandlers:              &handlerSet[O]{},
+		eventHandlers:              newHandlerSet[O](),
 		augmentation:               opts.augmentation,
 		synced:                     make(chan struct{}),
 		stop:                       opts.stop,
@@ -638,11 +638,11 @@ func (h *manyCollection[I, O]) List() (res []O) {
 	return maps.Values(h.collectionState.outputs)
 }
 
-func (h *manyCollection[I, O]) Register(f func(o Event[O])) Syncer {
+func (h *manyCollection[I, O]) Register(f func(o Event[O])) HandlerRegistration {
 	return registerHandlerAsBatched[O](h, f)
 }
 
-func (h *manyCollection[I, O]) RegisterBatch(f func(o []Event[O], initialSync bool), runExistingState bool) Syncer {
+func (h *manyCollection[I, O]) RegisterBatch(f func(o []Event[O], initialSync bool), runExistingState bool) HandlerRegistration {
 	if !runExistingState {
 		// If we don't to run the initial state this is simple, we just register the handler.
 		return h.eventHandlers.Insert(f, h, nil, h.stop)

--- a/pkg/kube/krt/core.go
+++ b/pkg/kube/krt/core.go
@@ -55,14 +55,14 @@ type EventStream[T any] interface {
 	// * Each handler has its own unbounded event queue. Slow handlers will cause this queue to accumulate, but will not block
 	//   other handlers.
 	// * Events will be sent in order, and will not be dropped or deduplicated.
-	Register(f func(o Event[T])) Syncer
+	Register(f func(o Event[T])) HandlerRegistration
 
 	// RegisterBatch registers a handler that accepts multiple events at once. This can be useful as an optimization.
 	// Otherwise, behaves the same as Register.
 	// Additionally, skipping the default behavior of "send all current state through the handler" can be turned off.
 	// This is important when we register in a handler itself, which would cause duplicative events.
 	// Handlers MUST not mutate the event list.
-	RegisterBatch(f func(o []Event[T], initialSync bool), runExistingState bool) Syncer
+	RegisterBatch(f func(o []Event[T], initialSync bool), runExistingState bool) HandlerRegistration
 }
 
 // internalCollection is a superset of Collection for internal usage. All collections must implement this type, but
@@ -91,7 +91,7 @@ type Singleton[T any] interface {
 	// Get returns the object, or nil if there is none.
 	Get() *T
 	// Register adds an event watcher to the object. Any time it changes, the handler will be called
-	Register(f func(o Event[T])) Syncer
+	Register(f func(o Event[T])) HandlerRegistration
 	AsCollection() Collection[T]
 }
 
@@ -123,6 +123,11 @@ func (e Event[T]) Latest() T {
 		return *e.New
 	}
 	return *e.Old
+}
+
+type HandlerRegistration interface {
+	Syncer
+	UnregisterHandler()
 }
 
 // HandlerContext is an opaque type passed into transformation functions.

--- a/pkg/kube/krt/informer.go
+++ b/pkg/kube/krt/informer.go
@@ -124,8 +124,7 @@ func (i *informer[I]) RegisterBatch(f func(o []Event[I], initialSync bool), runE
 	return informerHandlerRegistration{
 		Syncer: sync,
 		remove: func() {
-			// TODO we cannot do all of them!!
-			i.inf.ShutdownHandlers()
+			i.inf.ShutdownHandler(synced)
 		},
 	}
 }

--- a/pkg/kube/krt/informer.go
+++ b/pkg/kube/krt/informer.go
@@ -103,11 +103,11 @@ func (i *informer[I]) GetKey(k string) *I {
 	return nil
 }
 
-func (i *informer[I]) Register(f func(o Event[I])) Syncer {
+func (i *informer[I]) Register(f func(o Event[I])) HandlerRegistration {
 	return registerHandlerAsBatched[I](i, f)
 }
 
-func (i *informer[I]) RegisterBatch(f func(o []Event[I], initialSync bool), runExistingState bool) Syncer {
+func (i *informer[I]) RegisterBatch(f func(o []Event[I], initialSync bool), runExistingState bool) HandlerRegistration {
 	// Note: runExistingState is NOT respected here.
 	// Informer doesn't expose a way to do that. However, due to the runtime model of informers, this isn't a dealbreaker;
 	// the handlers are all called async, so we don't end up with the same deadlocks we would have in the other collection types.
@@ -120,7 +120,23 @@ func (i *informer[I]) RegisterBatch(f func(o []Event[I], initialSync bool), runE
 		name: fmt.Sprintf("%v handler", i.name()),
 		f:    synced.HasSynced,
 	}
-	return multiSyncer{syncers: []Syncer{base, handler}}
+	sync := multiSyncer{syncers: []Syncer{base, handler}}
+	return informerHandlerRegistration{
+		Syncer: sync,
+		remove: func() {
+			// TODO we cannot do all of them!!
+			i.inf.ShutdownHandlers()
+		},
+	}
+}
+
+type informerHandlerRegistration struct {
+	Syncer
+	remove func()
+}
+
+func (i informerHandlerRegistration) UnregisterHandler() {
+	i.remove()
 }
 
 // nolint: unused // (not true)

--- a/pkg/kube/krt/internal.go
+++ b/pkg/kube/krt/internal.go
@@ -29,7 +29,7 @@ import (
 
 // registerHandlerAsBatched is a helper to register the provided handler as a batched handler. This allows collections to
 // only implement RegisterBatch.
-func registerHandlerAsBatched[T any](c internalCollection[T], f func(o Event[T])) Syncer {
+func registerHandlerAsBatched[T any](c internalCollection[T], f func(o Event[T])) HandlerRegistration {
 	return c.RegisterBatch(func(events []Event[T], initialSync bool) {
 		for _, o := range events {
 			f(o)

--- a/pkg/kube/krt/processor.go
+++ b/pkg/kube/krt/processor.go
@@ -48,7 +48,12 @@ func newHandlerSet[O any]() *handlerSet[O] {
 	}
 }
 
-func (o *handlerSet[O]) Insert(f func(o []Event[O], initialSync bool), parentSynced Syncer, initialEvents []Event[O], stopCh <-chan struct{}) HandlerRegistration {
+func (o *handlerSet[O]) Insert(
+	f func(o []Event[O], initialSync bool),
+	parentSynced Syncer,
+	initialEvents []Event[O],
+	stopCh <-chan struct{},
+) HandlerRegistration {
 	o.mu.Lock()
 	l := newProcessListener(f, parentSynced, stopCh)
 	o.handlers.Insert(l)

--- a/pkg/kube/krt/processor.go
+++ b/pkg/kube/krt/processor.go
@@ -23,30 +23,60 @@ import (
 	"k8s.io/utils/buffer"
 
 	"istio.io/istio/pkg/slices"
+	"istio.io/istio/pkg/util/sets"
 )
+
+type handlerRegistration struct {
+	Syncer
+	remove func()
+}
+
+func (h handlerRegistration) UnregisterHandler() {
+	h.remove()
+}
 
 // handlerSet tracks a set of handlers. Handlers can be added at any time.
 type handlerSet[O any] struct {
 	mu       sync.RWMutex
-	handlers []*processorListener[O]
+	handlers sets.Set[*processorListener[O]]
 	wg       wait.Group
 }
 
-func (o *handlerSet[O]) Insert(f func(o []Event[O], initialSync bool), parentSynced Syncer, initialEvents []Event[O], stopCh <-chan struct{}) Syncer {
+func newHandlerSet[O any]() *handlerSet[O] {
+	return &handlerSet[O]{
+		handlers: sets.New[*processorListener[O]](),
+	}
+}
+
+func (o *handlerSet[O]) Insert(f func(o []Event[O], initialSync bool), parentSynced Syncer, initialEvents []Event[O], stopCh <-chan struct{}) HandlerRegistration {
 	o.mu.Lock()
 	l := newProcessListener(f, parentSynced, stopCh)
-	o.handlers = append(o.handlers, l)
+	o.handlers.Insert(l)
 	o.wg.Start(l.run)
 	o.wg.Start(l.pop)
 	o.mu.Unlock()
 	l.send(initialEvents, true)
-	return l.Synced()
+	reg := handlerRegistration{
+		Syncer: l.Synced(),
+		remove: func() {
+			o.remove(l)
+		},
+	}
+	return reg
+}
+
+func (o *handlerSet[O]) remove(p *processorListener[O]) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	delete(o.handlers, p)
+	close(p.addCh)
 }
 
 func (o *handlerSet[O]) Distribute(events []Event[O], initialSync bool) {
 	o.mu.RLock()
 	defer o.mu.RUnlock()
-	for _, listener := range o.handlers {
+	for listener := range o.handlers {
 		listener.send(slices.Clone(events), initialSync)
 	}
 }
@@ -55,7 +85,7 @@ func (o *handlerSet[O]) Distribute(events []Event[O], initialSync bool) {
 func (o *handlerSet[O]) Synced() Syncer {
 	o.mu.RLock()
 	syncer := multiSyncer{syncers: make([]Syncer, 0, len(o.handlers))}
-	for _, listener := range o.handlers {
+	for listener := range o.handlers {
 		syncer.syncers = append(syncer.syncers, listener.Synced())
 	}
 	o.mu.RUnlock()

--- a/pkg/kube/krt/singleton.go
+++ b/pkg/kube/krt/singleton.go
@@ -99,9 +99,18 @@ func (d *static[T]) RegisterBatch(f func(o []Event[T], initialSync bool), runExi
 			}}, true)
 		}
 	}
-	panic("TODO")
-	return nil
+
+	return staticHandler{d.syncer}
 	// return d.syncer
+}
+
+type staticHandler struct {
+	Syncer
+}
+
+func (s staticHandler) UnregisterHandler() {
+	// TODO!
+	panic("TODO")
 }
 
 func (d *static[T]) Synced() Syncer {

--- a/pkg/kube/krt/singleton.go
+++ b/pkg/kube/krt/singleton.go
@@ -84,11 +84,11 @@ func (d *static[T]) List() []T {
 	return []T{*v}
 }
 
-func (d *static[T]) Register(f func(o Event[T])) Syncer {
+func (d *static[T]) Register(f func(o Event[T])) HandlerRegistration {
 	return registerHandlerAsBatched[T](d, f)
 }
 
-func (d *static[T]) RegisterBatch(f func(o []Event[T], initialSync bool), runExistingState bool) Syncer {
+func (d *static[T]) RegisterBatch(f func(o []Event[T], initialSync bool), runExistingState bool) HandlerRegistration {
 	d.eventHandlers.Insert(f)
 	if runExistingState {
 		v := d.val.Load()
@@ -99,7 +99,9 @@ func (d *static[T]) RegisterBatch(f func(o []Event[T], initialSync bool), runExi
 			}}, true)
 		}
 	}
-	return d.syncer
+	panic("TODO")
+	return nil
+	// return d.syncer
 }
 
 func (d *static[T]) Synced() Syncer {
@@ -201,7 +203,7 @@ func (c collectionAdapter[T]) Get() *T {
 	return &res[0]
 }
 
-func (c collectionAdapter[T]) Register(f func(o Event[T])) Syncer {
+func (c collectionAdapter[T]) Register(f func(o Event[T])) HandlerRegistration {
 	return c.c.Register(f)
 }
 

--- a/pkg/kube/krt/static.go
+++ b/pkg/kube/krt/static.go
@@ -51,7 +51,7 @@ func NewStaticCollection[T any](vals []T, opts ...CollectionOption) StaticCollec
 	}
 
 	sl := &staticList[T]{
-		eventHandlers:  &handlerSet[T]{},
+		eventHandlers:  newHandlerSet[T](),
 		vals:           res,
 		id:             nextUID(),
 		stop:           o.stop,
@@ -209,7 +209,7 @@ func (s *staticList[T]) List() []T {
 	return maps.Values(s.vals)
 }
 
-func (s *staticList[T]) Register(f func(o Event[T])) Syncer {
+func (s *staticList[T]) Register(f func(o Event[T])) HandlerRegistration {
 	return registerHandlerAsBatched(s, f)
 }
 
@@ -226,7 +226,7 @@ func (s *staticList[T]) Synced() Syncer {
 	return alwaysSynced{}
 }
 
-func (s *staticList[T]) RegisterBatch(f func(o []Event[T], initialSync bool), runExistingState bool) Syncer {
+func (s *staticList[T]) RegisterBatch(f func(o []Event[T], initialSync bool), runExistingState bool) HandlerRegistration {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	var objs []Event[T]


### PR DESCRIPTION
kclient:
* allow removing a single handler instead of just all
* Ensure dynamic object filter events do not sent on removed handlers

krt:
* Allow removing a handler
* Utilize this to properly remove mesh config handlers instead of just marking them "inactive"

Tests:
* Add tests for removing single/all handlers in kclient
* Add test covering dynamic object case
* Add removing handlers to 'conformance' for krt, ensuning all collections get coverage
* Add a new test case specific to mesh config's usage to ensure the new change is functionally the same
