### PR TITLE
istioctl: use default revision automatically when --revision is not set

### DIFF
--- a/istioctl/pkg/admin/istiodconfig.go
+++ b/istioctl/pkg/admin/istiodconfig.go
@@ -418,20 +418,21 @@ func istiodLogCmd(ctx cli.Context) *cobra.Command {
 			return nil
 		},
 		RunE: func(logCmd *cobra.Command, args []string) error {
-			client, err := ctx.CLIClientWithRevision(opts.Revision)
+			resolvedRevision := ctx.RevisionOrDefault(opts.Revision)
+			client, err := ctx.CLIClientWithRevision(resolvedRevision)
 			if err != nil {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}
 
 			var podName, ns string
 			if len(args) == 0 {
-				if opts.Revision == "" {
-					opts.Revision = "default"
+				if resolvedRevision == "" {
+					resolvedRevision = "default"
 				}
 				if len(istiodLabelSelector) > 0 {
-					istiodLabelSelector = fmt.Sprintf("%s,%s=%s", istiodLabelSelector, label.IoIstioRev.Name, opts.Revision)
+					istiodLabelSelector = fmt.Sprintf("%s,%s=%s", istiodLabelSelector, label.IoIstioRev.Name, resolvedRevision)
 				} else {
-					istiodLabelSelector = fmt.Sprintf("%s=%s", label.IoIstioRev.Name, opts.Revision)
+					istiodLabelSelector = fmt.Sprintf("%s=%s", label.IoIstioRev.Name, resolvedRevision)
 				}
 				pl, err := client.PodsForSelector(context.TODO(), ctx.NamespaceOrDefault(ctx.IstioNamespace()), istiodLabelSelector)
 				if err != nil {

--- a/istioctl/pkg/cli/context.go
+++ b/istioctl/pkg/cli/context.go
@@ -28,6 +28,7 @@ import (
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/ptr"
+	"istio.io/istio/pkg/revisions"
 	"istio.io/istio/pkg/slices"
 )
 
@@ -36,6 +37,8 @@ type Context interface {
 	CLIClient() (kube.CLIClient, error)
 	// CLIClientWithRevision returns a client for the given revision
 	CLIClientWithRevision(rev string) (kube.CLIClient, error)
+	// RevisionOrDefault returns the given revision if non-empty, otherwise returns the default revision
+	RevisionOrDefault(rev string) string
 	// InferPodInfoFromTypedResource returns the pod name and namespace for the given typed resource
 	InferPodInfoFromTypedResource(name, namespace string) (pod string, ns string, err error)
 	// InferPodsFromTypedResource returns the pod names and namespace for the given typed resource
@@ -55,6 +58,8 @@ type instance struct {
 	clients map[string]kube.CLIClient
 	// remoteClients are cached clients for each context with empty revision.
 	remoteClients map[string]kube.CLIClient
+	// defaultWatcher watches for changes to the default revision
+	defaultWatcher revisions.DefaultWatcher
 	RootFlags
 }
 
@@ -203,6 +208,46 @@ func handleNamespace(ns, defaultNamespace string) string {
 	return ns
 }
 
+func (i *instance) RevisionOrDefault(rev string) string {
+	if rev != "" {
+		return rev
+	}
+
+	// Try to get the default revision from the default watcher
+	// We create a simple approach that doesn't cause circular dependencies
+	if i.defaultWatcher == nil {
+		// Try to initialize the default watcher using a basic client
+		if basicClient := i.getBasicClientForDefaultWatcher(); basicClient != nil {
+			i.defaultWatcher = revisions.NewDefaultWatcher(basicClient, "")
+		}
+	}
+
+	if i.defaultWatcher != nil {
+		if defaultRev := i.defaultWatcher.GetDefault(); defaultRev != "" {
+			return defaultRev
+		}
+	}
+
+	// If no default revision found, return empty string (which means default behavior)
+	return ""
+}
+
+// getBasicClientForDefaultWatcher creates a basic kube client just for watching default revisions
+// This avoids circular dependencies by not using RevisionOrDefault
+func (i *instance) getBasicClientForDefaultWatcher() kube.Client {
+	timeout, err := i.KubeClientTimeout()
+	if err != nil {
+		return nil
+	}
+
+	client, err := newKubeClientWithRevision(*i.kubeconfig, *i.configContext, "", timeout, i.getImpersonateConfig())
+	if err != nil {
+		return nil
+	}
+
+	return client
+}
+
 type fakeInstance struct {
 	// clients are cached clients for each revision
 	clients   map[string]kube.CLIClient
@@ -270,6 +315,11 @@ func (f *fakeInstance) Namespace() string {
 
 func (f *fakeInstance) IstioNamespace() string {
 	return f.rootFlags.IstioNamespace()
+}
+
+func (f *fakeInstance) RevisionOrDefault(rev string) string {
+	// For fake instance, just return the revision as-is (no default resolution)
+	return rev
 }
 
 type NewFakeContextOption struct {

--- a/istioctl/pkg/dashboard/dashboard.go
+++ b/istioctl/pkg/dashboard/dashboard.go
@@ -339,8 +339,8 @@ func controlZDashCmd(ctx cli.Context) *cobra.Command {
   istioctl dashboard controlz deployment/istiod.istio-system
 
   # with short syntax
-  istioctl dash controlz pilot-123-456.istio-system
-  istioctl d controlz pilot-123-456.istio-system
+  istioctl dash controlz istiod-56dd66799-jfdvs.istio-system
+  istioctl d controlz istiod-56dd66799-jfdvs.istio-system
 `,
 		RunE: func(c *cobra.Command, args []string) error {
 			if labelSelector == "" && opts.Revision == "" && len(args) < 1 {
@@ -413,8 +413,8 @@ func istioDebugDashCmd(ctx cli.Context) *cobra.Command {
   istioctl dashboard istiod-debug deployment/istiod.istio-system
 
   # with short syntax
-  istioctl dash istiod-debug pilot-123-456.istio-system
-  istioctl d istiod-debug pilot-123-456.istio-system
+  istioctl dash istiod-debug istiod-56dd66799-jfdvs.istio-system
+  istioctl d istiod-debug istiod-56dd66799-jfdvs.istio-system
 `,
 		RunE: func(c *cobra.Command, args []string) error {
 			if labelSelector == "" && opts.Revision == "" && len(args) < 1 {
@@ -426,14 +426,15 @@ func istioDebugDashCmd(ctx cli.Context) *cobra.Command {
 				c.Println(c.UsageString())
 				return fmt.Errorf("only one of name, --selector, or --revision can be specified")
 			}
-			client, err := ctx.CLIClientWithRevision(opts.Revision)
+			resolvedRevision := ctx.RevisionOrDefault(opts.Revision)
+			client, err := ctx.CLIClientWithRevision(resolvedRevision)
 			if err != nil {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}
 
 			var podName, ns string
-			if opts.Revision != "" {
-				labelSelector = "istio.io/rev=" + opts.Revision + ", app=istiod"
+			if resolvedRevision != "" {
+				labelSelector = "istio.io/rev=" + resolvedRevision + ", app=istiod"
 			}
 
 			if labelSelector != "" {

--- a/istioctl/pkg/describe/describe.go
+++ b/istioctl/pkg/describe/describe.go
@@ -161,7 +161,7 @@ the configuration objects that affect that pod.`,
 			}
 			// TODO look for port collisions between services targeting this pod
 
-			kubeClient, err := ctx.CLIClientWithRevision(opts.Revision)
+			kubeClient, err := ctx.CLIClientWithRevision(ctx.RevisionOrDefault(opts.Revision))
 			if err != nil {
 				return err
 			}
@@ -1281,7 +1281,7 @@ the configuration objects that affect that service.`,
 				return nil
 			}
 
-			kubeClient, err := ctx.CLIClientWithRevision(opts.Revision)
+			kubeClient, err := ctx.CLIClientWithRevision(ctx.RevisionOrDefault(opts.Revision))
 			if err != nil {
 				return err
 			}

--- a/istioctl/pkg/internaldebug/internal-debug.go
+++ b/istioctl/pkg/internaldebug/internal-debug.go
@@ -114,7 +114,7 @@ By default it will use the default serviceAccount from (istio-system) namespace 
   istioctl x internal-debug syncz --xds-label istio.io/rev=default
 `,
 		RunE: func(c *cobra.Command, args []string) error {
-			kubeClient, err := ctx.CLIClientWithRevision(opts.Revision)
+			kubeClient, err := ctx.CLIClientWithRevision(ctx.RevisionOrDefault(opts.Revision))
 			if err != nil {
 				return err
 			}

--- a/istioctl/pkg/kubeinject/kubeinject.go
+++ b/istioctl/pkg/kubeinject/kubeinject.go
@@ -555,7 +555,7 @@ It's best to do kube-inject when the resource is initially created.
 			var valuesConfig string
 			var sidecarTemplate inject.RawTemplates
 			var meshConfig *meshconfig.MeshConfig
-			rev := opts.Revision
+			rev := cliContext.RevisionOrDefault(opts.Revision)
 			// if the revision is "default", render templates with an empty revision
 			if rev == util.DefaultRevisionName {
 				rev = ""

--- a/istioctl/pkg/precheck/precheck.go
+++ b/istioctl/pkg/precheck/precheck.go
@@ -126,7 +126,7 @@ See %s for more information about causes and resolutions.`, url.ConfigAnalysis)
 }
 
 func checkFromVersion(ctx cli.Context, revision, version string) (diag.Messages, error) {
-	cli, err := ctx.CLIClientWithRevision(revision)
+	cli, err := ctx.CLIClientWithRevision(ctx.RevisionOrDefault(revision))
 	if err != nil {
 		return nil, err
 	}

--- a/istioctl/pkg/proxyconfig/clusters.go
+++ b/istioctl/pkg/proxyconfig/clusters.go
@@ -35,7 +35,7 @@ func ClustersCommand(ctx cli.Context) *cobra.Command {
 		Use:   "remote-clusters",
 		Short: "Lists the remote clusters each istiod instance is connected to.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			kubeClient, err := ctx.CLIClientWithRevision(opts.Revision)
+			kubeClient, err := ctx.CLIClientWithRevision(ctx.RevisionOrDefault(opts.Revision))
 			if err != nil {
 				return err
 			}

--- a/istioctl/pkg/proxystatus/proxystatus.go
+++ b/istioctl/pkg/proxystatus/proxystatus.go
@@ -118,7 +118,7 @@ Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in 
   istioctl proxy-status --output json`,
 		Aliases: []string{"ps"},
 		RunE: func(c *cobra.Command, args []string) error {
-			kubeClient, err := ctx.CLIClientWithRevision(opts.Revision)
+			kubeClient, err := ctx.CLIClientWithRevision(ctx.RevisionOrDefault(opts.Revision))
 			if err != nil {
 				return err
 			}

--- a/istioctl/pkg/version/version.go
+++ b/istioctl/pkg/version/version.go
@@ -64,7 +64,7 @@ func NewVersionCommand(ctx cli.Context) *cobra.Command {
 }
 
 func getRemoteInfo(ctx cli.Context, opts clioptions.ControlPlaneOptions) (*istioVersion.MeshInfo, error) {
-	kubeClient, err := ctx.CLIClientWithRevision(opts.Revision)
+	kubeClient, err := ctx.CLIClientWithRevision(ctx.RevisionOrDefault(opts.Revision))
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func getRemoteInfoWrapper(ctx cli.Context, pc **cobra.Command, opts *clioptions.
 
 func getProxyInfoWrapper(ctx cli.Context, opts *clioptions.ControlPlaneOptions) func() (*[]istioVersion.ProxyInfo, error) {
 	return func() (*[]istioVersion.ProxyInfo, error) {
-		client, err := ctx.CLIClientWithRevision(opts.Revision)
+		client, err := ctx.CLIClientWithRevision(ctx.RevisionOrDefault(opts.Revision))
 		if err != nil {
 			return nil, err
 		}

--- a/istioctl/pkg/workload/workload.go
+++ b/istioctl/pkg/workload/workload.go
@@ -222,7 +222,7 @@ Configure requires either the WorkloadGroup artifact path or its location on the
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			kubeClient, err := ctx.CLIClientWithRevision(opts.Revision)
+			kubeClient, err := ctx.CLIClientWithRevision(ctx.RevisionOrDefault(opts.Revision))
 			if err != nil {
 				return err
 			}

--- a/releasenotes/notes/54518.yaml
+++ b/releasenotes/notes/54518.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue:
+- 54518
+releaseNotes:
+- |
+  **Added** automatic detection of the default revision in `istioctl` commands. When `--revision` is not explicitly specified, the default revision (as configured by `istioctl tag set default`) will be used automatically.


### PR DESCRIPTION
Fixes #54518

**Please provide a description of this PR:**
Make istioctl use default revision if --revision is missing.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [x] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
