### PR TITLE
nftables: Install nftables-slim package in the distroless base image

### DIFF
--- a/docker/iptables.yaml
+++ b/docker/iptables.yaml
@@ -13,6 +13,7 @@ contents:
     - libnfnetlink
     - libmnl
     - libgcc
+    - nftables-slim
 archs:
   - x86_64
   - aarch64


### PR DESCRIPTION
This PR is following up https://github.com/istio/istio/pull/56363
When the nftables-slim package is ready in the wolfi-dev/os base repo, we can replace the nftables package with the nftables-slim one and reduce the distroless base image size.

This PR is waiting for https://github.com/wolfi-dev/os/pull/58274

- [X] Networking

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
