### PR TITLE
optimize: add concept of Forced PushRequest

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -153,6 +153,7 @@ func (s *Server) initK8SConfigStore(args *PilotArgs) error {
 		s.XDSServer.ConfigUpdate(&model.PushRequest{
 			Full:   true,
 			Reason: model.NewReasonStats(model.TagUpdate),
+			Forced: true,
 		})
 	})
 	if features.EnableGatewayAPI {
@@ -174,6 +175,7 @@ func (s *Server) initK8SConfigStore(args *PilotArgs) error {
 					s.XDSServer.ConfigUpdate(&model.PushRequest{
 						Full:   true,
 						Reason: model.NewReasonStats(model.GlobalUpdate),
+						Forced: true,
 					})
 					<-leaderStop
 					log.Infof("Stopping gateway status writer")

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -530,8 +530,7 @@ func (s *Server) initSDSServer() {
 			s.XDSServer.ConfigUpdate(&model.PushRequest{
 				Full:           false,
 				ConfigsUpdated: sets.New(model.ConfigKey{Kind: kind.Secret, Name: name, Namespace: namespace}),
-
-				Reason: model.NewReasonStats(model.SecretTrigger),
+				Reason:         model.NewReasonStats(model.SecretTrigger),
 			})
 		})
 		s.environment.CredentialsController = creds
@@ -927,6 +926,7 @@ func (s *Server) initRegistryEventHandlers() {
 				s.XDSServer.ConfigUpdate(&model.PushRequest{
 					Full:   true,
 					Reason: model.NewReasonStats(model.NamespaceUpdate),
+					Forced: true,
 				})
 			})
 			s.environment.GatewayAPIController.RegisterEventHandler(gvk.Secret, func(_ config.Config, gw config.Config, _ model.Event) {
@@ -1289,6 +1289,7 @@ func (s *Server) initMeshHandlers(changeHandler func(_ *meshconfig.MeshConfig)) 
 		s.XDSServer.ConfigUpdate(&model.PushRequest{
 			Full:   true,
 			Reason: model.NewReasonStats(model.GlobalUpdate),
+			Forced: true,
 		})
 	})
 }
@@ -1322,6 +1323,7 @@ func (s *Server) initWorkloadTrustBundle(args *PilotArgs) error {
 		pushReq := &model.PushRequest{
 			Full:   true,
 			Reason: model.NewReasonStats(model.GlobalUpdate),
+			Forced: true,
 		}
 		s.XDSServer.ConfigUpdate(pushReq)
 	})

--- a/pilot/pkg/config/kube/gateway/controller_test.go
+++ b/pilot/pkg/config/kube/gateway/controller_test.go
@@ -157,6 +157,7 @@ func TestNamespaceEvent(t *testing.T) {
 		s.ConfigUpdate(&model.PushRequest{
 			Full:   true,
 			Reason: model.NewReasonStats(model.NamespaceUpdate),
+			Forced: true,
 		})
 	})
 

--- a/pilot/pkg/model/network.go
+++ b/pilot/pkg/model/network.go
@@ -128,7 +128,7 @@ func (mgr *NetworkManager) reloadGateways() {
 
 	if changed && mgr.xdsUpdater != nil {
 		log.Infof("gateways changed, triggering push")
-		mgr.xdsUpdater.ConfigUpdate(&PushRequest{Full: true, Reason: NewReasonStats(NetworksTrigger)})
+		mgr.xdsUpdater.ConfigUpdate(&PushRequest{Full: true, Reason: NewReasonStats(NetworksTrigger), Forced: true})
 	}
 }
 

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -390,6 +390,9 @@ type PushRequest struct {
 	// Delta defines the resources that were added or removed as part of this push request.
 	// This is set only on requests from the client which change the set of resources they (un)subscribe from.
 	Delta ResourceDelta
+
+	// Forced defines that configs should be generated and pushed regardless if they have changed or not.
+	Forced bool
 }
 
 type ResourceDelta = xds.ResourceDelta
