### PR TITLE
Ambient: In ambient index, filter configs by revision

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_serviceentry_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_serviceentry_test.go
@@ -47,7 +47,7 @@ func TestAmbientIndexDuplicates(t *testing.T) {
 			if c.multicluster {
 				test.SetForTest(t, &features.EnableAmbientMultiNetwork, true)
 			}
-			s := newAmbientTestServer(t, testC, testNW)
+			s := newAmbientTestServer(t, testC, testNW, "")
 			s.addWorkloadEntries(t, "140.140.0.10", "name0", "sa1", map[string]string{"app": "a"})
 			s.addPods(t, "140.140.0.10", "pod0", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
 			s.addWorkloadEntries(t, "140.140.0.10", "name1", "sa1", map[string]string{"app": "a"})
@@ -78,7 +78,7 @@ func TestAmbientIndex_ServiceEntry(t *testing.T) {
 			if c.multicluster {
 				test.SetForTest(t, &features.EnableAmbientMultiNetwork, true)
 			}
-			s := newAmbientTestServer(t, testC, testNW)
+			s := newAmbientTestServer(t, testC, testNW, "")
 
 			// test code path where service entry creates a workload entry via `ServiceEntry.endpoints`
 			// and the inlined WE has a port override
@@ -522,7 +522,7 @@ func TestAmbientIndex_ServiceEntry_DisableK8SServiceSelectWorkloadEntries(t *tes
 			s := newAmbientTestServerWithFlags(t, testC, testNW, FeatureFlags{
 				DefaultAllowFromWaypoint:              features.DefaultAllowFromWaypoint,
 				EnableK8SServiceSelectWorkloadEntries: false,
-			})
+			}, "")
 
 			s.addPods(t, "140.140.0.10", "pod1", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
 			s.assertEvent(t, s.podXdsName("pod1"))

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -197,7 +197,7 @@ func TestAmbientIndex_WaypointForWorkloadTraffic(t *testing.T) {
 			if c.multicluster {
 				test.SetForTest(t, &features.EnableAmbientMultiNetwork, true)
 			}
-			s := newAmbientTestServer(t, testC, testNW)
+			s := newAmbientTestServer(t, testC, testNW, "")
 			// These steps happen for every test regardless of traffic type.
 			// It involves creating a waypoint for the specified traffic type
 			// then creating a workload and a service with no annotations set
@@ -271,7 +271,7 @@ func TestAmbientIndex_NetworkAndClusterIDs(t *testing.T) {
 			if c.multicluster {
 				test.SetForTest(t, &features.EnableAmbientMultiNetwork, true)
 			}
-			s := newAmbientTestServer(t, c.cluster, c.network)
+			s := newAmbientTestServer(t, c.cluster, c.network, "")
 			s.addPods(t, "127.0.0.1", "pod1", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
 			s.assertEvent(t, s.podXdsName("pod1"))
 			s.assertAddresses(t, s.addrXdsName("127.0.0.1"), "pod1")
@@ -297,7 +297,7 @@ func TestAmbientIndex_WorkloadNotFound(t *testing.T) {
 			if c.multicluster {
 				test.SetForTest(t, &features.EnableAmbientMultiNetwork, true)
 			}
-			s := newAmbientTestServer(t, testC, testNW)
+			s := newAmbientTestServer(t, testC, testNW, "")
 			// Add a pod.
 			s.addPods(t, "127.0.0.1", "pod1", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
 
@@ -325,7 +325,7 @@ func TestAmbientIndex_LookupWorkloads(t *testing.T) {
 			if c.multicluster {
 				test.SetForTest(t, &features.EnableAmbientMultiNetwork, true)
 			}
-			s := newAmbientTestServer(t, testC, testNW)
+			s := newAmbientTestServer(t, testC, testNW, "")
 			s.addPods(t, "127.0.0.1", "pod1", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
 			s.assertAddresses(t, "", "pod1")
 			s.assertEvent(t, s.podXdsName("pod1"))
@@ -384,7 +384,7 @@ func TestAmbientIndex_ServiceAttachedWaypoints(t *testing.T) {
 			if c.multicluster {
 				test.SetForTest(t, &features.EnableAmbientMultiNetwork, true)
 			}
-			s := newAmbientTestServer(t, testC, testNW)
+			s := newAmbientTestServer(t, testC, testNW, "")
 			s.addWaypoint(t, "10.0.0.10", "test-wp", "default", true)
 
 			s.addPods(t, "127.0.0.1", "pod1", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
@@ -427,7 +427,7 @@ func TestAmbientIndex_ServiceSelectsCorrectWorkloads(t *testing.T) {
 			if c.multicluster {
 				test.SetForTest(t, &features.EnableAmbientMultiNetwork, true)
 			}
-			s := newAmbientTestServer(t, testC, testNW)
+			s := newAmbientTestServer(t, testC, testNW, "")
 			// Add 2 pods with the "a" label, and one without.
 			// We should get an event for the new Service and the two *Pod* IPs impacted
 			s.addPods(t, "127.0.0.1", "pod1", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
@@ -520,7 +520,7 @@ func TestAmbientIndex_WaypointConfiguredOnlyWhenReady(t *testing.T) {
 			if c.multicluster {
 				test.SetForTest(t, &features.EnableAmbientMultiNetwork, true)
 			}
-			s := newAmbientTestServer(t, testC, testNW)
+			s := newAmbientTestServer(t, testC, testNW, "")
 			s.addPods(t,
 				"127.0.0.1",
 				"pod1",
@@ -553,7 +553,7 @@ func TestAmbientIndex_WaypointConfiguredOnlyWhenReady(t *testing.T) {
 }
 
 func TestAmbientIndex_WaypointAddressAddedToWorkloads(t *testing.T) {
-	s := newAmbientTestServer(t, testC, testNW)
+	s := newAmbientTestServer(t, testC, testNW, "")
 
 	s.ns.Update(&corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -751,7 +751,7 @@ func TestAmbientIndex_WaypointAddressAddedToWorkloads(t *testing.T) {
 }
 
 func TestAmbientIndex_WaypointInboundBinding(t *testing.T) {
-	s := newAmbientTestServer(t, testC, testNW)
+	s := newAmbientTestServer(t, testC, testNW, "")
 	s.gwcls.Update(&k8sbeta.GatewayClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: constants.WaypointGatewayClassName,
@@ -783,7 +783,7 @@ func TestAmbientIndex_ServicesForWaypoint(t *testing.T) {
 		Network:   testNW,
 	}
 	t.Run("hostname", func(t *testing.T) {
-		s := newAmbientTestServer(t, testC, testNW)
+		s := newAmbientTestServer(t, testC, testNW, "")
 		s.addService(t, "svc1",
 			map[string]string{label.IoIstioUseWaypoint.Name: "wp"},
 			map[string]string{},
@@ -804,7 +804,7 @@ func TestAmbientIndex_ServicesForWaypoint(t *testing.T) {
 		}, svc1Host)
 	})
 	t.Run("ip", func(t *testing.T) {
-		s := newAmbientTestServer(t, testC, testNW)
+		s := newAmbientTestServer(t, testC, testNW, "")
 
 		s.addService(t, "svc1",
 			map[string]string{label.IoIstioUseWaypoint.Name: "wp"},
@@ -826,7 +826,7 @@ func TestAmbientIndex_ServicesForWaypoint(t *testing.T) {
 		}, svc1Host)
 	})
 	t.Run("mixed", func(t *testing.T) {
-		s := newAmbientTestServer(t, testC, testNW)
+		s := newAmbientTestServer(t, testC, testNW, "")
 		s.addService(t, "svc1",
 			map[string]string{label.IoIstioUseWaypoint.Name: "wp"},
 			map[string]string{},
@@ -849,7 +849,7 @@ func TestAmbientIndex_ServicesForWaypoint(t *testing.T) {
 
 	t.Run("hostname (multicluster but unused)", func(t *testing.T) {
 		test.SetForTest(t, &features.EnableAmbientMultiNetwork, true)
-		s := newAmbientTestServer(t, testC, testNW)
+		s := newAmbientTestServer(t, testC, testNW, "")
 		s.addService(t, "svc1",
 			map[string]string{label.IoIstioUseWaypoint.Name: "wp"},
 			map[string]string{},
@@ -871,7 +871,7 @@ func TestAmbientIndex_ServicesForWaypoint(t *testing.T) {
 	})
 	t.Run("ip (multicluster but unused)", func(t *testing.T) {
 		test.SetForTest(t, &features.EnableAmbientMultiNetwork, true)
-		s := newAmbientTestServer(t, testC, testNW)
+		s := newAmbientTestServer(t, testC, testNW, "")
 
 		s.addService(t, "svc1",
 			map[string]string{label.IoIstioUseWaypoint.Name: "wp"},
@@ -894,7 +894,7 @@ func TestAmbientIndex_ServicesForWaypoint(t *testing.T) {
 	})
 	t.Run("mixed (multicluster but unused)", func(t *testing.T) {
 		test.SetForTest(t, &features.EnableAmbientMultiNetwork, true)
-		s := newAmbientTestServer(t, testC, testNW)
+		s := newAmbientTestServer(t, testC, testNW, "")
 		s.addService(t, "svc1",
 			map[string]string{label.IoIstioUseWaypoint.Name: "wp"},
 			map[string]string{},
@@ -963,6 +963,50 @@ func setupPolicyTest(t *testing.T, s *ambientTestServer) {
 	s.assertUnorderedEvent(t, s.podXdsName("waypoint-ns-pod"), s.svcXdsName("waypoint-ns"))
 }
 
+func TestAuthorizationPolicyRevisionFiltering(t *testing.T) {
+	s := newAmbientTestServer(t, testC, testNW, "some-rev")
+	policyName := "test-authz"
+
+	t.Run("no revision label: policy is present", func(t *testing.T) {
+		s.addPolicy(t, policyName, testNS, nil, gvk.AuthorizationPolicy, nil)
+		s.assertEvent(t, policyName)
+
+		// Should be present in s.authorizationPolicies
+		pol := s.authorizationPolicies.GetKey(testNS + "/" + policyName)
+		if pol == nil {
+			t.Errorf("AuthorizationPolicy without revision label should be present, but was not")
+		}
+	})
+
+	t.Run("with non-matching revision label: policy is ignored", func(t *testing.T) {
+		s.addPolicy(t, policyName+"-rev", testNS, nil, gvk.AuthorizationPolicy, func(obj controllers.Object) {
+			p := obj.(*clientsecurityv1beta1.AuthorizationPolicy)
+			if p.Labels == nil {
+				p.Labels = map[string]string{}
+			}
+			p.Labels[label.IoIstioRev.Name] = "non-matching-rev"
+		})
+		s.assertNoEvent(t)
+	})
+
+	t.Run("with matching revision label: policy is present", func(t *testing.T) {
+		s.addPolicy(t, policyName+"-rev", testNS, nil, gvk.AuthorizationPolicy, func(obj controllers.Object) {
+			p := obj.(*clientsecurityv1beta1.AuthorizationPolicy)
+			if p.Labels == nil {
+				p.Labels = map[string]string{}
+			}
+			p.Labels[label.IoIstioRev.Name] = "some-rev"
+		})
+		s.assertEvent(t, policyName+"-rev")
+
+		// Should be present in s.authorizationPolicies
+		pol := s.authorizationPolicies.GetKey(testNS + "/" + policyName + "-rev")
+		if pol == nil {
+			t.Errorf("AuthorizationPolicy without revision label should be present, but was not")
+		}
+	})
+}
+
 // TODO(nmittler): Consider splitting this into multiple, smaller tests.
 func TestAmbientIndex_Policy(t *testing.T) {
 	cases := []struct {
@@ -982,7 +1026,7 @@ func TestAmbientIndex_Policy(t *testing.T) {
 			if c.multicluster {
 				test.SetForTest(t, &features.EnableAmbientMultiNetwork, true)
 			}
-			s := newAmbientTestServer(t, testC, testNW)
+			s := newAmbientTestServer(t, testC, testNW, "")
 			setupPolicyTest(t, s)
 			selectorPolicyName := "selector"
 
@@ -1427,7 +1471,7 @@ func TestDefaultAllowWaypointPolicy(t *testing.T) {
 			s := newAmbientTestServerWithFlags(t, testC, testNW, FeatureFlags{
 				DefaultAllowFromWaypoint:              true,
 				EnableK8SServiceSelectWorkloadEntries: features.EnableK8SServiceSelectWorkloadEntries,
-			})
+			}, "")
 			setupPolicyTest(t, s)
 
 			t.Run("policy with service accounts", func(t *testing.T) {
@@ -1477,7 +1521,7 @@ func TestPodLifecycleWorkloadGates(t *testing.T) {
 			if c.multicluster {
 				test.SetForTest(t, &features.EnableAmbientMultiNetwork, true)
 			}
-			s := newAmbientTestServer(t, "", "")
+			s := newAmbientTestServer(t, "", "", "")
 
 			s.addPods(t, "127.0.0.1", "pod1", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
 			s.assertEvent(t, "//Pod/ns1/pod1")
@@ -1516,7 +1560,7 @@ func TestAddressInformation(t *testing.T) {
 			if c.multicluster {
 				test.SetForTest(t, &features.EnableAmbientMultiNetwork, true)
 			}
-			s := newAmbientTestServer(t, testC, testNW)
+			s := newAmbientTestServer(t, testC, testNW, "")
 			// Add 2 pods with the "a" label, and one without.
 			// We should get an event for the new Service and the two *Pod* IPs impacted
 			s.addPods(t, "127.0.0.1", "pod1", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
@@ -1753,7 +1797,7 @@ func TestUpdateWaypointForWorkload(t *testing.T) {
 			if c.multicluster {
 				test.SetForTest(t, &features.EnableAmbientMultiNetwork, true)
 			}
-			s := newAmbientTestServer(t, "", "")
+			s := newAmbientTestServer(t, "", "", "")
 
 			// add our waypoints but they won't be used until annotations are added
 			// add a new waypoint
@@ -1854,7 +1898,7 @@ func TestWorkloadsForWaypoint(t *testing.T) {
 			if c.multicluster {
 				test.SetForTest(t, &features.EnableAmbientMultiNetwork, true)
 			}
-			s := newAmbientTestServer(t, "", testNW)
+			s := newAmbientTestServer(t, "", testNW, "")
 
 			assertWaypoint := func(t *testing.T, waypointHostname string, expected ...string) {
 				t.Helper()
@@ -1925,7 +1969,7 @@ func TestWorkloadsForWaypointOrder(t *testing.T) {
 			if c.multicluster {
 				test.SetForTest(t, &features.EnableAmbientMultiNetwork, true)
 			}
-			s := newAmbientTestServer(t, "", testNW)
+			s := newAmbientTestServer(t, "", testNW, "")
 
 			assertOrderedWaypoint := func(t *testing.T, hostname string, expected ...string) {
 				t.Helper()
@@ -1998,7 +2042,7 @@ func TestPolicyAfterPod(t *testing.T) {
 			if c.multicluster {
 				test.SetForTest(t, &features.EnableAmbientMultiNetwork, true)
 			}
-			s := newAmbientTestServer(t, testC, testNW)
+			s := newAmbientTestServer(t, testC, testNW, "")
 
 			s.addService(t, "svc1",
 				map[string]string{},
@@ -2036,11 +2080,11 @@ type ambientTestServer struct {
 	t         *testing.T
 }
 
-func newAmbientTestServer(t *testing.T, clusterID cluster.ID, networkID network.ID) *ambientTestServer {
+func newAmbientTestServer(t *testing.T, clusterID cluster.ID, networkID network.ID, revision string) *ambientTestServer {
 	return newAmbientTestServerWithFlags(t, clusterID, networkID, FeatureFlags{
 		DefaultAllowFromWaypoint:              features.DefaultAllowFromWaypoint,
 		EnableK8SServiceSelectWorkloadEntries: features.EnableK8SServiceSelectWorkloadEntries,
-	})
+	}, revision)
 }
 
 func newAmbientTestServerFromOptions(t *testing.T, networkID network.ID, options Options, runClient bool) *ambientTestServer {
@@ -2145,7 +2189,7 @@ func newAmbientTestServerFromOptions(t *testing.T, networkID network.ID, options
 	return a
 }
 
-func newAmbientTestServerWithFlags(t *testing.T, clusterID cluster.ID, networkID network.ID, flags FeatureFlags) *ambientTestServer {
+func newAmbientTestServerWithFlags(t *testing.T, clusterID cluster.ID, networkID network.ID, flags FeatureFlags, revision string) *ambientTestServer {
 	up := xdsfake.NewFakeXDS()
 	up.SplitEvents = true
 	cl := kubeclient.NewFakeClient()
@@ -2157,6 +2201,7 @@ func newAmbientTestServerWithFlags(t *testing.T, clusterID cluster.ID, networkID
 
 	debugger := krt.GlobalDebugHandler
 	o := Options{
+		Revision:        revision,
 		Client:          cl,
 		SystemNamespace: systemNS,
 		DomainSuffix:    "company.com",

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_workloadentry_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_workloadentry_test.go
@@ -49,7 +49,7 @@ func TestAmbientIndex_WorkloadEntries(t *testing.T) {
 			if c.multicluster {
 				test.SetForTest(t, &features.EnableAmbientMultiNetwork, true)
 			}
-			s := newAmbientTestServer(t, testC, testNW)
+			s := newAmbientTestServer(t, testC, testNW, "")
 
 			s.addWorkloadEntries(t, "127.0.0.1", "name1", "sa1", map[string]string{"app": "a"})
 			s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "name1")
@@ -320,7 +320,7 @@ func TestAmbientIndex_EmptyAddrWorkloadEntries(t *testing.T) {
 			if c.multicluster {
 				test.SetForTest(t, &features.EnableAmbientMultiNetwork, true)
 			}
-			s := newAmbientTestServer(t, testC, testNW)
+			s := newAmbientTestServer(t, testC, testNW, "")
 			s.addWorkloadEntries(t, "", "emptyaddr1", "sa1", map[string]string{"app": "a"})
 			s.assertEvent(t, s.wleXdsName("emptyaddr1"))
 			s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "emptyaddr1")
@@ -363,7 +363,7 @@ func TestAmbientIndex_UpdateExistingWorkloadEntry(t *testing.T) {
 			if c.multicluster {
 				test.SetForTest(t, &features.EnableAmbientMultiNetwork, true)
 			}
-			s := newAmbientTestServer(t, testC, testNW)
+			s := newAmbientTestServer(t, testC, testNW, "")
 			s.addWorkloadEntries(t, "", "emptyaddr1", "sa1", map[string]string{"app": "a"})
 			s.assertEvent(t, s.wleXdsName("emptyaddr1"))
 			s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "emptyaddr1")
@@ -395,7 +395,7 @@ func TestAmbientIndex_InlinedWorkloadEntries(t *testing.T) {
 			if c.multicluster {
 				test.SetForTest(t, &features.EnableAmbientMultiNetwork, true)
 			}
-			s := newAmbientTestServer(t, testC, testNW)
+			s := newAmbientTestServer(t, testC, testNW, "")
 
 			s.addServiceEntry(t, "se.istio.io", []string{"240.240.23.45"}, "se1", testNS, map[string]string{"app": "a"}, []string{"127.0.0.1", "127.0.0.2"})
 			s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "se1")
@@ -447,7 +447,7 @@ func TestAmbientIndex_WorkloadEntries_DisableK8SServiceSelectWorkloadEntries(t *
 			s := newAmbientTestServerWithFlags(t, testC, testNW, FeatureFlags{
 				DefaultAllowFromWaypoint:              features.DefaultAllowFromWaypoint,
 				EnableK8SServiceSelectWorkloadEntries: false,
-			})
+			}, "")
 
 			s.addWorkloadEntries(t, "127.0.0.1", "name1", "sa1", map[string]string{"app": "a"})
 			s.assertEvent(t, s.wleXdsName("name1"))

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/sidecar_interop_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/sidecar_interop_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestIngressInterop(t *testing.T) {
 	// Test that we can get updates for EDS when we have service bound waypoints.
-	s := newAmbientTestServer(t, testC, testNW)
+	s := newAmbientTestServer(t, testC, testNW, "")
 	// the two types return different keys.. rename to make it more clear
 	addressUpdate := s.svcXdsName
 	edsUpdate := s.hostnameForService


### PR DESCRIPTION
**Please provide a description of this PR:**
Unlike sidecar mode, ambient index does not filter configs by revision. For example if istiod is revision `stable` and config CRs such as authz policy are `canary` revision labelled, still these configs are in ambient index and pushed to ztunnel.
This PR is adding the config filtering by revision.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
