### PR TITLE
Make tolerations in ztunnel configurable via helm values

### DIFF
--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -48,13 +48,10 @@ spec:
 {{ toYaml .Values.affinity | trim | indent 8 }}
 {{- end }}
       serviceAccountName: {{ include "ztunnel.release-name" . }}
+{{- if .Values.tolerations }}
       tolerations:
-        - effect: NoSchedule
-          operator: Exists
-        - key: CriticalAddonsOnly
-          operator: Exists
-        - effect: NoExecute
-          operator: Exists
+{{ toYaml .Values.tolerations | trim | indent 8 }}
+{{- end }}
       containers:
       - name: istio-proxy
 {{- if contains "/" .Values.image }}

--- a/manifests/charts/ztunnel/values.yaml
+++ b/manifests/charts/ztunnel/values.yaml
@@ -32,6 +32,15 @@ _internal_defaults_do_not_set:
 
   # Additional volumes to the ztunnel pod
   volumes: []
+  
+  # Tolerations for the ztunnel pod
+  tolerations:
+    - effect: NoSchedule
+      operator: Exists
+    - key: CriticalAddonsOnly
+      operator: Exists
+    - effect: NoExecute
+      operator: Exists
 
   # Annotations added to each pod. The default annotations are required for scraping prometheus (in most environments).
   podAnnotations:

--- a/operator/cmd/mesh/testdata/manifest-generate/input/ztunnel_tolerations.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/input/ztunnel_tolerations.yaml
@@ -1,0 +1,21 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  name: istio-operator
+spec:
+  profile: ambient
+  components:
+    ztunnel:
+      enabled: true
+      k8s:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+          limits:
+            cpu: 200m
+            memory: 200Mi
+        tolerations:
+        - key: "example-key"
+          operator: "Exists"
+          effect: "NoSchedule"

--- a/releasenotes/notes/56091.yaml
+++ b/releasenotes/notes/56091.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue:
+  - 56086
+
+releaseNotes:
+  - |
+    **Added** ztunnel tolerations are now configurable via helm


### PR DESCRIPTION
**Please provide a description of this PR:**

Make tolerations in ztunnel configurable via helm values.

Addresses the following enhancement request: https://github.com/istio/istio/issues/56086