@@ -506,17 +509,18 @@ func (pr *PushRequest) Merge(other *PushRequest) *PushRequest {
 	// If either is full we need a full push
 	pr.Full = pr.Full || other.Full
 
+	// If either is forced we need a forced push
+	pr.Forced = pr.Forced || other.Forced
+
 	// The other push context is presumed to be later and more up to date
 	if other.Push != nil {
 		pr.Push = other.Push
 	}
-	// Do not merge when any one is empty
-	if len(pr.ConfigsUpdated) == 0 || len(other.ConfigsUpdated) == 0 {
-		pr.ConfigsUpdated = nil
+
+	if pr.ConfigsUpdated == nil {
+		pr.ConfigsUpdated = other.ConfigsUpdated
 	} else {
-		for conf := range other.ConfigsUpdated {
-			pr.ConfigsUpdated.Insert(conf)
-		}
+		pr.ConfigsUpdated.Merge(other.ConfigsUpdated)
 	}
 
 	if pr.AddressesUpdated == nil {
@@ -552,6 +556,9 @@ func (pr *PushRequest) CopyMerge(other *PushRequest) *PushRequest {
 		// If either is full we need a full push
 		Full: pr.Full || other.Full,
 
+		// If either is forced we need a forced push
+		Forced: pr.Forced || other.Forced,
+
 		// The other push context is presumed to be later and more up to date
 		Push: other.Push,
 
@@ -559,8 +566,9 @@ func (pr *PushRequest) CopyMerge(other *PushRequest) *PushRequest {
 		Reason: reason,
 	}
 
-	// Do not merge when any one is empty
-	if len(pr.ConfigsUpdated) > 0 && len(other.ConfigsUpdated) > 0 {
+	if pr.ConfigsUpdated == nil && other.ConfigsUpdated == nil {
+		merged.ConfigsUpdated = nil
+	} else {
 		merged.ConfigsUpdated = make(sets.Set[ConfigKey], len(pr.ConfigsUpdated)+len(other.ConfigsUpdated))
 		merged.ConfigsUpdated.Merge(pr.ConfigsUpdated)
 		merged.ConfigsUpdated.Merge(other.ConfigsUpdated)
@@ -1330,7 +1338,7 @@ func (ps *PushContext) InitContext(env *Environment, oldPushContext *PushContext
 	ps.initDefaultExportMaps()
 
 	// create new or incremental update
-	if pushReq == nil || oldPushContext == nil || !oldPushContext.InitDone.Load() || len(pushReq.ConfigsUpdated) == 0 {
+	if pushReq == nil || oldPushContext == nil || !oldPushContext.InitDone.Load() || pushReq.Forced {
 		ps.createNewContext(env)
 	} else {
 		ps.updateContext(env, oldPushContext, pushReq)

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -75,14 +75,14 @@ func TestMergeUpdateRequest(t *testing.T) {
 		{
 			"left nil",
 			nil,
-			&PushRequest{Full: true},
-			PushRequest{Full: true},
+			&PushRequest{Full: true, Forced: true},
+			PushRequest{Full: true, Forced: true},
 		},
 		{
 			"right nil",
-			&PushRequest{Full: true},
+			&PushRequest{Full: true, Forced: true},
 			nil,
-			PushRequest{Full: true},
+			PushRequest{Full: true, Forced: true},
 		},
 		{
 			"simple merge",
@@ -94,6 +94,7 @@ func TestMergeUpdateRequest(t *testing.T) {
 					{Kind: kind.Kind(1), Namespace: "ns1"}: {},
 				},
 				Reason: NewReasonStats(ServiceUpdate, ServiceUpdate),
+				Forced: true,
 			},
 			&PushRequest{
 				Full:  false,
@@ -103,6 +104,7 @@ func TestMergeUpdateRequest(t *testing.T) {
 					{Kind: kind.Kind(2), Namespace: "ns2"}: {},
 				},
 				Reason: NewReasonStats(EndpointUpdate),
+				Forced: false,
 			},
 			PushRequest{
 				Full:  true,
@@ -113,15 +115,18 @@ func TestMergeUpdateRequest(t *testing.T) {
 					{Kind: kind.Kind(2), Namespace: "ns2"}: {},
 				},
 				Reason: NewReasonStats(ServiceUpdate, ServiceUpdate, EndpointUpdate),
+				Forced: true,
 			},
 		},
 		{
 			"skip config type merge: one empty",
-			&PushRequest{Full: true, ConfigsUpdated: nil},
+			&PushRequest{Full: true, ConfigsUpdated: nil, Forced: true},
 			&PushRequest{Full: true, ConfigsUpdated: sets.Set[ConfigKey]{{
 				Kind: kind.Kind(2),
 			}: {}}},
-			PushRequest{Full: true, ConfigsUpdated: nil, Reason: nil},
+			PushRequest{Full: true, ConfigsUpdated: sets.Set[ConfigKey]{{
+				Kind: kind.Kind(2),
+			}: {}}, Reason: nil, Forced: true},
 		},
 	}
 

--- a/pilot/pkg/networking/core/cluster.go
+++ b/pilot/pkg/networking/core/cluster.go
@@ -282,7 +282,7 @@ func (configgen *ConfigGeneratorImpl) buildClusters(proxy *model.Proxy, req *mod
 }
 
 func shouldUseDelta(updates *model.PushRequest) bool {
-	return updates != nil && deltaAwareConfigTypes(updates.ConfigsUpdated) && len(updates.ConfigsUpdated) > 0
+	return updates != nil && !updates.Forced && deltaAwareConfigTypes(updates.ConfigsUpdated)
 }
 
 // deltaAwareConfigTypes returns true if all updated configs are delta enabled.

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -421,7 +421,7 @@ func (c *Controller) deleteService(svc *model.Service) {
 		c.NotifyGatewayHandlers()
 		// TODO trigger push via handler
 		// networks are different, we need to update all eds endpoints
-		c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{Full: true, Reason: model.NewReasonStats(model.NetworksTrigger)})
+		c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{Full: true, Reason: model.NewReasonStats(model.NetworksTrigger), Forced: true})
 	}
 
 	shard := model.ShardKeyFromRegistry(c)
@@ -493,7 +493,7 @@ func (c *Controller) addOrUpdateService(pre, curr *v1.Service, currConv *model.S
 	// as that full push is only triggered for the specific service.
 	if needsFullPush {
 		// networks are different, we need to update all eds endpoints
-		c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{Full: true, Reason: model.NewReasonStats(model.NetworksTrigger)})
+		c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{Full: true, Reason: model.NewReasonStats(model.NetworksTrigger), Forced: true})
 	}
 
 	shard := model.ShardKeyFromRegistry(c)
@@ -559,6 +559,7 @@ func (c *Controller) onNodeEvent(_, node *v1.Node, event model.Event) error {
 		c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{
 			Full:   true,
 			Reason: model.NewReasonStats(model.ServiceUpdate),
+			Forced: true,
 		})
 	}
 	return nil

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -63,7 +63,7 @@ func (k *kubeController) Close() {
 		log.Warnf("failed cleaning up services in %s: %v", clusterID, err)
 	}
 	if k.opts.XDSUpdater != nil {
-		k.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{Full: true, Reason: model.NewReasonStats(model.ClusterUpdate)})
+		k.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{Full: true, Reason: model.NewReasonStats(model.ClusterUpdate), Forced: true})
 	}
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/network.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network.go
@@ -155,7 +155,7 @@ func (c *Controller) onNetworkChange() {
 		log.Errorf("one or more errors force-syncing endpoints: %v", err)
 	}
 	if c.reloadNetworkGateways() {
-		c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{Full: true, Reason: model.NewReasonStats(model.NetworksTrigger)})
+		c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{Full: true, Reason: model.NewReasonStats(model.NetworksTrigger), Forced: true})
 	}
 	c.NotifyGatewayHandlers()
 }

