### PR TITLE
Check for reachable ingress in TestGatewayAPI security test (#55028)

### DIFF
--- a/pkg/test/framework/components/istio/ingress.go
+++ b/pkg/test/framework/components/istio/ingress.go
@@ -34,6 +34,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/istio/ingress"
 	"istio.io/istio/pkg/test/framework/resource"
+	testKube "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/test/util/retry"
 )
@@ -233,6 +234,13 @@ func (c *ingressImpl) callEcho(opts echo.CallOptions) (echo.CallResult, error) {
 	}
 	addr = addrs[0]
 	port = ports[0]
+
+	// When the Ingress is a domain name (in public cloud), it might take a bit of time to make it reachable.
+	_, err := testKube.WaitUntilReachableIngress(addr)
+	if err != nil {
+		return echo.CallResult{}, fmt.Errorf("unable to get reachable ingress. Error: %v", err)
+	}
+
 	// Even if they set ServicePort, when load balancer is disabled, we may need to switch to NodePort, so replace it.
 	opts.Port.ServicePort = port
 	if opts.HTTP.Headers == nil {


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR cherry-picks the following change - https://github.com/istio/istio/pull/55028

While executing the TestGatewayAPIRequestAuthentication and TestGatewayAPIAuthorizationPolicy tests on a cluster that runs on a public cloud, the tests fail.

When the Ingress is a domain name, like in public cloud, it might take a bit for the DNS name to become populated.
Set a check to wait for the domain name to become resolvable.