### PR TITLE
fix TestBinarySizes for envoy arm64

### DIFF
--- a/tests/binary/binaries_test.go
+++ b/tests/binary/binaries_test.go
@@ -112,7 +112,7 @@ func TestBinarySizes(t *testing.T) {
 		"bug-report":      {60, 80},
 		"client":          {15, 30},
 		"server":          {15, 30},
-		"envoy":           {60, 140},
+		"envoy":           {60, 150},
 		"ztunnel":         {12, 17},
 	}
 


### PR DESCRIPTION
**Please provide a description of this PR:**

we need 146mb for arm64.

xref: https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/57111/unit-tests-arm64_istio/1948584644928606208

```
=== RUN   TestBinarySizes/envoy
    binaries_test.go:130: Actual size: 146mb. Range: [60mb, 140mb]
    binaries_test.go:132: Binary size of 146mb was greater than max allowed size 140mb

```