### PR TITLE
Do not split root CA, fixing 1.25.1 regression

### DIFF
--- a/istioctl/pkg/writer/ztunnel/configdump/api.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/api.go
@@ -127,6 +127,7 @@ type CertsDump struct {
 	Identity  string  `json:"identity"`
 	State     string  `json:"state"`
 	CertChain []*Cert `json:"certChain"`
+	RootCert  []*Cert `json:"rootCerts"`
 }
 
 type Cert struct {

--- a/istioctl/pkg/writer/ztunnel/configdump/certificates.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/certificates.go
@@ -63,17 +63,25 @@ func (c *ConfigWriter) PrintSecretSummary() error {
 			fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
 				secret.Identity, valueOrNA(""), secret.State, false, valueOrNA(""), valueOrNA(""), valueOrNA(""))
 		} else {
+			// Before, the root was part of the certChain.
+			legacyFormat := len(secret.RootCert) == 0
 			for i, ca := range secret.CertChain {
 				t := "Intermediate"
 				if i == 0 {
 					t = "Leaf"
-				} else if i == len(secret.CertChain)-1 {
+				} else if i == len(secret.CertChain)-1 && legacyFormat {
 					t = "Root"
 				}
 				n := new(big.Int)
 				n, _ = n.SetString(ca.SerialNumber, 10)
 				fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%x\t%v\t%v\n",
 					secret.Identity, t, secret.State, certNotExpired(ca), n, valueOrNA(ca.ExpirationTime), valueOrNA(ca.ValidFrom))
+			}
+			for _, ca := range secret.RootCert {
+				n := new(big.Int)
+				n, _ = n.SetString(ca.SerialNumber, 10)
+				fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%x\t%v\t%v\n",
+					secret.Identity, "Root", secret.State, certNotExpired(ca), n, valueOrNA(ca.ExpirationTime), valueOrNA(ca.ValidFrom))
 			}
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/55793

Also adds istioctl support for the ztunnel side fixes in https://github.com/istio/ztunnel/pull/1510
