### PR TITLE
Fix/gateway api e2es

### DIFF
--- a/pkg/test/framework/components/istioctl/istioctl.go
+++ b/pkg/test/framework/components/istioctl/istioctl.go
@@ -39,6 +39,9 @@ type Instance interface {
 type Config struct {
 	// Cluster to be used in a multicluster environment
 	Cluster cluster.Cluster
+
+	// IstioNamespace where istio is deployed
+	IstioNamespace string
 }
 
 // New returns a new instance of "istioctl".

--- a/pkg/test/framework/components/istioctl/kube.go
+++ b/pkg/test/framework/components/istioctl/kube.go
@@ -35,8 +35,9 @@ import (
 var invokeMutex sync.Mutex
 
 type kubeComponent struct {
-	config     Config
-	kubeconfig string
+	config         Config
+	kubeconfig     string
+	istioNamespace string
 }
 
 // Filenamer is an interface to avoid importing kubecluster package, instead build our own interface
@@ -51,8 +52,9 @@ func newKube(ctx resource.Context, config Config) (Instance, error) {
 		return nil, fmt.Errorf("cluster does not support fetching kube config")
 	}
 	n := &kubeComponent{
-		config:     config,
-		kubeconfig: fn.Filename(),
+		config:         config,
+		kubeconfig:     fn.Filename(),
+		istioNamespace: config.IstioNamespace,
 	}
 
 	return n, nil
@@ -86,6 +88,10 @@ func (c *kubeComponent) Invoke(args []string) (string, string, error) {
 	if !slices.Contains(args, "--kubeconfig") {
 		cmdArgs = []string{"--kubeconfig", c.kubeconfig}
 	}
+	if !slices.Contains(args, "--istioNamespace") {
+		cmdArgs = append(cmdArgs, "--istioNamespace", c.istioNamespace)
+	}
+
 	cmdArgs = append(cmdArgs, args...)
 
 	var out bytes.Buffer

--- a/tests/integration/pilot/gateway_test.go
+++ b/tests/integration/pilot/gateway_test.go
@@ -149,10 +149,17 @@ spec:
 }
 
 func ManagedGatewayTest(t framework.TestContext) {
-	t.ConfigIstio().YAML(apps.Namespace.Name(), `apiVersion: gateway.networking.k8s.io/v1beta1
+	templateArgs := map[string]string{
+		"revision": t.Settings().Revision,
+	}
+	t.ConfigIstio().Eval(apps.Namespace.Name(), templateArgs, `apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   name: gateway
+  {{- if .revision }}
+  labels:
+    istio.io/rev: {{.revision}}
+  {{- end }}
 spec:
   gatewayClassName: istio
   listeners:

--- a/tests/integration/pilot/gateway_test.go
+++ b/tests/integration/pilot/gateway_test.go
@@ -313,8 +313,13 @@ spec:
 }
 
 func TaggedGatewayTest(t framework.TestContext) {
+	revision := "default"
+	if t.Settings().Revision != "" {
+		revision = t.Settings().Revision
+	}
+
 	istioctl.NewOrFail(t, istioctl.Config{}).InvokeOrFail(
-		t, strings.Split("tag set tag --revision default", " "))
+		t, append(strings.Split("tag set tag --revision", " "), revision))
 
 	testCases := []struct {
 		check         echo.Checker

--- a/tests/integration/pilot/gateway_test.go
+++ b/tests/integration/pilot/gateway_test.go
@@ -325,7 +325,11 @@ func TaggedGatewayTest(t framework.TestContext) {
 		revision = t.Settings().Revision
 	}
 
-	istioctl.NewOrFail(t, istioctl.Config{}).InvokeOrFail(
+	i := istio.DefaultConfigOrFail(t, t)
+	istioctlCfg := istioctl.Config{
+		IstioNamespace: i.SystemNamespace,
+	}
+	istioctl.NewOrFail(t, istioctlCfg).InvokeOrFail(
 		t, append(strings.Split("tag set tag --revision", " "), revision))
 
 	testCases := []struct {


### PR DESCRIPTION
**Please provide a description of this PR:**

Some of the gateway API tests didn't consider some of the istio.test flags to locate the istio deploy (e.g. `--istio.test.revision`, `--istio.test.kube.systemNamespace`, `--istio.test.kube.ingressGatewayServiceName`, `--istio.test.kube.ingressGatewayServiceNamespace`).

This PR:

- Sets `istio.io/rev=rev` when revision is supplied in tests that installed `Gateway` resources (otherwise they are not considered by istiod)
- Installs the Gateway object in the ingress service namespace (which might be different than the istio namespace) for the UnmanagedGatewayTest
- Updates the istioctl.Config to include the `istioNamespace` when running `istioctl` commands in the TaggedGatewayTest (which is something that might be useful in other modules)

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
