### PR TITLE
krt: include more info in status equality check

### DIFF
--- a/pilot/pkg/status/manager.go
+++ b/pilot/pkg/status/manager.go
@@ -17,6 +17,8 @@
 package status
 
 import (
+	"strings"
+
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config"
@@ -40,7 +42,8 @@ func NewManager(store model.ConfigStore) *Manager {
 		_, err := store.UpdateStatus(*m)
 		if err != nil {
 			// TODO: need better error handling
-			scope.Errorf("Encountered unexpected error updating status for %v, will try again later: %s", m, err)
+			name := strings.Join([]string{m.GroupVersionKind.String(), m.Namespace, m.Name, m.ResourceVersion}, "/")
+			scope.Errorf("Encountered unexpected error updating status for %v, will try again later: %s", name, err)
 			return
 		}
 	}

--- a/pkg/kube/krt/status.go
+++ b/pkg/kube/krt/status.go
@@ -102,8 +102,10 @@ func (c ObjectWithStatus[I, IStatus]) ResourceName() string {
 }
 
 func (c ObjectWithStatus[I, IStatus]) Equals(o ObjectWithStatus[I, IStatus]) bool {
-	// we need to include object generation in the comparison to allow retrying status updates
+	// we need to include object generation/resource version in the comparison to allow retrying status updates
 	// if a conflict occurs
 	return c.Obj.GetGeneration() == o.Obj.GetGeneration() &&
+		c.Obj.GetResourceVersion() == o.Obj.GetResourceVersion() &&
+		c.Obj.GetUID() == o.Obj.GetUID() &&
 		equal(c.Status, o.Status)
 }


### PR DESCRIPTION
Without this, we end up not re-enqueueing if the resource version
changes. This leads to a race:

* Enqueue object with rv=1
* Start writing this
* Enqueue object with rv=1 again (new status to write)
* Initial write completes
* Second write fails due to rv mismatch (we use Update not Apply)

Second write is lost forever
