### PR TITLE
Add native nftables support for Ambient mode

### DIFF
--- a/cni/pkg/addressset/factory.go
+++ b/cni/pkg/addressset/factory.go
@@ -1,0 +1,39 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package addressset
+
+import (
+	"istio.io/istio/cni/pkg/config"
+	"istio.io/istio/cni/pkg/ipset"
+	"istio.io/istio/cni/pkg/nftables"
+)
+
+// New creates a new AddressSetManager instance based on the useNftables flag.
+// If useNftables is false, it returns an ipset-based implementation.
+// If useNftables is true, it returns an nftables-based implementation.
+func New(useNftables bool, enableIPv6 bool) (AddressSetManager, error) {
+	if useNftables {
+		return nftables.NewHostSetManager(config.ProbeIPSet, enableIPv6)
+	}
+
+	// Use existing ipset implementation
+	linDeps := ipset.RealNlDeps()
+	ipsetInstance, err := ipset.NewIPSet(config.ProbeIPSet, enableIPv6, linDeps)
+	if err != nil {
+		return nil, err
+	}
+
+	return &IPSetWrapper{ipset: ipsetInstance}, nil
+}

--- a/cni/pkg/addressset/interface.go
+++ b/cni/pkg/addressset/interface.go
@@ -1,0 +1,52 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package addressset
+
+import (
+	"net/netip"
+)
+
+// AddressSetManager defines the interface for managing host-level IP sets
+// for health check support in Ambient mode. This abstraction allows switching
+// between ipset and nftables set implementations.
+type AddressSetManager interface {
+	// AddIP adds an IP address to the set with the specified protocol, comment etc
+	AddIP(ip netip.Addr, ipProto uint8, comment string, replace bool) error
+
+	// DeleteIP removes an IP address with the specified protocol from the set
+	DeleteIP(ip netip.Addr, ipProto uint8) error
+
+	// Flush clears all entries from the set
+	Flush() error
+
+	// DestroySet completely destroys the set
+	DestroySet() error
+
+	// ClearEntriesWithComment removes all entries with the specified comment
+	ClearEntriesWithComment(comment string) error
+
+	// ClearEntriesWithIP removes all entries with the specified IP address
+	ClearEntriesWithIP(ip netip.Addr) error
+
+	// ClearEntriesWithIPAndComment removes entries with both IP and comment match
+	// Returns the mismatched comment if IP exists but comment doesn't match
+	ClearEntriesWithIPAndComment(ip netip.Addr, comment string) (string, error)
+
+	// ListEntriesByIP returns all IP addresses currently in the set
+	ListEntriesByIP() ([]netip.Addr, error)
+
+	// GetPrefix returns the set name prefix for logging purposes
+	GetPrefix() string
+}

--- a/cni/pkg/addressset/ipset_wrapper.go
+++ b/cni/pkg/addressset/ipset_wrapper.go
@@ -1,0 +1,78 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package addressset
+
+import (
+	"net/netip"
+
+	"istio.io/istio/cni/pkg/ipset"
+)
+
+// IPSetWrapper wraps the existing ipset.IPSet to implement AddressSetManager
+type IPSetWrapper struct {
+	ipset ipset.IPSet
+}
+
+var _ AddressSetManager = &IPSetWrapper{}
+
+// NewIPSetWrapper creates a new IPSetWrapper with the given ipset
+func NewIPSetWrapper(ipsetInstance ipset.IPSet) *IPSetWrapper {
+	return &IPSetWrapper{ipset: ipsetInstance}
+}
+
+// AddIP adds an IP address to the ipset
+func (w *IPSetWrapper) AddIP(ip netip.Addr, ipProto uint8, comment string, replace bool) error {
+	return w.ipset.AddIP(ip, ipProto, comment, replace)
+}
+
+// DeleteIP removes an IP address from the ipset
+func (w *IPSetWrapper) DeleteIP(ip netip.Addr, ipProto uint8) error {
+	return w.ipset.DeleteIP(ip, ipProto)
+}
+
+// Flush clears all entries from the ipset
+func (w *IPSetWrapper) Flush() error {
+	return w.ipset.Flush()
+}
+
+// DestroySet completely destroys the ipset
+func (w *IPSetWrapper) DestroySet() error {
+	return w.ipset.DestroySet()
+}
+
+// ClearEntriesWithComment removes all entries with the specified comment
+func (w *IPSetWrapper) ClearEntriesWithComment(comment string) error {
+	return w.ipset.ClearEntriesWithComment(comment)
+}
+
+// ClearEntriesWithIP removes all entries with the specified IP address
+func (w *IPSetWrapper) ClearEntriesWithIP(ip netip.Addr) error {
+	return w.ipset.ClearEntriesWithIP(ip)
+}
+
+// ClearEntriesWithIPAndComment removes entries with both IP and comment match
+func (w *IPSetWrapper) ClearEntriesWithIPAndComment(ip netip.Addr, comment string) (string, error) {
+	return w.ipset.ClearEntriesWithIPAndComment(ip, comment)
+}
+
+// ListEntriesByIP returns all IP addresses currently in the ipset
+func (w *IPSetWrapper) ListEntriesByIP() ([]netip.Addr, error) {
+	return w.ipset.ListEntriesByIP()
+}
+
+// GetPrefix returns the ipset name prefix for logging purposes
+func (w *IPSetWrapper) GetPrefix() string {
+	return w.ipset.Prefix
+}

