### PR TITLE
update bin/update_deps.sh and bin/update_ztunnel.sh to release-1.25

### DIFF
--- a/bin/update_deps.sh
+++ b/bin/update_deps.sh
@@ -16,7 +16,7 @@
 
 set -exo pipefail
 
-UPDATE_BRANCH=${UPDATE_BRANCH:-"master"}
+UPDATE_BRANCH=${UPDATE_BRANCH:-"release-1.25"}
 
 SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOTDIR=$(dirname "${SCRIPTPATH}")
@@ -35,10 +35,10 @@ go get -u "istio.io/api@${UPDATE_BRANCH}"
 go get -u "istio.io/client-go@${UPDATE_BRANCH}"
 go mod tidy
 
-sed -i "s/^BUILDER_SHA=.*\$/BUILDER_SHA=$(getSha release-builder)/" prow/release-commit.sh
+sed -i'.bak' -e "s/^BUILDER_SHA=.*\$/BUILDER_SHA=$(getSha release-builder)/" prow/release-commit.sh
 chmod +x prow/release-commit.sh
-sed -i '/PROXY_REPO_SHA/,/lastStableSHA/ { s/"lastStableSHA":.*/"lastStableSHA": "'"$(getSha proxy)"'"/  }; /ZTUNNEL_REPO_SHA/,/lastStableSHA/ { s/"lastStableSHA":.*/"lastStableSHA": "'"$(getSha ztunnel)"'"/  }' istio.deps
+sed -i'.bak' -e '/PROXY_REPO_SHA/,/lastStableSHA/ { s/"lastStableSHA":.*/"lastStableSHA": "'"$(getSha proxy)"'"/  }; /ZTUNNEL_REPO_SHA/,/lastStableSHA/ { s/"lastStableSHA":.*/"lastStableSHA": "'"$(getSha ztunnel)"'"/  }' istio.deps
 
 # shellcheck disable=SC1001
 LATEST_DISTROLESS_SHA256=$(crane digest cgr.dev/chainguard/static | awk -F\: '{print $2}')
-sed -i -E "s/sha256:[a-z0-9]+/sha256:${LATEST_DISTROLESS_SHA256}/g" docker/Dockerfile.distroless
+sed -i'.bak' -E "s/sha256:[a-z0-9]+/sha256:${LATEST_DISTROLESS_SHA256}/g" docker/Dockerfile.distroless

--- a/bin/update_ztunnel.sh
+++ b/bin/update_ztunnel.sh
@@ -16,7 +16,7 @@
 
 set -e
 
-UPDATE_BRANCH=${UPDATE_BRANCH:-"master"}
+UPDATE_BRANCH=${UPDATE_BRANCH:-"release-1.25"}
 
 SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOTDIR=$(dirname "${SCRIPTPATH}")
@@ -35,4 +35,4 @@ function getSha() {
   echo "${result}"
 }
 
-sed -i '/ZTUNNEL_REPO_SHA/,/lastStableSHA/ { s/"lastStableSHA":.*/"lastStableSHA": "'"$(getSha ztunnel)"'"/  }' istio.deps
+sed -i'.bak' '/ZTUNNEL_REPO_SHA/,/lastStableSHA/ { s/"lastStableSHA":.*/"lastStableSHA": "'"$(getSha ztunnel)"'"/  }' istio.deps

--- a/docker/Dockerfile.distroless
+++ b/docker/Dockerfile.distroless
@@ -1,5 +1,5 @@
 # prepare a distroless source context to copy files from
-FROM cgr.dev/chainguard/static@sha256:5497b01f36ef14a5198c0165e50ae6a0006d0c7457d4566f1110257e1c0812ed AS distroless_source
+FROM cgr.dev/chainguard/static@sha256:853bfd4495abb4b65ede8fc9332513ca2626235589c2cef59b4fce5082d0836d AS distroless_source
 
 # prepare a base dev to modify file contents
 FROM ubuntu:noble AS ubuntu_source

--- a/istio.deps
+++ b/istio.deps
@@ -11,6 +11,6 @@
     "name": "ZTUNNEL_REPO_SHA",
     "repoName": "ztunnel",
     "file": "",
-    "lastStableSHA": "87aa1e934c6f7be02054b57fdf7a1602653b528c"
+    "lastStableSHA": "fb2a7be8e49c82a8a0c722c19206a1199531984e"
   }
 ]

--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -37,7 +37,7 @@ docker run --rm --privileged "${DOCKER_HUB}/qemu-user-static" --reset -p yes
 export ISTIO_DOCKER_QEMU=true
 
 # Use a pinned version in case breaking changes are needed
-BUILDER_SHA=86ddbf9ccfc867a791f9bdec1057b3c7ca8d10b1
+BUILDER_SHA=cc7f5903d88937fbfd42d05ea48667bf8c9d6c3d
 
 # Reference to the next minor version of Istio
 # This will create a version like 1.4-alpha.sha
@@ -73,7 +73,7 @@ ${DEPENDENCIES:-$(cat <<EOD
     branch: master
   tools:
     git: https://github.com/istio/tools
-    branch: master
+    branch: release-1.25
   release-builder:
     git: https://github.com/istio/release-builder
     sha: ${BUILDER_SHA}


### PR DESCRIPTION
...and run `./bin/update_deps.sh` and `./bin/update_ztunnel.sh`. Equivalent to #53718 for 1.25

**FIXME:** these scripts currently do not run completely on macOS due to differences in syntax between GNU `sed` and BSD `sed`. Should these scripts be updated, or should they instead be run through a containerized workflow?

```
+ sed -i.bak -e '/PROXY_REPO_SHA/,/lastStableSHA/ { s/"lastStableSHA":.*/"lastStableSHA": "1a1039c27701ecefdc2ce1e8e4e2fe9c1feedc4a"/  }; /ZTUNNEL_REPO_SHA/,/lastStableSHA/ { s/"lastStableSHA":.*/"lastStableSHA": "fb2a7be8e49c82a8a0c722c19206a1199531984e"/  }' istio.deps
sed: 1: "/PROXY_REPO_SHA/,/lastS ...": bad flag in substitute command: '}'
```
```
sed: 1: "/ZTUNNEL_REPO_SHA/,/las ...": bad flag in substitute command: '}'
```

Refs https://stackoverflow.com/questions/4247068/sed-command-with-i-option-failing-on-mac-but-works-on-linux