### PR TITLE
Fix iptables detection logic

### DIFF
--- a/tools/istio-iptables/pkg/dependencies/implementation_linux.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation_linux.go
@@ -32,7 +32,7 @@ import (
 	"istio.io/istio/tools/istio-iptables/pkg/constants"
 )
 
-var testRuleAdd = []string{"-t", "filter", "-A", "INPUT", "-p", "255", "-j", "DROP", "-m", "comment", "--comment", `"Istio no-op iptables capability probe"`}
+var testRuleAdd = []string{"-t", "nat", "-A", "INPUT", "-p", "255", "-j", "RETURN", "-m", "comment", "--comment", `"Istio no-op iptables capability probe"`}
 
 // TODO the entire `istio-iptables` package is linux-specific, I'm not sure we really need
 // platform-differentiators for the `dependencies` package itself.


### PR DESCRIPTION
Istio’s DetectIptablesVersion method first checks for the iptables-legacy variant, and only falls back to iptables-nft if the binary is missing or validation fails. The validation logic was programming rules in the filter table instead of the nat table. As a result, when a platform included the iptable_filter module but not the iptable_nat module, validation still passed, which later caused errors when programming the actual rules. Since Istio doesn’t program rules in the filter table and mainly relies on the nat table, using the filter table for validation is unreliable. This PR fixes it.

Fixes: https://github.com/istio/istio/issues/57380
- [x] Networking
