### PR TITLE
Drop spammy env var

### DIFF
--- a/Makefile.overrides.mk
+++ b/Makefile.overrides.mk
@@ -21,8 +21,6 @@
 BUILD_WITH_CONTAINER ?= 1
 CONTAINER_OPTIONS = --mount type=bind,source=/tmp,destination=/tmp --net=host
 
-OVERCOVER_BIN ?= $(shell which overcover || echo "")
-
 export COMMONFILES_POSTPROCESS = tools/commonfiles-postprocess.sh
 
 ifeq ($(BUILD_WITH_CONTAINER),1)


### PR DESCRIPTION
This spams `which: no overcover in` about 100 times when you run any
command. Also, it serves no purpose.
