### PR TITLE
fix(inference): avoid panic on invalid backend ref

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -1070,7 +1070,7 @@ func buildDestination(ctx RouteContext, to k8s.BackendRef, ns string,
 		}
 	case gvk.InferencePool:
 		if !features.SupportGatewayAPIInferenceExtension {
-			return nil, nil, &ConfigError{
+			return &istio.Destination{}, nil, &ConfigError{
 				Reason:  InvalidDestinationKind,
 				Message: "InferencePool is not enabled. To enable, set SUPPORT_GATEWAY_API_INFERENCE_EXTENSION to true in istiod",
 			}


### PR DESCRIPTION
If the Gateway API Inference Extension CRDs exist but SUPPORT_GATEWAY_API_INFERENCE_EXTENSION is set to false, a HTTPRoute with an InfernecePool backend ref will create a Route with a nil destination causing nil ref panic in route.go's hash function.

  istio.io/istio/pilot/pkg/networking/core/route.HashForHTTPDestination

Change to behave like the default Invalid destination, return an empty Destination instead of nil.


**Please check any characteristics that apply to this pull request.**

- [ x ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.