### PR TITLE
test framework: clearly log Or() errors

### DIFF
--- a/pkg/test/framework/components/echo/check/checkers.go
+++ b/pkg/test/framework/components/echo/check/checkers.go
@@ -53,15 +53,16 @@ func And(checkers ...echo.Checker) echo.Checker {
 }
 
 // Or is an aggregate Checker that requires at least one Checker succeeds.
+// Note: the checkers must succeed for all requests; there is no per-request Or().
 func Or(checkers ...echo.Checker) echo.Checker {
 	return func(result echo.CallResult, err error) error {
 		out := istiomultierror.New()
-		for _, c := range checkers {
+		for idx, c := range checkers {
 			err := c(result, err)
 			if err == nil {
 				return nil
 			}
-			out = multierror.Append(out, err)
+			out = multierror.Append(out, fmt.Errorf("failed Or() index %d: %v", idx, err))
 		}
 		return out.ErrorOrNil()
 	}


### PR DESCRIPTION
Otherwise the errors are confusing since they don't explain we need only
1 to succeed, not all of them
