### PR TITLE
add inline header support in Authz Policy

### DIFF
--- a/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-in.yaml
@@ -39,6 +39,9 @@ spec:
         - key: "request.headers[X-header]"
           values: ["header", "header-prefix-*", "*-suffix-header", "*"]
           notValues: ["not-header", "not-header-prefix-*", "*-not-suffix-header", "*"]
+        - key: "request.experimental.inline.headers[X-inline-header]"
+          values: [ "header", "header-prefix-*", "*-suffix-header", "*" ]
+          notValues: [ "not-header", "not-header-prefix-*", "*-not-suffix-header", "*" ]
         - key: "source.ip"
           values: ["10.10.10.10", "192.168.10.0/24"]
           notValues: ["90.10.10.10", "90.168.10.0/24"]

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
@@ -555,6 +555,41 @@ typedConfig:
                       presentMatch: true
             - orIds:
                 ids:
+                - header:
+                    name: X-inline-header
+                    safeRegexMatch:
+                      regex: ^header$|^header,.*|.*,header,.*|.*,header$
+                - header:
+                    name: X-inline-header
+                    safeRegexMatch:
+                      regex: ^header-prefix-.*$|^header-prefix-.*,.*|.*,header-prefix-.*,.*|.*,header-prefix-.*$
+                - header:
+                    name: X-inline-header
+                    safeRegexMatch:
+                      regex: ^.*-suffix-header$|^.*-suffix-header,.*|.*,.*-suffix-header,.*|.*,.*-suffix-header$
+                - header:
+                    name: X-inline-header
+                    presentMatch: true
+            - notId:
+                orIds:
+                  ids:
+                  - header:
+                      name: X-inline-header
+                      safeRegexMatch:
+                        regex: ^not-header$|^not-header,.*|.*,not-header,.*|.*,not-header$
+                  - header:
+                      name: X-inline-header
+                      safeRegexMatch:
+                        regex: ^not-header-prefix-.*$|^not-header-prefix-.*,.*|.*,not-header-prefix-.*,.*|.*,not-header-prefix-.*$
+                  - header:
+                      name: X-inline-header
+                      safeRegexMatch:
+                        regex: ^.*-not-suffix-header$|^.*-not-suffix-header,.*|.*,.*-not-suffix-header,.*|.*,.*-not-suffix-header$
+                  - header:
+                      name: X-inline-header
+                      presentMatch: true
+            - orIds:
+                ids:
                 - directRemoteIp:
                     addressPrefix: 10.10.10.10
                     prefixLen: 32

--- a/pilot/pkg/security/authz/builder/testdata/http/extended-allow-full-rule-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/extended-allow-full-rule-out.yaml
@@ -555,6 +555,41 @@ typedConfig:
                       presentMatch: true
             - orIds:
                 ids:
+                - header:
+                    name: X-inline-header
+                    safeRegexMatch:
+                      regex: ^header$|^header,.*|.*,header,.*|.*,header$
+                - header:
+                    name: X-inline-header
+                    safeRegexMatch:
+                      regex: ^header-prefix-.*$|^header-prefix-.*,.*|.*,header-prefix-.*,.*|.*,header-prefix-.*$
+                - header:
+                    name: X-inline-header
+                    safeRegexMatch:
+                      regex: ^.*-suffix-header$|^.*-suffix-header,.*|.*,.*-suffix-header,.*|.*,.*-suffix-header$
+                - header:
+                    name: X-inline-header
+                    presentMatch: true
+            - notId:
+                orIds:
+                  ids:
+                  - header:
+                      name: X-inline-header
+                      safeRegexMatch:
+                        regex: ^not-header$|^not-header,.*|.*,not-header,.*|.*,not-header$
+                  - header:
+                      name: X-inline-header
+                      safeRegexMatch:
+                        regex: ^not-header-prefix-.*$|^not-header-prefix-.*,.*|.*,not-header-prefix-.*,.*|.*,not-header-prefix-.*$
+                  - header:
+                      name: X-inline-header
+                      safeRegexMatch:
+                        regex: ^.*-not-suffix-header$|^.*-not-suffix-header,.*|.*,.*-not-suffix-header,.*|.*,.*-not-suffix-header$
+                  - header:
+                      name: X-inline-header
+                      presentMatch: true
+            - orIds:
+                ids:
                 - directRemoteIp:
                     addressPrefix: 10.10.10.10
                     prefixLen: 32

