### PR TITLE
conradhanson/bug fix route status parentref reporting

### DIFF
--- a/pilot/pkg/config/kube/gateway/conditions.go
+++ b/pilot/pkg/config/kube/gateway/conditions.go
@@ -73,59 +73,59 @@ func createRouteStatus(parentResults []RouteParentResult, obj config.Config, cur
 			seenReasons.Insert(ParentNoError)
 		}
 	}
-	reasonRanking := []ParentErrorReason{
-		// No errors is preferred
-		ParentNoError,
-		// All route level errors
-		ParentErrorNotAllowed,
-		ParentErrorNoHostname,
-		ParentErrorParentRefConflict,
-		// Failures to match the Port or SectionName. These are last so that if we bind to 1 listener we
-		// just report errors for that 1 listener instead of for all sections we didn't bind to
-		ParentErrorNotAccepted,
+
+	const (
+		rankParentNoErrors = iota
+		rankParentErrorNotAllowed
+		rankParentErrorNoHostname
+		rankParentErrorParentRefConflict
+		rankParentErrorNotAccepted
+	)
+
+	rankParentError := func(result RouteParentResult) int {
+		if result.DeniedReason == nil {
+			return rankParentNoErrors
+		}
+		switch result.DeniedReason.Reason {
+		case ParentErrorNotAllowed:
+			return rankParentErrorNotAllowed
+		case ParentErrorNoHostname:
+			return rankParentErrorNoHostname
+		case ParentErrorParentRefConflict:
+			return rankParentErrorParentRefConflict
+		case ParentErrorNotAccepted:
+			return rankParentErrorNotAccepted
+		}
+		return rankParentNoErrors
 	}
+
 	// Next we want to collapse these. We need to report 1 type of error, or none.
 	report := map[k8s.ParentReference]RouteParentResult{}
-	for _, wantReason := range reasonRanking {
-		if !seenReasons.Contains(wantReason) {
+	for ref, results := range seen {
+		if len(results) == 0 {
 			continue
 		}
-		// We found our highest priority ranking, now we need to collapse this into a single message
-		for k, refs := range seen {
-			// can report and continue early if only single result for parentRef.
-			// this ensures that we do not skip a parentRef when there is only one result.
-			if len(refs) == 1 {
-				report[k] = refs[0]
-				continue
-			}
-			// otherwise, we need to collapse the results into a single message
-			for _, ref := range refs {
-				reason := ParentNoError
-				if ref.DeniedReason != nil {
-					reason = ref.DeniedReason.Reason
-				}
-				if wantReason != reason {
-					// Skip this one, it is for a less relevant reason
-					continue
-				}
-				exist, f := report[k]
-				if f {
-					if ref.DeniedReason != nil {
-						if exist.DeniedReason != nil {
-							// join the error
-							exist.DeniedReason.Message += "; " + ref.DeniedReason.Message
-						} else {
-							exist.DeniedReason = ref.DeniedReason
-						}
-					}
+
+		toReport := results[0]
+		mostSevereRankSeen := rankParentError(toReport)
+
+		for _, result := range results[1:] {
+			resultRank := rankParentError(result)
+			// lower number means more severe
+			if resultRank < mostSevereRankSeen {
+				mostSevereRankSeen = resultRank
+				toReport = result
+			} else if resultRank == mostSevereRankSeen {
+				// join the error messages
+				if toReport.DeniedReason == nil {
+					toReport.DeniedReason = result.DeniedReason
 				} else {
-					exist = ref
+					toReport.DeniedReason.Message += "; " + result.DeniedReason.Message
 				}
-				report[k] = exist
 			}
 		}
-		// Once we find the best reason, do not consider any others
-		break
+
+		report[ref] = toReport
 	}
 
 	// Now we fill in all the parents we do own

--- a/pilot/pkg/config/kube/gateway/conditions.go
+++ b/pilot/pkg/config/kube/gateway/conditions.go
@@ -92,6 +92,13 @@ func createRouteStatus(parentResults []RouteParentResult, obj config.Config, cur
 		}
 		// We found our highest priority ranking, now we need to collapse this into a single message
 		for k, refs := range seen {
+			// can report and continue early if only single result for parentRef.
+			// this ensures that we do not skip a parentRef when there is only one result.
+			if len(refs) == 1 {
+				report[k] = refs[0]
+				continue
+			}
+			// otherwise, we need to collapse the results into a single message
 			for _, ref := range refs {
 				reason := ParentNoError
 				if ref.DeniedReason != nil {

--- a/pilot/pkg/config/kube/gateway/testdata/route-binding.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/route-binding.status.yaml.golden
@@ -625,6 +625,23 @@ status:
       sectionName: slctr-expr-notin-yes
   - conditions:
     - lastTransitionTime: fake
+      message: hostnames matched parent hostname "*.slctr-expr-notin-no.example",
+        but namespace "group-namespace1" is not allowed by the parent
+      reason: NotAllowedByListeners
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: All references resolved
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: istio.io/gateway-controller
+    parentRef:
+      name: gateway
+      namespace: istio-system
+      sectionName: slctr-expr-notin-no
+  - conditions:
+    - lastTransitionTime: fake
       message: Route was valid
       reason: Accepted
       status: "True"
@@ -639,6 +656,23 @@ status:
       name: gateway
       namespace: istio-system
       sectionName: slctr-expr-in-yes
+  - conditions:
+    - lastTransitionTime: fake
+      message: hostnames matched parent hostname "*.slctr-expr-in-no.example", but
+        namespace "group-namespace1" is not allowed by the parent
+      reason: NotAllowedByListeners
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: All references resolved
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: istio.io/gateway-controller
+    parentRef:
+      name: gateway
+      namespace: istio-system
+      sectionName: slctr-expr-in-no
   - conditions:
     - lastTransitionTime: fake
       message: Route was valid
@@ -657,6 +691,23 @@ status:
       sectionName: slctr-expr-exists-yes
   - conditions:
     - lastTransitionTime: fake
+      message: hostnames matched parent hostname "*.slctr-expr-exists-no.example",
+        but namespace "group-namespace1" is not allowed by the parent
+      reason: NotAllowedByListeners
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: All references resolved
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: istio.io/gateway-controller
+    parentRef:
+      name: gateway
+      namespace: istio-system
+      sectionName: slctr-expr-exists-no
+  - conditions:
+    - lastTransitionTime: fake
       message: Route was valid
       reason: Accepted
       status: "True"
@@ -673,6 +724,23 @@ status:
       sectionName: slctr-expr-dne-yes
   - conditions:
     - lastTransitionTime: fake
+      message: hostnames matched parent hostname "*.slctr-expr-dne-no.example", but
+        namespace "group-namespace1" is not allowed by the parent
+      reason: NotAllowedByListeners
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: All references resolved
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: istio.io/gateway-controller
+    parentRef:
+      name: gateway
+      namespace: istio-system
+      sectionName: slctr-expr-dne-no
+  - conditions:
+    - lastTransitionTime: fake
       message: Route was valid
       reason: Accepted
       status: "True"
@@ -687,6 +755,23 @@ status:
       name: gateway
       namespace: istio-system
       sectionName: slctr-combined-yes
+  - conditions:
+    - lastTransitionTime: fake
+      message: hostnames matched parent hostname "*.slctr-combined-no.example", but
+        namespace "group-namespace1" is not allowed by the parent
+      reason: NotAllowedByListeners
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: All references resolved
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: istio.io/gateway-controller
+    parentRef:
+      name: gateway
+      namespace: istio-system
+      sectionName: slctr-combined-no
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute

--- a/pilot/pkg/config/kube/gateway/testdata/valid-invalid-parent-ref.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/valid-invalid-parent-ref.status.yaml.golden
@@ -92,6 +92,23 @@ status:
       name: egress
   - conditions:
     - lastTransitionTime: fake
+      message: 'parent service: "random" not found'
+      reason: NoMatchingParent
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: All references resolved
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: istio.io/gateway-controller
+    parentRef:
+      group: ""
+      kind: Service
+      name: random
+      namespace: nonexistent
+  - conditions:
+    - lastTransitionTime: fake
       message: Route was valid
       reason: Accepted
       status: "True"
@@ -106,4 +123,20 @@ status:
       name: gateway
       namespace: istio-system
       port: 80
+  - conditions:
+    - lastTransitionTime: fake
+      message: port 1234 not found
+      reason: NoMatchingParent
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: All references resolved
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: istio.io/gateway-controller
+    parentRef:
+      name: gateway
+      namespace: istio-system
+      port: 1234
 ---

--- a/releasenotes/notes/fix-httproute-status-parentref-single-result.yaml
+++ b/releasenotes/notes/fix-httproute-status-parentref-single-result.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+- |
+  **Fixed** an issue where HTTPRoute status was not reporting a parentRef associated with a single result 
+  due to complex logic for collapsing parentRefs of the same reference but different sectionNames.


### PR DESCRIPTION
**Please provide a description of this PR:**

This is a follow-up to https://github.com/istio/istio/pull/55381 and fixes a bug in our Route status logic where a parentRef that only has a single result could potentially be dropped due to complex code that collapses parentRefs of the same ref but different sectionNames. Now the unit test results from the linked PR shows the correct status parent entries. 