### PR TITLE
base image builder: fix script

### DIFF
--- a/tools/build-base-images.sh
+++ b/tools/build-base-images.sh
@@ -90,7 +90,7 @@ if [[ "${unexpectedFiles}" != "" ]]; then
   echo "Found unexpected binaries: ${unexpectedFiles}"
   exit 1
 fi
-
+popd > /dev/null
 # Now actually build it
 # shellcheck disable=SC2086
 apko publish --arch="${APKO_ARCHES}" docker/iptables.yaml ${APKO_IMAGES}


### PR DESCRIPTION
We pushd but did not popd so the config file was not found
