### PR TITLE
initial ClusterTrustBundle v1alpha1 support

### DIFF
--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -270,7 +270,7 @@ spec:
         name: workload-certs
 {{- if eq .Values.global.pilotCertProvider "istiod" }}
       - name: istiod-ca-cert
-{{- if ((.Values.pilot).env).ENABLE_CLUSTER_TRUST_BUNDLE_API }}
+{{- if eq ((.Values.pilot).env).ENABLE_CLUSTER_TRUST_BUNDLE_API true }}
         projected:
           sources:
           - clusterTrustBundle:

--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -274,7 +274,7 @@ spec:
         projected:
           sources:
           - clusterTrustBundle:
-              name: istio-ca-root-cert
+              name: istio.io:istiod-ca:root-cert
               path: root-cert.pem
 {{- else }}
         configMap:

--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -270,8 +270,16 @@ spec:
         name: workload-certs
 {{- if eq .Values.global.pilotCertProvider "istiod" }}
       - name: istiod-ca-cert
+{{- if ((.Values.pilot).env).ENABLE_CLUSTER_TRUST_BUNDLE_API }}
+        projected:
+          sources:
+          - clusterTrustBundle:
+              name: istio-ca-root-cert
+              path: root-cert.pem
+{{- else }}
         configMap:
           name: istio-ca-root-cert
+{{- end }}
 {{- end }}
       - name: podinfo
         downwardAPI:

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -270,7 +270,7 @@ spec:
         name: workload-certs
 {{- if eq .Values.global.pilotCertProvider "istiod" }}
       - name: istiod-ca-cert
-{{- if ((.Values.pilot).env).ENABLE_CLUSTER_TRUST_BUNDLE_API }}
+{{- if eq ((.Values.pilot).env).ENABLE_CLUSTER_TRUST_BUNDLE_API true }}
         projected:
           sources:
           - clusterTrustBundle:

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -274,7 +274,7 @@ spec:
         projected:
           sources:
           - clusterTrustBundle:
-              name: istio-ca-root-cert
+              name: istio.io:istiod-ca:root-cert
               path: root-cert.pem
 {{- else }}
         configMap:

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -270,8 +270,16 @@ spec:
         name: workload-certs
 {{- if eq .Values.global.pilotCertProvider "istiod" }}
       - name: istiod-ca-cert
+{{- if ((.Values.pilot).env).ENABLE_CLUSTER_TRUST_BUNDLE_API }}
+        projected:
+          sources:
+          - clusterTrustBundle:
+              name: istio-ca-root-cert
+              path: root-cert.pem
+{{- else }}
         configMap:
           name: istio-ca-root-cert
+{{- end }}
 {{- end }}
       - name: podinfo
         downwardAPI:

--- a/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
@@ -231,7 +231,7 @@ spec:
           audience: {{ .Values.global.sds.token.aud }}
   {{- if eq .Values.global.pilotCertProvider "istiod" }}
   - name: istiod-ca-cert
-  {{- if (.Values.pilot.env).ENABLE_CLUSTER_TRUST_BUNDLE_API }}
+  {{- if eq (.Values.pilot.env).ENABLE_CLUSTER_TRUST_BUNDLE_API true }}
     projected:
       sources:
       - clusterTrustBundle:

--- a/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
@@ -235,7 +235,7 @@ spec:
     projected:
       sources:
       - clusterTrustBundle:
-        name: istio-ca-root-cert
+        name: istio.io:istiod-ca:root-cert
         path: root-cert.pem
   {{- else }}
     configMap:

--- a/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
@@ -231,8 +231,16 @@ spec:
           audience: {{ .Values.global.sds.token.aud }}
   {{- if eq .Values.global.pilotCertProvider "istiod" }}
   - name: istiod-ca-cert
+  {{- if (.Values.pilot.env).ENABLE_CLUSTER_TRUST_BUNDLE_API }}
+    projected:
+      sources:
+      - clusterTrustBundle:
+        name: istio-ca-root-cert
+        path: root-cert.pem
+  {{- else }}
     configMap:
       name: istio-ca-root-cert
+  {{- end }}
   {{- end }}
   {{- if .Values.global.mountMtlsCerts }}
   # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.

--- a/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
@@ -282,7 +282,7 @@ spec:
           audience: {{ .Values.global.sds.token.aud }}
   {{- if eq .Values.global.pilotCertProvider "istiod" }}
   - name: istiod-ca-cert
-  {{- if (.Values.pilot.env).ENABLE_CLUSTER_TRUST_BUNDLE_API }}
+  {{- if eq (.Values.pilot.env).ENABLE_CLUSTER_TRUST_BUNDLE_API true }}
     projected:
       sources:
       - clusterTrustBundle:

--- a/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
@@ -282,8 +282,16 @@ spec:
           audience: {{ .Values.global.sds.token.aud }}
   {{- if eq .Values.global.pilotCertProvider "istiod" }}
   - name: istiod-ca-cert
+  {{- if (.Values.pilot.env).ENABLE_CLUSTER_TRUST_BUNDLE_API }}
+    projected:
+      sources:
+      - clusterTrustBundle:
+        name: istio-ca-root-cert
+        path: root-cert.pem
+  {{- else }}
     configMap:
       name: istio-ca-root-cert
+  {{- end }}
   {{- end }}
   {{- if .Values.global.mountMtlsCerts }}
   # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.

--- a/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
@@ -286,7 +286,7 @@ spec:
     projected:
       sources:
       - clusterTrustBundle:
-        name: istio-ca-root-cert
+        name: istio.io:istiod-ca:root-cert
         path: root-cert.pem
   {{- else }}
     configMap:

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -488,7 +488,7 @@ spec:
           audience: {{ .Values.global.sds.token.aud }}
   {{- if eq .Values.global.pilotCertProvider "istiod" }}
   - name: istiod-ca-cert
-  {{- if (.Values.pilot.env).ENABLE_CLUSTER_TRUST_BUNDLE_API }}
+  {{- if eq (.Values.pilot.env).ENABLE_CLUSTER_TRUST_BUNDLE_API true }}
     projected:
       sources:
       - clusterTrustBundle:

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -492,7 +492,7 @@ spec:
     projected:
       sources:
       - clusterTrustBundle:
