### PR TITLE
Expose final Helm values used to render the chart in a ConfigMap

### DIFF
--- a/manifests/charts/base/templates/zzz_profile.yaml
+++ b/manifests/charts/base/templates/zzz_profile.yaml
@@ -52,6 +52,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*

--- a/manifests/charts/default/templates/zzz_profile.yaml
+++ b/manifests/charts/default/templates/zzz_profile.yaml
@@ -52,6 +52,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*

--- a/manifests/charts/gateway/templates/zzz_profile.yaml
+++ b/manifests/charts/gateway/templates/zzz_profile.yaml
@@ -52,6 +52,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if true }}
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*

--- a/manifests/charts/gateways/istio-egress/templates/zzz_profile.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/zzz_profile.yaml
@@ -52,6 +52,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*

--- a/manifests/charts/gateways/istio-ingress/templates/zzz_profile.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/zzz_profile.yaml
@@ -52,6 +52,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*

--- a/manifests/charts/istio-cni/templates/zzz_profile.yaml
+++ b/manifests/charts/istio-cni/templates/zzz_profile.yaml
@@ -52,6 +52,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*

--- a/manifests/charts/istio-control/istio-discovery/templates/configmap-values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap-values.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: values{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    istio.io/rev: {{ .Values.revision | default "default" | quote }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Pilot"
+    release: {{ .Release.Name }}
+    app.kubernetes.io/name: "istiod"
+    {{- include "istio.labels" . | nindent 4 }}
+data:
+  values: |-
+{{ .Values | toPrettyJson | indent 4 }}

--- a/manifests/charts/istio-control/istio-discovery/templates/configmap-values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap-values.yaml
@@ -3,6 +3,9 @@ kind: ConfigMap
 metadata:
   name: values{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/description: This ConfigMap contains the Helm values used during chart rendering. Modifying
+      these values has no effect.
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}

--- a/manifests/charts/istio-control/istio-discovery/templates/configmap-values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap-values.yaml
@@ -4,8 +4,7 @@ metadata:
   name: values{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   namespace: {{ .Release.Namespace }}
   annotations:
-    kubernetes.io/description: This ConfigMap contains the Helm values used during chart rendering. Modifying
-      these values has no effect.
+    kubernetes.io/description: This ConfigMap contains the Helm values used during chart rendering. This ConfigMap is rendered for debugging purposes and external tooling; modifying these values has no effect.
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}

--- a/manifests/charts/istio-control/istio-discovery/templates/configmap-values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap-values.yaml
@@ -11,5 +11,5 @@ metadata:
     app.kubernetes.io/name: "istiod"
     {{- include "istio.labels" . | nindent 4 }}
 data:
-  values: |-
+  last-applied-values: |-
 {{ .Values | toPrettyJson | indent 4 }}

--- a/manifests/charts/istio-control/istio-discovery/templates/configmap-values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap-values.yaml
@@ -14,5 +14,8 @@ metadata:
     app.kubernetes.io/name: "istiod"
     {{- include "istio.labels" . | nindent 4 }}
 data:
-  last-applied-values: |-
+  original-values: |-
+{{ .Values._original | toPrettyJson | indent 4 }}
+{{- $_ := unset $.Values "_original" }}
+  merged-values: |-
 {{ .Values | toPrettyJson | indent 4 }}

--- a/manifests/charts/istio-control/istio-discovery/templates/zzz_profile.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/zzz_profile.yaml
@@ -52,6 +52,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if false }}
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*

--- a/manifests/charts/ztunnel/templates/zzz_profile.yaml
+++ b/manifests/charts/ztunnel/templates/zzz_profile.yaml
@@ -52,6 +52,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if true }}
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*

--- a/manifests/zzz_profile.yaml
+++ b/manifests/zzz_profile.yaml
@@ -52,6 +52,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- if FLATTEN_GLOBALS_REPLACEMENT }}
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
+{{- $x := set $.Values "_original" (deepCopy $.Values) }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*

--- a/releasenotes/notes/55803.yaml
+++ b/releasenotes/notes/55803.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue: []
+
+releaseNotes:
+  - |
+    **Added** a `values` ConfigMap containing the user-provided Helm values for the `istiod` chart, along with the merged values after applying profiles.


### PR DESCRIPTION
**Please provide a description of this PR:**

Before profiles were implemented within the helm charts, users were able to see the entire set of values that were used to render the chart by running `helm get values`. This is no longer possible, since the user profile, platform profile, and compatibility version values are applied during rendering. There is no way to get the final set of values. Some tools (e.g. the Sail operator) need to know the final set of values, as do some users.

This change adds a Configmap called `values` or `values-<revision>` that tools/users can inspect to see what values were actually used to render the templates.