### PR TITLE
support display connections info for ztunnel-config all

### DIFF
--- a/istioctl/pkg/writer/ztunnel/configdump/configdump.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/configdump.go
@@ -106,6 +106,10 @@ func (c *ConfigWriter) PrintFullSummary() error {
 	if err := c.PrintSecretSummary(); err != nil {
 		return err
 	}
+	_, _ = c.Stdout.Write([]byte("\n"))
+	if err := c.PrintConnectionsSummary(ConnectionsFilter{}); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/releasenotes/notes/57434.yaml
+++ b/releasenotes/notes/57434.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+releaseNotes:
+- |
+  **Added** support display connections info for `istioctl ztunnel-config all`


### PR DESCRIPTION
**Please provide a description of this PR:**

`istioctl ztunnel-config all` should print connections info (`istioctl ztunnel-config all -oyaml` was print it)