### PR TITLE
remove .values.taint.enabled which is unused

### DIFF
--- a/tests/integration/ambient/untaint/main_test.go
+++ b/tests/integration/ambient/untaint/main_test.go
@@ -59,7 +59,6 @@ func TestMain(m *testing.M) {
 values:
   pilot:
     taint:
-      enabled: true
       namespace: "%s"
     env:
       PILOT_ENABLE_NODE_UNTAINT_CONTROLLERS: "true"


### PR DESCRIPTION
**Please provide a description of this PR:**

DNM: Working on ux, understanding of untaint controller. 


Test seems to indicate enabled exists but near as I can tell from the helm it doesn't. I think potentially it should exist at the helm level and when that is true we can set the correct feature variable.