### PR TITLE
add test for multiple FilterIndex

### DIFF
--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -48,7 +48,8 @@ type dependencyState[I any] struct {
 	indexedDependencies map[indexedDependency]sets.Set[Key[I]]
 	// indexedDependenciesExtractor stores a map of [collection,fetch type] => an extractor to get change keys.
 	// Note that a given collection can have multiple Fetches, but they are limited to those of the different kind.
-	// I.e. you can do a `Fetch(c1, FilterIndex()) + Fetch(c1, FilterKey())` but not `Fetch(c1, FilterIndex()) + Fetch(c1, FilterIndex())`.
+	// I.e. you can do a `Fetch(c1, FilterIndex()) + Fetch(c1, FilterKey())` but not `Fetch(c1, FilterIndex(idxA)) + Fetch(c1, FilterIndex(idxB))`.
+	// Multiple `FetchIndex` within a single transformation must use the same index.
 	// This only applies within a single transformation; it is fine to fetch the the same `c1` in any way from different collections.
 	indexedDependenciesExtractor map[extractorKey]objectKeyExtractor
 }

--- a/pkg/kube/krt/filter.go
+++ b/pkg/kube/krt/filter.go
@@ -113,6 +113,8 @@ func FilterSelects(lbls map[string]string) FetchOption {
 }
 
 // FilterIndex selects only objects matching a key in an index.
+// NOTE: A single transformation function cannot call FilterIndex
+// using multiple indexes for the same collection.
 func FilterIndex[K comparable, I any](idx Index[K, I], k K) FetchOption {
 	return func(h *dependency) {
 		// Index is used to pre-filter on the List, and also to match in Matches. Provide type-erased methods for both

--- a/pkg/kube/krt/index_test.go
+++ b/pkg/kube/krt/index_test.go
@@ -15,6 +15,8 @@
 package krt_test
 
 import (
+	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -95,15 +97,17 @@ func TestIndexCollection(t *testing.T) {
 	c := kube.NewFakeClient()
 	kpc := kclient.New[*corev1.Pod](c)
 	pc := clienttest.Wrap(t, kpc)
-	pods := krt.WrapClient[*corev1.Pod](kpc, opts.WithName("Pods")...)
+	podsCol := krt.WrapClient[*corev1.Pod](kpc, opts.WithName("Pods")...)
 	c.RunAndWait(stop)
-	SimplePods := SimplePodCollection(pods, opts)
+	SimplePods := SimplePodCollection(podsCol, opts)
 	tt := assert.NewTracker[string](t)
 	IPIndex := krt.NewIndex[string, SimplePod](SimplePods, func(o SimplePod) []string {
 		return []string{o.IP}
 	})
 	Collection := krt.NewSingleton[string](func(ctx krt.HandlerContext) *string {
-		pods := krt.Fetch(ctx, SimplePods, krt.FilterIndex(IPIndex, "1.2.3.5"))
+		a := krt.Fetch(ctx, SimplePods, krt.FilterIndex(IPIndex, "2.2.2.2"))
+		b := krt.Fetch(ctx, SimplePods, krt.FilterIndex(IPIndex, "3.3.3.3"))
+		pods := append(a, b...)
 		names := slices.Sort(slices.Map(pods, SimplePod.ResourceName))
 		return ptr.Of(strings.Join(names, ","))
 	}, opts.WithName("Collection")...)
@@ -116,37 +120,49 @@ func TestIndexCollection(t *testing.T) {
 
 	SimplePods.Register(TrackerHandler[SimplePod](tt))
 
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "name",
-			Namespace: "namespace",
-		},
-		Status: corev1.PodStatus{PodIP: "1.2.3.4"},
+	var pods []*corev1.Pod
+	for i := range 3 {
+		pods = append(pods, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name" + strconv.Itoa(i+1),
+				Namespace: "namespace",
+			},
+			Status: corev1.PodStatus{PodIP: fmt.Sprintf("%d.%d.%d.%d", i+1, i+1, i+1, i+1)},
+		})
+
+		println("make ", pods[len(pods)-1].Name)
 	}
+	pod := pods[0]
+	pod2 := pods[1]
+	pod3 := pods[2]
+
+	// pod 1 with 1.1.1.1 doesn't show up in the collection
 	pc.CreateOrUpdateStatus(pod)
-	tt.WaitUnordered("add/namespace/name")
+	tt.WaitUnordered("add/namespace/name1")
 	assert.Equal(t, Collection.Get(), ptr.Of(""))
 
-	pod.Status.PodIP = "1.2.3.5"
+	// when we update it to what we Fetch with, we will see it
+	pod.Status.PodIP = "2.2.2.2"
 	pc.UpdateStatus(pod)
-	tt.WaitUnordered("update/namespace/name")
-	assert.EventuallyEqual(t, Collection.Get, ptr.Of("namespace/name"))
+	tt.WaitUnordered("update/namespace/name1")
+	assert.EventuallyEqual(t, Collection.Get, ptr.Of("namespace/name1"))
 
-	pod2 := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "name2",
-			Namespace: "namespace",
-		},
-		Status: corev1.PodStatus{PodIP: "1.2.3.5"},
-	}
+	// adding pod 2 with the same IP gives us both
 	pc.CreateOrUpdateStatus(pod2)
 	tt.WaitUnordered("add/namespace/name2")
-	assert.EventuallyEqual(t, Collection.Get, ptr.Of("namespace/name,namespace/name2"))
+	assert.EventuallyEqual(t, Collection.Get, ptr.Of("namespace/name1,namespace/name2"))
 
+	// add pod 3 to make sure our second fetch works
+	pc.CreateOrUpdateStatus(pod3)
+	tt.WaitUnordered("add/namespace/name3")
+	assert.EventuallyEqual(t, Collection.Get, ptr.Of("namespace/name1,namespace/name2,namespace/name3"))
+
+	// delete everything
 	pc.Delete(pod.Name, pod.Namespace)
 	pc.Delete(pod2.Name, pod2.Namespace)
-	tt.WaitUnordered("delete/namespace/name", "delete/namespace/name2")
-	assert.Equal(t, fetchSorted("1.2.3.4"), []SimplePod{})
+	pc.Delete(pod3.Name, pod3.Namespace)
+	tt.WaitUnordered("delete/namespace/name1", "delete/namespace/name2", "delete/namespace/name3")
+	assert.Equal(t, fetchSorted("1.1.1.1"), []SimplePod{})
 }
 
 type PodCount struct {


### PR DESCRIPTION
Ensure that the mechanisms introduced in #54074 #55515 don't prevent multiple FilterIndex in a single transformation, so long as we are filtering using the _same_ index. 