### PR TITLE
security: support use of ReferenceGrant API to allow Istio Gateway to reference k8s Secrets across namespaces similarly to Kubernetes gateway-api

### DIFF
--- a/pilot/pkg/features/experimental.go
+++ b/pilot/pkg/features/experimental.go
@@ -151,6 +151,13 @@ var (
 	EnableGatewayAPIGatewayClassController = env.Register("PILOT_ENABLE_GATEWAY_API_GATEWAYCLASS_CONTROLLER", true,
 		"If this is set to true, istiod will create and manage its default GatewayClasses").Get()
 
+	EnableReferenceGrantForIstioGateway = env.Register(
+		"PILOT_ENABLE_REFERENCE_GRANT_FOR_ISTIO_GATEWAY",
+		false,
+		"If enabled, support use of ReferenceGrant API to allow Istio Gateway to reference k8s Secrets across namespaces "+
+			"similarly to Kubernetes gateway-api.",
+	).Get()
+
 	DeltaXds = env.Register("ISTIO_DELTA_XDS", true,
 		"If enabled, pilot will only send the delta configs as opposed to the state of the world configuration on a Resource Request. "+
 			"While this feature uses the delta xds api, it may still occasionally send unchanged configurations instead of just the actual deltas.").Get()

--- a/pilot/pkg/xds/sds.go
+++ b/pilot/pkg/xds/sds.go
@@ -297,6 +297,8 @@ func filterAuthorizedResources(resources []SecretResource, proxy *model.Proxy, s
 			if sameNamespace && (isCAOnlySecret || isAuthorized()) {
 				// if sameNamespace && isAuthorized() {
 				allowedResources = append(allowedResources, r)
+			} else if features.EnableReferenceGrantForIstioGateway && !sameNamespace && verified {
+				allowedResources = append(allowedResources, r)
 			} else {
 				deniedResources = append(deniedResources, r.Name)
 			}

--- a/pilot/pkg/xds/sds.go
+++ b/pilot/pkg/xds/sds.go
@@ -297,7 +297,7 @@ func filterAuthorizedResources(resources []SecretResource, proxy *model.Proxy, s
 			if sameNamespace && (isCAOnlySecret || isAuthorized()) {
 				// if sameNamespace && isAuthorized() {
 				allowedResources = append(allowedResources, r)
-			} else if features.EnableReferenceGrantForIstioGateway && !sameNamespace && verified {
+			} else if features.EnableReferenceGrantForIstioGateway && verified {
 				allowedResources = append(allowedResources, r)
 			} else {
 				deniedResources = append(deniedResources, r.Name)


### PR DESCRIPTION
**Please provide a description of this PR:**

Support use of `ReferenceGrant API` to allow `Istio Gateway` to reference k8s Secrets across namespaces similarly to Kubernetes gateway-api.

Might fix #56232

**Usage example**

1. Deploy Istio Gateway into the `istio-ingress` namespace
2. Deploy Istio Bookinfo app into the `bookinfo` namespace
3. Create `Istio Gateway` and `k8s Secret` resources in the `bookinfo` namespace

   ```yaml
   apiVersion: networking.istio.io/v1
   kind: Gateway
   metadata:
     name: bookinfo-gateway
     namespace: bookinfo
   spec:
     selector:
       istio: ingressgateway
     servers:
     - port:
         number: 443
         name: https
         protocol: HTTPS
       hosts:
       - bookinfo.example.org
       tls:
         credentialName: bookinfo/bookinfo-secret # (1)
         mode: SIMPLE
   ```
   where
   (1)  - notice that `tls.credentialName` field MUST specify k8s secret using format `namespace/name` 

   ```yaml
   apiVersion: v1
   kind: Secret
   type: kubernetes.io/tls
   metadata:
     name: bookinfo-secret
     namespace: bookinfo
   data:
     tls.crt: ...
     tls.key: ...
   ```

4. Create `ReferenceGrant` in the `bookinfo` namespace

   ```yaml
   apiVersion: gateway.networking.k8s.io/v1beta1
   kind: ReferenceGrant
   metadata:
     name: bookinfo-secret
     namespace: bookinfo
   spec:
     from:
     - group: gateway.networking.k8s.io
       kind: Gateway
       namespace: istio-ingress # (1)
     to:
     - group: ""
       kind: Secret
   ```

   where

   (1) - allow Istio Gateway deployment in the `istio-ingress` namespace to refer to k8s Secrets in the `bookinfo` namespace

5. Access Istio Bookinfo app via Ingress Gateway in the `istio-ingress` namespace