### PR TITLE
pilot: include extra trust domains in cluster SANs verification

### DIFF
--- a/pilot/pkg/networking/core/cluster_traffic_policy.go
+++ b/pilot/pkg/networking/core/cluster_traffic_policy.go
@@ -34,6 +34,7 @@ import (
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/util/protomarshal"
 	"istio.io/istio/pkg/wellknown"
 )
@@ -54,7 +55,7 @@ func (cb *ClusterBuilder) applyTrafficPolicy(service *model.Service, opts buildC
 		if opts.clusterMode != SniDnatClusterMode {
 			autoMTLSEnabled := opts.mesh.GetEnableAutoMtls().Value
 			tls, mtlsCtxType := cb.buildUpstreamTLSSettings(tls, opts.serviceAccounts, opts.istioMtlsSni,
-				autoMTLSEnabled, opts.meshExternal, opts.serviceMTLSMode)
+				autoMTLSEnabled, opts.meshExternal, opts.serviceMTLSMode, spiffe.GetExtraTrustDomains(opts.mesh))
 			cb.applyUpstreamTLSSettings(&opts, tls, mtlsCtxType)
 			cb.applyUpstreamProxyProtocol(&opts, proxyProtocol)
 		}

--- a/pkg/spiffe/spiffe.go
+++ b/pkg/spiffe/spiffe.go
@@ -163,6 +163,14 @@ func GetTrustDomainFromURISAN(uriSan string) (string, error) {
 	return parsed.TrustDomain, nil
 }
 
+func GetExtraTrustDomains(meshCfg *meshconfig.MeshConfig) []string {
+	var extraTrustDomains []string
+	for _, ca := range meshCfg.CaCertificates {
+		extraTrustDomains = append(extraTrustDomains, ca.GetTrustDomains()...)
+	}
+	return extraTrustDomains
+}
+
 // RetrieveSpiffeBundleRootCerts retrieves the trusted CA certificates from a list of SPIFFE bundle endpoints.
 // It can use the system cert pool and the supplied certificates to validate the endpoints.
 func RetrieveSpiffeBundleRootCerts(config map[string]string, caCertPool *x509.CertPool, retryTimeout time.Duration) (

--- a/pkg/spiffe/spiffe_test.go
+++ b/pkg/spiffe/spiffe_test.go
@@ -31,6 +31,7 @@ import (
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/test/util"
+	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/util/sets"
 )
@@ -610,5 +611,21 @@ func TestIdentity(t *testing.T) {
 				t.Fatalf("round trip failed, expected %q got %q", tt.input, roundTrip)
 			}
 		})
+	}
+}
+
+func TestGetExtraTrustDomains(t *testing.T) {
+	mesh := &meshconfig.MeshConfig{
+		CaCertificates: []*meshconfig.MeshConfig_CertificateData{
+			{
+				TrustDomains: []string{"b", "a"},
+			},
+			{
+				TrustDomains: []string{"c"},
+			},
+		},
+	}
+	if result := GetExtraTrustDomains(mesh); !slices.Equal(result, []string{"b", "a", "c"}) {
+		t.Errorf("Unexpected trust domains. expected: [b a c], got: %v", result)
 	}
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

This change fixes cross cluster communication in multi-primary deployment with SPIRE and federated trust domains.

When a multi-cluster mesh is installed with extra CA certificates and trust domains, like below:
```
    caCertificates:
    - spiffeBundleUrl: https://spire-server.spire.svc.cluster.local:8443
      trustDomains:
      - east.local
    - spiffeBundleUrl: https://${REMOTE_BUNDLE_ENDPOINT}:8443
      trustDomains:
      - west.local
```
then the downstream TLS contexts in inbound listeners have configured SAN matchers for all trust domains, like this:
```
"typed_config": {
  "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
    "common_tls_context": {
      "combined_validation_context": {
        "default_validation_context": {
          "match_subject_alt_names": [
            {
              "prefix": "spiffe://east.local/"
            },
            {
              "prefix": "spiffe://west.local/"
            }
          ]
```
but the upstream TLS contexts in cluster configurations have SAN matchers only for the SPIFFE ID with the local trust domain:
```
"typed_config": {
  "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
  "combined_validation_context": {
    "default_validation_context": {
      "match_subject_alt_names": [
        {
          "exact": "spiffe://east.local/ns/default/sa/httpbin"
        }
      ]
```
so connections to remote endpoints fail on the client side due to unexpected SAN.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [X] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
