### PR TITLE
Fix Telemetry Tracint flaky tests failures

### DIFF
--- a/pkg/test/framework/components/zipkin/kube.go
+++ b/pkg/test/framework/components/zipkin/kube.go
@@ -282,7 +282,7 @@ func (c *kubeComponent) createHTTPClient(limit int, spanName, annotationQuery, h
 		return url, http.Client{Timeout: httpTimeout}, nil
 	}
 
-	ip, err := resolveHostDomainToIP(hostDomain)
+	ip, err := testKube.WaitUntilReachableIngress(hostDomain)
 	if err != nil {
 		return "", http.Client{}, fmt.Errorf("failed to resolve host domain %s: %w", hostDomain, err)
 	}
@@ -370,18 +370,4 @@ func buildSpan(obj any) Span {
 		s.Name = name.(string)
 	}
 	return s
-}
-
-func resolveHostDomainToIP(hostDomain string) (string, error) {
-	ips, err := net.LookupIP(hostDomain)
-	if err != nil {
-		return "", err
-	}
-	// Use the first resolved IP address
-	for _, ip := range ips {
-		if ipv4 := ip.To4(); ipv4 != nil {
-			return ipv4.String(), nil
-		}
-	}
-	return "", fmt.Errorf("no IPv4 address found for hostname: %s", hostDomain)
 }

--- a/tests/integration/telemetry/tracing/otelcollector/tracing_test.go
+++ b/tests/integration/telemetry/tracing/otelcollector/tracing_test.go
@@ -116,7 +116,7 @@ func TestProxyTracingOpenTelemetryProvider(t *testing.T) {
 										return errors.New("cannot find expected traces")
 									}
 									return nil
-								}, retry.Delay(3*time.Second), retry.Timeout(80*time.Second))
+								}, retry.Delay(3*time.Second), retry.Timeout(150*time.Second))
 							})
 						}
 					})

--- a/tests/integration/telemetry/tracing/zipkin/client_tracing_test.go
+++ b/tests/integration/telemetry/tracing/zipkin/client_tracing_test.go
@@ -64,7 +64,7 @@ func TestClientTracing(t *testing.T) {
 							return errors.New("cannot find expected traces")
 						}
 						return nil
-					}, retry.Delay(3*time.Second), retry.Timeout(80*time.Second))
+					}, retry.Delay(3*time.Second), retry.Timeout(150*time.Second))
 				})
 			}
 		})

--- a/tests/integration/telemetry/tracing/zipkin/server_tracing_test.go
+++ b/tests/integration/telemetry/tracing/zipkin/server_tracing_test.go
@@ -58,7 +58,7 @@ func TestServerTracing(t *testing.T) {
 							return errors.New("cannot find expected traces")
 						}
 						return nil
-					}, retry.Delay(3*time.Second), retry.Timeout(80*time.Second))
+					}, retry.Delay(3*time.Second), retry.Timeout(150*time.Second))
 				})
 			}
 		})


### PR DESCRIPTION
**Please provide a description of this PR:**
When running the telemetry tests on public cloud platforms, DNS endpoint resolve could take some time.
- Increase telemetry tracing tests timeout.
- Use the function with the wait and retry approach to get the endpoint resolvable.