### PR TITLE
Fixes panic due to uninitialized pointer when ClusterID is misconfigured

### DIFF
--- a/security/pkg/server/ca/authenticate/kubeauth/kube_jwt.go
+++ b/security/pkg/server/ca/authenticate/kubeauth/kube_jwt.go
@@ -119,8 +119,12 @@ func (a *KubeJWTAuthenticator) authenticateGrpc(ctx context.Context) (*security.
 func (a *KubeJWTAuthenticator) authenticate(targetJWT string, clusterID cluster.ID) (*security.Caller, error) {
 	kubeClient := a.getKubeClient(clusterID)
 	if kubeClient == nil {
+		var clusterList []cluster.ID
+		if a.remoteKubeClientGetter != nil {
+			clusterList = a.remoteKubeClientGetter.ListClusters()
+		}
 		return nil, fmt.Errorf("client claims to be in cluster %q, but we only know about local cluster %q and remote clusters %v",
-			clusterID, a.clusterID, a.remoteKubeClientGetter.ListClusters())
+			clusterID, a.clusterID, clusterList)
 	}
 
 	id, err := tokenreview.ValidateK8sJwt(kubeClient, targetJWT, security.TokenAudiences)


### PR DESCRIPTION
**Please provide a description of this PR:**
istio-csr panics when testing with a basic gRPC call(emulating istio certificate request) with incorrect ClusterID and when multi-cluster controllers are not initialized.

The fix checks whether the pointer var is initialized or not before using it.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [X ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
