### PR TITLE
Check for reachable ingress in TestGatewayAPI security test (#55028)

### DIFF
--- a/pkg/test/framework/components/istio/ingress.go
+++ b/pkg/test/framework/components/istio/ingress.go
@@ -34,6 +34,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/istio/ingress"
 	"istio.io/istio/pkg/test/framework/resource"
+	testKube "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/test/util/retry"
 )
@@ -233,6 +234,13 @@ func (c *ingressImpl) callEcho(opts echo.CallOptions) (echo.CallResult, error) {
 	}
 	addr = addrs[0]
 	port = ports[0]
+
+	// When the Ingress is a domain name (in public cloud), it might take a bit of time to make it reachable.
+	_, err := testKube.WaitUntilReachableIngress(addr)
+	if err != nil {
+		return echo.CallResult{}, fmt.Errorf("unable to get reachable ingress. Error: %v", err)
+	}
+
 	// Even if they set ServicePort, when load balancer is disabled, we may need to switch to NodePort, so replace it.
 	opts.Port.ServicePort = port
 	if opts.HTTP.Headers == nil {

--- a/pkg/test/kube/util.go
+++ b/pkg/test/kube/util.go
@@ -17,6 +17,7 @@ package kube
 import (
 	"context"
 	"fmt"
+	"net"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -323,4 +324,44 @@ func checkAllNamesExist(names []string, haystack []string) bool {
 	}
 
 	return true
+}
+
+// Resolve domain name and return ip address.
+// By default, return ipv4 address and if missing, return ipv6.
+func resolveHostDomainToIP(hostDomain string) (string, error) {
+	ips, err := net.LookupIP(hostDomain)
+	if err != nil {
+		return "", err
+	}
+
+	var ipv6Addr string
+
+	for _, ip := range ips {
+		if ip.To4() != nil {
+			return ip.String(), nil
+		} else if ipv6Addr == "" {
+			ipv6Addr = ip.String()
+		}
+	}
+
+	if ipv6Addr != "" {
+		return ipv6Addr, nil
+	}
+
+	return "", fmt.Errorf("no IP address found for hostname: %s", hostDomain)
+}
+
+// When the Ingress is a domain name (in public cloud), it might take a bit of time to make it reachable.
+func WaitUntilReachableIngress(hostDomain string) (string, error) {
+	var ip string
+	err := retry.UntilSuccess(func() error {
+		ipAddr, err := resolveHostDomainToIP(hostDomain)
+		if err != nil {
+			return err
+		}
+		ip = ipAddr
+		return nil
+	}, retry.Timeout(90*time.Second), retry.BackoffDelay(1*time.Second))
+
+	return ip, err
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
This is a cherry-pick of the following PR - https://github.com/istio/istio/pull/55028

When the Ingress is a domain name, like in public cloud, it might take a bit for the DNS name to become populated.
Set a check to wait for the domain name to become resolvable.