### PR TITLE
[release-1.25] Fix listener addr duplication for dualStack svc with IPv6 as primary …

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1693,6 +1693,10 @@ func (s *Service) getAllAddressesForProxy(node *Proxy) []string {
 }
 
 func filterAddresses(addresses []string, supportsV4, supportsV6 bool) []string {
+	if len(addresses) == 0 {
+		return nil
+	}
+
 	var ipv4Addresses []string
 	var ipv6Addresses []string
 	for _, addr := range addresses {
@@ -1717,6 +1721,34 @@ func filterAddresses(addresses []string, supportsV4, supportsV6 bool) []string {
 			}
 		}
 	}
+
+	if supportsV4 && supportsV6 {
+		firstAddrFamily := ""
+		if strings.Contains(addresses[0], "/") {
+			if prefix, err := netip.ParsePrefix(addresses[0]); err == nil {
+				if prefix.Addr().Is4() {
+					firstAddrFamily = "v4"
+				} else if prefix.Addr().Is6() {
+					firstAddrFamily = "v6"
+				}
+			}
+		} else {
+			if ipAddr, err := netip.ParseAddr(addresses[0]); err == nil {
+				if ipAddr.Is4() {
+					firstAddrFamily = "v4"
+				} else if ipAddr.Is6() {
+					firstAddrFamily = "v6"
+				}
+			}
+		}
+
+		if firstAddrFamily == "v4" {
+			return ipv4Addresses
+		} else if firstAddrFamily == "v6" {
+			return ipv6Addresses
+		}
+	}
+
 	if len(ipv4Addresses) > 0 {
 		return ipv4Addresses
 	}

--- a/pilot/pkg/model/service_test.go
+++ b/pilot/pkg/model/service_test.go
@@ -731,6 +731,104 @@ func TestGetAllAddresses(t *testing.T) {
 	}
 }
 
+func TestGetAddressForProxy(t *testing.T) {
+	tests := []struct {
+		name            string
+		service         *Service
+		proxy           *Proxy
+		expectedAddress string
+	}{
+		{
+			name: "IPv4 mode with IPv4 addresses, expected to return the first IPv4 address",
+			service: &Service{
+				ClusterVIPs: AddressMap{
+					Addresses: map[cluster.ID][]string{
+						"cl1": {"10.0.0.1", "10.0.0.2"},
+					},
+				},
+			},
+			proxy: &Proxy{
+				Metadata: &NodeMetadata{
+					ClusterID: "cl1",
+				},
+				ipMode: IPv4,
+			},
+			expectedAddress: "10.0.0.1",
+		},
+		{
+			name: "IPv6 mode with IPv6 addresses, expected to return the first IPv6 address",
+			service: &Service{
+				ClusterVIPs: AddressMap{
+					Addresses: map[cluster.ID][]string{
+						"cl1": {"2001:db8:abcd::1", "2001:db8:abcd::2"},
+					},
+				},
+			},
+			proxy: &Proxy{
+				Metadata: &NodeMetadata{
+					ClusterID: "cl1",
+				},
+				ipMode: IPv6,
+			},
+			expectedAddress: "2001:db8:abcd::1",
+		},
+		{
+			name: "Dual mode with both IPv6 and IPv4 addresses, expected to return the IPv6 address",
+			service: &Service{
+				ClusterVIPs: AddressMap{
+					Addresses: map[cluster.ID][]string{
+						"cl1": {"2001:db8:abcd::1", "10.0.0.1"},
+					},
+				},
+			},
+			proxy: &Proxy{
+				Metadata: &NodeMetadata{
+					ClusterID: "cl1",
+				},
+				ipMode: Dual,
+			},
+			expectedAddress: "2001:db8:abcd::1",
+		},
+		{
+			name: "IPv4 mode with Auto-allocated IPv4 address",
+			service: &Service{
+				DefaultAddress:           constants.UnspecifiedIP,
+				AutoAllocatedIPv4Address: "240.240.0.1",
+			},
+			proxy: &Proxy{
+				Metadata: &NodeMetadata{
+					DNSAutoAllocate: true,
+					DNSCapture:      true,
+				},
+				ipMode: IPv4,
+			},
+			expectedAddress: "240.240.0.1",
+		},
+		{
+			name: "IPv6 mode with Auto-allocated IPv6 address",
+			service: &Service{
+				DefaultAddress:           constants.UnspecifiedIP,
+				AutoAllocatedIPv6Address: "2001:2::f0f0:e351",
+			},
+			proxy: &Proxy{
+				Metadata: &NodeMetadata{
+					DNSAutoAllocate: true,
+					DNSCapture:      true,
+				},
+				ipMode: IPv6,
+			},
+			expectedAddress: "2001:2::f0f0:e351",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.service.GetAddressForProxy(tt.proxy)
+			assert.Equal(t, result, tt.expectedAddress)
+		})
+	}
+}
+
 func BenchmarkEndpointDeepCopy(b *testing.B) {
 	ep := &IstioEndpoint{
 		Labels:          labels.Instance{"label-foo": "aaa", "label-bar": "bbb"},


### PR DESCRIPTION
When a dual-stack service is configured with ipFamilies: [IPv6, IPv4], the listener ends up using the same IPv4 address for both address and additionalAddress (ignoring the IPv6 address). This happens because GetAddressForProxy() (via filterAddresses method) prioritizes IPv4 over IPv6, and GetExtraAddressesForProxy() also returns the same IPv4 address from the service. This PR modifies the filterAddresses to return the addresses based on the firstAddrFamily.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>
(cherry picked from commit 1bc024b509c7647777e11e7c9c2b3403cc1e5f60)

Fixes: https://github.com/istio/istio/issues/56182