### PR TITLE
fix(networking): Add absolute FQDNs (trailing dot) to VirtualHost domains

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -269,6 +269,17 @@ var (
 
 	EnableClusterTrustBundles = env.Register("ENABLE_CLUSTER_TRUST_BUNDLE_API", false,
 		"If enabled, uses the ClusterTrustBundle API instead of ConfigMaps to store the root certificate in the cluster.").Get()
+
+	// EnableAbsoluteFqdnVhostDomain controls whether the absolute FQDN (hostname followed by a dot,)
+	// e.g. my-service.my-ns.svc.cluster.local. / google.com. is added to the VirtualHost domains list.
+	// Setting this to false disables the addition.
+	// See https://github.com/istio/istio/issues/56007 for more details of this feature with examples.
+	EnableAbsoluteFqdnVhostDomain = env.Register(
+		"PILOT_ENABLE_ABSOLUTE_FQDN_VHOST_DOMAIN", // Environment variable name
+		true, // Default value (true = feature enabled by default)
+		"If set to true, Istio will add the absolute FQDN variant (e.g., my-service.my-ns.svc.cluster.local.) "+
+			"to the domains list for VirtualHost entries. Defaults to true, enabling the addition.",
+	).Get()
 )
 
 // UnsafeFeaturesEnabled returns true if any unsafe features are enabled.

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -277,8 +277,9 @@ var (
 	EnableAbsoluteFqdnVhostDomain = env.Register(
 		"PILOT_ENABLE_ABSOLUTE_FQDN_VHOST_DOMAIN", // Environment variable name
 		true, // Default value (true = feature enabled by default)
-		"If set to true, Istio will add the absolute FQDN variant (e.g., my-service.my-ns.svc.cluster.local.) "+
-			"to the domains list for VirtualHost entries. Defaults to true, enabling the addition.",
+		"If set to false, Istio will not add the absolute FQDN variant"+
+			" (e.g., my-service.my-ns.svc.cluster.local.) to the domains"+
+			" list for VirtualHost entries.",
 	).Get()
 )
 

--- a/pilot/pkg/networking/core/httproute.go
+++ b/pilot/pkg/networking/core/httproute.go
@@ -677,13 +677,16 @@ func appendDomainPort(domains []string, domain string, port int) []string {
 func GenerateAltVirtualHosts(hostname string, port int, proxyDomain string) []string {
 	var vhosts []string // Initialize the slice for alternate hosts
 
-	// Add the absolute FQDN variant (with trailing dot) if the hostname is not an IP address.
-	// This is considered another form of alternate host representation.
-	// See https://github.com/istio/istio/issues/56007 for context.
-	// "foo.local.campus.net" -> "foo.local.campus.net."
-	isIP := net.ParseIP(hostname) != nil
-	if !isIP {
-		vhosts = append(vhosts, hostname+".")
+	if features.EnableAbsoluteFqdnVhostDomain {
+		// Add the absolute FQDN variant (with trailing dot) if the hostname is not an IP address.
+		// This is considered another form of alternate host representation.
+		// See https://github.com/istio/istio/issues/56007 for context.
+		// "foo.local.campus.net" -> "foo.local.campus.net."
+		// "foo.bar.svc.cluster.local" -> "foo.bar.svc.cluster.local."
+		isIP := net.ParseIP(hostname) != nil
+		if !isIP {
+			vhosts = append(vhosts, hostname+".")
+		}
 	}
 
 	// If the dns/proxy domain contains `.svc`, only services following the <ns>.svc.<suffix>

--- a/pilot/pkg/networking/core/httproute.go
+++ b/pilot/pkg/networking/core/httproute.go
@@ -687,6 +687,9 @@ func GenerateAltVirtualHosts(hostname string, port int, proxyDomain string) []st
 		if !isIP {
 			vhosts = append(vhosts, hostname+".")
 		}
+		if port != portNoAppendPortSuffix {
+			vhosts = append(vhosts, util.DomainName(hostname+".", port))
+		}
 	}
 
 	// If the dns/proxy domain contains `.svc`, only services following the <ns>.svc.<suffix>

--- a/pilot/pkg/networking/core/httproute.go
+++ b/pilot/pkg/networking/core/httproute.go
@@ -627,6 +627,14 @@ func generateVirtualHostDomains(service *model.Service, listenerPort int, port i
 		all = append(all, a.Hostname.String())
 	}
 	for _, s := range all {
+		// Check if 's' is an IP address. We don't add trailing dots to IPs.
+		isIP := net.ParseIP(s) != nil
+		// Add the absolute FQDN variant (with trailing dot) if it's not an IP address.
+		if !isIP {
+			// Add the hostname with a trailing dot.
+			domains = append(domains, s+".")
+		}
+
 		altHosts := GenerateAltVirtualHosts(s, port, node.DNSDomain)
 		domains = appendDomainPort(domains, s, port)
 		domains = append(domains, altHosts...)

--- a/pilot/pkg/networking/core/httproute_test.go
+++ b/pilot/pkg/networking/core/httproute_test.go
@@ -66,6 +66,7 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				DNSDomain: "local.campus.net",
 			},
 			want: []string{
+				"foo.local.campus.net.",
 				"foo.local.campus.net",
 				"foo",
 			},
@@ -81,6 +82,7 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				DNSDomain: "remote.campus.net",
 			},
 			want: []string{
+				"foo.local.campus.net.",
 				"foo.local.campus.net",
 				"foo.local",
 				"foo.local.campus",
@@ -96,7 +98,10 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			node: &model.Proxy{
 				DNSDomain: "example.com",
 			},
-			want: []string{"foo.local.campus.net"},
+			want: []string{
+				"foo.local.campus.net.",
+				"foo.local.campus.net",
+			},
 		},
 		{
 			name: "k8s service with default domain",
@@ -109,6 +114,7 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				DNSDomain: "default.svc.cluster.local",
 			},
 			want: []string{
+				"echo.default.svc.cluster.local.",
 				"echo.default.svc.cluster.local",
 				"echo",
 				"echo.default.svc",
@@ -126,6 +132,7 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				DNSDomain: "default.svc.cluster.local",
 			},
 			want: []string{
+				"foo.default.svc.bar.baz.",
 				"foo.default.svc.bar.baz",
 			},
 		},
