### PR TITLE
handle allowedRoutes for PROXY waypoints

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
@@ -35,6 +35,7 @@ import (
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/slices"
+	"istio.io/istio/pkg/util/sets"
 	"istio.io/istio/pkg/workloadapi"
 )
 
@@ -313,11 +314,12 @@ func (a *index) makeWaypoint(
 	serviceAccounts []string,
 	trafficType string,
 ) *Waypoint {
+	binding := makeInboundBinding(gateway, gatewayClass)
 	return &Waypoint{
 		Named:           krt.NewNamed(gateway),
 		Address:         a.getGatewayAddress(ctx, gateway),
-		DefaultBinding:  makeInboundBinding(gateway, gatewayClass),
-		AllowedRoutes:   makeAllowedRoutes(gateway),
+		DefaultBinding:  binding,
+		AllowedRoutes:   makeAllowedRoutes(gateway, binding),
 		TrafficType:     trafficType,
 		ServiceAccounts: slices.Sort(serviceAccounts),
 	}
@@ -378,19 +380,34 @@ func (w *Waypoint) GetAddress() *workloadapi.GatewayAddress {
 	return w.Address
 }
 
-// if we find the HBONE listener, we always use it's WaypointSelector
-// if we find a PROXY listener, we may use the WaypointSelector for that listener when there is no HBONE listener
-// if we find neither, we default to the same namespace
-func makeAllowedRoutes(gateway *v1beta1.Gateway) WaypointSelector {
+// makeAllowedRoutes returns a WaypointSelector that matches the listener with the given binding
+// if we don't have a binding we use the default HBONE listener
+// if we have a binding we use the protocol and port defined in the binding
+func makeAllowedRoutes(gateway *v1beta1.Gateway, binding *InboundBinding) WaypointSelector {
+	matchProtocol := sets.New[gatewayv1.ProtocolType]()
+	matchPort := gatewayv1.PortNumber(15008)
+	// if we have a binding we should use it's protocol and port
+	if binding != nil {
+		// binding.Port to PortNumber is a conversion from uint32 to int32
+		matchPort = gatewayv1.PortNumber(binding.Port)
+		switch binding.Protocol {
+		case workloadapi.ApplicationTunnel_PROXY:
+			matchProtocol.Insert(gatewayv1.ProtocolType(constants.WaypointSandwichListenerProxyProtocol))
+			matchProtocol.Insert(gatewayv1.ProtocolType("PROXY"))
+		case workloadapi.ApplicationTunnel_NONE:
+			matchProtocol.Insert(gatewayv1.ProtocolType("NONE"))
+		}
+
+	} else {
+		// if we don't have a binding we use the default HBONE listener
+		matchProtocol.Insert(gatewayv1.ProtocolType("HBONE"))
+	}
+
 	maybeWaypointSelector := WaypointSelector{
 		FromNamespaces: gatewayv1.NamespacesFromSame,
 	}
 	for _, l := range gateway.Spec.Listeners {
-		if l.Protocol == "istio.io/PROXY" {
-			maybeWaypointSelector = makeWaypointSelector(l)
-		}
-		if l.Protocol == "HBONE" && l.Port == 15008 {
-			// This is our HBONE listener, if we find this we always use it's WaypointSelector
+		if matchProtocol.Contains(l.Protocol) && (l.Port == matchPort || matchPort == 0) {
 			if l.AllowedRoutes == nil || l.AllowedRoutes.Namespaces == nil {
 				break
 			}

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
@@ -406,7 +406,7 @@ func findBoundListener(gateway *v1beta1.Gateway, binding *InboundBinding) (v1bet
 	if binding == nil {
 		return v1beta1.Listener{}, false
 	}
-	var match func(l v1beta1.Listener) bool = nil
+	var match func(l v1beta1.Listener) bool
 	if binding.Port != 0 {
 		match = func(l v1beta1.Listener) bool {
 			return l.Port == gatewayv1.PortNumber(binding.Port)

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints_test.go
@@ -17,14 +17,15 @@ package ambient
 import (
 	"testing"
 
-	"istio.io/api/annotation"
-	"istio.io/istio/pkg/config/constants"
-	"istio.io/istio/pkg/ptr"
-	"istio.io/istio/pkg/test/util/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"istio.io/api/annotation"
+	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/ptr"
+	"istio.io/istio/pkg/test/util/assert"
 )
 
 func TestMakeAllowedRoutes(t *testing.T) {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints_test.go
@@ -140,7 +140,7 @@ func TestMakeAllowedRoutes(t *testing.T) {
 					GatewayClassName: gatewayv1.ObjectName(sandwichedWaypointClass.Name),
 					Listeners: []gatewayv1beta1.Listener{
 						{
-							Protocol: gatewayv1beta1.ProtocolType("PROXY"),
+							Protocol: gatewayv1beta1.ProtocolType(constants.WaypointSandwichListenerProxyProtocol),
 							Port:     15088,
 						},
 					},
@@ -164,7 +164,7 @@ func TestMakeAllowedRoutes(t *testing.T) {
 					Listeners: []gatewayv1beta1.Listener{
 						{
 							Name:     "should be ignored",
-							Protocol: gatewayv1beta1.ProtocolType("istio.io/PROXY"),
+							Protocol: gatewayv1beta1.ProtocolType(constants.WaypointSandwichListenerProxyProtocol),
 							Port:     15089,
 							AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
 								Namespaces: &gatewayv1.RouteNamespaces{
@@ -173,18 +173,8 @@ func TestMakeAllowedRoutes(t *testing.T) {
 							},
 						},
 						{
-							Name:     "ignored HBONE listener",
-							Protocol: gatewayv1beta1.ProtocolType("HBONE"),
-							Port:     15008,
-							AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
-								Namespaces: &gatewayv1.RouteNamespaces{
-									From: ptr.Of(gatewayv1.NamespacesFromSame),
-								},
-							},
-						},
-						{
 							Name:     "should be used",
-							Protocol: gatewayv1beta1.ProtocolType("istio.io/PROXY"),
+							Protocol: gatewayv1beta1.ProtocolType(constants.WaypointSandwichListenerProxyProtocol),
 							Port:     15088,
 							AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
 								Namespaces: &gatewayv1.RouteNamespaces{
@@ -214,12 +204,12 @@ func TestMakeAllowedRoutes(t *testing.T) {
 					Listeners: []gatewayv1beta1.Listener{
 						{
 							Name:     "should be ignored",
-							Protocol: gatewayv1beta1.ProtocolType("PROXY"),
+							Protocol: gatewayv1beta1.ProtocolType(constants.WaypointSandwichListenerProxyProtocol),
 							Port:     15089,
 						},
 						{
 							Name:     "should be used",
-							Protocol: gatewayv1beta1.ProtocolType("PROXY"),
+							Protocol: gatewayv1beta1.ProtocolType(constants.WaypointSandwichListenerProxyProtocol),
 							Port:     15088,
 							AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
 								Namespaces: &gatewayv1.RouteNamespaces{
@@ -248,13 +238,8 @@ func TestMakeAllowedRoutes(t *testing.T) {
 					GatewayClassName: gatewayv1.ObjectName(sandwichedWaypointClass.Name),
 					Listeners: []gatewayv1beta1.Listener{
 						{
-							Name:     "should be ignored",
-							Protocol: gatewayv1beta1.ProtocolType("HBONE"),
-							Port:     15008,
-						},
-						{
 							Name:     "should be used",
-							Protocol: gatewayv1beta1.ProtocolType("PROXY"),
+							Protocol: gatewayv1beta1.ProtocolType(constants.WaypointSandwichListenerProxyProtocol),
 							Port:     15015,
 							AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
 								Namespaces: &gatewayv1.RouteNamespaces{

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints_test.go
@@ -1,0 +1,292 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ambient
+
+import (
+	"testing"
+
+	"istio.io/api/annotation"
+	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/ptr"
+	"istio.io/istio/pkg/test/util/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+func TestMakeAllowedRoutes(t *testing.T) {
+	istioWaypointClass := &gatewayv1beta1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "istio-waypoint",
+		},
+		Spec: gatewayv1beta1.GatewayClassSpec{
+			ControllerName: constants.ManagedGatewayMeshController,
+		},
+	}
+	sandwichedWaypointClass := &gatewayv1beta1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "sandwiched-waypoint",
+		},
+		Spec: gatewayv1beta1.GatewayClassSpec{
+			ControllerName: "sandwiched-controller",
+		},
+	}
+	tests := []struct {
+		name         string
+		gateway      *gatewayv1beta1.Gateway
+		gatewayClass *gatewayv1beta1.GatewayClass
+		expected     WaypointSelector
+	}{
+		{
+			name: "istio-waypoint defaults to same namespace",
+			gateway: &gatewayv1beta1.Gateway{
+				Spec: gatewayv1beta1.GatewaySpec{
+					GatewayClassName: gatewayv1.ObjectName(istioWaypointClass.Name),
+					Listeners:        []gatewayv1beta1.Listener{},
+				},
+			},
+			gatewayClass: istioWaypointClass,
+			expected: WaypointSelector{
+				FromNamespaces: gatewayv1.NamespacesFromSame,
+			},
+		},
+		{
+			name: "istio-waypoint matching listener with no allowed routes",
+			gateway: &gatewayv1beta1.Gateway{
+				Spec: gatewayv1beta1.GatewaySpec{
+					Listeners: []gatewayv1beta1.Listener{
+						{
+							Protocol: gatewayv1beta1.ProtocolType("HBONE"),
+							Port:     15008,
+						},
+					},
+				},
+			},
+			gatewayClass: istioWaypointClass,
+			expected: WaypointSelector{
+				FromNamespaces: gatewayv1.NamespacesFromSame,
+			},
+		},
+		{
+			name: "istio-waypoint matching listener with allowed routes",
+			gateway: &gatewayv1beta1.Gateway{
+				Spec: gatewayv1beta1.GatewaySpec{
+					Listeners: []gatewayv1beta1.Listener{
+						{
+							Protocol: gatewayv1beta1.ProtocolType("HBONE"),
+							Port:     15008,
+							AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
+								Namespaces: &gatewayv1.RouteNamespaces{
+									From: ptr.Of(gatewayv1.NamespacesFromAll),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: WaypointSelector{
+				FromNamespaces: gatewayv1.NamespacesFromAll,
+				Selector:       labels.SelectorFromSet(labels.Set{}),
+			},
+		},
+		{
+			name: "istio-waypoint matching listener with selector",
+			gateway: &gatewayv1beta1.Gateway{
+				Spec: gatewayv1beta1.GatewaySpec{
+					Listeners: []gatewayv1beta1.Listener{
+						{
+							Protocol: gatewayv1beta1.ProtocolType("HBONE"),
+							Port:     15008,
+							AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
+								Namespaces: &gatewayv1.RouteNamespaces{
+									From: ptr.Of(gatewayv1.NamespacesFromSelector),
+									Selector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"app": "test"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: WaypointSelector{
+				FromNamespaces: gatewayv1.NamespacesFromSelector,
+				Selector:       labels.SelectorFromSet(labels.Set{"app": "test"}),
+			},
+		},
+		{
+			name: "sandwiched waypoint defaults to same namespace",
+			gateway: &gatewayv1beta1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						annotation.AmbientWaypointInboundBinding.Name: "PROXY/15088",
+					},
+				},
+				Spec: gatewayv1beta1.GatewaySpec{
+					GatewayClassName: gatewayv1.ObjectName(sandwichedWaypointClass.Name),
+					Listeners: []gatewayv1beta1.Listener{
+						{
+							Protocol: gatewayv1beta1.ProtocolType("PROXY"),
+							Port:     15088,
+						},
+					},
+				},
+			},
+			gatewayClass: sandwichedWaypointClass,
+			expected: WaypointSelector{
+				FromNamespaces: gatewayv1.NamespacesFromSame,
+			},
+		},
+		{
+			name: "sandwiched waypoint with listener with allowed routes",
+			gateway: &gatewayv1beta1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						annotation.AmbientWaypointInboundBinding.Name: "PROXY/15088",
+					},
+				},
+				Spec: gatewayv1beta1.GatewaySpec{
+					GatewayClassName: gatewayv1.ObjectName(sandwichedWaypointClass.Name),
+					Listeners: []gatewayv1beta1.Listener{
+						{
+							Name:     "should be ignored",
+							Protocol: gatewayv1beta1.ProtocolType("istio.io/PROXY"),
+							Port:     15089,
+							AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
+								Namespaces: &gatewayv1.RouteNamespaces{
+									From: ptr.Of(gatewayv1.NamespacesFromSame),
+								},
+							},
+						},
+						{
+							Name:     "ignored HBONE listener",
+							Protocol: gatewayv1beta1.ProtocolType("HBONE"),
+							Port:     15008,
+							AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
+								Namespaces: &gatewayv1.RouteNamespaces{
+									From: ptr.Of(gatewayv1.NamespacesFromSame),
+								},
+							},
+						},
+						{
+							Name:     "should be used",
+							Protocol: gatewayv1beta1.ProtocolType("istio.io/PROXY"),
+							Port:     15088,
+							AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
+								Namespaces: &gatewayv1.RouteNamespaces{
+									From: ptr.Of(gatewayv1.NamespacesFromAll),
+								},
+							},
+						},
+					},
+				},
+			},
+			gatewayClass: sandwichedWaypointClass,
+			expected: WaypointSelector{
+				FromNamespaces: gatewayv1.NamespacesFromAll,
+				Selector:       labels.SelectorFromSet(labels.Set{}),
+			},
+		},
+		{
+			name: "sandwiched waypoint with listener with allowed routes",
+			gateway: &gatewayv1beta1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						annotation.AmbientWaypointInboundBinding.Name: "PROXY/15088",
+					},
+				},
+				Spec: gatewayv1beta1.GatewaySpec{
+					GatewayClassName: gatewayv1.ObjectName(sandwichedWaypointClass.Name),
+					Listeners: []gatewayv1beta1.Listener{
+						{
+							Name:     "should be ignored",
+							Protocol: gatewayv1beta1.ProtocolType("PROXY"),
+							Port:     15089,
+						},
+						{
+							Name:     "should be used",
+							Protocol: gatewayv1beta1.ProtocolType("PROXY"),
+							Port:     15088,
+							AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
+								Namespaces: &gatewayv1.RouteNamespaces{
+									From: ptr.Of(gatewayv1.NamespacesFromAll),
+								},
+							},
+						},
+					},
+				},
+			},
+			gatewayClass: sandwichedWaypointClass,
+			expected: WaypointSelector{
+				FromNamespaces: gatewayv1.NamespacesFromAll,
+				Selector:       labels.SelectorFromSet(labels.Set{}),
+			},
+		},
+		{
+			name: "sandwiched waypoint with listener with allowed routes on port 0",
+			gateway: &gatewayv1beta1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						annotation.AmbientWaypointInboundBinding.Name: "PROXY",
+					},
+				},
+				Spec: gatewayv1beta1.GatewaySpec{
+					GatewayClassName: gatewayv1.ObjectName(sandwichedWaypointClass.Name),
+					Listeners: []gatewayv1beta1.Listener{
+						{
+							Name:     "should be ignored",
+							Protocol: gatewayv1beta1.ProtocolType("HBONE"),
+							Port:     15008,
+						},
+						{
+							Name:     "should be used",
+							Protocol: gatewayv1beta1.ProtocolType("PROXY"),
+							Port:     15015,
+							AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
+								Namespaces: &gatewayv1.RouteNamespaces{
+									From: ptr.Of(gatewayv1.NamespacesFromAll),
+								},
+							},
+						},
+					},
+				},
+			},
+			gatewayClass: sandwichedWaypointClass,
+			expected: WaypointSelector{
+				FromNamespaces: gatewayv1.NamespacesFromAll,
+				Selector:       labels.SelectorFromSet(labels.Set{}),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			binding := makeInboundBinding(tt.gateway, tt.gatewayClass)
+			result := makeAllowedRoutes(tt.gateway, binding)
+			assertWaypointSelector(t, result, tt.expected)
+		})
+	}
+}
+
+func assertWaypointSelector(t *testing.T, result, expected WaypointSelector) {
+	t.Helper()
+	assert.Equal(t, result.FromNamespaces, expected.FromNamespaces)
+	if expected.Selector == nil {
+		assert.Equal(t, result.Selector, nil)
+	} else {
+		assert.Equal(t, result.Selector.String(), expected.Selector.String())
+	}
+}

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -161,6 +161,10 @@ const (
 	ManagedGatewayEastWestController      = "istio.io/eastwest-controller"
 	ManagedGatewayEastWestControllerLabel = "istio.io-eastwest-controller"
 
+	// WaypointSandwichListenerProxyProtocol defines the protocol which is defined on the listener used by a waypoint sandwich
+	// This listener should align to the proto/port defined by the  "ambient.istio.io/waypoint-inbound-binding" annotation
+	WaypointSandwichListenerProxyProtocol = "istio.io/PROXY"
+
 	RemoteGatewayClassName   = "istio-remote"
 	WaypointGatewayClassName = "istio-waypoint"
 	EastWestGatewayClassName = "istio-east-west"

--- a/releasenotes/notes/56011-sandwich-allowedRoutes.yaml
+++ b/releasenotes/notes/56011-sandwich-allowedRoutes.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+issue:
+  - https://github.com/istio/istio/issues/56010
+
+releaseNotes:
+- |
+  **Fixed** issue where Istio did not correctly get allowedRoutes for a sandboxed waypoint. 


### PR DESCRIPTION
**Please provide a description of this PR:**
Adds determining allowedRoutes for waypoint based on the `ambient.istio.io/waypoint-inbound-binding` annotation used to determine the correct inbound binding.

This is required to support cross-namespace waypoints for 3rd-party waypoint proxies which are wrapped by ztunnel (a.k.a. "sandwiched" waypoints) rather than implementing their own HBONE listener.

fixes #56010 