### PR TITLE
Support MeshConfig defaultXExportTo as documented in the API

### DIFF
--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -2169,6 +2169,7 @@ func TestSetDestinationRuleWithWorkloadSelector(t *testing.T) {
 
 func TestSetDestinationRuleMerging(t *testing.T) {
 	ps := NewPushContext()
+	ps.Mesh = &meshconfig.MeshConfig{RootNamespace: "istio-system"}
 	ps.exportToDefaults.destinationRule = sets.New(visibility.Public)
 	testhost := "httpbin.org"
 	destinationRuleNamespace1 := config.Config{
@@ -2264,6 +2265,10 @@ func TestSetDestinationRuleMerging(t *testing.T) {
 func TestSetDestinationRuleWithExportTo(t *testing.T) {
 	ps := NewPushContext()
 	ps.Mesh = &meshconfig.MeshConfig{RootNamespace: "istio-system"}
+	// this is normally done in ps.InitContext but we don't have the other stuff needed
+	// to call the "right" method at hand here
+	ps.initDefaultExportMaps()
+
 	testhost := "httpbin.org"
 	appHost := "foo.app.org"
 	wildcardHost1 := "*.org"

--- a/releasenotes/notes/meshconfig-exportto-fix.yaml
+++ b/releasenotes/notes/meshconfig-exportto-fix.yaml
@@ -1,0 +1,25 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+issue:
+  - 17466
+  - 28558
+
+docs:
+  - "[reference] https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig-default_service_export_to"
+
+releaseNotes:
+  - |
+    **Fixed** the implementation of MeshConfig's defaultServiceExportTo, defaultVirtualServiceExportTo, and defaultDestinationRuleExportTo to align with the API documentation and the existing behavior of the `exportTo` field on each of those resources. In particular, lists of namespaces are now supported in addition to (and mixed with) the namespace aliases `*`, `.`, and `~`.
+
+upgradeNotes:
+  - title: Change in MechConfig.defaultServiceExportTo's Behavior
+    content: |
+      defaultServiceExportTo's behavior has been updated to match its documentation. If you are using the `exportTo` field in ServiceEntries or the `networking.istio.io/exportTo` annotation on your Kubernetes Service resources to get around previous limitations in defaultServiceExportTo's behavior, those can be reverted in favor of defaultServiceExportTo with a list of namespaces.
+  - title: Change the MechConfig.defaultVirtualServiceExportTo's Behavior
+    content: |
+      defaultVirtualServiceExportTo's behavior has been updated to match its documentation. If you are using the `exportTo` field in VirtualServices resources to get around previous limitations in defaultVirtualServiceExportTo's behavior, those can be reverted in favor of defaultVirtualServiceExportTo with a list of namespaces.
+  - title: Change the MechConfig.defaultDestinationRuleExportTo's Behavior
+    content: |
+      defaultDestinationRuleExportTo's behavior has been updated to match its documentation. If you are using the `exportTo` field in DestinationRules resources to get around previous limitations in defaultDestinationRuleExportTo's behavior, those can be reverted in favor of defaultDestinationRuleExportTo with a list of namespaces.


### PR DESCRIPTION
**Please provide a description of this PR:**
Since the addition of `defaultXExportTo` (X = VirtualService, ServiceEntry, DestinationRule) in mesh config, their implementation has not matched their documentation. This has caused [several](https://github.com/istio/istio/issues/17466) [user issues](https://github.com/istio/istio/issues/28558).

In the documentation we say:

> The value is a list of namespace names and reserved namespace aliases.

In practice, the `exportTo` field in the `spec` of each resource works as is documented here, but the `defaultXExportTo` fields on the mesh config (and only those) behave differently, supporting _only_ the namespace aliases `*`, `.`, and `~`. This PR corrects the implementation to support `defaultXExportTo` identically to how each resource's `exportTo` works today. It does this by removing special cases and net _reduces_ the code overall.

Draft at the moment as I need to add a few more test cases to ensure that the behavior is exercised. No existing test cases needed to be updated in light of these changes (with the exception of a setup step missing in one test method, who's code path wasn't tested before but is now).