### PR TITLE
fix waypoint-for and rev labels cannot be generated simultaneously by istioctl waypoint

### DIFF
--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -107,7 +107,11 @@ func Cmd(ctx cli.Context) *cobra.Command {
 		}
 
 		if revision != "" {
-			gw.Labels = map[string]string{label.IoIstioRev.Name: revision}
+			if gw.Labels == nil {
+				gw.Labels = map[string]string{}
+			}
+
+			gw.Labels[label.IoIstioRev.Name] = revision
 		}
 		return &gw, nil
 	}

--- a/releasenotes/notes/55465.yaml
+++ b/releasenotes/notes/55465.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+issue:
+- 55437
+releaseNotes:
+- |
+  **Fixed** `istio.io/waypoint-for` and `istio.io/rev` labels cannot be generated simultaneously when creating Waypoint Proxy with istioctl.


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix `istio.io/waypoint-for` and `istio.io/rev` labels cannot be generated simultaneously when creating Waypoint Proxy with istioctl.

Fix https://github.com/istio/istio/issues/55437

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
