### PR TITLE
fix(gw-inference): Add extra to the VirtualService Config clone/copy

### DIFF
--- a/pilot/pkg/config/kube/gateway/route_collections.go
+++ b/pilot/pkg/config/kube/gateway/route_collections.go
@@ -670,6 +670,7 @@ func mergeHTTPRoutes(baseVirtualServices krt.Collection[RouteWithKey], opts ...k
 				Meta:   nm,
 				Spec:   base.Spec,
 				Status: base.Status,
+				Extra:  base.Extra,
 			})
 		}
 		sortRoutesByCreationTime(configs)


### PR DESCRIPTION
Missing the Extra field in the Config cloning.