### PR TITLE
[release-1.25] Control Gateway API deploy in integration tests (#56596)

### DIFF
--- a/pkg/test/framework/components/crd/gateway.go
+++ b/pkg/test/framework/components/crd/gateway.go
@@ -26,6 +26,7 @@ import (
 
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/framework/resource/config/apply"
 	"istio.io/istio/pkg/test/util/retry"
@@ -54,6 +55,10 @@ func DeployGatewayAPIOrSkip(ctx framework.TestContext) {
 }
 
 func DeployGatewayAPI(ctx resource.Context) error {
+	cfg, _ := istio.DefaultConfig(ctx)
+	if !cfg.DeployGatewayAPI {
+		return nil
+	}
 	if !SupportsGatewayAPI(ctx) {
 		return errSkip
 	}

--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -105,6 +105,7 @@ var (
 		EgressGatewayServiceNamespace: DefaultSystemNamespace,
 		EgressGatewayServiceName:      DefaultEgressGatewayServiceName,
 		EgressGatewayIstioLabel:       DefaultEgressGatewayIstioLabel,
+		DeployGatewayAPI:              true,
 	}
 )
 
@@ -209,6 +210,9 @@ type Config struct {
 	// upon installing Istio.
 	// This field should only be set when DeployIstio is false.
 	SharedMeshConfigName string
+
+	// DeployGatewayAPI indicates that the test should deploy Gateway API during tests execution
+	DeployGatewayAPI bool
 }
 
 func (c *Config) OverridesYAML(s *resource.Settings) string {

--- a/pkg/test/framework/components/istio/flags.go
+++ b/pkg/test/framework/components/istio/flags.go
@@ -69,4 +69,7 @@ func init() {
 		settingsFromCommandline.SharedMeshConfigName,
 		`Specifies the name of the SHARED_MESH_CONFIG defined and created by the user upon installing Istio.
 		Should only be set when istio.test.kube.userSharedMeshConfig=true and istio.test.kube.deploy=false.`)
+	flag.BoolVar(&settingsFromCommandline.DeployGatewayAPI, "istio.test.kube.deployGatewayAPI",
+		settingsFromCommandline.DeployGatewayAPI,
+		"Deploy Gateway API into the target Kubernetes environment.")
 }

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -530,6 +530,7 @@ The test framework supports the following command-line flags:
 | --istio.test.kube.helm.values | string | Manual overrides for Helm values file. Only valid when deploying Istio. |
 | --istio.test.kube.helm.iopFile | string | IstioOperator spec file. This can be an absolute path or relative to the repository root. Defaults to "tests/integration/iop-integration-test-defaults.yaml". |
 | --istio.test.kube.loadbalancer | bool | Used to obtain the right IP address for ingress gateway. This should be false for any environment that doesn't support a LoadBalancer type. |
+| --istio.test.kube.deployGatewayAPI | bool | Deploy gateway API during tests execution. (default is "true"). |
 | --istio.test.revision | string | Overwrite the default namespace label (istio-enabled=true) with revision lable (istio.io/rev=XXX). (default is no overwrite). |
 | --istio.test.skip | []string | Skip tests matching the regular expression. This follows the semantics of -test.run. |
 | --istio.test.skipVM | bool | Skip all the VM related parts in all the tests. (default is "false"). |


### PR DESCRIPTION
**Please provide a description of this PR:**
This is a manual cherry-pick of https://github.com/istio/istio/pull/56596

Integration tests should be able to control deployment of Gateway API during execution.

In some cases, environment does not need to deploy Gateway API CRDs during integration tests execution.
For example, in Openshift 4.19, the cluster comes with pre installed Gateway API CRDs, which could not be modified by the users. In that case, no Gateway API deployment is needed.

Add a flag - "--istio.test.kube.deployGatewayAPI" to control the flow. By default - true.

Fixes: https://github.com/istio/istio/issues/56609
Fixes: https://github.com/istio/istio/issues/56607
Fixes: https://github.com/istio/istio/issues/56604