### PR TITLE
Bug Fix - Add Handling of `GatewayClass` to `WaypointPolicyStatusCollection`

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -221,6 +221,7 @@ func New(options Options) Index {
 			Waypoints,
 			Services,
 			ServiceEntries,
+			GatewayClasses,
 			Namespaces,
 			opts,
 		)

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/authorization_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/authorization_test.go
@@ -1095,7 +1095,7 @@ func TestWaypointPolicyStatusCollection(t *testing.T) {
 					Ancestor: "GatewayClass.gateway.networking.k8s.io:istio-system/not-for-waypoint",
 					Status: &model.StatusMessage{
 						Reason:  model.WaypointPolicyReasonInvalid,
-						Message: fmt.Sprintf("non-waypoint GatewayClass `not-for-waypoint` specified, GatewayClass must use controller name `%s`", constants.ManagedGatewayMeshController),
+						Message: fmt.Sprintf("GatewayClass must use controller name `%s` for waypoints", constants.ManagedGatewayMeshController),
 					},
 					Bound:              false,
 					ObservedGeneration: 1,

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/policies.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/policies.go
@@ -64,7 +64,11 @@ func WaypointPolicyStatusCollection(
 				switch target.GetKind() {
 				case gvk.GatewayClass_v1.Kind:
 					fetchedGatewayClasses := krt.Fetch(ctx, gatewayClasses, krt.FilterKey(target.GetName()))
-					if len(fetchedGatewayClasses) == 1 {
+
+					switch len(fetchedGatewayClasses) {
+					case 0:
+						reason = model.WaypointPolicyReasonTargetNotFound
+					case 1:
 						// verify GatewayClass is for waypoint
 						if fetchedGatewayClasses[0].Spec.ControllerName != constants.ManagedGatewayMeshController {
 							reason = model.WaypointPolicyReasonInvalid
@@ -74,11 +78,9 @@ func WaypointPolicyStatusCollection(
 							reason = model.WaypointPolicyReasonAccepted
 							message = fmt.Sprintf("bound to %s", fetchedGatewayClasses[0].GetName())
 						}
-					} else if len(fetchedGatewayClasses) > 1 {
+					default:
 						log.Warnf("found %d resources that match AuthorizationPolicy `%s/%s` GatewayClass target reference `%s`",
 							len(fetchedGatewayClasses), i.GetNamespace(), i.GetName(), target.GetName())
-					} else {
-						reason = model.WaypointPolicyReasonTargetNotFound
 					}
 				case gvk.KubernetesGateway.Kind:
 					fetchedWaypoints := krt.Fetch(ctx, waypoints, krt.FilterKey(key))

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/policies.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/policies.go
@@ -75,7 +75,8 @@ func WaypointPolicyStatusCollection(
 							message = fmt.Sprintf("bound to %s", fetchedGatewayClasses[0].GetName())
 						}
 					} else if len(fetchedGatewayClasses) > 1 {
-						log.Warnf("found %d resources that match AuthorizationPolicy `%s/%s` GatewayClass target reference `%s`", len(fetchedGatewayClasses), i.GetNamespace(), i.GetName(), target.GetName())
+						log.Warnf("found %d resources that match AuthorizationPolicy `%s/%s` GatewayClass target reference `%s`",
+							len(fetchedGatewayClasses), i.GetNamespace(), i.GetName(), target.GetName())
 					} else {
 						reason = model.WaypointPolicyReasonTargetNotFound
 					}

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/policies.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/policies.go
@@ -68,7 +68,7 @@ func WaypointPolicyStatusCollection(
 						// verify GatewayClass is for waypoint
 						if fetchedGatewayClasses[0].Spec.ControllerName != constants.ManagedGatewayMeshController {
 							reason = model.WaypointPolicyReasonInvalid
-							message = fmt.Sprintf("non-waypoint GatewayClass `%s` specified, GatewayClass must use controller name `%s`", fetchedGatewayClasses[0].GetName(), constants.ManagedGatewayMeshController)
+							message = fmt.Sprintf("GatewayClass must use controller name `%s` for waypoints", constants.ManagedGatewayMeshController)
 						} else {
 							bound = true
 							reason = model.WaypointPolicyReasonAccepted

--- a/releasenotes/notes/ap-gateway-class-status.yml
+++ b/releasenotes/notes/ap-gateway-class-status.yml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: bug-fix
-area: networking
+area: traffic-management
 releaseNotes:
 - |
   **Fixed** an issue where `AuthorizationPolicy`'s WaypointAccepted status condition was not being updated to reflect the resolution of a `GatewayClass` target reference.

--- a/releasenotes/notes/ap-gateway-class-status.yml
+++ b/releasenotes/notes/ap-gateway-class-status.yml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: networking
+releaseNotes:
+- |
+  **Fixed** an issue where `AuthorizationPolicy`'s WaypointAccepted status condition was not being updated to reflect the resolution of a `GatewayClass` target reference.


### PR DESCRIPTION
**Please provide a description of this PR:**
When applying an AuthorizationPolicy that specifies a targetRef of GatewayClass type, the status never shows a `WaypointAccepted` condition of status `true`. This PR adds resolution of `GatewayClass` type for this condition so it shows the proper status. 