### PR TITLE
optimize: avoid updating service targets when it's not really necessary

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -43,6 +43,7 @@ import (
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/mesh/meshwatcher"
 	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/maps"
 	pm "istio.io/istio/pkg/model"
 	"istio.io/istio/pkg/monitoring"
@@ -552,6 +553,17 @@ func (node *Proxy) SetGatewaysForProxy(ps *PushContext) {
 		ContainsAutoPassthroughGateways: prevMergedGateway.ContainsAutoPassthroughGateways,
 		AutoPassthroughSNIHosts:         prevMergedGateway.GetAutoPassthroughGatewaySNIHosts(),
 	}
+}
+
+func (node *Proxy) ShouldUpdateServiceTargets(updates sets.Set[ConfigKey]) bool {
+	// we only care for services which can actually select this proxy
+	for config := range updates {
+		if config.Kind == kind.ServiceEntry || config.Namespace == node.Metadata.Namespace {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (node *Proxy) SetServiceTargets(serviceDiscovery ServiceDiscovery) {

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -387,7 +387,7 @@ func (s *DiscoveryServer) computeProxyState(proxy *model.Proxy, request *model.P
 	// 1. If request == nil(initiation phase) or request.ConfigsUpdated == nil(global push), set proxy serviceTargets.
 	// 2. otherwise only set when svc update, this is for the case that a service may select the proxy
 	if request == nil || len(request.ConfigsUpdated) == 0 ||
-		model.HasConfigsOfKind(request.ConfigsUpdated, kind.ServiceEntry) {
+		proxy.ShouldUpdateServiceTargets(request.ConfigsUpdated) {
 		proxy.SetServiceTargets(s.Env.ServiceDiscovery)
 		// proxy.SetGatewaysForProxy depends on the serviceTargets,
 		// so when we reset serviceTargets, should reset gateway as well.


### PR DESCRIPTION
**Please provide a description of this PR:**
Currently we check if any `ServiceEntry` has been updated, but in reality we're only interested in `ServiceEntry` which can actually select this proxy, this means in the same namespace.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [x] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