--- a/pilot/pkg/serviceregistry/kube/controller/serviceimportcache.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceimportcache.go
@@ -215,8 +215,7 @@ func (ic *serviceImportCacheImpl) doFullPush(mcsHost host.Name, ns string) {
 	pushReq := &model.PushRequest{
 		Full:           true,
 		ConfigsUpdated: sets.New(model.ConfigKey{Kind: kind.ServiceEntry, Name: mcsHost.String(), Namespace: ns}),
-
-		Reason: model.NewReasonStats(model.ServiceUpdate),
+		Reason:         model.NewReasonStats(model.ServiceUpdate),
 	}
 	ic.opts.XDSUpdater.ConfigUpdate(pushReq)
 }

--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -345,11 +345,15 @@ func (s *Controller) workloadEntryHandler(old, curr config.Config, event model.E
 	// update eds cache only
 	s.edsUpdate(allInstances, false)
 
+	// TODO: if len(configsUpdated) == 0 we're firing a Forced push for compatibility because no configs have been updated,
+	// we should actually skip the push.
 	pushReq := &model.PushRequest{
 		Full:           true,
 		ConfigsUpdated: configsUpdated,
 		Reason:         model.NewReasonStats(model.EndpointUpdate),
+		Forced:         len(configsUpdated) == 0,
 	}
+
 	// trigger a full push
 	s.XdsUpdater.ConfigUpdate(pushReq)
 }
@@ -484,10 +488,13 @@ func (s *Controller) serviceEntryHandler(old, curr config.Config, event model.Ev
 
 	s.queueEdsEvent(keys, false)
 
+	// TODO: if len(configsUpdated) == 0 we're firing a Forced push for compatibility because no configs have been updated,
+	// we should actually skip the push.
 	pushReq := &model.PushRequest{
 		Full:           true,
 		ConfigsUpdated: configsUpdated,
 		Reason:         model.NewReasonStats(model.ServiceUpdate),
+		Forced:         len(configsUpdated) == 0,
 	}
 	s.XdsUpdater.ConfigUpdate(pushReq)
 }
