### PR TITLE
Fix log message in cni install.go file

### DIFF
--- a/cni/pkg/install/install.go
+++ b/cni/pkg/install/install.go
@@ -315,7 +315,7 @@ func checkValidCNIConfig(ctx context.Context, cfg *config.InstallConfig, cniConf
 					cfg.CNIConfName = firstCNIConfigFilename
 				}
 			}
-			log.Infof("jaellio - got error since defaultCNIConfigFilepath %s and cniConfigFilePath %s are not equal", defaultCNIConfigFilepath, cniConfigFilepath)
+			log.Infof("cniConfigFilePath mismatch: expected %s but found %s", defaultCNIConfigFilepath, cniConfigFilepath)
 			return fmt.Errorf("CNI config file %q preempted by %q", cniConfigFilepath, defaultCNIConfigFilepath)
 		}
 	}


### PR DESCRIPTION
Noticed the following log in the istio-cni logs.

```
2025-07-10T18:48:04.875292Z    info    jaellio - got error since defaultCNIConfigFilepath /host/etc/cni/net.d/10-kindnet.conflist and cniConfigFilePath  are not equal
```

Looks like the log message was accidentally committed with a developer's name.