### PR TITLE
Remove unnessary package wolfi-baselayout

### DIFF
--- a/docker/iptables.yaml
+++ b/docker/iptables.yaml
@@ -5,7 +5,6 @@ contents:
     - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
   packages:
     - ca-certificates-bundle
-    - wolfi-baselayout
     - glibc
     - iptables
     - ip6tables


### PR DESCRIPTION
This PR is removing the unnecessary package `wolfi-baselayout` in the docker/iptables.yaml. 

This package is causing conflicts in Jobs:  build-base-images_release-builder_release-1.25_periodic  and build-base-images_release-builder_release-1.26_periodic

The release-1.25 branch and release-1.26 branch have no change in the docker/iptables.yaml file since last year.
The error is about a conflict when apko publish the iptables image tag with the package wolfi-baselayout.

I haven't seen any usage of this package so far. Need to wait more CI job results and verify that it's safe to remove this package in the distroless base image build.

Error log in those two jobs:
https://storage.googleapis.com/istio-prow/logs/build-base-images_release-builder_release-1.25_periodic/1960779518805282816/build-log.txt
https://storage.googleapis.com/istio-prow/logs/build-base-images_release-builder_release-1.26_periodic/1960417126955094016/build-log.txt

```
+ apko publish --arch=amd64,arm64 docker/iptables.yaml docker.io/istio/iptables:1.25-2025-08-27T19-02-18 gcr.io/istio-release/iptables:1.25-2025-08-27T19-02-18

Error: failed to build image components: building "amd64" layer: installing apk packages: installing packages: installing wolfi-baselayout (ver:20230201-r23 arch:x86_64): unable to install files for pkg wolfi-baselayout: writing header for "lib": conflicting file for "lib" has no tar entry
2025/08/27 19:08:50 INFO error during command execution: failed to build image components: building "amd64" layer: installing apk packages: installing packages: installing wolfi-baselayout (ver:20230201-r23 arch:x86_64): unable to install files for pkg wolfi-baselayout: writing header for "lib": conflicting file for "lib" has no tar entry
Error: failed image scan: failed to build base images: exit status 1
```

~The root cause of this conflict is not clear. We may create a wolfi-dev/os issue later~
The root cause of this conflict was discussed in issue : https://github.com/wolfi-dev/os/issues/57413

- [X] Developer Infrastructure

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
