### PR TITLE
optimize: add missing cluster scoped known config types for sidecar

### DIFF
--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -60,7 +60,9 @@ var (
 		kind.EnvoyFilter,
 		kind.AuthorizationPolicy,
 		kind.RequestAuthentication,
+		kind.PeerAuthentication,
 		kind.WasmPlugin,
+		kind.Telemetry,
 	)
 )
 


### PR DESCRIPTION
**Please provide a description of this PR:**
These seem to have been missed.