### PR TITLE
Issue 56876: replace string values by IstioOperatorSpec struc on ambient test

### DIFF
--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -23,6 +23,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	iopv1alpha1 "istio.io/istio/operator/pkg/apis"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework/components/namespace"
@@ -132,7 +133,14 @@ type Config struct {
 	// Override values specifically for the ICP crd
 	// This is mostly required for cases where --set cannot be used
 	// These values are applied to non-remote clusters
+	// Deprecated: use ControlPlaneSpec instead
 	ControlPlaneValues string
+
+	// Override values specifically for the ICP crd
+	// This is mostly required for cases where --set cannot be used
+	// These values are applied to primary clusters
+	// using IstioOperatorSpec structure to pass values instead of a ControlPlaneValues string
+	ControlPlaneSpec *iopv1alpha1.IstioOperatorSpec
 
 	// Override values specifically for the ICP crd
 	// This is mostly required for cases where --set cannot be used

--- a/tests/integration/ambient/cni/main_test.go
+++ b/tests/integration/ambient/cni/main_test.go
@@ -105,7 +105,6 @@ func TestMain(m *testing.M) {
 			cfg.ControlPlaneSpec = &iopv1alpha1.IstioOperatorSpec{
 				Values: valuesConfigJSON,
 			}
-
 		}, cert.CreateCASecretAlt)).
 		Setup(func(t resource.Context) error {
 			return SetupApps(t, i, apps)

--- a/tests/integration/ambient/cniupgrade/main_test.go
+++ b/tests/integration/ambient/cniupgrade/main_test.go
@@ -18,10 +18,12 @@
 package cniupgrade
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
 	"istio.io/api/label"
+	iopv1alpha1 "istio.io/istio/operator/pkg/apis"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
@@ -82,16 +84,28 @@ func TestMain(m *testing.M) {
 			if ctx.Settings().AmbientMultiNetwork {
 				cfg.SkipDeployCrossClusterSecrets = true
 			}
-			cfg.ControlPlaneValues = `
-values:
-  cni:
-    repair:
-      enabled: true
-  ztunnel:
-    terminationGracePeriodSeconds: 5
-    env:
-      SECRET_TTL: 5m
-`
+
+			values := map[string]interface{}{
+				"cni": map[string]interface{}{
+					"repair": map[string]interface{}{
+						"enabled": true,
+					},
+				},
+				"ztunnel": map[string]interface{}{
+					"terminationGracePeriodSeconds": 5,
+					"env": map[string]interface{}{
+						"SCRET_TTL": "5m",
+					},
+				},
+			}
+
+			valuesConfigJSON, err := json.Marshal(values)
+			if err != nil {
+				scopes.Framework.Fatalf("failed to marshal values: %v", err)
+			}
+			cfg.ControlPlaneSpec = &iopv1alpha1.IstioOperatorSpec{
+				Values: valuesConfigJSON,
+			}
 		}, cert.CreateCASecretAlt)).
 		Setup(func(t resource.Context) error {
 			return SetupApps(t, i, apps)

--- a/tests/integration/ambient/main_test.go
+++ b/tests/integration/ambient/main_test.go
@@ -22,11 +22,11 @@ import (
 	"encoding/json"
 	"testing"
 
-	iopv1alpha1 "istio.io/istio/operator/pkg/apis"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/api/label"
+	iopv1alpha1 "istio.io/istio/operator/pkg/apis"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/ambient"

--- a/tests/integration/ambient/untaint/main_test.go
+++ b/tests/integration/ambient/untaint/main_test.go
@@ -22,10 +22,10 @@ import (
 	"encoding/json"
 	"testing"
 
-	iopv1alpha1 "istio.io/istio/operator/pkg/apis"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	iopv1alpha1 "istio.io/istio/operator/pkg/apis"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/label"


### PR DESCRIPTION
**Please provide a description of this PR:**
Related to #56876 

This PR updates the tests under the `ambient/` folder (The rest of the folders in a consecutive PR once this PR is merged) to use `ControlPlaneSpec` (a structured *IstioOperatorSpec) directly, instead of setting `ControlPlaneValues` as a plain YAML string.

The main goal with this change is to:
* Previously, tests assigned YAML strings to `ControlPlaneValues`, which were later parsed into structs. This change eliminates that extra step by constructing the `IstioOperatorSpec` directly.
* Reduce the chance of YAML formatting errors
* Easier extensibility: By working directly with structured data, it's easier to add support for new installation methods.
* Better foundation for future migration: This is the first step in a broader effort to migrate all integration tests away from raw YAML toward structured, programmatic setup