### PR TITLE
fix istio-revision-tag-default MutatingWebhookConfigurations is not created during installation

### DIFF
--- a/istioctl/pkg/tag/util.go
+++ b/istioctl/pkg/tag/util.go
@@ -106,7 +106,7 @@ func DeleteTagWebhooks(ctx context.Context, client kubernetes.Interface, tag str
 // whether to make an installation the default.
 func PreviousInstallExists(ctx context.Context, client kubernetes.Interface) bool {
 	mwhs, err := client.AdmissionregistrationV1().MutatingWebhookConfigurations().List(ctx, metav1.ListOptions{
-		LabelSelector: "app=sidecar-injector",
+		LabelSelector: "app=sidecar-injector, istio.io/tag=default",
 	})
 	if err != nil {
 		return false

--- a/releasenotes/notes/56004.yaml
+++ b/releasenotes/notes/56004.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+issue:
+- 55980
+releaseNotes:
+- |
+  **Fixed** during installation, `istio-revision-tag-default` MutatingWebhookConfiguration is never created when the revision is not default.


### PR DESCRIPTION
**Please provide a description of this PR:**

fix istio-revision-tag-default MutatingWebhookConfiguration is not created during installation when the revision is not default

Fix https://github.com/istio/istio/issues/55980