### PR TITLE
[release-1.25] Separate CNI agent network namespace from host

### DIFF
--- a/cni/pkg/config/config.go
+++ b/cni/pkg/config/config.go
@@ -148,7 +148,6 @@ func (c InstallConfig) String() string {
 	b.WriteString("AmbientDNSCapture: " + fmt.Sprint(c.AmbientDNSCapture) + "\n")
 	b.WriteString("AmbientIPv6: " + fmt.Sprint(c.AmbientIPv6) + "\n")
 	b.WriteString("AmbientDisableSafeUpgrade: " + fmt.Sprint(c.AmbientDisableSafeUpgrade) + "\n")
-
 	b.WriteString("AmbientReconcilePodRulesOnStartup: " + fmt.Sprint(c.AmbientReconcilePodRulesOnStartup) + "\n")
 	return b.String()
 }

--- a/cni/pkg/constants/constants.go
+++ b/cni/pkg/constants/constants.go
@@ -14,6 +14,11 @@
 
 package constants
 
+import (
+	"os"
+	"strconv"
+)
+
 // Command line arguments
 const (
 	// Install
@@ -69,6 +74,7 @@ const (
 	ReadinessEndpoint  = "/readyz"
 	ReadinessPort      = "8000"
 	ServiceAccountPath = "/var/run/secrets/kubernetes.io/serviceaccount"
+	SelfNetNSPath      = "/proc/self/ns/net"
 )
 
 // Exposed for testing "constants"
@@ -78,4 +84,15 @@ var (
 	// Well-known subpath we will mount any needed host-mounts under,
 	// to preclude shadowing or breaking any pod-internal mounts
 	HostMountsPath = "/host"
+	// HostNetNSPath is set to "/proc/self/ns/net" by default to prevent unintended execution on the host,
+	// even during test development. At runtime, it is overridden when the ALLOW_SWITCH_TO_HOST_NS
+	// environment variable is set to true (see CNI daemonset), which updates it to "/host/proc/1/ns/net" to align with the actual
+	// host network namespace.
+	HostNetNSPath = SelfNetNSPath
 )
+
+func init() {
+	if allowSwitch, err := strconv.ParseBool(os.Getenv("ALLOW_SWITCH_TO_HOST_NS")); err == nil && allowSwitch {
+		HostNetNSPath = HostMountsPath + "/proc/1/ns/net"
+	}
+}

--- a/cni/pkg/nodeagent/server.go
+++ b/cni/pkg/nodeagent/server.go
@@ -225,15 +225,16 @@ func (s *meshDataplane) Stop(skipCleanup bool) {
 	// already been captured will eventually start to fail kubelet healthchecks.
 	if !skipCleanup {
 		log.Info("CNI ambient server terminating, cleaning up node net rules")
-
 		log.Debug("removing host iptables rules")
 		s.hostIptables.DeleteHostRules()
-
-		log.Debug("destroying host ipset")
-		s.hostsideProbeIPSet.Flush()
-		if err := s.hostsideProbeIPSet.DestroySet(); err != nil {
-			log.Warnf("could not destroy host ipset on shutdown")
-		}
+		_ = util.RunAsHost(func() error {
+			log.Debug("destroying host ipset")
+			s.hostsideProbeIPSet.Flush()
+			if err := s.hostsideProbeIPSet.DestroySet(); err != nil {
+				log.Warnf("could not destroy host ipset on shutdown")
+			}
+			return nil
+		})
 	}
 
 	s.netServer.Stop(skipCleanup)
@@ -375,7 +376,6 @@ func (s *meshDataplane) syncHostIPSets(ambientPods []*corev1.Pod) error {
 			}
 			addedIPSnapshot = append(addedIPSnapshot, addedIps...)
 		}
-
 	}
 	return pruneHostIPset(sets.New(addedIPSnapshot...), &s.hostsideProbeIPSet)
 }
