### PR TITLE
Add Gateway service loadBalancerClass

### DIFF
--- a/manifests/charts/gateway/templates/service.yaml
+++ b/manifests/charts/gateway/templates/service.yaml
@@ -21,6 +21,9 @@ spec:
   {{- if hasKey .Values.service "allocateLoadBalancerNodePorts" }}
   allocateLoadBalancerNodePorts: {{ .Values.service.allocateLoadBalancerNodePorts }}
   {{- end }}
+  {{- if hasKey .Values.service "loadBalancerClass" }}
+  loadBalancerClass: {{ .Values.service.loadBalancerClass }}
+  {{- end }}
 {{- end }}
 {{- if .Values.service.ipFamilyPolicy }}
   ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -64,6 +64,8 @@ _internal_defaults_do_not_set:
     ipFamilies: []
     ## Whether to automatically allocate NodePorts (only for LoadBalancers).
     # allocateLoadBalancerNodePorts: false
+    ## Set LoadBalancer class (only for LoadBalancers).
+    # loadBalancerClass: ""
 
   resources:
     requests:

--- a/releasenotes/notes/55406.yaml
+++ b/releasenotes/notes/55406.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue:
+  - 39079
+releaseNotes:
+- |
+  **Added** Support for configuring service `loadBalancerClass` on the Gateway Helm Chart.


### PR DESCRIPTION
Related:
- https://github.com/istio/istio/issues/39079
- https://github.com/istio/istio/issues/48360

**Please provide a description of this PR:**

Allows the loadBalancer class to be set in the Gateway service, when using the Helm chart (feature already present on operator/crd).

The `loadBalancerClass` field has been stable since [Kubernetes 1.24](https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class) and is becoming the only way to control the type of LoadBalancer created since the annotation methods have been deprecated (e.g. AWS EKS Auto mode no longer supports annotations).


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Installation