### PR TITLE
Helm Chart Updates - istio-cni & ztunnel

### DIFF
--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -102,33 +102,7 @@ spec:
               path: /readyz
               port: 8000
           securityContext:
-            privileged: false
-            runAsGroup: 0
-            runAsUser: 0
-            runAsNonRoot: false
-            # Both ambient and sidecar repair mode require elevated node privileges to function.
-            # But we don't need _everything_ in `privileged`, so explicitly set it to false and
-            # add capabilities based on feature.
-            capabilities:
-              drop:
-              - ALL
-              add:
-              # CAP_NET_ADMIN is required to allow ipset and route table access
-              - NET_ADMIN
-              # CAP_NET_RAW is required to allow iptables mutation of the `nat` table
-              - NET_RAW
-              # CAP_SYS_PTRACE is required for repair and ambient mode to describe
-              # the pod's network namespace.
-              - SYS_PTRACE
-              # CAP_SYS_ADMIN is required for both ambient and repair, in order to open
-              # network namespaces in `/proc` to obtain descriptors for entering pod network
-              # namespaces. There does not appear to be a more granular capability for this.
-              - SYS_ADMIN
-              # While we run as a 'root' (UID/GID 0), since we drop all capabilities we lose
-              # the typical ability to read/write to folders owned by others.
-              # This can cause problems if the hostPath mounts we use, which we require write access into,
-              # are owned by non-root. DAC_OVERRIDE bypasses these and gives us write access into any folder.
-              - DAC_OVERRIDE
+{{ toYaml .Values.securityContext | trim | indent 14 }}
 {{- if .Values.seLinuxOptions }}
 {{ with (merge .Values.seLinuxOptions (dict "type" "spc_t")) }}
             seLinuxOptions:

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -169,3 +169,33 @@ _internal_defaults_do_not_set:
 
   # A `key: value` mapping of environment variables to add to the pod
   env: {}
+
+  securityContext:
+    privileged: false
+    runAsGroup: 0
+    runAsUser: 0
+    runAsNonRoot: false
+    # Both ambient and sidecar repair mode require elevated node privileges to function.
+    # But we don't need _everything_ in `privileged`, so explicitly set it to false and
+    # add capabilities based on feature.
+    capabilities:
+      drop:
+      - ALL
+      add:
+      # CAP_NET_ADMIN is required to allow ipset and route table access
+      - NET_ADMIN
+      # CAP_NET_RAW is required to allow iptables mutation of the `nat` table
+      - NET_RAW
+      # CAP_SYS_PTRACE is required for repair and ambient mode to describe
+      # the pod's network namespace.
+      - SYS_PTRACE
+      # CAP_SYS_ADMIN is required for both ambient and repair, in order to open
+      # network namespaces in `/proc` to obtain descriptors for entering pod network
+      # namespaces. There does not appear to be a more granular capability for this.
+      - SYS_ADMIN
+      # While we run as a 'root' (UID/GID 0), since we drop all capabilities we lose
+      # the typical ability to read/write to folders owned by others.
+      # This can cause problems if the hostPath mounts we use, which we require write access into,
+      # are owned by non-root. DAC_OVERRIDE bypasses these and gives us write access into any folder.
+      - DAC_OVERRIDE
+

--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -71,22 +71,7 @@ spec:
         imagePullPolicy: {{ . }}
 {{- end }}
         securityContext:
-          # K8S docs are clear that CAP_SYS_ADMIN *or* privileged: true
-          # both force this to `true`: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-          # But there is a K8S validation bug that doesn't propery catch this: https://github.com/kubernetes/kubernetes/issues/119568
-          allowPrivilegeEscalation: true
-          privileged: false
-          capabilities:
-            drop:
-            - ALL
-            add: # See https://man7.org/linux/man-pages/man7/capabilities.7.html
-            - NET_ADMIN # Required for TPROXY and setsockopt
-            - SYS_ADMIN # Required for `setns` - doing things in other netns
-            - NET_RAW # Required for RAW/PACKET sockets, TPROXY
-          readOnlyRootFilesystem: true
-          runAsGroup: 1337
-          runAsNonRoot: false
-          runAsUser: 0
+{{ toYaml .Values.securityContext | trim |indent 12 }}
 {{- if .Values.seLinuxOptions }}
           seLinuxOptions:
 {{ toYaml .Values.seLinuxOptions | trim | indent 12 }}

--- a/manifests/charts/ztunnel/values.yaml
+++ b/manifests/charts/ztunnel/values.yaml
@@ -127,3 +127,21 @@ _internal_defaults_do_not_set:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0
+
+  securityContext:
+    # K8S docs are clear that CAP_SYS_ADMIN *or* privileged: true
+    # both force this to `true`: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+    # But there is a K8S validation bug that doesn't propery catch this: https://github.com/kubernetes/kubernetes/issues/119568
+    allowPrivilegeEscalation: true
+    privileged: false
+    capabilities:
+      drop:
+      - ALL
+      add: # See https://man7.org/linux/man-pages/man7/capabilities.7.html
+      - NET_ADMIN # Required for TPROXY and setsockopt
+      - SYS_ADMIN # Required for `setns` - doing things in other netns
+      - NET_RAW # Required for RAW/PACKET sockets, TPROXY
+    readOnlyRootFilesystem: true
+    runAsGroup: 1337
+    runAsNonRoot: false
+    runAsUser: 0


### PR DESCRIPTION
Currently the istio-cni and ztunnel helm charts values.yaml do not support modifications to securityContext which is often needed.  This PR simply moves the hard-coded values out of the template and over into the values.yaml for easy manipulation when needed via overrides.

Motivation:  In order for installation to succeed in my environment I needed to change `securityContext.privileged` to true.
Changing the value inside the template itself is not the standard approach, updating variables in values.yaml is the proper form.

- [x ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
