### PR TITLE
istiod chart: migrate to EndpointSlices for remote istiod installs

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/remote-istiod-endpointslices.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/remote-istiod-endpointslices.yaml
@@ -1,8 +1,8 @@
 {{- if and .Values.global.remotePilotAddress .Values.istiodRemote.enabled }}
 # if the remotePilotAddress is an IP addr
 {{- if regexMatch "^([0-9]*\\.){3}[0-9]*$" .Values.global.remotePilotAddress }}
-apiVersion: v1
-kind: Endpoints
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
 metadata:
   {{- if .Values.istiodRemote.enabledLocalInjectorIstiod }}
   # This file is only used for remote `istiod` installs.
@@ -13,18 +13,28 @@ metadata:
   {{- end }}
   namespace: {{ .Release.Namespace }}
   labels:
+    {{- if .Values.istiodRemote.enabledLocalInjectorIstiod }}
+    # only primary `istiod` to xds and local `istiod` injection installs.
+    kubernetes.io/service-name: istiod{{- if .Values.revision }}-{{ .Values.revision}}{{- end }}-remote
+    {{- else }}
+    kubernetes.io/service-name: istiod{{- if .Values.revision }}-{{ .Values.revision}}{{- end }}
+    {{- end }}
+    {{- if .Release.Service }}
+    endpointslice.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    {{- end }}
     app.kubernetes.io/name: "istiod"
     {{- include "istio.labels" . | nindent 4 }}
-subsets:
+addressType: IPv4
+endpoints:
 - addresses:
-  - ip: {{ .Values.global.remotePilotAddress }}
-  ports:
-  - port: 15012
-    name: tcp-istiod
-    protocol: TCP
-  - port: 15017
-    name: tcp-webhook
-    protocol: TCP
+  - {{ .Values.global.remotePilotAddress }}
+ports:
+- port: 15012
+  name: tcp-istiod
+  protocol: TCP
+- port: 15017
+  name: tcp-webhook
+  protocol: TCP
 ---
 {{- end }}
 {{- end }}

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -413,9 +413,9 @@ func TestManifestGenerateIstiodRemote(t *testing.T) {
 		mwc := mustGetMutatingWebhookConfiguration(g, objs, "istio-sidecar-injector").Unstructured.Object
 		g.Expect(mwc).Should(HavePathValueEqual(PathValue{"webhooks.[0].clientConfig.url", "https://xxx:15017/inject"}))
 
-		ep := mustGetEndpoint(g, objs, primarySVCName).Unstructured.Object
-		g.Expect(ep).Should(HavePathValueEqual(PathValue{"subsets.[0].addresses.[0]", endpointSubsetAddressVal("", "169.10.112.88", "")}))
-		g.Expect(ep).Should(HavePathValueContain(PathValue{"subsets.[0].ports.[0]", portVal("tcp-istiod", 15012, -1)}))
+		ep := mustGetEndpointSlice(g, objs, primarySVCName).Unstructured.Object
+		g.Expect(ep).Should(HavePathValueEqual(PathValue{"endpoints.[0].addresses.[0]", "169.10.112.88"}))
+		g.Expect(ep).Should(HavePathValueContain(PathValue{"ports.[0]", portVal("tcp-istiod", 15012, -1)}))
 
 		checkClusterRoleBindingsReferenceRoles(g, objs)
 	}
