### PR TITLE
krt: allow fetching a collection by Index and Key

### DIFF
--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -28,28 +28,54 @@ import (
 	"istio.io/istio/pkg/util/sets"
 )
 
+type indexedDependencyType uint8
+
+const (
+	unknownIndexType indexedDependencyType = iota
+	indexType        indexedDependencyType = iota
+	getKeyType       indexedDependencyType = iota
+)
+
+var allIndexedDependencyTypes = []indexedDependencyType{indexType, getKeyType}
+
 type dependencyState[I any] struct {
 	// collectionDependencies specifies the set of collections we depend on from within the transformation functions (via Fetch).
 	// These are keyed by the internal uid() function on collections.
 	// Note this does not include `parent`, which is the *primary* dependency declared outside of transformation functions.
 	collectionDependencies sets.Set[collectionUID]
 	// Stores a map of I -> secondary dependencies (added via Fetch)
-	objectDependencies           map[Key[I]][]*dependency
-	indexedDependencies          map[indexedDependency]sets.Set[Key[I]]
-	indexedDependenciesExtractor map[collectionUID]objectKeyExtractor
+	objectDependencies  map[Key[I]][]*dependency
+	indexedDependencies map[indexedDependency]sets.Set[Key[I]]
+	// indexedDependenciesExtractor stores a map of [collection,fetch type] => an extractor to get change keys.
+	// Note that a given collection can have multiple Fetches, but they are limited to those of the different kind.
+	// I.e. you can do a `Fetch(c1, FilterIndex()) + Fetch(c1, FilterKey())` but not `Fetch(c1, FilterIndex()) + Fetch(c1, FilterIndex())`.
+	indexedDependenciesExtractor map[extractorKey]objectKeyExtractor
+}
+
+type extractorKey struct {
+	uid collectionUID
+	typ indexedDependencyType
 }
 
 func (i dependencyState[I]) update(key Key[I], deps []*dependency) {
 	// Update the I -> Dependency mapping
 	i.objectDependencies[key] = deps
 	for _, d := range deps {
-		if depKey, extractor, ok := d.filter.reverseIndexKey(); ok {
-			k := indexedDependency{
-				id:  d.id,
-				key: depKey,
+		if depKeys, typ, extractor, ok := d.filter.reverseIndexKey(); ok {
+			for _, depKey := range depKeys {
+				k := indexedDependency{
+					id:  d.id,
+					key: depKey,
+					typ: typ,
+				}
+				sets.InsertOrNew(i.indexedDependencies, k, key)
+				kk := extractorKey{
+					uid: d.id,
+					typ: typ,
+				}
+
+				i.indexedDependenciesExtractor[kk] = extractor
 			}
-			sets.InsertOrNew(i.indexedDependencies, k, key)
-			i.indexedDependenciesExtractor[d.id] = extractor
 		}
 	}
 }
@@ -61,12 +87,15 @@ func (i dependencyState[I]) delete(key Key[I]) {
 	}
 	delete(i.objectDependencies, key)
 	for _, d := range old {
-		if depKey, _, ok := d.filter.reverseIndexKey(); ok {
-			k := indexedDependency{
-				id:  d.id,
-				key: depKey,
+		if depKeys, typ, _, ok := d.filter.reverseIndexKey(); ok {
+			for _, depKey := range depKeys {
+				k := indexedDependency{
+					id:  d.id,
+					key: depKey,
+					typ: typ,
+				}
+				sets.DeleteCleanupLast(i.indexedDependencies, k, key)
 			}
-			sets.DeleteCleanupLast(i.indexedDependencies, k, key)
 		}
 	}
 }
@@ -79,25 +108,31 @@ func (i dependencyState[I]) changedInputKeys(sourceCollection collectionUID, eve
 		// Naively, we can look through every item in this collection and check if it matches the filter. However, this is
 		// inefficient, especially when the dependency changes frequently and the collection is large.
 		// Where possible, we utilize the reverse-indexing to get the precise list of potentially changed objects.
-		if extractor, f := i.indexedDependenciesExtractor[sourceCollection]; f {
-			// We have a reverse index
-			for _, item := range ev.Items() {
-				// Find all the reverse index keys for this object. For each key we will find impacted input objects.
-				keys := extractor(item)
-				for _, key := range keys {
-					for iKey := range i.indexedDependencies[indexedDependency{id: sourceCollection, key: key}] {
-						if changedInputKeys.Contains(iKey) {
-							// We may have already found this item, skip it
-							continue
-						}
-						dependencies := i.objectDependencies[iKey]
-						if changed := objectChanged(dependencies, sourceCollection, ev, true); changed {
-							changedInputKeys.Insert(iKey)
+		foundAny := false
+		for _, idxTypes := range allIndexedDependencyTypes {
+			ekey := extractorKey{uid: sourceCollection, typ: idxTypes}
+			if extractor, f := i.indexedDependenciesExtractor[ekey]; f {
+				foundAny = true
+				// We have a reverse index
+				for _, item := range ev.Items() {
+					// Find all the reverse index keys for this object. For each key we will find impacted input objects.
+					keys := extractor(item)
+					for _, key := range keys {
+						for iKey := range i.indexedDependencies[indexedDependency{id: sourceCollection, key: key, typ: idxTypes}] {
+							if changedInputKeys.Contains(iKey) {
+								// We may have already found this item, skip it
+								continue
+							}
+							dependencies := i.objectDependencies[iKey]
+							if changed := objectChanged(dependencies, sourceCollection, ev, true); changed {
+								changedInputKeys.Insert(iKey)
+							}
 						}
 					}
 				}
 			}
-		} else {
+		}
+		if !foundAny {
 			for iKey, dependencies := range i.objectDependencies {
 				if changed := objectChanged(dependencies, sourceCollection, ev, false); changed {
 					changedInputKeys.Insert(iKey)
@@ -537,7 +572,7 @@ func newManyCollection[I, O any](
 			collectionDependencies:       sets.New[collectionUID](),
 			objectDependencies:           map[Key[I]][]*dependency{},
 			indexedDependencies:          map[indexedDependency]sets.Set[Key[I]]{},
-			indexedDependenciesExtractor: map[collectionUID]func(o any) []string{},
+			indexedDependenciesExtractor: map[extractorKey]func(o any) []string{},
 		},
 		collectionState: multiIndex[I, O]{
 			inputs:   map[Key[I]]I{},
@@ -599,7 +634,7 @@ func (h *manyCollection[I, O]) onSecondaryDependencyEvent(sourceCollection colle
 	// A secondary dependency changed...
 	// Got an event. Now we need to find out who depends on it..
 	changedInputKeys := h.dependencyState.changedInputKeys(sourceCollection, events)
-	h.log.Debugf("event size %v, impacts %v objects", len(events), len(changedInputKeys))
+	h.log.Debugf("event size %v, impacts %v objects", len(events), changedInputKeys.UnsortedList())
 
 	toRun := make([]Event[I], 0, len(changedInputKeys))
 	// Now we have the set of input keys that changed. We need to recompute all of these.

--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -49,6 +49,7 @@ type dependencyState[I any] struct {
 	// indexedDependenciesExtractor stores a map of [collection,fetch type] => an extractor to get change keys.
 	// Note that a given collection can have multiple Fetches, but they are limited to those of the different kind.
 	// I.e. you can do a `Fetch(c1, FilterIndex()) + Fetch(c1, FilterKey())` but not `Fetch(c1, FilterIndex()) + Fetch(c1, FilterIndex())`.
+	// This only applies within a single transformation; it is fine to fetch the the same `c1` in any way from different collections.
 	indexedDependenciesExtractor map[extractorKey]objectKeyExtractor
 }
 

--- a/pkg/kube/krt/filter.go
+++ b/pkg/kube/krt/filter.go
@@ -50,14 +50,18 @@ func getKeyExtractor(o any) []string {
 	return []string{GetKey(o)}
 }
 
-func (f *filter) reverseIndexKey() (string, objectKeyExtractor, bool) {
-	if f.keys.Len() == 1 {
-		return f.keys.List()[0], getKeyExtractor, true
+// reverseIndexKey
+func (f *filter) reverseIndexKey() ([]string, indexedDependencyType, objectKeyExtractor, bool) {
+	if f.keys.Len() > 0 {
+		if f.index != nil {
+			panic("cannot filter by index and key")
+		}
+		return f.keys.List(), getKeyType, getKeyExtractor, true
 	}
 	if f.index != nil {
-		return f.index.key, f.index.extractKeys, true
+		return []string{f.index.key}, indexType, f.index.extractKeys, true
 	}
-	return "", nil, false
+	return nil, unknownIndexType, nil, false
 }
 
 func (f *filter) String() string {

--- a/pkg/kube/krt/index_test.go
+++ b/pkg/kube/krt/index_test.go
@@ -245,7 +245,6 @@ func TestReverseIndex(t *testing.T) {
 	})
 	Collection := krt.NewSingleton(func(ctx krt.HandlerContext) *PodCounts {
 		idxPods := krt.Fetch(ctx, SimplePods, krt.FilterIndex(IPIndex, "1.2.3.5"))
-		// namePods := krt.Fetch(ctx, SimplePods, krt.FilterKey("namespace/name"))
 		namePods := krt.Fetch(ctx, SimplePods, krt.FilterKeys("namespace/name", "namespace/name3"))
 		return &PodCounts{
 			ByIP:   len(idxPods),

--- a/pkg/kube/krt/index_test.go
+++ b/pkg/kube/krt/index_test.go
@@ -220,3 +220,77 @@ func TestIndexAsCollection(t *testing.T) {
 	assertion("1.2.3.4", 0)
 	assertion("1.2.3.5", 2)
 }
+
+type PodCounts struct {
+	ByIP   int
+	ByName int
+}
+
+func (p PodCounts) ResourceName() string {
+	return "singleton"
+}
+
+func TestReverseIndex(t *testing.T) {
+	stop := test.NewStop(t)
+	opts := testOptions(t)
+	c := kube.NewFakeClient()
+	kpc := kclient.New[*corev1.Pod](c)
+	pc := clienttest.Wrap(t, kpc)
+	pods := krt.WrapClient[*corev1.Pod](kpc, opts.WithName("Pods")...)
+	c.RunAndWait(stop)
+	SimplePods := SimplePodCollection(pods, opts)
+	tt := assert.NewTracker[string](t)
+	IPIndex := krt.NewIndex[string, SimplePod](SimplePods, func(o SimplePod) []string {
+		return []string{o.IP}
+	})
+	Collection := krt.NewSingleton(func(ctx krt.HandlerContext) *PodCounts {
+		idxPods := krt.Fetch(ctx, SimplePods, krt.FilterIndex(IPIndex, "1.2.3.5"))
+		// namePods := krt.Fetch(ctx, SimplePods, krt.FilterKey("namespace/name"))
+		namePods := krt.Fetch(ctx, SimplePods, krt.FilterKeys("namespace/name", "namespace/name3"))
+		return &PodCounts{
+			ByIP:   len(idxPods),
+			ByName: len(namePods),
+		}
+	}, opts.WithName("Collection")...)
+	Collection.AsCollection().WaitUntilSynced(stop)
+
+	SimplePods.Register(TrackerHandler[SimplePod](tt))
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name",
+			Namespace: "namespace",
+		},
+		Status: corev1.PodStatus{PodIP: "1.2.3.4"},
+	}
+	pc.CreateOrUpdateStatus(pod)
+	assert.EventuallyEqual(t, Collection.Get, &PodCounts{ByIP: 0, ByName: 1})
+
+	pod.Status.PodIP = "1.2.3.5"
+	pc.UpdateStatus(pod)
+	assert.EventuallyEqual(t, Collection.Get, &PodCounts{ByIP: 1, ByName: 1})
+
+	pod2 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name2",
+			Namespace: "namespace",
+		},
+		Status: corev1.PodStatus{PodIP: "1.2.3.5"},
+	}
+	pc.CreateOrUpdateStatus(pod2)
+	assert.EventuallyEqual(t, Collection.Get, &PodCounts{ByIP: 2, ByName: 1})
+
+	pod3 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name3",
+			Namespace: "namespace",
+		},
+		Status: corev1.PodStatus{PodIP: "1.2.3.7"},
+	}
+	pc.CreateOrUpdateStatus(pod3)
+	assert.EventuallyEqual(t, Collection.Get, &PodCounts{ByIP: 2, ByName: 2})
+
+	pc.Delete(pod.Name, pod.Namespace)
+	pc.Delete(pod2.Name, pod2.Namespace)
+	assert.EventuallyEqual(t, Collection.Get, &PodCounts{ByIP: 0, ByName: 1})
+}

--- a/pkg/kube/krt/internal.go
+++ b/pkg/kube/krt/internal.go
@@ -76,6 +76,7 @@ type collectionOptions struct {
 type indexedDependency struct {
 	id  collectionUID
 	key string
+	typ indexedDependencyType
 }
 
 // dependency is a specific thing that can be depended on


### PR DESCRIPTION
See test case added. Our optimization around reverse indexing only
allowed a single Index/Key fetch per collection. This allows doing both.

In theory you may want multiple distinct Index/Key lookups to a single
collection, but this is pretty hard to address.

How this works is instead of keying just by `collection`, we key by
`{collection, lookupType}`.

We explicitly detect the case of an Index+Key lookup on the same Fetch.
We cannot detect the case of 2 separate Fetch calls both doing an Index
or both doing a Get, though.

Fixes https://github.com/istio/istio/issues/55503
