### PR TITLE
[release-1.25] fix binary_test size for envoy, manual cp #57160

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,7 +4,7 @@
     "name": "PROXY_REPO_SHA",
     "repoName": "proxy",
     "file": "",
-    "lastStableSHA": "074c29ca9111b2a93283eebf613bac722d16cd39"
+    "lastStableSHA": "763ff7d5cc11ac1490e4dd33d20bc51d5f1636c7"
   },
   {
     "_comment": "",

--- a/tests/binary/binaries_test.go
+++ b/tests/binary/binaries_test.go
@@ -112,7 +112,7 @@ func TestBinarySizes(t *testing.T) {
 		"bug-report":      {60, 80},
 		"client":          {15, 30},
 		"server":          {15, 30},
-		"envoy":           {60, 130},
+		"envoy":           {60, 145},
 		"ztunnel":         {10, 15},
 	}
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Manual cherry-pick of #57160 with fix to binary size test to resolve unit test failures.