### PR TITLE
Add terminationGracePeriodSeconds to gateway injection template

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
@@ -23,6 +23,22 @@ spec:
     - name: net.ipv4.ip_unprivileged_port_start
       value: "0"
   {{- end }}
+  {{ - if .Values.gateways.affinity }}
+  affinity:
+  {{ - toYaml .Values.gateways.affinity | nindent 8 }}
+  {{ - end } }
+  {{ - if .Values.gateways.topologySpreadConstraints }}
+  topologySpreadConstraints:
+  {{ - toYaml .Values.gateways.topologySpreadConstraints | nindent 8 }}
+  {{ - end } }
+  {{ - if .Values.gateways.nodeSelector }}
+  nodeSelector:
+  {{ - toYaml .Values.gateways.nodeSelector | nindent 8 }}
+  {{ - end } }
+  {{ - if .Values.gateways.tolerations } }
+  tolerations:
+  {{ - toYaml .Values.gateways.tolerations | nindent 8 }}
+  {{ - end }}
   {{- if .Values.gateways.terminationGracePeriodSeconds }}
   terminationGracePeriodSeconds: {{ .Values.gateways.terminationGracePeriodSeconds }}
   {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
@@ -23,24 +23,24 @@ spec:
     - name: net.ipv4.ip_unprivileged_port_start
       value: "0"
   {{- end }}
-  {{- if .Values.gateways.affinity }}
+  {{- if .Values.global.gateway.affinity }}
   affinity:
-  {{- toYaml .Values.gateways.affinity | nindent 8 }}
+  {{- toYaml .Values.global.gateway.affinity | nindent 8 }}
   {{- end }}
-  {{- if .Values.gateways.topologySpreadConstraints }}
+  {{- if .Values.global.gateway.topologySpreadConstraints }}
   topologySpreadConstraints:
-  {{- toYaml .Values.gateways.topologySpreadConstraints | nindent 8 }}
+  {{- toYaml .Values.global.gateway.topologySpreadConstraints | nindent 8 }}
   {{- end }}
-  {{- if .Values.gateways.nodeSelector }}
+  {{- if .Values.global.gateway.nodeSelector }}
   nodeSelector:
-  {{- toYaml .Values.gateways.nodeSelector | nindent 8 }}
+  {{- toYaml .Values.global.gateway.nodeSelector | nindent 8 }}
   {{- end }}
-  {{- if .Values.gateways.tolerations }}
+  {{- if .Values.global.gateway.tolerations }}
   tolerations:
-  {{- toYaml .Values.gateways.tolerations | nindent 8 }}
+  {{- toYaml .Values.global.gateway.tolerations | nindent 8 }}
   {{- end }}
-  {{- if .Values.gateways.terminationGracePeriodSeconds }}
-  terminationGracePeriodSeconds: {{ .Values.gateways.terminationGracePeriodSeconds }}
+  {{- if .Values.global.gateway.terminationGracePeriodSeconds }}
+  terminationGracePeriodSeconds: {{ .Values.global.gateway.terminationGracePeriodSeconds }}
   {{- end }}
   containers:
   - name: istio-proxy

--- a/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
@@ -23,8 +23,8 @@ spec:
     - name: net.ipv4.ip_unprivileged_port_start
       value: "0"
   {{- end }}
-  {{- if .Values.global.proxy.terminationGracePeriodSeconds }}
-  terminationGracePeriodSeconds: {{ .Values.global.proxy.terminationGracePeriodSeconds }}
+  {{- if .Values.gateways.terminationGracePeriodSeconds }}
+  terminationGracePeriodSeconds: {{ .Values.gateways.terminationGracePeriodSeconds }}
   {{- end }}
   containers:
   - name: istio-proxy

--- a/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
@@ -23,6 +23,7 @@ spec:
     - name: net.ipv4.ip_unprivileged_port_start
       value: "0"
   {{- end }}
+  terminationGracePeriodSeconds: {{ .Values.global.proxy.terminationGracePeriodSeconds }}
   containers:
   - name: istio-proxy
   {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}

--- a/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
@@ -23,7 +23,9 @@ spec:
     - name: net.ipv4.ip_unprivileged_port_start
       value: "0"
   {{- end }}
+  {{- if .Values.global.proxy.terminationGracePeriodSeconds }}
   terminationGracePeriodSeconds: {{ .Values.global.proxy.terminationGracePeriodSeconds }}
+  {{- end }}
   containers:
   - name: istio-proxy
   {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}

--- a/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
@@ -23,22 +23,22 @@ spec:
     - name: net.ipv4.ip_unprivileged_port_start
       value: "0"
   {{- end }}
-  {{ - if .Values.gateways.affinity }}
+  {{- if .Values.gateways.affinity }}
   affinity:
-  {{ - toYaml .Values.gateways.affinity | nindent 8 }}
-  {{ - end }}
-  {{ - if .Values.gateways.topologySpreadConstraints }}
+  {{- toYaml .Values.gateways.affinity | nindent 8 }}
+  {{- end }}
+  {{- if .Values.gateways.topologySpreadConstraints }}
   topologySpreadConstraints:
-  {{ - toYaml .Values.gateways.topologySpreadConstraints | nindent 8 }}
-  {{ - end }}
-  {{ - if .Values.gateways.nodeSelector }}
+  {{- toYaml .Values.gateways.topologySpreadConstraints | nindent 8 }}
+  {{- end }}
+  {{- if .Values.gateways.nodeSelector }}
   nodeSelector:
-  {{ - toYaml .Values.gateways.nodeSelector | nindent 8 }}
-  {{ - end }}
-  {{ - if .Values.gateways.tolerations }}
+  {{- toYaml .Values.gateways.nodeSelector | nindent 8 }}
+  {{- end }}
+  {{- if .Values.gateways.tolerations }}
   tolerations:
-  {{ - toYaml .Values.gateways.tolerations | nindent 8 }}
-  {{ - end }}
+  {{- toYaml .Values.gateways.tolerations | nindent 8 }}
+  {{- end }}
   {{- if .Values.gateways.terminationGracePeriodSeconds }}
   terminationGracePeriodSeconds: {{ .Values.gateways.terminationGracePeriodSeconds }}
   {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
@@ -26,16 +26,16 @@ spec:
   {{ - if .Values.gateways.affinity }}
   affinity:
   {{ - toYaml .Values.gateways.affinity | nindent 8 }}
-  {{ - end } }
+  {{ - end }}
   {{ - if .Values.gateways.topologySpreadConstraints }}
   topologySpreadConstraints:
   {{ - toYaml .Values.gateways.topologySpreadConstraints | nindent 8 }}
-  {{ - end } }
+  {{ - end }}
   {{ - if .Values.gateways.nodeSelector }}
   nodeSelector:
   {{ - toYaml .Values.gateways.nodeSelector | nindent 8 }}
-  {{ - end } }
-  {{ - if .Values.gateways.tolerations } }
+  {{ - end }}
+  {{ - if .Values.gateways.tolerations }}
   tolerations:
   {{ - toYaml .Values.gateways.tolerations | nindent 8 }}
   {{ - end }}

--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -80,22 +80,22 @@ spec:
       {{- end }}
       {{- end }}
       serviceAccountName: {{.ServiceAccount | quote}}
-      { { - if .Values.gateways.affinity } }
+      {{ - if .Values.gateways.affinity }}
       affinity:
-      { { - toYaml .Values.gateways.affinity | nindent 8 } }
-      { { - end } }
-      { { - if .Values.gateways.topologySpreadConstraints } }
+      {{ - toYaml .Values.gateways.affinity | nindent 8 }}
+      {{ - end } }
+      {{ - if .Values.gateways.topologySpreadConstraints }}
       topologySpreadConstraints:
-      { { - toYaml .Values.gateways.topologySpreadConstraints | nindent 8 } }
-      { { - end } }
-      { { - if .Values.gateways.nodeSelector } }
+      {{ - toYaml .Values.gateways.topologySpreadConstraints | nindent 8 }}
+      {{ - end } }
+      {{ - if .Values.gateways.nodeSelector }}
       nodeSelector:
-      { { - toYaml .Values.gateways.nodeSelector | nindent 8 } }
-      { { - end } }
-      { { - if .Values.gateways.tolerations } }
+      {{ - toYaml .Values.gateways.nodeSelector | nindent 8 }}
+      {{ - end } }
+      {{ - if .Values.gateways.tolerations }}
       tolerations:
-      { { - toYaml .Values.gateways.tolerations | nindent 8 } }
-      { { - end } }
+      {{ - toYaml .Values.gateways.tolerations | nindent 8 }}
+      {{ - end }}
       {{- if .Values.gateways.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.gateways.terminationGracePeriodSeconds }}
       {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -83,15 +83,15 @@ spec:
       {{ - if .Values.gateways.affinity }}
       affinity:
       {{ - toYaml .Values.gateways.affinity | nindent 8 }}
-      {{ - end } }
+      {{ - end }}
       {{ - if .Values.gateways.topologySpreadConstraints }}
       topologySpreadConstraints:
       {{ - toYaml .Values.gateways.topologySpreadConstraints | nindent 8 }}
-      {{ - end } }
+      {{ - end }}
       {{ - if .Values.gateways.nodeSelector }}
       nodeSelector:
       {{ - toYaml .Values.gateways.nodeSelector | nindent 8 }}
-      {{ - end } }
+      {{ - end }}
       {{ - if .Values.gateways.tolerations }}
       tolerations:
       {{ - toYaml .Values.gateways.tolerations | nindent 8 }}

--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -80,8 +80,8 @@ spec:
       {{- end }}
       {{- end }}
       serviceAccountName: {{.ServiceAccount | quote}}
-      {{- if .Values.global.proxy.terminationGracePeriodSeconds }}
-      terminationGracePeriodSeconds: {{ .Values.global.proxy.terminationGracePeriodSeconds }}
+      {{- if .Values.gateways.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.gateways.terminationGracePeriodSeconds }}
       {{- end }}
       containers:
       - name: istio-proxy

--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -80,24 +80,24 @@ spec:
       {{- end }}
       {{- end }}
       serviceAccountName: {{.ServiceAccount | quote}}
-      {{- if .Values.gateways.affinity }}
+      {{- if .Values.global.gateway.affinity }}
       affinity:
-      {{- toYaml .Values.gateways.affinity | nindent 8 }}
+      {{- toYaml .Values.global.gateway.affinity | nindent 8 }}
       {{- end }}
-      {{- if .Values.gateways.topologySpreadConstraints }}
+      {{- if .Values.global.gateway.topologySpreadConstraints }}
       topologySpreadConstraints:
-      {{- toYaml .Values.gateways.topologySpreadConstraints | nindent 8 }}
+      {{- toYaml .Values.global.gateway.topologySpreadConstraints | nindent 8 }}
       {{- end }}
-      {{- if .Values.gateways.nodeSelector }}
+      {{- if .Values.global.gateway.nodeSelector }}
       nodeSelector:
-      {{- toYaml .Values.gateways.nodeSelector | nindent 8 }}
+      {{- toYaml .Values.global.gateway.nodeSelector | nindent 8 }}
       {{- end }}
-      {{- if .Values.gateways.tolerations }}
+      {{- if .Values.global.gateway.tolerations }}
       tolerations:
-      {{- toYaml .Values.gateways.tolerations | nindent 8 }}
+      {{- toYaml .Values.global.gateway.tolerations | nindent 8 }}
       {{- end }}
-      {{- if .Values.gateways.terminationGracePeriodSeconds }}
-      terminationGracePeriodSeconds: {{ .Values.gateways.terminationGracePeriodSeconds }}
+      {{- if .Values.global.gateway.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.global.gateway.terminationGracePeriodSeconds }}
       {{- end }}
       containers:
       - name: istio-proxy

--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -80,22 +80,22 @@ spec:
       {{- end }}
       {{- end }}
       serviceAccountName: {{.ServiceAccount | quote}}
-      {{ - if .Values.gateways.affinity }}
+      {{- if .Values.gateways.affinity }}
       affinity:
-      {{ - toYaml .Values.gateways.affinity | nindent 8 }}
-      {{ - end }}
-      {{ - if .Values.gateways.topologySpreadConstraints }}
+      {{- toYaml .Values.gateways.affinity | nindent 8 }}
+      {{- end }}
+      {{- if .Values.gateways.topologySpreadConstraints }}
       topologySpreadConstraints:
-      {{ - toYaml .Values.gateways.topologySpreadConstraints | nindent 8 }}
-      {{ - end }}
-      {{ - if .Values.gateways.nodeSelector }}
+      {{- toYaml .Values.gateways.topologySpreadConstraints | nindent 8 }}
+      {{- end }}
+      {{- if .Values.gateways.nodeSelector }}
       nodeSelector:
-      {{ - toYaml .Values.gateways.nodeSelector | nindent 8 }}
-      {{ - end }}
-      {{ - if .Values.gateways.tolerations }}
+      {{- toYaml .Values.gateways.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.gateways.tolerations }}
       tolerations:
-      {{ - toYaml .Values.gateways.tolerations | nindent 8 }}
-      {{ - end }}
+      {{- toYaml .Values.gateways.tolerations | nindent 8 }}
+      {{- end }}
       {{- if .Values.gateways.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.gateways.terminationGracePeriodSeconds }}
       {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -80,6 +80,7 @@ spec:
       {{- end }}
       {{- end }}
       serviceAccountName: {{.ServiceAccount | quote}}
+      terminationGracePeriodSeconds: {{ .Values.global.proxy.terminationGracePeriodSeconds }}
       containers:
       - name: istio-proxy
       {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}

--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -80,6 +80,22 @@ spec:
       {{- end }}
       {{- end }}
       serviceAccountName: {{.ServiceAccount | quote}}
+      { { - if .Values.gateways.affinity } }
+      affinity:
+      { { - toYaml .Values.gateways.affinity | nindent 8 } }
+      { { - end } }
+      { { - if .Values.gateways.topologySpreadConstraints } }
+      topologySpreadConstraints:
+      { { - toYaml .Values.gateways.topologySpreadConstraints | nindent 8 } }
+      { { - end } }
+      { { - if .Values.gateways.nodeSelector } }
+      nodeSelector:
+      { { - toYaml .Values.gateways.nodeSelector | nindent 8 } }
+      { { - end } }
+      { { - if .Values.gateways.tolerations } }
+      tolerations:
+      { { - toYaml .Values.gateways.tolerations | nindent 8 } }
+      { { - end } }
       {{- if .Values.gateways.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.gateways.terminationGracePeriodSeconds }}
       {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -80,7 +80,9 @@ spec:
       {{- end }}
       {{- end }}
       serviceAccountName: {{.ServiceAccount | quote}}
+      {{- if .Values.global.proxy.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.global.proxy.terminationGracePeriodSeconds }}
+      {{- end }}
       containers:
       - name: istio-proxy
       {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -383,10 +383,6 @@ _internal_defaults_do_not_set:
       # If using stackdriver tracer outside GCP, set env GOOGLE_APPLICATION_CREDENTIALS to the GCP credential file.
       tracer: "none"
 
-      # how many seconds wait to drain all the connections
-      # Default K8S value is 30 seconds
-      # terminationGracePeriodSeconds: 30
-
     proxy_init:
       # Base name for the proxy_init container, used to configure iptables.
       image: proxyv2
@@ -545,6 +541,10 @@ _internal_defaults_do_not_set:
 
     # Set to `type: RuntimeDefault` to use the default profile for templated gateways, if your container runtime supports it
     seccompProfile: {}
+
+    # how many seconds wait to drain all the connections
+    # Default K8S value is 30 seconds
+    # terminationGracePeriodSeconds: 30
 
   # gatewayClasses allows customizing the configuration of the default deployment of Gateways per GatewayClass.
   # For example:

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -385,7 +385,7 @@ _internal_defaults_do_not_set:
 
       # how many seconds wait to drain all the connections
       # Default K8S value is 30 seconds
-      terminationGracePeriodSeconds: 30
+      # terminationGracePeriodSeconds: 30
 
     proxy_init:
       # Base name for the proxy_init container, used to configure iptables.

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -528,6 +528,24 @@ _internal_defaults_do_not_set:
       # Tolerations for the waypoint proxy.
       tolerations: []
 
+    # Gateway Settings
+    gateway:
+      # If specified, affinity defines the scheduling constraints of gateway pods.
+      affinity: { }
+
+      # Topology Spread Constraints for the gateway.
+      topologySpreadConstraints: [ ]
+
+      # Node labels for the gateway.
+      nodeSelector: { }
+
+      # Tolerations for the gateway.
+      tolerations: [ ]
+
+      # how many seconds wait to drain all the connections
+      # Default K8S value is 30 seconds
+      # terminationGracePeriodSeconds: 30
+
   base:
     # For istioctl usage to disable istio config crds in base
     enableIstioConfigCRDs: true
@@ -541,23 +559,6 @@ _internal_defaults_do_not_set:
 
     # Set to `type: RuntimeDefault` to use the default profile for templated gateways, if your container runtime supports it
     seccompProfile: {}
-
-    # If specified, affinity defines the scheduling constraints of gateway pods.
-    affinity: { }
-
-    # Topology Spread Constraints for the gateway.
-    topologySpreadConstraints: [ ]
-
-    # Node labels for the gateway.
-    nodeSelector: { }
-
-    # Tolerations for the gateway.
-    tolerations: [ ]
-
-    # how many seconds wait to drain all the connections
-    # Default K8S value is 30 seconds
-    # terminationGracePeriodSeconds: 30
-
 
   # gatewayClasses allows customizing the configuration of the default deployment of Gateways per GatewayClass.
   # For example:

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -542,9 +542,22 @@ _internal_defaults_do_not_set:
     # Set to `type: RuntimeDefault` to use the default profile for templated gateways, if your container runtime supports it
     seccompProfile: {}
 
+    # If specified, affinity defines the scheduling constraints of gateway pods.
+    affinity: { }
+
+    # Topology Spread Constraints for the gateway.
+    topologySpreadConstraints: [ ]
+
+    # Node labels for the gateway.
+    nodeSelector: { }
+
+    # Tolerations for the gateway.
+    tolerations: [ ]
+
     # how many seconds wait to drain all the connections
     # Default K8S value is 30 seconds
     # terminationGracePeriodSeconds: 30
+
 
   # gatewayClasses allows customizing the configuration of the default deployment of Gateways per GatewayClass.
   # For example:

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -383,6 +383,10 @@ _internal_defaults_do_not_set:
       # If using stackdriver tracer outside GCP, set env GOOGLE_APPLICATION_CREDENTIALS to the GCP credential file.
       tracer: "none"
 
+      # how many seconds wait to drain all the connections
+      # Default K8S value is 30 seconds
+      terminationGracePeriodSeconds: 30
+
     proxy_init:
       # Base name for the proxy_init container, used to configure iptables.
       image: proxyv2

--- a/releasenotes/notes/gateway-chart-termgrace.yaml
+++ b/releasenotes/notes/gateway-chart-termgrace.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue: []
+
+releaseNotes:
+  - |
+    **Added** Allow setting terminationGracePeriodSeconds for gateway pod via Helm chart.


### PR DESCRIPTION
**Please provide a description of this PR:**

I would like to be able to set terminationGracePeriodSeconds for the gateway pods.

I need time until gateway pod will be deregistered [link](https://easoncao.com/zero-downtime-deployment-when-using-alb-ingress-controller-on-amazon-eks-and-prevent-502-error/#factor-2-graceful-shutdown-your-applications)

But I can not set it longer than terminationGracePeriodSeconds.

What i would like to do:
```yaml
      global = {
        proxy = {
          lifecycle = {
            preStop = {
              sleep = {
                seconds = 80
              }
            }
          }
        }
        gateway = {
          terminationGracePeriodSeconds = 300
          topologySpreadConstraints = [
            {
              maxSkew           = 1
              topologyKey       = "topology.kubernetes.io/zone"
              whenUnsatisfiable = "DoNotSchedule"
              minDomains        = 1
              labelSelector = {
                matchLabels = {
                  "gateway.networking.k8s.io/gateway-name" = local.gateway_name.public
                }
              }
            }
          ]
        }
        waypoint = {
          topologySpreadConstraints = [
            {
              maxSkew           = 1
              topologyKey       = "topology.kubernetes.io/zone"
              whenUnsatisfiable = "DoNotSchedule"
              minDomains        = 1
              labelSelector = {
                matchLabels = {
                  "gateway.networking.k8s.io/gateway-name" = local.gateway_name.internal
                }
              }
            }
          ]
        }
      }
```

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions


I am testing the cahnes and apply it om ny clusters here: https://github.com/GDXbsv/istio/tree/1.25.2/manifests/charts/istio-control