### PR TITLE
feat(gw-inference): Bumps InferencePool to v1.0.0-rc.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -107,7 +107,7 @@ require (
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 	sigs.k8s.io/controller-runtime v0.21.0
 	sigs.k8s.io/gateway-api v1.3.0
-	sigs.k8s.io/gateway-api-inference-extension v1.0.0-rc.1
+	sigs.k8s.io/gateway-api-inference-extension v1.0.0-rc.2
 	sigs.k8s.io/knftables v0.0.19-0.20250623122614-e4307300abb5
 	sigs.k8s.io/mcs-api v0.2.0
 	sigs.k8s.io/yaml v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -677,8 +677,8 @@ sigs.k8s.io/controller-runtime v0.21.0 h1:CYfjpEuicjUecRk+KAeyYh+ouUBn4llGyDYytI
 sigs.k8s.io/controller-runtime v0.21.0/go.mod h1:OSg14+F65eWqIu4DceX7k/+QRAbTTvxeQSNSOQpukWM=
 sigs.k8s.io/gateway-api v1.3.0 h1:q6okN+/UKDATola4JY7zXzx40WO4VISk7i9DIfOvr9M=
 sigs.k8s.io/gateway-api v1.3.0/go.mod h1:d8NV8nJbaRbEKem+5IuxkL8gJGOZ+FJ+NvOIltV8gDk=
-sigs.k8s.io/gateway-api-inference-extension v1.0.0-rc.1 h1:X9k0WffbxrQLZD0VLo1zXydc8B7lJ/2OChetfvGyzQQ=
-sigs.k8s.io/gateway-api-inference-extension v1.0.0-rc.1/go.mod h1:qxSY10qt2+YnZJ43VfpMXa6wpiENPderI2BnNZ4Kxfc=
+sigs.k8s.io/gateway-api-inference-extension v1.0.0-rc.2 h1:2rTHwWvI3FC5qvG9pvHq85PmaopjIZL/o7XIS2ZbvT4=
+sigs.k8s.io/gateway-api-inference-extension v1.0.0-rc.2/go.mod h1:qxSY10qt2+YnZJ43VfpMXa6wpiENPderI2BnNZ4Kxfc=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 h1:gBQPwqORJ8d8/YNZWEjoZs7npUVDpVXUUOFfW6CgAqE=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/knftables v0.0.19-0.20250623122614-e4307300abb5 h1:IvJLfQapBuBLXavhpQmA1raQx+VmPKTtRIT0Vmc0MvA=

--- a/pilot/pkg/config/kube/gateway/inferencepool_collection.go
+++ b/pilot/pkg/config/kube/gateway/inferencepool_collection.go
@@ -136,10 +136,11 @@ func createInferencePoolObject(pool *inferencev1.InferencePool, gatewayParents s
 		name: string(pool.Spec.EndpointPickerRef.Name),
 	}
 
-	extRef.port = 9002 // Default port for the inference extension
-	if pool.Spec.EndpointPickerRef.PortNumber != nil {
-		extRef.port = int32(*pool.Spec.EndpointPickerRef.PortNumber)
+	if pool.Spec.EndpointPickerRef.Port == nil {
+		log.Errorf("invalid InferencePool %s/%s; endpointPickerRef port is required", pool.Namespace, pool.Name)
+		return nil
 	}
+	extRef.port = int32(pool.Spec.EndpointPickerRef.Port.Number)
 
 	extRef.failureMode = string(inferencev1.EndpointPickerFailClose) // Default failure mode
 	if pool.Spec.EndpointPickerRef.FailureMode != inferencev1.EndpointPickerFailClose {

--- a/pilot/pkg/config/kube/gateway/inferencepool_test.go
+++ b/pilot/pkg/config/kube/gateway/inferencepool_test.go
@@ -24,7 +24,6 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/kube/krt"
-	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
 )
@@ -48,8 +47,10 @@ func TestReconcileInferencePool(t *testing.T) {
 				},
 			},
 			EndpointPickerRef: inferencev1.EndpointPickerRef{
-				Name:       "dummy",
-				PortNumber: ptr.Of(inferencev1.PortNumber(5421)),
+				Name: "dummy",
+				Port: &inferencev1.Port{
+					Number: inferencev1.PortNumber(5421),
+				},
 			},
 		},
 	}

--- a/pilot/pkg/config/kube/gateway/testdata/http.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/http.yaml
@@ -403,6 +403,8 @@ spec:
       app: vllm-llama3-8b-instruct
   endpointPickerRef:
     name: vllm-llama3-8b-instruct-epp
