### PR TITLE
Fix TLS from ratings sample

### DIFF
--- a/samples/bookinfo/src/ratings/Dockerfile
+++ b/samples/bookinfo/src/ratings/Dockerfile
@@ -16,7 +16,8 @@ FROM node:21.6-slim
 
 #hadolint ignore=DL3008
 RUN apt-get update \
-    && apt-get install curl --no-install-recommends -y \
+    && apt-get install curl ca-certificates --no-install-recommends -y \
+    && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 ARG service_version


### PR DESCRIPTION
We add curl, but the base has no CA certs so you cannot use it to hit
HTTPs endpoints. Not a big deal but useful for debugging sometimes.
