### PR TITLE
fix tls_inspector missing for workload-only waypoints

### DIFF
--- a/pilot/pkg/networking/core/listener_waypoint.go
+++ b/pilot/pkg/networking/core/listener_waypoint.go
@@ -473,6 +473,12 @@ func (lb *ListenerBuilder) buildWaypointInternal(wls []model.WorkloadInfo, svcs 
 		}
 	}
 	tlsInspector := func() *listener.ListenerFilter {
+		// If we have enrolled workloads, we should sniff TLS
+		// This is important if users want to assert authz against SNI.
+		if len(wls) > 0 {
+			// Default inspector with no excluded ports, workloads could listen on any port
+			return xdsfilters.TLSInspector
+		}
 		tlsPorts := sets.New[int]()
 		nonTLSPorts := sets.New[int]()
 		for _, s := range svcs {


### PR DESCRIPTION
**Please provide a description of this PR:**

Proposed fix for missing tls_inspector when using waypoint with `istio.io/waypoint-for: workload`. The issue occurs when handling only to-workload traffic. In this case, there will be no svcs and the tls_inspector will be omitted as a result.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
