### PR TITLE
Update "trustedZtunnelNamespace" in Ambient for Openshift

### DIFF
--- a/manifests/charts/base/files/profile-platform-openshift.yaml
+++ b/manifests/charts/base/files/profile-platform-openshift.yaml
@@ -16,4 +16,4 @@ pilot:
 seLinuxOptions:
   type: spc_t
 # Openshift requires privileged pods to run in kube-system
-trustedZtunnelNamespace: "kube-system"
+trustedZtunnelNamespace: "istio-system"

--- a/manifests/charts/default/files/profile-platform-openshift.yaml
+++ b/manifests/charts/default/files/profile-platform-openshift.yaml
@@ -16,4 +16,4 @@ pilot:
 seLinuxOptions:
   type: spc_t
 # Openshift requires privileged pods to run in kube-system
-trustedZtunnelNamespace: "kube-system"
+trustedZtunnelNamespace: "istio-system"

--- a/manifests/charts/gateway/files/profile-platform-openshift.yaml
+++ b/manifests/charts/gateway/files/profile-platform-openshift.yaml
@@ -16,4 +16,4 @@ pilot:
 seLinuxOptions:
   type: spc_t
 # Openshift requires privileged pods to run in kube-system
-trustedZtunnelNamespace: "kube-system"
+trustedZtunnelNamespace: "istio-system"

--- a/manifests/charts/gateways/istio-egress/files/profile-platform-openshift.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-platform-openshift.yaml
@@ -16,4 +16,4 @@ pilot:
 seLinuxOptions:
   type: spc_t
 # Openshift requires privileged pods to run in kube-system
-trustedZtunnelNamespace: "kube-system"
+trustedZtunnelNamespace: "istio-system"

--- a/manifests/charts/gateways/istio-ingress/files/profile-platform-openshift.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-platform-openshift.yaml
@@ -16,4 +16,4 @@ pilot:
 seLinuxOptions:
   type: spc_t
 # Openshift requires privileged pods to run in kube-system
-trustedZtunnelNamespace: "kube-system"
+trustedZtunnelNamespace: "istio-system"

--- a/manifests/charts/istio-cni/files/profile-platform-openshift.yaml
+++ b/manifests/charts/istio-cni/files/profile-platform-openshift.yaml
@@ -16,4 +16,4 @@ pilot:
 seLinuxOptions:
   type: spc_t
 # Openshift requires privileged pods to run in kube-system
-trustedZtunnelNamespace: "kube-system"
+trustedZtunnelNamespace: "istio-system"

--- a/manifests/charts/istio-control/istio-discovery/files/profile-platform-openshift.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-platform-openshift.yaml
@@ -16,4 +16,4 @@ pilot:
 seLinuxOptions:
   type: spc_t
 # Openshift requires privileged pods to run in kube-system
-trustedZtunnelNamespace: "kube-system"
+trustedZtunnelNamespace: "istio-system"

--- a/manifests/charts/ztunnel/files/profile-platform-openshift.yaml
+++ b/manifests/charts/ztunnel/files/profile-platform-openshift.yaml
@@ -16,4 +16,4 @@ pilot:
 seLinuxOptions:
   type: spc_t
 # Openshift requires privileged pods to run in kube-system
-trustedZtunnelNamespace: "kube-system"
+trustedZtunnelNamespace: "istio-system"


### PR DESCRIPTION
**Please provide a description of this PR:**
During deployment of Ambient mode in Openshift, ztunnel pods placed in
"istio-system" namespace.
It means that "trustedZtunnelNamespace" parameter should point to the
namespace, where ztunnel pods running - "istio-system".

Otherwise, the ztunnel pods are not able to prefetch the cetrificate and fail with:
"request impersonation authentication failure".