### PR TITLE
Add integration test for ztunnel secure metrics

### DIFF
--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -3597,7 +3597,6 @@ func TestZtunnelSecureMetrics(t *testing.T) {
 			k8sPods := tc.Clusters().Default().Kube().CoreV1().Pods(istioSystemNS)
 			patchOpts := metav1.PatchOptions{}
 
-
 			// Get ztunnel pod info
 			ztunnelPods, err := k8sPods.List(context.TODO(), metav1.ListOptions{LabelSelector: "app=ztunnel"})
 			if err != nil || len(ztunnelPods.Items) == 0 {


### PR DESCRIPTION
Adding integration test for testing secure (mTLS via HBONE) metrics endpoint in ztunnel added in [PR](https://github.com/istio/ztunnel/pull/1507) based on [RFC](https://docs.google.com/document/d/19vMr22inhLAPjWcVJkZWiG_GY6ZG3PLxG9QqAmIlnIc/edit?usp=sharing)