### PR TITLE
krt: support using indexes as collections

### DIFF
--- a/pkg/kube/krt/index.go
+++ b/pkg/kube/krt/index.go
@@ -121,14 +121,17 @@ type indexCollection[K comparable, O any] struct {
 	collectionName string
 }
 
+// nolint: unused // (not true, its to implement an interface)
 func (i indexCollection[K, O]) name() string {
 	return i.collectionName
 }
 
+// nolint: unused // (not true, its to implement an interface)
 func (i indexCollection[K, O]) uid() collectionUID {
 	return i.id
 }
 
+// nolint: unused // (not true, its to implement an interface)
 func (i indexCollection[K, O]) dump() CollectionDump {
 	return CollectionDump{
 		Outputs:         nil,
@@ -137,10 +140,12 @@ func (i indexCollection[K, O]) dump() CollectionDump {
 	}
 }
 
+// nolint: unused // (not true, its to implement an interface)
 func (i indexCollection[K, O]) augment(a any) any {
 	return a
 }
 
+// nolint: unused // (not true, its to implement an interface)
 func (i indexCollection[K, O]) index(extract func(o IndexObject[K, O]) []string) kclient.RawIndexer {
 	panic("an index cannot be indexed")
 }

--- a/pkg/kube/krt/index.go
+++ b/pkg/kube/krt/index.go
@@ -116,8 +116,9 @@ func toString(rk any) string {
 }
 
 type indexCollection[K comparable, O any] struct {
-	idx            index[K, O]
-	id             collectionUID
+	idx index[K, O]
+	id  collectionUID
+	// nolint: unused // (not true, its to implement an interface)
 	collectionName string
 }
 

--- a/pkg/kube/krt/index.go
+++ b/pkg/kube/krt/index.go
@@ -17,14 +17,26 @@ package krt
 import (
 	"fmt"
 
+	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/slices"
+	"istio.io/istio/pkg/util/sets"
 )
 
 type Index[K comparable, O any] interface {
 	Lookup(k K) []O
+	AsCollection() Collection[IndexObject[K, O]]
 	objectHasKey(obj O, k K) bool
 	extractKeys(o O) []K
+}
+
+type IndexObject[K comparable, O any] struct {
+	Key     K
+	Objects []O
+}
+
+func (i IndexObject[K, O]) ResourceName() string {
+	return toString(i.Key)
 }
 
 // NewNamespaceIndex is a small helper to index a collection by namespace
@@ -46,12 +58,27 @@ func NewIndex[K comparable, O any](
 		})
 	})
 
-	return index[K, O]{idx, extract}
+	return index[K, O]{idx, c, extract}
 }
 
 type index[K comparable, O any] struct {
 	kclient.RawIndexer
+	c       Collection[O]
 	extract func(o O) []K
+}
+
+// AsCollection does a best-effort approximation of turning an index into a Collection. This is intended to be used as a
+// primary input with NewCollection or similar transformations.
+// This has some limitations that impact usage *outside* of NewCollection:
+// * List() is not allowed.
+// * Building an index is not allowed
+// * Events are not 100% precise; only Add and Delete events are triggered. Updates will be `Add` events.
+// The intended use case for this is to do merging within a collection (like a SQL 'group by').
+func (i index[K, O]) AsCollection() Collection[IndexObject[K, O]] {
+	return indexCollection[K, O]{
+		idx: i,
+		id:  nextUID(),
+	}
 }
 
 // nolint: unused // (not true)
@@ -86,4 +113,97 @@ func toString(rk any) string {
 		return rk.(fmt.Stringer).String()
 	}
 	return tk
+}
+
+type indexCollection[K comparable, O any] struct {
+	idx            index[K, O]
+	id             collectionUID
+	collectionName string
+}
+
+func (i indexCollection[K, O]) name() string {
+	return i.collectionName
+}
+
+func (i indexCollection[K, O]) uid() collectionUID {
+	return i.id
+}
+
+func (i indexCollection[K, O]) dump() CollectionDump {
+	return CollectionDump{
+		Outputs:         nil,
+		InputCollection: "",
+		Inputs:          nil,
+	}
+}
+
+func (i indexCollection[K, O]) augment(a any) any {
+	return a
+}
+
+func (i indexCollection[K, O]) index(extract func(o IndexObject[K, O]) []string) kclient.RawIndexer {
+	panic("an index cannot be indexed")
+}
+
+func (i indexCollection[K, O]) GetKey(k string) *IndexObject[K, O] {
+	tk := any(k).(K)
+	objs := i.idx.Lookup(tk)
+	return &IndexObject[K, O]{
+		Key:     tk,
+		Objects: objs,
+	}
+}
+
+func (i indexCollection[K, O]) List() []IndexObject[K, O] {
+	panic("an index collection cannot be listed")
+}
+
+func (i indexCollection[K, O]) WaitUntilSynced(stop <-chan struct{}) bool {
+	return i.idx.c.WaitUntilSynced(stop)
+}
+
+func (i indexCollection[K, O]) HasSynced() bool {
+	return i.idx.c.HasSynced()
+}
+
+func (i indexCollection[K, O]) Register(f func(o Event[IndexObject[K, O]])) HandlerRegistration {
+	return i.RegisterBatch(func(events []Event[IndexObject[K, O]], initialSync bool) {
+		for _, o := range events {
+			f(o)
+		}
+	}, true)
+}
+
+func (i indexCollection[K, O]) RegisterBatch(f func(o []Event[IndexObject[K, O]], initialSync bool), runExistingState bool) HandlerRegistration {
+	return i.idx.c.RegisterBatch(func(o []Event[O], initialSync bool) {
+		allKeys := sets.New[K]()
+		for _, ev := range o {
+			if ev.Old != nil {
+				allKeys.InsertAll(i.idx.extractKeys(*ev.Old)...)
+			}
+			if ev.New != nil {
+				allKeys.InsertAll(i.idx.extractKeys(*ev.New)...)
+			}
+		}
+		downstream := make([]Event[IndexObject[K, O]], 0, len(allKeys))
+		for key := range allKeys {
+			v := i.GetKey(toString(key))
+			// Due to the semantics around indexes, we cannot reasonably compute exactly correctly.
+			// However, we don't really need to: simply triggering an Add/Delete is close enough to work.
+			// Building a collection from an indexCollection only uses the events to determine the changed keys, which is
+			// available with this information.
+			if len(v.Objects) == 0 {
+				downstream = append(downstream, Event[IndexObject[K, O]]{
+					Old:   &IndexObject[K, O]{Key: key, Objects: nil},
+					Event: controllers.EventDelete,
+				})
+			} else {
+				downstream = append(downstream, Event[IndexObject[K, O]]{
+					New:   v,
+					Event: controllers.EventAdd,
+				})
+			}
+		}
+		f(downstream, initialSync)
+	}, runExistingState)
 }


### PR DESCRIPTION
This adds support for using indexes as collections in krt. The primary motivation for this is aggregations.

For instance, maybe I want to take a `Collection[ServiceEntry]` and merge it by hostname.

This is a draft since its pretty hacky. Only the MVP amount of functionality is implemented. The primary challenge is we cannot get the old and new state for the index. We don't _need_ it to use it as an input to a transformation collection, but if you just register a raw handler you would get raw results. Probably we will just need to document the limitations.