### PR TITLE
Add stub for ambient multicluster tests

### DIFF
--- a/tests/integration/ambient/multicluster/main_test.go
+++ b/tests/integration/ambient/multicluster/main_test.go
@@ -1,0 +1,32 @@
+//go:build integ
+// +build integ
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicluster
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+)
+
+// TODO: Add all the tests
+func TestMain(m *testing.M) {
+	// nolint: staticcheck
+	framework.
+		NewSuite(m).
+		RequireMinVersion(24).Run()
+}


### PR DESCRIPTION
Creates a stub test dir so the prow job can reference something without breaking