### PR TITLE
Fix  false positive of serviceentry analyzer

### DIFF
--- a/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/pkg/config/analysis/analyzers/analyzers_test.go
@@ -1019,6 +1019,13 @@ var testGrid = []testCase{
 			{msg.DestinationRuleSubsetNotSelectPods, "DestinationRule default/subsets-not-select-pods"},
 		},
 	},
+	{
+		name:           "ServiceEntry Addresses Allocated",
+		inputFiles:     []string{"testdata/serviceentry-address-allocated.yaml"},
+		meshConfigFile: "testdata/serviceentry-address-allocated-mesh-cfg.yaml",
+		analyzer:       &serviceentry.ProtocolAddressesAnalyzer{},
+		expected:       []message{},
+	},
 }
 
 // regex patterns for analyzer names that should be explicitly ignored for testing

--- a/pkg/config/analysis/analyzers/serviceentry/protocoladdresses.go
+++ b/pkg/config/analysis/analyzers/serviceentry/protocoladdresses.go
@@ -67,7 +67,7 @@ func (serviceEntry *ProtocolAddressesAnalyzer) Analyze(context analysis.Context)
 
 func (serviceEntry *ProtocolAddressesAnalyzer) analyzeProtocolAddresses(r *resource.Instance, ctx analysis.Context, metaDNSAutoAllocated bool) {
 	se := r.Message.(*v1alpha3.ServiceEntry)
-	if se.Addresses == nil && !metaDNSAutoAllocated {
+	if se.Addresses == nil && !addressAllocated(r) && !metaDNSAutoAllocated {
 		for index, port := range se.Ports {
 			if port.Protocol == "" || strings.EqualFold(port.Protocol, "TCP") {
 				message := msg.NewServiceEntryAddressesRequired(r)
@@ -80,4 +80,13 @@ func (serviceEntry *ProtocolAddressesAnalyzer) analyzeProtocolAddresses(r *resou
 			}
 		}
 	}
+}
+
+func addressAllocated(r *resource.Instance) bool {
+	if r.Status == nil {
+		return false
+	}
+
+	status := r.Status.(*v1alpha3.ServiceEntryStatus)
+	return len(status.Addresses) > 0
 }

--- a/pkg/config/analysis/analyzers/testdata/serviceentry-address-allocated-mesh-cfg.yaml
+++ b/pkg/config/analysis/analyzers/testdata/serviceentry-address-allocated-mesh-cfg.yaml
@@ -1,0 +1,3 @@
+defaultConfig:
+  proxyMetadata:
+    ISTIO_META_DNS_CAPTURE: "true"

--- a/pkg/config/analysis/analyzers/testdata/serviceentry-address-allocated.yaml
+++ b/pkg/config/analysis/analyzers/testdata/serviceentry-address-allocated.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: address-allocated
+spec:
+  hosts:
+  - dummy.testing.io # not used
+  ports:
+  - name: tcp
+    number: 22
+    protocol: TCP
+status:
+  addresses:
+  - host: dummy.testing.io
+    value: 240.240.0.1
+  - host: dummy.testing.io
+    value: 2001:2::1


### PR DESCRIPTION
**Please provide a description of this PR:**
Fix serviceentry analyze false positive when address already allocated. Since from 1.25 `PILOT_ENABLE_IP_AUTOALLOCATE` is set to true by default, this may not be specified in meshconfig. Currently this analyzer will report a false positive message even though the address is written in the status field.