### PR TITLE
Add "trustedZtunnelNamespace" flag to integration tests

### DIFF
--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -213,6 +213,10 @@ type Config struct {
 	// ControlPlaneInstaller allows installation of custom control planes on istio deployments via an external script
 	// This field should only be set when DeployIstio is false
 	ControlPlaneInstaller string
+
+	// TrustedZtunnelNamespace allows to override the trusted namespace of ztunnel daemonset location.
+	// Used in Ambient mode
+	TrustedZtunnelNamespace string
 }
 
 func (c *Config) OverridesYAML(s *resource.Settings) string {

--- a/pkg/test/framework/components/istio/flags.go
+++ b/pkg/test/framework/components/istio/flags.go
@@ -24,6 +24,9 @@ func init() {
 		"Specifies the namespace where the istiod resides in a typical deployment. Defaults to istio-system")
 	flag.StringVar(&settingsFromCommandline.TelemetryNamespace, "istio.test.kube.telemetryNamespace", settingsFromCommandline.TelemetryNamespace,
 		"Specifies the namespace in which kiali, tracing providers, graphana, prometheus are deployed.")
+	flag.StringVar(&settingsFromCommandline.TrustedZtunnelNamespace, "istio.test.kube.trustedZtunnelNamespace",
+		settingsFromCommandline.TrustedZtunnelNamespace,
+		"Specifies the trusted namespace for ztunnel. Used in Ambient mode.")
 	flag.BoolVar(&settingsFromCommandline.DeployIstio, "istio.test.kube.deploy", settingsFromCommandline.DeployIstio,
 		"Deploy Istio into the target Kubernetes environment.")
 	flag.StringVar(&settingsFromCommandline.PrimaryClusterIOPFile, "istio.test.kube.helm.iopFile", settingsFromCommandline.PrimaryClusterIOPFile,

--- a/pkg/test/framework/components/istio/kube.go
+++ b/pkg/test/framework/components/istio/kube.go
@@ -607,6 +607,11 @@ func commonInstallArgs(ctx resource.Context, cfg Config, c cluster.Cluster, defa
 		args.AppendSet("components.cni.enabled", "true")
 	}
 
+	// Used in Ambient mode
+	if cfg.TrustedZtunnelNamespace != "" {
+		args.AppendSet("values.pilot.trustedZtunnelNamespace", cfg.TrustedZtunnelNamespace)
+	}
+
 	if len(ctx.Settings().IPFamilies) > 1 {
 		args.AppendSet("values.pilot.env.ISTIO_DUAL_STACK", "true")
 		args.AppendSet("values.pilot.ipFamilyPolicy", string(corev1.IPFamilyPolicyRequireDualStack))

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -566,6 +566,7 @@ The test framework supports the following command-line flags:
 | --istio.test.helmRepo | string | Overwrite the default helm Repo used for the tests. |
 | --istio.test.ambient | bool | Indicate the use of ambient mesh. |
 | --istio.test.openshift | bool | Set to `true` when running the tests in an OpenShift cluster, rather than in KinD. |
+| --istio.test.trustedZtunnelNamespace | string | Overwrite namespace of the ztunnel daemonset placement. |
 
 ## Notes
 


### PR DESCRIPTION
**Please provide a description of this PR:**
The "trustedZtunnelNamespace" parameter could change between environment according to system or security requirements.
Add a flag to set the trusted ztunnel namespace during integration tests execution to simplify the configuration.