### PR TITLE
ztunnel: revert resource naming

### DIFF
--- a/manifests/charts/ztunnel/templates/_helpers.tpl
+++ b/manifests/charts/ztunnel/templates/_helpers.tpl
@@ -1,1 +1,1 @@
-{{ define "ztunnel.release-name" }}{{ .Values.resourceName| default .Release.Name }}{{ end }}
+{{ define "ztunnel.release-name" }}{{ .Values.resourceName| default "ztunnel" }}{{ end }}

--- a/manifests/charts/ztunnel/values.yaml
+++ b/manifests/charts/ztunnel/values.yaml
@@ -12,8 +12,8 @@ _internal_defaults_do_not_set:
   # If Image contains a "/", it will replace the entire `image` in the pod.
   image: ztunnel
 
-  # resourceName, if set, will override the naming of resources. If not set, will default to the release name.
-  # It is recommended to not set this; this is primarily for backwards compatibility.
+  # resourceName, if set, will override the naming of resources. If not set, will default to 'ztunnel'.
+  # If you set this, you MUST also set `trustedZtunnelName` in the `istiod` chart.
   resourceName: ""
 
   # Labels to apply to all top level resources

--- a/releasenotes/notes/ztunnel-helm-chart-revert.yaml
+++ b/releasenotes/notes/ztunnel-helm-chart-revert.yaml
@@ -1,0 +1,15 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+releaseNotes:
+  - |
+    **Improved** the ztunnel Helm chart to no longer set resource names to `.Release.Name`, and instead default to `ztunnel`.
+    This reverts a change in Istio 1.25.
+upgradeNotes:
+  - title: Ztunnel Helm chart changes
+    content: |
+      In Istio 1.25, the resources in the ztunnel Helm chart were changed to be named `.Resource.Name`.
+      This often caused issues, as the name needs to be kept in sync with the Istiod Helm chart.
+      
+      In this release, we have reverted to default to a static `ztunnel` name again.
+      As previously, this can be overriden with `--set resourceName=my-custom-name`.


### PR DESCRIPTION
Following discussion in https://istio.slack.com/archives/C049TCZMPCP/p1744640460220049, I feel this change (from me) caused WAY more pain than it was worth. Reverting (not a full revert, since we keep the override `resourceName`) achieves the same goal with less pain