### PR TITLE
Inference pool Status handling and cross namespace references

### DIFF
--- a/pilot/pkg/config/kube/gateway/controller.go
+++ b/pilot/pkg/config/kube/gateway/controller.go
@@ -235,7 +235,7 @@ func NewController(
 
 	handlers := []krt.HandlerRegistration{}
 
-	httpRoutesByNamespace := krt.NewNamespaceIndex(inputs.HTTPRoutes)
+	httpRoutesByInferencePool := krt.NewIndex(inputs.HTTPRoutes, "inferencepool-route", indexHTTPRouteByInferencePool)
 
 	GatewayClassStatus, GatewayClasses := GatewayClassesCollection(inputs.GatewayClasses, opts)
 	status.RegisterStatus(c.status, GatewayClassStatus, GetStatus)
@@ -270,7 +270,7 @@ func NewController(
 		inputs.Services,
 		inputs.HTTPRoutes,
 		inputs.Gateways,
-		httpRoutesByNamespace,
+		httpRoutesByInferencePool,
 		c,
 		opts,
 	)

--- a/pilot/pkg/config/kube/gateway/inferencepool_collection.go
+++ b/pilot/pkg/config/kube/gateway/inferencepool_collection.go
@@ -182,7 +182,7 @@ func InferencePoolCollection(
 			for _, existingParent := range existingParents {
 				if !isManagedGateway(gateways, existingParent) {
 					finalParents = append(finalParents, existingParent)
-				} else if gatewayParentsToEnsure.Contains(types.NamespacedName{Name: string(existingParent.GatewayRef.Name), Namespace: string(existingParent.GatewayRef.Namespace)}) {
+				} else if gatewayParentsToEnsure.Contains(types.NamespacedName{Name: existingParent.GatewayRef.Name, Namespace: existingParent.GatewayRef.Namespace}) {
 					// only add our parents that are still referenced by an HTTPRoute
 					ourParents = append(ourParents, existingParent)
 				}
@@ -429,8 +429,8 @@ func indexHTTPRouteByInferencePool(o *gateway.HTTPRoute) []string {
 	var keys []string
 	for _, rule := range o.Spec.Rules {
 		for _, backendRef := range rule.BackendRefs {
-			if string(*backendRef.BackendRef.Group) == gvk.InferencePool.Group &&
-				string(*backendRef.BackendRef.Kind) == gvk.InferencePool.Kind {
+			if (backendRef.BackendRef.Group != nil && string(*backendRef.BackendRef.Group) == gvk.InferencePool.Group) &&
+				(backendRef.BackendRef.Kind != nil && string(*backendRef.BackendRef.Kind) == gvk.InferencePool.Kind) {
 				// If BackendRef.Namespace is not specified, the backend is in the same namespace as the HTTPRoute's
 				backendRefNamespace := o.Namespace
 				if backendRef.BackendRef.Namespace != nil && *backendRef.BackendRef.Namespace != "" {

--- a/pilot/pkg/config/kube/gateway/inferencepool_collection.go
+++ b/pilot/pkg/config/kube/gateway/inferencepool_collection.go
@@ -180,7 +180,8 @@ func InferencePoolCollection(
 			finalParents := []inferencev1alpha2.PoolStatus{}
 			// Add all existing parents from other controllers
 			for _, existingParent := range existingParents {
-				if !isManagedGateway(gateways, existingParent) {
+				// ignore default status parent
+				if !isManagedGateway(gateways, existingParent) && !(existingParent.GatewayRef.Kind == "Status" && existingParent.GatewayRef.Name == "default") {
 					finalParents = append(finalParents, existingParent)
 				} else if gatewayParentsToEnsure.Contains(types.NamespacedName{Name: existingParent.GatewayRef.Name, Namespace: existingParent.GatewayRef.Namespace}) {
 					// only add our parents that are still referenced by an HTTPRoute

--- a/pilot/pkg/config/kube/gateway/inferencepool_collection.go
+++ b/pilot/pkg/config/kube/gateway/inferencepool_collection.go
@@ -89,7 +89,7 @@ func InferencePoolCollection(
 	services krt.Collection[*corev1.Service],
 	httpRoutes krt.Collection[*gateway.HTTPRoute],
 	gateways krt.Collection[*gateway.Gateway],
-	routesByNamespace krt.Index[string, *gateway.HTTPRoute],
+	routesByInferencePool krt.Index[string, *gateway.HTTPRoute],
 	c *Controller,
 	opts krt.OptionsBuilder,
 ) (krt.StatusCollection[*inferencev1alpha2.InferencePool, inferencev1alpha2.InferencePoolStatus], krt.Collection[InferencePool]) {
@@ -130,23 +130,36 @@ func InferencePoolCollection(
 			}
 
 			gatewayParentsToEnsure := sets.New[types.NamespacedName]()
-			routeList := krt.Fetch(ctx, httpRoutes, krt.FilterIndex(routesByNamespace, pool.Namespace))
+			routeList := krt.Fetch(ctx, httpRoutes, krt.FilterIndex(routesByInferencePool, pool.Namespace+"/"+pool.Name))
 			for _, r := range routeList {
 				for _, rule := range r.Spec.Rules {
 					for _, httpBackendRef := range rule.BackendRefs {
 						if httpBackendRef.BackendRef.Group == nil || httpBackendRef.BackendRef.Kind == nil {
 							continue
 						}
+
 						if string(*httpBackendRef.BackendRef.Group) == gvk.InferencePool.Group &&
 							string(*httpBackendRef.BackendRef.Kind) == gvk.InferencePool.Kind &&
 							string(httpBackendRef.BackendRef.Name) == pool.ObjectMeta.Name {
-							for _, p := range r.Status.Parents {
-								if supportedControllers.Contains(p.ControllerName) {
-									ns := r.Namespace
-									if p.ParentRef.Namespace != nil && *p.ParentRef.Namespace != "" {
-										ns = string(*p.ParentRef.Namespace)
+
+							// Check if the backendRef namespace matches the InferencePool namespace.
+							// If BackendRef.Namespace is not specified, the backend is in the same namespace as the HTTPRoute's.
+							backendRefNamespace := r.Namespace
+							if httpBackendRef.BackendRef.Namespace != nil && *httpBackendRef.BackendRef.Namespace != "" {
+								backendRefNamespace = string(*httpBackendRef.BackendRef.Namespace)
+							}
+
+							if backendRefNamespace == pool.Namespace {
+								// If the backendRef points to the InferencePool in the correct namespace,
+								// check the HTTPRoute's parent status.
+								for _, p := range r.Status.Parents {
+									if supportedControllers.Contains(p.ControllerName) {
+										ns := r.Namespace
+										if p.ParentRef.Namespace != nil && *p.ParentRef.Namespace != "" {
+											ns = string(*p.ParentRef.Namespace)
+										}
+										gatewayParentsToEnsure.Insert(types.NamespacedName{Name: string(p.ParentRef.Name), Namespace: ns})
 									}
-									gatewayParentsToEnsure.Insert(types.NamespacedName{Name: string(p.ParentRef.Name), Namespace: ns})
 								}
 							}
 						}
@@ -154,41 +167,55 @@ func InferencePoolCollection(
 				}
 			}
 
-			existingParents := pool.Status.DeepCopy().Parents
-			existingParentsMap := make(map[types.NamespacedName]inferencev1alpha2.PoolStatus, len(existingParents))
-			newParents := []inferencev1alpha2.PoolStatus{}
-			for gtw := range gatewayParentsToEnsure {
-				newParents = append(newParents, *poolStatusTmpl(gtw.Name, gtw.Namespace, pool.Generation))
-			}
+			extensionReferenceResolvedStatus := resolveExtensionRef(services, *pool)
 
+			// Upate the parents status list;
+			//   - remove ours that are no longer used
+			//   - keep parents from other controllers as is
+			//   - update our current parents
+			existingParents := pool.Status.DeepCopy().Parents
+
+			// All ours from this reconciliation in a default unknown state
+			ourParents := []inferencev1alpha2.PoolStatus{}
 			finalParents := []inferencev1alpha2.PoolStatus{}
-			// First, look at existing parents and add them unconditionally if they are NOT managed by this controller
+			// Add all existing parents from other controllers
 			for _, existingParent := range existingParents {
-				gwKey := types.NamespacedName{Name: existingParent.GatewayRef.Name, Namespace: existingParent.GatewayRef.Namespace}
-				existingParentsMap[gwKey] = existingParent
 				if !isManagedGateway(gateways, existingParent) {
 					finalParents = append(finalParents, existingParent)
+				} else if gatewayParentsToEnsure.Contains(types.NamespacedName{Name: string(existingParent.GatewayRef.Name), Namespace: string(existingParent.GatewayRef.Namespace)}) {
+					// only add our parents that are still referenced by an HTTPRoute
+					ourParents = append(ourParents, existingParent)
 				}
 			}
-			for _, newParent := range newParents {
-				gwKey := types.NamespacedName{Name: newParent.GatewayRef.Name, Namespace: newParent.GatewayRef.Namespace}
-				if parent, ok := existingParentsMap[gwKey]; ok {
-					// There's an update of an existing parent we control, update it to accepted
-					// TODO: Update this is there are ever more conditions to consider
-					finalParents = append(finalParents, inferencev1alpha2.PoolStatus{
-						GatewayRef: newParent.GatewayRef,
-						Conditions: setConditions(pool.Generation, parent.Conditions, map[string]*condition{
-							string(inferencev1alpha2.InferencePoolConditionAccepted): {
-								reason:  string(inferencev1alpha2.InferencePoolReasonAccepted),
-								status:  metav1.ConditionTrue,
-								message: "Referenced by an HTTPRoute accepted by the parentRef Gateway",
-							},
-						}),
-					})
-				} else {
-					// If this is a net new parent, just add it
-					finalParents = append(finalParents, newParent)
+
+			// Create new default parents if this is a new parent
+			for gtw := range gatewayParentsToEnsure {
+				found := false
+				for _, ourExistingParent := range ourParents {
+					if ourExistingParent.GatewayRef.Name == gtw.Name && ourExistingParent.GatewayRef.Namespace == gtw.Namespace {
+						found = true
+						break
+					}
 				}
+				if !found {
+					ourParents = append(ourParents, *defaultUnknownStatus(gtw.Name, gtw.Namespace, pool.Generation))
+				}
+			}
+
+			// Add all our parents and update the conditions from previous default unknown state
+			for _, ourParent := range ourParents {
+				// TODO: Update this is there are ever more conditions to consider
+				finalParents = append(finalParents, inferencev1alpha2.PoolStatus{
+					GatewayRef: ourParent.GatewayRef,
+					Conditions: setConditions(pool.Generation, ourParent.Conditions, map[string]*condition{
+						string(inferencev1alpha2.InferencePoolConditionAccepted): {
+							reason:  string(inferencev1alpha2.InferencePoolReasonAccepted),
+							status:  metav1.ConditionTrue,
+							message: "Referenced by an HTTPRoute accepted by the parentRef Gateway",
+						},
+						string(inferencev1alpha2.ModelConditionResolvedRefs): extensionReferenceResolvedStatus,
+					}),
+				})
 			}
 
 			ipoolStatus := inferencev1alpha2.InferencePoolStatus{
@@ -203,6 +230,39 @@ func InferencePoolCollection(
 		}, opts.WithName("InferenceExtension")...)
 }
 
+// resolveExtensionRef checks if the extension ref is valid and returns a condition
+// checks if the kind is supported and if the service exists in the same namespace as the InferencePool
+func resolveExtensionRef(services krt.Collection[*corev1.Service], pool inferencev1alpha2.InferencePool) *condition {
+	// defaults to service
+	if pool.Spec.ExtensionRef.Kind != nil && string(*pool.Spec.ExtensionRef.Kind) != gvk.Service.Kind {
+		return &condition{
+			reason:  string(inferencev1alpha2.ModelReasonInvalidExtensionRef),
+			status:  metav1.ConditionFalse,
+			message: "Unsupported ExtensionRef kind " + string(*pool.Spec.ExtensionRef.Kind),
+		}
+	}
+	if string(pool.Spec.ExtensionRef.Name) == "" {
+		return &condition{
+			reason:  string(inferencev1alpha2.ModelReasonInvalidExtensionRef),
+			status:  metav1.ConditionFalse,
+			message: "ExtensionRef not defined",
+		}
+	}
+	svc := ptr.Flatten(services.GetKey(fmt.Sprintf("%s/%s", pool.Namespace, pool.Spec.ExtensionRef.Name)))
+	if svc == nil {
+		return &condition{
+			reason:  string(inferencev1alpha2.ModelReasonInvalidExtensionRef),
+			status:  metav1.ConditionFalse,
+			message: "Referenced ExtensionRef not found " + string(pool.Spec.ExtensionRef.Name),
+		}
+	}
+	return &condition{
+		reason:  string(inferencev1alpha2.ModelConditionResolvedRefs),
+		status:  metav1.ConditionTrue,
+		message: "Referenced ExtensionRef resolved successfully ",
+	}
+}
+
 // isManagedGateway checks if the Gateway is controlled by this controller
 func isManagedGateway(gateways krt.Collection[*gateway.Gateway], parent inferencev1alpha2.PoolStatus) bool {
 	gtw := ptr.Flatten(gateways.GetKey(fmt.Sprintf("%s/%s", parent.GatewayRef.Namespace, parent.GatewayRef.Name)))
@@ -213,7 +273,7 @@ func isManagedGateway(gateways krt.Collection[*gateway.Gateway], parent inferenc
 	return ok
 }
 
-func poolStatusTmpl(gwName, ns string, generation int64) *inferencev1alpha2.PoolStatus {
+func defaultUnknownStatus(gwName, ns string, generation int64) *inferencev1alpha2.PoolStatus {
 	return &inferencev1alpha2.PoolStatus{
 		GatewayRef: corev1.ObjectReference{
 			APIVersion: gatewayv1.GroupVersion.String(),
@@ -224,9 +284,17 @@ func poolStatusTmpl(gwName, ns string, generation int64) *inferencev1alpha2.Pool
 		Conditions: []metav1.Condition{
 			{
 				Type:               string(inferencev1alpha2.InferencePoolConditionAccepted),
-				Status:             metav1.ConditionTrue,
+				Status:             metav1.ConditionUnknown,
 				Reason:             string(inferencev1alpha2.InferencePoolReasonAccepted),
-				Message:            "Referenced by an HTTPRoute accepted by the parentRef Gateway",
+				Message:            "Unknown acceptance status",
+				ObservedGeneration: generation,
+				LastTransitionTime: metav1.NewTime(time.Now()),
+			},
+			{
+				Type:               string(inferencev1alpha2.ModelConditionResolvedRefs),
+				Status:             metav1.ConditionUnknown,
+				Reason:             string(inferencev1alpha2.ModelReasonResolvedRefs),
+				Message:            "Unknown resolved refs status",
 				ObservedGeneration: generation,
 				LastTransitionTime: metav1.NewTime(time.Now()),
 			},
@@ -355,4 +423,23 @@ func (c *Controller) canManageShadowServiceForInference(obj *corev1.Service) (bo
 	_, inferencePoolManaged := obj.GetLabels()[InferencePoolRefLabel]
 	// We can manage if it has no manager or if we are the manager
 	return inferencePoolManaged, obj.GetResourceVersion()
+}
+
+func indexHTTPRouteByInferencePool(o *gateway.HTTPRoute) []string {
+	var keys []string
+	for _, rule := range o.Spec.Rules {
+		for _, backendRef := range rule.BackendRefs {
+			if string(*backendRef.BackendRef.Group) == gvk.InferencePool.Group &&
+				string(*backendRef.BackendRef.Kind) == gvk.InferencePool.Kind {
+				// If BackendRef.Namespace is not specified, the backend is in the same namespace as the HTTPRoute's
+				backendRefNamespace := o.Namespace
+				if backendRef.BackendRef.Namespace != nil && *backendRef.BackendRef.Namespace != "" {
+					backendRefNamespace = string(*backendRef.BackendRef.Namespace)
+				}
+				key := backendRefNamespace + "/" + string(backendRef.Name)
+				keys = append(keys, key)
+			}
+		}
+	}
+	return keys
 }

--- a/pilot/pkg/config/kube/gateway/inferencepool_status_test.go
+++ b/pilot/pkg/config/kube/gateway/inferencepool_status_test.go
@@ -157,7 +157,9 @@ func TestInferencePoolStatusReconciliation(t *testing.T) {
 					WithParentRefAndStatus("gateway-1", DefaultTestNS, IstioController),
 					WithBackendRef("test-pool", DefaultTestNS)),
 			},
-			targetPool: NewInferencePool("test-pool", InNamespace(DefaultTestNS), WithParentStatus("gateway-1", DefaultTestNS, WithConditions(metav1.ConditionUnknown, "X", "Y", "Dummy"))),
+			targetPool: NewInferencePool("test-pool", InNamespace(DefaultTestNS),
+				WithParentStatus("gateway-1", DefaultTestNS,
+					WithConditions(metav1.ConditionUnknown, "X", "Y", "Dummy"))),
 			expectations: func(t *testing.T, status *inferencev1alpha2.InferencePoolStatus) {
 				require.Len(t, status.Parents, 1, "Expected one parent reference")
 				assert.Equal(t, "gateway-1", status.Parents[0].GatewayRef.Name)

--- a/pilot/pkg/config/kube/gateway/inferencepool_status_test.go
+++ b/pilot/pkg/config/kube/gateway/inferencepool_status_test.go
@@ -1,0 +1,627 @@
+package gateway
+
+import (
+	"fmt"
+	"strings"
+	"testing" // Only for context, not strictly needed for the scenario definitions themselves
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"istio.io/istio/pilot/pkg/status"
+	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/test"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	inferencev1alpha2 "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha2"
+	gateway "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+const IstioController = "istio.io/gateway-controller"
+const DefaultTestNS = "default"
+const GatewayTestNS = "gateway-ns"
+const AppTestNS = "app-ns"
+const EmptyTestNS = ""
+
+func TestInferencePoolStatusReconciliation(t *testing.T) {
+
+	testCases := []struct {
+		name         string
+		givens       []runtime.Object                 // Objects to create before the test
+		targetPool   *inferencev1alpha2.InferencePool // The InferencePool to check
+		expectations func(t *testing.T, pool *inferencev1alpha2.InferencePoolStatus)
+	}{
+		//
+		// Positive Test Scenarios
+		//
+		{
+			name: "should add gateway parentRef to inferencepool status",
+			givens: []runtime.Object{
+				NewGateway("main-gateway", InNamespace(DefaultTestNS), WithGatewayClass("istio")),
+				NewHTTPRoute("test-route", InNamespace(DefaultTestNS),
+					WithParentRefAndStatus("main-gateway", DefaultTestNS, IstioController),
+					WithBackendRef("test-pool", DefaultTestNS)),
+			},
+			targetPool: NewInferencePool("test-pool", InNamespace(DefaultTestNS)),
+			expectations: func(t *testing.T, status *inferencev1alpha2.InferencePoolStatus) {
+				require.Len(t, status.Parents, 1, "Expected one parent reference")
+				assert.Equal(t, "main-gateway", string(status.Parents[0].GatewayRef.Name))
+				assert.Equal(t, DefaultTestNS, string(status.Parents[0].GatewayRef.Namespace))
+				assertConditionContains(t, status.Parents[0].Conditions, metav1.Condition{
+					Type:    string(inferencev1alpha2.InferencePoolConditionAccepted),
+					Status:  metav1.ConditionTrue,
+					Reason:  string(inferencev1alpha2.InferencePoolReasonAccepted),
+					Message: "Referenced by an HTTPRoute",
+				}, "Expected condition with Accepted")
+			},
+		},
+		{
+			name: "should add only 1 gateway parentRef to status for multiple routes on different gateways wiht different controllers",
+			givens: []runtime.Object{
+				NewGateway("gateway-1", InNamespace(DefaultTestNS), WithGatewayClass("istio")),
+				NewGateway("gateway-2", InNamespace(DefaultTestNS), WithGatewayClass("other")),
+				NewHTTPRoute("route-1", InNamespace(DefaultTestNS),
+					WithParentRefAndStatus("gateway-1", DefaultTestNS, IstioController),
+					WithParentRefAndStatus("gateway-2", DefaultTestNS, "other-controller"),
+					WithBackendRef("test-pool", DefaultTestNS)),
+			},
+			targetPool: NewInferencePool("test-pool", InNamespace(DefaultTestNS)),
+			expectations: func(t *testing.T, status *inferencev1alpha2.InferencePoolStatus) {
+				require.Len(t, status.Parents, 1, "Expected one parent reference")
+				assert.Equal(t, "gateway-1", string(status.Parents[0].GatewayRef.Name))
+				assert.Equal(t, DefaultTestNS, string(status.Parents[0].GatewayRef.Namespace))
+			},
+		},
+		{
+			name: "should keep the status of the gateway parentRefs from antoher controller",
+			givens: []runtime.Object{
+				NewGateway("gateway-1", InNamespace(DefaultTestNS), WithGatewayClass("istio")),
+				NewGateway("gateway-2", InNamespace(DefaultTestNS), WithGatewayClass("other-class")),
+				NewHTTPRoute("route-1", InNamespace(DefaultTestNS),
+					WithParentRefAndStatus("gateway-1", DefaultTestNS, IstioController),
+					WithBackendRef("test-pool", DefaultTestNS)),
+				NewHTTPRoute("route-2", InNamespace(DefaultTestNS),
+					WithParentRefAndStatus("gateway-2", DefaultTestNS, "other-class"),
+					WithBackendRef("test-pool", DefaultTestNS)),
+			},
+			targetPool: NewInferencePool("test-pool", InNamespace(DefaultTestNS), WithParentStatus("gateway-2", DefaultTestNS, WithAcceptedConditions())),
+			expectations: func(t *testing.T, status *inferencev1alpha2.InferencePoolStatus) {
+				require.Len(t, status.Parents, 2, "Expected two parent references")
+				assert.ElementsMatch(t,
+					[]string{"gateway-1", "gateway-2"},
+					[]string{string(status.Parents[0].GatewayRef.Name), string(status.Parents[1].GatewayRef.Name)},
+				)
+			},
+		},
+		{
+			name: "should add multiple gateway parentRefs to status for multiple routes",
+			givens: []runtime.Object{
+				NewGateway("gateway-1", InNamespace(DefaultTestNS), WithGatewayClass("istio")),
+				NewGateway("gateway-2", InNamespace(DefaultTestNS), WithGatewayClass("istio")),
+				NewHTTPRoute("route-1", InNamespace(DefaultTestNS),
+					WithParentRefAndStatus("gateway-1", DefaultTestNS, IstioController),
+					WithBackendRef("test-pool", DefaultTestNS)),
+				NewHTTPRoute("route-2", InNamespace(DefaultTestNS),
+					WithParentRefAndStatus("gateway-2", DefaultTestNS, IstioController),
+					WithBackendRef("test-pool", DefaultTestNS)),
+			},
+			targetPool: NewInferencePool("test-pool", InNamespace(DefaultTestNS)),
+			expectations: func(t *testing.T, status *inferencev1alpha2.InferencePoolStatus) {
+				require.Len(t, status.Parents, 2, "Expected two parent references")
+				assert.ElementsMatch(t,
+					[]string{"gateway-1", "gateway-2"},
+					[]string{string(status.Parents[0].GatewayRef.Name), string(status.Parents[1].GatewayRef.Name)},
+				)
+			},
+		},
+		{
+			name: "should remove our status from previous reconciliation that is no longer referenced by any HTTPRoute",
+			givens: []runtime.Object{
+				NewGateway("gateway-1", InNamespace(DefaultTestNS), WithGatewayClass("istio")),
+				NewGateway("gateway-2", InNamespace(DefaultTestNS), WithGatewayClass("istio")),
+				NewHTTPRoute("route-1", InNamespace(DefaultTestNS),
+					WithParentRefAndStatus("gateway-1", DefaultTestNS, IstioController),
+					WithBackendRef("test-pool", DefaultTestNS)),
+			},
+			targetPool: NewInferencePool("test-pool", InNamespace(DefaultTestNS), WithParentStatus("gateway-2", DefaultTestNS, WithAcceptedConditions())),
+			expectations: func(t *testing.T, status *inferencev1alpha2.InferencePoolStatus) {
+				require.Len(t, status.Parents, 1, "Expected one parent reference")
+				assert.Equal(t, "gateway-1", string(status.Parents[0].GatewayRef.Name))
+			},
+		},
+		{
+			name: "should keep others status from previous reconciliation that is no longer referenced by any HTTPRoute",
+			givens: []runtime.Object{
+				NewGateway("gateway-1", InNamespace(DefaultTestNS), WithGatewayClass("istio")),
+				NewGateway("gateway-2", InNamespace(DefaultTestNS), WithGatewayClass("other-class")),
+				NewHTTPRoute("route-1", InNamespace(DefaultTestNS),
+					WithParentRefAndStatus("gateway-1", DefaultTestNS, IstioController),
+					WithBackendRef("test-pool", DefaultTestNS)),
+			},
+			targetPool: NewInferencePool("test-pool", InNamespace(DefaultTestNS), WithParentStatus("gateway-2", DefaultTestNS, WithAcceptedConditions())),
+			expectations: func(t *testing.T, status *inferencev1alpha2.InferencePoolStatus) {
+				require.Len(t, status.Parents, 2, "Expected two parent references")
+				assert.ElementsMatch(t,
+					[]string{"gateway-1", "gateway-2"},
+					[]string{string(status.Parents[0].GatewayRef.Name), string(status.Parents[1].GatewayRef.Name)},
+				)
+			},
+		},
+		{
+			name: "should handle cross-namespace gateway references correctly",
+			givens: []runtime.Object{
+				NewGateway("main-gateway", InNamespace(GatewayTestNS), WithGatewayClass("istio")),
+				NewHTTPRoute("test-route", InNamespace(AppTestNS),
+					WithParentRefAndStatus("main-gateway", GatewayTestNS, IstioController),
+					WithBackendRef("test-pool", AppTestNS)),
+			},
+			targetPool: NewInferencePool("test-pool", InNamespace(AppTestNS)),
+			expectations: func(t *testing.T, status *inferencev1alpha2.InferencePoolStatus) {
+				require.Len(t, status.Parents, 1, "Expected one parent reference")
+				assert.Equal(t, "main-gateway", string(status.Parents[0].GatewayRef.Name))
+				assert.Equal(t, GatewayTestNS, string(status.Parents[0].GatewayRef.Namespace))
+			},
+		},
+		{
+			name: "should handle cross-namespace httproute references correctly",
+			givens: []runtime.Object{
+				NewGateway("main-gateway", InNamespace(GatewayTestNS), WithGatewayClass("istio")),
+				NewHTTPRoute("test-route", InNamespace(AppTestNS),
+					WithParentRefAndStatus("main-gateway", GatewayTestNS, IstioController),
+					WithBackendRef("test-pool", DefaultTestNS)),
+			},
+			targetPool: NewInferencePool("test-pool", InNamespace(DefaultTestNS)),
+			expectations: func(t *testing.T, status *inferencev1alpha2.InferencePoolStatus) {
+				require.Len(t, status.Parents, 1, "Expected one parent reference")
+				assert.Equal(t, "main-gateway", string(status.Parents[0].GatewayRef.Name))
+				assert.Equal(t, GatewayTestNS, string(status.Parents[0].GatewayRef.Namespace))
+			},
+		},
+		{
+			name: "should handle HTTPRoute in same namespace (empty)",
+			givens: []runtime.Object{
+				NewGateway("main-gateway", InNamespace(GatewayTestNS), WithGatewayClass("istio")),
+				NewHTTPRoute("test-route", InNamespace(AppTestNS),
+					WithParentRefAndStatus("main-gateway", GatewayTestNS, IstioController),
+					WithBackendRef("test-pool", EmptyTestNS)),
+			},
+			targetPool: NewInferencePool("test-pool", InNamespace(AppTestNS)),
+			expectations: func(t *testing.T, status *inferencev1alpha2.InferencePoolStatus) {
+				require.Len(t, status.Parents, 1, "Expected one parent reference")
+				assert.Equal(t, "main-gateway", string(status.Parents[0].GatewayRef.Name))
+				assert.Equal(t, GatewayTestNS, string(status.Parents[0].GatewayRef.Namespace))
+			},
+		},
+		{
+			name: "should handle Gateway in same namespace (empty)",
+			givens: []runtime.Object{
+				NewGateway("main-gateway", InNamespace(AppTestNS), WithGatewayClass("istio")),
+				NewHTTPRoute("test-route", InNamespace(AppTestNS),
+					WithParentRefAndStatus("main-gateway", EmptyTestNS, IstioController),
+					WithBackendRef("test-pool", AppTestNS)),
+			},
+			targetPool: NewInferencePool("test-pool", InNamespace(AppTestNS)),
+			expectations: func(t *testing.T, status *inferencev1alpha2.InferencePoolStatus) {
+				require.Len(t, status.Parents, 1, "Expected one parent reference")
+				assert.Equal(t, "main-gateway", string(status.Parents[0].GatewayRef.Name))
+				assert.Equal(t, AppTestNS, string(status.Parents[0].GatewayRef.Namespace))
+			},
+		},
+		{
+			name: "should add only one parentRef for multiple routes on same gateway",
+			givens: []runtime.Object{
+				NewGateway("main-gateway", InNamespace(DefaultTestNS), WithGatewayClass("istio")),
+				NewHTTPRoute("route-a", InNamespace(DefaultTestNS),
+					WithParentRefAndStatus("main-gateway", DefaultTestNS, IstioController),
+					WithBackendRef("test-pool", DefaultTestNS)),
+				NewHTTPRoute("route-b", InNamespace(DefaultTestNS),
+					WithParentRefAndStatus("main-gateway", DefaultTestNS, IstioController),
+					WithBackendRef("test-pool", DefaultTestNS)),
+			},
+			targetPool: NewInferencePool("test-pool", InNamespace(DefaultTestNS)),
+			expectations: func(t *testing.T, status *inferencev1alpha2.InferencePoolStatus) {
+				require.Len(t, status.Parents, 1, "Expected only one parent reference for the same gateway")
+				assert.Equal(t, "main-gateway", string(status.Parents[0].GatewayRef.Name))
+			},
+		},
+		{
+			name: "should report ResolvedRef true when ExtensioNRef found",
+			givens: []runtime.Object{
+				NewService("test-epp", InNamespace(DefaultTestNS)),
+				NewGateway("main-gateway", InNamespace(GatewayTestNS), WithGatewayClass("istio")),
+				NewHTTPRoute("test-route", InNamespace(DefaultTestNS),
+					WithParentRefAndStatus("main-gateway", DefaultTestNS, IstioController),
+					WithBackendRef("test-pool", DefaultTestNS)),
+			},
+			targetPool: NewInferencePool("test-pool", InNamespace(DefaultTestNS), WithExtensionRef("Service", "test-epp")),
+			expectations: func(t *testing.T, status *inferencev1alpha2.InferencePoolStatus) {
+				require.Len(t, status.Parents, 1, "Expected one parent reference")
+				require.Len(t, status.Parents[0].Conditions, 2, "Expected two condition")
+				assertConditionContains(t, status.Parents[0].Conditions, metav1.Condition{
+					Type:    string(inferencev1alpha2.ModelConditionResolvedRefs),
+					Status:  metav1.ConditionTrue,
+					Reason:  string(inferencev1alpha2.ModelReasonResolvedRefs),
+					Message: "Referenced ExtensionRef resolved",
+				}, "Expected condition with InvalidExtensionRef")
+			},
+		},
+
+		//
+		// Negative Test Scenarios
+		//
+		{
+			name: "should not add parentRef for gatewayclass not controlled by us",
+			givens: []runtime.Object{
+				NewGateway("main-gateway", InNamespace(DefaultTestNS), WithGatewayClass("other")),
+				NewHTTPRoute("test-route", InNamespace(DefaultTestNS),
+					WithParentRefAndStatus("main-gateway", DefaultTestNS, "other-controller"),
+					WithBackendRef("test-pool", DefaultTestNS)),
+			},
+			targetPool: NewInferencePool("test-pool", InNamespace(DefaultTestNS)),
+			expectations: func(t *testing.T, status *inferencev1alpha2.InferencePoolStatus) {
+				assert.Empty(t, status.Parents, "ParentRefs should be empty")
+			},
+		},
+		{
+			name: "should not add parentRef if httproute has no backendref",
+			givens: []runtime.Object{
+				NewGateway("main-gateway", InNamespace(DefaultTestNS), WithGatewayClass("istio")),
+				NewHTTPRoute("test-route", InNamespace(DefaultTestNS),
+					WithParentRefAndStatus("main-gateway", DefaultTestNS, IstioController)), // No BackendRef
+			},
+			targetPool: NewInferencePool("test-pool", InNamespace(DefaultTestNS)),
+			expectations: func(t *testing.T, status *inferencev1alpha2.InferencePoolStatus) {
+				assert.Empty(t, status.Parents, "ParentRefs should be empty")
+			},
+		},
+		{
+			name: "should not add parentRef if httproute has no parentref",
+			givens: []runtime.Object{
+				NewHTTPRoute("test-route", InNamespace(DefaultTestNS),
+					WithBackendRef("test-pool", DefaultTestNS)), // No ParentRef
+			},
+			targetPool: NewInferencePool("test-pool", InNamespace(DefaultTestNS)),
+			expectations: func(t *testing.T, status *inferencev1alpha2.InferencePoolStatus) {
+				assert.Empty(t, status.Parents, "ParentRefs should be empty")
+			},
+		},
+		{
+			name: "should report ExtensionRef not found if no matching service found",
+			givens: []runtime.Object{
+				NewGateway("main-gateway", InNamespace(GatewayTestNS), WithGatewayClass("istio")),
+				NewHTTPRoute("test-route", InNamespace(DefaultTestNS),
+					WithParentRefAndStatus("main-gateway", DefaultTestNS, IstioController),
+					WithBackendRef("test-pool", DefaultTestNS)),
+			},
+			targetPool: NewInferencePool("test-pool", InNamespace(DefaultTestNS)),
+			expectations: func(t *testing.T, status *inferencev1alpha2.InferencePoolStatus) {
+				require.Len(t, status.Parents, 1, "Expected one parent reference")
+				require.Len(t, status.Parents[0].Conditions, 2, "Expected two condition")
+				assertConditionContains(t, status.Parents[0].Conditions, metav1.Condition{
+					Type:    string(inferencev1alpha2.ModelConditionResolvedRefs),
+					Status:  metav1.ConditionFalse,
+					Reason:  string(inferencev1alpha2.ModelReasonInvalidExtensionRef),
+					Message: "Referenced ExtensionRef not found",
+				}, "Expected condition with InvalidExtensionRef")
+			},
+		},
+		{
+			name: "should report unsupported ExtensionRef if kind is not service",
+			givens: []runtime.Object{
+				NewGateway("main-gateway", InNamespace(GatewayTestNS), WithGatewayClass("istio")),
+				NewHTTPRoute("test-route", InNamespace(DefaultTestNS),
+					WithParentRefAndStatus("main-gateway", DefaultTestNS, IstioController),
+					WithBackendRef("test-pool", DefaultTestNS)),
+			},
+			targetPool: NewInferencePool("test-pool", InNamespace(DefaultTestNS), WithExtensionRef("Gateway", "main-gateway")),
+			expectations: func(t *testing.T, status *inferencev1alpha2.InferencePoolStatus) {
+				require.Len(t, status.Parents, 1, "Expected one parent reference")
+				require.Len(t, status.Parents[0].Conditions, 2, "Expected two condition")
+				assertConditionContains(t, status.Parents[0].Conditions, metav1.Condition{
+					Type:    string(inferencev1alpha2.ModelConditionResolvedRefs),
+					Status:  metav1.ConditionFalse,
+					Reason:  string(inferencev1alpha2.ModelReasonInvalidExtensionRef),
+					Message: "Unsupported ExtensionRef kind",
+				}, "Expected condition with InvalidExtensionRef")
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			stop := test.NewStop(t)
+
+			controller := setupController(t,
+				append(tc.givens, tc.targetPool)...,
+			)
+
+			sq := &TestStatusQueue{
+				state: map[status.Resource]any{},
+			}
+			statusSynced := controller.status.SetQueue(sq)
+			for _, st := range statusSynced {
+				st.WaitUntilSynced(stop)
+			}
+
+			dumpOnFailure(t, krt.GlobalDebugHandler)
+
+			getInferencePoolStatus := func() *inferencev1alpha2.InferencePoolStatus {
+				statuses := sq.Statuses()
+				for _, status := range statuses {
+					if pool, ok := status.(*inferencev1alpha2.InferencePoolStatus); ok {
+						return pool
+					}
+				}
+				return nil
+			}
+			poolStatus := getInferencePoolStatus()
+			assert.NotNil(t, poolStatus)
+
+			// 5. Run the specific assertions for this test case.
+			tc.expectations(t, poolStatus)
+		})
+	}
+}
+
+func assertConditionContains(t *testing.T, conditions []metav1.Condition, expected metav1.Condition, msgAndArgs ...interface{}) {
+	t.Helper()
+
+	for _, condition := range conditions {
+		if (expected.Type == "" || condition.Type == expected.Type) &&
+			(expected.Status == "" || condition.Status == expected.Status) &&
+			(expected.Reason == "" || condition.Reason == expected.Reason) &&
+			(expected.Message == "" || strings.HasPrefix(condition.Message, expected.Message)) {
+			return // Found matching condition
+		}
+	}
+
+	// If we get here, no matching condition was found
+	assert.Fail(t, fmt.Sprintf("Expected condition with Type=%s, Status=%s, Reason=%s not found in conditions. Available conditions: %+v",
+		expected.Type, expected.Status, expected.Reason, conditions), msgAndArgs...)
+}
+
+// --- Mock Objects ---
+
+// Option is a function that mutates an object.
+type Option func(client.Object)
+type ParentOption func(*inferencev1alpha2.PoolStatus)
+
+// --- Helper functions to mutate objects ---
+
+func InNamespace(namespace string) Option {
+	return func(obj client.Object) {
+		obj.SetNamespace(namespace)
+	}
+}
+
+func WithController(name string) Option {
+	return func(obj client.Object) {
+		gw, ok := obj.(*gateway.GatewayClass)
+		if ok {
+			gw.Spec.ControllerName = gateway.GatewayController(name)
+		}
+	}
+}
+
+func WithGatewayClass(name string) Option {
+	return func(obj client.Object) {
+		gw, ok := obj.(*gateway.Gateway)
+		if ok {
+			gw.Spec.GatewayClassName = gateway.ObjectName(name)
+		}
+	}
+}
+
+func WithParentRef(name, namespace string) Option {
+	return func(obj client.Object) {
+		hr, ok := obj.(*gateway.HTTPRoute)
+		if ok {
+			namespaceName := gateway.Namespace(namespace)
+			hr.Spec.ParentRefs = []gateway.ParentReference{
+				{
+					Name:      gateway.ObjectName(name),
+					Namespace: &namespaceName,
+				},
+			}
+		}
+	}
+}
+
+func WithParentRefAndStatus(name, namespace, controllerName string) Option {
+	return func(obj client.Object) {
+		hr, ok := obj.(*gateway.HTTPRoute)
+		if ok {
+			namespaceName := gateway.Namespace(namespace)
+			if hr.Spec.ParentRefs == nil {
+				hr.Spec.ParentRefs = []gateway.ParentReference{}
+			}
+			hr.Spec.ParentRefs = append(hr.Spec.ParentRefs, gateway.ParentReference{
+				Name:      gateway.ObjectName(name),
+				Namespace: &namespaceName,
+			})
+			if hr.Status.Parents == nil {
+				hr.Status.Parents = []gateway.RouteParentStatus{}
+			}
+
+			parentStatusRef := &gateway.RouteParentStatus{
+				ParentRef: gateway.ParentReference{
+					Name:      gateway.ObjectName(name),
+					Namespace: &namespaceName,
+				},
+				ControllerName: gateway.GatewayController(controllerName),
+			}
+			hr.Status.Parents = append(hr.Status.Parents, *parentStatusRef)
+		}
+	}
+}
+
+func WithBackendRef(name, namespace string) Option {
+	return func(obj client.Object) {
+		hr, ok := obj.(*gateway.HTTPRoute)
+		if ok {
+			namespaceName := gateway.Namespace(namespace)
+			if hr.Spec.Rules == nil {
+				hr.Spec.Rules = []gateway.HTTPRouteRule{}
+			}
+			hr.Spec.Rules = append(hr.Spec.Rules, gateway.HTTPRouteRule{
+				BackendRefs: []gateway.HTTPBackendRef{
+					{
+						BackendRef: gateway.BackendRef{
+							BackendObjectReference: gateway.BackendObjectReference{
+								Name:      gateway.ObjectName(name),
+								Namespace: &namespaceName,
+								Kind:      &[]gateway.Kind{gateway.Kind(gvk.InferencePool.Kind)}[0],
+								Group:     &[]gateway.Group{gateway.Group(gvk.InferencePool.Group)}[0],
+							},
+						},
+					},
+				},
+			})
+		}
+	}
+}
+
+func WithParentStatus(gatewayName, namespace string, opt ...ParentOption) Option {
+	return func(obj client.Object) {
+		ip, ok := obj.(*inferencev1alpha2.InferencePool)
+		if ok {
+			if ip.Status.Parents == nil {
+				ip.Status.Parents = []inferencev1alpha2.PoolStatus{}
+			}
+			poolStatus := inferencev1alpha2.PoolStatus{
+				GatewayRef: corev1.ObjectReference{
+					Name:      gatewayName,
+					Namespace: namespace,
+				},
+			}
+			for _, opt := range opt {
+				opt(&poolStatus)
+			}
+			ip.Status.Parents = append(ip.Status.Parents, poolStatus)
+		}
+	}
+}
+
+func WithAcceptedConditions() ParentOption {
+	return func(parentStatusRef *inferencev1alpha2.PoolStatus) {
+		// Add condition to the first parent status
+		if parentStatusRef.Conditions == nil {
+			parentStatusRef.Conditions = []metav1.Condition{}
+		}
+		parentStatusRef.Conditions = append(parentStatusRef.Conditions, metav1.Condition{
+			Type:               string(inferencev1alpha2.InferencePoolConditionAccepted),
+			Status:             metav1.ConditionTrue,
+			Reason:             string(inferencev1alpha2.InferencePoolReasonAccepted),
+			Message:            "Accepted by the parentRef Gateway",
+			ObservedGeneration: 1,
+			LastTransitionTime: metav1.NewTime(time.Now()),
+		})
+		parentStatusRef.Conditions = append(parentStatusRef.Conditions, metav1.Condition{
+			Type:               string(inferencev1alpha2.ModelConditionResolvedRefs),
+			Status:             metav1.ConditionTrue,
+			Reason:             string(inferencev1alpha2.ModelReasonResolvedRefs),
+			Message:            "Resolved Ex",
+			ObservedGeneration: 1,
+			LastTransitionTime: metav1.NewTime(time.Now()),
+		})
+	}
+}
+
+func WithExtensionRef(kind, name string) Option {
+	return func(obj client.Object) {
+		ip, ok := obj.(*inferencev1alpha2.InferencePool)
+		if ok {
+			kind := inferencev1alpha2.Kind(kind)
+			ip.Spec.EndpointPickerConfig.ExtensionRef = &inferencev1alpha2.Extension{
+				ExtensionReference: inferencev1alpha2.ExtensionReference{
+					Name: inferencev1alpha2.ObjectName(name),
+					Kind: &kind,
+				},
+			}
+		}
+	}
+}
+
+// --- Object Creation Functions ---
+
+func NewGateway(name string, opts ...Option) *gateway.Gateway {
+	gw := &gateway.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: DefaultTestNS,
+		},
+		Spec: gateway.GatewaySpec{
+			GatewayClassName: "istio",
+		},
+	}
+	for _, opt := range opts {
+		opt(gw)
+	}
+	return gw
+}
+
+func NewHTTPRoute(name string, opts ...Option) *gateway.HTTPRoute {
+	hr := &gateway.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: DefaultTestNS,
+		},
+	}
+	for _, opt := range opts {
+		opt(hr)
+	}
+	return hr
+}
+
+func NewInferencePool(name string, opts ...Option) *inferencev1alpha2.InferencePool {
+	ip := &inferencev1alpha2.InferencePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: DefaultTestNS,
+		},
+		Spec: inferencev1alpha2.InferencePoolSpec{
+			Selector: map[inferencev1alpha2.LabelKey]inferencev1alpha2.LabelValue{
+				"app": "test",
+			},
+			EndpointPickerConfig: inferencev1alpha2.EndpointPickerConfig{
+				ExtensionRef: &inferencev1alpha2.Extension{
+					ExtensionReference: inferencev1alpha2.ExtensionReference{
+						Name: "endpoint-picker",
+					},
+				},
+			},
+		},
+	}
+	for _, opt := range opts {
+		opt(ip)
+	}
+	return ip
+}
+
+func NewService(name string, opts ...Option) *corev1.Service {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: DefaultTestNS,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "http",
+					Port:       80,
+					TargetPort: intstr.FromInt(9002),
+				},
+			},
+		},
+	}
+	for _, opt := range opts {
+		opt(svc)
+	}
+	return svc
+}


### PR DESCRIPTION
Includes tests for InferencePool.Status handling and cross namespace
lookups.

Test for the following basic scenarios:
* Cross namespace references
* Removing old state
* Keeping old state from other controllers
* ResolvedRef conditions
* Accepted conditions

A HTTPRoute can target BackendRefs in namespaces besides it self,
so when we try to do a reverse lookup from InferencePool to find parent
Gateways via HTTPRoute we need to list all HTTPRoutes in all Namespaces.

Added InferencePool to HTTPRoute.BackendRef index for easy access lookups.

@LiorLieberman @keithmattix 

Test case seems delayed until 0.5, but branch test ok kubernetes-sigs/gateway-api-inference-extension#1061