### PR TITLE
Make CONTAINER_OPTIONS customizable for different container runtimes

### DIFF
--- a/Makefile.overrides.mk
+++ b/Makefile.overrides.mk
@@ -19,7 +19,10 @@
 # For more information see: https://github.com/istio/istio/pull/19322/
 
 BUILD_WITH_CONTAINER ?= 1
-CONTAINER_OPTIONS = --mount type=bind,source=/tmp,destination=/tmp --net=host
+# Container options for the build container. Can be customized for different container runtimes.
+# Example for podman on macOS: CONTAINER_OPTIONS="--mount type=bind,source=/tmp,destination=/tmp --net=host --security-opt label=disable"
+# Note: --security-opt label=disable disables SELinux labeling (safer than --privileged)
+CONTAINER_OPTIONS ?= --mount type=bind,source=/tmp,destination=/tmp --net=host
 
 export COMMONFILES_POSTPROCESS = tools/commonfiles-postprocess.sh
 


### PR DESCRIPTION
**Please provide a description of this PR:**
Fixes: #57192

**Problem**
`CONTAINER_OPTIONS` is currently hardcoded, preventing users with different container runtimes from customizing build container options. This particularly affects:
* Podman users on macOS who need `--security-opt label=disable` for SELinux compatibility
* Users requiring runtime-specific flags for their build environment

**Solution**
Changed `CONTAINER_OPTIONS` from hardcoded assignment to default assignment, allowing user customization while maintaining backward compatibility.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [x] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
