### PR TITLE
Set the controlz port to a constant

### DIFF
--- a/istioctl/pkg/admin/istiodconfig.go
+++ b/istioctl/pkg/admin/istiodconfig.go
@@ -36,6 +36,7 @@ import (
 	"istio.io/istio/istioctl/pkg/cli"
 	"istio.io/istio/istioctl/pkg/clioptions"
 	"istio.io/istio/istioctl/pkg/completion"
+	"istio.io/istio/istioctl/pkg/util"
 	"istio.io/istio/pkg/log"
 )
 
@@ -479,7 +480,7 @@ func istiodLogCmd(ctx cli.Context) *cobra.Command {
 	}
 	opts.AttachControlPlaneFlags(logCmd)
 	logCmd.PersistentFlags().BoolVar(&istiodReset, "reset", istiodReset, "Reset levels to default value. (info)")
-	logCmd.PersistentFlags().IntVar(&controlzPort, "ctrlz_port", 9876, "ControlZ port")
+	logCmd.PersistentFlags().IntVar(&controlzPort, "ctrlz_port", util.DefaultControlZPort, "ControlZ port")
 	logCmd.PersistentFlags().StringVar(&outputLogLevel, "level", outputLogLevel,
 		"Comma-separated list of output logging level for scopes in the format of <scope>:<level>[,<scope>:<level>,...]. "+
 			"Possible values for <level>: none, error, warn, info, debug")

--- a/istioctl/pkg/admin/istiodconfig.go
+++ b/istioctl/pkg/admin/istiodconfig.go
@@ -36,7 +36,7 @@ import (
 	"istio.io/istio/istioctl/pkg/cli"
 	"istio.io/istio/istioctl/pkg/clioptions"
 	"istio.io/istio/istioctl/pkg/completion"
-	"istio.io/istio/istioctl/pkg/util"
+	"istio.io/istio/pkg/ctrlz"
 	"istio.io/istio/pkg/log"
 )
 
@@ -480,7 +480,7 @@ func istiodLogCmd(ctx cli.Context) *cobra.Command {
 	}
 	opts.AttachControlPlaneFlags(logCmd)
 	logCmd.PersistentFlags().BoolVar(&istiodReset, "reset", istiodReset, "Reset levels to default value. (info)")
-	logCmd.PersistentFlags().IntVar(&controlzPort, "ctrlz_port", util.DefaultControlZPort, "ControlZ port")
+	logCmd.PersistentFlags().IntVar(&controlzPort, "ctrlz_port", ctrlz.DefaultControlZPort, "ControlZ port")
 	logCmd.PersistentFlags().StringVar(&outputLogLevel, "level", outputLogLevel,
 		"Comma-separated list of output logging level for scopes in the format of <scope>:<level>[,<scope>:<level>,...]. "+
 			"Possible values for <level>: none, error, warn, info, debug")

--- a/istioctl/pkg/dashboard/dashboard.go
+++ b/istioctl/pkg/dashboard/dashboard.go
@@ -649,7 +649,7 @@ func Dashboard(cliContext cli.Context) *cobra.Command {
 	dashboardCmd.AddCommand(proxy)
 
 	controlz := controlZDashCmd(cliContext)
-	controlz.PersistentFlags().IntVar(&controlZport, "ctrlz_port", 9876, "ControlZ port")
+	controlz.PersistentFlags().IntVar(&controlZport, "ctrlz_port", util.DefaultControlZPort, "ControlZ port")
 	controlz.PersistentFlags().StringVarP(&labelSelector, "selector", "l", "", "Label selector")
 	dashboardCmd.AddCommand(controlz)
 

--- a/istioctl/pkg/dashboard/dashboard.go
+++ b/istioctl/pkg/dashboard/dashboard.go
@@ -30,6 +30,7 @@ import (
 	"istio.io/istio/istioctl/pkg/cli"
 	"istio.io/istio/istioctl/pkg/clioptions"
 	"istio.io/istio/istioctl/pkg/util"
+	"istio.io/istio/pkg/ctrlz"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/log"
 )
@@ -649,7 +650,7 @@ func Dashboard(cliContext cli.Context) *cobra.Command {
 	dashboardCmd.AddCommand(proxy)
 
 	controlz := controlZDashCmd(cliContext)
-	controlz.PersistentFlags().IntVar(&controlZport, "ctrlz_port", util.DefaultControlZPort, "ControlZ port")
+	controlz.PersistentFlags().IntVar(&controlZport, "ctrlz_port", ctrlz.DefaultControlZPort, "ControlZ port")
 	controlz.PersistentFlags().StringVarP(&labelSelector, "selector", "l", "", "Label selector")
 	dashboardCmd.AddCommand(controlz)
 

--- a/istioctl/pkg/util/constants.go
+++ b/istioctl/pkg/util/constants.go
@@ -18,6 +18,9 @@ const (
 	// DefaultProxyAdminPort is the default port for the proxy admin server
 	DefaultProxyAdminPort = 15000
 
+	// DefaultControlzPort is the default port for the ControlZ server
+	DefaultControlZPort = 9876
+
 	// DefaultMeshConfigMapName is the default name of the ConfigMap with the mesh config
 	// The actual name can be different - use getMeshConfigMapName
 	DefaultMeshConfigMapName = "istio"

--- a/istioctl/pkg/util/constants.go
+++ b/istioctl/pkg/util/constants.go
@@ -18,9 +18,6 @@ const (
 	// DefaultProxyAdminPort is the default port for the proxy admin server
 	DefaultProxyAdminPort = 15000
 
-	// DefaultControlzPort is the default port for the ControlZ server
-	DefaultControlZPort = 9876
-
 	// DefaultMeshConfigMapName is the default name of the ConfigMap with the mesh config
 	// The actual name can be different - use getMeshConfigMapName
 	DefaultMeshConfigMapName = "istio"

--- a/pkg/ctrlz/options.go
+++ b/pkg/ctrlz/options.go
@@ -30,10 +30,13 @@ type Options struct {
 	EnablePprof bool
 }
 
+// DefaultControlZPort is the default port for the ControlZ server
+const DefaultControlZPort = 9876
+
 // DefaultOptions returns a new set of options, initialized to the defaults
 func DefaultOptions() *Options {
 	return &Options{
-		Port:    9876,
+		Port:    DefaultControlZPort,
 		Address: "localhost",
 	}
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

The controlz port is set to 9847 in many places. It would be better to set it to a constant.