### PR TITLE
do not add the new --ca flag during custome grpc template

### DIFF
--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -356,6 +356,7 @@ func deploymentParams(ctx resource.Context, cfg echo.Config, settings *resource.
 			"ImageFullPath":  settings.CustomGRPCEchoImage, // This overrides image hub/tag if it's not empty.
 			"ContainerPorts": grpcPorts,
 			"FallbackPort":   grpcFallbackPort,
+			"DisableCAFlag":  "true", // the old cpp image doesn't support this new flag, so we elide it in templating
 		})
 	}
 

--- a/pkg/test/framework/components/echo/kube/templates/deployment.yaml
+++ b/pkg/test/framework/components/echo/kube/templates/deployment.yaml
@@ -140,14 +140,18 @@ spec:
 {{- if $.TLSSettings }}
           - --crt=/etc/certs/custom/cert-chain.pem
           - --key=/etc/certs/custom/key.pem
+{{- if not $appContainer.DisableCAFlag }}
           - --ca=/etc/certs/custom/root-cert.pem
+{{- end }}
 {{- if $.TLSSettings.AcceptAnyALPN}}
           - --disable-alpn
 {{- end }}
 {{- else }}
           - --crt=/cert.crt
           - --key=/cert.key
+{{- if not $appContainer.DisableCAFlag }}
           - --ca=/root-cert.pem
+{{- end}}
 {{- end }}
         ports:
 {{- range $i, $p := $appContainer.ContainerPorts }}


### PR DESCRIPTION
**Please provide a description of this PR:**

This fixes the postsubmit failures due to proxyless grpc cpp server not supporting the new echo flag `--ca` used for mTLS testing to validate client certificates.

Example of the failure: https://istio.slack.com/archives/CNWHGSBHA/p1756109507221459