### PR TITLE
CNI Pod delete edge case

### DIFF
--- a/cni/pkg/nodeagent/informers.go
+++ b/cni/pkg/nodeagent/informers.go
@@ -353,8 +353,10 @@ func (s *InformerHandlers) reconcilePod(input any) error {
 		// we *do not* want to check the cache for the pod - because it (probably)
 		// won't be there anymore. So for this case *alone*, we check the most recent
 		// pod information from the triggering event.
-		if util.PodFullyEnrolled(latestEventPod) || util.PodPartiallyEnrolled(latestEventPod) {
-			log.Debugf("pod is deleted and was (fully or partially) captured, removing from ztunnel")
+		if util.PodFullyEnrolled(latestEventPod) ||
+			util.PodPartiallyEnrolled(latestEventPod) ||
+			s.enablementSelector.Matches(latestEventPod.Labels, latestEventPod.Annotations, ns.Labels) {
+			log.Debugf("pod is deleted and was or should be captured, removing from ztunnel")
 			if err := s.dataplane.RemovePodFromMesh(s.ctx, latestEventPod, true); err != nil {
 				log.Warnf("Unable to send pod to ztunnel for removal. Will retry. RemovePodFrmMesh returned: %v", err)
 				return err

--- a/cni/pkg/nodeagent/net_linux.go
+++ b/cni/pkg/nodeagent/net_linux.go
@@ -112,6 +112,8 @@ func (s *NetServer) AddPodToMesh(ctx context.Context, pod *corev1.Pod, podIPs []
 	s.currentPodSnapshot.Ensure(string(pod.UID))
 	openNetns, err := s.getOrOpenNetns(pod, netNs)
 	if err != nil {
+		// if we fail, we should not leave a dangling UID in the snapshot.
+		s.currentPodSnapshot.Take(string(pod.UID))
 		return NewErrNonRetryableAdd(err)
 	}
 
@@ -124,6 +126,7 @@ func (s *NetServer) AddPodToMesh(ctx context.Context, pod *corev1.Pod, podIPs []
 		// We currently treat any failure to create inpod rules as non-retryable/catastrophic,
 		// and return a NonRetryableError in this case.
 		log.Errorf("failed to update POD inpod: %s/%s %v", pod.Namespace, pod.Name, err)
+		s.currentPodSnapshot.Take(string(pod.UID))
 		return NewErrNonRetryableAdd(err)
 	}
 

--- a/releasenotes/notes/56738.yaml
+++ b/releasenotes/notes/56738.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 56738
+releaseNotes:
+- |
+  **Fixed** CNI incorrectly handled pod deletion when the pod was not yet marked as enrolled in the mesh. In some cases, this could cause a pod which has been deleted to be included in the zds snapshot and never cleaned up. If this occurs ztunnel will not be able to become ready.


### PR DESCRIPTION
**Please provide a description of this PR:**

An edge case race condition in the cni: If a pod is deleted before we mark it as captured but that pod would have been captured it can wind up being included in our zds snapshot even though the pod no longer exists. If this occurs timed such that we send the snapshot but throw away the Kubernetes delete event (because the pod was not captured), it can cause ztunnel to endlessly retry setting up a proxy for a pod which is not going to exist and prevent ztunnel from becoming ready.

I'm honestly not that sure how to automate testing. I have a script which stresses this scenario on my machine. Using my script it takes an average of 4 loops to reach this broken state (as noted by a restarting ztunnel never becoming ready). In attempting to find this issue, the longest my script took to break the system was 12 loops. With this fix in place I have run over 200 loops of my script without encountering an issue.

Note: The first commit (dangling UID in `cni/pkg/nodeagent/net_linux.go`) doesn't seem to actually effect this particular bug. It seems correct so I left it, however since it is unrelated I can remove that commit (or break it out into a second PR) if folks would prefer.