### PR TITLE
not consider ServiceEntries as cluster-local

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1315,6 +1315,11 @@ func (ps *PushContext) IsClusterLocal(service *Service) bool {
 	if ps == nil || service == nil {
 		return false
 	}
+	// If ServiceRegistry is not Kubernetes, ServiceEntries for example,
+	// we should not consider it as cluster-local.
+	if service.Attributes.ServiceRegistry != provider.Kubernetes {
+		return false
+	}
 	return ps.clusterLocalHosts.IsClusterLocal(service.Hostname)
 }
 


### PR DESCRIPTION
**Please provide a description of this PR:**
resolve #55798, I tried to fix this by adding locality info for ServiceEntry with DNS resolution in #55816, this works fine for single-cluster scenario. However, when I tested in primary-remote mode, this failed again for remote clusters since the cluster id of ServiceEntry is the id of primary cluster.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
