### PR TITLE
xds: add stats for max recv size

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -80,6 +80,7 @@ import (
 	"istio.io/istio/pkg/security"
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/util/sets"
+	xdspkg "istio.io/istio/pkg/xds"
 	"istio.io/istio/security/pkg/pki/ca"
 	"istio.io/istio/security/pkg/pki/ra"
 	caserver "istio.io/istio/security/pkg/server/ca"
@@ -758,7 +759,7 @@ func (s *Server) initGrpcServer(options *istiokeepalive.Options) {
 		// setup server prometheus monitoring (as final interceptor in chain)
 		grpcprom.UnaryServerInterceptor,
 	}
-	grpcOptions := istiogrpc.ServerOptions(options, interceptors...)
+	grpcOptions := istiogrpc.ServerOptions(options, xdspkg.RecordRecvSize, interceptors...)
 	s.grpcServer = grpc.NewServer(grpcOptions...)
 	s.XDSServer.Register(s.grpcServer)
 	reflection.Register(s.grpcServer)
@@ -807,7 +808,7 @@ func (s *Server) initSecureDiscoveryService(args *PilotArgs, trustDomain string)
 		// setup server prometheus monitoring (as final interceptor in chain)
 		grpcprom.UnaryServerInterceptor,
 	}
-	opts := istiogrpc.ServerOptions(args.KeepaliveOptions, interceptors...)
+	opts := istiogrpc.ServerOptions(args.KeepaliveOptions, xdspkg.RecordRecvSize, interceptors...)
 	opts = append(opts, grpc.Creds(tlsCreds))
 
 	s.secureGrpcServer = grpc.NewServer(opts...)

--- a/pilot/pkg/grpc/grpc.go
+++ b/pilot/pkg/grpc/grpc.go
@@ -15,15 +15,18 @@
 package grpc
 
 import (
+	"context"
 	"io"
 	"math"
 	"strings"
 
 	middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
 
 	"istio.io/istio/pilot/pkg/features"
@@ -31,7 +34,7 @@ import (
 	"istio.io/istio/pkg/util/sets"
 )
 
-func ServerOptions(options *istiokeepalive.Options, interceptors ...grpc.UnaryServerInterceptor) []grpc.ServerOption {
+func ServerOptions(options *istiokeepalive.Options, statHandler func(int64), interceptors ...grpc.UnaryServerInterceptor) []grpc.ServerOption {
 	maxStreams := features.MaxConcurrentStreams
 	maxRecvMsgSize := features.MaxRecvMsgSize
 
@@ -44,6 +47,7 @@ func ServerOptions(options *istiokeepalive.Options, interceptors ...grpc.UnarySe
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 			MinTime: options.Time / 2,
 		}),
+		grpc.StatsHandler(StatsHandler(statHandler)),
 		grpc.KeepaliveParams(keepalive.ServerParameters{
 			Time:                  options.Time,
 			Timeout:               options.Timeout,
@@ -53,6 +57,45 @@ func ServerOptions(options *istiokeepalive.Options, interceptors ...grpc.UnarySe
 	}
 
 	return grpcOptions
+}
+
+func StatsHandler(callback func(int64)) stats.Handler {
+	return grpcStatsHandler{max: atomic.NewInt64(0), callback: callback}
+}
+
+type grpcStatsHandler struct {
+	max      *atomic.Int64
+	callback func(int64)
+}
+
+func (h grpcStatsHandler) TagConn(ctx context.Context, info *stats.ConnTagInfo) context.Context {
+	return ctx
+}
+
+func (h grpcStatsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
+	return ctx
+}
+
+func (h grpcStatsHandler) HandleConn(ctx context.Context, s stats.ConnStats) {
+}
+
+func (h grpcStatsHandler) HandleRPC(ctx context.Context, s stats.RPCStats) {
+	if ts, ok := s.(*stats.InPayload); ok {
+		l := int64(ts.Length)
+		// Set h.max = max(h.max, l)
+		// We need a CAS loop here, there is no native support for t his.
+		for {
+			cur := h.max.Load()
+			if l < cur {
+				return
+			}
+			if h.max.CompareAndSwap(cur, l) {
+				// Success, exit
+				h.callback(l)
+				return
+			}
+		}
+	}
 }
 
 const (

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -45,6 +45,7 @@ import (
 	"istio.io/istio/pkg/model"
 	"istio.io/istio/pkg/uds"
 	"istio.io/istio/pkg/wasm"
+	xdspkg "istio.io/istio/pkg/xds"
 	"istio.io/istio/security/pkg/nodeagent/caclient"
 	"istio.io/istio/security/pkg/pki/util"
 )
@@ -596,7 +597,7 @@ func (p *XdsProxy) initDownstreamServer() error {
 	}
 	// TODO: Expose keepalive options to agent cmd line flags.
 	opts := p.downstreamGrpcOptions
-	opts = append(opts, istiogrpc.ServerOptions(istiokeepalive.DefaultOption())...)
+	opts = append(opts, istiogrpc.ServerOptions(istiokeepalive.DefaultOption(), xdspkg.RecordRecvSize)...)
 	grpcs := grpc.NewServer(opts...)
 	discovery.RegisterAggregatedDiscoveryServiceServer(grpcs, p)
 	reflection.Register(grpcs)

--- a/pkg/xds/monitoring.go
+++ b/pkg/xds/monitoring.go
@@ -74,12 +74,23 @@ var (
 		"Pilot XDS response write timeouts.",
 	)
 
+	// Maximum side XDS request received so far.
+	// This is useful for monitoring that we have not exceeded the hard gRPC recv limit (defaults 4mb).
+	maxXdsRecv = monitoring.NewGauge(
+		"pilot_xds_recv_max",
+		"The maximum size request we have received so far.",
+	)
+
 	sendTime = monitoring.NewDistribution(
 		"pilot_xds_send_time",
 		"Total time in seconds Pilot takes to send generated configuration.",
 		[]float64{.01, .1, 1, 3, 5, 10, 20, 30},
 	)
 )
+
+func RecordRecvSize(s int64) {
+	maxXdsRecv.RecordInt(s)
+}
 
 func IncrementXDSRejects(xdsType string, node, errCode string) {
 	totalXDSRejects.With(typeTag.Value(model.GetMetricType(xdsType))).Increment()


### PR DESCRIPTION
This has a hard limit (4mb default) which will cause an outage once
reached. However, we have no metrics for it!

This adds a guage to indicate the max recieved message so far. This is
not keyed by type since the type doesn't matter; the value is global.
This is not a histogram since they are expensive and inprecise; here we
only care about the max seen.
