### PR TITLE
Update gateway service.yaml to add option of internalTrafficPolicy Local

### DIFF
--- a/manifests/charts/gateway/templates/service.yaml
+++ b/manifests/charts/gateway/templates/service.yaml
@@ -41,6 +41,9 @@ spec:
 {{- with .Values.service.externalTrafficPolicy }}
   externalTrafficPolicy: "{{ . }}"
 {{- end }}
+{{- with .Values.service.internalTrafficPolicy }}
+  internalTrafficPolicy: "{{ . }}"
+{{- end }}
   type: {{ .Values.service.type }}
   ports:
 {{- if .Values.networkGateway }}

--- a/releasenotes/notes/gateway-service.yaml
+++ b/releasenotes/notes/gateway-service.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+- |
+  **Fixed** gateway service has only option to set the externalTrafficPolicy, but some applications requires to change the 
+  internalTrafficPolicy as well (for example when you try to install Argocd with gateway which is internal application)
+  

--- a/releasenotes/notes/gateway-service.yaml
+++ b/releasenotes/notes/gateway-service.yaml
@@ -1,5 +1,5 @@
 apiVersion: release-notes/v2
-kind: bug-fix
+kind: feature
 area: installation
 releaseNotes:
 - |


### PR DESCRIPTION
this will add option to define internalTrafficPolicy of the gateway service (for example Argo-cd requires internalTrafficPolicy: Local in order to work properly)





- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.