### PR TITLE
Fix broken IstioCNI config for enabling repair mode

### DIFF
--- a/manifests/charts/istio-cni/templates/configmap-cni.yaml
+++ b/manifests/charts/istio-cni/templates/configmap-cni.yaml
@@ -22,7 +22,7 @@ data:
   {{- end }}
   CHAINED_CNI_PLUGIN: {{ .Values.chained | quote }}
   EXCLUDE_NAMESPACES: "{{ range $idx, $ns := .Values.excludeNamespaces }}{{ if $idx }},{{ end }}{{ $ns }}{{ end }}"
-  REPAIR_ENABLED: {{ .Values.chained | quote }}
+  REPAIR_ENABLED: {{ .Values.repair.enabled | quote }}
   REPAIR_LABEL_PODS: {{ .Values.repair.labelPods | quote }}
   REPAIR_DELETE_PODS: {{ .Values.repair.deletePods | quote }}
   REPAIR_REPAIR_PODS: {{ .Values.repair.repairPods | quote }}


### PR DESCRIPTION
Currently, the CNI `REPAIR_ENABLED` flag is mistakenly enabled based on `.cni.chained` value instead of `.repair.enabled`. This PR fixes it.
