### PR TITLE
`istio-cni`: Fixup iptables tests + make iptables binary detect more robust

### DIFF
--- a/cni/pkg/iptables/iptables_e2e_test.go
+++ b/cni/pkg/iptables/iptables_e2e_test.go
@@ -16,11 +16,11 @@ package iptables
 
 import (
 	"bytes"
+	"fmt"
 	"os/exec"
 	"path/filepath"
 	"sync"
 	"testing"
-	"fmt"
 
 	// Create a new network namespace. This will have the 'lo' interface ready but nothing else.
 	_ "github.com/howardjohn/unshare-go/netns"

--- a/cni/pkg/iptables/iptables_e2e_test.go
+++ b/cni/pkg/iptables/iptables_e2e_test.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"fmt"
 
 	// Create a new network namespace. This will have the 'lo' interface ready but nothing else.
 	_ "github.com/howardjohn/unshare-go/netns"
@@ -47,57 +48,44 @@ func TestIdempotentEquivalentInPodRerun(t *testing.T) {
 
 	tests := GetCommonInPodTestCases()
 
-	ext := &dep.RealDependencies{
-		UsePodScopedXtablesLock: false,
-		NetworkNamespace:        "",
-	}
-	iptVer, err := ext.DetectIptablesVersion(false)
-	if err != nil {
-		t.Fatalf("Can't detect iptables version: %v", err)
-	}
-	ipt6Ver, err := ext.DetectIptablesVersion(true)
-	if err != nil {
-		t.Fatalf("Can't detect ip6tables version")
-	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := constructTestConfig()
 			tt.config(cfg)
 
 			deps := &dep.RealDependencies{}
-			iptConfigurator, _, err := NewIptablesConfigurator(cfg, cfg, deps, deps, EmptyNlDeps())
-			builder := iptConfigurator.AppendInpodRules(tt.podOverrides)
+			_, iptConfiguratorPod, err := NewIptablesConfigurator(cfg, cfg, deps, deps, EmptyNlDeps())
+			builder := iptConfiguratorPod.AppendInpodRules(tt.podOverrides)
 			if err != nil {
 				t.Fatalf("failed to setup iptables configurator: %v", err)
 			}
 			defer func() {
-				assert.NoError(t, iptConfigurator.DeleteInpodRules(log))
-				residueExists, deltaExists := iptablescapture.VerifyIptablesState(log, iptConfigurator.ext, builder, &iptVer, &ipt6Ver)
+				assert.NoError(t, iptConfiguratorPod.DeleteInpodRules(log))
+				residueExists, deltaExists := iptablescapture.VerifyIptablesState(log, iptConfiguratorPod.ext, builder, &iptConfiguratorPod.iptV, &iptConfiguratorPod.ipt6V)
 				assert.Equal(t, residueExists, false)
 				assert.Equal(t, deltaExists, true)
 			}()
-			assert.NoError(t, iptConfigurator.CreateInpodRules(scopes.CNIAgent, tt.podOverrides))
-			residueExists, deltaExists := iptablescapture.VerifyIptablesState(log, iptConfigurator.ext, builder, &iptVer, &ipt6Ver)
+			assert.NoError(t, iptConfiguratorPod.CreateInpodRules(scopes.CNIAgent, tt.podOverrides))
+			residueExists, deltaExists := iptablescapture.VerifyIptablesState(log, iptConfiguratorPod.ext, builder, &iptConfiguratorPod.iptV, &iptConfiguratorPod.ipt6V)
 			assert.Equal(t, residueExists, true)
 			assert.Equal(t, deltaExists, false)
 
 			t.Log("Starting cleanup")
 			// Cleanup, should work
-			assert.NoError(t, iptConfigurator.DeleteInpodRules(log))
-			residueExists, deltaExists = iptablescapture.VerifyIptablesState(log, iptConfigurator.ext, builder, &iptVer, &ipt6Ver)
+			assert.NoError(t, iptConfiguratorPod.DeleteInpodRules(log))
+			residueExists, deltaExists = iptablescapture.VerifyIptablesState(log, iptConfiguratorPod.ext, builder, &iptConfiguratorPod.iptV, &iptConfiguratorPod.ipt6V)
 			assert.Equal(t, residueExists, false)
 			assert.Equal(t, deltaExists, true)
 
 			t.Log("Second run")
 			// Apply should work again
-			assert.NoError(t, iptConfigurator.CreateInpodRules(scopes.CNIAgent, tt.podOverrides))
-			residueExists, deltaExists = iptablescapture.VerifyIptablesState(log, iptConfigurator.ext, builder, &iptVer, &ipt6Ver)
+			assert.NoError(t, iptConfiguratorPod.CreateInpodRules(scopes.CNIAgent, tt.podOverrides))
+			residueExists, deltaExists = iptablescapture.VerifyIptablesState(log, iptConfiguratorPod.ext, builder, &iptConfiguratorPod.iptV, &iptConfiguratorPod.ipt6V)
 			assert.Equal(t, residueExists, true)
 			assert.Equal(t, deltaExists, false)
 
 			t.Log("Third run")
-			assert.NoError(t, iptConfigurator.CreateInpodRules(scopes.CNIAgent, tt.podOverrides))
+			assert.NoError(t, iptConfiguratorPod.CreateInpodRules(scopes.CNIAgent, tt.podOverrides))
 		})
 	}
 }
@@ -107,69 +95,56 @@ func TestIdempotentUnequalInPodRerun(t *testing.T) {
 
 	tests := GetCommonInPodTestCases()
 
-	ext := &dep.RealDependencies{
-		UsePodScopedXtablesLock: false,
-		NetworkNamespace:        "",
-	}
-	iptVer, err := ext.DetectIptablesVersion(false)
-	if err != nil {
-		t.Fatalf("Can't detect iptables version: %v", err)
-	}
-	ipt6Ver, err := ext.DetectIptablesVersion(true)
-	if err != nil {
-		t.Fatalf("Can't detect ip6tables version")
-	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := constructTestConfig()
 			tt.config(cfg)
 			var stdout, stderr bytes.Buffer
 			deps := &dep.RealDependencies{}
-			iptConfigurator, _, err := NewIptablesConfigurator(cfg, cfg, deps, deps, EmptyNlDeps())
-			builder := iptConfigurator.AppendInpodRules(tt.podOverrides)
+			_, iptConfiguratorPod, err := NewIptablesConfigurator(cfg, cfg, deps, deps, EmptyNlDeps())
+			builder := iptConfiguratorPod.AppendInpodRules(tt.podOverrides)
 			if err != nil {
 				t.Fatalf("failed to setup iptables configurator: %v", err)
 			}
 
 			defer func() {
-				assert.NoError(t, iptConfigurator.DeleteInpodRules(log))
-				residueExists, deltaExists := iptablescapture.VerifyIptablesState(log, iptConfigurator.ext, builder, &iptVer, &ipt6Ver)
+				assert.NoError(t, iptConfiguratorPod.DeleteInpodRules(log))
+				residueExists, deltaExists := iptablescapture.VerifyIptablesState(log, iptConfiguratorPod.ext, builder, &iptConfiguratorPod.iptV, &iptConfiguratorPod.ipt6V)
 				assert.Equal(t, residueExists, true)
 				assert.Equal(t, deltaExists, true)
 				// Remove additional rule
-				cmd := exec.Command("iptables", "-t", "nat", "-D", "OUTPUT", "-p", "tcp", "--dport", "123", "-j", "ACCEPT")
+				cmd := exec.Command(iptConfiguratorPod.iptV.DetectedBinary, "-t", "nat", "-D", "OUTPUT", "-p", "tcp", "--dport", "123", "-j", "ACCEPT")
 				cmd.Stdout = &stdout
 				cmd.Stderr = &stderr
 				if err := cmd.Run(); err != nil {
 					t.Errorf("iptables cmd (%s %s) failed: %s", cmd.Path, cmd.Args, stderr.String())
 				}
-				residueExists, deltaExists = iptablescapture.VerifyIptablesState(log, iptConfigurator.ext, builder, &iptVer, &ipt6Ver)
+				residueExists, deltaExists = iptablescapture.VerifyIptablesState(log, iptConfiguratorPod.ext, builder, &iptConfiguratorPod.iptV, &iptConfiguratorPod.ipt6V)
 				assert.Equal(t, residueExists, false)
 				assert.Equal(t, deltaExists, true)
 			}()
 
-			assert.NoError(t, iptConfigurator.CreateInpodRules(scopes.CNIAgent, tt.podOverrides))
-			residueExists, deltaExists := iptablescapture.VerifyIptablesState(log, iptConfigurator.ext, builder, &iptVer, &ipt6Ver)
+			assert.NoError(t, iptConfiguratorPod.CreateInpodRules(scopes.CNIAgent, tt.podOverrides))
+			residueExists, deltaExists := iptablescapture.VerifyIptablesState(log, iptConfiguratorPod.ext, builder, &iptConfiguratorPod.iptV, &iptConfiguratorPod.ipt6V)
 			assert.Equal(t, residueExists, true)
 			assert.Equal(t, deltaExists, false)
 
 			// Diverge by creating new ISTIO chains
-			cmd := exec.Command("iptables", "-t", "nat", "-N", "ISTIO_TEST")
+			cmd := exec.Command(iptConfiguratorPod.iptV.DetectedBinary, "-t", "nat", "-N", "ISTIO_TEST")
 			cmd.Stdout = &stdout
 			cmd.Stderr = &stderr
 			if err := cmd.Run(); err != nil {
 				t.Errorf("iptables cmd (%s %s) failed: %s", cmd.Path, cmd.Args, stderr.String())
 			}
 
-			cmd = exec.Command("iptables", "-t", "nat", "-A", "OUTPUT", "-j", "ISTIO_TEST")
+			cmd = exec.Command(iptConfiguratorPod.iptV.DetectedBinary, "-t", "nat", "-A", "OUTPUT", "-j", "ISTIO_TEST")
 			cmd.Stdout = &stdout
 			cmd.Stderr = &stderr
 			if err := cmd.Run(); err != nil {
 				t.Errorf("iptables cmd (%s %s) failed: %s", cmd.Path, cmd.Args, stderr.String())
 			}
 
-			cmd = exec.Command("iptables", "-t", "nat", "-A", "ISTIO_TEST", "-p", "tcp", "--dport", "123", "-j", "ACCEPT")
+			cmd = exec.Command(iptConfiguratorPod.iptV.DetectedBinary, "-t", "nat", "-A", "ISTIO_TEST", "-p", "tcp", "--dport", "123", "-j", "ACCEPT")
 			cmd.Stdout = &stdout
 			cmd.Stderr = &stderr
 			if err := cmd.Run(); err != nil {
@@ -177,27 +152,27 @@ func TestIdempotentUnequalInPodRerun(t *testing.T) {
 			}
 
 			// Apply required after tempering with ISTIO chains
-			residueExists, deltaExists = iptablescapture.VerifyIptablesState(log, iptConfigurator.ext, builder, &iptVer, &ipt6Ver)
+			residueExists, deltaExists = iptablescapture.VerifyIptablesState(log, iptConfiguratorPod.ext, builder, &iptConfiguratorPod.iptV, &iptConfiguratorPod.ipt6V)
 			assert.Equal(t, residueExists, true)
 			assert.Equal(t, deltaExists, true)
 
 			// Creating new inpod rules should fail if reconciliation is disabled
 			cfg.Reconcile = false
-			assert.Error(t, iptConfigurator.CreateInpodRules(scopes.CNIAgent, tt.podOverrides))
+			assert.Error(t, iptConfiguratorPod.CreateInpodRules(scopes.CNIAgent, tt.podOverrides))
 
 			// Creating new inpod rules should succeed if reconciliation is enabled
 			cfg.Reconcile = true
-			assert.NoError(t, iptConfigurator.CreateInpodRules(scopes.CNIAgent, tt.podOverrides))
-			residueExists, deltaExists = iptablescapture.VerifyIptablesState(log, iptConfigurator.ext, builder, &iptVer, &ipt6Ver)
+			assert.NoError(t, iptConfiguratorPod.CreateInpodRules(scopes.CNIAgent, tt.podOverrides))
+			residueExists, deltaExists = iptablescapture.VerifyIptablesState(log, iptConfiguratorPod.ext, builder, &iptConfiguratorPod.iptV, &iptConfiguratorPod.ipt6V)
 			assert.Equal(t, residueExists, true)
 			assert.Equal(t, deltaExists, false)
 
 			// Jump added by tempering shall no longer exist
-			cmd = exec.Command("iptables", "-t", "nat", "-C", "OUTPUT", "-j", "ISTIO_TEST")
+			cmd = exec.Command(iptConfiguratorPod.iptV.DetectedBinary, "-t", "nat", "-C", "OUTPUT", "-j", "ISTIO_TEST")
 			assert.Error(t, cmd.Run())
 
 			// Diverge from installation
-			cmd = exec.Command("iptables", "-t", "nat", "-A", "OUTPUT", "-p", "tcp", "--dport", "123", "-j", "ACCEPT")
+			cmd = exec.Command(iptConfiguratorPod.iptV.DetectedBinary, "-t", "nat", "-A", "OUTPUT", "-p", "tcp", "--dport", "123", "-j", "ACCEPT")
 			cmd.Stdout = &stdout
 			cmd.Stderr = &stderr
 			if err := cmd.Run(); err != nil {
@@ -205,7 +180,7 @@ func TestIdempotentUnequalInPodRerun(t *testing.T) {
 			}
 
 			// No delta after tempering with non-ISTIO chains
-			residueExists, deltaExists = iptablescapture.VerifyIptablesState(log, iptConfigurator.ext, builder, &iptVer, &ipt6Ver)
+			residueExists, deltaExists = iptablescapture.VerifyIptablesState(log, iptConfiguratorPod.ext, builder, &iptConfiguratorPod.iptV, &iptConfiguratorPod.ipt6V)
 			assert.Equal(t, residueExists, true)
 			assert.Equal(t, deltaExists, false)
 		})

--- a/cni/pkg/iptables/iptables_e2e_test.go
+++ b/cni/pkg/iptables/iptables_e2e_test.go
@@ -16,7 +16,6 @@ package iptables
 
 import (
 	"bytes"
-	"fmt"
 	"os/exec"
 	"path/filepath"
 	"sync"

--- a/releasenotes/notes/55281.yaml
+++ b/releasenotes/notes/55281.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Improved** iptables binary detection to verify a degree of baseline kernel support exists,
+    and prefer `nft` in a `tie` situation where both legacy and nft are available, but neither has any rules.

--- a/tools/istio-iptables/pkg/capture/run.go
+++ b/tools/istio-iptables/pkg/capture/run.go
@@ -43,14 +43,28 @@ type IptablesConfigurator struct {
 	// TODO(abhide): Fix dep.Dependencies with better interface
 	ext dep.Dependencies
 	cfg *config.Config
+	iptV   dep.IptablesVersion
+	ipt6V  dep.IptablesVersion
 }
 
-func NewIptablesConfigurator(cfg *config.Config, ext dep.Dependencies) *IptablesConfigurator {
+func NewIptablesConfigurator(cfg *config.Config, ext dep.Dependencies) (*IptablesConfigurator, error) {
+	iptVer, err := ext.DetectIptablesVersion(false)
+	if err != nil {
+		return nil, err
+	}
+
+	ipt6Ver, err := ext.DetectIptablesVersion(true)
+	if err != nil {
+		return nil, err
+	}
+
 	return &IptablesConfigurator{
 		ruleBuilder: builder.NewIptablesRuleBuilder(cfg),
 		ext:         ext,
 		cfg:         cfg,
-	}
+		iptV: iptVer,
+		ipt6V: ipt6Ver,
+	}, nil
 }
 
 type NetworkRange struct {
@@ -267,23 +281,13 @@ func configureIPv6Addresses(cfg *config.Config) error {
 }
 
 func (cfg *IptablesConfigurator) Run() error {
-	iptVer, err := cfg.ext.DetectIptablesVersion(false)
-	if err != nil {
-		return err
-	}
-
-	ipt6Ver, err := cfg.ext.DetectIptablesVersion(true)
-	if err != nil {
-		return err
-	}
-
 	defer func() {
 		// Best effort since we don't know if the commands exist
-		if state, err := cfg.ext.Run(log.WithLabels(), true, constants.IPTablesSave, &iptVer, nil); err == nil {
+		if state, err := cfg.ext.Run(log.WithLabels(), true, constants.IPTablesSave, &cfg.iptV, nil); err == nil {
 			log.Infof("Final iptables state (IPv4):\n%s", state)
 		}
 		if cfg.cfg.EnableIPv6 {
-			if state, err := cfg.ext.Run(log.WithLabels(), true, constants.IPTablesSave, &ipt6Ver, nil); err == nil {
+			if state, err := cfg.ext.Run(log.WithLabels(), true, constants.IPTablesSave, &cfg.ipt6V, nil); err == nil {
 				log.Infof("Final iptables state (IPv6):\n%s", state)
 			}
 		}
@@ -517,7 +521,7 @@ func (cfg *IptablesConfigurator) Run() error {
 		cfg.ruleBuilder.InsertRule(constants.ISTIOINBOUND, "mangle", 3,
 			"-p", "tcp", "-i", "lo", "-m", "mark", "!", "--mark", constants.OutboundMark, "-j", "RETURN")
 	}
-	return cfg.executeCommands(&iptVer, &ipt6Ver)
+	return cfg.executeCommands(&cfg.iptV, &cfg.ipt6V)
 }
 
 // SetupDNSRedir is a helper function to tackle with DNS UDP specific operations.

--- a/tools/istio-iptables/pkg/capture/run.go
+++ b/tools/istio-iptables/pkg/capture/run.go
@@ -41,10 +41,10 @@ const (
 type IptablesConfigurator struct {
 	ruleBuilder *builder.IptablesRuleBuilder
 	// TODO(abhide): Fix dep.Dependencies with better interface
-	ext dep.Dependencies
-	cfg *config.Config
-	iptV   dep.IptablesVersion
-	ipt6V  dep.IptablesVersion
+	ext   dep.Dependencies
+	cfg   *config.Config
+	iptV  dep.IptablesVersion
+	ipt6V dep.IptablesVersion
 }
 
 func NewIptablesConfigurator(cfg *config.Config, ext dep.Dependencies) (*IptablesConfigurator, error) {
@@ -62,8 +62,8 @@ func NewIptablesConfigurator(cfg *config.Config, ext dep.Dependencies) (*Iptable
 		ruleBuilder: builder.NewIptablesRuleBuilder(cfg),
 		ext:         ext,
 		cfg:         cfg,
-		iptV: iptVer,
-		ipt6V: ipt6Ver,
+		iptV:        iptVer,
+		ipt6V:       ipt6Ver,
 	}, nil
 }
 

--- a/tools/istio-iptables/pkg/capture/run_test.go
+++ b/tools/istio-iptables/pkg/capture/run_test.go
@@ -17,8 +17,8 @@ package capture
 import (
 	"bytes"
 	"net/netip"
-	"os/exec"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"

--- a/tools/istio-iptables/pkg/capture/run_test.go
+++ b/tools/istio-iptables/pkg/capture/run_test.go
@@ -17,7 +17,6 @@ package capture
 import (
 	"bytes"
 	"net/netip"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"reflect"
@@ -25,8 +24,6 @@ import (
 	"sync"
 	"testing"
 
-	// Create a new mount namespace.
-	"github.com/howardjohn/unshare-go/mountns"
 	// Create a new network namespace. This will have the 'lo' interface ready but nothing else.
 	_ "github.com/howardjohn/unshare-go/netns"
 	// Create a new user namespace. This will map the current UID/GID to 0.
@@ -429,20 +426,19 @@ func setup(t *testing.T) {
 		assert.NoError(t, userns.WriteGroupMap(map[uint32]uint32{userns.OriginalGID(): 0}))
 		// Istio iptables expects to find a non-localhost IP in some interface
 		assert.NoError(t, exec.Command("ip", "addr", "add", "240.240.240.240/32", "dev", "lo").Run())
-		// Put a new file we have permission to access over xtables.lock
-		xtables := filepath.Join(t.TempDir(), "xtables.lock")
-		_, err := os.Create(xtables)
-		assert.NoError(t, err)
-		_ = os.Mkdir("/run", 0o777)
-		_ = mountns.BindMount(xtables, "/run/xtables.lock")
 	})
+
+	tempDir := t.TempDir()
+	xtables := filepath.Join(tempDir, "xtables.lock")
+	// Override lockfile directory so that we don't need to unshare the mount namespace
+	t.Setenv("XTABLES_LOCKFILE", xtables)
 }
 
 func TestIdempotentUnequaledRerun(t *testing.T) {
 	setup(t)
 	commonCases := getCommonTestCases()
 	ext := &dep.RealDependencies{
-		UsePodScopedXtablesLock: true,
+		UsePodScopedXtablesLock: false,
 		NetworkNamespace:        "",
 	}
 	scope := log.FindScope(log.DefaultScopeName)

--- a/tools/istio-iptables/pkg/capture/run_test.go
+++ b/tools/istio-iptables/pkg/capture/run_test.go
@@ -424,7 +424,6 @@ func TestIdempotentEquivalentRerun(t *testing.T) {
 var initialized = &sync.Once{}
 
 func setup(t *testing.T) {
-
 	initialized.Do(func() {
 		// Setup group namespace so iptables --gid-owner will work
 		assert.NoError(t, userns.WriteGroupMap(map[uint32]uint32{userns.OriginalGID(): 0}))

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -207,7 +207,10 @@ func ProgramIptables(cfg *config.Config) error {
 		}
 	}
 
-	iptConfigurator := capture.NewIptablesConfigurator(cfg, ext)
+	iptConfigurator, err := capture.NewIptablesConfigurator(cfg, ext)
+	if err != nil {
+		return err
+	}
 
 	if !cfg.SkipRuleApply {
 		if err := iptConfigurator.Run(); err != nil {

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -207,7 +207,6 @@ func ProgramIptables(cfg *config.Config) error {
 		}
 	}
 
-
 	if !cfg.SkipRuleApply {
 		iptConfigurator, err := capture.NewIptablesConfigurator(cfg, ext)
 		if err != nil {

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -207,12 +207,12 @@ func ProgramIptables(cfg *config.Config) error {
 		}
 	}
 
-	iptConfigurator, err := capture.NewIptablesConfigurator(cfg, ext)
-	if err != nil {
-		return err
-	}
 
 	if !cfg.SkipRuleApply {
+		iptConfigurator, err := capture.NewIptablesConfigurator(cfg, ext)
+		if err != nil {
+			return err
+		}
 		if err := iptConfigurator.Run(); err != nil {
 			return err
 		}

--- a/tools/istio-iptables/pkg/dependencies/implementation.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation.go
@@ -148,16 +148,7 @@ func (r *RealDependencies) DetectIptablesVersion(ipV6 bool) (IptablesVersion, er
 
 	// 1. What binaries we have
 	// 2. What binary we should use, based on existing rules defined in our current context.
-	// does the nft binary set exist, and are nft rules present?
-	nftVer, err := shouldUseBinaryForCurrentContext(nftBin)
-	if err == nil && nftVer.ExistingRules {
-		// if so, immediately use it.
-		return nftVer, nil
-	}
-	// not critical, may find another.
-	log.Debugf("did not find (or cannot use) iptables binary, error was %v: %+v", err, nftVer)
-
-	// Check again
+	//
 	// does the legacy binary set exist, and are legacy rules present?
 	legVer, err := shouldUseBinaryForCurrentContext(legacyBin)
 	if err == nil && legVer.ExistingRules {
@@ -167,11 +158,24 @@ func (r *RealDependencies) DetectIptablesVersion(ipV6 bool) (IptablesVersion, er
 	// not critical, may find another.
 	log.Debugf("did not find (or cannot use) iptables binary, error was %v: %+v", err, legVer)
 
+	// Check again
+	// does the nft binary set exist and seem usable?
+	// (at this point we don't need to check for existing rules,
+	// since we know legacy doesn't have any, and `nft` is usable, prefer `nft`)
+	nftVer, err := shouldUseBinaryForCurrentContext(nftBin)
+	if err == nil {
+		// if so, immediately use it.
+		return nftVer, nil
+	}
+	// not critical, may find another.
+	log.Debugf("did not find (or cannot use) iptables binary, error was %v: %+v", err, nftVer)
+
 	// regular non-suffixed binary set is our last resort.
 	//
-	// If it's there, and rules do not already exist for a specific variant,
-	// we should use the default non-suffixed binary.
-	// If it's NOT there, just propagate the error, we can't do anything, no iptables here
+	// If the aliased/non-suffixed binary is available and appears to work where the others did not,
+	// just use it. In practice this should *never* happen, as the non-suffixed binary is invariably
+	// softlinked to one or the other binary.
+	// Either way, this is our last option, so just propagate the error if it fails, we can't do anything either way.
 	return shouldUseBinaryForCurrentContext(plainBin)
 }
 

--- a/tools/istio-iptables/pkg/dependencies/implementation_linux.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation_linux.go
@@ -32,6 +32,10 @@ import (
 	"istio.io/istio/tools/istio-iptables/pkg/constants"
 )
 
+var (
+	testRuleAdd []string = []string{"-t", "filter", "-A", "INPUT", "-p", "255", "-j", "DROP", "-m", "comment", "--comment", `"Istio no-op iptables capability probe"`}
+)
+
 // TODO the entire `istio-iptables` package is linux-specific, I'm not sure we really need
 // platform-differentiators for the `dependencies` package itself.
 
@@ -50,6 +54,7 @@ var (
 )
 
 func shouldUseBinaryForCurrentContext(iptablesBin string) (IptablesVersion, error) {
+	log := log.WithLabels("binary", iptablesBin)
 	// We assume that whatever `iptablesXXX` binary you pass us also has a `iptablesXXX-save` and `iptablesXXX-restore`
 	// binary - which should always be true for any valid iptables installation
 	// (we use both in our iptables code later on anyway)
@@ -96,6 +101,27 @@ func shouldUseBinaryForCurrentContext(iptablesBin string) (IptablesVersion, erro
 		// So assume it's legacy/an unknown version, but assume we can use it since it's in PATH
 		parsedVer = utilversion.MustParseGeneric("0.0.0")
 		isNft = false
+	}
+
+	// `filter` should ALWAYS exist if kernel support for this version is locally present,
+	// so try to add a no-op rule to that table, and make sure it doesn't fail - if it does, we can't use this version
+	// as the host is missing kernel support for it.
+	// (255 is a nonexistent protocol number, IANA reserved, see `cat /etc/protocols`, so this rule will never match anything)
+	testCmd := exec.Command(iptablesBin, testRuleAdd...)
+
+	var testStdOut bytes.Buffer
+	testCmd.Stdout = &testStdOut
+	testRes := testCmd.Run()
+	// If we can't add a rule to the basic `filter` table, we can't use this binary - bail out.
+	// Otherwise, delete the no-op rule and carry on with other checks
+	if testRes != nil || strings.Contains(testStdOut.String(), "does not exist") {
+		return IptablesVersion{}, fmt.Errorf("iptables binary %s has no loaded kernel support and cannot be used, err: %v out: %s", iptablesBin, testRes, testStdOut.String())
+	} else {
+		testRuleDel := append(make([]string, 0, len(testRuleAdd)), testRuleAdd...)
+		testRuleDel[2] = "-D"
+
+		testCmd = exec.Command(iptablesBin, testRuleDel...)
+		testCmd.Run()
 	}
 
 	// if binary seems to exist, check the dump of rules in our netns, and see if any rules exist there

--- a/tools/istio-iptables/pkg/dependencies/implementation_linux.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation_linux.go
@@ -107,14 +107,14 @@ func shouldUseBinaryForCurrentContext(iptablesBin string) (IptablesVersion, erro
 	// (255 is a nonexistent protocol number, IANA reserved, see `cat /etc/protocols`, so this rule will never match anything)
 	testCmd := exec.Command(iptablesBin, testRuleAdd...)
 
-	var testStdOut bytes.Buffer
-	testCmd.Stdout = &testStdOut
+	var testStdErr bytes.Buffer
+	testCmd.Stderr = &testStdErr
 	testRes := testCmd.Run()
 	// If we can't add a rule to the basic `filter` table, we can't use this binary - bail out.
 	// Otherwise, delete the no-op rule and carry on with other checks
-	if testRes != nil || strings.Contains(testStdOut.String(), "does not exist") {
+	if testRes != nil || strings.Contains(testStdErr.String(), "does not exist") {
 		return IptablesVersion{}, fmt.Errorf("iptables binary %s has no loaded kernel support and cannot be used, err: %v out: %s",
-			iptablesBin, testRes, testStdOut.String())
+			iptablesBin, testRes, testStdErr.String())
 	}
 
 	testRuleDel := append(make([]string, 0, len(testRuleAdd)), testRuleAdd...)

--- a/tools/istio-iptables/pkg/dependencies/implementation_linux.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation_linux.go
@@ -32,9 +32,7 @@ import (
 	"istio.io/istio/tools/istio-iptables/pkg/constants"
 )
 
-var (
-	testRuleAdd []string = []string{"-t", "filter", "-A", "INPUT", "-p", "255", "-j", "DROP", "-m", "comment", "--comment", `"Istio no-op iptables capability probe"`}
-)
+var testRuleAdd []string = []string{"-t", "filter", "-A", "INPUT", "-p", "255", "-j", "DROP", "-m", "comment", "--comment", `"Istio no-op iptables capability probe"`}
 
 // TODO the entire `istio-iptables` package is linux-specific, I'm not sure we really need
 // platform-differentiators for the `dependencies` package itself.

--- a/tools/istio-iptables/pkg/dependencies/interface.go
+++ b/tools/istio-iptables/pkg/dependencies/interface.go
@@ -29,5 +29,8 @@ type Dependencies interface {
 
 	// DetectIptablesVersion consults the available binaries and in-use tables to determine
 	// which iptables variant (legacy, nft, v6, v4) we should use in the current context.
+	// NOTE that this uses existing rules as part of its heuristic when choosing which binary
+	// to use, so detection should typically happen *once-per-netns*, or different results
+	// might be returned on subsequent calls if the rules in the netnamespace have changed.
 	DetectIptablesVersion(ipV6 bool) (IptablesVersion, error)
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
Followon from https://github.com/istio/istio/pull/55276, xref: https://github.com/istio/istio/issues/55215

After https://github.com/istio/istio/pull/55228/ and https://github.com/istio/istio/pull/54845 I started getting `cni/pkg/iptables` test failures within the build container that I hadn't gotten before, which led me to a few of these fixes.

1. `iptables_e2e_test.go` was detecting iptables 2x, which in some contexts would result in them failing because the detected binary changed mid-test. Also some tests were ignoring the detected binary and using `iptables` when that wasn't contextually correct - I've removed the double-detect and made sure that tests use the detected binary in all cases, rather than hardcoding `iptables`.

2. The iptables `detect` logic within the container was failing in a new way - the binary existed and `iptables-xxx-save` reported no rules (which was enough to prefer it), but when we actually used it in the tests, it failed:

  > ip6tables v1.8.10 (legacy): can't initialize ip6tables table `filter': Table does not exist (do you need to insmod?)
  Perhaps ip6tables or your kernel needs to be upgraded.
  
So this adds a more robust "hard" check to validate the built-in `filter` table actually exists for the chosen version of iptables - if it does not, your kernel doesn't have the (minimum) modules we need loaded, so we won't prefer these binaries anymore.
  
NOTE that this *does* introduce a desirable user-facing change.
Before:
  - If `iptables-legacy-save` worked and had rules, we would use it, otherwise if `iptables-nft-save` worked and had rules, we would use it. If both worked but *neither* had any rules, we would fall back to the $PATH alias `iptables-save`.

Now:
  - If `iptables-legacy-save/iptables-legacy` works and has rules, we will use it, otherwise if `iptables-nft-save/iptables-nft` works *whether it has rules or not*, we will use it. If neither work, we will fall back to the $PATH alias `iptables-save/iptables`. This is effectively implementing what was mentioned in another issue here https://github.com/istio/istio/issues/52357#issuecomment-2253300746