### PR TITLE
Read configmaps from remote clusters

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/reader-clusterrole.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/reader-clusterrole.yaml
@@ -20,7 +20,9 @@ rules:
     resources: ["*"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
-    resources: ["endpoints", "pods", "services", "nodes", "replicationcontrollers", "namespaces", "secrets"]
+    # TODO(keithmattix): See if we can conditionally give permission to read secrets and configmaps iff externalIstiod
+    # is enabled. Best I can tell, these two resources are only needed for configuring proxy TLS (i.e. CA certs).
+    resources: ["endpoints", "pods", "services", "nodes", "replicationcontrollers", "namespaces", "secrets", "configmaps"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["networking.istio.io"]
     verbs: [ "get", "watch", "list" ]


### PR DESCRIPTION
**Please provide a description of this PR:**
Fixes istio/istio.io#16427 - after #55545 istiod reads configmaps from remote clusters in order to pass public CA chains to proxies in remote clusters (based on configuration like DR or BackendTLSPolicy). This also appears to be why we need to read secrets. Best I can tell, the only valid scenario for this is when `externalIstiod` is true and istiod is programming proxies for multiple clusters. Thus, I believe that we could probably conditionally add these permissions to the reader clusterrole based on if that flag is true. However, that's a bigger change, so I'll rely on folks like @hzxuzhonghu @ramaraochavali and @stevenctl to confirm my findings before moving forward with it. In the meantime, to unblock the 1.26 release and re-enable the docs tests, we'll just add configmap reading to the clusterrole permissions.

**UPDATE** - looks like the fact that we set EXTERNAL_ISTIOD in the multicluster integration tests means we need to read configmaps for the namespace controller as well (to copy the ca configmap to every namespace). We never catch this in our tests because we don't test secret syncing the way that the docs tests do; istiod eventually gets ready even though a cluster is unsynced. If the docs tests had EXTERNAL_ISTIOD set to true, we would've seen failures two years ago.