### PR TITLE
operator: fix merging map values

### DIFF
--- a/operator/pkg/values/map.go
+++ b/operator/pkg/values/map.go
@@ -133,7 +133,7 @@ func (m Map) MergeFrom(other Map) {
 	for k, v := range other {
 		// Might be a Map or map, possibly recurse
 		if vm, ok := v.(Map); ok {
-			v = map[string]any(vm)
+			v = map[string]any(vm.DeepClone())
 		}
 		if v, ok := v.(map[string]any); ok {
 			// It's a map...

--- a/releasenotes/notes/55238.yaml
+++ b/releasenotes/notes/55238.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+  - |
+    **Fixed** Some user specified values in `IstioOperator` were being overwritten with default values.
+              Specifying `.values.pilot.cni.enabled=true` did not work without specifying `.components.cni.enabled=true`.


### PR DESCRIPTION
**Please provide a description of this PR:**

In case the type was `.Map`, the current code was referencing the original map and overwriting it.
I realised this while trying to set `values.pilot.cni.enabled=true` without enabling the `spec.components.cni`. This breaks the upgrade experience in 1.24 with same istio operator manifest.