### PR TITLE
Fix validation for 0s connectionPool.tcp.IdleTimeout

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1109,7 +1109,10 @@ func validateConnectionPool(settings *networking.ConnectionPoolSettings) (errs e
 			errs = appendErrors(errs, agent.ValidateDuration(tcp.MaxConnectionDuration))
 		}
 		if tcp.IdleTimeout != nil {
-			errs = appendErrors(errs, agent.ValidateDuration(tcp.IdleTimeout))
+			// Skip validation if value is 0s since it is a valid input
+			if tcp.IdleTimeout.AsDuration().Milliseconds() != 0 {
+				errs = appendErrors(errs, agent.ValidateDuration(tcp.IdleTimeout))
+			}
 		}
 		if ka := tcp.TcpKeepalive; ka != nil {
 			if ka.Time != nil {

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1109,7 +1109,7 @@ func validateConnectionPool(settings *networking.ConnectionPoolSettings) (errs e
 			errs = appendErrors(errs, agent.ValidateDuration(tcp.MaxConnectionDuration))
 		}
 		if tcp.IdleTimeout != nil {
-			// Skip validation if value is 0s since it is a valid input
+			// Skip validation if the value is 0s, as it indicates that the timeout is disabled entirely.
 			if tcp.IdleTimeout.AsDuration().Milliseconds() != 0 {
 				errs = appendErrors(errs, agent.ValidateDuration(tcp.IdleTimeout))
 			}

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -3175,6 +3175,13 @@ func TestValidateConnectionPool(t *testing.T) {
 		},
 
 		{
+			name: "valid connection pool, tcp timeout disabled", in: &networking.ConnectionPoolSettings{
+				Tcp: &networking.ConnectionPoolSettings_TCPSettings{IdleTimeout: &durationpb.Duration{Seconds: 0}},
+			},
+			valid: true,
+		},
+
+		{
 			name: "invalid connection pool, bad max concurrent streams", in: &networking.ConnectionPoolSettings{
 				Http: &networking.ConnectionPoolSettings_HTTPSettings{MaxConcurrentStreams: -1},
 			},

--- a/releasenotes/notes/55409.yaml
+++ b/releasenotes/notes/55409.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 55409
+releaseNotes:
+- |
+  **Fixed** validation webhook rejecting an otherwise valid connectionPool.tcp.IdleTimeout=0s


### PR DESCRIPTION
Fixes #55409
Regression from #51946

I added a small unit test to prevent regressions in the future