### PR TITLE
k8s workqueue: Do not clobber MetricsProvider for new queues

### DIFF
--- a/pkg/kube/controllers/queue.go
+++ b/pkg/kube/controllers/queue.go
@@ -93,10 +93,7 @@ func NewQueue(name string, options ...func(*Queue)) Queue {
 		q.queue = workqueue.NewTypedRateLimitingQueueWithConfig[any](
 			workqueue.DefaultTypedControllerRateLimiter[any](),
 			workqueue.TypedRateLimitingQueueConfig[any]{
-				Name:            name,
-				MetricsProvider: nil,
-				Clock:           nil,
-				DelayingQueue:   nil,
+				Name: name,
 			},
 		)
 	}


### PR DESCRIPTION
Removes `nil` assignments for various k8s queue configuration parameters when instantiating a new k8s queue wrapper. There are cases where things like a MetricsProvider has already been created and assigned as the default, so creating new queues with `nil` MetricsProviders breaks this.

---