### PR TITLE
tests: assign privileged SCC to tproxy SA on OpenShift

### DIFF
--- a/pkg/test/framework/components/echo/deployment/builder.go
+++ b/pkg/test/framework/components/echo/deployment/builder.go
@@ -311,7 +311,7 @@ func (b *builder) deployServices() (err error) {
 		} else {
 			cfg.IPFamilyPolicy = string(corev1.IPFamilyPolicyRequireDualStack)
 		}
-		svc, err := kube.GenerateService(cfg)
+		svc, err := kube.GenerateService(cfg, b.ctx.Settings().OpenShift)
 		if err != nil {
 			return err
 		}

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -264,8 +264,8 @@ func GenerateDeployment(ctx resource.Context, cfg echo.Config, settings *resourc
 	return tmpl.Execute(deploy, params)
 }
 
-func GenerateService(cfg echo.Config) (string, error) {
-	params := serviceParams(cfg)
+func GenerateService(cfg echo.Config, openshift bool) (string, error) {
+	params := serviceParams(cfg, openshift)
 	return tmpl.Execute(getTemplate(serviceTemplateFile), params)
 }
 
@@ -395,6 +395,7 @@ func deploymentParams(ctx resource.Context, cfg echo.Config, settings *resource.
 		"OverlayIstioProxy":       canCreateIstioProxy(settings.Revisions.Minimum()) && !settings.Ambient,
 		"Ambient":                 settings.Ambient,
 		"BindFamily":              cfg.BindFamily,
+		"OpenShift":               settings.OpenShift,
 	}
 
 	vmIstioHost, vmIstioIP := "", ""
@@ -422,7 +423,7 @@ func deploymentParams(ctx resource.Context, cfg echo.Config, settings *resource.
 	return params, nil
 }
 
-func serviceParams(cfg echo.Config) map[string]any {
+func serviceParams(cfg echo.Config, openshift bool) map[string]any {
 	if cfg.ServiceWaypointProxy != "" {
 		if cfg.ServiceLabels == nil {
 			cfg.ServiceLabels = make(map[string]string)
@@ -438,6 +439,8 @@ func serviceParams(cfg echo.Config) map[string]any {
 		"IPFamilies":         cfg.IPFamilies,
 		"IPFamilyPolicy":     cfg.IPFamilyPolicy,
 		"ServiceAnnotations": cfg.ServiceAnnotations,
+		"Namespace":          cfg.Namespace.Name(),
+		"OpenShift":          openshift,
 	}
 }
 

--- a/pkg/test/framework/components/echo/kube/templates/deployment.yaml
+++ b/pkg/test/framework/components/echo/kube/templates/deployment.yaml
@@ -76,6 +76,7 @@ spec:
   (ne (index $subset.Annotations "sidecar.istio.io/inject") "false")
   (ne (index $subset.Annotations "inject.istio.io/templates") "grpc")
   ($.OverlayIstioProxy)
+  (not (and $.OpenShift (eq $.Service "tproxy")))
 }}
       - name: istio-proxy
         image: auto

--- a/pkg/test/framework/components/echo/kube/templates/service.yaml
+++ b/pkg/test/framework/components/echo/kube/templates/service.yaml
@@ -4,6 +4,21 @@ kind: ServiceAccount
 metadata:
   name: {{ .Service }}
 ---
+{{- if (and .OpenShift (eq .Service "tproxy")) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: privilged-scc-{{ .Service }}-{{ .Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: {{ .Service }}
+  namespace: {{ .Namespace }}
+---
+{{- end }}
 {{- end }}
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
**Please provide a description of this PR:**

Running integration tests on OpenShift requires disabling tproxy echo service (`--istio.test.skipTProxy=true`), because tproxy redirection mode requires setting `runAsUser: 0`, `runAsGroup: 1337` and adding `NET_ADMIN` capability, and by default pods can't run with these settings on OCP.
To make it work, we have to bind privileged `SecurityContextConstraint` to tproxy service account.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [X] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
