### PR TITLE
feat: enable support for proxy protocol on status port

### DIFF
--- a/pilot/pkg/features/experimental.go
+++ b/pilot/pkg/features/experimental.go
@@ -198,4 +198,7 @@ var (
 
 	CACertConfigMapName = env.Register("PILOT_CA_CERT_CONFIGMAP", "istio-ca-root-cert",
 		"The name of the ConfigMap that stores the Root CA Certificate that is used by istiod").Get()
+
+	EnvoyStatusPortEnableProxyProtocol = env.Register("ENVOY_STATUS_PORT_ENABLE_PROXY_PROTOCOL", false,
+		"If enabled, Envoy will support requests with proxy protocol on its status port").Get()
 )

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -201,6 +201,10 @@ func (cfg Config) toTemplateParams() (map[string]any, error) {
 		}
 	}
 
+	if features.EnvoyStatusPortEnableProxyProtocol {
+		opts = append(opts, option.EnvoyStatusPortEnableProxyProtocol(true))
+	}
+
 	proxyOpts, err := getProxyConfigOptions(cfg.Metadata)
 	if err != nil {
 		return nil, err

--- a/pkg/bootstrap/option/instances.go
+++ b/pkg/bootstrap/option/instances.go
@@ -231,6 +231,10 @@ func EnvoyStatusPort(value int) Instance {
 	return newOption("envoy_status_port", value)
 }
 
+func EnvoyStatusPortEnableProxyProtocol(value bool) Instance {
+	return newOption("envoy_status_port_enable_proxy_protocol", value)
+}
+
 func EnvoyPrometheusPort(value int) Instance {
 	return newOption("envoy_prometheus_port", value)
 }

--- a/releasenotes/notes/envoy-status-port-proxy-protocol.yaml
+++ b/releasenotes/notes/envoy-status-port-proxy-protocol.yaml
@@ -1,0 +1,46 @@
+apiVersion: release-notes/v2
+
+# This YAML file describes the format for specifying a release notes entry for Istio.
+# This should be filled in for all user facing changes.
+
+# kind describes the type of change that this represents.
+# Valid Values are:
+# - bug-fix -- Used to specify that this change represents a bug fix.
+# - security-fix -- Used to specify that this change represents a vulnerability fix.
+# - feature -- Used to specify a new feature that has been added.
+# - test -- Used to describe additional testing added. This file is optional for
+#   tests, but included for completeness.
+kind: feature
+
+# area describes the area that this change affects.
+# Valid values are:
+# - traffic-management
+# - security
+# - telemetry
+# - installation
+# - istioctl
+# - documentation
+area: installation
+
+# issue is a list of GitHub issues resolved in this note.
+# If issue is not in the current repo, specify its full URL instead.
+issue:
+  - 39868
+
+# releaseNotes is a markdown listing of any user facing changes. This will appear in the
+# release notes.
+releaseNotes:
+  - |
+    **Added** support for proxy protocol on status port
+
+# upgradeNotes is a markdown listing of any changes that will affect the upgrade
+# process. This will appear in the release notes.
+# upgradeNotes:
+
+# docs is a list of related docs to the change.
+docs:
+  - '[reference] https://istio.io/latest/docs/reference/commands/pilot-agent/#envvars'
+
+# securityNotes is a markdown listing of any changes related to the security of
+# Istio.
+# securityNotes:

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -685,6 +685,17 @@
           }
         ],
         {{- end}}
+        {{- if .envoy_status_port_enable_proxy_protocol }}
+        "listener_filters": [
+          {
+            "name": "envoy.listener.proxy_protocol",
+            "typed_config": {
+              "@type": "type.googleapis.com/envoy.extensions.filters.listener.proxy_protocol.v3.ProxyProtocol",
+              "allow_requests_without_proxy_protocol": true,
+            }
+          }
+        ],
+        {{- end }}
         "filter_chains": [
           {
             "filters": [


### PR DESCRIPTION
**Please provide a description of this PR:**

On AWS network load balancers, when enabling proxy protocol and configuring health check to query Istio status port on the path /healthz/ready, the health check fails, because Istio status port does not support proxy protocol. However, on the load balancer, proxy protocol cannot be disabled for the health check only.

Envoy supports the proxy protocol with an option to allow requests without proxy protocol. This option breaks conformance to the proxy protocol specification, and should only be enabled when the traffic to the listener comes from a trusted source, which should be the case for the status port. This seems to be a good compromise to allow both requests with and without proxy protocol on the status port.

Fixes #39868

This PR is meant to open a discussion. I’d need help to write some tests if it has a chance of being accepted.