### PR TITLE
Add AllowCRDsMismatch parameter to gateway conformance options.

### DIFF
--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -226,6 +226,13 @@ func init() {
 	flag.BoolVar(&settingsFromCommandLine.AmbientMultiNetwork, "istio.test.ambient.multinetwork", settingsFromCommandLine.AmbientMultiNetwork,
 		"Indicate the use of ambient multicluster.")
 
+	flag.BoolVar(
+		&settingsFromCommandLine.GatewayConformanceAllowCRDsMismatch,
+		"istio.test.GatewayConformanceAllowCRDsMismatch",
+		settingsFromCommandLine.GatewayConformanceAllowCRDsMismatch,
+		"If set, gateway conformance tests will run even if the environment has pre-installed Gateway API CRDs that differ from the current Gateway API version.",
+	)
+
 	initGatewayConformanceTimeouts()
 }
 

--- a/pkg/test/framework/resource/settings.go
+++ b/pkg/test/framework/resource/settings.go
@@ -187,6 +187,9 @@ type Settings struct {
 
 	GatewayConformanceTimeoutConfig gwConformanceConfig.TimeoutConfig
 
+	// GatewayConformanceAllowCRDsMismatch lets gateway conformance tests to run on environments with pre-installed gateway-api CRDs
+	GatewayConformanceAllowCRDsMismatch bool
+
 	// OpenShift indicates the tests run in an OpenShift platform rather than in plain Kubernetes.
 	OpenShift bool
 }
@@ -270,6 +273,7 @@ func (s *Settings) String() string {
 	result += fmt.Sprintf("HelmRepo:          						 %v\n", s.HelmRepo)
 	result += fmt.Sprintf("IPFamilies:							 %v\n", s.IPFamilies)
 	result += fmt.Sprintf("GatewayConformanceStandardOnly: %v\n", s.GatewayConformanceStandardOnly)
+	result += fmt.Sprintf("GatewayConformanceAllowCRDsMismatch: %v\n", s.GatewayConformanceAllowCRDsMismatch)
 	return result
 }
 

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -140,6 +140,9 @@ func TestGatewayConformance(t *testing.T) {
 					"istio-injection": "enabled",
 				}
 			}
+			if ctx.Settings().GatewayConformanceAllowCRDsMismatch {
+				opts.AllowCRDsMismatch = true
+			}
 			ctx.Cleanup(func() {
 				if !ctx.Failed() {
 					return


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR adds a test flag which lets users to use AllowCRDsMismatch parameter defined in Gateway API Conformance suite.