### PR TITLE
update supported groups for TLS

### DIFF
--- a/pkg/config/security/security.go
+++ b/pkg/config/security/security.go
@@ -305,7 +305,7 @@ var ValidCipherSuites = sets.New(
 
 // ValidECDHCurves contains a list of all ecdh curves supported in MeshConfig.TlsDefaults.ecdhCurves
 // Source:
-// https://github.com/google/boringssl/blob/45cf810dbdbd767f09f8cb0b0fcccd342c39041f/src/ssl/ssl_key_share.cc#L285-L293
+// https://github.com/google/boringssl/blob/58f3bc83230d2958bb9710bc910972c4f5d382dc/ssl/ssl_key_share.cc#L376-L385
 var ValidECDHCurves = sets.New(
 	"P-224",
 	"P-256",
@@ -313,6 +313,7 @@ var ValidECDHCurves = sets.New(
 	"P-384",
 	"X25519",
 	"X25519Kyber768Draft00",
+	"X25519MLKEM768",
 )
 
 func IsValidCipherSuite(cs string) bool {


### PR DESCRIPTION
**Please provide a description of this PR:**

The underlying boringssl version used in envoy now supports the hybrid group `X25519MLKEM768` for TLS key exchange. Enable support for this group in Istio.

The dependency of istio -> proxy -> envoy -> boringssl is the following:  
Istio -> proxy : [proxy SHA](https://github.com/istio/istio/blob/master/istio.deps#L7)  
Proxy -> envoy: [envoy SHA](https://github.com/istio/proxy/blob/b3920fcf56f95a71e6a1d74a3ce34647920f3c3f/WORKSPACE#L26)  
Envoy -> boringssl: [boringssl version](https://github.com/envoyproxy/envoy/blob/f31c99db74965c20b9636a0e44a95ae89271a345/bazel/repository_locations.bzl#L129-L147)
BoringSSL - [supported groups](https://github.com/google/boringssl/blob/58f3bc83230d2958bb9710bc910972c4f5d382dc/ssl/ssl_key_share.cc#L376-L385)