### PR TITLE
Add customized CA headers/metadata support to istio-agent

### DIFF
--- a/pilot/cmd/pilot-agent/options/security_test.go
+++ b/pilot/cmd/pilot-agent/options/security_test.go
@@ -59,6 +59,7 @@ func TestCheckGkeWorkloadCertificate(t *testing.T) {
 		}
 	}
 }
+
 func TestExtractCAHeadersFromEnv(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/pilot/cmd/pilot-agent/options/security_test.go
+++ b/pilot/cmd/pilot-agent/options/security_test.go
@@ -59,3 +59,80 @@ func TestCheckGkeWorkloadCertificate(t *testing.T) {
 		}
 	}
 }
+func TestExtractCAHeadersFromEnv(t *testing.T) {
+	tests := []struct {
+		name              string
+		envVars           map[string]string
+		expectedCAHeaders map[string]string
+	}{
+		{
+			name: "no CA headers",
+			envVars: map[string]string{
+				"RANDOM_KEY": "value",
+			},
+			expectedCAHeaders: map[string]string{},
+		},
+		{
+			name: "single CA header",
+			envVars: map[string]string{
+				"CA_HEADER_FOO": "foo",
+			},
+			expectedCAHeaders: map[string]string{
+				"FOO": "foo",
+			},
+		},
+		{
+			name: "multiple CA headers",
+			envVars: map[string]string{
+				"CA_HEADER_FOO": "foo",
+				"CA_HEADER_BAR": "bar",
+			},
+			expectedCAHeaders: map[string]string{
+				"FOO": "foo",
+				"BAR": "bar",
+			},
+		},
+		{
+			name: "mixed CA and non-CA headers",
+			envVars: map[string]string{
+				"CA_HEADER_FOO":  "foo",
+				"XDS_HEADER_BAR": "bar",
+				"CA_HEADER_BAZ":  "=baz",
+			},
+			expectedCAHeaders: map[string]string{
+				"FOO": "foo",
+				"BAZ": "=baz",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set environment variables
+			for k, v := range tt.envVars {
+				os.Setenv(k, v)
+			}
+			// Clean up environment variables after test
+			defer func() {
+				for k := range tt.envVars {
+					os.Unsetenv(k)
+				}
+			}()
+
+			o := &security.Options{
+				CAHeaders: map[string]string{},
+			}
+			extractCAHeadersFromEnv(o)
+
+			if len(o.CAHeaders) != len(tt.expectedCAHeaders) {
+				t.Errorf("expected %d CA headers, got %d", len(tt.expectedCAHeaders), len(o.CAHeaders))
+			}
+
+			for k, v := range tt.expectedCAHeaders {
+				if o.CAHeaders[k] != v {
+					t.Errorf("expected CA header %s to be %s, got %s", k, v, o.CAHeaders[k])
+				}
+			}
+		})
+	}
+}

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -255,6 +255,9 @@ type Options struct {
 	KeyFilePath string
 	// The path for an existing root certificate bundle
 	RootCertFilePath string
+
+	// Extra headers to add to the CA connection.
+	CAHeaders map[string]string
 }
 
 // Client interface defines the clients need to implement to talk to CA for CSR.

--- a/releasenotes/notes/add-customized-ca-metadata-support-to-istio-agent.yaml
+++ b/releasenotes/notes/add-customized-ca-metadata-support-to-istio-agent.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+- 55064
+releaseNotes:
+- |
+  **Added** an environment variable prefix `CA_HEADER_` (similar to `XDS_HEADER_``) that can be added to CA requests for different purposes, such as routing to appropriate external Istiods. Istio sidecar proxy, router, and waypoint now support this feature.

--- a/security/pkg/nodeagent/caclient/providers/citadel/client.go
+++ b/security/pkg/nodeagent/caclient/providers/citadel/client.go
@@ -105,6 +105,10 @@ func (c *CitadelClient) CSRSign(csrPEM []byte, certValidTTLInSec int64) (res []s
 	}()
 
 	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("ClusterID", c.opts.ClusterID))
+	for k, v := range c.opts.CAHeaders {
+		ctx = metadata.AppendToOutgoingContext(ctx, k, v)
+	}
+
 	resp, err := c.client.CreateCertificate(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("create certificate: %v", err)


### PR DESCRIPTION
**Please provide a description of this PR:**
- Add an environment variable prefix `CA_HEADER_` (similar to `XDS_HEADER_`) that can be added to CA requests for different purposes, such as routing to appropriate external Istiods.
- Istio sidecar proxy, router, and waypoint now support this feature.
- Fix https://github.com/istio/istio/issues/55064