@@ -140,6 +147,7 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				DNSDomain: "mesh.svc.cluster.local",
 			},
 			want: []string{
+				"echo.default.svc.cluster.local.",
 				"echo.default.svc.cluster.local",
 				"echo.default",
 				"echo.default.svc",
@@ -155,7 +163,10 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			node: &model.Proxy{
 				DNSDomain: "foo.svc.custom.k8s.local",
 			},
-			want: []string{"google.local"},
+			want: []string{
+				"google.local.",
+				"google.local",
+			},
 		},
 		{
 			name: "ipv4 domain",
@@ -191,7 +202,10 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			node: &model.Proxy{
 				DNSDomain: "tests.svc.cluster.local",
 			},
-			want: []string{"aaa.example.local"},
+			want: []string{
+				"aaa.example.local.",
+				"aaa.example.local",
+			},
 		},
 		{
 			name: "front subset of cluster domain in address",
@@ -203,7 +217,10 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			node: &model.Proxy{
 				DNSDomain: "tests.svc.my.long.domain.suffix",
 			},
-			want: []string{"aaa.example.my"},
+			want: []string{
+				"aaa.example.my.",
+				"aaa.example.my",
+			},
 		},
 		{
 			name: "large subset of cluster domain in address",
@@ -215,7 +232,10 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			node: &model.Proxy{
 				DNSDomain: "tests.svc.my.long.domain.suffix",
 			},
-			want: []string{"aaa.example.my.long"},
+			want: []string{
+				"aaa.example.my.long.",
+				"aaa.example.my.long",
+			},
 		},
 		{
 			name: "no overlap of cluster domain in address",
@@ -227,7 +247,10 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			node: &model.Proxy{
 				DNSDomain: "tests.svc.cluster.local",
 			},
-			want: []string{"aaa.example.com"},
+			want: []string{
+				"aaa.example.com.",
+				"aaa.example.com",
+			},
 		},
 		{
 			name: "wildcard",
@@ -242,10 +265,12 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				DNSDomain: "default.svc.cluster.local",
 			},
 			want: []string{
+				"headless.default.svc.cluster.local.",
 				"headless.default.svc.cluster.local",
 				"headless",
 				"headless.default.svc",
 				"headless.default",
+				"*.headless.default.svc.cluster.local.",
 				"*.headless.default.svc.cluster.local",
 				"*.headless",
 				"*.headless.default.svc",
@@ -273,6 +298,7 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				},
 			},
 			want: []string{
+				"echo.default.svc.cluster.local.",
 				"echo.default.svc.cluster.local",
 				"echo",
 				"echo.default.svc",
@@ -304,6 +330,7 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				IPAddresses: []string{"1.1.1.1"},
 			},
 			want: []string{
+				"echo.default.svc.cluster.local.",
 				"echo.default.svc.cluster.local",
 				"echo",
 				"echo.default.svc",
@@ -334,6 +361,7 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				IPAddresses: []string{"2406:3003:2064:35b8:864:a648:4b96:e37d"},
 			},
 			want: []string{
+				"echo.default.svc.cluster.local.",
 				"echo.default.svc.cluster.local",
 				"echo",
 				"echo.default.svc",
@@ -354,8 +382,10 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				DNSDomain: "local.campus.net",
 			},
 			want: []string{
+				"foo.local.campus.net.",
 				"foo.local.campus.net",
 				"foo",
+				"alias.local.campus.net.",
 				"alias.local.campus.net",
 				"alias",
 			},

