### PR TITLE
Fix WasmPlugin url validation

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -3281,7 +3281,8 @@ func strictParseURL(originalURL string) (*url.URL, error) {
 	u := originalURL
 	ur, err := url.ParseRequestURI(u)
 	if err != nil {
-		u = "http://" + originalURL
+		// When no scheme is given, default to oci:// to be consistent with the runtime behavior
+		u = "oci://" + originalURL
 		nu, nerr := url.ParseRequestURI(u)
 		if nerr != nil {
 			return nil, fmt.Errorf("failed to parse url: %s", err) // return original err

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -7686,25 +7686,49 @@ func TestStrictParseURL(t *testing.T) {
 			valid:       true,
 		},
 		{
-			name:        "without scheme - should default to oci",
+			name:        "with explicit oci scheme and tag",
+			input:       "oci://example.com/path:tag",
+			expectedURL: "oci://example.com/path:tag",
+			valid:       true,
+		},
+		{
+			name:        "with explicit oci scheme port and tag",
+			input:       "oci://example.com:5000/path:tag",
+			expectedURL: "oci://example.com:5000/path:tag",
+			valid:       true,
+		},
+		{
+			name:        "without scheme or tag - should default to oci",
 			input:       "example.com/path",
 			expectedURL: "oci://example.com/path",
+			valid:       true,
+		},
+		{
+			name:        "without scheme with tag - should default to oci",
+			input:       "example.com/path:tag",
+			expectedURL: "oci://example.com/path:tag",
+			valid:       true,
+		},
+		{
+			name:        "without scheme with tag and port number",
+			input:       "foo.bar.com:8080/repo/app:latest",
+			expectedURL: "oci://foo.bar.com:8080/repo/app:latest",
 			valid:       true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := strictParseURL(tt.input)
+			result, err := strictParseWasmPluginURL(tt.input)
 			if tt.valid && err != nil {
-				t.Errorf("strictParseURL(%q) returned unexpected error: %v", tt.input, err)
+				t.Errorf("strictParseWasmPluginURL(%q) returned unexpected error: %v", tt.input, err)
 			} else if !tt.valid && err == nil {
-				t.Errorf("strictParseURL(%q) did not return expected error", tt.input)
+				t.Errorf("strictParseWasmPluginURL(%q) did not return expected error", tt.input)
 			}
 
 			if tt.valid {
 				if result.String() != tt.expectedURL {
-					t.Errorf("strictParseURL(%q) = %q, want %q", tt.input, result.String(), tt.expectedURL)
+					t.Errorf("strictParseWasmPluginURL(%q) = %q, want %q", tt.input, result.String(), tt.expectedURL)
 				}
 			}
 		})

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -7660,6 +7660,57 @@ func TestValidateTelemetryFilter(t *testing.T) {
 	}
 }
 
+func TestStrictParseURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expectedURL string
+		valid       bool
+	}{
+		{
+			name:        "with explicit http scheme",
+			input:       "http://example.com/path",
+			expectedURL: "http://example.com/path",
+			valid:       true,
+		},
+		{
+			name:        "with explicit https scheme",
+			input:       "https://example.com/path",
+			expectedURL: "https://example.com/path",
+			valid:       true,
+		},
+		{
+			name:        "with explicit oci scheme",
+			input:       "oci://example.com/path",
+			expectedURL: "oci://example.com/path",
+			valid:       true,
+		},
+		{
+			name:        "without scheme - should default to oci",
+			input:       "example.com/path",
+			expectedURL: "oci://example.com/path",
+			valid:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := strictParseURL(tt.input)
+			if tt.valid && err != nil {
+				t.Errorf("strictParseURL(%q) returned unexpected error: %v", tt.input, err)
+			} else if !tt.valid && err == nil {
+				t.Errorf("strictParseURL(%q) did not return expected error", tt.input)
+			}
+
+			if tt.valid {
+				if result.String() != tt.expectedURL {
+					t.Errorf("strictParseURL(%q) = %q, want %q", tt.input, result.String(), tt.expectedURL)
+				}
+			}
+		})
+	}
+}
+
 func TestValidateWasmPlugin(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
 ## Summary

According to the [docs](https://istio.io/latest/docs/reference/config/proxy_extensions/wasm-plugin/#WasmPlugin-url), there are a few valid formats for `WasmPlugin` `.spec.url`:
- `<reference>` a valid oci/docker image reference.
- `oci://<reference>` a valid oci/docker image reference with the `oci://` protocol prefix.
- `file://<path>` a reference to a local file.
- `http[s]://<path>` a valid URL pointing to the plugin.

## Issues
There are two notable issues with the current `validation.go` logic for checking these values:
1. Hostnames with port numbers are valid in a docker/oci image reference (i.e. `foo.com:5000/bar:baz`), but the curent logic parses `foo.bar` as the protocol scheme. 
2. The validation logic attempts to validate the given url, and if invalid, it falls back to prefixing with `http://`. This runs counter to the documentation and implementation, which states that the default should be to use `oci://`.

The actual extension implementation also suffers from issue (1) above.

## What does this PR do?
1. I added a list of test cases to cover valid docker/oci image references with and without the `oci://` prefix.
2. I renamed `strictParseURL` to make clear that this is specific to WASM plugins (since the `oci://` default is not generalizable to other cases of URL validation) per @howardjohn's request.
3. I changed the validation to properly support port numbers in the docker/oci image reference, and fixed the default URL behavior
4. I changed the URL parsing behavior in the extension itself to properly detect image references with port numbers.