### PR TITLE
Improvements to GKE install

### DIFF
--- a/manifests/charts/base/files/profile-platform-gke.yaml
+++ b/manifests/charts/base/files/profile-platform-gke.yaml
@@ -4,3 +4,7 @@
 
 cni:
   cniBinDir: "" # intentionally unset for gke to allow template-based autodetection to work
+  resourceQuotas:
+    enabled: true
+resourceQuotas:
+  enabled: true

--- a/manifests/charts/default/files/profile-platform-gke.yaml
+++ b/manifests/charts/default/files/profile-platform-gke.yaml
@@ -4,3 +4,7 @@
 
 cni:
   cniBinDir: "" # intentionally unset for gke to allow template-based autodetection to work
+  resourceQuotas:
+    enabled: true
+resourceQuotas:
+  enabled: true

--- a/manifests/charts/gateway/files/profile-platform-gke.yaml
+++ b/manifests/charts/gateway/files/profile-platform-gke.yaml
@@ -4,3 +4,7 @@
 
 cni:
   cniBinDir: "" # intentionally unset for gke to allow template-based autodetection to work
+  resourceQuotas:
+    enabled: true
+resourceQuotas:
+  enabled: true

--- a/manifests/charts/gateways/istio-egress/files/profile-platform-gke.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-platform-gke.yaml
@@ -4,3 +4,7 @@
 
 cni:
   cniBinDir: "" # intentionally unset for gke to allow template-based autodetection to work
+  resourceQuotas:
+    enabled: true
+resourceQuotas:
+  enabled: true

--- a/manifests/charts/gateways/istio-ingress/files/profile-platform-gke.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-platform-gke.yaml
@@ -4,3 +4,7 @@
 
 cni:
   cniBinDir: "" # intentionally unset for gke to allow template-based autodetection to work
+  resourceQuotas:
+    enabled: true
+resourceQuotas:
+  enabled: true

--- a/manifests/charts/istio-cni/files/profile-platform-gke.yaml
+++ b/manifests/charts/istio-cni/files/profile-platform-gke.yaml
@@ -4,3 +4,7 @@
 
 cni:
   cniBinDir: "" # intentionally unset for gke to allow template-based autodetection to work
+  resourceQuotas:
+    enabled: true
+resourceQuotas:
+  enabled: true

--- a/manifests/charts/istio-control/istio-discovery/files/profile-platform-gke.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-platform-gke.yaml
@@ -4,3 +4,7 @@
 
 cni:
   cniBinDir: "" # intentionally unset for gke to allow template-based autodetection to work
+  resourceQuotas:
+    enabled: true
+resourceQuotas:
+  enabled: true

--- a/manifests/charts/ztunnel/files/profile-platform-gke.yaml
+++ b/manifests/charts/ztunnel/files/profile-platform-gke.yaml
@@ -4,3 +4,7 @@
 
 cni:
   cniBinDir: "" # intentionally unset for gke to allow template-based autodetection to work
+  resourceQuotas:
+    enabled: true
+resourceQuotas:
+  enabled: true

