### PR TITLE
krt: use stop and debugger everywhere

### DIFF
--- a/pilot/pkg/controllers/untaint/nodeuntainter_test.go
+++ b/pilot/pkg/controllers/untaint/nodeuntainter_test.go
@@ -24,6 +24,7 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	kubelib "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/kclient/clienttest"
+	"istio.io/istio/pkg/kube/krt"
 	istiolog "istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
@@ -58,7 +59,7 @@ func newNodeUntainterTestServer(t *testing.T) *nodeTainterTestServer {
 	t.Cleanup(func() { close(stop) })
 	client := kubelib.NewFakeClient()
 
-	nodeUntainter := NewNodeUntainter(stop, client, systemNS, systemNS, nil)
+	nodeUntainter := NewNodeUntainter(stop, client, systemNS, systemNS, krt.GlobalDebugHandler)
 	go nodeUntainter.Run(stop)
 	client.RunAndWait(stop)
 	kubelib.WaitForCacheSync("test", stop, nodeUntainter.HasSynced)

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
@@ -1690,7 +1690,7 @@ func newAmbientUnitTest(t test.Failer) *index {
 		Options{
 			SystemNamespace: systemNS,
 			ClusterID:       testC,
-		}, krt.NewOptionsBuilder(test.NewStop(t), "", nil))
+		}, krt.NewOptionsBuilder(test.NewStop(t), "", krt.GlobalDebugHandler))
 	idx := &index{
 		networks:        networks,
 		SystemNamespace: systemNS,

--- a/pilot/pkg/serviceregistry/kube/controller/fake.go
+++ b/pilot/pkg/serviceregistry/kube/controller/fake.go
@@ -31,6 +31,7 @@ import (
 	kubelib "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/kube/kclient/clienttest"
+	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/kube/namespace"
 	"istio.io/istio/pkg/queue"
 	"istio.io/istio/pkg/test"
@@ -108,6 +109,7 @@ func NewFakeControllerWithOptions(t test.Failer, opts FakeControllerOptions) (*F
 		ConfigCluster:         opts.ConfigCluster,
 		SystemNamespace:       opts.SystemNamespace,
 		StatusWritingEnabled:  activenotifier.New(false),
+		KrtDebugger:           new(krt.DebugHandler),
 	}
 	c := NewController(opts.Client, options)
 	meshServiceController.AddRegistry(c)

--- a/pkg/kube/krt/conformance_test.go
+++ b/pkg/kube/krt/conformance_test.go
@@ -104,7 +104,7 @@ func TestConformance(t *testing.T) {
 	t.Run("informer", func(t *testing.T) {
 		fc := kube.NewFakeClient()
 		kc := kclient.New[*corev1.ConfigMap](fc)
-		col := krt.WrapClient(kc, krt.WithStop(test.NewStop(t)))
+		col := krt.WrapClient(kc, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler))
 		rig := &informerRig{
 			Collection: col,
 			client:     kc,
@@ -113,16 +113,16 @@ func TestConformance(t *testing.T) {
 		runConformance[*corev1.ConfigMap](t, rig)
 	})
 	t.Run("static list", func(t *testing.T) {
-		col := krt.NewStaticCollection[Named](nil, krt.WithStop(test.NewStop(t)))
+		col := krt.NewStaticCollection[Named](nil, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler))
 		rig := &staticRig{
 			StaticCollection: col,
 		}
 		runConformance[Named](t, rig)
 	})
 	t.Run("join", func(t *testing.T) {
-		col1 := krt.NewStaticCollection[Named](nil, krt.WithStop(test.NewStop(t)))
-		col2 := krt.NewStaticCollection[Named](nil, krt.WithStop(test.NewStop(t)))
-		j := krt.JoinCollection[Named]([]krt.Collection[Named]{col1, col2})
+		col1 := krt.NewStaticCollection[Named](nil, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler))
+		col2 := krt.NewStaticCollection[Named](nil, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler))
+		j := krt.JoinCollection[Named]([]krt.Collection[Named]{col1, col2}, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler))
 		rig := &joinRig{
 			Collection: j,
 			inner:      [2]krt.StaticCollection[Named]{col1, col2},
@@ -130,14 +130,14 @@ func TestConformance(t *testing.T) {
 		runConformance[Named](t, rig)
 	})
 	t.Run("manyCollection", func(t *testing.T) {
-		namespaces := krt.NewStaticCollection[string](nil, krt.WithStop(test.NewStop(t)))
-		names := krt.NewStaticCollection[string](nil, krt.WithStop(test.NewStop(t)))
+		namespaces := krt.NewStaticCollection[string](nil, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler))
+		names := krt.NewStaticCollection[string](nil, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler))
 		col := krt.NewManyCollection(namespaces, func(ctx krt.HandlerContext, ns string) []Named {
 			names := krt.Fetch[string](ctx, names)
 			return slices.Map(names, func(e string) Named {
 				return Named{Namespace: ns, Name: e}
 			})
-		}, krt.WithStop(test.NewStop(t)))
+		}, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler))
 		rig := &manyRig{
 			Collection: col,
 			namespaces: namespaces,
@@ -147,7 +147,7 @@ func TestConformance(t *testing.T) {
 	})
 	t.Run("files", func(t *testing.T) {
 		t.Skip("https://github.com/istio/istio/issues/54731")
-		col := krt.NewFileCollection[Named](krt.WithStop(test.NewStop(t)))
+		col := krt.NewFileCollection[Named](krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler))
 		rig := &fileRig{
 			FileCollection: col,
 			rootPath:       t.TempDir(),

--- a/pkg/kube/krt/join_test.go
+++ b/pkg/kube/krt/join_test.go
@@ -33,10 +33,14 @@ import (
 )
 
 func TestJoinCollection(t *testing.T) {
+	opts := testOptions(t)
 	c1 := krt.NewStatic[Named](nil, true)
 	c2 := krt.NewStatic[Named](nil, true)
 	c3 := krt.NewStatic[Named](nil, true)
-	j := krt.JoinCollection([]krt.Collection[Named]{c1.AsCollection(), c2.AsCollection(), c3.AsCollection()})
+	j := krt.JoinCollection(
+		[]krt.Collection[Named]{c1.AsCollection(), c2.AsCollection(), c3.AsCollection()},
+		opts.WithName("Join")...,
+	)
 	last := atomic.NewString("")
 	j.Register(func(o krt.Event[Named]) {
 		last.Store(o.Latest().ResourceName())
@@ -87,8 +91,14 @@ func TestCollectionJoin(t *testing.T) {
 	}, true)
 	SimpleServices := SimpleServiceCollection(services, opts)
 	SimpleServiceEntries := SimpleServiceCollectionFromEntries(serviceEntries, opts)
-	AllServices := krt.JoinCollection([]krt.Collection[SimpleService]{SimpleServices, SimpleServiceEntries})
-	AllPods := krt.JoinCollection([]krt.Collection[SimplePod]{SimplePods, ExtraSimplePods.AsCollection()})
+	AllServices := krt.JoinCollection(
+		[]krt.Collection[SimpleService]{SimpleServices, SimpleServiceEntries},
+		opts.WithName("AllServices")...,
+	)
+	AllPods := krt.JoinCollection(
+		[]krt.Collection[SimplePod]{SimplePods, ExtraSimplePods.AsCollection()},
+		opts.WithName("AllPods")...,
+	)
 	SimpleEndpoints := SimpleEndpointsCollection(AllPods, AllServices, opts)
 
 	fetch := func() []SimpleEndpoint {
@@ -185,7 +195,10 @@ func TestCollectionJoinSync(t *testing.T) {
 		Labeled: Labeled{map[string]string{"app": "foo"}},
 		IP:      "9.9.9.9",
 	}, true)
-	AllPods := krt.JoinCollection([]krt.Collection[SimplePod]{SimplePods, ExtraSimplePods.AsCollection()})
+	AllPods := krt.JoinCollection(
+		[]krt.Collection[SimplePod]{SimplePods, ExtraSimplePods.AsCollection()},
+		opts.WithName("AllPods")...,
+	)
 	assert.Equal(t, AllPods.WaitUntilSynced(stop), true)
 	// Assert Equal -- not EventuallyEqual -- to ensure our WaitForCacheSync is proper
 	assert.Equal(t, fetcherSorted(AllPods)(), []SimplePod{

--- a/pkg/kube/krt/krttest/helpers.go
+++ b/pkg/kube/krt/krttest/helpers.go
@@ -47,7 +47,7 @@ func NewMock(t test.Failer, inputs []any) *MockCollection {
 }
 
 func GetMockCollection[T any](mc *MockCollection) krt.Collection[T] {
-	return krt.NewStaticCollection(extractType[T](&mc.inputs))
+	return krt.NewStaticCollection(extractType[T](&mc.inputs), krt.WithStop(test.NewStop(mc.t)), krt.WithDebugging(krt.GlobalDebugHandler))
 }
 
 func GetMockSingleton[T any](mc *MockCollection) krt.StaticSingleton[T] {

--- a/pkg/kube/krt/recomputetrigger_test.go
+++ b/pkg/kube/krt/recomputetrigger_test.go
@@ -26,13 +26,14 @@ import (
 )
 
 func TestRecomputeTrigger(t *testing.T) {
+	opts := testOptions(t)
 	rt := krt.NewRecomputeTrigger(false)
 	col1 := krt.NewStatic(ptr.Of("foo"), true).AsCollection()
 	response := atomic.NewString("foo")
 	col2 := krt.NewCollection(col1, func(ctx krt.HandlerContext, i string) *string {
 		rt.MarkDependant(ctx)
 		return ptr.Of(response.Load())
-	}, krt.WithStop(test.NewStop(t)))
+	}, opts.WithName("col2")...)
 
 	assert.Equal(t, col2.HasSynced(), false)
 	rt.MarkSynced()

--- a/pkg/kube/krt/singleton_test.go
+++ b/pkg/kube/krt/singleton_test.go
@@ -33,8 +33,9 @@ import (
 
 func TestSingleton(t *testing.T) {
 	stop := test.NewStop(t)
+	opts := testOptions(t)
 	c := kube.NewFakeClient()
-	ConfigMaps := krt.NewInformer[*corev1.ConfigMap](c, krt.WithStop(stop))
+	ConfigMaps := krt.NewInformer[*corev1.ConfigMap](c, opts.WithName("ConfigMaps")...)
 	c.RunAndWait(stop)
 	cmt := clienttest.NewWriter[*corev1.ConfigMap](t, c)
 	ConfigMapNames := krt.NewSingleton[string](
@@ -43,7 +44,7 @@ func TestSingleton(t *testing.T) {
 			return ptr.Of(slices.Join(",", slices.Map(cms, func(c *corev1.ConfigMap) string {
 				return config.NamespacedName(c).String()
 			})...))
-		}, krt.WithStop(stop),
+		}, opts.WithName("ConfigMapNames")...,
 	)
 	ConfigMapNames.AsCollection().WaitUntilSynced(stop)
 	tt := assert.NewTracker[string](t)

--- a/pkg/kube/krt/static_test.go
+++ b/pkg/kube/krt/static_test.go
@@ -18,13 +18,12 @@ import (
 	"testing"
 
 	"istio.io/istio/pkg/kube/krt"
-	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
 )
 
 func TestStaticCollection(t *testing.T) {
-	stop := test.NewStop(t)
-	c := krt.NewStaticCollection[Named]([]Named{{"ns", "a"}}, krt.WithStop(stop))
+	opts := testOptions(t)
+	c := krt.NewStaticCollection[Named]([]Named{{"ns", "a"}}, opts.WithName("c")...)
 	assert.Equal(t, c.Synced().HasSynced(), true, "should start synced")
 	assert.Equal(t, c.List(), []Named{{"ns", "a"}})
 


### PR DESCRIPTION
To make sure we avoid https://github.com/istio/istio/pull/55377 for
other places. Fortunately, all places missing it were tests, but
consistently using it everywhere ensures we can add checks that enforce
its always set.
