### PR TITLE
Disable metadata lookup on SotW

### DIFF
--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -107,6 +107,11 @@ func (cfg Config) toTemplateParams() (map[string]any, error) {
 	if metadataDiscovery != nil && *metadataDiscovery {
 		mDiscovery = true
 	}
+	if mDiscovery && xdsType == "GRPC" {
+		log.Warnf("disabling metadata discovery; not supported on SotW XDS")
+		// Not supported on legacy SotW protocol
+		mDiscovery = false
+	}
 	customSDSPath := ""
 	if _, f := cfg.RawMetadata[security.CredentialFileMetaDataName]; f {
 		customSDSPath = security.FileCredentialNameSocketPath


### PR DESCRIPTION
WDS only supports Delta. This maybe could have a restriction on the
server side, too, but there are some tooling (debug interface, etc) that
always expect to use the SOTW flow which makes it hard.
