### PR TITLE
Increase zt bin limit

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -11,6 +11,6 @@
     "name": "ZTUNNEL_REPO_SHA",
     "repoName": "ztunnel",
     "file": "",
-    "lastStableSHA": "79dfd10249a2fdf34ed54117e33a37349e90a7bb"
+    "lastStableSHA": "3d1223af09b04f2b98cd48d6133ef4200e43f759"
   }
 ]

--- a/tests/binary/binaries_test.go
+++ b/tests/binary/binaries_test.go
@@ -113,7 +113,7 @@ func TestBinarySizes(t *testing.T) {
 		"client":          {15, 30},
 		"server":          {15, 30},
 		"envoy":           {60, 130},
-		"ztunnel":         {10, 15},
+		"ztunnel":         {12, 17},
 	}
 
 	runBinariesTest(t, func(t *testing.T, name string) {


### PR DESCRIPTION
**Please provide a description of this PR:**

We've been at the upper limit of ztunnel binary size. The latest ztunnel is failing that test, bump the allowed size range a little.

Adopt the zt SHA which failed to merge due to binary size.