### PR TITLE
Create ambient multinetwork flag

### DIFF
--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -118,6 +118,10 @@ spec:
         - name: LOG_FORMAT
           value: json
         {{- end}}
+        {{- if .Values.global.network }}
+        - name: NETWORK
+          value: {{ .Values.global.network | quote }}
+        {{- end }}
         - name: RUST_LOG
           value: {{ .Values.logLevel | quote }}
         - name: RUST_BACKTRACE

--- a/manifests/charts/ztunnel/values.yaml
+++ b/manifests/charts/ztunnel/values.yaml
@@ -12,6 +12,12 @@ _internal_defaults_do_not_set:
   # If Image contains a "/", it will replace the entire `image` in the pod.
   image: ztunnel
 
+  # We keep the global namespace around for backwards-compatibility
+  global:
+    # Network defines the network this cluster belong to. This name
+    # corresponds to the networks in the map of mesh networks.
+    network: ""
+
   # resourceName, if set, will override the naming of resources. If not set, will default to 'ztunnel'.
   # If you set this, you MUST also set `trustedZtunnelName` in the `istiod` chart.
   resourceName: ""

--- a/pkg/test/framework/components/ambient/waypoint.go
+++ b/pkg/test/framework/components/ambient/waypoint.go
@@ -28,6 +28,7 @@ import (
 	istioKube "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/components/crd"
 	"istio.io/istio/pkg/test/framework/components/istioctl"
 	"istio.io/istio/pkg/test/framework/components/namespace"
@@ -86,6 +87,65 @@ type WaypointProxy interface {
 	PodIP() string
 }
 
+func NewWaypointProxyForCluster(ctx resource.Context, ns namespace.Instance, name string, cls cluster.Cluster) (WaypointProxy, error) {
+	server := &kubeComponent{
+		ns: ns,
+	}
+	server.id = ctx.TrackResource(server)
+	if err := crd.DeployGatewayAPI(ctx); err != nil {
+		return nil, err
+	}
+
+	ik, err := istioctl.New(ctx, istioctl.Config{
+		Cluster: cls,
+	})
+	if err != nil {
+		return nil, err
+	}
+	// TODO: detect from UseWaypointProxy in echo.Config
+	_, _, err = ik.Invoke([]string{
+		"waypoint",
+		"apply",
+		"--namespace",
+		ns.Name(),
+		"--name",
+		name,
+		"--for",
+		constants.AllTraffic,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Find the Waypoint pod and service, and start forwarding a local port.
+	fetchFn := testKube.NewSinglePodFetch(cls, ns.Name(), fmt.Sprintf("%s=%s", label.IoK8sNetworkingGatewayGatewayName.Name, name))
+	pods, err := testKube.WaitUntilPodsAreReady(fetchFn)
+	if err != nil {
+		return nil, err
+	}
+	pod := pods[0]
+	inbound, err := cls.NewPortForwarder(pod.Name, pod.Namespace, "", 0, 15008)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := inbound.Start(); err != nil {
+		return nil, err
+	}
+	outbound, err := cls.NewPortForwarder(pod.Name, pod.Namespace, "", 0, 15001)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := outbound.Start(); err != nil {
+		return nil, err
+	}
+	server.inbound = inbound
+	server.outbound = outbound
+	server.pod = pod
+	return server, nil
+}
+
 // NewWaypointProxy creates a new WaypointProxy.
 func NewWaypointProxy(ctx resource.Context, ns namespace.Instance, name string) (WaypointProxy, error) {
 	server := &kubeComponent{
@@ -95,6 +155,8 @@ func NewWaypointProxy(ctx resource.Context, ns namespace.Instance, name string) 
 	if err := crd.DeployGatewayAPI(ctx); err != nil {
 		return nil, err
 	}
+
+	// TODO return a component per cluster for more targeted tests
 
 	for _, cls := range ctx.AllClusters() {
 		ik, err := istioctl.New(ctx, istioctl.Config{
@@ -119,7 +181,6 @@ func NewWaypointProxy(ctx resource.Context, ns namespace.Instance, name string) 
 		}
 	}
 
-	// TODO return a component per cluster for more targeted tests
 	cls := ctx.Clusters().Default()
 	// Find the Waypoint pod and service, and start forwarding a local port.
 	fetchFn := testKube.NewSinglePodFetch(cls, ns.Name(), fmt.Sprintf("%s=%s", label.IoK8sNetworkingGatewayGatewayName.Name, name))
@@ -148,6 +209,15 @@ func NewWaypointProxy(ctx resource.Context, ns namespace.Instance, name string) 
 	server.outbound = outbound
 	server.pod = pod
 	return server, nil
+}
+
+func NewWaypointProxyOrFailForCluster(t framework.TestContext, ns namespace.Instance, name string, cls cluster.Cluster) WaypointProxy {
+	t.Helper()
+	s, err := NewWaypointProxyForCluster(t, ns, name, cls)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
 }
 
 // NewWaypointProxyOrFail calls NewWaypointProxy and fails if an error occurs.

--- a/pkg/test/framework/components/istio/ca.go
+++ b/pkg/test/framework/components/istio/ca.go
@@ -73,9 +73,9 @@ func CreateCertificateForCluster(t framework.TestContext, i Instance, serviceAcc
 		Csr:              string(csrPEM),
 		ValidityDuration: int64((time.Hour * 24 * 7).Seconds()),
 	}
-	clusterName := c.Name()
-	if clusterName == "" {
-		clusterName = constants.DefaultClusterName
+	clusterName := constants.DefaultClusterName
+	if t.Settings().AmbientMultiNetwork {
+		clusterName = c.Name()
 	}
 	rctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("Authorization", "Bearer "+token, "ClusterID", clusterName))
 	resp, err := client.CreateCertificate(rctx, req)

--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -223,6 +223,9 @@ func init() {
 	flag.BoolVar(&settingsFromCommandLine.OpenShift, "istio.test.openshift", settingsFromCommandLine.OpenShift,
 		"Indicate the tests run in an OpenShift platform rather than in plain Kubernetes.")
 
+	flag.BoolVar(&settingsFromCommandLine.AmbientMultiNetwork, "istio.test.ambient.multinetwork", settingsFromCommandLine.AmbientMultiNetwork,
+		"Indicate the use of ambient multicluster.")
+
 	initGatewayConformanceTimeouts()
 }
 

--- a/pkg/test/framework/resource/settings.go
+++ b/pkg/test/framework/resource/settings.go
@@ -145,6 +145,8 @@ type Settings struct {
 	// Use ambient instead of sidecars
 	AmbientEverywhere bool
 
+	AmbientMultiNetwork bool
+
 	// Compatibility determines whether we should transparently deploy echo workloads attached to each revision
 	// specified in `Revisions` when creating echo instances. Used primarily for compatibility testing between revisions
 	// on different control plane versions.

--- a/prow/config/topology/ambient-multicluster.json
+++ b/prow/config/topology/ambient-multicluster.json
@@ -1,0 +1,16 @@
+[
+  {
+    "kind": "Kubernetes",
+    "clusterName": "primary",
+    "podSubnet": "10.10.0.0/16",
+    "svcSubnet": "10.255.10.0/24",
+    "network": "network-1"
+  },
+  {
+    "kind": "Kubernetes",
+    "clusterName": "cross-network-primary",
+    "podSubnet": "10.30.0.0/16",
+    "svcSubnet": "10.255.30.0/24",
+    "network": "network-2"
+  }
+]

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -85,7 +85,7 @@ while (( "$#" )); do
     --topology)
       case $2 in
         # TODO(landow) get rid of MULTICLUSTER_SINGLE_NETWORK after updating Prow job
-        SINGLE_CLUSTER | MULTICLUSTER_SINGLE_NETWORK | MULTICLUSTER )
+        SINGLE_CLUSTER | MULTICLUSTER_SINGLE_NETWORK | MULTICLUSTER | AMBIENT_MULTICLUSTER )
           TOPOLOGY=$2
           echo "Running with topology ${TOPOLOGY}"
           ;;

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -3377,7 +3377,6 @@ func TestZtunnelRestart(t *testing.T) {
 }
 
 func TestServiceDynamicEnroll(t *testing.T) {
-
 	const callInterval = 50 * time.Millisecond
 	// TODO(https://github.com/istio/istio/issues/53064) make this 100%
 	successThreshold := 0.5

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -252,6 +252,11 @@ func TestPodIP(t *testing.T) {
 								if src.Config().HasSidecar() {
 									t.Skip("not supported yet")
 								}
+
+								if srcWl.Cluster() != dstWl.Cluster() {
+									// TODO: Enable when we support multi-network workload addressing
+									t.Skip("not supported yet")
+								}
 								for _, opt := range basicCalls {
 									opt := opt.DeepCopy()
 									selfSend := dstWl.Address() == srcWl.Address()

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -1257,7 +1257,7 @@ metadata:
  name: allow-nothing-waypoint
 spec:
   targetRefs:
-  - group: "gateway.networking.k8s.io" 
+  - group: "gateway.networking.k8s.io"
     kind: "GatewayClass"
     name: "istio-waypoint"`).ApplyOrFail(t)
 
@@ -3110,14 +3110,17 @@ func TestDirect(t *testing.T) {
 				HBONE:   hbsvc,
 				Check:   check.OK(),
 			})
-			run("VIP destination, FQDN authority", echo.CallOptions{
-				To:      apps.ServiceAddressedWaypoint,
-				Count:   1,
-				Address: apps.ServiceAddressedWaypoint.ClusterLocalFQDN(),
-				Port:    echo.Port{Name: ports.HTTP.Name},
-				HBONE:   hbsvc,
-				Check:   check.OK(),
-			})
+			// Only works with multinetwork
+			if t.Settings().AmbientMultiNetwork {
+				run("VIP destination, FQDN authority", echo.CallOptions{
+					To:      apps.ServiceAddressedWaypoint,
+					Count:   1,
+					Address: apps.ServiceAddressedWaypoint.ClusterLocalFQDN(),
+					Port:    echo.Port{Name: ports.HTTP.Name},
+					HBONE:   hbsvc,
+					Check:   check.OK(),
+				})
+			}
 			run("VIP destination, unknown port", echo.CallOptions{
 				To:      apps.ServiceAddressedWaypoint,
 				Count:   1,

--- a/tests/integration/ambient/cni/main_test.go
+++ b/tests/integration/ambient/cni/main_test.go
@@ -82,6 +82,9 @@ func TestMain(m *testing.M) {
 			ctx.Settings().SkipVMs()
 			cfg.EnableCNI = true
 			cfg.DeployEastWestGW = false
+			if ctx.Settings().AmbientMultiNetwork {
+				cfg.SkipDeployCrossClusterSecrets = true
+			}
 			cfg.ControlPlaneValues = `
 values:
   ztunnel:

--- a/tests/integration/ambient/cnirepair/main_test.go
+++ b/tests/integration/ambient/cnirepair/main_test.go
@@ -78,6 +78,9 @@ func TestMain(m *testing.M) {
 			ctx.Settings().SkipVMs()
 			cfg.EnableCNI = true
 			cfg.DeployEastWestGW = false
+			if ctx.Settings().AmbientMultiNetwork {
+				cfg.SkipDeployCrossClusterSecrets = true
+			}
 			cfg.ControlPlaneValues = `
 values:
   cni:

--- a/tests/integration/ambient/cniupgrade/main_test.go
+++ b/tests/integration/ambient/cniupgrade/main_test.go
@@ -79,6 +79,9 @@ func TestMain(m *testing.M) {
 			ctx.Settings().SkipVMs()
 			cfg.EnableCNI = true
 			cfg.DeployEastWestGW = false
+			if ctx.Settings().AmbientMultiNetwork {
+				cfg.SkipDeployCrossClusterSecrets = true
+			}
 			cfg.ControlPlaneValues = `
 values:
   cni:

--- a/tests/integration/ambient/main_test.go
+++ b/tests/integration/ambient/main_test.go
@@ -138,6 +138,9 @@ func TestMain(m *testing.M) {
 			cfg.ControlPlaneValues = ambientControlPlaneValues
 			if ctx.Settings().AmbientMultiNetwork {
 				cfg.ControlPlaneValues = ambientMultiNetworkControlPlaneValues
+				// TODO: Remove once we're actually ready to test the multi-cluster
+				// features
+				cfg.SkipDeployCrossClusterSecrets = true
 			}
 		}, cert.CreateCASecretAlt)).
 		Setup(func(t resource.Context) error {

--- a/tests/integration/ambient/main_test.go
+++ b/tests/integration/ambient/main_test.go
@@ -144,6 +144,7 @@ func TestMain(m *testing.M) {
 			}
 		}, cert.CreateCASecretAlt)).
 		Setup(func(t resource.Context) error {
+			gatewayConformanceInputs.Cluster = t.Clusters().Default()
 			gatewayConformanceInputs.Client = t.Clusters().Default()
 			gatewayConformanceInputs.Cleanup = !t.Settings().NoCleanup
 

--- a/tests/integration/ambient/main_test.go
+++ b/tests/integration/ambient/main_test.go
@@ -54,6 +54,39 @@ var (
 	prom prometheus.Instance
 )
 
+const (
+	ambientControlPlaneValues = `
+values:
+  cni:
+    # The CNI repair feature is disabled for these tests because this is a controlled environment,
+    # and it is important to catch issues that might otherwise be automatically fixed.
+    # Refer to issue #49207 for more context.
+    repair:
+      enabled: false
+  ztunnel:
+    terminationGracePeriodSeconds: 5
+    env:
+      SECRET_TTL: 5m
+`
+
+	ambientMultiNetworkControlPlaneValues = `
+values:
+  pilot:
+    env:
+      AMBIENT_ENABLE_MULTI_NETWORK: "true"
+  cni:
+    # The CNI repair feature is disabled for these tests because this is a controlled environment,
+    # and it is important to catch issues that might otherwise be automatically fixed.
+    # Refer to issue #49207 for more context.
+    repair:
+      enabled: false
+  ztunnel:
+    terminationGracePeriodSeconds: 5
+    env:
+      SECRET_TTL: 5m
+`
+)
+
 type EchoDeployments struct {
 	// Namespace echo apps will be deployed
 	Namespace         namespace.Instance
@@ -102,22 +135,10 @@ func TestMain(m *testing.M) {
 			ctx.Settings().SkipVMs()
 			cfg.EnableCNI = true
 			cfg.DeployEastWestGW = false
-			cfg.ControlPlaneValues = `
-values:
-  pilot:
-    env:
-      AMBIENT_ENABLE_MULTI_NETWORK: "true"
-  cni:
-    # The CNI repair feature is disabled for these tests because this is a controlled environment,
-    # and it is important to catch issues that might otherwise be automatically fixed.
-    # Refer to issue #49207 for more context.
-    repair:
-      enabled: false
-  ztunnel:
-    terminationGracePeriodSeconds: 5
-    env:
-      SECRET_TTL: 5m
-`
+			cfg.ControlPlaneValues = ambientControlPlaneValues
+			if ctx.Settings().AmbientMultiNetwork {
+				cfg.ControlPlaneValues = ambientMultiNetworkControlPlaneValues
+			}
 		}, cert.CreateCASecretAlt)).
 		Setup(func(t resource.Context) error {
 			gatewayConformanceInputs.Client = t.Clusters().Default()

--- a/tests/integration/ambient/untaint/main_test.go
+++ b/tests/integration/ambient/untaint/main_test.go
@@ -52,6 +52,9 @@ func TestMain(m *testing.M) {
 			// can't deploy VMs without eastwest gateway
 			ctx.Settings().SkipVMs()
 			cfg.DeployEastWestGW = false
+			if ctx.Settings().AmbientMultiNetwork {
+				cfg.SkipDeployCrossClusterSecrets = true
+			}
 			cfg.ControlPlaneValues = fmt.Sprintf(`
 values:
   pilot:

--- a/tests/integration/ambient/wasm_test.go
+++ b/tests/integration/ambient/wasm_test.go
@@ -132,11 +132,12 @@ func sendTraffic(ctx framework.TestContext, checker echo.Checker, options ...ret
 	if len(GetClientInstances()) == 0 {
 		ctx.Fatal("there is no client")
 	}
-	cltInstance := GetClientInstances()[0]
+	// TODO: Figure out if/how to support multiple clusters
+	cltInstance := GetClientInstances().ForCluster(ctx.Clusters().Default().Name())[0]
 
 	defaultOptions := []retry.Option{retry.Delay(100 * time.Millisecond), retry.Timeout(200 * time.Second)}
 	httpOpts := echo.CallOptions{
-		To: GetTarget(),
+		To: GetTarget().Instances().ForCluster(ctx.Clusters().Default().Name()),
 		Port: echo.Port{
 			Name: "http",
 		},
@@ -222,7 +223,7 @@ func TestWasmPluginConfigurations(t *testing.T) {
 					desc:       "Configure WebAssembly filter for specific service",
 					name:       "service-wasm-test",
 					targetType: "service",
-					targetName: GetTarget().(echo.Instances).ServiceName(),
+					targetName: GetTarget().Instances().ServiceName(),
 				},
 			}
 
@@ -230,7 +231,7 @@ func TestWasmPluginConfigurations(t *testing.T) {
 				if tc.name == "gateway-wasm-test" {
 					crd.DeployGatewayAPIOrSkip(t)
 					args := map[string]any{
-						"To": GetTarget().(echo.Instances),
+						"To": GetTarget().Instances(),
 					}
 					t.ConfigIstio().EvalFile(apps.Namespace.Name(), args, "testdata/gateway-api.yaml").ApplyOrFail(t)
 				}

--- a/tests/integration/ambient/waypoint_test.go
+++ b/tests/integration/ambient/waypoint_test.go
@@ -270,8 +270,8 @@ spec:
     allowedRoutes:
       namespaces:
         from: Same
-  # HACK:zTunnel currently expects the HBONE port to always be on the Waypoint's Service 
-  # This will be fixed in future PRs to both istio and zTunnel. 
+  # HACK:zTunnel currently expects the HBONE port to always be on the Waypoint's Service
+  # This will be fixed in future PRs to both istio and zTunnel.
   - name: fake-hbone-port
     port: 15008
     protocol: TCP
@@ -643,6 +643,9 @@ spec:
     name: {{.Waypoint}}
 `).ApplyOrFail(t)
 		t.NewSubTest("sidecar-service").Run(func(t framework.TestContext) {
+			if t.Settings().AmbientMultiNetwork {
+				t.Skip("https://github.com/istio/istio/issues/54245")
+			}
 			for _, src := range apps.Sidecar {
 				for _, dst := range apps.ServiceAddressedWaypoint {
 					for _, opt := range basicCalls {
@@ -658,6 +661,9 @@ spec:
 			}
 		})
 		t.NewSubTest("sidecar-workload").Run(func(t framework.TestContext) {
+			if t.Settings().AmbientMultiNetwork {
+				t.Skip("https://github.com/istio/istio/issues/54245")
+			}
 			for _, src := range apps.Sidecar {
 				for _, dst := range apps.WorkloadAddressedWaypoint {
 					for _, dstWl := range dst.WorkloadsOrFail(t) {
@@ -676,6 +682,9 @@ spec:
 			}
 		})
 		t.NewSubTest("ingress-service").Run(func(t framework.TestContext) {
+			if t.Settings().AmbientMultiNetwork {
+				t.Skip("https://github.com/istio/istio/issues/54245")
+			}
 			t.ConfigIstio().Eval(apps.Namespace.Name(), map[string]string{
 				"Destination": apps.ServiceAddressedWaypoint.ServiceName(),
 			}, `apiVersion: networking.istio.io/v1alpha3


### PR DESCRIPTION
So that we can separate the multinetwork tests. Also pass Values.global.network to ztunnel so that the cluster's network gets plumbed through to it and it doesn't do faulty service lookups