-        name: istio-ca-root-cert
+        name: istio.io:istiod-ca:root-cert
         path: root-cert.pem
   {{- else }}
     configMap:

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -488,8 +488,16 @@ spec:
           audience: {{ .Values.global.sds.token.aud }}
   {{- if eq .Values.global.pilotCertProvider "istiod" }}
   - name: istiod-ca-cert
+  {{- if (.Values.pilot.env).ENABLE_CLUSTER_TRUST_BUNDLE_API }}
+    projected:
+      sources:
+      - clusterTrustBundle:
+        name: istio-ca-root-cert
+        path: root-cert.pem
+  {{- else }}
     configMap:
       name: istio-ca-root-cert
+  {{- end }}
   {{- end }}
   {{- if .Values.global.mountMtlsCerts }}
   # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.

--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -299,7 +299,7 @@ spec:
               audience: {{ .Values.global.sds.token.aud }}
       {{- if eq .Values.global.pilotCertProvider "istiod" }}
       - name: istiod-ca-cert
-      {{- if ((.Values.pilot).env).ENABLE_CLUSTER_TRUST_BUNDLE_API }}
+      {{- if eq ((.Values.pilot).env).ENABLE_CLUSTER_TRUST_BUNDLE_API true }}
         projected:
           sources:
           - clusterTrustBundle:

--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -299,8 +299,16 @@ spec:
               audience: {{ .Values.global.sds.token.aud }}
       {{- if eq .Values.global.pilotCertProvider "istiod" }}
       - name: istiod-ca-cert
+      {{- if ((.Values.pilot).env).ENABLE_CLUSTER_TRUST_BUNDLE_API }}
+        projected:
+          sources:
+          - clusterTrustBundle:
+              name: istio-ca-root-cert
+              path: root-cert.pem
+      {{- else }}
         configMap:
           name: istio-ca-root-cert
+      {{- end }}
       {{- end }}
       {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:

--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -303,7 +303,7 @@ spec:
         projected:
           sources:
           - clusterTrustBundle:
-              name: istio-ca-root-cert
+              name: istio.io:istiod-ca:root-cert
               path: root-cert.pem
       {{- else }}
         configMap:

--- a/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
@@ -292,7 +292,7 @@ spec:
         projected:
           sources:
           - clusterTrustBundle:
-              name: istio-ca-root-cert
+              name: istio.io:istiod-ca:root-cert
               path: root-cert.pem
       {{- else }}
         configMap:

--- a/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
@@ -288,7 +288,7 @@ spec:
               expirationSeconds: 43200
               path: istio-token
       - name: istiod-ca-cert
-      {{- if (.Values.pilot.env).ENABLE_CLUSTER_TRUST_BUNDLE_API }}
+      {{- if eq (.Values.pilot.env).ENABLE_CLUSTER_TRUST_BUNDLE_API true }}
         projected:
           sources:
           - clusterTrustBundle:

--- a/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
@@ -287,9 +287,17 @@ spec:
               audience: istio-ca
               expirationSeconds: 43200
               path: istio-token
-      - configMap:
+      - name: istiod-ca-cert
+      {{- if (.Values.pilot.env).ENABLE_CLUSTER_TRUST_BUNDLE_API }}
+        projected:
+          sources:
+          - clusterTrustBundle:
+              name: istio-ca-root-cert
+              path: root-cert.pem
+      {{- else }}
+        configMap:
           name: istio-ca-root-cert
-        name: istiod-ca-cert
+      {{- end }}
       {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- range .Values.global.imagePullSecrets }}

--- a/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
@@ -117,7 +117,7 @@ rules:
 {{- end }}
     verbs: ["approve"]
 {{- end}}
-{{- if (.Values.env).ENABLE_CLUSTER_TRUST_BUNDLE_API }}
+{{- if eq (.Values.env).ENABLE_CLUSTER_TRUST_BUNDLE_API true }}
   - apiGroups: ["certificates.k8s.io"]
     resources:
       - "clustertrustbundles"

--- a/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
@@ -117,6 +117,12 @@ rules:
 {{- end }}
     verbs: ["approve"]
 {{- end}}
+{{- if (.Values.env).ENABLE_CLUSTER_TRUST_BUNDLE_API }}
+  - apiGroups: ["certificates.k8s.io"]
+    resources:
+      - "clustertrustbundles"
+    verbs: ["update", "create", "delete"]
+{{- end }}
 
   # Used by Istiod to verify the JWT tokens
   - apiGroups: ["authentication.k8s.io"]

--- a/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
@@ -119,9 +119,12 @@ rules:
 {{- end}}
 {{- if eq (.Values.env).ENABLE_CLUSTER_TRUST_BUNDLE_API true }}
   - apiGroups: ["certificates.k8s.io"]
-    resources:
-      - "clustertrustbundles"
+    resources: ["clustertrustbundles"]
     verbs: ["update", "create", "delete"]
+  - apiGroups: ["certificates.k8s.io"]
+    resources: ["signers"]
+    resourceNames: ["istio.io/istiod-ca"]
+    verbs: ["attest"]
 {{- end }}
 
   # Used by Istiod to verify the JWT tokens

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -283,7 +283,7 @@ spec:
         projected:
           sources:
           - clusterTrustBundle:
-              name: istio-ca-root-cert
+              name: istio.io:istiod-ca:root-cert
               path: root-cert.pem
               optional: true
   {{- else }}

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -279,10 +279,19 @@ spec:
           secretName: istiod-tls
           optional: true
       - name: istio-csr-ca-configmap
+  {{- if (.Values.env).ENABLE_CLUSTER_TRUST_BUNDLE_API }}
+        projected:
+          sources:
+          - clusterTrustBundle:
+              name: istio-ca-root-cert
+              path: root-cert.pem
+              optional: true
+  {{- else }}
         configMap:
           name: istio-ca-root-cert
           defaultMode: 420
           optional: true
+  {{- end }}
   {{- if .Values.jwksResolverExtraRootCA }}
       - name: extracacerts
         configMap:

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -279,7 +279,7 @@ spec:
           secretName: istiod-tls
           optional: true
       - name: istio-csr-ca-configmap
-  {{- if (.Values.env).ENABLE_CLUSTER_TRUST_BUNDLE_API }}
+  {{- if eq (.Values.env).ENABLE_CLUSTER_TRUST_BUNDLE_API true }}
         projected:
           sources:
           - clusterTrustBundle:

