### PR TITLE
Template ztunnel name for CA_TRUSTED_NODE_ACCOUNTS environment.

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -169,9 +169,10 @@ spec:
           # Also, check for an explicit ENV override (legacy approach) and prefer that
           # if present
           {{ $ztTrustedNS := or .Values.trustedZtunnelNamespace .Release.Namespace }}
+          {{ $ztTrustedName := or .Values.trustedZtunnelName "ztunnel" }}
           {{- if not .Values.env.CA_TRUSTED_NODE_ACCOUNTS }}
           - name: CA_TRUSTED_NODE_ACCOUNTS
-            value: "{{ $ztTrustedNS }}/ztunnel"
+            value: "{{ $ztTrustedNS }}/{{ $ztTrustedName }}"
           {{- end }}
           {{- if .Values.env }}
           {{- range $key, $val := .Values.env }}

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -104,6 +104,8 @@ _internal_defaults_do_not_set:
   # If unset, `istiod` will assume the trusted node proxy ztunnel resides
   # in the same namespace as itself.
   trustedZtunnelNamespace: ""
+  # Set this if you install ztunnel with a name different from the default.
+  trustedZtunnelName: ""
 
   sidecarInjectorWebhook:
     # You can use the field called alwaysInjectSelector and neverInjectSelector which will always inject the sidecar or


### PR DESCRIPTION
References: https://github.com/istio/istio/pull/55360

**Please provide a description of this PR:**
The error occurs when we install ztunnel with a name different from the default.
`identity error: signing gRPC error (The request does not have valid authentication credentials): request authenticate failure`