### PR TITLE
Make revisionTag work when Istio remote is enabled

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags.yaml
@@ -32,8 +32,6 @@ a unique prefix to each. */}}
   reinvocationPolicy: "{{ .reinvocationPolicy }}"
   admissionReviewVersions: ["v1"]
 {{- end }}
-# Not created if istiod is running remotely
-{{- if not .Values.istiodRemote.enabled }}
 {{- range $tagName := $.Values.revisionTags }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -148,5 +146,4 @@ webhooks:
 
 {{- end }}
 ---
-{{- end }}
 {{- end }}

--- a/releasenotes/notes/make-revision-tag-work-when-istiod-remote-is-enabled.yaml
+++ b/releasenotes/notes/make-revision-tag-work-when-istiod-remote-is-enabled.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+- 54743
+releaseNotes:
+- |
+  **Removed** the restriction that revision tag only works when Istiod remote is not enabled. Revision tag now works as long as the `revisionTags` is specified no matter Istiod remote is enabled or not.

--- a/releasenotes/notes/make-revision-tag-work-when-istiod-remote-is-enabled.yaml
+++ b/releasenotes/notes/make-revision-tag-work-when-istiod-remote-is-enabled.yaml
@@ -5,4 +5,4 @@ issue:
 - 54743
 releaseNotes:
 - |
-  **Removed** the restriction that revision tag only works when Istiod remote is not enabled. Revision tag now works as long as the `revisionTags` is specified no matter Istiod remote is enabled or not.
+  **Removed** the restriction that revision tag only works when `istiodRemote` is not enabled in the istiod helm chart. Revision tag now works as long as the `revisionTags` is specified no matter `istiodRemote` is enabled or not.


### PR DESCRIPTION
**Please provide a description of this PR:**
- This PR tries to fix issue #54743.
- When enabling Istiod remote, right now even if the `revisionTags` is specified, no mutating webhooks will be created. This PR tries to create one mutating webhook for each revision tag as long as `revisionTags` is specified, no matter Istiod remote is enabled or not.