### PR TITLE
Add counters in the nftable rules

### DIFF
--- a/tools/istio-nftables/pkg/capture/testdata/basic-exclude-nic.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/basic-exclude-nic.golden
@@ -6,17 +6,17 @@ add chain inet istio-proxy-nat istio-inbound
 add chain inet istio-proxy-nat istio-redirect
 add chain inet istio-proxy-nat istio-in-redirect
 add chain inet istio-proxy-nat istio-output
-add rule inet istio-proxy-nat prerouting iifname not-istio-nic return
-add rule inet istio-proxy-nat output oifname not-istio-nic return
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 return
-add rule inet istio-proxy-nat istio-redirect meta l4proto tcp redirect to :15001
-add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp redirect to :15006
-add rule inet istio-proxy-nat output jump istio-output
-add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 return
-add rule inet istio-proxy-nat istio-output skuid 1337 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 return
-add rule inet istio-proxy-nat istio-output skgid 1337 return
-add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 return
+add rule inet istio-proxy-nat prerouting iifname not-istio-nic counter return
+add rule inet istio-proxy-nat output oifname not-istio-nic counter return
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 counter return
+add rule inet istio-proxy-nat istio-redirect meta l4proto tcp counter redirect to :15001
+add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp counter redirect to :15006
+add rule inet istio-proxy-nat output counter jump istio-output
+add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skuid 1337 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skgid 1337 counter return
+add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 counter return

--- a/tools/istio-nftables/pkg/capture/testdata/dns-uid-gid.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/dns-uid-gid.golden
@@ -6,52 +6,52 @@ add chain inet istio-proxy-nat istio-redirect
 add chain inet istio-proxy-nat istio-in-redirect
 add chain inet istio-proxy-nat istio-output
 add chain inet istio-proxy-nat istio-output-dns
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 return
-add rule inet istio-proxy-nat istio-redirect meta l4proto tcp redirect to :15001
-add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp redirect to :15006
-add rule inet istio-proxy-nat output jump istio-output
-add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 return
-add rule inet istio-proxy-nat istio-output oifname lo ip6 saddr ::6/128 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != { 53, 15008 } skuid 3 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != { 53, 15008 } skuid 3 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skuid != 3 return
-add rule inet istio-proxy-nat istio-output skuid 3 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != { 53, 15008 } skuid 4 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != { 53, 15008 } skuid 4 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skuid != 4 return
-add rule inet istio-proxy-nat istio-output skuid 4 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skgid 1 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skgid != 1 return
-add rule inet istio-proxy-nat istio-output skgid 1 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 2 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skgid 2 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skgid != 2 return
-add rule inet istio-proxy-nat istio-output skgid 2 return
-add rule inet istio-proxy-nat istio-output jump istio-output-dns
-add rule inet istio-proxy-nat istio-output-dns ip daddr 127.0.0.53/32 tcp dport 53 redirect to :15053
-add rule inet istio-proxy-nat istio-output-dns ip6 daddr ::127.0.0.53/128 tcp dport 53 redirect to :15053
-add rule inet istio-proxy-nat istio-output-dns ip daddr 127.0.0.53/32 udp dport 53 redirect to :15053
-add rule inet istio-proxy-nat istio-output-dns ip6 daddr ::127.0.0.53/128 udp dport 53 redirect to :15053
-add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 return
-add rule inet istio-proxy-nat istio-output ip6 daddr ::1/128 return
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 counter return
+add rule inet istio-proxy-nat istio-redirect meta l4proto tcp counter redirect to :15001
+add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp counter redirect to :15006
+add rule inet istio-proxy-nat output counter jump istio-output
+add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 counter return
+add rule inet istio-proxy-nat istio-output oifname lo ip6 saddr ::6/128 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != { 53, 15008 } skuid 3 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != { 53, 15008 } skuid 3 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skuid != 3 counter return
+add rule inet istio-proxy-nat istio-output skuid 3 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != { 53, 15008 } skuid 4 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != { 53, 15008 } skuid 4 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skuid != 4 counter return
+add rule inet istio-proxy-nat istio-output skuid 4 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skgid 1 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skgid != 1 counter return
+add rule inet istio-proxy-nat istio-output skgid 1 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 2 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skgid 2 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skgid != 2 counter return
+add rule inet istio-proxy-nat istio-output skgid 2 counter return
+add rule inet istio-proxy-nat istio-output counter jump istio-output-dns
+add rule inet istio-proxy-nat istio-output-dns ip daddr 127.0.0.53/32 tcp dport 53 counter redirect to :15053
+add rule inet istio-proxy-nat istio-output-dns ip6 daddr ::127.0.0.53/128 tcp dport 53 counter redirect to :15053
+add rule inet istio-proxy-nat istio-output-dns ip daddr 127.0.0.53/32 udp dport 53 counter redirect to :15053
+add rule inet istio-proxy-nat istio-output-dns ip6 daddr ::127.0.0.53/128 udp dport 53 counter redirect to :15053
+add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 counter return
+add rule inet istio-proxy-nat istio-output ip6 daddr ::1/128 counter return
 add table inet istio-proxy-raw
 flush table inet istio-proxy-raw
 add chain inet istio-proxy-raw prerouting { type filter hook prerouting priority -300 ; }
 add chain inet istio-proxy-raw output { type filter hook output priority -300 ; }
 add chain inet istio-proxy-raw istio-inbound
 add chain inet istio-proxy-raw istio-output-dns
-add rule inet istio-proxy-raw output jump istio-output-dns
-add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skuid 3 ct zone set 1
-add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skuid 3 ct zone set 2
-add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skuid 4 ct zone set 1
-add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skuid 4 ct zone set 2
-add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skgid 1 ct zone set 1
-add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skgid 1 ct zone set 2
-add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skgid 2 ct zone set 1
-add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skgid 2 ct zone set 2
-add rule inet istio-proxy-raw prerouting jump istio-inbound
-add rule inet istio-proxy-raw istio-output-dns udp dport 53 ip daddr 127.0.0.53/32 ct zone set 2
-add rule inet istio-proxy-raw istio-inbound udp sport 53 ip saddr 127.0.0.53/32 ct zone set 1
-add rule inet istio-proxy-raw istio-output-dns udp dport 53 ip6 daddr ::127.0.0.53/128 ct zone set 2
-add rule inet istio-proxy-raw istio-inbound udp sport 53 ip6 saddr ::127.0.0.53/128 ct zone set 1
+add rule inet istio-proxy-raw output counter jump istio-output-dns
+add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skuid 3 counter ct zone set 1
+add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skuid 3 counter ct zone set 2
+add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skuid 4 counter ct zone set 1
+add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skuid 4 counter ct zone set 2
+add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skgid 1 counter ct zone set 1
+add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skgid 1 counter ct zone set 2
+add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skgid 2 counter ct zone set 1
+add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skgid 2 counter ct zone set 2
+add rule inet istio-proxy-raw prerouting counter jump istio-inbound
+add rule inet istio-proxy-raw istio-output-dns udp dport 53 ip daddr 127.0.0.53/32 counter ct zone set 2
+add rule inet istio-proxy-raw istio-inbound udp sport 53 ip saddr 127.0.0.53/32 counter ct zone set 1
+add rule inet istio-proxy-raw istio-output-dns udp dport 53 ip6 daddr ::127.0.0.53/128 counter ct zone set 2
+add rule inet istio-proxy-raw istio-inbound udp sport 53 ip6 saddr ::127.0.0.53/128 counter ct zone set 1

--- a/tools/istio-nftables/pkg/capture/testdata/drop-invalid.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/drop-invalid.golden
@@ -5,21 +5,21 @@ add chain inet istio-proxy-nat istio-inbound
 add chain inet istio-proxy-nat istio-redirect
 add chain inet istio-proxy-nat istio-in-redirect
 add chain inet istio-proxy-nat istio-output
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 return
-add rule inet istio-proxy-nat istio-redirect meta l4proto tcp redirect to :15001
-add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp redirect to :15006
-add rule inet istio-proxy-nat output jump istio-output
-add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 return
-add rule inet istio-proxy-nat istio-output skuid 1337 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 return
-add rule inet istio-proxy-nat istio-output skgid 1337 return
-add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 return
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 counter return
+add rule inet istio-proxy-nat istio-redirect meta l4proto tcp counter redirect to :15001
+add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp counter redirect to :15006
+add rule inet istio-proxy-nat output counter jump istio-output
+add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skuid 1337 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skgid 1337 counter return
+add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 counter return
 add table inet istio-proxy-mangle
 flush table inet istio-proxy-mangle
 add chain inet istio-proxy-mangle prerouting { type filter hook prerouting priority -150 ; }
 add chain inet istio-proxy-mangle istio-drop
-add rule inet istio-proxy-mangle prerouting meta l4proto tcp ct state invalid jump istio-drop
-add rule inet istio-proxy-mangle istio-drop drop
+add rule inet istio-proxy-mangle prerouting meta l4proto tcp ct state invalid counter jump istio-drop
+add rule inet istio-proxy-mangle istio-drop counter drop

