### PR TITLE
ambient: support fqdn in workloadentry

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
@@ -181,9 +181,9 @@ func (a *index) workloadEntryWorkloadBuilder(
 
 		if addr, err := netip.ParseAddr(wle.Spec.Address); err == nil {
 			w.Addresses = [][]byte{addr.AsSlice()}
-		} else if wle.Spec.Address != "" {
-			log.Warnf("skipping workload entry %s/%s; DNS Address resolution is not yet implemented", wle.Namespace, wle.Name)
-		} // Else it is an empty address with network set, this is ok
+		} else {
+			w.Hostname = wle.Spec.Address
+		}
 
 		w.WorkloadName = kubelabels.WorkloadNameFromWorkloadEntry(wle.Name, wle.Annotations, wle.Labels)
 		w.WorkloadType = workloadapi.WorkloadType_POD // XXX(shashankram): HACK to impersonate pod

--- a/pkg/test/framework/components/istio/ingress.go
+++ b/pkg/test/framework/components/istio/ingress.go
@@ -280,6 +280,10 @@ func (c *ingressImpl) PodID(i int) (string, error) {
 	return pods.Items[i].Name, nil
 }
 
+func (c *ingressImpl) ServiceName() string {
+	return c.service.Name
+}
+
 func (c *ingressImpl) Namespace() string {
 	return c.service.Namespace
 }

--- a/pkg/test/framework/components/istio/ingress/interface.go
+++ b/pkg/test/framework/components/istio/ingress/interface.go
@@ -57,6 +57,9 @@ type Instance interface {
 	// Cluster the ingress is deployed to
 	Cluster() cluster.Cluster
 
+	// ServiceName of the ingress
+	ServiceName() string
+
 	// Namespace of the ingress
 	Namespace() string
 }

--- a/releasenotes/notes/55569.yaml
+++ b/releasenotes/notes/55569.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed** an issue ServiceEntry with WorkloadEntry not working in Ambient.

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -2298,10 +2298,10 @@ spec:
 				if tc.resolution != v1alpha3.ServiceEntry_DNS {
 					continue
 				}
-				ingressIP := fmt.Sprintf("%s.%s.svc.cluster.local", ingress.ServiceName(), ingress.Namespace())
-				t.Logf("run DNS test with ingress IP %s", ingressIP)
+				ingressHost := fmt.Sprintf("%s.%s.svc.cluster.local", ingress.ServiceName(), ingress.Namespace())
+				t.Logf("run %s test with ingress %s", tc.resolution, ingressHost)
 				for idx := range ports {
-					t.NewSubTestf("%s %s %d", tc.location, tc.resolution, i).Run(func(t framework.TestContext) {
+					t.NewSubTestf("DNS hostname %s %d", tc.location, idx).Run(func(t framework.TestContext) {
 						echotest.
 							New(t, apps.All).
 							// TODO eventually we can do this for uncaptured -> l7
@@ -2312,7 +2312,7 @@ spec:
 							Config(cfg.WithParams(param.Params{
 								"Resolution":      tc.resolution.String(),
 								"Location":        tc.location.String(),
-								"IngressIp":       ingressIP,
+								"IngressIp":       ingressHost,
 								"IngressHttpPort": ports[idx],
 							})).
 							Run(func(t framework.TestContext, from echo.Instance, to echo.Target) {

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -2191,7 +2191,11 @@ func TestServiceEntrySelectsWorkloadEntry(t *testing.T) {
 					resolution: v1alpha3.ServiceEntry_STATIC,
 					to:         apps.MeshExternal,
 				},
-				// TODO dns cases
+				{
+					location:   v1alpha3.ServiceEntry_MESH_EXTERNAL,
+					resolution: v1alpha3.ServiceEntry_DNS,
+					to:         apps.MeshExternal,
+				},
 			}
 
 			// Configure a gateway with one app as the destination to be accessible through the ingress
@@ -2258,9 +2262,11 @@ spec:
 `).
 				WithParams(param.Params{}.SetWellKnown(param.Namespace, apps.Namespace))
 
-			ips, ports := istio.DefaultIngressOrFail(t, t).HTTPAddresses()
+			ingress := istio.DefaultIngressOrFail(t, t)
+			ips, ports := ingress.HTTPAddresses()
 			for _, tc := range testCases {
 				for i, ip := range ips {
+					t.Logf("run %s test with ingress IP %s", tc.resolution, ip)
 					t.NewSubTestf("%s %s %d", tc.location, tc.resolution, i).Run(func(t framework.TestContext) {
 						echotest.
 							New(t, apps.All).
@@ -2274,6 +2280,40 @@ spec:
 								"Location":        tc.location.String(),
 								"IngressIp":       ip,
 								"IngressHttpPort": ports[i],
+							})).
+							Run(func(t framework.TestContext, from echo.Instance, to echo.Target) {
+								// TODO validate L7 processing/some headers indicating we reach the svc we wanted
+								from.CallOrFail(t, echo.CallOptions{
+									Address:   "dummy.example.com",
+									DualStack: true,
+									Port:      to.PortForName("http"),
+									Timeout:   time.Millisecond * 500,
+								})
+							})
+					})
+				}
+			}
+
+			for _, tc := range testCases {
+				if tc.resolution != v1alpha3.ServiceEntry_DNS {
+					continue
+				}
+				ingressIP := fmt.Sprintf("%s.%s.svc.cluster.local", ingress.ServiceName(), ingress.Namespace())
+				t.Logf("run DNS test with ingress IP %s", ingressIP)
+				for idx := range ports {
+					t.NewSubTestf("%s %s %d", tc.location, tc.resolution, i).Run(func(t framework.TestContext) {
+						echotest.
+							New(t, apps.All).
+							// TODO eventually we can do this for uncaptured -> l7
+							FromMatch(match.Not(match.ServiceName(echo.NamespacedName{
+								Name:      "uncaptured",
+								Namespace: apps.Namespace,
+							}))).
+							Config(cfg.WithParams(param.Params{
+								"Resolution":      tc.resolution.String(),
+								"Location":        tc.location.String(),
+								"IngressIp":       ingressIP,
+								"IngressHttpPort": ports[idx],
 							})).
 							Run(func(t framework.TestContext, from echo.Instance, to echo.Target) {
 								// TODO validate L7 processing/some headers indicating we reach the svc we wanted


### PR DESCRIPTION
**Please provide a description of this PR:**

following configuration is valid in sidecar mode, as a follow up of #51152, this patch make it also work in ambient

```
apiVersion: networking.istio.io/v1
kind: WorkloadEntry
metadata:
  name: httpbin-we
spec:
  address: httpbin.local
  labels:
    app: httpbin-local
  # ports:
  #   http: 8000
---
apiVersion: networking.istio.io/v1
kind: ServiceEntry
metadata:
  name: httpbin-local
spec:
  exportTo:
    - "*"
  hosts:
    - httpbin.local
  location: MESH_EXTERNAL
  ports:
    - name: tcp
      number: 8000
      protocol: TCP
  resolution: DNS
  workloadSelector:
    labels:
      app: httpbin-local
```

@howardjohn PTAL