### PR TITLE
nftables: Revert the package change in distroless base image and build-base-images.sh

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -12,6 +12,7 @@ RUN apt-get update && \
   ca-certificates \
   curl \
   iptables \
+  nftables \
   iproute2 \
   iputils-ping \
   knot-dnsutils \

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -12,7 +12,6 @@ RUN apt-get update && \
   ca-certificates \
   curl \
   iptables \
-  nftables \
   iproute2 \
   iputils-ping \
   knot-dnsutils \

--- a/docker/iptables.yaml
+++ b/docker/iptables.yaml
@@ -3,8 +3,6 @@ contents:
     - https://packages.wolfi.dev/os
   keyring:
     - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
-  # TODO: Replace the nftables package with a nftables-slim package from wolfi-dev/os.
-  # Note that the nftables-slim package is pending in https://github.com/wolfi-dev/os/pull/58274
   packages:
     - ca-certificates-bundle
     - wolfi-baselayout
@@ -15,7 +13,6 @@ contents:
     - libnfnetlink
     - libmnl
     - libgcc
-    - nftables
 archs:
   - x86_64
   - aarch64

--- a/tools/build-base-images.sh
+++ b/tools/build-base-images.sh
@@ -75,7 +75,6 @@ unexpectedFiles="$(
     grep -v '^usr/bin/xtables' | \
     grep -v '^usr/bin/ldconfig$' | \
     grep -v '^etc/apk/commit_hooks.d/ldconfig-commit.sh$' | \
-    grep -v '^usr/bin/clear' | \
     grep -v '.*\.so[0-9\.]*' || true
 )"
 expectedFiles=(


### PR DESCRIPTION
This PR is following today's WG Meeting discussion about the nft binary package for the Istio 1.27 release.

We will include the nft binary only in the distro debug image (docker/Dockerfile.base) . And this PR is reverting changes in the distroless iptables.yaml base image and the build-base-images.sh
I have run the part of expectedFiles and unexpectedFiles checking in the build-base-image.sh locally. There is no error in this PR.

There are other action items such as alerting the user that the distroless image does not include nft binary when a user enables  nativeNftables=true and selects distroless image. We will address that suggestion and golang library for nftables support in other PRs later. Thanks.

- [X] Test and Release

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
