### PR TITLE
clarify route status

### DIFF
--- a/pilot/pkg/config/kube/gateway/conditions.go
+++ b/pilot/pkg/config/kube/gateway/conditions.go
@@ -122,8 +122,26 @@ func createRouteStatus(parentResults []RouteParentResult, obj config.Config, cur
 	// Now we fill in all the parents we do own
 	for k, gw := range report {
 		msg := "Route was valid"
+
+		parentType := func(kind *k8s.Kind) string {
+			defaultParents := "listeners"
+			if kind == nil {
+				return defaultParents
+			}
+
+			switch string(*kind) {
+			case gvk.Service.Kind:
+				return "services"
+			case gvk.ServiceEntry.Kind:
+				return "service entries"
+			default:
+				return defaultParents
+			}
+		}
+
 		if successCount[k] > 1 {
-			msg = fmt.Sprintf("Route was valid, bound to %d parents listeners", successCount[k])
+			msg = fmt.Sprintf("Route was valid, bound to %d parents %s",
+				successCount[k], parentType(k.Kind))
 		}
 		conds := map[string]*condition{
 			string(k8s.RouteConditionAccepted): {

--- a/pilot/pkg/config/kube/gateway/conditions.go
+++ b/pilot/pkg/config/kube/gateway/conditions.go
@@ -123,7 +123,7 @@ func createRouteStatus(parentResults []RouteParentResult, obj config.Config, cur
 	for k, gw := range report {
 		msg := "Route was valid"
 		if successCount[k] > 1 {
-			msg = fmt.Sprintf("Route was valid, bound to %d parents", successCount[k])
+			msg = fmt.Sprintf("Route was valid, bound to %d parents listeners", successCount[k])
 		}
 		conds := map[string]*condition{
 			string(k8s.RouteConditionAccepted): {

--- a/pilot/pkg/config/kube/gateway/testdata/route-binding.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/route-binding.status.yaml.golden
@@ -462,7 +462,7 @@ status:
   parents:
   - conditions:
     - lastTransitionTime: fake
-      message: Route was valid, bound to 6 parents
+      message: Route was valid, bound to 6 parents listeners
       reason: Accepted
       status: "True"
       type: Accepted


### PR DESCRIPTION
**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] User Experience


```yaml
status:
  parents:
  - conditions:
    - lastTransitionTime: "2024-10-11T07:15:38Z"
      message: Route was valid, bound to 2 parents
      observedGeneration: 1
      reason: Accepted
      status: "True"
      type: Accepted
    - lastTransitionTime: "2024-10-11T07:15:38Z"
      message: All references resolved
      observedGeneration: 1
      reason: ResolvedRefs
      status: "True"
      type: ResolvedRefs
```


bound to 2 parents gateway or listener ? we need to clarify it.