+    port:
+      number: 9002
 ---
 apiVersion: inference.networking.k8s.io/v1
 kind: InferencePool
@@ -417,3 +419,5 @@ spec:
       app: vllm-llama3-8b-instruct
   endpointPickerRef:
     name: vllm-llama3-8b-instruct-epp
+    port:
+      number: 9002

--- a/pilot/pkg/config/kube/gateway/testdata/reference-policy-inferencepool.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/reference-policy-inferencepool.yaml
@@ -28,6 +28,8 @@ spec:
     group: ""
     kind: Service
     name: endpoint-picker-svc
+    port:
+      number: 9002
   selector:
     matchLabels:
       app: model-server

--- a/releasenotes/notes/57219-rc2.yaml
+++ b/releasenotes/notes/57219-rc2.yaml
@@ -1,0 +1,17 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+- 57219
+
+releaseNotes:
+- |
+  **Removed** support for InferencePool v1.0.0-rc.1.
+  **Added** support for InferencePool v1.0.0-rc.2.
+upgradeNotes:
+- title: InferencePool
+  content: |
+    The InferencePool API v1.0.0-rc.1 has been replaced with v1.0.0-rc.2. In this version, `inferencePool.spec.endpointPickerRef.portNumber`
+    field has been replaced with `inferencePool.spec.endpointPickerRef.port.number`. The `inferencePool.spec.endpointPickerRef.port` field
+    is a non-pointer and required when `inferencePool.spec.endpointPickerRef.kind` is unset or "Service". The port number 9002 is no longer
+    inferred. Update your configurations to use the new API version.

--- a/tests/integration/pilot/testdata/gateway-api-inference-extension-crd.yaml
+++ b/tests/integration/pilot/testdata/gateway-api-inference-extension-crd.yaml
@@ -1,9 +1,9 @@
-# Generated with `kubectl kustomize "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd/?ref=v1.0.0-rc.1"`
+# Generated with `kubectl kustomize "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd/?ref=v1.0.0-rc.2"`
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    inference.networking.k8s.io/bundle-version: v1.0.0-rc.1
+    inference.networking.k8s.io/bundle-version: v1.0.0-rc.2
   creationTimestamp: null
   name: inferenceobjectives.inference.networking.x-k8s.io
 spec:
@@ -205,7 +205,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/1173
-    inference.networking.k8s.io/bundle-version: v1.0.0-rc.1
+    inference.networking.k8s.io/bundle-version: v1.0.0-rc.2
   creationTimestamp: null
   name: inferencepools.inference.networking.k8s.io
 spec:
@@ -291,18 +291,33 @@ spec:
                     maxLength: 253
                     minLength: 1
                     type: string
-                  portNumber:
+                  port:
                     description: |-
-                      PortNumber is the port number of the Endpoint Picker extension service. When unspecified,
-                      implementations SHOULD infer a default value of 9002 when the kind field is "Service" or
-                      unspecified (defaults to "Service").
-                    format: int32
-                    maximum: 65535
-                    minimum: 1
-                    type: integer
+                      Port is the port of the Endpoint Picker extension service.
+
+                      Port is required when the referent is a Kubernetes Service. In this
+                      case, the port number is the service port number, not the target port.
+                      For other resources, destination port might be derived from the referent
+                      resource or this field.
+                    properties:
+                      number:
+                        description: |-
+                          Number defines the port number to access the selected model server Pods.
+                          The number must be in the range 1 to 65535.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                    required:
+                    - number
+                    type: object
                 required:
                 - name
                 type: object
+                x-kubernetes-validations:
+                - message: port is required when kind is 'Service' or unspecified
+                    (defaults to 'Service')
+                  rule: self.kind != 'Service' || has(self.port)
               selector:
                 description: |-
                   Selector determines which Pods are members of this inference pool.
@@ -526,7 +541,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: unapproved, experimental-only
-    inference.networking.k8s.io/bundle-version: v1.0.0-rc.1
+    inference.networking.k8s.io/bundle-version: v1.0.0-rc.2
   creationTimestamp: null
   name: inferencepools.inference.networking.x-k8s.io
 spec:


### PR DESCRIPTION
**Please provide a description of this PR:**

Bumps InferencePool to v1.0.0-rc.2. In this version, `inferencePool.spec.endpointPickerRef.portNumber` field has been replaced with `inferencePool.spec.endpointPickerRef.port.number`. The `inferencePool.spec.endpointPickerRef.port` field is a non-pointer and required when `inferencePool.spec.endpointPickerRef.kind` is unset or "Service". The port number `9002` is no longer inferred.