### PR TITLE
feat: support adding a prefix to the sidecar injector MutatingWebhookConfiguration

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -41,9 +41,9 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
 {{- if eq .Release.Namespace "istio-system"}}
-  name: istio-sidecar-injector{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  name: {{ .Values.sidecarInjectorWebhook.prefix }}istio-sidecar-injector{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
 {{- else }}
-  name: istio-sidecar-injector{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}-{{ .Release.Namespace }}
+  name: {{ .Values.sidecarInjectorWebhook.prefix }}istio-sidecar-injector{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}-{{ .Release.Namespace }}
 {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -113,6 +113,9 @@ _internal_defaults_do_not_set:
   trustedZtunnelName: ""
 
   sidecarInjectorWebhook:
+    # prefix - Optionally set a prefix on the MutatingWebhookConfiguration resource, allows you to somewhat control when the istio sidecar is injected, e.g. before or after some other MutatingWebhookConfiguration.
+    prefix: ""
+
     # You can use the field called alwaysInjectSelector and neverInjectSelector which will always inject the sidecar or
     # always skip the injection on pods that match that label selector, regardless of the global policy.
     # See https://istio.io/docs/setup/kubernetes/additional-setup/sidecar-injection/#more-control-adding-exceptions


### PR DESCRIPTION
**Please provide a description of this PR:**

[Multiple](https://kubernetes.slack.com/archives/C09NXKJKA/p1691425564734209?thread_ts=1691407293.911769&cid=C09NXKJKA) https://github.com/linkerd/linkerd2/issues/3750#issuecomment-854774436 seem to confirm that the Kubernetes admission webhook requests are processed serially in lexicographical order. Issues start to arise when you have multiple mutating webhooks that change the containers within a pod that should be injected with an istio sidecar.

For example, say I have a mutating webhook that injects a sidecar container into pods with a specific annotation, if that webhook is executed _after_ the istio sidecar injector webhook then any readiness, liveness or startup probes would fail when Istio is configured to `rewriteAppHTTPProbers`. You can sort of work around this by setting `reinvocationPolicy` on the sidecar webhook to `IfNeeded` however if both mutating webhooks (istio sidecar injector and another sidecar injector) have this then the last (in terms of ordering of execution) mutating webhook will always take precedence.

Below is an example:

You have a cluster with the below MutatingWebhookConfigurations
- MutatingWebhookConfiguration `kyverno-resource-mutating-webhook-cfg` that injects a custom sidecar
- MutatingWebhookConfiguration `istio-sidecar` that injects the istio sidecar

1. New Pod with _no_ sidecars hits the kube api
2. The `istio-sidecar` webhook injects the istio sidecar, parses the pod spec and rewrites all the container probes to work with Istio
3. `kyverno-resource-mutating-webhook-cfg` then injects a custom sidecar - The issue starts here, the newly injected container would not have any of it's probes rewritten and the istio-proxy sidecar would not be aware of them.