### PR TITLE
nftables: remove the helm TestNativeNftablesInstall test

### DIFF
--- a/tests/integration/helm/install_test.go
+++ b/tests/integration/helm/install_test.go
@@ -160,9 +160,17 @@ func TestRevisionedReleaseChannels(t *testing.T) {
 		}, revision))
 }
 
-// TODO: Reintroduce TestNativeNftablesInstall as a NewTest
-// once the nft binary is available in the distroless image.
-// See: https://github.com/istio/istio/pull/56917
+func TestNativeNftablesInstall(t *testing.T) {
+	t.Skip("https://github.com/istio/istio/issues/57237")
+	values := map[string]interface{}{
+		"global": map[string]interface{}{
+			"nativeNftables": true,
+		},
+	}
+	framework.
+		NewTest(t).
+		Run(setupInstallation(values, false, DefaultNamespaceConfig, ""))
+}
 
 // nolint: unparam
 func setupInstallation(values map[string]interface{}, isAmbient bool, config NamespaceConfig, revision string) func(t framework.TestContext) {

--- a/tests/integration/helm/install_test.go
+++ b/tests/integration/helm/install_test.go
@@ -160,8 +160,9 @@ func TestRevisionedReleaseChannels(t *testing.T) {
 		}, revision))
 }
 
-// TODO: Add a TestNativeNftablesInstall NewTest.
-// when the nftables-slim package is ready in the distroless base image (https://github.com/istio/istio/pull/56917).
+// TODO: Reintroduce TestNativeNftablesInstall as a NewTest 
+// once the nft binary is available in the distroless image.
+// See: https://github.com/istio/istio/pull/56917
 
 // nolint: unparam
 func setupInstallation(values map[string]interface{}, isAmbient bool, config NamespaceConfig, revision string) func(t framework.TestContext) {

--- a/tests/integration/helm/install_test.go
+++ b/tests/integration/helm/install_test.go
@@ -160,7 +160,7 @@ func TestRevisionedReleaseChannels(t *testing.T) {
 		}, revision))
 }
 
-// TODO: Reintroduce TestNativeNftablesInstall as a NewTest 
+// TODO: Reintroduce TestNativeNftablesInstall as a NewTest
 // once the nft binary is available in the distroless image.
 // See: https://github.com/istio/istio/pull/56917
 

--- a/tests/integration/helm/install_test.go
+++ b/tests/integration/helm/install_test.go
@@ -160,16 +160,8 @@ func TestRevisionedReleaseChannels(t *testing.T) {
 		}, revision))
 }
 
-func TestNativeNftablesInstall(t *testing.T) {
-	values := map[string]interface{}{
-		"global": map[string]interface{}{
-			"nativeNftables": true,
-		},
-	}
-	framework.
-		NewTest(t).
-		Run(setupInstallation(values, false, DefaultNamespaceConfig, ""))
-}
+// TODO: Add a TestNativeNftablesInstall NewTest.
+// when the nftables-slim package is ready in the distroless base image (https://github.com/istio/istio/pull/56917).
 
 // nolint: unparam
 func setupInstallation(values map[string]interface{}, isAmbient bool, config NamespaceConfig, revision string) func(t framework.TestContext) {


### PR DESCRIPTION
This PR removes the helm TestNativeNftablesInstall test because the `nft` binary isn't available in the distroless base image.
Ref: https://prow.istio.io/view/gs/istio-prow/logs/integ-distroless_istio_postsubmit/1951292367382253568

The pilot's nftables test suite (i.e., TestMain), already provides good coverage for NativeNftables. Until the nft binary is available in the distroless image, this Helm test is being removed.

- [X] Test and Release

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
