### PR TITLE
Add domain resolve to Ambient TestServiceEntrySelectsWorkloadEntry test

### DIFF
--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -2303,7 +2303,17 @@ spec:
 				WithParams(param.Params{}.SetWellKnown(param.Namespace, apps.Namespace))
 
 			ingress := istio.DefaultIngressOrFail(t, t)
-			ips, ports := ingress.HTTPAddresses()
+			rawIPs, ports := ingress.HTTPAddresses()
+			var ips []string
+			for _, ip := range rawIPs {
+				// Resolve ingress domain name into ip address
+				addr, err := kubetest.WaitUntilReachableIngress(ip)
+				if err != nil {
+					t.Fatalf("unable to resolve domain name to ip address - %q: %v", ip, err)
+				}
+				t.Logf("Resolved ingress %q to %q", ip, addr)
+				ips = append(ips, addr)
+			}
 			for _, tc := range testCases {
 				for i, ip := range ips {
 					t.Logf("run %s test with ingress IP %s", tc.resolution, ip)


### PR DESCRIPTION
**Please provide a description of this PR:**
When executing the TestServiceEntrySelectsWorkloadEntry Ambient test in a public cloud based cluster, the created ingress is a domain based name and the test fails to operate with the domain name instead of the ip address.

Add a domain name resolution to ip based address.

The PR similar to the fix being done for another test:
https://github.com/istio/istio/pull/56784

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [X] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
