### PR TITLE
Fix: create-remote-secret create redundant rbac resources

### DIFF
--- a/istioctl/pkg/multicluster/remote_secret.go
+++ b/istioctl/pkg/multicluster/remote_secret.go
@@ -440,7 +440,7 @@ func generateServiceAccountYAML(opt RemoteSecretOptions) (string, error) {
 			continue
 		}
 		for _, m := range mf.Manifests {
-			if m.GetKind() == "ClusterRole" || m.GetKind() == "ClusterRoleBinding" {
+			if (m.GetKind() == "ClusterRole" || m.GetKind() == "ClusterRoleBinding") && strings.HasPrefix(m.GetName(), "istio-reader-clusterrole") {
 				included = append(included, m.Content)
 			}
 			if m.GetKind() == "ServiceAccount" && m.GetName() == "istio-reader-service-account" {

--- a/releasenotes/notes/56559.yaml
+++ b/releasenotes/notes/56559.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+issue:
+  - 56558
+
+releaseNotes:
+- |
+  **Fixed** `create-remote-secret` create redundant rbac resources.


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix `istioctl create-remote-secret --type remote` create redundant rbac resources.

Fix https://github.com/istio/istio/issues/56558


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [x] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