--- a/cni/pkg/cmd/root.go
+++ b/cni/pkg/cmd/root.go
@@ -121,6 +121,7 @@ var rootCmd = &cobra.Command{
 					DNSCapture:                 cfg.InstallConfig.AmbientDNSCapture,
 					EnableIPv6:                 cfg.InstallConfig.AmbientIPv6,
 					ReconcilePodRulesOnStartup: cfg.InstallConfig.AmbientReconcilePodRulesOnStartup,
+					NativeNftables:             cfg.InstallConfig.NativeNftables,
 				})
 			if err != nil {
 				return fmt.Errorf("failed to create ambient nodeagent service: %v", err)

--- a/cni/pkg/config/config.go
+++ b/cni/pkg/config/config.go
@@ -19,7 +19,7 @@ import (
 	"net/netip"
 	"strings"
 
-	iptablesconfig "istio.io/istio/tools/common/config"
+	cfg "istio.io/istio/tools/common/config"
 )
 
 // These constants are shared between iptables and nftables implementations
@@ -57,8 +57,8 @@ type PodLevelOverrides struct {
 	DNSProxy          PodDNSOverride
 }
 
-// IptablesConfig represents the "global"/per-instance IptablesConfig
-type IptablesConfig struct {
+// AmbientConfig represents the "global"/per-instance configuration for Ambient mode traffic management
+type AmbientConfig struct {
 	TraceLogging           bool       `json:"IPTABLES_TRACE_LOGGING"`
 	EnableIPv6             bool       `json:"ENABLE_INBOUND_IPV6"`
 	RedirectDNS            bool       `json:"REDIRECT_DNS"`
@@ -69,9 +69,9 @@ type IptablesConfig struct {
 	ForceApply             bool       `json:"FORCE_APPLY"`
 }
 
-// IpbuildConfig converts IptablesConfig to tools common config format
-func IpbuildConfig(c *IptablesConfig) *iptablesconfig.Config {
-	return &iptablesconfig.Config{
+// GetConfig converts AmbientConfig to tools common config format
+func GetConfig(c *AmbientConfig) *cfg.Config {
+	return &cfg.Config{
 		EnableIPv6:  c.EnableIPv6,
 		RedirectDNS: c.RedirectDNS,
 		Reconcile:   c.Reconcile,

--- a/cni/pkg/config/config.go
+++ b/cni/pkg/config/config.go
@@ -16,7 +16,10 @@ package config
 
 import (
 	"fmt"
+	"net/netip"
 	"strings"
+
+	iptablesconfig "istio.io/istio/tools/common/config"
 )
 
 // These constants are shared between iptables and nftables implementations
@@ -36,6 +39,45 @@ const (
 	ZtunnelInboundPlaintextPort = 15006
 	ProbeIPSet                  = "istio-inpod-probes"
 )
+
+// PodDNSOverride represents DNS proxy configuration for a pod
+type PodDNSOverride int
+
+const (
+	PodDNSUnset PodDNSOverride = iota
+	PodDNSEnabled
+	PodDNSDisabled
+)
+
+// PodLevelOverrides holds runtime/dynamic pod-level config overrides
+// that may need to be taken into account when injecting pod rules
+type PodLevelOverrides struct {
+	VirtualInterfaces []string
+	IngressMode       bool
+	DNSProxy          PodDNSOverride
+}
+
+// IptablesConfig represents the "global"/per-instance IptablesConfig
+type IptablesConfig struct {
+	TraceLogging           bool       `json:"IPTABLES_TRACE_LOGGING"`
+	EnableIPv6             bool       `json:"ENABLE_INBOUND_IPV6"`
+	RedirectDNS            bool       `json:"REDIRECT_DNS"`
+	HostProbeSNATAddress   netip.Addr `json:"HOST_PROBE_SNAT_ADDRESS"`
+	HostProbeV6SNATAddress netip.Addr `json:"HOST_PROBE_V6_SNAT_ADDRESS"`
+	Reconcile              bool       `json:"RECONCILE"`
+	CleanupOnly            bool       `json:"CLEANUP_ONLY"`
+	ForceApply             bool       `json:"FORCE_APPLY"`
+}
+
+// IpbuildConfig converts IptablesConfig to tools common config format
+func IpbuildConfig(c *IptablesConfig) *iptablesconfig.Config {
+	return &iptablesconfig.Config{
+		EnableIPv6:  c.EnableIPv6,
+		RedirectDNS: c.RedirectDNS,
+		Reconcile:   c.Reconcile,
+		ForceApply:  c.ForceApply,
+	}
+}
 
 type Config struct {
 	InstallConfig InstallConfig

--- a/cni/pkg/config/config.go
+++ b/cni/pkg/config/config.go
@@ -19,6 +19,24 @@ import (
 	"strings"
 )
 
+// These constants are shared between iptables and nftables implementations
+const (
+	// INPOD marks/masks
+	InpodTProxyMark   = 0x111
+	InpodTProxyMask   = 0xfff
+	InpodMark         = 1337 // this needs to match the inpod config mark in ztunnel.
+	InpodMask         = 0xfff
+	InpodRestoreMask  = 0xffffffff
+	RouteTableInbound = 100
+
+	// Port constants
+	DNSCapturePort              = 15053
+	ZtunnelInboundPort          = 15008
+	ZtunnelOutboundPort         = 15001
+	ZtunnelInboundPlaintextPort = 15006
+	ProbeIPSet                  = "istio-inpod-probes"
+)
+
 type Config struct {
 	InstallConfig InstallConfig
 	RepairConfig  RepairConfig

--- a/cni/pkg/iptables/common_test.go
+++ b/cni/pkg/iptables/common_test.go
@@ -18,30 +18,30 @@ import "istio.io/istio/cni/pkg/config"
 
 func GetCommonInPodTestCases() []struct {
 	name         string
-	config       func(cfg *config.IptablesConfig)
+	config       func(cfg *config.AmbientConfig)
 	podOverrides config.PodLevelOverrides
 } {
 	return []struct {
 		name         string
-		config       func(cfg *config.IptablesConfig)
+		config       func(cfg *config.AmbientConfig)
 		podOverrides config.PodLevelOverrides
 	}{
 		{
 			name: "default",
-			config: func(cfg *config.IptablesConfig) {
+			config: func(cfg *config.AmbientConfig) {
 				cfg.RedirectDNS = true
 			},
 			podOverrides: config.PodLevelOverrides{},
 		},
 		{
 			name: "ingress",
-			config: func(cfg *config.IptablesConfig) {
+			config: func(cfg *config.AmbientConfig) {
 			},
 			podOverrides: config.PodLevelOverrides{IngressMode: true},
 		},
 		{
 			name: "virtual_interfaces",
-			config: func(cfg *config.IptablesConfig) {
+			config: func(cfg *config.AmbientConfig) {
 			},
 			podOverrides: config.PodLevelOverrides{
 				VirtualInterfaces: []string{"fake1s0f0", "fake1s0f1"},
@@ -49,7 +49,7 @@ func GetCommonInPodTestCases() []struct {
 		},
 		{
 			name: "ingress_and_virtual_interfaces",
-			config: func(cfg *config.IptablesConfig) {
+			config: func(cfg *config.AmbientConfig) {
 			},
 			podOverrides: config.PodLevelOverrides{
 				IngressMode:       true,
@@ -58,14 +58,14 @@ func GetCommonInPodTestCases() []struct {
 		},
 		{
 			name: "dns_pod_enabled_and_off_globally",
-			config: func(cfg *config.IptablesConfig) {
+			config: func(cfg *config.AmbientConfig) {
 				cfg.RedirectDNS = false
 			},
 			podOverrides: config.PodLevelOverrides{DNSProxy: config.PodDNSEnabled},
 		},
 		{
 			name: "dns_pod_disabled_and_on_globally",
-			config: func(cfg *config.IptablesConfig) {
+			config: func(cfg *config.AmbientConfig) {
 				cfg.RedirectDNS = true
 			},
 			podOverrides: config.PodLevelOverrides{DNSProxy: config.PodDNSDisabled},
@@ -75,15 +75,15 @@ func GetCommonInPodTestCases() []struct {
 
 func GetCommonHostTestCases() []struct {
 	name   string
-	config func(cfg *config.IptablesConfig)
+	config func(cfg *config.AmbientConfig)
 } {
 	return []struct {
 		name   string
-		config func(cfg *config.IptablesConfig)
+		config func(cfg *config.AmbientConfig)
 	}{
 		{
 			name: "hostprobe",
-			config: func(cfg *config.IptablesConfig) {
+			config: func(cfg *config.AmbientConfig) {
 				cfg.RedirectDNS = true
 			},
 		},

--- a/cni/pkg/iptables/common_test.go
+++ b/cni/pkg/iptables/common_test.go
@@ -14,74 +14,76 @@
 
 package iptables
 
+import "istio.io/istio/cni/pkg/config"
+
 func GetCommonInPodTestCases() []struct {
 	name         string
-	config       func(cfg *IptablesConfig)
-	podOverrides PodLevelOverrides
+	config       func(cfg *config.IptablesConfig)
+	podOverrides config.PodLevelOverrides
 } {
 	return []struct {
 		name         string
-		config       func(cfg *IptablesConfig)
-		podOverrides PodLevelOverrides
+		config       func(cfg *config.IptablesConfig)
+		podOverrides config.PodLevelOverrides
 	}{
 		{
 			name: "default",
-			config: func(cfg *IptablesConfig) {
+			config: func(cfg *config.IptablesConfig) {
 				cfg.RedirectDNS = true
 			},
-			podOverrides: PodLevelOverrides{},
+			podOverrides: config.PodLevelOverrides{},
 		},
 		{
 			name: "ingress",
-			config: func(cfg *IptablesConfig) {
+			config: func(cfg *config.IptablesConfig) {
 			},
-			podOverrides: PodLevelOverrides{IngressMode: true},
+			podOverrides: config.PodLevelOverrides{IngressMode: true},
 		},
 		{
 			name: "virtual_interfaces",
-			config: func(cfg *IptablesConfig) {
+			config: func(cfg *config.IptablesConfig) {
 			},
-			podOverrides: PodLevelOverrides{
+			podOverrides: config.PodLevelOverrides{
 				VirtualInterfaces: []string{"fake1s0f0", "fake1s0f1"},
 			},
 		},
 		{
 			name: "ingress_and_virtual_interfaces",
-			config: func(cfg *IptablesConfig) {
+			config: func(cfg *config.IptablesConfig) {
 			},
-			podOverrides: PodLevelOverrides{
+			podOverrides: config.PodLevelOverrides{
 				IngressMode:       true,
 				VirtualInterfaces: []string{"fake1s0f0", "fake1s0f1"},
 			},
 		},
 		{
 			name: "dns_pod_enabled_and_off_globally",
-			config: func(cfg *IptablesConfig) {
+			config: func(cfg *config.IptablesConfig) {
 				cfg.RedirectDNS = false
 			},
-			podOverrides: PodLevelOverrides{DNSProxy: PodDNSEnabled},
+			podOverrides: config.PodLevelOverrides{DNSProxy: config.PodDNSEnabled},
 		},
 		{
 			name: "dns_pod_disabled_and_on_globally",
-			config: func(cfg *IptablesConfig) {
+			config: func(cfg *config.IptablesConfig) {
 				cfg.RedirectDNS = true
 			},
-			podOverrides: PodLevelOverrides{DNSProxy: PodDNSDisabled},
+			podOverrides: config.PodLevelOverrides{DNSProxy: config.PodDNSDisabled},
 		},
 	}
 }
 
 func GetCommonHostTestCases() []struct {
 	name   string
-	config func(cfg *IptablesConfig)
+	config func(cfg *config.IptablesConfig)
 } {
 	return []struct {
 		name   string
-		config func(cfg *IptablesConfig)
+		config func(cfg *config.IptablesConfig)
 	}{
 		{
 			name: "hostprobe",
-			config: func(cfg *IptablesConfig) {
+			config: func(cfg *config.IptablesConfig) {
 				cfg.RedirectDNS = true
 			},
 		},

--- a/cni/pkg/iptables/iptables.go
+++ b/cni/pkg/iptables/iptables.go
@@ -42,23 +42,23 @@ const (
 type IptablesConfigurator struct {
 	ext    dep.Dependencies
 	nlDeps NetlinkDependencies
-	cfg    *config.IptablesConfig
+	cfg    *config.AmbientConfig
 	iptV   dep.IptablesVersion
 	ipt6V  dep.IptablesVersion
 }
 
 func NewIptablesConfigurator(
-	hostCfg *config.IptablesConfig,
-	podCfg *config.IptablesConfig,
+	hostCfg *config.AmbientConfig,
+	podCfg *config.AmbientConfig,
 	hostDeps dep.Dependencies,
 	podDeps dep.Dependencies,
 	nlDeps NetlinkDependencies,
 ) (*IptablesConfigurator, *IptablesConfigurator, error) {
 	if hostCfg == nil {
-		hostCfg = &config.IptablesConfig{}
+		hostCfg = &config.AmbientConfig{}
 	}
 	if podCfg == nil {
-		podCfg = &config.IptablesConfig{}
+		podCfg = &config.AmbientConfig{}
 	}
 
 	configurator := &IptablesConfigurator{
@@ -201,7 +201,7 @@ func (cfg *IptablesConfigurator) AppendInpodRules(podOverrides config.PodLevelOv
 	inpodMark := fmt.Sprintf("0x%x", config.InpodMark) + "/" + fmt.Sprintf("0x%x", config.InpodMask)
 	inpodTproxyMark := fmt.Sprintf("0x%x", config.InpodTProxyMark) + "/" + fmt.Sprintf("0x%x", config.InpodTProxyMask)
 
-	iptablesBuilder := builder.NewIptablesRuleBuilder(config.IpbuildConfig(cfg.cfg))
+	iptablesBuilder := builder.NewIptablesRuleBuilder(config.GetConfig(cfg.cfg))
 
 	// Insert jumps to our custom chains
 	// This is mostly just for visual tidiness and cleanup, as we can delete the secondary chains and jumps
@@ -609,7 +609,7 @@ func (cfg *IptablesConfigurator) DeleteHostRules() {
 }
 
 func (cfg *IptablesConfigurator) AppendHostRules() *builder.IptablesRuleBuilder {
-	iptablesBuilder := builder.NewIptablesRuleBuilder(config.IpbuildConfig(cfg.cfg))
+	iptablesBuilder := builder.NewIptablesRuleBuilder(config.GetConfig(cfg.cfg))
 
 	// For easier cleanup, insert a jump into an owned chain
 	// -I POSTROUTING 1 -p tcp -j ISTIO_POSTRT

--- a/cni/pkg/iptables/iptables_e2e_linux_test.go
+++ b/cni/pkg/iptables/iptables_e2e_linux_test.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/howardjohn/unshare-go/netns"
 	"github.com/howardjohn/unshare-go/userns"
 
+	"istio.io/istio/cni/pkg/config"
 	"istio.io/istio/cni/pkg/ipset"
 	"istio.io/istio/cni/pkg/scopes"
 	"istio.io/istio/pkg/test/util/assert"
@@ -34,7 +35,7 @@ import (
 
 func createHostsideProbeIpset(isV6 bool) (ipset.IPSet, error) {
 	linDeps := ipset.RealNlDeps()
-	probeSet, err := ipset.NewIPSet(ProbeIPSet, isV6, linDeps)
+	probeSet, err := ipset.NewIPSet(config.ProbeIPSet, isV6, linDeps)
 	if err != nil {
 		return probeSet, err
 	}

--- a/cni/pkg/iptables/iptables_linux.go
+++ b/cni/pkg/iptables/iptables_linux.go
@@ -24,6 +24,7 @@ import (
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
+	cniconfig "istio.io/istio/cni/pkg/config"
 	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/tools/common/config"
 )
@@ -57,9 +58,9 @@ func forEachInpodMarkIPRule(cfg *IptablesConfig, f func(*netlink.Rule) error) er
 		// TODO largely identical/copied from tools/istio-iptables/pkg/capture/run_linux.go
 		inpodMarkRule := netlink.NewRule()
 		inpodMarkRule.Family = family
-		inpodMarkRule.Table = RouteTableInbound
-		inpodMarkRule.Mark = InpodTProxyMark
-		inpodMarkRule.Mask = ptr.Of(uint32(InpodTProxyMask))
+		inpodMarkRule.Table = cniconfig.RouteTableInbound
+		inpodMarkRule.Mark = cniconfig.InpodTProxyMark
+		inpodMarkRule.Mask = ptr.Of(uint32(cniconfig.InpodTProxyMask))
 		inpodMarkRule.Priority = 32764
 		rules = append(rules, inpodMarkRule)
 	}
@@ -127,7 +128,7 @@ func forEachLoopbackRoute(cfg *IptablesConfig, operation string, f func(*netlink
 				Dst:       localhostDst,
 				Scope:     netlink.SCOPE_HOST,
 				Type:      unix.RTN_LOCAL,
-				Table:     RouteTableInbound,
+				Table:     cniconfig.RouteTableInbound,
 				LinkIndex: loopbackLink.Attrs().Index,
 			},
 		}

--- a/cni/pkg/iptables/iptables_linux.go
+++ b/cni/pkg/iptables/iptables_linux.go
@@ -29,7 +29,7 @@ import (
 	"istio.io/istio/tools/common/config"
 )
 
-func AddInpodMarkIPRule(cfg *IptablesConfig) error {
+func AddInpodMarkIPRule(cfg *cniconfig.IptablesConfig) error {
 	err := forEachInpodMarkIPRule(cfg, netlink.RuleAdd)
 	if errors.Is(err, unix.EEXIST) {
 		log.Debugf("Ignoring exists error adding inpod mark ip rule: %v", err)
@@ -38,11 +38,11 @@ func AddInpodMarkIPRule(cfg *IptablesConfig) error {
 	return err
 }
 
-func DelInpodMarkIPRule(cfg *IptablesConfig) error {
+func DelInpodMarkIPRule(cfg *cniconfig.IptablesConfig) error {
 	return forEachInpodMarkIPRule(cfg, netlink.RuleDel)
 }
 
-func forEachInpodMarkIPRule(cfg *IptablesConfig, f func(*netlink.Rule) error) error {
+func forEachInpodMarkIPRule(cfg *cniconfig.IptablesConfig, f func(*netlink.Rule) error) error {
 	var rules []*netlink.Rule
 	families := []int{unix.AF_INET}
 	if cfg.EnableIPv6 {
@@ -75,11 +75,11 @@ func forEachInpodMarkIPRule(cfg *IptablesConfig, f func(*netlink.Rule) error) er
 	return nil
 }
 
-func AddLoopbackRoutes(cfg *IptablesConfig) error {
+func AddLoopbackRoutes(cfg *cniconfig.IptablesConfig) error {
 	return forEachLoopbackRoute(cfg, "add", netlink.RouteReplace)
 }
 
-func DelLoopbackRoutes(cfg *IptablesConfig) error {
+func DelLoopbackRoutes(cfg *cniconfig.IptablesConfig) error {
 	return forEachLoopbackRoute(cfg, "remove", netlink.RouteDel)
 }
 
@@ -93,7 +93,7 @@ func ReadSysctl(key string) (string, error) {
 	return strings.TrimSpace(string(data)), nil
 }
 
-func forEachLoopbackRoute(cfg *IptablesConfig, operation string, f func(*netlink.Route) error) error {
+func forEachLoopbackRoute(cfg *cniconfig.IptablesConfig, operation string, f func(*netlink.Route) error) error {
 	loopbackLink, err := config.LinkByNameWithRetries("lo")
 	if err != nil {
 		return fmt.Errorf("failed to find 'lo' link: %v", err)

--- a/cni/pkg/iptables/iptables_linux.go
+++ b/cni/pkg/iptables/iptables_linux.go
@@ -29,7 +29,7 @@ import (
 	"istio.io/istio/tools/common/config"
 )
 
-func AddInpodMarkIPRule(cfg *cniconfig.IptablesConfig) error {
+func AddInpodMarkIPRule(cfg *cniconfig.AmbientConfig) error {
 	err := forEachInpodMarkIPRule(cfg, netlink.RuleAdd)
 	if errors.Is(err, unix.EEXIST) {
 		log.Debugf("Ignoring exists error adding inpod mark ip rule: %v", err)
@@ -38,11 +38,11 @@ func AddInpodMarkIPRule(cfg *cniconfig.IptablesConfig) error {
 	return err
 }
 
-func DelInpodMarkIPRule(cfg *cniconfig.IptablesConfig) error {
+func DelInpodMarkIPRule(cfg *cniconfig.AmbientConfig) error {
 	return forEachInpodMarkIPRule(cfg, netlink.RuleDel)
 }
 
-func forEachInpodMarkIPRule(cfg *cniconfig.IptablesConfig, f func(*netlink.Rule) error) error {
+func forEachInpodMarkIPRule(cfg *cniconfig.AmbientConfig, f func(*netlink.Rule) error) error {
 	var rules []*netlink.Rule
 	families := []int{unix.AF_INET}
 	if cfg.EnableIPv6 {
@@ -75,11 +75,11 @@ func forEachInpodMarkIPRule(cfg *cniconfig.IptablesConfig, f func(*netlink.Rule)
 	return nil
 }
 
-func AddLoopbackRoutes(cfg *cniconfig.IptablesConfig) error {
+func AddLoopbackRoutes(cfg *cniconfig.AmbientConfig) error {
 	return forEachLoopbackRoute(cfg, "add", netlink.RouteReplace)
 }
 
-func DelLoopbackRoutes(cfg *cniconfig.IptablesConfig) error {
+func DelLoopbackRoutes(cfg *cniconfig.AmbientConfig) error {
 	return forEachLoopbackRoute(cfg, "remove", netlink.RouteDel)
 }
 
@@ -93,7 +93,7 @@ func ReadSysctl(key string) (string, error) {
 	return strings.TrimSpace(string(data)), nil
 }
 
-func forEachLoopbackRoute(cfg *cniconfig.IptablesConfig, operation string, f func(*netlink.Route) error) error {
+func forEachLoopbackRoute(cfg *cniconfig.AmbientConfig, operation string, f func(*netlink.Route) error) error {
 	loopbackLink, err := config.LinkByNameWithRetries("lo")
 	if err != nil {
 		return fmt.Errorf("failed to find 'lo' link: %v", err)

--- a/cni/pkg/iptables/iptables_test.go
+++ b/cni/pkg/iptables/iptables_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"istio.io/istio/cni/pkg/config"
 	"istio.io/istio/cni/pkg/scopes"
 	testutil "istio.io/istio/pilot/test/util"
 	"istio.io/istio/pkg/test/util/assert"
@@ -132,10 +133,10 @@ func compareToGolden(t *testing.T, ipv6 bool, name string, actual []string) {
 	testutil.CompareContent(t, gotBytes, goldenFile)
 }
 
-func constructTestConfig() *IptablesConfig {
+func constructTestConfig() *config.IptablesConfig {
 	probeSNATipv4 := netip.MustParseAddr("169.254.7.127")
 	probeSNATipv6 := netip.MustParseAddr("e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164")
-	return &IptablesConfig{
+	return &config.IptablesConfig{
 		HostProbeSNATAddress:   probeSNATipv4,
 		HostProbeV6SNATAddress: probeSNATipv6,
 	}

--- a/cni/pkg/iptables/iptables_test.go
+++ b/cni/pkg/iptables/iptables_test.go
@@ -133,10 +133,10 @@ func compareToGolden(t *testing.T, ipv6 bool, name string, actual []string) {
 	testutil.CompareContent(t, gotBytes, goldenFile)
 }
 
-func constructTestConfig() *config.IptablesConfig {
+func constructTestConfig() *config.AmbientConfig {
 	probeSNATipv4 := netip.MustParseAddr("169.254.7.127")
 	probeSNATipv6 := netip.MustParseAddr("e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164")
-	return &config.IptablesConfig{
+	return &config.AmbientConfig{
 		HostProbeSNATAddress:   probeSNATipv4,
 		HostProbeV6SNATAddress: probeSNATipv6,
 	}

--- a/cni/pkg/iptables/iptables_unspecified.go
+++ b/cni/pkg/iptables/iptables_unspecified.go
@@ -18,20 +18,22 @@ package iptables
 
 import (
 	"errors"
+
+	"istio.io/istio/cni/pkg/config"
 )
 
-func AddInpodMarkIPRule(cfg *IptablesConfig) error {
+func AddInpodMarkIPRule(cfg *config.IptablesConfig) error {
 	return errors.New("not implemented on this platform")
 }
 
-func DelInpodMarkIPRule(cfg *IptablesConfig) error {
+func DelInpodMarkIPRule(cfg *config.IptablesConfig) error {
 	return errors.New("not implemented on this platform")
 }
 
-func AddLoopbackRoutes(cfg *IptablesConfig) error {
+func AddLoopbackRoutes(cfg *config.IptablesConfig) error {
 	return errors.New("not implemented on this platform")
 }
 
-func DelLoopbackRoutes(cfg *IptablesConfig) error {
+func DelLoopbackRoutes(cfg *config.IptablesConfig) error {
 	return errors.New("not implemented on this platform")
 }

--- a/cni/pkg/iptables/iptables_unspecified.go
+++ b/cni/pkg/iptables/iptables_unspecified.go
@@ -22,18 +22,18 @@ import (
 	"istio.io/istio/cni/pkg/config"
 )
 
-func AddInpodMarkIPRule(cfg *config.IptablesConfig) error {
+func AddInpodMarkIPRule(cfg *config.AmbientConfig) error {
 	return errors.New("not implemented on this platform")
 }
 
-func DelInpodMarkIPRule(cfg *config.IptablesConfig) error {
+func DelInpodMarkIPRule(cfg *config.AmbientConfig) error {
 	return errors.New("not implemented on this platform")
 }
 
-func AddLoopbackRoutes(cfg *config.IptablesConfig) error {
+func AddLoopbackRoutes(cfg *config.AmbientConfig) error {
 	return errors.New("not implemented on this platform")
 }
 
-func DelLoopbackRoutes(cfg *config.IptablesConfig) error {
+func DelLoopbackRoutes(cfg *config.AmbientConfig) error {
 	return errors.New("not implemented on this platform")
 }

--- a/cni/pkg/iptables/nldeps.go
+++ b/cni/pkg/iptables/nldeps.go
@@ -17,10 +17,10 @@ package iptables
 import "istio.io/istio/cni/pkg/config"
 
 type NetlinkDependencies interface {
-	AddInpodMarkIPRule(cfg *config.IptablesConfig) error
-	DelInpodMarkIPRule(cfg *config.IptablesConfig) error
-	AddLoopbackRoutes(cfg *config.IptablesConfig) error
-	DelLoopbackRoutes(cfg *config.IptablesConfig) error
+	AddInpodMarkIPRule(cfg *config.AmbientConfig) error
+	DelInpodMarkIPRule(cfg *config.AmbientConfig) error
+	AddLoopbackRoutes(cfg *config.AmbientConfig) error
+	DelLoopbackRoutes(cfg *config.AmbientConfig) error
 }
 
 func RealNlDeps() NetlinkDependencies {
@@ -29,19 +29,19 @@ func RealNlDeps() NetlinkDependencies {
 
 type realDeps struct{}
 
-func (r *realDeps) AddInpodMarkIPRule(cfg *config.IptablesConfig) error {
+func (r *realDeps) AddInpodMarkIPRule(cfg *config.AmbientConfig) error {
 	return AddInpodMarkIPRule(cfg)
 }
 
-func (r *realDeps) DelInpodMarkIPRule(cfg *config.IptablesConfig) error {
+func (r *realDeps) DelInpodMarkIPRule(cfg *config.AmbientConfig) error {
 	return DelInpodMarkIPRule(cfg)
 }
 
-func (r *realDeps) AddLoopbackRoutes(cfg *config.IptablesConfig) error {
+func (r *realDeps) AddLoopbackRoutes(cfg *config.AmbientConfig) error {
 	return AddLoopbackRoutes(cfg)
 }
 
-func (r *realDeps) DelLoopbackRoutes(cfg *config.IptablesConfig) error {
+func (r *realDeps) DelLoopbackRoutes(cfg *config.AmbientConfig) error {
 	return DelLoopbackRoutes(cfg)
 }
 
@@ -51,18 +51,18 @@ func EmptyNlDeps() NetlinkDependencies {
 	return &emptyDeps{}
 }
 
-func (r *emptyDeps) AddInpodMarkIPRule(cfg *config.IptablesConfig) error {
+func (r *emptyDeps) AddInpodMarkIPRule(cfg *config.AmbientConfig) error {
 	return nil
 }
 
-func (r *emptyDeps) DelInpodMarkIPRule(cfg *config.IptablesConfig) error {
+func (r *emptyDeps) DelInpodMarkIPRule(cfg *config.AmbientConfig) error {
 	return nil
 }
 
-func (r *emptyDeps) AddLoopbackRoutes(cfg *config.IptablesConfig) error {
+func (r *emptyDeps) AddLoopbackRoutes(cfg *config.AmbientConfig) error {
 	return nil
 }
 
-func (r *emptyDeps) DelLoopbackRoutes(cfg *config.IptablesConfig) error {
+func (r *emptyDeps) DelLoopbackRoutes(cfg *config.AmbientConfig) error {
 	return nil
 }

--- a/cni/pkg/iptables/nldeps.go
+++ b/cni/pkg/iptables/nldeps.go
@@ -14,11 +14,13 @@
 
 package iptables
 
+import "istio.io/istio/cni/pkg/config"
+
 type NetlinkDependencies interface {
-	AddInpodMarkIPRule(cfg *IptablesConfig) error
-	DelInpodMarkIPRule(cfg *IptablesConfig) error
-	AddLoopbackRoutes(cfg *IptablesConfig) error
-	DelLoopbackRoutes(cfg *IptablesConfig) error
+	AddInpodMarkIPRule(cfg *config.IptablesConfig) error
+	DelInpodMarkIPRule(cfg *config.IptablesConfig) error
+	AddLoopbackRoutes(cfg *config.IptablesConfig) error
+	DelLoopbackRoutes(cfg *config.IptablesConfig) error
 }
 
 func RealNlDeps() NetlinkDependencies {
@@ -27,19 +29,19 @@ func RealNlDeps() NetlinkDependencies {
 
 type realDeps struct{}
 
-func (r *realDeps) AddInpodMarkIPRule(cfg *IptablesConfig) error {
+func (r *realDeps) AddInpodMarkIPRule(cfg *config.IptablesConfig) error {
 	return AddInpodMarkIPRule(cfg)
 }
 
-func (r *realDeps) DelInpodMarkIPRule(cfg *IptablesConfig) error {
+func (r *realDeps) DelInpodMarkIPRule(cfg *config.IptablesConfig) error {
 	return DelInpodMarkIPRule(cfg)
 }
 
-func (r *realDeps) AddLoopbackRoutes(cfg *IptablesConfig) error {
+func (r *realDeps) AddLoopbackRoutes(cfg *config.IptablesConfig) error {
 	return AddLoopbackRoutes(cfg)
 }
 
-func (r *realDeps) DelLoopbackRoutes(cfg *IptablesConfig) error {
+func (r *realDeps) DelLoopbackRoutes(cfg *config.IptablesConfig) error {
 	return DelLoopbackRoutes(cfg)
 }
 
@@ -49,18 +51,18 @@ func EmptyNlDeps() NetlinkDependencies {
 	return &emptyDeps{}
 }
 
-func (r *emptyDeps) AddInpodMarkIPRule(cfg *IptablesConfig) error {
+func (r *emptyDeps) AddInpodMarkIPRule(cfg *config.IptablesConfig) error {
 	return nil
 }
 
-func (r *emptyDeps) DelInpodMarkIPRule(cfg *IptablesConfig) error {
+func (r *emptyDeps) DelInpodMarkIPRule(cfg *config.IptablesConfig) error {
 	return nil
 }
 
-func (r *emptyDeps) AddLoopbackRoutes(cfg *IptablesConfig) error {
+func (r *emptyDeps) AddLoopbackRoutes(cfg *config.IptablesConfig) error {
 	return nil
 }
 
-func (r *emptyDeps) DelLoopbackRoutes(cfg *IptablesConfig) error {
+func (r *emptyDeps) DelLoopbackRoutes(cfg *config.IptablesConfig) error {
 	return nil
 }

--- a/cni/pkg/nftables/common_test.go
+++ b/cni/pkg/nftables/common_test.go
@@ -1,0 +1,91 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nftables
+
+import "istio.io/istio/cni/pkg/config"
+
+func GetCommonInPodTestCases() []struct {
+	name         string
+	config       func(cfg *config.AmbientConfig)
+	podOverrides config.PodLevelOverrides
+} {
+	return []struct {
+		name         string
+		config       func(cfg *config.AmbientConfig)
+		podOverrides config.PodLevelOverrides
+	}{
+		{
+			name: "default",
+			config: func(cfg *config.AmbientConfig) {
+				cfg.RedirectDNS = true
+			},
+			podOverrides: config.PodLevelOverrides{},
+		},
+		{
+			name: "ingress",
+			config: func(cfg *config.AmbientConfig) {
+			},
+			podOverrides: config.PodLevelOverrides{IngressMode: true},
+		},
+		{
+			name: "virtual_interfaces",
+			config: func(cfg *config.AmbientConfig) {
+			},
+			podOverrides: config.PodLevelOverrides{
+				VirtualInterfaces: []string{"fake1s0f0", "fake1s0f1"},
+			},
+		},
+		{
+			name: "ingress_and_virtual_interfaces",
+			config: func(cfg *config.AmbientConfig) {
+			},
+			podOverrides: config.PodLevelOverrides{
+				IngressMode:       true,
+				VirtualInterfaces: []string{"fake1s0f0", "fake1s0f1"},
+			},
+		},
+		{
+			name: "dns_pod_enabled_and_off_globally",
+			config: func(cfg *config.AmbientConfig) {
+				cfg.RedirectDNS = false
+			},
+			podOverrides: config.PodLevelOverrides{DNSProxy: config.PodDNSEnabled},
+		},
+		{
+			name: "dns_pod_disabled_and_on_globally",
+			config: func(cfg *config.AmbientConfig) {
+				cfg.RedirectDNS = true
+			},
+			podOverrides: config.PodLevelOverrides{DNSProxy: config.PodDNSDisabled},
+		},
+	}
+}
+
+func GetCommonHostTestCases() []struct {
+	name   string
+	config func(cfg *config.AmbientConfig)
+} {
+	return []struct {
+		name   string
+		config func(cfg *config.AmbientConfig)
+	}{
+		{
+			name: "hostprobe",
+			config: func(cfg *config.AmbientConfig) {
+				cfg.RedirectDNS = true
+			},
+		},
+	}
+}

--- a/cni/pkg/nftables/host_sets.go
+++ b/cni/pkg/nftables/host_sets.go
@@ -298,7 +298,7 @@ func (h *HostNftSetManager) ClearEntriesWithIPAndComment(ip netip.Addr, comment 
 		}
 	}
 
-	return "", fmt.Errorf("element with IP %s not found in set %s", ip, setName)
+	return "", nil
 }
 
 // ListEntriesByIP returns all IP addresses currently in both sets

--- a/cni/pkg/nftables/host_sets.go
+++ b/cni/pkg/nftables/host_sets.go
@@ -1,0 +1,246 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nftables
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+
+	"sigs.k8s.io/knftables"
+
+	"istio.io/istio/tools/istio-nftables/pkg/builder"
+)
+
+// HostNftSetManager implements AddressSetManager using nftables sets
+type HostNftSetManager struct {
+	v4SetName   string
+	v6SetName   string
+	prefix      string
+	enableIPv6  bool
+	nftProvider NftProviderFunc
+}
+
+// NewHostSetManager creates a new nftables-based host set manager
+func NewHostSetManager(setPrefix string, enableIPv6 bool) (*HostNftSetManager, error) {
+	// Lets use the same naming convention as ipset
+	v4SetName := fmt.Sprintf("%s-v4", setPrefix)
+	v6SetName := fmt.Sprintf("%s-v6", setPrefix)
+
+	// Use the real implementation when the package level variable is not set
+	nftProvider := nftProviderVar
+	if nftProvider == nil {
+		nftProvider = func(family knftables.Family, table string) (builder.NftablesAPI, error) {
+			return builder.NewNftImpl(family, table)
+		}
+	}
+
+	manager := &HostNftSetManager{
+		v4SetName:   v4SetName,
+		v6SetName:   v6SetName,
+		prefix:      setPrefix,
+		enableIPv6:  enableIPv6,
+		nftProvider: nftProvider,
+	}
+
+	// Initialize the sets
+	if err := manager.initializeSets(); err != nil {
+		return nil, err
+	}
+
+	return manager, nil
+}
+
+// initializeSets creates the nftables table and sets
+func (h *HostNftSetManager) initializeSets() error {
+	nft, err := h.nftProvider(knftables.InetFamily, AmbientNatTable)
+	if err != nil {
+		return err
+	}
+
+	tx := nft.NewTransaction()
+
+	// Create table
+	tx.Add(&knftables.Table{})
+
+	// Create IPv4 set
+	tx.Add(&knftables.Set{
+		Name:    h.v4SetName,
+		Type:    "ipv4_addr",
+		Comment: knftables.PtrTo("UUID of the pods that are part of ambient mesh"),
+	})
+
+	// Create IPv6 set if enabled
+	if h.enableIPv6 {
+		tx.Add(&knftables.Set{
+			Name:    h.v6SetName,
+			Type:    "ipv6_addr",
+			Comment: knftables.PtrTo("UUID of the pods that are part of ambient mesh"),
+		})
+	}
+
+	if err := nft.Run(context.TODO(), tx); err != nil {
+		return fmt.Errorf("failed to initialize nftables sets: %w", err)
+	}
+
+	builder.LogNftRules(tx)
+	return nil
+}
+
+// AddIP adds an IP address to the appropriate set (v4 or v6)
+func (h *HostNftSetManager) AddIP(ip netip.Addr, ipProto uint8, comment string, replace bool) error {
+	ipToInsert := ip.Unmap()
+	setName := h.v4SetName
+	if ipToInsert.Is6() {
+		if !h.enableIPv6 {
+			log.Debugf("IPv6 is not enabled. Skipping the addition of IP: %v", ip)
+			return nil
+		}
+		setName = h.v6SetName
+	}
+
+	nft, err := h.nftProvider(knftables.InetFamily, AmbientNatTable)
+	if err != nil {
+		return err
+	}
+
+	tx := nft.NewTransaction()
+
+	// Add element to the set
+	tx.Add(&knftables.Element{
+		Set:     setName,
+		Key:     []string{ipToInsert.String()},
+		Comment: knftables.PtrTo(comment),
+	})
+
+	if err := nft.Run(context.TODO(), tx); err != nil {
+		return fmt.Errorf("failed to add IP %s to nftables set %s: %w", ip, setName, err)
+	}
+
+	builder.LogNftRules(tx)
+	return nil
+}
+
+// DeleteIP removes an IP address from the appropriate set
+func (h *HostNftSetManager) DeleteIP(ip netip.Addr, ipProto uint8) error {
+	nft, err := h.nftProvider(knftables.InetFamily, AmbientNatTable)
+	if err != nil {
+		return err
+	}
+
+	ipToDel := ip.Unmap()
+	setName := h.v4SetName
+	if ipToDel.Is6() {
+		if !h.enableIPv6 {
+			log.Debugf("IPv6 is not enabled. Skipping the deletion of IP: %v", ip)
+			return nil
+		}
+		setName = h.v6SetName
+	}
+
+	tx := nft.NewTransaction()
+
+	// Delete element from the set
+	tx.Delete(&knftables.Element{
+		Set: setName,
+		Key: []string{ipToDel.String()},
+	})
+
+	if err := nft.Run(context.TODO(), tx); err != nil {
+		return fmt.Errorf("failed to delete IP %s from nftables set %s: %w", ip, setName, err)
+	}
+
+	builder.LogNftRules(tx)
+	return nil
+}
+
+// Flush clears all entries from both sets
+func (h *HostNftSetManager) Flush() error {
+	nft, err := h.nftProvider(knftables.InetFamily, AmbientNatTable)
+	if err != nil {
+		return err
+	}
+
+	tx := nft.NewTransaction()
+
+	// Flush IPv4 set
+	tx.Flush(&knftables.Set{
+		Name: h.v4SetName,
+	})
+
+	// Flush IPv6 set if enabled
+	if h.enableIPv6 {
+		tx.Flush(&knftables.Set{
+			Name: h.v6SetName,
+		})
+	}
+
+	if err := nft.Run(context.TODO(), tx); err != nil {
+		return fmt.Errorf("failed to flush nftables sets: %w", err)
+	}
+
+	builder.LogNftRules(tx)
+	return nil
+}
+
+// DestroySet completely destroys both sets and the table
+func (h *HostNftSetManager) DestroySet() error {
+	nft, err := h.nftProvider(knftables.InetFamily, AmbientNatTable)
+	if err != nil {
+		return err
+	}
+
+	tx := nft.NewTransaction()
+
+	// Delete the entire table (which will delete sets and rules)
+	tx.Delete(&knftables.Table{})
+
+	if err := nft.Run(context.TODO(), tx); err != nil {
+		return fmt.Errorf("failed to destroy nftables table %s: %w", AmbientNatTable, err)
+	}
+
+	builder.LogNftRules(tx)
+	return nil
+}
+
+// ClearEntriesWithComment removes all entries with the specified comment
+func (h *HostNftSetManager) ClearEntriesWithComment(comment string) error {
+	// TODO: For nftables, we need to list elements and delete those with matching comments
+
+	return nil
+}
+
+// ClearEntriesWithIP removes all entries with the specified IP address
+func (h *HostNftSetManager) ClearEntriesWithIP(ip netip.Addr) error {
+	return h.DeleteIP(ip, 0)
+}
+
+// ClearEntriesWithIPAndComment removes entries with both IP and comment match
+func (h *HostNftSetManager) ClearEntriesWithIPAndComment(ip netip.Addr, comment string) (string, error) {
+	// TODO: Implement this method properly. For now, just using DeleteIP()
+	err := h.DeleteIP(ip, 0)
+	return "", err
+}
+
+// ListEntriesByIP returns all IP addresses currently in both sets
+func (h *HostNftSetManager) ListEntriesByIP() ([]netip.Addr, error) {
+	// TODO: Implement this method properly. For now, just using DeleteIP()
+	return []netip.Addr{}, nil
+}
+
+// GetPrefix returns the set name prefix for logging purposes
+func (h *HostNftSetManager) GetPrefix() string {
+	return h.prefix
+}

--- a/cni/pkg/nftables/nftables.go
+++ b/cni/pkg/nftables/nftables.go
@@ -415,12 +415,12 @@ func (cfg *NftablesConfigurator) CreateHostRulesForHealthChecks() error {
 	cfg.ruleBuilder = builder.NewNftablesRuleBuilder(config.GetConfig(cfg.cfg))
 
 	// TODO: Investigate how to support "-m owner --socket-exists" with nftable rules.
-	cfg.ruleBuilder.AppendRule(PostroutingChain, AmbientNatTable, "ip", "daddr", fmt.Sprintf("@%s-v4", config.ProbeIPSet),
-		"meta l4proto tcp", Counter, "snat", "to", cfg.cfg.HostProbeSNATAddress.String())
+	// cfg.ruleBuilder.AppendRule(PostroutingChain, AmbientNatTable, "ip", "daddr", fmt.Sprintf("@%s-v4", config.ProbeIPSet),
+	//	"meta l4proto tcp", Counter, "snat", "to", cfg.cfg.HostProbeSNATAddress.String())
 
 	// For V6 we have to use a different set and a different SNAT IP
-	cfg.ruleBuilder.AppendRule(PostroutingChain, AmbientNatTable, "ip6", "daddr", fmt.Sprintf("@%s-v6", config.ProbeIPSet),
-		"meta l4proto tcp", Counter, "snat", "to", cfg.cfg.HostProbeV6SNATAddress.String())
+	// cfg.ruleBuilder.AppendRule(PostroutingChain, AmbientNatTable, "ip6", "daddr", fmt.Sprintf("@%s-v6", config.ProbeIPSet),
+	//	"meta l4proto tcp", Counter, "snat", "to", cfg.cfg.HostProbeV6SNATAddress.String())
 
 	return util.RunAsHost(func() error {
 		tx, err := cfg.executeHostCommands()

--- a/cni/pkg/nftables/nftables.go
+++ b/cni/pkg/nftables/nftables.go
@@ -1,0 +1,110 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nftables
+
+import (
+	"istio.io/istio/cni/pkg/iptables"
+	"istio.io/istio/cni/pkg/scopes"
+	istiolog "istio.io/istio/pkg/log"
+	dep "istio.io/istio/tools/istio-iptables/pkg/dependencies"
+)
+
+var log = scopes.CNIAgent
+
+// NftablesConfigurator handles nftables rule management for Ambient mode
+type NftablesConfigurator struct {
+	ext    dep.Dependencies
+	nlDeps iptables.NetlinkDependencies
+	cfg    *iptables.IptablesConfig
+}
+
+// NewNftablesConfigurator creates both host and pod nftables configurators
+func NewNftablesConfigurator(
+	hostCfg *iptables.IptablesConfig,
+	podCfg *iptables.IptablesConfig,
+	hostDeps dep.Dependencies,
+	podDeps dep.Dependencies,
+	nlDeps iptables.NetlinkDependencies,
+) (*NftablesConfigurator, *NftablesConfigurator, error) {
+	if hostCfg == nil {
+		hostCfg = &iptables.IptablesConfig{}
+	}
+	if podCfg == nil {
+		podCfg = &iptables.IptablesConfig{}
+	}
+
+	hostConfigurator := &NftablesConfigurator{
+		ext:    hostDeps,
+		nlDeps: nlDeps,
+		cfg:    hostCfg,
+	}
+
+	podConfigurator := &NftablesConfigurator{
+		ext:    podDeps,
+		nlDeps: nlDeps,
+		cfg:    podCfg,
+	}
+
+	return hostConfigurator, podConfigurator, nil
+}
+
+// CreateInpodRules creates nftables rules within a pod's network namespace
+func (cfg *NftablesConfigurator) CreateInpodRules(log *istiolog.Scope, podOverrides iptables.PodLevelOverrides) error {
+	log.Info("native nftables enabled, using nft rules for inpod traffic redirection")
+
+	return nil
+}
+
+// DeleteInpodRules removes nftables rules from a pod's network namespace
+func (cfg *NftablesConfigurator) DeleteInpodRules(log *istiolog.Scope) error {
+	log.Info("removing nftables inpod rules")
+
+	return nil
+}
+
+// CreateHostRulesForHealthChecks creates host-level nftables rules for health check handling
+// NOTE: This expects to be run from within the HOST network namespace!
+func (cfg *NftablesConfigurator) CreateHostRulesForHealthChecks() error {
+	log.Info("configuring host-level nftables rules (healthchecks, etc)")
+
+	return nil
+}
+
+// DeleteHostRules removes host-level nftables rules
+func (cfg *NftablesConfigurator) DeleteHostRules() {
+	log.Debug("Attempting to delete hostside nftables rules (if they exist)")
+	log.Debug("hostside nftables rules deletion completed (stub implementation)")
+}
+
+// ReconcileModeEnabled returns true if reconciliation mode is enabled
+func (cfg *NftablesConfigurator) ReconcileModeEnabled() bool {
+	return cfg.cfg.Reconcile
+}
+
+func (cfg *NftablesConfigurator) addLoopbackRoute() error {
+	return cfg.nlDeps.AddLoopbackRoutes(cfg.cfg)
+}
+
+func (cfg *NftablesConfigurator) delLoopbackRoute() error {
+	return cfg.nlDeps.DelLoopbackRoutes(cfg.cfg)
+}
+
+func (cfg *NftablesConfigurator) addInpodMarkIPRule() error {
+	return cfg.nlDeps.AddInpodMarkIPRule(cfg.cfg)
+}
+
+func (cfg *NftablesConfigurator) delInpodMarkIPRule() error {
+	return cfg.nlDeps.DelInpodMarkIPRule(cfg.cfg)
+}

--- a/cni/pkg/nftables/nftables.go
+++ b/cni/pkg/nftables/nftables.go
@@ -15,11 +15,18 @@
 package nftables
 
 import (
+	"context"
+	"errors"
+	"fmt"
+
+	"sigs.k8s.io/knftables"
+
 	"istio.io/istio/cni/pkg/config"
 	"istio.io/istio/cni/pkg/iptables"
 	"istio.io/istio/cni/pkg/scopes"
 	istiolog "istio.io/istio/pkg/log"
 	dep "istio.io/istio/tools/istio-iptables/pkg/dependencies"
+	"istio.io/istio/tools/istio-nftables/pkg/builder"
 )
 
 const (
@@ -35,16 +42,22 @@ const (
 	// Regular chains prefixed with "istio" to distinguish them from base chains
 	IstioOutputChain     = "istio-output"
 	IstioPreroutingChain = "istio-prerouting"
+
+	Counter = "counter"
 )
 
 var log = scopes.CNIAgent
 
+type NftProviderFunc func(family knftables.Family, table string) (builder.NftablesAPI, error)
+
+var nftProviderVar NftProviderFunc
+
 // NftablesConfigurator handles nftables rule management for Ambient mode
-// This follows the same pattern as iptables.IptablesConfigurator
 type NftablesConfigurator struct {
-	ext    dep.Dependencies
-	nlDeps iptables.NetlinkDependencies
-	cfg    *config.AmbientConfig
+	nlDeps      iptables.NetlinkDependencies
+	cfg         *config.AmbientConfig
+	ruleBuilder *builder.NftablesRuleBuilder
+	nftProvider NftProviderFunc
 }
 
 // NewNftablesConfigurator creates both host and pod nftables configurators
@@ -62,16 +75,26 @@ func NewNftablesConfigurator(
 		podCfg = &config.AmbientConfig{}
 	}
 
+	// Use the real implementation when the package level variable is not set (i.e., during unit tests)
+	nftProvider := nftProviderVar
+	if nftProvider == nil {
+		nftProvider = func(family knftables.Family, table string) (builder.NftablesAPI, error) {
+			return builder.NewNftImpl(family, table)
+		}
+	}
+
 	hostConfigurator := &NftablesConfigurator{
-		ext:    hostDeps,
-		nlDeps: nlDeps,
-		cfg:    hostCfg,
+		nlDeps:      nlDeps,
+		cfg:         hostCfg,
+		ruleBuilder: builder.NewNftablesRuleBuilder(config.GetConfig(hostCfg)),
+		nftProvider: nftProvider,
 	}
 
 	podConfigurator := &NftablesConfigurator{
-		ext:    podDeps,
-		nlDeps: nlDeps,
-		cfg:    podCfg,
+		nlDeps:      nlDeps,
+		cfg:         podCfg,
+		ruleBuilder: builder.NewNftablesRuleBuilder(config.GetConfig(podCfg)),
+		nftProvider: nftProvider,
 	}
 
 	return hostConfigurator, podConfigurator, nil
@@ -81,40 +104,306 @@ func NewNftablesConfigurator(
 func (cfg *NftablesConfigurator) CreateInpodRules(log *istiolog.Scope, podOverrides config.PodLevelOverrides) error {
 	log.Info("native nftables enabled, using nft rules for inpod traffic redirection")
 
-	// TODO: Implement nftables rule creation for inpod traffic redirection
+	rules, err := cfg.AppendInpodRules(podOverrides)
+	if err != nil {
+		return err
+	}
+	builder.LogNftRules(rules)
 
-	// Add loopback routes (still needed for nftables)
+	// Add loopback routes
 	if err := cfg.addLoopbackRoute(); err != nil {
 		return err
 	}
 
-	// Add inpod mark IP rule (still needed for nftables)
+	// Add inpod mark IP rule
 	if err := cfg.addInpodMarkIPRule(); err != nil {
 		return err
 	}
 
-	log.Info("nftables inpod rules creation completed (stub implementation)")
+	log.Info("nftables inpod rules creation completed")
 	return nil
+}
+
+func (cfg *NftablesConfigurator) AppendInpodRules(podOverrides config.PodLevelOverrides) (*knftables.Transaction, error) {
+	var redirectDNS bool
+
+	switch podOverrides.DNSProxy {
+	case config.PodDNSUnset:
+		redirectDNS = cfg.cfg.RedirectDNS
+	case config.PodDNSEnabled:
+		redirectDNS = true
+	case config.PodDNSDisabled:
+		redirectDNS = false
+	}
+
+	cfg.ruleBuilder.AppendRule(
+		PreroutingChain, AmbientMangleTable,
+		"jump", IstioPreroutingChain,
+	)
+
+	cfg.ruleBuilder.AppendRule(
+		OutputChain, AmbientMangleTable,
+		"jump", IstioOutputChain,
+	)
+
+	cfg.ruleBuilder.AppendRule(
+		OutputChain, AmbientNatTable,
+		"jump", IstioOutputChain,
+	)
+
+	if redirectDNS {
+		cfg.ruleBuilder.AppendRule(
+			PreroutingChain, AmbientRawTable,
+			"jump", IstioPreroutingChain,
+		)
+		cfg.ruleBuilder.AppendRule(
+			OutputChain, AmbientRawTable,
+			"jump", IstioOutputChain,
+		)
+	}
+
+	cfg.ruleBuilder.AppendRule(
+		PreroutingChain, AmbientNatTable,
+		"jump", IstioPreroutingChain,
+	)
+
+	// To keep things manageable, the first rules in the istio-prerouting chain should be short-circuits, like
+	// virtual interface exclusions/redirects:
+	if len(podOverrides.VirtualInterfaces) != 0 {
+		for _, virtInterface := range podOverrides.VirtualInterfaces {
+			// DESC: For any configured virtual interfaces, treat inbound as outbound traffic (useful for kubeVirt, VMs, DinD, etc)
+			// and just shunt it directly to the outbound port of the proxy.
+			// Note that for now this explicitly excludes UDP traffic, as we can't proxy arbitrary UDP stuff,
+			// and this is a difference from the old sidecar `traffic.sidecar.istio.io/kubevirtInterfaces` annotation.
+			cfg.ruleBuilder.AppendRule(IstioPreroutingChain, AmbientNatTable,
+				"iifname", fmt.Sprint(virtInterface),
+				"meta l4proto tcp", Counter,
+				"redirect to", ":"+fmt.Sprint(config.ZtunnelOutboundPort),
+			)
+
+			cfg.ruleBuilder.AppendRule(IstioPreroutingChain, AmbientNatTable,
+				"iifname", fmt.Sprint(virtInterface),
+				"meta l4proto tcp", Counter,
+				"return",
+			)
+		}
+	}
+
+	if !podOverrides.IngressMode {
+		// CLI: nft add rule inet istio-ambient-mangle istio-prerouting meta mark & 0xfff == 0x539 counter ct mark set ct mark & 0xfffff000 | 0x111
+		// DESC: If we have a packet mark, set a connmark.
+		cfg.ruleBuilder.AppendRule(IstioPreroutingChain, AmbientMangleTable,
+			"meta mark & 0xfff ==",
+			fmt.Sprintf("0x%x", config.InpodMark), Counter, "ct mark set ct mark & 0xfffff000 | ",
+			fmt.Sprintf("0x%x", config.InpodTProxyMark))
+
+		// Handle healthcheck probes from the host node. In the host netns, before the packet enters the pod, we SNAT
+		// the healthcheck packet to a fixed IP if the packet is coming from a node-local process with a socket.
+		//
+		// We do this so we can exempt this traffic from ztunnel capture/proxy - otherwise both kube-proxy (legit)
+		// and kubelet (skippable) traffic would have the same srcip once they got to the pod, and would be indistinguishable.
+
+		// CLI: nft add rule inet istio-ambient-nat istio-prerouting meta l4proto tcp ip saddr 169.254.7.127 counter accept
+		//
+		// DESC: If this is one of our node-probe ports and is from our SNAT-ed/"special" hostside IP, short-circuit out here
+		cfg.ruleBuilder.AppendRule(IstioPreroutingChain, AmbientNatTable,
+			"meta l4proto tcp",
+			"ip saddr", cfg.cfg.HostProbeSNATAddress.String(), Counter,
+			"accept",
+		)
+
+		// CLI: nft add rule inet istio-ambient-nat istio-prerouting meta l4proto tcp ip6 saddr
+		// fd16:9254:7127:1337:ffff:ffff:ffff:ffff counter accept
+		cfg.ruleBuilder.AppendRule(IstioPreroutingChain, AmbientNatTable,
+			"meta l4proto tcp",
+			"ip6 saddr", cfg.cfg.HostProbeV6SNATAddress.String(), Counter,
+			"accept",
+		)
+	}
+
+	// CLI: nft add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr 169.254.7.127 counter accept
+	// DESC: Anything coming BACK from the pod healthcheck port with a dest of our SNAT-ed hostside IP we also short-circuit.
+	cfg.ruleBuilder.AppendRule(IstioOutputChain, AmbientNatTable,
+		"meta l4proto tcp",
+		"ip daddr", cfg.cfg.HostProbeSNATAddress.String(), Counter,
+		"accept",
+	)
+
+	// CLI: nft add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr fd16:9254:7127:1337:ffff:ffff:ffff:ffff counter accept
+	cfg.ruleBuilder.AppendRule(IstioOutputChain, AmbientNatTable,
+		"meta l4proto tcp",
+		"ip6 daddr", cfg.cfg.HostProbeV6SNATAddress.String(), Counter,
+		"accept",
+	)
+
+	if !podOverrides.IngressMode {
+		// CLI: nft add rule inet istio-ambient-nat istio-prerouting ip daddr != 127.0.0.1 tcp dport != 15008 mark and 0xfff != 0x539
+		// counter redirect to :15006
+		//
+		// DESC: Anything that is not bound for localhost and does not have the mark, REDIRECT to ztunnel inbound plaintext port <INPLAINPORT>
+		// Skip 15008, which will go direct without redirect needed.
+		cfg.ruleBuilder.AppendRule(IstioPreroutingChain, AmbientNatTable,
+			"ip daddr", "!=", "127.0.0.1/32",
+			"tcp dport", "!=", fmt.Sprint(config.ZtunnelInboundPort),
+			"mark and 0xfff ", "!=", fmt.Sprintf("0x%x", config.InpodMark), Counter,
+			"redirect to", ":"+fmt.Sprint(config.ZtunnelInboundPlaintextPort),
+		)
+
+		cfg.ruleBuilder.AppendRule(IstioPreroutingChain, AmbientNatTable,
+			"ip6 daddr", "!=", "::1/128",
+			"tcp dport", "!=", fmt.Sprint(config.ZtunnelInboundPort),
+			"mark and 0xfff", "!=", fmt.Sprintf("0x%x", config.InpodMark), Counter,
+			"redirect to", ":"+fmt.Sprint(config.ZtunnelInboundPlaintextPort),
+		)
+	}
+
+	// CLI: nft add rule inet istio-ambient-mangle istio-output ct mark and 0xfff == 0x111 counter meta mark set ct mark
+	//
+	// DESC: Propagate/restore connmark (if we had one) for outbound
+	cfg.ruleBuilder.AppendRule(
+		IstioOutputChain, AmbientMangleTable,
+		"ct mark and", fmt.Sprintf("0x%x", config.InpodTProxyMask),
+		"==", fmt.Sprintf("0x%x", config.InpodTProxyMark), Counter,
+		"meta mark set ct mark",
+	)
+
+	if redirectDNS {
+		// CLI: nft add rule inet istio-ambient-nat istio-output oifname != "lo" mark and 0xfff != 0x539 udp dport 53 counter redirect to :15053
+		//
+		// DESC: If this is a UDP DNS request to a non-localhost resolver, send it to ztunnel DNS proxy port
+		cfg.ruleBuilder.AppendRule(
+			IstioOutputChain, AmbientNatTable,
+			"oifname", "!=", "lo",
+			"mark and", fmt.Sprintf("0x%x", config.InpodMask),
+			"!=", fmt.Sprintf("0x%x", config.InpodMark),
+			"udp dport", "53", Counter,
+			"redirect to", ":"+fmt.Sprintf("%d", config.DNSCapturePort),
+		)
+
+		// CLI: nft add rule inet istio-ambient-nat istio-output ip daddr != 127.0.0.1/32 tcp dport 53 mark and 0xfff != 0x539 counter redirect to :15053
+		cfg.ruleBuilder.AppendRule(
+			IstioOutputChain, AmbientNatTable,
+			"ip daddr", "!=", "127.0.0.1/32",
+			"tcp dport", "53",
+			"mark and", fmt.Sprintf("0x%x", config.InpodMask),
+			"!=", fmt.Sprintf("0x%x", config.InpodMark), Counter,
+			"redirect to", ":"+fmt.Sprintf("%d", config.DNSCapturePort),
+		)
+
+		// CLI: nft add rule inet istio-ambient-nat istio-output ip6 daddr != ::1/128 tcp dport 53 mark and 0xfff != 0x539 counter redirect to :15053
+		cfg.ruleBuilder.AppendRule(
+			IstioOutputChain, AmbientNatTable,
+			"ip6 daddr", "!=", "::1/128",
+			"tcp dport", "53",
+			"mark and", fmt.Sprintf("0x%x", config.InpodMask),
+			"!=", fmt.Sprintf("0x%x", config.InpodMark), Counter,
+			"redirect to", ":"+fmt.Sprintf("%d", config.DNSCapturePort),
+		)
+
+		// Assign packets between the proxy and upstream DNS servers to their own conntrack zones to avoid issues in port collision
+		// See https://github.com/istio/istio/issues/33469
+		// CLI: nft add rule inet istio-ambient-raw istio-output udp dport 53 meta mark and 0xfff == 0x539 counter ct zone set 1
+		// Proxy --> Upstream
+		cfg.ruleBuilder.AppendRule(
+			IstioOutputChain, AmbientRawTable,
+			"udp dport", "53",
+			"meta mark and", fmt.Sprintf("0x%x", config.InpodMask),
+			"==", fmt.Sprintf("0x%x", config.InpodMark), Counter,
+			"ct zone set", "1",
+		)
+
+		// CLI: nft add rule inet istio-ambient-raw istio-prerouting udp sport 53 meta mark and 0xfff != 0x539 counter ct zone set 1
+		// Upstream --> Proxy return packets
+		cfg.ruleBuilder.AppendRule(
+			IstioPreroutingChain, AmbientRawTable,
+			"udp sport", "53",
+			"meta mark and", fmt.Sprintf("0x%x", config.InpodMask),
+			"!=", fmt.Sprintf("0x%x", config.InpodMark), Counter,
+			"ct zone set", "1",
+		)
+	}
+
+	// CLI: nft add rule inet istio-ambient-nat istio-output meta l4proto tcp mark and 0xfff == 0x111 counter accept
+	//
+	// DESC: If this is outbound and has our mark, let it go.
+	cfg.ruleBuilder.AppendRule(
+		IstioOutputChain, AmbientNatTable,
+		"meta l4proto tcp",
+		"mark and", fmt.Sprintf("0x%x", config.InpodTProxyMask),
+		"==", fmt.Sprintf("0x%x", config.InpodTProxyMark), Counter,
+		"accept",
+	)
+
+	// Do not redirect app calls to back itself via Ztunnel when using the endpoint address
+	// e.g. appN => appN by lo
+	// CLI: nft add rule inet istio-ambient-nat istio-output oifname "lo" ip daddr != 127.0.0.1 counter accept
+	cfg.ruleBuilder.AppendRule(
+		IstioOutputChain, AmbientNatTable,
+		"oifname", "lo",
+		"ip daddr",
+		"!=", "127.0.0.1/32", Counter,
+		"accept",
+	)
+
+	// CLI: nft add rule inet istio-ambient-nat istio-output oifname "lo" ip6 daddr != ::1/128 counter accept
+	cfg.ruleBuilder.AppendRule(
+		IstioOutputChain, AmbientNatTable,
+		"oifname", "lo",
+		"ip6 daddr",
+		"!=", "::1/128", Counter,
+		"accept",
+	)
+
+	// CLI: nft add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr != 127.0.0.1 mark and 0xfff != 0x539 counter redirect to :15001
+	//
+	// DESC: If this is outbound, not bound for localhost, and does not have our packet mark, redirect to ztunnel proxy <OUTPORT>
+	cfg.ruleBuilder.AppendRule(
+		IstioOutputChain, AmbientNatTable,
+		"meta l4proto tcp",
+		"ip daddr",
+		"!=", "127.0.0.1/32",
+		"mark and", fmt.Sprintf("0x%x", config.InpodMask),
+		"!=", fmt.Sprintf("0x%x", config.InpodMark), Counter,
+		"redirect to", ":"+fmt.Sprintf("%d", config.ZtunnelOutboundPort),
+	)
+
+	cfg.ruleBuilder.AppendRule(
+		IstioOutputChain, AmbientNatTable,
+		"meta l4proto tcp",
+		"ip6 daddr",
+		"!=", "::1/128",
+		"mark and", fmt.Sprintf("0x%x", config.InpodMask),
+		"!=", fmt.Sprintf("0x%x", config.InpodMark), Counter,
+		"redirect to", ":"+fmt.Sprintf("%d", config.ZtunnelOutboundPort),
+	)
+
+	return cfg.executeCommands()
 }
 
 // DeleteInpodRules removes nftables rules from a pod's network namespace
 func (cfg *NftablesConfigurator) DeleteInpodRules(log *istiolog.Scope) error {
 	log.Info("removing nftables inpod rules")
 
-	// TODO: Implement nftables rule deletion for inpod traffic
-
-	// Remove loopback routes
-	if err := cfg.delLoopbackRoute(); err != nil {
-		log.Warnf("failed to remove loopback route: %v", err)
+	nft, err := cfg.nftProvider("", "")
+	if err != nil {
+		return err
 	}
 
-	// Remove inpod mark IP rule
-	if err := cfg.delInpodMarkIPRule(); err != nil {
-		log.Warnf("failed to remove inpod mark IP rule: %v", err)
+	tx := nft.NewTransaction()
+	// nftables delete command will delete the table along with the chains and rules.
+	tx.Delete(&knftables.Table{Name: AmbientNatTable, Family: knftables.InetFamily})
+	tx.Delete(&knftables.Table{Name: AmbientMangleTable, Family: knftables.InetFamily})
+	tx.Delete(&knftables.Table{Name: AmbientRawTable, Family: knftables.InetFamily})
+
+	if tx.NumOperations() > 0 {
+		if err := nft.Run(context.TODO(), tx); err != nil {
+			log.Errorf("error while trying to delete the ambient nftable rules: %w", err)
+		}
 	}
 
-	log.Info("nftables inpod rules deletion completed (stub implementation)")
-	return nil
+	var inpodErrs []error
+	inpodErrs = append(inpodErrs, cfg.delInpodMarkIPRule(), cfg.delLoopbackRoute())
+	return errors.Join(inpodErrs...)
 }
 
 // CreateHostRulesForHealthChecks creates host-level nftables rules for health check handling
@@ -122,7 +411,7 @@ func (cfg *NftablesConfigurator) CreateHostRulesForHealthChecks() error {
 	log.Info("configuring host-level nftables rules (healthchecks, etc)")
 
 	// TODO: Implement host-level nftables rules for health check handling
-	log.Info("host-level nftables rules creation completed (stub implementation)")
+	log.Info("host-level nftables rules creation completed")
 	return nil
 }
 
@@ -131,7 +420,7 @@ func (cfg *NftablesConfigurator) DeleteHostRules() {
 	log.Debug("Attempting to delete hostside nftables rules (if they exist)")
 
 	// TODO: Implement host-level nftables rule deletion
-	log.Debug("hostside nftables rules deletion completed (stub implementation)")
+	log.Debug("hostside nftables rules deletion completed")
 }
 
 // ReconcileModeEnabled returns true if reconciliation mode is enabled
@@ -154,4 +443,188 @@ func (cfg *NftablesConfigurator) addInpodMarkIPRule() error {
 
 func (cfg *NftablesConfigurator) delInpodMarkIPRule() error {
 	return cfg.nlDeps.DelInpodMarkIPRule(cfg.cfg)
+}
+
+// executeCommands creates a transaction including all needed modifications and runs it.
+func (cfg *NftablesConfigurator) executeCommands() (*knftables.Transaction, error) {
+	nft, err := cfg.nftProvider("", "")
+	if err != nil {
+		return nil, err
+	}
+
+	tx := nft.NewTransaction()
+	tx = cfg.addIstioNatTableRules(tx)
+	tx = cfg.addIstioMangleTableRules(tx)
+	tx = cfg.addIstioRawTableRules(tx)
+
+	// If there are any transactions to apply, run them in a batch.
+	if tx.NumOperations() > 0 {
+		if err := nft.Run(context.TODO(), tx); err != nil {
+			return tx, fmt.Errorf("nftables run failed: %w", err)
+		}
+	}
+	return tx, nil
+}
+
+// addIstioNatTableRules updates a transaction to include the nftables rules for the AmbientNatTable table.
+// It makes sure the table and the necessary chains exist, then adds rules from the rule builder.
+func (cfg *NftablesConfigurator) addIstioNatTableRules(tx *knftables.Transaction) *knftables.Transaction {
+	if len(cfg.ruleBuilder.Rules[AmbientNatTable]) == 0 {
+		return tx
+	}
+
+	chains := []knftables.Chain{
+		{
+			Name:     PreroutingChain,
+			Table:    AmbientNatTable,
+			Family:   knftables.InetFamily,
+			Type:     knftables.PtrTo(knftables.NATType),
+			Hook:     knftables.PtrTo(knftables.PreroutingHook),
+			Priority: knftables.PtrTo(knftables.DNATPriority),
+		},
+		{
+			Name:     OutputChain,
+			Table:    AmbientNatTable,
+			Family:   knftables.InetFamily,
+			Type:     knftables.PtrTo(knftables.NATType),
+			Hook:     knftables.PtrTo(knftables.OutputHook),
+			Priority: knftables.PtrTo(knftables.DNATPriority),
+		},
+		{Name: IstioPreroutingChain, Table: AmbientNatTable, Family: knftables.InetFamily},
+		{Name: IstioOutputChain, Table: AmbientNatTable, Family: knftables.InetFamily},
+	}
+
+	rules := cfg.ruleBuilder.Rules[AmbientNatTable]
+
+	return cfg.addIstioTableRules(tx, AmbientNatTable, chains, rules)
+}
+
+// addIstioMangleTableRules updates a transaction to include the nftables rules for the AmbientMangleTable table.
+// It makes sure the table and the necessary chains exist, then adds rules from the rule builder.
+func (cfg *NftablesConfigurator) addIstioMangleTableRules(tx *knftables.Transaction) *knftables.Transaction {
+	if len(cfg.ruleBuilder.Rules[AmbientMangleTable]) == 0 {
+		return tx
+	}
+
+	chains := []knftables.Chain{
+		{
+			Name:     PreroutingChain,
+			Table:    AmbientMangleTable,
+			Family:   knftables.InetFamily,
+			Type:     knftables.PtrTo(knftables.FilterType),
+			Hook:     knftables.PtrTo(knftables.PreroutingHook),
+			Priority: knftables.PtrTo(knftables.ManglePriority),
+		},
+		{
+			Name:     OutputChain,
+			Table:    AmbientMangleTable,
+			Family:   knftables.InetFamily,
+			Type:     knftables.PtrTo(knftables.RouteType),
+			Hook:     knftables.PtrTo(knftables.OutputHook),
+			Priority: knftables.PtrTo(knftables.ManglePriority),
+		},
+		{Name: IstioPreroutingChain, Table: AmbientMangleTable, Family: knftables.InetFamily},
+		{Name: IstioOutputChain, Table: AmbientMangleTable, Family: knftables.InetFamily},
+	}
+
+	rules := cfg.ruleBuilder.Rules[AmbientMangleTable]
+
+	return cfg.addIstioTableRules(tx, AmbientMangleTable, chains, rules)
+}
+
+// addIstioRawTableRules updates a transaction to include the nftables rules for the AmbientRawTable table.
+// It makes sure the table and the necessary chains exist, then adds rules from the rule builder.
+func (cfg *NftablesConfigurator) addIstioRawTableRules(tx *knftables.Transaction) *knftables.Transaction {
+	if len(cfg.ruleBuilder.Rules[AmbientRawTable]) == 0 {
+		return tx
+	}
+
+	chains := []knftables.Chain{
+		{
+			Name:     PreroutingChain,
+			Table:    AmbientRawTable,
+			Family:   knftables.InetFamily,
+			Type:     knftables.PtrTo(knftables.FilterType),
+			Hook:     knftables.PtrTo(knftables.PreroutingHook),
+			Priority: knftables.PtrTo(knftables.RawPriority),
+		},
+		{
+			Name:     OutputChain,
+			Table:    AmbientRawTable,
+			Family:   knftables.InetFamily,
+			Type:     knftables.PtrTo(knftables.FilterType),
+			Hook:     knftables.PtrTo(knftables.OutputHook),
+			Priority: knftables.PtrTo(knftables.RawPriority),
+		},
+		{Name: IstioPreroutingChain, Table: AmbientRawTable, Family: knftables.InetFamily},
+		{Name: IstioOutputChain, Table: AmbientRawTable, Family: knftables.InetFamily},
+	}
+
+	rules := cfg.ruleBuilder.Rules[AmbientRawTable]
+
+	return cfg.addIstioTableRules(tx, AmbientRawTable, chains, rules)
+}
+
+func (cfg *NftablesConfigurator) addIstioTableRules(
+	tx *knftables.Transaction,
+	tableName string,
+	chains []knftables.Chain,
+	rules []knftables.Rule,
+) *knftables.Transaction {
+	// Track how many rules have been added to each chain
+	chainRuleCount := make(map[string]int)
+
+	// Count the number of rules present in each of the chains
+	for _, rule := range rules {
+		chainRuleCount[rule.Chain]++
+	}
+
+	// Let's filter out the chains that have rules
+	chainsWithRules := []knftables.Chain{}
+	for _, chain := range chains {
+		if chainRuleCount[chain.Name] > 0 {
+			chainsWithRules = append(chainsWithRules, chain)
+		}
+	}
+
+	// Skip creating the table itself if none of the chains have any rules
+	if len(chainsWithRules) == 0 {
+		return tx
+	}
+
+	// Ensure that the table exists
+	tx.Add(&knftables.Table{Name: tableName, Family: knftables.InetFamily})
+
+	// Flush the table to remove all existing rules before applying new ones
+	tx.Flush(&knftables.Table{Name: tableName, Family: knftables.InetFamily})
+
+	// Add the chains that have rules
+	for _, chain := range chainsWithRules {
+		tx.Add(&chain)
+	}
+
+	// Reset chainRuleCount to handle the use-case mentioned below.
+	chainRuleCount = make(map[string]int)
+
+	// Add the rules to the transaction
+	for _, rule := range rules {
+		chain := rule.Chain
+
+		// In IPtables, inserting a rule at position 1 means it gets placed at the head of the chain. In contrast,
+		// nftables starts rule indexing at 0. However, nftables doesn't allow inserting a rule at index 0 if the
+		// chain is empty. So to handle this case, we check if the chain is empty, and if it is, we use appendRule instead.
+		if rule.Index != nil && chainRuleCount[chain] == 0 {
+			rule.Index = nil
+		}
+
+		// When a rule includes the Index, its considered as an Insert request.
+		if rule.Index != nil {
+			tx.Insert(&rule)
+		} else {
+			tx.Add(&rule)
+		}
+		chainRuleCount[chain]++
+	}
+
+	return tx
 }

--- a/cni/pkg/nftables/nftables.go
+++ b/cni/pkg/nftables/nftables.go
@@ -15,6 +15,7 @@
 package nftables
 
 import (
+	"istio.io/istio/cni/pkg/config"
 	"istio.io/istio/cni/pkg/iptables"
 	"istio.io/istio/cni/pkg/scopes"
 	istiolog "istio.io/istio/pkg/log"
@@ -39,25 +40,26 @@ const (
 var log = scopes.CNIAgent
 
 // NftablesConfigurator handles nftables rule management for Ambient mode
+// This follows the same pattern as iptables.IptablesConfigurator
 type NftablesConfigurator struct {
 	ext    dep.Dependencies
 	nlDeps iptables.NetlinkDependencies
-	cfg    *iptables.IptablesConfig
+	cfg    *config.IptablesConfig
 }
 
 // NewNftablesConfigurator creates both host and pod nftables configurators
 func NewNftablesConfigurator(
-	hostCfg *iptables.IptablesConfig,
-	podCfg *iptables.IptablesConfig,
+	hostCfg *config.IptablesConfig,
+	podCfg *config.IptablesConfig,
 	hostDeps dep.Dependencies,
 	podDeps dep.Dependencies,
 	nlDeps iptables.NetlinkDependencies,
 ) (*NftablesConfigurator, *NftablesConfigurator, error) {
 	if hostCfg == nil {
-		hostCfg = &iptables.IptablesConfig{}
+		hostCfg = &config.IptablesConfig{}
 	}
 	if podCfg == nil {
-		podCfg = &iptables.IptablesConfig{}
+		podCfg = &config.IptablesConfig{}
 	}
 
 	hostConfigurator := &NftablesConfigurator{
@@ -76,9 +78,22 @@ func NewNftablesConfigurator(
 }
 
 // CreateInpodRules creates nftables rules within a pod's network namespace
-func (cfg *NftablesConfigurator) CreateInpodRules(log *istiolog.Scope, podOverrides iptables.PodLevelOverrides) error {
+func (cfg *NftablesConfigurator) CreateInpodRules(log *istiolog.Scope, podOverrides config.PodLevelOverrides) error {
 	log.Info("native nftables enabled, using nft rules for inpod traffic redirection")
 
+	// TODO: Implement nftables rule creation for inpod traffic redirection
+
+	// Add loopback routes (still needed for nftables)
+	if err := cfg.addLoopbackRoute(); err != nil {
+		return err
+	}
+
+	// Add inpod mark IP rule (still needed for nftables)
+	if err := cfg.addInpodMarkIPRule(); err != nil {
+		return err
+	}
+
+	log.Info("nftables inpod rules creation completed (stub implementation)")
 	return nil
 }
 
@@ -86,20 +101,36 @@ func (cfg *NftablesConfigurator) CreateInpodRules(log *istiolog.Scope, podOverri
 func (cfg *NftablesConfigurator) DeleteInpodRules(log *istiolog.Scope) error {
 	log.Info("removing nftables inpod rules")
 
+	// TODO: Implement nftables rule deletion for inpod traffic
+
+	// Remove loopback routes
+	if err := cfg.delLoopbackRoute(); err != nil {
+		log.Warnf("failed to remove loopback route: %v", err)
+	}
+
+	// Remove inpod mark IP rule
+	if err := cfg.delInpodMarkIPRule(); err != nil {
+		log.Warnf("failed to remove inpod mark IP rule: %v", err)
+	}
+
+	log.Info("nftables inpod rules deletion completed (stub implementation)")
 	return nil
 }
 
 // CreateHostRulesForHealthChecks creates host-level nftables rules for health check handling
-// NOTE: This expects to be run from within the HOST network namespace!
 func (cfg *NftablesConfigurator) CreateHostRulesForHealthChecks() error {
 	log.Info("configuring host-level nftables rules (healthchecks, etc)")
 
+	// TODO: Implement host-level nftables rules for health check handling
+	log.Info("host-level nftables rules creation completed (stub implementation)")
 	return nil
 }
 
 // DeleteHostRules removes host-level nftables rules
 func (cfg *NftablesConfigurator) DeleteHostRules() {
 	log.Debug("Attempting to delete hostside nftables rules (if they exist)")
+
+	// TODO: Implement host-level nftables rule deletion
 	log.Debug("hostside nftables rules deletion completed (stub implementation)")
 }
 
@@ -108,6 +139,7 @@ func (cfg *NftablesConfigurator) ReconcileModeEnabled() bool {
 	return cfg.cfg.Reconcile
 }
 
+// Helper functions for route and rule management (delegated to netlink dependencies)
 func (cfg *NftablesConfigurator) addLoopbackRoute() error {
 	return cfg.nlDeps.AddLoopbackRoutes(cfg.cfg)
 }

--- a/cni/pkg/nftables/nftables.go
+++ b/cni/pkg/nftables/nftables.go
@@ -44,22 +44,22 @@ var log = scopes.CNIAgent
 type NftablesConfigurator struct {
 	ext    dep.Dependencies
 	nlDeps iptables.NetlinkDependencies
-	cfg    *config.IptablesConfig
+	cfg    *config.AmbientConfig
 }
 
 // NewNftablesConfigurator creates both host and pod nftables configurators
 func NewNftablesConfigurator(
-	hostCfg *config.IptablesConfig,
-	podCfg *config.IptablesConfig,
+	hostCfg *config.AmbientConfig,
+	podCfg *config.AmbientConfig,
 	hostDeps dep.Dependencies,
 	podDeps dep.Dependencies,
 	nlDeps iptables.NetlinkDependencies,
 ) (*NftablesConfigurator, *NftablesConfigurator, error) {
 	if hostCfg == nil {
-		hostCfg = &config.IptablesConfig{}
+		hostCfg = &config.AmbientConfig{}
 	}
 	if podCfg == nil {
-		podCfg = &config.IptablesConfig{}
+		podCfg = &config.AmbientConfig{}
 	}
 
 	hostConfigurator := &NftablesConfigurator{

--- a/cni/pkg/nftables/nftables.go
+++ b/cni/pkg/nftables/nftables.go
@@ -21,6 +21,21 @@ import (
 	dep "istio.io/istio/tools/istio-iptables/pkg/dependencies"
 )
 
+const (
+	AmbientNatTable    = "istio-ambient-nat"
+	AmbientMangleTable = "istio-ambient-mangle"
+	AmbientRawTable    = "istio-ambient-raw"
+
+	// Base chains.
+	PreroutingChain  = "prerouting"
+	PostroutingChain = "postrouting"
+	OutputChain      = "output"
+
+	// Regular chains prefixed with "istio" to distinguish them from base chains
+	IstioOutputChain     = "istio-output"
+	IstioPreroutingChain = "istio-prerouting"
+)
+
 var log = scopes.CNIAgent
 
 // NftablesConfigurator handles nftables rule management for Ambient mode

--- a/cni/pkg/nftables/nftables_test.go
+++ b/cni/pkg/nftables/nftables_test.go
@@ -1,0 +1,199 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nftables
+
+import (
+	"context"
+	"net/netip"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"sigs.k8s.io/knftables"
+
+	"istio.io/istio/cni/pkg/config"
+	"istio.io/istio/cni/pkg/iptables"
+	"istio.io/istio/cni/pkg/scopes"
+	testutil "istio.io/istio/pilot/test/util"
+	dep "istio.io/istio/tools/istio-iptables/pkg/dependencies"
+	"istio.io/istio/tools/istio-nftables/pkg/builder"
+)
+
+// MockNftablesCapture wraps the MockNftables to capture all executed transactions
+type MockNftablesCapture struct {
+	*builder.MockNftables
+	lock         sync.Mutex
+	transactions []string
+}
+
+func NewMockNftablesCapture() *MockNftablesCapture {
+	return &MockNftablesCapture{
+		MockNftables: builder.NewMockNftables("", ""),
+		transactions: make([]string, 0),
+	}
+}
+
+func (m *MockNftablesCapture) Run(ctx context.Context, tx *knftables.Transaction) error {
+	// Lets store the transaction as string before running it using the actual mock
+	m.lock.Lock()
+	if tx.NumOperations() > 0 {
+		m.transactions = append(m.transactions, tx.String())
+	}
+	m.lock.Unlock()
+
+	// Run the actual transaction through the mock
+	return m.MockNftables.Run(ctx, tx)
+}
+
+func (m *MockNftablesCapture) GetCapturedRules() []string {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	// Return a copy to avoid race conditions
+	result := make([]string, len(m.transactions))
+	copy(result, m.transactions)
+	return result
+}
+
+func TestNftablesPodOverrides(t *testing.T) {
+	cases := GetCommonInPodTestCases()
+
+	for _, tt := range cases {
+		for _, ipv6 := range []bool{false, true} {
+			t.Run(tt.name+"_"+ipstr(ipv6), func(t *testing.T) {
+				cfg := constructTestConfig()
+				cfg.EnableIPv6 = ipv6
+				tt.config(cfg)
+				ext := &dep.DependenciesStub{}
+
+				mock := NewMockNftablesCapture()
+				originalProvider := nftProviderVar
+				nftProviderVar = func(_ knftables.Family, table string) (builder.NftablesAPI, error) {
+					return mock, nil
+				}
+				defer func() {
+					nftProviderVar = originalProvider
+				}()
+
+				iptConfigurator, _, _ := NewNftablesConfigurator(cfg, cfg, ext, ext, iptables.EmptyNlDeps())
+				err := iptConfigurator.CreateInpodRules(scopes.CNIAgent, tt.podOverrides)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				compareToGolden(t, ipv6, tt.name, mock.GetCapturedRules())
+			})
+		}
+	}
+}
+
+func TestNftablesHostRules(t *testing.T) {
+	cases := GetCommonHostTestCases()
+
+	for _, tt := range cases {
+		for _, ipv6 := range []bool{false, true} {
+			t.Run(tt.name+"_"+ipstr(ipv6), func(t *testing.T) {
+				cfg := constructTestConfig()
+				cfg.EnableIPv6 = ipv6
+				tt.config(cfg)
+				ext := &dep.DependenciesStub{}
+
+				mock := NewMockNftablesCapture()
+				originalProvider := nftProviderVar
+				nftProviderVar = func(_ knftables.Family, table string) (builder.NftablesAPI, error) {
+					return mock, nil
+				}
+				defer func() {
+					nftProviderVar = originalProvider
+				}()
+
+				iptConfigurator, _, _ := NewNftablesConfigurator(cfg, cfg, ext, ext, iptables.EmptyNlDeps())
+				err := iptConfigurator.CreateHostRulesForHealthChecks()
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				compareToGolden(t, ipv6, tt.name, mock.GetCapturedRules())
+			})
+		}
+	}
+}
+
+func TestInvokedTwiceIsIdempotent(t *testing.T) {
+	tests := GetCommonInPodTestCases()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := constructTestConfig()
+			tt.config(cfg)
+			ext := &dep.DependenciesStub{}
+
+			mock := NewMockNftablesCapture()
+			originalProvider := nftProviderVar
+			nftProviderVar = func(_ knftables.Family, table string) (builder.NftablesAPI, error) {
+				return mock, nil
+			}
+			defer func() {
+				nftProviderVar = originalProvider
+			}()
+
+			iptConfigurator, _, _ := NewNftablesConfigurator(cfg, cfg, ext, ext, iptables.EmptyNlDeps())
+			err := iptConfigurator.CreateInpodRules(scopes.CNIAgent, tt.podOverrides)
+			if err != nil {
+				t.Fatal(err)
+			}
+			compareToGolden(t, false, tt.name, mock.GetCapturedRules())
+
+			// Reset the mock to capture only the second run
+			mock = NewMockNftablesCapture()
+			nftProviderVar = func(_ knftables.Family, table string) (builder.NftablesAPI, error) {
+				return mock, nil
+			}
+
+			// run another time to make sure its idempotent
+			err = iptConfigurator.CreateInpodRules(scopes.CNIAgent, tt.podOverrides)
+			if err != nil {
+				t.Fatal(err)
+			}
+			compareToGolden(t, false, tt.name, mock.GetCapturedRules())
+		})
+	}
+}
+
+func ipstr(ipv6 bool) string {
+	if ipv6 {
+		return "ipv6"
+	}
+	return "ipv4"
+}
+
+func compareToGolden(t *testing.T, ipv6 bool, name string, actual []string) {
+	t.Helper()
+	gotBytes := []byte(strings.Join(actual, "\n"))
+	goldenFile := filepath.Join("testdata", name+".golden")
+	if ipv6 {
+		goldenFile = filepath.Join("testdata", name+"_ipv6.golden")
+	}
+	testutil.CompareContent(t, gotBytes, goldenFile)
+}
+
+func constructTestConfig() *config.AmbientConfig {
+	probeSNATipv4 := netip.MustParseAddr("169.254.7.127")
+	probeSNATipv6 := netip.MustParseAddr("e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164")
+	return &config.AmbientConfig{
+		HostProbeSNATAddress:   probeSNATipv4,
+		HostProbeV6SNATAddress: probeSNATipv6,
+	}
+}

--- a/cni/pkg/nftables/testdata/default.golden
+++ b/cni/pkg/nftables/testdata/default.golden
@@ -1,0 +1,42 @@
+add table inet istio-ambient-nat
+flush table inet istio-ambient-nat
+add chain inet istio-ambient-nat prerouting { type nat hook prerouting priority -100 ; }
+add chain inet istio-ambient-nat output { type nat hook output priority -100 ; }
+add chain inet istio-ambient-nat istio-prerouting
+add chain inet istio-ambient-nat istio-output
+add rule inet istio-ambient-nat output jump istio-output
+add rule inet istio-ambient-nat prerouting jump istio-prerouting
+add rule inet istio-ambient-nat istio-prerouting meta l4proto tcp ip saddr 169.254.7.127 counter accept
+add rule inet istio-ambient-nat istio-prerouting meta l4proto tcp ip6 saddr e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr 169.254.7.127 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 counter accept
+add rule inet istio-ambient-nat istio-prerouting ip daddr != 127.0.0.1/32 tcp dport != 15008 mark and 0xfff  != 0x539 counter redirect to :15006
+add rule inet istio-ambient-nat istio-prerouting ip6 daddr != ::1/128 tcp dport != 15008 mark and 0xfff != 0x539 counter redirect to :15006
+add rule inet istio-ambient-nat istio-output oifname != lo mark and 0xfff != 0x539 udp dport 53 counter redirect to :15053
+add rule inet istio-ambient-nat istio-output ip daddr != 127.0.0.1/32 tcp dport 53 mark and 0xfff != 0x539 counter redirect to :15053
+add rule inet istio-ambient-nat istio-output ip6 daddr != ::1/128 tcp dport 53 mark and 0xfff != 0x539 counter redirect to :15053
+add rule inet istio-ambient-nat istio-output meta l4proto tcp mark and 0xfff == 0x111 counter accept
+add rule inet istio-ambient-nat istio-output oifname lo ip daddr != 127.0.0.1/32 counter accept
+add rule inet istio-ambient-nat istio-output oifname lo ip6 daddr != ::1/128 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr != 127.0.0.1/32 mark and 0xfff != 0x539 counter redirect to :15001
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr != ::1/128 mark and 0xfff != 0x539 counter redirect to :15001
+add table inet istio-ambient-mangle
+flush table inet istio-ambient-mangle
+add chain inet istio-ambient-mangle prerouting { type filter hook prerouting priority -150 ; }
+add chain inet istio-ambient-mangle output { type route hook output priority -150 ; }
+add chain inet istio-ambient-mangle istio-prerouting
+add chain inet istio-ambient-mangle istio-output
+add rule inet istio-ambient-mangle prerouting jump istio-prerouting
+add rule inet istio-ambient-mangle output jump istio-output
+add rule inet istio-ambient-mangle istio-prerouting meta mark & 0xfff == 0x539 counter ct mark set ct mark & 0xfffff000 |  0x111
+add rule inet istio-ambient-mangle istio-output ct mark and 0xfff == 0x111 counter meta mark set ct mark
+add table inet istio-ambient-raw
+flush table inet istio-ambient-raw
+add chain inet istio-ambient-raw prerouting { type filter hook prerouting priority -300 ; }
+add chain inet istio-ambient-raw output { type filter hook output priority -300 ; }
+add chain inet istio-ambient-raw istio-prerouting
+add chain inet istio-ambient-raw istio-output
+add rule inet istio-ambient-raw prerouting jump istio-prerouting
+add rule inet istio-ambient-raw output jump istio-output
+add rule inet istio-ambient-raw istio-output udp dport 53 meta mark and 0xfff == 0x539 counter ct zone set 1
+add rule inet istio-ambient-raw istio-prerouting udp sport 53 meta mark and 0xfff != 0x539 counter ct zone set 1

--- a/cni/pkg/nftables/testdata/default_ipv6.golden
+++ b/cni/pkg/nftables/testdata/default_ipv6.golden
@@ -1,0 +1,42 @@
+add table inet istio-ambient-nat
+flush table inet istio-ambient-nat
+add chain inet istio-ambient-nat prerouting { type nat hook prerouting priority -100 ; }
+add chain inet istio-ambient-nat output { type nat hook output priority -100 ; }
+add chain inet istio-ambient-nat istio-prerouting
+add chain inet istio-ambient-nat istio-output
+add rule inet istio-ambient-nat output jump istio-output
+add rule inet istio-ambient-nat prerouting jump istio-prerouting
+add rule inet istio-ambient-nat istio-prerouting meta l4proto tcp ip saddr 169.254.7.127 counter accept
+add rule inet istio-ambient-nat istio-prerouting meta l4proto tcp ip6 saddr e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr 169.254.7.127 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 counter accept
+add rule inet istio-ambient-nat istio-prerouting ip daddr != 127.0.0.1/32 tcp dport != 15008 mark and 0xfff  != 0x539 counter redirect to :15006
+add rule inet istio-ambient-nat istio-prerouting ip6 daddr != ::1/128 tcp dport != 15008 mark and 0xfff != 0x539 counter redirect to :15006
+add rule inet istio-ambient-nat istio-output oifname != lo mark and 0xfff != 0x539 udp dport 53 counter redirect to :15053
+add rule inet istio-ambient-nat istio-output ip daddr != 127.0.0.1/32 tcp dport 53 mark and 0xfff != 0x539 counter redirect to :15053
+add rule inet istio-ambient-nat istio-output ip6 daddr != ::1/128 tcp dport 53 mark and 0xfff != 0x539 counter redirect to :15053
+add rule inet istio-ambient-nat istio-output meta l4proto tcp mark and 0xfff == 0x111 counter accept
+add rule inet istio-ambient-nat istio-output oifname lo ip daddr != 127.0.0.1/32 counter accept
+add rule inet istio-ambient-nat istio-output oifname lo ip6 daddr != ::1/128 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr != 127.0.0.1/32 mark and 0xfff != 0x539 counter redirect to :15001
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr != ::1/128 mark and 0xfff != 0x539 counter redirect to :15001
+add table inet istio-ambient-mangle
+flush table inet istio-ambient-mangle
+add chain inet istio-ambient-mangle prerouting { type filter hook prerouting priority -150 ; }
+add chain inet istio-ambient-mangle output { type route hook output priority -150 ; }
+add chain inet istio-ambient-mangle istio-prerouting
+add chain inet istio-ambient-mangle istio-output
+add rule inet istio-ambient-mangle prerouting jump istio-prerouting
+add rule inet istio-ambient-mangle output jump istio-output
+add rule inet istio-ambient-mangle istio-prerouting meta mark & 0xfff == 0x539 counter ct mark set ct mark & 0xfffff000 |  0x111
+add rule inet istio-ambient-mangle istio-output ct mark and 0xfff == 0x111 counter meta mark set ct mark
+add table inet istio-ambient-raw
+flush table inet istio-ambient-raw
+add chain inet istio-ambient-raw prerouting { type filter hook prerouting priority -300 ; }
+add chain inet istio-ambient-raw output { type filter hook output priority -300 ; }
+add chain inet istio-ambient-raw istio-prerouting
+add chain inet istio-ambient-raw istio-output
+add rule inet istio-ambient-raw prerouting jump istio-prerouting
+add rule inet istio-ambient-raw output jump istio-output
+add rule inet istio-ambient-raw istio-output udp dport 53 meta mark and 0xfff == 0x539 counter ct zone set 1
+add rule inet istio-ambient-raw istio-prerouting udp sport 53 meta mark and 0xfff != 0x539 counter ct zone set 1

--- a/cni/pkg/nftables/testdata/dns_pod_disabled_and_on_globally.golden
+++ b/cni/pkg/nftables/testdata/dns_pod_disabled_and_on_globally.golden
@@ -1,0 +1,29 @@
+add table inet istio-ambient-nat
+flush table inet istio-ambient-nat
+add chain inet istio-ambient-nat prerouting { type nat hook prerouting priority -100 ; }
+add chain inet istio-ambient-nat output { type nat hook output priority -100 ; }
+add chain inet istio-ambient-nat istio-prerouting
+add chain inet istio-ambient-nat istio-output
+add rule inet istio-ambient-nat output jump istio-output
+add rule inet istio-ambient-nat prerouting jump istio-prerouting
+add rule inet istio-ambient-nat istio-prerouting meta l4proto tcp ip saddr 169.254.7.127 counter accept
+add rule inet istio-ambient-nat istio-prerouting meta l4proto tcp ip6 saddr e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr 169.254.7.127 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 counter accept
+add rule inet istio-ambient-nat istio-prerouting ip daddr != 127.0.0.1/32 tcp dport != 15008 mark and 0xfff  != 0x539 counter redirect to :15006
+add rule inet istio-ambient-nat istio-prerouting ip6 daddr != ::1/128 tcp dport != 15008 mark and 0xfff != 0x539 counter redirect to :15006
+add rule inet istio-ambient-nat istio-output meta l4proto tcp mark and 0xfff == 0x111 counter accept
+add rule inet istio-ambient-nat istio-output oifname lo ip daddr != 127.0.0.1/32 counter accept
+add rule inet istio-ambient-nat istio-output oifname lo ip6 daddr != ::1/128 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr != 127.0.0.1/32 mark and 0xfff != 0x539 counter redirect to :15001
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr != ::1/128 mark and 0xfff != 0x539 counter redirect to :15001
+add table inet istio-ambient-mangle
+flush table inet istio-ambient-mangle
+add chain inet istio-ambient-mangle prerouting { type filter hook prerouting priority -150 ; }
+add chain inet istio-ambient-mangle output { type route hook output priority -150 ; }
+add chain inet istio-ambient-mangle istio-prerouting
+add chain inet istio-ambient-mangle istio-output
+add rule inet istio-ambient-mangle prerouting jump istio-prerouting
+add rule inet istio-ambient-mangle output jump istio-output
+add rule inet istio-ambient-mangle istio-prerouting meta mark & 0xfff == 0x539 counter ct mark set ct mark & 0xfffff000 |  0x111
+add rule inet istio-ambient-mangle istio-output ct mark and 0xfff == 0x111 counter meta mark set ct mark

--- a/cni/pkg/nftables/testdata/dns_pod_disabled_and_on_globally_ipv6.golden
+++ b/cni/pkg/nftables/testdata/dns_pod_disabled_and_on_globally_ipv6.golden
@@ -1,0 +1,29 @@
+add table inet istio-ambient-nat
+flush table inet istio-ambient-nat
+add chain inet istio-ambient-nat prerouting { type nat hook prerouting priority -100 ; }
+add chain inet istio-ambient-nat output { type nat hook output priority -100 ; }
+add chain inet istio-ambient-nat istio-prerouting
+add chain inet istio-ambient-nat istio-output
+add rule inet istio-ambient-nat output jump istio-output
+add rule inet istio-ambient-nat prerouting jump istio-prerouting
+add rule inet istio-ambient-nat istio-prerouting meta l4proto tcp ip saddr 169.254.7.127 counter accept
+add rule inet istio-ambient-nat istio-prerouting meta l4proto tcp ip6 saddr e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr 169.254.7.127 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 counter accept
+add rule inet istio-ambient-nat istio-prerouting ip daddr != 127.0.0.1/32 tcp dport != 15008 mark and 0xfff  != 0x539 counter redirect to :15006
+add rule inet istio-ambient-nat istio-prerouting ip6 daddr != ::1/128 tcp dport != 15008 mark and 0xfff != 0x539 counter redirect to :15006
+add rule inet istio-ambient-nat istio-output meta l4proto tcp mark and 0xfff == 0x111 counter accept
+add rule inet istio-ambient-nat istio-output oifname lo ip daddr != 127.0.0.1/32 counter accept
+add rule inet istio-ambient-nat istio-output oifname lo ip6 daddr != ::1/128 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr != 127.0.0.1/32 mark and 0xfff != 0x539 counter redirect to :15001
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr != ::1/128 mark and 0xfff != 0x539 counter redirect to :15001
+add table inet istio-ambient-mangle
+flush table inet istio-ambient-mangle
+add chain inet istio-ambient-mangle prerouting { type filter hook prerouting priority -150 ; }
+add chain inet istio-ambient-mangle output { type route hook output priority -150 ; }
+add chain inet istio-ambient-mangle istio-prerouting
+add chain inet istio-ambient-mangle istio-output
+add rule inet istio-ambient-mangle prerouting jump istio-prerouting
+add rule inet istio-ambient-mangle output jump istio-output
+add rule inet istio-ambient-mangle istio-prerouting meta mark & 0xfff == 0x539 counter ct mark set ct mark & 0xfffff000 |  0x111
+add rule inet istio-ambient-mangle istio-output ct mark and 0xfff == 0x111 counter meta mark set ct mark

--- a/cni/pkg/nftables/testdata/dns_pod_enabled_and_off_globally.golden
+++ b/cni/pkg/nftables/testdata/dns_pod_enabled_and_off_globally.golden
@@ -1,0 +1,42 @@
+add table inet istio-ambient-nat
+flush table inet istio-ambient-nat
+add chain inet istio-ambient-nat prerouting { type nat hook prerouting priority -100 ; }
+add chain inet istio-ambient-nat output { type nat hook output priority -100 ; }
+add chain inet istio-ambient-nat istio-prerouting
+add chain inet istio-ambient-nat istio-output
+add rule inet istio-ambient-nat output jump istio-output
+add rule inet istio-ambient-nat prerouting jump istio-prerouting
+add rule inet istio-ambient-nat istio-prerouting meta l4proto tcp ip saddr 169.254.7.127 counter accept
+add rule inet istio-ambient-nat istio-prerouting meta l4proto tcp ip6 saddr e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr 169.254.7.127 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 counter accept
+add rule inet istio-ambient-nat istio-prerouting ip daddr != 127.0.0.1/32 tcp dport != 15008 mark and 0xfff  != 0x539 counter redirect to :15006
+add rule inet istio-ambient-nat istio-prerouting ip6 daddr != ::1/128 tcp dport != 15008 mark and 0xfff != 0x539 counter redirect to :15006
+add rule inet istio-ambient-nat istio-output oifname != lo mark and 0xfff != 0x539 udp dport 53 counter redirect to :15053
+add rule inet istio-ambient-nat istio-output ip daddr != 127.0.0.1/32 tcp dport 53 mark and 0xfff != 0x539 counter redirect to :15053
+add rule inet istio-ambient-nat istio-output ip6 daddr != ::1/128 tcp dport 53 mark and 0xfff != 0x539 counter redirect to :15053
+add rule inet istio-ambient-nat istio-output meta l4proto tcp mark and 0xfff == 0x111 counter accept
+add rule inet istio-ambient-nat istio-output oifname lo ip daddr != 127.0.0.1/32 counter accept
+add rule inet istio-ambient-nat istio-output oifname lo ip6 daddr != ::1/128 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr != 127.0.0.1/32 mark and 0xfff != 0x539 counter redirect to :15001
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr != ::1/128 mark and 0xfff != 0x539 counter redirect to :15001
+add table inet istio-ambient-mangle
+flush table inet istio-ambient-mangle
+add chain inet istio-ambient-mangle prerouting { type filter hook prerouting priority -150 ; }
+add chain inet istio-ambient-mangle output { type route hook output priority -150 ; }
+add chain inet istio-ambient-mangle istio-prerouting
+add chain inet istio-ambient-mangle istio-output
+add rule inet istio-ambient-mangle prerouting jump istio-prerouting
+add rule inet istio-ambient-mangle output jump istio-output
+add rule inet istio-ambient-mangle istio-prerouting meta mark & 0xfff == 0x539 counter ct mark set ct mark & 0xfffff000 |  0x111
+add rule inet istio-ambient-mangle istio-output ct mark and 0xfff == 0x111 counter meta mark set ct mark
+add table inet istio-ambient-raw
+flush table inet istio-ambient-raw
+add chain inet istio-ambient-raw prerouting { type filter hook prerouting priority -300 ; }
+add chain inet istio-ambient-raw output { type filter hook output priority -300 ; }
+add chain inet istio-ambient-raw istio-prerouting
+add chain inet istio-ambient-raw istio-output
+add rule inet istio-ambient-raw prerouting jump istio-prerouting
+add rule inet istio-ambient-raw output jump istio-output
+add rule inet istio-ambient-raw istio-output udp dport 53 meta mark and 0xfff == 0x539 counter ct zone set 1
+add rule inet istio-ambient-raw istio-prerouting udp sport 53 meta mark and 0xfff != 0x539 counter ct zone set 1

--- a/cni/pkg/nftables/testdata/dns_pod_enabled_and_off_globally_ipv6.golden
+++ b/cni/pkg/nftables/testdata/dns_pod_enabled_and_off_globally_ipv6.golden
@@ -1,0 +1,42 @@
+add table inet istio-ambient-nat
+flush table inet istio-ambient-nat
+add chain inet istio-ambient-nat prerouting { type nat hook prerouting priority -100 ; }
+add chain inet istio-ambient-nat output { type nat hook output priority -100 ; }
+add chain inet istio-ambient-nat istio-prerouting
+add chain inet istio-ambient-nat istio-output
+add rule inet istio-ambient-nat output jump istio-output
+add rule inet istio-ambient-nat prerouting jump istio-prerouting
+add rule inet istio-ambient-nat istio-prerouting meta l4proto tcp ip saddr 169.254.7.127 counter accept
+add rule inet istio-ambient-nat istio-prerouting meta l4proto tcp ip6 saddr e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr 169.254.7.127 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 counter accept
+add rule inet istio-ambient-nat istio-prerouting ip daddr != 127.0.0.1/32 tcp dport != 15008 mark and 0xfff  != 0x539 counter redirect to :15006
+add rule inet istio-ambient-nat istio-prerouting ip6 daddr != ::1/128 tcp dport != 15008 mark and 0xfff != 0x539 counter redirect to :15006
+add rule inet istio-ambient-nat istio-output oifname != lo mark and 0xfff != 0x539 udp dport 53 counter redirect to :15053
+add rule inet istio-ambient-nat istio-output ip daddr != 127.0.0.1/32 tcp dport 53 mark and 0xfff != 0x539 counter redirect to :15053
+add rule inet istio-ambient-nat istio-output ip6 daddr != ::1/128 tcp dport 53 mark and 0xfff != 0x539 counter redirect to :15053
+add rule inet istio-ambient-nat istio-output meta l4proto tcp mark and 0xfff == 0x111 counter accept
+add rule inet istio-ambient-nat istio-output oifname lo ip daddr != 127.0.0.1/32 counter accept
+add rule inet istio-ambient-nat istio-output oifname lo ip6 daddr != ::1/128 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr != 127.0.0.1/32 mark and 0xfff != 0x539 counter redirect to :15001
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr != ::1/128 mark and 0xfff != 0x539 counter redirect to :15001
+add table inet istio-ambient-mangle
+flush table inet istio-ambient-mangle
+add chain inet istio-ambient-mangle prerouting { type filter hook prerouting priority -150 ; }
+add chain inet istio-ambient-mangle output { type route hook output priority -150 ; }
+add chain inet istio-ambient-mangle istio-prerouting
+add chain inet istio-ambient-mangle istio-output
+add rule inet istio-ambient-mangle prerouting jump istio-prerouting
+add rule inet istio-ambient-mangle output jump istio-output
+add rule inet istio-ambient-mangle istio-prerouting meta mark & 0xfff == 0x539 counter ct mark set ct mark & 0xfffff000 |  0x111
+add rule inet istio-ambient-mangle istio-output ct mark and 0xfff == 0x111 counter meta mark set ct mark
+add table inet istio-ambient-raw
+flush table inet istio-ambient-raw
+add chain inet istio-ambient-raw prerouting { type filter hook prerouting priority -300 ; }
+add chain inet istio-ambient-raw output { type filter hook output priority -300 ; }
+add chain inet istio-ambient-raw istio-prerouting
+add chain inet istio-ambient-raw istio-output
+add rule inet istio-ambient-raw prerouting jump istio-prerouting
+add rule inet istio-ambient-raw output jump istio-output
+add rule inet istio-ambient-raw istio-output udp dport 53 meta mark and 0xfff == 0x539 counter ct zone set 1
+add rule inet istio-ambient-raw istio-prerouting udp sport 53 meta mark and 0xfff != 0x539 counter ct zone set 1

--- a/cni/pkg/nftables/testdata/ingress.golden
+++ b/cni/pkg/nftables/testdata/ingress.golden
@@ -1,0 +1,24 @@
+add table inet istio-ambient-nat
+flush table inet istio-ambient-nat
+add chain inet istio-ambient-nat prerouting { type nat hook prerouting priority -100 ; }
+add chain inet istio-ambient-nat output { type nat hook output priority -100 ; }
+add chain inet istio-ambient-nat istio-prerouting
+add chain inet istio-ambient-nat istio-output
+add rule inet istio-ambient-nat output jump istio-output
+add rule inet istio-ambient-nat prerouting jump istio-prerouting
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr 169.254.7.127 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp mark and 0xfff == 0x111 counter accept
+add rule inet istio-ambient-nat istio-output oifname lo ip daddr != 127.0.0.1/32 counter accept
+add rule inet istio-ambient-nat istio-output oifname lo ip6 daddr != ::1/128 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr != 127.0.0.1/32 mark and 0xfff != 0x539 counter redirect to :15001
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr != ::1/128 mark and 0xfff != 0x539 counter redirect to :15001
+add table inet istio-ambient-mangle
+flush table inet istio-ambient-mangle
+add chain inet istio-ambient-mangle prerouting { type filter hook prerouting priority -150 ; }
+add chain inet istio-ambient-mangle output { type route hook output priority -150 ; }
+add chain inet istio-ambient-mangle istio-prerouting
+add chain inet istio-ambient-mangle istio-output
+add rule inet istio-ambient-mangle prerouting jump istio-prerouting
+add rule inet istio-ambient-mangle output jump istio-output
+add rule inet istio-ambient-mangle istio-output ct mark and 0xfff == 0x111 counter meta mark set ct mark

--- a/cni/pkg/nftables/testdata/ingress_and_virtual_interfaces.golden
+++ b/cni/pkg/nftables/testdata/ingress_and_virtual_interfaces.golden
@@ -1,0 +1,28 @@
+add table inet istio-ambient-nat
+flush table inet istio-ambient-nat
+add chain inet istio-ambient-nat prerouting { type nat hook prerouting priority -100 ; }
+add chain inet istio-ambient-nat output { type nat hook output priority -100 ; }
+add chain inet istio-ambient-nat istio-prerouting
+add chain inet istio-ambient-nat istio-output
+add rule inet istio-ambient-nat output jump istio-output
+add rule inet istio-ambient-nat prerouting jump istio-prerouting
+add rule inet istio-ambient-nat istio-prerouting iifname fake1s0f0 meta l4proto tcp counter redirect to :15001
+add rule inet istio-ambient-nat istio-prerouting iifname fake1s0f0 meta l4proto tcp counter return
+add rule inet istio-ambient-nat istio-prerouting iifname fake1s0f1 meta l4proto tcp counter redirect to :15001
+add rule inet istio-ambient-nat istio-prerouting iifname fake1s0f1 meta l4proto tcp counter return
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr 169.254.7.127 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp mark and 0xfff == 0x111 counter accept
+add rule inet istio-ambient-nat istio-output oifname lo ip daddr != 127.0.0.1/32 counter accept
+add rule inet istio-ambient-nat istio-output oifname lo ip6 daddr != ::1/128 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr != 127.0.0.1/32 mark and 0xfff != 0x539 counter redirect to :15001
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr != ::1/128 mark and 0xfff != 0x539 counter redirect to :15001
+add table inet istio-ambient-mangle
+flush table inet istio-ambient-mangle
+add chain inet istio-ambient-mangle prerouting { type filter hook prerouting priority -150 ; }
+add chain inet istio-ambient-mangle output { type route hook output priority -150 ; }
+add chain inet istio-ambient-mangle istio-prerouting
+add chain inet istio-ambient-mangle istio-output
+add rule inet istio-ambient-mangle prerouting jump istio-prerouting
+add rule inet istio-ambient-mangle output jump istio-output
+add rule inet istio-ambient-mangle istio-output ct mark and 0xfff == 0x111 counter meta mark set ct mark

--- a/cni/pkg/nftables/testdata/ingress_and_virtual_interfaces_ipv6.golden
+++ b/cni/pkg/nftables/testdata/ingress_and_virtual_interfaces_ipv6.golden
@@ -1,0 +1,28 @@
+add table inet istio-ambient-nat
+flush table inet istio-ambient-nat
+add chain inet istio-ambient-nat prerouting { type nat hook prerouting priority -100 ; }
+add chain inet istio-ambient-nat output { type nat hook output priority -100 ; }
+add chain inet istio-ambient-nat istio-prerouting
+add chain inet istio-ambient-nat istio-output
+add rule inet istio-ambient-nat output jump istio-output
+add rule inet istio-ambient-nat prerouting jump istio-prerouting
+add rule inet istio-ambient-nat istio-prerouting iifname fake1s0f0 meta l4proto tcp counter redirect to :15001
+add rule inet istio-ambient-nat istio-prerouting iifname fake1s0f0 meta l4proto tcp counter return
+add rule inet istio-ambient-nat istio-prerouting iifname fake1s0f1 meta l4proto tcp counter redirect to :15001
+add rule inet istio-ambient-nat istio-prerouting iifname fake1s0f1 meta l4proto tcp counter return
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr 169.254.7.127 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp mark and 0xfff == 0x111 counter accept
+add rule inet istio-ambient-nat istio-output oifname lo ip daddr != 127.0.0.1/32 counter accept
+add rule inet istio-ambient-nat istio-output oifname lo ip6 daddr != ::1/128 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr != 127.0.0.1/32 mark and 0xfff != 0x539 counter redirect to :15001
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr != ::1/128 mark and 0xfff != 0x539 counter redirect to :15001
+add table inet istio-ambient-mangle
+flush table inet istio-ambient-mangle
+add chain inet istio-ambient-mangle prerouting { type filter hook prerouting priority -150 ; }
+add chain inet istio-ambient-mangle output { type route hook output priority -150 ; }
+add chain inet istio-ambient-mangle istio-prerouting
+add chain inet istio-ambient-mangle istio-output
+add rule inet istio-ambient-mangle prerouting jump istio-prerouting
+add rule inet istio-ambient-mangle output jump istio-output
+add rule inet istio-ambient-mangle istio-output ct mark and 0xfff == 0x111 counter meta mark set ct mark

--- a/cni/pkg/nftables/testdata/ingress_ipv6.golden
+++ b/cni/pkg/nftables/testdata/ingress_ipv6.golden
@@ -1,0 +1,24 @@
+add table inet istio-ambient-nat
+flush table inet istio-ambient-nat
+add chain inet istio-ambient-nat prerouting { type nat hook prerouting priority -100 ; }
+add chain inet istio-ambient-nat output { type nat hook output priority -100 ; }
+add chain inet istio-ambient-nat istio-prerouting
+add chain inet istio-ambient-nat istio-output
+add rule inet istio-ambient-nat output jump istio-output
+add rule inet istio-ambient-nat prerouting jump istio-prerouting
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr 169.254.7.127 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp mark and 0xfff == 0x111 counter accept
+add rule inet istio-ambient-nat istio-output oifname lo ip daddr != 127.0.0.1/32 counter accept
+add rule inet istio-ambient-nat istio-output oifname lo ip6 daddr != ::1/128 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr != 127.0.0.1/32 mark and 0xfff != 0x539 counter redirect to :15001
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr != ::1/128 mark and 0xfff != 0x539 counter redirect to :15001
+add table inet istio-ambient-mangle
+flush table inet istio-ambient-mangle
+add chain inet istio-ambient-mangle prerouting { type filter hook prerouting priority -150 ; }
+add chain inet istio-ambient-mangle output { type route hook output priority -150 ; }
+add chain inet istio-ambient-mangle istio-prerouting
+add chain inet istio-ambient-mangle istio-output
+add rule inet istio-ambient-mangle prerouting jump istio-prerouting
+add rule inet istio-ambient-mangle output jump istio-output
+add rule inet istio-ambient-mangle istio-output ct mark and 0xfff == 0x111 counter meta mark set ct mark

--- a/cni/pkg/nftables/testdata/virtual_interfaces.golden
+++ b/cni/pkg/nftables/testdata/virtual_interfaces.golden
@@ -1,0 +1,33 @@
+add table inet istio-ambient-nat
+flush table inet istio-ambient-nat
+add chain inet istio-ambient-nat prerouting { type nat hook prerouting priority -100 ; }
+add chain inet istio-ambient-nat output { type nat hook output priority -100 ; }
+add chain inet istio-ambient-nat istio-prerouting
+add chain inet istio-ambient-nat istio-output
+add rule inet istio-ambient-nat output jump istio-output
+add rule inet istio-ambient-nat prerouting jump istio-prerouting
+add rule inet istio-ambient-nat istio-prerouting iifname fake1s0f0 meta l4proto tcp counter redirect to :15001
+add rule inet istio-ambient-nat istio-prerouting iifname fake1s0f0 meta l4proto tcp counter return
+add rule inet istio-ambient-nat istio-prerouting iifname fake1s0f1 meta l4proto tcp counter redirect to :15001
+add rule inet istio-ambient-nat istio-prerouting iifname fake1s0f1 meta l4proto tcp counter return
+add rule inet istio-ambient-nat istio-prerouting meta l4proto tcp ip saddr 169.254.7.127 counter accept
+add rule inet istio-ambient-nat istio-prerouting meta l4proto tcp ip6 saddr e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr 169.254.7.127 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 counter accept
+add rule inet istio-ambient-nat istio-prerouting ip daddr != 127.0.0.1/32 tcp dport != 15008 mark and 0xfff  != 0x539 counter redirect to :15006
+add rule inet istio-ambient-nat istio-prerouting ip6 daddr != ::1/128 tcp dport != 15008 mark and 0xfff != 0x539 counter redirect to :15006
+add rule inet istio-ambient-nat istio-output meta l4proto tcp mark and 0xfff == 0x111 counter accept
+add rule inet istio-ambient-nat istio-output oifname lo ip daddr != 127.0.0.1/32 counter accept
+add rule inet istio-ambient-nat istio-output oifname lo ip6 daddr != ::1/128 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr != 127.0.0.1/32 mark and 0xfff != 0x539 counter redirect to :15001
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr != ::1/128 mark and 0xfff != 0x539 counter redirect to :15001
+add table inet istio-ambient-mangle
+flush table inet istio-ambient-mangle
+add chain inet istio-ambient-mangle prerouting { type filter hook prerouting priority -150 ; }
+add chain inet istio-ambient-mangle output { type route hook output priority -150 ; }
+add chain inet istio-ambient-mangle istio-prerouting
+add chain inet istio-ambient-mangle istio-output
+add rule inet istio-ambient-mangle prerouting jump istio-prerouting
+add rule inet istio-ambient-mangle output jump istio-output
+add rule inet istio-ambient-mangle istio-prerouting meta mark & 0xfff == 0x539 counter ct mark set ct mark & 0xfffff000 |  0x111
+add rule inet istio-ambient-mangle istio-output ct mark and 0xfff == 0x111 counter meta mark set ct mark

--- a/cni/pkg/nftables/testdata/virtual_interfaces_ipv6.golden
+++ b/cni/pkg/nftables/testdata/virtual_interfaces_ipv6.golden
@@ -1,0 +1,33 @@
+add table inet istio-ambient-nat
+flush table inet istio-ambient-nat
+add chain inet istio-ambient-nat prerouting { type nat hook prerouting priority -100 ; }
+add chain inet istio-ambient-nat output { type nat hook output priority -100 ; }
+add chain inet istio-ambient-nat istio-prerouting
+add chain inet istio-ambient-nat istio-output
+add rule inet istio-ambient-nat output jump istio-output
+add rule inet istio-ambient-nat prerouting jump istio-prerouting
+add rule inet istio-ambient-nat istio-prerouting iifname fake1s0f0 meta l4proto tcp counter redirect to :15001
+add rule inet istio-ambient-nat istio-prerouting iifname fake1s0f0 meta l4proto tcp counter return
+add rule inet istio-ambient-nat istio-prerouting iifname fake1s0f1 meta l4proto tcp counter redirect to :15001
+add rule inet istio-ambient-nat istio-prerouting iifname fake1s0f1 meta l4proto tcp counter return
+add rule inet istio-ambient-nat istio-prerouting meta l4proto tcp ip saddr 169.254.7.127 counter accept
+add rule inet istio-ambient-nat istio-prerouting meta l4proto tcp ip6 saddr e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr 169.254.7.127 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 counter accept
+add rule inet istio-ambient-nat istio-prerouting ip daddr != 127.0.0.1/32 tcp dport != 15008 mark and 0xfff  != 0x539 counter redirect to :15006
+add rule inet istio-ambient-nat istio-prerouting ip6 daddr != ::1/128 tcp dport != 15008 mark and 0xfff != 0x539 counter redirect to :15006
+add rule inet istio-ambient-nat istio-output meta l4proto tcp mark and 0xfff == 0x111 counter accept
+add rule inet istio-ambient-nat istio-output oifname lo ip daddr != 127.0.0.1/32 counter accept
+add rule inet istio-ambient-nat istio-output oifname lo ip6 daddr != ::1/128 counter accept
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr != 127.0.0.1/32 mark and 0xfff != 0x539 counter redirect to :15001
+add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr != ::1/128 mark and 0xfff != 0x539 counter redirect to :15001
+add table inet istio-ambient-mangle
+flush table inet istio-ambient-mangle
+add chain inet istio-ambient-mangle prerouting { type filter hook prerouting priority -150 ; }
+add chain inet istio-ambient-mangle output { type route hook output priority -150 ; }
+add chain inet istio-ambient-mangle istio-prerouting
+add chain inet istio-ambient-mangle istio-output
+add rule inet istio-ambient-mangle prerouting jump istio-prerouting
+add rule inet istio-ambient-mangle output jump istio-output
+add rule inet istio-ambient-mangle istio-prerouting meta mark & 0xfff == 0x539 counter ct mark set ct mark & 0xfffff000 |  0x111
+add rule inet istio-ambient-mangle istio-output ct mark and 0xfff == 0x111 counter meta mark set ct mark

--- a/cni/pkg/nodeagent/fakes_test.go
+++ b/cni/pkg/nodeagent/fakes_test.go
@@ -170,22 +170,22 @@ type fakeIptablesDeps struct {
 
 var _ iptables.NetlinkDependencies = &fakeIptablesDeps{}
 
-func (r *fakeIptablesDeps) AddInpodMarkIPRule(cfg *config.IptablesConfig) error {
+func (r *fakeIptablesDeps) AddInpodMarkIPRule(cfg *config.AmbientConfig) error {
 	r.AddInpodMarkIPRuleCnt.Add(1)
 	return nil
 }
 
-func (r *fakeIptablesDeps) DelInpodMarkIPRule(cfg *config.IptablesConfig) error {
+func (r *fakeIptablesDeps) DelInpodMarkIPRule(cfg *config.AmbientConfig) error {
 	r.DelInpodMarkIPRuleCnt.Add(1)
 	return nil
 }
 
-func (r *fakeIptablesDeps) AddLoopbackRoutes(cfg *config.IptablesConfig) error {
+func (r *fakeIptablesDeps) AddLoopbackRoutes(cfg *config.AmbientConfig) error {
 	r.AddLoopbackRoutesCnt.Add(1)
 	return r.AddRouteErr
 }
 
-func (r *fakeIptablesDeps) DelLoopbackRoutes(cfg *config.IptablesConfig) error {
+func (r *fakeIptablesDeps) DelLoopbackRoutes(cfg *config.AmbientConfig) error {
 	r.DelLoopbackRoutesCnt.Add(1)
 	return nil
 }

--- a/cni/pkg/nodeagent/fakes_test.go
+++ b/cni/pkg/nodeagent/fakes_test.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"istio.io/istio/cni/pkg/config"
 	"istio.io/istio/cni/pkg/iptables"
 )
 
@@ -169,22 +170,22 @@ type fakeIptablesDeps struct {
 
 var _ iptables.NetlinkDependencies = &fakeIptablesDeps{}
 
-func (r *fakeIptablesDeps) AddInpodMarkIPRule(cfg *iptables.IptablesConfig) error {
+func (r *fakeIptablesDeps) AddInpodMarkIPRule(cfg *config.IptablesConfig) error {
 	r.AddInpodMarkIPRuleCnt.Add(1)
 	return nil
 }
 
-func (r *fakeIptablesDeps) DelInpodMarkIPRule(cfg *iptables.IptablesConfig) error {
+func (r *fakeIptablesDeps) DelInpodMarkIPRule(cfg *config.IptablesConfig) error {
 	r.DelInpodMarkIPRuleCnt.Add(1)
 	return nil
 }
 
-func (r *fakeIptablesDeps) AddLoopbackRoutes(cfg *iptables.IptablesConfig) error {
+func (r *fakeIptablesDeps) AddLoopbackRoutes(cfg *config.IptablesConfig) error {
 	r.AddLoopbackRoutesCnt.Add(1)
 	return r.AddRouteErr
 }
 
-func (r *fakeIptablesDeps) DelLoopbackRoutes(cfg *iptables.IptablesConfig) error {
+func (r *fakeIptablesDeps) DelLoopbackRoutes(cfg *config.IptablesConfig) error {
 	r.DelLoopbackRoutesCnt.Add(1)
 	return nil
 }

--- a/cni/pkg/nodeagent/meshdataplane_linux.go
+++ b/cni/pkg/nodeagent/meshdataplane_linux.go
@@ -24,6 +24,7 @@ import (
 
 	"istio.io/istio/cni/pkg/ipset"
 	"istio.io/istio/cni/pkg/iptables"
+	"istio.io/istio/cni/pkg/trafficmanager"
 	"istio.io/istio/cni/pkg/util"
 	"istio.io/istio/pkg/util/sets"
 )
@@ -31,7 +32,7 @@ import (
 type meshDataplane struct {
 	kubeClient         kubernetes.Interface
 	netServer          MeshDataplane
-	hostIptables       *iptables.IptablesConfigurator
+	hostTrafficManager trafficmanager.TrafficRuleManager
 	hostsideProbeIPSet ipset.IPSet
 }
 
@@ -61,8 +62,8 @@ func (s *meshDataplane) Stop(skipCleanup bool) {
 	if !skipCleanup {
 		log.Info("CNI ambient server terminating, cleaning up node net rules")
 
-		log.Debug("removing host iptables rules")
-		s.hostIptables.DeleteHostRules()
+		log.Debug("removing host traffic rules")
+		s.hostTrafficManager.DeleteHostRules()
 		_ = util.RunAsHost(func() error {
 			log.Debug("destroying host ipset")
 			s.hostsideProbeIPSet.Flush()

--- a/cni/pkg/nodeagent/meshdataplane_linux.go
+++ b/cni/pkg/nodeagent/meshdataplane_linux.go
@@ -66,7 +66,6 @@ func (s *meshDataplane) Stop(skipCleanup bool) {
 		_ = util.RunAsHost(func() error {
 			log.Debug("destroying host addressSet")
 			s.hostAddrSet.Flush()
-			// SGM: TODO: Verify that we delete the table as well as we are not deleting it as part of DeleteHostRules.
 			if err := s.hostAddrSet.DestroySet(); err != nil {
 				log.Warnf("could not destroy host addressSet on shutdown")
 			}
@@ -281,7 +280,6 @@ func removePodFromHostAddrSet(pod *corev1.Pod, hostsideProbeSet set.AddressSetMa
 	podIPs := util.GetPodIPsIfPresent(pod)
 	return util.RunAsHost(func() error {
 		for _, pip := range podIPs {
-			// SGM: TODO Verify if we have to implement this API for nftable sets.
 			if uidMismatch, err := hostsideProbeSet.ClearEntriesWithIPAndComment(pip, podUID); err != nil {
 				return err
 			} else if uidMismatch != "" {
@@ -295,7 +293,6 @@ func removePodFromHostAddrSet(pod *corev1.Pod, hostsideProbeSet set.AddressSetMa
 
 func pruneHostAddrSet(expected sets.Set[netip.Addr], hostsideProbeSet set.AddressSetManager) error {
 	return util.RunAsHost(func() error {
-		// SGM: TODO Verify if we have to implement this API for nftable sets.
 		actualIPSetContents, err := hostsideProbeSet.ListEntriesByIP()
 		if err != nil {
 			log.Warnf("unable to list addressSet: %v", err)

--- a/cni/pkg/nodeagent/meshdataplane_linux.go
+++ b/cni/pkg/nodeagent/meshdataplane_linux.go
@@ -22,8 +22,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"istio.io/istio/cni/pkg/config"
 	"istio.io/istio/cni/pkg/ipset"
-	"istio.io/istio/cni/pkg/iptables"
 	"istio.io/istio/cni/pkg/trafficmanager"
 	"istio.io/istio/cni/pkg/util"
 	"istio.io/istio/pkg/util/sets"
@@ -280,7 +280,7 @@ func createHostsideProbeIpset(isV6 bool) (ipset.IPSet, error) {
 	runErr := util.RunAsHost(func() error {
 		var err error
 		linDeps := ipset.RealNlDeps()
-		probeSet, err = ipset.NewIPSet(iptables.ProbeIPSet, isV6, linDeps)
+		probeSet, err = ipset.NewIPSet(config.ProbeIPSet, isV6, linDeps)
 		if err != nil {
 			return err
 		}

--- a/cni/pkg/nodeagent/net.go
+++ b/cni/pkg/nodeagent/net.go
@@ -20,27 +20,27 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"istio.io/api/annotation"
-	"istio.io/istio/cni/pkg/iptables"
+	"istio.io/istio/cni/pkg/config"
 	"istio.io/istio/cni/pkg/util"
 )
 
-func getPodLevelTrafficOverrides(pod *corev1.Pod) iptables.PodLevelOverrides {
+func getPodLevelTrafficOverrides(pod *corev1.Pod) config.PodLevelOverrides {
 	// If true, the pod will run in 'ingress mode'. This is intended to be used for "ingress" type workloads which handle
 	// non-mesh traffic on inbound, and send to the mesh on outbound.
 	// Basically, this just disables inbound redirection.
-	podCfg := iptables.PodLevelOverrides{IngressMode: false}
+	podCfg := config.PodLevelOverrides{IngressMode: false}
 
 	if ingressMode, present := util.CheckBooleanAnnotation(pod, annotation.AmbientBypassInboundCapture.Name); present {
 		podCfg.IngressMode = ingressMode
 	}
 
-	podCfg.DNSProxy = iptables.PodDNSUnset
+	podCfg.DNSProxy = config.PodDNSUnset
 
 	if dnsCapture, present := util.CheckBooleanAnnotation(pod, annotation.AmbientDnsCapture.Name); present {
 		if dnsCapture {
-			podCfg.DNSProxy = iptables.PodDNSEnabled
+			podCfg.DNSProxy = config.PodDNSEnabled
 		} else {
-			podCfg.DNSProxy = iptables.PodDNSDisabled
+			podCfg.DNSProxy = config.PodDNSDisabled
 		}
 	}
 

--- a/cni/pkg/nodeagent/net_linux.go
+++ b/cni/pkg/nodeagent/net_linux.go
@@ -42,7 +42,7 @@ var _ MeshDataplane = &NetServer{}
 // ConstructInitialSnapshot is always called first, before Start.
 // It takes a "snapshot" of ambient pods that were already running when the server started, and:
 //
-// - initializes a an internal cache of pod info and netns handles with these existing pods.
+// - initializes an internal cache of pod info and netns handles with these existing pods.
 // This cache will also be updated when the K8S informer gets a new pod.
 // This cache represents the "state of the world" of all enrolled pods on the node this agent
 // knows about, and will be sent to any connecting ztunnel as a startup message.

--- a/cni/pkg/nodeagent/net_linux.go
+++ b/cni/pkg/nodeagent/net_linux.go
@@ -23,16 +23,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	"istio.io/istio/cni/pkg/iptables"
+	"istio.io/istio/cni/pkg/trafficmanager"
 	"istio.io/istio/pkg/slices"
-	dep "istio.io/istio/tools/istio-iptables/pkg/dependencies"
 )
 
 // Adapts CNI to ztunnel server. decoupled from k8s for easier integration testing.
 type NetServer struct {
 	ztunnelServer      ZtunnelServer
 	currentPodSnapshot *podNetnsCache
-	podIptables        *iptables.IptablesConfigurator
+	trafficManager     trafficmanager.TrafficRuleManager
 	podNs              PodNetnsFinder
 	// allow overriding for tests
 	netnsRunner func(fdable NetnsFd, toRun func() error) error
@@ -60,7 +59,7 @@ func (s *NetServer) ConstructInitialSnapshot(existingAmbientPods []*corev1.Pod) 
 		consErr = append(consErr, err)
 	}
 
-	if s.podIptables.ReconcileModeEnabled() {
+	if s.trafficManager.ReconcileModeEnabled() {
 		log.Info("inpod reconcile mode enabled")
 		for _, pod := range existingAmbientPods {
 			log := log.WithLabels("ns", pod.Namespace, "name", pod.Name)
@@ -121,7 +120,7 @@ func (s *NetServer) AddPodToMesh(ctx context.Context, pod *corev1.Pod, podIPs []
 
 	log.Debug("calling CreateInpodRules")
 	if err := s.netnsRunner(openNetns, func() error {
-		return s.podIptables.CreateInpodRules(log, podCfg)
+		return s.trafficManager.CreateInpodRules(log, podCfg)
 	}); err != nil {
 		// We currently treat any failure to create inpod rules as non-retryable/catastrophic,
 		// and return a NonRetryableError in this case.
@@ -166,9 +165,9 @@ func (s *NetServer) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod, isDe
 	// If the pod is already deleted or terminated, we do not need to clean up the pod network -- only the host side.
 	if !isDelete {
 		if openNetns != nil {
-			// pod is removed from the mesh, but is still running. remove iptables rules
+			// pod is removed from the mesh, but is still running. remove traffic rules
 			log.Debugf("calling DeleteInpodRules")
-			if err := s.netnsRunner(openNetns, func() error { return s.podIptables.DeleteInpodRules(log) }); err != nil {
+			if err := s.netnsRunner(openNetns, func() error { return s.trafficManager.DeleteInpodRules(log) }); err != nil {
 				return fmt.Errorf("failed to delete inpod rules: %w", err)
 			}
 		} else {
@@ -184,12 +183,12 @@ func (s *NetServer) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod, isDe
 	return nil
 }
 
-func newNetServer(ztunnelServer ZtunnelServer, podNsMap *podNetnsCache, podIptables *iptables.IptablesConfigurator, podNs PodNetnsFinder) *NetServer {
+func newNetServer(ztunnelServer ZtunnelServer, podNsMap *podNetnsCache, trafficManager trafficmanager.TrafficRuleManager, podNs PodNetnsFinder) *NetServer {
 	return &NetServer{
 		ztunnelServer:      ztunnelServer,
 		currentPodSnapshot: podNsMap,
 		podNs:              podNs,
-		podIptables:        podIptables,
+		trafficManager:     trafficManager,
 		netnsRunner:        NetnsDo,
 	}
 }
@@ -208,7 +207,7 @@ func (s *NetServer) reconcileExistingPod(pod *corev1.Pod) error {
 	podCfg := getPodLevelTrafficOverrides(pod)
 
 	if err := s.netnsRunner(openNetns, func() error {
-		return s.podIptables.CreateInpodRules(log, podCfg)
+		return s.trafficManager.CreateInpodRules(log, podCfg)
 	}); err != nil {
 		return err
 	}
@@ -283,18 +282,4 @@ func (s *NetServer) scanProcForPodsAndCache(pods map[types.UID]*corev1.Pod) erro
 		s.currentPodSnapshot.UpsertPodCacheWithNetns(uid, wl)
 	}
 	return nil
-}
-
-func realDependenciesHost() *dep.RealDependencies {
-	return &dep.RealDependencies{
-		UsePodScopedXtablesLock: false,
-		NetworkNamespace:        "",
-	}
-}
-
-func realDependenciesInpod(useScopedLocks bool) *dep.RealDependencies {
-	return &dep.RealDependencies{
-		UsePodScopedXtablesLock: useScopedLocks,
-		NetworkNamespace:        "",
-	}
 }

--- a/cni/pkg/nodeagent/net_test.go
+++ b/cni/pkg/nodeagent/net_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"istio.io/api/annotation"
+	"istio.io/istio/cni/pkg/config"
 	"istio.io/istio/cni/pkg/iptables"
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/tools/istio-iptables/pkg/dependencies"
@@ -49,7 +50,7 @@ func getTestFixure(ctx context.Context) netTestFixture {
 }
 
 // nolint: lll
-func getTestFixureWithIptablesConfig(ctx context.Context, fakeDeps *dependencies.DependenciesStub, hostConfig, podConfig *iptables.IptablesConfig) netTestFixture {
+func getTestFixureWithIptablesConfig(ctx context.Context, fakeDeps *dependencies.DependenciesStub, hostConfig, podConfig *config.IptablesConfig) netTestFixture {
 	podNsMap := newPodNetnsCache(openNsTestOverride)
 	nlDeps := &fakeIptablesDeps{}
 	_, podIptC, _ := iptables.NewIptablesConfigurator(hostConfig, podConfig, fakeDeps, fakeDeps, nlDeps)
@@ -370,7 +371,7 @@ func TestConstructInitialSnapReconcilesPodsIfIptConfiguratorSupportsReconciliati
 	defer cancel()
 	setupLogging()
 
-	podCfg := iptables.IptablesConfig{
+	podCfg := config.IptablesConfig{
 		Reconcile: true,
 	}
 
@@ -403,7 +404,7 @@ func TestConstructInitialSnapDoesNotReconcilePodIfIptablesReconciliationDisabled
 	defer cancel()
 	setupLogging()
 
-	podCfg := iptables.IptablesConfig{
+	podCfg := config.IptablesConfig{
 		Reconcile: false,
 	}
 
@@ -436,7 +437,7 @@ func TestReconcilePodReturnsErrorIfNoNetnsFound(t *testing.T) {
 	defer cancel()
 	setupLogging()
 
-	podCfg := iptables.IptablesConfig{
+	podCfg := config.IptablesConfig{
 		Reconcile: true,
 	}
 
@@ -468,7 +469,7 @@ func TestReconcilePodReturnsNoErrorIfPodReconciles(t *testing.T) {
 	defer cancel()
 	setupLogging()
 
-	podCfg := iptables.IptablesConfig{
+	podCfg := config.IptablesConfig{
 		Reconcile: true,
 	}
 
@@ -503,7 +504,7 @@ func TestReconcilePodReturnsNoErrorIfPodReconciles(t *testing.T) {
 
 var overrideTests = map[string]struct {
 	in  corev1.Pod
-	out iptables.PodLevelOverrides
+	out config.PodLevelOverrides
 }{
 	"pod dns override": {
 		in: corev1.Pod{
@@ -514,10 +515,10 @@ var overrideTests = map[string]struct {
 				Annotations: map[string]string{annotation.AmbientDnsCapture.Name: "true"},
 			},
 		},
-		out: iptables.PodLevelOverrides{
+		out: config.PodLevelOverrides{
 			VirtualInterfaces: []string{},
 			IngressMode:       false,
-			DNSProxy:          iptables.PodDNSEnabled,
+			DNSProxy:          config.PodDNSEnabled,
 		},
 	},
 
@@ -529,10 +530,10 @@ var overrideTests = map[string]struct {
 				UID:       "12345",
 			},
 		},
-		out: iptables.PodLevelOverrides{
+		out: config.PodLevelOverrides{
 			VirtualInterfaces: []string{},
 			IngressMode:       false,
-			DNSProxy:          iptables.PodDNSUnset,
+			DNSProxy:          config.PodDNSUnset,
 		},
 	},
 
@@ -545,10 +546,10 @@ var overrideTests = map[string]struct {
 				Annotations: map[string]string{annotation.AmbientDnsCapture.Name: "false"},
 			},
 		},
-		out: iptables.PodLevelOverrides{
+		out: config.PodLevelOverrides{
 			VirtualInterfaces: []string{},
 			IngressMode:       false,
-			DNSProxy:          iptables.PodDNSDisabled,
+			DNSProxy:          config.PodDNSDisabled,
 		},
 	},
 
@@ -565,10 +566,10 @@ var overrideTests = map[string]struct {
 				},
 			},
 		},
-		out: iptables.PodLevelOverrides{
+		out: config.PodLevelOverrides{
 			VirtualInterfaces: []string{"en0ps1", "en1ps1"},
 			IngressMode:       true,
-			DNSProxy:          iptables.PodDNSEnabled,
+			DNSProxy:          config.PodDNSEnabled,
 		},
 	},
 
@@ -585,10 +586,10 @@ var overrideTests = map[string]struct {
 				},
 			},
 		},
-		out: iptables.PodLevelOverrides{
+		out: config.PodLevelOverrides{
 			VirtualInterfaces: []string{"asd^&&*$&*(#$&*(#&$*()))"},
 			IngressMode:       false,
-			DNSProxy:          iptables.PodDNSUnset,
+			DNSProxy:          config.PodDNSUnset,
 		},
 	},
 }

--- a/cni/pkg/nodeagent/net_test.go
+++ b/cni/pkg/nodeagent/net_test.go
@@ -50,7 +50,7 @@ func getTestFixure(ctx context.Context) netTestFixture {
 }
 
 // nolint: lll
-func getTestFixureWithIptablesConfig(ctx context.Context, fakeDeps *dependencies.DependenciesStub, hostConfig, podConfig *config.IptablesConfig) netTestFixture {
+func getTestFixureWithIptablesConfig(ctx context.Context, fakeDeps *dependencies.DependenciesStub, hostConfig, podConfig *config.AmbientConfig) netTestFixture {
 	podNsMap := newPodNetnsCache(openNsTestOverride)
 	nlDeps := &fakeIptablesDeps{}
 	_, podIptC, _ := iptables.NewIptablesConfigurator(hostConfig, podConfig, fakeDeps, fakeDeps, nlDeps)
@@ -371,7 +371,7 @@ func TestConstructInitialSnapReconcilesPodsIfIptConfiguratorSupportsReconciliati
 	defer cancel()
 	setupLogging()
 
-	podCfg := config.IptablesConfig{
+	podCfg := config.AmbientConfig{
 		Reconcile: true,
 	}
 
@@ -404,7 +404,7 @@ func TestConstructInitialSnapDoesNotReconcilePodIfIptablesReconciliationDisabled
 	defer cancel()
 	setupLogging()
 
-	podCfg := config.IptablesConfig{
+	podCfg := config.AmbientConfig{
 		Reconcile: false,
 	}
 
@@ -437,7 +437,7 @@ func TestReconcilePodReturnsErrorIfNoNetnsFound(t *testing.T) {
 	defer cancel()
 	setupLogging()
 
-	podCfg := config.IptablesConfig{
+	podCfg := config.AmbientConfig{
 		Reconcile: true,
 	}
 
@@ -469,7 +469,7 @@ func TestReconcilePodReturnsNoErrorIfPodReconciles(t *testing.T) {
 	defer cancel()
 	setupLogging()
 
-	podCfg := config.IptablesConfig{
+	podCfg := config.AmbientConfig{
 		Reconcile: true,
 	}
 

--- a/cni/pkg/nodeagent/options.go
+++ b/cni/pkg/nodeagent/options.go
@@ -54,4 +54,5 @@ type AmbientArgs struct {
 	DNSCapture                 bool
 	EnableIPv6                 bool
 	ReconcilePodRulesOnStartup bool
+	NativeNftables             bool
 }

--- a/cni/pkg/nodeagent/server_linux.go
+++ b/cni/pkg/nodeagent/server_linux.go
@@ -29,14 +29,14 @@ import (
 
 func initMeshDataplane(client kube.Client, args AmbientArgs) (*meshDataplane, error) {
 	// Linux specific startup operations
-	hostCfg := &config.IptablesConfig{
+	hostCfg := &config.AmbientConfig{
 		RedirectDNS:            args.DNSCapture,
 		EnableIPv6:             args.EnableIPv6,
 		HostProbeSNATAddress:   HostProbeSNATIP,
 		HostProbeV6SNATAddress: HostProbeSNATIPV6,
 	}
 
-	podCfg := &config.IptablesConfig{
+	podCfg := &config.AmbientConfig{
 		RedirectDNS:            args.DNSCapture,
 		EnableIPv6:             args.EnableIPv6,
 		HostProbeSNATAddress:   HostProbeSNATIP,

--- a/cni/pkg/nodeagent/server_linux.go
+++ b/cni/pkg/nodeagent/server_linux.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"istio.io/istio/cni/pkg/config"
 	pconstants "istio.io/istio/cni/pkg/constants"
 	"istio.io/istio/cni/pkg/iptables"
 	"istio.io/istio/cni/pkg/trafficmanager"
@@ -28,14 +29,14 @@ import (
 
 func initMeshDataplane(client kube.Client, args AmbientArgs) (*meshDataplane, error) {
 	// Linux specific startup operations
-	hostCfg := &iptables.IptablesConfig{
+	hostCfg := &config.IptablesConfig{
 		RedirectDNS:            args.DNSCapture,
 		EnableIPv6:             args.EnableIPv6,
 		HostProbeSNATAddress:   HostProbeSNATIP,
 		HostProbeV6SNATAddress: HostProbeSNATIPV6,
 	}
 
-	podCfg := &iptables.IptablesConfig{
+	podCfg := &config.IptablesConfig{
 		RedirectDNS:            args.DNSCapture,
 		EnableIPv6:             args.EnableIPv6,
 		HostProbeSNATAddress:   HostProbeSNATIP,

--- a/cni/pkg/trafficmanager/interface.go
+++ b/cni/pkg/trafficmanager/interface.go
@@ -1,0 +1,56 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trafficmanager
+
+import (
+	"istio.io/istio/cni/pkg/iptables"
+	istiolog "istio.io/istio/pkg/log"
+)
+
+// TrafficRuleManager defines the interface for managing traffic redirection rules
+// in Ambient mode. This abstraction allows switching between iptables and nftables
+// implementations without changing the higher-level logic.
+type TrafficRuleManager interface {
+	CreateInpodRules(log *istiolog.Scope, podOverrides iptables.PodLevelOverrides) error
+	DeleteInpodRules(log *istiolog.Scope) error
+	CreateHostRulesForHealthChecks() error
+	DeleteHostRules()
+	ReconcileModeEnabled() bool
+}
+
+type TrafficRuleManagerConfig struct {
+	// Use native nftables instead of iptables
+	NativeNftables bool
+
+	// Host-level configuration
+	HostConfig *iptables.IptablesConfig
+
+	// Pod-level configuration
+	PodConfig *iptables.IptablesConfig
+
+	// Dependencies for iptables (host and pod)
+	HostDeps interface{}
+	PodDeps  interface{}
+
+	NlDeps iptables.NetlinkDependencies
+}
+
+// NewTrafficRuleManager creates both host and pod traffic rule managers based on configuration
+func NewTrafficRuleManager(cfg *TrafficRuleManagerConfig) (hostManager, podManager TrafficRuleManager, err error) {
+	if cfg.NativeNftables {
+		return NewNftablesTrafficManager(cfg)
+	}
+	return NewIptablesTrafficManager(cfg)
+}

--- a/cni/pkg/trafficmanager/interface.go
+++ b/cni/pkg/trafficmanager/interface.go
@@ -15,6 +15,7 @@
 package trafficmanager
 
 import (
+	"istio.io/istio/cni/pkg/config"
 	"istio.io/istio/cni/pkg/iptables"
 	istiolog "istio.io/istio/pkg/log"
 )
@@ -23,7 +24,7 @@ import (
 // in Ambient mode. This abstraction allows switching between iptables and nftables
 // implementations without changing the higher-level logic.
 type TrafficRuleManager interface {
-	CreateInpodRules(log *istiolog.Scope, podOverrides iptables.PodLevelOverrides) error
+	CreateInpodRules(log *istiolog.Scope, podOverrides config.PodLevelOverrides) error
 	DeleteInpodRules(log *istiolog.Scope) error
 	CreateHostRulesForHealthChecks() error
 	DeleteHostRules()
@@ -35,10 +36,10 @@ type TrafficRuleManagerConfig struct {
 	NativeNftables bool
 
 	// Host-level configuration
-	HostConfig *iptables.IptablesConfig
+	HostConfig *config.IptablesConfig
 
 	// Pod-level configuration
-	PodConfig *iptables.IptablesConfig
+	PodConfig *config.IptablesConfig
 
 	// Dependencies for iptables (host and pod)
 	HostDeps interface{}

--- a/cni/pkg/trafficmanager/interface.go
+++ b/cni/pkg/trafficmanager/interface.go
@@ -36,10 +36,10 @@ type TrafficRuleManagerConfig struct {
 	NativeNftables bool
 
 	// Host-level configuration
-	HostConfig *config.IptablesConfig
+	HostConfig *config.AmbientConfig
 
 	// Pod-level configuration
-	PodConfig *config.IptablesConfig
+	PodConfig *config.AmbientConfig
 
 	// Dependencies for iptables (host and pod)
 	HostDeps interface{}

--- a/cni/pkg/trafficmanager/iptables_manager.go
+++ b/cni/pkg/trafficmanager/iptables_manager.go
@@ -17,6 +17,7 @@ package trafficmanager
 import (
 	"fmt"
 
+	"istio.io/istio/cni/pkg/config"
 	"istio.io/istio/cni/pkg/iptables"
 	istiolog "istio.io/istio/pkg/log"
 	dep "istio.io/istio/tools/istio-iptables/pkg/dependencies"
@@ -73,7 +74,7 @@ func NewIptablesTrafficManager(cfg *TrafficRuleManagerConfig) (hostManager, podM
 }
 
 // CreateInpodRules creates iptables rules within a pod's network namespace
-func (m *IptablesTrafficManager) CreateInpodRules(log *istiolog.Scope, podOverrides iptables.PodLevelOverrides) error {
+func (m *IptablesTrafficManager) CreateInpodRules(log *istiolog.Scope, podOverrides config.PodLevelOverrides) error {
 	if m.podIptables == nil {
 		return fmt.Errorf("pod iptables configurator not available (this is likely a host-only traffic manager)")
 	}

--- a/cni/pkg/trafficmanager/iptables_manager.go
+++ b/cni/pkg/trafficmanager/iptables_manager.go
@@ -1,0 +1,113 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trafficmanager
+
+import (
+	"fmt"
+
+	"istio.io/istio/cni/pkg/iptables"
+	istiolog "istio.io/istio/pkg/log"
+	dep "istio.io/istio/tools/istio-iptables/pkg/dependencies"
+)
+
+// IptablesTrafficManager implements TrafficRuleManager with iptables backend
+type IptablesTrafficManager struct {
+	hostIptables *iptables.IptablesConfigurator
+	podIptables  *iptables.IptablesConfigurator
+}
+
+var _ TrafficRuleManager = &IptablesTrafficManager{}
+
+// NewIptablesTrafficManager creates both host and pod iptables-based traffic managers
+func NewIptablesTrafficManager(cfg *TrafficRuleManagerConfig) (hostManager, podManager TrafficRuleManager, err error) {
+	hostDeps, ok := cfg.HostDeps.(*dep.RealDependencies)
+	if !ok {
+		hostDeps = &dep.RealDependencies{
+			UsePodScopedXtablesLock: false,
+			NetworkNamespace:        "",
+		}
+	}
+
+	podDeps, ok := cfg.PodDeps.(*dep.RealDependencies)
+	if !ok {
+		podDeps = &dep.RealDependencies{
+			UsePodScopedXtablesLock: true,
+			NetworkNamespace:        "",
+		}
+	}
+
+	hostIptables, podIptables, err := iptables.NewIptablesConfigurator(
+		cfg.HostConfig,
+		cfg.PodConfig,
+		hostDeps,
+		podDeps,
+		cfg.NlDeps,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	hostManager = &IptablesTrafficManager{
+		hostIptables: hostIptables,
+		podIptables:  nil, // Host manager doesn't need pod iptables
+	}
+
+	podManager = &IptablesTrafficManager{
+		hostIptables: nil, // Pod manager doesn't need host iptables
+		podIptables:  podIptables,
+	}
+
+	return hostManager, podManager, nil
+}
+
+// CreateInpodRules creates iptables rules within a pod's network namespace
+func (m *IptablesTrafficManager) CreateInpodRules(log *istiolog.Scope, podOverrides iptables.PodLevelOverrides) error {
+	if m.podIptables == nil {
+		return fmt.Errorf("pod iptables configurator not available (this is likely a host-only traffic manager)")
+	}
+	return m.podIptables.CreateInpodRules(log, podOverrides)
+}
+
+// DeleteInpodRules removes iptables rules from a pod's network namespace
+func (m *IptablesTrafficManager) DeleteInpodRules(log *istiolog.Scope) error {
+	if m.podIptables == nil {
+		return fmt.Errorf("pod iptables configurator not available (this is likely a host-only traffic manager)")
+	}
+	return m.podIptables.DeleteInpodRules(log)
+}
+
+// CreateHostRulesForHealthChecks creates host-level iptables rules for health check handling
+func (m *IptablesTrafficManager) CreateHostRulesForHealthChecks() error {
+	if m.hostIptables == nil {
+		return fmt.Errorf("host iptables configurator not available (this is likely a pod-only traffic manager)")
+	}
+	return m.hostIptables.CreateHostRulesForHealthChecks()
+}
+
+// DeleteHostRules removes host-level iptables rules
+func (m *IptablesTrafficManager) DeleteHostRules() {
+	if m.hostIptables != nil {
+		m.hostIptables.DeleteHostRules()
+	}
+}
+
+// ReconcileModeEnabled returns true if reconciliation mode is enabled
+func (m *IptablesTrafficManager) ReconcileModeEnabled() bool {
+	if m.podIptables == nil {
+		// Default to false if pod configurator not available
+		return false
+	}
+	return m.podIptables.ReconcileModeEnabled()
+}

--- a/cni/pkg/trafficmanager/nftables_manager.go
+++ b/cni/pkg/trafficmanager/nftables_manager.go
@@ -1,0 +1,97 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trafficmanager
+
+import (
+	"fmt"
+
+	"istio.io/istio/cni/pkg/iptables"
+	"istio.io/istio/cni/pkg/nftables"
+	istiolog "istio.io/istio/pkg/log"
+)
+
+// NftablesTrafficManager implements TrafficRuleManager using nftables backend
+type NftablesTrafficManager struct {
+	hostNftables *nftables.NftablesConfigurator
+	podNftables  *nftables.NftablesConfigurator
+}
+
+var _ TrafficRuleManager = &NftablesTrafficManager{}
+
+// NewNftablesTrafficManager creates both host and pod nftables-based traffic managers
+func NewNftablesTrafficManager(cfg *TrafficRuleManagerConfig) (hostManager, podManager TrafficRuleManager, err error) {
+	hostNftables, podNftables, err := nftables.NewNftablesConfigurator(
+		cfg.HostConfig,
+		cfg.PodConfig,
+		nil,
+		nil,
+		cfg.NlDeps,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	hostManager = &NftablesTrafficManager{
+		hostNftables: hostNftables,
+		podNftables:  nil, // Host manager doesn't need pod nftables
+	}
+
+	podManager = &NftablesTrafficManager{
+		hostNftables: nil, // Pod manager doesn't need host nftables
+		podNftables:  podNftables,
+	}
+
+	return hostManager, podManager, nil
+}
+
+// CreateInpodRules creates nftables rules within a pod's network namespace
+func (m *NftablesTrafficManager) CreateInpodRules(log *istiolog.Scope, podOverrides iptables.PodLevelOverrides) error {
+	if m.podNftables == nil {
+		return fmt.Errorf("pod nftables configurator not available (this is likely a host-only traffic manager)")
+	}
+	return m.podNftables.CreateInpodRules(log, podOverrides)
+}
+
+// DeleteInpodRules removes nftables rules from a pod's network namespace
+func (m *NftablesTrafficManager) DeleteInpodRules(log *istiolog.Scope) error {
+	if m.podNftables == nil {
+		return fmt.Errorf("pod nftables configurator not available (this is likely a host-only traffic manager)")
+	}
+	return m.podNftables.DeleteInpodRules(log)
+}
+
+// CreateHostRulesForHealthChecks creates host-level nftables rules for health check handling
+func (m *NftablesTrafficManager) CreateHostRulesForHealthChecks() error {
+	if m.hostNftables == nil {
+		return fmt.Errorf("host nftables configurator not available (this is likely a pod-only traffic manager)")
+	}
+	return m.hostNftables.CreateHostRulesForHealthChecks()
+}
+
+// DeleteHostRules removes host-level nftables rules
+func (m *NftablesTrafficManager) DeleteHostRules() {
+	if m.hostNftables != nil {
+		m.hostNftables.DeleteHostRules()
+	}
+}
+
+// ReconcileModeEnabled returns true if reconciliation mode is enabled
+func (m *NftablesTrafficManager) ReconcileModeEnabled() bool {
+	if m.podNftables == nil {
+		// Default to false if pod nftables configurator not available
+		return false
+	}
+	return m.podNftables.ReconcileModeEnabled()
+}

--- a/cni/pkg/trafficmanager/nftables_manager.go
+++ b/cni/pkg/trafficmanager/nftables_manager.go
@@ -17,7 +17,7 @@ package trafficmanager
 import (
 	"fmt"
 
-	"istio.io/istio/cni/pkg/iptables"
+	"istio.io/istio/cni/pkg/config"
 	"istio.io/istio/cni/pkg/nftables"
 	istiolog "istio.io/istio/pkg/log"
 )
@@ -57,7 +57,7 @@ func NewNftablesTrafficManager(cfg *TrafficRuleManagerConfig) (hostManager, podM
 }
 
 // CreateInpodRules creates nftables rules within a pod's network namespace
-func (m *NftablesTrafficManager) CreateInpodRules(log *istiolog.Scope, podOverrides iptables.PodLevelOverrides) error {
+func (m *NftablesTrafficManager) CreateInpodRules(log *istiolog.Scope, podOverrides config.PodLevelOverrides) error {
 	if m.podNftables == nil {
 		return fmt.Errorf("pod nftables configurator not available (this is likely a host-only traffic manager)")
 	}

--- a/releasenotes/notes/nftables-ambient.yaml
+++ b/releasenotes/notes/nftables-ambient.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 57324
+releaseNotes:
+  - |
+    **Added** support for native nftables when using Istio Ambient mode. This update makes it possible to use nftables
+    instead of iptables to manage network rules, offering more efficient approach to traffic redirection for pods and
+    services. To enable the nftables mode, use "--set values.global.nativeNftables=true" when installing istio-cni.

--- a/tests/integration/ambient/nftables/main_test.go
+++ b/tests/integration/ambient/nftables/main_test.go
@@ -1,0 +1,396 @@
+//go:build integ
+// +build integ
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nftables
+
+import (
+	"context"
+	"testing"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"istio.io/api/label"
+	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/ambient"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	cdeployment "istio.io/istio/pkg/test/framework/components/echo/common/deployment"
+	"istio.io/istio/pkg/test/framework/components/echo/common/ports"
+	"istio.io/istio/pkg/test/framework/components/echo/deployment"
+	"istio.io/istio/pkg/test/framework/components/echo/match"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/components/prometheus"
+	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/framework/resource/config/apply"
+	"istio.io/istio/pkg/test/scopes"
+	"istio.io/istio/tests/integration/security/util/cert"
+)
+
+var (
+	i istio.Instance
+
+	// Below are various preconfigured echo deployments. Whenever possible, tests should utilize these
+	// to avoid excessive creation/tear down of deployments. In general, a test should only deploy echo if
+	// its doing something unique to that specific test.
+	apps = &EchoDeployments{}
+
+	// used to validate telemetry in-cluster
+	prom prometheus.Instance
+)
+
+const (
+	ambientNftablesControlPlaneValues = `
+values:
+  cni:
+    # The CNI repair feature is disabled for these tests because this is a controlled environment,
+    # and it is important to catch issues that might otherwise be automatically fixed.
+    # Refer to issue #49207 for more context.
+    repair:
+      enabled: false
+  global:
+    nativeNftables: true
+  ztunnel:
+    terminationGracePeriodSeconds: 5
+    env:
+      SECRET_TTL: 5m
+    podLabels:
+      networking.istio.io/tunnel: "http"
+`
+
+	ambientMultiNetworkControlPlaneValues = `
+values:
+  pilot:
+    env:
+      AMBIENT_ENABLE_MULTI_NETWORK: "true"
+  ztunnel:
+    terminationGracePeriodSeconds: 5
+    env:
+      SECRET_TTL: 5m
+    podLabels:
+      networking.istio.io/tunnel: "http"
+  cni:
+    # The CNI repair feature is disabled for these tests because this is a controlled environment,
+    # and it is important to catch issues that might otherwise be automatically fixed.
+    # Refer to issue #49207 for more context.
+    repair:
+      enabled: false
+`
+)
+
+type EchoDeployments struct {
+	// Namespace echo apps will be deployed
+	Namespace         namespace.Instance
+	ExternalNamespace namespace.Instance
+
+	// AllWaypoint is a waypoint for all types
+	AllWaypoint echo.Instances
+	// WorkloadAddressedWaypoint is a workload only waypoint
+	WorkloadAddressedWaypoint echo.Instances
+	// ServiceAddressedWaypoint is a serviceonly waypoint
+	ServiceAddressedWaypoint echo.Instances
+	// Captured echo service
+	Captured echo.Instances
+	// Uncaptured echo Service
+	Uncaptured echo.Instances
+	// Sidecar echo services with sidecar
+	Sidecar echo.Instances
+
+	// All echo services
+	All echo.Instances
+	// Echo services that are in the mesh
+	Mesh echo.Instances
+	// Echo services that are not in mesh
+	MeshExternal echo.Instances
+
+	MockExternal echo.Instances
+
+	// WaypointProxies by
+	WaypointProxies map[string]ambient.WaypointProxy
+}
+
+// TestMain defines the entrypoint for pilot tests using a standard Istio installation.
+// If a test requires a custom install it should go into its own package, otherwise it should go
+// here to reuse a single install across tests.
+func TestMain(m *testing.M) {
+	// nolint: staticcheck
+	framework.
+		NewSuite(m).
+		RequireMinVersion(24).
+		Setup(func(t resource.Context) error {
+			t.Settings().Ambient = true
+			return nil
+		}).
+		Setup(istio.Setup(&i, func(ctx resource.Context, cfg *istio.Config) {
+			// can't deploy VMs without eastwest gateway
+			ctx.Settings().SkipVMs()
+			cfg.EnableCNI = true
+			cfg.DeployEastWestGW = false
+			cfg.ControlPlaneValues = ambientNftablesControlPlaneValues
+			if ctx.Settings().AmbientMultiNetwork {
+				cfg.DeployEastWestGW = true
+				cfg.DeployGatewayAPI = true
+				cfg.ControlPlaneValues = ambientMultiNetworkControlPlaneValues
+				// TODO: Remove once we're actually ready to test the multi-cluster
+				// features
+				cfg.SkipDeployCrossClusterSecrets = true
+			}
+		}, cert.CreateCASecretAlt)).
+		SetupParallel(
+			func(t resource.Context) error {
+				return SetupApps(t, i, apps)
+			},
+			func(t resource.Context) (err error) {
+				prom, err = prometheus.New(t, prometheus.Config{})
+				if err != nil {
+					return err
+				}
+				return
+			},
+		).
+		Run()
+}
+
+const (
+	WorkloadAddressedWaypoint = "workload-addressed-waypoint"
+	ServiceAddressedWaypoint  = "service-addressed-waypoint"
+	Captured                  = "captured"
+	Uncaptured                = "uncaptured"
+	Sidecar                   = "sidecar"
+	Global                    = "global"
+	Local                     = "local"
+	EastWestGateway           = "eastwest-gateway"
+)
+
+var inMesh = match.Matcher(func(instance echo.Instance) bool {
+	return instance.Config().HasProxyCapabilities()
+})
+
+func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) error {
+	var err error
+	apps.Namespace, err = namespace.New(t, namespace.Config{
+		Prefix: "echo",
+		Inject: false,
+		Labels: map[string]string{
+			label.IoIstioDataplaneMode.Name: "ambient",
+		},
+	})
+	if err != nil {
+		return err
+	}
+	apps.ExternalNamespace, err = namespace.New(t, namespace.Config{
+		Prefix: "external",
+		Inject: false,
+		Labels: map[string]string{
+			"istio.io/test-exclude-namespace": "true",
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	// Headless services don't work with targetPort, set to same port
+	headlessPorts := make([]echo.Port, len(ports.All()))
+	for i, p := range ports.All() {
+		p.ServicePort = p.WorkloadPort
+		headlessPorts[i] = p
+	}
+	builder := deployment.New(t).
+		WithClusters(t.Clusters()...).
+		WithConfig(echo.Config{
+			Service:               WorkloadAddressedWaypoint,
+			Namespace:             apps.Namespace,
+			Ports:                 ports.All(),
+			ServiceAccount:        true,
+			WorkloadWaypointProxy: "waypoint",
+			Subsets: []echo.SubsetConfig{
+				{
+					Replicas: 1,
+					Version:  "v1",
+					Labels: map[string]string{
+						"app":                         WorkloadAddressedWaypoint,
+						"version":                     "v1",
+						label.IoIstioUseWaypoint.Name: "waypoint",
+					},
+				},
+				{
+					Replicas: 1,
+					Version:  "v2",
+					Labels: map[string]string{
+						"app":                         WorkloadAddressedWaypoint,
+						"version":                     "v2",
+						label.IoIstioUseWaypoint.Name: "waypoint",
+					},
+				},
+			},
+		}).
+		WithConfig(echo.Config{
+			Service:              ServiceAddressedWaypoint,
+			Namespace:            apps.Namespace,
+			Ports:                ports.All(),
+			ServiceLabels:        map[string]string{label.IoIstioUseWaypoint.Name: "waypoint"},
+			ServiceAccount:       true,
+			ServiceWaypointProxy: "waypoint",
+			Subsets: []echo.SubsetConfig{
+				{
+					Replicas: 1,
+					Version:  "v1",
+					Labels: map[string]string{
+						"app":     ServiceAddressedWaypoint,
+						"version": "v1",
+					},
+				},
+				{
+					Replicas: 1,
+					Version:  "v2",
+					Labels: map[string]string{
+						"app":     ServiceAddressedWaypoint,
+						"version": "v2",
+					},
+				},
+			},
+		}).
+		WithConfig(echo.Config{
+			Service:        Captured,
+			Namespace:      apps.Namespace,
+			Ports:          ports.All(),
+			ServiceAccount: true,
+			Subsets: []echo.SubsetConfig{
+				{
+					Replicas: 1,
+					Version:  "v1",
+				},
+				{
+					Replicas: 1,
+					Version:  "v2",
+				},
+			},
+		}).
+		WithConfig(echo.Config{
+			Service:        Uncaptured,
+			Namespace:      apps.Namespace,
+			Ports:          ports.All(),
+			ServiceAccount: true,
+			Subsets: []echo.SubsetConfig{
+				{
+					Replicas: 1,
+					Version:  "v1",
+					Labels:   map[string]string{label.IoIstioDataplaneMode.Name: constants.DataplaneModeNone},
+				},
+				{
+					Replicas: 1,
+					Version:  "v2",
+					Labels:   map[string]string{label.IoIstioDataplaneMode.Name: constants.DataplaneModeNone},
+				},
+			},
+		})
+
+	_, whErr := t.Clusters().Default().
+		Kube().AdmissionregistrationV1().MutatingWebhookConfigurations().
+		Get(context.Background(), "istio-sidecar-injector", metav1.GetOptions{})
+	if whErr != nil && !kerrors.IsNotFound(whErr) {
+		return whErr
+	}
+	// Only setup sidecar tests if webhook is installed
+	if whErr == nil {
+		builder = builder.WithConfig(echo.Config{
+			Service:        Sidecar,
+			Namespace:      apps.Namespace,
+			Ports:          ports.All(),
+			ServiceAccount: true,
+			Subsets: []echo.SubsetConfig{
+				{
+					Replicas: 1,
+					Version:  "v1",
+					Labels: map[string]string{
+						"sidecar.istio.io/inject":       "true",
+						label.IoIstioDataplaneMode.Name: constants.DataplaneModeNone,
+					},
+				},
+				{
+					Replicas: 1,
+					Version:  "v2",
+					Labels: map[string]string{
+						"sidecar.istio.io/inject":       "true",
+						label.IoIstioDataplaneMode.Name: constants.DataplaneModeNone,
+					},
+				},
+			},
+		})
+	}
+
+	external := cdeployment.External{Namespace: apps.ExternalNamespace}
+	external.Build(t, builder)
+
+	echos, err := builder.Build()
+	if err != nil {
+		return err
+	}
+	for _, b := range echos {
+		scopes.Framework.Infof("built %v", b.Config().Service)
+	}
+
+	external.LoadValues(echos)
+	apps.MockExternal = external.All
+
+	// All does not include external
+	echos = match.Not(match.ServiceName(echo.NamespacedName{Name: cdeployment.ExternalSvc, Namespace: apps.ExternalNamespace})).GetMatches(echos)
+	apps.All = echos
+	apps.WorkloadAddressedWaypoint = match.ServiceName(echo.NamespacedName{Name: WorkloadAddressedWaypoint, Namespace: apps.Namespace}).GetMatches(echos)
+	apps.ServiceAddressedWaypoint = match.ServiceName(echo.NamespacedName{Name: ServiceAddressedWaypoint, Namespace: apps.Namespace}).GetMatches(echos)
+	apps.AllWaypoint = apps.AllWaypoint.Append(apps.WorkloadAddressedWaypoint)
+	apps.AllWaypoint = apps.AllWaypoint.Append(apps.ServiceAddressedWaypoint)
+	apps.Uncaptured = match.ServiceName(echo.NamespacedName{Name: Uncaptured, Namespace: apps.Namespace}).GetMatches(echos)
+	apps.Captured = match.ServiceName(echo.NamespacedName{Name: Captured, Namespace: apps.Namespace}).GetMatches(echos)
+	apps.Sidecar = match.ServiceName(echo.NamespacedName{Name: Sidecar, Namespace: apps.Namespace}).GetMatches(echos)
+	apps.Mesh = inMesh.GetMatches(echos)
+	apps.MeshExternal = match.Not(inMesh).GetMatches(echos)
+
+	if err := cdeployment.DeployExternalServiceEntry(t.ConfigIstio(), apps.Namespace, apps.ExternalNamespace, false).
+		Apply(apply.CleanupConditionally); err != nil {
+		return err
+	}
+
+	if apps.WaypointProxies == nil {
+		apps.WaypointProxies = make(map[string]ambient.WaypointProxy)
+	}
+
+	for _, echo := range echos {
+		svcwp := echo.Config().ServiceWaypointProxy
+		wlwp := echo.Config().WorkloadWaypointProxy
+		if svcwp != "" {
+			if _, found := apps.WaypointProxies[svcwp]; !found {
+				apps.WaypointProxies[svcwp], err = ambient.NewWaypointProxy(t, apps.Namespace, svcwp)
+				if err != nil {
+					return err
+				}
+			}
+		}
+		if wlwp != "" {
+			if _, found := apps.WaypointProxies[wlwp]; !found {
+				apps.WaypointProxies[wlwp], err = ambient.NewWaypointProxy(t, apps.Namespace, wlwp)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+	}
+
+	return nil
+}

--- a/tests/integration/ambient/nftables/traffic_test.go
+++ b/tests/integration/ambient/nftables/traffic_test.go
@@ -1,0 +1,38 @@
+//go:build integ
+// +build integ
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nftables
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo/common/deployment"
+	"istio.io/istio/tests/integration/pilot/common"
+)
+
+func TestTraffic(t *testing.T) {
+	framework.NewTest(t).
+		TopLevel().
+		Run(func(t framework.TestContext) {
+			apps := deployment.NewOrFail(t, deployment.Config{
+				NoExternalNamespace: true,
+				IncludeExtAuthz:     false,
+			})
+			common.RunAllTrafficTests(t, i, apps.SingleNamespaceView())
+		})
+}

--- a/tools/istio-nftables/pkg/builder/nftables_api.go
+++ b/tools/istio-nftables/pkg/builder/nftables_api.go
@@ -70,14 +70,12 @@ func (r *NftImpl) ListElements(ctx context.Context, objectType, name string) ([]
 // It uses knftables.Fake to simulate nftables behavior without making changes to the system.
 type MockNftables struct {
 	*knftables.Fake
-	DumpResults []string
 }
 
 // NewMockNftables creates a new mock object with a fake backend. It is used in the unit tests.
 func NewMockNftables(family knftables.Family, table string) *MockNftables {
 	return &MockNftables{
-		Fake:        knftables.NewFake(family, table),
-		DumpResults: make([]string, 0),
+		Fake: knftables.NewFake(family, table),
 	}
 }
 
@@ -98,13 +96,8 @@ func LogNftRules(rules *knftables.Transaction) {
 		return
 	}
 
-	nftProvider, err := NewNftImpl("", "")
-	if err != nil {
-		log.Errorf("Error creating NftImpl interface: %v", err)
-		return
-	}
-
-	dump := nftProvider.Dump(rules)
+	// For logging purposes, we can just use the transaction's String() method
+	dump := rules.String()
 	if dump != "" {
 		log.Infof("nftables rules programmed:\n%s \n", dump)
 	} else {

--- a/tools/istio-nftables/pkg/builder/nftables_api.go
+++ b/tools/istio-nftables/pkg/builder/nftables_api.go
@@ -15,6 +15,7 @@ package builder
 
 import (
 	"context"
+	"istio.io/istio/pkg/log"
 
 	"sigs.k8s.io/knftables"
 )
@@ -76,4 +77,24 @@ func NewMockNftables(family knftables.Family, table string) *MockNftables {
 // We don't want to sort objects in the Dump result so we are not using the Fake.Dump method.
 func (m *MockNftables) Dump(tx *knftables.Transaction) string {
 	return tx.String()
+}
+
+func LogNftRules(rules *knftables.Transaction) {
+	if rules.NumOperations() == 0 {
+		log.Infof("There are no nftables rules to log")
+		return
+	}
+
+	nftProvider, err := NewNftImpl("", "")
+	if err != nil {
+		log.Errorf("Error creating NftImpl interface: %v", err)
+		return
+	}
+
+	dump := nftProvider.Dump(rules)
+	if dump != "" {
+		log.Infof("nftables rules programmed:\n%s \n", dump)
+	} else {
+		log.Info("There are no nftables rules.")
+	}
 }

--- a/tools/istio-nftables/pkg/builder/nftables_api.go
+++ b/tools/istio-nftables/pkg/builder/nftables_api.go
@@ -15,9 +15,10 @@ package builder
 
 import (
 	"context"
-	"istio.io/istio/pkg/log"
 
 	"sigs.k8s.io/knftables"
+
+	"istio.io/istio/pkg/log"
 )
 
 // NftablesAPI defines the interface for interacting with nftables.

--- a/tools/istio-nftables/pkg/builder/nftables_api.go
+++ b/tools/istio-nftables/pkg/builder/nftables_api.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package capture
+package builder
 
 import (
 	"context"

--- a/tools/istio-nftables/pkg/capture/run.go
+++ b/tools/istio-nftables/pkg/capture/run.go
@@ -28,7 +28,7 @@ import (
 )
 
 // NftProviderFunc is a type for the function signature of the nftProvider function.
-type NftProviderFunc func(family knftables.Family, table string) (NftablesAPI, error)
+type NftProviderFunc func(family knftables.Family, table string) (builder.NftablesAPI, error)
 
 // NftablesConfigurator is the main struct used to create nftables rules based on Istio configuration.
 // It builds the necessary rules and applies them using a provided nftProvider function.
@@ -47,8 +47,8 @@ func NewNftablesConfigurator(cfg *config.Config, nftProvider NftProviderFunc) (*
 	}
 
 	if nftProvider == nil {
-		nftProvider = func(family knftables.Family, table string) (NftablesAPI, error) {
-			return NewNftImpl(family, table)
+		nftProvider = func(family knftables.Family, table string) (builder.NftablesAPI, error) {
+			return builder.NewNftImpl(family, table)
 		}
 	}
 

--- a/tools/istio-nftables/pkg/capture/run_linux_test.go
+++ b/tools/istio-nftables/pkg/capture/run_linux_test.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/knftables"
 
 	"istio.io/istio/pkg/test/util/assert"
+	"istio.io/istio/tools/istio-nftables/pkg/builder"
 )
 
 func dumpRuleset(t *testing.T) string {
@@ -57,8 +58,8 @@ func TestIdempotentEquivalentRerun(t *testing.T) {
 				cfg.OwnerGroupsInclude = "0"
 			}
 			// This provider function will interact with the real system's nftables.
-			nftProvider := func(_ knftables.Family, _ string) (NftablesAPI, error) {
-				return NewNftImpl("", "")
+			nftProvider := func(_ knftables.Family, _ string) (builder.NftablesAPI, error) {
+				return builder.NewNftImpl("", "")
 			}
 
 			// Cleanup logic

--- a/tools/istio-nftables/pkg/capture/run_test.go
+++ b/tools/istio-nftables/pkg/capture/run_test.go
@@ -21,6 +21,7 @@ import (
 
 	testutil "istio.io/istio/pilot/test/util"
 	"istio.io/istio/tools/common/config"
+	"istio.io/istio/tools/istio-nftables/pkg/builder"
 	"istio.io/istio/tools/istio-nftables/pkg/constants"
 )
 
@@ -279,9 +280,9 @@ func TestNftables(t *testing.T) {
 			cfg := constructTestConfig()
 			tt.config(cfg)
 			// Create a map to store mock instances for each table.
-			mock := NewMockNftables("", "")
+			mock := builder.NewMockNftables("", "")
 
-			nftProvider := func(_ knftables.Family, table string) (NftablesAPI, error) {
+			nftProvider := func(_ knftables.Family, table string) (builder.NftablesAPI, error) {
 				return mock, nil
 			}
 

--- a/tools/istio-nftables/pkg/constants/constants.go
+++ b/tools/istio-nftables/pkg/constants/constants.go
@@ -22,11 +22,6 @@ const (
 	IstioProxyMangleTable = "istio-proxy-mangle"
 	IstioProxyRawTable    = "istio-proxy-raw"
 
-	// Table names used in Ambient mode when applying native nftables rules
-	IstioAmbientNatTable    = "istio-ambient-nat"
-	IstioAmbientMangleTable = "istio-ambient-mangle"
-	IstioAmbientRawTable    = "istio-ambient-raw"
-
 	// Base chains.
 	PreroutingChain = "prerouting"
 	OutputChain     = "output"

--- a/tools/istio-nftables/pkg/nft/program.go
+++ b/tools/istio-nftables/pkg/nft/program.go
@@ -22,6 +22,7 @@ import (
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/tools/common/config"
 	"istio.io/istio/tools/common/tproxy"
+	"istio.io/istio/tools/istio-nftables/pkg/builder"
 	"istio.io/istio/tools/istio-nftables/pkg/capture"
 )
 
@@ -55,7 +56,7 @@ func logNftRules(rules *knftables.Transaction) {
 		return
 	}
 
-	nftProvider, err := capture.NewNftImpl("", "")
+	nftProvider, err := builder.NewNftImpl("", "")
 	if err != nil {
 		log.Errorf("Error creating NftImpl interface: %v", err)
 		return

--- a/tools/istio-nftables/pkg/nft/program.go
+++ b/tools/istio-nftables/pkg/nft/program.go
@@ -17,8 +17,6 @@ package nft
 import (
 	"fmt"
 
-	"sigs.k8s.io/knftables"
-
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/tools/common/config"
 	"istio.io/istio/tools/common/tproxy"
@@ -45,27 +43,7 @@ func ProgramNftables(cfg *config.Config) error {
 		if err := tproxy.ConfigureRoutes(cfg); err != nil {
 			return fmt.Errorf("failed to configure routes: %v", err)
 		}
-		logNftRules(rules)
+		builder.LogNftRules(rules)
 	}
 	return nil
-}
-
-func logNftRules(rules *knftables.Transaction) {
-	if rules.NumOperations() == 0 {
-		log.Infof("There are no nftables rules to log")
-		return
-	}
-
-	nftProvider, err := builder.NewNftImpl("", "")
-	if err != nil {
-		log.Errorf("Error creating NftImpl interface: %v", err)
-		return
-	}
-
-	dump := nftProvider.Dump(rules)
-	if dump != "" {
-		log.Infof("nftables rules programmed:\n%s \n", dump)
-	} else {
-		log.Info("There are no nftables rules.")
-	}
 }


### PR DESCRIPTION
This PR builds on #56487 and introduces native nftables as an alternative
backend for Ambient mode. Nftables provides a modern, consistent interface
that aligns with the direction of many Linux distributions.

With this change, users can optionally enable nftables for setting up traffic
redirection rules when using Ambient mode.

**Key changes:**
* Added a `TrafficRuleManager` interface to abstract iptables/nftables logic,
  keeping higher-level components like `netServer`, `meshDataplane` unchanged.
* Renamed `IptablesConfig` to `AmbientConfig` which is used by both backends.
* Wrapped existing iptables logic in `IptablesTrafficManager` for full
  backward compatibility.
* Added `NftablesTrafficManager` implementing the complete rule set for
  Ambient features (like traffic redirection to ztunnel, DNS proxy support,
  VM/container support, etc..,), using the `knftables` library.
* Introduced `AddressSetManager` interface for ipset and nftables set mgmt.
* Added comprehensive unit tests with golden files similar to iptables backend.

**Backward compatibility:**
* Iptables remains the default.
* All existing iptables functionality and tests remain unchanged.
* Native nftables is enabled only when `global.nativeNftables=true` is
  used while installing istio-cni.

**Pending (WIP):**
* Kubelet health-check support for pods that are part of the ambient mesh.
* Idempotent tests using `unshare-go` library.

Fixes: https://github.com/istio/istio/issues/57324