### PR TITLE
krt: fix panic when we remove handlers before sync

### DIFF
--- a/pkg/kube/krt/processor.go
+++ b/pkg/kube/krt/processor.go
@@ -73,6 +73,12 @@ func (o *handlerSet[O]) Insert(
 		o.wg.Start(func() {
 			// If we didn't start synced, register a callback to mark ourselves synced once the parent is synced.
 			if parentSynced.WaitUntilSynced(stopCh) {
+				o.mu.RLock()
+				defer o.mu.RUnlock()
+				if !o.handlers.Contains(l) {
+					return
+				}
+
 				select {
 				case <-l.stop:
 					return


### PR DESCRIPTION
```
panic: send on closed channel

goroutine 1545 [running]:
istio.io/istio/pkg/kube/krt.(*handlerSet[...]).Insert.func3()
	istio.io/istio/pkg/kube/krt/processor.go:76 +0x95
k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
	k8s.io/apimachinery@v0.32.3/pkg/util/wait/wait.go:72 +0x4c
created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 1517
	k8s.io/apimachinery@v0.32.3/pkg/util/wait/wait.go:70 +0x73
```

In rare cases, we already have a handler unregistered before we even sync the parent collection, causing this panic. 

This PR has a test that easily reproduces the panic, and simply guards that  the handler is still in the set before we send to that channel. 

Set membership is a good proxy for the channel not being closed, because we close the channel at the same place as we remove from the set: 

https://github.com/istio/istio/blob/c2e9871f340c0e0b114bcd1b73208284f1d17c9e/pkg/kube/krt/processor.go#L102-L103