### PR TITLE
Fix execution of e2e iptables TCs in build-tools container

### DIFF
--- a/cni/pkg/iptables/iptables_e2e_test.go
+++ b/cni/pkg/iptables/iptables_e2e_test.go
@@ -16,7 +16,6 @@ package iptables
 
 import (
 	"bytes"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"sync"
@@ -101,7 +100,6 @@ func TestIdempotentEquivalentInPodRerun(t *testing.T) {
 			assert.NoError(t, iptConfigurator.CreateInpodRules(scopes.CNIAgent, tt.podOverrides))
 		})
 	}
-	teardown()
 }
 
 func TestIdempotentUnequalInPodRerun(t *testing.T) {
@@ -212,7 +210,6 @@ func TestIdempotentUnequalInPodRerun(t *testing.T) {
 			assert.Equal(t, deltaExists, false)
 		})
 	}
-	teardown()
 }
 
 func TestIptablesHostCleanRoundTrip(t *testing.T) {
@@ -281,7 +278,6 @@ func TestIptablesHostCleanRoundTrip(t *testing.T) {
 			assert.NoError(t, iptConfigurator.CreateHostRulesForHealthChecks())
 		})
 	}
-	teardown()
 }
 
 var initialized = &sync.Once{}
@@ -297,10 +293,5 @@ func setup(t *testing.T) {
 	tempDir := t.TempDir()
 	xtables := filepath.Join(tempDir, "xtables.lock")
 	// Override lockfile directory so that we don't need to unshare the mount namespace
-	assert.NoError(t, os.Setenv("XTABLES_LOCKFILE", xtables))
-}
-
-func teardown() {
-	// Remove xtables override
-	_ = os.Unsetenv("XTABLES_LOCKFILE")
+	t.Setenv("XTABLES_LOCKFILE", xtables)
 }

--- a/common/scripts/run.sh
+++ b/common/scripts/run.sh
@@ -47,6 +47,7 @@ read -ra DOCKER_RUN_OPTIONS <<< "${DOCKER_RUN_OPTIONS:-}"
     "${DOCKER_RUN_OPTIONS[@]}" \
     --init \
     --sig-proxy=true \
+    --cap-add=SYS_ADMIN \
     ${DOCKER_SOCKET_MOUNT:--v /var/run/docker.sock:/var/run/docker.sock} \
     $CONTAINER_OPTIONS \
     --env-file <(env | grep -v ${ENV_BLOCKLIST}) \

--- a/tools/istio-iptables/pkg/capture/run_test.go
+++ b/tools/istio-iptables/pkg/capture/run_test.go
@@ -17,7 +17,6 @@ package capture
 import (
 	"bytes"
 	"net/netip"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"reflect"
@@ -414,7 +413,6 @@ func TestIdempotentEquivalentRerun(t *testing.T) {
 			cfg.ForceApply = false
 		})
 	}
-	teardown()
 }
 
 var initialized = &sync.Once{}
@@ -430,12 +428,7 @@ func setup(t *testing.T) {
 	tempDir := t.TempDir()
 	xtables := filepath.Join(tempDir, "xtables.lock")
 	// Override lockfile directory so that we don't need to unshare the mount namespace
-	assert.NoError(t, os.Setenv("XTABLES_LOCKFILE", xtables))
-}
-
-func teardown() {
-	// Remove xtables override
-	_ = os.Unsetenv("XTABLES_LOCKFILE")
+	t.Setenv("XTABLES_LOCKFILE", xtables)
 }
 
 func TestIdempotentUnequaledRerun(t *testing.T) {
@@ -534,7 +527,6 @@ func TestIdempotentUnequaledRerun(t *testing.T) {
 			assert.NoError(t, iptConfigurator.Run())
 		})
 	}
-	teardown()
 }
 
 func compareToGolden(t *testing.T, name string, actual []string) {


### PR DESCRIPTION
**Please provide a description of this PR:**

The issue was caused by a combination of problems: a lack of permissions for userns and netns, along with the inability to change permissions on /run/.
I added SYS_ADMIN capability and an override to the path of the xtables lockfile, eliminating the need to unshare the mount namespace or worry about permissions in /run/.