### PR TITLE
Allow customization of Ambient enablement labels

### DIFF
--- a/cni/pkg/config/config.go
+++ b/cni/pkg/config/config.go
@@ -77,6 +77,9 @@ type InstallConfig struct {
 	// Whether ambient is enabled
 	AmbientEnabled bool
 
+	// The labelSelector to enable ambient for specific pods or namespaces
+	AmbientEnablementSelector string
+
 	// Whether ambient DNS capture is enabled
 	AmbientDNSCapture bool
 
@@ -149,6 +152,7 @@ func (c InstallConfig) String() string {
 	b.WriteString("ZtunnelUDSAddress: " + fmt.Sprint(c.ZtunnelUDSAddress) + "\n")
 
 	b.WriteString("AmbientEnabled: " + fmt.Sprint(c.AmbientEnabled) + "\n")
+	b.WriteString("AmbientEnablementSelector: " + c.AmbientEnablementSelector + "\n")
 	b.WriteString("AmbientDNSCapture: " + fmt.Sprint(c.AmbientDNSCapture) + "\n")
 	b.WriteString("AmbientIPv6: " + fmt.Sprint(c.AmbientIPv6) + "\n")
 	b.WriteString("AmbientDisableSafeUpgrade: " + fmt.Sprint(c.AmbientDisableSafeUpgrade) + "\n")

--- a/cni/pkg/constants/constants.go
+++ b/cni/pkg/constants/constants.go
@@ -39,6 +39,7 @@ const (
 	ExcludeNamespaces                 = "exclude-namespaces"
 	PodNamespace                      = "pod-namespace"
 	AmbientEnabled                    = "ambient-enabled"
+	AmbientEnablementSelector         = "ambient-enablement-selector"
 	AmbientDNSCapture                 = "ambient-dns-capture"
 	AmbientIPv6                       = "ambient-ipv6"
 	AmbientDisableSafeUpgrade         = "ambient-disable-safe-upgrade"

--- a/cni/pkg/install/cniconfig.go
+++ b/cni/pkg/install/cniconfig.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/containernetworking/cni/libcni"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/cni/pkg/config"
 	"istio.io/istio/cni/pkg/plugin"
@@ -32,13 +33,17 @@ import (
 )
 
 func createCNIConfigFile(ctx context.Context, cfg *config.InstallConfig) (string, error) {
+	selectors := []util.EnablementSelector{}
+	if err := yaml.Unmarshal([]byte(cfg.AmbientEnablementSelector), &selectors); err != nil {
+		return "", fmt.Errorf("failed to parse ambient enablement selector: %v", err)
+	}
 	pluginConfig := plugin.Config{
-		PluginLogLevel:     cfg.PluginLogLevel,
-		CNIAgentRunDir:     cfg.CNIAgentRunDir,
-		AmbientEnabled:     cfg.AmbientEnabled,
-		EnablementSelector: cfg.AmbientEnablementSelector,
-		ExcludeNamespaces:  strings.Split(cfg.ExcludeNamespaces, ","),
-		PodNamespace:       cfg.PodNamespace,
+		PluginLogLevel:      cfg.PluginLogLevel,
+		CNIAgentRunDir:      cfg.CNIAgentRunDir,
+		AmbientEnabled:      cfg.AmbientEnabled,
+		EnablementSelectors: selectors,
+		ExcludeNamespaces:   strings.Split(cfg.ExcludeNamespaces, ","),
+		PodNamespace:        cfg.PodNamespace,
 	}
 
 	pluginConfig.Name = "istio-cni"

--- a/cni/pkg/install/cniconfig.go
+++ b/cni/pkg/install/cniconfig.go
@@ -33,11 +33,12 @@ import (
 
 func createCNIConfigFile(ctx context.Context, cfg *config.InstallConfig) (string, error) {
 	pluginConfig := plugin.Config{
-		PluginLogLevel:    cfg.PluginLogLevel,
-		CNIAgentRunDir:    cfg.CNIAgentRunDir,
-		AmbientEnabled:    cfg.AmbientEnabled,
-		ExcludeNamespaces: strings.Split(cfg.ExcludeNamespaces, ","),
-		PodNamespace:      cfg.PodNamespace,
+		PluginLogLevel:     cfg.PluginLogLevel,
+		CNIAgentRunDir:     cfg.CNIAgentRunDir,
+		AmbientEnabled:     cfg.AmbientEnabled,
+		EnablementSelector: cfg.AmbientEnablementSelector,
+		ExcludeNamespaces:  strings.Split(cfg.ExcludeNamespaces, ","),
+		PodNamespace:       cfg.PodNamespace,
 	}
 
 	pluginConfig.Name = "istio-cni"

--- a/cni/pkg/install/testdata/bridge.conf.golden
+++ b/cni/pkg/install/testdata/bridge.conf.golden
@@ -21,6 +21,7 @@
       "ambient_enabled": false,
       "cni_agent_run_dir": "/path/to/kubeconfig",
       "dns": {},
+      "enablement_selectors": [],
       "exclude_namespaces": [
         ""
       ],

--- a/cni/pkg/install/testdata/istio-cni.conf
+++ b/cni/pkg/install/testdata/istio-cni.conf
@@ -7,6 +7,7 @@
   "plugin_log_level": "debug",
   "cni_agent_run_dir": "/path/to/kubeconfig",
   "ambient_enabled": false,
+  "enablement_selectors": [],
   "exclude_namespaces": [
     ""
   ],

--- a/cni/pkg/install/testdata/list-with-istio.conflist.golden
+++ b/cni/pkg/install/testdata/list-with-istio.conflist.golden
@@ -31,6 +31,7 @@
       "ambient_enabled": false,
       "cni_agent_run_dir": "/path/to/kubeconfig",
       "dns": {},
+      "enablement_selectors": [],
       "exclude_namespaces": [
         ""
       ],

--- a/cni/pkg/install/testdata/list.conflist.golden
+++ b/cni/pkg/install/testdata/list.conflist.golden
@@ -31,6 +31,7 @@
       "ambient_enabled": false,
       "cni_agent_run_dir": "/path/to/kubeconfig",
       "dns": {},
+      "enablement_selectors": [],
       "exclude_namespaces": [
         ""
       ],

--- a/cni/pkg/nodeagent/cni-watcher_test.go
+++ b/cni/pkg/nodeagent/cni-watcher_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 
 	"istio.io/api/label"
@@ -34,6 +35,10 @@ import (
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/util/assert"
 )
+
+var defaultAmbientSelector = labels.SelectorFromSet(labels.Set{
+	label.IoIstioDataplaneMode.Name: constants.DataplaneModeAmbient,
+})
 
 func TestProcessAddEventGoodPayload(t *testing.T) {
 	valid := CNIPluginAddEvent{
@@ -111,7 +116,7 @@ func TestCNIPluginServer(t *testing.T) {
 
 	dpServer := getFakeDP(fs, client.Kube())
 
-	handlers := setupHandlers(ctx, client, dpServer, "istio-system")
+	handlers := setupHandlers(ctx, client, dpServer, "istio-system", defaultAmbientSelector)
 
 	// We are not going to start the server, so the sockpath is irrelevant
 	pluginServer := startCniPluginServer(ctx, "/tmp/test.sock", handlers, dpServer)
@@ -184,7 +189,7 @@ func TestGetPodWithRetry(t *testing.T) {
 
 	dpServer := getFakeDP(fs, client.Kube())
 
-	handlers := setupHandlers(ctx, client, dpServer, "istio-system")
+	handlers := setupHandlers(ctx, client, dpServer, "istio-system", defaultAmbientSelector)
 
 	// We are not going to start the server, so the sockpath is irrelevant
 	pluginServer := startCniPluginServer(ctx, "/tmp/test.sock", handlers, dpServer)
@@ -259,7 +264,7 @@ func TestCNIPluginServerPrefersCNIProvidedPodIP(t *testing.T) {
 
 	dpServer := getFakeDP(fs, client.Kube())
 
-	handlers := setupHandlers(ctx, client, dpServer, "istio-system")
+	handlers := setupHandlers(ctx, client, dpServer, "istio-system", defaultAmbientSelector)
 
 	// We are not going to start the server, so the sockpath is irrelevant
 	pluginServer := startCniPluginServer(ctx, "/tmp/test.sock", handlers, dpServer)

--- a/cni/pkg/nodeagent/informers.go
+++ b/cni/pkg/nodeagent/informers.go
@@ -27,9 +27,7 @@ import (
 	klabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/util/workqueue"
 
-	"istio.io/api/label"
 	"istio.io/istio/cni/pkg/util"
-	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/kclient"
@@ -51,17 +49,20 @@ type K8sHandlers interface {
 }
 
 type InformerHandlers struct {
-	ctx             context.Context
-	dataplane       MeshDataplane
-	systemNamespace string
+	ctx                context.Context
+	dataplane          MeshDataplane
+	systemNamespace    string
+	enablementSelector klabels.Selector
 
 	queue      controllers.Queue
 	pods       kclient.Client[*corev1.Pod]
 	namespaces kclient.Client[*corev1.Namespace]
 }
 
-func setupHandlers(ctx context.Context, kubeClient kube.Client, dataplane MeshDataplane, systemNamespace string) *InformerHandlers {
-	s := &InformerHandlers{ctx: ctx, dataplane: dataplane, systemNamespace: systemNamespace}
+func setupHandlers(ctx context.Context, kubeClient kube.Client, dataplane MeshDataplane,
+	systemNamespace string, enablementSelector klabels.Selector,
+) *InformerHandlers {
+	s := &InformerHandlers{ctx: ctx, dataplane: dataplane, systemNamespace: systemNamespace, enablementSelector: enablementSelector}
 	s.queue = controllers.NewQueue("ambient",
 		controllers.WithGenericReconciler(s.reconcile),
 		// Effectively uncapped max attempts.
@@ -125,7 +126,7 @@ func (s *InformerHandlers) GetPodIfAmbientEnabled(podName, podNamespace string) 
 	if pod == nil {
 		return nil, fmt.Errorf("failed to find pod %v", ns)
 	}
-	if util.PodRedirectionEnabled(ns, pod) {
+	if util.PodRedirectionEnabled(ns, pod, s.enablementSelector) {
 		return pod, nil
 	}
 	return nil, nil
@@ -170,7 +171,7 @@ func (s *InformerHandlers) GetActiveAmbientPodSnapshot() []*corev1.Pod {
 func (s *InformerHandlers) enqueueNamespace(o controllers.Object) {
 	namespace := o.GetName()
 	labels := o.GetLabels()
-	matchAmbient := labels[label.IoIstioDataplaneMode.Name] == constants.DataplaneModeAmbient
+	matchAmbient := s.enablementSelector.Matches(klabels.Set(labels))
 	if matchAmbient {
 		log.Infof("Namespace %s is enabled in ambient mesh", namespace)
 	} else {
@@ -220,18 +221,12 @@ func (s *InformerHandlers) reconcileNamespace(input any) {
 		newNs := event.New.(*corev1.Namespace)
 		oldNs := event.Old.(*corev1.Namespace)
 
-		if getModeLabel(oldNs.Labels) != getModeLabel(newNs.Labels) {
+		if s.enablementSelector.Matches(klabels.Set(oldNs.Labels)) !=
+			s.enablementSelector.Matches(klabels.Set(newNs.Labels)) {
 			log.Debugf("Namespace %s updated", newNs.Name)
 			s.enqueueNamespace(newNs)
 		}
 	}
-}
-
-func getModeLabel(m map[string]string) string {
-	if m == nil {
-		return ""
-	}
-	return m[label.IoIstioDataplaneMode.Name]
 }
 
 func (s *InformerHandlers) reconcilePod(input any) error {
@@ -275,7 +270,7 @@ func (s *InformerHandlers) reconcilePod(input any) error {
 		oldPod := event.Old.(*corev1.Pod)
 		isEnrolled := util.PodFullyEnrolled(currentPod)
 		isPartiallyEnrolled := util.PodPartiallyEnrolled(currentPod)
-		shouldBeEnabled := util.PodRedirectionEnabled(ns, currentPod)
+		shouldBeEnabled := util.PodRedirectionEnabled(ns, currentPod, s.enablementSelector)
 		isTerminated := kube.CheckPodTerminal(currentPod)
 		// Check intent (labels) versus status (annotation) - is there a delta we need to fix?
 		changeNeeded := (isEnrolled != shouldBeEnabled) || isPartiallyEnrolled

--- a/cni/pkg/nodeagent/informers_test.go
+++ b/cni/pkg/nodeagent/informers_test.go
@@ -833,7 +833,7 @@ func TestInformerGetActiveAmbientPodSnapshotOnlyReturnsActivePods(t *testing.T) 
 
 	server := getFakeDP(fs, client.Kube())
 
-	handlers := setupHandlers(ctx, client, server, "istio-system")
+	handlers := setupHandlers(ctx, client, server, "istio-system", defaultAmbientSelector)
 	client.RunAndWait(ctx.Done())
 	pods := handlers.GetActiveAmbientPodSnapshot()
 
@@ -893,7 +893,7 @@ func TestInformerGetActiveAmbientPodSnapshotSkipsTerminatedJobPods(t *testing.T)
 
 	server := getFakeDP(fs, client.Kube())
 
-	handlers := setupHandlers(ctx, client, server, "istio-system")
+	handlers := setupHandlers(ctx, client, server, "istio-system", defaultAmbientSelector)
 	client.RunAndWait(ctx.Done())
 	pods := handlers.GetActiveAmbientPodSnapshot()
 
@@ -934,7 +934,7 @@ func TestInformerAmbientEnabledReturnsPodIfEnabled(t *testing.T) {
 
 	server := getFakeDP(fs, client.Kube())
 
-	handlers := setupHandlers(ctx, client, server, "istio-system")
+	handlers := setupHandlers(ctx, client, server, "istio-system", defaultAmbientSelector)
 	client.RunAndWait(ctx.Done())
 	_, err := handlers.GetPodIfAmbientEnabled(pod.Name, ns.Name)
 
@@ -1014,7 +1014,7 @@ func TestInformerAmbientEnabledReturnsErrorIfBogusNS(t *testing.T) {
 
 	server := getFakeDP(fs, client.Kube())
 
-	handlers := setupHandlers(ctx, client, server, "istio-system")
+	handlers := setupHandlers(ctx, client, server, "istio-system", defaultAmbientSelector)
 	client.RunAndWait(ctx.Done())
 	disabledPod, err := handlers.GetPodIfAmbientEnabled(pod.Name, "what")
 
@@ -1283,7 +1283,7 @@ func populateClientAndWaitForInformer(ctx context.Context, t *testing.T, client 
 
 	server := getFakeDP(fs, client.Kube())
 
-	handlers := setupHandlers(ctx, client, server, "istio-system")
+	handlers := setupHandlers(ctx, client, server, "istio-system", defaultAmbientSelector)
 	client.RunAndWait(ctx.Done())
 	handlers.Start()
 

--- a/cni/pkg/nodeagent/options.go
+++ b/cni/pkg/nodeagent/options.go
@@ -17,6 +17,8 @@ package nodeagent
 import (
 	"net/netip"
 
+	"k8s.io/apimachinery/pkg/labels"
+
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/env"
 )
@@ -49,6 +51,7 @@ type AmbientArgs struct {
 	Revision                   string
 	KubeConfig                 string
 	ServerSocket               string
+	EnablementSelector         labels.Selector
 	DNSCapture                 bool
 	EnableIPv6                 bool
 	ReconcilePodRulesOnStartup bool

--- a/cni/pkg/nodeagent/options.go
+++ b/cni/pkg/nodeagent/options.go
@@ -17,8 +17,7 @@ package nodeagent
 import (
 	"net/netip"
 
-	"k8s.io/apimachinery/pkg/labels"
-
+	"istio.io/istio/cni/pkg/util"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/env"
 )
@@ -51,7 +50,7 @@ type AmbientArgs struct {
 	Revision                   string
 	KubeConfig                 string
 	ServerSocket               string
-	EnablementSelector         labels.Selector
+	EnablementSelector         *util.CompiledEnablementSelectors
 	DNSCapture                 bool
 	EnableIPv6                 bool
 	ReconcilePodRulesOnStartup bool

--- a/cni/pkg/nodeagent/server.go
+++ b/cni/pkg/nodeagent/server.go
@@ -74,7 +74,7 @@ func NewServer(ctx context.Context, ready *atomic.Value, pluginSocket string, ar
 	}
 
 	s.NotReady()
-	s.handlers = setupHandlers(s.ctx, s.kubeClient, s.dataplane, args.SystemNamespace)
+	s.handlers = setupHandlers(s.ctx, s.kubeClient, s.dataplane, args.SystemNamespace, args.EnablementSelector)
 
 	cniServer := startCniPluginServer(ctx, pluginSocket, s.handlers, s.dataplane)
 	err = cniServer.Start()

--- a/cni/pkg/plugin/plugin.go
+++ b/cni/pkg/plugin/plugin.go
@@ -33,6 +33,7 @@ import (
 	"github.com/containernetworking/cni/pkg/version"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/yaml"
 
 	"istio.io/api/annotation"
 	"istio.io/api/label"
@@ -63,11 +64,12 @@ type Config struct {
 	types.NetConf
 
 	// Add plugin-specific flags here
-	PluginLogLevel    string   `json:"plugin_log_level"`
-	CNIAgentRunDir    string   `json:"cni_agent_run_dir"`
-	AmbientEnabled    bool     `json:"ambient_enabled"`
-	ExcludeNamespaces []string `json:"exclude_namespaces"`
-	PodNamespace      string   `json:"pod_namespace"`
+	PluginLogLevel     string   `json:"plugin_log_level"`
+	CNIAgentRunDir     string   `json:"cni_agent_run_dir"`
+	AmbientEnabled     bool     `json:"ambient_enabled"`
+	EnablementSelector string   `json:"enablement_selector"`
+	ExcludeNamespaces  []string `json:"exclude_namespaces"`
+	PodNamespace       string   `json:"pod_namespace"`
 }
 
 // K8sArgs is the valid CNI_ARGS used for Kubernetes
@@ -215,7 +217,7 @@ func doAddRun(args *skel.CmdArgs, conf *Config, kClient kubernetes.Interface, ru
 	// For ambient pods, this is all the logic we need to run
 	if conf.AmbientEnabled {
 		log.Debugf("istio-cni ambient cmdAdd podName: %s - checking if ambient enabled", podName)
-		podIsAmbient, err := isAmbientPod(kClient, podName, podNamespace)
+		podIsAmbient, err := isAmbientPod(kClient, podName, podNamespace, conf.EnablementSelector)
 		if err != nil {
 			log.Errorf("istio-cni cmdAdd failed to check ambient: %s", err)
 		}
@@ -364,7 +366,16 @@ func CmdDelete(args *skel.CmdArgs) (err error) {
 	return nil
 }
 
-func isAmbientPod(client kubernetes.Interface, podName, podNamespace string) (bool, error) {
+func isAmbientPod(client kubernetes.Interface, podName, podNamespace, enablementSelectorStr string) (bool, error) {
+	lsCfg := &metav1.LabelSelector{}
+	err := yaml.Unmarshal([]byte(enablementSelectorStr), lsCfg)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse ambient enablement selector: %v", err)
+	}
+	enablementSelector, err := metav1.LabelSelectorAsSelector(lsCfg)
+	if err != nil {
+		return false, fmt.Errorf("failed to instantiate ambient enablement selector: %v", err)
+	}
 	pod, err := client.CoreV1().Pods(podNamespace).Get(context.Background(), podName, metav1.GetOptions{})
 	if err != nil {
 		return false, err
@@ -374,5 +385,5 @@ func isAmbientPod(client kubernetes.Interface, podName, podNamespace string) (bo
 		return false, err
 	}
 
-	return util.PodRedirectionEnabled(ns, pod), nil
+	return util.PodRedirectionEnabled(ns, pod, enablementSelector), nil
 }

--- a/cni/pkg/plugin/plugin_test.go
+++ b/cni/pkg/plugin/plugin_test.go
@@ -79,6 +79,31 @@ var mockConfTmpl = `{
     "plugin_log_level": "debug",
     "cni_agent_run_dir": "%s",
     "ambient_enabled": %t,
+	"enablement_selectors": [
+		{
+			"podSelector": {
+				"matchLabels": {
+					"istio.io/dataplane-mode": "ambient"
+				}
+			}
+        },
+		{
+			"podSelector": {
+				"matchExpressions": [
+					{
+						"key": "istio.io/dataplane-mode",
+						"operator": "NotIn",
+						"values": ["none"]
+					}
+				]
+			},
+			"namespaceSelector": {
+				"matchLabels": {
+					"istio.io/dataplane-mode": "ambient"
+				}
+			}
+		}
+	],
 	"exclude_namespaces": ["testExcludeNS"],
     "kubernetes": {
         "k8s_api_root": "APIRoot",
@@ -529,6 +554,31 @@ func TestCmdAddNoPrevResult(t *testing.T) {
     },
     "loglevel": "debug",
 	"ambient_enabled": %t,
+	"enablement_selectors": [
+		{
+			"podSelector": {
+				"matchLabels": {
+					"istio.io/dataplane-mode": "ambient"
+				}
+			}
+        },
+		{
+			"podSelector": {
+				"matchExpressions": [
+					{
+						"key": "istio.io/dataplane-mode",
+						"operator": "NotIn",
+						"values": ["none"]
+					}
+				]
+			},
+			"namespaceSelector": {
+				"matchLabels": {
+					"istio.io/dataplane-mode": "ambient"
+				}
+			}
+		}
+	],
     "kubernetes": {
         "k8sapiroot": "APIRoot",
         "kubeconfig": "testK8sConfig",

--- a/cni/pkg/util/enablement_selector.go
+++ b/cni/pkg/util/enablement_selector.go
@@ -1,0 +1,102 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+type EnablementSelector struct {
+	PodSelector       metav1.LabelSelector `json:"podSelector"`
+	NamespaceSelector metav1.LabelSelector `json:"namespaceSelector"`
+}
+
+type CompiledEnablementSelectors struct {
+	SourceSelectors    []EnablementSelector
+	podSelectors       []labels.Selector
+	namespaceSelectors []labels.Selector
+}
+
+func NewCompiledEnablementSelectors(selectors []EnablementSelector) (*CompiledEnablementSelectors, error) {
+	podSelectors := []labels.Selector{}
+	namespaceSelectors := []labels.Selector{}
+
+	for _, selector := range selectors {
+		var podSelector labels.Selector
+		var namespaceSelector labels.Selector
+		var err error
+
+		// TODO (mitch): there has got to be a better way to do equality here...
+		s := selector.PodSelector.String()
+		o := (&metav1.LabelSelector{}).String()
+		if s == o {
+			// if selector.PodSelector.String() == (&metav1.LabelSelector{}).String() {
+			podSelector = labels.Everything()
+		} else {
+			podSelector, err = metav1.LabelSelectorAsSelector(&selector.PodSelector)
+			if err != nil {
+				return nil, fmt.Errorf("failed to instantiate ambient enablement pod selector: %v", err)
+			}
+		}
+		if selector.NamespaceSelector.String() == ((&metav1.LabelSelector{}).String()) {
+			namespaceSelector = labels.Everything()
+		} else {
+			namespaceSelector, err = metav1.LabelSelectorAsSelector(&selector.NamespaceSelector)
+			if err != nil {
+				return nil, fmt.Errorf("failed to instantiate ambient enablement namespace selector: %v", err)
+			}
+		}
+
+		podSelectors = append(podSelectors, podSelector)
+		namespaceSelectors = append(namespaceSelectors, namespaceSelector)
+	}
+
+	return &CompiledEnablementSelectors{
+		SourceSelectors:    selectors,
+		podSelectors:       podSelectors,
+		namespaceSelectors: namespaceSelectors,
+	}, nil
+}
+
+func (c *CompiledEnablementSelectors) Matches(podLabels, podAnnotations, namespaceLabels map[string]string) bool {
+	if podHasSidecar(podAnnotations) {
+		// Ztunnel and sidecar for a single pod is currently not supported; opt out.
+		return false
+	}
+	podls := labels.Set(podLabels)
+	namespacels := labels.Set(namespaceLabels)
+	for i, podSelector := range c.podSelectors {
+		if podSelector.Matches(podls) && c.namespaceSelectors[i].Matches(namespacels) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *CompiledEnablementSelectors) MatchesNamespace(nsLabels map[string]string) bool {
+	namespacels := labels.Set(nsLabels)
+	for _, namespaceSelector := range c.namespaceSelectors {
+		if namespaceSelector.Empty() {
+			continue
+		}
+		if namespaceSelector.Matches(namespacels) {
+			return true
+		}
+	}
+	return false
+}

--- a/cni/pkg/util/podutil.go
+++ b/cni/pkg/util/podutil.go
@@ -48,36 +48,6 @@ var annotationRemovePatch = []byte(fmt.Sprintf(
 	annotation.AmbientRedirection.Name,
 ))
 
-// PodRedirectionEnabled determines if a pod should or should not be configured
-// to have traffic redirected thru the node proxy.
-// func PodRedirectionEnabled(namespace *corev1.Namespace, pod *corev1.Pod, enablementSelector labels.Selector) bool {
-// 	nsMatches := enablementSelector.Matches(labels.Set(namespace.GetLabels()))
-// 	podMatches := enablementSelector.Matches(labels.Set(pod.GetLabels()))
-// 	if !(nsMatches || podMatches) {
-// 		// Neither namespace nor pod has ambient mode enabled
-// 		return false
-// 	}
-// 	if podHasSidecar(pod) {
-// 		// Ztunnel and sidecar for a single pod is currently not supported; opt out.
-// 		return false
-// 	}
-// 	// TODO (therealmitchconnors): how to accomplish this with the enablement selector?
-// 	reqs, _ := enablementSelector.Requirements()
-// 	if len(reqs) == 1 {
-// 		_, explicitPodLabeled := pod.GetLabels()[reqs[0].Key()]
-// 		if explicitPodLabeled && !podMatches {
-// 			// Pod explicitly asked to not have ambient redirection enabled
-// 			return false
-// 		}
-// 	}
-// 	if pod.Spec.HostNetwork {
-// 		// Host network pods cannot be captured, as we require inserting rules into the pod network namespace.
-// 		// If we were to allow them, we would be writing these rules into the host network namespace, effectively breaking the host.
-// 		return false
-// 	}
-// 	return true
-// }
-
 // PodFullyEnrolled reports on whether the pod _has_ actually been fully configured for traffic redirection.
 //
 // That is, have we annotated it after successfully setting up iptables rules AND sending it to a node proxy instance.

--- a/cni/pkg/util/podutil_test.go
+++ b/cni/pkg/util/podutil_test.go
@@ -19,12 +19,17 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"istio.io/api/annotation"
 	"istio.io/api/label"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/test/util/assert"
 )
+
+var defaultAmbientSelector = labels.SelectorFromSet(labels.Set{
+	label.IoIstioDataplaneMode.Name: constants.DataplaneModeAmbient,
+})
 
 func TestGetPodIPIfPodIPPresent(t *testing.T) {
 	pod := &corev1.Pod{
@@ -207,7 +212,7 @@ func TestPodRedirectionEnabled(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := PodRedirectionEnabled(tt.args.namespace, tt.args.pod); got != tt.want {
+			if got := PodRedirectionEnabled(tt.args.namespace, tt.args.pod, defaultAmbientSelector); got != tt.want {
 				t.Errorf("PodRedirectionEnabled() = %v, want %v", got, tt.want)
 			}
 		})

--- a/cni/pkg/util/podutil_test.go
+++ b/cni/pkg/util/podutil_test.go
@@ -260,10 +260,14 @@ func TestEnablementFromString(t *testing.T) {
 		},
 		{
 			name: "default",
-			args: `- podSelector:\n    matchLabels:
-      istio.io/dataplane-mode: ambient\n- namespaceSelector:\n    matchLabels:
-      istio.io/dataplane-mode: ambient\n  podSelector:\n    matchExpressions:\n    - key: istio.io/dataplane-mode
-	  operator: NotIn\n      values:\n      - none`,
+			args: "- podSelector:\n    matchLabels:\n      istio.io/dataplane-mode: ambient\n- podSelector:\n    matchExpressions:\n    - { key: istio.io/dataplane-mode, operator: NotIn, values: [none] }\n  namespaceSelector:\n    matchLabels:\n      istio.io/dataplane-mode: ambient", //nolint:all
+			// 			args: `- podSelector:
+			// 	matchLabels: { istio.io/dataplane-mode: ambient }
+			// - podSelector:
+			// 	matchExpressions:
+			// 	- { key: istio.io/dataplane-mode, operator: NotIn, values: [none] }
+			//   namespaceSelector:
+			// 	matchLabels: { istio.io/dataplane-mode: ambient }`,
 		},
 		{
 			name: "namespace only",

--- a/cni/pkg/util/podutil_test.go
+++ b/cni/pkg/util/podutil_test.go
@@ -261,13 +261,6 @@ func TestEnablementFromString(t *testing.T) {
 		{
 			name: "default",
 			args: "- podSelector:\n    matchLabels:\n      istio.io/dataplane-mode: ambient\n- podSelector:\n    matchExpressions:\n    - { key: istio.io/dataplane-mode, operator: NotIn, values: [none] }\n  namespaceSelector:\n    matchLabels:\n      istio.io/dataplane-mode: ambient", //nolint:all
-			// 			args: `- podSelector:
-			// 	matchLabels: { istio.io/dataplane-mode: ambient }
-			// - podSelector:
-			// 	matchExpressions:
-			// 	- { key: istio.io/dataplane-mode, operator: NotIn, values: [none] }
-			//   namespaceSelector:
-			// 	matchLabels: { istio.io/dataplane-mode: ambient }`,
 		},
 		{
 			name: "namespace only",

--- a/cni/pkg/util/podutil_test.go
+++ b/cni/pkg/util/podutil_test.go
@@ -260,7 +260,10 @@ func TestEnablementFromString(t *testing.T) {
 		},
 		{
 			name: "default",
-			args: "- podSelector:\n    matchLabels:\n      istio.io/dataplane-mode: ambient\n- namespaceSelector:\n    matchLabels:\n      istio.io/dataplane-mode: ambient\n  podSelector:\n    matchExpressions:\n    - key: istio.io/dataplane-mode\n      operator: NotIn\n      values:\n      - none",
+			args: `- podSelector:\n    matchLabels:
+      istio.io/dataplane-mode: ambient\n- namespaceSelector:\n    matchLabels:
+      istio.io/dataplane-mode: ambient\n  podSelector:\n    matchExpressions:\n    - key: istio.io/dataplane-mode
+	  operator: NotIn\n      values:\n      - none`,
 		},
 		{
 			name: "namespace only",

--- a/cni/test/testdata/expected/10-calico.conflist-istioconfig
+++ b/cni/test/testdata/expected/10-calico.conflist-istioconfig
@@ -28,7 +28,7 @@
       "ambient_enabled": false,
       "cni_agent_run_dir": "/tmp",
       "dns": {},
-      "enablement_selector": "",
+      "enablement_selectors": [],
       "exclude_namespaces": [
         "istio-system"
       ],

--- a/cni/test/testdata/expected/10-calico.conflist-istioconfig
+++ b/cni/test/testdata/expected/10-calico.conflist-istioconfig
@@ -28,6 +28,7 @@
       "ambient_enabled": false,
       "cni_agent_run_dir": "/tmp",
       "dns": {},
+      "enablement_selector": "",
       "exclude_namespaces": [
         "istio-system"
       ],

--- a/cni/test/testdata/expected/YYY-istio-cni.conf
+++ b/cni/test/testdata/expected/YYY-istio-cni.conf
@@ -7,7 +7,7 @@
   "plugin_log_level": "debug",
   "cni_agent_run_dir": "/tmp",
   "ambient_enabled": false,
-  "enablement_selector": "",
+  "enablement_selectors": [],
   "exclude_namespaces": [
     "istio-system"
   ],

--- a/cni/test/testdata/expected/YYY-istio-cni.conf
+++ b/cni/test/testdata/expected/YYY-istio-cni.conf
@@ -7,6 +7,7 @@
   "plugin_log_level": "debug",
   "cni_agent_run_dir": "/tmp",
   "ambient_enabled": false,
+  "enablement_selector": "",
   "exclude_namespaces": [
     "istio-system"
   ],

--- a/cni/test/testdata/expected/minikube_cni.conflist.expected
+++ b/cni/test/testdata/expected/minikube_cni.conflist.expected
@@ -25,7 +25,7 @@
       "ambient_enabled": false,
       "cni_agent_run_dir": "/tmp",
       "dns": {},
-      "enablement_selector": "",
+      "enablement_selectors": [],
       "exclude_namespaces": [
         "istio-system"
       ],

--- a/cni/test/testdata/expected/minikube_cni.conflist.expected
+++ b/cni/test/testdata/expected/minikube_cni.conflist.expected
@@ -25,6 +25,7 @@
       "ambient_enabled": false,
       "cni_agent_run_dir": "/tmp",
       "dns": {},
+      "enablement_selector": "",
       "exclude_namespaces": [
         "istio-system"
       ],

--- a/manifests/charts/istio-cni/templates/configmap-cni.yaml
+++ b/manifests/charts/istio-cni/templates/configmap-cni.yaml
@@ -14,7 +14,7 @@ metadata:
 data:
   CURRENT_AGENT_VERSION: {{ .Values.tag | default .Values.global.tag | quote }}
   AMBIENT_ENABLED: {{ .Values.ambient.enabled | quote }}
-  AMBIENT_ENABLEMENT_SELECTOR: {{ .Values.ambient.enablementSelector | toYaml | quote }}
+  AMBIENT_ENABLEMENT_SELECTOR: {{ .Values.ambient.enablementSelectors | toYaml | quote }}
   AMBIENT_DNS_CAPTURE: {{ .Values.ambient.dnsCapture | quote  }}
   AMBIENT_IPV6: {{ .Values.ambient.ipv6 | quote }}
   AMBIENT_RECONCILE_POD_RULES_ON_STARTUP: {{ .Values.ambient.reconcileIptablesOnStartup | quote }}

--- a/manifests/charts/istio-cni/templates/configmap-cni.yaml
+++ b/manifests/charts/istio-cni/templates/configmap-cni.yaml
@@ -14,6 +14,7 @@ metadata:
 data:
   CURRENT_AGENT_VERSION: {{ .Values.tag | default .Values.global.tag | quote }}
   AMBIENT_ENABLED: {{ .Values.ambient.enabled | quote }}
+  AMBIENT_ENABLEMENT_SELECTOR: {{ .Values.ambient.enablementSelector | toYaml | quote }}
   AMBIENT_DNS_CAPTURE: {{ .Values.ambient.dnsCapture | quote  }}
   AMBIENT_IPV6: {{ .Values.ambient.ipv6 | quote }}
   AMBIENT_RECONCILE_POD_RULES_ON_STARTUP: {{ .Values.ambient.reconcileIptablesOnStartup | quote }}

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -51,7 +51,7 @@ _internal_defaults_do_not_set:
         matchLabels: {istio.io/dataplane-mode: ambient}
     - podSelector:
         matchExpressions:
-        - { key:istio.io/dataplane-mode, operator:NotIn, values: [none] }
+        - { key: istio.io/dataplane-mode, operator: NotIn, values: [none] }
       namespaceSelector:
         matchLabels: {istio.io/dataplane-mode: ambient}
     # Set ambient config dir path: defaults to /etc/ambient-config

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -45,6 +45,8 @@ _internal_defaults_do_not_set:
   ambient:
     # If enabled, ambient redirection will be enabled
     enabled: false
+    # If ambient is enabled, this selector will be used to identify the ambient-enabled pods
+    enablementSelector: "matchLabels: {istio.io/dataplane-mode: ambient}"
     # Set ambient config dir path: defaults to /etc/ambient-config
     configDir: ""
     # If enabled, and ambient is enabled, DNS redirection will be enabled

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -46,7 +46,14 @@ _internal_defaults_do_not_set:
     # If enabled, ambient redirection will be enabled
     enabled: false
     # If ambient is enabled, this selector will be used to identify the ambient-enabled pods
-    enablementSelector: "matchLabels: {istio.io/dataplane-mode: ambient}"
+    enablementSelectors: 
+    - podSelector:
+        matchLabels: {istio.io/dataplane-mode: ambient}
+    - podSelector:
+        matchExpressions:
+        - { key:istio.io/dataplane-mode, operator:NotIn, values: [none] }
+      namespaceSelector:
+        matchLabels: {istio.io/dataplane-mode: ambient}
     # Set ambient config dir path: defaults to /etc/ambient-config
     configDir: ""
     # If enabled, and ambient is enabled, DNS redirection will be enabled

--- a/releasenotes/notes/56048.yaml
+++ b/releasenotes/notes/56048.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue:
+- 53578
+releaseNotes:
+- |
+  **Added** support customizing Ambient Enablement Labels.


### PR DESCRIPTION
Fixes #53578 .

Allows users to control what labels cause Ambient enablement.  User can do opt-out enablement, or whatever label selectors support.