@@ -626,10 +633,13 @@ func (s *Controller) WorkloadInstanceHandler(wi *model.WorkloadInstance, event m
 	if fullPush {
 		log.Debugf("Full push triggered during event %s for workload instance (%s/%v) in namespace %s", event,
 			wi.Kind, wi.Endpoint.Addresses, wi.Namespace)
+		// TODO: if len(configsUpdated) == 0 we're firing a Forced push for compatibility because no configs have been updated,
+		// we should actually skip the push.
 		pushReq := &model.PushRequest{
 			Full:           true,
 			ConfigsUpdated: configsUpdated,
 			Reason:         model.NewReasonStats(model.EndpointUpdate),
+			Forced:         len(configsUpdated) == 0,
 		}
 		s.XdsUpdater.ConfigUpdate(pushReq)
 	}

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -148,7 +148,7 @@ func (s *DiscoveryServer) processRequest(req *discovery.DiscoveryRequest, con *C
 	if strings.HasPrefix(req.TypeUrl, v3.DebugType) {
 		return s.pushXds(con,
 			&model.WatchedResource{TypeUrl: req.TypeUrl, ResourceNames: sets.New(req.ResourceNames...)},
-			&model.PushRequest{Full: true, Push: con.proxy.LastPushContext})
+			&model.PushRequest{Full: true, Push: con.proxy.LastPushContext, Forced: true})
 	}
 
 	shouldRespond, delta := xds.ShouldRespond(con.proxy, con.ID(), req)
@@ -164,8 +164,9 @@ func (s *DiscoveryServer) processRequest(req *discovery.DiscoveryRequest, con *C
 		// The usage of LastPushTime (rather than time.Now()), is critical here for correctness; This time
 		// is used by the XDS cache to determine if a entry is stale. If we use Now() with an old push context,
 		// we may end up overriding active cache entries with stale ones.
-		Start: con.proxy.LastPushTime,
-		Delta: delta,
+		Start:  con.proxy.LastPushTime,
+		Delta:  delta,
+		Forced: true,
 	}
 
 	// SidecarScope for the proxy may not have been updated based on this pushContext.
@@ -386,7 +387,7 @@ func (s *DiscoveryServer) computeProxyState(proxy *model.Proxy, request *model.P
 	var shouldResetGateway, shouldResetSidecarScope bool
 	// 1. If request == nil(initiation phase) or request.ConfigsUpdated == nil(global push), set proxy serviceTargets.
 	// 2. otherwise only set when svc update, this is for the case that a service may select the proxy
-	if request == nil || len(request.ConfigsUpdated) == 0 ||
+	if request == nil || request.Forced ||
 		proxy.ShouldUpdateServiceTargets(request.ConfigsUpdated) {
 		proxy.SetServiceTargets(s.Env.ServiceDiscovery)
 		// proxy.SetGatewaysForProxy depends on the serviceTargets,
@@ -411,7 +412,7 @@ func (s *DiscoveryServer) computeProxyState(proxy *model.Proxy, request *model.P
 		shouldResetSidecarScope = true
 	} else {
 		push = request.Push
-		if len(request.ConfigsUpdated) == 0 {
+		if request.Forced {
 			shouldResetSidecarScope = true
 		}
 		for conf := range request.ConfigsUpdated {
@@ -540,6 +541,7 @@ func (s *DiscoveryServer) ProxyUpdate(clusterID cluster.ID, ip string) {
 		Push:   s.globalPushContext(),
 		Start:  time.Now(),
 		Reason: model.NewReasonStats(model.ProxyUpdate),
+		Forced: true,
 	})
 }
 
@@ -550,6 +552,7 @@ func AdsPushAll(s *DiscoveryServer) {
 		Full:   true,
 		Push:   s.globalPushContext(),
 		Reason: model.NewReasonStats(model.DebugTrigger),
+		Forced: true,
 	})
 }
 

--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -76,7 +76,7 @@ func TestAdsReconnectRequests(t *testing.T) {
 	eres := ads.RequestResponseAck(t, &discovery.DiscoveryRequest{TypeUrl: v3.EndpointType, ResourceNames: []string{"my-resource"}})
 
 	// A push should get a response for both
-	s.Discovery.ConfigUpdate(&model.PushRequest{Full: true})
+	s.Discovery.ConfigUpdate(&model.PushRequest{Full: true, Forced: true})
 	ads.ExpectResponse(t)
 	ads.ExpectResponse(t)
 	// Close the connection and reconnect
@@ -781,7 +781,7 @@ func TestAdsUpdate(t *testing.T) {
 			Namespace: "default",
 		},
 	})
-	s.Discovery.ConfigUpdate(&model.PushRequest{Full: true})
+	s.Discovery.ConfigUpdate(&model.PushRequest{Full: true, Forced: true})
 	time.Sleep(time.Millisecond * 200)
 	s.MemRegistry.SetEndpoints("adsupdate.default.svc.cluster.local", "default",
 		newEndpointWithAccount("10.2.0.1", "hello-sa", "v1"))
@@ -976,6 +976,6 @@ func TestPushQueueLeak(t *testing.T) {
 	for _, c := range ds.Discovery.AllClients() {
 		leak.MustGarbageCollect(t, c)
 	}
-	ds.Discovery.AdsPushAll(&model.PushRequest{Push: ds.PushContext()})
+	ds.Discovery.AdsPushAll(&model.PushRequest{Push: ds.PushContext(), Forced: true})
 	p.Cleanup()
 }

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -262,6 +262,7 @@ var wdsCases = []ConfigInput{
 		KubernetesClient: true,
 		PushRequest: &model.PushRequest{
 			Reason: model.NewReasonStats(model.ProxyRequest),
+			Forced: true,
 		},
 	},
 }
