### PR TITLE
Fix e2e tests when using '--istio.test.revisions' to specify multiple revisions

### DIFF
--- a/pkg/test/framework/components/echo/check/checkers.go
+++ b/pkg/test/framework/components/echo/check/checkers.go
@@ -250,8 +250,8 @@ func Hostname(expected string) echo.Checker {
 	})
 }
 
-// Hostnames check whether the hostname the request landed on is from the expected slice. This differs from Host which is the request we called.
-func Hostnames(expects []string) echo.Checker {
+// ResponseHosts checks that the response hostnames match the expected values.
+func ResponseHosts(expects []string) echo.Checker {
 	return Each(func(r echoClient.Response) error {
 		if !slices.Contains(expects, r.Hostname) {
 			return fmt.Errorf("expected hostnames %v, received %s", expects, r.Hostname)

--- a/pkg/test/framework/components/echo/check/checkers.go
+++ b/pkg/test/framework/components/echo/check/checkers.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/netip"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -244,6 +245,16 @@ func Hostname(expected string) echo.Checker {
 	return Each(func(r echoClient.Response) error {
 		if r.Hostname != expected {
 			return fmt.Errorf("expected hostname %s, received %s", expected, r.Hostname)
+		}
+		return nil
+	})
+}
+
+// Hostnames check whether the hostname the request landed on is from the expected slice. This differs from Host which is the request we called.
+func Hostnames(expects []string) echo.Checker {
+	return Each(func(r echoClient.Response) error {
+		if !slices.Contains(expects, r.Hostname) {
+			return fmt.Errorf("expected hostnames %v, received %s", expects, r.Hostname)
 		}
 		return nil
 	})

--- a/pkg/test/framework/components/echo/check/checkers.go
+++ b/pkg/test/framework/components/echo/check/checkers.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/netip"
-	"slices"
 	"strconv"
 	"strings"
 
@@ -27,6 +26,7 @@ import (
 	"google.golang.org/grpc/codes"
 
 	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/slices"
 	echoClient "istio.io/istio/pkg/test/echo"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/cluster"

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -132,7 +132,7 @@ func (d *deployment) Restart() error {
 	for _, s := range d.cfg.Subsets {
 		// TODO(Monkeyanator) move to common place so doesn't fall out of sync with templates
 		if settings.Compatibility {
-			for rev, _ := range settings.Revisions {
+			for rev := range settings.Revisions {
 				deploymentNames = append(deploymentNames, fmt.Sprintf("%s-%s-%s", d.cfg.Service, s.Version, rev))
 			}
 		} else {

--- a/releasenotes/notes/56548.yaml
+++ b/releasenotes/notes/56548.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 56548
+releaseNotes:
+- |
+  **Fixed** e2e tests when using `--istio.test.revisions` option to specify multiple revisions. Make sure e2e tests deal with correct deployments and pods with revisions in their names.

--- a/releasenotes/notes/56548.yaml
+++ b/releasenotes/notes/56548.yaml
@@ -1,8 +1,0 @@
-apiVersion: release-notes/v2
-kind: bug-fix
-area: traffic-management
-issue:
-- 56548
-releaseNotes:
-- |
-  **Fixed** e2e tests when using `--istio.test.revisions` option to specify multiple revisions. Make sure e2e tests deal with correct deployments and pods with revisions in their names.

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -610,7 +610,7 @@ spec:
 				opt.Count = 10
 				opt.Check = check.And(
 					check.OK(),
-					check.Hostnames(exps))
+					check.ResponseHosts(exps))
 				src.CallOrFail(t, opt)
 			})
 		})

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -598,19 +598,19 @@ spec:
       version: v2
     name: v2
 `).ApplyOrFail(t)
-				var exp string
+				var exps []string
 				for _, w := range dst.WorkloadsOrFail(t) {
 					if t.Settings().AmbientMultiNetwork && src.Config().Cluster != w.Cluster() {
 						t.Skip("skipping cross-cluster test")
 					}
 					if strings.Contains(w.PodName(), "-v1") {
-						exp = w.PodName()
+						exps = append(exps, w.PodName())
 					}
 				}
 				opt.Count = 10
 				opt.Check = check.And(
 					check.OK(),
-					check.Hostname(exp))
+					check.Hostnames(exps))
 				src.CallOrFail(t, opt)
 			})
 		})


### PR DESCRIPTION
**Please provide a description of this PR:**
- When using `--istio.test.revisions` to specify multiple Istio revisions for the e2e tests, deployment names will append with the revision name. Here is the K8s yaml template: https://github.com/istio/istio/blob/1.26.1/pkg/test/framework/components/echo/kube/templates/deployment.yaml#L13-L17.
- This PR makes corresponding changes to fix the e2e tests when using '--istio.test.revisions' to specify multiple revisions.
  - `TestServerRouting`: make the expected podnames contains all items with certain subset version instead of only the first item.
  - `TestServiceRestart`: make sure find the correct deployment names to restart when there are multiple Istio revision.