### PR TITLE
Fix maps size computation for allocation may overflow

### DIFF
--- a/pkg/maps/maps.go
+++ b/pkg/maps/maps.go
@@ -57,11 +57,16 @@ func Keys[M ~map[K]V, K comparable, V any](m M) []K {
 // When a key in override is already present in base,
 // the value in base will be overwritten by the value associated
 // with the key in override.
-func MergeCopy[M1 ~map[K]V, M2 ~map[K]V, K comparable, V any](base M1, override M2) M1 {
-	dst := make(M1, len(base)+len(override))
+func MergeCopy[M1 ~map[K]V, M2 ~map[K]V, K comparable, V any](base M1, override M2) (M1, error) {
+	baseLen := len(base)
+	overrideLen := len(override)
+	if baseLen > (int(^uint(0) >> 1)) - overrideLen { // Check for overflow
+		return nil, fmt.Errorf("map size computation overflow: base size %d, override size %d", baseLen, overrideLen)
+	}
+	dst := make(M1, baseLen+overrideLen)
 	maps.Copy(dst, base)
 	maps.Copy(dst, override)
-	return dst
+	return dst, nil
 }
 
 // Contains checks if all key-value pairs in 'subset' are present in 'superset'.


### PR DESCRIPTION
https://github.com/istio/istio/blob/ca8187a6b0efd36c958d38d0662a5d3ca1cb259e/pkg/maps/maps.go#L60-L61


Fix the issue need to validate the size of `override` before performing the arithmetic operation. Specifically:
1. Add a guard to ensure that `len(override)` is within a safe range and that the sum `len(base) + len(override)` does not exceed the maximum value of `int`.
2. If the size exceeds a predefined safe limit, return an error or handle the situation gracefully.

The fix will involve modifying the `MergeCopy` function in `pkg/maps/maps.go` to include this validation.

---