### PR TITLE
Fix goroutine leak when sync fails

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
@@ -98,6 +98,7 @@ func NewNamespaceController(kubeClient kube.Client, caBundleWatcher *keycertbund
 // Run starts the NamespaceController until a value is sent to stopCh.
 func (nc *NamespaceController) Run(stopCh <-chan struct{}) {
 	if !kube.WaitForCacheSync("namespace controller", stopCh, nc.namespaces.HasSynced, nc.configmaps.HasSynced) {
+		nc.queue.ShutDownEarly()
 		return
 	}
 

--- a/pkg/kube/controllers/queue.go
+++ b/pkg/kube/controllers/queue.go
@@ -114,6 +114,13 @@ func (q Queue) AddObject(obj Object) {
 	q.queue.Add(config.NamespacedName(obj))
 }
 
+// ShutDownEarly shuts down the queue *before* it has been Run.
+// Creating a queue without running it causes a leak, so this must be called on any queue that is closed without
+func (q Queue) ShutDownEarly() {
+	q.log.Infof("shutdown early")
+	q.queue.ShutDown()
+}
+
 // Run the queue. This is synchronous, so should typically be called in a goroutine.
 func (q Queue) Run(stop <-chan struct{}) {
 	defer q.queue.ShutDown()

--- a/pkg/kube/multicluster/secretcontroller.go
+++ b/pkg/kube/multicluster/secretcontroller.go
@@ -183,6 +183,7 @@ func (c *Controller) Run(stopCh <-chan struct{}) error {
 			c.secrets.Start(stopCh)
 		}
 		if !kube.WaitForCacheSync("multicluster remote secrets", stopCh, c.secrets.HasSynced) {
+			c.queue.ShutDownEarly()
 			return
 		}
 		log.Infof("multicluster remote secrets controller cache synced in %v", time.Since(t0))

--- a/pkg/kube/watcher/configmapwatcher/configmapwatcher.go
+++ b/pkg/kube/watcher/configmapwatcher/configmapwatcher.go
@@ -67,6 +67,7 @@ func (c *Controller) Run(stop <-chan struct{}) {
 	// during startup.
 	c.configmaps.Start(stop)
 	if !kube.WaitForCacheSync("configmap "+c.configMapName, stop, c.configmaps.HasSynced) {
+		c.queue.ShutDownEarly()
 		return
 	}
 	c.queue.Run(stop)

--- a/pkg/revisions/tag_watcher.go
+++ b/pkg/revisions/tag_watcher.go
@@ -77,6 +77,7 @@ func NewTagWatcher(client kube.Client, revision string) TagWatcher {
 
 func (p *tagWatcher) Run(stopCh <-chan struct{}) {
 	if !kube.WaitForCacheSync("tag watcher", stopCh, p.webhooks.HasSynced) {
+		p.queue.ShutDownEarly()
 		return
 	}
 	// Notify handlers of initial state


### PR DESCRIPTION
The k8s queue MUST be shutdown after its created. This is done
automatically with Run(stop), but if we never run it, we never shutdown.
This change ensures we always shutdown, even if we exit before we run.

Example test failure: https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/55761/unit-tests-arm64_istio/1906970954236432384