@@ -391,7 +392,7 @@ func testBenchmark(t *testing.T, tpe string, testCases []ConfigInput) {
 func runBenchmarkCase(t testing.TB, tt ConfigInput, tpe string, n int, reset func()) model.Resources {
 	s, proxy := setupAndInitializeTest(t, tt)
 	wr := getWatchedResources(tpe, tt, s, proxy)
-	pr := &model.PushRequest{Full: true, Push: s.PushContext()}
+	pr := &model.PushRequest{Full: true, Push: s.PushContext(), Forced: true}
 	if tt.PushRequest != nil {
 		// Some types get watched resources populated on the first run. So generate with a full push first
 		_, _, _ = s.Discovery.Generators[tpe].Generate(proxy, wr, pr)

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -601,7 +601,7 @@ func (s *DiscoveryServer) getResourceTypes(req *http.Request) []string {
 func (s *DiscoveryServer) getConfigDumpByResourceType(conn *Connection, req *model.PushRequest, ts []string) map[string][]*discoveryv3.Resource {
 	dumps := make(map[string][]*discoveryv3.Resource)
 	if req == nil {
-		req = &model.PushRequest{Push: conn.proxy.LastPushContext, Start: time.Now(), Full: true}
+		req = &model.PushRequest{Push: conn.proxy.LastPushContext, Start: time.Now(), Full: true, Forced: true}
 	}
 
 	for _, resourceType := range ts {
@@ -678,7 +678,7 @@ func (s *DiscoveryServer) getConfigDumpByResourceType(conn *Connection, req *mod
 // connectionConfigDump converts the connection internal state into an Envoy Admin API config dump proto
 // It is used in debugging to create a consistent object for comparison between Envoy and Pilot outputs
 func (s *DiscoveryServer) connectionConfigDump(conn *Connection, includeEds bool) (*admin.ConfigDump, error) {
-	req := &model.PushRequest{Push: conn.proxy.LastPushContext, Start: time.Now(), Full: true}
+	req := &model.PushRequest{Push: conn.proxy.LastPushContext, Start: time.Now(), Full: true, Forced: true}
 	version := req.Push.PushVersion
 
 	dump := s.getConfigDumpByResourceType(conn, req, []string{

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -274,7 +274,7 @@ func (s *DiscoveryServer) processDeltaRequest(req *discovery.DeltaDiscoveryReque
 	if strings.HasPrefix(req.TypeUrl, v3.DebugType) {
 		return s.pushDeltaXds(con,
 			&model.WatchedResource{TypeUrl: req.TypeUrl, ResourceNames: sets.New(req.ResourceNamesSubscribe...)},
-			&model.PushRequest{Full: true, Push: con.proxy.LastPushContext})
+			&model.PushRequest{Full: true, Push: con.proxy.LastPushContext, Forced: true})
 	}
 
 	shouldRespond := shouldRespondDelta(con, req)
@@ -297,6 +297,7 @@ func (s *DiscoveryServer) processDeltaRequest(req *discovery.DeltaDiscoveryReque
 			Subscribed:   subs,
 			Unsubscribed: sets.New(req.ResourceNamesUnsubscribe...).Delete("*"),
 		},
+		Forced: true,
 	}
 	// SidecarScope for the proxy may has not been updated based on this pushContext.
 	// It can happen when `processRequest` comes after push context has been updated(s.initPushContext),
@@ -338,6 +339,7 @@ func (s *DiscoveryServer) forceEDSPush(con *Connection) error {
 			Push:   con.proxy.LastPushContext,
 			Reason: model.NewReasonStats(model.DependentResource),
 			Start:  con.proxy.LastPushTime,
+			Forced: true,
 		}
 		deltaLog.Infof("ADS:%s: FORCE %s PUSH for warming.", v3.GetShortType(v3.EndpointType), con.ID())
 		return s.pushDeltaXds(con, dwr, request)

--- a/pilot/pkg/xds/delta_test.go
+++ b/pilot/pkg/xds/delta_test.go
@@ -283,7 +283,7 @@ func TestDeltaReconnectRequests(t *testing.T) {
 	}
 
 	// A push should get a response
-	s.Discovery.ConfigUpdate(&model.PushRequest{Full: true})
+	s.Discovery.ConfigUpdate(&model.PushRequest{Full: true, Forced: true})
 	ads.ExpectResponse()
 
 	// Close the connection

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -182,7 +182,7 @@ func (s *DiscoveryServer) initJwksResolver() {
 
 	// Flush cached discovery responses when detecting jwt public key change.
 	s.JwtKeyResolver.PushFunc = func() {
-		s.ConfigUpdate(&model.PushRequest{Full: true, Reason: model.NewReasonStats(model.UnknownTrigger)})
+		s.ConfigUpdate(&model.PushRequest{Full: true, Reason: model.NewReasonStats(model.UnknownTrigger), Forced: true})
 	}
 }
 
@@ -246,7 +246,7 @@ func (s *DiscoveryServer) periodicRefreshMetrics(stopCh <-chan struct{}) {
 // dropCacheForRequest clears the cache in response to a push request
 func (s *DiscoveryServer) dropCacheForRequest(req *model.PushRequest) {
 	// If we don't know what updated, cannot safely cache. Clear the whole cache
-	if len(req.ConfigsUpdated) == 0 {
+	if req.Forced {
 		s.Cache.ClearAll()
 	} else {
 		// Otherwise, just clear the updated configs

--- a/pilot/pkg/xds/ecds_test.go
+++ b/pilot/pkg/xds/ecds_test.go
@@ -129,7 +129,7 @@ func TestECDSGenerate(t *testing.T) {
 		{
 			name:             "simple",
 			proxyNamespace:   "default",
-			request:          &model.PushRequest{Full: true},
+			request:          &model.PushRequest{Full: true, Forced: true},
 			watchedResources: []string{"extensions.istio.io/wasmplugin/default.default-plugin"},
 			wantExtensions:   sets.String{"extensions.istio.io/wasmplugin/default.default-plugin": {}},
 			wantSecrets:      sets.String{},
@@ -137,7 +137,7 @@ func TestECDSGenerate(t *testing.T) {
 		{
 			name:             "simple_with_secret",
 			proxyNamespace:   "default",
-			request:          &model.PushRequest{Full: true},
+			request:          &model.PushRequest{Full: true, Forced: true},
 			watchedResources: []string{"extensions.istio.io/wasmplugin/default.default-plugin-with-sec"},
 			wantExtensions:   sets.String{"extensions.istio.io/wasmplugin/default.default-plugin-with-sec": {}},
 			wantSecrets:      sets.String{"default-docker-credential": {}},
@@ -145,7 +145,7 @@ func TestECDSGenerate(t *testing.T) {
 		{
 			name:             "miss_secret",
 			proxyNamespace:   "default",
-			request:          &model.PushRequest{Full: true},
+			request:          &model.PushRequest{Full: true, Forced: true},
 			watchedResources: []string{"extensions.istio.io/wasmplugin/default.default-plugin-wrong-sec"},
 			wantExtensions:   sets.String{"extensions.istio.io/wasmplugin/default.default-plugin-wrong-sec": {}},
 			wantSecrets:      sets.String{},
@@ -153,7 +153,7 @@ func TestECDSGenerate(t *testing.T) {
 		{
 			name:             "wrong_secret_type",
 			proxyNamespace:   "default",
-			request:          &model.PushRequest{Full: true},
+			request:          &model.PushRequest{Full: true, Forced: true},
 			watchedResources: []string{"extensions.istio.io/wasmplugin/default.default-plugin-wrong-sec-type"},
 			wantExtensions:   sets.String{"extensions.istio.io/wasmplugin/default.default-plugin-wrong-sec-type": {}},
 			wantSecrets:      sets.String{},
@@ -161,7 +161,7 @@ func TestECDSGenerate(t *testing.T) {
 		{
 			name:           "root_and_default",
 			proxyNamespace: "default",
-			request:        &model.PushRequest{Full: true},
+			request:        &model.PushRequest{Full: true, Forced: true},
 			watchedResources: []string{
 				"extensions.istio.io/wasmplugin/default.default-plugin-with-sec",
 				"extensions.istio.io/wasmplugin/istio-system.root-plugin",
@@ -175,7 +175,7 @@ func TestECDSGenerate(t *testing.T) {
 		{
 			name:             "only_root",
 			proxyNamespace:   "somenamespace",
-			request:          &model.PushRequest{Full: true},
+			request:          &model.PushRequest{Full: true, Forced: true},
 			watchedResources: []string{"extensions.istio.io/wasmplugin/istio-system.root-plugin"},
 			wantExtensions:   sets.String{"extensions.istio.io/wasmplugin/istio-system.root-plugin": {}},
 			wantSecrets:      sets.String{"root-docker-credential": {}},

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -154,7 +154,7 @@ func shouldUseDeltaEds(req *model.PushRequest) bool {
 // This allows us to perform more efficient pushes where we only update the endpoints that did change.
 func canSendPartialFullPushes(req *model.PushRequest) bool {
 	// If we don't know what configs are updated, just send a full push
-	if len(req.ConfigsUpdated) == 0 {
+	if req.Forced {
 		return false
 	}
 	for cfg := range req.ConfigsUpdated {

--- a/pilot/pkg/xds/eds_sh_test.go
+++ b/pilot/pkg/xds/eds_sh_test.go
@@ -77,7 +77,7 @@ func TestSplitHorizonEds(t *testing.T) {
 	initRegistry(s, 4, []string{}, 4)
 
 	// Push contexts needs to be updated
-	s.Discovery.ConfigUpdate(&model.PushRequest{Full: true})
+	s.Discovery.ConfigUpdate(&model.PushRequest{Full: true, Forced: true})
 	time.Sleep(time.Millisecond * 200) // give time for cache to clear
 
 	tests := []struct {

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -72,7 +72,7 @@ func TestIncrementalPush(t *testing.T) {
 	})
 	ads := s.Connect(nil, nil, watchAll)
 	t.Run("Full Push", func(t *testing.T) {
-		s.Discovery.Push(&model.PushRequest{Full: true})
+		s.Discovery.Push(&model.PushRequest{Full: true, Forced: true})
 		if _, err := ads.Wait(time.Second*5, watchAll...); err != nil {
 			t.Fatal(err)
 		}
@@ -763,7 +763,7 @@ func TestDeleteService(t *testing.T) {
 }
 
 func fullPush(s *xdsfake.FakeDiscoveryServer) {
-	s.Discovery.Push(&model.PushRequest{Full: true})
+	s.Discovery.Push(&model.PushRequest{Full: true, Forced: true})
 }
 
 func addTestClientEndpoints(m *memory.ServiceDiscovery) {
@@ -1198,6 +1198,7 @@ func addUdsEndpoint(s *xds.DiscoveryServer, m *memory.ServiceDiscovery) {
 	pushReq := &model.PushRequest{
 		Full:   true,
 		Reason: model.NewReasonStats(model.ConfigUpdate),
+		Forced: true,
 	}
 	s.ConfigUpdate(pushReq)
 }

--- a/pilot/pkg/xds/nds_test.go
+++ b/pilot/pkg/xds/nds_test.go
@@ -127,19 +127,19 @@ func TestGenerate(t *testing.T) {
 		{
 			name:      "partial push with headless endpoint update",
 			proxy:     &model.Proxy{Type: model.SidecarProxy},
-			request:   &model.PushRequest{Reason: model.NewReasonStats(model.HeadlessEndpointUpdate)},
+			request:   &model.PushRequest{Reason: model.NewReasonStats(model.HeadlessEndpointUpdate), Forced: true},
 			nameTable: emptyNameTable,
 		},
 		{
 			name:      "full push",
 			proxy:     &model.Proxy{Type: model.SidecarProxy},
-			request:   &model.PushRequest{Full: true},
+			request:   &model.PushRequest{Full: true, Forced: true},
 			nameTable: emptyNameTable,
 		},
 		{
 			name:      "partial push with no headless endpoint update",
 			proxy:     &model.Proxy{Type: model.SidecarProxy},
-			request:   &model.PushRequest{},
+			request:   &model.PushRequest{Forced: true},
 			nameTable: emptyNameTable,
 		},
 	}

--- a/pilot/pkg/xds/pcds.go
+++ b/pilot/pkg/xds/pcds.go
@@ -44,7 +44,7 @@ func pcdsNeedsPush(req *model.PushRequest) bool {
 		return false
 	}
 
-	if len(req.ConfigsUpdated) == 0 {
+	if req.Forced {
 		// This needs to be better optimized
 		return true
 	}

--- a/pilot/pkg/xds/proxy_dependencies.go
+++ b/pilot/pkg/xds/proxy_dependencies.go
@@ -33,8 +33,7 @@ var UnAffectedConfigKinds = map[model.NodeType]sets.Set[kind.Kind]{
 // ConfigAffectsProxy checks if a pushEv will affect a specified proxy. That means whether the push will be performed
 // towards the proxy.
 func ConfigAffectsProxy(req *model.PushRequest, proxy *model.Proxy) bool {
-	// Empty changes means "all" to get a backward compatibility.
-	if len(req.ConfigsUpdated) == 0 {
+	if req.Forced {
 		return true
 	}
 	if proxy.IsWaypointProxy() || proxy.IsZTunnel() {

--- a/pilot/pkg/xds/sds.go
+++ b/pilot/pkg/xds/sds.go
@@ -71,8 +71,8 @@ func (sr SecretResource) Cacheable() bool {
 	return true
 }
 
-func sdsNeedsPush(updates model.XdsUpdates) bool {
-	if len(updates) == 0 {
+func sdsNeedsPush(forced bool, updates model.XdsUpdates) bool {
+	if forced {
 		return true
 	}
 	for update := range updates {
@@ -112,7 +112,7 @@ func (s *SecretGen) Generate(proxy *model.Proxy, w *model.WatchedResource, req *
 		log.Warnf("proxy %s is not authorized to receive credscontroller. Ensure you are connecting over TLS port and are authenticated.", proxy.ID)
 		return nil, model.DefaultXdsLogDetails, nil
 	}
-	if req == nil || !sdsNeedsPush(req.ConfigsUpdated) {
+	if req == nil || !sdsNeedsPush(req.Forced, req.ConfigsUpdated) {
 		return nil, model.DefaultXdsLogDetails, nil
 	}
 	var updatedSecrets sets.Set[model.ConfigKey]

--- a/pilot/pkg/xds/sds_test.go
+++ b/pilot/pkg/xds/sds_test.go
@@ -123,7 +123,7 @@ func TestGenerateSDS(t *testing.T) {
 			name:      "simple",
 			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, Type: model.Router},
 			resources: []string{"kubernetes://generic"},
-			request:   &model.PushRequest{Full: true},
+			request:   &model.PushRequest{Full: true, Forced: true},
 			expect: map[string]Expected{
 				"kubernetes://generic": {
 					Key:  string(genericCert.Data[credentials.GenericScrtKey]),
@@ -135,7 +135,7 @@ func TestGenerateSDS(t *testing.T) {
 			name:      "sidecar",
 			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}},
 			resources: []string{"kubernetes://generic"},
-			request:   &model.PushRequest{Full: true},
+			request:   &model.PushRequest{Full: true, Forced: true},
 			expect: map[string]Expected{
 				"kubernetes://generic": {
 					Key:  string(genericCert.Data[credentials.GenericScrtKey]),
@@ -147,14 +147,14 @@ func TestGenerateSDS(t *testing.T) {
 			name:      "unauthenticated",
 			proxy:     &model.Proxy{Type: model.Router},
 			resources: []string{"kubernetes://generic"},
-			request:   &model.PushRequest{Full: true},
+			request:   &model.PushRequest{Full: true, Forced: true},
 			expect:    map[string]Expected{},
 		},
 		{
 			name:      "multiple",
 			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, Type: model.Router},
 			resources: allResources,
-			request:   &model.PushRequest{Full: true},
+			request:   &model.PushRequest{Full: true, Forced: true},
 			expect: map[string]Expected{
 				"kubernetes://generic": {
 					Key:  string(genericCert.Data[credentials.GenericScrtKey]),
@@ -300,7 +300,7 @@ func TestGenerateSDS(t *testing.T) {
 			name:      "unknown",
 			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, Type: model.Router},
 			resources: []string{"kubernetes://generic", "foo://invalid", "kubernetes://not-found", "default", "builtin://"},
-			request:   &model.PushRequest{Full: true},
+			request:   &model.PushRequest{Full: true, Forced: true},
 			expect: map[string]Expected{
 				"kubernetes://generic": {
 					Key:  string(genericCert.Data[credentials.GenericScrtKey]),
@@ -313,7 +313,7 @@ func TestGenerateSDS(t *testing.T) {
 			name:      "unauthorized",
 			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, Type: model.Router},
 			resources: []string{"kubernetes://generic"},
-			request:   &model.PushRequest{Full: true},
+			request:   &model.PushRequest{Full: true, Forced: true},
 			// Should get a response, but it will be empty
 			expect: map[string]Expected{},
 			accessReviewResponse: func(action k8stesting.Action) (bool, runtime.Object, error) {
@@ -325,7 +325,7 @@ func TestGenerateSDS(t *testing.T) {
 			name:      "partially unauthorized",
 			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, Type: model.Router},
 			resources: allResources,
-			request:   &model.PushRequest{Full: true},
+			request:   &model.PushRequest{Full: true, Forced: true},
 			// Should get a response, but it will be empty
 			expect: map[string]Expected{
 				"kubernetes://ca-only-cacert": {
@@ -355,7 +355,7 @@ func TestGenerateSDS(t *testing.T) {
 			name:      "tricky cacert name",
 			proxy:     &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"}, Type: model.Router},
 			resources: []string{"kubernetes://tricky-cacert", "kubernetes://tricky-cacert-cacert"},
-			request:   &model.PushRequest{Full: true},
+			request:   &model.PushRequest{Full: true, Forced: true},
 			expect: map[string]Expected{
 				// They should NOT be able to get the private key material
 				"kubernetes://tricky-cacert": {
@@ -434,7 +434,7 @@ func TestCaching(t *testing.T) {
 	})
 	gen := s.Discovery.Generators[v3.SecretType]
 
-	fullPush := &model.PushRequest{Full: true, Start: time.Now()}
+	fullPush := &model.PushRequest{Full: true, Start: time.Now(), Forced: true}
 	istiosystem := &model.Proxy{
 		Metadata:         &model.NodeMetadata{ClusterID: constants.DefaultClusterName},
 		VerifiedIdentity: &spiffe.Identity{Namespace: "istio-system"},
@@ -495,7 +495,7 @@ func TestPrivateKeyProviderProxyConfig(t *testing.T) {
 		},
 	})
 	gen := s.Discovery.Generators[v3.SecretType]
-	fullPush := &model.PushRequest{Full: true, Start: time.Now()}
+	fullPush := &model.PushRequest{Full: true, Start: time.Now(), Forced: true}
 	secrets, _, _ := gen.Generate(s.SetupProxy(rawProxy), &model.WatchedResource{ResourceNames: sets.New("kubernetes://generic")}, fullPush)
 	raw := xdstest.ExtractTLSSecrets(t, xdsserver.ResourcesToAny(secrets))
 	for _, scrt := range raw {

--- a/pilot/pkg/xds/xdsgen.go
+++ b/pilot/pkg/xds/xdsgen.go
@@ -203,7 +203,7 @@ func xdsNeedsPush(req *model.PushRequest, proxy *model.Proxy) (needsPush, defini
 		return true, true
 	}
 	// If none set, we will always push
-	if len(req.ConfigsUpdated) == 0 {
+	if req.Forced {
 		return true, true
 	}
 

--- a/pilot/test/xds/fake.go
+++ b/pilot/test/xds/fake.go
@@ -162,6 +162,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 			s.ConfigUpdate(&model.PushRequest{
 				Full:   true,
 				Reason: model.NewReasonStats(model.NetworksTrigger),
+				Forced: true,
 			})
 		})
 	}
@@ -338,7 +339,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 
 	// Send an update. This ensures that even if there are no configs provided, the push context is
 	// initialized.
-	s.ConfigUpdate(&model.PushRequest{Full: true})
+	s.ConfigUpdate(&model.PushRequest{Full: true, Forced: true})
 
 	// Wait until initial updates are committed
 	c := s.InboundUpdates.Load()


### PR DESCRIPTION
**Please provide a description of this PR:**
Currently, whenever `len(PushRequest.ConfigsUpdated) == 0` a push is forced, this makes things very confusing since we're forcing pushes when configs haven't changed, I understand that this is for legacy reasons, but removing these conditions makes things easier to understand and simplifies some other changes I have planned.

I introduced a `Forced` flag in `PushRequest` that creators use to specify if they require a forced push, regardless of the amount of updated configs. Apparently `serviceEntryHandler`, `workloadEntryHandler` and `WorkloadInstanceHandler` are handlers that can *accidentally* fire `PushRequests` with empty `ConfigsUpdated` instead of just skipping updates.

I still don't full understand why we need to keep this functionallity though, why can't these handlers just skip empty updates? Maybe @howardjohn @ramaraochavali you can help me clarify this?