### PR TITLE
Add custom env vars loginc into CNI daemonset chart

### DIFF
--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -186,6 +186,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- if .Values.env }}
+            {{- range $key, $val := .Values.env }}
+            - name: {{ $key }}
+              value: "{{ $val }}"
+            {{- end }}
+            {{- end }}
           volumeMounts:
             - mountPath: /host/opt/cni/bin
               name: cni-bin-dir


### PR DESCRIPTION
**Please provide a description of this PR:**
The CNI helm chart already contains "env: {}" value within the "values.yaml" file, but the logic to add the actual environment variable to the pod is missing.

Add the ability to define custom environment variables into the CNI pods.