### PR TITLE
Disable non-host-net `istio-cni` on `master` for now

### DIFF
--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -55,7 +55,8 @@ _internal_defaults_do_not_set:
     # This will eventually be enabled by default
     reconcileIptablesOnStartup: false
     # If enabled, and ambient is enabled, the CNI agent will always share the network namespace of the host node it is running on
-    shareHostNetworkNamespace: false
+    # TODO this breaks some envs and tests, disabling for now, tracking: https://github.com/istio/istio/issues/55215
+    shareHostNetworkNamespace: true
 
 
   repair:


### PR DESCRIPTION
**Please provide a description of this PR:**

https://github.com/istio/istio/pull/54845 is breaking in some envs and causing (seems like) some test flakes,
so disabling the feature flag for now.

https://github.com/istio/istio/issues/55215 is the tracking issue, when fixed we can turn it back on.