### PR TITLE
revert ambient: disable accidental EnvoyFilter implementation

### DIFF
--- a/pilot/pkg/model/envoyfilter.go
+++ b/pilot/pkg/model/envoyfilter.go
@@ -22,7 +22,6 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	networking "istio.io/api/networking/v1alpha3"
-	"istio.io/api/type/v1beta1"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
@@ -40,31 +39,6 @@ type EnvoyFilterWrapper struct {
 	Patches                      map[networking.EnvoyFilter_ApplyTo][]*EnvoyFilterConfigPatchWrapper
 	Priority                     int32
 	creationTime                 time.Time
-
-	fullSpec *networking.EnvoyFilter
-}
-
-var _ TargetablePolicy = &EnvoyFilterWrapper{}
-
-func (efw *EnvoyFilterWrapper) GetTargetRef() *v1beta1.PolicyTargetReference {
-	// This API never had this legacy field
-	return nil
-}
-
-func (efw *EnvoyFilterWrapper) GetTargetRefs() []*v1beta1.PolicyTargetReference {
-	if efw.fullSpec == nil {
-		return nil
-	}
-	return efw.fullSpec.TargetRefs
-}
-
-func (efw *EnvoyFilterWrapper) GetSelector() *v1beta1.WorkloadSelector {
-	if efw.workloadSelector != nil {
-		return &v1beta1.WorkloadSelector{
-			MatchLabels: efw.workloadSelector,
-		}
-	}
-	return nil
 }
 
 // EnvoyFilterConfigPatchWrapper is a wrapper over the EnvoyFilter ConfigPatch api object
