### PR TITLE
fix dns althost name generation

### DIFF
--- a/pkg/dns/client/dns.go
+++ b/pkg/dns/client/dns.go
@@ -617,7 +617,7 @@ func (table *LookupTable) buildDNSAnswers(altHosts map[string]struct{}, ipv4 []n
 		if len(ipv6) > 0 {
 			table.name6[h] = aaaa(h, ipv6)
 		}
-		if len(searchNamespaces) > 0 {
+		if len(searchNamespaces) > 0 && !strings.HasSuffix(h, searchNamespaces[0]+".") {
 			// NOTE: Right now, rather than storing one expanded host for each one of the search namespace
 			// entries, we are going to store just the first one (assuming that most clients will
 			// do sequential dns resolution, starting with the first search namespace)

--- a/pkg/dns/client/dns_test.go
+++ b/pkg/dns/client/dns_test.go
@@ -680,21 +680,3 @@ func equalsDNSrecords(got []dns.RR, want []dns.RR) bool {
 	}
 	return reflect.DeepEqual(got, want)
 }
-
-func TestAlternateHosts(t *testing.T) {
-	server := initDNS(t, false)
-	server.searchNamespaces = []string{"ns1.svc.cluster.local", "svc.cluster.local", "cluster.local"}
-	server.UpdateLookupTable(&dnsProto.NameTable{
-		Table: map[string]*dnsProto.NameTable_NameInfo{
-			"productpage.ns1.svc.cluster.local": {
-				Ips:       []string{"9.9.9.9"},
-				Registry:  "Kubernetes",
-				Namespace: "ns1",
-				Shortname: "productpage",
-			},
-		},
-	})
-	nt := server.NameTable()
-	fmt.Println(nt)
-	t.Cleanup(server.Close)
-}


### PR DESCRIPTION
Because we unconditionally add searchNamespace[0] and then check for existence, we unnecessarily create a 
CNAME for productpage.ns1.svc.cluster.local.ns1.svc.cluster.local (notice search namespace repeat)

This PR fixes it

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions