### PR TITLE
Include the underlay error in the mesh dataplane initialization error

### DIFF
--- a/cni/pkg/nodeagent/server.go
+++ b/cni/pkg/nodeagent/server.go
@@ -70,7 +70,7 @@ func NewServer(ctx context.Context, ready *atomic.Value, pluginSocket string, ar
 
 	s.dataplane, err = initMeshDataplane(client, args)
 	if err != nil {
-		return nil, fmt.Errorf("error initializing mesh dataplane")
+		return nil, fmt.Errorf("error initializing mesh dataplane: %w", err)
 	}
 
 	s.NotReady()


### PR DESCRIPTION
**Please provide a description of this PR:**

When mesh dataplane initialization fails, the cause was unclear in the logs because the error was dropped by `NewServer`. The patch ensures that the underlay error is included, making it easier to diagnose:

Before:
```
Error: failed to create ambient nodeagent service: error initializing mesh dataplane
```
After:
```
Error: failed to create ambient nodeagent service: error initializing mesh dataplane: stat 1/ns/net: permission denied
```