### PR TITLE
echo: fallback to IPv4 if there are no address

### DIFF
--- a/pkg/test/echo/cmd/server/main.go
+++ b/pkg/test/echo/cmd/server/main.go
@@ -214,6 +214,8 @@ func (s *Shutdown) WaitForShutdown() {
 		return
 	case <-ti.C:
 		log.Infof("Shutdown complete")
+	case <-sigs:
+		log.Infof("Shutdown forced")
 	}
 }
 

--- a/pkg/test/echo/server/instance.go
+++ b/pkg/test/echo/server/instance.go
@@ -165,7 +165,7 @@ func getBindAddresses(ip []string) []string {
 		}
 	}
 	addrs := []string{}
-	if v4 {
+	if v4 || !v6 {
 		if localhost {
 			addrs = append(addrs, "127.0.0.1")
 		} else {


### PR DESCRIPTION
Reproducer:
```
unshare --map-root-user --net sh -c 'ip link set dev lo up; server'
```

Also, add a small helper to make ctrl-C twice drain instantly
