### PR TITLE
[release-1.25] pin envoyproxy/go-control-plane to last change before Envoy v1.33 cut

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.8.2 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.1 // indirect
-	github.com/envoyproxy/go-control-plane v0.13.5-0.20250123154839-2a6715911fec // indirect
+	github.com/envoyproxy/go-control-plane v0.13.5-0.20250114143102-4eb1955954fa // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.1.0 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
 	github.com/fatih/camelcase v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -17,8 +17,8 @@ require (
 	github.com/coreos/go-oidc/v3 v3.12.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/docker/cli v27.5.1+incompatible
-	github.com/envoyproxy/go-control-plane/contrib v1.32.4-0.20250124152931-009f366fdf49
-	github.com/envoyproxy/go-control-plane/envoy v1.32.4-0.20250124152931-009f366fdf49
+	github.com/envoyproxy/go-control-plane/contrib v1.32.4-0.20250114143102-4eb1955954fa
+	github.com/envoyproxy/go-control-plane/envoy v1.32.4-0.20250114143102-4eb1955954fa
 	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/fatih/color v1.18.0
 	github.com/felixge/fgprof v0.9.5

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/emicklei/go-restful/v3 v3.12.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRr
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
+github.com/envoyproxy/go-control-plane v0.13.5-0.20250114143102-4eb1955954fa h1:hKkXohR1YL4YGPNB/CfVUS07I1uF4uc1qvPNfILlex8=
+github.com/envoyproxy/go-control-plane v0.13.5-0.20250114143102-4eb1955954fa/go.mod h1:kDfuBlDVsSj2MjrLEtRWtHlsWIFcGyB2RMO44Dc5GZA=
 github.com/envoyproxy/go-control-plane v0.13.5-0.20250123154839-2a6715911fec h1:JSSbRTQjlgxvbu742IwK/v3mrNWRz2U1GjY66DqogNo=
 github.com/envoyproxy/go-control-plane v0.13.5-0.20250123154839-2a6715911fec/go.mod h1:yz4MTDY0h9ObVlfP15ykR737j5tP/z64qu0OzSRoobk=
 github.com/envoyproxy/go-control-plane/contrib v1.32.4-0.20250124152931-009f366fdf49 h1:GibP3W2AIwgBjvdyCcn6rTgaDaVEBKtPoR/CxlFf/Hw=

--- a/go.sum
+++ b/go.sum
@@ -117,16 +117,10 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/go-control-plane v0.13.5-0.20250114143102-4eb1955954fa h1:hKkXohR1YL4YGPNB/CfVUS07I1uF4uc1qvPNfILlex8=
 github.com/envoyproxy/go-control-plane v0.13.5-0.20250114143102-4eb1955954fa/go.mod h1:kDfuBlDVsSj2MjrLEtRWtHlsWIFcGyB2RMO44Dc5GZA=
-github.com/envoyproxy/go-control-plane v0.13.5-0.20250123154839-2a6715911fec h1:JSSbRTQjlgxvbu742IwK/v3mrNWRz2U1GjY66DqogNo=
-github.com/envoyproxy/go-control-plane v0.13.5-0.20250123154839-2a6715911fec/go.mod h1:yz4MTDY0h9ObVlfP15ykR737j5tP/z64qu0OzSRoobk=
 github.com/envoyproxy/go-control-plane/contrib v1.32.4-0.20250114143102-4eb1955954fa h1:j0kuAlZuJWhHn2Xc8IsqZKSzlQh3MtgA5U2ElqcvCug=
 github.com/envoyproxy/go-control-plane/contrib v1.32.4-0.20250114143102-4eb1955954fa/go.mod h1:HMK/OApOHoma+0RnR4oxmK4PeiUpwdu2r6qVSfwsLHg=
-github.com/envoyproxy/go-control-plane/contrib v1.32.4-0.20250124152931-009f366fdf49 h1:GibP3W2AIwgBjvdyCcn6rTgaDaVEBKtPoR/CxlFf/Hw=
-github.com/envoyproxy/go-control-plane/contrib v1.32.4-0.20250124152931-009f366fdf49/go.mod h1:HMK/OApOHoma+0RnR4oxmK4PeiUpwdu2r6qVSfwsLHg=
 github.com/envoyproxy/go-control-plane/envoy v1.32.4-0.20250114143102-4eb1955954fa h1:TPxj84Kkcm0VLNpL3jGO00jIzBOJH/wFY7LrCPx1zGQ=
 github.com/envoyproxy/go-control-plane/envoy v1.32.4-0.20250114143102-4eb1955954fa/go.mod h1:c955gQjaXHsMxMjHjEZ7nwIzMJYxXpN+sJIGufsSbg4=
-github.com/envoyproxy/go-control-plane/envoy v1.32.4-0.20250124152931-009f366fdf49 h1:QYBGFqfvJrV1M44PooyT1moMnWQk91t65/MMyXtJzFo=
-github.com/envoyproxy/go-control-plane/envoy v1.32.4-0.20250124152931-009f366fdf49/go.mod h1:c955gQjaXHsMxMjHjEZ7nwIzMJYxXpN+sJIGufsSbg4=
 github.com/envoyproxy/go-control-plane/ratelimit v0.1.0 h1:/G9QYbddjL25KvtKTv3an9lx6VBE2cnb8wp1vEGNYGI=
 github.com/envoyproxy/go-control-plane/ratelimit v0.1.0/go.mod h1:Wk+tMFAFbCXaJPzVVHnPgRKdUdwW/KdbRt94AzgRee4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,12 @@ github.com/envoyproxy/go-control-plane v0.13.5-0.20250114143102-4eb1955954fa h1:
 github.com/envoyproxy/go-control-plane v0.13.5-0.20250114143102-4eb1955954fa/go.mod h1:kDfuBlDVsSj2MjrLEtRWtHlsWIFcGyB2RMO44Dc5GZA=
 github.com/envoyproxy/go-control-plane v0.13.5-0.20250123154839-2a6715911fec h1:JSSbRTQjlgxvbu742IwK/v3mrNWRz2U1GjY66DqogNo=
 github.com/envoyproxy/go-control-plane v0.13.5-0.20250123154839-2a6715911fec/go.mod h1:yz4MTDY0h9ObVlfP15ykR737j5tP/z64qu0OzSRoobk=
+github.com/envoyproxy/go-control-plane/contrib v1.32.4-0.20250114143102-4eb1955954fa h1:j0kuAlZuJWhHn2Xc8IsqZKSzlQh3MtgA5U2ElqcvCug=
+github.com/envoyproxy/go-control-plane/contrib v1.32.4-0.20250114143102-4eb1955954fa/go.mod h1:HMK/OApOHoma+0RnR4oxmK4PeiUpwdu2r6qVSfwsLHg=
 github.com/envoyproxy/go-control-plane/contrib v1.32.4-0.20250124152931-009f366fdf49 h1:GibP3W2AIwgBjvdyCcn6rTgaDaVEBKtPoR/CxlFf/Hw=
 github.com/envoyproxy/go-control-plane/contrib v1.32.4-0.20250124152931-009f366fdf49/go.mod h1:HMK/OApOHoma+0RnR4oxmK4PeiUpwdu2r6qVSfwsLHg=
+github.com/envoyproxy/go-control-plane/envoy v1.32.4-0.20250114143102-4eb1955954fa h1:TPxj84Kkcm0VLNpL3jGO00jIzBOJH/wFY7LrCPx1zGQ=
+github.com/envoyproxy/go-control-plane/envoy v1.32.4-0.20250114143102-4eb1955954fa/go.mod h1:c955gQjaXHsMxMjHjEZ7nwIzMJYxXpN+sJIGufsSbg4=
 github.com/envoyproxy/go-control-plane/envoy v1.32.4-0.20250124152931-009f366fdf49 h1:QYBGFqfvJrV1M44PooyT1moMnWQk91t65/MMyXtJzFo=
 github.com/envoyproxy/go-control-plane/envoy v1.32.4-0.20250124152931-009f366fdf49/go.mod h1:c955gQjaXHsMxMjHjEZ7nwIzMJYxXpN+sJIGufsSbg4=
 github.com/envoyproxy/go-control-plane/ratelimit v0.1.0 h1:/G9QYbddjL25KvtKTv3an9lx6VBE2cnb8wp1vEGNYGI=

--- a/pkg/config/xds/filter_types.gen.go
+++ b/pkg/config/xds/filter_types.gen.go
@@ -46,7 +46,6 @@ import (
 	_ "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/private_key_providers/qat/v3alpha"
 	_ "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/regex_engines/hyperscan/v3alpha"
 	_ "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/router/cluster_specifier/golang/v3alpha"
-	_ "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/tap_sinks/udp_sink/v3alpha"
 	_ "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/vcl/v3alpha"
 	_ "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"


### PR DESCRIPTION
Pin `envoyproxy/go-control-plane`, `envoyproxy/go-control-plane/contrib` and `envoyproxy/go-control-plane/envoy` to the last mirrored change from Envoy repo before Envoy v1.33 release branch cut.