--- a/manifests/charts/ztunnel/templates/resourcequota.yaml
+++ b/manifests/charts/ztunnel/templates/resourcequota.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.resourceQuotas.enabled }}
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: {{ include "ztunnel.release-name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: ztunnel
+    {{- include "istio.labels" . | nindent 4}}
+    {{ with .Values.labels -}}{{ toYaml . | nindent 4}}{{ end }}
+spec:
+  hard:
+    pods: {{ .Values.resourceQuotas.pods | quote }}
+  scopeSelector:
+    matchExpressions:
+    - operator: In
+      scopeName: PriorityClass
+      values:
+      - system-node-critical
+{{- end }}

--- a/manifests/charts/ztunnel/values.yaml
+++ b/manifests/charts/ztunnel/values.yaml
@@ -43,6 +43,10 @@ _internal_defaults_do_not_set:
       # While there are many factors, this is enough for ~200k pod cluster or 100k concurrently open connections.
       memory: 512Mi
 
+  resourceQuotas:
+    enabled: false
+    pods: 5000
+
   # List of secret names to add to the service account as image pull secrets
   imagePullSecrets: []
 

--- a/manifests/helm-profiles/platform-gke.yaml
+++ b/manifests/helm-profiles/platform-gke.yaml
@@ -1,2 +1,6 @@
 cni:
   cniBinDir: "" # intentionally unset for gke to allow template-based autodetection to work
+  resourceQuotas:
+    enabled: true
+resourceQuotas:
+  enabled: true

--- a/operator/pkg/render/manifest.go
+++ b/operator/pkg/render/manifest.go
@@ -420,7 +420,7 @@ func readProfileInternal(path string, profile string) (values.Map, error) {
 	return values.MapFromYaml(pb)
 }
 
-var allowGKEAutoDetection = env.Register("AUTO_GKE_DETECTION", true, "If true, GKE weill be detected automatically.").Get()
+var allowGKEAutoDetection = env.Register("AUTO_GKE_DETECTION", true, "If true, GKE will be detected automatically.").Get()
 
 // clusterSpecificSettings computes any automatically detected settings from the cluster.
 func clusterSpecificSettings(client kube.Client) []string {

--- a/operator/pkg/render/manifest.go
+++ b/operator/pkg/render/manifest.go
@@ -431,7 +431,14 @@ func clusterSpecificSettings(client kube.Client) []string {
 	// https://istio.io/latest/docs/setup/additional-setup/cni/#hosted-kubernetes-settings
 	// GKE requires deployment in kube-system namespace.
 	if strings.Contains(ver.GitVersion, "-gke") {
-		return []string{"components.cni.namespace=kube-system"}
+		return []string{
+			// This could be in istio-system with ResourceQuotas, but for backwards compatibility we move it to kube-system still
+			"components.cni.namespace=kube-system",
+			// Enable GKE profile, which ensures CNI Bin Dir is set appropriately
+			"values.global.platform=gke",
+			// Since we already put it in kube-system, don't bother deploying a resource quota
+			"values.cni.resourceQuotas.enabled=false",
+		}
 	}
 	return nil
 }

--- a/operator/pkg/render/manifest.go
+++ b/operator/pkg/render/manifest.go
@@ -32,6 +32,7 @@ import (
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/operator/pkg/util/clog"
 	"istio.io/istio/operator/pkg/values"
+	"istio.io/istio/pkg/env"
 	"istio.io/istio/pkg/kube"
 	pkgversion "istio.io/istio/pkg/version"
 )
@@ -419,6 +420,8 @@ func readProfileInternal(path string, profile string) (values.Map, error) {
 	return values.MapFromYaml(pb)
 }
 
+var allowGKEAutoDetection = env.Register("AUTO_GKE_DETECTION", true, "If true, GKE weill be detected automatically.").Get()
+
 // clusterSpecificSettings computes any automatically detected settings from the cluster.
 func clusterSpecificSettings(client kube.Client) []string {
 	if client == nil {
@@ -430,7 +433,7 @@ func clusterSpecificSettings(client kube.Client) []string {
 	}
 	// https://istio.io/latest/docs/setup/additional-setup/cni/#hosted-kubernetes-settings
 	// GKE requires deployment in kube-system namespace.
-	if strings.Contains(ver.GitVersion, "-gke") {
+	if allowGKEAutoDetection && strings.Contains(ver.GitVersion, "-gke") {
 		return []string{
 			// This could be in istio-system with ResourceQuotas, but for backwards compatibility we move it to kube-system still
 			"components.cni.namespace=kube-system",

--- a/releasenotes/notes/gke-install.yaml
+++ b/releasenotes/notes/gke-install.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+releaseNotes:
+  - |
+    **Improved** installation on GKE. When deploying with `global.platform=gke`, required `ResourceQuota` resources are deployed automatically.
+    Additionally, when installing via `istioctl`, the `global.platform=gke` setting is automatically enabled when GKE is detected.
+    In addition to the new `ResourceQuota` resources, this also automatically configures the required `cniBinDir`.


### PR DESCRIPTION
Right now, if you install ambient on GKE it doesn't work. There are two
things you need to do:

* Set platform=gke
* Manually deploy a ResourceQuota

We already have detection of GKE, so this makes it so we automatically
use the platform profile in that case.

This also adds a chart-installed ResourceQuota to Ztunnel. This already
exists for CNI so it makes sense to have for Ztunnel as well IMO.
