### PR TITLE
Add domain resolve to Ambient TestServiceEntryInlinedWorkloadEntry test

### DIFF
--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -2154,7 +2154,17 @@ spec:
 `).
 				WithParams(param.Params{}.SetWellKnown(param.Namespace, apps.Namespace))
 
-			ips, ports := istio.DefaultIngressOrFail(t, t).HTTPAddresses()
+			rawIPs, ports := istio.DefaultIngressOrFail(t, t).HTTPAddresses()
+			var ips []string
+			for _, ip := range rawIPs {
+				// Resolve ingress domain name into ip address
+				addr, err := kubetest.WaitUntilReachableIngress(ip)
+				if err != nil {
+					t.Fatalf("unable to resolve domain name to ip address - %q: %v", ip, err)
+				}
+				t.Logf("Resolved ingress %q to %q", ip, addr)
+				ips = append(ips, addr)
+			}
 			for _, tc := range testCases {
 				for i, ip := range ips {
 					t.NewSubTestf("%s %s %d", tc.location, tc.resolution, i).Run(func(t framework.TestContext) {


### PR DESCRIPTION
**Please provide a description of this PR:**
When executing TestServiceEntryInlinedWorkloadEntry Ambient test in a public cloud based cluster, the created ingress is a domain based name and the test fails with the following error:

configuration is invalid: endpoint address
"a6eec2a91721a42b0aa8e140fc6611fc-1873540778.us-east-1.elb.amazonaws.com" is not a valid IP address

Add a domain name resolution to ip based address.