### PR TITLE
IsCatchAllRoute support empty route match

### DIFF
--- a/pilot/pkg/networking/core/route/route.go
+++ b/pilot/pkg/networking/core/route/route.go
@@ -1580,6 +1580,9 @@ func IsCatchAllRoute(r *route.Route) bool {
 		catchall = ir.PathSeparatedPrefix == "/"
 	case *route.RouteMatch_SafeRegex:
 		catchall = ir.SafeRegex.GetRegex() == ".*"
+	case nil:
+		// If there is no path specified, it is a catchall route.
+		catchall = true
 	}
 
 	return catchall && len(r.Match.Headers) == 0 && len(r.Match.QueryParameters) == 0 && len(r.Match.DynamicMetadata) == 0

--- a/pilot/pkg/networking/core/route/route_internal_test.go
+++ b/pilot/pkg/networking/core/route/route_internal_test.go
@@ -81,6 +81,14 @@ func TestIsCatchAllRoute(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "catch all with empty match",
+			route: &route.Route{
+				Name:  "catch-all",
+				Match: &route.RouteMatch{},
+			},
+			want: true,
+		},
+		{
 			name: "catch all prefix with headers",
 			route: &route.Route{
 				Name: "catch-all",


### PR DESCRIPTION
**Please provide a description of this PR:**
We met a case that the VirtualService has an empty route match. 
```
http:
    - match:
        - uri: {}
      route:
        - destination:
            host: my-svc
            port:
              number: 443
```
The data plane is working, however it seems that the pilot misses the IsCatchAllRoute checking for this case. 