### PR TITLE
wasmplugin: Allow configuration of fail reload strategy

### DIFF
--- a/pilot/pkg/model/extensions.go
+++ b/pilot/pkg/model/extensions.go
@@ -174,6 +174,8 @@ func (p *WasmPluginWrapper) buildPluginConfig(proxy *Proxy) *wasmextensions.Plug
 			wasmConfig.FailurePolicy = wasmextensions.FailurePolicy_FAIL_OPEN
 		case extensions.FailStrategy_FAIL_CLOSE:
 			wasmConfig.FailurePolicy = wasmextensions.FailurePolicy_FAIL_CLOSED
+		case extensions.FailStrategy_FAIL_RELOAD:
+			wasmConfig.FailurePolicy = wasmextensions.FailurePolicy_FAIL_RELOAD
 		}
 		// TODO: support more failure policies
 	} else {

--- a/pilot/pkg/model/extensions_test.go
+++ b/pilot/pkg/model/extensions_test.go
@@ -331,6 +331,17 @@ func TestFailurePolicy(t *testing.T) {
 			},
 			out: wasmextensions.FailurePolicy_FAIL_OPEN,
 		},
+		{
+			desc: "RELOAD",
+			proxy: &Proxy{
+				IstioVersion: &IstioVersion{Major: 1, Minor: 25, Patch: 0},
+			},
+			in: &extensions.WasmPlugin{
+				Url:          "file://fake.wasm",
+				FailStrategy: extensions.FailStrategy_FAIL_RELOAD,
+			},
+			out: wasmextensions.FailurePolicy_FAIL_RELOAD,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/releasenotes/notes/wasm-fail-reload.yaml
+++ b/releasenotes/notes/wasm-fail-reload.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: extensibility
+releaseNotes:
+- |
+  **Added** an option to reload the wasm VM on new requests if the VM has failed.


### PR DESCRIPTION
**Please provide a description of this PR:**

Pairs with https://github.com/istio/api/pull/3471 to allow configuration of [Envoy's WASM FailurePolicy](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/wasm/v3/wasm.proto#enum-extensions-wasm-v3-failurepolicy) `FAIL_RELOAD`