### PR TITLE
krt: various improvements split out

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -664,8 +664,8 @@ type (
 	LookupNetworkGateways func() []model.NetworkGateway
 )
 
-func PushXds[T any](xds model.XDSUpdater, f func(T) model.ConfigKey) func(events []krt.Event[T], initialSync bool) {
-	return func(events []krt.Event[T], initialSync bool) {
+func PushXds[T any](xds model.XDSUpdater, f func(T) model.ConfigKey) func(events []krt.Event[T]) {
+	return func(events []krt.Event[T]) {
 		cu := sets.New[model.ConfigKey]()
 		for _, e := range events {
 			for _, i := range e.Items() {
@@ -686,8 +686,8 @@ func PushXds[T any](xds model.XDSUpdater, f func(T) model.ConfigKey) func(events
 	}
 }
 
-func PushXdsAddress[T any](xds model.XDSUpdater, f func(T) string) func(events []krt.Event[T], initialSync bool) {
-	return func(events []krt.Event[T], initialSync bool) {
+func PushXdsAddress[T any](xds model.XDSUpdater, f func(T) string) func(events []krt.Event[T]) {
+	return func(events []krt.Event[T]) {
 		au := sets.New[string]()
 		for _, e := range events {
 			for _, i := range e.Items() {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/statusqueue/queue.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/statusqueue/queue.go
@@ -157,7 +157,7 @@ func Register[T StatusWriter](q *StatusQueue, name string, col krt.Collection[T]
 			}
 		},
 		start: func() {
-			col.RegisterBatch(func(events []krt.Event[T], initialSync bool) {
+			col.RegisterBatch(func(events []krt.Event[T]) {
 				if !q.statusEnabled.CurrentlyActive() {
 					return
 				}

--- a/pkg/config/mesh/meshwatcher/mesh.go
+++ b/pkg/config/mesh/meshwatcher/mesh.go
@@ -54,7 +54,7 @@ func (a adapter) Mesh() *meshconfig.MeshConfig {
 // The returned WatcherHandlerRegistration can be used to un-register the handler at a later time.
 func (a adapter) AddMeshHandler(h func()) *mesh.WatcherHandlerRegistration {
 	// Do not run initial state to match existing semantics
-	colReg := a.Singleton.AsCollection().RegisterBatch(func(o []krt.Event[MeshConfigResource], initialSync bool) {
+	colReg := a.Singleton.AsCollection().RegisterBatch(func(o []krt.Event[MeshConfigResource]) {
 		h()
 	}, false)
 	reg := mesh.NewWatcherHandlerRegistration(func() {

--- a/pkg/config/mesh/meshwatcher/networks.go
+++ b/pkg/config/mesh/meshwatcher/networks.go
@@ -31,7 +31,7 @@ func (n networksAdapter) Networks() *meshconfig.MeshNetworks {
 
 // AddNetworksHandler registers a callback handler for changes to the networks config.
 func (n networksAdapter) AddNetworksHandler(h func()) *mesh.WatcherHandlerRegistration {
-	colReg := n.Singleton.AsCollection().RegisterBatch(func(o []krt.Event[MeshNetworksResource], initialSync bool) {
+	colReg := n.Singleton.AsCollection().RegisterBatch(func(o []krt.Event[MeshNetworksResource]) {
 		h()
 	}, false)
 

--- a/pkg/kube/krt/collection_test.go
+++ b/pkg/kube/krt/collection_test.go
@@ -253,7 +253,9 @@ func TestCollectionHandlerSync(t *testing.T) {
 	pods := krt.NewInformer[*corev1.Pod](c, opts.WithName("Pods")...)
 	SimplePods := SimplePodCollection(pods, opts)
 	gotEvent := atomic.NewBool(false)
-	reg := SimplePods.Register(func(o krt.Event[SimplePod]) {
+	var reg krt.HandlerRegistration
+	reg = SimplePods.Register(func(o krt.Event[SimplePod]) {
+		assert.Equal(t, reg.HasSynced(), false)
 		gotEvent.Store(true)
 	})
 	c.RunAndWait(stop)

--- a/pkg/kube/krt/collection_test.go
+++ b/pkg/kube/krt/collection_test.go
@@ -237,6 +237,31 @@ func TestCollectionInitialState(t *testing.T) {
 	assert.Equal(t, fetcherSorted(SimpleEndpoints)(), []SimpleEndpoint{{"pod", "svc", "namespace", "1.2.3.4"}})
 }
 
+func TestCollectionHandlerSync(t *testing.T) {
+	stop := test.NewStop(t)
+	opts := testOptions(t)
+	c := kube.NewFakeClient(
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod",
+				Namespace: "namespace",
+				Labels:    map[string]string{"app": "foo"},
+			},
+			Status: corev1.PodStatus{PodIP: "1.2.3.4"},
+		},
+	)
+	pods := krt.NewInformer[*corev1.Pod](c, opts.WithName("Pods")...)
+	SimplePods := SimplePodCollection(pods, opts)
+	gotEvent := atomic.NewBool(false)
+	reg := SimplePods.Register(func(o krt.Event[SimplePod]) {
+		gotEvent.Store(true)
+	})
+	c.RunAndWait(stop)
+	reg.WaitUntilSynced(stop)
+	// reg synced means the event handler was call, so this must be true immediately.
+	assert.Equal(t, gotEvent.Load(), true)
+}
+
 func TestCollectionMerged(t *testing.T) {
 	stop := test.NewStop(t)
 	opts := testOptions(t)

--- a/pkg/kube/krt/conformance_test.go
+++ b/pkg/kube/krt/conformance_test.go
@@ -113,15 +113,15 @@ func TestConformance(t *testing.T) {
 		runConformance[*corev1.ConfigMap](t, rig)
 	})
 	t.Run("static list", func(t *testing.T) {
-		col := krt.NewStaticCollection[Named](nil, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler))
+		col := krt.NewStaticCollection[Named](nil, nil, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler))
 		rig := &staticRig{
 			StaticCollection: col,
 		}
 		runConformance[Named](t, rig)
 	})
 	t.Run("join", func(t *testing.T) {
-		col1 := krt.NewStaticCollection[Named](nil, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler))
-		col2 := krt.NewStaticCollection[Named](nil, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler))
+		col1 := krt.NewStaticCollection[Named](nil, nil, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler))
+		col2 := krt.NewStaticCollection[Named](nil, nil, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler))
 		j := krt.JoinCollection[Named]([]krt.Collection[Named]{col1, col2}, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler))
 		rig := &joinRig{
 			Collection: j,
@@ -130,8 +130,8 @@ func TestConformance(t *testing.T) {
 		runConformance[Named](t, rig)
 	})
 	t.Run("manyCollection", func(t *testing.T) {
-		namespaces := krt.NewStaticCollection[string](nil, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler))
-		names := krt.NewStaticCollection[string](nil, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler))
+		namespaces := krt.NewStaticCollection[string](nil, nil, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler))
+		names := krt.NewStaticCollection[string](nil, nil, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler))
 		col := krt.NewManyCollection(namespaces, func(ctx krt.HandlerContext, ns string) []Named {
 			names := krt.Fetch[string](ctx, names)
 			return slices.Map(names, func(e string) Named {

--- a/pkg/kube/krt/core.go
+++ b/pkg/kube/krt/core.go
@@ -62,7 +62,7 @@ type EventStream[T any] interface {
 	// Additionally, skipping the default behavior of "send all current state through the handler" can be turned off.
 	// This is important when we register in a handler itself, which would cause duplicative events.
 	// Handlers MUST not mutate the event list.
-	RegisterBatch(f func(o []Event[T], initialSync bool), runExistingState bool) HandlerRegistration
+	RegisterBatch(f func(o []Event[T]), runExistingState bool) HandlerRegistration
 }
 
 // internalCollection is a superset of Collection for internal usage. All collections must implement this type, but

--- a/pkg/kube/krt/fetch.go
+++ b/pkg/kube/krt/fetch.go
@@ -30,8 +30,18 @@ func FetchOne[T any](ctx HandlerContext, c Collection[T], opts ...FetchOption) *
 	}
 }
 
+// FetchOrList runs a query against the provided collection and subscribes to updates if ctx is set.
+// If unset, this will just be a one time list operation.
+func FetchOrList[T any](ctx HandlerContext, cc Collection[T], opts ...FetchOption) []T {
+	return fetch[T](ctx, cc, true, opts...)
+}
+
+// Fetch runs a query against the provided collection and subscribes to updates.
 func Fetch[T any](ctx HandlerContext, cc Collection[T], opts ...FetchOption) []T {
-	h := ctx.(registerDependency)
+	return fetch[T](ctx, cc, false, opts...)
+}
+
+func fetch[T any](ctx HandlerContext, cc Collection[T], allowMissingContext bool, opts ...FetchOption) []T {
 	c := cc.(internalCollection[T])
 	d := &dependency{
 		id:             c.uid(),
@@ -41,15 +51,22 @@ func Fetch[T any](ctx HandlerContext, cc Collection[T], opts ...FetchOption) []T
 	for _, o := range opts {
 		o(d)
 	}
-	// Important: register before we List(), so we cannot miss any events
-	h.registerDependency(d, c, func(f erasedEventHandler) Syncer {
-		ff := func(o []Event[T], initialSync bool) {
-			f(slices.Map(o, castEvent[T, any]), initialSync)
-		}
-		// Skip calling all the existing state for secondary dependencies, otherwise we end up with a deadlock due to
-		// rerunning the same collection's recomputation at the same time (once for the initial event, then for the initial registration).
-		return c.RegisterBatch(ff, false)
-	})
+	var parent string
+	if ctx != nil {
+		h := ctx.(registerDependency)
+		// Important: register before we List(), so we cannot miss any events
+		h.registerDependency(d, c, func(f erasedEventHandler) Syncer {
+			ff := func(o []Event[T]) {
+				f(slices.Map(o, castEvent[T, any]))
+			}
+			// Skip calling all the existing state for secondary dependencies, otherwise we end up with a deadlock due to
+			// rerunning the same collection's recomputation at the same time (once for the initial event, then for the initial registration).
+			return c.RegisterBatch(ff, false)
+		})
+		parent = h.name()
+	} else if !allowMissingContext {
+		panic("Fetch() requires a valid context")
+	}
 
 	// Now we can do the real fetching
 	// Compute our list of all possible objects that can match. Then we will filter them later.
@@ -76,7 +93,7 @@ func Fetch[T any](ctx HandlerContext, cc Collection[T], opts ...FetchOption) []T
 	})
 	if log.DebugEnabled() {
 		log.WithLabels(
-			"parent", h.name(),
+			"parent", parent,
 			"fetch", c.name(),
 			"filter", d.filter,
 			"size", len(list),

--- a/pkg/kube/krt/helpers.go
+++ b/pkg/kube/krt/helpers.go
@@ -49,6 +49,10 @@ func GetKey[O any](a O) string {
 	if ok {
 		return keyFunc(ac.Name, ac.Namespace)
 	}
+	acp, ok := any(a).(*config.Config)
+	if ok {
+		return keyFunc(acp.Name, acp.Namespace)
+	}
 	arn, ok := any(a).(ResourceNamer)
 	if ok {
 		return arn.ResourceName()

--- a/pkg/kube/krt/index.go
+++ b/pkg/kube/krt/index.go
@@ -173,15 +173,15 @@ func (i indexCollection[K, O]) HasSynced() bool {
 }
 
 func (i indexCollection[K, O]) Register(f func(o Event[IndexObject[K, O]])) HandlerRegistration {
-	return i.RegisterBatch(func(events []Event[IndexObject[K, O]], initialSync bool) {
+	return i.RegisterBatch(func(events []Event[IndexObject[K, O]]) {
 		for _, o := range events {
 			f(o)
 		}
 	}, true)
 }
 
-func (i indexCollection[K, O]) RegisterBatch(f func(o []Event[IndexObject[K, O]], initialSync bool), runExistingState bool) HandlerRegistration {
-	return i.idx.c.RegisterBatch(func(o []Event[O], initialSync bool) {
+func (i indexCollection[K, O]) RegisterBatch(f func(o []Event[IndexObject[K, O]]), runExistingState bool) HandlerRegistration {
+	return i.idx.c.RegisterBatch(func(o []Event[O]) {
 		allKeys := sets.New[K]()
 		for _, ev := range o {
 			if ev.Old != nil {
@@ -210,6 +210,6 @@ func (i indexCollection[K, O]) RegisterBatch(f func(o []Event[IndexObject[K, O]]
 				})
 			}
 		}
-		f(downstream, initialSync)
+		f(downstream)
 	}, runExistingState)
 }

--- a/pkg/kube/krt/informer.go
+++ b/pkg/kube/krt/informer.go
@@ -107,13 +107,13 @@ func (i *informer[I]) Register(f func(o Event[I])) HandlerRegistration {
 	return registerHandlerAsBatched[I](i, f)
 }
 
-func (i *informer[I]) RegisterBatch(f func(o []Event[I], initialSync bool), runExistingState bool) HandlerRegistration {
+func (i *informer[I]) RegisterBatch(f func(o []Event[I]), runExistingState bool) HandlerRegistration {
 	// Note: runExistingState is NOT respected here.
 	// Informer doesn't expose a way to do that. However, due to the runtime model of informers, this isn't a dealbreaker;
 	// the handlers are all called async, so we don't end up with the same deadlocks we would have in the other collection types.
 	// While this is quite kludgy, this is an internal interface so its not too bad.
 	synced := i.inf.AddEventHandler(informerEventHandler[I](func(o Event[I], initialSync bool) {
-		f([]Event[I]{o}, initialSync)
+		f([]Event[I]{o})
 	}))
 	base := i.baseSyncer
 	handler := pollSyncer{

--- a/pkg/kube/krt/internal.go
+++ b/pkg/kube/krt/internal.go
@@ -58,6 +58,9 @@ func buildCollectionOptions(opts ...CollectionOption) collectionOptions {
 	for _, o := range opts {
 		o(c)
 	}
+	if c.stop == nil {
+		c.stop = make(chan struct{})
+	}
 	return *c
 }
 

--- a/pkg/kube/krt/internal.go
+++ b/pkg/kube/krt/internal.go
@@ -30,7 +30,7 @@ import (
 // registerHandlerAsBatched is a helper to register the provided handler as a batched handler. This allows collections to
 // only implement RegisterBatch.
 func registerHandlerAsBatched[T any](c internalCollection[T], f func(o Event[T])) HandlerRegistration {
-	return c.RegisterBatch(func(events []Event[T], initialSync bool) {
+	return c.RegisterBatch(func(events []Event[T]) {
 		for _, o := range events {
 			f(o)
 		}
@@ -58,9 +58,6 @@ func buildCollectionOptions(opts ...CollectionOption) collectionOptions {
 	for _, o := range opts {
 		o(c)
 	}
-	if c.stop == nil {
-		c.stop = make(chan struct{})
-	}
 	return *c
 }
 
@@ -86,7 +83,7 @@ type dependency struct {
 	filter *filter
 }
 
-type erasedEventHandler = func(o []Event[any], initialSync bool)
+type erasedEventHandler = func(o []Event[any])
 
 // registerDependency is an internal interface for things that can register dependencies.
 // This is called from Fetch to Collections, generally.

--- a/pkg/kube/krt/join.go
+++ b/pkg/kube/krt/join.go
@@ -88,7 +88,7 @@ func (j *join[T]) Register(f func(o Event[T])) HandlerRegistration {
 	return registerHandlerAsBatched[T](j, f)
 }
 
-func (j *join[T]) RegisterBatch(f func(o []Event[T], initialSync bool), runExistingState bool) HandlerRegistration {
+func (j *join[T]) RegisterBatch(f func(o []Event[T]), runExistingState bool) HandlerRegistration {
 	sync := multiSyncer{}
 	removes := []func(){}
 	for _, c := range j.collections {

--- a/pkg/kube/krt/krttest/helpers.go
+++ b/pkg/kube/krt/krttest/helpers.go
@@ -47,7 +47,12 @@ func NewMock(t test.Failer, inputs []any) *MockCollection {
 }
 
 func GetMockCollection[T any](mc *MockCollection) krt.Collection[T] {
-	return krt.NewStaticCollection(extractType[T](&mc.inputs), krt.WithStop(test.NewStop(mc.t)), krt.WithDebugging(krt.GlobalDebugHandler))
+	return krt.NewStaticCollection(
+		nil, // Always synced
+		extractType[T](&mc.inputs),
+		krt.WithStop(test.NewStop(mc.t)),
+		krt.WithDebugging(krt.GlobalDebugHandler),
+	)
 }
 
 func GetMockSingleton[T any](mc *MockCollection) krt.StaticSingleton[T] {

--- a/pkg/kube/krt/processor_test.go
+++ b/pkg/kube/krt/processor_test.go
@@ -1,0 +1,169 @@
+package krt
+
+import (
+	"fmt"
+	"testing"
+
+	"istio.io/istio/pkg/slices"
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/assert"
+)
+
+func TestProcessor(t *testing.T) {
+	t.Run("initial sync without initial events", func(t *testing.T) {
+		hs := newHandlerSet[Named]()
+		tracker := assert.NewTracker[string](t)
+		handler := BatchedTrackerHandler[Named](tracker)
+		stop := test.NewStop(t)
+		reg := hs.Insert(handler, alwaysSynced{}, nil, stop)
+		assert.Equal(t, reg.HasSynced(), true)
+		tracker.Empty()
+	})
+	t.Run("initial un-sync without initial events", func(t *testing.T) {
+		ready := make(chan struct{})
+		sync := channelSyncer{synced: ready}
+		hs := newHandlerSet[Named]()
+		tracker := assert.NewTracker[string](t)
+		handler := BatchedTrackerHandler[Named](tracker)
+		stop := test.NewStop(t)
+		reg := hs.Insert(handler, sync, nil, stop)
+		assert.Equal(t, reg.HasSynced(), false)
+		close(ready)
+		assert.EventuallyEqual(t, reg.HasSynced, true)
+		tracker.Empty()
+	})
+	t.Run("initial un-sync without initial events then more events", func(t *testing.T) {
+		ready := make(chan struct{})
+		sync := channelSyncer{synced: ready}
+		hs := newHandlerSet[Named]()
+		tracker := assert.NewTracker[string](t)
+		allowEvent := make(chan struct{})
+		handler := BlockingBatchedTrackerHandler[Named](allowEvent, tracker)
+		stop := test.NewStop(t)
+		reg := hs.Insert(handler, sync, nil, stop)
+		assert.Equal(t, reg.HasSynced(), false)
+
+		// Send some events. They are blocked
+		hs.Distribute([]Event[Named]{{New: &Named{Name: "a"}}}, true)
+		hs.Distribute([]Event[Named]{{New: &Named{Name: "b"}}}, true)
+		// Tracker should be empty since they are blocked
+		tracker.Empty()
+
+		// Parent ready; we are still not ready!
+		close(ready)
+		assert.Equal(t, reg.HasSynced(), false)
+
+		allowEvent <- struct{}{}
+		tracker.WaitOrdered("add//a")
+		allowEvent <- struct{}{}
+		tracker.WaitOrdered("add//b")
+		assert.EventuallyEqual(t, reg.HasSynced, true)
+	})
+	t.Run("initial un-sync with initial events then more events", func(t *testing.T) {
+		ready := make(chan struct{})
+		sync := channelSyncer{synced: ready}
+		hs := newHandlerSet[Named]()
+		tracker := assert.NewTracker[string](t)
+		allowEvent := make(chan struct{})
+		handler := BlockingBatchedTrackerHandler[Named](allowEvent, tracker)
+		stop := test.NewStop(t)
+		reg := hs.Insert(handler, sync, []Event[Named]{{New: &Named{Name: "init"}}}, stop)
+		assert.Equal(t, reg.HasSynced(), false)
+
+		// Send some events. They are blocked
+		hs.Distribute([]Event[Named]{{New: &Named{Name: "a"}}}, true)
+		hs.Distribute([]Event[Named]{{New: &Named{Name: "b"}}}, true)
+		// Tracker should be empty since they are blocked
+		tracker.Empty()
+
+		// Parent ready; we are still not ready!
+		close(ready)
+		assert.Equal(t, reg.HasSynced(), false)
+
+		allowEvent <- struct{}{}
+		tracker.WaitOrdered("add//init")
+		assert.Equal(t, reg.HasSynced(), false)
+		allowEvent <- struct{}{}
+		tracker.WaitOrdered("add//a")
+		allowEvent <- struct{}{}
+		tracker.WaitOrdered("add//b")
+		assert.EventuallyEqual(t, reg.HasSynced, true)
+	})
+	t.Run("initial un-sync with initial events then continually more events", func(t *testing.T) {
+		ready := make(chan struct{})
+		sync := channelSyncer{synced: ready}
+		hs := newHandlerSet[Named]()
+		tracker := assert.NewTracker[string](t)
+		allowEvent := make(chan struct{})
+		handler := BlockingBatchedTrackerHandler[Named](allowEvent, tracker)
+		stop := test.NewStop(t)
+		reg := hs.Insert(handler, sync, []Event[Named]{{New: &Named{Name: "init"}}}, stop)
+		assert.Equal(t, reg.HasSynced(), false)
+
+		// Send some events. They are blocked
+		hs.Distribute([]Event[Named]{{New: &Named{Name: "a"}}}, true)
+		hs.Distribute([]Event[Named]{{New: &Named{Name: "b"}}}, true)
+		// Tracker should be empty since they are blocked
+		tracker.Empty()
+
+		// Parent ready; we are still not ready!
+		close(ready)
+		assert.Equal(t, reg.HasSynced(), false)
+		hs.Distribute([]Event[Named]{{New: &Named{Name: "after"}}}, false)
+
+		allowEvent <- struct{}{}
+		tracker.WaitOrdered("add//init")
+		assert.Equal(t, reg.HasSynced(), false)
+		allowEvent <- struct{}{}
+		tracker.WaitOrdered("add//a")
+		allowEvent <- struct{}{}
+		tracker.WaitOrdered("add//b")
+		// We should be marked synced now, event though we haven't processed 'after'
+		assert.EventuallyEqual(t, reg.HasSynced, true)
+		allowEvent <- struct{}{}
+		tracker.WaitOrdered("add//after")
+	})
+	t.Run("initial sync with initial events then more events", func(t *testing.T) {
+		hs := newHandlerSet[Named]()
+		tracker := assert.NewTracker[string](t)
+		allowEvent := make(chan struct{})
+		handler := BlockingBatchedTrackerHandler[Named](allowEvent, tracker)
+		stop := test.NewStop(t)
+		reg := hs.Insert(handler, alwaysSynced{}, []Event[Named]{{New: &Named{Name: "init"}}}, stop)
+		assert.Equal(t, reg.HasSynced(), false)
+
+		// Send some events. They are blocked
+		hs.Distribute([]Event[Named]{{New: &Named{Name: "a"}}}, false)
+		hs.Distribute([]Event[Named]{{New: &Named{Name: "b"}}}, false)
+		// Tracker should be empty since they are blocked
+		tracker.Empty()
+		// We are not ready even though parent is synced since we haven't handled
+		assert.Equal(t, reg.HasSynced(), false)
+
+		allowEvent <- struct{}{}
+		tracker.WaitOrdered("add//init")
+		assert.EventuallyEqual(t, reg.HasSynced, true)
+		allowEvent <- struct{}{}
+		tracker.WaitOrdered("add//a")
+		allowEvent <- struct{}{}
+		tracker.WaitOrdered("add//b")
+		assert.EventuallyEqual(t, reg.HasSynced, true)
+	})
+}
+
+func BlockingBatchedTrackerHandler[T any](allowEvents chan struct{}, tracker *assert.Tracker[string]) func([]Event[T]) {
+	return func(o []Event[T]) {
+		<-allowEvents
+		tracker.Record(slices.Join(",", slices.Map(o, func(o Event[T]) string {
+			return fmt.Sprintf("%v/%v", o.Event, GetKey(o.Latest()))
+		})...))
+	}
+}
+
+func BatchedTrackerHandler[T any](tracker *assert.Tracker[string]) func([]Event[T]) {
+	return func(o []Event[T]) {
+		tracker.Record(slices.Join(",", slices.Map(o, func(o Event[T]) string {
+			return fmt.Sprintf("%v/%v", o.Event, GetKey(o.Latest()))
+		})...))
+	}
+}

--- a/pkg/kube/krt/processor_test.go
+++ b/pkg/kube/krt/processor_test.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package krt
 
 import (

--- a/pkg/kube/krt/singleton.go
+++ b/pkg/kube/krt/singleton.go
@@ -88,7 +88,7 @@ func (d *static[T]) Register(f func(o Event[T])) HandlerRegistration {
 	return registerHandlerAsBatched[T](d, f)
 }
 
-func (d *static[T]) RegisterBatch(f func(o []Event[T], initialSync bool), runExistingState bool) HandlerRegistration {
+func (d *static[T]) RegisterBatch(f func(o []Event[T]), runExistingState bool) HandlerRegistration {
 	reg := d.eventHandlers.Insert(f)
 	if runExistingState {
 		v := d.val.Load()
@@ -96,7 +96,7 @@ func (d *static[T]) RegisterBatch(f func(o []Event[T], initialSync bool), runExi
 			f([]Event[T]{{
 				New:   v,
 				Event: controllers.EventAdd,
-			}}, true)
+			}})
 		}
 	}
 
@@ -137,7 +137,7 @@ func (d *static[T]) Set(now *T) {
 		return
 	}
 	for _, h := range d.eventHandlers.Get() {
-		h([]Event[T]{toEvent[T](old, now)}, false)
+		h([]Event[T]{toEvent[T](old, now)})
 	}
 }
 

--- a/pkg/kube/krt/singleton_test.go
+++ b/pkg/kube/krt/singleton_test.go
@@ -94,8 +94,8 @@ func TrackerHandler[T any](tracker *assert.Tracker[string]) func(krt.Event[T]) {
 	}
 }
 
-func BatchedTrackerHandler[T any](tracker *assert.Tracker[string]) func([]krt.Event[T], bool) {
-	return func(o []krt.Event[T], initialSync bool) {
+func BatchedTrackerHandler[T any](tracker *assert.Tracker[string]) func([]krt.Event[T]) {
+	return func(o []krt.Event[T]) {
 		tracker.Record(slices.Join(",", slices.Map(o, func(o krt.Event[T]) string {
 			return fmt.Sprintf("%v/%v", o.Event, krt.GetKey(o.Latest()))
 		})...))

--- a/pkg/kube/krt/static_test.go
+++ b/pkg/kube/krt/static_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestStaticCollection(t *testing.T) {
 	opts := testOptions(t)
-	c := krt.NewStaticCollection[Named]([]Named{{"ns", "a"}}, opts.WithName("c")...)
+	c := krt.NewStaticCollection[Named](nil, []Named{{"ns", "a"}}, opts.WithName("c")...)
 	assert.Equal(t, c.Synced().HasSynced(), true, "should start synced")
 	assert.Equal(t, c.List(), []Named{{"ns", "a"}})
 

--- a/pkg/kube/krt/util.go
+++ b/pkg/kube/krt/util.go
@@ -22,8 +22,8 @@ import (
 // For instance, I can make a transformation from `object => object.name` to only trigger events for changes to the name;
 // the output will be compared (using standard equality checking), and only changes will trigger the handler.
 // Note this is in addition to the normal event mechanics, so this can only filter things further.
-func BatchedEventFilter[I, O any](cf func(a I) O, handler func(events []Event[I], initialSync bool)) func(o []Event[I], initialSync bool) {
-	return func(events []Event[I], initialSync bool) {
+func BatchedEventFilter[I, O any](cf func(a I) O, handler func(events []Event[I])) func(o []Event[I]) {
+	return func(events []Event[I]) {
 		ev := slices.Filter(events, func(e Event[I]) bool {
 			if e.Old != nil && e.New != nil {
 				if equal(cf(*e.Old), cf(*e.New)) {
@@ -36,6 +36,6 @@ func BatchedEventFilter[I, O any](cf func(a I) O, handler func(events []Event[I]
 		if len(ev) == 0 {
 			return
 		}
-		handler(ev, initialSync)
+		handler(ev)
 	}
 }


### PR DESCRIPTION
1. Drop the 'initial sync' arg to handlers. This was added in
   https://github.com/istio/istio/pull/49843 to fix a bug that doesn't
exist anymore (due to the queue we added a while back), makes things
more complex, isn't tested, isn't used, and doesn't work properly.
2. Fix a bug where event handlers could be marked as synced before
   the processed all events. Many tests addeed to cover these cases.
3. Fixed a bug in the status controller (which is not used today, yet)
   that doesn't properly handle syncing at all.
  3a. Allow static collection to be marked as synced after startup,
instead of assuming it starts synced. This is to help implement the fix.
This is useful in general IMO.
4. Add a new `RecomputeProtected`. This is a wrapper around data that
   ensures any access is properly marked as dependant.
