### PR TITLE
Remove ENABLE_DELIMITED_STATS_TAG_REGEX flag and code paths

### DIFF
--- a/pilot/pkg/features/telemetry.go
+++ b/pilot/pkg/features/telemetry.go
@@ -76,7 +76,4 @@ var (
 
 	EnableControllerQueueMetrics = env.Register("ISTIO_ENABLE_CONTROLLER_QUEUE_METRICS", false,
 		"If enabled, publishes metrics for queue depth, latency and processing times.").Get()
-
-	EnableDelimitedStatsTagRegex = env.Register("ENABLE_DELIMITED_STATS_TAG_REGEX", true,
-		"If true, pilot will use the new delimited stat tag regex to generate Envoy stats tags.").Get()
 )

--- a/pilot/pkg/networking/core/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/cluster_builder_test.go
@@ -303,33 +303,6 @@ func TestApplyDestinationRule(t *testing.T) {
 			},
 		},
 		{
-			name:        "cluster with OutboundClusterStatName and stats tag regex disabled",
-			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
-			clusterMode: DefaultClusterMode,
-			service:     service,
-			port:        servicePort[0],
-			proxyView:   model.ProxyViewAll,
-			destRule: &networking.DestinationRule{
-				Host: "foo.default.svc.cluster.local",
-				Subsets: []*networking.Subset{
-					{
-						Name:   "foobar",
-						Labels: map[string]string{"foo": "bar"},
-					},
-				},
-			},
-			expectedSubsetClusters: []*cluster.Cluster{
-				{
-					Name:                 "outbound|8080|foobar|foo.default.svc.cluster.local",
-					ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS},
-					EdsClusterConfig: &cluster.Cluster_EdsClusterConfig{
-						ServiceName: "outbound|8080|foobar|foo.default.svc.cluster.local",
-					},
-					AltStatName: "foo.default.svc.cluster.local_foobar_default_8080",
-				},
-			},
-		},
-		{
 			name:        "destination rule with subset traffic policy and alt statname",
 			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
 			clusterMode: DefaultClusterMode,

--- a/pilot/pkg/networking/core/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/cluster_builder_test.go
@@ -113,7 +113,6 @@ func TestApplyDestinationRule(t *testing.T) {
 		proxyView              model.ProxyView
 		destRule               *networking.DestinationRule
 		meshConfig             *meshconfig.MeshConfig
-		disableDelimitedStats  bool
 		expectedSubsetClusters []*cluster.Cluster
 	}{
 		// TODO(ramaraochavali): Add more tests to cover additional conditions.
@@ -317,14 +316,6 @@ func TestApplyDestinationRule(t *testing.T) {
 						Name:   "foobar",
 						Labels: map[string]string{"foo": "bar"},
 					},
-				},
-			},
-			disableDelimitedStats: true,
-			meshConfig: &meshconfig.MeshConfig{
-				OutboundClusterStatName: "%SERVICE%_%SUBSET_NAME%_%SERVICE_PORT_NAME%_%SERVICE_PORT%",
-				InboundTrafficPolicy:    &meshconfig.MeshConfig_InboundTrafficPolicy{},
-				EnableAutoMtls: &wrappers.BoolValue{
-					Value: false,
 				},
 			},
 			expectedSubsetClusters: []*cluster.Cluster{
@@ -825,7 +816,6 @@ func TestApplyDestinationRule(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			test.SetForTest(t, &features.EnableDelimitedStatsTagRegex, !tt.disableDelimitedStats)
 			instances := []*model.ServiceInstance{
 				{
 					Service:     tt.service,

--- a/pilot/pkg/networking/core/cluster_test.go
+++ b/pilot/pkg/networking/core/cluster_test.go
@@ -1276,25 +1276,16 @@ func TestStatNamePattern(t *testing.T) {
 		InboundClusterStatName:  "LocalService_%SERVICE%",
 		OutboundClusterStatName: "%SERVICE%_%SERVICE_PORT_NAME%_%SERVICE_PORT%",
 	}
-	enableDelimitedStatsTagValues := []bool{true, false}
 
-	for _, enableDelimitedStatsTagValue := range enableDelimitedStatsTagValues {
-		test.SetForTest(t, &features.EnableDelimitedStatsTagRegex, enableDelimitedStatsTagValue)
-		clusters := buildTestClusters(clusterTest{
-			t: t, serviceHostname: "*.example.org", serviceResolution: model.DNSLB, nodeType: model.SidecarProxy,
-			locality: &core.Locality{}, mesh: statConfigMesh,
-			destRule: &networking.DestinationRule{
-				Host: "*.example.org",
-			},
-		})
-		if enableDelimitedStatsTagValue {
-			g.Expect(xdstest.ExtractCluster("outbound|8080||*.example.org", clusters).AltStatName).To(Equal("*.example.org_default_8080;"))
-			g.Expect(xdstest.ExtractCluster("inbound|10001||", clusters).AltStatName).To(Equal("LocalService_*.example.org;"))
-		} else {
-			g.Expect(xdstest.ExtractCluster("outbound|8080||*.example.org", clusters).AltStatName).To(Equal("*.example.org_default_8080"))
-			g.Expect(xdstest.ExtractCluster("inbound|10001||", clusters).AltStatName).To(Equal("LocalService_*.example.org"))
-		}
-	}
+	clusters := buildTestClusters(clusterTest{
+		t: t, serviceHostname: "*.example.org", serviceResolution: model.DNSLB, nodeType: model.SidecarProxy,
+		locality: &core.Locality{}, mesh: statConfigMesh,
+		destRule: &networking.DestinationRule{
+			Host: "*.example.org",
+		},
+	})
+	g.Expect(xdstest.ExtractCluster("outbound|8080||*.example.org", clusters).AltStatName).To(Equal("*.example.org_default_8080;"))
+	g.Expect(xdstest.ExtractCluster("inbound|10001||", clusters).AltStatName).To(Equal("LocalService_*.example.org;"))
 }
 
 func TestDuplicateClusters(t *testing.T) {

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -889,8 +889,6 @@ func VersionGreaterOrEqual124(proxy *model.Proxy) bool {
 }
 
 func DelimitedStatsPrefix(statPrefix string) string {
-	if features.EnableDelimitedStatsTagRegex {
-		statPrefix += constants.StatPrefixDelimiter
-	}
+	statPrefix += constants.StatPrefixDelimiter
 	return statPrefix
 }

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -311,7 +311,6 @@ func getStatsOptions(meta *model.BootstrapNodeMetadata) []option.Instance {
 		option.EnvoyExtraStatTags(extraStatTags),
 		option.EnvoyHistogramBuckets(buckets),
 		option.EnvoyStatsCompression(compression),
-		option.DelimitedStatsTagsEnabled(features.EnableDelimitedStatsTagRegex),
 	}
 }
 

--- a/pkg/bootstrap/instance_test.go
+++ b/pkg/bootstrap/instance_test.go
@@ -119,12 +119,6 @@ func TestGolden(t *testing.T) {
 			base: "explicit_internal_address",
 		},
 		{
-			base: "legacy_stats_tags_regex",
-			envVars: map[string]string{
-				"ENABLE_DELIMITED_STATS_TAG_REGEX": "false",
-			},
-		},
-		{
 			base: "running",
 			envVars: map[string]string{
 				"ISTIO_META_ISTIO_PROXY_SHA":   "istio-proxy:sha",

--- a/pkg/bootstrap/option/instances.go
+++ b/pkg/bootstrap/option/instances.go
@@ -259,10 +259,6 @@ func MetadataDiscovery(value bool) Instance {
 	return newOption("metadata_discovery", value)
 }
 
-func DelimitedStatsTagsEnabled(value bool) Instance {
-	return newOption("delimited_stats_tags_enabled", value)
-}
-
 func MetricsLocalhostAccessOnly(proxyMetadata map[string]string) Instance {
 	value, ok := proxyMetadata["METRICS_LOCALHOST_ACCESS_ONLY"]
 	if ok && value == "true" {

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -76,7 +76,6 @@
   "stats_config": {
     "use_all_default_tags": false,
     "stats_tags": [
-      {{- if .delimited_stats_tags_enabled }}
       {
         "tag_name": "cluster_name",
         "regex": "^cluster(\\.(.+);)"
@@ -85,16 +84,6 @@
         "tag_name": "http_conn_manager_prefix",
         "regex": "^http\\.(((?:[_.[:digit:]\\w]*|[_\\[\\]aAbBcCdDeEfF[:digit:]\\w\\:]*));\\.)"
       },
-      {{- else }}
-      {
-        "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
-      },
-      {
-        "tag_name": "http_conn_manager_prefix",
-        "regex": "^http\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
-      },
-      {{- end }}
       {
         "tag_name": "thread_name",
         "regex": "^server(\\.(.+))\\.watchdog"


### PR DESCRIPTION
**Please provide a description of this PR:**

The flag has reached the end of its deprecation period now that the last compatibility profile with it set to false (1.22) is being removed in 1.26.

If there are no objections the flag and code paths can be removed