### PR TITLE
[release-1.24] Fix tests resources cleanup for Openshift

### DIFF
--- a/pkg/test/framework/components/istio/cleanup.go
+++ b/pkg/test/framework/components/istio/cleanup.go
@@ -16,6 +16,8 @@ package istio
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"regexp"
 	"time"
 
@@ -27,7 +29,13 @@ import (
 	"istio.io/istio/pkg/test/framework/resource"
 	kube2 "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/pkg/test/scopes"
+	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/test/util/yml"
+)
+
+const (
+	RetryDelay   = 2 * time.Second
+	RetryTimeOut = 5 * time.Minute
 )
 
 func (i *istioImpl) Close() error {
@@ -105,6 +113,29 @@ func (i *istioImpl) Dump(ctx resource.Context) {
 
 func (i *istioImpl) cleanupCluster(c cluster.Cluster, errG *multierror.Group) {
 	scopes.Framework.Infof("clean up cluster %s", c.Name())
+
+	// Tail `istio-cni` termination/shutdown logs, if any such pods present
+	// in the system namespace
+	label := "k8s-app=istio-cni-node"
+
+	fetchFunc := kube2.NewPodFetch(c, i.cfg.SystemNamespace, label)
+
+	fetched, e := fetchFunc()
+	if e != nil {
+		scopes.Framework.Infof("Failed retrieving pods: %v", e)
+	}
+
+	if len(fetched) != 0 {
+		workDir, err := i.ctx.CreateTmpDirectory("istio-state")
+		if err != nil {
+			scopes.Framework.Errorf("Unable to create directory for dumping istio-cni termlogs: %v", err)
+			return
+		}
+		for _, pod := range fetched {
+			go kube2.DumpTerminationLogs(context.Background(), c, workDir, pod, "install-cni")
+		}
+	}
+
 	errG.Go(func() (err error) {
 		if e := i.installer.Close(c); e != nil {
 			err = multierror.Append(err, e)
@@ -132,6 +163,38 @@ func (i *istioImpl) cleanupCluster(c cluster.Cluster, errG *multierror.Group) {
 			context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}); e != nil {
 			err = multierror.Append(err, e)
 		}
+
+		// We deleted all resources, but don't report cleanup finished until all Istio pods
+		// in the system namespace have actually terminated.
+		cleanErr := retry.UntilSuccess(func() error {
+			label := "app.kubernetes.io/part-of=istio"
+
+			fetchPodFunc := kube2.NewPodFetch(c, i.cfg.SystemNamespace, label)
+
+			fetchedPod, e := fetchPodFunc()
+			if e != nil {
+				scopes.Framework.Infof("Failed retrieving pods: %v", e)
+			}
+
+			// In Openshift if takes time to cleanup the services.
+			// Lets check for the services cleanup as well.
+			fetchSvcFunc := kube2.NewServiceFetch(c, i.cfg.SystemNamespace, label)
+
+			fetchedSvc, e := fetchSvcFunc()
+			if e != nil {
+				scopes.Framework.Infof("Failed retrieving services: %v", e)
+			}
+
+			if len(fetchedPod) == 0 && len(fetchedSvc) == 0 {
+				return nil
+			}
+			res := fmt.Sprintf("Still waiting for %d pods and %d services to terminate in %s ", len(fetchedPod), len(fetchedSvc), i.cfg.SystemNamespace)
+			scopes.Framework.Infof(res)
+			return errors.New(res)
+		}, retry.Timeout(RetryTimeOut), retry.Delay(RetryDelay))
+
+		err = multierror.Append(err, cleanErr)
+
 		return
 	})
 }

--- a/pkg/test/kube/dump.go
+++ b/pkg/test/kube/dump.go
@@ -643,3 +643,18 @@ func DumpPodAgent(ctx resource.Context, c cluster.Cluster, workDir string, _ str
 		scopes.Framework.Errorf("failed to dump ndsz: %v", err)
 	}
 }
+
+// Will capture pod logs until target pod/container terminates, and then will write them to file.
+// Generally should be run in a goroutine while deletion happens
+func DumpTerminationLogs(ctx context.Context, c cluster.Cluster, workDir string, pod corev1.Pod, containerName string) {
+	fname := podOutputPath(workDir, c, pod, fmt.Sprintf("%s.termination.log", containerName))
+	l, err := c.PodLogsFollow(ctx, pod.Name, pod.Namespace, containerName)
+	if err != nil && len(l) == 0 {
+		scopes.Framework.Warnf("Unable to capture termination logs for cluster/pod/container: %s/%s/%s/%s: %v",
+			c.Name(), pod.Namespace, pod.Name, containerName, err)
+	}
+	if err = os.WriteFile(fname, []byte(l), os.ModePerm); err != nil {
+		scopes.Framework.Warnf("Unable to write termination logs for cluster/pod/container: %s/%s/%s/%s: %v",
+			c.Name(), pod.Namespace, pod.Name, containerName, err)
+	}
+}

--- a/pkg/test/kube/util.go
+++ b/pkg/test/kube/util.go
@@ -39,8 +39,13 @@ var (
 	ErrNoPodsFetched = fmt.Errorf("no pods fetched")
 )
 
-// PodFetchFunc fetches pods from a k8s Client.
-type PodFetchFunc func() ([]corev1.Pod, error)
+type (
+	// PodFetchFunc fetches pods from a k8s Client.
+	PodFetchFunc func() ([]corev1.Pod, error)
+
+	// SvcFetchFunc fetches services from a k8s Client.
+	SvcFetchFunc func() ([]corev1.Service, error)
+)
 
 // NewPodFetch creates a new PodFetchFunction that fetches all pods matching the namespace and label selectors.
 func NewPodFetch(a istioKube.CLIClient, namespace string, selectors ...string) PodFetchFunc {
@@ -117,6 +122,17 @@ func CheckPodsAreReady(fetchFunc PodFetchFunc) ([]corev1.Pod, error) {
 	}
 
 	return fetched, nil
+}
+
+// NewServiceFetch creates a new ServiceFetchFunction that fetches all services matching the namespace and label selectors.
+func NewServiceFetch(a istioKube.CLIClient, namespace string, selectors ...string) SvcFetchFunc {
+	return func() ([]corev1.Service, error) {
+		services, err := a.ServicesForSelector(context.TODO(), namespace, selectors...)
+		if err != nil {
+			return nil, err
+		}
+		return services.Items, nil
+	}
 }
 
 // DeleteOptionsForeground creates new delete options that will block until the operation completes.


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR contains cherry-pick for the following PRs:
- https://github.com/istio/istio/pull/54447
- https://github.com/istio/istio/pull/54377 (partially. only cleanup part)


When test resources cleaned up in Openshift, it takes time for the "istio-ingressgateway" and "istio-egressgateway" services to be deleted.

As a result, when the resources are cleaned after one test and the next test starts, ittend to fail because the services are in deletion state and failed to be used by the next test.

Check for the services to be deleted completely before ending the test.