### PR TITLE
Enhance `genHTMLFragment` to Include Anchor Tags in Environment Variable Table Output

### DIFF
--- a/pkg/collateral/control.go
+++ b/pkg/collateral/control.go
@@ -39,6 +39,7 @@ import (
 	"fmt"
 	"html"
 	"os"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -712,12 +713,13 @@ func (g *generator) genVars(root *cobra.Command, selectFn SelectEnvFn) {
 			continue
 		}
 
+		id := slugifyID(html.EscapeString(v.Name))
 		if v.Deprecated {
-			g.emit("<tr class='deprecated'>")
+			g.emit(fmt.Sprintf("<tr id='%s' class='deprecated'>", id))
 		} else {
-			g.emit("<tr>")
+			g.emit(fmt.Sprintf("<tr id='%s'>", id))
 		}
-		g.emit("<td><code>", html.EscapeString(v.Name), "</code></td>")
+		g.emit(fmt.Sprintf("<td><a href='#%s'><code>%s</code></a></td>", id, html.EscapeString(v.Name)))
 
 		switch v.Type {
 		case env.STRING:
@@ -764,4 +766,14 @@ func (g *generator) genMetrics(selectFn SelectMetricFn) {
 
 	g.emit(`</tbody>
 </table>`)
+}
+
+func slugifyID(text string) string {
+	text = strings.ToLower(text)
+
+	// Replace non-alphanumeric characters with dashes
+	re := regexp.MustCompile(`[^a-z0-9]+`)
+	text = re.ReplaceAllString(text, "-")
+
+	return strings.Trim(text, "-")
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

Resolves https://github.com/istio/istio.io/issues/16552. 

This PR adds anchor link tags to the tool that generates the environment variable tables for the documentation of each CLI. 

I tested this change by running `make build` followed by `./out/darwin_arm64/pilot-discovery collateral --html_fragment_with_front_matter`.

This change outputs HTML in the following format: 

```html
<tr id='ambient-enable-multi-network'>
<td><a href='#ambient-enable-multi-network'><code>AMBIENT_ENABLE_MULTI_NETWORK</code></a></td>
<td>Boolean</td>
<td><code>false</code></td>
<td>If true, the multi-network functionality will be enabled.</td>
</tr>
```

I then took the HTML that was generated and ran in locally through the website via `make serve` from the `istio.io` repository.