### PR TITLE
Add option to customize updateStrategy in istio-cni/ztunnel daemonsets helm charts

### DIFF
--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -32,10 +32,10 @@ spec:
   selector:
     matchLabels:
       k8s-app: {{ template "name" . }}-node
+  {{- with .Values.updateStrategy }}
   updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: {{ .Values.rollingMaxUnavailable }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -98,12 +98,12 @@ _internal_defaults_do_not_set:
     enabled: false
     pods: 5000
 
-  # The number of pods that can be unavailable during rolling update (see
-  # `updateStrategy.rollingUpdate.maxUnavailable` here:
+  # K8s DaemonSet update strategy.
   # https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/#DaemonSetSpec).
-  # May be specified as a number of pods or as a percent of the total number
-  # of pods at the start of the update.
-  rollingMaxUnavailable: 1
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
 
   # Revision is set as 'version' label and part of the resource names when installing multiple control planes.
   revision: ""

--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -15,10 +15,10 @@ metadata:
     {{- .Values.annotations | toYaml | nindent 4 }}
 {{- end }}
 spec:
+  {{- with .Values.updateStrategy }}
   updateStrategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app: ztunnel

--- a/manifests/charts/ztunnel/values.yaml
+++ b/manifests/charts/ztunnel/values.yaml
@@ -104,3 +104,11 @@ _internal_defaults_do_not_set:
   # TODO Ambient inpod - for OpenShift, set to the following to get writable sockets in hostmounts to work, eventually consider CSI driver instead
   #seLinuxOptions:
   #  type: spc_t
+
+  # K8s DaemonSet update strategy.
+  # https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/#DaemonSetSpec).
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0

--- a/releasenotes/notes/ambient-customize-updatestrategy.yaml
+++ b/releasenotes/notes/ambient-customize-updatestrategy.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+releaseNotes:
+  - |
+    **Added** updateStrategy value to ztunnel and istio-cni helm charts


### PR DESCRIPTION
**Please provide a description of this PR:**

k8s provides two updates strategies for updating pods in daemonset:
* RollingUpdate
* [OnDelete](https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy)

OnDelete is very handy during ambient updates since you can update the version and only the new pods will have this version. In my case I use the OnDelete strategy with Karpenter to rotate all nodes gradually.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Ambient
