### PR TITLE
Add configurable client timeout to istioctl commands

### DIFF
--- a/istioctl/pkg/cli/context.go
+++ b/istioctl/pkg/cli/context.go
@@ -119,7 +119,7 @@ func (i *instance) CLIClientWithRevision(rev string) (kube.CLIClient, error) {
 
 	timeout, err := i.KubeClientTimeout()
 	if err != nil {
-		return nil, fmt.Errorf("error parsing kube-timeout: %v", err)
+		return nil, fmt.Errorf("error parsing kubeclient-timeout: %v", err)
 	}
 
 	if i.clients[rev] == nil {

--- a/istioctl/pkg/cli/context.go
+++ b/istioctl/pkg/cli/context.go
@@ -155,7 +155,7 @@ func (i *instance) CLIClientsForContexts(contexts []string) ([]kube.CLIClient, e
 
 	clientTimeout, err := i.KubeClientTimeout()
 	if err != nil {
-		return nil, fmt.Errorf("error parsing kube-timeout: %v", err)
+		return nil, fmt.Errorf("error parsing kubeclient-timeout: %v", err)
 	}
 
 	var clients []kube.CLIClient

--- a/istioctl/pkg/cli/option.go
+++ b/istioctl/pkg/cli/option.go
@@ -83,12 +83,19 @@ func (r *RootFlags) Namespace() string {
 	return *r.namespace
 }
 
-func (r *RootFlags) KubeClientTimeout() time.Duration {
+// KubeClientTimeout returns the kubeclient-timeout value.
+func (r *RootFlags) KubeClientTimeout() (time.Duration, error) {
+	if *r.kubeTimeout == "" {
+		// Preserve original behavior of defaulting to 15s if not set
+		return time.Second * 15, nil
+	}
+
 	d, err := time.ParseDuration(*r.kubeTimeout)
 	if err != nil {
-		d = 15 * time.Second
+		return 0, err
 	}
-	return d
+
+	return d, nil
 }
 
 // IstioNamespace returns the istioNamespace flag value.

--- a/istioctl/pkg/cli/option.go
+++ b/istioctl/pkg/cli/option.go
@@ -15,6 +15,8 @@
 package cli
 
 import (
+	"time"
+
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,6 +33,7 @@ const (
 	FlagImpersonateGroup = "as-group"
 	FlagNamespace        = "namespace"
 	FlagIstioNamespace   = "istioNamespace"
+	FlagKubeTimeout      = "kubeclient-timeout"
 )
 
 type RootFlags struct {
@@ -41,6 +44,7 @@ type RootFlags struct {
 	impersonateGroup *[]string
 	namespace        *string
 	istioNamespace   *string
+	kubeTimeout      *string
 
 	defaultNamespace string
 }
@@ -54,6 +58,7 @@ func AddRootFlags(flags *pflag.FlagSet) *RootFlags {
 		impersonateGroup: ptr.Of[[]string](nil),
 		namespace:        ptr.Of[string](""),
 		istioNamespace:   ptr.Of[string](""),
+		kubeTimeout:      ptr.Of[string](""),
 	}
 	flags.StringVarP(r.kubeconfig, FlagKubeConfig, "c", "",
 		"Kubernetes configuration file")
@@ -68,6 +73,7 @@ func AddRootFlags(flags *pflag.FlagSet) *RootFlags {
 		"Kubernetes namespace")
 	flags.StringVarP(r.istioNamespace, FlagIstioNamespace, "i", viper.GetString(FlagIstioNamespace),
 		"Istio system namespace")
+	flags.StringVar(r.kubeTimeout, FlagKubeTimeout, "15s", "Kubernetes client timeout as a time.Duration string, defaults to 15 seconds.")
 
 	return r
 }
@@ -75,6 +81,14 @@ func AddRootFlags(flags *pflag.FlagSet) *RootFlags {
 // Namespace returns the namespace flag value.
 func (r *RootFlags) Namespace() string {
 	return *r.namespace
+}
+
+func (r *RootFlags) KubeClientTimeout() time.Duration {
+	d, err := time.ParseDuration(*r.kubeTimeout)
+	if err != nil {
+		d = 15 * time.Second
+	}
+	return d
 }
 
 // IstioNamespace returns the istioNamespace flag value.

--- a/istioctl/pkg/cli/option_test.go
+++ b/istioctl/pkg/cli/option_test.go
@@ -30,4 +30,5 @@ func Test_AddRootFlags(t *testing.T) {
 	assert.Equal(t, *r.impersonate, impersonateConfig.UserName)
 	assert.Equal(t, *r.impersonateUID, impersonateConfig.UID)
 	assert.Equal(t, *r.impersonateGroup, impersonateConfig.Groups)
+	assert.Equal(t, *r.kubeTimeout, "15s")
 }

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -483,7 +483,7 @@ func newClientInternal(clientFactory *clientFactory, opts ...ClientOption) (*cli
 	if c.config != nil && c.config.Timeout != 0 {
 		c.http.Timeout = c.config.Timeout
 	} else {
-		c.http.Timeout = time.Second * 5
+		c.http.Timeout = time.Second * 15
 	}
 
 	var clientWithTimeout kubernetes.Interface

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -479,14 +479,21 @@ func newClientInternal(clientFactory *clientFactory, opts ...ClientOption) (*cli
 		return nil, err
 	}
 
-	c.http = &http.Client{
-		Timeout: time.Second * 15,
+	c.http = &http.Client{}
+	if c.config != nil && c.config.Timeout != 0 {
+		c.http.Timeout = c.config.Timeout
+	} else {
+		c.http.Timeout = time.Second * 5
 	}
+
 	var clientWithTimeout kubernetes.Interface
 	clientWithTimeout = c.kube
 	restConfig := c.RESTConfig()
 	if restConfig != nil {
-		restConfig.Timeout = time.Second * 5
+		if restConfig.Timeout == 0 {
+			restConfig.Timeout = time.Second * 5
+		}
+
 		kubeClient, err := kubernetes.NewForConfig(restConfig)
 		if err == nil {
 			clientWithTimeout = kubeClient
@@ -541,6 +548,20 @@ func WithRevision(revision string) ClientOption {
 	return func(c CLIClient) CLIClient {
 		client := c.(*client)
 		client.revision = revision
+		return client
+	}
+}
+
+// WithTimeout sets the timeout for the client.
+func WithTimeout(timeout time.Duration) ClientOption {
+	return func(c CLIClient) CLIClient {
+		client := c.(*client)
+		if client.config == nil {
+			client.config = &rest.Config{}
+		}
+
+		client.config.Timeout = timeout
+
 		return client
 	}
 }

--- a/releasenotes/notes/54962-istioctl-timeout.yaml
+++ b/releasenotes/notes/54962-istioctl-timeout.yaml
@@ -1,0 +1,12 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue:
+- 54962
+releaseNotes:
+- |
+    **Added** `--kubeclient-timeout` flag to `istioctl` root flags. May be unset, or set to a valid `time.Duration` string.
+    When specified, this will override the default 15s timeout for all `istioctl` commands that use the Kubernetes client.
+    This is useful for environments with slow Kubernetes API servers, such as those with high latency or low bandwidth.
+    Note that this flag is just used for the Kubernetes client, and does not affect other timeouts in `istioctl`, such as 
+    installation timeouts.


### PR DESCRIPTION
**Please provide a description of this PR:**
Resolve https://github.com/istio/istio/issues/54962 and https://github.com/istio/istio/issues/55109 by adding a `--kubeclient-timeout` flag to `istioctl` root command flags to allow the user to specify a desired timeout for the kube client or port-forward commands.