### PR TITLE
fix the behavior change of istio ps will breaks foreign tooling calling

### DIFF
--- a/istioctl/pkg/proxystatus/proxystatus_test.go
+++ b/istioctl/pkg/proxystatus/proxystatus_test.go
@@ -66,8 +66,8 @@ func TestProxyStatus(t *testing.T) {
 		},
 		{ // case 1, with Istiod instance but no proxies
 			args:           []string{},
-			expectedOutput: "Error: failed to setup status print: no proxies found (checked 1 istiods)\n",
-			wantException:  true,
+			expectedOutput: "NAME     CLUSTER     ISTIOD     VERSION     SUBSCRIBED TYPES\n",
+			wantException:  false,
 		},
 		{ // case 2: supplying nonexistent pod name should result in error with flag
 			args:          strings.Split("deployment/random-gibberish", " "),
@@ -87,9 +87,9 @@ func TestProxyStatus(t *testing.T) {
 		},
 		{ // case 6: new --revision argument, but no proxies
 			args:           strings.Split("--revision canary", " "),
-			expectedOutput: "Error: failed to setup status print: no proxies found (checked 1 istiods)\n",
+			expectedOutput: "NAME     CLUSTER     ISTIOD     VERSION     SUBSCRIBED TYPES\n",
 			revision:       "canary",
-			wantException:  true,
+			wantException:  false,
 		},
 		{ // case 7: supplying type that doesn't select pods should fail
 			args:          strings.Split("serviceaccount/sleep", " "),

--- a/istioctl/pkg/writer/pilot/status.go
+++ b/istioctl/pkg/writer/pilot/status.go
@@ -189,10 +189,6 @@ func (s *XdsStatusWriter) setupStatusPrint(drs map[string]*discovery.DiscoveryRe
 		}
 	}
 
-	if len(fullStatus) == 0 {
-		return nil, nil, nil, fmt.Errorf("no proxies found (checked %d istiods)", len(drs))
-	}
-
 	// Sort types for consistent output, preserving legacy order for core types
 	coreOrder := []string{
 		xdsresource.ClusterType,  // CDS

--- a/releasenotes/notes/57340.yaml
+++ b/releasenotes/notes/57340.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+issue:
+  - 57339
+releaseNotes:
+- |
+  **Fixed** the behavior change of `istioctl proxy-status` when no proxy is present will breaks foreign tooling calling.


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixed the behavior change of `istioctl proxy-status` when no proxy is present will breaks foreign tooling calling.

Fix https://github.com/istio/istio/issues/57339

Related discussions：https://github.com/istio/istio/pull/56441#discussion_r2274074541