### PR TITLE
tls: do not modify shared objects

### DIFF
--- a/pilot/pkg/networking/core/cluster_test.go
+++ b/pilot/pkg/networking/core/cluster_test.go
@@ -3102,52 +3102,6 @@ func TestTelemetryMetadata(t *testing.T) {
 	}
 }
 
-func TestVerifyCertAtClient(t *testing.T) {
-	testCases := []struct {
-		name               string
-		policy             *networking.TrafficPolicy
-		expectedCARootPath string
-	}{
-		{
-			name: "Check that certs are verfied against the OS CA certificate bundle",
-			policy: &networking.TrafficPolicy{
-				ConnectionPool: &networking.ConnectionPoolSettings{
-					Http: &networking.ConnectionPoolSettings_HTTPSettings{
-						MaxRetries: 10,
-					},
-				},
-				Tls: &networking.ClientTLSSettings{
-					CaCertificates: "",
-				},
-			},
-			expectedCARootPath: "system",
-		},
-		{
-			name: "Check that CaCertificates has priority over OS CA certificate bundle",
-			policy: &networking.TrafficPolicy{
-				ConnectionPool: &networking.ConnectionPoolSettings{
-					Http: &networking.ConnectionPoolSettings_HTTPSettings{
-						MaxRetries: 10,
-					},
-				},
-				Tls: &networking.ClientTLSSettings{
-					CaCertificates: "file-root:certPath",
-				},
-			},
-			expectedCARootPath: "file-root:certPath",
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			selectTrafficPolicyComponents(testCase.policy)
-			if testCase.policy.Tls.CaCertificates != testCase.expectedCARootPath {
-				t.Errorf("%v got %v when expecting %v", testCase.name, testCase.policy.Tls.CaCertificates, testCase.expectedCARootPath)
-			}
-		})
-	}
-}
-
 func TestBuildDeltaClusters(t *testing.T) {
 	testService1 := &model.Service{
 		Hostname: host.Name("test.com"),

--- a/pilot/pkg/networking/core/cluster_tls.go
+++ b/pilot/pkg/networking/core/cluster_tls.go
@@ -34,6 +34,7 @@ import (
 	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
 	"istio.io/istio/pkg/log"
 	pm "istio.io/istio/pkg/model"
+	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/security"
 	"istio.io/istio/pkg/wellknown"
 )
@@ -201,7 +202,7 @@ func constructUpstreamTLS(opts *buildClusterOpts, tls *networking.ClientTLSSetti
 		// Rather than reading directly in Envoy, which does not support rotation, we will
 		// serve them over SDS by reading the files.
 		res := security.SdsCertificateConfig{
-			CaCertificatePath: tls.CaCertificates,
+			CaCertificatePath: ptr.NonEmptyOrDefault(tls.CaCertificates, "system"),
 		}
 		// If CredentialName is not set fallback to file based approach
 		if mutual {

--- a/pilot/pkg/networking/core/cluster_traffic_policy.go
+++ b/pilot/pkg/networking/core/cluster_traffic_policy.go
@@ -82,11 +82,6 @@ func selectTrafficPolicyComponents(policy *networking.TrafficPolicy) (
 	tls := policy.Tls
 	proxyProtocol := policy.ProxyProtocol
 
-	// Check if CA Certificate should be System CA Certificate
-	if tls != nil && tls.CaCertificates == "" {
-		tls.CaCertificates = "system"
-	}
-
 	return connectionPool, outlierDetection, loadBalancer, tls, proxyProtocol
 }
 


### PR DESCRIPTION
We are modifying the TLS type, which is shared object. This is not
supposed to be done. Change this to just modify the place we use it.

We had 2 tests for the same thing. I deleted one after verifying it has
identical coverage, and modified the other to check the resulting XDS
instead of asserting that we mutate the DestinationRule
