### PR TITLE
cni: give hint when platform is not set appropriately

### DIFF
--- a/cni/pkg/install/install.go
+++ b/cni/pkg/install/install.go
@@ -59,6 +59,10 @@ func (in *Installer) installAll(ctx context.Context) (sets.String, error) {
 	// and we harm no one by doing so.
 	copiedFiles, err := copyBinaries(in.cfg.CNIBinSourceDir, in.cfg.CNIBinTargetDirs)
 	if err != nil {
+		if strings.Contains(err.Error(), "read-only file system") {
+			log.Warnf("hint: some Kubernetes environments require customization of the CNI directory." +
+				" Ensure you properly set global.platform=<name> during installation")
+		}
 		cniInstalls.With(resultLabel.Value(resultCopyBinariesFailure)).Increment()
 		return copiedFiles, fmt.Errorf("copy binaries: %v", err)
 	}


### PR DESCRIPTION
```
2025-03-14T18:37:17.759977Z     error   cni-agent       failed file copy of /opt/cni/bin/istio-cni to /host/opt/cni/bin: open /host/opt/cni/bin/istio-cni.tmp.2628672928: read-only file system
2025-03-14T18:37:17.760096Z     warn    hint: some Kubernetes environments require customization of the CNI directory. Ensure you properly set global.platform=<name> during installation
2025-03-14T18:37:17.760202Z     error   cni-agent       installer failed: copy binaries: open /host/opt/cni/bin/istio-cni.tmp.2628672928: read-only file system
```
