### PR TITLE
krt: add assertions

### DIFF
--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -35,6 +35,9 @@ const (
 	getKeyType       indexedDependencyType = iota
 )
 
+// EnableAssertions, if true, will enable assertions. These typically are violations of the krt collection requirements.
+const EnableAssertions = false
+
 type dependencyState[I any] struct {
 	// collectionDependencies specifies the set of collections we depend on from within the transformation functions (via Fetch).
 	// These are keyed by the internal uid() function on collections.
@@ -506,6 +509,9 @@ func (h *manyCollection[I, O]) onPrimaryInputEventLocked(items []Event[I]) {
 					e.New = &newRes
 					h.collectionState.outputs[key] = newRes
 				} else {
+					if !oldExists && EnableAssertions {
+						panic(fmt.Sprintf("!oldExists and !newExists, how did we get here? for output key %v input key %v", key, iKey))
+					}
 					e.Event = controllers.EventDelete
 					e.Old = &oldRes
 					delete(h.collectionState.outputs, key)
@@ -522,7 +528,9 @@ func (h *manyCollection[I, O]) onPrimaryInputEventLocked(items []Event[I]) {
 			}
 		}
 	}
-
+	if EnableAssertions {
+		h.assertIndexConsistency()
+	}
 	// Short circuit if we have nothing to do
 	if len(events) == 0 {
 		return
@@ -745,6 +753,24 @@ func (h *manyCollection[I, O]) name() string {
 // nolint: unused // (not true, its to implement an interface)
 func (h *manyCollection[I, O]) uid() collectionUID {
 	return h.id
+}
+
+func (h *manyCollection[I, O]) assertIndexConsistency() {
+	oToI := map[Key[O]]Key[I]{}
+	for i, os := range h.collectionState.mappings {
+		if _, f := h.collectionState.inputs[i]; !f {
+			panic(fmt.Sprintf("for mapping key %v, no input found", i))
+		}
+		for o := range os {
+			if ci, f := oToI[o]; f {
+				panic(fmt.Sprintf("duplicate mapping %v: input %v and %v both map to it", o, ci, i))
+			}
+			oToI[o] = i
+			if _, f := h.collectionState.outputs[o]; !f {
+				panic(fmt.Sprintf("for mapping key %v->%v, no output found", i, o))
+			}
+		}
+	}
 }
 
 // collectionDependencyTracker tracks, for a single transformation call, all dependencies registered.

--- a/pkg/kube/krt/collection_test.go
+++ b/pkg/kube/krt/collection_test.go
@@ -47,6 +47,15 @@ type SimpleSizedPod struct {
 	Size string
 }
 
+type RenamedSimplePod struct {
+	Key string
+	SimplePod
+}
+
+func (r RenamedSimplePod) ResourceName() string {
+	return r.Key
+}
+
 type SimplePod struct {
 	Named
 	Labeled


### PR DESCRIPTION
Krt places a number of un-checked requirements on collections.

This PR introduces a new knob to turn on assertions to be used during
development. IT IS OFF for production.

For the record, I had two tests that fail these assertions:

```go


func TestCollectionInvalid(t *testing.T) {
	//return
	stop := test.NewStop(t)
	opts := testOptions(t)
	c := kube.NewFakeClient()
	kpc := kclient.New[*corev1.Pod](c)
	pc := clienttest.Wrap(t, kpc)
	pods := krt.WrapClient[*corev1.Pod](kpc, opts.WithName("Pods")...)
	c.RunAndWait(stop)
	BadPods := krt.NewCollection(pods, func(ctx krt.HandlerContext, i *corev1.Pod) *SimplePod {
		return &SimplePod{
			// Ignore namespace, so we will have 2 inputs map to one output.
			Named: Named{Name: i.Name},
			IP:    i.Status.PodIP,
		}
	}, opts.WithName("Broken")...)
	BadPods.Register(func(o krt.Event[SimplePod]) {
		log.Errorf("howardjohn: %v %v %v", o.Event, o.Old, o.New)
	})

	assert.Equal(t, fetcherSorted(BadPods)(), nil)
	pod := &corev1.Pod{
		ObjectMeta: metav1.ObjectMeta{
			Name:      "name",
			Namespace: "namespace",
		},
		Status: corev1.PodStatus{PodIP: "1.2.3.4"},
	}
	pc.CreateOrUpdateStatus(pod)
	assert.EventuallyEqual(t, fetcherSorted(BadPods), []SimplePod{{Named{Name: "name"}, Labeled{}, "1.2.3.4"}})

	pod2 := &corev1.Pod{
		ObjectMeta: metav1.ObjectMeta{
			Name:      "name",
			Namespace: "namespace2",
		},
		Status: corev1.PodStatus{PodIP: "1.2.3.5"},
	}
	pc.Create(pod2)
	assert.EventuallyEqual(t, fetcherSorted(BadPods), []SimplePod{
		{Named{Name: "name"}, Labeled{}, "1.2.3.4"},
	})
	time.Sleep(time.Millisecond*50)

	pc.Delete("name", "namespace2")
	assert.EventuallyEqual(t, fetcherSorted(BadPods), []SimplePod{
		{Named{Name: "name"}, Labeled{}, "1.2.3.4"},
	})
	time.Sleep(time.Millisecond*50)
}


func TestIndexMerge(t *testing.T) {
	return
	opts := testOptions(t)
	dumpOnFailure(t, opts.Debugger())
	c := kube.NewFakeClient()
	kpc := kclient.New[*corev1.ConfigMap](c)
	cmt := clienttest.Wrap(t, kpc)
	cms := krt.WrapClient[*corev1.ConfigMap](kpc, opts.WithName("ConfigMaps")...)
	index := krt.NewIndex[string, *corev1.ConfigMap](cms, "key", func(o *corev1.ConfigMap) []string {
		return []string{o.Data["key"]}
	})
	c.RunAndWait(opts.Stop())
	merged := krt.SafeMerge(index, func(ctx krt.HandlerContext, objects []*corev1.ConfigMap) **corev1.ConfigMap {
		log.Errorf("howardjohn: compute %v configmaps", len(objects))
		cms := slices.SortBy(objects, (*corev1.ConfigMap).GetName)
		if len(cms) == 0 {
			return nil
		}
		base := cms[0].DeepCopy()
		for _, cm := range cms[1:] {
			base.Data["value"] = base.Data["value"] + "," + cm.Data["value"]
		}
		return &base
	})
	//merged := krt.NewCollection(index.AsCollection(),
	//	func(ctx krt.HandlerContext, io krt.IndexObject[string, *corev1.ConfigMap]) **corev1.ConfigMap {
	//		log.Errorf("howardjohn: COMPUTE %v, %v", io.Key, len(io.Objects))
	//		cms := slices.SortBy(io.Objects, (*corev1.ConfigMap).GetName)
	//		if len(cms) == 0 {
	//			return nil
	//		}
	//		base := cms[0].DeepCopy()
	//		for _, cm := range cms[1:] {
	//			base.Data["value"] = base.Data["value"] + "," + cm.Data["value"]
	//		}
	//		return &base
	//	}, opts.WithName("merged")...)
	merged.Register(func(o krt.Event[*corev1.ConfigMap]) {
		log.Errorf("howardjohn: %v %v", o.Items(), krt.GetKey(o.Items()[0]))
	})

	tt := assert.NewTracker[string](t)
	index.AsCollection().Register(TrackerHandler[krt.IndexObject[string, *corev1.ConfigMap]](tt))

	assertion := func(name, key, value string) {
		t.Helper()
		assert.EventuallyEqual(t, func() *corev1.ConfigMap {
			v := merged.GetKey(name)
			log.Errorf("howardjohn: get key %v %v", name, v)
			log.Errorf("howardjohn: list %v", merged.List())
			if len(merged.List()) > 0 {
				log.Errorf("howardjohn: list key %v", krt.GetKey(merged.List()[0]))
			}
			return ptr.Flatten(v)
		}, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: name}, Data: map[string]string{"key": key, "value": value}})
	}

	cmt.CreateOrUpdate(&corev1.ConfigMap{
		ObjectMeta: metav1.ObjectMeta{Name: "a"},
		Data:       map[string]string{"key": "key1", "value": "valuea"},
	})
	assertion("a", "key1", "valuea")
	tt.WaitOrdered("add/key1")

	cmt.CreateOrUpdate(&corev1.ConfigMap{
		ObjectMeta: metav1.ObjectMeta{Name: "b"},
		Data:       map[string]string{"key": "key1", "value": "valueb"},
	})
	assertion("a", "key1", "valuea,valueb")
	tt.WaitOrdered("add/key1")

	cmt.CreateOrUpdate(&corev1.ConfigMap{
		ObjectMeta: metav1.ObjectMeta{Name: "b"},
		Data:       map[string]string{"key": "key2", "value": "valueb"},
	})
	assertion("a", "key1", "valuea")
	assertion("b", "key2", "valueb")
	tt.WaitUnordered("add/key2", "add/key1")

	cmt.CreateOrUpdate(&corev1.ConfigMap{
		ObjectMeta: metav1.ObjectMeta{Name: "a"},
		Data:       map[string]string{"key": "key2", "value": "valuea"},
	})
	assertion("a", "key2", "valuea,valueb")
	tt.WaitUnordered("delete/key1", "add/key2")

}
```

Additionally, Itried to make a wrapper to allow safe merging:

```

type WithKeyPrefix[T any] struct {
	KeyPrefix string
	Inner T
}

func (w WithKeyPrefix[T]) ResourceName() string {
	return w.KeyPrefix + "/" + GetKey(w.Inner)
}

func SafeMerge[K comparable, O any](
	idx Index[K, O],
	f func(ctx HandlerContext, objects []O) *O,
	opts ...CollectionOption,
) Collection[O] {
	base := NewCollection(idx.AsCollection(), func(ctx HandlerContext, i IndexObject[K, O]) *WithKeyPrefix[O] {
		merged := f(ctx, i.Objects)
		prefix := toString(i.Key)
		if merged == nil {
			return nil
		}
		return &WithKeyPrefix[O]{
			KeyPrefix: prefix,
			Inner: *merged,
		}
	}, opts...)
	mapped := MapCollection(base, func(t WithKeyPrefix[O]) O {
		return t.Inner
	})
	return mapped
}
```

However, this does not work due to MapCollection requiring the input and output key to be the same. I added an assertion to verify this.
