### PR TITLE
Remove flaky test

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_multicluster_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_multicluster_test.go
@@ -29,7 +29,6 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller/ambient/multicluster"
-	"istio.io/istio/pilot/pkg/serviceregistry/util/xdsfake"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/kube/kclient/clienttest"

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_multicluster_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_multicluster_test.go
@@ -29,6 +29,7 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller/ambient/multicluster"
+	"istio.io/istio/pilot/pkg/serviceregistry/util/xdsfake"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/kube/kclient/clienttest"
@@ -67,17 +68,20 @@ func TestAmbientMulticlusterIndex_WaypointForWorkloadTraffic(t *testing.T) {
 	cases := []struct {
 		name         string
 		trafficType  string
-		podAssertion func(s *ambientTestServer)
-		svcAssertion func(s *ambientTestServer)
+		podAssertion func(s *ambientTestServer, c cluster.ID)
+		svcAssertion func(s *ambientTestServer, svcKey string)
 	}{
 		{
 			name:        "service traffic",
 			trafficType: constants.ServiceTraffic,
-			podAssertion: func(s *ambientTestServer) {
+			podAssertion: func(s *ambientTestServer, c cluster.ID) {
 				s.t.Helper()
-				s.assertNoEvent(s.t)
+				// Test that there's no events for workloads in our cluster
+				// as a result of our actions (we can't control pushes for
+				// workloads from other clusters)
+				s.assertNoMatchingEvent(s.t, c.String())
 			},
-			svcAssertion: func(s *ambientTestServer) {
+			svcAssertion: func(s *ambientTestServer, _ string) {
 				s.t.Helper()
 				s.assertEvent(s.t, s.svcXdsName("svc2"))
 			},
@@ -85,11 +89,11 @@ func TestAmbientMulticlusterIndex_WaypointForWorkloadTraffic(t *testing.T) {
 		{
 			name:        "all traffic",
 			trafficType: constants.AllTraffic,
-			podAssertion: func(s *ambientTestServer) {
+			podAssertion: func(s *ambientTestServer, _ cluster.ID) {
 				s.t.Helper()
 				s.assertEvent(s.t, s.podXdsName("pod1"))
 			},
-			svcAssertion: func(s *ambientTestServer) {
+			svcAssertion: func(s *ambientTestServer, _ string) {
 				s.t.Helper()
 				s.assertEvent(s.t, s.svcXdsName("svc2"))
 			},
@@ -97,25 +101,25 @@ func TestAmbientMulticlusterIndex_WaypointForWorkloadTraffic(t *testing.T) {
 		{
 			name:        "workload traffic",
 			trafficType: constants.WorkloadTraffic,
-			podAssertion: func(s *ambientTestServer) {
+			podAssertion: func(s *ambientTestServer, c cluster.ID) {
 				s.t.Helper()
 				s.assertEvent(s.t, s.podXdsName("pod1"))
 			},
-			svcAssertion: func(s *ambientTestServer) {
+			svcAssertion: func(s *ambientTestServer, svcKey string) {
 				s.t.Helper()
-				s.assertNoEvent(s.t)
+				s.assertNoMatchingEvent(s.t, svcKey)
 			},
 		},
 		{
 			name:        "no traffic",
 			trafficType: constants.NoTraffic,
-			podAssertion: func(s *ambientTestServer) {
+			podAssertion: func(s *ambientTestServer, c cluster.ID) {
 				s.t.Helper()
-				s.assertNoEvent(s.t)
+				s.assertNoMatchingEvent(s.t, c.String())
 			},
-			svcAssertion: func(s *ambientTestServer) {
+			svcAssertion: func(s *ambientTestServer, svcKey string) {
 				s.t.Helper()
-				s.assertNoEvent(s.t)
+				s.assertNoMatchingEvent(s.t, svcKey)
 			},
 		},
 	}
@@ -214,6 +218,23 @@ func TestAmbientMulticlusterIndex_WaypointForWorkloadTraffic(t *testing.T) {
 							ControllerName: constants.ManagedGatewayMeshController,
 						},
 					})
+
+					// Ensure the namespace network is set in up in the collection before doing other assertions
+					assert.EventuallyEqual(t, func() bool {
+						networks := s.networks.SystemNamespaceNetworkByCluster.Lookup(client.clusterID)
+						if len(networks) == 0 {
+							return false
+						}
+						singleton := networks[0]
+						if singleton == nil {
+							return false
+						}
+						nw := singleton.Get()
+						if nw == nil {
+							return false
+						}
+						return *nw == clusterToNetwork[client.clusterID]
+					}, true)
 				}
 				if networkGatewayIps[client.clusterID] != "" {
 					s.addNetworkGatewayForClient(t, networkGatewayIps[client.clusterID], clusterToNetwork[client.clusterID], client.grc)
@@ -270,7 +291,7 @@ func TestAmbientMulticlusterIndex_WaypointForWorkloadTraffic(t *testing.T) {
 			// Label the pod and check that the correct event is produced.
 			s.labelPod(t, "pod1", testNS,
 				map[string]string{"app": "a", label.IoIstioUseWaypoint.Name: "test-wp"})
-			c.podAssertion(s)
+			c.podAssertion(s, testC)
 
 			// Label the service and check that the correct event is produced.
 			s.labelService(t, "svc2", testNS,
@@ -278,7 +299,7 @@ func TestAmbientMulticlusterIndex_WaypointForWorkloadTraffic(t *testing.T) {
 					label.IoIstioUseWaypoint.Name: "test-wp",
 					"istio.io/global":             "true",
 				})
-			c.svcAssertion(s)
+			c.svcAssertion(s, s.svcXdsName("svc2"))
 
 			// clean up resources
 			s.deleteService(t, "svc2")

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -2658,6 +2658,11 @@ func (s *ambientTestServer) assertUnorderedEvent(t *testing.T, ip ...string) {
 	s.fx.MatchOrFail(t, ev...)
 }
 
+func (s *ambientTestServer) assertNoMatchingEvent(t *testing.T, ip string) {
+	t.Helper()
+	s.fx.AssertNoMatch(t, time.Millisecond*10, xdsfake.EventMatcher{Type: "xds", IDPrefix: ip})
+}
+
 func (s *ambientTestServer) assertNoEvent(t *testing.T) {
 	t.Helper()
 	s.fx.AssertEmpty(t, time.Millisecond*10)

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
@@ -422,7 +422,7 @@ func MergedGlobalWorkloadsCollection(
 						return c.ID
 					},
 					func(hc krt.HandlerContext) network.ID {
-						nwPtr := krt.FetchOne(ctx, globalNetworks.RemoteSystemNamespaceNetworks, krt.FilterIndex(globalNetworks.SystemNamespaceNetworkByCluster, c.ID))
+						nwPtr := krt.FetchOne(hc, globalNetworks.RemoteSystemNamespaceNetworks, krt.FilterIndex(globalNetworks.SystemNamespaceNetworkByCluster, c.ID))
 						if nwPtr == nil {
 							log.Warnf("Cluster %s does not have a network, skipping global workloads", c.ID)
 							hc.DiscardResult()

--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -795,8 +795,11 @@ func (i *collectionDependencyTracker[I, O]) registerDependency(
 ) {
 	i.d = append(i.d, d)
 
+	i.mu.Lock()
+	existed := i.dependencyState.collectionDependencies.InsertContains(d.id)
+	i.mu.Unlock()
 	// For any new collections we depend on, start watching them if its the first time we have watched them.
-	if !i.dependencyState.collectionDependencies.InsertContains(d.id) {
+	if !existed {
 		i.log.WithLabels("collection", d.collectionName).Debugf("register new dependency")
 		syncer.WaitUntilSynced(i.stop)
 		register(func(o []Event[any]) {


### PR DESCRIPTION
**Please provide a description of this PR:**

Its hard to consistently test "action A will only cause this event" because event could have occurred before A and there is no way of saying "wait until all events propagate/KRT state is stable, then run A".