### PR TITLE
pilot: use per revision leader for namespace controller

### DIFF
--- a/pilot/pkg/leaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/leaderelection.go
@@ -240,8 +240,8 @@ func NewPerRevisionLeaderElection(namespace, name, electionID, revision string, 
 	return newLeaderElection(namespace, name, electionID, revision, true, false, true, client)
 }
 
-func NewLeaderElectionMulticluster(namespace, name, electionID, revision string, remote bool, client kube.Client) *LeaderElection {
-	return newLeaderElection(namespace, name, electionID, revision, false, remote, false, client)
+func NewLeaderElectionMulticluster(namespace, name, electionID, revision string, perRevision, remote bool, client kube.Client) *LeaderElection {
+	return newLeaderElection(namespace, name, electionID, revision, perRevision, remote, false, client)
 }
 
 func newLeaderElection(namespace, name, electionID, revision string, perRevision bool, remote bool, leaseLock bool, client kube.Client) *LeaderElection {

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -191,7 +191,7 @@ func (m *Multicluster) initializeCluster(cluster *multicluster.Cluster, kubeCont
 					log.Infof("joining leader-election for %s in %s on cluster %s",
 						leaderelection.ClusterTrustBundleController, options.SystemNamespace, options.ClusterID)
 					election := leaderelection.
-						NewLeaderElectionMulticluster(options.SystemNamespace, m.serverID, leaderelection.NamespaceController, m.revision, !configCluster, client).
+						NewLeaderElectionMulticluster(options.SystemNamespace, m.serverID, leaderelection.NamespaceController, m.revision, false, !configCluster, client).
 						AddRunFunction(func(leaderStop <-chan struct{}) {
 							log.Infof("starting clustertrustbundle controller for cluster %s", cluster.ID)
 							c := clustertrustbundle.NewController(client, m.caBundleWatcher)
@@ -206,8 +206,15 @@ func (m *Multicluster) initializeCluster(cluster *multicluster.Cluster, kubeCont
 				m.s.RunComponentAsyncAndWait("namespace controller", func(_ <-chan struct{}) error {
 					log.Infof("joining leader-election for %s in %s on cluster %s",
 						leaderelection.NamespaceController, options.SystemNamespace, options.ClusterID)
+					perRevision := false
+					// Use per revision namespace controller if we have discovery selectors,
+					// because they may watch with different selectors.
+					if len(options.MeshWatcher.Mesh().GetDiscoverySelectors()) > 0 {
+						perRevision = true
+					}
 					election := leaderelection.
-						NewLeaderElectionMulticluster(options.SystemNamespace, m.serverID, leaderelection.NamespaceController, m.revision, !configCluster, client).
+						NewLeaderElectionMulticluster(options.SystemNamespace, m.serverID, leaderelection.NamespaceController, m.revision,
+							perRevision, !configCluster, client).
 						AddRunFunction(func(leaderStop <-chan struct{}) {
 							log.Infof("starting namespace controller for cluster %s", cluster.ID)
 							nc := NewNamespaceController(client, m.caBundleWatcher)
@@ -251,7 +258,8 @@ func (m *Multicluster) initializeCluster(cluster *multicluster.Cluster, kubeCont
 		// Block server exit on graceful termination of the leader controller.
 		m.s.RunComponentAsyncAndWait("auto serviceexport controller", func(_ <-chan struct{}) error {
 			leaderelection.
-				NewLeaderElectionMulticluster(options.SystemNamespace, m.serverID, leaderelection.ServiceExportController, m.revision, !configCluster, client).
+				NewLeaderElectionMulticluster(options.SystemNamespace, m.serverID, leaderelection.ServiceExportController, m.revision,
+					false, !configCluster, client).
 				AddRunFunction(func(leaderStop <-chan struct{}) {
 					serviceExportController := newAutoServiceExportController(autoServiceExportOptions{
 						Client:       client,

--- a/releasenotes/notes/56595.yaml
+++ b/releasenotes/notes/56595.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issues:
+  - 56594
+releaseNotes:
+  - |
+    **Fixed** an issue that namespace controller failed to start when both revision and discovery selector enabled at the same time.


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes: https://github.com/istio/istio/issues/56594

This should be per revision, otherwise multi reversions with `discoverySelector` won't work as #56594 mentioned.