### PR TITLE
feat: represent revision tags using services

### DIFF
--- a/istioctl/pkg/tag/generate.go
+++ b/istioctl/pkg/tag/generate.go
@@ -23,12 +23,15 @@ import (
 	"strings"
 
 	admitv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/client-go/kubernetes"
 
+	"istio.io/api/label"
 	"istio.io/istio/operator/pkg/helm"
 	"istio.io/istio/operator/pkg/render"
 	"istio.io/istio/operator/pkg/values"
@@ -86,45 +89,33 @@ type GenerateOptions struct {
 	// UserManaged indicates whether the revision tag is user managed.
 	// If true, the revision tag will not be affected by the installer.
 	UserManaged bool
+	// IstioNamespace indicates the namespace of the istio installation.
+	IstioNamespace string
 }
 
 // Generate generates the manifests for a revision tag pointed the given revision.
-func Generate(ctx context.Context, client kube.Client, opts *GenerateOptions, istioNS string) (string, error) {
+func Generate(ctx context.Context, client kube.Client, opts *GenerateOptions) (string, error) {
 	// abort if there exists a revision with the target tag name
-	revWebhookCollisions, err := GetWebhooksWithRevision(ctx, client.Kube(), opts.Tag)
+	err := checkTagNameCollidesWithRevisionName(ctx, client.Kube(), opts)
 	if err != nil {
 		return "", err
 	}
-	if !opts.Generate && !opts.Overwrite &&
-		len(revWebhookCollisions) > 0 && opts.Tag != DefaultRevisionName {
-		return "", fmt.Errorf("cannot create revision tag %q: found existing control plane revision with same name", opts.Tag)
-	}
 
-	// find canonical revision webhook to base our tag webhook off of
-	revWebhooks, err := GetWebhooksWithRevision(ctx, client.Kube(), opts.Revision)
+	canonWebhook, err := checkControlPlaneExistenceOrDuplicate(ctx, client.Kube(), opts)
 	if err != nil {
 		return "", err
 	}
-	if len(revWebhooks) == 0 {
-		return "", fmt.Errorf("cannot modify tag: cannot find MutatingWebhookConfiguration with revision %q", opts.Revision)
-	}
-	if len(revWebhooks) > 1 {
-		return "", fmt.Errorf("cannot modify tag: found multiple canonical webhooks with revision %q", opts.Revision)
-	}
-
-	whs, err := GetWebhooksWithTag(ctx, client.Kube(), opts.Tag)
+	err = checkTagDuplicate(ctx, client.Kube(), opts)
 	if err != nil {
 		return "", err
 	}
-	if len(whs) > 0 && !opts.Overwrite {
-		return "", fmt.Errorf("revision tag %q already exists, and --overwrite is false", opts.Tag)
-	}
 
-	tagWhConfig, err := tagWebhookConfigFromCanonicalWebhook(revWebhooks[0], opts.Tag, istioNS)
+	tagWhConfig, err := tagWebhookConfigFromCanonicalWebhook(*canonWebhook, opts.Tag, opts.IstioNamespace)
 	if err != nil {
 		return "", fmt.Errorf("failed to create tag webhook config: %w", err)
 	}
 	tagWhYAML, err := generateMutatingWebhook(tagWhConfig, opts)
+	var vwhYAML string
 	if err != nil {
 		return "", fmt.Errorf("failed to create tag webhook: %w", err)
 	}
@@ -146,16 +137,103 @@ func Generate(ctx context.Context, client kube.Client, opts *GenerateOptions, is
 			return "", fmt.Errorf("failed to create validating webhook config: %w", err)
 		}
 
-		vwhYAML, err := generateValidatingWebhook(validationWhConfig, opts)
+		vwhYAML, err = generateValidatingWebhook(validationWhConfig, opts)
 		if err != nil {
 			return "", fmt.Errorf("failed to create validating webhook: %w", err)
 		}
-		tagWhYAML = fmt.Sprintf(`%s
----
-%s`, tagWhYAML, vwhYAML)
+	}
+	tagServiceYAML, err := generateTagService(opts)
+	if err != nil {
+		return "", err
 	}
 
-	return tagWhYAML, nil
+	resources := []string{
+		tagWhYAML,
+		vwhYAML,
+		tagServiceYAML,
+	}
+	resourcesStrings := []string{}
+	for _, resource := range resources {
+		if resource == "" {
+			continue
+		}
+		resourcesStrings = append(resourcesStrings, resource)
+	}
+
+	return strings.Join(resourcesStrings, "\n---\n"), nil
+}
+
+// checkTagNameCollidesWithRevisionName returns an error if user attempts to
+// override a revision using a tag name
+func checkTagNameCollidesWithRevisionName(
+	ctx context.Context,
+	client kubernetes.Interface,
+	opts *GenerateOptions,
+) error {
+	if opts.Generate || opts.Overwrite || opts.Tag == DefaultRevisionName {
+		return nil
+	}
+	revServiceCollisions, err := GetServicesWithRevision(ctx, client, opts.IstioNamespace, opts.Tag)
+	if err != nil {
+		return err
+	}
+	// abort if there exists a revision with the target tag name
+	revWebhookCollisions, err := GetWebhooksWithRevision(ctx, client, opts.Tag)
+	if err != nil {
+		return err
+	}
+	if len(revWebhookCollisions) > 0 || len(revServiceCollisions) > 0 {
+		return fmt.Errorf("cannot create revision tag %q: found existing control plane revision with same name", opts.Tag)
+	}
+	return nil
+}
+
+func checkControlPlaneExistenceOrDuplicate(
+	ctx context.Context,
+	client kubernetes.Interface,
+	opts *GenerateOptions,
+) (*admitv1.MutatingWebhookConfiguration, error) {
+	revServices, err := GetServicesWithRevision(ctx, client, opts.IstioNamespace, opts.Revision)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(revServices) > 1 {
+		return nil, fmt.Errorf("cannot modify tag: found multiple canonical services with revision %q in namespace %q", opts.Revision, opts.IstioNamespace)
+	}
+	revWebhooks, err := GetWebhooksWithRevision(ctx, client, opts.Revision)
+	if err != nil {
+		return nil, err
+	}
+	if len(revWebhooks) == 0 && len(revServices) == 0 {
+		return nil, fmt.Errorf("cannot modify tag: cannot find MutatingWebhookConfiguration or Service with revision %q", opts.Revision)
+	}
+	if len(revWebhooks) > 1 || len(revServices) > 1 {
+		return nil, fmt.Errorf("cannot modify tag: found multiple canonical webhooks or services with revision %q", opts.Revision)
+	}
+	return &revWebhooks[0], nil
+}
+
+func checkTagDuplicate(
+	ctx context.Context,
+	client kubernetes.Interface,
+	opts *GenerateOptions,
+) error {
+	if opts.Overwrite {
+		return nil
+	}
+	tagServices, err := GetServicesWithTag(ctx, client, opts.IstioNamespace, opts.Tag)
+	if err != nil {
+		return err
+	}
+	whs, err := GetWebhooksWithTag(ctx, client, opts.Tag)
+	if err != nil {
+		return err
+	}
+	if len(whs) > 0 || len(tagServices) > 0 {
+		return fmt.Errorf("revision tag %q already exists, and --overwrite is false", opts.Tag)
+	}
+	return nil
 }
 
 func fixWhConfig(client kube.Client, whConfig *tagWebhookConfig) (*tagWebhookConfig, error) {
@@ -250,7 +328,6 @@ func generateValidatingWebhook(config *tagWebhookConfig, opts *GenerateOptions) 
 			decodedWh.Webhooks[i].FailurePolicy = failurePolicy
 		}
 	}
