### PR TITLE
Add support for envFrom in ingress gateway Helm chart

### DIFF
--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -218,6 +218,18 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          {{- if .Values.gateway.envFrom }}
+            envFrom:
+            {{- range .Values.gateway.envFrom }}
+              {{- if .secretRef }}
+              - secretRef:
+                name: "{{ .secretRef.name }}"
+              {{- else if .configMapRef }}
+              - configMapRef:
+                name: "{{ .configMapRef.name }}"
+              {{- end }}
+            {{- end }}
+            {{- end }}
           volumeMounts:
           - name: workload-socket
             mountPath: /var/run/secrets/workload-spiffe-uds

--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -88,6 +88,7 @@ _internal_defaults_do_not_set:
 
       ### Advanced options ############
       env: {}
+      envFrom: []
       nodeSelector: {}
       tolerations: []
 


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR adds support for the envFrom field in the Istio ingress gateway Helm chart, allowing users to inject environment variables from Kubernetes Secrets and ConfigMaps. This enhances flexibility and simplifies the configuration of the ingress gateway, especially in environments that rely on externalized configuration or secret management.

The change introduces a new optional gateway.envFrom field in values.yaml, which is conditionally rendered in the deployment.yaml template.




Example configuration:
gateway:
  envFrom:
    - secretRef:
        name: my-ingress-secrets
    - configMapRef:
        name: my-ingress-config