### PR TITLE
Removes unnecessary interaction with compartments

### DIFF
--- a/cni/pkg/iptables/iptables.go
+++ b/cni/pkg/iptables/iptables.go
@@ -59,8 +59,8 @@ type IptablesConfig struct {
 
 type InPodRouter interface {
 	// by convention use 1st Addr for ipv4 and 2nd for ipv6 SNAT host
-	CreateInpodRules(*istiolog.Scope, PodLevelOverrides) error
-	DeleteInpodRules(*istiolog.Scope) error
+	CreateInpodRules(*istiolog.Scope, PodLevelOverrides, string) error
+	DeleteInpodRules(*istiolog.Scope, string) error
 	ReconcileModeEnabled() bool
 }
 

--- a/cni/pkg/iptables/iptables_e2e_linux_test.go
+++ b/cni/pkg/iptables/iptables_e2e_linux_test.go
@@ -59,32 +59,32 @@ func TestIdempotentEquivalentInPodRerun(t *testing.T) {
 				t.Fatalf("failed to setup iptables configurator: %v", err)
 			}
 			defer func() {
-				assert.NoError(t, iptConfiguratorPod.DeleteInpodRules(log))
+				assert.NoError(t, iptConfiguratorPod.DeleteInpodRules(log, ""))
 				residueExists, deltaExists := iptablescapture.VerifyIptablesState(log, iptConfiguratorPod.ext, builder, &iptConfiguratorPod.iptV, &iptConfiguratorPod.ipt6V)
 				assert.Equal(t, residueExists, false)
 				assert.Equal(t, deltaExists, true)
 			}()
-			assert.NoError(t, iptConfiguratorPod.CreateInpodRules(scopes.CNIAgent, tt.podOverrides))
+			assert.NoError(t, iptConfiguratorPod.CreateInpodRules(scopes.CNIAgent, tt.podOverrides, ""))
 			residueExists, deltaExists := iptablescapture.VerifyIptablesState(log, iptConfiguratorPod.ext, builder, &iptConfiguratorPod.iptV, &iptConfiguratorPod.ipt6V)
 			assert.Equal(t, residueExists, true)
 			assert.Equal(t, deltaExists, false)
 
 			t.Log("Starting cleanup")
 			// Cleanup, should work
-			assert.NoError(t, iptConfiguratorPod.DeleteInpodRules(log))
+			assert.NoError(t, iptConfiguratorPod.DeleteInpodRules(log, ""))
 			residueExists, deltaExists = iptablescapture.VerifyIptablesState(log, iptConfiguratorPod.ext, builder, &iptConfiguratorPod.iptV, &iptConfiguratorPod.ipt6V)
 			assert.Equal(t, residueExists, false)
 			assert.Equal(t, deltaExists, true)
 
 			t.Log("Second run")
 			// Apply should work again
-			assert.NoError(t, iptConfiguratorPod.CreateInpodRules(scopes.CNIAgent, tt.podOverrides))
+			assert.NoError(t, iptConfiguratorPod.CreateInpodRules(scopes.CNIAgent, tt.podOverrides, ""))
 			residueExists, deltaExists = iptablescapture.VerifyIptablesState(log, iptConfiguratorPod.ext, builder, &iptConfiguratorPod.iptV, &iptConfiguratorPod.ipt6V)
 			assert.Equal(t, residueExists, true)
 			assert.Equal(t, deltaExists, false)
 
 			t.Log("Third run")
-			assert.NoError(t, iptConfiguratorPod.CreateInpodRules(scopes.CNIAgent, tt.podOverrides))
+			assert.NoError(t, iptConfiguratorPod.CreateInpodRules(scopes.CNIAgent, tt.podOverrides, ""))
 		})
 	}
 }
