### PR TITLE
do not use discovery filter for system namespace network

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -178,8 +178,8 @@ type Controller struct {
 
 	queue queue.Instance
 
-	namespaces kclient.Client[*v1.Namespace]
-	services   kclient.Client[*v1.Service]
+	systemNamespace kclient.Client[*v1.Namespace]
+	services        kclient.Client[*v1.Service]
 
 	endpoints *endpointSliceController
 
@@ -245,12 +245,17 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 	}
 	c.networkManager = initNetworkManager(c, options)
 
-	c.namespaces = kclient.NewFiltered[*v1.Namespace](kubeClient, kclient.Filter{ObjectFilter: kubeClient.ObjectFilter()})
+	// currently NOT using kubeClient.ObjectFilter() here as we only care about the system namespace
+	// if in the future we want to watch other namespaces here, we will need to alter the discoveryNamespacesFilter
+	// to have an exception for the system namespace
+	c.systemNamespace = kclient.NewFiltered[*v1.Namespace](kubeClient, kclient.Filter{
+		LabelSelector: "kubernetes.io/metadata.name=" + c.opts.SystemNamespace,
+	})
 
 	if c.opts.SystemNamespace != "" {
 		registerHandlers[*v1.Namespace](
 			c,
-			c.namespaces,
+			c.systemNamespace,
 			"Namespaces",
 			func(old *v1.Namespace, cur *v1.Namespace, event model.Event) error {
 				if cur.Name == c.opts.SystemNamespace {
@@ -625,7 +630,7 @@ func (c *Controller) HasSynced() bool {
 }
 
 func (c *Controller) informersSynced() bool {
-	return c.namespaces.HasSynced() &&
+	return c.systemNamespace.HasSynced() &&
 		c.services.HasSynced() &&
 		c.endpoints.slices.HasSynced() &&
 		c.pods.pods.HasSynced() &&

--- a/pilot/pkg/serviceregistry/kube/controller/network_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network_test.go
@@ -265,7 +265,7 @@ func TestAmbientSystemNamespaceNetworkChange(t *testing.T) {
 
 	tracker := assert.NewTracker[string](t)
 
-	s.systemNamespace.AddEventHandler(controllers.ObjectHandler(func(o controllers.Object) {
+	s.namespaces.AddEventHandler(controllers.ObjectHandler(func(o controllers.Object) {
 		tracker.Record(o.GetName())
 	}))
 
@@ -421,5 +421,5 @@ func createOrUpdateNamespace(t *testing.T, c *FakeController, name, network stri
 			},
 		},
 	}
-	clienttest.Wrap(t, c.systemNamespace).CreateOrUpdate(namespace)
+	clienttest.Wrap(t, c.namespaces).CreateOrUpdate(namespace)
 }

--- a/pilot/pkg/serviceregistry/kube/controller/network_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network_test.go
@@ -265,7 +265,7 @@ func TestAmbientSystemNamespaceNetworkChange(t *testing.T) {
 
 	tracker := assert.NewTracker[string](t)
 
-	s.namespaces.AddEventHandler(controllers.ObjectHandler(func(o controllers.Object) {
+	s.systemNamespace.AddEventHandler(controllers.ObjectHandler(func(o controllers.Object) {
 		tracker.Record(o.GetName())
 	}))
 
@@ -421,5 +421,5 @@ func createOrUpdateNamespace(t *testing.T, c *FakeController, name, network stri
 			},
 		},
 	}
-	clienttest.Wrap(t, c.namespaces).CreateOrUpdate(namespace)
+	clienttest.Wrap(t, c.systemNamespace).CreateOrUpdate(namespace)
 }

--- a/releasenotes/notes/56687.yaml
+++ b/releasenotes/notes/56687.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+- 56687
+releaseNotes:
+- |
+  **Fixed** ignoring the `topology.istio.io/network` label on the system namespace when `discoverySelectors` are in use.


### PR DESCRIPTION
**Please provide a description of this PR:**

When discoveryFilters are set, this will make us potentially NOT watch the system namespace.. this has multiple bad effects:

1. We will never see events for the system namespace, so we never set the network for local pods. This does _not_ affect sidecars base-case, because we rely on the injector setting the label directly on the pods. 

https://github.com/istio/istio/blob/4bcf5060e46052d869c9207e44f10fb5e0b78e06/pilot/pkg/serviceregistry/kube/controller/controller.go#L248

2. If we're using waypoints, the waypoints will send plaintext to their backends. We do a lookup using `<network>/<ip>` to check the ambient indexes. The ambient index watches the system namespace separately, without this discovery selector. There will be a mismatch of `"" != "your-network"`, so we assume !supportTunnel 

https://github.com/istio/istio/blob/4bcf5060e46052d869c9207e44f10fb5e0b78e06/pilot/pkg/model/push_context.go#L2581-L2583