### PR TITLE
Fix TestAnalysisWritesStatus flaky on Openshift Cloud Platform

### DIFF
--- a/tests/integration/pilot/analysis/analysis_test.go
+++ b/tests/integration/pilot/analysis/analysis_test.go
@@ -80,7 +80,7 @@ spec:
 			// Status should report error
 			retry.UntilSuccessOrFail(t, func() error {
 				return expectVirtualServiceStatus(t, ns, true)
-			}, retry.Timeout(time.Second*5))
+			}, retry.Timeout(time.Second*10))
 			// Apply config to make this not invalid
 			t.ConfigIstio().YAML(ns.Name(), `
 apiVersion: networking.istio.io/v1


### PR DESCRIPTION
Increasing timeout since TestAnalysisWritesStatus is flaky on Openshift Cloud Platform

**Please provide a description of this PR:**