### PR TITLE
Remove unused multiCluster values

### DIFF
--- a/manifests/charts/gateways/istio-egress/values.yaml
+++ b/manifests/charts/gateways/istio-egress/values.yaml
@@ -241,11 +241,6 @@ _internal_defaults_do_not_set:
     mountMtlsCerts: false
 
     multiCluster:
-      # Set to true to connect two kubernetes clusters via their respective
-      # ingressgateway services when pods in each cluster cannot directly
-      # talk to one another. All clusters should be using Istio mTLS and must
-      # have a shared root CA for this model to work.
-      enabled: false
       # Should be set to the name of the cluster this installation will run in. This is required for sidecar injection
       # to properly label proxies
       clusterName: ""

--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -257,18 +257,9 @@ _internal_defaults_do_not_set:
     mountMtlsCerts: false
 
     multiCluster:
-      # Set to true to connect two kubernetes clusters via their respective
-      # ingressgateway services when pods in each cluster cannot directly
-      # talk to one another. All clusters should be using Istio mTLS and must
-      # have a shared root CA for this model to work.
-      enabled: false
       # Should be set to the name of the cluster this installation will run in. This is required for sidecar injection
       # to properly label proxies
       clusterName: ""
-      # The suffix for global service names
-      globalDomainSuffix: "global"
-      # Enable envoy filter to translate `globalDomainSuffix` to cluster local suffix for cross cluster communication
-      includeEnvoyFilter: true
 
     # Network defines the network this cluster belong to. This name
     # corresponds to the networks in the map of mesh networks.

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -468,11 +468,6 @@ _internal_defaults_do_not_set:
     mountMtlsCerts: false
 
     multiCluster:
-      # Set to true to connect two kubernetes clusters via their respective
-      # ingressgateway services when pods in each cluster cannot directly
-      # talk to one another. All clusters should be using Istio mTLS and must
-      # have a shared root CA for this model to work.
-      enabled: false
       # Should be set to the name of the cluster this installation will run in. This is required for sidecar injection
       # to properly label proxies
       clusterName: ""

--- a/releasenotes/notes/remove-extra-multicluster-helm-values.yaml
+++ b/releasenotes/notes/remove-extra-multicluster-helm-values.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+
+kind: bug-fix
+
+area: installation
+
+issue: []
+
+releaseNotes: 
+- |
+  **Removed** unsed multicluster-related Helm values.


### PR DESCRIPTION
**Please provide a description of this PR:**

We seem to have a bunch of unused helm values under the `multiCluster` key. The only value we use is `multiCluster.clusterName`.

(On master branch)

```
/home/sj/istio/manifests $ rg multiCluster
charts/ztunnel/values.yaml
75:  multiCluster:

charts/gateways/istio-egress/templates/deployment.yaml
216:            value: "{{ $.Values.global.multiCluster.clusterName | default `Kubernetes` }}"

charts/gateways/istio-egress/values.yaml
243:    multiCluster:

charts/ztunnel/templates/daemonset.yaml
127:          value: {{ .Values.multiCluster.clusterName | default "Kubernetes" }}

charts/gateways/istio-ingress/templates/deployment.yaml
216:            value: "{{ $.Values.global.multiCluster.clusterName | default `Kubernetes` }}"

charts/gateways/istio-ingress/values.yaml
259:    multiCluster:

charts/istio-control/istio-discovery/values.yaml
470:    multiCluster:

charts/istio-control/istio-discovery/templates/deployment.yaml
204:            value: "{{ $.Values.global.multiCluster.clusterName | default `Kubernetes` }}"

charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
122:      value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"

charts/istio-control/istio-discovery/files/waypoint.yaml
185:          value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"

charts/istio-control/istio-discovery/files/kube-gateway.yaml
185:          value: "{{ valueOrDefault .Values.global.multiCluster.clusterName .ClusterID }}"

charts/istio-control/istio-discovery/files/grpc-agent.yaml
135:      value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"

charts/istio-control/istio-discovery/files/injection-template.yaml
297:      value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
```