### PR TITLE
Change host iptables rule addition from Append to Insert to ensure Istio's rules take precedence

### DIFF
--- a/cni/pkg/iptables/iptables.go
+++ b/cni/pkg/iptables/iptables.go
@@ -652,8 +652,8 @@ func (cfg *IptablesConfigurator) AppendHostRules() *builder.IptablesRuleBuilder 
 
 	// For easier cleanup, insert a jump into an owned chain
 	// -A POSTROUTING -p tcp -j ISTIO_POSTRT
-	iptablesBuilder.AppendRule(
-		"POSTROUTING", "nat",
+	iptablesBuilder.InsertRule(
+		"POSTROUTING", "nat", 1,
 		"-j", ChainHostPostrouting,
 	)
 

--- a/cni/pkg/iptables/iptables.go
+++ b/cni/pkg/iptables/iptables.go
@@ -651,7 +651,7 @@ func (cfg *IptablesConfigurator) AppendHostRules() *builder.IptablesRuleBuilder 
 	iptablesBuilder := builder.NewIptablesRuleBuilder(ipbuildConfig(cfg.cfg))
 
 	// For easier cleanup, insert a jump into an owned chain
-	// -A POSTROUTING -p tcp -j ISTIO_POSTRT
+	// -I POSTROUTING 1 -p tcp -j ISTIO_POSTRT
 	iptablesBuilder.InsertRule(
 		"POSTROUTING", "nat", 1,
 		"-j", ChainHostPostrouting,

--- a/cni/pkg/iptables/testdata/hostprobe.golden
+++ b/cni/pkg/iptables/testdata/hostprobe.golden
@@ -2,6 +2,6 @@ iptables-save
 ip6tables-save
 * nat
 -N ISTIO_POSTRT
--A POSTROUTING -j ISTIO_POSTRT
+-I POSTROUTING 1 -j ISTIO_POSTRT
 -A ISTIO_POSTRT -m owner --socket-exists -p tcp -m set --match-set istio-inpod-probes-v4 dst -j SNAT --to-source 169.254.7.127
 COMMIT

--- a/cni/pkg/iptables/testdata/hostprobe_ipv6.golden
+++ b/cni/pkg/iptables/testdata/hostprobe_ipv6.golden
@@ -2,11 +2,11 @@ iptables-save
 ip6tables-save
 * nat
 -N ISTIO_POSTRT
--A POSTROUTING -j ISTIO_POSTRT
+-I POSTROUTING 1 -j ISTIO_POSTRT
 -A ISTIO_POSTRT -m owner --socket-exists -p tcp -m set --match-set istio-inpod-probes-v4 dst -j SNAT --to-source 169.254.7.127
 COMMIT
 * nat
 -N ISTIO_POSTRT
--A POSTROUTING -j ISTIO_POSTRT
+-I POSTROUTING 1 -j ISTIO_POSTRT
 -A ISTIO_POSTRT -m owner --socket-exists -p tcp -m set --match-set istio-inpod-probes-v6 dst -j SNAT --to-source fd16:9254:7127:1337:ffff:ffff:ffff:ffff
 COMMIT

--- a/releasenotes/notes/56414.yaml
+++ b/releasenotes/notes/56414.yaml
@@ -5,6 +5,6 @@ issue:
   - 56414
 releaseNotes:
   - |
-    **Fixed**  existing iptables rules matched and handled targeted traffic before it reached Istio's rules.
+    **Fixed**  Ambient host network iptables rules were being skipped due to higher-priority CNI rules in some deployments.
 
 

--- a/releasenotes/notes/56414.yaml
+++ b/releasenotes/notes/56414.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 56414
+releaseNotes:
+  - |
+    **Fixed**  existing iptables rules matched and handled targeted traffic before it reached Istio's rules.
+
+


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR modifies the existing host iptables rule addition logic from using the Append method to the Insert method. By inserting Istio's rules at the front of the iptables chain, we ensure these rules have higher matching priority compared to existing iptables rules.

Previously, appending rules caused issues in scenarios where existing iptables rules matched and handled targeted traffic before it reached Istio's rules. Consequently, the rules configured by Istio became ineffective.

We use a whitelist with iptables on the host, which only affects pods within the istio ipset. Therefore, matching it first will not cause any issues.

