### PR TITLE
add more policies to integration testing web fuzzing

### DIFF
--- a/tests/integration/security/fuzz/fuzz_test.go
+++ b/tests/integration/security/fuzz/fuzz_test.go
@@ -50,7 +50,6 @@ spec:
     - operation:
         paths: ["/private/secret.html"]
 `
-
 	authzDenyPolicy2 = `
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
@@ -63,7 +62,6 @@ spec:
     - operation:
         paths: ["/private/secre*.html"]
 `
-
 	authzDenyPolicy3 = `
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
@@ -76,7 +74,6 @@ spec:
     - operation:
         paths: ["/private/secret*.html"]
 `
-
 	authzDenyPolicy4 = `
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy


### PR DESCRIPTION
**Please provide a description of this PR:**

Adds more policies to the integration testing web fuzzing. The policies fit into the existing test, and we should expect the same outcome from any of the new policies as we do from the existing policy. As such, we can re-use the backends and fuzzers and test the new policies in addition to the existing one.

To test this, you need a local cluster and Istio installed and then:

```bash
cd tests/integration/security/fuzz
go test ./... -p 1 -v -tags="integfuzz integ" \
                      -test.run "TestFuzzAuthorization" \
                      --istio.test.nocleanup \
                      --istio.test.env kube  \
                      --istio.test.kube.deploy=false \
                      -timeout 0  \
                      --istio.test.pullpolicy=IfNotPresent \
                      --istio.test.kube.loadbalancer=false \
                      --log_output_level=tf:warn
```