### PR TITLE
Run nftable tests even with distroless images

### DIFF
--- a/tests/integration/helm/install_test.go
+++ b/tests/integration/helm/install_test.go
@@ -161,7 +161,6 @@ func TestRevisionedReleaseChannels(t *testing.T) {
 }
 
 func TestNativeNftablesInstall(t *testing.T) {
-	t.Skip("https://github.com/istio/istio/issues/57237")
 	values := map[string]interface{}{
 		"global": map[string]interface{}{
 			"nativeNftables": true,

--- a/tests/integration/pilot/nftables/main_test.go
+++ b/tests/integration/pilot/nftables/main_test.go
@@ -18,8 +18,6 @@
 package nftables
 
 import (
-	"os"
-	"strings"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
@@ -43,13 +41,6 @@ var (
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
-		SkipIf("distroless variant doesn't include nft binary. https://github.com/istio/istio/pull/56917",
-			func(ctx resource.Context) bool {
-				// Lets check both environment variable and test settings
-				variant := os.Getenv("DOCKER_BUILD_VARIANTS")
-
-				return variant == "distroless" || strings.Contains(strings.ToLower(ctx.Settings().Image.Variant), "distroless")
-			}).
 		Setup(istio.Setup(&i, func(_ resource.Context, cfg *istio.Config) {
 			cfg.ControlPlaneValues = `
 values:


### PR DESCRIPTION
The nftables-slim package was recently merged into the Wolfi repo, and it has also been updated in Istio as part of PR #56917. So, we can now remove the logic that skips the test when the image is distroless.

Related to: https://github.com/istio/istio/issues/57429
