### PR TITLE
Helm/cluster trust bundle env

### DIFF
--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -188,7 +188,7 @@ spec:
               expirationSeconds: 43200
               audience: istio-ca
       - name: istiod-ca-cert
-        {{- if eq (.Values.env).ENABLE_CLUSTER_TRUST_BUNDLE_API true }}
+        {{- if eq (get .Values.env "ENABLE_CLUSTER_TRUST_BUNDLE_API" false) true }}
         projected:
           sources:
           - clusterTrustBundle:

--- a/releasenotes/notes/cluster-trust-bundle-api-helm.yaml
+++ b/releasenotes/notes/cluster-trust-bundle-api-helm.yaml
@@ -1,0 +1,31 @@
+apiVersion: release-notes/v2
+
+# This YAML file describes the format for specifying a release notes entry for Istio.
+# This should be filled in for all user facing changes.
+
+# kind describes the type of change that this represents.
+# Valid Values are:
+# - bug-fix -- Used to specify that this change represents a bug fix.
+# - security-fix -- Used to specify that this change represents a vulnerability fix.
+# - feature -- Used to specify a new feature that has been added.
+# - test -- Used to describe additional testing added. This file is optional for
+#   tests, but included for completeness.
+kind: bug-fix
+
+# area describes the area that this change affects.
+# Valid values are:
+# - traffic-management
+# - security
+# - telemetry
+# - installation
+# - istioctl
+# - documentation
+area: installation
+
+
+# releaseNotes is a markdown listing of any user facing changes. This will appear in the
+# release notes.
+releaseNotes:
+  - |
+    **Fixed** a bug when installing the ztunnel chart with the `global.env` key set without `ENABLE_CLUSTER_TRUST_BUNDLE_API`
+    would fail.


### PR DESCRIPTION
**Please provide a description of this PR:**

Allows installing ztunnel chart while setting `globals.env`