### PR TITLE
support reset log level or stack trace level separately for admin log

### DIFF
--- a/istioctl/pkg/admin/istiodconfig.go
+++ b/istioctl/pkg/admin/istiodconfig.go
@@ -232,28 +232,30 @@ func (id *istiodConfigLog) execute(out io.Writer) error {
 	return id.state.run(out)
 }
 
-func chooseClientFlag(ctrzClient *ControlzClient, logRest bool, strackTraceReset bool, reset bool, outputLogLevel, stackTraceLevel, outputFormat string) *istiodConfigLog {
-	if reset {
+func chooseClientFlag(ctrzClient *ControlzClient, logRest, stackTraceReset, reset bool, outputLogLevel, stackTraceLevel, outputFormat string) *istiodConfigLog {
+	switch {
+	case reset:
 		return &istiodConfigLog{state: &resetState{ctrzClient}}
-	} else if logRest {
+	case logRest:
 		return &istiodConfigLog{state: &logResetState{ctrzClient}}
-	} else if strackTraceReset {
+	case stackTraceReset:
 		return &istiodConfigLog{state: &stackTraceResetState{ctrzClient}}
-	} else if outputLogLevel != "" {
+	case outputLogLevel != "":
 		return &istiodConfigLog{state: &logLevelState{
 			client:         ctrzClient,
 			outputLogLevel: outputLogLevel,
 		}}
-	} else if stackTraceLevel != "" {
+	case stackTraceLevel != "":
 		return &istiodConfigLog{state: &stackTraceLevelState{
 			client:          ctrzClient,
 			stackTraceLevel: stackTraceLevel,
 		}}
+	default:
+		return &istiodConfigLog{state: &getAllLogLevelsState{
+			client:       ctrzClient,
+			outputFormat: outputFormat,
+		}}
 	}
-	return &istiodConfigLog{state: &getAllLogLevelsState{
-		client:       ctrzClient,
-		outputFormat: outputFormat,
-	}}
 }
 
 type ScopeInfo struct {

--- a/istioctl/pkg/admin/istiodconfig.go
+++ b/istioctl/pkg/admin/istiodconfig.go
@@ -232,7 +232,7 @@ func (id *istiodConfigLog) execute(out io.Writer) error {
 	return id.state.run(out)
 }
 
-func chooseClientFlag(ctrzClient *ControlzClient, logReset, stackTraceReset, reset bool, outputLogLevel, stackTraceLevel, outputFormat string) *istiodConfigLog {
+func chooseClientFlag(ctrzClient *ControlzClient, logReset, stackTraceReset, reset bool, logLevel, stackTraceLevel, outputFormat string) *istiodConfigLog {
 	switch {
 	case reset:
 		return &istiodConfigLog{state: &resetState{ctrzClient}}
@@ -240,10 +240,10 @@ func chooseClientFlag(ctrzClient *ControlzClient, logReset, stackTraceReset, res
 		return &istiodConfigLog{state: &logResetState{ctrzClient}}
 	case stackTraceReset:
 		return &istiodConfigLog{state: &stackTraceResetState{ctrzClient}}
-	case outputLogLevel != "":
+	case logLevel != "":
 		return &istiodConfigLog{state: &logLevelState{
 			client:         ctrzClient,
-			outputLogLevel: outputLogLevel,
+			outputLogLevel: logLevel,
 		}}
 	case stackTraceLevel != "":
 		return &istiodConfigLog{state: &stackTraceLevelState{

--- a/istioctl/pkg/admin/istiodconfig.go
+++ b/istioctl/pkg/admin/istiodconfig.go
@@ -232,11 +232,11 @@ func (id *istiodConfigLog) execute(out io.Writer) error {
 	return id.state.run(out)
 }
 
-func chooseClientFlag(ctrzClient *ControlzClient, logRest, stackTraceReset, reset bool, outputLogLevel, stackTraceLevel, outputFormat string) *istiodConfigLog {
+func chooseClientFlag(ctrzClient *ControlzClient, logReset, stackTraceReset, reset bool, outputLogLevel, stackTraceLevel, outputFormat string) *istiodConfigLog {
 	switch {
 	case reset:
 		return &istiodConfigLog{state: &resetState{ctrzClient}}
-	case logRest:
+	case logReset:
 		return &istiodConfigLog{state: &logResetState{ctrzClient}}
 	case stackTraceReset:
 		return &istiodConfigLog{state: &stackTraceResetState{ctrzClient}}
@@ -476,6 +476,9 @@ func istiodLogCmd(ctx cli.Context) *cobra.Command {
 			if istiodReset && stackTraceReset && stackTraceLevel != "" {
 				logCmd.Println(logCmd.UsageString())
 				return fmt.Errorf("--stack-trace-level cannot be combined with --reset, --stack-trace-reset")
+			}
+			if stackTraceReset && logReset {
+				return fmt.Errorf("--log-reset cannot be combined with --stack-trace-reset, please use --reset if you want to reset both stack trace and log level")
 			}
 			return nil
 		},

--- a/istioctl/pkg/admin/istiodconfig.go
+++ b/istioctl/pkg/admin/istiodconfig.go
@@ -234,7 +234,7 @@ func (id *istiodConfigLog) execute(out io.Writer) error {
 
 func chooseClientFlag(ctrzClient *ControlzClient, logReset, stackTraceReset, reset bool, logLevel, stackTraceLevel, outputFormat string) *istiodConfigLog {
 	switch {
-	case reset:
+	case reset || (logReset && stackTraceReset):
 		return &istiodConfigLog{state: &resetState{ctrzClient}}
 	case logReset:
 		return &istiodConfigLog{state: &logResetState{ctrzClient}}
@@ -476,9 +476,6 @@ func istiodLogCmd(ctx cli.Context) *cobra.Command {
 			if istiodReset && stackTraceReset && stackTraceLevel != "" {
 				logCmd.Println(logCmd.UsageString())
 				return fmt.Errorf("--stack-trace-level cannot be combined with --reset, --stack-trace-reset")
-			}
-			if stackTraceReset && logReset {
-				return fmt.Errorf("--log-reset cannot be combined with --stack-trace-reset, please use --reset if you want to reset both stack trace and log level")
 			}
 			return nil
 		},

--- a/istioctl/pkg/admin/istiodconfig_test.go
+++ b/istioctl/pkg/admin/istiodconfig_test.go
@@ -98,6 +98,8 @@ func Test_chooseClientFlag(t *testing.T) {
 	type args struct {
 		ctrzClient      *ControlzClient
 		reset           bool
+		logReset        bool
+		stackTraceReset bool
 		outputLogLevel  string
 		stackTraceLevel string
 		outputFormat    string
@@ -112,6 +114,8 @@ func Test_chooseClientFlag(t *testing.T) {
 			args: args{
 				ctrzClient:      ctrzClient,
 				reset:           true,
+				logReset:        false,
+				stackTraceReset: false,
 				outputLogLevel:  "",
 				stackTraceLevel: "",
 				outputFormat:    "",
@@ -121,10 +125,42 @@ func Test_chooseClientFlag(t *testing.T) {
 			}},
 		},
 		{
+			name: "given --log-reset flag return log reset command",
+			args: args{
+				ctrzClient:      ctrzClient,
+				reset:           false,
+				logReset:        true,
+				stackTraceReset: false,
+				outputLogLevel:  "",
+				stackTraceLevel: "",
+				outputFormat:    "",
+			},
+			want: &istiodConfigLog{state: &logResetState{
+				client: ctrzClient,
+			}},
+		},
+		{
+			name: "given --stack-trace-reset flag return stackTraceReset command",
+			args: args{
+				ctrzClient:      ctrzClient,
+				reset:           false,
+				logReset:        false,
+				stackTraceReset: true,
+				outputLogLevel:  "",
+				stackTraceLevel: "",
+				outputFormat:    "",
+			},
+			want: &istiodConfigLog{state: &stackTraceResetState{
+				client: ctrzClient,
+			}},
+		},
+		{
 			name: "given --level flag return outputLogLevel command",
 			args: args{
 				ctrzClient:      ctrzClient,
 				reset:           false,
+				logReset:        false,
+				stackTraceReset: false,
 				outputLogLevel:  "resource:info",
 				stackTraceLevel: "",
 				outputFormat:    "",
@@ -139,6 +175,8 @@ func Test_chooseClientFlag(t *testing.T) {
 			args: args{
 				ctrzClient:      ctrzClient,
 				reset:           false,
+				logReset:        false,
+				stackTraceReset: false,
 				outputLogLevel:  "resource-foo:none",
 				stackTraceLevel: "",
 				outputFormat:    "",
@@ -153,6 +191,8 @@ func Test_chooseClientFlag(t *testing.T) {
 			args: args{
 				ctrzClient:      ctrzClient,
 				reset:           false,
+				logReset:        false,
+				stackTraceReset: false,
 				outputLogLevel:  "",
 				stackTraceLevel: "resource:info",
 				outputFormat:    "",
@@ -167,7 +207,7 @@ func Test_chooseClientFlag(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := chooseClientFlag(tt.args.ctrzClient, tt.args.reset, tt.args.outputLogLevel,
+			if got := chooseClientFlag(tt.args.ctrzClient, tt.args.logReset, tt.args.stackTraceReset, tt.args.reset, tt.args.outputLogLevel,
 				tt.args.stackTraceLevel, tt.args.outputFormat); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("chooseClientFlag() = %v, want %v", got, tt.want)
 			}

--- a/istioctl/pkg/admin/istiodconfig_test.go
+++ b/istioctl/pkg/admin/istiodconfig_test.go
@@ -155,6 +155,21 @@ func Test_chooseClientFlag(t *testing.T) {
 			}},
 		},
 		{
+			name: "given --log-reset and --stack-trace-reset flag return reset command",
+			args: args{
+				ctrzClient:      ctrzClient,
+				reset:           false,
+				logReset:        true,
+				stackTraceReset: true,
+				outputLogLevel:  "",
+				stackTraceLevel: "",
+				outputFormat:    "",
+			},
+			want: &istiodConfigLog{state: &resetState{
+				client: ctrzClient,
+			}},
+		},
+		{
 			name: "given --level flag return outputLogLevel command",
 			args: args{
 				ctrzClient:      ctrzClient,

--- a/releasenotes/notes/56600.yaml
+++ b/releasenotes/notes/56600.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+releaseNotes:
+- |
+  **Added** support reset log level or stack trace level separately for `istioctl admin log`.


### PR DESCRIPTION
**Please provide a description of this PR:**

Currently there is only one `--reset` flag to reset the log level for both log and stack trace. It would be better to be able to reset two convenient log levels separately (like `--level` and `--stack-trace-level` for each).

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
