### PR TITLE
krt: typed indexers to avoid unnecessary conversions

### DIFF
--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -19,7 +19,6 @@ import (
 	"sync"
 
 	"istio.io/istio/pkg/kube/controllers"
-	"istio.io/istio/pkg/kube/kclient"
 	istiolog "istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/ptr"
@@ -225,11 +224,12 @@ type collectionIndex[I, O any] struct {
 	parent  *manyCollection[I, O]
 }
 
-func (c collectionIndex[I, O]) Lookup(key string) []any {
+func (c collectionIndex[I, O]) Lookup(key string) []O {
 	c.parent.mu.Lock()
 	defer c.parent.mu.Unlock()
 	keys := c.index[key]
-	res := make([]any, 0, len(keys))
+
+	res := make([]O, 0, len(keys))
 	for k := range keys {
 		v, f := c.parent.collectionState.outputs[k]
 		if !f {
@@ -367,7 +367,7 @@ func (h *manyCollection[I, O]) augment(a any) any {
 }
 
 // nolint: unused // (not true)
-func (h *manyCollection[I, O]) index(name string, extract func(o O) []string) kclient.RawIndexer {
+func (h *manyCollection[I, O]) index(name string, extract func(o O) []string) indexer[O] {
 	if idx, ok := h.indexes[name]; ok {
 		return idx
 	}

--- a/pkg/kube/krt/core.go
+++ b/pkg/kube/krt/core.go
@@ -16,7 +16,6 @@ package krt
 
 import (
 	"istio.io/istio/pkg/kube/controllers"
-	"istio.io/istio/pkg/kube/kclient"
 	istiolog "istio.io/istio/pkg/log"
 )
 
@@ -86,7 +85,11 @@ type internalCollection[T any] interface {
 	augment(any) any
 
 	// Create a new index into the collection
-	index(name string, extract func(o T) []string) kclient.RawIndexer
+	index(name string, extract func(o T) []string) indexer[T]
+}
+
+type indexer[T any] interface {
+	Lookup(key string) []T
 }
 
 type uidable interface {

--- a/pkg/kube/krt/dynamic.go
+++ b/pkg/kube/krt/dynamic.go
@@ -16,8 +16,6 @@ package krt
 
 import (
 	"sync"
-
-	"istio.io/istio/pkg/kube/kclient"
 )
 
 type dynamicJoinHandlerRegistration struct {
@@ -76,14 +74,14 @@ type collectionChangeEvent[T any] struct {
 }
 
 // nolint: unused // (not true)
-type dynamicJoinIndexer struct {
-	indexers map[collectionUID]kclient.RawIndexer
+type dynamicJoinIndexer[T any] struct {
+	indexers map[collectionUID]indexer[T]
 	sync.RWMutex
 }
 
 // nolint: unused // (not true)
-func (j *dynamicJoinIndexer) Lookup(key string) []any {
-	var res []any
+func (j *dynamicJoinIndexer[T]) Lookup(key string) []T {
+	var res []T
 	first := true
 	j.RLock()
 	defer j.RUnlock() // keithmattix: we're probably fine to defer as long as we don't have nested dynamic indexers

--- a/pkg/kube/krt/index.go
+++ b/pkg/kube/krt/index.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"istio.io/istio/pkg/kube/controllers"
-	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/sets"
@@ -76,7 +75,7 @@ func NewIndex[K comparable, O any](
 
 type index[K comparable, O any] struct {
 	uid collectionUID
-	kclient.RawIndexer
+	indexer[O]
 	c       Collection[O]
 	extract func(o O) []K
 }
@@ -143,13 +142,10 @@ func (i index[K, O]) id() collectionUID {
 
 // Lookup finds all objects matching a given key
 func (i index[K, O]) Lookup(k K) []O {
-	if i.RawIndexer == nil {
+	if i.indexer == nil {
 		return nil
 	}
-	res := i.RawIndexer.Lookup(toString(k))
-	return slices.Map(res, func(e any) O {
-		return e.(O)
-	})
+	return i.indexer.Lookup(toString(k))
 }
 
 func toString(rk any) string {
@@ -194,7 +190,7 @@ func (i indexCollection[K, O]) augment(a any) any {
 }
 
 // nolint: unused // (not true, its to implement an interface)
-func (i indexCollection[K, O]) index(name string, extract func(o IndexObject[K, O]) []string) kclient.RawIndexer {
+func (i indexCollection[K, O]) index(name string, extract func(o IndexObject[K, O]) []string) indexer[IndexObject[K, O]] {
 	panic("an index cannot be indexed")
 }
 

--- a/pkg/kube/krt/informer.go
+++ b/pkg/kube/krt/informer.go
@@ -145,9 +145,23 @@ func (i informerHandlerRegistration) UnregisterHandler() {
 }
 
 // nolint: unused // (not true)
-func (i *informer[I]) index(name string, extract func(o I) []string) kclient.RawIndexer {
+type informerIndex[I any] struct {
+	idx kclient.RawIndexer
+}
+
+// nolint: unused // (not true)
+func (ii *informerIndex[I]) Lookup(key string) []I {
+	return slices.Map(ii.idx.Lookup(key), func(i any) I {
+		return i.(I)
+	})
+}
+
+// nolint: unused // (not true)
+func (i *informer[I]) index(name string, extract func(o I) []string) indexer[I] {
 	idx := i.inf.Index(name, extract)
-	return idx
+	return &informerIndex[I]{
+		idx: idx,
+	}
 }
 
 func informerEventHandler[I controllers.ComparableObject](handler func(o Event[I], initialSync bool)) cache.ResourceEventHandler {

--- a/pkg/kube/krt/join.go
+++ b/pkg/kube/krt/join.go
@@ -19,7 +19,6 @@ import (
 	"sync"
 
 	"istio.io/istio/pkg/kube/controllers"
-	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/sets"
@@ -278,13 +277,13 @@ func (j *join[I]) dump() CollectionDump {
 }
 
 // nolint: unused // (not true)
-type joinIndexer struct {
-	indexers []kclient.RawIndexer
+type joinIndexer[T any] struct {
+	indexers []indexer[T]
 }
 
 // nolint: unused // (not true)
-func (j joinIndexer) Lookup(key string) []any {
-	var res []any
+func (j joinIndexer[T]) Lookup(key string) []T {
+	var res []T
 	first := true
 	for _, i := range j.indexers {
 		l := i.Lookup(key)
@@ -300,8 +299,8 @@ func (j joinIndexer) Lookup(key string) []any {
 }
 
 // nolint: unused // (not true, its to implement an interface)
-func (j *join[T]) index(name string, extract func(o T) []string) kclient.RawIndexer {
-	ji := joinIndexer{indexers: make([]kclient.RawIndexer, 0, len(j.collections))}
+func (j *join[T]) index(name string, extract func(o T) []string) indexer[T] {
+	ji := joinIndexer[T]{indexers: make([]indexer[T], 0, len(j.collections))}
 	for _, c := range j.collections {
 		ji.indexers = append(ji.indexers, c.index(name, extract))
 	}

--- a/pkg/kube/krt/nestedjoin.go
+++ b/pkg/kube/krt/nestedjoin.go
@@ -19,7 +19,6 @@ import (
 	"sync"
 
 	"istio.io/istio/pkg/kube/controllers"
-	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/util/sets"
@@ -128,8 +127,8 @@ func (j *nestedjoin[T]) List() []T {
 }
 
 // nolint: unused // (not true, its to implement an interface)
-func (j *nestedjoin[T]) index(name string, extract func(o T) []string) kclient.RawIndexer {
-	ji := &dynamicJoinIndexer{indexers: make(map[collectionUID]kclient.RawIndexer)}
+func (j *nestedjoin[T]) index(name string, extract func(o T) []string) indexer[T] {
+	ji := &dynamicJoinIndexer[T]{indexers: make(map[collectionUID]indexer[T])}
 	for _, c := range j.collections.List() {
 		ic := c.(internalCollection[T])
 		ji.indexers[ic.uid()] = ic.index(name, extract)

--- a/pkg/kube/krt/singleton.go
+++ b/pkg/kube/krt/singleton.go
@@ -19,7 +19,6 @@ import (
 	"sync/atomic"
 
 	"istio.io/istio/pkg/kube/controllers"
-	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/slices"
 )
@@ -176,7 +175,7 @@ func (d *static[T]) uid() collectionUID {
 }
 
 // nolint: unused // (not true, its to implement an interface)
-func (d *static[T]) index(name string, extract func(o T) []string) kclient.RawIndexer {
+func (d *static[T]) index(name string, extract func(o T) []string) indexer[T] {
 	panic("TODO")
 }
 

--- a/pkg/kube/krt/static.go
+++ b/pkg/kube/krt/static.go
@@ -19,7 +19,6 @@ import (
 	"sync"
 
 	"istio.io/istio/pkg/kube/controllers"
-	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/slices"
@@ -232,10 +231,11 @@ type staticListIndex[T any] struct {
 }
 
 // nolint: unused // (not true)
-func (s staticListIndex[T]) Lookup(key string) []any {
-	var res []any
+func (s staticListIndex[T]) Lookup(key string) []T {
+	var res []T
 	s.parent.mu.RLock()
 	defer s.parent.mu.RUnlock()
+
 	for _, v := range s.parent.vals {
 		have := s.extract(v)
 		if slices.Contains(have, key) {
@@ -246,7 +246,7 @@ func (s staticListIndex[T]) Lookup(key string) []any {
 }
 
 // nolint: unused // (not true, its to implement an interface)
-func (s *staticList[T]) index(name string, extract func(o T) []string) kclient.RawIndexer {
+func (s *staticList[T]) index(name string, extract func(o T) []string) indexer[T] {
 	return staticListIndex[T]{
 		extract: extract,
 		parent:  s,


### PR DESCRIPTION
Replace usage of `kclient.RawIndexer` internally in krt to a typed `indexer[T]` which allows us to skip unnecessary conversions on every call to `index.Lookup()`.