### PR TITLE
Fix ztunnel service account name

### DIFF
--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -47,7 +47,7 @@ spec:
       affinity:
 {{ toYaml .Values.affinity | trim | indent 8 }}
 {{- end }}
-      serviceAccountName: ztunnel
+      serviceAccountName: {{ include "ztunnel.release-name" . }}
       tolerations:
         - effect: NoSchedule
           operator: Exists


### PR DESCRIPTION
Ztunnel resources are name from release since 1.25.0 If the release name is not ztunnel, the daemonset will fail because
 it can not find the service account

Not to sure about the "Does not have any user-facing"

Related issue : https://github.com/istio/istio/issues/55359