### PR TITLE
gateway: fix regression around shared name cross-namespace

### DIFF
--- a/pilot/pkg/config/kube/gateway/gateway_collection.go
+++ b/pilot/pkg/config/kube/gateway/gateway_collection.go
@@ -42,7 +42,7 @@ type Gateway struct {
 }
 
 func (g Gateway) ResourceName() string {
-	return config.NamespacedName(g.Config).Name
+	return config.NamespacedName(g.Config).String()
 }
 
 func (g Gateway) Equals(other Gateway) bool {


### PR DESCRIPTION
The key name was not distinct, leading to forgetting the other
namespaces if we have the same name
