### PR TITLE
Add integ tests for sidecar mode with nftables enabled

### DIFF
--- a/tests/integration/helm/install_test.go
+++ b/tests/integration/helm/install_test.go
@@ -171,6 +171,7 @@ func TestNativeNftablesInstall(t *testing.T) {
 		Run(setupInstallation(values, false, DefaultNamespaceConfig, ""))
 }
 
+//nolint: unparam
 func setupInstallation(values map[string]interface{}, isAmbient bool, config NamespaceConfig, revision string) func(t framework.TestContext) {
 	return baseSetup(values, isAmbient, config, func(t framework.TestContext) {
 		sanitycheck.RunTrafficTest(t, isAmbient)

--- a/tests/integration/helm/install_test.go
+++ b/tests/integration/helm/install_test.go
@@ -160,6 +160,17 @@ func TestRevisionedReleaseChannels(t *testing.T) {
 		}, revision))
 }
 
+func TestNativeNftablesInstall(t *testing.T) {
+	values := map[string]interface{}{
+		"global": map[string]interface{}{
+			"nativeNftables": true,
+		},
+	}
+	framework.
+		NewTest(t).
+		Run(setupInstallation(values, false, DefaultNamespaceConfig, ""))
+}
+
 func setupInstallation(values map[string]interface{}, isAmbient bool, config NamespaceConfig, revision string) func(t framework.TestContext) {
 	return baseSetup(values, isAmbient, config, func(t framework.TestContext) {
 		sanitycheck.RunTrafficTest(t, isAmbient)

--- a/tests/integration/helm/install_test.go
+++ b/tests/integration/helm/install_test.go
@@ -171,7 +171,7 @@ func TestNativeNftablesInstall(t *testing.T) {
 		Run(setupInstallation(values, false, DefaultNamespaceConfig, ""))
 }
 
-//nolint: unparam
+// nolint: unparam
 func setupInstallation(values map[string]interface{}, isAmbient bool, config NamespaceConfig, revision string) func(t framework.TestContext) {
 	return baseSetup(values, isAmbient, config, func(t framework.TestContext) {
 		sanitycheck.RunTrafficTest(t, isAmbient)

--- a/tests/integration/pilot/nftables/main_test.go
+++ b/tests/integration/pilot/nftables/main_test.go
@@ -18,6 +18,8 @@
 package nftables
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
@@ -41,6 +43,13 @@ var (
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
+		SkipIf("distroless variant doesn't include nft binary. https://github.com/istio/istio/pull/56917",
+			func(ctx resource.Context) bool {
+				// Lets check both environment variable and test settings
+				variant := os.Getenv("DOCKER_BUILD_VARIANTS")
+
+				return variant == "distroless" || strings.Contains(strings.ToLower(ctx.Settings().Image.Variant), "distroless")
+			}).
 		Setup(istio.Setup(&i, func(_ resource.Context, cfg *istio.Config) {
 			cfg.ControlPlaneValues = `
 values:

--- a/tests/integration/pilot/nftables/main_test.go
+++ b/tests/integration/pilot/nftables/main_test.go
@@ -1,0 +1,53 @@
+//go:build integ
+// +build integ
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nftables
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo/common/deployment"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+var (
+	i istio.Instance
+
+	// Below are various preconfigured echo deployments. Whenever possible, tests should utilize these
+	// to avoid excessive creation/tear down of deployments. In general, a test should only deploy echo if
+	// its doing something unique to that specific test.
+	apps = deployment.SingleNamespaceView{}
+)
+
+// TestMain defines the entrypoint for pilot tests using a NativeNftables value Istio installation.
+// If a test requires a custom install it should go into its own package, otherwise it should go
+// here to reuse a single install across tests.
+func TestMain(m *testing.M) {
+	framework.
+		NewSuite(m).
+		Setup(istio.Setup(&i, func(_ resource.Context, cfg *istio.Config) {
+			cfg.ControlPlaneValues = `
+values:
+  global:
+    nativeNftables: true	
+`
+		})).
+		Setup(deployment.SetupSingleNamespace(&apps, deployment.Config{})).
+		Run()
+}

--- a/tests/integration/pilot/nftables/routing_test.go
+++ b/tests/integration/pilot/nftables/routing_test.go
@@ -1,0 +1,33 @@
+//go:build integ
+// +build integ
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nftables
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/tests/integration/pilot/common"
+)
+
+func TestTraffic(t *testing.T) {
+	framework.
+		NewTest(t).
+		Run(func(t framework.TestContext) {
+			common.RunAllTrafficTests(t, i, apps)
+		})
+}

--- a/tools/istio-nftables/pkg/capture/run.go
+++ b/tools/istio-nftables/pkg/capture/run.go
@@ -387,7 +387,7 @@ func (cfg *NftablesConfigurator) Run() (*knftables.Transaction, error) {
 					"oifname", "lo",
 					"meta l4proto tcp",
 					"tcp dport", "!=", "53",
-					"skuid", uid,
+					"skuid", "!=", uid,
 					"return")
 			} else {
 				cfg.ruleBuilder.AppendRule(constants.IstioOutputChain, constants.IstioProxyNatTable,
@@ -724,7 +724,7 @@ func (cfg *NftablesConfigurator) addDNSConntrackZones(
 			// Mark all UDP dns traffic with src port 53 as zone 1. These are response packets from the DNS resolvers.
 			nft.AppendRule(constants.IstioInboundChain, constants.IstioProxyRawTable,
 				"udp sport", "53",
-				"ip daddr", s+"/32",
+				"ip saddr", s+"/32",
 				"ct", "zone", "set", "1")
 		}
 
@@ -737,7 +737,7 @@ func (cfg *NftablesConfigurator) addDNSConntrackZones(
 			// Mark all UDP dns traffic with src port 53 as zone 1. These are response packets from the DNS resolvers.
 			nft.AppendV6RuleIfSupported(constants.IstioInboundChain, constants.IstioProxyRawTable,
 				"udp sport", "53",
-				"ip6 daddr", s+"/128",
+				"ip6 saddr", s+"/128",
 				"ct", "zone", "set", "1")
 		}
 	}
@@ -908,7 +908,7 @@ func (cfg *NftablesConfigurator) addIstioMangleTableRules(tx *knftables.Transact
 			Name:     constants.OutputChain,
 			Table:    constants.IstioProxyMangleTable,
 			Family:   knftables.InetFamily,
-			Type:     knftables.PtrTo(knftables.FilterType),
+			Type:     knftables.PtrTo(knftables.RouteType),
 			Hook:     knftables.PtrTo(knftables.OutputHook),
 			Priority: knftables.PtrTo(knftables.ManglePriority),
 		},

--- a/tools/istio-nftables/pkg/capture/testdata/dns-uid-gid.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/dns-uid-gid.golden
@@ -14,11 +14,11 @@ add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 retu
 add rule inet istio-proxy-nat istio-output oifname lo ip6 saddr ::6/128 return
 add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != { 53, 15008 } skuid 3 jump istio-in-redirect
 add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != { 53, 15008 } skuid 3 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skuid 3 return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skuid != 3 return
 add rule inet istio-proxy-nat istio-output skuid 3 return
 add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != { 53, 15008 } skuid 4 jump istio-in-redirect
 add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != { 53, 15008 } skuid 4 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skuid 4 return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skuid != 4 return
 add rule inet istio-proxy-nat istio-output skuid 4 return
 add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1 jump istio-in-redirect
 add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skgid 1 jump istio-in-redirect
@@ -52,6 +52,6 @@ add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skgid 2 ct zone
 add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skgid 2 ct zone set 2
 add rule inet istio-proxy-raw prerouting jump istio-inbound
 add rule inet istio-proxy-raw istio-output-dns udp dport 53 ip daddr 127.0.0.53/32 ct zone set 2
-add rule inet istio-proxy-raw istio-inbound udp sport 53 ip daddr 127.0.0.53/32 ct zone set 1
+add rule inet istio-proxy-raw istio-inbound udp sport 53 ip saddr 127.0.0.53/32 ct zone set 1
 add rule inet istio-proxy-raw istio-output-dns udp dport 53 ip6 daddr ::127.0.0.53/128 ct zone set 2
-add rule inet istio-proxy-raw istio-inbound udp sport 53 ip6 daddr ::127.0.0.53/128 ct zone set 1
+add rule inet istio-proxy-raw istio-inbound udp sport 53 ip6 saddr ::127.0.0.53/128 ct zone set 1

--- a/tools/istio-nftables/pkg/capture/testdata/inbound-ports-tproxy.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/inbound-ports-tproxy.golden
@@ -20,7 +20,7 @@ add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 return
 add table inet istio-proxy-mangle
 flush table inet istio-proxy-mangle
 add chain inet istio-proxy-mangle prerouting { type filter hook prerouting priority -150 ; }
-add chain inet istio-proxy-mangle output { type filter hook output priority -150 ; }
+add chain inet istio-proxy-mangle output { type route hook output priority -150 ; }
 add chain inet istio-proxy-mangle istio-divert
 add chain inet istio-proxy-mangle istio-tproxy
 add chain inet istio-proxy-mangle istio-inbound

--- a/tools/istio-nftables/pkg/capture/testdata/inbound-ports-wildcard-tproxy.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/inbound-ports-wildcard-tproxy.golden
@@ -20,7 +20,7 @@ add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 return
 add table inet istio-proxy-mangle
 flush table inet istio-proxy-mangle
 add chain inet istio-proxy-mangle prerouting { type filter hook prerouting priority -150 ; }
-add chain inet istio-proxy-mangle output { type filter hook output priority -150 ; }
+add chain inet istio-proxy-mangle output { type route hook output priority -150 ; }
 add chain inet istio-proxy-mangle istio-divert
 add chain inet istio-proxy-mangle istio-tproxy
 add chain inet istio-proxy-mangle istio-inbound

--- a/tools/istio-nftables/pkg/capture/testdata/ip-range.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/ip-range.golden
@@ -12,10 +12,10 @@ add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp redirect to :15
 add rule inet istio-proxy-nat output jump istio-output
 add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 return
 add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != { 53, 15008 } skuid 3 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skuid 3 return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skuid != 3 return
 add rule inet istio-proxy-nat istio-output skuid 3 return
 add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != { 53, 15008 } skuid 4 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skuid 4 return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skuid != 4 return
 add rule inet istio-proxy-nat istio-output skuid 4 return
 add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1 jump istio-in-redirect
 add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skgid != 1 return
@@ -46,4 +46,4 @@ add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skgid 2 ct zone
 add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skgid 2 ct zone set 2
 add rule inet istio-proxy-raw prerouting jump istio-inbound
 add rule inet istio-proxy-raw istio-output-dns udp dport 53 ip daddr 127.0.0.53/32 ct zone set 2
-add rule inet istio-proxy-raw istio-inbound udp sport 53 ip daddr 127.0.0.53/32 ct zone set 1
+add rule inet istio-proxy-raw istio-inbound udp sport 53 ip saddr 127.0.0.53/32 ct zone set 1

--- a/tools/istio-nftables/pkg/capture/testdata/loopback-outbound-iprange.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/loopback-outbound-iprange.golden
@@ -41,4 +41,4 @@ add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skgid 2 ct zone
 add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skgid 2 ct zone set 2
 add rule inet istio-proxy-raw prerouting jump istio-inbound
 add rule inet istio-proxy-raw istio-output-dns udp dport 53 ip daddr 127.0.0.53/32 ct zone set 2
-add rule inet istio-proxy-raw istio-inbound udp sport 53 ip daddr 127.0.0.53/32 ct zone set 1
+add rule inet istio-proxy-raw istio-inbound udp sport 53 ip saddr 127.0.0.53/32 ct zone set 1

--- a/tools/istio-nftables/pkg/capture/testdata/tproxy.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/tproxy.golden
@@ -17,7 +17,7 @@ add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 retu
 add rule inet istio-proxy-nat istio-output oifname lo ip6 saddr ::6/128 return
 add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != { 53, 15008 } skuid 1337 jump istio-in-redirect
 add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != { 53, 15008 } skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skuid 1337 return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skuid != 1337 return
 add rule inet istio-proxy-nat istio-output skuid 1337 return
 add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 jump istio-in-redirect
 add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skgid 1337 jump istio-in-redirect
@@ -33,7 +33,7 @@ add rule inet istio-proxy-nat istio-output ip daddr 9.9.0.0/16 jump istio-redire
 add table inet istio-proxy-mangle
 flush table inet istio-proxy-mangle
 add chain inet istio-proxy-mangle prerouting { type filter hook prerouting priority -150 ; }
-add chain inet istio-proxy-mangle output { type filter hook output priority -150 ; }
+add chain inet istio-proxy-mangle output { type route hook output priority -150 ; }
 add chain inet istio-proxy-mangle istio-divert
 add chain inet istio-proxy-mangle istio-tproxy
 add chain inet istio-proxy-mangle istio-inbound
@@ -70,4 +70,4 @@ add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skgid 1337 ct z
 add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skgid 1337 ct zone set 2
 add rule inet istio-proxy-raw prerouting jump istio-inbound
 add rule inet istio-proxy-raw istio-output-dns udp dport 53 ip daddr 127.0.0.53/32 ct zone set 2
-add rule inet istio-proxy-raw istio-inbound udp sport 53 ip daddr 127.0.0.53/32 ct zone set 1
+add rule inet istio-proxy-raw istio-inbound udp sport 53 ip saddr 127.0.0.53/32 ct zone set 1


### PR DESCRIPTION
This PR re-runs the pilot integration tests with native nftables mode enabled.

Related to: https://github.com/istio/istio/issues/47821
Co-authored-by: Yuanlin Xu <yuanlin.xu@redhat.com>