@@ -413,16 +413,22 @@ func (s *meshDataplane) addPodToHostNSIpset(pod *corev1.Pod, podIPs []netip.Addr
 	var addedIps []netip.Addr
 
 	// For each pod IP
-	for _, pip := range podIPs {
-		// Add to host ipset
-		log.Debugf("adding probe ip %s to set", pip)
-		if err := s.hostsideProbeIPSet.AddIP(pip, ipProto, podUID, true); err != nil {
-			ipsetAddrErrs = append(ipsetAddrErrs, err)
-			log.Errorf("failed adding ip %s to set, error was %s",
-				pod.Name, &s.hostsideProbeIPSet.Prefix, pip, podUID, err)
-		} else {
-			addedIps = append(addedIps, pip)
+	err := util.RunAsHost(func() error {
+		for _, pip := range podIPs {
+			// Add to host ipset
+			log.Debugf("adding probe ip %s to set", pip)
+			if err := s.hostsideProbeIPSet.AddIP(pip, ipProto, podUID, true); err != nil {
+				ipsetAddrErrs = append(ipsetAddrErrs, err)
+				log.Errorf("failed adding ip %s to set, error was %s",
+					pod.Name, &s.hostsideProbeIPSet.Prefix, pip, podUID, err)
+			} else {
+				addedIps = append(addedIps, pip)
+			}
 		}
+		return nil
+	})
+	if err != nil {
+		ipsetAddrErrs = append(ipsetAddrErrs, err)
 	}
 
 	return addedIps, errors.Join(ipsetAddrErrs...)
@@ -433,13 +439,18 @@ func (s *meshDataplane) addPodToHostNSIpset(pod *corev1.Pod, podIPs []netip.Addr
 //
 // We will unconditionally flush our set before use here, so it shouldn't matter.
 func createHostsideProbeIpset(isV6 bool) (ipset.IPSet, error) {
-	linDeps := ipset.RealNlDeps()
-	probeSet, err := ipset.NewIPSet(iptables.ProbeIPSet, isV6, linDeps)
-	if err != nil {
-		return probeSet, err
-	}
-	probeSet.Flush()
-	return probeSet, nil
+	var probeSet ipset.IPSet
+	runErr := util.RunAsHost(func() error {
+		var err error
+		linDeps := ipset.RealNlDeps()
+		probeSet, err = ipset.NewIPSet(iptables.ProbeIPSet, isV6, linDeps)
+		if err != nil {
+			return err
+		}
+		probeSet.Flush()
+		return nil
+	})
+	return probeSet, runErr
 }
 
 // removePodFromHostNSIpset will remove (v4, v6) pod IPs from the host IP set(s).
@@ -450,34 +461,38 @@ func removePodFromHostNSIpset(pod *corev1.Pod, hostsideProbeSet *ipset.IPSet) er
 	log := log.WithLabels("ns", pod.Namespace, "name", pod.Name, "podUID", podUID, "ipset", hostsideProbeSet.Prefix)
 
 	podIPs := util.GetPodIPsIfPresent(pod)
-	for _, pip := range podIPs {
-		if uidMismatch, err := hostsideProbeSet.ClearEntriesWithIPAndComment(pip, podUID); err != nil {
-			return err
-		} else if uidMismatch != "" {
-			log.Warnf("pod ip %s could not be removed from ipset, found entry with pod UID %s instead", pip, uidMismatch)
+	return util.RunAsHost(func() error {
+		for _, pip := range podIPs {
+			if uidMismatch, err := hostsideProbeSet.ClearEntriesWithIPAndComment(pip, podUID); err != nil {
+				return err
+			} else if uidMismatch != "" {
+				log.Warnf("pod ip %s could not be removed from ipset, found entry with pod UID %s instead", pip, uidMismatch)
+			}
+			log.Debugf("removed pod from host ipset by ip %s", pip)
 		}
-		log.Debugf("removed pod from host ipset by ip %s", pip)
-	}
-
-	return nil
+		return nil
+	})
 }
 
+// pruneHostIPset removes stale IPs from the specified host-side IP set that are not part of the expected set of IPs.
 func pruneHostIPset(expected sets.Set[netip.Addr], hostsideProbeSet *ipset.IPSet) error {
-	actualIPSetContents, err := hostsideProbeSet.ListEntriesByIP()
-	if err != nil {
-		log.Warnf("unable to list IPSet: %v", err)
-		return err
-	}
-	actual := sets.New(actualIPSetContents...)
-	stales := actual.DifferenceInPlace(expected)
-
-	for staleIP := range stales {
-		if err := hostsideProbeSet.ClearEntriesWithIP(staleIP); err != nil {
+	return util.RunAsHost(func() error {
+		actualIPSetContents, err := hostsideProbeSet.ListEntriesByIP()
+		if err != nil {
+			log.Warnf("unable to list IPSet: %v", err)
 			return err
 		}
-		log.Debugf("removed stale ip %s from host ipset %s", staleIP, hostsideProbeSet.Prefix)
-	}
-	return nil
+		actual := sets.New(actualIPSetContents...)
+		stales := actual.DifferenceInPlace(expected)
+
+		for staleIP := range stales {
+			if err := hostsideProbeSet.ClearEntriesWithIP(staleIP); err != nil {
+				return err
+			}
+			log.Debugf("removed stale ip %s from host ipset %s", staleIP, hostsideProbeSet.Prefix)
+		}
+		return nil
+	})
 }
 
 // buildKubeClient creates the kube client

--- a/cni/pkg/util/netnsutil.go
+++ b/cni/pkg/util/netnsutil.go
@@ -1,0 +1,36 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	netns "github.com/containernetworking/plugins/pkg/ns"
+
+	pconstants "istio.io/istio/cni/pkg/constants"
+)
+
+// RunAsHost executes the given function `f` within the host network namespace
+func RunAsHost(f func() error) error {
+	if f == nil {
+		return nil
+	}
+
+	// A network namespace switch is definitely not required in this case, which helps with testing
+	if pconstants.HostNetNSPath == pconstants.SelfNetNSPath {
+		return f()
+	}
+	return netns.WithNetNSPath(pconstants.HostNetNSPath, func(_ netns.NetNS) error {
+		return f()
+	})
+}

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -57,10 +57,10 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
         {{- end }}
     spec:
-{{if .Values.ambient.enabled }}
+{{- if and .Values.ambient.enabled .Values.ambient.shareHostNetworkNamespace }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
-{{ end }}
+{{- end }}
       nodeSelector:
         kubernetes.io/os: linux
       # Can be configured to allow for excluding istio-cni from being scheduled on specified nodes
@@ -160,6 +160,10 @@ spec:
               value: "true"
             - name: REPAIR_SIDECAR_ANNOTATION
               value: "sidecar.istio.io/status"
+            {{- if not (and .Values.ambient.enabled .Values.ambient.shareHostNetworkNamespace) }}
+            - name: ALLOW_SWITCH_TO_HOST_NS
+              value: "true"
+            {{- end }}
             - name: NODE_NAME
               valueFrom:
                 fieldRef:

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -54,6 +54,8 @@ _internal_defaults_do_not_set:
     # If enabled, and ambient is enabled, the CNI agent will reconcile incompatible iptables rules and chains at startup.
     # This will eventually be enabled by default
     reconcileIptablesOnStartup: false
+    # If enabled, and ambient is enabled, the CNI agent will always share the network namespace of the host node it is running on
+    shareHostNetworkNamespace: true
 
 
   repair:

--- a/releasenotes/notes/54726.yaml
+++ b/releasenotes/notes/54726.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+- 54726
+releaseNotes:
+- |
+  **Improved** The CNI agent to no longer require `hostNetwork`, improving compatibility. Dynamic switching to the host network is now performed whenever necessary.
+  The old behavior can temporarily be restored by setting the `ambient.shareHostNetworkNamespace` field in the `istio-cni` chart.

--- a/releasenotes/notes/54726.yaml
+++ b/releasenotes/notes/54726.yaml
@@ -6,4 +6,4 @@ issue:
 releaseNotes:
 - |
   **Improved** The CNI agent to no longer require `hostNetwork`, improving compatibility. Dynamic switching to the host network is now performed whenever necessary.
-  The old behavior can temporarily be restored by setting the `ambient.shareHostNetworkNamespace` field in the `istio-cni` chart.
+  The feature is opt-in and can be enabled by setting `ambient.shareHostNetworkNamespace` field to `false` in the `istio-cni` chart. This feature will be enabled by default in Istio 1.26.


### PR DESCRIPTION
Manual cherry-pick of #54845 .
Given that the 1.25.0 code freeze already took place I have put the new logic off by default, unlike the commit on master.