### PR TITLE
cni: improve tests a bit

### DIFF
--- a/cni/pkg/nodeagent/cni-watcher_test.go
+++ b/cni/pkg/nodeagent/cni-watcher_test.go
@@ -139,6 +139,9 @@ func TestCNIPluginServer(t *testing.T) {
 	assertPodAnnotated(t, client, pod)
 	// Assert expected calls actually made
 	fs.AssertExpectations(t)
+	// Weird to start at the end of a test, but we want to manually run things in the test, while the actual handlers MUST
+	// be started to avoid leaks
+	handlers.Start()
 }
 
 func TestGetPodWithRetry(t *testing.T) {
@@ -214,6 +217,9 @@ func TestGetPodWithRetry(t *testing.T) {
 		assert.Equal(t, true, strings.Contains(err.Error(), "unexpectedly not eligible for ambient enrollment"))
 		assert.Equal(t, p, nil)
 	})
+	// Weird to start at the end of a test, but we want to manually run things in the test, while the actual handlers MUST
+	// be started to avoid leaks
+	handlers.Start()
 }
 
 func TestCNIPluginServerPrefersCNIProvidedPodIP(t *testing.T) {
@@ -287,4 +293,7 @@ func TestCNIPluginServerPrefersCNIProvidedPodIP(t *testing.T) {
 	assertPodAnnotated(t, client, pod)
 	// Assert expected calls actually made
 	fs.AssertExpectations(t)
+	// Weird to start at the end of a test, but we want to manually run things in the test, while the actual handlers MUST
+	// be started to avoid leaks
+	handlers.Start()
 }

--- a/cni/pkg/nodeagent/informers_test.go
+++ b/cni/pkg/nodeagent/informers_test.go
@@ -841,6 +841,9 @@ func TestInformerGetActiveAmbientPodSnapshotOnlyReturnsActivePods(t *testing.T) 
 	// not pods that are just scheduled to be enrolled.
 	assert.Equal(t, len(pods), 1)
 	assert.Equal(t, pods[0], redirectedNotEnrolled)
+	// Weird to start at the end of a test, but we want to manually run things in the test, while the actual handlers MUST
+	// be started to avoid leaks
+	handlers.Start()
 }
 
 func TestInformerGetActiveAmbientPodSnapshotSkipsTerminatedJobPods(t *testing.T) {
@@ -899,6 +902,9 @@ func TestInformerGetActiveAmbientPodSnapshotSkipsTerminatedJobPods(t *testing.T)
 
 	// Should skip both pods - the one that's labeled but not annotated, and the one that's annotated but terminated.
 	assert.Equal(t, len(pods), 0)
+	// Weird to start at the end of a test, but we want to manually run things in the test, while the actual handlers MUST
+	// be started to avoid leaks
+	handlers.Start()
 }
 
 func TestInformerAmbientEnabledReturnsPodIfEnabled(t *testing.T) {
@@ -939,6 +945,9 @@ func TestInformerAmbientEnabledReturnsPodIfEnabled(t *testing.T) {
 	_, err := handlers.GetPodIfAmbientEnabled(pod.Name, ns.Name)
 
 	assert.NoError(t, err)
+	// Weird to start at the end of a test, but we want to manually run things in the test, while the actual handlers MUST
+	// be started to avoid leaks
+	handlers.Start()
 }
 
 func TestInformerAmbientEnabledReturnsNoPodIfNotEnabled(t *testing.T) {
@@ -1020,6 +1029,9 @@ func TestInformerAmbientEnabledReturnsErrorIfBogusNS(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Equal(t, disabledPod, nil)
+	// Weird to start at the end of a test, but we want to manually run things in the test, while the actual handlers MUST
+	// be started to avoid leaks
+	handlers.Start()
 }
 
 func TestInformerExistingPodAddedWhenItPreExists(t *testing.T) {

--- a/cni/pkg/nodeagent/leak_test.go
+++ b/cni/pkg/nodeagent/leak_test.go
@@ -1,0 +1,26 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodeagent
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util/leak"
+)
+
+func TestMain(m *testing.M) {
+	// CheckMain asserts that no goroutines are leaked after a test package exits.
+	leak.CheckMain(m)
+}


### PR DESCRIPTION
* Allow concurrent runs by not using a stable UDS naming scheme
* Allow passing the leak test

This doesn't fix the flakyness of the test
