### PR TITLE
[release-1.25] Ambient: In ambient index, filter configs by revision (#56477) (#56689)

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -33,6 +33,7 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller/ambient/statusqueue"
 	"istio.io/istio/pkg/activenotifier"
 	"istio.io/istio/pkg/cluster"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/mesh/meshwatcher"
@@ -110,6 +111,7 @@ type index struct {
 	DomainSuffix    string
 	ClusterID       cluster.ID
 	XDSUpdater      model.XDSUpdater
+	revision        string
 	Flags           FeatureFlags
 
 	stop chan struct{}
@@ -144,31 +146,34 @@ func New(options Options) Index {
 		DomainSuffix:    options.DomainSuffix,
 		ClusterID:       options.ClusterID,
 		XDSUpdater:      options.XDSUpdater,
+		revision:        options.Revision,
 		Flags:           options.Flags,
 		stop:            make(chan struct{}),
 	}
-
 	filter := kclient.Filter{
 		ObjectFilter: options.Client.ObjectFilter(),
+	}
+	configFilter := kclient.Filter{
+		ObjectFilter: kubetypes.ComposeFilters(options.Client.ObjectFilter(), a.inRevision),
 	}
 	opts := krt.NewOptionsBuilder(a.stop, options.Debugger)
 
 	MeshConfig := options.MeshConfig
 	authzPolicies := kclient.NewDelayedInformer[*securityclient.AuthorizationPolicy](options.Client,
-		gvr.AuthorizationPolicy, kubetypes.StandardInformer, filter)
-	AuthzPolicies := krt.WrapClient[*securityclient.AuthorizationPolicy](authzPolicies, opts.WithName("AuthorizationPolicies")...)
+		gvr.AuthorizationPolicy, kubetypes.StandardInformer, configFilter)
+	AuthzPolicies := krt.WrapClient[*securityclient.AuthorizationPolicy](authzPolicies, opts.WithName("informer/AuthorizationPolicies")...)
 
 	peerAuths := kclient.NewDelayedInformer[*securityclient.PeerAuthentication](options.Client,
-		gvr.PeerAuthentication, kubetypes.StandardInformer, filter)
-	PeerAuths := krt.WrapClient[*securityclient.PeerAuthentication](peerAuths, opts.WithName("PeerAuthentications")...)
+		gvr.PeerAuthentication, kubetypes.StandardInformer, configFilter)
+	PeerAuths := krt.WrapClient[*securityclient.PeerAuthentication](peerAuths, opts.WithName("informer/PeerAuthentications")...)
 
 	serviceEntries := kclient.NewDelayedInformer[*networkingclient.ServiceEntry](options.Client,
-		gvr.ServiceEntry, kubetypes.StandardInformer, filter)
-	ServiceEntries := krt.WrapClient[*networkingclient.ServiceEntry](serviceEntries, opts.WithName("ServiceEntries")...)
+		gvr.ServiceEntry, kubetypes.StandardInformer, configFilter)
+	ServiceEntries := krt.WrapClient[*networkingclient.ServiceEntry](serviceEntries, opts.WithName("informer/ServiceEntries")...)
 
 	workloadEntries := kclient.NewDelayedInformer[*networkingclient.WorkloadEntry](options.Client,
-		gvr.WorkloadEntry, kubetypes.StandardInformer, filter)
-	WorkloadEntries := krt.WrapClient[*networkingclient.WorkloadEntry](workloadEntries, opts.WithName("WorkloadEntries")...)
+		gvr.WorkloadEntry, kubetypes.StandardInformer, configFilter)
+	WorkloadEntries := krt.WrapClient[*networkingclient.WorkloadEntry](workloadEntries, opts.WithName("informer/WorkloadEntries")...)
 
 	gatewayClient := kclient.NewDelayedInformer[*v1beta1.Gateway](options.Client, gvr.KubernetesGateway, kubetypes.StandardInformer, filter)
 	Gateways := krt.WrapClient[*v1beta1.Gateway](gatewayClient, opts.WithName("Gateways")...)
@@ -495,6 +500,15 @@ func (a *index) lookupService(key string) *model.ServiceInfo {
 		ip:      ip,
 	})
 	return slices.First(services)
