### PR TITLE
pilot: fix bug in Alias type RDS cache

### DIFF
--- a/pilot/pkg/networking/core/route/route_cache.go
+++ b/pilot/pkg/networking/core/route/route_cache.go
@@ -147,6 +147,12 @@ func (r *Cache) Key() any {
 		h.Write(Slash)
 		h.WriteString(svc.Attributes.Namespace)
 		h.Write(Separator)
+		for _, alias := range svc.Attributes.Aliases {
+			h.WriteString(string(alias.Hostname))
+			h.Write(Slash)
+			h.WriteString(alias.Namespace)
+			h.Write(Separator)
+		}
 	}
 	h.Write(Separator)
 

--- a/releasenotes/notes/rds-cache-alias.yaml
+++ b/releasenotes/notes/rds-cache-alias.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed** an issue causing changes to ExternalName services to sometimes be skipped due to a cache eviction bug.


### PR DESCRIPTION
We accounted for this in DependantConfigs() but not Key(). Can reproduce
by adding/removing a Alias service from a Sidecar scope and you will see
its not updated before this PR. With RDS cache off, or
`cachez?clear=true`, or this PR, it is updated.
