### PR TITLE
cacerts file watcher bug

### DIFF
--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -331,7 +331,7 @@ func handleEvent(s *Server) {
 
 	var newCABundle []byte
 	var err error
-	var updateRootCA, updateCRL bool
+	var updateCRL bool
 
 	fileBundle, err := detectSigningCABundleAndCRL()
 	if err != nil {
@@ -360,7 +360,6 @@ func handleEvent(s *Server) {
 		if bytes.Contains(currentCABundle, newCABundle) ||
 			bytes.Contains(newCABundle, currentCABundle) {
 			log.Info("Updating new ROOT-CA")
-			updateRootCA = true
 		} else {
 			log.Warn("Updating new ROOT-CA not supported")
 			return
@@ -384,11 +383,6 @@ func handleEvent(s *Server) {
 				updateCRL = true
 			}
 		}
-	}
-
-	if !updateRootCA && !updateCRL {
-		log.Info("No changes detected in root cert or CRL file data, skipping update")
-		return
 	}
 
 	// process updated root cert or crl file

--- a/releasenotes/notes/cacerts-file-watcher-bug.yaml
+++ b/releasenotes/notes/cacerts-file-watcher-bug.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+
+releaseNotes:
+- |
+  **Fixed** an issue where CA certificates derived from ROOT_CA_DIR env var value (i.e. default of ./etc/cacerts) were only updated when either the root ca or the crl file was updated.


### PR DESCRIPTION
**Please provide a description of this PR:**
[This pr](https://github.com/istio/istio/pull/55696) introduced a check in the cacerts file watcher to exit early if no changes to either the root ca or crl files had been detected. This caused an issue where intermediate certs could be updated but istiod would fail to propogate them since they would only be loaded in if the root ca or crl contents were also updated. This unnecessary check has been removed and a unit test has been added to validate partial ca bundle updates are successfully loaded into istiod. 


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [x] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
