### PR TITLE
Temporarily set shareHostNetworkNamespace to true

### DIFF
--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -55,7 +55,7 @@ _internal_defaults_do_not_set:
     # This will eventually be enabled by default
     reconcileIptablesOnStartup: false
     # If enabled, and ambient is enabled, the CNI agent will always share the network namespace of the host node it is running on
-    shareHostNetworkNamespace: false
+    shareHostNetworkNamespace: true
 
 
   repair:


### PR DESCRIPTION
**Please provide a description of this PR:**

I'm temporarily turning on this flag (restore of old behavior) while we wait for a release of 1.25.x that includes the backport of #55304, the backport is needed as mentioned in https://github.com/istio/istio/pull/55304#issuecomment-2700949386 and https://github.com/istio/istio/pull/55304#issuecomment-2700949386

With this temporary revert we are at least preventing the Helm upgrade tests from almost always failing in postsubmit, which could make other regressions harder to spot.