### PR TITLE
fix: fixed ambient (l4) respect WorkloadEntry ports map for service port name

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
@@ -705,14 +705,22 @@ func constructServicesFromWorkloadEntry(p *networkingv1alpha3.WorkloadEntry, ser
 			// Named targetPort has different semantics from Service vs ServiceEntry
 			if svc.Source.Kind == kind.Service {
 				// Service has explicit named targetPorts.
-				if named, f := svc.PortNames[int32(port.ServicePort)]; f && named.TargetPortName != "" {
-					// This port is a named target port, look it up
-					tv, ok := p.Ports[named.TargetPortName]
-					if !ok {
-						// We needed an explicit port, but didn't find one - skip this port
-						continue
+				if named, f := svc.PortNames[int32(port.ServicePort)]; f {
+					// Target port name should be respected first. Otherwise, fallback to port name
+					portName := named.TargetPortName
+					if named.TargetPortName == "" {
+						portName = named.PortName
 					}
-					targetPort = tv
+
+					if portName != "" {
+						// This port is a named target port, look it up
+						tv, ok := p.Ports[portName]
+						if !ok {
+							// We needed an explicit port, but didn't find one - skip this port
+							continue
+						}
+						targetPort = tv
+					}
 				}
 			} else {
 				// ServiceEntry has no explicit named targetPorts; targetPort only allows a number

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
@@ -707,19 +707,18 @@ func constructServicesFromWorkloadEntry(p *networkingv1alpha3.WorkloadEntry, ser
 				// Service has explicit named targetPorts.
 				if named, f := svc.PortNames[int32(port.ServicePort)]; f {
 					// Target port name should be respected first. Otherwise, fallback to port name
-					portName := named.TargetPortName
-					if named.TargetPortName == "" {
-						portName = named.PortName
-					}
-
-					if portName != "" {
-						// This port is a named target port, look it up
-						tv, ok := p.Ports[portName]
+					if named.TargetPortName != "" {
+						tv, ok := p.Ports[named.TargetPortName]
 						if !ok {
 							// We needed an explicit port, but didn't find one - skip this port
 							continue
 						}
 						targetPort = tv
+					} else {
+						tv, ok := p.Ports[named.PortName]
+						if ok {
+							targetPort = tv
+						}
 					}
 				}
 			} else {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
@@ -1275,6 +1275,127 @@ func TestWorkloadEntryWorkloads(t *testing.T) {
 			},
 		},
 		{
+			name: "we with target port name and port name",
+			inputs: []any{
+				model.ServiceInfo{
+					Source: model.TypedObject{Kind: kind.Service},
+					Service: &workloadapi.Service{
+
+						Name:      "svc",
+						Namespace: "ns",
+						Hostname:  "hostname",
+						Ports: []*workloadapi.Port{{
+							ServicePort: 80,
+						}},
+					},
+					PortNames: map[int32]model.ServicePortName{
+						80: model.ServicePortName{
+							TargetPortName: "http",
+							PortName:       "failure",
+						},
+					},
+					LabelSelector: model.NewSelector(map[string]string{"app": "foo"}),
+				},
+			},
+			we: &networkingclient.WorkloadEntry{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "ns",
+					Labels: map[string]string{
+						"app": "foo",
+					},
+				},
+				Spec: networking.WorkloadEntry{
+					Address: "1.2.3.4",
+					Ports: map[string]uint32{
+						"http": 8080,
+					},
+				},
+			},
+			result: &workloadapi.Workload{
+				Uid:               "cluster0/networking.istio.io/WorkloadEntry/ns/name",
+				Name:              "name",
+				Namespace:         "ns",
+				Addresses:         [][]byte{netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice()},
+				Network:           testNW,
+				CanonicalName:     "foo",
+				CanonicalRevision: "latest",
+				WorkloadType:      workloadapi.WorkloadType_POD,
+				WorkloadName:      "name",
+				Status:            workloadapi.WorkloadStatus_HEALTHY,
+				ClusterId:         testC,
+				Services: map[string]*workloadapi.PortList{
+					"ns/hostname": {
+						Ports: []*workloadapi.Port{{
+							ServicePort: 80,
+							TargetPort:  8080,
+						}},
+					},
+				},
+			},
+		},
+		{
+			name: "we with port name",
+			inputs: []any{
+				model.ServiceInfo{
+					Source: model.TypedObject{Kind: kind.Service},
+					Service: &workloadapi.Service{
+
+						Name:      "svc",
+						Namespace: "ns",
+						Hostname:  "hostname",
+						Ports: []*workloadapi.Port{{
+							ServicePort: 80,
+						}},
+					},
+					PortNames: map[int32]model.ServicePortName{
+						80: model.ServicePortName{
+							PortName: "http",
+						},
+					},
+					LabelSelector: model.NewSelector(map[string]string{"app": "foo"}),
+				},
+			},
+			we: &networkingclient.WorkloadEntry{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "ns",
+					Labels: map[string]string{
+						"app": "foo",
+					},
+				},
+				Spec: networking.WorkloadEntry{
+					Address: "1.2.3.4",
+					Ports: map[string]uint32{
+						"http": 8080,
+					},
+				},
+			},
+			result: &workloadapi.Workload{
+				Uid:               "cluster0/networking.istio.io/WorkloadEntry/ns/name",
+				Name:              "name",
+				Namespace:         "ns",
+				Addresses:         [][]byte{netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice()},
+				Network:           testNW,
+				CanonicalName:     "foo",
+				CanonicalRevision: "latest",
+				WorkloadType:      workloadapi.WorkloadType_POD,
+				WorkloadName:      "name",
+				Status:            workloadapi.WorkloadStatus_HEALTHY,
+				ClusterId:         testC,
+				Services: map[string]*workloadapi.PortList{
+					"ns/hostname": {
+						Ports: []*workloadapi.Port{{
+							ServicePort: 80,
+							TargetPort:  8080,
+						}},
+					},
+				},
+			},
+		},
+		{
 			name: "waypoint binding",
 			inputs: []any{
 				Waypoint{

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
@@ -1275,7 +1275,7 @@ func TestWorkloadEntryWorkloads(t *testing.T) {
 			},
 		},
 		{
-			name: "we with target port name and port name",
+			name: "Service targetPortName in WorkloadEntry port map",
 			inputs: []any{
 				model.ServiceInfo{
 					Source: model.TypedObject{Kind: kind.Service},
@@ -1335,7 +1335,7 @@ func TestWorkloadEntryWorkloads(t *testing.T) {
 			},
 		},
 		{
-			name: "we with port name",
+			name: "Service port name in WorkloadEntry port map",
 			inputs: []any{
 				model.ServiceInfo{
 					Source: model.TypedObject{Kind: kind.Service},

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
@@ -1289,9 +1289,9 @@ func TestWorkloadEntryWorkloads(t *testing.T) {
 						}},
 					},
 					PortNames: map[int32]model.ServicePortName{
-						80: model.ServicePortName{
+						80: {
 							TargetPortName: "http",
-							PortName:       "failure",
+							PortName:       "80",
 						},
 					},
 					LabelSelector: model.NewSelector(map[string]string{"app": "foo"}),
@@ -1350,7 +1350,7 @@ func TestWorkloadEntryWorkloads(t *testing.T) {
 						}},
 					},
 					PortNames: map[int32]model.ServicePortName{
-						80: model.ServicePortName{
+						80: {
 							PortName: "http",
 						},
 					},

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
@@ -1340,7 +1340,6 @@ func TestWorkloadEntryWorkloads(t *testing.T) {
 				model.ServiceInfo{
 					Source: model.TypedObject{Kind: kind.Service},
 					Service: &workloadapi.Service{
-
 						Name:      "svc",
 						Namespace: "ns",
 						Hostname:  "hostname",

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
@@ -1280,7 +1280,6 @@ func TestWorkloadEntryWorkloads(t *testing.T) {
 				model.ServiceInfo{
 					Source: model.TypedObject{Kind: kind.Service},
 					Service: &workloadapi.Service{
-
 						Name:      "svc",
 						Namespace: "ns",
 						Hostname:  "hostname",

--- a/releasenotes/notes/56396.yaml
+++ b/releasenotes/notes/56396.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 56251
+
+# releaseNotes is a markdown listing of any user facing changes. This will appear in the
+# release notes.
+releaseNotes:
+- |
+  **Fixed** zTunnel will now respect WorkloadEntry port map when referencing Service port name.


### PR DESCRIPTION
**Please provide a description of this PR:**
Closes #56251. Ambient does not respect WorkloadEntry ports when a service only has port names without a target port name.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
