### PR TITLE
optimization: do not copy when we do not need to

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1734,19 +1734,13 @@ func (ps *PushContext) initVirtualServices(env *Environment) {
 
 	virtualServices := env.List(gvk.VirtualService, NamespaceAll)
 
-	// values returned from ConfigStore.List are immutable.
-	// Therefore, we make a copy
 	vservices := make([]config.Config, len(virtualServices))
-
-	for i := range vservices {
-		vservices[i] = virtualServices[i].DeepCopy()
-	}
 
 	totalVirtualServices.Record(float64(len(virtualServices)))
 
 	// convert all shortnames in virtual services into FQDNs
-	for _, r := range vservices {
-		resolveVirtualServiceShortnames(r.Spec.(*networking.VirtualService), r.Meta)
+	for i, r := range virtualServices {
+		vservices[i] = resolveVirtualServiceShortnames(r)
 	}
 
 	vservices, ps.virtualServiceIndex.delegates = mergeVirtualServicesIfNeeded(vservices, ps.exportToDefaults.virtualService)


### PR DESCRIPTION
We do not need to clone VS for GW objects since we just return anyways. Thios is about 10% of CPU on a GW-API heavy cluster