### PR TITLE
don't warning when se is set workloadSelector with resolution DNS

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -2931,10 +2931,6 @@ var ValidateServiceEntry = RegisterValidateFunc("ValidateServiceEntry",
 				}
 			}
 
-			if serviceEntry.WorkloadSelector != nil {
-				errs = AppendWarningf(errs, "workloadSelector should not be set when resolution mode is %v", serviceEntry.Resolution)
-			}
-
 			if len(serviceEntry.Addresses) > 0 {
 				for _, port := range serviceEntry.Ports {
 					if port == nil {

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -3854,7 +3854,7 @@ func TestValidateServiceEntries(t *testing.T) {
 				Resolution: networking.ServiceEntry_DNS,
 			},
 			valid:   true,
-			warning: true,
+			warning: false,
 		},
 		{
 			name: "bad selector key", in: &networking.ServiceEntry{

--- a/releasenotes/notes/55567.yaml
+++ b/releasenotes/notes/55567.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 50164
+releaseNotes:
+  - |
+    **Fixed** an issue that validation webhook incorrectly report a warning when a ServiceEntry configures `workloadSelector`` with DNS resolution.


### PR DESCRIPTION
**Please provide a description of this PR:**

xref: https://github.com/istio/istio/issues/50164#issuecomment-2731904656

This warn message confuse me a lot, maybe it's better to remove it.

cc @ramaraochavali @hzxuzhonghu 

fixes: #50164