--- a/pilot/pkg/networking/core/httproute_test.go
+++ b/pilot/pkg/networking/core/httproute_test.go
@@ -66,8 +66,8 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				DNSDomain: "local.campus.net",
 			},
 			want: []string{
-				"foo.local.campus.net.",
 				"foo.local.campus.net",
+				"foo.local.campus.net.",
 				"foo",
 			},
 		},
@@ -82,8 +82,8 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				DNSDomain: "remote.campus.net",
 			},
 			want: []string{
-				"foo.local.campus.net.",
 				"foo.local.campus.net",
+				"foo.local.campus.net.",
 				"foo.local",
 				"foo.local.campus",
 			},
@@ -99,8 +99,8 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				DNSDomain: "example.com",
 			},
 			want: []string{
-				"foo.local.campus.net.",
 				"foo.local.campus.net",
+				"foo.local.campus.net.",
 			},
 		},
 		{
@@ -114,8 +114,8 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				DNSDomain: "default.svc.cluster.local",
 			},
 			want: []string{
-				"echo.default.svc.cluster.local.",
 				"echo.default.svc.cluster.local",
+				"echo.default.svc.cluster.local.",
 				"echo",
 				"echo.default.svc",
 				"echo.default",
@@ -132,8 +132,8 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				DNSDomain: "default.svc.cluster.local",
 			},
 			want: []string{
-				"foo.default.svc.bar.baz.",
 				"foo.default.svc.bar.baz",
+				"foo.default.svc.bar.baz.",
 			},
 		},
 		{
@@ -147,8 +147,8 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				DNSDomain: "mesh.svc.cluster.local",
 			},
 			want: []string{
-				"echo.default.svc.cluster.local.",
 				"echo.default.svc.cluster.local",
+				"echo.default.svc.cluster.local.",
 				"echo.default",
 				"echo.default.svc",
 			},
