### PR TITLE
support initContainers and additionalContainers in gateway helmchart

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -63,6 +63,10 @@ spec:
       volumes:
         {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: istio-proxy
           # "auto" will be populated at runtime by the mutating webhook. See https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#customizing-injection
@@ -116,6 +120,9 @@ spec:
           lifecycle:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      {{- with .Values.additionalContainers }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -175,6 +175,12 @@ _internal_defaults_do_not_set:
   # https://kubernetes.io/docs/concepts/storage/volumes/.
   volumeMounts: []
 
+  # Inject initContainers into the Gateway Pods.
+  initContainers: []
+
+  # Inject additional containers into the Gateway Pods.
+  additionalContainers: []
+
   # Configure this to a higher priority class in order to make sure your Istio gateway pods
   # will not be killed because of low priority class.
   # Refer to https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass

--- a/operator/pkg/helm/helm_test.go
+++ b/operator/pkg/helm/helm_test.go
@@ -53,6 +53,20 @@ func TestRender(t *testing.T) {
 			chartName:   "gateway",
 			diffSelect:  "Deployment:*:istio-ingress",
 		},
+		{
+			desc:        "gateway-additional-containers",
+			releaseName: "istio-ingress",
+			namespace:   "istio-ingress",
+			chartName:   "gateway",
+			diffSelect:  "Deployment:*:istio-ingress",
+		},
+		{
+			desc:        "gateway-init-containers",
+			releaseName: "istio-ingress",
+			namespace:   "istio-ingress",
+			chartName:   "gateway",
+			diffSelect:  "Deployment:*:istio-ingress",
+		},
 	}
 
 	for _, tc := range cases {

--- a/operator/pkg/helm/testdata/input/gateway-additional-containers.yaml
+++ b/operator/pkg/helm/testdata/input/gateway-additional-containers.yaml
@@ -1,0 +1,8 @@
+spec:
+  values:
+    additionalContainers:
+    - name: additional-container
+      image: additional-image:latest
+      ports:
+      - containerPort: 8080
+        protocol: TCP

--- a/operator/pkg/helm/testdata/input/gateway-init-containers.yaml
+++ b/operator/pkg/helm/testdata/input/gateway-init-containers.yaml
@@ -1,0 +1,9 @@
+spec:
+  values:
+    initContainers:
+    - name: init-container
+      image: init-image:latest
+      command:
+      - /bin/sh
+      - -c
+      - echo Hello

--- a/operator/pkg/helm/testdata/output/gateway-additional-containers.golden.yaml
+++ b/operator/pkg/helm/testdata/output/gateway-additional-containers.golden.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: istio-ingress
+  namespace: istio-ingress
+  labels:
+    app.kubernetes.io/name: istio-ingress
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "istio-ingress"
+    app.kubernetes.io/part-of: "istio"
+    app.kubernetes.io/version: "1.0.0"
+    helm.sh/chart: gateway-1.0.0
+    app: istio-ingress
+    istio: ingress
+    "istio.io/dataplane-mode": "none"
+  annotations:
+    {}
+spec:
+  selector:
+    matchLabels:
+      app: istio-ingress
+      istio: ingress
+  template:
+    metadata:
+      annotations:
+        inject.istio.io/templates: gateway
+        prometheus.io/path: /stats/prometheus
+        prometheus.io/port: "15020"
+        prometheus.io/scrape: "true"
+        sidecar.istio.io/inject: "true"
+      labels:
+        sidecar.istio.io/inject: "true"
+        app: istio-ingress
+        istio: ingress
+        app.kubernetes.io/name: istio-ingress
+        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/instance: "istio-ingress"
+        app.kubernetes.io/part-of: "istio"
+        app.kubernetes.io/version: "1.0.0"
+        helm.sh/chart: gateway-1.0.0
+        "istio.io/dataplane-mode": "none"
+    spec:
+      serviceAccountName: istio-ingress
+      securityContext:
+        # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+        sysctls:
+        - name: net.ipv4.ip_unprivileged_port_start
+          value: "0"
+      containers:
+        - name: istio-proxy
+          # "auto" will be populated at runtime by the mutating webhook. See https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#customizing-injection
+          image: auto
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1337
+            runAsGroup: 1337
+            runAsNonRoot: true
+          env:
+          ports:
+          - containerPort: 15090
+            protocol: TCP
+            name: http-envoy-prom
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 1024Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+        - image: additional-image:latest
+          name: additional-container
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+      terminationGracePeriodSeconds: 30

--- a/operator/pkg/helm/testdata/output/gateway-init-containers.golden.yaml
+++ b/operator/pkg/helm/testdata/output/gateway-init-containers.golden.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: istio-ingress
+  namespace: istio-ingress
+  labels:
+    app.kubernetes.io/name: istio-ingress
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "istio-ingress"
+    app.kubernetes.io/part-of: "istio"
+    app.kubernetes.io/version: "1.0.0"
+    helm.sh/chart: gateway-1.0.0
+    app: istio-ingress
+    istio: ingress
+    "istio.io/dataplane-mode": "none"
+  annotations:
+    {}
+spec:
+  selector:
+    matchLabels:
+      app: istio-ingress
+      istio: ingress
+  template:
+    metadata:
+      annotations:
+        inject.istio.io/templates: gateway
+        prometheus.io/path: /stats/prometheus
+        prometheus.io/port: "15020"
+        prometheus.io/scrape: "true"
+        sidecar.istio.io/inject: "true"
+      labels:
+        sidecar.istio.io/inject: "true"
+        app: istio-ingress
+        istio: ingress
+        app.kubernetes.io/name: istio-ingress
+        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/instance: "istio-ingress"
+        app.kubernetes.io/part-of: "istio"
+        app.kubernetes.io/version: "1.0.0"
+        helm.sh/chart: gateway-1.0.0
+        "istio.io/dataplane-mode": "none"
+    spec:
+      serviceAccountName: istio-ingress
+      securityContext:
+        # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+        sysctls:
+        - name: net.ipv4.ip_unprivileged_port_start
+          value: "0"
+      initContainers:
+        - command:
+          - /bin/sh
+          - -c
+          - echo Hello
+          image: init-image:latest
+          name: init-container
+      containers:
+        - name: istio-proxy
+          # "auto" will be populated at runtime by the mutating webhook. See https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#customizing-injection
+          image: auto
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1337
+            runAsGroup: 1337
+            runAsNonRoot: true
+          env:
+          ports:
+          - containerPort: 15090
+            protocol: TCP
+            name: http-envoy-prom
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 1024Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+      terminationGracePeriodSeconds: 30

--- a/releasenotes/notes/56076.yaml
+++ b/releasenotes/notes/56076.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+releaseNotes:
+- |
+  **Added** Support for configuring `additionalContainers` and `initContainers` on the Gateway Helm Chart.


### PR DESCRIPTION
**Please provide a description of this PR:**

support `additionalContainers` in gateway helm chart similar to the legacy [helm chart](https://github.com/lizzzcai/istio/blob/master/manifests/charts/gateways/istio-ingress/values.yaml#L82), so user can add sidecar to the gateway.

As sidecar can be in [init containers](https://kubernetes.io/blog/2023/08/25/native-sidecar-containers/) as well, also support `initContainers`.