### PR TITLE
Avoid unnecesary service target logs

### DIFF
--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -420,6 +420,11 @@ func (c *Controller) GetProxyServiceTargets(node *model.Proxy) []model.ServiceTa
 		}
 	}
 
+	if len(out) == 0 {
+		log.Debugf("GetProxyServiceTargets(): no service targets found for proxy %s with clusterID %s",
+			node.ID, nodeClusterID.String())
+	}
+
 	return out
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -882,10 +882,7 @@ func (c *Controller) GetProxyServiceTargets(proxy *model.Proxy) []model.ServiceT
 		// metadata already. Because of this, we can still get most of the information we need.
 		// If we cannot accurately construct ServiceEndpoints from just the metadata, this will return an error and we can
 		// attempt to read the real pod.
-		out, err := c.GetProxyServiceTargetsFromMetadata(proxy)
-		if err != nil && !features.EnableServiceEntrySelectPods {
-			log.Warnf("GetProxyServiceTargetsFromMetadata for %v failed: %v", proxy.ID, err)
-		}
+		out, _ := c.GetProxyServiceTargetsFromMetadata(proxy)
 		return out
 	}
 


### PR DESCRIPTION
**Please provide a description of this PR:**
Avoids unnecessary missing service target logs whenever `PILOT_ENABLE_SERVICEENTRY_SELECT_PODS` is enabled.
Fixes #57103