### PR TITLE
126/krt assert

### DIFF
--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -38,6 +38,9 @@ const (
 
 var allIndexedDependencyTypes = []indexedDependencyType{indexType, getKeyType}
 
+// EnableAssertions, if true, will enable assertions. These typically are violations of the krt collection requirements.
+const EnableAssertions = false
+
 type dependencyState[I any] struct {
 	// collectionDependencies specifies the set of collections we depend on from within the transformation functions (via Fetch).
 	// These are keyed by the internal uid() function on collections.
@@ -492,6 +495,9 @@ func (h *manyCollection[I, O]) onPrimaryInputEventLocked(items []Event[I]) {
 					e.New = &newRes
 					h.collectionState.outputs[key] = newRes
 				} else {
+					if !oldExists && EnableAssertions {
+						panic(fmt.Sprintf("!oldExists and !newExists, how did we get here? for output key %v input key %v", key, iKey))
+					}
 					e.Event = controllers.EventDelete
 					e.Old = &oldRes
 					delete(h.collectionState.outputs, key)
@@ -508,7 +514,9 @@ func (h *manyCollection[I, O]) onPrimaryInputEventLocked(items []Event[I]) {
 			}
 		}
 	}
-
+	if EnableAssertions {
+		h.assertIndexConsistency()
+	}
 	// Short circuit if we have nothing to do
 	if len(events) == 0 {
 		return
@@ -728,6 +736,24 @@ func (h *manyCollection[I, O]) name() string {
 // nolint: unused // (not true, its to implement an interface)
 func (h *manyCollection[I, O]) uid() collectionUID {
 	return h.id
+}
+
+func (h *manyCollection[I, O]) assertIndexConsistency() {
+	oToI := map[Key[O]]Key[I]{}
+	for i, os := range h.collectionState.mappings {
+		if _, f := h.collectionState.inputs[i]; !f {
+			panic(fmt.Sprintf("for mapping key %v, no input found", i))
+		}
+		for o := range os {
+			if ci, f := oToI[o]; f {
+				panic(fmt.Sprintf("duplicate mapping %v: input %v and %v both map to it", o, ci, i))
+			}
+			oToI[o] = i
+			if _, f := h.collectionState.outputs[o]; !f {
+				panic(fmt.Sprintf("for mapping key %v->%v, no output found", i, o))
+			}
+		}
+	}
 }
 
 // collectionDependencyTracker tracks, for a single transformation call, all dependencies registered.


### PR DESCRIPTION

Krt places a number of un-checked requirements on collections.

This PR introduces a new knob to turn on assertions to be used during
development. IT IS OFF for production

(cherry picked from commit https://github.com/howardjohn/istio/commit/d8748b7beeeebaa5de3f31c83bf836a9b1b5c844)