--- a/pilot/pkg/security/authz/matcher/header.go
+++ b/pilot/pkg/security/authz/matcher/header.go
@@ -57,10 +57,10 @@ func HeaderMatcher(k, v string) *routepb.HeaderMatcher {
 	}
 }
 
-// HeaderMatcherWithRegex converts a key, value string pair to a corresponding
+// InlineHeaderMatcher converts a key, value string pair to a corresponding
 // HeaderMatcher to support matching the value presented in the inline header with
 // multiple values concatenated by commas, as per RFC7230.
-func HeaderMatcherWithRegex(k, v string) *routepb.HeaderMatcher {
+func InlineHeaderMatcher(k, v string) *routepb.HeaderMatcher {
 	// We must check "*" first to distinguish present match from the other
 	// cases.
 	var regex string

--- a/pilot/pkg/security/authz/matcher/header_test.go
+++ b/pilot/pkg/security/authz/matcher/header_test.go
@@ -86,7 +86,7 @@ func TestHeaderMatcher(t *testing.T) {
 	}
 }
 
-func TestHeaderMatcherWithRegex(t *testing.T) {
+func TestInlineHeaderMatcher(t *testing.T) {
 	testCases := []struct {
 		Name   string
 		K      string
@@ -107,6 +107,19 @@ func TestHeaderMatcherWithRegex(t *testing.T) {
 			},
 		},
 		{
+			Name: "exact match with whitespace around",
+			K:    ":path",
+			V:    " /productpage ",
+			Expect: &routepb.HeaderMatcher{
+				Name: ":path",
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
+					SafeRegexMatch: &matcher.RegexMatcher{
+						Regex: "^ /productpage $|^ /productpage ,.*|.*, /productpage ,.*|.*, /productpage $",
+					},
+				},
+			},
+		},
+		{
 			Name: "suffix match",
 			K:    ":path",
 			V:    "*/productpage*",
@@ -115,6 +128,19 @@ func TestHeaderMatcherWithRegex(t *testing.T) {
 				HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
 					SafeRegexMatch: &matcher.RegexMatcher{
 						Regex: `^.*/productpage\*$|^.*/productpage\*,.*|.*,.*/productpage\*,.*|.*,.*/productpage\*$`,
+					},
+				},
+			},
+		},
+		{
+			Name: "suffix match with whitespace behind",
+			K:    ":path",
+			V:    "*/productpage* ",
+			Expect: &routepb.HeaderMatcher{
+				Name: ":path",
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
+					SafeRegexMatch: &matcher.RegexMatcher{
+						Regex: `^.*/productpage\* $|^.*/productpage\* ,.*|.*,.*/productpage\* ,.*|.*,.*/productpage\* $`,
 					},
 				},
 			},
@@ -133,6 +159,19 @@ func TestHeaderMatcherWithRegex(t *testing.T) {
 			},
 		},
 		{
+			Name: "prefix match with whitespace before",
+			K:    ":path",
+			V:    " /productpage*",
+			Expect: &routepb.HeaderMatcher{
+				Name: ":path",
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
+					SafeRegexMatch: &matcher.RegexMatcher{
+						Regex: `^ /productpage.*$|^ /productpage.*,.*|.*, /productpage.*,.*|.*, /productpage.*$`,
+					},
+				},
+			},
+		},
+		{
 			Name: "present match",
 			K:    ":path",
 			V:    "*",
@@ -146,7 +185,7 @@ func TestHeaderMatcherWithRegex(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		actual := HeaderMatcherWithRegex(tc.K, tc.V)
+		actual := InlineHeaderMatcher(tc.K, tc.V)
 		if !cmp.Equal(tc.Expect, actual, protocmp.Transform()) {
 			t.Errorf("expecting %v, but got %v", tc.Expect, actual)
 		}

--- a/pilot/pkg/security/authz/model/generator.go
+++ b/pilot/pkg/security/authz/model/generator.go
@@ -351,7 +351,7 @@ func (requestInlineHeaderGenerator) principal(key, value string, forTCP bool, _ 
 	if err != nil {
 		return nil, err
 	}
-	m := matcher.HeaderMatcherWithRegex(header, value)
+	m := matcher.InlineHeaderMatcher(header, value)
 	return principalHeader(m), nil
 }
 

--- a/pilot/pkg/security/authz/model/generator.go
+++ b/pilot/pkg/security/authz/model/generator.go
@@ -336,6 +336,25 @@ func (requestHeaderGenerator) principal(key, value string, forTCP bool, _ bool) 
 	return principalHeader(m), nil
 }
 
+type requestInlineHeaderGenerator struct{}
+
+func (requestInlineHeaderGenerator) permission(_, _ string, _ bool) (*rbacpb.Permission, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+
+func (requestInlineHeaderGenerator) principal(key, value string, forTCP bool, _ bool) (*rbacpb.Principal, error) {
+	if forTCP {
+		return nil, fmt.Errorf("%q is HTTP only", key)
+	}
+
+	header, err := extractNameInBrackets(strings.TrimPrefix(key, attrRequestInlineHeader))
+	if err != nil {
+		return nil, err
+	}
+	m := matcher.HeaderMatcherWithRegex(header, value)
+	return principalHeader(m), nil
+}
+
 type requestClaimGenerator struct{}
 
 func (requestClaimGenerator) extendedPermission(_ string, _ []string, _ bool) (*rbacpb.Permission, error) {

--- a/pilot/pkg/security/authz/model/generator_test.go
+++ b/pilot/pkg/security/authz/model/generator_test.go
@@ -378,6 +378,17 @@ func TestGenerator(t *testing.T) {
             exact: foo`),
 		},
 		{
+			name:  "requestInlineHeaderGenerator",
+			g:     requestInlineHeaderGenerator{},
+			key:   "request.experimental.inline.headers[x-foo]",
+			value: "foo",
+			want: yamlPrincipal(t, `
+         header:
+          name: x-foo
+          safeRegexMatch:
+            regex: ^foo$|^foo,.*|.*,foo,.*|.*,foo$`),
+		},
+		{
 			name:  "hostGenerator",
 			g:     hostGenerator{},
 			value: "foo",

--- a/pilot/pkg/security/authz/model/model.go
+++ b/pilot/pkg/security/authz/model/model.go
@@ -34,20 +34,21 @@ const (
 	RBACExtAuthzShadowRulesStatPrefix = "istio_ext_authz_"
 
 	attrRequestHeader       = "request.headers"                     // header name is surrounded by brackets, e.g. "request.headers[User-Agent]".
-	attrRequestInlineHeader = "request.experimental.inline.headers" // header name is surrounded by brackets, e.g. "request.experimental.inline.headers[User-Agent]".
-	attrSrcIP               = "source.ip"                           // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
-	attrRemoteIP            = "remote.ip"                           // original client ip determined from x-forwarded-for or proxy protocol.
-	attrSrcNamespace        = "source.namespace"                    // e.g. "default".
-	attrSrcServiceAccount   = "source.serviceAccount"               // e.g. "default/productpage".
-	attrSrcPrincipal        = "source.principal"                    // source identity, e,g, "cluster.local/ns/default/sa/productpage".
-	attrRequestPrincipal    = "request.auth.principal"              // authenticated principal of the request.
-	attrRequestAudiences    = "request.auth.audiences"              // intended audience(s) for this authentication information.
-	attrRequestPresenter    = "request.auth.presenter"              // authorized presenter of the credential.
-	attrRequestClaims       = "request.auth.claims"                 // claim name is surrounded by brackets, e.g. "request.auth.claims[iss]".
-	attrDestIP              = "destination.ip"                      // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
-	attrDestPort            = "destination.port"                    // must be in the range [0, 65535].
-	attrConnSNI             = "connection.sni"                      // server name indication, e.g. "www.example.com".
-	attrEnvoyFilter         = "experimental.envoy.filters."         // an experimental attribute for checking Envoy Metadata directly.
+	attrRequestInlineHeader = "request.experimental.inline.headers" // header name is surrounded by brackets,
+	// e.g. "request.experimental.inline.headers[User-Agent]".
+	attrSrcIP             = "source.ip"                   // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
+	attrRemoteIP          = "remote.ip"                   // original client ip determined from x-forwarded-for or proxy protocol.
+	attrSrcNamespace      = "source.namespace"            // e.g. "default".
+	attrSrcServiceAccount = "source.serviceAccount"       // e.g. "default/productpage".
+	attrSrcPrincipal      = "source.principal"            // source identity, e,g, "cluster.local/ns/default/sa/productpage".
+	attrRequestPrincipal  = "request.auth.principal"      // authenticated principal of the request.
+	attrRequestAudiences  = "request.auth.audiences"      // intended audience(s) for this authentication information.
+	attrRequestPresenter  = "request.auth.presenter"      // authorized presenter of the credential.
+	attrRequestClaims     = "request.auth.claims"         // claim name is surrounded by brackets, e.g. "request.auth.claims[iss]".
+	attrDestIP            = "destination.ip"              // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
+	attrDestPort          = "destination.port"            // must be in the range [0, 65535].
+	attrConnSNI           = "connection.sni"              // server name indication, e.g. "www.example.com".
+	attrEnvoyFilter       = "experimental.envoy.filters." // an experimental attribute for checking Envoy Metadata directly.
 
 	// Internal names used to generate corresponding Envoy matcher.
 	methodHeader = ":method"

--- a/pilot/pkg/security/authz/model/model.go
+++ b/pilot/pkg/security/authz/model/model.go
@@ -33,20 +33,21 @@ const (
 	RBACShadowRulesDenyStatPrefix     = "istio_dry_run_deny_"
 	RBACExtAuthzShadowRulesStatPrefix = "istio_ext_authz_"
 
-	attrRequestHeader     = "request.headers"             // header name is surrounded by brackets, e.g. "request.headers[User-Agent]".
-	attrSrcIP             = "source.ip"                   // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
-	attrRemoteIP          = "remote.ip"                   // original client ip determined from x-forwarded-for or proxy protocol.
-	attrSrcNamespace      = "source.namespace"            // e.g. "default".
-	attrSrcServiceAccount = "source.serviceAccount"       // e.g. "default/productpage".
-	attrSrcPrincipal      = "source.principal"            // source identity, e,g, "cluster.local/ns/default/sa/productpage".
-	attrRequestPrincipal  = "request.auth.principal"      // authenticated principal of the request.
-	attrRequestAudiences  = "request.auth.audiences"      // intended audience(s) for this authentication information.
-	attrRequestPresenter  = "request.auth.presenter"      // authorized presenter of the credential.
-	attrRequestClaims     = "request.auth.claims"         // claim name is surrounded by brackets, e.g. "request.auth.claims[iss]".
-	attrDestIP            = "destination.ip"              // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
-	attrDestPort          = "destination.port"            // must be in the range [0, 65535].
-	attrConnSNI           = "connection.sni"              // server name indication, e.g. "www.example.com".
-	attrEnvoyFilter       = "experimental.envoy.filters." // an experimental attribute for checking Envoy Metadata directly.
+	attrRequestHeader       = "request.headers"                     // header name is surrounded by brackets, e.g. "request.headers[User-Agent]".
+	attrRequestInlineHeader = "request.experimental.inline.headers" // header name is surrounded by brackets, e.g. "request.experimental.inline.headers[User-Agent]".
+	attrSrcIP               = "source.ip"                           // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
+	attrRemoteIP            = "remote.ip"                           // original client ip determined from x-forwarded-for or proxy protocol.
+	attrSrcNamespace        = "source.namespace"                    // e.g. "default".
+	attrSrcServiceAccount   = "source.serviceAccount"               // e.g. "default/productpage".
+	attrSrcPrincipal        = "source.principal"                    // source identity, e,g, "cluster.local/ns/default/sa/productpage".
+	attrRequestPrincipal    = "request.auth.principal"              // authenticated principal of the request.
+	attrRequestAudiences    = "request.auth.audiences"              // intended audience(s) for this authentication information.
+	attrRequestPresenter    = "request.auth.presenter"              // authorized presenter of the credential.
+	attrRequestClaims       = "request.auth.claims"                 // claim name is surrounded by brackets, e.g. "request.auth.claims[iss]".
+	attrDestIP              = "destination.ip"                      // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
+	attrDestPort            = "destination.port"                    // must be in the range [0, 65535].
+	attrConnSNI             = "connection.sni"                      // server name indication, e.g. "www.example.com".
+	attrEnvoyFilter         = "experimental.envoy.filters."         // an experimental attribute for checking Envoy Metadata directly.
 
 	// Internal names used to generate corresponding Envoy matcher.
 	methodHeader = ":method"
@@ -111,6 +112,8 @@ func New(policyName types.NamespacedName, r *authzpb.Rule) (*Model, error) {
 			basePrincipal.appendLastExtended(requestPresenterGenerator{}, k, when.Values, when.NotValues)
 		case strings.HasPrefix(k, attrRequestHeader):
 			basePrincipal.appendLast(requestHeaderGenerator{}, k, when.Values, when.NotValues)
+		case strings.HasPrefix(k, attrRequestInlineHeader):
+			basePrincipal.appendLast(requestInlineHeaderGenerator{}, k, when.Values, when.NotValues)
 		case strings.HasPrefix(k, attrRequestClaims):
 			basePrincipal.appendLastExtended(requestClaimGenerator{}, k, when.Values, when.NotValues)
 		default:

--- a/pkg/config/security/security.go
+++ b/pkg/config/security/security.go
@@ -40,24 +40,25 @@ type JwksInfo struct {
 
 const (
 	attrRequestHeader       = "request.headers"                     // header name is surrounded by brackets, e.g. "request.headers[User-Agent]".
-	attrRequestInlineHeader = "request.experimental.inline.headers" // header name is surrounded by brackets, e.g. "request.experimental.inline.headers[User-Agent]".
-	attrSrcIP               = "source.ip"                           // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
-	attrRemoteIP            = "remote.ip"                           // original client ip determined from x-forwarded-for or proxy protocol.
-	attrSrcNamespace        = "source.namespace"                    // e.g. "default".
-	attrSrcServiceAccount   = "source.serviceAccount"               // e.g. "default/productpage".
-	attrSrcPrincipal        = "source.principal"                    // source identity, e,g, "cluster.local/ns/default/sa/productpage".
-	attrRequestPrincipal    = "request.auth.principal"              // authenticated principal of the request.
-	attrRequestAudiences    = "request.auth.audiences"              // intended audience(s) for this authentication information.
-	attrRequestPresenter    = "request.auth.presenter"              // authorized presenter of the credential.
-	attrRequestClaims       = "request.auth.claims"                 // claim name is surrounded by brackets, e.g. "request.auth.claims[iss]".
-	attrDestIP              = "destination.ip"                      // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
-	attrDestPort            = "destination.port"                    // must be in the range [0, 65535].
-	attrDestLabel           = "destination.labels"                  // label name is surrounded by brackets, e.g. "destination.labels[version]".
-	attrDestName            = "destination.name"                    // short service name, e.g. "productpage".
-	attrDestNamespace       = "destination.namespace"               // e.g. "default".
-	attrDestUser            = "destination.user"                    // service account, e.g. "bookinfo-productpage".
-	attrConnSNI             = "connection.sni"                      // server name indication, e.g. "www.example.com".
-	attrExperimental        = "experimental.envoy.filters."
+	attrRequestInlineHeader = "request.experimental.inline.headers" // header name is surrounded by brackets,
+	// e.g. "request.experimental.inline.headers[User-Agent]".
+	attrSrcIP             = "source.ip"              // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
+	attrRemoteIP          = "remote.ip"              // original client ip determined from x-forwarded-for or proxy protocol.
+	attrSrcNamespace      = "source.namespace"       // e.g. "default".
+	attrSrcServiceAccount = "source.serviceAccount"  // e.g. "default/productpage".
+	attrSrcPrincipal      = "source.principal"       // source identity, e,g, "cluster.local/ns/default/sa/productpage".
+	attrRequestPrincipal  = "request.auth.principal" // authenticated principal of the request.
+	attrRequestAudiences  = "request.auth.audiences" // intended audience(s) for this authentication information.
+	attrRequestPresenter  = "request.auth.presenter" // authorized presenter of the credential.
+	attrRequestClaims     = "request.auth.claims"    // claim name is surrounded by brackets, e.g. "request.auth.claims[iss]".
+	attrDestIP            = "destination.ip"         // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
+	attrDestPort          = "destination.port"       // must be in the range [0, 65535].
+	attrDestLabel         = "destination.labels"     // label name is surrounded by brackets, e.g. "destination.labels[version]".
+	attrDestName          = "destination.name"       // short service name, e.g. "productpage".
+	attrDestNamespace     = "destination.namespace"  // e.g. "default".
+	attrDestUser          = "destination.user"       // service account, e.g. "bookinfo-productpage".
+	attrConnSNI           = "connection.sni"         // server name indication, e.g. "www.example.com".
+	attrExperimental      = "experimental.envoy.filters."
 )
 
 var (

--- a/pkg/config/security/security.go
+++ b/pkg/config/security/security.go
@@ -39,24 +39,25 @@ type JwksInfo struct {
 }
 
 const (
-	attrRequestHeader     = "request.headers"        // header name is surrounded by brackets, e.g. "request.headers[User-Agent]".
-	attrSrcIP             = "source.ip"              // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
-	attrRemoteIP          = "remote.ip"              // original client ip determined from x-forwarded-for or proxy protocol.
-	attrSrcNamespace      = "source.namespace"       // e.g. "default".
-	attrSrcServiceAccount = "source.serviceAccount"  // e.g. "default/productpage".
-	attrSrcPrincipal      = "source.principal"       // source identity, e,g, "cluster.local/ns/default/sa/productpage".
-	attrRequestPrincipal  = "request.auth.principal" // authenticated principal of the request.
-	attrRequestAudiences  = "request.auth.audiences" // intended audience(s) for this authentication information.
-	attrRequestPresenter  = "request.auth.presenter" // authorized presenter of the credential.
-	attrRequestClaims     = "request.auth.claims"    // claim name is surrounded by brackets, e.g. "request.auth.claims[iss]".
-	attrDestIP            = "destination.ip"         // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
-	attrDestPort          = "destination.port"       // must be in the range [0, 65535].
-	attrDestLabel         = "destination.labels"     // label name is surrounded by brackets, e.g. "destination.labels[version]".
-	attrDestName          = "destination.name"       // short service name, e.g. "productpage".
-	attrDestNamespace     = "destination.namespace"  // e.g. "default".
-	attrDestUser          = "destination.user"       // service account, e.g. "bookinfo-productpage".
-	attrConnSNI           = "connection.sni"         // server name indication, e.g. "www.example.com".
-	attrExperimental      = "experimental.envoy.filters."
+	attrRequestHeader       = "request.headers"                     // header name is surrounded by brackets, e.g. "request.headers[User-Agent]".
+	attrRequestInlineHeader = "request.experimental.inline.headers" // header name is surrounded by brackets, e.g. "request.experimental.inline.headers[User-Agent]".
+	attrSrcIP               = "source.ip"                           // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
+	attrRemoteIP            = "remote.ip"                           // original client ip determined from x-forwarded-for or proxy protocol.
+	attrSrcNamespace        = "source.namespace"                    // e.g. "default".
+	attrSrcServiceAccount   = "source.serviceAccount"               // e.g. "default/productpage".
+	attrSrcPrincipal        = "source.principal"                    // source identity, e,g, "cluster.local/ns/default/sa/productpage".
+	attrRequestPrincipal    = "request.auth.principal"              // authenticated principal of the request.
+	attrRequestAudiences    = "request.auth.audiences"              // intended audience(s) for this authentication information.
+	attrRequestPresenter    = "request.auth.presenter"              // authorized presenter of the credential.
+	attrRequestClaims       = "request.auth.claims"                 // claim name is surrounded by brackets, e.g. "request.auth.claims[iss]".
+	attrDestIP              = "destination.ip"                      // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
+	attrDestPort            = "destination.port"                    // must be in the range [0, 65535].
+	attrDestLabel           = "destination.labels"                  // label name is surrounded by brackets, e.g. "destination.labels[version]".
+	attrDestName            = "destination.name"                    // short service name, e.g. "productpage".
+	attrDestNamespace       = "destination.namespace"               // e.g. "default".
+	attrDestUser            = "destination.user"                    // service account, e.g. "bookinfo-productpage".
+	attrConnSNI             = "connection.sni"                      // server name indication, e.g. "www.example.com".
+	attrExperimental        = "experimental.envoy.filters."
 )
 
 var (
@@ -202,6 +203,8 @@ func ValidateAttribute(key string, values []string) error {
 	}
 	switch {
 	case hasPrefix(key, attrRequestHeader):
+		return validateMapKey(key)
+	case hasPrefix(key, attrRequestInlineHeader):
 		return validateMapKey(key)
 	case isEqual(key, attrSrcIP):
 		return ValidateIPs(values)

--- a/pkg/config/security/security_test.go
+++ b/pkg/config/security/security_test.go
@@ -100,11 +100,25 @@ func TestValidateCondition(t *testing.T) {
 			wantError: true,
 		},
 		{
+			key:       "request.experimental.inline.headers[:authority]",
+			values:    []string{"productpage", ""},
+			wantError: true,
+		},
+		{
 			key:    "request.headers[:authority]",
 			values: []string{"productpage"},
 		},
 		{
+			key:    "request.experimental.inline.headers[:authority]",
+			values: []string{"productpage"},
+		},
+		{
 			key:       "request.headers[]",
+			values:    []string{"productpage"},
+			wantError: true,
+		},
+		{
+			key:       "request.experimental.inline.headers[]",
 			values:    []string{"productpage"},
 			wantError: true,
 		},

--- a/releasenotes/notes/support-inline-header-authz.yaml
+++ b/releasenotes/notes/support-inline-header-authz.yaml
@@ -7,7 +7,7 @@ issue:
 
 releaseNotes:
   - |
-    **Support** inline multi-values header format by using safe regex in AuthorizationPolicy.Condition header match.
+    **Added** inline multi-values header matching by using safe regex in AuthorizationPolicy.Condition header match.
 # upgradeNotes is a markdown listing of any changes that will affect the upgrade
 # process. This will appear in the release notes.
 upgradeNotes:
@@ -22,13 +22,8 @@ upgradeNotes:
 
 # securityNotes is a markdown listing of any changes related to the security of
 # Istio.
-securityNotes: |
-  This change supports a new attribute `request.experimental.inline.headers[X-inline-header]` in Authorization Policy, which uses safe regex
-  match to split the header values concatenated by commas when matching. Before this change, the AuthorizationPolicy does not support matching on
-  multiple-valued headers.
-  For example, given an allow policy `Allow{header: x-foo, value: [a, b]}`, the request with inline header `{key: x-foo value: "a,b,c"}` will be allowed
-  when using `request.experimental.inline.headers[X-inline-header]`, while this is not allowed when using `request.headers[X-inline-header]`.
-  Note that this new attribute also supports prefix match, suffix match and present match for per header value.
-  
-  When this attribute is used, you need to make sure the request being checked by this AuthorizationPolicy does following the inline header definition as per as per RFC7230, that inline headers treat headers
-  with multiple inline values as a comma-delimited string. Otherwise, you shouldn't use this attribute.
+securityNotes:
+  - |
+    When this attribute is used, you need to make sure the request being checked by this AuthorizationPolicy does following the inline
+    header definition as per as per RFC7230, that inline headers treat headers with multiple inline values as a comma-delimited string.
+    Otherwise, you shouldn't use this attribute as the AuthorizationPolicy might not match the wanted header value as expected.

--- a/releasenotes/notes/support-inline-header-authz.yaml
+++ b/releasenotes/notes/support-inline-header-authz.yaml
@@ -1,0 +1,34 @@
+apiVersion: release-notes/v2
+
+kind: feature
+area: security
+issue:
+  - 39680
+
+releaseNotes:
+  - |
+    **Support** inline multi-values header format by using safe regex in AuthorizationPolicy.Condition header match.
+# upgradeNotes is a markdown listing of any changes that will affect the upgrade
+# process. This will appear in the release notes.
+upgradeNotes:
+  - title: Support Inline Multi-values Header Match in Authz
+    content: |
+      This change supports a new attribute `request.experimental.inline.headers[X-inline-header]` in Authorization Policy, which uses safe regex
+      match to split the header values concatenated by commas when matching. Before this change, the AuthorizationPolicy does not support matching on
+      multiple-valued headers.
+      For example, given an allow policy `Allow{header: x-foo, value: [a, b]}`, the request with inline header `{key: x-foo value: "a,b,c"}` will be allowed
+      when using `request.experimental.inline.headers[X-inline-header]`, while this is not allowed when using `request.headers[X-inline-header]`.
+      Note that this new attribute also supports prefix match, suffix match and present match for per header value.
+
+# securityNotes is a markdown listing of any changes related to the security of
+# Istio.
+securityNotes: |
+  This change supports a new attribute `request.experimental.inline.headers[X-inline-header]` in Authorization Policy, which uses safe regex
+  match to split the header values concatenated by commas when matching. Before this change, the AuthorizationPolicy does not support matching on
+  multiple-valued headers.
+  For example, given an allow policy `Allow{header: x-foo, value: [a, b]}`, the request with inline header `{key: x-foo value: "a,b,c"}` will be allowed
+  when using `request.experimental.inline.headers[X-inline-header]`, while this is not allowed when using `request.headers[X-inline-header]`.
+  Note that this new attribute also supports prefix match, suffix match and present match for per header value.
+  
+  When this attribute is used, you need to make sure the request being checked by this AuthorizationPolicy does following the inline header definition as per as per RFC7230, that inline headers treat headers
+  with multiple inline values as a comma-delimited string. Otherwise, you shouldn't use this attribute.


### PR DESCRIPTION
**Please provide a description of this PR:**

This is the PR to revive https://github.com/istio/istio/pull/40499 and add the inline header support as a separate experimental attribute from the normal header.

Fix issue: https://github.com/istio/istio/issues/39680 & https://github.com/istio/istio/issues/55660
This PR adds support in Authorization Policy to recognize inline multi-values header format by using safe regex match.

For example:
given the allow policy for header `{ header: x-foo, value: [a, b]}` the request with header `{key: x-foo value: "a,b,c"}` will be allowed when using this new attribute. Before this fix, this is not allowed by the normal header attribute in authz.