### PR TITLE
status: fix busyloop

### DIFF
--- a/pilot/pkg/status/resourcelock.go
+++ b/pilot/pkg/status/resourcelock.go
@@ -194,10 +194,9 @@ func (wp *WorkerPool) maybeAddWorker() {
 			target, perControllerWork := wp.q.Pop(wp.currentlyWorking)
 
 			if target == (Resource{}) {
-				// continue or return?
-				// could have been deleted, or could be no items in queue not currently worked on.  need a way to differentiate.
+				// could have been deleted, or could be no items in queue not currently worked on
 				wp.lock.Unlock()
-				continue
+				return
 			}
 			wp.q.Delete(target)
 			wp.currentlyWorking.Insert(convert(target))


### PR DESCRIPTION
This has been observed to cause extremely high CPU usage as we busyloop.

Basically if we have at least 1 pending item, and we re-enqueue and
actively worked on item, it will busy loop until the actively worked on
item is handled.

We should instead kill this worker. The other worker will handle the
task when it completes
