### PR TITLE
nftables: Install nft binary in base and distroless images

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -12,6 +12,7 @@ RUN apt-get update && \
   ca-certificates \
   curl \
   iptables \
+  nftables \
   iproute2 \
   iputils-ping \
   knot-dnsutils \

--- a/docker/iptables.yaml
+++ b/docker/iptables.yaml
@@ -9,6 +9,7 @@ contents:
     - glibc
     - iptables
     - ip6tables
+    - nftables
     - libnetfilter_conntrack
     - libnfnetlink
     - libmnl

--- a/tools/build-base-images.sh
+++ b/tools/build-base-images.sh
@@ -79,6 +79,7 @@ unexpectedFiles="$(
 )"
 expectedFiles=(
   "usr/bin/xtables-legacy-multi"
+  "usr/bin/nft"
 )
 for want in "${expectedFiles[@]}"; do
   if ! grep -q "${want}" <<<"${exefiles}"; then

--- a/tools/packaging/packaging.mk
+++ b/tools/packaging/packaging.mk
@@ -67,6 +67,7 @@ rpm/fpm:
 		--description "Istio Sidecar" \
 		--depends iproute \
 		--depends iptables \
+		--depends nftables \
 		--depends sudo \
 		--depends hostname \
 		$(RPM_COMPRESSION) \
@@ -87,6 +88,7 @@ deb/fpm:
 		--description "Istio Sidecar" \
 		--depends iproute2 \
 		--depends iptables \
+		--depends nftables \
 		--depends sudo \
 		--depends hostname \
 		$(DEB_COMPRESSION) \


### PR DESCRIPTION
Hello, this change is related to https://github.com/istio/istio/issues/47821

We'd like to have the nft binary installed in the gcr.io/istio-release/base image. And then we can build istio images such as proxyv2 with nftables alternative tool and run commands for traffic redirection.

Following John's suggestion in https://github.com/istio/tools/pull/3209, this PR also includes the distroless image change.


The diff before/after adding nftables package in a distroless image is listed below:

Before adding it (quay.io/yuaxu/apko-istio:latest-amd64)
After adding it (quay.io/yuaxu/apko-istio:test-amd64) 

```sh
$ diff <(crane export quay.io/yuaxu/apko-istio:latest-amd64 - | tar -tvf - | sort) <(crane export quay.io/yuaxu/apko-istio:test-amd64 - | tar -tvf - | sort) | grep nft
> drwxr-xr-x root/root         0 2025-04-22 08:24 etc/nftables
> drwxr-xr-x root/root         0 2025-04-22 08:24 etc/nftables/osf
> drwxr-xr-x root/root         0 2025-04-22 08:24 usr/share/doc/nftables
> drwxr-xr-x root/root         0 2025-04-22 08:24 usr/share/doc/nftables/examples
> drwxr-xr-x root/root         0 2025-04-22 08:24 usr/share/nftables
> lrwxrwxrwx root/root         0 2025-04-22 08:24 usr/lib/libnftables.so.1 -> libnftables.so.1.1.0
> -rw-r--r-- root/root      1016 2025-04-22 08:24 usr/share/nftables/all-in-one.nft
> -rw-r--r-- root/root       128 2025-04-22 08:24 usr/share/nftables/netdev-ingress.nft
> -rw-r--r-- root/root       129 2025-04-22 08:24 usr/share/nftables/arp-filter.nft
> -rw-r--r-- root/root       137 2025-04-22 08:24 usr/share/nftables/ipv4-raw.nft
> -rw-r--r-- root/root       141 2025-04-22 08:24 usr/share/nftables/ipv6-raw.nft
> -rw-r--r-- root/root       182 2025-04-22 08:24 usr/share/nftables/ipv4-filter.nft
> -rw-r--r-- root/root       186 2025-04-22 08:24 usr/share/nftables/ipv6-filter.nft
> -rw-r--r-- root/root       187 2025-04-22 08:24 usr/share/nftables/inet-filter.nft
> -rw-r--r-- root/root       197 2025-04-22 08:24 usr/share/nftables/bridge-filter.nft
> -rw-r--r-- root/root       246 2025-04-22 08:24 usr/share/nftables/ipv4-nat.nft
> -rw-r--r-- root/root       251 2025-04-22 08:24 usr/share/nftables/inet-nat.nft
> -rw-r--r-- root/root       253 2025-04-22 08:24 usr/share/nftables/ipv6-nat.nft
> -rw-r--r-- root/root     28884 2025-04-22 08:24 etc/nftables/osf/pf.os
> -rw-r--r-- root/root        74 2025-04-22 08:24 usr/share/nftables/ipv4-mangle.nft
> -rw-r--r-- root/root        78 2025-04-22 08:24 usr/share/nftables/ipv6-mangle.nft
> -rw-rw-rw- root/root      2976 2025-04-22 08:24 var/lib/db/sbom/nftables-1.1.3-r0.spdx.json
> -rwxr-xr-x root/root   1007696 2025-04-22 08:24 usr/lib/libnftables.so.1.1.0
> -rwxr-xr-x root/root      1263 2025-04-22 08:24 usr/share/doc/nftables/examples/ct_helpers.nft
> -rwxr-xr-x root/root      1278 2025-04-22 08:24 usr/share/doc/nftables/examples/sets_and_maps.nft
> -rwxr-xr-x root/root      1858 2025-04-22 08:24 usr/share/doc/nftables/examples/load_balancing.nft
> -rwxr-xr-x root/root      2404 2025-04-22 08:24 usr/share/doc/nftables/examples/secmark.nft
> -rwxr-xr-x root/root     31000 2025-04-22 08:24 usr/bin/nft
$ 

```


- [X] Networking


**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