@@ -164,8 +164,8 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				DNSDomain: "foo.svc.custom.k8s.local",
 			},
 			want: []string{
-				"google.local.",
 				"google.local",
+				"google.local.",
 			},
 		},
 		{
@@ -203,8 +203,8 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				DNSDomain: "tests.svc.cluster.local",
 			},
 			want: []string{
-				"aaa.example.local.",
 				"aaa.example.local",
+				"aaa.example.local.",
 			},
 		},
 		{
@@ -218,8 +218,8 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				DNSDomain: "tests.svc.my.long.domain.suffix",
 			},
 			want: []string{
-				"aaa.example.my.",
 				"aaa.example.my",
+				"aaa.example.my.",
 			},
 		},
 		{
@@ -233,8 +233,8 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				DNSDomain: "tests.svc.my.long.domain.suffix",
 			},
 			want: []string{
-				"aaa.example.my.long.",
 				"aaa.example.my.long",
+				"aaa.example.my.long.",
 			},
 		},
 		{
@@ -248,8 +248,8 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				DNSDomain: "tests.svc.cluster.local",
 			},
 			want: []string{
-				"aaa.example.com.",
 				"aaa.example.com",
+				"aaa.example.com.",
 			},
 		},
 		{
@@ -265,13 +265,13 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				DNSDomain: "default.svc.cluster.local",
 			},
 			want: []string{
-				"headless.default.svc.cluster.local.",
 				"headless.default.svc.cluster.local",
+				"headless.default.svc.cluster.local.",
 				"headless",
 				"headless.default.svc",
 				"headless.default",
-				"*.headless.default.svc.cluster.local.",
 				"*.headless.default.svc.cluster.local",
+				"*.headless.default.svc.cluster.local.",
 				"*.headless",
 				"*.headless.default.svc",
 				"*.headless.default",
@@ -298,8 +298,8 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				},
 			},
 			want: []string{
-				"echo.default.svc.cluster.local.",
 				"echo.default.svc.cluster.local",
+				"echo.default.svc.cluster.local.",
 				"echo",
 				"echo.default.svc",
 				"echo.default",
@@ -330,8 +330,8 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				IPAddresses: []string{"1.1.1.1"},
 			},
 			want: []string{
-				"echo.default.svc.cluster.local.",
 				"echo.default.svc.cluster.local",
+				"echo.default.svc.cluster.local.",
 				"echo",
 				"echo.default.svc",
 				"echo.default",
@@ -361,8 +361,8 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				IPAddresses: []string{"2406:3003:2064:35b8:864:a648:4b96:e37d"},
 			},
 			want: []string{
-				"echo.default.svc.cluster.local.",
 				"echo.default.svc.cluster.local",
+				"echo.default.svc.cluster.local.",
 				"echo",
 				"echo.default.svc",
 				"echo.default",
@@ -382,11 +382,11 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				DNSDomain: "local.campus.net",
 			},
 			want: []string{
-				"foo.local.campus.net.",
 				"foo.local.campus.net",
+				"foo.local.campus.net.",
 				"foo",
-				"alias.local.campus.net.",
 				"alias.local.campus.net",
+				"alias.local.campus.net.",
 				"alias",
 			},
 		},

--- a/pilot/pkg/networking/core/httproute_test.go
+++ b/pilot/pkg/networking/core/httproute_test.go
@@ -1585,7 +1585,12 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			sidecarConfig:         sidecarConfig,
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
-				"test-headless.com:8888": {"test-headless.com:8888": true, "*.test-headless.com:8888": true, "test-headless.com.:8888": true, "*.test-headless.com.:8888": true},
+				"test-headless.com:8888": {
+					"test-headless.com:8888":    true,
+					"*.test-headless.com:8888":  true,
+					"test-headless.com.:8888":   true,
+					"*.test-headless.com.:8888": true,
+				},
 				"block_all": {
 					"*": true,
 				},

