### PR TITLE
manifests: add optional network policies for gateway resources

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -330,8 +330,14 @@ copy-templates:
 
 	# gateway charts
 	cp -r manifests/charts/gateways/istio-ingress/templates/* manifests/charts/gateways/istio-egress/templates
-	find ./manifests/charts/gateways/istio-egress/templates -type f -exec sed -i -e 's/ingress/egress/g' {} \;
-	find ./manifests/charts/gateways/istio-egress/templates -type f -exec sed -i -e 's/Ingress/Egress/g' {} \;
+	find ./manifests/charts/gateways/istio-egress/templates -type f -name "*.yaml" ! -name "networkpolicy.yaml" -exec sed -i -e 's/ingress/egress/g' {} \;
+	find ./manifests/charts/gateways/istio-egress/templates -type f -name "*.yaml" ! -name "networkpolicy.yaml" -exec sed -i -e 's/Ingress/Egress/g' {} \;
+	if [ -f ./manifests/charts/gateways/istio-egress/templates/networkpolicy.yaml ]; then \
+		sed -i -e 's/"IngressGateways"/"EgressGateways"/g' ./manifests/charts/gateways/istio-egress/templates/networkpolicy.yaml; \
+		sed -i -e 's/istio-ingress/istio-egress/g' ./manifests/charts/gateways/istio-egress/templates/networkpolicy.yaml; \
+		sed -i -e 's/app: istio-ingress/app: istio-egress/g' ./manifests/charts/gateways/istio-egress/templates/networkpolicy.yaml; \
+		sed -i -e 's/istio: ingressgateway/istio: egressgateway/g' ./manifests/charts/gateways/istio-egress/templates/networkpolicy.yaml; \
+	fi
 
 	# copy istio-discovery values, but apply some local customizations
 	warning=$$(cat manifests/helm-profiles/warning-edit.txt | sed ':a;N;$$!ba;s/\n/\\n/g') ; \

--- a/manifests/charts/gateway/templates/networkpolicy.yaml
+++ b/manifests/charts/gateway/templates/networkpolicy.yaml
@@ -26,9 +26,11 @@ spec:
     ports:
     - protocol: TCP
       port: 15021
-  # Metrics endpoint for monitoring/prometheus
+  # Metrics endpoints for monitoring/prometheus
   - from: []
     ports:
+    - protocol: TCP
+      port: 15020
     - protocol: TCP
       port: 15090
   # Main gateway traffic ports

--- a/manifests/charts/gateway/templates/networkpolicy.yaml
+++ b/manifests/charts/gateway/templates/networkpolicy.yaml
@@ -1,0 +1,46 @@
+{{- if (.Values.global.networkPolicy).enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "gateway.name" . }}{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "gateway.name" . }}
+    istio.io/rev: {{ .Values.revision | default "default" | quote }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Gateway"
+    istio: {{ (.Values.labels.istio | quote) | default (include "gateway.name" . | trimPrefix "istio-") }}
+    release: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ include "gateway.name" . }}
+    {{- include "gateway.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "gateway.selectorLabels" . | nindent 6 }}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Status/health check port
+  - from: []
+    ports:
+    - protocol: TCP
+      port: 15021
+  # Metrics endpoint for monitoring/prometheus
+  - from: []
+    ports:
+    - protocol: TCP
+      port: 15090
+  # Main gateway traffic ports
+{{- if .Values.service.ports }}
+{{- range .Values.service.ports }}
+  - from: []
+    ports:
+    - protocol: {{ .protocol | default "TCP" }}
+      port: {{ .targetPort | default .port }}
+{{- end }}
+{{- end }}
+  egress:
+  # Allow all egress (gateways need to reach external services, istiod, and other cluster services)
+  - {}
+{{- end }}

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -190,3 +190,8 @@ _internal_defaults_do_not_set:
   # Configure the lifecycle hooks for the gateway. See
   # https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/.
   lifecycle: {}
+
+  # When enabled, a default NetworkPolicy for gateways will be created
+  global:
+    networkPolicy:
+      enabled: false

--- a/manifests/charts/gateways/istio-egress/templates/networkpolicy.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/networkpolicy.yaml
@@ -27,12 +27,14 @@ spec:
     ports:
     - protocol: TCP
       port: 15021
-  # Metrics endpoint for monitoring/prometheus
+  # Metrics endpoints for monitoring/prometheus
   - from: []
     ports:
     - protocol: TCP
+      port: 15020
+    - protocol: TCP
       port: 15090
-  # Main egress gateway traffic ports (from other pods in mesh)
+  # Main gateway traffic ports
 {{- if $gateway.ports }}
 {{- range $gateway.ports }}
   - from: []
@@ -42,6 +44,6 @@ spec:
 {{- end }}
 {{- end }}
   egress:
-  # Allow all egress (egress gateways need to reach external services)
+  # Allow all egress (gateways need to reach external services, istiod, and other cluster services)
   - {}
 {{- end }} 

--- a/manifests/charts/gateways/istio-egress/templates/networkpolicy.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/networkpolicy.yaml
@@ -1,0 +1,47 @@
+{{- $gateway := index .Values "gateways" "istio-egressgateway" }}
+{{- if (.Values.global.networkPolicy).enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $gateway.name }}{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ $gateway.name }}
+    istio.io/rev: {{ .Values.revision | default "default" | quote }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "EgressGateways"
+    istio: egressgateway
+    release: {{ .Release.Name }}
+    app.kubernetes.io/name: "istio-egressgateway"
+    {{- include "istio.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+{{ $gateway.labels | toYaml | indent 6 }}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Status/health check port
+  - from: []
+    ports:
+    - protocol: TCP
+      port: 15021
+  # Metrics endpoint for monitoring/prometheus
+  - from: []
+    ports:
+    - protocol: TCP
+      port: 15090
+  # Main egress gateway traffic ports (from other pods in mesh)
+{{- if $gateway.ports }}
+{{- range $gateway.ports }}
+  - from: []
+    ports:
+    - protocol: {{ .protocol | default "TCP" }}
+      port: {{ .targetPort | default .port }}
+{{- end }}
+{{- end }}
+  egress:
+  # Allow all egress (egress gateways need to reach external services)
+  - {}
+{{- end }} 

--- a/manifests/charts/gateways/istio-egress/values.yaml
+++ b/manifests/charts/gateways/istio-egress/values.yaml
@@ -267,6 +267,10 @@ _internal_defaults_do_not_set:
       # Setting this port to a non-zero value enables STS server.
       servicePort: 0
 
+    # When enabled, a default NetworkPolicy for gateways will be created
+    networkPolicy:
+      enabled: false
+
   meshConfig:
     enablePrometheusMerge: true
 

--- a/manifests/charts/gateways/istio-ingress/templates/networkpolicy.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/networkpolicy.yaml
@@ -1,0 +1,47 @@
+{{- $gateway := index .Values "gateways" "istio-ingressgateway" }}
+{{- if (.Values.global.networkPolicy).enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $gateway.name }}{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ $gateway.name }}
+    istio.io/rev: {{ .Values.revision | default "default" | quote }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "IngressGateways"
+    istio: ingressgateway
+    release: {{ .Release.Name }}
+    app.kubernetes.io/name: "istio-ingressgateway"
+    {{- include "istio.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+{{ $gateway.labels | toYaml | indent 6 }}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Status/health check port
+  - from: []
+    ports:
+    - protocol: TCP
+      port: 15021
+  # Metrics endpoint for monitoring/prometheus
+  - from: []
+    ports:
+    - protocol: TCP
+      port: 15090
+  # Main gateway traffic ports
+{{- if $gateway.ports }}
+{{- range $gateway.ports }}
+  - from: []
+    ports:
+    - protocol: {{ .protocol | default "TCP" }}
+      port: {{ .targetPort | default .port }}
+{{- end }}
+{{- end }}
+  egress:
+  # Allow all egress (gateways need to reach external services, istiod, and other cluster services)
+  - {}
+{{- end }} 

--- a/manifests/charts/gateways/istio-ingress/templates/networkpolicy.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/networkpolicy.yaml
@@ -27,9 +27,11 @@ spec:
     ports:
     - protocol: TCP
       port: 15021
-  # Metrics endpoint for monitoring/prometheus
+  # Metrics endpoints for monitoring/prometheus
   - from: []
     ports:
+    - protocol: TCP
+      port: 15020
     - protocol: TCP
       port: 15090
   # Main gateway traffic ports

--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -282,6 +282,10 @@ _internal_defaults_do_not_set:
       # The service port used by Security Token Service (STS) server to handle token exchange requests.
       # Setting this port to a non-zero value enables STS server.
       servicePort: 0
+    
+    # When enabled, a default NetworkPolicy for gateways will be created
+    networkPolicy:
+      enabled: false
 
   meshConfig:
     enablePrometheusMerge: true
@@ -301,3 +305,4 @@ _internal_defaults_do_not_set:
       #        sni:               # example: tracer.somedomain
       #        subjectAltNames: []
       # - tracer.somedomain
+

--- a/releasenotes/notes/56877.yaml
+++ b/releasenotes/notes/56877.yaml
@@ -9,6 +9,5 @@ releaseNotes:
   - |
     **Added** optional NetworkPolicy deployment for istiod
 
-    You can set `global.networkPolicy.enabled=true` to deploy a default NetworkPolicy for istiod.
-    We're planning to extend this to later also include NetworkPolicy for istio-cni, ztunnel and
-    gateways.
+    You can set `global.networkPolicy.enabled=true` to deploy a default NetworkPolicy for istiod and gateways.
+    We're planning to extend this to later also include NetworkPolicy for istio-cni and ztunnel.


### PR DESCRIPTION
**Please provide a description of this PR:**

Expanding on other recent PRs for cases where users want to create a default deny-all policy for their cluster. Creation is turned off by default. Fixes: #57031 