### PR TITLE
krt: implement folder based collections

### DIFF
--- a/pkg/config/mesh/meshwatcher/collection.go
+++ b/pkg/config/mesh/meshwatcher/collection.go
@@ -21,6 +21,7 @@ import (
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/filewatcher"
 	"istio.io/istio/pkg/kube/krt"
+	krtfiles "istio.io/istio/pkg/kube/krt/files"
 	"istio.io/istio/pkg/log"
 )
 
@@ -29,7 +30,7 @@ type MeshConfigSource = krt.Singleton[string]
 
 // NewFileSource creates a MeshConfigSource from a file. The file must exist.
 func NewFileSource(fileWatcher filewatcher.FileWatcher, filename string, opts krt.OptionsBuilder) (MeshConfigSource, error) {
-	return krt.NewFileSingleton[string](fileWatcher, filename, func(filename string) (string, error) {
+	return krtfiles.NewFileSingleton[string](fileWatcher, filename, func(filename string) (string, error) {
 		b, err := os.ReadFile(filename)
 		if err != nil {
 			return "", err

--- a/pkg/kube/krt/conformance_test.go
+++ b/pkg/kube/krt/conformance_test.go
@@ -30,6 +30,7 @@ import (
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/kube/krt"
+	krtfiles "istio.io/istio/pkg/kube/krt/files"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test"
@@ -90,7 +91,7 @@ func (r *manyRig) CreateObject(key string) {
 }
 
 type fileRig struct {
-	krt.FileCollection[Named]
+	krtfiles.FileCollection[Named]
 	rootPath string
 	t        test.Failer
 }
@@ -161,11 +162,11 @@ func TestConformance(t *testing.T) {
 	t.Run("files", func(t *testing.T) {
 		stop := test.NewStop(t)
 		root := t.TempDir()
-		fw, err := krt.NewFolderWatch[[]byte](root, func(bytes []byte) ([][]byte, error) {
+		fw, err := krtfiles.NewFolderWatch[[]byte](root, func(bytes []byte) ([][]byte, error) {
 			return [][]byte{bytes}, nil
 		}, stop)
 		assert.NoError(t, err)
-		col := krt.NewFileCollection[[]byte, Named](fw, func(f []byte) *Named {
+		col := krtfiles.NewFileCollection[[]byte, Named](fw, func(f []byte) *Named {
 			var res Named
 			err := yaml.Unmarshal(f, &res)
 			if err != nil {

--- a/pkg/kube/krt/conformance_test.go
+++ b/pkg/kube/krt/conformance_test.go
@@ -17,16 +17,20 @@ package krt_test
 import (
 	"fmt"
 	"math/rand"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
@@ -88,11 +92,20 @@ func (r *manyRig) CreateObject(key string) {
 type fileRig struct {
 	krt.FileCollection[Named]
 	rootPath string
+	t        test.Failer
 }
 
 // CreateObject is a stub
-// TODO(https://github.com/istio/istio/issues/54731) implement this
 func (r *fileRig) CreateObject(key string) {
+	fp := filepath.Join(r.rootPath, strings.ReplaceAll(key, "/", "_")+".yaml")
+	ns, name, _ := strings.Cut(key, "/")
+	contents, _ := yaml.Marshal(Named{
+		Namespace: ns,
+		Name:      name,
+	})
+	err := os.WriteFile(fp, contents, 0o600)
+	log.Errorf("howardjohn: wrote %v", fp)
+	assert.NoError(r.t, err)
 }
 
 // TestConformance aims to provide a 'conformance' suite for Collection implementations to ensure each collection behaves
@@ -146,11 +159,24 @@ func TestConformance(t *testing.T) {
 		runConformance[Named](t, rig)
 	})
 	t.Run("files", func(t *testing.T) {
-		t.Skip("https://github.com/istio/istio/issues/54731")
-		col := krt.NewFileCollection[Named](krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler))
+		stop := test.NewStop(t)
+		root := t.TempDir()
+		fw, err := krt.NewFolderWatch[[]byte](root, func(bytes []byte) ([][]byte, error) {
+			return [][]byte{bytes}, nil
+		}, stop)
+		assert.NoError(t, err)
+		col := krt.NewFileCollection[[]byte, Named](fw, func(f []byte) *Named {
+			var res Named
+			err := yaml.Unmarshal(f, &res)
+			if err != nil {
+				return nil
+			}
+			return &res
+		}, krt.WithStop(stop), krt.WithDebugging(krt.GlobalDebugHandler))
 		rig := &fileRig{
 			FileCollection: col,
-			rootPath:       t.TempDir(),
+			rootPath:       root,
+			t:              t,
 		}
 		runConformance[Named](t, rig)
 	})

--- a/pkg/kube/krt/conformance_test.go
+++ b/pkg/kube/krt/conformance_test.go
@@ -105,7 +105,6 @@ func (r *fileRig) CreateObject(key string) {
 		Name:      name,
 	})
 	err := os.WriteFile(fp, contents, 0o600)
-	log.Errorf("howardjohn: wrote %v", fp)
 	assert.NoError(r.t, err)
 }
 

--- a/pkg/kube/krt/conformance_test.go
+++ b/pkg/kube/krt/conformance_test.go
@@ -31,7 +31,6 @@ import (
 	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/kube/krt"
 	krtfiles "istio.io/istio/pkg/kube/krt/files"
-	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"

--- a/pkg/kube/krt/files.go
+++ b/pkg/kube/krt/files.go
@@ -17,21 +17,208 @@ package krt
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"sync"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"go.uber.org/atomic"
 	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/pkg/filewatcher"
 	"istio.io/istio/pkg/ptr"
+	"istio.io/istio/pkg/slices"
+	"istio.io/istio/pkg/util/sets"
 )
+
+type FolderWatch[T any] struct {
+	root  string
+	parse func([]byte) ([]T, error)
+
+	mu        sync.RWMutex
+	state     []T
+	callbacks []func()
+}
+
+func NewFolderWatch[T any](fileDir string, parse func([]byte) ([]T, error), stop <-chan struct{}) (*FolderWatch[T], error) {
+	fw := &FolderWatch[T]{root: fileDir, parse: parse}
+	// Read initial state
+	if err := fw.readOnce(); err != nil {
+		return nil, err
+	}
+	go fw.watch(stop)
+	return fw, nil
+}
+
+var supportedExtensions = sets.New(".yaml", ".yml")
+
+func (f *FolderWatch[T]) get() []T {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.state
+}
+
+func (f *FolderWatch[T]) readOnce() error {
+	var result []T
+
+	err := filepath.Walk(f.root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		} else if !supportedExtensions.Contains(filepath.Ext(path)) || (info.Mode()&os.ModeType) != 0 {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			log.Warnf("Failed to readOnce %s: %v", path, err)
+			return err
+		}
+		parsed, err := f.parse(data)
+		if err != nil {
+			log.Warnf("Failed to parse %s: %v", path, err)
+			return err
+		}
+		result = append(result, parsed...)
+		return nil
+	})
+	if err != nil {
+		log.Warnf("failure during filepath.Walk: %v", err)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.state = result
+	for _, c := range f.callbacks {
+		c()
+	}
+	return nil
+}
+
+func (f *FolderWatch[T]) watch(stop <-chan struct{}) {
+	c := make(chan struct{}, 1)
+	if err := f.fileTrigger(c, stop); err != nil {
+		log.Errorf("Unable to setup FileTrigger for %s: %v", f.root, err)
+		return
+	}
+	// Run the close loop asynchronously.
+	go func() {
+		for {
+			select {
+			case <-c:
+				log.Infof("Triggering reload of file configuration")
+				if err := f.readOnce(); err != nil {
+					log.Warnf("unable to reload file configuration %v: %v", f.root, err)
+				}
+			case <-stop:
+				return
+			}
+		}
+	}()
+}
+
+const watchDebounceDelay = 50 * time.Millisecond
+
+// Trigger notifications when a file is mutated
+func (f *FolderWatch[T]) fileTrigger(events chan struct{}, stop <-chan struct{}) error {
+	fs, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	watcher := recursiveWatcher{fs}
+	if err = watcher.watchRecursive(f.root); err != nil {
+		return err
+	}
+	go func() {
+		defer watcher.Close()
+		var debounceC <-chan time.Time
+		for {
+			select {
+			case <-debounceC:
+				debounceC = nil
+				events <- struct{}{}
+			case e := <-watcher.Events:
+				s, err := os.Stat(e.Name)
+				if err == nil && s != nil && s.IsDir() {
+					// If it's a directory, add a watch for it so we see nested files.
+					if e.Op&fsnotify.Create != 0 {
+						log.Debugf("add watch for %v: %v", s.Name(), watcher.watchRecursive(e.Name))
+					}
+				}
+				// Can't stat a deleted directory, so attempt to remove it. If it fails it is not a problem
+				if e.Op&fsnotify.Remove != 0 {
+					_ = watcher.Remove(e.Name)
+				}
+				if debounceC == nil {
+					debounceC = time.After(watchDebounceDelay)
+				}
+			case err := <-watcher.Errors:
+				log.Warnf("Error watching file trigger: %v %v", f.root, err)
+				return
+			case signal := <-stop:
+				log.Infof("Shutting down file watcher: %v %v", f.root, signal)
+				return
+			}
+		}
+	}()
+	return nil
+}
+
+func (f *FolderWatch[T]) subscribe(fn func()) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.callbacks = append(f.callbacks, fn)
+}
+
+// recursiveWatcher wraps a fsnotify wrapper to add a best-effort recursive directory watching in user
+// space. See https://github.com/fsnotify/fsnotify/issues/18. The implementation is inherently racy,
+// as files added to a directory immediately after creation may not trigger events; as such it is only useful
+// when an event causes a full reconciliation, rather than acting on an individual event
+type recursiveWatcher struct {
+	*fsnotify.Watcher
+}
+
+// watchRecursive adds all directories under the given one to the watch list.
+func (m recursiveWatcher) watchRecursive(path string) error {
+	err := filepath.Walk(path, func(walkPath string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if fi.IsDir() {
+			if err = m.Watcher.Add(walkPath); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	return err
+}
 
 type FileCollection[T any] struct {
 	StaticCollection[T]
+	read func() []T
 }
 
-func NewFileCollection[T any](opts ...CollectionOption) FileCollection[T] {
-	panic("not yet implemented")
+func NewFileCollection[F any, O any](w *FolderWatch[F], transform func(F) *O, opts ...CollectionOption) FileCollection[O] {
+	res := FileCollection[O]{
+		read: func() []O {
+			return readSnapshot[F, O](w, transform)
+		},
+	}
+	sc := NewStaticCollection[O](res.read(), opts...)
+	w.subscribe(func() {
+		now := res.read()
+		sc.Reset(now)
+	})
+	res.StaticCollection = sc
+	return res
+}
+
+func readSnapshot[F any, O any](w *FolderWatch[F], transform func(F) *O) []O {
+	res := w.state
+	return slices.MapFilter(res, transform)
 }
 
 type FileSingleton[T any] struct {
@@ -39,7 +226,7 @@ type FileSingleton[T any] struct {
 }
 
 // NewFileSingleton returns a collection that reads and watches a single file
-// The `readFile` function is used to read and deserialize the file and will be called each time the file changes.
+// The `readFile` function is used to readOnce and deserialize the file and will be called each time the file changes.
 // This will also be called during the initial construction of the collection; if the initial readFile fails an error is returned.
 func NewFileSingleton[T any](
 	fileWatcher filewatcher.FileWatcher,
@@ -77,10 +264,10 @@ func ReadFileAsYaml[T any](filename string) (T, error) {
 	target := ptr.Empty[T]()
 	y, err := os.ReadFile(filename)
 	if err != nil {
-		return target, fmt.Errorf("failed to read file %s: %v", filename, err)
+		return target, fmt.Errorf("failed to readOnce file %s: %v", filename, err)
 	}
 	if err := yaml.Unmarshal(y, &target); err != nil {
-		return target, fmt.Errorf("failed to read file %s: %v", filename, err)
+		return target, fmt.Errorf("failed to readOnce file %s: %v", filename, err)
 	}
 	return target, nil
 }

--- a/pkg/kube/krt/files/files.go
+++ b/pkg/kube/krt/files/files.go
@@ -219,7 +219,7 @@ func NewFileCollection[F any, O any](w *FolderWatch[F], transform func(F) *O, op
 }
 
 func readSnapshot[F any, O any](w *FolderWatch[F], transform func(F) *O) []O {
-	res := w.state
+	res := w.get()
 	return slices.MapFilter(res, transform)
 }
 

--- a/pkg/kube/krt/files/files.go
+++ b/pkg/kube/krt/files/files.go
@@ -48,7 +48,7 @@ func NewFolderWatch[T any](fileDir string, parse func([]byte) ([]T, error), stop
 	if err := fw.readOnce(); err != nil {
 		return nil, err
 	}
-	go fw.watch(stop)
+	fw.watch(stop)
 	return fw, nil
 }
 

--- a/pkg/kube/krt/files/files_test.go
+++ b/pkg/kube/krt/files/files_test.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package files_test
 
 import (

--- a/pkg/kube/krt/files/files_test.go
+++ b/pkg/kube/krt/files/files_test.go
@@ -1,0 +1,156 @@
+package files_test
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"path/filepath"
+	goruntime "runtime"
+	"strings"
+	"testing"
+
+	"golang.org/x/sync/errgroup"
+	v1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	yamlserializer "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/yaml"
+
+	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/resource"
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/controllers"
+	"istio.io/istio/pkg/kube/krt"
+	krtfiles "istio.io/istio/pkg/kube/krt/files"
+	"istio.io/istio/pkg/ptr"
+	"istio.io/istio/pkg/slices"
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/assert"
+	"istio.io/istio/pkg/test/util/file"
+)
+
+func TestFilesCollection(t *testing.T) {
+	stop := test.NewStop(t)
+	root := t.TempDir()
+
+	file.WriteOrFail(t, filepath.Join(root, "cm.yaml"), []byte(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+  namespace: default`))
+
+	fw, err := krtfiles.NewFolderWatch[controllers.Object](root, func(b []byte) ([]controllers.Object, error) {
+		return parseInputs(bytes.NewReader(b))
+	}, stop)
+	assert.NoError(t, err)
+
+	col := newKubernetesFromFiles[*v1.ConfigMap](fw, krt.WithStop(stop))
+	col.WaitUntilSynced(test.NewStop(t))
+	tt := assert.NewTracker[string](t)
+	col.Register(TrackerHandler[*v1.ConfigMap](tt))
+	tt.WaitOrdered("add/default/test")
+
+	file.WriteOrFail(t, filepath.Join(root, "cm2.yaml"), []byte(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test2
+  namespace: default`))
+	tt.WaitOrdered("add/default/test2")
+
+	file.WriteOrFail(t, filepath.Join(root, "cm.yaml"), []byte(``))
+	tt.WaitOrdered("delete/default/test")
+}
+
+func newKubernetesFromFiles[T controllers.Object](fw *krtfiles.FolderWatch[controllers.Object], opts ...krt.CollectionOption) krt.Collection[T] {
+	return krtfiles.NewFileCollection[controllers.Object, T](fw, func(f controllers.Object) *T {
+		if t, ok := f.(T); ok {
+			return &t
+		}
+		return nil
+	}, opts...)
+}
+
+func parseInputs(f io.Reader) ([]controllers.Object, error) {
+	codecs := serializer.NewCodecFactory(kube.IstioScheme)
+	deserializer := codecs.UniversalDeserializer()
+
+	reader := yamlutil.NewYAMLReader(bufio.NewReader(f))
+
+	g := &errgroup.Group{}
+	g.SetLimit(goruntime.GOMAXPROCS(0))
+	resp := []controllers.Object{}
+	for {
+		chunk, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		resp = append(resp, nil)
+		idx := len(resp) - 1
+		// This is obnoxious but YAML parsing really is a bottleneck on this!
+		g.Go(func() error {
+			// TODO: this doubles parsing costs
+			gvk, err := yamlserializer.DefaultMetaFactory.Interpret(chunk)
+			if err != nil {
+				return err
+			}
+
+			var defaultGVK *schema.GroupVersionKind
+			var obj runtime.Object
+
+			// We want to normalize types to a single version
+			s, exists := collections.PilotGatewayAPI().FindByGroupVersionAliasesKind(resource.FromKubernetesGVK(gvk))
+			if exists {
+				defaultGVK = ptr.Of(s.GroupVersionKind().Kubernetes())
+				raw, err := kube.IstioScheme.New(s.GroupVersionKind().Kubernetes())
+				if err != nil {
+					return err
+				}
+				if err := yaml.Unmarshal(chunk, &raw); err != nil {
+					return err
+				}
+				tm, err := apimeta.TypeAccessor(raw)
+				if err != nil {
+					return err
+				}
+				tm.SetAPIVersion(s.APIVersion())
+				obj = raw
+			} else {
+				obj, _, err = deserializer.Decode(chunk, defaultGVK, obj)
+				if err != nil {
+					if strings.Contains(err.Error(), "no kind") {
+						return nil
+					} else {
+						return fmt.Errorf("cannot parse message: %v", err)
+					}
+				}
+			}
+
+			resp[idx] = obj.(controllers.Object)
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	resp = slices.FilterInPlace(resp, func(object controllers.Object) bool {
+		return object != nil
+	})
+
+	return resp, nil
+}
+
+func TrackerHandler[T any](tracker *assert.Tracker[string]) func(krt.Event[T]) {
+	return func(o krt.Event[T]) {
+		tracker.Record(fmt.Sprintf("%v/%v", o.Event, krt.GetKey(o.Latest())))
+	}
+}

--- a/pkg/kube/krt/internal.go
+++ b/pkg/kube/krt/internal.go
@@ -53,6 +53,11 @@ func castEvent[I, O any](o Event[I]) Event[O] {
 	return e
 }
 
+func GetStop(opts ...CollectionOption) <-chan struct{} {
+	o := buildCollectionOptions(opts...)
+	return o.stop
+}
+
 func buildCollectionOptions(opts ...CollectionOption) collectionOptions {
 	c := &collectionOptions{}
 	for _, o := range opts {


### PR DESCRIPTION
This gives us the ability to register a collection based on a folder. The intent is to allow us to be able to have the same config as https://github.com/istio/istio/blob/b59d3f59928046f3a0cc64563004f70152530888/pilot/pkg/bootstrap/configcontroller.go#L258