### PR TITLE
Enforce FIPS-202205 compliance policy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/docker/cli v28.0.1+incompatible
 	github.com/envoyproxy/go-control-plane/contrib v1.32.5-0.20250411033633-fceb350c06ca
-	github.com/envoyproxy/go-control-plane/envoy v1.32.5-0.20250411033633-fceb350c06ca
+	github.com/envoyproxy/go-control-plane/envoy v1.32.5-0.20250415162219-ec399c4f2d93
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/fatih/color v1.18.0
 	github.com/felixge/fgprof v0.9.5
@@ -54,7 +54,7 @@ require (
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240409071808-615f978279ca
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/prometheus/client_golang v1.21.1
-	github.com/prometheus/client_model v0.6.1
+	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.62.0
 	github.com/prometheus/procfs v0.15.1
 	github.com/prometheus/prometheus v0.302.1

--- a/go.sum
+++ b/go.sum
@@ -120,10 +120,6 @@ github.com/envoyproxy/go-control-plane v0.13.5-0.20250123154839-2a6715911fec h1:
 github.com/envoyproxy/go-control-plane v0.13.5-0.20250123154839-2a6715911fec/go.mod h1:yz4MTDY0h9ObVlfP15ykR737j5tP/z64qu0OzSRoobk=
 github.com/envoyproxy/go-control-plane/contrib v1.32.5-0.20250411033633-fceb350c06ca h1:mwv6byj7anReeKt/N229AppQ5QLxez+Cp8hJfWg7Nwo=
 github.com/envoyproxy/go-control-plane/contrib v1.32.5-0.20250411033633-fceb350c06ca/go.mod h1:zD9QKAwQBnb9DWvRrkMa7cOuuMOt+ITrm4ZLoZ0aa30=
-github.com/envoyproxy/go-control-plane/envoy v1.32.4 h1:jb83lalDRZSpPWW2Z7Mck/8kXZ5CQAFYVjQcdVIr83A=
-github.com/envoyproxy/go-control-plane/envoy v1.32.4/go.mod h1:Gzjc5k8JcJswLjAx1Zm+wSYE20UrLtt7JZMWiWQXQEw=
-github.com/envoyproxy/go-control-plane/envoy v1.32.5-0.20250411033633-fceb350c06ca h1:W3dwBr7nRhgYadWcB1153flIHd9yvaVoJ3CymRIgVT8=
-github.com/envoyproxy/go-control-plane/envoy v1.32.5-0.20250411033633-fceb350c06ca/go.mod h1:pY0vLp032ToSdejxKtzWZs/TzoAtdK0+50ELjTkXiYA=
 github.com/envoyproxy/go-control-plane/envoy v1.32.5-0.20250415162219-ec399c4f2d93 h1:dyjocQqwgWI6DlzFSrXyoKPzA2X7bBNALGM7VWnrKgI=
 github.com/envoyproxy/go-control-plane/envoy v1.32.5-0.20250415162219-ec399c4f2d93/go.mod h1:RoXzVIu983XaKoLydN2Rh0Kxf0FD9+mkt/mMO+fR4+w=
 github.com/envoyproxy/go-control-plane/ratelimit v0.1.0 h1:/G9QYbddjL25KvtKTv3an9lx6VBE2cnb8wp1vEGNYGI=
@@ -379,8 +375,6 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH
 github.com/prometheus/client_golang v1.21.1 h1:DOvXXTqVzvkIewV/CDPFdejpMCGeMcbGCQ8YOmu+Ibk=
 github.com/prometheus/client_golang v1.21.1/go.mod h1:U9NM32ykUErtVBxdvD3zfi+EuFkkaBvMb09mIfe0Zgg=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/prometheus/client_model v0.6.1 h1:ZKSh/rekM+n3CeS952MLRAdFwIKqeY8b62p8ais2e9E=
-github.com/prometheus/client_model v0.6.1/go.mod h1:OrxVMOVHjw3lKMa8+x6HeMGkHMQyHDk9E3jmP2AmGiY=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=
 github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
 github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ2Io=

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,12 @@ github.com/envoyproxy/go-control-plane v0.13.5-0.20250123154839-2a6715911fec h1:
 github.com/envoyproxy/go-control-plane v0.13.5-0.20250123154839-2a6715911fec/go.mod h1:yz4MTDY0h9ObVlfP15ykR737j5tP/z64qu0OzSRoobk=
 github.com/envoyproxy/go-control-plane/contrib v1.32.5-0.20250411033633-fceb350c06ca h1:mwv6byj7anReeKt/N229AppQ5QLxez+Cp8hJfWg7Nwo=
 github.com/envoyproxy/go-control-plane/contrib v1.32.5-0.20250411033633-fceb350c06ca/go.mod h1:zD9QKAwQBnb9DWvRrkMa7cOuuMOt+ITrm4ZLoZ0aa30=
+github.com/envoyproxy/go-control-plane/envoy v1.32.4 h1:jb83lalDRZSpPWW2Z7Mck/8kXZ5CQAFYVjQcdVIr83A=
+github.com/envoyproxy/go-control-plane/envoy v1.32.4/go.mod h1:Gzjc5k8JcJswLjAx1Zm+wSYE20UrLtt7JZMWiWQXQEw=
 github.com/envoyproxy/go-control-plane/envoy v1.32.5-0.20250411033633-fceb350c06ca h1:W3dwBr7nRhgYadWcB1153flIHd9yvaVoJ3CymRIgVT8=
 github.com/envoyproxy/go-control-plane/envoy v1.32.5-0.20250411033633-fceb350c06ca/go.mod h1:pY0vLp032ToSdejxKtzWZs/TzoAtdK0+50ELjTkXiYA=
+github.com/envoyproxy/go-control-plane/envoy v1.32.5-0.20250415162219-ec399c4f2d93 h1:dyjocQqwgWI6DlzFSrXyoKPzA2X7bBNALGM7VWnrKgI=
+github.com/envoyproxy/go-control-plane/envoy v1.32.5-0.20250415162219-ec399c4f2d93/go.mod h1:RoXzVIu983XaKoLydN2Rh0Kxf0FD9+mkt/mMO+fR4+w=
 github.com/envoyproxy/go-control-plane/ratelimit v0.1.0 h1:/G9QYbddjL25KvtKTv3an9lx6VBE2cnb8wp1vEGNYGI=
 github.com/envoyproxy/go-control-plane/ratelimit v0.1.0/go.mod h1:Wk+tMFAFbCXaJPzVVHnPgRKdUdwW/KdbRt94AzgRee4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
@@ -377,6 +381,8 @@ github.com/prometheus/client_golang v1.21.1/go.mod h1:U9NM32ykUErtVBxdvD3zfi+EuF
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.6.1 h1:ZKSh/rekM+n3CeS952MLRAdFwIKqeY8b62p8ais2e9E=
 github.com/prometheus/client_model v0.6.1/go.mod h1:OrxVMOVHjw3lKMa8+x6HeMGkHMQyHDk9E3jmP2AmGiY=
+github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=
+github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
 github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ2Io=
 github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=

--- a/pkg/features/security.go
+++ b/pkg/features/security.go
@@ -22,6 +22,8 @@ const (
 	// FIPS_140_2 compliance policy.
 	// nolint: revive, stylecheck
 	FIPS_140_2 = "fips-140-2"
+
+	FIPS_202205 = "fips-202205"
 )
 
 // Define common security feature flags shared among the Istio components.
@@ -33,7 +35,11 @@ settings, including in-mesh mTLS and external TLS. Valid values are:
 * '' or unset places no additional restrictions.
 * 'fips-140-2' which enforces a version of the TLS protocol and a subset
 of cipher suites overriding any user preferences or defaults for all runtime
-components, including Envoy, gRPC Go SDK, and gRPC C++ SDK.
+components, including Envoy, gRPC Go SDK, and gRPC C++ SDK. Enforced via control
+plane-owned configuration of Envoy settings (e.g. TLS version).
+* 'fips-202205' which enforces the either TLS 1.2 or TLS 1.3 protocol as well
+as a subset of cipher suites and keys. Based on the BoringSSL FIPS certificate
+of the same name.
 
 WARNING: Setting compliance policy in the control plane is a necessary but
 not a sufficient requirement to achieve compliance. There are additional

--- a/pkg/features/security.go
+++ b/pkg/features/security.go
@@ -38,8 +38,8 @@ settings, including in-mesh mTLS and external TLS. Valid values are:
 of cipher suites overriding any user preferences or defaults for all runtime
 components, including Envoy, gRPC Go SDK, and gRPC C++ SDK. Enforced via control
 plane-owned configuration of Envoy settings (e.g. TLS version).
-* 'fips-202205' which enforces the either TLS 1.2 or TLS 1.3 protocol as well
-as a subset of cipher suites and keys. Based on the BoringSSL FIPS certificate
+* 'fips-202205' which enforces that either TLS 1.2 or TLS 1.3 protocol, as well
+as a subset of cipher suites and keys, must be used. It is based on the BoringSSL FIPS certificate
 of the same name.
 
 WARNING: Setting compliance policy in the control plane is a necessary but

--- a/pkg/features/security.go
+++ b/pkg/features/security.go
@@ -23,6 +23,7 @@ const (
 	// nolint: revive, stylecheck
 	FIPS_140_2 = "fips-140-2"
 
+	// nolint: revive, stylecheck
 	FIPS_202205 = "fips-202205"
 )
 

--- a/pkg/model/fips.go
+++ b/pkg/model/fips.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	gotls "crypto/tls"
+	"slices"
 
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 
@@ -59,6 +60,30 @@ func EnforceGoCompliance(ctx *gotls.Config) {
 		ctx.CipherSuites = fipsGoCiphers
 		ctx.CurvePreferences = []gotls.CurveID{gotls.CurveP256}
 		return
+	case common_features.FIPS_202205:
+		// Mirror the settings from Envoy
+		// https://github.com/envoyproxy/envoy/blob/a0c9c494a4405d78de15c246c0b915d83612f81a/api/envoy/extensions/transport_sockets/tls/v3/common.proto#L49
+		ctx.GetConfigForClient = func(chi *gotls.ClientHelloInfo) (*gotls.Config, error) {
+			// TODO: Go doesn't allow us to change signature requirements so this is all we can do
+			cfg := &gotls.Config{
+				CurvePreferences: []gotls.CurveID{gotls.CurveP256, gotls.CurveP384},
+				MinVersion:       gotls.VersionTLS12,
+			}
+			greatestVersion := slices.Max(chi.SupportedVersions)
+			if greatestVersion == gotls.VersionTLS13 {
+				cfg.MaxVersion = gotls.VersionTLS13
+				cfg.CipherSuites = []uint16{
+					gotls.TLS_AES_128_GCM_SHA256,
+					gotls.TLS_AES_256_GCM_SHA384,
+				}
+			} else {
+				cfg.MaxVersion = gotls.VersionTLS12
+				cfg.CipherSuites = fipsGoCiphers
+			}
+
+			return cfg, nil
+		}
+
 	default:
 		log.Warnf("unknown compliance policy: %q", common_features.CompliancePolicy)
 		return
@@ -91,6 +116,13 @@ func EnforceCompliance(ctx *tls.CommonTlsContext) {
 		// Default (unset) is P-256
 		ctx.TlsParams.EcdhCurves = nil
 		return
+	case common_features.FIPS_202205:
+		if ctx.TlsParams == nil {
+			ctx.TlsParams = &tls.TlsParameters{}
+		}
+		ctx.TlsParams.CompliancePolicies = []tls.TlsParameters_CompliancePolicy{
+			tls.TlsParameters_FIPS_202205,
+		}
 	default:
 		log.Warnf("unknown compliance policy: %q", common_features.CompliancePolicy)
 		return

--- a/releasenotes/notes/fips-202205.yaml
+++ b/releasenotes/notes/fips-202205.yaml
@@ -1,0 +1,16 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+issue:
+- 52926
+
+releaseNotes:
+- |
+  **Added** fips-202205 to `COMPLIANCE_POLICY` for enforcing TLS restriction for compliance
+  with FIPS. This field configures a TLS connection to use:
+  * TLS 1.2 or 1.3
+  * For TLS 1.2, only ECDHE_[RSA|ECDSA]_WITH_AES_*_GCM_SHA*.
+  * For TLS 1.3, only AES-GCM
+  * P-256 or P-384 for key agreement.
+  * For server signatures, only ``PKCS#1/PSS`` with ``SHA256/384/512``, or ECDSA
+    with P-256 or P-384.

--- a/releasenotes/notes/fips-202205.yaml
+++ b/releasenotes/notes/fips-202205.yaml
@@ -6,11 +6,10 @@ issue:
 
 releaseNotes:
 - |
-  **Added** fips-202205 to `COMPLIANCE_POLICY` for enforcing TLS restriction for compliance
+  **Added** `fips-202205` to `COMPLIANCE_POLICY` for enforcing TLS restriction for compliance
   with FIPS. This field configures a TLS connection to use:
-  * TLS 1.2 or 1.3
-  * For TLS 1.2, only ECDHE_[RSA|ECDSA]_WITH_AES_*_GCM_SHA*.
-  * For TLS 1.3, only AES-GCM
-  * P-256 or P-384 for key agreement.
-  * For server signatures, only ``PKCS#1/PSS`` with ``SHA256/384/512``, or ECDSA
-    with P-256 or P-384.
+  - TLS 1.2 or 1.3.
+  - For TLS 1.2, only `ECDHE_[RSA|ECDSA]_WITH_AES_*_GCM_SHA*`.
+  - For TLS 1.3, only AES-GCM.
+  - P-256 or P-384 for key agreement.
+  - For server signatures, only `PKCS#1/PSS` with `SHA256/384/512`, or `ECDSA` with `P-256` or `P-384`.


### PR DESCRIPTION
**Please provide a description of this PR:**
Fixes #52926 for istiod/envoy.

One thing to note is that Go doesn't seem to allow us to change signatures in the TLS config; open to suggestions on how to achieve it. For now, we just block any clients with non-fips signatures