### PR TITLE
manifests: switch to securityContext.appArmorProfile

### DIFF
--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -50,12 +50,14 @@ spec:
         prometheus.io/scrape: 'true'
         prometheus.io/port: "15014"
         prometheus.io/path: '/metrics'
+        {{- if semverCompare "<1.30.0-0" .Capabilities.KubeVersion.Version }}
         # Add AppArmor annotation
         # This is required to avoid conflicts with AppArmor profiles which block certain
         # privileged pod capabilities.
         # Required for Kubernetes 1.29 which does not support setting appArmorProfile in the
         # securityContext which is otherwise preferred.
         container.apparmor.security.beta.kubernetes.io/install-cni: unconfined
+        {{- end }}
         # Custom annotations
         {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
@@ -102,6 +104,10 @@ spec:
               path: /readyz
               port: 8000
           securityContext:
+            {{- if semverCompare ">=1.30.0-0" .Capabilities.KubeVersion.Version }}
+            appArmorProfile:
+              type: Unconfined
+            {{- end }}
             privileged: false
             runAsGroup: 0
             runAsUser: 0


### PR DESCRIPTION
The annotation `container.apparmor.security.beta.kubernetes.io` has been deprecated in k8s 1.30.

This patch uses the `.Capabilities.KubeVersion.Version` field set by helm, [which defaults to `v1.20.0` if helm is not connected to a live cluster](https://github.com/helm/helm/blob/8e5ce79e62655ec28eaaea6a25d36f1ee29cbfe0/pkg/chart/v2/util/capabilities.go#L33-L51) (or given a cmdline parameter) - so it defaults to the old annotation, e.g. when using `helm template`.