### PR TITLE
integration tests: remove Config.Values

### DIFF
--- a/pkg/test/framework/components/istio/eastwest.go
+++ b/pkg/test/framework/components/istio/eastwest.go
@@ -86,11 +86,6 @@ func (i *istioImpl) deployEastWestGateway(cluster cluster.Cluster, revision stri
 		setArgs = append(setArgs, "values.global.istioNamespace="+i.cfg.SystemNamespace)
 	}
 
-	// Include all user-specified values.
-	for k, v := range i.cfg.Values {
-		setArgs = append(setArgs, fmt.Sprintf("values.%s=%s", k, v))
-	}
-
 	for k, v := range i.cfg.OperatorOptions {
 		setArgs = append(setArgs, fmt.Sprintf("%s=%s", k, v))
 	}

--- a/pkg/test/framework/components/istio/flags.go
+++ b/pkg/test/framework/components/istio/flags.go
@@ -29,7 +29,8 @@ func init() {
 	flag.StringVar(&settingsFromCommandline.PrimaryClusterIOPFile, "istio.test.kube.helm.iopFile", settingsFromCommandline.PrimaryClusterIOPFile,
 		"IstioOperator spec file. This can be an absolute path or relative to repository root.")
 	flag.StringVar(&helmValues, "istio.test.kube.helm.values", helmValues,
-		"Manual overrides for Helm values file. Only valid when deploying Istio.")
+		`DEPRECATED: Use istio.test.kube.helm.iopFile or istio.test.istio.operatorOptions instead.
+		Manual overrides for Helm values file. Only valid when deploying Istio.`)
 	flag.BoolVar(&settingsFromCommandline.DeployEastWestGW, "istio.test.kube.deployEastWestGW", settingsFromCommandline.DeployEastWestGW,
 		"Deploy Istio east west gateway into the target Kubernetes environment.")
 	flag.BoolVar(&settingsFromCommandline.DumpKubernetesManifests, "istio.test.istio.dumpManifests", settingsFromCommandline.DumpKubernetesManifests,

--- a/pkg/test/framework/components/istio/kube.go
+++ b/pkg/test/framework/components/istio/kube.go
@@ -615,11 +615,6 @@ func commonInstallArgs(ctx resource.Context, cfg Config, c cluster.Cluster, defa
 		args.AppendSet("values.gateways.istio-egressgateway.ipFamilyPolicy", string(corev1.IPFamilyPolicyRequireDualStack))
 	}
 
-	// Include all user-specified values.
-	for k, v := range cfg.Values {
-		args.AppendSet("values."+k, v)
-	}
-
 	for k, v := range cfg.OperatorOptions {
 		args.AppendSet(k, v)
 	}

--- a/tests/integration/pilot/multiplecontrolplanes/main_test.go
+++ b/tests/integration/pilot/multiplecontrolplanes/main_test.go
@@ -73,7 +73,6 @@ func TestMain(m *testing.M) {
 			s.SkipWorkloadClasses = append(s.SkipWorkloadClasses, echo.VM)
 			s.DisableDefaultExternalServiceConnectivity = true
 
-			cfg.Values["global.istioNamespace"] = userGroup1NS.Name()
 			cfg.SystemNamespace = userGroup1NS.Name()
 			cfg.ControlPlaneValues = fmt.Sprintf(`
 namespace: %s
@@ -96,7 +95,6 @@ values:
 			// TODO test framework has to be enhanced to use istioNamespace in istioctl commands used for VM config
 			s.SkipWorkloadClasses = append(s.SkipWorkloadClasses, echo.VM)
 
-			cfg.Values["global.istioNamespace"] = userGroup2NS.Name()
 			cfg.SystemNamespace = userGroup2NS.Name()
 			cfg.ControlPlaneValues = fmt.Sprintf(`
 namespace: %s

--- a/tests/integration/telemetry/api/setup_test.go
+++ b/tests/integration/telemetry/api/setup_test.go
@@ -80,6 +80,9 @@ func setupConfig(_ resource.Context, cfg *istio.Config) {
 	}
 	cfg.ControlPlaneValues = `
 values:
+  global:
+    logging:
+      level: "xdsproxy:debug,wasm:debug"
   pilot:
     env:
       PILOT_MX_ADDITIONAL_LABELS: "custom-label"
@@ -93,7 +96,6 @@ meshConfig:
         text: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %FILTER_STATE(upstream_peer)% %FILTER_STATE(downstream_peer)%\n"
 `
 	cfg.RemoteClusterValues = cfg.ControlPlaneValues
-	cfg.Values["global.logging.level"] = "xdsproxy:debug,wasm:debug"
 }
 
 // SetupSuite set up echo app for stats testing.

--- a/tests/integration/telemetry/tracing/zipkin/main_test.go
+++ b/tests/integration/telemetry/tracing/zipkin/main_test.go
@@ -39,7 +39,13 @@ func setupConfig(ctx resource.Context, cfg *istio.Config) {
 	if cfg == nil {
 		return
 	}
-	cfg.Values["meshConfig.enableTracing"] = "true"
-	cfg.Values["pilot.traceSampling"] = "100.0"
-	cfg.Values["global.proxy.tracer"] = "zipkin"
+	cfg.ControlPlaneValues = `
+values:
+  global:
+    proxy:
+      tracer: zipkin
+  pilot:
+    traceSampling: 100.0
+  meshConfig:
+    enableTracing: true`
 }


### PR DESCRIPTION
You can set any value with `ControlPlaneValues` or `OperatorOptions` already.

**Please provide a description of this PR:**