### PR TITLE
[WIP] Ambient mode init container

### DIFF
--- a/istioctl/pkg/checkinject/checkinject_test.go
+++ b/istioctl/pkg/checkinject/checkinject_test.go
@@ -298,7 +298,7 @@ func Test_analyzeRunningWebhooks(t *testing.T) {
 	whFiles := []string{
 		"testdata/check-inject/default-injector.yaml",
 		"testdata/check-inject/rev-16-injector.yaml",
-		"testdata/check-inject/never-match-injector.yaml",
+		"testdata/check-inject/-injector.yaml",
 	}
 	var whs []admitv1.MutatingWebhookConfiguration
 	for _, whName := range whFiles {

--- a/manifests/charts/istio-control/istio-discovery/files/ambient-validation.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/ambient-validation.yaml
@@ -1,6 +1,7 @@
 spec:
   initContainers:
   - name: ambient-validation
+    # TODO(jaellio): Add back logic around proxy image selection
     image: "{{ .ProxyImage }}"
     args:
     - istio-iptables

--- a/manifests/charts/istio-control/istio-discovery/files/ambient-validation.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/ambient-validation.yaml
@@ -1,0 +1,18 @@
+spec:
+  initContainers:
+  - name: ambient-validation
+    image: "{{ .ProxyImage }}"
+    args:
+    - istio-iptables
+    - "--ambient-mode"
+    {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+    securityContext:
+      allowPrivilegeEscalation: false
+      privileged: false
+      capabilities:
+        drop:
+        - ALL
+      readOnlyRootFilesystem: true
+      runAsGroup: 1337
+      runAsUser: 1337
+      runAsNonRoot: true

--- a/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
@@ -75,6 +75,10 @@ data:
       kube-gateway: |
 {{ .Files.Get "files/kube-gateway.yaml" | trim | indent 8 }}
 {{- end }}
+{{- if not (hasKey .Values.sidecarInjectorWebhook.templates "ambient-validation") }}
+      ambient-validation: |
+{{ .Files.Get "files/ambient-validation.yaml" | trim | indent 8 }}
+{{- end }}
 {{- with .Values.sidecarInjectorWebhook.templates }}
 {{ toYaml . | trim | indent 6 }}
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -106,6 +106,31 @@ webhooks:
       {{- end }}
 
 
+{{- /* Ambient Init Container Injection */}}
+{{- if .Values.ambientInitContainerInjection }}
+{{- include "core" (mergeOverwrite (deepCopy $whv) (dict "Prefix" "rev.ambient.") ) }}
+  namespaceSelector:
+    matchExpressions:
+    - key: istio.io/rev
+      operator: DoesNotExist
+    - key: istio-injection
+      operator: DoesNotExist
+  objectSelector:
+    matchExpressions:
+    - key: ambient.istio.io/init
+      operator: NotIn
+      values:
+      - "false"
+    - key: istio.io/rev
+      operator: In
+      values:
+      {{- if (eq .Values.revision "") }}
+      - "default"
+      {{- else }}
+      - "{{ .Values.revision }}"
+      {{- end }}
+{{- end }}
+
 {{- /* Webhooks for default revision */}}
 {{- if (eq .Values.revision "") }}
 
@@ -140,6 +165,25 @@ webhooks:
       - "true"
     - key: istio.io/rev
       operator: DoesNotExist
+
+{{- /* Ambient Init Container Injection */}}
+{{- if .Values.ambientInitContainerInjection }}
+{{- include "core" (mergeOverwrite (deepCopy $whv) (dict "Prefix" "ambient.") ) }}
+  namespaceSelector:
+    matchExpressions:
+    - key: istio.io/rev
+      operator: DoesNotExist
+    - key: istio-injection
+      operator: DoesNotExist
+  objectSelector:
+    matchExpressions:
+    - key: ambient.istio.io/init
+      operator: In
+      values:
+      - "true"
+    - key: istio.io/rev
+      operator: DoesNotExist
+{{- end }}
 
 {{- if .Values.sidecarInjectorWebhook.enableNamespacesByDefault }}
 {{- /* Special case 3: no labels at all */}}

--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags-mwc.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags-mwc.yaml
@@ -90,6 +90,29 @@ webhooks:
       values:
       - "{{ $tagName }}"
 
+{{- /* Ambient Init Container Injection */}}
+{{- if .Values.ambientInitContainerInjection }}
+{{- include "core" (mergeOverwrite (deepCopy $whv) (dict "Prefix" "rev.ambient.") ) }}
+  namespaceSelector:
+    matchExpressions:
+    - key: istio.io/rev
+      operator: DoesNotExist
+  objectSelector:
+    matchExpressions:
+    - key: ambient.istio.io/init
+      operator: NotIn
+      values:
+      - "false"
+    - key: istio.io/rev
+      operator: In
+      values:
+      {{- if (eq .Values.revision "") }}
+      - "default"
+      {{- else }}
+      - "{{ .Values.revision }}"
+      {{- end }}
+{{- end }}
+
 {{- /* When the tag is "default" we want to create webhooks for the default revision */}}
 {{- /* These webhooks should be kept in sync with istio-discovery/templates/mutatingwebhook.yaml */}}
 {{- if (eq $tagName "default") }}
@@ -125,6 +148,23 @@ webhooks:
       - "true"
     - key: istio.io/rev
       operator: DoesNotExist
+
+{{- /* Ambient Init Container Injection */}}
+{{- if .Values.ambientInitContainerInjection }}
+{{- include "core" (mergeOverwrite (deepCopy $whv) (dict "Prefix" "ambient.") ) }}
+  namespaceSelector:
+    matchExpressions:
+    - key: istio.io/rev
+      operator: DoesNotExist
+  objectSelector:
+    matchExpressions:
+    - key: ambient.istio.io/init
+      operator: In
+      values:
+      - "true"
+    - key: istio.io/rev
+      operator: DoesNotExist
+{{- end }}
 
 {{- if $.Values.sidecarInjectorWebhook.enableNamespacesByDefault }}
 {{- /* Special case 3: no labels at all */}}

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -112,6 +112,12 @@ _internal_defaults_do_not_set:
   # Set this if you install ztunnel with a name different from the default.
   trustedZtunnelName: ""
 
+  # Ambient mode only.
+  # Set this to true if you want to deploy selectors in the mutating webhook
+  # to allow the injection of ambient init containers.
+  # TODO(jaellio): return to false after testing
+  ambientInitContainerInjection: true
+
   sidecarInjectorWebhook:
     # You can use the field called alwaysInjectSelector and neverInjectSelector which will always inject the sidecar or
     # always skip the injection on pods that match that label selector, regardless of the global policy.
@@ -285,7 +291,7 @@ _internal_defaults_do_not_set:
     # The control plane has different scopes depending on component, but can configure default log level across all components
     # If empty, default scope and level will be used as configured in code
     logging:
-      level: "default:info"
+      level: "default:debug"
 
     # When enabled, default NetworkPolicy resources will be created
     networkPolicy:

--- a/tools/common/config/config.go
+++ b/tools/common/config/config.go
@@ -91,6 +91,7 @@ type Config struct {
 	CleanupOnly              bool       `json:"CLEANUP_ONLY"`
 	ForceApply               bool       `json:"FORCE_APPLY"`
 	NativeNftables           bool       `json:"NATIVE_NFTABLES"`
+	AmbientMode              bool       `json:"AMBIENT_MODE"`
 }
 
 type NetworkRange struct {

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -88,6 +88,7 @@ const (
 	CleanupOnly               = "cleanup-only"
 	ForceApply                = "force-apply"
 	NativeNftables            = "native-nftables"
+	AmbientMode	              = "ambient-mode"
 )
 
 // Environment variables that deliberately have no equivalent command-line flags.


### PR DESCRIPTION
**Please provide a description of this PR:**

Draft implementation. In ambient mode when a pod is
labeled with ambient.istio.io/init a init container will be
injected that blocks until the network is configured by
istio-cni.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
