### PR TITLE
ambient: WorkloadEntry supports a Service with a target port number

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
@@ -1365,14 +1365,21 @@ func constructServicesFromWorkloadEntry(p *networkingv1alpha3.WorkloadEntry, ser
 			// Named targetPort has different semantics from Service vs ServiceEntry
 			if svc.Source.Kind == kind.Service {
 				// Service has explicit named targetPorts.
-				if named, f := svc.PortNames[int32(port.ServicePort)]; f && named.TargetPortName != "" {
-					// This port is a named target port, look it up
-					tv, ok := p.Ports[named.TargetPortName]
-					if !ok {
-						// We needed an explicit port, but didn't find one - skip this port
-						continue
+				if named, f := svc.PortNames[int32(port.ServicePort)]; f {
+					if named.TargetPortName != "" {
+						// This port is a named target port, look it up
+						tv, ok := p.Ports[named.TargetPortName]
+						if !ok {
+							// We needed an explicit port, but didn't find one - skip this port
+							continue
+						}
+						targetPort = tv
+					} else {
+						tv, ok := p.Ports[named.PortName]
+						if ok {
+							targetPort = tv
+						}
 					}
-					targetPort = tv
 				}
 			} else {
 				// ServiceEntry has no explicit named targetPorts; targetPort only allows a number

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
@@ -966,7 +966,7 @@ func TestWorkloadEntryWorkloads(t *testing.T) {
 							},
 							{
 								ServicePort: 81,
-								TargetPort:  0,
+								TargetPort:  8081,
 							},
 							{
 								ServicePort: 82,
@@ -982,7 +982,7 @@ func TestWorkloadEntryWorkloads(t *testing.T) {
 						// Not a named port
 						80: {PortName: "80"},
 						// Named port found in WE
-						81: {PortName: "81", TargetPortName: "81-target"},
+						81: {PortName: "81"},
 						// Named port target found in WE
 						82: {PortName: "82", TargetPortName: "82-target"},
 						// Named port not found in WE
@@ -1027,6 +1027,10 @@ func TestWorkloadEntryWorkloads(t *testing.T) {
 							{
 								ServicePort: 80,
 								TargetPort:  8080,
+							},
+							{
+								ServicePort: 81,
+								TargetPort:  8180,
 							},
 							{
 								ServicePort: 82,

--- a/releasenotes/notes/56251.yaml
+++ b/releasenotes/notes/56251.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 56251
+
+releaseNotes:
+- |
+  **Fixed** zTunnel will now respect WorkloadEntry port map when referencing Service port name.


### PR DESCRIPTION
**Please provide a description of this PR:**

The target port of a service can either reference a port (number) or a name (string). The existing code handled a named target port and required the port map to contain the target port.

When the target port is a number, the port map can override the target port but the service port name must be used instead.

Fixes #56251 