### PR TITLE
fix istioctl admin log cannot modify the log level of ip-autoallocate

### DIFF
--- a/istioctl/pkg/admin/istiodconfig.go
+++ b/istioctl/pkg/admin/istiodconfig.go
@@ -371,7 +371,7 @@ func (c *ControlzClient) GetScope(scope string) (*ScopeInfo, error) {
 var (
 	istiodLabelSelector = ""
 	istiodReset         = false
-	validationPattern   = `^[\w\- ]+:(error|warn|info|debug)`
+	validationPattern   = `^[\w\- ]+:(none|error|warn|info|debug)`
 )
 
 func istiodLogCmd(ctx cli.Context) *cobra.Command {

--- a/istioctl/pkg/admin/istiodconfig.go
+++ b/istioctl/pkg/admin/istiodconfig.go
@@ -371,7 +371,7 @@ func (c *ControlzClient) GetScope(scope string) (*ScopeInfo, error) {
 var (
 	istiodLabelSelector = ""
 	istiodReset         = false
-	validationPattern   = `^[\w ]+:(debug|error|warn|info|debug)`
+	validationPattern   = `^[\w\- ]+:(debug|error|warn|info|debug)`
 )
 
 func istiodLogCmd(ctx cli.Context) *cobra.Command {

--- a/istioctl/pkg/admin/istiodconfig.go
+++ b/istioctl/pkg/admin/istiodconfig.go
@@ -371,7 +371,7 @@ func (c *ControlzClient) GetScope(scope string) (*ScopeInfo, error) {
 var (
 	istiodLabelSelector = ""
 	istiodReset         = false
-	validationPattern   = `^[\w\- ]+:(debug|error|warn|info|debug)`
+	validationPattern   = `^[\w\- ]+:(error|warn|info|debug)`
 )
 
 func istiodLogCmd(ctx cli.Context) *cobra.Command {

--- a/istioctl/pkg/admin/istiodconfig_test.go
+++ b/istioctl/pkg/admin/istiodconfig_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func Test_newScopeLevelPair(t *testing.T) {
-	validationPattern := `^\w+:(debug|error|warn|info|debug)`
+	validationPattern := `^[\w\- ]+:(none|error|warn|info|debug)`
 	type args struct {
 		slp               string
 		validationPattern string
@@ -56,7 +56,7 @@ func Test_newScopeLevelPair(t *testing.T) {
 }
 
 func Test_newScopeStackTraceLevelPair(t *testing.T) {
-	validationPattern := `^\w+:(debug|error|warn|info|debug)`
+	validationPattern := `^[\w\- ]+:(none|error|warn|info|debug)`
 	type args struct {
 		sslp              string
 		validationPattern string
@@ -132,6 +132,20 @@ func Test_chooseClientFlag(t *testing.T) {
 			want: &istiodConfigLog{state: &logLevelState{
 				client:         ctrzClient,
 				outputLogLevel: "resource:info",
+			}},
+		},
+		{
+			name: "given --level flag containing '-' and none level return outputLogLevel command",
+			args: args{
+				ctrzClient:      ctrzClient,
+				reset:           false,
+				outputLogLevel:  "resource-foo:none",
+				stackTraceLevel: "",
+				outputFormat:    "",
+			},
+			want: &istiodConfigLog{state: &logLevelState{
+				client:         ctrzClient,
+				outputLogLevel: "resource-foo:none",
 			}},
 		},
 		{

--- a/releasenotes/notes/55976.yaml
+++ b/releasenotes/notes/55976.yaml
@@ -5,4 +5,4 @@ issue:
 - 55741
 releaseNotes:
 - |
-  **Fixed** `istioctl admin log` cannot modify the log level of `ip-autoallocate`.
+  **Fixed** `istioctl admin log` now supports configuring the log level of `ip-autoallocate`.

--- a/releasenotes/notes/55976.yaml
+++ b/releasenotes/notes/55976.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+issue:
+- 55741
+releaseNotes:
+- |
+  **Fixed** `istioctl admin log` cannot modify the log level of `ip-autoallocate`.


### PR DESCRIPTION
**Please provide a description of this PR:**

Related: https://github.com/istio/istio/issues/55741#issuecomment-2812343990

 Fix`istioctl admin log` cannot modify the log level of `ip-autoallocate`.