--- a/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
@@ -15,7 +15,7 @@ data:
 {{/* Scope the values to just top level fields used in the template, to reduce the size. */}}
   values: |-
 {{ $vals := pick .Values "global" "sidecarInjectorWebhook" "revision" -}}
-{{ $pilotVals := pick .Values "cni" -}}
+{{ $pilotVals := pick .Values "cni" "env" -}}
 {{ $vals = set $vals "pilot" $pilotVals -}}
 {{ $gatewayVals := pick .Values.gateways "securityContext" "seccompProfile" -}}
 {{ $vals = set $vals "gateways" $gatewayVals -}}

--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -183,8 +183,16 @@ spec:
               expirationSeconds: 43200
               audience: istio-ca
       - name: istiod-ca-cert
+        {{- if (.Values.env).ENABLE_CLUSTER_TRUST_BUNDLE_API }}
+        projected:
+          sources:
+          - clusterTrustBundle:
+              name: istio-ca-root-cert
+              path: root-cert.pem
+        {{- else }}
         configMap:
           name: istio-ca-root-cert
+        {{- end }}
       - name: cni-ztunnel-sock-dir
         hostPath:
           path: /var/run/ztunnel

--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -183,7 +183,7 @@ spec:
               expirationSeconds: 43200
               audience: istio-ca
       - name: istiod-ca-cert
-        {{- if (.Values.env).ENABLE_CLUSTER_TRUST_BUNDLE_API }}
+        {{- if eq (.Values.env).ENABLE_CLUSTER_TRUST_BUNDLE_API true }}
         projected:
           sources:
           - clusterTrustBundle:

--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -187,7 +187,7 @@ spec:
         projected:
           sources:
           - clusterTrustBundle:
-              name: istio-ca-root-cert
+              name: istio.io:istiod-ca:root-cert
               path: root-cert.pem
         {{- else }}
         configMap:

--- a/pilot/pkg/config/kube/clustertrustbundle/controller.go
+++ b/pilot/pkg/config/kube/clustertrustbundle/controller.go
@@ -48,14 +48,12 @@ type ClusterTrustBundleController struct {
 	caBundleWatcher     *keycertbundle.Watcher
 	queue               controllers.Queue
 	clustertrustbundles kclient.Client[*certificatesv1alpha1.ClusterTrustBundle]
-	stopChan            chan struct{}
 }
 
 // NewClusterTrustBundleController creates a new ClusterTrustBundleController
 func NewClusterTrustBundleController(kubeClient kube.Client, caBundleWatcher *keycertbundle.Watcher) *ClusterTrustBundleController {
 	c := &ClusterTrustBundleController{
 		client:          kubeClient,
-		stopChan:        make(chan struct{}),
 		caBundleWatcher: caBundleWatcher,
 	}
 
@@ -104,7 +102,6 @@ func (c *ClusterTrustBundleController) Run(stopCh <-chan struct{}) {
 		return
 	}
 	go c.startCaBundleWatcher(stopCh)
-	defer close(c.stopChan)
 
 	// queue an initial event
 	c.queue.AddObject(&certificatesv1alpha1.ClusterTrustBundle{

--- a/pilot/pkg/config/kube/clustertrustbundle/controller.go
+++ b/pilot/pkg/config/kube/clustertrustbundle/controller.go
@@ -1,0 +1,142 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clustertrustbundle
+
+import (
+	"context"
+
+	certificatesv1alpha1 "k8s.io/api/certificates/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"istio.io/istio/pilot/pkg/keycertbundle"
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/controllers"
+	"istio.io/istio/pkg/kube/kclient"
+)
+
+const (
+	// The name of the ClusterTrustBundle resource that will store Istio's root certificate
+	istioClusterTrustBundleName = "istio-ca-root-cert"
+
+	// maxRetries is the number of times a ClusterTrustBundle reconciliation will be retried before it is dropped
+	// out of the queue.
+	// With the current rate-limiter in use (5ms*2^(maxRetries-1)) the following numbers represent the
+	// sequence of delays between successive queuing of a namespace.
+	//
+	// 5ms, 10ms, 20ms, 40ms, 80ms
+	maxRetries = 5
+)
+
+// ClusterTrustBundleController manages the lifecycle of the Istio root certificate in ClusterTrustBundle
+// It watches Istio's KeyCert bundle as well as ClusterTrustBundles in the cluster, and it updates ClusterTrustBundles whenever
+// the certificate is rotated. Later on, we might want to add reading from other ClusterTrustBundles as well
+type ClusterTrustBundleController struct {
+	client              kube.Client
+	caBundleWatcher     *keycertbundle.Watcher
+	queue               controllers.Queue
+	clustertrustbundles kclient.Client[*certificatesv1alpha1.ClusterTrustBundle]
+	stopChan            chan struct{}
+}
+
+// NewClusterTrustBundleController creates a new ClusterTrustBundleController
+func NewClusterTrustBundleController(kubeClient kube.Client, caBundleWatcher *keycertbundle.Watcher) *ClusterTrustBundleController {
+	c := &ClusterTrustBundleController{
+		client:          kubeClient,
+		stopChan:        make(chan struct{}),
+		caBundleWatcher: caBundleWatcher,
+	}
+
+	c.queue = controllers.NewQueue("clustertrustbundle controller",
+		controllers.WithReconciler(c.reconcileClusterTrustBundle),
+		controllers.WithMaxAttempts(maxRetries))
+
+	c.clustertrustbundles = kclient.NewFiltered[*certificatesv1alpha1.ClusterTrustBundle](kubeClient, kclient.Filter{
+		FieldSelector: "metadata.name=" + istioClusterTrustBundleName,
+		ObjectFilter:  kubeClient.ObjectFilter(),
+	})
+
+	c.clustertrustbundles.AddEventHandler(controllers.FilteredObjectSpecHandler(c.queue.AddObject, func(o controllers.Object) bool { return true }))
+
+	return c
+}
+
+// startCaBundleWatcher listens for updates to the CA bundle and queues a reconciliation of the ClusterTrustBundle
+func (c *ClusterTrustBundleController) startCaBundleWatcher(stop <-chan struct{}) {
+	id, watchCh := c.caBundleWatcher.AddWatcher()
+	defer c.caBundleWatcher.RemoveWatcher(id)
+	for {
+		select {
+		case <-watchCh:
+			c.queue.AddObject(&certificatesv1alpha1.ClusterTrustBundle{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: istioClusterTrustBundleName,
+				},
+			})
+		case <-stop:
+			return
+		}
+	}
+}
+
+func (c *ClusterTrustBundleController) reconcileClusterTrustBundle(o types.NamespacedName) error {
+	if o.Name == istioClusterTrustBundleName {
+		return c.updateClusterTrustBundle(c.caBundleWatcher.GetCABundle())
+	}
+	return nil
+}
+
+// Run starts the controller
+func (c *ClusterTrustBundleController) Run(stopCh <-chan struct{}) {
+	if !kube.WaitForCacheSync("clustertrustbundle controller", stopCh, c.clustertrustbundles.HasSynced) {
+		return
+	}
+	go c.startCaBundleWatcher(stopCh)
+	defer close(c.stopChan)
+
+	// queue an initial event
+	c.queue.AddObject(&certificatesv1alpha1.ClusterTrustBundle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: istioClusterTrustBundleName,
+		},
+	})
+
+	c.queue.Run(stopCh)
+	controllers.ShutdownAll(c.clustertrustbundles)
+}
+
+// updateClusterTrustBundle updates the root certificate in the ClusterTrustBundle
+func (c *ClusterTrustBundleController) updateClusterTrustBundle(rootCert []byte) error {
+	bundle := &certificatesv1alpha1.ClusterTrustBundle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: istioClusterTrustBundleName,
+		},
+		Spec: certificatesv1alpha1.ClusterTrustBundleSpec{
+			TrustBundle: string(rootCert),
+		},
+	}
+
+	existing, err := c.client.Kube().CertificatesV1alpha1().ClusterTrustBundles().Get(context.Background(), istioClusterTrustBundleName, metav1.GetOptions{})
+	if err == nil {
+		// Update existing bundle
+		existing.Spec.TrustBundle = string(rootCert)
+		_, err = c.client.Kube().CertificatesV1alpha1().ClusterTrustBundles().Update(context.Background(), existing, metav1.UpdateOptions{})
+		return err
+	}
+
+	// Create new bundle
+	_, err = c.client.Kube().CertificatesV1alpha1().ClusterTrustBundles().Create(context.Background(), bundle, metav1.CreateOptions{})
+	return err
+}

