### PR TITLE
default maxconnectionstoacceptpersocketevent to a sensible value

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -18,8 +18,6 @@ import (
 	"strings"
 	"time"
 
-	"google.golang.org/protobuf/types/known/wrapperspb"
-
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/env"
 	"istio.io/istio/pkg/jwt"
@@ -266,14 +264,8 @@ var (
 	EnableGatewayAPIManualDeployment = env.Register("ENABLE_GATEWAY_API_MANUAL_DEPLOYMENT", true,
 		"If true, allows users to bind Gateway API resources to existing gateway deployments.").Get()
 
-	MaxConnectionsToAcceptPerSocketEvent = func() *wrapperspb.UInt32Value {
-		v := env.Register("MAX_CONNECTIONS_PER_SOCKET_EVENT_LOOP", 1,
-			"The maximum number of connections to accept from the kernel per socket event.").Get()
-		if v > 0 {
-			return &wrapperspb.UInt32Value{Value: uint32(v)}
-		}
-		return nil
-	}()
+	MaxConnectionsToAcceptPerSocketEvent = env.Register("MAX_CONNECTIONS_PER_SOCKET_EVENT_LOOP", 1,
+		"The maximum number of connections to accept from the kernel per socket event. Set this to '0' to accept unlimited connections.").Get()
 )
 
 // UnsafeFeaturesEnabled returns true if any unsafe features are enabled.

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"google.golang.org/protobuf/types/known/wrapperspb"
+
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/env"
 	"istio.io/istio/pkg/jwt"

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"google.golang.org/protobuf/types/known/wrapperspb"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/env"
 	"istio.io/istio/pkg/jwt"
@@ -263,6 +264,15 @@ var (
 
 	EnableGatewayAPIManualDeployment = env.Register("ENABLE_GATEWAY_API_MANUAL_DEPLOYMENT", true,
 		"If true, allows users to bind Gateway API resources to existing gateway deployments.").Get()
+
+	MaxConnectionsToAcceptPerSocketEvent = func() *wrapperspb.UInt32Value {
+		v := env.Register("MAX_CONNECTIONS_PER_SOCKET_EVENT_LOOP", 1,
+			"The maximum number of connections to accept from the kernel per socket event.").Get()
+		if v > 0 {
+			return &wrapperspb.UInt32Value{Value: uint32(v)}
+		}
+		return nil
+	}()
 )
 
 // UnsafeFeaturesEnabled returns true if any unsafe features are enabled.

--- a/pilot/pkg/networking/core/listener.go
+++ b/pilot/pkg/networking/core/listener.go
@@ -1129,7 +1129,7 @@ func buildGatewayListener(opts gatewayListenerOpts, transport istionetworking.Tr
 		// by avoiding slow requests that could otherwise lead to such issues.
 		// Note that this timer only takes effect when a listener filter is present.
 
-		MaxConnectionsToAcceptPerSocketEvent: features.MaxConnectionsToAcceptPerSocketEvent,
+		MaxConnectionsToAcceptPerSocketEvent: maxConnectionsToAcceptPerSocketEvent(),
 	}
 	switch transport {
 	case istionetworking.TransportProtocolTCP:

--- a/pilot/pkg/networking/core/listener.go
+++ b/pilot/pkg/networking/core/listener.go
@@ -1128,6 +1128,8 @@ func buildGatewayListener(opts gatewayListenerOpts, transport istionetworking.Tr
 		// This timeout setting helps prevent memory leaks in Envoy when a TLS inspector filter is present,
 		// by avoiding slow requests that could otherwise lead to such issues.
 		// Note that this timer only takes effect when a listener filter is present.
+
+		MaxConnectionsToAcceptPerSocketEvent: features.MaxConnectionsToAcceptPerSocketEvent,
 	}
 	switch transport {
 	case istionetworking.TransportProtocolTCP:

--- a/pilot/pkg/networking/core/listener_builder.go
+++ b/pilot/pkg/networking/core/listener_builder.go
@@ -88,6 +88,13 @@ func NewListenerBuilder(node *model.Proxy, push *model.PushContext) *ListenerBui
 	return builder
 }
 
+func maxConnectionsToAcceptPerSocketEvent() *wrappers.UInt32Value {
+	if features.MaxConnectionsToAcceptPerSocketEvent > 0 {
+		return &wrappers.UInt32Value{Value: uint32(features.MaxConnectionsToAcceptPerSocketEvent)}
+	}
+	return nil
+}
+
 func (lb *ListenerBuilder) appendSidecarInboundListeners() *ListenerBuilder {
 	lb.inboundListeners = lb.buildInboundListeners()
 	if lb.node.EnableHBONEListen() {
@@ -133,7 +140,7 @@ func (lb *ListenerBuilder) buildVirtualOutboundListener() *ListenerBuilder {
 		UseOriginalDst:                       proto.BoolTrue,
 		FilterChains:                         filterChains,
 		TrafficDirection:                     core.TrafficDirection_OUTBOUND,
-		MaxConnectionsToAcceptPerSocketEvent: features.MaxConnectionsToAcceptPerSocketEvent,
+		MaxConnectionsToAcceptPerSocketEvent: maxConnectionsToAcceptPerSocketEvent(),
 	}
 	// add extra addresses for the listener
 	if features.EnableDualStack && len(actualWildcards) > 1 {

--- a/pilot/pkg/networking/core/listener_builder.go
+++ b/pilot/pkg/networking/core/listener_builder.go
@@ -127,12 +127,13 @@ func (lb *ListenerBuilder) buildVirtualOutboundListener() *ListenerBuilder {
 	actualWildcards, _ := getWildcardsAndLocalHost(lb.node.GetIPMode())
 	// add an extra listener that binds to the port that is the recipient of the iptables redirect
 	ipTablesListener := &listener.Listener{
-		Name:             model.VirtualOutboundListenerName,
-		Address:          util.BuildAddress(actualWildcards[0], uint32(lb.push.Mesh.ProxyListenPort)),
-		Transparent:      isTransparentProxy,
-		UseOriginalDst:   proto.BoolTrue,
-		FilterChains:     filterChains,
-		TrafficDirection: core.TrafficDirection_OUTBOUND,
+		Name:                                 model.VirtualOutboundListenerName,
+		Address:                              util.BuildAddress(actualWildcards[0], uint32(lb.push.Mesh.ProxyListenPort)),
+		Transparent:                          isTransparentProxy,
+		UseOriginalDst:                       proto.BoolTrue,
+		FilterChains:                         filterChains,
+		TrafficDirection:                     core.TrafficDirection_OUTBOUND,
+		MaxConnectionsToAcceptPerSocketEvent: features.MaxConnectionsToAcceptPerSocketEvent,
 	}
 	// add extra addresses for the listener
 	if features.EnableDualStack && len(actualWildcards) > 1 {

--- a/pilot/pkg/networking/core/listener_inbound.go
+++ b/pilot/pkg/networking/core/listener_inbound.go
@@ -293,7 +293,7 @@ func (lb *ListenerBuilder) buildInboundListener(name string, addresses []string,
 		Address:                              address,
 		TrafficDirection:                     core.TrafficDirection_INBOUND,
 		ContinueOnListenerFiltersTimeout:     true,
-		MaxConnectionsToAcceptPerSocketEvent: features.MaxConnectionsToAcceptPerSocketEvent,
+		MaxConnectionsToAcceptPerSocketEvent: maxConnectionsToAcceptPerSocketEvent(),
 	}
 	if features.EnableDualStack && len(addresses) > 1 {
 		// add extra addresses for the listener

--- a/pilot/pkg/networking/core/listener_inbound.go
+++ b/pilot/pkg/networking/core/listener_inbound.go
@@ -289,10 +289,11 @@ func (lb *ListenerBuilder) buildInboundListener(name string, addresses []string,
 	}
 	address := util.BuildAddress(addresses[0], tPort)
 	l := &listener.Listener{
-		Name:                             name,
-		Address:                          address,
-		TrafficDirection:                 core.TrafficDirection_INBOUND,
-		ContinueOnListenerFiltersTimeout: true,
+		Name:                                 name,
+		Address:                              address,
+		TrafficDirection:                     core.TrafficDirection_INBOUND,
+		ContinueOnListenerFiltersTimeout:     true,
+		MaxConnectionsToAcceptPerSocketEvent: features.MaxConnectionsToAcceptPerSocketEvent,
 	}
 	if features.EnableDualStack && len(addresses) > 1 {
 		// add extra addresses for the listener

--- a/releasenotes/notes/max-socket-events.yaml
+++ b/releasenotes/notes/max-socket-events.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+- |
+  **Updated** the default value of maximum connections to accept per socket event to 1 as a performance improvement.
+   To get the old behavior, you can set `MAX_CONNECTIONS_PER_SOCKET_EVENT_LOOP` to zero.


### PR DESCRIPTION
See https://github.com/envoyproxy/envoy/pull/38999 and https://github.com/envoyproxy/envoy/issues/19103#issuecomment-2719261380

I think compatibility version is not needed as it is most sensible default but if there are concerns I can add

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions