### PR TITLE
iptables: gracefully handle missing IPv6 support

### DIFF
--- a/cni/pkg/iptables/iptables.go
+++ b/cni/pkg/iptables/iptables.go
@@ -145,9 +145,14 @@ func NewIptablesConfigurator(
 
 		ipt6Ver, err := hostDeps.DetectIptablesVersion(true)
 		if err != nil {
-			return err
+			if hostCfg.EnableIPv6 {
+				return err
+			}
+			log.Warnf("Failed to detect a working ip6tables binary; continuing because IPv6 support is disabled (ENABLE_INBOUND_IPV6=false): %v", err)
+			ipt6Ver = dep.IptablesVersion{}
+		} else {
+			log.Debugf("found iptables v6 binary: %+v", ipt6Ver)
 		}
-		log.Debugf("found iptables v6 binary: %+v", iptVer)
 
 		configurator.ipt6V = ipt6Ver
 		return nil
@@ -489,7 +494,9 @@ func (cfg *IptablesConfigurator) executeCommands(log *istiolog.Scope, iptablesBu
 			log.Info("Removing guardrails")
 			guardrailsCleanup := iptablesBuilder.BuildCleanupGuardrails()
 			_ = cfg.executeIptablesCommands(log, &cfg.iptV, guardrailsCleanup)
-			_ = cfg.executeIptablesCommands(log, &cfg.ipt6V, guardrailsCleanup)
+			if cfg.cfg.EnableIPv6 {
+				_ = cfg.executeIptablesCommands(log, &cfg.ipt6V, guardrailsCleanup)
+			}
 		}
 	}()
 	residueExists, deltaExists := iptablescapture.VerifyIptablesState(log, cfg.ext, iptablesBuilder, &cfg.iptV, &cfg.ipt6V)
