### PR TITLE
Rename BuiltInChainsMap to BuiltInChainsAndTargetsMap

### DIFF
--- a/tools/istio-iptables/pkg/builder/iptables_builder_impl.go
+++ b/tools/istio-iptables/pkg/builder/iptables_builder_impl.go
@@ -138,7 +138,7 @@ func (rb *IptablesRuleBuilder) buildRules(rules []Rule) [][]string {
 		// Create new chain if key: `chainTable` isn't present in map
 		if !chainTableLookupSet.Contains(chainTable) {
 			// Ignore chain creation for built-in chains for iptables
-			if !constants.BuiltInChainsMap.Contains(r.chain) {
+			if !constants.BuiltInChainsAndTargetsMap.Contains(r.chain) {
 				cmd := []string{"-t", r.table, "-N", r.chain}
 				output = append(output, cmd)
 				chainTableLookupSet.Insert(chainTable)
@@ -181,7 +181,7 @@ func (rb *IptablesRuleBuilder) buildCleanupRules(rules []Rule) [][]string {
 		// Delete chain if key: `chainTable` isn't present in map
 		if !chainTableLookupSet.Contains(chainTable) {
 			// Don't delete iptables built-in chains
-			if !constants.BuiltInChainsMap.Contains(r.chain) {
+			if !constants.BuiltInChainsAndTargetsMap.Contains(r.chain) {
 				cmd := []string{"-t", r.table, "-F", r.chain}
 				output = append(output, cmd)
 				cmd = []string{"-t", r.table, "-X", r.chain}
@@ -276,7 +276,7 @@ func (rb *IptablesRuleBuilder) buildRestore(rules []Rule) string {
 		// Create new chain if key: `chainTable` isn't present in map
 		if !chainTableLookupMap.InsertContains(chainTable) {
 			// Ignore chain creation for built-in chains for iptables
-			if !constants.BuiltInChainsMap.Contains(r.chain) {
+			if !constants.BuiltInChainsAndTargetsMap.Contains(r.chain) {
 				tableRulesMap[r.table] = append(tableRulesMap[r.table], fmt.Sprintf("-N %s", r.chain))
 			}
 		}
@@ -284,13 +284,13 @@ func (rb *IptablesRuleBuilder) buildRestore(rules []Rule) string {
 	// Also look for chains we jump to, even if we have no rules in them
 	for _, r := range rules {
 		if len(r.params) >= 2 && r.params[len(r.params)-2] == "-j" {
-			chain := r.params[len(r.params)-1]
-			chainTable := fmt.Sprintf("%s:%s", chain, r.table)
+			jumpTarget := r.params[len(r.params)-1]
+			chainTable := fmt.Sprintf("%s:%s", jumpTarget, r.table)
 			// Create new chain if key: `chainTable` isn't present in map
 			if !chainTableLookupMap.InsertContains(chainTable) {
 				// Ignore chain creation for built-in chains for iptables
-				if !constants.BuiltInChainsMap.Contains(chain) {
-					tableRulesMap[r.table] = append(tableRulesMap[r.table], fmt.Sprintf("-N %s", chain))
+				if !constants.BuiltInChainsAndTargetsMap.Contains(jumpTarget) {
+					tableRulesMap[r.table] = append(tableRulesMap[r.table], fmt.Sprintf("-N %s", jumpTarget))
 				}
 			}
 		}

--- a/tools/istio-iptables/pkg/capture/run.go
+++ b/tools/istio-iptables/pkg/capture/run.go
@@ -334,7 +334,7 @@ func (cfg *IptablesConfigurator) Run() error {
 		}
 	}
 
-	// 127.0.0.6/::7 is bind connect from inbound passthrough cluster
+	// 127.0.0.6/::6 is bind connect from inbound passthrough cluster
 	cfg.ruleBuilder.AppendVersionedRule("127.0.0.6/32", "::6/128", constants.ISTIOOUTPUT, "nat",
 		"-o", "lo", "-s", constants.IPVersionSpecific, "-j", "RETURN")
 
@@ -585,7 +585,6 @@ func SetupDNSRedir(iptables *builder.IptablesRuleBuilder, proxyUID, proxyGID str
 func addDNSConntrackZones(
 	iptables *builder.IptablesRuleBuilder, proxyUID, proxyGID string, dnsServersV4 []string, dnsServersV6 []string, captureAllDNS bool,
 ) {
-	// TODO: add ip6 as well
 	for _, uid := range split(proxyUID) {
 		// Packets with dst port 53 from istio to zone 1. These are Istio calls to upstream resolvers
 		iptables.AppendRule(constants.ISTIOOUTPUTDNS, "raw", "-p", "udp", "--dport", "53", "-m", "owner", "--uid-owner", uid, "-j", "CT", "--zone", "1")

--- a/tools/istio-iptables/pkg/capture/run_linux.go
+++ b/tools/istio-iptables/pkg/capture/run_linux.go
@@ -122,6 +122,6 @@ func configureIPv6Addresses(cfg *config.Config) error {
 	if ignoreExists(err) != nil {
 		return fmt.Errorf("failed to add IPv6 inbound address: %v", err)
 	}
-	log.Infof("Added ::6 address")
+	log.Infof("Added ::6 address on the loopback iface")
 	return nil
 }

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -27,9 +27,6 @@ var BuiltInChainsMap = sets.New(
 	"FORWARD",
 	"PREROUTING",
 	"POSTROUTING",
-	"ACCEPT",
-	"RETURN",
-	"DROP",
 )
 
 const (

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -21,12 +21,15 @@ import (
 	"istio.io/istio/pkg/util/sets"
 )
 
-var BuiltInChainsMap = sets.New(
+var BuiltInChainsAndTargetsMap = sets.New(
 	"INPUT",
 	"OUTPUT",
 	"FORWARD",
 	"PREROUTING",
 	"POSTROUTING",
+	"ACCEPT",
+	"RETURN",
+	"DROP",
 )
 
 const (


### PR DESCRIPTION
Currently, the `BuiltInChainsMap` is used in various places to ignore the creation/deletion of built-in chains. However, the map also includes `ACCEPT`, `RETURN`, and `DROP`, which are targets, not chain names. This PR removes these target names from the list.
