### PR TITLE
Handle istio-cni on node cleanup

### DIFF
--- a/cni/pkg/nodeagent/server.go
+++ b/cni/pkg/nodeagent/server.go
@@ -21,7 +21,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 
@@ -31,7 +33,10 @@ import (
 
 const defaultZTunnelKeepAliveCheckInterval = 5 * time.Second
 
-var log = scopes.CNIAgent
+var (
+	log = scopes.CNIAgent
+	tokenWaitBackoff = time.Second
+)
 
 type MeshDataplane interface {
 	// MUST be called first, (even before Start()).
@@ -119,18 +124,36 @@ func (s *Server) Stop(skipCleanup bool) {
 	s.dataplane.Stop(skipCleanup)
 }
 
-func (s *Server) ShouldStopForUpgrade(selfName, selfNamespace string) bool {
+// ShouldStopCleanup of istio-cni config and binary when upgrading or on node reboot
+func (s *Server) ShouldStopCleanup(selfName, selfNamespace string) bool {
 	dsName := fmt.Sprintf("%s-node", selfName)
-	cniDS, err := s.kubeClient.Kube().AppsV1().DaemonSets(selfNamespace).Get(context.Background(), dsName, metav1.GetOptions{})
-	log.Debugf("Daemonset %s has deletion timestamp?: %+v", dsName, cniDS.DeletionTimestamp)
-	if err == nil && cniDS != nil && cniDS.DeletionTimestamp == nil {
-		log.Infof("terminating, but parent DS %s is still present, this is an upgrade, leaving plugin in place", dsName)
-		return true
-	}
+	shouldStopCleanup := true
+	err := backoff.Retry(
+		func() error {
+			cniDS, err := s.kubeClient.Kube().AppsV1().DaemonSets(selfNamespace).Get(context.Background(), dsName, metav1.GetOptions{})
 
-	// If the DS is gone, it's definitely not an upgrade, so carry on like normal.
-	log.Infof("parent DS %s is gone or marked for deletion, this is not an upgrade, shutting down normally %s", dsName, err)
-	return false
+			log.Debugf("Daemonset %s has deletion timestamp?: %+v", dsName, cniDS.DeletionTimestamp)
+			if err == nil && cniDS != nil && cniDS.DeletionTimestamp == nil {
+				log.Infof("terminating, but parent DS %s is still present, this is an upgrade or a node reboot, leaving plugin in place", dsName)
+				shouldStopCleanup = true
+				return nil
+			}
+			// TODO(jaellio): Not certain "not found" error can be interpreted as not a node reboot
+			if errors.IsNotFound(err) || (cniDS != nil && cniDS.DeletionTimestamp != nil) {
+				// If the DS is gone, or marked for deletion, this is not an upgrade.
+				// We can safely shut down the plugin.
+				log.Infof("parent DS %s is not found or marked for deletion, this is not an upgrade, shutting down normally", dsName)
+				shouldStopCleanup = false
+				return nil
+			}
+			log.Infof("failed to get parent DS %s, retrying: %v", dsName, err)
+			return err
+		},
+		backoff.WithMaxRetries(backoff.NewConstantBackOff(tokenWaitBackoff), 5))
+	if err != nil {
+		log.Infof("failed to get parent DS %s, returning %s: %v", dsName, shouldStopCleanup, err)
+	}
+	return shouldStopCleanup
 }
 
 // buildKubeClient creates the kube client


### PR DESCRIPTION
**Please provide a description of this PR:**

Currently on cleanup if safe upgrades are enable we check if the cni daemonset has a deletion time stamp. If it didn't have a stamp then we are in the process of upgrade or rebooting the node. Otherwise we should cleanup. This didn't handle failures on the get request for the DS (other than not found) which could indicate the node is in an unhealthy state / restarting. Previously an err would mean we would cleanup. Now we will retry the get, and assume we shouldn't cleanup by default.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
