### PR TITLE
telemetry: computedLoggingConfig cached should be versioned

### DIFF
--- a/pilot/pkg/model/telemetry.go
+++ b/pilot/pkg/model/telemetry.go
@@ -93,6 +93,7 @@ type loggingKey struct {
 	telemetryKey
 	Class    networking.ListenerClass
 	Protocol networking.ListenerProtocol
+	Version  string
 }
 
 // metricsKey defines a key into the computedMetricsFilters cache.
@@ -248,6 +249,7 @@ func (t *Telemetries) AccessLogging(push *PushContext, proxy *Proxy, class netwo
 	key := loggingKey{
 		telemetryKey: ct.telemetryKey,
 		Class:        class,
+		Version:      proxy.GetIstioVersion(),
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()


### PR DESCRIPTION
**Please provide a description of this PR:**

follow up: https://github.com/istio/istio/pull/56041

without this, we may send accesslog config of v1.26 to a v1.25 sidecar with same telemetry configs