### PR TITLE
istioctl: support rune specific analyzer

### DIFF
--- a/istioctl/pkg/analyze/analyze.go
+++ b/istioctl/pkg/analyze/analyze.go
@@ -81,6 +81,7 @@ var (
 	ignoreUnknown     bool
 	revisionSpecified string
 	remoteContexts    []string
+	selectedAnalyzers []string
 
 	fileExtensions = []string{".json", ".yaml", ".yml"}
 )
@@ -168,7 +169,12 @@ func Analyze(ctx cli.Context) *cobra.Command {
 				selectedNamespace = metav1.NamespaceDefault
 			}
 
-			sa := local.NewIstiodAnalyzer(analyzers.AllCombined(),
+			combinedAnalyzers := analyzers.AllCombined()
+			if len(selectedAnalyzers) != 0 {
+				combinedAnalyzers = analyzers.NamedCombined(selectedNamespace)
+			}
+
+			sa := local.NewIstiodAnalyzer(combinedAnalyzers,
 				resource.Namespace(selectedNamespace),
 				resource.Namespace(ctx.IstioNamespace()), nil)
 
@@ -359,6 +365,8 @@ func Analyze(ctx cli.Context) *cobra.Command {
 	analysisCmd.PersistentFlags().StringArrayVar(&remoteContexts, "remote-contexts", []string{},
 		`Kubernetes configuration contexts for remote clusters to be used in multi-cluster analysis. Not to be confused with '--context'. `+
 			"If unspecified, contexts are read from the remote secrets in the cluster.")
+	analysisCmd.PersistentFlags().StringArrayVarP(&selectedAnalyzers, "analyzer", "a", []string{},
+		"Select specific analyzers to run. Can be repeated. If not specified, all analyzers are run.")
 	return analysisCmd
 }
 

--- a/pkg/config/analysis/analyzers/all.go
+++ b/pkg/config/analysis/analyzers/all.go
@@ -35,6 +35,7 @@ import (
 	"istio.io/istio/pkg/config/analysis/analyzers/telemetry"
 	"istio.io/istio/pkg/config/analysis/analyzers/virtualservice"
 	"istio.io/istio/pkg/config/analysis/analyzers/webhook"
+	"istio.io/istio/pkg/util/sets"
 )
 
 // All returns all analyzers
@@ -95,4 +96,16 @@ func AllCombined() analysis.CombinedAnalyzer {
 // AllMultiClusterCombined returns all multi-cluster analyzers combined as one
 func AllMultiClusterCombined() analysis.CombinedAnalyzer {
 	return analysis.Combine("all-multi-cluster", AllMultiCluster()...)
+}
+
+func NamedCombined(names ...string) analysis.CombinedAnalyzer {
+	selected := make([]analysis.Analyzer, 0, len(All()))
+	nameSet := sets.New(names...)
+	for _, a := range All() {
+		if nameSet.Contains(a.Metadata().Name) {
+			selected = append(selected, a)
+		}
+	}
+
+	return analysis.Combine("named", selected...)
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

In a large size cluster, it take too long to run all analyzer, this enable users to run specific analyzer by a new flag.

```console
istioctl analyze -a "gateway.ConflictingGatewayAnalyzer"
```


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
