### PR TITLE
add status for when ap is not in root ns and gw class target ref is used

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -222,6 +222,7 @@ func New(options Options) Index {
 			Services,
 			ServiceEntries,
 			GatewayClasses,
+			MeshConfig,
 			Namespaces,
 			opts,
 		)

--- a/releasenotes/notes/ap-not-in-root-ns-gwclass-targetref.yml
+++ b/releasenotes/notes/ap-not-in-root-ns-gwclass-targetref.yml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+- |
+  **Fixed** an issue where WaypointAccepted status condition for AuthorizationPolicies that reference a GatewayClass and do not reside in the root namespace was not being updated with the correct reason and message.


### PR DESCRIPTION
**Please provide a description of this PR:**
When an `AuthorizationPolicy` uses a target reference of `GatewayClass` type, it must reside in the root namespace. This PR adds a check to the waypoint status collection to update the status condition `WaypointAccepted` when this use case is violated. 