### PR TITLE
fix(gw-inference): Shadow service should only exist if it has to

### DIFF
--- a/pilot/pkg/config/kube/gateway/inferencepool_collection.go
+++ b/pilot/pkg/config/kube/gateway/inferencepool_collection.go
@@ -109,8 +109,12 @@ func InferencePoolCollection(
 			// TODO: If no gateway parents, we should not do anything
 			// 		note: we stil need to filter out our Status to clean up previous reconciliations
 
-			// Create the InferencePool object
-			inferencePool := createInferencePoolObject(pool, gatewayParents)
+			// Create the InferencePool only if there are Gateways connected
+			var inferencePool *InferencePool
+			if len(gatewayParents) > 0 {
+				// Create the InferencePool object
+				inferencePool = createInferencePoolObject(pool, gatewayParents)
+			}
 
 			// Calculate status
 			status := calculateInferencePoolStatus(pool, gatewayParents, services, gateways, routeList)

--- a/pilot/pkg/config/kube/gateway/inferencepool_test.go
+++ b/pilot/pkg/config/kube/gateway/inferencepool_test.go
@@ -51,6 +51,11 @@ func TestReconcileInferencePool(t *testing.T) {
 	}
 	controller := setupController(t,
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+		NewGateway("test-gw", InNamespace(DefaultTestNS), WithGatewayClass("istio")),
+		NewHTTPRoute("test-route", InNamespace(DefaultTestNS),
+			WithParentRefAndStatus("test-gw", DefaultTestNS, IstioController),
+			WithBackendRef("test-pool", DefaultTestNS),
+		),
 		pool,
 	)
 


### PR DESCRIPTION
The InferencePool should only create a shadow service if a HTTPRoute that has a Gateway that we control is connected. Else do nothing.

Clean up Service and Status if the HTTPRoute disconnects.

@LiorLieberman @keithmattix 