### PR TITLE
networking: deduplicate envoy routes translated from virtual service if match block is equal

### DIFF
--- a/pilot/pkg/networking/core/route/route.go
+++ b/pilot/pkg/networking/core/route/route.go
@@ -419,20 +419,19 @@ translateLoop:
 				out = append(out, r)
 			}
 			break translateLoop
-		} else {
-			for _, match := range http.Match {
-				if r := TranslateRoute(node, http, match, listenPort, virtualService, gatewayNames, opts); r != nil {
-					if lastMatch != nil && proto.Equal(lastMatch, r.Match) {
-						continue
-					}
-					out = append(out, r)
-					// This is a catch all path. Routes are matched in order, so we will never go beyond this match
-					// As an optimization, we can just stop sending any more routes here.
-					if IsCatchAllRoute(r) {
-						break translateLoop
-					}
-					lastMatch = r.Match
+		}
+		for _, match := range http.Match {
+			if r := TranslateRoute(node, http, match, listenPort, virtualService, gatewayNames, opts); r != nil {
+				if lastMatch != nil && proto.Equal(lastMatch, r.Match) {
+					continue
 				}
+				out = append(out, r)
+				// This is a catch all path. Routes are matched in order, so we will never go beyond this match
+				// As an optimization, we can just stop sending any more routes here.
+				if IsCatchAllRoute(r) {
+					break translateLoop
+				}
+				lastMatch = r.Match
 			}
 		}
 	}

--- a/releasenotes/notes/deduplicate-adjacent-vs-routes.yaml
+++ b/releasenotes/notes/deduplicate-adjacent-vs-routes.yaml
@@ -1,0 +1,15 @@
+apiVersion: release-notes/v2
+
+kind: feature
+
+area: traffic-management
+
+# releaseNotes is a markdown listing of any user facing changes. This will appear in the
+# release notes.
+releaseNotes:
+  - |
+    This change improves the routing configuration by deduplicating adjacent routes in a virtual service.
+    This means that if two routes are adjacent and reduce to the same match conditions, only the first route
+    will be kept. This should result in more efficient routing configurations generated from some large virtual 
+    services, especially those that match on properties of the source proxy itself.
+

--- a/releasenotes/notes/deduplicate-adjacent-vs-routes.yaml
+++ b/releasenotes/notes/deduplicate-adjacent-vs-routes.yaml
@@ -1,14 +1,9 @@
 apiVersion: release-notes/v2
-
 kind: feature
-
 area: traffic-management
-
-# releaseNotes is a markdown listing of any user facing changes. This will appear in the
-# release notes.
 releaseNotes:
   - |
-    This change improves the routing configuration by deduplicating adjacent routes in a virtual service.
+    **Optimized** This change improves the routing configuration by deduplicating adjacent routes in a virtual service.
     This means that if two routes are adjacent and reduce to the same match conditions, only the first route
     will be kept. This should result in more efficient routing configurations generated from some large virtual 
     services, especially those that match on properties of the source proxy itself.


### PR DESCRIPTION
**Please provide a description of this PR:**
Consider a virtual service of the following format:
```
apiVersion: networking.istio.io/v1
kind: VirtualService
metadata:
  name: foo
  namespace: foo
spec:
  hosts:
  - foo
  http:
  - match:
    - uri:
        prefix: "/foo"
        sourceLabels:
           app: "app"
    route:
    - destination:
        host: foo
        subset: v1
  - match:
     - uri:
         prefix: "/foo"
    route:
    - destination:
        host: foo
        subset: v2
```
For a pod with label "app: app", Istio will generate two http routes with the same match clause. This becomes an issue for large virtual services (e.g. 100-1000+ routes) that frequently use similar "source selecting" fields in the HTTPMatchRequest block. Extraneous routes can slow down total throughput as routes are iterated in order in Envoy as well as increase the memory footprint.

A quick optimization one can do is simply post-process the Envoy HTTP routes and remove any route that has the same match block as a previously-generated route. This moves the processing from the data plane to the control plane. This PR does this, but only deduplicates adjacent routes to avoid O(n^2) processing.

Although this is a **very, very** niche problem, given the small amount of code changes necessary and the fact that some deduplication already occurs in the TLS route processing code, I felt it may be worth posting a PR :).