-
 	whBuf := new(bytes.Buffer)
 	if err = serializer.Encode(decodedWh, whBuf); err != nil {
 		return "", err
@@ -270,6 +347,60 @@ func generateLabels(whLabels, curLabels, customLabels map[string]string, userMan
 		}
 	}
 	return whLabels
+}
+
+func generateTagService(opts *GenerateOptions) (string, error) {
+	flags := []string{
+		"installPackagePath=" + opts.ManifestsPath,
+		"profile=empty",
+		"components.pilot.enabled=true",
+		"revision=" + opts.Revision,
+		"values.revisionTags.[0]=" + opts.Tag,
+		"values.global.istioNamespace=" + opts.IstioNamespace,
+	}
+
+	mfs, _, err := render.GenerateManifest(nil, flags, false, nil, nil)
+	if err != nil {
+		return "", err
+	}
+	var tagServiceYaml string
+	for _, mf := range mfs {
+		for _, m := range mf.Manifests {
+			tag := m.GetLabels()[label.IoIstioTag.Name]
+			if m.GetKind() == "Service" && tag == opts.Tag {
+				tagServiceYaml = m.Content
+				break
+			}
+		}
+	}
+	if tagServiceYaml == "" {
+		return "", fmt.Errorf("could not find Service tag in manifests")
+	}
+
+	scheme := runtime.NewScheme()
+	codecFactory := serializer.NewCodecFactory(scheme)
+	deserializer := codecFactory.UniversalDeserializer()
+	serializer := json.NewSerializerWithOptions(
+		json.DefaultMetaFactory, nil, nil, json.SerializerOptions{
+			Yaml:   true,
+			Pretty: true,
+			Strict: true,
+		})
+
+	whService, _, err := deserializer.Decode([]byte(tagServiceYaml), nil, &corev1.Service{})
+	if err != nil {
+		return "", fmt.Errorf("could not decode generated webhook: %w", err)
+	}
+	decodedSvc := whService.(*corev1.Service)
+
+	decodedSvc.Labels = generateLabels(decodedSvc.Labels, map[string]string{}, opts.CustomLabels, opts.UserManaged)
+
+	svcBuf := new(bytes.Buffer)
+	if err = serializer.Encode(decodedSvc, svcBuf); err != nil {
+		return "", err
+	}
+
+	return svcBuf.String(), nil
 }
 
 // generateMutatingWebhook renders a mutating webhook configuration from the given tagWebhookConfig.

