### PR TITLE
nftables-slim: ignore checking examples doc files

### DIFF
--- a/tools/build-base-images.sh
+++ b/tools/build-base-images.sh
@@ -75,6 +75,7 @@ unexpectedFiles="$(
     grep -v '^usr/bin/xtables' | \
     grep -v '^usr/bin/ldconfig$' | \
     grep -v '^usr/bin/nft' | \
+    grep -v '^usr/share/doc/nftables/examples/.*.nft' | \
     grep -v '^etc/apk/commit_hooks.d/ldconfig-commit.sh$' | \
     grep -v '.*\.so[0-9\.]*' || true
 )"


### PR DESCRIPTION
This PR is fixing the build-base-images.sh unexpectedFiles check by ignoring the `usr/share/doc/nftables/examples/.*.nft` files. Those files were added back in the package when wolfi-dev moved the `nftables-slim` package as a subpackage in:
https://github.com/wolfi-dev/os/pull/63313

Those are small example doc files. So I updated the unexpectedFiles check list and ignore those doc files.
The `etc/apk/commit_hooks.d/ldconfig-commit.sh` has already been ignored in the check list. When the previous item ends with `\n` , it was captured in the list.

Related PR: https://github.com/istio/istio/pull/56917

- [X] Developer Infrastructure

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
