### PR TITLE
integ: add support for ClusterTrustBundle

### DIFF
--- a/pkg/test/framework/components/istio/flags.go
+++ b/pkg/test/framework/components/istio/flags.go
@@ -26,6 +26,8 @@ func init() {
 		"Specifies the namespace in which kiali, tracing providers, graphana, prometheus are deployed.")
 	flag.BoolVar(&settingsFromCommandline.DeployIstio, "istio.test.kube.deploy", settingsFromCommandline.DeployIstio,
 		"Deploy Istio into the target Kubernetes environment.")
+	flag.StringVar(&settingsFromCommandline.BaseIOPFile, "istio.test.kube.helm.baseIopFile", settingsFromCommandline.BaseIOPFile,
+		"Base IstioOperator spec file. This can be an absolute path or relative to repository root.")
 	flag.StringVar(&settingsFromCommandline.PrimaryClusterIOPFile, "istio.test.kube.helm.iopFile", settingsFromCommandline.PrimaryClusterIOPFile,
 		"IstioOperator spec file. This can be an absolute path or relative to repository root.")
 	flag.StringVar(&helmValues, "istio.test.kube.helm.values", helmValues,

--- a/prow/config/clustertrustbundles.yaml
+++ b/prow/config/clustertrustbundles.yaml
@@ -1,5 +1,5 @@
 # This configs KinD to spin up a k8s cluster with ClusterTrustBundle support enabled
-# This should only be used to create K8s clusters with versions >= 1.27
+# This should only be used to create K8s clusters with versions >= 1.33
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 kubeadmConfigPatches:

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -41,6 +41,7 @@ NODE_IMAGE="gcr.io/istio-testing/kind-node:v1.32.0"
 KIND_CONFIG=""
 CLUSTER_TOPOLOGY_CONFIG_FILE="${ROOT}/prow/config/topology/multicluster.json"
 CLUSTER_NAME="${CLUSTER_NAME:-istio-testing}"
+CLUSTER_YAML="${CLUSTER_YAML:-prow/config/default.yaml}"
 
 export FAST_VM_BUILDS=true
 export ISTIO_DOCKER_BUILDER="${ISTIO_DOCKER_BUILDER:-crane}"
@@ -157,7 +158,7 @@ export ARTIFACTS="${ARTIFACTS:-$(mktemp -d)}"
 trace "init" make init
 
 if [[ -z "${SKIP_SETUP:-}" ]]; then
-  export DEFAULT_CLUSTER_YAML="./prow/config/default.yaml"
+  export DEFAULT_CLUSTER_YAML="${ROOT}/${CLUSTER_YAML}"
   export METRICS_SERVER_CONFIG_DIR='./prow/config/metrics'
 
   if [[ "${TOPOLOGY}" == "SINGLE_CLUSTER" ]]; then

--- a/tests/integration/base-clustertrustbundle.yaml
+++ b/tests/integration/base-clustertrustbundle.yaml
@@ -1,0 +1,43 @@
+# This file provides some defaults for integration testing.
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  name: install
+spec:
+  meshConfig:
+    # Disable retries. This avoids confusing logs and errors, and allows finer grain control for tests
+    defaultHttpRetryPolicy: {}
+    accessLogFile: "/dev/stdout"
+    defaultConfig:
+      proxyMetadata:
+        ISTIO_META_DNS_CAPTURE: "true"
+  values:
+    pilot:
+      # Lower the reconnect time so we test reconnects. The default of 30min means we almost never trigger in tests.
+      keepaliveMaxServerConnectionAge: 120s
+      autoscaleEnabled: false
+      env:
+        ENABLE_EXTERNAL_NAME_ALIAS: true
+        UNSAFE_ENABLE_ADMIN_ENDPOINTS: true
+        PILOT_REMOTE_CLUSTER_TIMEOUT: 15s
+        PILOT_ENABLE_ALPHA_GATEWAY_API: "true"
+        ENABLE_CLUSTER_TRUST_BUNDLE_API: "true"
+    global:
+      proxy:
+        resources:
+          requests:
+            cpu: 10m
+            memory: 40Mi
+    gateways:
+      istio-ingressgateway:
+        autoscaleEnabled: false
+        resources:
+          requests:
+            cpu: 10m
+            memory: 40Mi
+      istio-egressgateway:
+        autoscaleEnabled: false
+        resources:
+          requests:
+            cpu: 10m
+            memory: 40Mi


### PR DESCRIPTION
**Please provide a description of this PR:**

With this patch we should be able to run integ-pilot test suite with ClusterTrustBundle enabled:
- set env flag `CLUSTER_YAML` to `prow/config/clustertrustbundles.yaml`
- add `INTEGRATION_TEST_FLAGS` with `--istio.test.kube.helm.baseIopFile tests/integration/base-clustertrustbundle.yaml`