### PR TITLE
fix(manifests): fix cniBinDir path for k3d

### DIFF
--- a/manifests/charts/base/files/profile-platform-k3d.yaml
+++ b/manifests/charts/base/files/profile-platform-k3d.yaml
@@ -4,4 +4,4 @@
 
 cni:
   cniConfDir: /var/lib/rancher/k3s/agent/etc/cni/net.d
-  cniBinDir: /bin
+  cniBinDir: /var/lib/rancher/k3s/data/cni

--- a/manifests/charts/default/files/profile-platform-k3d.yaml
+++ b/manifests/charts/default/files/profile-platform-k3d.yaml
@@ -4,4 +4,4 @@
 
 cni:
   cniConfDir: /var/lib/rancher/k3s/agent/etc/cni/net.d
-  cniBinDir: /bin
+  cniBinDir: /var/lib/rancher/k3s/data/cni

--- a/manifests/charts/gateway/files/profile-platform-k3d.yaml
+++ b/manifests/charts/gateway/files/profile-platform-k3d.yaml
@@ -4,4 +4,4 @@
 
 cni:
   cniConfDir: /var/lib/rancher/k3s/agent/etc/cni/net.d
-  cniBinDir: /bin
+  cniBinDir: /var/lib/rancher/k3s/data/cni

--- a/manifests/charts/gateways/istio-egress/files/profile-platform-k3d.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-platform-k3d.yaml
@@ -4,4 +4,4 @@
 
 cni:
   cniConfDir: /var/lib/rancher/k3s/agent/etc/cni/net.d
-  cniBinDir: /bin
+  cniBinDir: /var/lib/rancher/k3s/data/cni

--- a/manifests/charts/gateways/istio-ingress/files/profile-platform-k3d.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-platform-k3d.yaml
@@ -4,4 +4,4 @@
 
 cni:
   cniConfDir: /var/lib/rancher/k3s/agent/etc/cni/net.d
-  cniBinDir: /bin
+  cniBinDir: /var/lib/rancher/k3s/data/cni

--- a/manifests/charts/istio-cni/files/profile-platform-k3d.yaml
+++ b/manifests/charts/istio-cni/files/profile-platform-k3d.yaml
@@ -4,4 +4,4 @@
 
 cni:
   cniConfDir: /var/lib/rancher/k3s/agent/etc/cni/net.d
-  cniBinDir: /bin
+  cniBinDir: /var/lib/rancher/k3s/data/cni

--- a/manifests/charts/istio-control/istio-discovery/files/profile-platform-k3d.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-platform-k3d.yaml
@@ -4,4 +4,4 @@
 
 cni:
   cniConfDir: /var/lib/rancher/k3s/agent/etc/cni/net.d
-  cniBinDir: /bin
+  cniBinDir: /var/lib/rancher/k3s/data/cni

--- a/manifests/charts/ztunnel/files/profile-platform-k3d.yaml
+++ b/manifests/charts/ztunnel/files/profile-platform-k3d.yaml
@@ -4,4 +4,4 @@
 
 cni:
   cniConfDir: /var/lib/rancher/k3s/agent/etc/cni/net.d
-  cniBinDir: /bin
+  cniBinDir: /var/lib/rancher/k3s/data/cni

--- a/manifests/helm-profiles/platform-k3d.yaml
+++ b/manifests/helm-profiles/platform-k3d.yaml
@@ -1,3 +1,3 @@
 cni:
   cniConfDir: /var/lib/rancher/k3s/agent/etc/cni/net.d
-  cniBinDir: /bin
+  cniBinDir: /var/lib/rancher/k3s/data/cni


### PR DESCRIPTION
**Please provide a description of this PR:**

Hello everyone,

I was following the new documentation for bootstrapping a cluster with Istio in ambient mode when I ran into a problem:

When I deploy the cluster, it is impossible to run ztunnel. I am receiving the following error message:


```bash
k describe -n istio-system pods/ztunnel-rbq8m

Events:
  Type     Reason                  Age   From               Message
  ----     ------                  ----  ----               -------
  Normal   Scheduled               25s   default-scheduler  Successfully assigned istio-system/ztunnel-rbq8m to k3d-no-point-agent-1
  Warning  FailedCreatePodSandBox  25s   kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "092b4ba4229c17e8ed0a1a4ad4117e0dfdb00ead73f5ff2550d9e817c9161c99": plugin type="istio-cni" name="istio-cni" failed (add): failed to find plugin "istio-cni" in path [/var/lib/rancher/k3s/data/cni]
  Warning  FailedCreatePodSandBox  12s   kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "165937b1e654398113d9f579f135bb92d4f7cdc421a7067151bc6c8f5bb8d52d": plugin type="istio-cni" name="istio-cni" failed (add): failed to find plugin "istio-cni" in path [/var/lib/rancher/k3s/data/cni]
  Warning  FailedCreatePodSandBox  1s    kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "45086982ed0378cd13d8e69456a5ca669a45395a2977c04088caac7e41c6afd3": plugin type="istio-cni" name="istio-cni" failed (add): failed to find plugin "istio-cni" in path [/var/lib/rancher/k3s/data/cni]
```

I quickly realized that this problem was related to this PR.
https://github.com/istio/istio/pull/54112

To fix this, I used the values from k3s.
```yaml
        profile: ambient
        global:
          platform: k3s  # broken with k3d but works fine with k3s
```

With that, the cluster starts normally.

And istio-cni is in the location expected by the chart ztunnel

```bash
docker exec -it k3d-no-point-agent-0 sh -c "ls /var/lib/rancher/k3s/data/cni"   1
bandwidth  bridge  cni  firewall  flannel  host-local  istio-cni  loopback  portmap
```



<details open>
<summary>k3d version</summary>
<br>

```bash
k3d version v5.8.3
k3s version rancher/k3s:v1.33.2-rc2-k3s1
```

</details> 



<details open>
<summary>k8s version</summary>
<br>

```bash
Client Version: v1.33.3
Kustomize Version: v5.6.0
Server Version: v1.33.2-rc2+k3s1
```

</details> 



<details open>
<summary>k3d-config.yaml</summary>
<br>

```yaml
---
apiVersion: k3d.io/v1alpha5
kind: Simple
metadata:
  name: mycluster
servers: 1
agents: 2
image: rancher/k3s:v1.33.2-rc2-k3s1
kubeAPI:
  hostPort: "6550"
ports:
  - port: 9080:80 
    nodeFilters:
      - loadbalancer
  - port: 9443:443 
    nodeFilters:
      - loadbalancer
options:
  k3s:
    extraArgs:
      - arg: "--disable=traefik"
        nodeFilters:
          - server:*
```

</details> 

<details open>
<summary>helmfile</summary>
<br>

```yaml

---
repositories:
  - name: istio
    url: https://istio-release.storage.googleapis.com/charts

releases:
  - name: istio-base
    namespace: istio-system 
    createNamespace: true
    chart: istio/base
    version: ~1.26.0
    wait: true

  - name: istiod
    namespace: istio-system 
    createNamespace: true
    chart: istio/istiod
    version: ~1.26.0
    wait: true
    values:
      - profile: ambient
    needs: 
      - istio-base

  - name: istio-cni
    namespace: istio-system 
    createNamespace: true
    chart: istio/cni
    version: ~1.26.0
    wait: true
    values:
      - profile: ambient
        global:
          platform: k3s # broken with k3d but works fine with k3s
    needs: 
      - istiod

  - name: ztunnel
    namespace: istio-system 
    createNamespace: true
    chart: istio/ztunnel
    version: ~1.26.0
    wait: true
    needs: 
      - istio-cni

```

</details> 