### PR TITLE
feat: support cacert in configMaps

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -2159,17 +2159,6 @@ func buildTLS(
 			// If we have no valid certificates, return an error
 			return out, combinedErr
 		}
-		if tls.FrontendValidation != nil && len(tls.FrontendValidation.CACertificateRefs) > 0 {
-			out.Mode = istio.ServerTLSSettings_MUTUAL
-			for _, ref := range tls.FrontendValidation.CACertificateRefs {
-				if (string(ref.Group) == gvk.ConfigMap.Group && string(ref.Kind) == gvk.ConfigMap.Kind) {
-					caCertNs := ptr.OrDefault((*string)(ref.Namespace), gw.Namespace)
-					caCert := fmt.Sprintf("%s://%s/%s%s", creds.KubernetesConfigMapType, caCertNs, ref.Name, creds.SdsCaSuffix)
-					credNames = append(credNames, caCert)
-					validCertCount++
-				}
-			}
-		}
 		if validCertCount == 1 {
 			out.CredentialName = credNames[0]
 		} else {

--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -2159,6 +2159,17 @@ func buildTLS(
 			// If we have no valid certificates, return an error
 			return out, combinedErr
 		}
+		if tls.FrontendValidation != nil && len(tls.FrontendValidation.CACertificateRefs) > 0 {
+			out.Mode = istio.ServerTLSSettings_MUTUAL
+			for _, ref := range tls.FrontendValidation.CACertificateRefs {
+				if (string(ref.Group) == gvk.ConfigMap.Group && string(ref.Kind) == gvk.ConfigMap.Kind) {
+					caCertNs := ptr.OrDefault((*string)(ref.Namespace), gw.Namespace)
+					caCert := fmt.Sprintf("%s://%s/%s%s", creds.KubernetesConfigMapType, caCertNs, ref.Name, creds.SdsCaSuffix)
+					credNames = append(credNames, caCert)
+					validCertCount++
+				}
+			}
+		}
 		if validCertCount == 1 {
 			out.CredentialName = credNames[0]
 		} else {

--- a/pilot/pkg/security/model/authentication.go
+++ b/pilot/pkg/security/model/authentication.go
@@ -261,7 +261,8 @@ func ApplyCredentialSDSToServerCommonTLSContext(tlsContext *tls.CommonTlsContext
 					hasCacert = true
 				}
 			} else {
-				tlsContext.TlsCertificateSdsSecretConfigs = append(tlsContext.TlsCertificateSdsSecretConfigs, ConstructSdsSecretConfigForCredential(name, credentialSocketExist, push))
+				tlsContext.TlsCertificateSdsSecretConfigs = append(tlsContext.TlsCertificateSdsSecretConfigs,
+					ConstructSdsSecretConfigForCredential(name, credentialSocketExist, push))
 			}
 		}
 		// If MUTUAL, we only support one CA certificate for all credentialNames. Thus we use the first one as CA.

--- a/releasenotes/notes/56549.yaml
+++ b/releasenotes/notes/56549.yaml
@@ -3,6 +3,9 @@ kind: feature
 area: security
 issue:
   - 43966
+docs:
+  - '[usage] https://istio.io/latest/docs/tasks/traffic-management/ingress/secure-ingress/#key-formats'
+  - '[reference] https://istio.io/latest/docs/reference/config/networking/gateway/#ServerTLSSettings-credential_names'
 releaseNotes:
   - |
     **Added** Support client CA certificate references with `-cacert` suffix in ServerTLSSettings.credentialsNames

--- a/releasenotes/notes/56549.yaml
+++ b/releasenotes/notes/56549.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+issue:
+  - 43966
+releaseNotes:
+  - |
+    **Added** Support client CA certificate references with `-cacert` suffix in ServerTLSSettings.credentialsNames

--- a/releasenotes/notes/56549.yaml
+++ b/releasenotes/notes/56549.yaml
@@ -5,7 +5,7 @@ issue:
   - 43966
 docs:
   - '[usage] https://istio.io/latest/docs/tasks/traffic-management/ingress/secure-ingress/#key-formats'
-  - '[reference] https://istio.io/latest/docs/reference/config/networking/gateway/#ServerTLSSettings-credential_names'
+  - '[reference] https://istio.io/latest/docs/reference/config/networking/gateway/#ServerTLSSettings-ca_cert_credential_name'
 releaseNotes:
   - |
-    **Added** Support client CA certificate references with `-cacert` suffix in ServerTLSSettings.credentialsNames
+    **Added** `caCertCredentialName` field in `ServerTLSSettings` to reference a Secret/ConfigMap that holds CA certificates for mTLS


### PR DESCRIPTION
**Please provide a description of this PR:**

This PR allows to store a trust bundle for client certificate validation in a ConfigMap.
For example, istiod will try to find envoy's secret `kubernetes-gateway://default/server-tls-cacert` in:
1. ConfigMap `default/server-tls` (added by this PR)
2. Secret `default/server-tls-cacert`
3. Secret `default/server-tls`

ConfigMap is a more natural storage type for a trust bundle, because trust bundles don't contain any secret info.

This change will make Istio compatible with [trust-manager](https://cert-manager.io/docs/trust/trust-manager/) (from the developer of cert-manager), which automates the management of configMaps containing trust bundles.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [x] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
