### PR TITLE
57158: fix cni values

### DIFF
--- a/manifests/charts/install-OpenShift.md
+++ b/manifests/charts/install-OpenShift.md
@@ -18,7 +18,7 @@ The installation process using the Helm charts is as follows:
 helm install istio-base -n istio-system manifests/charts/base --set profile=openshift
 ```
 
-2) `istio-cni` chart installs the CNI plugin. This should be installed after the `base` chart and prior to `istiod` chart. Need to add `--set pilot.cni.enabled=true` to the `istiod` install to enable its usage.
+2) `istio-cni` chart installs the CNI plugin. This should be installed after the `base` chart and prior to `istiod` chart. Need to add `--set cni.enabled=true` to the `istiod` install to enable its usage.
 
 ```console
 helm install istio-cni -n kube-system manifests/charts/istio-cni --set profile=openshift

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -47,8 +47,8 @@ metadata:
     kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
     {{- end }}
     {{- end }}
-{{- if .Values.pilot.cni.enabled }}
-    {{- if eq .Values.pilot.cni.provider "multus" }}
+{{- if .Values.cni.enabled }}
+    {{- if eq .Values.cni.provider "multus" }}
     k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
     {{- end }}
     sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -79,7 +79,7 @@ spec:
   {{ else -}}
   initContainers:
   {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-  {{ if .Values.pilot.cni.enabled -}}
+  {{ if .Values.cni.enabled -}}
   - name: istio-validation
   {{ else -}}
   - name: istio-init
@@ -135,7 +135,7 @@ spec:
     {{ if .Values.global.logAsJson -}}
     - "--log_as_json"
     {{ end -}}
-    {{ if .Values.pilot.cni.enabled -}}
+    {{ if .Values.cni.enabled -}}
     - "--run-validation"
     - "--skip-rule-apply"
     {{ else if .Values.global.proxy_init.forceApplyIptables -}}
@@ -158,14 +158,14 @@ spec:
       allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
       privileged: {{ .Values.global.proxy.privileged }}
       capabilities:
-    {{- if not .Values.pilot.cni.enabled }}
+    {{- if not .Values.cni.enabled }}
         add:
         - NET_ADMIN
         - NET_RAW
     {{- end }}
         drop:
         - ALL
-    {{- if not .Values.pilot.cni.enabled }}
+    {{- if not .Values.cni.enabled }}
       readOnlyRootFilesystem: false
       runAsGroup: 0
       runAsNonRoot: false
@@ -496,7 +496,7 @@ spec:
           audience: {{ .Values.global.sds.token.aud }}
   {{- if eq .Values.global.pilotCertProvider "istiod" }}
   - name: istiod-ca-cert
-  {{- if eq (.Values.pilot.env).ENABLE_CLUSTER_TRUST_BUNDLE_API true }}
+  {{- if eq (.Values.env).ENABLE_CLUSTER_TRUST_BUNDLE_API true }}
     projected:
       sources:
       - clusterTrustBundle:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -17116,8 +17116,8 @@ data:
             kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
             {{- end }}
             {{- end }}
-        {{- if .Values.pilot.cni.enabled }}
-            {{- if eq .Values.pilot.cni.provider "multus" }}
+        {{- if .Values.cni.enabled }}
+            {{- if eq .Values.cni.provider "multus" }}
             k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
             {{- end }}
             sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -17141,7 +17141,7 @@ data:
               (not $nativeSidecar) }}
           initContainers:
           {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-          {{ if .Values.pilot.cni.enabled -}}
+          {{ if .Values.cni.enabled -}}
           - name: istio-validation
           {{ else -}}
           - name: istio-init
@@ -17193,7 +17193,7 @@ data:
             {{ if .Values.global.logAsJson -}}
             - "--log_as_json"
             {{ end -}}
-            {{ if .Values.pilot.cni.enabled -}}
+            {{ if .Values.cni.enabled -}}
             - "--run-validation"
             - "--skip-rule-apply"
             {{ end -}}
@@ -17211,14 +17211,14 @@ data:
               allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
               privileged: {{ .Values.global.proxy.privileged }}
               capabilities:
-            {{- if not .Values.pilot.cni.enabled }}
+            {{- if not .Values.cni.enabled }}
                 add:
                 - NET_ADMIN
                 - NET_RAW
             {{- end }}
                 drop:
                 - ALL
-            {{- if not .Values.pilot.cni.enabled }}
+            {{- if not .Values.cni.enabled }}
               readOnlyRootFilesystem: false
               runAsGroup: 0
               runAsNonRoot: false

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -533,8 +533,8 @@ data:
             kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
             {{- end }}
             {{- end }}
-        {{- if .Values.pilot.cni.enabled }}
-            {{- if eq .Values.pilot.cni.provider "multus" }}
+        {{- if .Values.cni.enabled }}
+            {{- if eq .Values.cni.provider "multus" }}
             k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
             {{- end }}
             sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -558,7 +558,7 @@ data:
               (not $nativeSidecar) }}
           initContainers:
           {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-          {{ if .Values.pilot.cni.enabled -}}
+          {{ if .Values.cni.enabled -}}
           - name: istio-validation
           {{ else -}}
           - name: istio-init
@@ -610,7 +610,7 @@ data:
             {{ if .Values.global.logAsJson -}}
             - "--log_as_json"
             {{ end -}}
-            {{ if .Values.pilot.cni.enabled -}}
+            {{ if .Values.cni.enabled -}}
             - "--run-validation"
             - "--skip-rule-apply"
             {{ end -}}
@@ -628,14 +628,14 @@ data:
               allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
               privileged: {{ .Values.global.proxy.privileged }}
               capabilities:
-            {{- if not .Values.pilot.cni.enabled }}
+            {{- if not .Values.cni.enabled }}
                 add:
                 - NET_ADMIN
                 - NET_RAW
             {{- end }}
                 drop:
                 - ALL
-            {{- if not .Values.pilot.cni.enabled }}
+            {{- if not .Values.cni.enabled }}
               readOnlyRootFilesystem: false
               runAsGroup: 0
               runAsNonRoot: false

--- a/operator/cmd/mesh/testdata/manifest-generate/output/sidecar_template.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/sidecar_template.golden.yaml
@@ -61,8 +61,8 @@ data:
             kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
             {{- end }}
             {{- end }}
-        {{- if .Values.pilot.cni.enabled }}
-            {{- if eq .Values.pilot.cni.provider "multus" }}
+        {{- if .Values.cni.enabled }}
+            {{- if eq .Values.cni.provider "multus" }}
             k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
             {{- end }}
             sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -86,7 +86,7 @@ data:
               (not $nativeSidecar) }}
           initContainers:
           {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-          {{ if .Values.pilot.cni.enabled -}}
+          {{ if .Values.cni.enabled -}}
           - name: istio-validation
           {{ else -}}
           - name: istio-init
@@ -138,7 +138,7 @@ data:
             {{ if .Values.global.logAsJson -}}
             - "--log_as_json"
             {{ end -}}
-            {{ if .Values.pilot.cni.enabled -}}
+            {{ if .Values.cni.enabled -}}
             - "--run-validation"
             - "--skip-rule-apply"
             {{ end -}}
@@ -156,14 +156,14 @@ data:
               allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
               privileged: {{ .Values.global.proxy.privileged }}
               capabilities:
-            {{- if not .Values.pilot.cni.enabled }}
+            {{- if not .Values.cni.enabled }}
                 add:
                 - NET_ADMIN
                 - NET_RAW
             {{- end }}
                 drop:
                 - ALL
-            {{- if not .Values.pilot.cni.enabled }}
+            {{- if not .Values.cni.enabled }}
               readOnlyRootFilesystem: false
               runAsGroup: 0
               runAsNonRoot: false

--- a/operator/pkg/render/manifest.go
+++ b/operator/pkg/render/manifest.go
@@ -373,7 +373,7 @@ func translateIstioOperatorToHelm(base values.Map) (values.Map, error) {
 	if err := base.SetPath("spec.values.pilot.enabled", base.GetPathBool("spec.components.pilot.enabled")); err != nil {
 		return nil, err
 	}
-	if err := base.SetPath("spec.values.pilot.cni.enabled", base.GetPathBool("spec.components.cni.enabled")); err != nil {
+	if err := base.SetPath("spec.values.cni.enabled", base.GetPathBool("spec.components.cni.enabled")); err != nil {
 		return nil, err
 	}
 	if n := base.GetPathString("spec.values.global.istioNamespace"); n != "" {

--- a/pkg/config/analysis/analyzers/testdata/common/sidecar-injector-configmap.yaml
+++ b/pkg/config/analysis/analyzers/testdata/common/sidecar-injector-configmap.yaml
@@ -8,10 +8,10 @@ data:
       []
     template: |
       rewriteAppHTTPProbe: {{ valueOrDefault .Values.sidecarInjectorWebhook.rewriteAppHTTPProbe false }}
-      {{- if or (not .Values.pilot.cni.enabled) .Values.global.proxy.enableCoreDump }}
+      {{- if or (not .Values.cni.enabled) .Values.global.proxy.enableCoreDump }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{- if not .Values.pilot.cni.enabled }}
+      {{- if not .Values.cni.enabled }}
       - name: istio-init
       {{- if contains "/" .Values.global.proxy_init.image }}
         image: "{{ .Values.global.proxy_init.image }}"

--- a/pkg/config/analysis/analyzers/testdata/common/sidecar-injector-enabled-nsbydefault.yaml
+++ b/pkg/config/analysis/analyzers/testdata/common/sidecar-injector-enabled-nsbydefault.yaml
@@ -8,10 +8,10 @@ data:
       []
     template: |
       rewriteAppHTTPProbe: {{ valueOrDefault .Values.sidecarInjectorWebhook.rewriteAppHTTPProbe false }}
-      {{- if or (not .Values.pilot.cni.enabled) .Values.global.proxy.enableCoreDump }}
+      {{- if or (not .Values.cni.enabled) .Values.global.proxy.enableCoreDump }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{- if not .Values.pilot.cni.enabled }}
+      {{- if not .Values.cni.enabled }}
       - name: istio-init
       {{- if contains "/" .Values.global.proxy_init.image }}
         image: "{{ .Values.global.proxy_init.image }}"

--- a/pkg/config/analysis/analyzers/testdata/sidecar-injector-configmap-absolute-override.yaml
+++ b/pkg/config/analysis/analyzers/testdata/sidecar-injector-configmap-absolute-override.yaml
@@ -8,10 +8,10 @@ data:
       []
     template: |
       rewriteAppHTTPProbe: {{ valueOrDefault .Values.sidecarInjectorWebhook.rewriteAppHTTPProbe false }}
-      {{- if not .Values.pilot.cni.enabled .Values.global.proxy.enableCoreDump }}
+      {{- if not .Values.cni.enabled .Values.global.proxy.enableCoreDump }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{- if not .Values.pilot.cni.enabled }}
+      {{- if not .Values.cni.enabled }}
       - name: istio-init
       {{- if contains "/" .Values.global.proxy_init.image }}
         image: "{{ .Values.global.proxy_init.image }}"

--- a/pkg/config/analysis/analyzers/testdata/sidecar-injector-configmap-with-revision-canary.yaml
+++ b/pkg/config/analysis/analyzers/testdata/sidecar-injector-configmap-with-revision-canary.yaml
@@ -8,10 +8,10 @@ data:
       []
     template: |
       rewriteAppHTTPProbe: {{ valueOrDefault .Values.sidecarInjectorWebhook.rewriteAppHTTPProbe false }}
-      {{- if or (not .Values.pilot.cni.enabled) .Values.global.proxy.enableCoreDump }}
+      {{- if or (not .Values.cni.enabled) .Values.global.proxy.enableCoreDump }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{- if not .Values.pilot.cni.enabled }}
+      {{- if not .Values.cni.enabled }}
       - name: istio-init
       {{- if contains "/" .Values.global.proxy_init.image }}
         image: "{{ .Values.global.proxy_init.image }}"

--- a/releasenotes/notes/57158.yaml
+++ b/releasenotes/notes/57158.yaml
@@ -1,0 +1,17 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+  - https://github.com/istio/istio/issues/57158
+# releaseNotes is a markdown listing of any user facing changes. This will appear in the
+# release notes.
+releaseNotes:
+  - |
+    **Fixed** a bug where the `env`, `cni.enabled` and `cni.provider` values were not correctly
+    picked up in `files/injection-template`.
+
+upgradeNotes:
+  - title: Review changes to the sidecar injection-template
+    content: |
+      Review the sidecar injection template in the `istio-sidecar-injector[-<revision>]` ConfigMap for
+      changes. This change corrects errors in the template.


### PR DESCRIPTION
**Please provide a description of this PR:**

I identified an issue with some regressions to referencing `.Values.pilot.cni.*` instead of `.Values.cni.*` as seen in the modern charts `values.yaml` 

This PR patches any observance of `.Values.pilot.cni.*`  and also `.Values.pilot.env` in istio-discovery.

[Issue](https://github.com/istio/istio/issues/57158)