### PR TITLE
test: fix race condition in TestIPAllocateWithEnvCIDR

### DIFF
--- a/releasenotes/notes/57195.yaml
+++ b/releasenotes/notes/57195.yaml
@@ -1,8 +1,0 @@
-apiVersion: release-notes/v2
-kind: test
-area: traffic-management
-issue: 
-- 57195
-releaseNotes:
-- |
-  **Fixed** `TestIPAllocateWithEnvCIDR` test race condition that occasionally caused test failures due to inconsistent IP allocation timing during controller initialization.


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR fixes a race condition in the `TestIPAllocateWithEnvCIDR` test that was causing occasional test failures.
Fixes #57195