### PR TITLE
[release-1.25] Fix build-base-images_release-builder_release-1.25_periodic job error

### DIFF
--- a/tools/build-base-images.sh
+++ b/tools/build-base-images.sh
@@ -90,7 +90,7 @@ if [[ "${unexpectedFiles}" != "" ]]; then
   echo "Found unexpected binaries: ${unexpectedFiles}"
   exit 1
 fi
-
+popd > /dev/null
 # Now actually build it
 # shellcheck disable=SC2086
 apko publish --arch="${APKO_ARCHES}" docker/iptables.yaml ${APKO_IMAGES}


### PR DESCRIPTION
This PR is cherry-picking two commits for the `istio/tools/build-base-images.sh` file.
The two commits added a step of "apko build .." command.

After comparing the failed periodic job log in release-1.25 with the passed one in release-1.26, this difference may fix the failed job error. 
The fix of https://github.com/istio/istio/pull/57484 removed a conflict package. It looks like the `apko build` will install a non conflict package from a cache. However, it shows different behavior from release-1.25 branch with the `apko publish` only script.  

...

https://storage.googleapis.com/istio-prow/logs/build-base-images_release-builder_release-1.25_periodic/1961141910764523520/build-log.txt
https://storage.googleapis.com/istio-prow/logs/build-base-images_release-builder_release-1.26_periodic/1961141910856798208/build-log.txt 

This PR is related to the fix PR in https://github.com/istio/istio/pull/57484

- [X] Developer Infrastructure

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
