### PR TITLE
kind_provisioner: reduce redundant log messages

### DIFF
--- a/common/scripts/kind_provisioner.sh
+++ b/common/scripts/kind_provisioner.sh
@@ -413,6 +413,7 @@ function install_metallb() {
   if [ -z "${METALLB_IPS4+x}" ]; then
     # Take IPs from the end of the docker kind network subnet to use for MetalLB IPs
     DOCKER_KIND_SUBNET="$(docker inspect kind | jq '.[0].IPAM.Config[0].Subnet' -r)"
+    set +x
     METALLB_IPS4=()
     while read -r ip; do
       METALLB_IPS4+=("$ip")
@@ -425,6 +426,7 @@ function install_metallb() {
         METALLB_IPS6+=("$ip")
       done < <(cidr_to_ips "$DOCKER_KIND_SUBNET" | tail -n 100)
     fi
+    set -x
   fi
 
   # Give this cluster of those IPs


### PR DESCRIPTION
This small change reduces dozens of the redundant lines in each integration test job build log. It saves a lit bit trouble shooting time when scrolling down each job artifacts build logs.

Previous logs
```
+ DOCKER_KIND_SUBNET=fc00:f853:ccd:e793::/64
+ METALLB_IPS4=()
+ read -r ip
++ cidr_to_ips fc00:f853:ccd:e793::/64
++ CIDR=fc00:f853:ccd:e793::/64
++ python3 -
++ tail -n 100
+ METALLB_IPS4+=("$ip")
+ read -r ip
+ METALLB_IPS4+=("$ip")
+ read -r ip
+ METALLB_IPS4+=("$ip")
+ read -r ip
+ METALLB_IPS4+=("$ip")
+ read -r ip
+ METALLB_IPS4+=("$ip")
+ read -r ip
...
+ DOCKER_KIND_SUBNET=172.18.0.0/16
+ read -r ip
++ cidr_to_ips 172.18.0.0/16
++ tail -n 100
++ CIDR=172.18.0.0/16
++ python3 -
+ METALLB_IPS6+=("$ip")
+ read -r ip
+ METALLB_IPS6+=("$ip")
+ read -r ip
+ METALLB_IPS6+=("$ip")
+ read -r ip
+ METALLB_IPS6+=("$ip")
+ read -r ip
+ METALLB_IPS6+=("$ip")
+ read -r ip
...
+ RANGE='['
+ for i in {0..19}
+ RANGE+=172.18.7.110/32,
+ METALLB_IPS4=("${METALLB_IPS4[@]:1}")
+ [[ 100 != 0 ]]
+ RANGE+=fc00:f853:ccd:e793::76e/128,
+ METALLB_IPS6=("${METALLB_IPS6[@]:1}")
...
```

Now
```
+ DOCKER_KIND_SUBNET=fc00:f853:ccd:e793::/64
+ set +x
+ RANGE='['
+ for i in {0..19}
+ RANGE+=172.18.7.110/32,
+ METALLB_IPS4=("${METALLB_IPS4[@]:1}")
+ [[ 100 != 0 ]]
+ RANGE+=fc00:f853:ccd:e793::76e/128,
+ METALLB_IPS6=("${METALLB_IPS6[@]:1}")
```


- [X] Developer Infrastructure

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