@@ -503,9 +510,13 @@ func (cfg *IptablesConfigurator) executeCommands(log *istiolog.Scope, iptablesBu
 			log.Info("Setting up guardrails")
 			guardrailsCleanup := iptablesBuilder.BuildCleanupGuardrails()
 			guardrailsRules := iptablesBuilder.BuildGuardrails()
-			for _, ver := range []*dep.IptablesVersion{&cfg.iptV, &cfg.ipt6V} {
-				cfg.tryExecuteIptablesCommands(log, ver, guardrailsCleanup)
-				if err := cfg.executeIptablesCommands(log, ver, guardrailsRules); err != nil {
+			iptVersions := []dep.IptablesVersion{cfg.iptV}
+			if cfg.cfg.EnableIPv6 {
+				iptVersions = append(iptVersions, cfg.ipt6V)
+			}
+			for _, ver := range iptVersions {
+				cfg.tryExecuteIptablesCommands(log, &ver, guardrailsCleanup)
+				if err := cfg.executeIptablesCommands(log, &ver, guardrailsRules); err != nil {
 					return err
 				}
 				guardrails = true
@@ -514,7 +525,9 @@ func (cfg *IptablesConfigurator) executeCommands(log *istiolog.Scope, iptablesBu
 		// Remove old iptables
 		log.Info("Performing cleanup of existing iptables")
 		cfg.tryExecuteIptablesCommands(log, &cfg.iptV, iptablesBuilder.BuildCleanupV4())
-		cfg.tryExecuteIptablesCommands(log, &cfg.ipt6V, iptablesBuilder.BuildCleanupV6())
+		if cfg.cfg.EnableIPv6 {
+			cfg.tryExecuteIptablesCommands(log, &cfg.ipt6V, iptablesBuilder.BuildCleanupV6())
+		}
 
 		// Remove leftovers from non-matching istio iptables cfg
 		if cfg.cfg.Reconcile {
@@ -540,7 +553,7 @@ func (cfg *IptablesConfigurator) cleanupIstioLeftovers(log *istiolog.Scope, ext 
 	iptV *dep.IptablesVersion, ipt6V *dep.IptablesVersion,
 ) {
 	for _, ipVer := range []*dep.IptablesVersion{iptV, ipt6V} {
-		if ipVer == nil {
+		if ipVer.DetectedBinary == "" {
 			continue
 		}
 		output, err := ext.Run(log, true, iptablesconstants.IPTablesSave, ipVer, nil)

--- a/cni/pkg/iptables/iptables_test.go
+++ b/cni/pkg/iptables/iptables_test.go
@@ -22,6 +22,7 @@ import (
 
 	"istio.io/istio/cni/pkg/scopes"
 	testutil "istio.io/istio/pilot/test/util"
+	"istio.io/istio/pkg/test/util/assert"
 	dep "istio.io/istio/tools/istio-iptables/pkg/dependencies"
 )
 
@@ -45,6 +46,23 @@ func TestIptablesPodOverrides(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestIPv6NotAvailable(t *testing.T) {
+	setup(t)
+	cfg := constructTestConfig()
+	ext := &dep.DependenciesStub{
+		ForceIPv6DetectionFail: true,
+	}
+
+	// Istio shouldn't fail if we're working with IPv4 interfaces only, and ip6tables is unavailable.
+	cfg.EnableIPv6 = false
+	_, _, err := NewIptablesConfigurator(cfg, cfg, ext, ext, EmptyNlDeps())
+	assert.NoError(t, err)
+
+	cfg.EnableIPv6 = true
+	_, _, err = NewIptablesConfigurator(cfg, cfg, ext, ext, EmptyNlDeps())
+	assert.Error(t, err)
 }
 
 func TestIptablesHostRules(t *testing.T) {

--- a/tools/istio-iptables/pkg/capture/run_linux_test.go
+++ b/tools/istio-iptables/pkg/capture/run_linux_test.go
@@ -98,6 +98,23 @@ func TestIdempotentEquivalentRerun(t *testing.T) {
 	}
 }
 
+func TestIPv6NotAvailable(t *testing.T) {
+	setup(t)
+	cfg := constructTestConfig()
+	ext := &dep.DependenciesStub{
+		ForceIPv6DetectionFail: true,
+	}
+
+	// Istio shouldn't fail if we're working with IPv4 interfaces only, and ip6tables is unavailable.
+	cfg.EnableIPv6 = false
+	iptConfigurator, _ := NewIptablesConfigurator(cfg, ext)
+	assert.NoError(t, iptConfigurator.Run())
+
+	cfg.EnableIPv6 = true
+	_, err := NewIptablesConfigurator(cfg, ext)
+	assert.Error(t, err)
+}
+
 var initialized = &sync.Once{}
 
 func setup(t *testing.T) {

--- a/tools/istio-iptables/pkg/dependencies/stub.go
+++ b/tools/istio-iptables/pkg/dependencies/stub.go
@@ -31,10 +31,12 @@ var DryRunFilePath = env.Register("DRY_RUN_FILE_PATH", "", "If provided, StdoutS
 
 // TODO BML replace DIY mocks/state with something better
 type DependenciesStub struct {
-	ExecutedNormally []string
-	ExecutedQuietly  []string
-	ExecutedStdin    []string
-	ExecutedAll      []string
+	ExecutedNormally       []string
+	ExecutedQuietly        []string
+	ExecutedStdin          []string
+	ExecutedAll            []string
+	ForceIPv4DetectionFail bool
+	ForceIPv6DetectionFail bool
 }
 
 func (s *DependenciesStub) Run(logger *log.Scope,
@@ -51,11 +53,17 @@ func (s *DependenciesStub) Run(logger *log.Scope,
 
 func (s *DependenciesStub) DetectIptablesVersion(ipV6 bool) (IptablesVersion, error) {
 	if ipV6 {
+		if s.ForceIPv6DetectionFail {
+			return IptablesVersion{}, fmt.Errorf("ip6tables binary not found")
+		}
 		return IptablesVersion{
 			DetectedBinary:        "ip6tables",
 			DetectedSaveBinary:    "ip6tables-save",
 			DetectedRestoreBinary: "ip6tables-restore",
 		}, nil
+	}
+	if s.ForceIPv4DetectionFail {
+		return IptablesVersion{}, fmt.Errorf("iptables binary not found")
 	}
 	return IptablesVersion{
 		DetectedBinary:        "iptables",


### PR DESCRIPTION
When IPv6 support is disabled (`EnableIPv6=false`), iptables initialization now skips detection of the `ip6tables` binary instead of returning an error. This allows running in IPv4-only mode even when IPv6 is disabled in the kernel (e.g. `ipv6.disable=1` kernel parameter).

**Please provide a description of this PR:** Fixes https://github.com/istio/istio/issues/57199