+}
+
+func (a *index) inRevision(obj any) bool {
+	object := controllers.ExtractObject(obj)
+	if object == nil {
+		return false
+	}
+	result := config.LabelsInRevision(object.GetLabels(), a.revision)
+	return result
 }
 
 // All return all known workloads. Result is un-ordered

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_serviceentry_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_serviceentry_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestAmbientIndexDuplicates(t *testing.T) {
-	s := newAmbientTestServer(t, testC, testNW)
+	s := newAmbientTestServer(t, testC, testNW, "")
 	s.addWorkloadEntries(t, "140.140.0.10", "name0", "sa1", map[string]string{"app": "a"})
 	s.addPods(t, "140.140.0.10", "pod0", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
 	s.addWorkloadEntries(t, "140.140.0.10", "name1", "sa1", map[string]string{"app": "a"})
@@ -37,7 +37,7 @@ func TestAmbientIndexDuplicates(t *testing.T) {
 }
 
 func TestAmbientIndex_ServiceEntry(t *testing.T) {
-	s := newAmbientTestServer(t, testC, testNW)
+	s := newAmbientTestServer(t, testC, testNW, "")
 
 	// test code path where service entry creates a workload entry via `ServiceEntry.endpoints`
 	// and the inlined WE has a port override
@@ -417,7 +417,7 @@ func TestAmbientIndex_ServiceEntry_DisableK8SServiceSelectWorkloadEntries(t *tes
 	s := newAmbientTestServerWithFlags(t, testC, testNW, FeatureFlags{
 		DefaultAllowFromWaypoint:              features.DefaultAllowFromWaypoint,
 		EnableK8SServiceSelectWorkloadEntries: false,
-	})
+	}, "")
 
 	s.addPods(t, "140.140.0.10", "pod1", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
 	s.assertEvent(t, s.podXdsName("pod1"))

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -141,7 +141,7 @@ func TestAmbientIndex_WaypointForWorkloadTraffic(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := newAmbientTestServer(t, testC, testNW)
+			s := newAmbientTestServer(t, testC, testNW, "")
 			// These steps happen for every test regardless of traffic type.
 			// It involves creating a waypoint for the specified traffic type
 			// then creating a workload and a service with no annotations set
@@ -197,7 +197,7 @@ func TestAmbientIndex_NetworkAndClusterIDs(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := newAmbientTestServer(t, c.cluster, c.network)
+			s := newAmbientTestServer(t, c.cluster, c.network, "")
 			s.addPods(t, "127.0.0.1", "pod1", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
 			s.assertEvent(t, s.podXdsName("pod1"))
 			s.assertAddresses(t, s.addrXdsName("127.0.0.1"), "pod1")
@@ -206,7 +206,7 @@ func TestAmbientIndex_NetworkAndClusterIDs(t *testing.T) {
 }
 
 func TestAmbientIndex_WorkloadNotFound(t *testing.T) {
-	s := newAmbientTestServer(t, testC, testNW)
+	s := newAmbientTestServer(t, testC, testNW, "")
 
 	// Add a pod.
 	s.addPods(t, "127.0.0.1", "pod1", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
@@ -216,7 +216,7 @@ func TestAmbientIndex_WorkloadNotFound(t *testing.T) {
 }
 
 func TestAmbientIndex_LookupWorkloads(t *testing.T) {
-	s := newAmbientTestServer(t, testC, testNW)
+	s := newAmbientTestServer(t, testC, testNW, "")
 
 	s.addPods(t, "127.0.0.1", "pod1", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
 	s.assertAddresses(t, "", "pod1")
@@ -257,7 +257,7 @@ func TestAmbientIndex_LookupWorkloads(t *testing.T) {
 }
 
 func TestAmbientIndex_ServiceAttachedWaypoints(t *testing.T) {
-	s := newAmbientTestServer(t, testC, testNW)
+	s := newAmbientTestServer(t, testC, testNW, "")
 
 	s.addWaypoint(t, "10.0.0.10", "test-wp", "default", true)
 
@@ -282,7 +282,7 @@ func TestAmbientIndex_ServiceAttachedWaypoints(t *testing.T) {
 }
 
 func TestAmbientIndex_ServiceSelectsCorrectWorkloads(t *testing.T) {
-	s := newAmbientTestServer(t, testC, testNW)
+	s := newAmbientTestServer(t, testC, testNW, "")
 
 	// Add 2 pods with the "a" label, and one without.
 	// We should get an event for the new Service and the two *Pod* IPs impacted
@@ -357,7 +357,7 @@ func TestAmbientIndex_ServiceSelectsCorrectWorkloads(t *testing.T) {
 }
 
 func TestAmbientIndex_WaypointConfiguredOnlyWhenReady(t *testing.T) {
-	s := newAmbientTestServer(t, testC, testNW)
+	s := newAmbientTestServer(t, testC, testNW, "")
 
 	s.addPods(t,
 		"127.0.0.1",
@@ -389,7 +389,7 @@ func TestAmbientIndex_WaypointConfiguredOnlyWhenReady(t *testing.T) {
 }
 
 func TestAmbientIndex_WaypointAddressAddedToWorkloads(t *testing.T) {
-	s := newAmbientTestServer(t, testC, testNW)
+	s := newAmbientTestServer(t, testC, testNW, "")
 
 	s.ns.Update(&corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -587,7 +587,7 @@ func TestAmbientIndex_WaypointAddressAddedToWorkloads(t *testing.T) {
 }
 
 func TestAmbientIndex_WaypointInboundBinding(t *testing.T) {
-	s := newAmbientTestServer(t, testC, testNW)
+	s := newAmbientTestServer(t, testC, testNW, "")
 	s.gwcls.Update(&k8sbeta.GatewayClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: constants.WaypointGatewayClassName,
@@ -619,7 +619,7 @@ func TestAmbientIndex_ServicesForWaypoint(t *testing.T) {
 		Network:   testNW,
 	}
 	t.Run("hostname", func(t *testing.T) {
-		s := newAmbientTestServer(t, testC, testNW)
+		s := newAmbientTestServer(t, testC, testNW, "")
 		s.addService(t, "svc1",
 			map[string]string{label.IoIstioUseWaypoint.Name: "wp"},
 			map[string]string{},
@@ -640,7 +640,7 @@ func TestAmbientIndex_ServicesForWaypoint(t *testing.T) {
 		}, svc1Host)
 	})
 	t.Run("ip", func(t *testing.T) {
-		s := newAmbientTestServer(t, testC, testNW)
+		s := newAmbientTestServer(t, testC, testNW, "")
 
 		s.addService(t, "svc1",
 			map[string]string{label.IoIstioUseWaypoint.Name: "wp"},
@@ -662,7 +662,7 @@ func TestAmbientIndex_ServicesForWaypoint(t *testing.T) {
 		}, svc1Host)
 	})
 	t.Run("mixed", func(t *testing.T) {
-		s := newAmbientTestServer(t, testC, testNW)
+		s := newAmbientTestServer(t, testC, testNW, "")
 		s.addService(t, "svc1",
 			map[string]string{label.IoIstioUseWaypoint.Name: "wp"},
 			map[string]string{},
@@ -731,9 +731,53 @@ func setupPolicyTest(t *testing.T, s *ambientTestServer) {
 	s.assertUnorderedEvent(t, s.podXdsName("waypoint-ns-pod"), s.svcXdsName("waypoint-ns"))
 }
 
+func TestAuthorizationPolicyRevisionFiltering(t *testing.T) {
+	s := newAmbientTestServer(t, testC, testNW, "some-rev")
+	policyName := "test-authz"
+
+	t.Run("no revision label: policy is present", func(t *testing.T) {
+		s.addPolicy(t, policyName, testNS, nil, gvk.AuthorizationPolicy, nil)
+		s.assertEvent(t, policyName)
+
+		// Should be present in s.authorizationPolicies
+		pol := s.authorizationPolicies.GetKey(testNS + "/" + policyName)
+		if pol == nil {
+			t.Errorf("AuthorizationPolicy without revision label should be present, but was not")
+		}
+	})
+
+	t.Run("with non-matching revision label: policy is ignored", func(t *testing.T) {
+		s.addPolicy(t, policyName+"-rev", testNS, nil, gvk.AuthorizationPolicy, func(obj controllers.Object) {
+			p := obj.(*clientsecurityv1beta1.AuthorizationPolicy)
+			if p.Labels == nil {
+				p.Labels = map[string]string{}
+			}
+			p.Labels[label.IoIstioRev.Name] = "non-matching-rev"
+		})
+		s.assertNoEvent(t)
+	})
+
+	t.Run("with matching revision label: policy is present", func(t *testing.T) {
+		s.addPolicy(t, policyName+"-rev", testNS, nil, gvk.AuthorizationPolicy, func(obj controllers.Object) {
+			p := obj.(*clientsecurityv1beta1.AuthorizationPolicy)
+			if p.Labels == nil {
+				p.Labels = map[string]string{}
+			}
+			p.Labels[label.IoIstioRev.Name] = "some-rev"
+		})
+		s.assertEvent(t, policyName+"-rev")
+
+		// Should be present in s.authorizationPolicies
+		pol := s.authorizationPolicies.GetKey(testNS + "/" + policyName + "-rev")
+		if pol == nil {
+			t.Errorf("AuthorizationPolicy without revision label should be present, but was not")
+		}
+	})
+}
+
 // TODO(nmittler): Consider splitting this into multiple, smaller tests.
 func TestAmbientIndex_Policy(t *testing.T) {
-	s := newAmbientTestServer(t, testC, testNW)
+	s := newAmbientTestServer(t, testC, testNW, "")
 	setupPolicyTest(t, s)
 
 	selectorPolicyName := "selector"
@@ -1159,7 +1203,7 @@ func TestDefaultAllowWaypointPolicy(t *testing.T) {
 	s := newAmbientTestServerWithFlags(t, testC, testNW, FeatureFlags{
 		DefaultAllowFromWaypoint:              true,
 		EnableK8SServiceSelectWorkloadEntries: features.EnableK8SServiceSelectWorkloadEntries,
-	})
+	}, "")
 	setupPolicyTest(t, s)
 
 	t.Run("policy with service accounts", func(t *testing.T) {
@@ -1189,7 +1233,7 @@ func TestDefaultAllowWaypointPolicy(t *testing.T) {
 }
 
 func TestPodLifecycleWorkloadGates(t *testing.T) {
-	s := newAmbientTestServer(t, "", "")
+	s := newAmbientTestServer(t, "", "", "")
 
 	s.addPods(t, "127.0.0.1", "pod1", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
 	s.assertEvent(t, "//Pod/ns1/pod1")
@@ -1208,7 +1252,7 @@ func TestPodLifecycleWorkloadGates(t *testing.T) {
 }
 
 func TestAddressInformation(t *testing.T) {
-	s := newAmbientTestServer(t, testC, testNW)
+	s := newAmbientTestServer(t, testC, testNW, "")
 
 	// Add 2 pods with the "a" label, and one without.
 	// We should get an event for the new Service and the two *Pod* IPs impacted
@@ -1406,7 +1450,7 @@ func (s *ambientTestServer) assertWaypointAddressForPod(t *testing.T, key, expec
 }
 
 func TestUpdateWaypointForWorkload(t *testing.T) {
-	s := newAmbientTestServer(t, "", "")
+	s := newAmbientTestServer(t, "", "", "")
 
 	// add our waypoints but they won't be used until annotations are added
 	// add a new waypoint
@@ -1487,7 +1531,7 @@ func TestUpdateWaypointForWorkload(t *testing.T) {
 }
 
 func TestWorkloadsForWaypoint(t *testing.T) {
-	s := newAmbientTestServer(t, "", testNW)
+	s := newAmbientTestServer(t, "", testNW, "")
 
 	assertWaypoint := func(t *testing.T, waypointHostname string, expected ...string) {
 		t.Helper()
@@ -1538,7 +1582,7 @@ func TestWorkloadsForWaypoint(t *testing.T) {
 }
 
 func TestWorkloadsForWaypointOrder(t *testing.T) {
-	s := newAmbientTestServer(t, "", testNW)
+	s := newAmbientTestServer(t, "", testNW, "")
 
 	assertOrderedWaypoint := func(t *testing.T, hostname string, expected ...string) {
 		t.Helper()
@@ -1591,7 +1635,7 @@ func TestWorkloadsForWaypointOrder(t *testing.T) {
 // This is a regression test for a case where policies added after pods were not applied when
 // querying by service
 func TestPolicyAfterPod(t *testing.T) {
-	s := newAmbientTestServer(t, testC, testNW)
+	s := newAmbientTestServer(t, testC, testNW, "")
 
 	s.addService(t, "svc1",
 		map[string]string{},
@@ -1622,14 +1666,14 @@ type ambientTestServer struct {
 	t         *testing.T
 }
 
-func newAmbientTestServer(t *testing.T, clusterID cluster.ID, networkID network.ID) *ambientTestServer {
+func newAmbientTestServer(t *testing.T, clusterID cluster.ID, networkID network.ID, revision string) *ambientTestServer {
 	return newAmbientTestServerWithFlags(t, clusterID, networkID, FeatureFlags{
 		DefaultAllowFromWaypoint:              features.DefaultAllowFromWaypoint,
 		EnableK8SServiceSelectWorkloadEntries: features.EnableK8SServiceSelectWorkloadEntries,
-	})
+	}, revision)
 }
 
-func newAmbientTestServerWithFlags(t *testing.T, clusterID cluster.ID, networkID network.ID, flags FeatureFlags) *ambientTestServer {
+func newAmbientTestServerWithFlags(t *testing.T, clusterID cluster.ID, networkID network.ID, flags FeatureFlags, revision string) *ambientTestServer {
 	up := xdsfake.NewFakeXDS()
 	up.SplitEvents = true
 	cl := kubeclient.NewFakeClient()
@@ -1659,6 +1703,7 @@ func newAmbientTestServerWithFlags(t *testing.T, clusterID cluster.ID, networkID
 		},
 		StatusNotifier: activenotifier.New(true),
 		Debugger:       debugger,
+		Revision:       revision,
 		Flags:          flags,
 		MeshConfig:     meshwatcher.NewTestWatcher(nil),
 	})

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_workloadentry_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_workloadentry_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestAmbientIndex_WorkloadEntries(t *testing.T) {
-	s := newAmbientTestServer(t, testC, testNW)
+	s := newAmbientTestServer(t, testC, testNW, "")
 
 	s.addWorkloadEntries(t, "127.0.0.1", "name1", "sa1", map[string]string{"app": "a"})
 	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "name1")
@@ -281,7 +281,7 @@ func TestAmbientIndex_WorkloadEntries(t *testing.T) {
 }
 
 func TestAmbientIndex_EmptyAddrWorkloadEntries(t *testing.T) {
-	s := newAmbientTestServer(t, testC, testNW)
+	s := newAmbientTestServer(t, testC, testNW, "")
 	s.addWorkloadEntries(t, "", "emptyaddr1", "sa1", map[string]string{"app": "a"})
 	s.assertEvent(t, s.wleXdsName("emptyaddr1"))
 	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "emptyaddr1")
@@ -304,7 +304,7 @@ func TestAmbientIndex_EmptyAddrWorkloadEntries(t *testing.T) {
 }
 
 func TestAmbientIndex_UpdateExistingWorkloadEntry(t *testing.T) {
-	s := newAmbientTestServer(t, testC, testNW)
+	s := newAmbientTestServer(t, testC, testNW, "")
 	s.addWorkloadEntries(t, "", "emptyaddr1", "sa1", map[string]string{"app": "a"})
 	s.assertEvent(t, s.wleXdsName("emptyaddr1"))
 	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "emptyaddr1")
@@ -316,7 +316,7 @@ func TestAmbientIndex_UpdateExistingWorkloadEntry(t *testing.T) {
 }
 
 func TestAmbientIndex_InlinedWorkloadEntries(t *testing.T) {
-	s := newAmbientTestServer(t, testC, testNW)
+	s := newAmbientTestServer(t, testC, testNW, "")
 
 	s.addServiceEntry(t, "se.istio.io", []string{"240.240.23.45"}, "se1", testNS, map[string]string{"app": "a"}, []string{"127.0.0.1", "127.0.0.2"})
 	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "se1")
@@ -348,7 +348,7 @@ func TestAmbientIndex_WorkloadEntries_DisableK8SServiceSelectWorkloadEntries(t *
 	s := newAmbientTestServerWithFlags(t, testC, testNW, FeatureFlags{
 		DefaultAllowFromWaypoint:              features.DefaultAllowFromWaypoint,
 		EnableK8SServiceSelectWorkloadEntries: false,
-	})
+	}, "")
 
 	s.addWorkloadEntries(t, "127.0.0.1", "name1", "sa1", map[string]string{"app": "a"})
 	s.assertEvent(t, s.wleXdsName("name1"))

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/sidecar_interop_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/sidecar_interop_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestIngressInterop(t *testing.T) {
 	// Test that we can get updates for EDS when we have service bound waypoints.
-	s := newAmbientTestServer(t, testC, testNW)
+	s := newAmbientTestServer(t, testC, testNW, "")
 	// the two types return different keys.. rename to make it more clear
 	addressUpdate := s.svcXdsName
 	edsUpdate := s.hostnameForService

--- a/releasenotes/notes/56477.yaml
+++ b/releasenotes/notes/56477.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 56477
+
+# releaseNotes is a markdown listing of any user facing changes. This will appear in the
+# release notes.
+releaseNotes:
+- |
+  **Fixed** ambient index to filter configs by revision.


### PR DESCRIPTION
…

* Ambient: In ambient index, filter configs by revision (#56477)

* In ambient index, filter configs by revision

* release notes

* Address feedback



* Update releasenotes/notes/56477.yaml

---------

**Please provide a description of this PR:**