### PR TITLE
fix default kind config for prow

### DIFF
--- a/prow/config/clustertrustbundles.yaml
+++ b/prow/config/clustertrustbundles.yaml
@@ -1,5 +1,5 @@
-# This configs KinD to spin up a k8s cluster with mixed protocol LB support and GRPCContainerProbe enabled
-# This should be used to create K8s clusters with versions >= 1.23
+# This configs KinD to spin up a k8s cluster with ClusterTrustBundle support enabled
+# This should only be used to create K8s clusters with versions >= 1.27
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 kubeadmConfigPatches:
@@ -27,3 +27,8 @@ containerdConfigPatches:
   - |-
     [plugins."io.containerd.grpc.v1.cri".registry]
       config_path = "/etc/containerd/certs.d"
+featureGates:
+  "ClusterTrustBundle": true
+  "ClusterTrustBundleProjection": true
+runtimeConfig:
+  "certificates.k8s.io/v1alpha1/clustertrustbundles": true


### PR DESCRIPTION
**Please provide a description of this PR:**
In #55592, the default prow config was changed to include support for ClusterTrustBundles by default, which breaks on k8s<v1.27. This moves the ClusterTrustBundle enablement into a separate config, as it's only used in manual tests anyway. We can use the separate config when we write an integration test.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