--- a/pilot/pkg/config/kube/clustertrustbundle/controller.go
+++ b/pilot/pkg/config/kube/clustertrustbundle/controller.go
@@ -127,6 +127,10 @@ func (c *ClusterTrustBundleController) updateClusterTrustBundle(rootCert []byte)
 
 	existing := c.clustertrustbundles.Get(istioClusterTrustBundleName, "")
 	if existing != nil {
+		if existing.Spec.TrustBundle == string(rootCert) {
+			// trustbundle is up to date. nothing to do
+			return nil
+		}
 		// Update existing bundle
 		existing.Spec.TrustBundle = string(rootCert)
 		_, err := c.clustertrustbundles.Update(existing)

--- a/pilot/pkg/config/kube/clustertrustbundle/controller.go
+++ b/pilot/pkg/config/kube/clustertrustbundle/controller.go
@@ -29,7 +29,10 @@ import (
 
 const (
 	// The name of the ClusterTrustBundle resource that will store Istio's root certificate
-	istioClusterTrustBundleName = "istio-ca-root-cert"
+	istioClusterTrustBundleName = "istio.io:istiod-ca:root-cert"
+
+	// The signerName of the ClusterTrustBundle
+	istioClusterTrustBundleSignerName = "istio.io/istiod-ca"
 
 	// maxRetries is the number of times a ClusterTrustBundle reconciliation will be retried before it is dropped
 	// out of the queue.
@@ -121,6 +124,7 @@ func (c *ClusterTrustBundleController) updateClusterTrustBundle(rootCert []byte)
 			Name: istioClusterTrustBundleName,
 		},
 		Spec: certificatesv1alpha1.ClusterTrustBundleSpec{
+			SignerName:  istioClusterTrustBundleSignerName,
 			TrustBundle: string(rootCert),
 		},
 	}

--- a/pilot/pkg/config/kube/clustertrustbundle/controller_test.go
+++ b/pilot/pkg/config/kube/clustertrustbundle/controller_test.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package clustertrustbundle
 
 import (

--- a/pilot/pkg/config/kube/clustertrustbundle/controller_test.go
+++ b/pilot/pkg/config/kube/clustertrustbundle/controller_test.go
@@ -1,0 +1,70 @@
+package clustertrustbundle
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/api/certificates/v1alpha1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"istio.io/istio/pilot/pkg/keycertbundle"
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/test"
+)
+
+func TestController(t *testing.T) {
+	initialRootCert := "root"
+	g := NewWithT(t)
+	testCases := []struct {
+		name              string
+		rootcertUpdate    string
+		trustbundleUpdate string
+	}{
+		{
+			name:           "rootcert_update",
+			rootcertUpdate: "abc",
+		},
+		{
+			name:              "rootcert_update",
+			trustbundleUpdate: "def",
+		},
+	}
+
+	clientSet := kube.NewFakeClient()
+	stop := test.NewStop(t)
+	watcher := keycertbundle.NewWatcher()
+	watcher.SetAndNotify(nil, nil, []byte(initialRootCert))
+	controller := NewController(clientSet, watcher)
+	clientSet.RunAndWait(stop)
+	go controller.Run(stop)
+
+	g.Eventually(func() {
+		trustbundle := controller.clustertrustbundles.Get(istioClusterTrustBundleName, "")
+		g.Expect(trustbundle).ToNot(BeNil())
+		g.Expect(trustbundle.Spec.TrustBundle).To(Equal(initialRootCert))
+	})
+
+	for _, tc := range testCases {
+		expectedTrustBundle := initialRootCert
+		if tc.rootcertUpdate != "" {
+			watcher.SetAndNotify(nil, nil, []byte(tc.rootcertUpdate))
+			expectedTrustBundle = tc.rootcertUpdate
+		} else if tc.trustbundleUpdate != "" {
+			controller.clustertrustbundles.Update(&v1alpha1.ClusterTrustBundle{
+				ObjectMeta: v1.ObjectMeta{
+					Name: istioClusterTrustBundleName,
+				},
+				Spec: v1alpha1.ClusterTrustBundleSpec{
+					SignerName:  istioClusterTrustBundleSignerName,
+					TrustBundle: tc.trustbundleUpdate,
+				},
+			})
+		}
+
+		g.Eventually(func() {
+			trustbundle := controller.clustertrustbundles.Get(istioClusterTrustBundleName, "")
+			g.Expect(trustbundle).ToNot(BeNil())
+			g.Expect(trustbundle.Spec.TrustBundle).To(Equal(expectedTrustBundle))
+		})
+	}
+}

--- a/pilot/pkg/config/kube/crdclient/types.gen.go
+++ b/pilot/pkg/config/kube/crdclient/types.gen.go
@@ -18,6 +18,7 @@ import (
 	k8sioapiappsv1 "k8s.io/api/apps/v1"
 	k8sioapiautoscalingv2 "k8s.io/api/autoscaling/v2"
 	k8sioapicertificatesv1 "k8s.io/api/certificates/v1"
+	k8sioapicertificatesv1alpha1 "k8s.io/api/certificates/v1alpha1"
 	k8sioapicoordinationv1 "k8s.io/api/coordination/v1"
 	k8sioapicorev1 "k8s.io/api/core/v1"
 	k8sioapidiscoveryv1 "k8s.io/api/discovery/v1"
@@ -820,6 +821,24 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) config.C
 			},
 			Spec:   &obj.Spec,
 			Status: &obj.Status,