--- a/istioctl/pkg/tag/generate_test.go
+++ b/istioctl/pkg/tag/generate_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	admitv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -464,17 +465,53 @@ func TestGenerateMutatingWebhook(t *testing.T) {
 	}
 }
 
+func TestGenerateTagService(t *testing.T) {
+	scheme := runtime.NewScheme()
+	codecFactory := serializer.NewCodecFactory(scheme)
+	deserializer := codecFactory.UniversalDeserializer()
+
+	tag := "canary"
+	revision := "revision"
+	opts := &GenerateOptions{
+		IstioNamespace: "istio-system",
+		Tag:            tag,
+		Revision:       revision,
+	}
+	svcYAML, err := generateTagService(opts)
+	if err != nil {
+		t.Fatalf("Could not generate tag service: %q", err)
+	}
+
+	svcObject, _, err := deserializer.Decode([]byte(svcYAML), nil, &corev1.Service{})
+	if err != nil {
+		t.Fatalf("Could not parse service: %q", svcYAML)
+	}
+
+	service := svcObject.(*corev1.Service)
+
+	labels := service.GetLabels()
+	assert.Equal(t, labels[label.IoIstioRev.Name], revision, "Tag service does not have expected revision")
+	assert.Equal(t, labels[label.IoIstioTag.Name], tag, "Tag service does not have expected tag")
+	assert.Equal(t, service.GetName(), "istiod-revision-tag-canary", "Tag service does not have expected name")
+	assert.Equal(t, service.GetNamespace(), "istio-system", "Tag service does not have expected namespace")
+
+	selector := service.Spec.Selector
+
+	assert.Equal(t, selector[label.IoIstioRev.Name], revision, "Selector istio.io/rev does not match expected value")
+}
+
 func testGenerateOption(t *testing.T, generate bool, assertFunc func(*testing.T, []admitv1.MutatingWebhook, []admitv1.MutatingWebhook)) {
 	defaultWh := defaultRevisionCanonicalWebhook.DeepCopy()
 	fakeClient := kube.NewFakeClient(defaultWh)
 
 	opts := &GenerateOptions{
-		Generate: generate,
-		Tag:      "default",
-		Revision: "default",
+		Generate:       generate,
+		Tag:            "default",
+		Revision:       "default",
+		IstioNamespace: "istio-system",
 	}
 
-	_, err := Generate(context.TODO(), fakeClient, opts, "istio-system")
+	_, err := Generate(context.TODO(), fakeClient, opts)
 	assert.NoError(t, err)
 
 	wh, err := fakeClient.Kube().AdmissionregistrationV1().MutatingWebhookConfigurations().

--- a/istioctl/pkg/tag/util.go
+++ b/istioctl/pkg/tag/util.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	admitv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -60,6 +61,32 @@ func GetWebhooksWithRevision(ctx context.Context, client kubernetes.Interface, r
 	return webhooks.Items, nil
 }
 
+// GetServicesWithRevision returns services tagged with istio.io/rev=<rev> and NOT TAGGED with istio.io/tag.
+// This retrieves the services created at revision installation rather than tag services.
+func GetServicesWithRevision(ctx context.Context, client kubernetes.Interface, istioNS, rev string) ([]corev1.Service, error) {
+	services, err := client.CoreV1().Services(istioNS).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s,!%s,%s=%s",
+			label.IoIstioRev.Name, rev,
+			label.IoIstioTag.Name,
+			"app", "istiod"),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return services.Items, nil
+}
+
+// GetServicesWithTag returns services tagged with istio.io/tag=<tag>.
+func GetServicesWithTag(ctx context.Context, client kubernetes.Interface, istioNS, tag string) ([]corev1.Service, error) {
+	services, err := client.CoreV1().Services(istioNS).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", label.IoIstioTag.Name, tag),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return services.Items, nil
+}
+
 // GetNamespacesWithTag retrieves all namespaces pointed at the given tag.
 func GetNamespacesWithTag(ctx context.Context, client kubernetes.Interface, tag string) ([]string, error) {
 	namespaces, err := client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{
@@ -89,6 +116,30 @@ func GetWebhookRevision(wh admitv1.MutatingWebhookConfiguration) (string, error)
 	return "", fmt.Errorf("could not extract tag revision from webhook")
 }
 
+// GetRevisionServices retrieves all services with the istio.io/rev label within a given namespace.
+func GetRevisionServices(ctx context.Context, client kubernetes.Interface, istioNS string) ([]corev1.Service, error) {
+	services, err := client.CoreV1().Services(istioNS).List(ctx, metav1.ListOptions{
+		LabelSelector: label.IoIstioRev.Name, // Select services that have the tag label
+	})
+	if err != nil {
+		return nil, err
+	}
+	return services.Items, nil
+}
+
+// GetServiceTagName extracts tag name from service object.
+func GetServiceTagName(svc corev1.Service) string {
+	return svc.ObjectMeta.Labels[label.IoIstioTag.Name]
+}
+
+// GetServiceRevision extracts tag target revision from service object.
+func GetServiceRevision(svc corev1.Service) (string, error) {
+	if revName, ok := svc.ObjectMeta.Labels[label.IoIstioRev.Name]; ok {
+		return revName, nil
+	}
+	return "", fmt.Errorf("could not extract tag revision from service %s/%s", svc.Namespace, svc.Name)
+}
+
 // DeleteTagWebhooks deletes the given webhooks.
 func DeleteTagWebhooks(ctx context.Context, client kubernetes.Interface, tag string) error {
 	webhooks, err := GetWebhooksWithTag(ctx, client, tag)
@@ -98,6 +149,19 @@ func DeleteTagWebhooks(ctx context.Context, client kubernetes.Interface, tag str
 	var result error
 	for _, wh := range webhooks {
 		result = multierror.Append(result, client.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(ctx, wh.Name, metav1.DeleteOptions{})).ErrorOrNil()
+	}
+	return result
+}
+
+// DeleteTagServices deletes the given tag services
+func DeleteTagServices(ctx context.Context, client kubernetes.Interface, istioNS, tag string) error {
+	services, err := GetServicesWithTag(ctx, client, istioNS, tag)
+	if err != nil {
+		return err
+	}
+	var result error
+	for _, svc := range services {
+		result = multierror.Append(result, client.CoreV1().Services(istioNS).Delete(ctx, svc.Name, metav1.DeleteOptions{})).ErrorOrNil()
 	}
 	return result
 }

--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags-mwc.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags-mwc.yaml
@@ -33,6 +33,7 @@ a unique prefix to each. */}}
   reinvocationPolicy: "{{ .reinvocationPolicy }}"
   admissionReviewVersions: ["v1"]
 {{- end }}
