### PR TITLE
krt: remove restrictions on multiple Fetch calls

### DIFF
--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -49,16 +49,16 @@ type dependencyState[I any] struct {
 }
 
 type extractorKey struct {
-	uid    collectionUID
-	idxUid string
-	typ    indexedDependencyType
+	uid       collectionUID
+	filterUID string
+	typ       indexedDependencyType
 }
 
 func (i dependencyState[I]) update(key Key[I], deps []*dependency) {
 	// Update the I -> Dependency mapping
 	i.objectDependencies[key] = deps
 	for _, d := range deps {
-		if depKeys, typ, extractor, idxId, ok := d.filter.reverseIndexKey(); ok {
+		if depKeys, typ, extractor, filterId, ok := d.filter.reverseIndexKey(); ok {
 			for _, depKey := range depKeys {
 				k := indexedDependency{
 					id:  d.id,
@@ -67,9 +67,9 @@ func (i dependencyState[I]) update(key Key[I], deps []*dependency) {
 				}
 				sets.InsertOrNew(i.indexedDependencies, k, key)
 				kk := extractorKey{
-					idxUid: idxId,
-					uid:    d.id,
-					typ:    typ,
+					filterUID: filterId,
+					uid:       d.id,
+					typ:       typ,
 				}
 
 				i.indexedDependenciesExtractor[kk] = extractor

--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -58,7 +58,7 @@ func (i dependencyState[I]) update(key Key[I], deps []*dependency) {
 	// Update the I -> Dependency mapping
 	i.objectDependencies[key] = deps
 	for _, d := range deps {
-		if depKeys, typ, extractor, filterId, ok := d.filter.reverseIndexKey(); ok {
+		if depKeys, typ, extractor, filterID, ok := d.filter.reverseIndexKey(); ok {
 			for _, depKey := range depKeys {
 				k := indexedDependency{
 					id:  d.id,
@@ -73,7 +73,7 @@ func (i dependencyState[I]) update(key Key[I], deps []*dependency) {
 
 				sets.InsertOrNew(i.indexedDependencies, k, key)
 				kk := extractorKey{
-					filterUID: filterId,
+					filterUID: filterID,
 					uid:       d.id,
 					typ:       typ,
 				}

--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -36,8 +36,6 @@ const (
 	getKeyType       indexedDependencyType = iota
 )
 
-var allIndexedDependencyTypes = []indexedDependencyType{indexType, getKeyType}
-
 type dependencyState[I any] struct {
 	// collectionDependencies specifies the set of collections we depend on from within the transformation functions (via Fetch).
 	// These are keyed by the internal uid() function on collections.
@@ -46,24 +44,21 @@ type dependencyState[I any] struct {
 	// Stores a map of I -> secondary dependencies (added via Fetch)
 	objectDependencies  map[Key[I]][]*dependency
 	indexedDependencies map[indexedDependency]sets.Set[Key[I]]
-	// indexedDependenciesExtractor stores a map of [collection,fetch type] => an extractor to get change keys.
-	// Note that a given collection can have multiple Fetches, but they are limited to those of the different kind.
-	// I.e. you can do a `Fetch(c1, FilterIndex()) + Fetch(c1, FilterKey())` but not `Fetch(c1, FilterIndex(idxA)) + Fetch(c1, FilterIndex(idxB))`.
-	// Multiple `FetchIndex` within a single transformation must use the same index.
-	// This only applies within a single transformation; it is fine to fetch the the same `c1` in any way from different collections.
+	// indexedDependenciesExtractor stores a map of [collection,fetch type,(optional)index id] => an extractor to get change keys.
 	indexedDependenciesExtractor map[extractorKey]objectKeyExtractor
 }
 
 type extractorKey struct {
-	uid collectionUID
-	typ indexedDependencyType
+	uid    collectionUID
+	idxUid string
+	typ    indexedDependencyType
 }
 
 func (i dependencyState[I]) update(key Key[I], deps []*dependency) {
 	// Update the I -> Dependency mapping
 	i.objectDependencies[key] = deps
 	for _, d := range deps {
-		if depKeys, typ, extractor, ok := d.filter.reverseIndexKey(); ok {
+		if depKeys, typ, extractor, idxId, ok := d.filter.reverseIndexKey(); ok {
 			for _, depKey := range depKeys {
 				k := indexedDependency{
 					id:  d.id,
@@ -72,8 +67,9 @@ func (i dependencyState[I]) update(key Key[I], deps []*dependency) {
 				}
 				sets.InsertOrNew(i.indexedDependencies, k, key)
 				kk := extractorKey{
-					uid: d.id,
-					typ: typ,
+					idxUid: idxId,
+					uid:    d.id,
+					typ:    typ,
 				}
 
 				i.indexedDependenciesExtractor[kk] = extractor
@@ -89,7 +85,7 @@ func (i dependencyState[I]) delete(key Key[I]) {
 	}
 	delete(i.objectDependencies, key)
 	for _, d := range old {
-		if depKeys, typ, _, ok := d.filter.reverseIndexKey(); ok {
+		if depKeys, typ, _, _, ok := d.filter.reverseIndexKey(); ok {
 			for _, depKey := range depKeys {
 				k := indexedDependency{
 					id:  d.id,
@@ -111,8 +107,17 @@ func (i dependencyState[I]) changedInputKeys(sourceCollection collectionUID, eve
 		// inefficient, especially when the dependency changes frequently and the collection is large.
 		// Where possible, we utilize the reverse-indexing to get the precise list of potentially changed objects.
 		foundAny := false
-		for _, idxTypes := range allIndexedDependencyTypes {
-			ekey := extractorKey{uid: sourceCollection, typ: idxTypes}
+
+		// find all the indexes/collections we depend on
+		// N here is collections/indexes so it should be small
+		extractorKeys := []extractorKey{}
+		for k := range i.indexedDependenciesExtractor {
+			if k.uid == sourceCollection {
+				extractorKeys = append(extractorKeys, k)
+			}
+		}
+
+		for _, ekey := range extractorKeys {
 			if extractor, f := i.indexedDependenciesExtractor[ekey]; f {
 				foundAny = true
 				// We have a reverse index
@@ -120,7 +125,7 @@ func (i dependencyState[I]) changedInputKeys(sourceCollection collectionUID, eve
 					// Find all the reverse index keys for this object. For each key we will find impacted input objects.
 					keys := extractor(item)
 					for _, key := range keys {
-						for iKey := range i.indexedDependencies[indexedDependency{id: sourceCollection, key: key, typ: idxTypes}] {
+						for iKey := range i.indexedDependencies[indexedDependency{id: sourceCollection, key: key, typ: ekey.typ}] {
 							if changedInputKeys.Contains(iKey) {
 								// We may have already found this item, skip it
 								continue

--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -50,7 +50,7 @@ type dependencyState[I any] struct {
 
 type extractorKey struct {
 	uid       collectionUID
-	filterUID string
+	filterUID collectionUID
 	typ       indexedDependencyType
 }
 

--- a/pkg/kube/krt/filter.go
+++ b/pkg/kube/krt/filter.go
@@ -39,7 +39,7 @@ type filter struct {
 }
 
 type indexFilter struct {
-	filterUid    uint64
+	filterUID    uint64
 	list         func() any
 	indexMatches func(any) bool
 	extractKeys  objectKeyExtractor
@@ -61,7 +61,7 @@ func (f *filter) reverseIndexKey() ([]string, indexedDependencyType, objectKeyEx
 		return f.keys.List(), getKeyType, getKeyExtractor, "", true
 	}
 	if f.index != nil {
-		return []string{f.index.key}, indexType, f.index.extractKeys, strconv.Itoa(int(f.index.filterUid)), true
+		return []string{f.index.key}, indexType, f.index.extractKeys, strconv.Itoa(int(f.index.filterUID)), true
 	}
 	return nil, unknownIndexType, nil, "", false
 }
@@ -119,7 +119,7 @@ func FilterIndex[K comparable, I any](idx Index[K, I], k K) FetchOption {
 	return func(h *dependency) {
 		// Index is used to pre-filter on the List, and also to match in Matches. Provide type-erased methods for both
 		h.filter.index = &indexFilter{
-			filterUid: idx.ID(),
+			filterUID: idx.ID(),
 			list: func() any {
 				return idx.Lookup(k)
 			},

--- a/pkg/kube/krt/filter.go
+++ b/pkg/kube/krt/filter.go
@@ -16,6 +16,7 @@ package krt
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -38,7 +39,7 @@ type filter struct {
 }
 
 type indexFilter struct {
-	indexId      string
+	filterUid    uint64
 	list         func() any
 	indexMatches func(any) bool
 	extractKeys  objectKeyExtractor
@@ -60,7 +61,7 @@ func (f *filter) reverseIndexKey() ([]string, indexedDependencyType, objectKeyEx
 		return f.keys.List(), getKeyType, getKeyExtractor, "", true
 	}
 	if f.index != nil {
-		return []string{f.index.key}, indexType, f.index.extractKeys, f.index.indexId, true
+		return []string{f.index.key}, indexType, f.index.extractKeys, strconv.Itoa(int(f.index.filterUid)), true
 	}
 	return nil, unknownIndexType, nil, "", false
 }
@@ -118,7 +119,7 @@ func FilterIndex[K comparable, I any](idx Index[K, I], k K) FetchOption {
 	return func(h *dependency) {
 		// Index is used to pre-filter on the List, and also to match in Matches. Provide type-erased methods for both
 		h.filter.index = &indexFilter{
-			indexId: idx.ID(),
+			filterUid: idx.ID(),
 			list: func() any {
 				return idx.Lookup(k)
 			},

--- a/pkg/kube/krt/index.go
+++ b/pkg/kube/krt/index.go
@@ -17,7 +17,6 @@ package krt
 import (
 	"fmt"
 
-	"github.com/google/uuid"
 	"k8s.io/client-go/tools/cache"
 
 	"istio.io/istio/pkg/kube/controllers"
@@ -28,7 +27,7 @@ import (
 )
 
 type Index[K comparable, O any] interface {
-	ID() string
+	ID() uint64
 	Lookup(k K) []O
 	AsCollection(opts ...CollectionOption) Collection[IndexObject[K, O]]
 	objectHasKey(obj O, k K) bool
@@ -68,7 +67,7 @@ func NewIndex[K comparable, O any](
 	})
 
 	return index[K, O]{
-		uuid.NewString(),
+		nextUID(),
 		idx,
 		c,
 		extract,
@@ -76,7 +75,7 @@ func NewIndex[K comparable, O any](
 }
 
 type index[K comparable, O any] struct {
-	id string
+	uid collectionUID
 	kclient.RawIndexer
 	c       Collection[O]
 	extract func(o O) []K
@@ -137,8 +136,8 @@ func (i index[K, O]) extractKeys(o O) []K {
 	return i.extract(o)
 }
 
-func (i index[K, O]) ID() string {
-	return i.id
+func (i index[K, O]) ID() uint64 {
+	return uint64(i.uid)
 }
 
 // Lookup finds all objects matching a given key

--- a/pkg/kube/krt/index.go
+++ b/pkg/kube/krt/index.go
@@ -17,6 +17,7 @@ package krt
 import (
 	"fmt"
 
+	"github.com/google/uuid"
 	"k8s.io/client-go/tools/cache"
 
 	"istio.io/istio/pkg/kube/controllers"
@@ -27,6 +28,7 @@ import (
 )
 
 type Index[K comparable, O any] interface {
+	ID() string
 	Lookup(k K) []O
 	AsCollection(opts ...CollectionOption) Collection[IndexObject[K, O]]
 	objectHasKey(obj O, k K) bool
@@ -65,10 +67,16 @@ func NewIndex[K comparable, O any](
 		})
 	})
 
-	return index[K, O]{idx, c, extract}
+	return index[K, O]{
+		uuid.NewString(),
+		idx,
+		c,
+		extract,
+	}
 }
 
 type index[K comparable, O any] struct {
+	id string
 	kclient.RawIndexer
 	c       Collection[O]
 	extract func(o O) []K
@@ -127,6 +135,10 @@ func (i index[K, O]) objectHasKey(obj O, k K) bool {
 // nolint: unused // (not true)
 func (i index[K, O]) extractKeys(o O) []K {
 	return i.extract(o)
+}
+
+func (i index[K, O]) ID() string {
+	return i.id
 }
 
 // Lookup finds all objects matching a given key

--- a/pkg/kube/krt/index.go
+++ b/pkg/kube/krt/index.go
@@ -27,11 +27,11 @@ import (
 )
 
 type Index[K comparable, O any] interface {
-	ID() uint64
 	Lookup(k K) []O
 	AsCollection(opts ...CollectionOption) Collection[IndexObject[K, O]]
 	objectHasKey(obj O, k K) bool
 	extractKeys(o O) []K
+	id() collectionUID
 }
 
 type IndexObject[K comparable, O any] struct {
@@ -136,8 +136,8 @@ func (i index[K, O]) extractKeys(o O) []K {
 	return i.extract(o)
 }
 
-func (i index[K, O]) ID() uint64 {
-	return uint64(i.uid)
+func (i index[K, O]) id() collectionUID {
+	return i.uid
 }
 
 // Lookup finds all objects matching a given key

--- a/pkg/kube/krt/index.go
+++ b/pkg/kube/krt/index.go
@@ -136,6 +136,7 @@ func (i index[K, O]) extractKeys(o O) []K {
 	return i.extract(o)
 }
 
+// nolint: unused // (not true)
 func (i index[K, O]) id() collectionUID {
 	return i.uid
 }

--- a/tests/binary/binaries_test.go
+++ b/tests/binary/binaries_test.go
@@ -108,7 +108,7 @@ func TestBinarySizes(t *testing.T) {
 		// For now, having two small a range will result in lots of "merge conflicts"
 		"istioctl":        {60, 92},
 		"pilot-agent":     {20, 26},
-		"pilot-discovery": {60, 100},
+		"pilot-discovery": {60, 105},
 		"bug-report":      {60, 80},
 		"client":          {15, 30},
 		"server":          {15, 30},


### PR DESCRIPTION
**Please provide a description of this PR:**

https://github.com/istio/istio/issues/56036

This PR makes the following example _safe_ without subscriptions being missed/overwritten:

```
// same collection, same transform, different index
krt.NewCollection(..., func (ctx krt.HandlerContext, o I) *O {
  Fetch(colA, krt.FilterIndex(indexA, "key 1"))
  Fetch(colA, krt.FilterIndex(indexB, "key 2"))
}
```



- [X] Developer Infrastructure