+		}
+	},
+	gvk.ClusterTrustBundle: func(r runtime.Object) config.Config {
+		obj := r.(*k8sioapicertificatesv1alpha1.ClusterTrustBundle)
+		return config.Config{
+			Meta: config.Meta{
+				GroupVersionKind:  gvk.ClusterTrustBundle,
+				Name:              obj.Name,
+				Namespace:         obj.Namespace,
+				Labels:            obj.Labels,
+				Annotations:       obj.Annotations,
+				ResourceVersion:   obj.ResourceVersion,
+				CreationTimestamp: obj.CreationTimestamp.Time,
+				OwnerReferences:   obj.OwnerReferences,
+				UID:               string(obj.UID),
+				Generation:        obj.Generation,
+			},
+			Spec: &obj.Spec,
 		}
 	},
 	gvk.ConfigMap: func(r runtime.Object) config.Config {

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -266,6 +266,9 @@ var (
 
 	MaxConnectionsToAcceptPerSocketEvent = env.Register("MAX_CONNECTIONS_PER_SOCKET_EVENT_LOOP", 1,
 		"The maximum number of connections to accept from the kernel per socket event. Set this to '0' to accept unlimited connections.").Get()
+
+	EnableClusterTrustBundles = env.Register("ENABLE_CLUSTER_TRUST_BUNDLE_API", false,
+		"If enabled, uses the ClusterTrustBundle API instead of ConfigMaps to store the root certificate in the cluster.").Get()
 )
 
 // UnsafeFeaturesEnabled returns true if any unsafe features are enabled.

--- a/pilot/pkg/leaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/leaderelection.go
@@ -36,8 +36,9 @@ import (
 
 // Various locks used throughout the code
 const (
-	NamespaceController     = "istio-namespace-controller-election"
-	ServiceExportController = "istio-serviceexport-controller-election"
+	NamespaceController          = "istio-namespace-controller-election"
+	ClusterTrustBundleController = "istio-clustertrustbundle-controller-election"
+	ServiceExportController      = "istio-serviceexport-controller-election"
 	// This holds the legacy name to not conflict with older control plane deployments which are just
 	// doing the ingress syncing.
 	IngressController = "istio-leader"

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/api/annotation"
+	"istio.io/istio/pilot/pkg/config/kube/clustertrustbundle"
 	"istio.io/istio/pilot/pkg/config/kube/crdclient"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/keycertbundle"
@@ -81,9 +82,9 @@ type Multicluster struct {
 
 	clusterLocal model.ClusterLocalProvider
 
-	startNsController bool
-	caBundleWatcher   *keycertbundle.Watcher
-	revision          string
+	distributeCACert bool
+	caBundleWatcher  *keycertbundle.Watcher
+	revision         string
 
 	component *multicluster.Component[*kubeController]
 }
@@ -95,7 +96,7 @@ func NewMulticluster(
 	serviceEntryController *serviceentry.Controller,
 	caBundleWatcher *keycertbundle.Watcher,
 	revision string,
-	startNsController bool,
+	distributeCACert bool,
 	clusterLocal model.ClusterLocalProvider,
 	s server.Instance,
 	controller *multicluster.Controller,
@@ -104,7 +105,7 @@ func NewMulticluster(
 		serverID:               serverID,
 		opts:                   opts,
 		serviceEntryController: serviceEntryController,
-		startNsController:      startNsController,
+		distributeCACert:       distributeCACert,
 		caBundleWatcher:        caBundleWatcher,
 		revision:               revision,
 		clusterLocal:           clusterLocal,
@@ -182,27 +183,46 @@ func (m *Multicluster) initializeCluster(cluster *multicluster.Cluster, kubeCont
 			shouldLead = m.checkShouldLead(client, options.SystemNamespace, clusterStopCh)
 			log.Infof("should join leader-election for cluster %s: %t", cluster.ID, shouldLead)
 		}
-		if m.startNsController && (shouldLead || configCluster) {
-			// Block server exit on graceful termination of the leader controller.
-			m.s.RunComponentAsyncAndWait("namespace controller", func(_ <-chan struct{}) error {
-				log.Infof("joining leader-election for %s in %s on cluster %s",
-					leaderelection.NamespaceController, options.SystemNamespace, options.ClusterID)
-				election := leaderelection.
-					NewLeaderElectionMulticluster(options.SystemNamespace, m.serverID, leaderelection.NamespaceController, m.revision, !configCluster, client).
-					AddRunFunction(func(leaderStop <-chan struct{}) {
-						log.Infof("starting namespace controller for cluster %s", cluster.ID)
-						nc := NewNamespaceController(client, m.caBundleWatcher)
-						// Start informers again. This fixes the case where informers for namespace do not start,
-						// as we create them only after acquiring the leader lock
-						// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are
-						// basically lazy loading the informer, if we stop it when we lose the lock we will never
-						// recreate it again.
-						client.RunAndWait(clusterStopCh)
-						nc.Run(leaderStop)
-					})
-				election.Run(clusterStopCh)
-				return nil
-			})
+
+		if m.distributeCACert && (shouldLead || configCluster) {
+			if features.EnableClusterTrustBundles {
+				// Block server exit on graceful termination of the leader controller.
+				m.s.RunComponentAsyncAndWait("clustertrustbundle controller", func(_ <-chan struct{}) error {
+					log.Infof("joining leader-election for %s in %s on cluster %s",
+						leaderelection.ClusterTrustBundleController, options.SystemNamespace, options.ClusterID)
+					election := leaderelection.
+						NewLeaderElectionMulticluster(options.SystemNamespace, m.serverID, leaderelection.NamespaceController, m.revision, !configCluster, client).
+						AddRunFunction(func(leaderStop <-chan struct{}) {
+							log.Infof("starting clustertrustbundle controller for cluster %s", cluster.ID)
+							c := clustertrustbundle.NewClusterTrustBundleController(client, m.caBundleWatcher)
+							client.RunAndWait(clusterStopCh)
+							c.Run(leaderStop)
+						})
+					election.Run(clusterStopCh)
+					return nil
+				})
+			} else {
+				// Block server exit on graceful termination of the leader controller.
+				m.s.RunComponentAsyncAndWait("namespace controller", func(_ <-chan struct{}) error {
+					log.Infof("joining leader-election for %s in %s on cluster %s",
+						leaderelection.NamespaceController, options.SystemNamespace, options.ClusterID)
+					election := leaderelection.
+						NewLeaderElectionMulticluster(options.SystemNamespace, m.serverID, leaderelection.NamespaceController, m.revision, !configCluster, client).
+						AddRunFunction(func(leaderStop <-chan struct{}) {
+							log.Infof("starting namespace controller for cluster %s", cluster.ID)
+							nc := NewNamespaceController(client, m.caBundleWatcher)
+							// Start informers again. This fixes the case where informers for namespace do not start,
+							// as we create them only after acquiring the leader lock
+							// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are
+							// basically lazy loading the informer, if we stop it when we lose the lock we will never
+							// recreate it again.
+							client.RunAndWait(clusterStopCh)
+							nc.Run(leaderStop)
+						})
+					election.Run(clusterStopCh)
+					return nil
+				})
+			}
 		}
 		// Set up injection webhook patching for remote clusters we are controlling.
 		// The config cluster has this patching set up elsewhere. We may eventually want to move it here.

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -194,7 +194,7 @@ func (m *Multicluster) initializeCluster(cluster *multicluster.Cluster, kubeCont
 						NewLeaderElectionMulticluster(options.SystemNamespace, m.serverID, leaderelection.NamespaceController, m.revision, !configCluster, client).
 						AddRunFunction(func(leaderStop <-chan struct{}) {
 							log.Infof("starting clustertrustbundle controller for cluster %s", cluster.ID)
-							c := clustertrustbundle.NewClusterTrustBundleController(client, m.caBundleWatcher)
+							c := clustertrustbundle.NewController(client, m.caBundleWatcher)
 							client.RunAndWait(clusterStopCh)
 							c.Run(leaderStop)
 						})

--- a/pkg/config/schema/collections/collections.gen.go
+++ b/pkg/config/schema/collections/collections.gen.go
@@ -12,6 +12,7 @@ import (
 	k8sioapiappsv1 "k8s.io/api/apps/v1"
 	k8sioapiautoscalingv2 "k8s.io/api/autoscaling/v2"
 	k8sioapicertificatesv1 "k8s.io/api/certificates/v1"
+	k8sioapicertificatesv1alpha1 "k8s.io/api/certificates/v1alpha1"
 	k8sioapicoordinationv1 "k8s.io/api/coordination/v1"
 	k8sioapicorev1 "k8s.io/api/core/v1"
 	k8sioapidiscoveryv1 "k8s.io/api/discovery/v1"
@@ -63,6 +64,21 @@ var (
 		Proto:      "k8s.io.api.certificates.v1.CertificateSigningRequestSpec", StatusProto: "k8s.io.api.certificates.v1.CertificateSigningRequestStatus",
 		ReflectType: reflect.TypeOf(&k8sioapicertificatesv1.CertificateSigningRequestSpec{}).Elem(), StatusType: reflect.TypeOf(&k8sioapicertificatesv1.CertificateSigningRequestStatus{}).Elem(),
 		ProtoPackage: "k8s.io/api/certificates/v1", StatusPackage: "k8s.io/api/certificates/v1",
+		ClusterScoped: true,
+		Synthetic:     false,
+		Builtin:       true,
+		ValidateProto: validation.EmptyValidate,
+	}.MustBuild()
+
+	ClusterTrustBundle = resource.Builder{
+		Identifier:    "ClusterTrustBundle",
+		Group:         "certificates.k8s.io",
+		Kind:          "ClusterTrustBundle",
+		Plural:        "clustertrustbundles",
+		Version:       "v1alpha1",
+		Proto:         "k8s.io.api.certificates.v1alpha1.ClusterTrustBundleSpec",
+		ReflectType:   reflect.TypeOf(&k8sioapicertificatesv1alpha1.ClusterTrustBundleSpec{}).Elem(),
+		ProtoPackage:  "k8s.io/api/certificates/v1alpha1",
 		ClusterScoped: true,
 		Synthetic:     false,
 		Builtin:       true,
@@ -773,6 +789,7 @@ var (
 	All = collection.NewSchemasBuilder().
 		MustAdd(AuthorizationPolicy).
 		MustAdd(CertificateSigningRequest).
+		MustAdd(ClusterTrustBundle).
 		MustAdd(ConfigMap).
 		MustAdd(CustomResourceDefinition).
 		MustAdd(DaemonSet).
@@ -821,6 +838,7 @@ var (
 	// Kube contains only kubernetes collections.
 	Kube = collection.NewSchemasBuilder().
 		MustAdd(CertificateSigningRequest).
+		MustAdd(ClusterTrustBundle).
 		MustAdd(ConfigMap).
 		MustAdd(CustomResourceDefinition).
 		MustAdd(DaemonSet).

--- a/pkg/config/schema/gvk/resources.gen.go
+++ b/pkg/config/schema/gvk/resources.gen.go
@@ -13,6 +13,7 @@ var (
 	AuthorizationPolicy            = config.GroupVersionKind{Group: "security.istio.io", Version: "v1", Kind: "AuthorizationPolicy"}
 	AuthorizationPolicy_v1beta1    = config.GroupVersionKind{Group: "security.istio.io", Version: "v1beta1", Kind: "AuthorizationPolicy"}
 	CertificateSigningRequest      = config.GroupVersionKind{Group: "certificates.k8s.io", Version: "v1", Kind: "CertificateSigningRequest"}
+	ClusterTrustBundle             = config.GroupVersionKind{Group: "certificates.k8s.io", Version: "v1alpha1", Kind: "ClusterTrustBundle"}
 	ConfigMap                      = config.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
 	CustomResourceDefinition       = config.GroupVersionKind{Group: "apiextensions.k8s.io", Version: "v1", Kind: "CustomResourceDefinition"}
 	DaemonSet                      = config.GroupVersionKind{Group: "apps", Version: "v1", Kind: "DaemonSet"}
@@ -92,6 +93,8 @@ func ToGVR(g config.GroupVersionKind) (schema.GroupVersionResource, bool) {
 		return gvr.AuthorizationPolicy_v1beta1, true
 	case CertificateSigningRequest:
 		return gvr.CertificateSigningRequest, true
+	case ClusterTrustBundle:
+		return gvr.ClusterTrustBundle, true
 	case ConfigMap:
 		return gvr.ConfigMap, true
 	case CustomResourceDefinition:
@@ -250,6 +253,8 @@ func FromGVR(g schema.GroupVersionResource) (config.GroupVersionKind, bool) {
 		return AuthorizationPolicy, true
 	case gvr.CertificateSigningRequest:
 		return CertificateSigningRequest, true
+	case gvr.ClusterTrustBundle:
+		return ClusterTrustBundle, true
 	case gvr.ConfigMap:
 		return ConfigMap, true
 	case gvr.CustomResourceDefinition:

--- a/pkg/config/schema/gvr/resources.gen.go
+++ b/pkg/config/schema/gvr/resources.gen.go
@@ -10,6 +10,7 @@ var (
 	AuthorizationPolicy            = schema.GroupVersionResource{Group: "security.istio.io", Version: "v1", Resource: "authorizationpolicies"}
 	AuthorizationPolicy_v1beta1    = schema.GroupVersionResource{Group: "security.istio.io", Version: "v1beta1", Resource: "authorizationpolicies"}
 	CertificateSigningRequest      = schema.GroupVersionResource{Group: "certificates.k8s.io", Version: "v1", Resource: "certificatesigningrequests"}
+	ClusterTrustBundle             = schema.GroupVersionResource{Group: "certificates.k8s.io", Version: "v1alpha1", Resource: "clustertrustbundles"}
 	ConfigMap                      = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
 	CustomResourceDefinition       = schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}
 	DaemonSet                      = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "daemonsets"}
@@ -91,6 +92,8 @@ func IsClusterScoped(g schema.GroupVersionResource) bool {
 	case AuthorizationPolicy_v1beta1:
 		return false
 	case CertificateSigningRequest:
+		return true
+	case ClusterTrustBundle:
 		return true
 	case ConfigMap:
 		return false

--- a/pkg/config/schema/kind/resources.gen.go
+++ b/pkg/config/schema/kind/resources.gen.go
@@ -11,6 +11,7 @@ const (
 	Address Kind = iota
 	AuthorizationPolicy
 	CertificateSigningRequest
+	ClusterTrustBundle
 	ConfigMap
 	CustomResourceDefinition
 	DNSName
@@ -65,6 +66,8 @@ func (k Kind) String() string {
 		return "AuthorizationPolicy"
 	case CertificateSigningRequest:
 		return "CertificateSigningRequest"
+	case ClusterTrustBundle:
+		return "ClusterTrustBundle"
 	case ConfigMap:
 		return "ConfigMap"
 	case CustomResourceDefinition:
@@ -164,6 +167,8 @@ func MustFromGVK(g config.GroupVersionKind) Kind {
 		return AuthorizationPolicy
 	case gvk.CertificateSigningRequest:
 		return CertificateSigningRequest
+	case gvk.ClusterTrustBundle:
+		return ClusterTrustBundle
 	case gvk.ConfigMap:
 		return ConfigMap
 	case gvk.CustomResourceDefinition:

--- a/pkg/config/schema/kubeclient/resources.gen.go
+++ b/pkg/config/schema/kubeclient/resources.gen.go
@@ -21,6 +21,7 @@ import (
 	k8sioapiappsv1 "k8s.io/api/apps/v1"
 	k8sioapiautoscalingv2 "k8s.io/api/autoscaling/v2"
 	k8sioapicertificatesv1 "k8s.io/api/certificates/v1"
+	k8sioapicertificatesv1alpha1 "k8s.io/api/certificates/v1alpha1"
 	k8sioapicoordinationv1 "k8s.io/api/coordination/v1"
 	k8sioapicorev1 "k8s.io/api/core/v1"
 	k8sioapidiscoveryv1 "k8s.io/api/discovery/v1"
@@ -45,6 +46,8 @@ func GetWriteClient[T runtime.Object](c ClientGetter, namespace string) ktypes.W
 		return c.Istio().SecurityV1().AuthorizationPolicies(namespace).(ktypes.WriteAPI[T])
 	case *k8sioapicertificatesv1.CertificateSigningRequest:
 		return c.Kube().CertificatesV1().CertificateSigningRequests().(ktypes.WriteAPI[T])
+	case *k8sioapicertificatesv1alpha1.ClusterTrustBundle:
+		return c.Kube().CertificatesV1alpha1().ClusterTrustBundles().(ktypes.WriteAPI[T])
 	case *k8sioapicorev1.ConfigMap:
 		return c.Kube().CoreV1().ConfigMaps(namespace).(ktypes.WriteAPI[T])
 	case *k8sioapiextensionsapiserverpkgapisapiextensionsv1.CustomResourceDefinition:
@@ -138,6 +141,8 @@ func GetClient[T, TL runtime.Object](c ClientGetter, namespace string) ktypes.Re
 		return c.Istio().SecurityV1().AuthorizationPolicies(namespace).(ktypes.ReadWriteAPI[T, TL])
 	case *k8sioapicertificatesv1.CertificateSigningRequest:
 		return c.Kube().CertificatesV1().CertificateSigningRequests().(ktypes.ReadWriteAPI[T, TL])
+	case *k8sioapicertificatesv1alpha1.ClusterTrustBundle:
+		return c.Kube().CertificatesV1alpha1().ClusterTrustBundles().(ktypes.ReadWriteAPI[T, TL])
 	case *k8sioapicorev1.ConfigMap:
 		return c.Kube().CoreV1().ConfigMaps(namespace).(ktypes.ReadWriteAPI[T, TL])
 	case *k8sioapiextensionsapiserverpkgapisapiextensionsv1.CustomResourceDefinition:
@@ -231,6 +236,8 @@ func gvrToObject(g schema.GroupVersionResource) runtime.Object {
 		return &apiistioioapisecurityv1.AuthorizationPolicy{}
 	case gvr.CertificateSigningRequest:
 		return &k8sioapicertificatesv1.CertificateSigningRequest{}
+	case gvr.ClusterTrustBundle:
+		return &k8sioapicertificatesv1alpha1.ClusterTrustBundle{}
 	case gvr.ConfigMap:
 		return &k8sioapicorev1.ConfigMap{}
 	case gvr.CustomResourceDefinition:
@@ -336,6 +343,13 @@ func getInformerFiltered(c ClientGetter, opts ktypes.InformerOptions, g schema.G
 		}
 		w = func(options metav1.ListOptions) (watch.Interface, error) {
 			return c.Kube().CertificatesV1().CertificateSigningRequests().Watch(context.Background(), options)
+		}
+	case gvr.ClusterTrustBundle:
+		l = func(options metav1.ListOptions) (runtime.Object, error) {
+			return c.Kube().CertificatesV1alpha1().ClusterTrustBundles().List(context.Background(), options)
+		}
+		w = func(options metav1.ListOptions) (watch.Interface, error) {
+			return c.Kube().CertificatesV1alpha1().ClusterTrustBundles().Watch(context.Background(), options)
 		}
 	case gvr.ConfigMap:
 		l = func(options metav1.ListOptions) (runtime.Object, error) {

--- a/pkg/config/schema/kubetypes/resources.gen.go
+++ b/pkg/config/schema/kubetypes/resources.gen.go
@@ -7,6 +7,7 @@ import (
 	k8sioapiappsv1 "k8s.io/api/apps/v1"
 	k8sioapiautoscalingv2 "k8s.io/api/autoscaling/v2"
 	k8sioapicertificatesv1 "k8s.io/api/certificates/v1"
+	k8sioapicertificatesv1alpha1 "k8s.io/api/certificates/v1alpha1"
 	k8sioapicoordinationv1 "k8s.io/api/coordination/v1"
 	k8sioapicorev1 "k8s.io/api/core/v1"
 	k8sioapidiscoveryv1 "k8s.io/api/discovery/v1"
@@ -41,6 +42,8 @@ func getGvk(obj any) (config.GroupVersionKind, bool) {
 		return gvk.AuthorizationPolicy, true
 	case *k8sioapicertificatesv1.CertificateSigningRequest:
 		return gvk.CertificateSigningRequest, true
+	case *k8sioapicertificatesv1alpha1.ClusterTrustBundle:
+		return gvk.ClusterTrustBundle, true
 	case *k8sioapicorev1.ConfigMap:
 		return gvk.ConfigMap, true
 	case *k8sioapiextensionsapiserverpkgapisapiextensionsv1.CustomResourceDefinition:

--- a/pkg/config/schema/metadata.yaml
+++ b/pkg/config/schema/metadata.yaml
@@ -151,6 +151,15 @@ resources:
     statusProto: "k8s.io.api.certificates.v1.CertificateSigningRequestStatus"
     statusProtoPackage: "k8s.io/api/certificates/v1"
 
+  - kind: "ClusterTrustBundle"
+    plural: "clustertrustbundles"
+    group: "certificates.k8s.io"
+    version: "v1alpha1"
+    builtin: true
+    clusterScoped: true
+    proto: "k8s.io.api.certificates.v1alpha1.ClusterTrustBundleSpec"
+    protoPackage: "k8s.io/api/certificates/v1alpha1"
+
   - kind: "Ingress"
     plural: "ingresses"
     group: "networking.k8s.io"

--- a/prow/config/default.yaml
+++ b/prow/config/default.yaml
@@ -27,3 +27,8 @@ containerdConfigPatches:
   - |-
     [plugins."io.containerd.grpc.v1.cri".registry]
       config_path = "/etc/containerd/certs.d"
+featureGates:
+  "ClusterTrustBundle": true
+  "ClusterTrustBundleProjection": true
+runtimeConfig:
+  "certificates.k8s.io/v1alpha1/clustertrustbundles": true

--- a/releasenotes/notes/43986.yaml
+++ b/releasenotes/notes/43986.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+issue:
+  - 43986
+releaseNotes:
+- |
+  **Added** experimental support for the v1alpha1 ClusterTrustBundle API. This can be enabled by setting `values.pilot.env.ENABLE_CLUSTER_TRUST_BUNDLE_API=true`. Note that you will have to make sure to also enable the respective feature gates in your cluster, see KEP-3257 (https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/3257-cluster-trust-bundles) for details.

--- a/releasenotes/notes/43986.yaml
+++ b/releasenotes/notes/43986.yaml
@@ -5,4 +5,4 @@ issue:
   - 43986
 releaseNotes:
 - |
-  **Added** experimental support for the v1alpha1 ClusterTrustBundle API. This can be enabled by setting `values.pilot.env.ENABLE_CLUSTER_TRUST_BUNDLE_API=true`. Note that you will have to make sure to also enable the respective feature gates in your cluster, see KEP-3257 (https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/3257-cluster-trust-bundles) for details.
+  **Added** experimental support for the v1alpha1 `ClusterTrustBundle` API. This can be enabled by setting `values.pilot.env.ENABLE_CLUSTER_TRUST_BUNDLE_API=true`. Note that you will have to make sure to also enable the respective feature gates in your cluster, see [KEP-3257](https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/3257-cluster-trust-bundles) for details.


### PR DESCRIPTION
This adds a feature flag to enable basic ClusterTrustBundle API support. If enabled, it replaces the old Namespace controller with a simpler ClusterTrustBundle controller.

Fixes #43986 