### PR TITLE
[release-1.24] Adapt telemetry api "registry-redirector" tests to Openshift (#54348)

### DIFF
--- a/tests/integration/telemetry/api/customize_metrics_test.go
+++ b/tests/integration/telemetry/api/customize_metrics_test.go
@@ -111,7 +111,19 @@ spec:
 }
 
 func setupWasmExtension(t framework.TestContext) {
-	attrGenImageURL := fmt.Sprintf("oci://%v/istio-testing/wasm/attributegen:0.0.1", registry.Address())
+	isKind, err := IsKindCluster()
+	if err != nil {
+		t.Errorf("failed to identify cluster type: %v", err)
+	}
+
+	// By default, for any platform, the test will pull the test image from public "gcr.io" registry.
+	// For "Kind" environment, it will pull the images from the "kind-registry".
+	// For "Kind", this is due to DNS issues in IPv6 cluster
+	attrGenImageTag := "359dcd3a19f109c50e97517fe6b1e2676e870c4d"
+	if isKind {
+		attrGenImageTag = "0.0.1"
+	}
+	attrGenImageURL := fmt.Sprintf("oci://%v/istio-testing/wasm/attributegen:%v", registry.Address(), attrGenImageTag)
 	args := map[string]any{
 		"AttributeGenURL": attrGenImageURL,
 	}

--- a/tests/integration/telemetry/api/registry_setup_test.go
+++ b/tests/integration/telemetry/api/registry_setup_test.go
@@ -34,11 +34,25 @@ const (
 )
 
 func testRegistrySetup(ctx resource.Context) (err error) {
-	registry, err = registryredirector.New(ctx, registryredirector.Config{
-		Cluster:        ctx.AllClusters().Default(),
-		TargetRegistry: "kind-registry:5000",
-		Scheme:         "http",
-	})
+	var config registryredirector.Config
+
+	isKind, err := IsKindCluster()
+	if err != nil {
+		return
+	}
+
+	// By default, for any platform, the test will pull the test image from public "gcr.io" registry.
+	// For "Kind" environment, it will pull the images from the "kind-registry".
+	// For "Kind", this is due to DNS issues in IPv6 cluster
+	if isKind {
+		config = registryredirector.Config{
+			Cluster:        ctx.AllClusters().Default(),
+			TargetRegistry: "kind-registry:5000",
+			Scheme:         "http",
+		}
+	}
+
+	registry, err = registryredirector.New(ctx, config)
 	if err != nil {
 		return
 	}

--- a/tests/integration/telemetry/api/setup_test.go
+++ b/tests/integration/telemetry/api/setup_test.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"testing"
 
+	"k8s.io/client-go/tools/clientcmd"
+
 	"istio.io/api/annotation"
 	"istio.io/istio/pkg/test/echo/common"
 	"istio.io/istio/pkg/test/framework"
@@ -150,4 +152,16 @@ proxyMetadata:
 		return err
 	}
 	return nil
+}
+
+// The function validates if the cluster is a "Kind" cluster,
+// By looking into a context name. Expects "kind-" prefix.
+// That is required by some tests for specific actions on "Kind".
+func IsKindCluster() (bool, error) {
+	config, err := clientcmd.LoadFromFile(clientcmd.RecommendedHomeFile)
+	if err != nil {
+		return false, err
+	}
+	currentContext := config.CurrentContext
+	return currentContext == "kind-kind" || len(currentContext) > 5 && currentContext[:5] == "kind-", nil
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
This is a cherry-pick of the following PR - https://github.com/istio/istio/pull/54348

Make the telemetry api "registry-redirector" tests agnostic to any platform, including Openshift.
Kind environment require to keep the images in "kind-registry" to avoid DNS issues in IPv6.

For that add "IsKindCluster" function to identify if the cluster is "Kind" based. If so, apply the "kind-registry" config.