--- a/tools/istio-nftables/pkg/capture/testdata/empty.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/empty.golden
@@ -5,15 +5,15 @@ add chain inet istio-proxy-nat istio-inbound
 add chain inet istio-proxy-nat istio-redirect
 add chain inet istio-proxy-nat istio-in-redirect
 add chain inet istio-proxy-nat istio-output
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 return
-add rule inet istio-proxy-nat istio-redirect meta l4proto tcp redirect to :15001
-add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp redirect to :15006
-add rule inet istio-proxy-nat output jump istio-output
-add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 return
-add rule inet istio-proxy-nat istio-output skuid 1337 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 return
-add rule inet istio-proxy-nat istio-output skgid 1337 return
-add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 return
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 counter return
+add rule inet istio-proxy-nat istio-redirect meta l4proto tcp counter redirect to :15001
+add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp counter redirect to :15006
+add rule inet istio-proxy-nat output counter jump istio-output
+add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skuid 1337 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skgid 1337 counter return
+add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 counter return

--- a/tools/istio-nftables/pkg/capture/testdata/host-ipv4-loopback-cidr.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/host-ipv4-loopback-cidr.golden
@@ -5,15 +5,15 @@ add chain inet istio-proxy-nat istio-inbound
 add chain inet istio-proxy-nat istio-redirect
 add chain inet istio-proxy-nat istio-in-redirect
 add chain inet istio-proxy-nat istio-output
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 return
-add rule inet istio-proxy-nat istio-redirect meta l4proto tcp redirect to :15001
-add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp redirect to :15006
-add rule inet istio-proxy-nat output jump istio-output
-add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/8 tcp dport != 15008 skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 return
-add rule inet istio-proxy-nat istio-output skuid 1337 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/8 tcp dport != 15008 skgid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 return
-add rule inet istio-proxy-nat istio-output skgid 1337 return
-add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/8 return
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 counter return
+add rule inet istio-proxy-nat istio-redirect meta l4proto tcp counter redirect to :15001
+add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp counter redirect to :15006
+add rule inet istio-proxy-nat output counter jump istio-output
+add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/8 tcp dport != 15008 skuid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skuid 1337 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/8 tcp dport != 15008 skgid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skgid 1337 counter return
+add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/8 counter return

--- a/tools/istio-nftables/pkg/capture/testdata/inbound-ports-include.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/inbound-ports-include.golden
@@ -6,18 +6,18 @@ add chain inet istio-proxy-nat istio-inbound
 add chain inet istio-proxy-nat istio-redirect
 add chain inet istio-proxy-nat istio-in-redirect
 add chain inet istio-proxy-nat istio-output
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 return
-add rule inet istio-proxy-nat istio-redirect meta l4proto tcp redirect to :15001
-add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp redirect to :15006
-add rule inet istio-proxy-nat prerouting meta l4proto tcp jump istio-inbound
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 32000 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 31000 jump istio-in-redirect
-add rule inet istio-proxy-nat output jump istio-output
-add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 return
-add rule inet istio-proxy-nat istio-output skuid 1337 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 return
-add rule inet istio-proxy-nat istio-output skgid 1337 return
-add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 return
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 counter return
+add rule inet istio-proxy-nat istio-redirect meta l4proto tcp counter redirect to :15001
+add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp counter redirect to :15006
+add rule inet istio-proxy-nat prerouting meta l4proto tcp counter jump istio-inbound
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 32000 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 31000 counter jump istio-in-redirect
+add rule inet istio-proxy-nat output counter jump istio-output
+add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skuid 1337 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skgid 1337 counter return
+add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 counter return

--- a/tools/istio-nftables/pkg/capture/testdata/inbound-ports-tproxy.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/inbound-ports-tproxy.golden
@@ -5,18 +5,18 @@ add chain inet istio-proxy-nat istio-inbound
 add chain inet istio-proxy-nat istio-redirect
 add chain inet istio-proxy-nat istio-in-redirect
 add chain inet istio-proxy-nat istio-output
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 return
-add rule inet istio-proxy-nat istio-redirect meta l4proto tcp redirect to :15001
-add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp redirect to :15006
-add rule inet istio-proxy-nat output jump istio-output
-add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 return
-add rule inet istio-proxy-nat istio-output skuid 1337 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 return
-add rule inet istio-proxy-nat istio-output skgid 1337 return
-add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 return
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 counter return
+add rule inet istio-proxy-nat istio-redirect meta l4proto tcp counter redirect to :15001
+add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp counter redirect to :15006
+add rule inet istio-proxy-nat output counter jump istio-output
+add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skuid 1337 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skgid 1337 counter return
+add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 counter return
 add table inet istio-proxy-mangle
 flush table inet istio-proxy-mangle
 add chain inet istio-proxy-mangle prerouting { type filter hook prerouting priority -150 ; }
