### PR TITLE
Support multiple err msg in TestMultiTlsGateway_InvalidSecret test

### DIFF
--- a/tests/integration/security/ingress_test.go
+++ b/tests/integration/security/ingress_test.go
@@ -411,7 +411,10 @@ func TestMultiTlsGateway_InvalidSecret(t *testing.T) {
 					},
 					hostName: "testmultitlsgateway-invalidsecret1.example.com",
 					expectedResponse: ingressutil.ExpectedResponse{
-						ErrorMessage: "connection reset by peer",
+						AllowedErrorMessages: []string{
+							"connection reset by peer",
+							"EOF",
+						},
 					},
 					callType: ingressutil.TLS,
 					tlsContext: ingressutil.TLSContext{
@@ -427,7 +430,10 @@ func TestMultiTlsGateway_InvalidSecret(t *testing.T) {
 					},
 					hostName: "testmultitlsgateway-invalidsecret2.example.com",
 					expectedResponse: ingressutil.ExpectedResponse{
-						ErrorMessage: "connection reset by peer",
+						AllowedErrorMessages: []string{
+							"connection reset by peer",
+							"EOF",
+						},
 					},
 					callType: ingressutil.TLS,
 					tlsContext: ingressutil.TLSContext{
@@ -443,7 +449,10 @@ func TestMultiTlsGateway_InvalidSecret(t *testing.T) {
 					},
 					hostName: "testmultitlsgateway-invalidsecret3.example.com",
 					expectedResponse: ingressutil.ExpectedResponse{
-						ErrorMessage: "connection reset by peer",
+						AllowedErrorMessages: []string{
+							"connection reset by peer",
+							"EOF",
+						},
 					},
 					callType: ingressutil.TLS,
 					tlsContext: ingressutil.TLSContext{
@@ -458,7 +467,10 @@ func TestMultiTlsGateway_InvalidSecret(t *testing.T) {
 					},
 					hostName: "testmultitlsgateway-invalidsecret4.example.com",
 					expectedResponse: ingressutil.ExpectedResponse{
-						ErrorMessage: "connection reset by peer",
+						AllowedErrorMessages: []string{
+							"connection reset by peer",
+							"EOF",
+						},
 					},
 					callType: ingressutil.TLS,
 					tlsContext: ingressutil.TLSContext{
@@ -473,7 +485,10 @@ func TestMultiTlsGateway_InvalidSecret(t *testing.T) {
 					},
 					hostName: "testmultitlsgateway-invalidsecret5.example.com",
 					expectedResponse: ingressutil.ExpectedResponse{
-						ErrorMessage: "connection reset by peer",
+						AllowedErrorMessages: []string{
+							"connection reset by peer",
+							"EOF",
+						},
 					},
 					callType: ingressutil.TLS,
 					tlsContext: ingressutil.TLSContext{
@@ -540,7 +555,10 @@ func TestMultiMtlsGateway_InvalidSecret(t *testing.T) {
 					},
 					hostName: "testmultimtlsgateway-invalidsecret1.example.com",
 					expectedResponse: ingressutil.ExpectedResponse{
-						ErrorMessage: "connection reset by peer",
+						AllowedErrorMessages: []string{
+							"connection reset by peer",
+							"EOF",
+						},
 					},
 					callType: ingressutil.Mtls,
 					tlsContext: ingressutil.TLSContext{
@@ -558,7 +576,10 @@ func TestMultiMtlsGateway_InvalidSecret(t *testing.T) {
 					},
 					hostName: "testmultimtlsgateway-invalidsecret2.example.com",
 					expectedResponse: ingressutil.ExpectedResponse{
-						ErrorMessage: "connection reset by peer",
+						AllowedErrorMessages: []string{
+							"connection reset by peer",
+							"EOF",
+						},
 					},
 					callType: ingressutil.Mtls,
 					tlsContext: ingressutil.TLSContext{
@@ -577,7 +598,10 @@ func TestMultiMtlsGateway_InvalidSecret(t *testing.T) {
 					},
 					hostName: "testmultimtlsgateway-invalidsecret3.example.com",
 					expectedResponse: ingressutil.ExpectedResponse{
-						ErrorMessage: "error decrypting message",
+						AllowedErrorMessages: []string{
+							"connection reset by peer",
+							"tls: error decrypting message",
+						},
 					},
 					callType: ingressutil.Mtls,
 					tlsContext: ingressutil.TLSContext{

--- a/tests/integration/security/sds_ingress/util/util.go
+++ b/tests/integration/security/sds_ingress/util/util.go
@@ -269,6 +269,7 @@ type ExpectedResponse struct {
 	StatusCode                   int
 	SkipErrorMessageVerification bool
 	ErrorMessage                 string
+	AllowedErrorMessages         []string
 }
 
 type TLSContext struct {
@@ -321,12 +322,24 @@ func doSendRequestsOrFail(ctx framework.TestContext, ing ingress.Instance, host 
 				// message then it should be treated as error when error message
 				// verification is not skipped. Error message verification is skipped
 				// when the error message is non-deterministic.
-				if !exRsp.SkipErrorMessageVerification && len(exRsp.ErrorMessage) == 0 {
-					return fmt.Errorf("unexpected error: %w", err)
-				}
-				if !exRsp.SkipErrorMessageVerification && !strings.Contains(err.Error(), exRsp.ErrorMessage) {
-					return fmt.Errorf("expected response error message %s but got %w",
-						exRsp.ErrorMessage, err)
+				if !exRsp.SkipErrorMessageVerification {
+					if len(exRsp.ErrorMessage) == 0 && len(exRsp.AllowedErrorMessages) == 0 {
+						return fmt.Errorf("unexpected error: %w", err)
+					}
+					matched := false
+					if exRsp.ErrorMessage != "" && strings.Contains(err.Error(), exRsp.ErrorMessage) {
+						matched = true
+					}
+					for _, allowed := range exRsp.AllowedErrorMessages {
+						if strings.Contains(err.Error(), allowed) {
+							matched = true
+							break
+						}
+					}
+					if !matched {
+						return fmt.Errorf("expected one of %v but got error: %w",
+							append([]string{exRsp.ErrorMessage}, exRsp.AllowedErrorMessages...), err)
+					}
 				}
 				return nil
 			}


### PR DESCRIPTION
**Please provide a description of this PR:**
Support multiple error messages in TestMultiTlsGateway_InvalidSecret and TestMultiMtlsGateway_InvalidSecret tests, where the error may differ across different environments.
In Openshift, the expected error for the test appear as "EOF" instead of "connection reset by peer".

Enhanced ExpectedResponse to allow a list of allowed error message substrings via the new AllowedErrorMessages field. This improves test reliability across environments (e.g., Kind vs OpenShift), where error messages like "connection reset by peer" and "EOF" may differ.

Maintains backward compatibility with the original ErrorMessage field.

Includes updated validation logic to check against both single and multiple expected error messages.