### PR TITLE
Fix listener addr duplication for dualStack svc with IPv6 as primary

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1706,6 +1706,10 @@ func (s *Service) getAllAddressesForProxy(node *Proxy) []string {
 }
 
 func filterAddresses(addresses []string, supportsV4, supportsV6 bool) []string {
+	if len(addresses) == 0 {
+		return nil
+	}
+
 	var ipv4Addresses []string
 	var ipv6Addresses []string
 	for _, addr := range addresses {

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1730,6 +1730,34 @@ func filterAddresses(addresses []string, supportsV4, supportsV6 bool) []string {
 			}
 		}
 	}
+
+	if supportsV4 && supportsV6 {
+		firstAddrFamily := ""
+		if strings.Contains(addresses[0], "/") {
+			if prefix, err := netip.ParsePrefix(addresses[0]); err == nil {
+				if prefix.Addr().Is4() {
+					firstAddrFamily = "v4"
+				} else if prefix.Addr().Is6() {
+					firstAddrFamily = "v6"
+				}
+			}
+		} else {
+			if ipAddr, err := netip.ParseAddr(addresses[0]); err == nil {
+				if ipAddr.Is4() {
+					firstAddrFamily = "v4"
+				} else if ipAddr.Is6() {
+					firstAddrFamily = "v6"
+				}
+			}
+		}
+
+		if firstAddrFamily == "v4" {
+			return ipv4Addresses
+		} else if firstAddrFamily == "v6" {
+			return ipv6Addresses
+		}
+	}
+
 	if len(ipv4Addresses) > 0 {
 		return ipv4Addresses
 	}


### PR DESCRIPTION
When a dual-stack service is configured with ipFamilies: [IPv6, IPv4], the listener ends up using the same IPv4 address for both address and additionalAddress (ignoring the IPv6 address). This happens because [GetAddressForProxy](https://github.com/istio/istio/blob/82bee2b455527f406cd7dbd884316070f1232a21/pilot/pkg/model/service.go#L1599)() (via [filterAddresses](https://github.com/istio/istio/blob/82bee2b455527f406cd7dbd884316070f1232a21/pilot/pkg/model/service.go#L1733) method) prioritizes IPv4 over IPv6, and [GetExtraAddressesForProxy](https://github.com/istio/istio/blob/82bee2b455527f406cd7dbd884316070f1232a21/pilot/pkg/model/service.go#L1629)() also returns the same IPv4 address from the service. This PR modifies the filterAddresses to return the addresses based on the firstAddrFamily.

```
./istio-1.24.0/bin/istioctl proxy-config listeners "$(kubectl get pod -n dual-stack -l app=tcp-echo -o jsonpath='{.items[0].metadata.name}')" -n dual-stack --port 9000 -ojson | jq '.[] | {name: .name, address: .address, additionalAddresses: .additionalAddresses}'
{
  "name": "10.96.122.185_9000",
  "address": {
	"socketAddress": {
	  "address": "10.96.122.185",
	  "portValue": 9000
	}
  },
  "additionalAddresses": [
	{
	  "address": {
		"socketAddress": {
		  "address": "10.96.122.185",
		  "portValue": 9000
		}
	  }
	}
  ]
}
```


**Please provide a description of this PR:**