### PR TITLE
WIP/POC experiment: deep merge Any in EnvoyFilter

### DIFF
--- a/pilot/pkg/networking/core/envoyfilter/cluster_patch.go
+++ b/pilot/pkg/networking/core/envoyfilter/cluster_patch.go
@@ -69,6 +69,7 @@ func ApplyClusterMerge(pctx networking.EnvoyFilter_PatchContext, efw *model.Merg
 // Returns a boolean indicating if the merge was handled by this function; if false, it should still be called
 // outside of this function.
 func mergeTransportSocketCluster(c *cluster.Cluster, cp *model.EnvoyFilterConfigPatchWrapper) (merged bool, err error) {
+	//return false, nil
 	cpValueCast, okCpCast := (cp.Value).(*cluster.Cluster)
 	if !okCpCast {
 		return false, fmt.Errorf("cast of cp.Value failed: %v", okCpCast)

--- a/pkg/proto/merge/merge.go
+++ b/pkg/proto/merge/merge.go
@@ -25,14 +25,18 @@ package merge
 
 import (
 	"fmt"
+	"strings"
 
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"istio.io/istio/pkg/log"
 )
 
 type (
-	MergeFunction func(dst, src protoreflect.Message) protoreflect.Message
+	MergeFunction func(mo mergeOptions, dst, src protoreflect.Message) protoreflect.Message
 	mergeOptions  struct {
 		customMergeFn map[protoreflect.FullName]MergeFunction
 	}
@@ -47,14 +51,80 @@ func MergeFunctionOptionFn(name protoreflect.FullName, function MergeFunction) O
 }
 
 // ReplaceMergeFn instead of merging all subfields one by one, returns src
-var ReplaceMergeFn MergeFunction = func(dst, src protoreflect.Message) protoreflect.Message {
+var ReplaceMergeFn MergeFunction = func(mo mergeOptions, dst, src protoreflect.Message) protoreflect.Message {
+	log.Errorf("howardjohn: CALL REPLACE")
 	// we can return src directly because this is a replace
 	return src
+}
+
+// ReplaceMergeFn instead of merging all subfields one by one, returns src
+var AnyMergeFn MergeFunction = func(mo mergeOptions, dst, src protoreflect.Message) protoreflect.Message {
+	// we can return src directly because this is a replace
+	tu := dst.Descriptor().Fields().ByName("type_url")
+	v := dst.Descriptor().Fields().ByName("value")
+	dt := dst.Get(tu).String()
+	st := src.Get(tu).String()
+	dv := dst.Get(v).Bytes()
+	sv := src.Get(v).Bytes()
+	log.Errorf("howardjohn: merge %v into %v", dt, st)
+	log.Errorf("howardjohn: merge %+v %T %T", dst.Get(v).Interface(), dv, sv)
+	_ = v
+	log.Errorf("howardjohn: ANY MERGE %v / %+v", dst.Descriptor().FullName(), dst.Interface())
+	if dt != st {
+		// not the same type, just overwrite entirely
+		return src
+	}
+	// They are the same type! we want to deep merge
+
+	t, err := protoregistry.GlobalTypes.FindMessageByName(protoreflect.FullName(strings.TrimPrefix(dt, "type.googleapis.com/")))
+	if err != nil || t == nil {
+		panic(fmt.Sprintf("failed to find reflect type %q", protoreflect.FullName(dt))) // TODO
+	}
+	dun := t.New().Interface()
+	dany := dst.Interface().(*anypb.Any)
+	if err := dany.UnmarshalTo(dun); err != nil {
+		panic(err.Error())
+	}
+	sun := t.New().Interface()
+	sany := src.Interface().(*anypb.Any)
+	if err := sany.UnmarshalTo(sun); err != nil {
+		panic(err.Error())
+	}
+	log.Errorf("howardjohn: pre %+v", dun)
+	mo.mergeMessage(dun.ProtoReflect(), sun.ProtoReflect())
+	log.Errorf("howardjohn: post %+v", dun)
+
+	//dun.MarshalFrom()
+	a, err := MessageToAnyWithError(dun)
+	if err != nil {
+		panic(err.Error())
+	}
+	return  a.ProtoReflect()
+}
+
+
+// MessageToAnyWithError converts from proto message to proto Any
+func MessageToAnyWithError(msg proto.Message) (*anypb.Any, error) {
+	b, err := marshal(msg)
+	if err != nil {
+		return nil, err
+	}
+	return &anypb.Any{
+		// nolint: staticcheck
+		TypeUrl: "type.googleapis.com/" + string(msg.ProtoReflect().Descriptor().FullName()),
+		Value:   b,
+	}, nil
+}
+
+func marshal(msg proto.Message) ([]byte, error) {
+	// If not available, fallback to normal implementation
+	return proto.MarshalOptions{Deterministic: true}.Marshal(msg)
 }
 
 var options = []OptionFn{
 	// Workaround https://github.com/golang/protobuf/issues/1359, merge duration properly
 	MergeFunctionOptionFn((&durationpb.Duration{}).ProtoReflect().Descriptor().FullName(), ReplaceMergeFn),
+	MergeFunctionOptionFn((&anypb.Any{}).ProtoReflect().Descriptor().FullName(), AnyMergeFn),
 }
 
 func Merge(dst, src proto.Message) {
@@ -66,6 +136,9 @@ func merge(dst, src proto.Message, opts ...OptionFn) {
 	mo := mergeOptions{customMergeFn: map[protoreflect.FullName]MergeFunction{}}
 	for _, opt := range opts {
 		mo = opt(mo)
+	}
+	for c := range mo.customMergeFn {
+		log.Errorf("howardjohn: have %v", c)
 	}
 	dstMsg, srcMsg := dst.ProtoReflect(), src.ProtoReflect()
 	if dstMsg.Descriptor() != srcMsg.Descriptor() {
@@ -83,21 +156,28 @@ func (o mergeOptions) mergeMessage(dst, src protoreflect.Message) {
 	if !dst.IsValid() {
 		panic(fmt.Sprintf("cannot merge into invalid %v message", dst.Descriptor().FullName()))
 	}
+	mergeFn, exists := o.customMergeFn[dst.Descriptor().FullName()]
+	if exists {
+		nv := mergeFn(o, dst, src)
+		for fn :=  range dst.Descriptor().Fields().Len() {
+			fd := dst.Descriptor().Fields().Get(fn)
+			dst.Clear(fd)
+			log.Errorf("howardjohn: set %v to %v", fd.FullName(), nv.Get(fd))
+			dst.Set(fd, nv.Get(fd))
+		}
+		return
+	}
 
 	src.Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
+		log.Errorf("howardjohn: range over message %v %v", fd.FullName(), v)
 		switch {
 		case fd.IsList():
 			o.mergeList(dst.Mutable(fd).List(), v.List(), fd)
 		case fd.IsMap():
 			o.mergeMap(dst.Mutable(fd).Map(), v.Map(), fd.MapValue())
 		case fd.Message() != nil:
-			mergeFn, exists := o.customMergeFn[fd.Message().FullName()]
-			if exists {
-				dstV := mergeFn(dst.Mutable(fd).Message(), v.Message())
-				dst.Set(fd, protoreflect.ValueOf(dstV))
-			} else {
-				o.mergeMessage(dst.Mutable(fd).Message(), v.Message())
-			}
+			log.Errorf("howardjohn: check method %v", fd.Message().FullName())
+			o.mergeMaybeCustom(fd, v, dst)
 		case fd.Kind() == protoreflect.BytesKind:
 			dst.Set(fd, o.cloneBytes(v))
 		default:
@@ -111,13 +191,35 @@ func (o mergeOptions) mergeMessage(dst, src protoreflect.Message) {
 	}
 }
 
+func (o mergeOptions) mergeMaybeCustom(fd protoreflect.FieldDescriptor, v protoreflect.Value, dst protoreflect.Message) {
+	mergeFn, exists := o.customMergeFn[fd.Message().FullName()]
+	if exists {
+		dstV := mergeFn(o, dst.Mutable(fd).Message(), v.Message())
+		dst.Set(fd, protoreflect.ValueOf(dstV))
+	} else {
+		o.mergeMessage(dst.Mutable(fd).Message(), v.Message())
+	}
+}
+
+func (o mergeOptions) mergeMaybeCustom2(fd protoreflect.FieldDescriptor, v protoreflect.Value, dst protoreflect.Message) {
+	o.mergeMessage(dst.Mutable(fd).Message(), v.Message())
+	//mergeFn, exists := o.customMergeFn[fd.FullName()]
+	//if exists {
+	//	dstV := mergeFn(dst.Mutable(fd).Message(), v.Message())
+	//	dst.Set(fd, protoreflect.ValueOf(dstV))
+	//} else {
+	//	o.mergeMessage(dst.Mutable(fd).Message(), v.Message())
+	//}
+}
+
 func (o mergeOptions) mergeList(dst, src protoreflect.List, fd protoreflect.FieldDescriptor) {
 	// Merge semantics appends to the end of the existing list.
 	for i, n := 0, src.Len(); i < n; i++ {
 		switch v := src.Get(i); {
 		case fd.Message() != nil:
+			log.Errorf("howardjohn: check method list %v", fd.Message().FullName())
 			dstv := dst.NewElement()
-			o.mergeMessage(dstv.Message(), v.Message())
+			o.mergeMaybeCustom(fd, v, dstv.Message())
 			dst.Append(dstv)
 		case fd.Kind() == protoreflect.BytesKind:
 			dst.Append(o.cloneBytes(v))
@@ -132,9 +234,21 @@ func (o mergeOptions) mergeMap(dst, src protoreflect.Map, fd protoreflect.FieldD
 	src.Range(func(k protoreflect.MapKey, v protoreflect.Value) bool {
 		switch {
 		case fd.Message() != nil:
-			dstv := dst.NewValue()
+			log.Errorf("howardjohn: check method map %v", fd.Message().FullName())
+			dstv := dst.Get(k)
+			if !dstv.IsValid() {
+				dstv = dst.NewValue()
+			}
 			o.mergeMessage(dstv.Message(), v.Message())
 			dst.Set(k, dstv)
+			//dstv := dst.NewValue()
+			//log.Errorf("howardjohn: run new value %v / %v / %v / %v", dstv, dstv.Message(), dstv.Message().Type(), dstv.Message().Descriptor().FullName())
+			//log.Errorf("howardjohn: run new value  fd %v / %v/%v", fd, fd.FullName(), fd.Message().FullName())
+			//
+			//ff := dstv.Message().Descriptor().Fields().ByName("value")
+			//log.Errorf("howardjohn: run new value ff %v / %v", ff, ff.FullName())
+			//o.mergeMaybeCustom2(ff, v, dstv.Message())
+			//dst.Set(k, dstv)
 		case fd.Kind() == protoreflect.BytesKind:
 			dst.Set(k, o.cloneBytes(v))
 		default:

--- a/pkg/proto/merge/merge_test.go
+++ b/pkg/proto/merge/merge_test.go
@@ -15,13 +15,38 @@
 package merge
 
 import (
+	"reflect"
 	"testing"
+	"time"
 
+	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	http "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+	"istio.io/istio/pilot/pkg/util/protoconv"
+	v3 "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/util/protomarshal"
 
 	"istio.io/istio/pkg/test/util/assert"
 )
+
+// TestMergeDirect tests if we merge an object with a custom merge function, we use that function
+// Previously, we only handled it for nested fields.
+func TestMergeDirect(t *testing.T) {
+	src := &durationpb.Duration{Nanos: 456}
+	dst := &durationpb.Duration{Seconds: 789}
+
+	Merge(dst, src)
+
+	assert.Equal(t, dst, &durationpb.Duration{Nanos: 456})
+	// src duration not changed after merge
+	assert.Equal(t, src, &durationpb.Duration{Nanos: 456})
+}
 
 func TestMerge(t *testing.T) {
 	src := &durationpb.Duration{Seconds: 123, Nanos: 456}
@@ -36,4 +61,62 @@ func TestMerge(t *testing.T) {
 
 	// dst duration not changed after merge
 	assert.Equal(t, dst, &durationpb.Duration{Seconds: 789, Nanos: 999})
+}
+
+// Test that we can handle merge of Any types
+func TestMergeAny(t *testing.T) {
+	src := &cluster.Cluster{TypedExtensionProtocolOptions: map[string]*anypb.Any{
+		v3.HttpProtocolOptionsType: protoconv.MessageToAny(&http.HttpProtocolOptions{
+			CommonHttpProtocolOptions: &core.HttpProtocolOptions{
+				IdleTimeout:     durationpb.New(5 * time.Minute),
+				MaxHeadersCount: wrapperspb.UInt32(5),
+			},
+		}),
+	}}
+	srcCpy := proto.Clone(src).(*cluster.Cluster)
+	dst := &cluster.Cluster{TypedExtensionProtocolOptions: map[string]*anypb.Any{
+		v3.HttpProtocolOptionsType: protoconv.MessageToAny(&http.HttpProtocolOptions{
+			CommonHttpProtocolOptions: &core.HttpProtocolOptions{
+				IdleTimeout: durationpb.New(6 * time.Minute),
+			},
+			UpstreamProtocolOptions: &http.HttpProtocolOptions_UseDownstreamProtocolConfig{
+				UseDownstreamProtocolConfig: &http.HttpProtocolOptions_UseDownstreamHttpConfig{
+					HttpProtocolOptions: &core.Http1ProtocolOptions{AcceptHttp_10: true},
+				},
+			},
+		}),
+	}}
+
+	Merge(dst, src)
+	t.Log(Dump(t, dst))
+	merged := &cluster.Cluster{TypedExtensionProtocolOptions: map[string]*anypb.Any{
+		v3.HttpProtocolOptionsType: protoconv.MessageToAny(&http.HttpProtocolOptions{
+			CommonHttpProtocolOptions: &core.HttpProtocolOptions{
+				IdleTimeout:     durationpb.New(5 * time.Minute),
+				MaxHeadersCount: wrapperspb.UInt32(5),
+			},
+			UpstreamProtocolOptions: &http.HttpProtocolOptions_UseDownstreamProtocolConfig{
+				UseDownstreamProtocolConfig: &http.HttpProtocolOptions_UseDownstreamHttpConfig{
+					HttpProtocolOptions: &core.Http1ProtocolOptions{AcceptHttp_10: true},
+				},
+			},
+		}),
+	}}
+
+	assert.Equal(t, dst, merged)
+	//
+	// Source should not change
+	assert.Equal(t, src, srcCpy)
+}
+
+func Dump(t test.Failer, p proto.Message) string {
+	v := reflect.ValueOf(p)
+	if p == nil || (v.Kind() == reflect.Ptr && v.IsNil()) {
+		return "nil"
+	}
+	s, err := protomarshal.ToJSONWithIndent(p, "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
 }


### PR DESCRIPTION
Today with Envoyfilter, you cannot merge an Any.

So a config like:

```
typed_extension_protocol_options:
  envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
    "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
    common_http_protocol_options:
      idle_timeout: 5s
```

is pretty broken, since it doesn't just set idle_timeout but also overrides the entire typed_extension_protocol_options. As envoy adds more and more things under `Any` this is increasingly problematic.

Here I experiment with a custom merge function that does a deep merge of the Any by unmarshalling, merging, and marshalling again. Without this, the Any is treated as a `[]byte` which is just replaced.

Along the way, I found 3 bugs with the existing custom-merge-function replacement, causing the function to not be called if the type is the top level type initially called on Merge(), if its in a list, or if its in a map (it only works if its a field in a message). this PR also fixes these.

**This PR does not fully work, needs more testing, and needs to be more robust - just a POC**