### PR TITLE
xds: skip CDS for VS changes when possible

### DIFF
--- a/pilot/pkg/xds/cds.go
+++ b/pilot/pkg/xds/cds.go
@@ -91,6 +91,13 @@ func cdsNeedsPush(req *model.PushRequest, proxy *model.Proxy) (*model.PushReques
 					continue
 				}
 			}
+			if config.Kind == kind.VirtualService {
+				// We largely don't use VirtualService for CDS building. However, we do use it as part of Sidecar scoping, which
+				// implicitly includes VS destinations.
+				// Since Routers do not use Sidecar, though, we can skip for Router.
+				filtered = true
+				continue
+			}
 		}
 
 		if _, f := skippedCdsConfigs[config.Kind]; !f {


### PR DESCRIPTION
Prior attempts: https://github.com/istio/istio/issues/27650, https://github.com/istio/istio/pull/34552

The problem is its needed for Sidecar. But its an easy workaround, we
can at least scope it for `Router`