@@ -107,7 +107,7 @@ func TestIdempotentUnequalInPodRerun(t *testing.T) {
 			}
 
 			defer func() {
-				assert.NoError(t, iptConfiguratorPod.DeleteInpodRules(log))
+				assert.NoError(t, iptConfiguratorPod.DeleteInpodRules(log, ""))
 				residueExists, deltaExists := iptablescapture.VerifyIptablesState(log, iptConfiguratorPod.ext, builder, &iptConfiguratorPod.iptV, &iptConfiguratorPod.ipt6V)
 				assert.Equal(t, residueExists, true)
 				assert.Equal(t, deltaExists, true)
@@ -123,7 +123,7 @@ func TestIdempotentUnequalInPodRerun(t *testing.T) {
 				assert.Equal(t, deltaExists, true)
 			}()
 
-			assert.NoError(t, iptConfiguratorPod.CreateInpodRules(scopes.CNIAgent, tt.podOverrides))
+			assert.NoError(t, iptConfiguratorPod.CreateInpodRules(scopes.CNIAgent, tt.podOverrides, ""))
 			residueExists, deltaExists := iptablescapture.VerifyIptablesState(log, iptConfiguratorPod.ext, builder, &iptConfiguratorPod.iptV, &iptConfiguratorPod.ipt6V)
 			assert.Equal(t, residueExists, true)
 			assert.Equal(t, deltaExists, false)
@@ -157,11 +157,11 @@ func TestIdempotentUnequalInPodRerun(t *testing.T) {
 
 			// Creating new inpod rules should fail if reconciliation is disabled
 			cfg.Reconcile = false
-			assert.Error(t, iptConfiguratorPod.CreateInpodRules(scopes.CNIAgent, tt.podOverrides))
+			assert.Error(t, iptConfiguratorPod.CreateInpodRules(scopes.CNIAgent, tt.podOverrides, ""))
 
 			// Creating new inpod rules should succeed if reconciliation is enabled
 			cfg.Reconcile = true
-			assert.NoError(t, iptConfiguratorPod.CreateInpodRules(scopes.CNIAgent, tt.podOverrides))
+			assert.NoError(t, iptConfiguratorPod.CreateInpodRules(scopes.CNIAgent, tt.podOverrides, ""))
 			residueExists, deltaExists = iptablescapture.VerifyIptablesState(log, iptConfiguratorPod.ext, builder, &iptConfiguratorPod.iptV, &iptConfiguratorPod.ipt6V)
 			assert.Equal(t, residueExists, true)
 			assert.Equal(t, deltaExists, false)

--- a/cni/pkg/iptables/iptables_linux.go
+++ b/cni/pkg/iptables/iptables_linux.go
@@ -245,7 +245,7 @@ func NewIptablesConfigurator(
 	return configurator, inPodConfigurator, nil
 }
 
-func (cfg *IptablesConfigurator) DeleteInpodRules(log *istiolog.Scope) error {
+func (cfg *IptablesConfigurator) DeleteInpodRules(log *istiolog.Scope, ns string) error {
 	var inpodErrs []error
 
 	log.Debug("deleting iptables rules")
@@ -294,7 +294,7 @@ func (cfg *IptablesConfigurator) executeDeleteCommands(log *istiolog.Scope) {
 
 // Setup iptables rules for in-pod mode. Ideally this should be an idempotent function.
 // NOTE that this expects to be run from within the pod network namespace!
-func (cfg *IptablesConfigurator) CreateInpodRules(log *istiolog.Scope, podOverrides PodLevelOverrides) error {
+func (cfg *IptablesConfigurator) CreateInpodRules(log *istiolog.Scope, podOverrides PodLevelOverrides, ns string) error {
 	// Append our rules here
 	builder := cfg.AppendInpodRules(podOverrides)
 

--- a/cni/pkg/iptables/iptables_test.go
+++ b/cni/pkg/iptables/iptables_test.go
@@ -38,7 +38,7 @@ func TestIptablesPodOverrides(t *testing.T) {
 				tt.config(cfg)
 				ext := &dep.DependenciesStub{}
 				iptConfigurator, _, _ := NewIptablesConfigurator(cfg, cfg, ext, ext, EmptyNlDeps())
-				err := iptConfigurator.CreateInpodRules(scopes.CNIAgent, tt.podOverrides)
+				err := iptConfigurator.CreateInpodRules(scopes.CNIAgent, tt.podOverrides, "")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -82,7 +82,7 @@ func TestInvokedTwiceIsIdempotent(t *testing.T) {
 			tt.config(cfg)
 			ext := &dep.DependenciesStub{}
 			iptConfigurator, _, _ := NewIptablesConfigurator(cfg, cfg, ext, ext, EmptyNlDeps())
-			err := iptConfigurator.CreateInpodRules(scopes.CNIAgent, tt.podOverrides)
+			err := iptConfigurator.CreateInpodRules(scopes.CNIAgent, tt.podOverrides, "")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -90,7 +90,7 @@ func TestInvokedTwiceIsIdempotent(t *testing.T) {
 
 			*ext = dep.DependenciesStub{}
 			// run another time to make sure we are idempotent
-			err = iptConfigurator.CreateInpodRules(scopes.CNIAgent, tt.podOverrides)
+			err = iptConfigurator.CreateInpodRules(scopes.CNIAgent, tt.podOverrides, "")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cni/pkg/nodeagent/net_linux.go
+++ b/cni/pkg/nodeagent/net_linux.go
@@ -165,7 +165,7 @@ func (s *NetServer) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod, isDe
 		if openNetns != nil {
 			// pod is removed from the mesh, but is still running. remove iptables rules
 			log.Debugf("calling DeleteInpodRules")
-			if err := s.netnsRunner(openNetns, func() error { return s.podIptables.DeleteInpodRules(log) }); err != nil {
+			if err := s.netnsRunner(openNetns, func() error { return s.podIptables.DeleteInpodRules(log, "") }); err != nil {
 				return fmt.Errorf("failed to delete inpod rules: %w", err)
 			}
 		} else {
@@ -205,7 +205,7 @@ func (s *NetServer) reconcileExistingPod(pod *corev1.Pod) error {
 	podCfg := getPodLevelTrafficOverrides(pod)
 
 	if err := s.netnsRunner(openNetns, func() error {
-		return s.podIptables.CreateInpodRules(log, podCfg)
+		return s.podIptables.CreateInpodRules(log, podCfg, "")
 	}); err != nil {
 		return err
 	}

--- a/cni/pkg/nodeagent/net_linux.go
+++ b/cni/pkg/nodeagent/net_linux.go
@@ -119,7 +119,7 @@ func (s *NetServer) AddPodToMesh(ctx context.Context, pod *corev1.Pod, podIPs []
 
 	log.Debug("calling CreateInpodRules")
 	if err := s.netnsRunner(openNetns, func() error {
-		return s.podIptables.CreateInpodRules(log, podCfg)
+		return s.podIptables.CreateInpodRules(log, podCfg, "")
 	}); err != nil {
 		// We currently treat any failure to create inpod rules as non-retryable/catastrophic,
 		// and return a NonRetryableError in this case.

--- a/cni/pkg/nodeagent/pod_cache_windows.go
+++ b/cni/pkg/nodeagent/pod_cache_windows.go
@@ -66,7 +66,7 @@ func (p *podNetnsCache) ReadCurrentPodSnapshot() map[string]WorkloadInfo {
 	return maps.Clone(p.currentPodCache)
 }
 
-func (p *podNetnsCache) GetEndpointsForNamespaceID(id uint32) ([]string, error) {
+func (p *podNetnsCache) GetEndpointsForNamespaceGUID(guid string) ([]string, error) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	if len(p.currentPodCache) == 0 {
@@ -77,12 +77,12 @@ func (p *podNetnsCache) GetEndpointsForNamespaceID(id uint32) ([]string, error) 
 		if !ok {
 			return nil, fmt.Errorf("pod cache entry is not a NamespaceCloser")
 		}
-		if namespaceCloser.Namespace().ID == id {
+		if namespaceCloser.Namespace().GUID == guid {
 			return namespaceCloser.Namespace().EndpointIds, nil
 		}
-		log.Infof("workload %s with id %d doesn't match id %d", info.Workload().Name, namespaceCloser.Namespace().ID, id)
+		log.Infof("workload %s with id %s doesn't match id %s", info.Workload().Name, namespaceCloser.Namespace().GUID, guid)
 	}
-	return nil, fmt.Errorf("no namespace found in cache for id %d", id)
+	return nil, fmt.Errorf("no namespace found in cache for guid %s", guid)
 
 }
 
@@ -134,7 +134,7 @@ func (p *podNetnsCache) UpsertPodCacheWithNetns(uid string, workload WorkloadInf
 	}
 
 	// Doesn't exist yet, add it
-	log.Infof("adding pod to cache %s with guid %s", workload.Workload().Name, workloadNetns.Namespace().GUID)
+	log.Infof("adding pod to cache %s with namespace guid %s", workload.Workload().Name, workloadNetns.Namespace().GUID)
 	p.currentPodCache[uid] = workload
 	return workloadNetns
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

This PR removes the unnecessary interaction with network compartments. HCN/HNS is made to be accessible from the host system. As HCN namespaces can give us the endpoints involved in a certain pod, that's all we need to set up the WFP policies needed to proxy the packets with ztunnel.