### PR TITLE
fix: issue where selector flag of admin log cannot be empty

### DIFF
--- a/istioctl/pkg/admin/admin.go
+++ b/istioctl/pkg/admin/admin.go
@@ -44,7 +44,7 @@ func Cmd(ctx cli.Context) *cobra.Command {
 
 	istiodLog := istiodLogCmd(ctx)
 	adminCmd.AddCommand(istiodLog)
-	adminCmd.PersistentFlags().StringVarP(&istiodLabelSelector, "selector", "l", "app=istiod", "label selector")
+	adminCmd.PersistentFlags().StringVarP(&istiodLabelSelector, "selector", "l", "", "label selector")
 
 	return adminCmd
 }

--- a/istioctl/pkg/admin/istiodconfig.go
+++ b/istioctl/pkg/admin/istiodconfig.go
@@ -480,9 +480,9 @@ func istiodLogCmd(ctx cli.Context) *cobra.Command {
 			if len(args) == 0 {
 				// resolvedRevision is already set by ctx.RevisionOrDefault(opts.Revision)
 				if len(istiodLabelSelector) > 0 {
-					istiodLabelSelector = fmt.Sprintf("%s,%s=%s", istiodLabelSelector, label.IoIstioRev.Name, resolvedRevision)
+					istiodLabelSelector = fmt.Sprintf("%s,%s=%s,app=istiod", istiodLabelSelector, label.IoIstioRev.Name, resolvedRevision)
 				} else {
-					istiodLabelSelector = fmt.Sprintf("%s=%s", label.IoIstioRev.Name, resolvedRevision)
+					istiodLabelSelector = fmt.Sprintf("%s=%s,app=istiod", label.IoIstioRev.Name, resolvedRevision)
 				}
 				pl, err := client.PodsForSelector(context.TODO(), ctx.NamespaceOrDefault(ctx.IstioNamespace()), istiodLabelSelector)
 				if err != nil {

--- a/releasenotes/notes/56449.yaml
+++ b/releasenotes/notes/56449.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+- |
+  **Fixed** logic issue where `--selector` flag of `istioctl admin log` was not set to empty as expected.


### PR DESCRIPTION
**Please provide a description of this PR:**

- Fix logic issue where `--selector` flag of `istioctl admin log` cannot be set to empty.

  Because the istiodLabelSelector variable has a default value: https://github.com/istio/istio/blob/master/istioctl/pkg/admin/admin.go#L47
that istiodLabelSelector is never empty, so this logic can never be executed: https://github.com/istio/istio/blob/master/istioctl/pkg/admin/istiodconfig.go#L431-L433

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
