### PR TITLE
krt: add name prefix to naming scheme

### DIFF
--- a/pilot/pkg/bootstrap/mesh.go
+++ b/pilot/pkg/bootstrap/mesh.go
@@ -61,7 +61,7 @@ func (s *Server) initMeshConfiguration(args *PilotArgs, fileWatcher filewatcher.
 func (s *Server) getMeshConfiguration(args *PilotArgs, fileWatcher filewatcher.FileWatcher) krt.Singleton[meshwatcher.MeshConfigResource] {
 	// We need to get mesh configuration up-front, before we start anything, so we use internalStop rather than scheduling a task to run
 	// later.
-	opts := krt.NewOptionsBuilder(s.internalStop, args.KrtDebugger)
+	opts := krt.NewOptionsBuilder(s.internalStop, "", args.KrtDebugger)
 	sources := s.getConfigurationSources(args, fileWatcher, args.MeshConfigFile, kubemesh.MeshConfigKey)
 	if len(sources) == 0 {
 		log.Warnf("Using default mesh - missing file %s and no k8s client", args.MeshConfigFile)
@@ -82,7 +82,7 @@ func (s *Server) initMeshNetworks(args *PilotArgs, fileWatcher filewatcher.FileW
 func (s *Server) getMeshNetworks(args *PilotArgs, fileWatcher filewatcher.FileWatcher) krt.Singleton[meshwatcher.MeshNetworksResource] {
 	// We need to get mesh networks up-front, before we start anything, so we use internalStop rather than scheduling a task to run
 	// later.
-	opts := krt.NewOptionsBuilder(s.internalStop, args.KrtDebugger)
+	opts := krt.NewOptionsBuilder(s.internalStop, "", args.KrtDebugger)
 	sources := s.getConfigurationSources(args, fileWatcher, args.NetworksConfigFile, kubemesh.MeshNetworksKey)
 	if len(sources) == 0 {
 		log.Warnf("Using default mesh networks - missing file %s and no k8s client", args.NetworksConfigFile)
@@ -106,7 +106,7 @@ func getMeshConfigMapName(revision string) string {
 // * default + configmap + configmap
 // * default
 func (s *Server) getConfigurationSources(args *PilotArgs, fileWatcher filewatcher.FileWatcher, file string, cmKey string) []meshwatcher.MeshConfigSource {
-	opts := krt.NewOptionsBuilder(s.internalStop, args.KrtDebugger)
+	opts := krt.NewOptionsBuilder(s.internalStop, "", args.KrtDebugger)
 	// Watcher will be merging more than one mesh config source?
 	var userMeshConfig *meshwatcher.MeshConfigSource
 	if features.SharedMeshConfig != "" && s.kubeClient != nil {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -151,48 +151,48 @@ func New(options Options) Index {
 	filter := kclient.Filter{
 		ObjectFilter: options.Client.ObjectFilter(),
 	}
-	opts := krt.NewOptionsBuilder(a.stop, options.Debugger)
+	opts := krt.NewOptionsBuilder(a.stop, "ambient", options.Debugger)
 
 	MeshConfig := options.MeshConfig
 	authzPolicies := kclient.NewDelayedInformer[*securityclient.AuthorizationPolicy](options.Client,
 		gvr.AuthorizationPolicy, kubetypes.StandardInformer, filter)
-	AuthzPolicies := krt.WrapClient[*securityclient.AuthorizationPolicy](authzPolicies, opts.WithName("AuthorizationPolicies")...)
+	AuthzPolicies := krt.WrapClient[*securityclient.AuthorizationPolicy](authzPolicies, opts.WithName("informer/AuthorizationPolicies")...)
 
 	peerAuths := kclient.NewDelayedInformer[*securityclient.PeerAuthentication](options.Client,
 		gvr.PeerAuthentication, kubetypes.StandardInformer, filter)
-	PeerAuths := krt.WrapClient[*securityclient.PeerAuthentication](peerAuths, opts.WithName("PeerAuthentications")...)
+	PeerAuths := krt.WrapClient[*securityclient.PeerAuthentication](peerAuths, opts.WithName("informer/PeerAuthentications")...)
 
 	serviceEntries := kclient.NewDelayedInformer[*networkingclient.ServiceEntry](options.Client,
 		gvr.ServiceEntry, kubetypes.StandardInformer, filter)
-	ServiceEntries := krt.WrapClient[*networkingclient.ServiceEntry](serviceEntries, opts.WithName("ServiceEntries")...)
+	ServiceEntries := krt.WrapClient[*networkingclient.ServiceEntry](serviceEntries, opts.WithName("informer/ServiceEntries")...)
 
 	workloadEntries := kclient.NewDelayedInformer[*networkingclient.WorkloadEntry](options.Client,
 		gvr.WorkloadEntry, kubetypes.StandardInformer, filter)
-	WorkloadEntries := krt.WrapClient[*networkingclient.WorkloadEntry](workloadEntries, opts.WithName("WorkloadEntries")...)
+	WorkloadEntries := krt.WrapClient[*networkingclient.WorkloadEntry](workloadEntries, opts.WithName("informer/WorkloadEntries")...)
 
 	gatewayClient := kclient.NewDelayedInformer[*v1beta1.Gateway](options.Client, gvr.KubernetesGateway, kubetypes.StandardInformer, filter)
-	Gateways := krt.WrapClient[*v1beta1.Gateway](gatewayClient, opts.WithName("Gateways")...)
+	Gateways := krt.WrapClient[*v1beta1.Gateway](gatewayClient, opts.WithName("informer/Gateways")...)
 
 	gatewayClassClient := kclient.NewDelayedInformer[*v1beta1.GatewayClass](options.Client, gvr.GatewayClass, kubetypes.StandardInformer, filter)
-	GatewayClasses := krt.WrapClient[*v1beta1.GatewayClass](gatewayClassClient, opts.WithName("GatewayClasses")...)
+	GatewayClasses := krt.WrapClient[*v1beta1.GatewayClass](gatewayClassClient, opts.WithName("informer/GatewayClasses")...)
 
 	servicesClient := kclient.NewFiltered[*v1.Service](options.Client, filter)
-	Services := krt.WrapClient[*v1.Service](servicesClient, opts.WithName("Services")...)
+	Services := krt.WrapClient[*v1.Service](servicesClient, opts.WithName("informer/Services")...)
 	Nodes := krt.NewInformerFiltered[*v1.Node](options.Client, kclient.Filter{
 		ObjectFilter:    options.Client.ObjectFilter(),
 		ObjectTransform: kubeclient.StripNodeUnusedFields,
-	}, opts.WithName("Nodes")...)
+	}, opts.WithName("informer/Nodes")...)
 	Pods := krt.NewInformerFiltered[*v1.Pod](options.Client, kclient.Filter{
 		ObjectFilter:    options.Client.ObjectFilter(),
 		ObjectTransform: kubeclient.StripPodUnusedFields,
-	}, opts.WithName("Pods")...)
+	}, opts.WithName("informer/Pods")...)
 
 	// TODO: Should this go ahead and transform the full ns into some intermediary with just the details we care about?
-	Namespaces := krt.NewInformer[*v1.Namespace](options.Client, opts.WithName("Namespaces")...)
+	Namespaces := krt.NewInformer[*v1.Namespace](options.Client, opts.WithName("informer/Namespaces")...)
 
 	EndpointSlices := krt.NewInformerFiltered[*discovery.EndpointSlice](options.Client, kclient.Filter{
 		ObjectFilter: options.Client.ObjectFilter(),
-	}, opts.WithName("EndpointSlices")...)
+	}, opts.WithName("informer/EndpointSlices")...)
 
 	Networks := buildNetworkCollections(Namespaces, Gateways, options, opts)
 	a.networks = Networks

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
@@ -1690,7 +1690,7 @@ func newAmbientUnitTest(t test.Failer) *index {
 		Options{
 			SystemNamespace: systemNS,
 			ClusterID:       testC,
-		}, krt.NewOptionsBuilder(test.NewStop(t), nil))
+		}, krt.NewOptionsBuilder(test.NewStop(t), "", nil))
 	idx := &index{
 		networks:        networks,
 		SystemNamespace: systemNS,

--- a/pkg/kube/krt/collection_test.go
+++ b/pkg/kube/krt/collection_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 func testOptions(t test.Failer) krt.OptionsBuilder {
-	return krt.NewOptionsBuilder(test.NewStop(t), krt.GlobalDebugHandler)
+	return krt.NewOptionsBuilder(test.NewStop(t), "test", krt.GlobalDebugHandler)
 }
 
 type SimplePod struct {

--- a/pkg/kube/krt/krttest/helpers.go
+++ b/pkg/kube/krt/krttest/helpers.go
@@ -76,5 +76,5 @@ func extractType[T any](items *[]any) []T {
 }
 
 func Options(t test.Failer) krt.OptionsBuilder {
-	return krt.NewOptionsBuilder(test.NewStop(t), krt.GlobalDebugHandler)
+	return krt.NewOptionsBuilder(test.NewStop(t), "test", krt.GlobalDebugHandler)
 }

--- a/pkg/kube/krt/options.go
+++ b/pkg/kube/krt/options.go
@@ -17,20 +17,28 @@ package krt
 // OptionsBuilder is a small wrapper around KRT options to make it easy to provide a common set of options to all collections
 // without excessive duplication.
 type OptionsBuilder struct {
-	stop     chan struct{}
-	debugger *DebugHandler
+	// namePrefix, if set, will prefix every name with the common prefix.
+	// For example `<namePrefix>/<name>`.
+	namePrefix string
+	stop       chan struct{}
+	debugger   *DebugHandler
 }
 
-func NewOptionsBuilder(stop chan struct{}, debugger *DebugHandler) OptionsBuilder {
+func NewOptionsBuilder(stop chan struct{}, namePrefix string, debugger *DebugHandler) OptionsBuilder {
 	return OptionsBuilder{
-		stop:     stop,
-		debugger: debugger,
+		namePrefix: namePrefix,
+		stop:       stop,
+		debugger:   debugger,
 	}
 }
 
 // WithName applies the base options with a specific name
 func (k OptionsBuilder) WithName(n string) []CollectionOption {
-	return []CollectionOption{WithDebugging(k.debugger), WithStop(k.stop), WithName(n)}
+	name := n
+	if k.namePrefix != "" {
+		name = k.namePrefix + "/" + name
+	}
+	return []CollectionOption{WithDebugging(k.debugger), WithStop(k.stop), WithName(name)}
 }
 
 // With applies arbitrary options along with the base options.


### PR DESCRIPTION
Today we only use krt in 2 places, so the names are fine. As we expand
it, the naming is quite confusing. What is the difference between a
Gateway in ambient vs in the Gateway controller vs in some other
controller, for instance.

Adding a namespace to this makes things much more clear. I accomplish
this by adding this to the common opts builder, so we just set it once.

I also establish a pattern of prefixing informers with `informer/`. This
is helpful since often the collections are `k8s.Type` --> `internal.Type`,
so now we can name these `informer/Type` and `Type` and clearly
distinguish them.
