### PR TITLE
support for customizing securityContext of the istiod deployment via Helm [closed& raised new PR]

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -88,6 +88,10 @@ spec:
       initContainers:
         {{- tpl (toYaml .) $ | nindent 8 }}
 {{- end }}
+{{- if .Values.securityContext }}
+      securityContext:
+{{- toYaml .Values.securityContext | nindent 8 }}
+{{- end}}
       containers:
         - name: discovery
 {{- if contains "/" .Values.image }}
@@ -217,6 +221,9 @@ spec:
 {{ toYaml .Values.global.defaultResources | trim | indent 12 }}
 {{- end }}
           securityContext:
+{{- if .Values.containerSecurityContext }}
+{{- toYaml .Values.containerSecurityContext | nindent 12 }}
+{{- else }}
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true
@@ -226,6 +233,7 @@ spec:
 {{- if .Values.seccompProfile }}
             seccompProfile:
 {{ toYaml .Values.seccompProfile | trim | indent 14 }}
+{{- end }}
 {{- end }}
           volumeMounts:
           - name: istio-token

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -23,7 +23,12 @@ _internal_defaults_do_not_set:
       cpu: 500m
       memory: 2048Mi
 
-  # Set to `type: RuntimeDefault` to use the default profile if available.
+  # Define the security context for the pod.
+  # If unset, this will be automatically set to default in the deployment, if you wish to not define it you can still configure `seccompProfile: {}` for the container below.
+  securityContext: {}
+  containerSecurityContext: {}
+
+  # Set to `type: RuntimeDefault` to use the default profile if available, do not set if you are setting whole `containerSecurityContext`.
   seccompProfile: {}
 
   # Whether to use an existing CNI installation


### PR DESCRIPTION
This change introduces two new optional fields in the Helm chart:

    1) securityContext: applies to the pod-level securityContext

    2) containerSecurityContext: applies to the istiod container's securityContext

By default, Istiod does not allow set these fields explicitly (but it's available in istio gateway chart), which may lead to violations in environments enforcing strict pod security policies (e.g., PSA, Kyverno, OPA/Gatekeeper).

✅ Benefits
   1) Enables compliance with hardened security environments (runAsNonRoot, seccompProfile, runAsGroup, fsGroup etc.)

   2) Removes the need for patching or forking the Helm chart for basic security configuration

   3) Fully backward compatible; if unset, no behavior is changed

   4) These additions provide flexibility for platform teams to enforce security baselines without manual post-install patching.



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [X] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [X] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [X] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions