### PR TITLE
support --weight parameter for istioctl x workload group create

### DIFF
--- a/istioctl/pkg/workload/workload.go
+++ b/istioctl/pkg/workload/workload.go
@@ -74,6 +74,7 @@ var (
 	namespace      string
 	network        string
 	locality       string
+	weight         uint32
 )
 
 const (
@@ -155,6 +156,7 @@ The default output is serialized YAML, which can be piped into 'kubectl apply -f
 					ServiceAccount: serviceAccount,
 					Network:        network,
 					Locality:       locality,
+					Weight:         weight,
 				},
 			}
 			wgYAML, err := generateWorkloadGroupYAML(u, spec)
@@ -173,6 +175,7 @@ The default output is serialized YAML, which can be piped into 'kubectl apply -f
 	createCmd.PersistentFlags().StringVarP(&serviceAccount, "serviceAccount", "s", "default", "The service identity to associate with the workload instances")
 	createCmd.PersistentFlags().StringVar(&network, "network", "", "Network enables Istio to group endpoints resident in the same L3 domain/network.")
 	createCmd.PersistentFlags().StringVar(&locality, "locality", "", "The locality associated with the endpoint.")
+	createCmd.PersistentFlags().Uint32VarP(&weight, "weight", "w", 0, "The load balancing weight associated with the endpoint.")
 	_ = createCmd.RegisterFlagCompletionFunc("serviceAccount", func(
 		cmd *cobra.Command, args []string, toComplete string,
 	) ([]string, cobra.ShellCompDirective) {

--- a/istioctl/pkg/workload/workload_test.go
+++ b/istioctl/pkg/workload/workload_test.go
@@ -66,6 +66,7 @@ spec:
       grpc: 3550
       http: 8080
     serviceAccount: test
+    weight: 100
 `
 )
 
@@ -106,14 +107,14 @@ func TestWorkloadGroupCreate(t *testing.T) {
 		{
 			description: "valid case - create full workload group",
 			args: strings.Split("group create --name foo --namespace bar --labels app=foo,bar=baz "+
-				" --annotations annotation=foobar --ports grpc=3550,http=8080 --serviceAccount test", " "),
+				" --annotations annotation=foobar --ports grpc=3550,http=8080 --serviceAccount test --weight 100", " "),
 			expectedException: false,
 			expectedOutput:    customYAML,
 		},
 		{
 			description: "valid case - create full workload group with shortnames",
 			args: strings.Split("group create --name foo -n bar -l app=foo,bar=baz -p grpc=3550,http=8080"+
-				" -a annotation=foobar --serviceAccount test", " "),
+				" -a annotation=foobar --serviceAccount test --weight 100", " "),
 			expectedException: false,
 			expectedOutput:    customYAML,
 		},

--- a/releasenotes/notes/56666.yaml
+++ b/releasenotes/notes/56666.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+releaseNotes:
+- |
+  **Added** support `--weight` parameter for `istioctl experimental workload group create`.


### PR DESCRIPTION
**Please provide a description of this PR:**

It is better for user can use `istioctl experimental workload group create` to specify any parameter for workload group.