@@ -113,7 +87,6 @@ func convertToEnvoyFilterWrapper(local *config.Config) *EnvoyFilterWrapper {
 		Patches:                      nil,
 		Priority:                     localEnvoyFilter.Priority,
 		creationTime:                 local.CreationTimestamp,
-		fullSpec:                     localEnvoyFilter,
 	}
 	if localEnvoyFilter.WorkloadSelector != nil {
 		out.workloadSelector = localEnvoyFilter.WorkloadSelector.Labels

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -2331,11 +2331,6 @@ func (ps *PushContext) EnvoyFilters(proxy *Proxy) *MergedEnvoyFilterWrapper {
 func (ps *PushContext) getMatchedEnvoyFilters(proxy *Proxy, namespaces string) []*EnvoyFilterWrapper {
 	matchedEnvoyFilters := make([]*EnvoyFilterWrapper, 0)
 	for _, efw := range ps.envoyFiltersByNamespace[namespaces] {
-		if efw.GetTargetRefs() != nil {
-			// These are meant for a specific target, so we shouldn't treat these as "always match"
-			// In the future, targetRef for EnvoyFilter will likely be implemented -- but currently these would never match
-			continue
-		}
 		if efw.workloadSelector == nil || efw.workloadSelector.SubsetOf(proxy.Labels) {
 			matchedEnvoyFilters = append(matchedEnvoyFilters, efw)
 		}

--- a/pilot/pkg/networking/core/cluster.go
+++ b/pilot/pkg/networking/core/cluster.go
@@ -240,14 +240,16 @@ func (configgen *ConfigGeneratorImpl) buildClusters(proxy *model.Proxy, req *mod
 	case model.Waypoint:
 		_, wps := findWaypointResources(proxy, req.Push)
 		// Waypoint proxies do not need outbound clusters in most cases, unless we have a route pointing to something
-		emptyPatcher := clusterPatcher{} // EnvoyFilter is not implemented for waypoints
+		outboundPatcher := clusterPatcher{efw: envoyFilterPatches, pctx: networking.EnvoyFilter_SIDECAR_OUTBOUND}
 		extraNamespacedHosts, extraHosts := req.Push.ExtraWaypointServices(proxy, envoyFilterPatches)
-		ob, cs := configgen.buildOutboundClusters(cb, proxy, emptyPatcher, filterWaypointOutboundServices(
+		ob, cs := configgen.buildOutboundClusters(cb, proxy, outboundPatcher, filterWaypointOutboundServices(
 			req.Push.ServicesAttachedToMesh(), wps.services, extraNamespacedHosts, extraHosts, services))
 		cacheStats = cacheStats.merge(cs)
 		resources = append(resources, ob...)
 		// Setup inbound clusters
+		inboundPatcher := clusterPatcher{efw: envoyFilterPatches, pctx: networking.EnvoyFilter_SIDECAR_INBOUND}
 		clusters = append(clusters, configgen.buildWaypointInboundClusters(cb, proxy, req.Push, wps.services)...)
+		clusters = append(clusters, inboundPatcher.insertedClusters()...)
 	default: // Gateways
 		patcher := clusterPatcher{efw: envoyFilterPatches, pctx: networking.EnvoyFilter_GATEWAY}
 		ob, cs := configgen.buildOutboundClusters(cb, proxy, patcher, services)

--- a/pilot/pkg/networking/core/httproute.go
+++ b/pilot/pkg/networking/core/httproute.go
@@ -129,10 +129,8 @@ func buildSidecarInboundHTTPRouteConfig(lb *ListenerBuilder, cc inboundChainConf
 		VirtualHosts:     []*route.VirtualHost{inboundVHost},
 		ValidateClusters: proto.BoolFalse,
 	}
-	if !lb.node.IsWaypointProxy() {
-		efw := lb.push.EnvoyFilters(lb.node)
-		r = envoyfilter.ApplyRouteConfigurationPatches(networking.EnvoyFilter_SIDECAR_INBOUND, lb.node, efw, r)
-	}
+	efw := lb.push.EnvoyFilters(lb.node)
+	r = envoyfilter.ApplyRouteConfigurationPatches(networking.EnvoyFilter_SIDECAR_INBOUND, lb.node, efw, r)
 	return r
 }
 
@@ -203,9 +201,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(
 	}
 
 	// apply envoy filter patches
-	if !node.IsWaypointProxy() {
-		out = envoyfilter.ApplyRouteConfigurationPatches(networking.EnvoyFilter_SIDECAR_OUTBOUND, node, efw, out)
-	}
+	out = envoyfilter.ApplyRouteConfigurationPatches(networking.EnvoyFilter_SIDECAR_OUTBOUND, node, efw, out)
 
 	resource = &discovery.Resource{
 		Name:     out.Name,

--- a/pilot/pkg/networking/core/listener_builder.go
+++ b/pilot/pkg/networking/core/listener_builder.go
@@ -171,10 +171,6 @@ func (lb *ListenerBuilder) patchOneListener(l *listener.Listener, ctx networking
 }
 
 func (lb *ListenerBuilder) patchListeners() {
-	if lb.node.IsWaypointProxy() {
-		// EnvoyFilter is not implemented for waypoints
-		return
-	}
 	lb.envoyFilterWrapper = lb.push.EnvoyFilters(lb.node)
 	if lb.envoyFilterWrapper == nil {
 		return

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -675,12 +675,11 @@ spec:
 `).ApplyOrFail(t)
 			opt.Count = 5
 			opt.Timeout = time.Second * 10
-			// Test that we do NOT apply this envoyfilter, since EnvoyFilter is not implemented for waypoints
 			opt.Check = check.And(
 				check.OK(),
 				check.RequestHeaders(map[string]string{
-					"X-Lua-Inbound":   "",
-					"X-Vhost-Inbound": "",
+					"X-Lua-Inbound":   "hello world",
+					"X-Vhost-Inbound": "hello world",
 				}))
 			src.CallOrFail(t, opt)
 		})


### PR DESCRIPTION
**Please provide a description of this PR:**

this revert #55149 to prvent break end users, because https://github.com/istio/api/pull/3442 didn't land in `v1.26`.

**https://github.com/istio/api/pull/3442 still the future plan**


cc @therealmitchconnors @howardjohn  @hzxuzhonghu @keithmattix @linsun @vikaschoudhary16 