@@ -24,19 +24,19 @@ add chain inet istio-proxy-mangle output { type route hook output priority -150 
 add chain inet istio-proxy-mangle istio-divert
 add chain inet istio-proxy-mangle istio-tproxy
 add chain inet istio-proxy-mangle istio-inbound
-add rule inet istio-proxy-mangle istio-divert meta mark set 1337
-add rule inet istio-proxy-mangle istio-divert accept
-add rule inet istio-proxy-mangle istio-tproxy meta l4proto tcp ip daddr != 127.0.0.1/32 tproxy ip to :15006 meta mark set 1337 accept
-add rule inet istio-proxy-mangle prerouting meta l4proto tcp jump istio-inbound
-add rule inet istio-proxy-mangle istio-inbound meta l4proto tcp ct state related,established tcp dport 32000 jump istio-divert
-add rule inet istio-proxy-mangle istio-inbound meta l4proto tcp tcp dport 32000 jump istio-tproxy
-add rule inet istio-proxy-mangle istio-inbound meta l4proto tcp ct state related,established tcp dport 31000 jump istio-divert
-add rule inet istio-proxy-mangle istio-inbound meta l4proto tcp tcp dport 31000 jump istio-tproxy
-add rule inet istio-proxy-mangle prerouting meta l4proto tcp mark 1337 ct mark set mark
-add rule inet istio-proxy-mangle output oifname lo meta l4proto tcp mark 1337 return
-add rule inet istio-proxy-mangle output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 skuid 1337 meta mark set 1338
-add rule inet istio-proxy-mangle output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 skgid 1337 meta mark set 1338
-add rule inet istio-proxy-mangle output meta l4proto tcp ct mark 1337 meta mark set ct mark
-insert rule inet istio-proxy-mangle istio-inbound index 0 meta l4proto tcp mark 1337 return
-insert rule inet istio-proxy-mangle istio-inbound index 1 iifname lo meta l4proto tcp ip saddr 127.0.0.6/32 return
-insert rule inet istio-proxy-mangle istio-inbound index 2 iifname lo meta l4proto tcp mark != 1338 return
+add rule inet istio-proxy-mangle istio-divert counter meta mark set 1337
+add rule inet istio-proxy-mangle istio-divert counter accept
+add rule inet istio-proxy-mangle istio-tproxy meta l4proto tcp ip daddr != 127.0.0.1/32 tproxy ip to :15006 meta mark set 1337 counter accept
+add rule inet istio-proxy-mangle prerouting meta l4proto tcp counter jump istio-inbound
+add rule inet istio-proxy-mangle istio-inbound meta l4proto tcp ct state related,established tcp dport 32000 counter jump istio-divert
+add rule inet istio-proxy-mangle istio-inbound meta l4proto tcp tcp dport 32000 counter jump istio-tproxy
+add rule inet istio-proxy-mangle istio-inbound meta l4proto tcp ct state related,established tcp dport 31000 counter jump istio-divert
+add rule inet istio-proxy-mangle istio-inbound meta l4proto tcp tcp dport 31000 counter jump istio-tproxy
+add rule inet istio-proxy-mangle prerouting meta l4proto tcp mark 1337 counter ct mark set mark
+add rule inet istio-proxy-mangle output oifname lo meta l4proto tcp mark 1337 counter return
+add rule inet istio-proxy-mangle output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 skuid 1337 counter meta mark set 1338
+add rule inet istio-proxy-mangle output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 skgid 1337 counter meta mark set 1338
+add rule inet istio-proxy-mangle output meta l4proto tcp ct mark 1337 counter meta mark set ct mark
+insert rule inet istio-proxy-mangle istio-inbound index 0 meta l4proto tcp mark 1337 counter return
+insert rule inet istio-proxy-mangle istio-inbound index 1 iifname lo meta l4proto tcp ip saddr 127.0.0.6/32 counter return
+insert rule inet istio-proxy-mangle istio-inbound index 2 iifname lo meta l4proto tcp mark != 1338 counter return

--- a/tools/istio-nftables/pkg/capture/testdata/inbound-ports-wildcard-tproxy.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/inbound-ports-wildcard-tproxy.golden
@@ -5,18 +5,18 @@ add chain inet istio-proxy-nat istio-inbound
 add chain inet istio-proxy-nat istio-redirect
 add chain inet istio-proxy-nat istio-in-redirect
 add chain inet istio-proxy-nat istio-output
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 return
-add rule inet istio-proxy-nat istio-redirect meta l4proto tcp redirect to :15001
-add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp redirect to :15006
-add rule inet istio-proxy-nat output jump istio-output
-add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 return
-add rule inet istio-proxy-nat istio-output skuid 1337 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 return
-add rule inet istio-proxy-nat istio-output skgid 1337 return
-add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 return
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 counter return
+add rule inet istio-proxy-nat istio-redirect meta l4proto tcp counter redirect to :15001
+add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp counter redirect to :15006
+add rule inet istio-proxy-nat output counter jump istio-output
+add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skuid 1337 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skgid 1337 counter return
+add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 counter return
 add table inet istio-proxy-mangle
 flush table inet istio-proxy-mangle
 add chain inet istio-proxy-mangle prerouting { type filter hook prerouting priority -150 ; }
@@ -24,17 +24,17 @@ add chain inet istio-proxy-mangle output { type route hook output priority -150 
 add chain inet istio-proxy-mangle istio-divert
 add chain inet istio-proxy-mangle istio-tproxy
 add chain inet istio-proxy-mangle istio-inbound
-add rule inet istio-proxy-mangle istio-divert meta mark set 1337
-add rule inet istio-proxy-mangle istio-divert accept
-add rule inet istio-proxy-mangle istio-tproxy meta l4proto tcp ip daddr != 127.0.0.1/32 tproxy ip to :15006 meta mark set 1337 accept
-add rule inet istio-proxy-mangle prerouting meta l4proto tcp jump istio-inbound
-add rule inet istio-proxy-mangle istio-inbound meta l4proto tcp ct state related,established jump istio-divert
-add rule inet istio-proxy-mangle istio-inbound meta l4proto tcp jump istio-tproxy
-add rule inet istio-proxy-mangle prerouting meta l4proto tcp mark 1337 ct mark set mark
-add rule inet istio-proxy-mangle output oifname lo meta l4proto tcp mark 1337 return
-add rule inet istio-proxy-mangle output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 skuid 1337 meta mark set 1338
-add rule inet istio-proxy-mangle output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 skgid 1337 meta mark set 1338
-add rule inet istio-proxy-mangle output meta l4proto tcp ct mark 1337 meta mark set ct mark
-insert rule inet istio-proxy-mangle istio-inbound index 0 meta l4proto tcp mark 1337 return
-insert rule inet istio-proxy-mangle istio-inbound index 1 iifname lo meta l4proto tcp ip saddr 127.0.0.6/32 return
-insert rule inet istio-proxy-mangle istio-inbound index 2 iifname lo meta l4proto tcp mark != 1338 return
+add rule inet istio-proxy-mangle istio-divert counter meta mark set 1337
+add rule inet istio-proxy-mangle istio-divert counter accept
+add rule inet istio-proxy-mangle istio-tproxy meta l4proto tcp ip daddr != 127.0.0.1/32 tproxy ip to :15006 meta mark set 1337 counter accept
+add rule inet istio-proxy-mangle prerouting meta l4proto tcp counter jump istio-inbound
+add rule inet istio-proxy-mangle istio-inbound meta l4proto tcp ct state related,established counter jump istio-divert
+add rule inet istio-proxy-mangle istio-inbound meta l4proto tcp counter jump istio-tproxy
+add rule inet istio-proxy-mangle prerouting meta l4proto tcp mark 1337 counter ct mark set mark
+add rule inet istio-proxy-mangle output oifname lo meta l4proto tcp mark 1337 counter return
+add rule inet istio-proxy-mangle output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 skuid 1337 counter meta mark set 1338
+add rule inet istio-proxy-mangle output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 skgid 1337 counter meta mark set 1338
+add rule inet istio-proxy-mangle output meta l4proto tcp ct mark 1337 counter meta mark set ct mark
+insert rule inet istio-proxy-mangle istio-inbound index 0 meta l4proto tcp mark 1337 counter return
+insert rule inet istio-proxy-mangle istio-inbound index 1 iifname lo meta l4proto tcp ip saddr 127.0.0.6/32 counter return
+insert rule inet istio-proxy-mangle istio-inbound index 2 iifname lo meta l4proto tcp mark != 1338 counter return

--- a/tools/istio-nftables/pkg/capture/testdata/inbound-ports-wildcard.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/inbound-ports-wildcard.golden
@@ -6,17 +6,17 @@ add chain inet istio-proxy-nat istio-inbound
 add chain inet istio-proxy-nat istio-redirect
 add chain inet istio-proxy-nat istio-in-redirect
 add chain inet istio-proxy-nat istio-output
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 return
-add rule inet istio-proxy-nat istio-redirect meta l4proto tcp redirect to :15001
-add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp redirect to :15006
-add rule inet istio-proxy-nat prerouting meta l4proto tcp jump istio-inbound
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp jump istio-in-redirect
-add rule inet istio-proxy-nat output jump istio-output
-add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 return
-add rule inet istio-proxy-nat istio-output skuid 1337 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 return
-add rule inet istio-proxy-nat istio-output skgid 1337 return
-add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 return
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 counter return
+add rule inet istio-proxy-nat istio-redirect meta l4proto tcp counter redirect to :15001
+add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp counter redirect to :15006
+add rule inet istio-proxy-nat prerouting meta l4proto tcp counter jump istio-inbound
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp counter jump istio-in-redirect
+add rule inet istio-proxy-nat output counter jump istio-output
+add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skuid 1337 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skgid 1337 counter return
+add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 counter return

--- a/tools/istio-nftables/pkg/capture/testdata/ip-range.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/ip-range.golden
@@ -6,44 +6,44 @@ add chain inet istio-proxy-nat istio-redirect
 add chain inet istio-proxy-nat istio-in-redirect
 add chain inet istio-proxy-nat istio-output
 add chain inet istio-proxy-nat istio-output-dns
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 return
-add rule inet istio-proxy-nat istio-redirect meta l4proto tcp redirect to :15001
-add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp redirect to :15006
-add rule inet istio-proxy-nat output jump istio-output
-add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != { 53, 15008 } skuid 3 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skuid != 3 return
-add rule inet istio-proxy-nat istio-output skuid 3 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != { 53, 15008 } skuid 4 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skuid != 4 return
-add rule inet istio-proxy-nat istio-output skuid 4 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skgid != 1 return
-add rule inet istio-proxy-nat istio-output skgid 1 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 2 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skgid != 2 return
-add rule inet istio-proxy-nat istio-output skgid 2 return
-add rule inet istio-proxy-nat istio-output jump istio-output-dns
-add rule inet istio-proxy-nat istio-output-dns ip daddr 127.0.0.53/32 tcp dport 53 redirect to :15053
-add rule inet istio-proxy-nat istio-output-dns ip daddr 127.0.0.53/32 udp dport 53 redirect to :15053
-add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 return
-add rule inet istio-proxy-nat istio-output ip daddr 1.1.0.0/16 return
-add rule inet istio-proxy-nat istio-output ip daddr 9.9.0.0/16 jump istio-redirect
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 counter return
+add rule inet istio-proxy-nat istio-redirect meta l4proto tcp counter redirect to :15001
+add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp counter redirect to :15006
+add rule inet istio-proxy-nat output counter jump istio-output
+add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != { 53, 15008 } skuid 3 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skuid != 3 counter return
+add rule inet istio-proxy-nat istio-output skuid 3 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != { 53, 15008 } skuid 4 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skuid != 4 counter return
+add rule inet istio-proxy-nat istio-output skuid 4 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skgid != 1 counter return
+add rule inet istio-proxy-nat istio-output skgid 1 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 2 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skgid != 2 counter return
+add rule inet istio-proxy-nat istio-output skgid 2 counter return
+add rule inet istio-proxy-nat istio-output counter jump istio-output-dns
+add rule inet istio-proxy-nat istio-output-dns ip daddr 127.0.0.53/32 tcp dport 53 counter redirect to :15053
+add rule inet istio-proxy-nat istio-output-dns ip daddr 127.0.0.53/32 udp dport 53 counter redirect to :15053
+add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 counter return
+add rule inet istio-proxy-nat istio-output ip daddr 1.1.0.0/16 counter return
+add rule inet istio-proxy-nat istio-output ip daddr 9.9.0.0/16 counter jump istio-redirect
 add table inet istio-proxy-raw
 flush table inet istio-proxy-raw
 add chain inet istio-proxy-raw prerouting { type filter hook prerouting priority -300 ; }
 add chain inet istio-proxy-raw output { type filter hook output priority -300 ; }
 add chain inet istio-proxy-raw istio-inbound
 add chain inet istio-proxy-raw istio-output-dns
-add rule inet istio-proxy-raw output jump istio-output-dns
-add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skuid 3 ct zone set 1
-add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skuid 3 ct zone set 2
-add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skuid 4 ct zone set 1
-add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skuid 4 ct zone set 2
-add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skgid 1 ct zone set 1
-add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skgid 1 ct zone set 2
-add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skgid 2 ct zone set 1
-add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skgid 2 ct zone set 2
-add rule inet istio-proxy-raw prerouting jump istio-inbound
-add rule inet istio-proxy-raw istio-output-dns udp dport 53 ip daddr 127.0.0.53/32 ct zone set 2
-add rule inet istio-proxy-raw istio-inbound udp sport 53 ip saddr 127.0.0.53/32 ct zone set 1
+add rule inet istio-proxy-raw output counter jump istio-output-dns
+add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skuid 3 counter ct zone set 1
+add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skuid 3 counter ct zone set 2
+add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skuid 4 counter ct zone set 1
+add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skuid 4 counter ct zone set 2
+add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skgid 1 counter ct zone set 1
+add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skgid 1 counter ct zone set 2
+add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skgid 2 counter ct zone set 1
+add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skgid 2 counter ct zone set 2
+add rule inet istio-proxy-raw prerouting counter jump istio-inbound
+add rule inet istio-proxy-raw istio-output-dns udp dport 53 ip daddr 127.0.0.53/32 counter ct zone set 2
+add rule inet istio-proxy-raw istio-inbound udp sport 53 ip saddr 127.0.0.53/32 counter ct zone set 1

--- a/tools/istio-nftables/pkg/capture/testdata/ipnets-with-kube-virt-interfaces.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/ipnets-with-kube-virt-interfaces.golden
@@ -6,20 +6,20 @@ add chain inet istio-proxy-nat istio-inbound
 add chain inet istio-proxy-nat istio-redirect
 add chain inet istio-proxy-nat istio-in-redirect
 add chain inet istio-proxy-nat istio-output
-add rule inet istio-proxy-nat prerouting iifname eth1 return
-insert rule inet istio-proxy-nat prerouting index 0 iifname eth2 return
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 return
-add rule inet istio-proxy-nat istio-redirect meta l4proto tcp redirect to :15001
-add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp redirect to :15006
-add rule inet istio-proxy-nat output jump istio-output
-add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 return
-add rule inet istio-proxy-nat istio-output skuid 1337 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 return
-add rule inet istio-proxy-nat istio-output skgid 1337 return
-add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 return
-insert rule inet istio-proxy-nat prerouting index 0 iifname eth1 ip daddr 10.0.0.0/8 jump istio-redirect
-insert rule inet istio-proxy-nat prerouting index 0 iifname eth2 ip daddr 10.0.0.0/8 jump istio-redirect
-add rule inet istio-proxy-nat istio-output ip daddr 10.0.0.0/8 jump istio-redirect
+add rule inet istio-proxy-nat prerouting iifname eth1 counter return
+insert rule inet istio-proxy-nat prerouting index 0 iifname eth2 counter return
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 counter return
+add rule inet istio-proxy-nat istio-redirect meta l4proto tcp counter redirect to :15001
+add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp counter redirect to :15006
+add rule inet istio-proxy-nat output counter jump istio-output
+add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skuid 1337 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skgid 1337 counter return
+add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 counter return
+insert rule inet istio-proxy-nat prerouting index 0 iifname eth1 ip daddr 10.0.0.0/8 counter jump istio-redirect
+insert rule inet istio-proxy-nat prerouting index 0 iifname eth2 ip daddr 10.0.0.0/8 counter jump istio-redirect
+add rule inet istio-proxy-nat istio-output ip daddr 10.0.0.0/8 counter jump istio-redirect

--- a/tools/istio-nftables/pkg/capture/testdata/ipnets.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/ipnets.golden
@@ -5,16 +5,16 @@ add chain inet istio-proxy-nat istio-inbound
 add chain inet istio-proxy-nat istio-redirect
 add chain inet istio-proxy-nat istio-in-redirect
 add chain inet istio-proxy-nat istio-output
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 return
-add rule inet istio-proxy-nat istio-redirect meta l4proto tcp redirect to :15001
-add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp redirect to :15006
-add rule inet istio-proxy-nat output jump istio-output
-add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 return
-add rule inet istio-proxy-nat istio-output skuid 1337 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 return
-add rule inet istio-proxy-nat istio-output skgid 1337 return
-add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 return
-add rule inet istio-proxy-nat istio-output ip daddr 10.0.0.0/8 jump istio-redirect
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 counter return
+add rule inet istio-proxy-nat istio-redirect meta l4proto tcp counter redirect to :15001
+add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp counter redirect to :15006
+add rule inet istio-proxy-nat output counter jump istio-output
+add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skuid 1337 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skgid 1337 counter return
+add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 counter return
+add rule inet istio-proxy-nat istio-output ip daddr 10.0.0.0/8 counter jump istio-redirect

--- a/tools/istio-nftables/pkg/capture/testdata/ipv6-dns-outbound-owner-groups-exclude.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/ipv6-dns-outbound-owner-groups-exclude.golden
@@ -5,21 +5,21 @@ add chain inet istio-proxy-nat istio-inbound
 add chain inet istio-proxy-nat istio-redirect
 add chain inet istio-proxy-nat istio-in-redirect
 add chain inet istio-proxy-nat istio-output
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 return
-add rule inet istio-proxy-nat istio-redirect meta l4proto tcp redirect to :15001
-add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp redirect to :15006
-add rule inet istio-proxy-nat output jump istio-output
-add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 return
-add rule inet istio-proxy-nat istio-output oifname lo ip6 saddr ::6/128 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 return
-add rule inet istio-proxy-nat istio-output skuid 1337 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skgid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 return
-add rule inet istio-proxy-nat istio-output skgid 1337 return
-add rule inet istio-proxy-nat istio-output skgid 888 return
-add rule inet istio-proxy-nat istio-output skgid ftp return
-add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 return
-add rule inet istio-proxy-nat istio-output ip6 daddr ::1/128 return
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 counter return
+add rule inet istio-proxy-nat istio-redirect meta l4proto tcp counter redirect to :15001
+add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp counter redirect to :15006
+add rule inet istio-proxy-nat output counter jump istio-output
+add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 counter return
+add rule inet istio-proxy-nat istio-output oifname lo ip6 saddr ::6/128 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skuid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skuid 1337 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skgid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skgid 1337 counter return
+add rule inet istio-proxy-nat istio-output skgid 888 counter return
+add rule inet istio-proxy-nat istio-output skgid ftp counter return
+add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 counter return
+add rule inet istio-proxy-nat istio-output ip6 daddr ::1/128 counter return

--- a/tools/istio-nftables/pkg/capture/testdata/ipv6-dns-outbound-owner-groups.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/ipv6-dns-outbound-owner-groups.golden
@@ -5,20 +5,20 @@ add chain inet istio-proxy-nat istio-inbound
 add chain inet istio-proxy-nat istio-redirect
 add chain inet istio-proxy-nat istio-in-redirect
 add chain inet istio-proxy-nat istio-output
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 return
-add rule inet istio-proxy-nat istio-redirect meta l4proto tcp redirect to :15001
-add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp redirect to :15006
-add rule inet istio-proxy-nat output jump istio-output
-add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 return
-add rule inet istio-proxy-nat istio-output oifname lo ip6 saddr ::6/128 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 return
-add rule inet istio-proxy-nat istio-output skuid 1337 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skgid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 return
-add rule inet istio-proxy-nat istio-output skgid 1337 return
-add rule inet istio-proxy-nat istio-output skgid != java skgid != 202 return
-add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 return
-add rule inet istio-proxy-nat istio-output ip6 daddr ::1/128 return
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 counter return
+add rule inet istio-proxy-nat istio-redirect meta l4proto tcp counter redirect to :15001
+add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp counter redirect to :15006
+add rule inet istio-proxy-nat output counter jump istio-output
+add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 counter return
+add rule inet istio-proxy-nat istio-output oifname lo ip6 saddr ::6/128 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skuid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skuid 1337 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skgid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skgid 1337 counter return
+add rule inet istio-proxy-nat istio-output skgid != java skgid != 202 counter return
+add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 counter return
+add rule inet istio-proxy-nat istio-output ip6 daddr ::1/128 counter return

--- a/tools/istio-nftables/pkg/capture/testdata/ipv6-dns-uid-gid.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/ipv6-dns-uid-gid.golden
@@ -5,27 +5,27 @@ add chain inet istio-proxy-nat istio-inbound
 add chain inet istio-proxy-nat istio-redirect
 add chain inet istio-proxy-nat istio-in-redirect
 add chain inet istio-proxy-nat istio-output
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 return
-add rule inet istio-proxy-nat istio-redirect meta l4proto tcp redirect to :15001
-add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp redirect to :15006
-add rule inet istio-proxy-nat output jump istio-output
-add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 return
-add rule inet istio-proxy-nat istio-output oifname lo ip6 saddr ::6/128 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 3 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skuid 3 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skuid != 3 return
-add rule inet istio-proxy-nat istio-output skuid 3 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 4 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skuid 4 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skuid != 4 return
-add rule inet istio-proxy-nat istio-output skuid 4 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skgid 1 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skgid != 1 return
-add rule inet istio-proxy-nat istio-output skgid 1 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 2 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skgid 2 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skgid != 2 return
-add rule inet istio-proxy-nat istio-output skgid 2 return
-add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 return
-add rule inet istio-proxy-nat istio-output ip6 daddr ::1/128 return
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 counter return
+add rule inet istio-proxy-nat istio-redirect meta l4proto tcp counter redirect to :15001
+add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp counter redirect to :15006
+add rule inet istio-proxy-nat output counter jump istio-output
+add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 counter return
+add rule inet istio-proxy-nat istio-output oifname lo ip6 saddr ::6/128 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 3 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skuid 3 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skuid != 3 counter return
+add rule inet istio-proxy-nat istio-output skuid 3 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 4 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skuid 4 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skuid != 4 counter return
+add rule inet istio-proxy-nat istio-output skuid 4 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skgid 1 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skgid != 1 counter return
+add rule inet istio-proxy-nat istio-output skgid 1 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 2 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skgid 2 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skgid != 2 counter return
+add rule inet istio-proxy-nat istio-output skgid 2 counter return
+add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 counter return
+add rule inet istio-proxy-nat istio-output ip6 daddr ::1/128 counter return

--- a/tools/istio-nftables/pkg/capture/testdata/ipv6-empty-inbound-ports.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/ipv6-empty-inbound-ports.golden
@@ -5,19 +5,19 @@ add chain inet istio-proxy-nat istio-inbound
 add chain inet istio-proxy-nat istio-redirect
 add chain inet istio-proxy-nat istio-in-redirect
 add chain inet istio-proxy-nat istio-output
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 return
-add rule inet istio-proxy-nat istio-redirect meta l4proto tcp redirect to :15001
-add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp redirect to :15006
-add rule inet istio-proxy-nat output jump istio-output
-add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 return
-add rule inet istio-proxy-nat istio-output oifname lo ip6 saddr ::6/128 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 return
-add rule inet istio-proxy-nat istio-output skuid 1337 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skgid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 return
-add rule inet istio-proxy-nat istio-output skgid 1337 return
-add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 return
-add rule inet istio-proxy-nat istio-output ip6 daddr ::1/128 return
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 counter return
+add rule inet istio-proxy-nat istio-redirect meta l4proto tcp counter redirect to :15001
+add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp counter redirect to :15006
+add rule inet istio-proxy-nat output counter jump istio-output
+add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 counter return
+add rule inet istio-proxy-nat istio-output oifname lo ip6 saddr ::6/128 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skuid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skuid 1337 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skgid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skgid 1337 counter return
+add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 counter return
+add rule inet istio-proxy-nat istio-output ip6 daddr ::1/128 counter return

--- a/tools/istio-nftables/pkg/capture/testdata/ipv6-inbound-ports.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/ipv6-inbound-ports.golden
@@ -6,22 +6,22 @@ add chain inet istio-proxy-nat istio-inbound
 add chain inet istio-proxy-nat istio-redirect
 add chain inet istio-proxy-nat istio-in-redirect
 add chain inet istio-proxy-nat istio-output
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 return
-add rule inet istio-proxy-nat istio-redirect meta l4proto tcp redirect to :15001
-add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp redirect to :15006
-add rule inet istio-proxy-nat prerouting meta l4proto tcp jump istio-inbound
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 4000 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 5000 jump istio-in-redirect
-add rule inet istio-proxy-nat output jump istio-output
-add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 return
-add rule inet istio-proxy-nat istio-output oifname lo ip6 saddr ::6/128 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 return
-add rule inet istio-proxy-nat istio-output skuid 1337 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skgid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 return
-add rule inet istio-proxy-nat istio-output skgid 1337 return
-add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 return
-add rule inet istio-proxy-nat istio-output ip6 daddr ::1/128 return
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 counter return
+add rule inet istio-proxy-nat istio-redirect meta l4proto tcp counter redirect to :15001
+add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp counter redirect to :15006
+add rule inet istio-proxy-nat prerouting meta l4proto tcp counter jump istio-inbound
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 4000 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 5000 counter jump istio-in-redirect
+add rule inet istio-proxy-nat output counter jump istio-output
+add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 counter return
+add rule inet istio-proxy-nat istio-output oifname lo ip6 saddr ::6/128 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skuid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skuid 1337 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skgid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skgid 1337 counter return
+add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 counter return
+add rule inet istio-proxy-nat istio-output ip6 daddr ::1/128 counter return

--- a/tools/istio-nftables/pkg/capture/testdata/ipv6-ipnets.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/ipv6-ipnets.golden
@@ -6,28 +6,28 @@ add chain inet istio-proxy-nat istio-inbound
 add chain inet istio-proxy-nat istio-redirect
 add chain inet istio-proxy-nat istio-in-redirect
 add chain inet istio-proxy-nat istio-output
-add rule inet istio-proxy-nat prerouting iifname eth0 return
-insert rule inet istio-proxy-nat prerouting index 0 iifname eth1 return
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 return
-add rule inet istio-proxy-nat istio-redirect meta l4proto tcp redirect to :15001
-add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp redirect to :15006
-add rule inet istio-proxy-nat prerouting meta l4proto tcp jump istio-inbound
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 4000 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 5000 jump istio-in-redirect
-add rule inet istio-proxy-nat output jump istio-output
-add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 return
-add rule inet istio-proxy-nat istio-output oifname lo ip6 saddr ::6/128 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 return
-add rule inet istio-proxy-nat istio-output skuid 1337 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skgid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 return
-add rule inet istio-proxy-nat istio-output skgid 1337 return
-add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 return
-add rule inet istio-proxy-nat istio-output ip6 daddr ::1/128 return
-add rule inet istio-proxy-nat istio-output ip6 daddr 2001:db8::/32 return
-insert rule inet istio-proxy-nat prerouting index 0 iifname eth0 ip6 daddr 2001:db8::/32 jump istio-redirect
-insert rule inet istio-proxy-nat prerouting index 0 iifname eth1 ip6 daddr 2001:db8::/32 jump istio-redirect
-add rule inet istio-proxy-nat istio-output ip6 daddr 2001:db8::/32 jump istio-redirect
+add rule inet istio-proxy-nat prerouting iifname eth0 counter return
+insert rule inet istio-proxy-nat prerouting index 0 iifname eth1 counter return
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 counter return
+add rule inet istio-proxy-nat istio-redirect meta l4proto tcp counter redirect to :15001
+add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp counter redirect to :15006
+add rule inet istio-proxy-nat prerouting meta l4proto tcp counter jump istio-inbound
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 4000 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 5000 counter jump istio-in-redirect
+add rule inet istio-proxy-nat output counter jump istio-output
+add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 counter return
+add rule inet istio-proxy-nat istio-output oifname lo ip6 saddr ::6/128 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skuid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skuid 1337 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skgid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skgid 1337 counter return
+add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 counter return
+add rule inet istio-proxy-nat istio-output ip6 daddr ::1/128 counter return
+add rule inet istio-proxy-nat istio-output ip6 daddr 2001:db8::/32 counter return
+insert rule inet istio-proxy-nat prerouting index 0 iifname eth0 ip6 daddr 2001:db8::/32 counter jump istio-redirect
+insert rule inet istio-proxy-nat prerouting index 0 iifname eth1 ip6 daddr 2001:db8::/32 counter jump istio-redirect
+add rule inet istio-proxy-nat istio-output ip6 daddr 2001:db8::/32 counter jump istio-redirect

--- a/tools/istio-nftables/pkg/capture/testdata/ipv6-outbound-ports.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/ipv6-outbound-ports.golden
@@ -5,21 +5,21 @@ add chain inet istio-proxy-nat istio-inbound
 add chain inet istio-proxy-nat istio-redirect
 add chain inet istio-proxy-nat istio-in-redirect
 add chain inet istio-proxy-nat istio-output
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 return
-add rule inet istio-proxy-nat istio-redirect meta l4proto tcp redirect to :15001
-add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp redirect to :15006
-add rule inet istio-proxy-nat output jump istio-output
-add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 return
-add rule inet istio-proxy-nat istio-output oifname lo ip6 saddr ::6/128 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 return
-add rule inet istio-proxy-nat istio-output skuid 1337 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skgid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 return
-add rule inet istio-proxy-nat istio-output skgid 1337 return
-add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 return
-add rule inet istio-proxy-nat istio-output ip6 daddr ::1/128 return
-add rule inet istio-proxy-nat istio-output tcp dport 32000 jump istio-redirect
-add rule inet istio-proxy-nat istio-output tcp dport 31000 jump istio-redirect
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 counter return
+add rule inet istio-proxy-nat istio-redirect meta l4proto tcp counter redirect to :15001
+add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp counter redirect to :15006
+add rule inet istio-proxy-nat output counter jump istio-output
+add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 counter return
+add rule inet istio-proxy-nat istio-output oifname lo ip6 saddr ::6/128 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skuid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skuid 1337 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skgid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skgid 1337 counter return
+add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 counter return
+add rule inet istio-proxy-nat istio-output ip6 daddr ::1/128 counter return
+add rule inet istio-proxy-nat istio-output tcp dport 32000 counter jump istio-redirect
+add rule inet istio-proxy-nat istio-output tcp dport 31000 counter jump istio-redirect

--- a/tools/istio-nftables/pkg/capture/testdata/ipv6-uid-gid.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/ipv6-uid-gid.golden
@@ -6,36 +6,36 @@ add chain inet istio-proxy-nat istio-inbound
 add chain inet istio-proxy-nat istio-redirect
 add chain inet istio-proxy-nat istio-in-redirect
 add chain inet istio-proxy-nat istio-output
-add rule inet istio-proxy-nat prerouting iifname eth0 return
-insert rule inet istio-proxy-nat prerouting index 0 iifname eth1 return
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 return
-add rule inet istio-proxy-nat istio-redirect meta l4proto tcp redirect to :15001
-add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp redirect to :15006
-add rule inet istio-proxy-nat prerouting meta l4proto tcp jump istio-inbound
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 4000 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 5000 jump istio-in-redirect
-add rule inet istio-proxy-nat output jump istio-output
-add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 return
-add rule inet istio-proxy-nat istio-output oifname lo ip6 saddr ::6/128 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 3 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skuid 3 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skuid != 3 return
-add rule inet istio-proxy-nat istio-output skuid 3 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 4 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skuid 4 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skuid != 4 return
-add rule inet istio-proxy-nat istio-output skuid 4 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skgid 1 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skgid != 1 return
-add rule inet istio-proxy-nat istio-output skgid 1 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 2 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skgid 2 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skgid != 2 return
-add rule inet istio-proxy-nat istio-output skgid 2 return
-add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 return
-add rule inet istio-proxy-nat istio-output ip6 daddr ::1/128 return
-add rule inet istio-proxy-nat istio-output ip6 daddr 2001:db8::/32 return
-insert rule inet istio-proxy-nat prerouting index 0 iifname eth0 ip6 daddr 2001:db8::/32 jump istio-redirect
-insert rule inet istio-proxy-nat prerouting index 0 iifname eth1 ip6 daddr 2001:db8::/32 jump istio-redirect
-add rule inet istio-proxy-nat istio-output ip6 daddr 2001:db8::/32 jump istio-redirect
+add rule inet istio-proxy-nat prerouting iifname eth0 counter return
+insert rule inet istio-proxy-nat prerouting index 0 iifname eth1 counter return
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 counter return
+add rule inet istio-proxy-nat istio-redirect meta l4proto tcp counter redirect to :15001
+add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp counter redirect to :15006
+add rule inet istio-proxy-nat prerouting meta l4proto tcp counter jump istio-inbound
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 4000 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 5000 counter jump istio-in-redirect
+add rule inet istio-proxy-nat output counter jump istio-output
+add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 counter return
+add rule inet istio-proxy-nat istio-output oifname lo ip6 saddr ::6/128 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 3 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skuid 3 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skuid != 3 counter return
+add rule inet istio-proxy-nat istio-output skuid 3 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 4 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skuid 4 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skuid != 4 counter return
+add rule inet istio-proxy-nat istio-output skuid 4 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skgid 1 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skgid != 1 counter return
+add rule inet istio-proxy-nat istio-output skgid 1 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 2 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skgid 2 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skgid != 2 counter return
+add rule inet istio-proxy-nat istio-output skgid 2 counter return
+add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 counter return
+add rule inet istio-proxy-nat istio-output ip6 daddr ::1/128 counter return
+add rule inet istio-proxy-nat istio-output ip6 daddr 2001:db8::/32 counter return
+insert rule inet istio-proxy-nat prerouting index 0 iifname eth0 ip6 daddr 2001:db8::/32 counter jump istio-redirect
+insert rule inet istio-proxy-nat prerouting index 0 iifname eth1 ip6 daddr 2001:db8::/32 counter jump istio-redirect
+add rule inet istio-proxy-nat istio-output ip6 daddr 2001:db8::/32 counter jump istio-redirect

--- a/tools/istio-nftables/pkg/capture/testdata/ipv6-virt-interfaces.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/ipv6-virt-interfaces.golden
@@ -6,24 +6,24 @@ add chain inet istio-proxy-nat istio-inbound
 add chain inet istio-proxy-nat istio-redirect
 add chain inet istio-proxy-nat istio-in-redirect
 add chain inet istio-proxy-nat istio-output
-add rule inet istio-proxy-nat prerouting iifname eth0 return
-insert rule inet istio-proxy-nat prerouting index 0 iifname eth1 return
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 return
-add rule inet istio-proxy-nat istio-redirect meta l4proto tcp redirect to :15001
-add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp redirect to :15006
-add rule inet istio-proxy-nat prerouting meta l4proto tcp jump istio-inbound
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 4000 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 5000 jump istio-in-redirect
-add rule inet istio-proxy-nat output jump istio-output
-add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 return
-add rule inet istio-proxy-nat istio-output oifname lo ip6 saddr ::6/128 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 return
-add rule inet istio-proxy-nat istio-output skuid 1337 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skgid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 return
-add rule inet istio-proxy-nat istio-output skgid 1337 return
-add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 return
-add rule inet istio-proxy-nat istio-output ip6 daddr ::1/128 return
+add rule inet istio-proxy-nat prerouting iifname eth0 counter return
+insert rule inet istio-proxy-nat prerouting index 0 iifname eth1 counter return
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 counter return
+add rule inet istio-proxy-nat istio-redirect meta l4proto tcp counter redirect to :15001
+add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp counter redirect to :15006
+add rule inet istio-proxy-nat prerouting meta l4proto tcp counter jump istio-inbound
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 4000 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 5000 counter jump istio-in-redirect
+add rule inet istio-proxy-nat output counter jump istio-output
+add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 counter return
+add rule inet istio-proxy-nat istio-output oifname lo ip6 saddr ::6/128 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skuid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skuid 1337 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skgid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skgid 1337 counter return
+add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 counter return
+add rule inet istio-proxy-nat istio-output ip6 daddr ::1/128 counter return

--- a/tools/istio-nftables/pkg/capture/testdata/kube-virt-interfaces.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/kube-virt-interfaces.golden
@@ -6,20 +6,20 @@ add chain inet istio-proxy-nat istio-inbound
 add chain inet istio-proxy-nat istio-redirect
 add chain inet istio-proxy-nat istio-in-redirect
 add chain inet istio-proxy-nat istio-output
-add rule inet istio-proxy-nat prerouting iifname eth1 return
-insert rule inet istio-proxy-nat prerouting index 0 iifname eth2 return
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 return
-add rule inet istio-proxy-nat istio-redirect meta l4proto tcp redirect to :15001
-add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp redirect to :15006
-add rule inet istio-proxy-nat output jump istio-output
-add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 return
-add rule inet istio-proxy-nat istio-output skuid 1337 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 return
-add rule inet istio-proxy-nat istio-output skgid 1337 return
-add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 return
-add rule inet istio-proxy-nat istio-output jump istio-redirect
-insert rule inet istio-proxy-nat prerouting index 0 iifname eth1 jump istio-redirect
-insert rule inet istio-proxy-nat prerouting index 0 iifname eth2 jump istio-redirect
+add rule inet istio-proxy-nat prerouting iifname eth1 counter return
+insert rule inet istio-proxy-nat prerouting index 0 iifname eth2 counter return
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 counter return
+add rule inet istio-proxy-nat istio-redirect meta l4proto tcp counter redirect to :15001
+add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp counter redirect to :15006
+add rule inet istio-proxy-nat output counter jump istio-output
+add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skuid 1337 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skgid 1337 counter return
+add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 counter return
+add rule inet istio-proxy-nat istio-output counter jump istio-redirect
+insert rule inet istio-proxy-nat prerouting index 0 iifname eth1 counter jump istio-redirect
+insert rule inet istio-proxy-nat prerouting index 0 iifname eth2 counter jump istio-redirect

--- a/tools/istio-nftables/pkg/capture/testdata/loopback-outbound-iprange.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/loopback-outbound-iprange.golden
@@ -6,39 +6,39 @@ add chain inet istio-proxy-nat istio-redirect
 add chain inet istio-proxy-nat istio-in-redirect
 add chain inet istio-proxy-nat istio-output
 add chain inet istio-proxy-nat istio-output-dns
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 return
-add rule inet istio-proxy-nat istio-redirect meta l4proto tcp redirect to :15001
-add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp redirect to :15006
-add rule inet istio-proxy-nat output jump istio-output
-add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != { 53, 15008 } skuid 3 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output skuid 3 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != { 53, 15008 } skuid 4 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output skuid 4 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output skgid 1 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 2 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output skgid 2 return
-add rule inet istio-proxy-nat istio-output jump istio-output-dns
-add rule inet istio-proxy-nat istio-output-dns ip daddr 127.0.0.53/32 tcp dport 53 redirect to :15053
-add rule inet istio-proxy-nat istio-output-dns ip daddr 127.0.0.53/32 udp dport 53 redirect to :15053
-add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 return
-add rule inet istio-proxy-nat istio-output ip daddr 127.1.2.3/32 jump istio-redirect
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 counter return
+add rule inet istio-proxy-nat istio-redirect meta l4proto tcp counter redirect to :15001
+add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp counter redirect to :15006
+add rule inet istio-proxy-nat output counter jump istio-output
+add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != { 53, 15008 } skuid 3 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output skuid 3 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != { 53, 15008 } skuid 4 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output skuid 4 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output skgid 1 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 2 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output skgid 2 counter return
+add rule inet istio-proxy-nat istio-output counter jump istio-output-dns
+add rule inet istio-proxy-nat istio-output-dns ip daddr 127.0.0.53/32 tcp dport 53 counter redirect to :15053
+add rule inet istio-proxy-nat istio-output-dns ip daddr 127.0.0.53/32 udp dport 53 counter redirect to :15053
+add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 counter return
+add rule inet istio-proxy-nat istio-output ip daddr 127.1.2.3/32 counter jump istio-redirect
 add table inet istio-proxy-raw
 flush table inet istio-proxy-raw
 add chain inet istio-proxy-raw prerouting { type filter hook prerouting priority -300 ; }
 add chain inet istio-proxy-raw output { type filter hook output priority -300 ; }
 add chain inet istio-proxy-raw istio-inbound
 add chain inet istio-proxy-raw istio-output-dns
-add rule inet istio-proxy-raw output jump istio-output-dns
-add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skuid 3 ct zone set 1
-add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skuid 3 ct zone set 2
-add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skuid 4 ct zone set 1
-add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skuid 4 ct zone set 2
-add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skgid 1 ct zone set 1
-add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skgid 1 ct zone set 2
-add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skgid 2 ct zone set 1
-add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skgid 2 ct zone set 2
-add rule inet istio-proxy-raw prerouting jump istio-inbound
-add rule inet istio-proxy-raw istio-output-dns udp dport 53 ip daddr 127.0.0.53/32 ct zone set 2
-add rule inet istio-proxy-raw istio-inbound udp sport 53 ip saddr 127.0.0.53/32 ct zone set 1
+add rule inet istio-proxy-raw output counter jump istio-output-dns
+add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skuid 3 counter ct zone set 1
+add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skuid 3 counter ct zone set 2
+add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skuid 4 counter ct zone set 1
+add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skuid 4 counter ct zone set 2
+add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skgid 1 counter ct zone set 1
+add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skgid 1 counter ct zone set 2
+add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skgid 2 counter ct zone set 1
+add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skgid 2 counter ct zone set 2
+add rule inet istio-proxy-raw prerouting counter jump istio-inbound
+add rule inet istio-proxy-raw istio-output-dns udp dport 53 ip daddr 127.0.0.53/32 counter ct zone set 2
+add rule inet istio-proxy-raw istio-inbound udp sport 53 ip saddr 127.0.0.53/32 counter ct zone set 1

--- a/tools/istio-nftables/pkg/capture/testdata/outbound-owner-groups-exclude.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/outbound-owner-groups-exclude.golden
@@ -5,17 +5,17 @@ add chain inet istio-proxy-nat istio-inbound
 add chain inet istio-proxy-nat istio-redirect
 add chain inet istio-proxy-nat istio-in-redirect
 add chain inet istio-proxy-nat istio-output
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 return
-add rule inet istio-proxy-nat istio-redirect meta l4proto tcp redirect to :15001
-add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp redirect to :15006
-add rule inet istio-proxy-nat output jump istio-output
-add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 return
-add rule inet istio-proxy-nat istio-output skuid 1337 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 return
-add rule inet istio-proxy-nat istio-output skgid 1337 return
-add rule inet istio-proxy-nat istio-output skgid 888 return
-add rule inet istio-proxy-nat istio-output skgid ftp return
-add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 return
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 counter return
+add rule inet istio-proxy-nat istio-redirect meta l4proto tcp counter redirect to :15001
+add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp counter redirect to :15006
+add rule inet istio-proxy-nat output counter jump istio-output
+add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skuid 1337 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skgid 1337 counter return
+add rule inet istio-proxy-nat istio-output skgid 888 counter return
+add rule inet istio-proxy-nat istio-output skgid ftp counter return
+add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 counter return

--- a/tools/istio-nftables/pkg/capture/testdata/outbound-owner-groups.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/outbound-owner-groups.golden
@@ -5,16 +5,16 @@ add chain inet istio-proxy-nat istio-inbound
 add chain inet istio-proxy-nat istio-redirect
 add chain inet istio-proxy-nat istio-in-redirect
 add chain inet istio-proxy-nat istio-output
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 return
-add rule inet istio-proxy-nat istio-redirect meta l4proto tcp redirect to :15001
-add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp redirect to :15006
-add rule inet istio-proxy-nat output jump istio-output
-add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 return
-add rule inet istio-proxy-nat istio-output skuid 1337 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 return
-add rule inet istio-proxy-nat istio-output skgid 1337 return
-add rule inet istio-proxy-nat istio-output skgid != java skgid != 202 return
-add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 return
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 counter return
+add rule inet istio-proxy-nat istio-redirect meta l4proto tcp counter redirect to :15001
+add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp counter redirect to :15006
+add rule inet istio-proxy-nat output counter jump istio-output
+add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skuid 1337 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skgid 1337 counter return
+add rule inet istio-proxy-nat istio-output skgid != java skgid != 202 counter return
+add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 counter return

--- a/tools/istio-nftables/pkg/capture/testdata/outbound-ports-include.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/outbound-ports-include.golden
@@ -5,17 +5,17 @@ add chain inet istio-proxy-nat istio-inbound
 add chain inet istio-proxy-nat istio-redirect
 add chain inet istio-proxy-nat istio-in-redirect
 add chain inet istio-proxy-nat istio-output
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 return
-add rule inet istio-proxy-nat istio-redirect meta l4proto tcp redirect to :15001
-add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp redirect to :15006
-add rule inet istio-proxy-nat output jump istio-output
-add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 return
-add rule inet istio-proxy-nat istio-output skuid 1337 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 return
-add rule inet istio-proxy-nat istio-output skgid 1337 return
-add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 return
-add rule inet istio-proxy-nat istio-output tcp dport 32000 jump istio-redirect
-add rule inet istio-proxy-nat istio-output tcp dport 31000 jump istio-redirect
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 counter return
+add rule inet istio-proxy-nat istio-redirect meta l4proto tcp counter redirect to :15001
+add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp counter redirect to :15006
+add rule inet istio-proxy-nat output counter jump istio-output
+add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skuid 1337 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skgid 1337 counter return
+add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 counter return
+add rule inet istio-proxy-nat istio-output tcp dport 32000 counter jump istio-redirect
+add rule inet istio-proxy-nat istio-output tcp dport 31000 counter jump istio-redirect

--- a/tools/istio-nftables/pkg/capture/testdata/tproxy.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/tproxy.golden
@@ -7,29 +7,29 @@ add chain inet istio-proxy-nat istio-redirect
 add chain inet istio-proxy-nat istio-in-redirect
 add chain inet istio-proxy-nat istio-output
 add chain inet istio-proxy-nat istio-output-dns
-add rule inet istio-proxy-nat prerouting iifname not-istio-nic return
-add rule inet istio-proxy-nat output oifname not-istio-nic return
-add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 return
-add rule inet istio-proxy-nat istio-redirect meta l4proto tcp redirect to :15001
-add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp redirect to :15006
-add rule inet istio-proxy-nat output jump istio-output
-add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 return
-add rule inet istio-proxy-nat istio-output oifname lo ip6 saddr ::6/128 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != { 53, 15008 } skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != { 53, 15008 } skuid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skuid != 1337 return
-add rule inet istio-proxy-nat istio-output skuid 1337 return
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skgid 1337 jump istio-in-redirect
-add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skgid != 1337 return
-add rule inet istio-proxy-nat istio-output skgid 1337 return
-add rule inet istio-proxy-nat istio-output jump istio-output-dns
-add rule inet istio-proxy-nat istio-output-dns ip daddr 127.0.0.53/32 tcp dport 53 redirect to :15053
-add rule inet istio-proxy-nat istio-output-dns ip daddr 127.0.0.53/32 udp dport 53 redirect to :15053
-add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 return
-add rule inet istio-proxy-nat istio-output ip6 daddr ::1/128 return
-add rule inet istio-proxy-nat istio-output ip daddr 1.1.0.0/16 return
-add rule inet istio-proxy-nat istio-output ip daddr 9.9.0.0/16 jump istio-redirect
+add rule inet istio-proxy-nat prerouting iifname not-istio-nic counter return
+add rule inet istio-proxy-nat output oifname not-istio-nic counter return
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 counter return
+add rule inet istio-proxy-nat istio-redirect meta l4proto tcp counter redirect to :15001
+add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp counter redirect to :15006
+add rule inet istio-proxy-nat output counter jump istio-output
+add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 counter return
+add rule inet istio-proxy-nat istio-output oifname lo ip6 saddr ::6/128 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != { 53, 15008 } skuid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != { 53, 15008 } skuid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skuid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skuid 1337 counter return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip6 daddr != ::1/128 tcp dport != 15008 skgid 1337 counter jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp tcp dport != 53 skgid != 1337 counter return
+add rule inet istio-proxy-nat istio-output skgid 1337 counter return
+add rule inet istio-proxy-nat istio-output counter jump istio-output-dns
+add rule inet istio-proxy-nat istio-output-dns ip daddr 127.0.0.53/32 tcp dport 53 counter redirect to :15053
+add rule inet istio-proxy-nat istio-output-dns ip daddr 127.0.0.53/32 udp dport 53 counter redirect to :15053
+add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 counter return
+add rule inet istio-proxy-nat istio-output ip6 daddr ::1/128 counter return
+add rule inet istio-proxy-nat istio-output ip daddr 1.1.0.0/16 counter return
+add rule inet istio-proxy-nat istio-output ip daddr 9.9.0.0/16 counter jump istio-redirect
 add table inet istio-proxy-mangle
 flush table inet istio-proxy-mangle
 add chain inet istio-proxy-mangle prerouting { type filter hook prerouting priority -150 ; }
@@ -37,37 +37,37 @@ add chain inet istio-proxy-mangle output { type route hook output priority -150 
 add chain inet istio-proxy-mangle istio-divert
 add chain inet istio-proxy-mangle istio-tproxy
 add chain inet istio-proxy-mangle istio-inbound
-add rule inet istio-proxy-mangle prerouting iifname not-istio-nic return
-add rule inet istio-proxy-mangle output oifname not-istio-nic return
-add rule inet istio-proxy-mangle istio-divert meta mark set 1337
-add rule inet istio-proxy-mangle istio-divert accept
-add rule inet istio-proxy-mangle istio-tproxy meta l4proto tcp ip daddr != 127.0.0.1/32 tproxy ip to :15006 meta mark set 1337 accept
-add rule inet istio-proxy-mangle istio-tproxy meta l4proto tcp ip6 daddr != ::1/128 tproxy ip6 to :15006 meta mark set 1337 accept
-add rule inet istio-proxy-mangle prerouting meta l4proto tcp jump istio-inbound
-add rule inet istio-proxy-mangle istio-inbound meta l4proto tcp ct state related,established jump istio-divert
-add rule inet istio-proxy-mangle istio-inbound meta l4proto tcp jump istio-tproxy
-add rule inet istio-proxy-mangle prerouting meta l4proto tcp mark 1337 ct mark set mark
-add rule inet istio-proxy-mangle output oifname lo meta l4proto tcp mark 1337 return
-add rule inet istio-proxy-mangle output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 skuid 1337 meta mark set 1338
-add rule inet istio-proxy-mangle output oifname lo meta l4proto tcp ip6 daddr != ::1/128 skuid 1337 meta mark set 1338
-add rule inet istio-proxy-mangle output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 skgid 1337 meta mark set 1338
-add rule inet istio-proxy-mangle output oifname lo meta l4proto tcp ip6 daddr != ::1/128 skgid 1337 meta mark set 1338
-add rule inet istio-proxy-mangle output meta l4proto tcp ct mark 1337 meta mark set ct mark
-insert rule inet istio-proxy-mangle istio-inbound index 0 meta l4proto tcp mark 1337 return
-insert rule inet istio-proxy-mangle istio-inbound index 1 iifname lo meta l4proto tcp ip saddr 127.0.0.6/32 return
-insert rule inet istio-proxy-mangle istio-inbound index 1 iifname lo meta l4proto tcp ip6 saddr ::6/128 return
-insert rule inet istio-proxy-mangle istio-inbound index 2 iifname lo meta l4proto tcp mark != 1338 return
+add rule inet istio-proxy-mangle prerouting iifname not-istio-nic counter return
+add rule inet istio-proxy-mangle output oifname not-istio-nic counter return
+add rule inet istio-proxy-mangle istio-divert counter meta mark set 1337
+add rule inet istio-proxy-mangle istio-divert counter accept
+add rule inet istio-proxy-mangle istio-tproxy meta l4proto tcp ip daddr != 127.0.0.1/32 tproxy ip to :15006 meta mark set 1337 counter accept
+add rule inet istio-proxy-mangle istio-tproxy meta l4proto tcp ip6 daddr != ::1/128 tproxy ip6 to :15006 meta mark set 1337 counter accept
+add rule inet istio-proxy-mangle prerouting meta l4proto tcp counter jump istio-inbound
+add rule inet istio-proxy-mangle istio-inbound meta l4proto tcp ct state related,established counter jump istio-divert
+add rule inet istio-proxy-mangle istio-inbound meta l4proto tcp counter jump istio-tproxy
+add rule inet istio-proxy-mangle prerouting meta l4proto tcp mark 1337 counter ct mark set mark
+add rule inet istio-proxy-mangle output oifname lo meta l4proto tcp mark 1337 counter return
+add rule inet istio-proxy-mangle output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 skuid 1337 counter meta mark set 1338
+add rule inet istio-proxy-mangle output oifname lo meta l4proto tcp ip6 daddr != ::1/128 skuid 1337 counter meta mark set 1338
+add rule inet istio-proxy-mangle output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 skgid 1337 counter meta mark set 1338
+add rule inet istio-proxy-mangle output oifname lo meta l4proto tcp ip6 daddr != ::1/128 skgid 1337 counter meta mark set 1338
+add rule inet istio-proxy-mangle output meta l4proto tcp ct mark 1337 counter meta mark set ct mark
+insert rule inet istio-proxy-mangle istio-inbound index 0 meta l4proto tcp mark 1337 counter return
+insert rule inet istio-proxy-mangle istio-inbound index 1 iifname lo meta l4proto tcp ip saddr 127.0.0.6/32 counter return
+insert rule inet istio-proxy-mangle istio-inbound index 1 iifname lo meta l4proto tcp ip6 saddr ::6/128 counter return
+insert rule inet istio-proxy-mangle istio-inbound index 2 iifname lo meta l4proto tcp mark != 1338 counter return
 add table inet istio-proxy-raw
 flush table inet istio-proxy-raw
 add chain inet istio-proxy-raw prerouting { type filter hook prerouting priority -300 ; }
 add chain inet istio-proxy-raw output { type filter hook output priority -300 ; }
 add chain inet istio-proxy-raw istio-inbound
 add chain inet istio-proxy-raw istio-output-dns
-add rule inet istio-proxy-raw output jump istio-output-dns
-add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skuid 1337 ct zone set 1
-add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skuid 1337 ct zone set 2
-add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skgid 1337 ct zone set 1
-add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skgid 1337 ct zone set 2
-add rule inet istio-proxy-raw prerouting jump istio-inbound
-add rule inet istio-proxy-raw istio-output-dns udp dport 53 ip daddr 127.0.0.53/32 ct zone set 2
-add rule inet istio-proxy-raw istio-inbound udp sport 53 ip saddr 127.0.0.53/32 ct zone set 1
+add rule inet istio-proxy-raw output counter jump istio-output-dns
+add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skuid 1337 counter ct zone set 1
+add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skuid 1337 counter ct zone set 2
+add rule inet istio-proxy-raw istio-output-dns udp dport 53 meta skgid 1337 counter ct zone set 1
+add rule inet istio-proxy-raw istio-output-dns udp sport 15053 meta skgid 1337 counter ct zone set 2
+add rule inet istio-proxy-raw prerouting counter jump istio-inbound
+add rule inet istio-proxy-raw istio-output-dns udp dport 53 ip daddr 127.0.0.53/32 counter ct zone set 2
+add rule inet istio-proxy-raw istio-inbound udp sport 53 ip saddr 127.0.0.53/32 counter ct zone set 1

--- a/tools/istio-nftables/pkg/constants/constants.go
+++ b/tools/istio-nftables/pkg/constants/constants.go
@@ -47,6 +47,9 @@ const (
 // this is to prevent it being intercepted to envoy inbound listener.
 const OutboundMark = "1338"
 
+// A counter statement helps us in tracking the number of packets that match the rule.
+const Counter = "counter"
+
 // DNS ports
 const (
 	IstioAgentDNSListenerPort = "15053"


### PR DESCRIPTION
Unlike iptables, where packet counters are available by default in verbose mode, nftables requires explicit use of the counter flag in rules. This PR adds counter in the nftables rules to aid in troubleshooting, understanding traffic flow, and verifying that specific match conditions are being triggered.

Related to: https://github.com/istio/istio/issues/47821