@@ -444,10 +444,10 @@ func TestManifestGenerateIstiodRemoteConfigCluster(t *testing.T) {
 		g.Expect(mwc).Should(HavePathValueEqual(PathValue{"webhooks.[0].clientConfig.service.name", primarySVCName}))
 
 		g.Expect(objs.kind(gvk.Service.Kind).nameEquals(primarySVCName)).Should(Not(BeNil()))
-		ep := mustGetEndpoint(g, objs, primarySVCName).Unstructured.Object
+		ep := mustGetEndpointSlice(g, objs, primarySVCName).Unstructured.Object
 
-		g.Expect(ep).Should(HavePathValueEqual(PathValue{"subsets.[0].addresses.[0]", endpointSubsetAddressVal("", "169.10.112.88", "")}))
-		g.Expect(ep).Should(HavePathValueContain(PathValue{"subsets.[0].ports.[0]", portVal("tcp-istiod", 15012, -1)}))
+		g.Expect(ep).Should(HavePathValueEqual(PathValue{"endpoints.[0].addresses.[0]", "169.10.112.88"}))
+		g.Expect(ep).Should(HavePathValueContain(PathValue{"ports.[0]", portVal("tcp-istiod", 15012, -1)}))
 
 		// validation webhook
 		vwc := mustGetValidatingWebhookConfiguration(g, objs, "istio-validator-istio-system").Unstructured.Object
@@ -484,10 +484,10 @@ func TestManifestGenerateIstiodRemoteLocalInjection(t *testing.T) {
 		mwc := mustGetMutatingWebhookConfiguration(g, objs, "istio-sidecar-injector").Unstructured.Object
 		g.Expect(mwc).Should(HavePathValueEqual(PathValue{"webhooks.[0].clientConfig.service.name", istiodInjectionServiceName}))
 
-		ep := mustGetEndpoint(g, objs, istiodPrimaryXDSServiceName).Unstructured.Object
+		ep := mustGetEndpointSlice(g, objs, istiodPrimaryXDSServiceName).Unstructured.Object
 		g.Expect(objs.kind(gvk.Service.Kind).nameEquals(istiodPrimaryXDSServiceName)).Should(Not(BeNil()))
-		g.Expect(ep).Should(HavePathValueEqual(PathValue{"subsets.[0].addresses.[0]", endpointSubsetAddressVal("", "169.10.112.88", "")}))
-		g.Expect(ep).Should(HavePathValueContain(PathValue{"subsets.[0].ports.[0]", portVal("tcp-istiod", 15012, -1)}))
+		g.Expect(ep).Should(HavePathValueEqual(PathValue{"endpoints.[0].addresses.[0]", "169.10.112.88"}))
+		g.Expect(ep).Should(HavePathValueContain(PathValue{"ports.[0]", portVal("tcp-istiod", 15012, -1)}))
 
 		// validation webhook
 		vwc := mustGetValidatingWebhookConfiguration(g, objs, "istio-validator-istio-system").Unstructured.Object

--- a/operator/cmd/mesh/test-util_test.go
+++ b/operator/cmd/mesh/test-util_test.go
@@ -224,10 +224,10 @@ func mustGetContainerFromDaemonset(g *WithT, objs *ObjectSet, daemonSetName, con
 	return container
 }
 
-// mustGetEndpoint returns the endpoint tree with the given name in the deployment with the given name.
-func mustGetEndpoint(g *WithT, objs *ObjectSet, endpointName string) *manifest.Manifest {
-	obj := objs.kind(gvk.Endpoints.Kind).nameEquals(endpointName)
-	g.Expect(obj).Should(Not(BeNil()), fmt.Sprintf("Expected to get endpoints %s", endpointName))
+// mustGetEndpointSlice returns the EndpointSlice with the given name or fails if it's not found in objs.
+func mustGetEndpointSlice(g *WithT, objs *ObjectSet, endpointSliceName string) *manifest.Manifest {
+	obj := objs.kind(gvk.EndpointSlice.Kind).nameEquals(endpointSliceName)
+	g.Expect(obj).Should(Not(BeNil()), fmt.Sprintf("Expected to get EndpointSlice %s", endpointSliceName))
 	return obj
 }
 
@@ -456,21 +456,6 @@ func toMap(s string) map[string]any {
 	}
 	if len(out) == 0 {
 		return nil
-	}
-	return out
-}
-
-// endpointSubsetAddressVal returns a map having subset address type for an endpoint.
-func endpointSubsetAddressVal(hostname, ip, nodeName string) map[string]any {
-	out := make(map[string]any)
-	if hostname != "" {
-		out["hostname"] = hostname
-	}
-	if ip != "" {
-		out["ip"] = ip
-	}
-	if nodeName != "" {
-		out["nodeName"] = nodeName
 	}
 	return out
 }

--- a/pkg/config/schema/collections/collections.gen.go
+++ b/pkg/config/schema/collections/collections.gen.go
@@ -183,7 +183,7 @@ var (
 
 	EndpointSlice = resource.Builder{
 		Identifier:    "EndpointSlice",
-		Group:         "",
+		Group:         "discovery.k8s.io",
 		Kind:          "EndpointSlice",
 		Plural:        "endpointslices",
 		Version:       "v1",

--- a/pkg/config/schema/gvk/resources.gen.go
+++ b/pkg/config/schema/gvk/resources.gen.go
@@ -23,7 +23,7 @@ var (
 	DestinationRule                = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1", Kind: "DestinationRule"}
 	DestinationRule_v1alpha3       = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "DestinationRule"}
 	DestinationRule_v1beta1        = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1beta1", Kind: "DestinationRule"}
-	EndpointSlice                  = config.GroupVersionKind{Group: "", Version: "v1", Kind: "EndpointSlice"}
+	EndpointSlice                  = config.GroupVersionKind{Group: "discovery.k8s.io", Version: "v1", Kind: "EndpointSlice"}
 	Endpoints                      = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Endpoints"}
 	EnvoyFilter                    = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "EnvoyFilter"}
 	GRPCRoute                      = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "GRPCRoute"}

--- a/pkg/config/schema/gvr/resources.gen.go
+++ b/pkg/config/schema/gvr/resources.gen.go
@@ -19,7 +19,7 @@ var (
 	DestinationRule                = schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1", Resource: "destinationrules"}
 	DestinationRule_v1alpha3       = schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1alpha3", Resource: "destinationrules"}
 	DestinationRule_v1beta1        = schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1beta1", Resource: "destinationrules"}
-	EndpointSlice                  = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "endpointslices"}
+	EndpointSlice                  = schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1", Resource: "endpointslices"}
 	Endpoints                      = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "endpoints"}
 	EnvoyFilter                    = schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1alpha3", Resource: "envoyfilters"}
 	GRPCRoute                      = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "grpcroutes"}

--- a/pkg/config/schema/metadata.yaml
+++ b/pkg/config/schema/metadata.yaml
@@ -62,6 +62,7 @@ resources:
 
   - kind: "EndpointSlice"
     plural: "endpointslices"
+    group: "discovery.k8s.io"
     version: "v1"
     builtin: true
     specless: true

--- a/releasenotes/notes/istiod-helm-endpointslices.yaml
+++ b/releasenotes/notes/istiod-helm-endpointslices.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+  - 57037
+releaseNotes:
+  - |
+    **Updated** the istiod helm chart to create EndpointSlice resources instead of Endpoints for remote istiod installs due to Endpoints' deprecation as of Kubernetes 1.33.
+


### PR DESCRIPTION
**Please provide a description of this PR:**
In the istiod Helm chart, switches to generating an EndpointSlice instead of an Endpoints resource for remote istiod installs since Endpoints are officially deprecated as of Kubernetes 1.33.

Fixes #57037 