### PR TITLE
Fix regression in strict header validation

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -75,8 +75,9 @@ var (
 	tchars               = "!#$%&'*+-.^_`|~" + "A-Z" + "a-z" + "0-9"
 	validHeaderNameRegex = regexp.MustCompile("^[" + tchars + "]+$")
 
-	validProbeHeaderNameRegex  = regexp.MustCompile("^[-A-Za-z0-9]+$")
-	validStrictHeaderNameRegex = validProbeHeaderNameRegex
+	validProbeHeaderNameRegex = regexp.MustCompile("^[-A-Za-z0-9]+$")
+	// This is kept as a semi-arbitrary set of allowed characters for backwards compatibility.
+	validStrictHeaderNameRegex = regexp.MustCompile("^[-_A-Za-z0-9]+$")
 )
 
 const (

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -1087,6 +1087,7 @@ func TestStrictValidateHTTPHeaderName(t *testing.T) {
 		{name: "X-Requested-With", valid: true},
 		{name: ":authority", valid: false},
 		{name: "", valid: false},
+		{name: "foo_bar", valid: true},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/56686

This accidentally removed `_` which was allowed in the old regex
