### PR TITLE
waypoints: fix HTTP auto-protocol detection

### DIFF
--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -670,7 +670,7 @@ func (cb *ClusterBuilder) setUpstreamProtocol(cluster *clusterWrapper, port *mod
 	// h2. Clients would then connect with h2, while the upstream may not support it. This is not a
 	// concern for plaintext, but we do not have a way to distinguish https vs http here. If users of
 	// gateway want this behavior, they can configure UseClientProtocol explicitly.
-	if cb.sidecarProxy() && isAutoProtocol {
+	if (cb.sidecarProxy() || cb.proxyType == model.Waypoint) && isAutoProtocol {
 		// Use downstream protocol. If the incoming traffic use HTTP 1.1, the
 		// upstream cluster will use HTTP 1.1, if incoming traffic use HTTP2,
 		// the upstream cluster will use HTTP2.

--- a/pkg/test/echo/server/forwarder/grpc.go
+++ b/pkg/test/echo/server/forwarder/grpc.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"strconv"
 	"strings"
 	"time"
 
@@ -103,15 +102,12 @@ func (c *grpcCall) makeRequest(ctx context.Context, cfg *Config, requestID int) 
 			outMD.Set(k, v...)
 		}
 	}
-	outMD.Set("X-Request-Id", strconv.Itoa(requestID))
 	ctx = metadata.NewOutgoingContext(ctx, outMD)
 
 	var outBuffer bytes.Buffer
 	grpcReq := &proto.EchoRequest{
 		Message: cfg.Request.Message,
 	}
-	// TODO(nmittler): This doesn't fit in with the field pattern. Do we need this?
-	outBuffer.WriteString(fmt.Sprintf("[%d] grpcecho.Echo(%v)\n", requestID, cfg.Request))
 
 	start := time.Now()
 	client := proto.NewEchoTestServiceClient(conn)

--- a/releasenotes/notes/waypoint-auto-http2.yaml
+++ b/releasenotes/notes/waypoint-auto-http2.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed** an issue causing waypoints to downgrade HTTP2 traffic to HTTP/1.1 if the port was not explicitly declared as `http2`.

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -102,36 +102,44 @@ func IsL4() echo.Checker {
 var (
 	httpValidator = check.And(check.OK(), IsL7())
 	tcpValidator  = check.And(check.OK(), IsL4())
-	callOptions   = []echo.CallOptions{
+	basicCalls    = []echo.CallOptions{
 		{
 			Port:   echo.Port{Name: "http"},
 			Scheme: scheme.HTTP,
 			Count:  10, // TODO use more
 		},
-		//{
-		//	Port: echo.Port{Name: "http"},
-		//	Scheme:   scheme.WebSocket,
-		//	Count:    4,
-		//	Timeout:  time.Second * 2,
-		//},
 		{
 			Port:   echo.Port{Name: "tcp"},
 			Scheme: scheme.TCP,
 			Count:  1,
 		},
-		//{
-		//	Port: echo.Port{Name: "grpc"},
-		//	Scheme:   scheme.GRPC,
-		//	Count:    4,
-		//	Timeout:  time.Second * 2,
-		//},
-		//{
-		//	Port: echo.Port{Name: "https"},
-		//	Scheme:   scheme.HTTPS,
-		//	Count:    4,
-		//	Timeout:  time.Second * 2,
-		//},
 	}
+	allCalls = func() (res []echo.CallOptions) {
+		cases := []struct {
+			Port echo.Port
+			HTTP echo.HTTP
+		}{
+			{Port: ports.HTTP},
+			{Port: ports.GRPC},
+			{Port: ports.HTTP2},
+			{Port: ports.TCP},
+			{Port: ports.HTTPS},
+			{Port: ports.TCPServer},
+			{Port: ports.AutoTCP},
+			{Port: ports.AutoHTTP},
+			{Port: ports.AutoHTTP},
+			{Port: ports.AutoGRPC},
+			{Port: ports.AutoHTTPS},
+			{Port: ports.AutoHTTPS},
+			{Port: ports.HTTPInstance},
+			{Port: ports.HTTPLocalHost},
+			{Port: ports.TCPForHTTP},
+		}
+		for _, c := range cases {
+			res = append(res, echo.CallOptions{Port: c.Port})
+		}
+		return
+	}()
 )
 
 func OriginalSourceCheck(t framework.TestContext, src echo.Instance) echo.Checker {
@@ -148,7 +156,14 @@ func OriginalSourceCheck(t framework.TestContext, src echo.Instance) echo.Checke
 func supportsL7(opt echo.CallOptions, src, dst echo.Instance) bool {
 	s := src.Config().HasSidecar()
 	d := dst.Config().HasSidecar() || dst.Config().HasAnyWaypointProxy()
-	isL7Scheme := opt.Scheme == scheme.HTTP || opt.Scheme == scheme.GRPC || opt.Scheme == scheme.WebSocket
+	sch := opt.Scheme
+	if sch == "" {
+		sch, _ = opt.Port.Scheme()
+	}
+	isL7Scheme := sch == scheme.HTTP || sch == scheme.GRPC || sch == scheme.WebSocket
+	if opt.Port.Name == ports.TCPForHTTP.Name {
+		isL7Scheme = false
+	}
 	return (s || d) && isL7Scheme
 }
 
@@ -159,7 +174,7 @@ func hboneClient(instance echo.Instance) bool {
 }
 
 func TestServices(t *testing.T) {
-	runTest(t, func(t framework.TestContext, src echo.Instance, dst echo.Instance, opt echo.CallOptions) {
+	runAllCallsTest(t, func(t framework.TestContext, src echo.Instance, dst echo.Instance, opt echo.CallOptions) {
 		if supportsL7(opt, src, dst) {
 			opt.Check = httpValidator
 		} else {
@@ -204,6 +219,22 @@ func TestServices(t *testing.T) {
 			opt.Check = check.And(opt.Check, check.RequestHeader("X-Envoy-Peer-Metadata", ""))
 		}
 
+		// Applications listening on localhost cannot receive traffic
+		if opt.Port.LocalhostIP {
+			opt.Check = check.Or(check.Error(), check.Status(503))
+		}
+
+		if dst.Config().HasServiceAddressedWaypointProxy() && opt.Port.ServerFirst {
+			// This is a testing gap, not a functional gap. Server first protocols only work for service-only waypoints.
+			// We use a single waypoint for service+workloads, though, which makes this not work
+			t.Skip("https://github.com/istio/istio/issues/55420")
+		}
+
+		if !src.Config().HasProxyCapabilities() && dst.Config().HasSidecar() && opt.Port.ServerFirst {
+			// This is expected to be broken (src clause is because mTLS makes it work)
+			return
+		}
+
 		// TODO test from all source workloads as well
 		src.CallOrFail(t, opt)
 	})
@@ -221,7 +252,7 @@ func TestPodIP(t *testing.T) {
 								if src.Config().HasSidecar() {
 									t.Skip("not supported yet")
 								}
-								for _, opt := range callOptions {
+								for _, opt := range basicCalls {
 									opt := opt.DeepCopy()
 									selfSend := dstWl.Address() == srcWl.Address()
 									if supportsL7(opt, src, dst) {
@@ -2398,7 +2429,7 @@ func RunReachability(testCases []reachability.TestCase, t framework.TestContext)
 			t.NewSubTestf("from %v", src.Config().Service).RunParallel(func(t framework.TestContext) {
 				for _, dst := range svcs {
 					t.NewSubTestf("to %v", dst.Config().Service).RunParallel(func(t framework.TestContext) {
-						for _, opt := range callOptions {
+						for _, opt := range basicCalls {
 							t.NewSubTestf("%v", opt.Scheme).RunParallel(func(t framework.TestContext) {
 								opt := opt.DeepCopy()
 								opt.To = dst
@@ -2566,9 +2597,9 @@ var CheckDeny = check.Or(
 )
 
 // runTest runs a given function against every src/dst pair
-func runTest(t *testing.T, f func(t framework.TestContext, src echo.Instance, dst echo.Instance, opt echo.CallOptions)) {
+func runAllCallsTest(t *testing.T, f func(t framework.TestContext, src echo.Instance, dst echo.Instance, opt echo.CallOptions)) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
-		runTestContext(t, f)
+		runAllTests(t, f)
 	})
 }
 
@@ -2591,13 +2622,25 @@ func runTestToServiceWaypoint(t framework.TestContext, f func(t framework.TestCo
 }
 
 func runTestContext(t framework.TestContext, f func(t framework.TestContext, src echo.Instance, dst echo.Instance, opt echo.CallOptions)) {
+	runTestContextForCalls(t, basicCalls, f)
+}
+
+func runAllTests(t framework.TestContext, f func(t framework.TestContext, src echo.Instance, dst echo.Instance, opt echo.CallOptions)) {
+	runTestContextForCalls(t, allCalls, f)
+}
+
+func runTestContextForCalls(
+	t framework.TestContext,
+	callOptions []echo.CallOptions,
+	f func(t framework.TestContext, src echo.Instance, dst echo.Instance, opt echo.CallOptions),
+) {
 	svcs := apps.All
 	for _, src := range svcs {
 		t.NewSubTestf("from %v", src.Config().Service).Run(func(t framework.TestContext) {
 			for _, dst := range svcs {
 				t.NewSubTestf("to %v", dst.Config().Service).Run(func(t framework.TestContext) {
 					for _, opt := range callOptions {
-						t.NewSubTestf("%v", opt.Scheme).Run(func(t framework.TestContext) {
+						t.NewSubTestf("%v", opt.Port.Name).Run(func(t framework.TestContext) {
 							opt := opt.DeepCopy()
 							opt.To = dst
 							opt.Check = check.OK()

--- a/tests/integration/ambient/waypoint_test.go
+++ b/tests/integration/ambient/waypoint_test.go
@@ -645,7 +645,7 @@ spec:
 		t.NewSubTest("sidecar-service").Run(func(t framework.TestContext) {
 			for _, src := range apps.Sidecar {
 				for _, dst := range apps.ServiceAddressedWaypoint {
-					for _, opt := range callOptions {
+					for _, opt := range basicCalls {
 						t.NewSubTestf("%v", opt.Scheme).Run(func(t framework.TestContext) {
 							opt = opt.DeepCopy()
 							opt.To = dst
@@ -661,7 +661,7 @@ spec:
 			for _, src := range apps.Sidecar {
 				for _, dst := range apps.WorkloadAddressedWaypoint {
 					for _, dstWl := range dst.WorkloadsOrFail(t) {
-						for _, opt := range callOptions {
+						for _, opt := range basicCalls {
 							t.NewSubTestf("%v-%v", opt.Scheme, dstWl.Address()).Run(func(t framework.TestContext) {
 								opt = opt.DeepCopy()
 								opt.Address = dstWl.Address()


### PR DESCRIPTION
A simple fix - we meant to skip this for gateways, but accidentally skip
this for waypoints, too. The end result is for `auto` protocol we get no
config, which envoy treats as HTTP1.

The rest is all to test this properly. We had a pretty limited set of
protocol tests (due to some being commented out...) so I expanded those.

Shoutout to @kflynn for finding this.
