### PR TITLE
Fix build-base-images_release-builder_periodic job error: Found unexpected binaries

### DIFF
--- a/tools/build-base-images.sh
+++ b/tools/build-base-images.sh
@@ -75,6 +75,7 @@ unexpectedFiles="$(
     grep -v '^usr/bin/xtables' | \
     grep -v '^usr/bin/ldconfig$' | \
     grep -v '^etc/apk/commit_hooks.d/ldconfig-commit.sh$' | \
+    grep -v '^usr/bin/clear' | \
     grep -v '.*\.so[0-9\.]*' || true
 )"
 expectedFiles=(


### PR DESCRIPTION

The PR is fixing  build-base-images_release-builder_periodic job error since July 14.
Reference: https://prow.istio.io/job-history/gs/istio-prow/logs/build-base-images_release-builder_periodic

The failed job logs shows the error: 

```
+ exefiles+='\n'
++ grep -v '^usr/lib/xtables'
++ grep -v '^usr/bin/xtables'
++ grep -v '^usr/bin/ldconfig$'
++ grep -v '^etc/apk/commit_hooks.d/ldconfig-commit.sh$'
++ grep -v '.*\.so[0-9\.]*'
+ unexpectedFiles='usr/bin/clear

+ echo 'Found unexpected binaries: usr/bin/clear
```

The failure happened between 	Jul 14 15:00:39 and Jul 15 15:00:41 
Checking the commit history and it was caused by https://github.com/istio/istio/pull/56363
I added a new package `nftables` in the docker/iptables.yaml 


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [X] Test and Release