### PR TITLE
refactor(manifest): move descope logic to zzz_profile file

### DIFF
--- a/manifests/charts/base/templates/zzz_profile.yaml
+++ b/manifests/charts/base/templates/zzz_profile.yaml
@@ -53,7 +53,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
 {{- $x := set $.Values "_original" (deepCopy $.Values) }}
-{{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
+{{- if $defaults.descopeKey }}
+{{- $b := mustMergeOverwrite $defaults (index $defaults $defaults.descopeKey) }}
+{{- $c := mustMergeOverwrite $.Values (index $.Values $defaults.descopeKey) }}
+{{- end }}
+{{- $d := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*
 Labels that should be applied to ALL resources.

--- a/manifests/charts/default/templates/zzz_profile.yaml
+++ b/manifests/charts/default/templates/zzz_profile.yaml
@@ -53,7 +53,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
 {{- $x := set $.Values "_original" (deepCopy $.Values) }}
-{{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
+{{- if $defaults.descopeKey }}
+{{- $b := mustMergeOverwrite $defaults (index $defaults $defaults.descopeKey) }}
+{{- $c := mustMergeOverwrite $.Values (index $.Values $defaults.descopeKey) }}
+{{- end }}
+{{- $d := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*
 Labels that should be applied to ALL resources.

--- a/manifests/charts/gateway/templates/zzz_profile.yaml
+++ b/manifests/charts/gateway/templates/zzz_profile.yaml
@@ -53,7 +53,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
 {{- $x := set $.Values "_original" (deepCopy $.Values) }}
-{{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
+{{- if $defaults.descopeKey }}
+{{- $b := mustMergeOverwrite $defaults (index $defaults $defaults.descopeKey) }}
+{{- $c := mustMergeOverwrite $.Values (index $.Values $defaults.descopeKey) }}
+{{- end }}
+{{- $d := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*
 Labels that should be applied to ALL resources.

--- a/manifests/charts/gateways/istio-egress/templates/zzz_profile.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/zzz_profile.yaml
@@ -53,7 +53,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
 {{- $x := set $.Values "_original" (deepCopy $.Values) }}
-{{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
+{{- if $defaults.descopeKey }}
+{{- $b := mustMergeOverwrite $defaults (index $defaults $defaults.descopeKey) }}
+{{- $c := mustMergeOverwrite $.Values (index $.Values $defaults.descopeKey) }}
+{{- end }}
+{{- $d := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*
 Labels that should be applied to ALL resources.

--- a/manifests/charts/gateways/istio-ingress/templates/zzz_profile.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/zzz_profile.yaml
@@ -53,7 +53,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
 {{- $x := set $.Values "_original" (deepCopy $.Values) }}
-{{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
+{{- if $defaults.descopeKey }}
+{{- $b := mustMergeOverwrite $defaults (index $defaults $defaults.descopeKey) }}
+{{- $c := mustMergeOverwrite $.Values (index $.Values $defaults.descopeKey) }}
+{{- end }}
+{{- $d := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*
 Labels that should be applied to ALL resources.

--- a/manifests/charts/istio-cni/templates/zzy_descope_legacy.yaml
+++ b/manifests/charts/istio-cni/templates/zzy_descope_legacy.yaml
@@ -1,3 +1,0 @@
-{{/* Copy anything under `.cni` to `.`, to avoid the need to specify a redundant prefix.
-Due to the file naming, this always happens after zzz_profile.yaml */}}
-{{- $_ := mustMergeOverwrite $.Values (index $.Values "cni") }}

--- a/manifests/charts/istio-cni/templates/zzz_profile.yaml
+++ b/manifests/charts/istio-cni/templates/zzz_profile.yaml
@@ -53,7 +53,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
 {{- $x := set $.Values "_original" (deepCopy $.Values) }}
-{{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
+{{- if $defaults.descopeKey }}
+{{- $b := mustMergeOverwrite $defaults (index $defaults $defaults.descopeKey) }}
+{{- $c := mustMergeOverwrite $.Values (index $.Values $defaults.descopeKey) }}
+{{- end }}
+{{- $d := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*
 Labels that should be applied to ALL resources.

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -182,3 +182,7 @@ _internal_defaults_do_not_set:
 
   # A `key: value` mapping of environment variables to add to the pod
   env: {}
+
+  # Key to descope values defined in profile.
+  # Used at zzz_profile.yaml file.
+  descopeKey: "cni"

--- a/manifests/charts/istio-control/istio-discovery/templates/zzy_descope_legacy.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/zzy_descope_legacy.yaml
@@ -1,3 +1,0 @@
-{{/* Copy anything under `.pilot` to `.`, to avoid the need to specify a redundant prefix.
-Due to the file naming, this always happens after zzz_profile.yaml */}}
-{{- $_ := mustMergeOverwrite $.Values (index $.Values "pilot") }}

--- a/manifests/charts/istio-control/istio-discovery/templates/zzz_profile.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/zzz_profile.yaml
@@ -53,7 +53,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
 {{- $x := set $.Values "_original" (deepCopy $.Values) }}
-{{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
+{{- if $defaults.descopeKey }}
+{{- $b := mustMergeOverwrite $defaults (index $defaults $defaults.descopeKey) }}
+{{- $c := mustMergeOverwrite $.Values (index $.Values $defaults.descopeKey) }}
+{{- end }}
+{{- $d := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*
 Labels that should be applied to ALL resources.

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -571,3 +571,7 @@ _internal_defaults_do_not_set:
     # -- Eviction policy for unhealthy pods guarded by PodDisruptionBudget.
     # Ref: https://kubernetes.io/blog/2023/01/06/unhealthy-pod-eviction-policy-for-pdbs/
     unhealthyPodEvictionPolicy: ""
+
+  # Key to descope values defined in profile.
+  # Used at zzz_profile.yaml file.
+  descopeKey: "pilot"

--- a/manifests/charts/ztunnel/templates/zzz_profile.yaml
+++ b/manifests/charts/ztunnel/templates/zzz_profile.yaml
@@ -53,7 +53,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
 {{- $x := set $.Values "_original" (deepCopy $.Values) }}
-{{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
+{{- if $defaults.descopeKey }}
+{{- $b := mustMergeOverwrite $defaults (index $defaults $defaults.descopeKey) }}
+{{- $c := mustMergeOverwrite $.Values (index $.Values $defaults.descopeKey) }}
+{{- end }}
+{{- $d := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*
 Labels that should be applied to ALL resources.

--- a/manifests/zzz_profile.yaml
+++ b/manifests/zzz_profile.yaml
@@ -53,7 +53,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
 {{- $x := set $.Values "_original" (deepCopy $.Values) }}
-{{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
+{{- if $defaults.descopeKey }}
+{{- $b := mustMergeOverwrite $defaults (index $defaults $defaults.descopeKey) }}
+{{- $c := mustMergeOverwrite $.Values (index $.Values $defaults.descopeKey) }}
+{{- end }}
+{{- $d := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 
 {{/*
 Labels that should be applied to ALL resources.

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -194,7 +194,7 @@ func TestManifestGenerateComponentHubTag(t *testing.T) {
 	g := NewWithT(t)
 
 	objs := runManifestCommands(t, "component_hub_tag", "", liveCharts,
-		[]string{"templates/deployment.yaml", "templates/daemonset.yaml", "templates/zzy_descope_legacy.yaml"})
+		[]string{"templates/deployment.yaml", "templates/daemonset.yaml"})
 
 	tests := []struct {
 		deploymentName string

--- a/operator/cmd/mesh/manifest_shared_test.go
+++ b/operator/cmd/mesh/manifest_shared_test.go
@@ -195,7 +195,7 @@ func runManifestCommand(command string, filenames []string, flags string, chartS
 		filters := []string{}
 		filters = append(filters, fileSelect...)
 		// Everything needs these
-		filters = append(filters, "templates/_affinity.tpl", "templates/_helpers.tpl", "templates/zzz_profile.yaml", "zzy_descope_legacy.yaml")
+		filters = append(filters, "templates/_affinity.tpl", "templates/_helpers.tpl", "templates/zzz_profile.yaml")
 		args += " --filter " + strings.Join(filters, ",")
 	}
 	args += " --set installPackagePath=" + string(chartSource)


### PR DESCRIPTION
**Please provide a description of this PR:**

This change removes the `zzy_descope_legacy.yaml` file and move its logic into the `zzz_profile.yaml` template.
This improves template clarity and reduces the chance of misconfiguration.

---

<br>

When deploying CNI Helm chart with ArgoCD application, I had trouble with detecting GKE platform with `.Capabilities.KubeVersion.GitVersion`.

```yaml
# cni/template/daemonset.yaml
{{- $detectedBinDir := (.Capabilities.KubeVersion.GitVersion | contains "-gke") | ternary
    "/home/kubernetes/bin"
    "/opt/cni/bin"
}}
{{- if .Values.cniBinDir }}
{{ $detectedBinDir = .Values.cniBinDir }}
{{- end }}
```

To chage `$detectedBinDir`, I changed `.Values.cniBinDir` in my custom values file:

```yaml
# my_values.yaml
profile: ambient

global:
  platform: gke

cniBinDir: /home/kubernetes/bin
```

However, my input value was ignored due to `zzzy_descope_legacy.yaml`, which expects values to be nested:

```yaml
# my_values.yaml
profile: ambient

global:
  platform: gke

cni:
  cniBinDir: /home/kubernetes/bin
```

And, I think this is not familiar way to use Helm.

So, I recommend to move `zzy_descope_legacy.yaml` logic to `zzz_profile`, users can now simply define flat values like this:
```yaml
# my_values.yaml
profile: ambient

global:
  platform: gke

cniBinDir: /home/kubernetes/bin
```

---
<br>

Summary
```
helm install istio-cni -> no autodetect
helm install istio-cni --set cniBinDir=/my/path -> no autodetect
helm install istio-cni --set platform=gke -> autodetect
helm install istio-cni --set platform=gke --set cni.cniBinDir=/my/path -> override /my/path
helm install istio-cni --set platform=gke --set cniBinDir=/my/path -> override /my/path
```