--- a/pilot/pkg/networking/core/httproute_test.go
+++ b/pilot/pkg/networking/core/httproute_test.go
@@ -468,10 +468,9 @@ func TestSidecarOutboundHTTPRouteConfigWithDuplicateHosts(t *testing.T) {
 			},
 			nil,
 			map[string][]string{
-				"allow_any": {"*"},
-				// BUG: test should be below
-				"test.local:80": {"test.local"},
-				"test:80":       {"test"},
+				"allow_any":     {"*"},
+				"test.local:80": {"test.local", "test.local."},
+				"test:80":       {"test", "test."},
 			},
 			map[string]string{
 				"allow_any":     "PassthroughCluster",
@@ -490,10 +489,11 @@ func TestSidecarOutboundHTTPRouteConfigWithDuplicateHosts(t *testing.T) {
 				"allow_any": {"*"},
 				"test.default.svc.cluster.local:80": {
 					"test.default.svc.cluster.local",
+					"test.default.svc.cluster.local.",
 					"test.default.svc",
 					"test.default",
 				},
-				"test:80": {"test"},
+				"test:80": {"test", "test."},
 			},
 			map[string]string{
 				"allow_any":                         "PassthroughCluster",
@@ -510,8 +510,8 @@ func TestSidecarOutboundHTTPRouteConfigWithDuplicateHosts(t *testing.T) {
 			nil,
 			map[string][]string{
 				"allow_any":     {"*"},
-				"test.local:80": {"test.local"},
-				"test:80":       {"test"},
+				"test.local:80": {"test.local", "test.local."},
+				"test:80":       {"test", "test."},
 			},
 			map[string]string{
 				"allow_any":     "PassthroughCluster",
@@ -535,6 +535,7 @@ func TestSidecarOutboundHTTPRouteConfigWithDuplicateHosts(t *testing.T) {
 				"allow_any": {"*"},
 				"test-duplicate-domains.default.svc.cluster.local:80": {
 					"test-duplicate-domains.default.svc.cluster.local",
+					"test-duplicate-domains.default.svc.cluster.local.",
 					"test-duplicate-domains",
 					"test-duplicate-domains.default.svc",
 				},
@@ -572,6 +573,7 @@ func TestSidecarOutboundHTTPRouteConfigWithDuplicateHosts(t *testing.T) {
 				"allow_any": {"*"},
 				"test-duplicate-domains.default.svc.cluster.local:80": {
 					"test-duplicate-domains.default.svc.cluster.local",
+					"test-duplicate-domains.default.svc.cluster.local.",
 					"test-duplicate-domains",
 					"test-duplicate-domains.default.svc",
 				},
@@ -600,6 +602,7 @@ func TestSidecarOutboundHTTPRouteConfigWithDuplicateHosts(t *testing.T) {
 				"allow_any": {"*"},
 				"test.default.svc.cluster.local:80": {
 					"test.default.svc.cluster.local",
+					"test.default.svc.cluster.local.",
 					"test",
 					"test.default.svc",
 				},
@@ -620,7 +623,7 @@ func TestSidecarOutboundHTTPRouteConfigWithDuplicateHosts(t *testing.T) {
 			nil,
 			map[string][]string{
 				"allow_any":     {"*"},
-				"test.local:80": {"test.local"},
+				"test.local:80": {"test.local", "test.local."},
 			},
 			map[string]string{
 				"allow_any":     "PassthroughCluster",
@@ -1256,8 +1259,8 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			sidecarConfig:         sidecarConfig,
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
-				"bookinfo.com:9999": {"bookinfo.com:9999": true, "*.bookinfo.com:9999": true},
-				"bookinfo.com:70":   {"bookinfo.com:70": true, "*.bookinfo.com:70": true},
+				"bookinfo.com:9999": {"bookinfo.com:9999": true, "*.bookinfo.com:9999": true, "bookinfo.com.:9999": true, "*.bookinfo.com.:9999": true},
+				"bookinfo.com:70":   {"bookinfo.com:70": true, "*.bookinfo.com:70": true, "bookinfo.com.:70": true, "*.bookinfo.com.:70": true},
 				"allow_any": {
 					"*": true,
 				},
@@ -1269,7 +1272,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			sidecarConfig:         sidecarConfig,
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
-				"test.com:8080": {"test.com": true, "8.8.8.8": true},
+				"test.com:8080": {"test.com": true, "8.8.8.8": true, "test.com.": true},
 				"block_all": {
 					"*": true,
 				},
@@ -1283,7 +1286,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"test-private.com:80": {
-					"test-private.com": true, "9.9.9.9": true,
+					"test-private.com": true, "9.9.9.9": true, "test-private.com.": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1298,7 +1301,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"test-private.com:80": {
-					"test-private.com": true, "9.9.9.9": true,
+					"test-private.com": true, "9.9.9.9": true, "test-private.com.": true,
 				},
 				"allow_any": {
 					"*": true,
@@ -1315,7 +1318,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			expectedHosts: map[string]map[string]bool{
 				// does not include `match-no-service`
 				"test-private.com:80": {
-					"test-private.com": true, "9.9.9.9": true,
+					"test-private.com": true, "9.9.9.9": true, "test-private.com.": true,
 				},
 				"match-no-service.not-default:80": {"match-no-service.not-default": true},
 				"allow_any": {
@@ -1333,7 +1336,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			expectedHosts: map[string]map[string]bool{
 				// does not include `match-no-service`
 				"test-private.com:80": {
-					"test-private.com": true, "9.9.9.9": true,
+					"test-private.com": true, "9.9.9.9": true, "test-private.com.": true,
 				},
 				"match-no-service.not-default:80": {"match-no-service.not-default": true},
 				"allow_any": {
@@ -1350,8 +1353,10 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"bookinfo.com:9999": {
-					"bookinfo.com":   true,
-					"*.bookinfo.com": true,
+					"bookinfo.com":    true,
+					"*.bookinfo.com":  true,
+					"bookinfo.com.":   true,
+					"*.bookinfo.com.": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1366,7 +1371,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"test-private.com:80": {
-					"test-private.com": true, "9.9.9.9": true,
+					"test-private.com": true, "9.9.9.9": true, "test-private.com.": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1381,11 +1386,13 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"test-private.com:70": {
-					"test-private.com": true, "9.9.9.9": true,
+					"test-private.com": true, "9.9.9.9": true, "test-private.com.": true,
 				},
 				"bookinfo.com:70": {
-					"bookinfo.com":   true,
-					"*.bookinfo.com": true,
+					"bookinfo.com":    true,
+					"*.bookinfo.com":  true,
+					"bookinfo.com.":   true,
+					"*.bookinfo.com.": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1400,8 +1407,10 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"bookinfo.com:9999": {
-					"bookinfo.com":   true,
-					"*.bookinfo.com": true,
+					"bookinfo.com":    true,
+					"*.bookinfo.com":  true,
+					"bookinfo.com.":   true,
+					"*.bookinfo.com.": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1416,7 +1425,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"test.com:8080": {
-					"test.com": true, "8.8.8.8": true,
+					"test.com": true, "8.8.8.8": true, "test.com.": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1431,7 +1440,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"test-private.com:80": {
-					"test-private.com": true, "9.9.9.9": true,
+					"test-private.com": true, "9.9.9.9": true, "test-private.com.": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1446,11 +1455,13 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"test-private.com:70": {
-					"test-private.com": true, "9.9.9.9": true,
+					"test-private.com": true, "9.9.9.9": true, "test-private.com.": true,
 				},
 				"bookinfo.com:70": {
-					"bookinfo.com":   true,
-					"*.bookinfo.com": true,
+					"bookinfo.com":    true,
+					"*.bookinfo.com":  true,
+					"bookinfo.com.":   true,
+					"*.bookinfo.com.": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1477,7 +1488,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"test-private.com:80": {
-					"test-private.com": true, "9.9.9.9": true,
+					"test-private.com": true, "9.9.9.9": true, "test-private.com.": true,
 				},
 				"allow_any": {
 					"*": true,
@@ -1492,7 +1503,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"test-private.com:80": {
-					"test-private.com": true, "9.9.9.9": true,
+					"test-private.com": true, "9.9.9.9": true, "test-private.com.": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1507,7 +1518,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: []*config.Config{&virtualService1, &virtualService2},
 			expectedHosts: map[string]map[string]bool{
 				"test-private-2.com:60": {
-					"test-private-2.com": true, "9.9.9.10": true,
+					"test-private-2.com": true, "9.9.9.10": true, "test-private-2.com.": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1522,7 +1533,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: []*config.Config{&virtualService3},
 			expectedHosts: map[string]map[string]bool{
 				"test-private.com:80": {
-					"test-private.com": true, "9.9.9.9": true,
+					"test-private.com": true, "9.9.9.9": true, "test-private.com.": true,
 				},
 				"test-private-3.com:80": {
 					"test-private-3.com": true,
@@ -1540,7 +1551,8 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"test-headless.com:8888": {
-					"test-headless.com": true, "*.test-headless.com": true,
+					"test-headless.com": true, "*.test-headless.com": true, "test-headless.com.": true,
+					"*.test-headless.com.": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1555,7 +1567,8 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: []*config.Config{&virtualService4},
 			expectedHosts: map[string]map[string]bool{
 				"test-headless.com:8888": {
-					"test-headless.com": true, "*.test-headless.com": true,
+					"test-headless.com": true, "*.test-headless.com": true, "test-headless.com.": true,
+					"*.test-headless.com.": true,
 				},
 				"example.com:8888": {
 					"example.com": true,
@@ -1572,7 +1585,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			sidecarConfig:         sidecarConfig,
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
-				"test-headless.com:8888": {"test-headless.com:8888": true, "*.test-headless.com:8888": true},
+				"test-headless.com:8888": {"test-headless.com:8888": true, "*.test-headless.com:8888": true, "test-headless.com.:8888": true, "*.test-headless.com.:8888": true},
 				"block_all": {
 					"*": true,
 				},
@@ -1609,23 +1622,50 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			sidecarConfig:         sidecarConfigWitHTTPProxy,
 			virtualServiceConfigs: []*config.Config{&virtualService5},
 			expectedHosts: map[string]map[string]bool{
-				"bookinfo.com:9999":      {"bookinfo.com:9999": true, "*.bookinfo.com:9999": true},
-				"bookinfo.com:70":        {"bookinfo.com:70": true, "*.bookinfo.com:70": true},
-				"test-headless.com:8888": {"test-headless.com:8888": true, "*.test-headless.com:8888": true},
+				"bookinfo.com:9999": {
+					"bookinfo.com:9999":    true,
+					"*.bookinfo.com:9999":  true,
+					"bookinfo.com.:9999":   true,
+					"*.bookinfo.com.:9999": true,
+				},
+				"bookinfo.com:70": {
+					"bookinfo.com:70":    true,
+					"*.bookinfo.com:70":  true,
+					"bookinfo.com.:70":   true,
+					"*.bookinfo.com.:70": true,
+				},
+				"test-headless.com:8888": {
+					"test-headless.com:8888":    true,
+					"*.test-headless.com:8888":  true,
+					"test-headless.com.:8888":   true,
+					"*.test-headless.com.:8888": true,
+				},
 				"test-private-2.com:60": {
-					"test-private-2.com:60": true, "9.9.9.10:60": true,
+					"test-private-2.com:60":  true,
+					"9.9.9.10:60":            true,
+					"test-private-2.com.:60": true,
 				},
 				"test-private.com:70": {
-					"test-private.com:70": true, "9.9.9.9:70": true,
+					"test-private.com:70":  true,
+					"9.9.9.9:70":           true,
+					"test-private.com.:70": true,
 				},
 				"test-private.com:80": {
-					"test-private.com": true, "test-private.com:80": true, "9.9.9.9": true, "9.9.9.9:80": true,
+					"test-private.com":     true,
+					"test-private.com:80":  true,
+					"9.9.9.9":              true,
+					"9.9.9.9:80":           true,
+					"test-private.com.":    true,
+					"test-private.com.:80": true,
 				},
 				"test.com:8080": {
-					"test.com:8080": true, "8.8.8.8:8080": true,
+					"test.com:8080":  true,
+					"8.8.8.8:8080":   true,
+					"test.com.:8080": true,
 				},
 				"service-A.default.svc.cluster.local:7777": {
-					"service-A.default.svc.cluster.local:7777": true,
+					"service-A.default.svc.cluster.local:7777":  true,
+					"service-A.default.svc.cluster.local.:7777": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1643,7 +1683,8 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 					"*": true,
 				},
 				"service-A.default.svc.cluster.local:7777": {
-					"service-A.default.svc.cluster.local": true,
+					"service-A.default.svc.cluster.local":  true,
+					"service-A.default.svc.cluster.local.": true,
 				},
 				"service-A.v2:7777": {
 					"service-A.v2": true,

--- a/releasenotes/notes/fix-enable-absolute-fqdn-domain-vhost.yaml
+++ b/releasenotes/notes/fix-enable-absolute-fqdn-domain-vhost.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+issue:
+  - https://github.com/istio/istio/issues/56007
+
+releaseNotes:
+- |
+  **Fixed** an issue where Istio's outbound route configuration did not include the absolute/fully qualified domain name (FQDN) variant (with trailing dot) in the domains list for VirtualHost entries. This ensures that requests using absolute FQDNs (ending with a dot, e.g., `my-service.my-ns.svc.cluster.local.`) are properly routed to the intended service instead of falling back to PassthroughCluster.


### PR DESCRIPTION
**Description:**

This PR fixes an issue where Istio's outbound route configuration (`RouteConfiguration`) did not include the absolute/fully qualified domain name (FQDN) variant (e.g., `my-service.my-ns.svc.cluster.local.`) in the `domains` list for `VirtualHost` entries.

Updated the TestGenerateVirtualHostDomains test to verify new functionality

**Problem:**

When clients make requests using the absolute FQDN (with the trailing dot) in the `Host` header, Envoy would fail to match this against the specific `VirtualHost` domains generated by Istio. This caused such requests to fall back to the wildcard (`*`) virtual host, typically resulting in routing to the `PassthroughCluster` or `BlackHoleCluster` instead of the intended service cluster and associated Istio policies (like VirtualServices, DestinationRules).

Example scenario from issue report:
- `curl http://foo.bar.svc.cluster.local/` -> Correctly matches `outbound|80||foo.bar.svc.cluster.local`
- `curl http://foo.bar.svc.cluster.local./` -> Incorrectly matches `PassthroughCluster`

**Solution:**

The `generateVirtualHostDomains` function in `pilot/pkg/networking/core/route.go` has been modified to explicitly add the absolute FQDN variant (`hostname + "."`) to the list of generated domains for each service hostname and alias, provided the name is not an IP address.

Fixes https://github.com/istio/istio/issues/56007