### PR TITLE
add locality info for ServiceEntry endpoints

### DIFF
--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -392,6 +392,9 @@ func (s *Controller) convertServiceEntryToInstances(cfg config.Config, services 
 						LegacyClusterPortKey: int(serviceEntryPort.Number),
 						Labels:               nil,
 						TLSMode:              model.DisabledTLSModeLabel,
+						Locality: model.Locality{
+							ClusterID: s.clusterID,
+						},
 					},
 					Service:     service,
 					ServicePort: convertPort(serviceEntryPort),


### PR DESCRIPTION
**Please provide a description of this PR:**
resolve #55798, ensure ServiceEntry with DNS resolution to work when clusterLocal enabled for all services.