### PR TITLE
[release-1.23] Fix broken IstioCNI config for enabling repair mode (#55665)

### DIFF
--- a/manifests/charts/istio-cni/templates/configmap-cni.yaml
+++ b/manifests/charts/istio-cni/templates/configmap-cni.yaml
@@ -20,7 +20,7 @@ data:
   CNI_NET_DIR: {{ .Values.cni.cniConfDir | default "/etc/cni/net.d" }} # Directory where the CNI config file is going to be created. 
   CHAINED_CNI_PLUGIN: {{ .Values.cni.chained | quote }}
   EXCLUDED_NAMESPACES: "{{ range $idx, $ns := .Values.cni.excludeNamespaces }}{{ if $idx }},{{ end }}{{ $ns }}{{ end }}"
-  REPAIR_ENABLED: {{ .Values.cni.chained | quote }}
+  REPAIR_ENABLED: {{ .Values.cni.repair.enabled | quote }}
   REPAIR_LABEL_PODS: {{ .Values.cni.repair.labelPods | quote }}
   REPAIR_DELETE_PODS: {{ .Values.cni.repair.deletePods | quote }}
   REPAIR_REPAIR_PODS: {{ .Values.cni.repair.repairPods | quote }}


### PR DESCRIPTION
Currently, the CNI `REPAIR_ENABLED` flag is mistakenly enabled based on `.cni.chained` value instead of `.repair.enabled`. This PR fixes it.

Fixes: https://github.com/istio/istio/issues/55704
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>
cherry picked from commit af784e7e2e4840ea8902ebdc7958cfbdf058244a
