### PR TITLE
remove finding of pods by IP

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -275,6 +275,9 @@ var (
 			" (e.g., my-service.my-ns.svc.cluster.local.) to the domains"+
 			" list for VirtualHost entries.",
 	).Get()
+
+	EnableProxyFindPodByIP = env.Register("ENABLE_PROXY_FIND_POD_BY_IP", false,
+		"If enabled, the pod controller will allow findig pods matching proxies by IP if it fails to find them by name.").Get()
 )
 
 // UnsafeFeaturesEnabled returns true if any unsafe features are enabled.

--- a/pilot/pkg/serviceregistry/kube/controller/pod.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod.go
@@ -348,36 +348,13 @@ func (pc *PodCache) getPodByKey(key types.NamespacedName) *v1.Pod {
 
 // getPodByKey returns the pod of the proxy
 func (pc *PodCache) getPodByProxy(proxy *model.Proxy) *v1.Pod {
-	var pod *v1.Pod
 	key := podKeyByProxy(proxy)
 	if key.Name != "" {
-		pod = pc.getPodByKey(key)
+		pod := pc.getPodByKey(key)
 		if pod != nil {
 			return pod
 		}
 	}
 
-	// only need to fetch the corresponding pod through the first IP, although there are multiple IP scenarios,
-	// because multiple ips belong to the same pod
-	proxyIP := proxy.IPAddresses[0]
-	// just in case the proxy ID is bad formatted
-	pods := pc.getPodsByIP(proxyIP)
-	switch len(pods) {
-	case 0:
-		return nil
-	case 1:
-		return pods[0]
-	default:
-		// This should only happen with hostNetwork pods, which cannot be proxy clients...
-		log.Errorf("unexpected: found multiple pods for proxy %v (%v)", proxy.ID, proxyIP)
-		// Try to handle it gracefully
-		for _, p := range pods {
-			// At least filter out wrong namespaces...
-			if proxy.ConfigNamespace != p.Namespace {
-				continue
-			}
-			return p
-		}
-		return nil
-	}
+	return nil
 }

--- a/pilot/pkg/serviceregistry/kube/controller/pod.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod.go
@@ -356,5 +356,31 @@ func (pc *PodCache) getPodByProxy(proxy *model.Proxy) *v1.Pod {
 		}
 	}
 
+	if features.EnableProxyFindPodByIP {
+		// only need to fetch the corresponding pod through the first IP, although there are multiple IP scenarios,
+		// because multiple ips belong to the same pod
+		proxyIP := proxy.IPAddresses[0]
+		// just in case the proxy ID is bad formatted
+		pods := pc.getPodsByIP(proxyIP)
+		switch len(pods) {
+		case 0:
+			return nil
+		case 1:
+			return pods[0]
+		default:
+			// This should only happen with hostNetwork pods, which cannot be proxy clients...
+			log.Errorf("unexpected: found multiple pods for proxy %v (%v)", proxy.ID, proxyIP)
+			// Try to handle it gracefully
+			for _, p := range pods {
+				// At least filter out wrong namespaces...
+				if proxy.ConfigNamespace != p.Namespace {
+					continue
+				}
+				return p
+			}
+			return nil
+		}
+	}
+
 	return nil
 }

--- a/pilot/pkg/serviceregistry/kube/controller/util.go
+++ b/pilot/pkg/serviceregistry/kube/controller/util.go
@@ -150,9 +150,9 @@ func isNodePortGatewayService(svc *v1.Service) bool {
 
 // Get the pod key of the proxy which can be used to get pod from the informer cache
 func podKeyByProxy(proxy *model.Proxy) types.NamespacedName {
-	parts := strings.Split(proxy.ID, ".")
-	if len(parts) == 2 && proxy.Metadata.Namespace == parts[1] {
-		return types.NamespacedName{Name: parts[0], Namespace: parts[1]}
+	name, namespace, ok := strings.Cut(proxy.ID, ".")
+	if ok && proxy.Metadata.Namespace == namespace {
+		return types.NamespacedName{Name: name, Namespace: namespace}
 	}
 
 	return types.NamespacedName{}

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -1900,7 +1900,7 @@ func TestLocality(t *testing.T) {
 	namespace := "default"
 	basePod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pod",
+			Name:      "test-1",
 			Namespace: namespace,
 			Labels:    map[string]string{},
 		},
@@ -2061,8 +2061,10 @@ func TestLocality(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := xds.FakeOptions{}
+			proxyName := ""
 			if tt.pod != nil {
 				opts.KubernetesObjects = append(opts.KubernetesObjects, tt.pod)
+				proxyName = tt.pod.Name + "." + tt.pod.Namespace
 			}
 			if tt.node != nil {
 				opts.KubernetesObjects = append(opts.KubernetesObjects, tt.node)
@@ -2071,7 +2073,7 @@ func TestLocality(t *testing.T) {
 				opts.Configs = append(opts.Configs, tt.obj)
 			}
 			s := xds.NewFakeDiscoveryServer(t, opts)
-			s.Connect(s.SetupProxy(&model.Proxy{IPAddresses: []string{"1.2.3.4"}}), nil, []string{v3.ClusterType})
+			s.Connect(s.SetupProxy(&model.Proxy{ID: proxyName, IPAddresses: []string{"1.2.3.4"}}), nil, []string{v3.ClusterType})
 			retry.UntilSuccessOrFail(t, func() error {
 				clients := s.Discovery.AllClients()
 				if len(clients) != 1 {

--- a/releasenotes/notes/pod-controller-avoid-ip-search.yaml
+++ b/releasenotes/notes/pod-controller-avoid-ip-search.yaml
@@ -1,0 +1,14 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+- |
+  **Added** feature ENABLE_PROXY_FIND_POD_BY_IP that allows to enable association of Pods to Proxies by IP address if association by name and namespace fails.
+
+upgradeNodes:
+- title: Change in behaviour of how Istio finds matching Pods for a given Proxy
+  content: |
+    In previous versions, Istio  would search for matching Pods for a given Proxy by IP address when it failed to find
+    them by name and namespace. This behaviour is now disabled by default and can be enabled using the
+    `ENABLE_PROXY_FIND_POD_BY_IP` feature flag. This will only impact users who are customizing the Istio Proxy and that
+    are not correctly setting the Proxy ID and Metadata required to find the worload name. For context see https://github.com/istio/istio/pull/56502


### PR DESCRIPTION
**Please provide a description of this PR:**
Creating this as a draft to check if tests pass, I'm not sure why we still maintain this logic, I cannot understand in which cases we would fail to find a Pod by it's name+namespace but find them by IP.