### PR TITLE
internaldebug: add flags support list supported debug types

### DIFF
--- a/istioctl/pkg/internaldebug/internal-debug_test.go
+++ b/istioctl/pkg/internaldebug/internal-debug_test.go
@@ -60,7 +60,7 @@ func TestInternalDebug(t *testing.T) {
 		{ // case 0, no args
 			args:           []string{},
 			noIstiod:       true,
-			expectedOutput: "Error: debug type is required\n",
+			expectedOutput: "Error: debug type is required, you can specify --list flag to list supported debug types\n",
 			wantException:  true,
 		},
 		{ // case 1, no istiod

--- a/releasenotes/notes/57373.yaml
+++ b/releasenotes/notes/57373.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue:
+- 57372
+releaseNotes:
+- |
+  **Added** flags to support list debug types for `istioctl experimental internal-debug`


### PR DESCRIPTION
**Please provide a description of this PR:**

 **Added** `--list` flags to support list debug types for `istioctl experimental internal-debug`

Fix https://github.com/istio/istio/issues/57372