### PR TITLE
fix TestHandlerEnqueueFunction setup

### DIFF
--- a/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
@@ -1005,7 +1005,7 @@ func TestHandlerEnqueueFunction(t *testing.T) {
 			d.queue = controllers.NewQueue("fake gateway queue",
 				controllers.WithReconciler(dummyReconcile))
 			go d.queue.Run(stop)
-			kube.WaitForCacheSync("test", stop, d.queue.HasSynced, d.gateways.HasSynced)
+			kube.WaitForCacheSync("test", stop, d.queue.HasSynced, d.gateways.HasSynced, tw.HasSynced)
 
 			switch tt.event.Event {
 			case controllers.EventAdd:


### PR DESCRIPTION
**Please provide a description of this PR:**

If the add event occurs before the tag watcher has synced, you will have 2 reconcile events (informer and tag watcher).