+{{- if not .Values.global.operatorManageWebhooks }}
 {{- range $tagName := $.Values.revisionTags }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -147,4 +148,5 @@ webhooks:
 
 {{- end }}
 ---
+{{- end }}
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags-svc.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags-svc.yaml
@@ -1,0 +1,56 @@
+# Adapted from istio-discovery/templates/service.yaml
+{{- range $tagName := .Values.revisionTags }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: istiod-revision-tag-{{ $tagName }}
+  namespace: {{ $.Release.Namespace }}
+  {{- if $.Values.serviceAnnotations }}
+  annotations:
+{{ toYaml $.Values.serviceAnnotations | indent 4 }}
+  {{- end }}
+  labels:
+    istio.io/rev: {{ $.Values.revision | default "default" | quote }}
+    istio.io/tag: {{ $tagName }}
+    install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Pilot"
+    app: istiod
+    istio: pilot
+    release: {{ $.Release.Name }}
+    app.kubernetes.io/name: "istiod"
+    {{- include "istio.labels" $ | nindent 4 }}
+spec:
+  ports:
+    - port: 15010
+      name: grpc-xds # plaintext
+      protocol: TCP
+    - port: 15012
+      name: https-dns # mTLS with k8s-signed cert
+      protocol: TCP
+    - port: 443
+      name: https-webhook # validation and injection
+      targetPort: 15017
+      protocol: TCP
+    - port: 15014
+      name: http-monitoring # prometheus stats
+      protocol: TCP
+  selector:
+    app: istiod
+    {{- if ne $.Values.revision "" }}
+    istio.io/rev: {{ $.Values.revision | quote }}
+    {{- else }}
+    # Label used by the 'default' service. For versioned deployments we match with app and version.
+    # This avoids default deployment picking the canary
+    istio: pilot
+    {{- end }}
+  {{- if $.Values.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ $.Values.ipFamilyPolicy }}
+  {{- end }}
+  {{- if $.Values.ipFamilies }}
+  ipFamilies:
+  {{- range $.Values.ipFamilies }}
+  - {{ . }}
+  {{- end }}
+  {{- end }}
+---
+{{- end -}}

--- a/operator/pkg/install/install.go
+++ b/operator/pkg/install/install.go
@@ -79,7 +79,8 @@ func (i Installer) InstallManifests(manifests []manifest.ManifestSet) error {
 	}
 
 	// We may need to manually deploy some webhooks out-of-band from the install, making this th
-	webhooks, err := webhook.WebhooksToDeploy(i.Values, i.Kube, i.DryRun)
+	ownerLabels := getOwnerLabels(i.Values, "")
+	webhooks, err := webhook.WebhooksToDeploy(i.Values, i.Kube, ownerLabels, i.DryRun)
 	if err != nil {
 		return fmt.Errorf("failed generating webhooks: %v", err)
 	}

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -148,7 +148,7 @@ func (s *Server) initK8SConfigStore(args *PilotArgs) error {
 	}
 	configController := s.makeKubeConfigController(args)
 	s.ConfigStores = append(s.ConfigStores, configController)
-	tw := revisions.NewTagWatcher(s.kubeClient, args.Revision)
+	tw := revisions.NewTagWatcher(s.kubeClient, args.Revision, args.Namespace)
 	s.addStartFunc("tag-watcher", func(stop <-chan struct{}) error {
 		go tw.Run(stop)
 		return nil
@@ -195,7 +195,7 @@ func (s *Server) initK8SConfigStore(args *PilotArgs) error {
 					AddRunFunction(func(leaderStop <-chan struct{}) {
 						// We can only run this if the Gateway CRD is created
 						if s.kubeClient.CrdWatcher().WaitForCRD(gvr.KubernetesGateway, leaderStop) {
-							tagWatcher := revisions.NewTagWatcher(s.kubeClient, args.Revision)
+							tagWatcher := revisions.NewTagWatcher(s.kubeClient, args.Revision, args.Namespace)
 							controller := gateway.NewDeploymentController(s.kubeClient, s.clusterID, s.environment,
 								s.webhookInfo.getWebhookConfig, s.webhookInfo.addHandler, tagWatcher, args.Revision, args.Namespace)
 							// Start informers again. This fixes the case where informers for namespace do not start,

--- a/pilot/pkg/config/kube/gateway/controller.go
+++ b/pilot/pkg/config/kube/gateway/controller.go
@@ -155,7 +155,7 @@ func NewController(
 	stop := make(chan struct{})
 	opts := krt.NewOptionsBuilder(stop, "gateway", options.KrtDebugger)
 
-	tw := revisions.NewTagWatcher(kc, options.Revision)
+	tw := revisions.NewTagWatcher(kc, options.Revision, options.SystemNamespace)
 	c := &Controller{
 		client:         kc,
 		cluster:        options.ClusterID,

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
@@ -575,7 +575,7 @@ metadata:
 			stop := test.NewStop(t)
 			env := model.NewEnvironment()
 			env.PushContext().ProxyConfigs = tt.pcs
-			tw := revisions.NewTagWatcher(client, "")
+			tw := revisions.NewTagWatcher(client, "", "istio-system")
 			go tw.Run(stop)
 			d := NewDeploymentController(client, cluster.ID(features.ClusterName), env, testInjectionConfig(t, tt.values), func(fn func()) {
 			}, tw, "", "")
@@ -636,7 +636,7 @@ func TestVersionManagement(t *testing.T) {
 			Name: "default",
 		},
 	})
-	tw := revisions.NewTagWatcher(c, "default")
+	tw := revisions.NewTagWatcher(c, "default", "istio-system")
 	env := &model.Environment{}
 	d := NewDeploymentController(c, "", env, testInjectionConfig(t, ""), func(fn func()) {}, tw, "", "")
 	reconciles := atomic.NewInt32(0)

--- a/pkg/revisions/tag_watcher.go
+++ b/pkg/revisions/tag_watcher.go
@@ -25,8 +25,11 @@ import (
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/kube/kubetypes"
+	istiolog "istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/util/sets"
 )
+
+var log = istiolog.RegisterScope("tag-watcher", "Revision tags watcher")
 
 // TagWatcher keeps track of the current tags and can notify watchers
 // when the tags change.
@@ -45,13 +48,16 @@ type tagWatcher struct {
 	revision string
 	handlers []TagHandler
 
-	namespaces kclient.Client[*corev1.Namespace]
-	queue      controllers.Queue
-	webhooks   kclient.Client[*admissionregistrationv1.MutatingWebhookConfiguration]
-	index      kclient.Index[string, *admissionregistrationv1.MutatingWebhookConfiguration]
+	namespaces    kclient.Client[*corev1.Namespace]
+	queue         controllers.Queue
+	webhooks      kclient.Client[*admissionregistrationv1.MutatingWebhookConfiguration]
+	services      kclient.Client[*corev1.Service]
+	webhooksIndex kclient.Index[string, *admissionregistrationv1.MutatingWebhookConfiguration]
+	servicesIndex kclient.Index[string, *corev1.Service]
 }
 
-func NewTagWatcher(client kube.Client, revision string) TagWatcher {
+func NewTagWatcher(client kube.Client, revision string, systemNamespace string) TagWatcher {
+	log.Debugf("Creating tag watcher for revision %s in namespace %s", revision, systemNamespace)
 	p := &tagWatcher{
 		revision: revision,
 	}
@@ -63,7 +69,7 @@ func NewTagWatcher(client kube.Client, revision string) TagWatcher {
 		ObjectFilter: kubetypes.NewStaticObjectFilter(isTagWebhook),
 	})
 	p.webhooks.AddEventHandler(controllers.ObjectHandler(p.queue.AddObject))
-	p.index = kclient.CreateStringIndex(p.webhooks, "istioRev",
+	p.webhooksIndex = kclient.CreateStringIndex(p.webhooks, "istioRev",
 		func(o *admissionregistrationv1.MutatingWebhookConfiguration) []string {
 			rev := o.GetLabels()[label.IoIstioRev.Name]
 			if rev == "" || !isTagWebhook(o) {
@@ -72,11 +78,29 @@ func NewTagWatcher(client kube.Client, revision string) TagWatcher {
 			return []string{rev}
 		})
 	p.namespaces = kclient.New[*corev1.Namespace](client)
+
+	// Initialize the services client with a namespace filter
+	p.services = kclient.NewFiltered[*corev1.Service](client, kubetypes.Filter{
+		ObjectFilter: kubetypes.NewStaticObjectFilter(isTagService),
+		Namespace:    systemNamespace,
+	})
+	p.services.AddEventHandler(controllers.ObjectHandler(p.queue.AddObject))
+
+	// Create a service index similar to the webhooks index
+	p.servicesIndex = kclient.CreateStringIndex(p.services, "istioRevSvc",
+		func(svc *corev1.Service) []string {
+			rev := svc.GetLabels()[label.IoIstioRev.Name]
+			if rev == "" || !isTagService(svc) {
+				return nil
+			}
+			return []string{rev}
+		})
+
 	return p
 }
 
 func (p *tagWatcher) Run(stopCh <-chan struct{}) {
-	if !kube.WaitForCacheSync("tag watcher", stopCh, p.webhooks.HasSynced) {
+	if !kube.WaitForCacheSync("tag watcher", stopCh, p.webhooks.HasSynced, p.services.HasSynced) {
 		p.queue.ShutDownEarly()
 		return
 	}
@@ -109,8 +133,19 @@ func (p *tagWatcher) IsMine(obj metav1.ObjectMeta) bool {
 
 func (p *tagWatcher) GetMyTags() sets.String {
 	res := sets.New(p.revision)
-	for _, wh := range p.index.Lookup(p.revision) {
+	mwhTags := sets.New[string]()
+	for _, wh := range p.webhooksIndex.Lookup(p.revision) {
 		res.Insert(wh.GetLabels()[label.IoIstioTag.Name])
+		mwhTags.Insert(wh.GetLabels()[label.IoIstioTag.Name])
+	}
+	for _, svc := range p.servicesIndex.Lookup(p.revision) {
+		tagName := svc.GetLabels()[label.IoIstioTag.Name]
+		res.Insert(tagName)
+
+		if mwhTags.Contains(tagName) {
+			log.Warnf("Tag name %s is already defined by a service. Delete the %s-%s MutatingWebhookConfiguration ", tagName, "istio-revision-tag", tagName)
+			mwhTags.Delete(tagName)
+		}
 	}
 	return res
 }
@@ -118,12 +153,24 @@ func (p *tagWatcher) GetMyTags() sets.String {
 // notifyHandlers notifies all registered handlers on tag change.
 func (p *tagWatcher) notifyHandlers() {
 	myTags := p.GetMyTags()
+	log.Debugf("Current tags: %s", myTags)
+
 	for _, handler := range p.handlers {
 		handler(myTags)
 	}
 }
 
 func isTagWebhook(uobj any) bool {
+	obj := controllers.ExtractObject(uobj)
+	if obj == nil {
+		return false
+	}
+	_, ok := obj.GetLabels()[label.IoIstioTag.Name]
+	return ok
+}
+
+// isTagService filters services based on specific criteria.
+func isTagService(uobj any) bool {
 	obj := controllers.ExtractObject(uobj)
 	if obj == nil {
 		return false

--- a/pkg/revisions/tag_watcher_test.go
+++ b/pkg/revisions/tag_watcher_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/api/label"
@@ -31,8 +32,9 @@ import (
 
 func TestTagWatcher(t *testing.T) {
 	c := kube.NewFakeClient()
-	tw := NewTagWatcher(c, "revision").(*tagWatcher)
+	tw := NewTagWatcher(c, "revision", "istio-system").(*tagWatcher)
 	whs := clienttest.Wrap(t, tw.webhooks)
+	svcs := clienttest.Wrap(t, tw.services)
 	stop := test.NewStop(t)
 	c.RunAndWait(stop)
 	track := assert.NewTracker[string](t)
@@ -64,6 +66,27 @@ func TestTagWatcher(t *testing.T) {
 	whs.Create(makeTag("revision", "tag-foo"))
 	track.WaitOrdered("revision,tag-foo")
 	assert.Equal(t, tw.GetMyTags(), sets.New("revision", "tag-foo"))
+
+	// TagWatcher should get all tag names from all services and mutatingwebhooks using the same revision
+	whs.Delete(makeTag("revision", "tag-foo").Name, "")
+	track.WaitOrdered("revision")
+	svcs.Create(makeServiceTag("revision", "tag-svc-foo"))
+	track.WaitOrdered("revision,tag-svc-foo")
+	whs.Create(makeTag("revision", "tag-mwc-foo"))
+	track.WaitOrdered("revision,tag-mwc-foo,tag-svc-foo")
+	assert.Equal(t, tw.GetMyTags(), sets.New("revision", "tag-mwc-foo", "tag-svc-foo"))
+
+	// If a svc and a mwc have the same tag but different revisions, svc should have more priority
+	svcs.Create(makeServiceTag("revision", "shared-tag"))
+	track.WaitOrdered("revision,shared-tag,tag-mwc-foo,tag-svc-foo")
+	whs.Create(makeTag("not-revision", "shared-tag"))
+	track.WaitOrdered("revision,shared-tag,tag-mwc-foo,tag-svc-foo")
+	assert.Equal(t, tw.GetMyTags(), sets.New("revision", "tag-mwc-foo", "tag-svc-foo", "shared-tag"))
+
+	// If a svc and mwc have same tag and revisions, there should not be duplicates
+	whs.Update(makeTag("revision", "shared-tag"))
+	track.WaitOrdered("revision,shared-tag,tag-mwc-foo,tag-svc-foo")
+	assert.Equal(t, tw.GetMyTags(), sets.New("revision", "tag-mwc-foo", "tag-svc-foo", "shared-tag"))
 }
 
 func makeTag(revision string, tg string) *admissionregistrationv1.MutatingWebhookConfiguration {
@@ -75,6 +98,20 @@ func makeTag(revision string, tg string) *admissionregistrationv1.MutatingWebhoo
 				label.IoIstioRev.Name: revision,
 				label.IoIstioTag.Name: tg,
 			},
+		},
+	}
+}
+
+func makeServiceTag(revision string, tg string) *corev1.Service {
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: tg,
+			Labels: map[string]string{
+				label.IoIstioRev.Name: revision,
+				label.IoIstioTag.Name: tg,
+			},
+			Namespace: "istio-system",
 		},
 	}
 }

--- a/releasenotes/notes/revision-tags-as-svc.yaml
+++ b/releasenotes/notes/revision-tags-as-svc.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue: []
+releaseNotes:
+  - |
+    **Added** a new representation of revision tags using cluster IP services, meant to stop using mutating webhooks in ambient mode.
+    `istioctl tag set <tag> --revision <rev>` and the `revisionTags` helm value will both create a MutatingWebhook using the current
+    specifications and a Service similar to the istiod Service but including the `istio.io/tag` label to store the mapping.

--- a/tests/integration/helm/util.go
+++ b/tests/integration/helm/util.go
@@ -494,7 +494,7 @@ func SetRevisionTagWithVersion(ctx framework.TestContext, h *helm.Helm, revision
 func SetRevisionTag(ctx framework.TestContext, h *helm.Helm, fileSuffix, revision, revisionTag, relPath, version string) {
 	scopes.Framework.Infof("=== setting revision tag === ")
 	template, err := h.Template(IstiodReleaseName+"-"+revision, filepath.Join(relPath, version, ControlChartsDir, DiscoveryChartsDir)+fileSuffix,
-		IstioNamespace, "templates/revision-tags.yaml", Timeout, "--set",
+		IstioNamespace, "templates/revision-tags-mwc.yaml", Timeout, "--set",
 		fmt.Sprintf("revision=%s", revision), "--set", fmt.Sprintf("revisionTags={%s}", revisionTag))
 	if err != nil {
 		ctx.Fatalf("failed to install istio %s chart", DiscoveryChartsDir)


### PR DESCRIPTION
Reattempting https://github.com/istio/istio/pull/56141

Commit 9d56196abb1e09cf8ef7c1244ae160bdbb4ed449 is the fix. I don't like to manually delete the revision tag service but it seems like we are doing it anyways for mutatingwebhookconfigurations