### PR TITLE
Enable multi-persona helm install

### DIFF
--- a/manifests/charts/base/templates/crds.yaml
+++ b/manifests/charts/base/templates/crds.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "CLUSTER") }}
 # TODO enableCRDTemplates is now defaulted to true as we
 # want to always self-manage CRD upgrades via plain templates,
 # so we should remove this flag after a few releases
@@ -18,4 +19,5 @@
 {{- end }}
 {{- else }}
 {{ .Files.Get "files/crd-all.gen.yaml" }}
+{{- end }}
 {{- end }}

--- a/manifests/charts/base/templates/crds.yaml
+++ b/manifests/charts/base/templates/crds.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "CLUSTER") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "cluster") }}
 # TODO enableCRDTemplates is now defaulted to true as we
 # want to always self-manage CRD upgrades via plain templates,
 # so we should remove this flag after a few releases

--- a/manifests/charts/base/templates/defaultrevision-validatingadmissionpolicy.yaml
+++ b/manifests/charts/base/templates/defaultrevision-validatingadmissionpolicy.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "CLUSTER") }}
 {{- if and .Values.experimental.stableValidationPolicy (not (eq .Values.defaultRevision "")) }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
@@ -50,4 +51,5 @@ metadata:
 spec:
   policyName: "stable-channel-default-policy.istio.io"
   validationActions: [Deny]
+{{- end }}
 {{- end }}

--- a/manifests/charts/base/templates/defaultrevision-validatingadmissionpolicy.yaml
+++ b/manifests/charts/base/templates/defaultrevision-validatingadmissionpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "CLUSTER") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "cluster") }}
 {{- if and .Values.experimental.stableValidationPolicy (not (eq .Values.defaultRevision "")) }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy

--- a/manifests/charts/base/templates/defaultrevision-validatingwebhookconfiguration.yaml
+++ b/manifests/charts/base/templates/defaultrevision-validatingwebhookconfiguration.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "CLUSTER") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "cluster") }}
 {{- if not (eq .Values.defaultRevision "") }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/manifests/charts/base/templates/defaultrevision-validatingwebhookconfiguration.yaml
+++ b/manifests/charts/base/templates/defaultrevision-validatingwebhookconfiguration.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "CLUSTER") }}
 {{- if not (eq .Values.defaultRevision "") }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -53,4 +54,5 @@ webhooks:
     {{- end }}
     sideEffects: None
     admissionReviewVersions: ["v1"]
+{{- end }}
 {{- end }}

--- a/manifests/charts/base/templates/reader-serviceaccount.yaml
+++ b/manifests/charts/base/templates/reader-serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
 # This singleton service account aggregates reader permissions for the revisions in a given cluster
 # ATM this is a singleton per cluster with Istio installed, and is not revisioned. It maybe should be,
 # as otherwise compromising the token for this SA would give you access to *every* installed revision.
@@ -18,3 +19,4 @@ metadata:
     release: {{ .Release.Name }}
     app.kubernetes.io/name: "istio-reader"
     {{- include "istio.labels" . | nindent 4 }}
+{{- end }}

--- a/manifests/charts/base/templates/reader-serviceaccount.yaml
+++ b/manifests/charts/base/templates/reader-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 # This singleton service account aggregates reader permissions for the revisions in a given cluster
 # ATM this is a singleton per cluster with Istio installed, and is not revisioned. It maybe should be,
 # as otherwise compromising the token for this SA would give you access to *every* installed revision.

--- a/manifests/charts/base/values.yaml
+++ b/manifests/charts/base/values.yaml
@@ -14,10 +14,10 @@ _internal_defaults_do_not_set:
     # resourceScope controls what resources will be processed by helm.
     # This is useful when installing Istio on a cluster where some resources need to be owned by a cluster administrator and some can be owned by the mesh administrator.
     # It can be one of:
-    # - ALL: all resources are processed
-    # - CLUSTER: only cluster-scoped resources are processed
-    # - NAMESPACE: only namespace-scoped resources are processed
-    resourceScope: ALL
+    # - all: all resources are processed
+    # - cluster: only cluster-scoped resources are processed
+    # - namespace: only namespace-scoped resources are processed
+    resourceScope: all
   base:
     # A list of CRDs to exclude. Requires `enableCRDTemplates` to be true.
     # Example: `excludedCRDs: ["envoyfilters.networking.istio.io"]`.

--- a/manifests/charts/base/values.yaml
+++ b/manifests/charts/base/values.yaml
@@ -10,6 +10,14 @@ _internal_defaults_do_not_set:
 
     # Used to locate istiod.
     istioNamespace: istio-system
+
+    # resourceScope controls what resources will be processed by helm.
+    # This is useful when installing Istio on a cluster where some resources need to be owned by a cluster administrator and some can be owned by the mesh administrator.
+    # It can be one of:
+    # - ALL: all resources are processed
+    # - CLUSTER: only cluster-scoped resources are processed
+    # - NAMESPACE: only namespace-scoped resources are processed
+    resourceScope: ALL
   base:
     # A list of CRDs to exclude. Requires `enableCRDTemplates` to be true.
     # Example: `excludedCRDs: ["envoyfilters.networking.istio.io"]`.

--- a/manifests/charts/istio-cni/templates/clusterrole.yaml
+++ b/manifests/charts/istio-cni/templates/clusterrole.yaml
@@ -1,3 +1,5 @@
+# Created if cluster resources are not omitted
+{{- if not .Values.global.omitClusterResources }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -77,4 +79,5 @@ rules:
   resources: ["daemonsets"]
   resourceNames: ["{{ template "name" . }}-node"]
   verbs: ["get"]
+{{- end }}
 {{- end }}

--- a/manifests/charts/istio-cni/templates/clusterrole.yaml
+++ b/manifests/charts/istio-cni/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 # Created if cluster resources are not omitted
-{{- if not .Values.global.omitClusterResources }}
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "CLUSTER") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/manifests/charts/istio-cni/templates/clusterrole.yaml
+++ b/manifests/charts/istio-cni/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 # Created if cluster resources are not omitted
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "CLUSTER") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "cluster") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/manifests/charts/istio-cni/templates/clusterrolebinding.yaml
+++ b/manifests/charts/istio-cni/templates/clusterrolebinding.yaml
@@ -1,3 +1,5 @@
+# Created if cluster resources are not omitted
+{{- if not .Values.global.omitClusterResources }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -63,4 +65,5 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ template "name" . }}-ambient
+{{- end }}
 {{- end }}

--- a/manifests/charts/istio-cni/templates/clusterrolebinding.yaml
+++ b/manifests/charts/istio-cni/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 # Created if cluster resources are not omitted
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "CLUSTER") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "cluster") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/manifests/charts/istio-cni/templates/clusterrolebinding.yaml
+++ b/manifests/charts/istio-cni/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 # Created if cluster resources are not omitted
-{{- if not .Values.global.omitClusterResources }}
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "CLUSTER") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/manifests/charts/istio-cni/templates/configmap-cni.yaml
+++ b/manifests/charts/istio-cni/templates/configmap-cni.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -40,3 +41,4 @@ data:
   {{ $key }}: "{{ $val }}"
   {{- end }}
   {{- end }}
+{{- end }}

--- a/manifests/charts/istio-cni/templates/configmap-cni.yaml
+++ b/manifests/charts/istio-cni/templates/configmap-cni.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 kind: ConfigMap
 apiVersion: v1
 metadata:

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
 # This manifest installs the Istio install-cni container, as well
 # as the Istio CNI plugin and config on
 # each master and worker node in a Kubernetes cluster.
@@ -249,3 +250,4 @@ spec:
             type: DirectoryOrCreate # DirectoryOrCreate instead of Directory for the following reason - CNI may not bind mount this until a non-hostnetwork pod is scheduled on the node,
             # and we don't want to block CNI agent pod creation on waiting for the first non-hostnetwork pod.
             # Once the CNI does mount this, it will get populated and we're good.
+{{- end }}

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 # This manifest installs the Istio install-cni container, as well
 # as the Istio CNI plugin and config on
 # each master and worker node in a Kubernetes cluster.

--- a/manifests/charts/istio-cni/templates/network-attachment-definition.yaml
+++ b/manifests/charts/istio-cni/templates/network-attachment-definition.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 {{- if eq .Values.provider "multus" }}
 apiVersion: k8s.cni.cncf.io/v1
 kind: NetworkAttachmentDefinition

--- a/manifests/charts/istio-cni/templates/network-attachment-definition.yaml
+++ b/manifests/charts/istio-cni/templates/network-attachment-definition.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
 {{- if eq .Values.provider "multus" }}
 apiVersion: k8s.cni.cncf.io/v1
 kind: NetworkAttachmentDefinition
@@ -8,4 +9,5 @@ metadata:
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/manifests/charts/istio-cni/templates/resourcequota.yaml
+++ b/manifests/charts/istio-cni/templates/resourcequota.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
 {{- if .Values.resourceQuotas.enabled }}
 apiVersion: v1
 kind: ResourceQuota
@@ -16,4 +17,5 @@ spec:
       scopeName: PriorityClass
       values:
       - system-node-critical
+{{- end }}
 {{- end }}

--- a/manifests/charts/istio-cni/templates/resourcequota.yaml
+++ b/manifests/charts/istio-cni/templates/resourcequota.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 {{- if .Values.resourceQuotas.enabled }}
 apiVersion: v1
 kind: ResourceQuota

--- a/manifests/charts/istio-cni/templates/serviceaccount.yaml
+++ b/manifests/charts/istio-cni/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.global.imagePullSecrets }}
@@ -17,3 +18,4 @@ metadata:
     operator.istio.io/component: "Cni"
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}
+{{- end }}

--- a/manifests/charts/istio-cni/templates/serviceaccount.yaml
+++ b/manifests/charts/istio-cni/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.global.imagePullSecrets }}

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -183,10 +183,10 @@ _internal_defaults_do_not_set:
     # resourceScope controls what resources will be processed by helm.
     # This is useful when installing Istio on a cluster where some resources need to be owned by a cluster administrator and some can be owned by the mesh administrator.
     # It can be one of:
-    # - ALL: all resources are processed
-    # - CLUSTER: only cluster-scoped resources are processed
-    # - NAMESPACE: only namespace-scoped resources are processed
-    resourceScope: ALL
+    # - all: all resources are processed
+    # - cluster: only cluster-scoped resources are processed
+    # - namespace: only namespace-scoped resources are processed
+    resourceScope: all
 
   # A `key: value` mapping of environment variables to add to the pod
   env: {}

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -180,5 +180,8 @@ _internal_defaults_do_not_set:
     # In order to use native nftable rules instead of iptable rules, set this flag to true.
     nativeNftables: false
 
+    # Whether to omit cluster resources for persona-based installations
+    omitClusterResources: false
+
   # A `key: value` mapping of environment variables to add to the pod
   env: {}

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -180,8 +180,13 @@ _internal_defaults_do_not_set:
     # In order to use native nftable rules instead of iptable rules, set this flag to true.
     nativeNftables: false
 
-    # Whether to omit cluster resources for persona-based installations
-    omitClusterResources: false
+    # resourceScope controls what resources will be processed by helm.
+    # This is useful when installing Istio on a cluster where some resources need to be owned by a cluster administrator and some can be owned by the mesh administrator.
+    # It can be one of:
+    # - ALL: all resources are processed
+    # - CLUSTER: only cluster-scoped resources are processed
+    # - NAMESPACE: only namespace-scoped resources are processed
+    resourceScope: ALL
 
   # A `key: value` mapping of environment variables to add to the pod
   env: {}

--- a/manifests/charts/istio-control/istio-discovery/templates/autoscale.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/autoscale.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 # Not created if istiod is running remotely
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled .Values.istiodRemote.enabledLocalInjectorIstiod) }}
 {{- if and .Values.autoscaleEnabled .Values.autoscaleMin .Values.autoscaleMax }}
@@ -40,5 +41,6 @@ spec:
   behavior: {{ toYaml .Values.autoscaleBehavior | nindent 4 }}
   {{- end }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/autoscale.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/autoscale.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
 # Not created if istiod is running remotely
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled .Values.istiodRemote.enabledLocalInjectorIstiod) }}
 {{- if and .Values.autoscaleEnabled .Values.autoscaleMin .Values.autoscaleMax }}

--- a/manifests/charts/istio-control/istio-discovery/templates/autoscale.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/autoscale.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 # Not created if istiod is running remotely
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled .Values.istiodRemote.enabledLocalInjectorIstiod) }}
 {{- if and .Values.autoscaleEnabled .Values.autoscaleMin .Values.autoscaleMax }}

--- a/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 # Created if cluster resources are not omitted
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "CLUSTER") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "cluster") }}
 # Created if this is not a remote istiod, OR if it is and is also a config cluster
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled (or .Values.global.configCluster .Values.istiodRemote.enabledLocalInjectorIstiod)) }}
 {{ $mcsAPIGroup := or .Values.env.MCS_API_GROUP "multicluster.x-k8s.io" }}

--- a/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 # Created if cluster resources are not omitted
-{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "cluster") }}
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "CLUSTER") }}
 # Created if this is not a remote istiod, OR if it is and is also a config cluster
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled (or .Values.global.configCluster .Values.istiodRemote.enabledLocalInjectorIstiod)) }}
 {{ $mcsAPIGroup := or .Values.env.MCS_API_GROUP "multicluster.x-k8s.io" }}

--- a/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
@@ -1,3 +1,5 @@
+# Created if cluster resources are not omitted
+{{- if not .Values.global.omitClusterResources }}
 # Created if this is not a remote istiod, OR if it is and is also a config cluster
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled (or .Values.global.configCluster .Values.istiodRemote.enabledLocalInjectorIstiod)) }}
 {{ $mcsAPIGroup := or .Values.env.MCS_API_GROUP "multicluster.x-k8s.io" }}
@@ -209,5 +211,6 @@ rules:
   - apiGroups: [""]
     verbs: [ "get", "watch", "list", "update", "patch", "create", "delete" ]
     resources: [ "serviceaccounts"]
+{{- end }}
 {{- end }}
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 # Created if cluster resources are not omitted
-{{- if not .Values.global.omitClusterResources }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "cluster") }}
 # Created if this is not a remote istiod, OR if it is and is also a config cluster
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled (or .Values.global.configCluster .Values.istiodRemote.enabledLocalInjectorIstiod)) }}
 {{ $mcsAPIGroup := or .Values.env.MCS_API_GROUP "multicluster.x-k8s.io" }}

--- a/manifests/charts/istio-control/istio-discovery/templates/clusterrolebinding.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/clusterrolebinding.yaml
@@ -1,3 +1,5 @@
+# Created if cluster resources are not omitted
+{{- if not .Values.global.omitClusterResources }}
 # Created if this is not a remote istiod, OR if it is and is also a config cluster
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled (or .Values.global.configCluster .Values.istiodRemote.enabledLocalInjectorIstiod)) }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -36,5 +38,6 @@ subjects:
 - kind: ServiceAccount
   name: istiod{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}
   namespace: {{ .Values.global.istioNamespace }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/clusterrolebinding.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 # Created if cluster resources are not omitted
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "CLUSTER") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "cluster") }}
 # Created if this is not a remote istiod, OR if it is and is also a config cluster
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled (or .Values.global.configCluster .Values.istiodRemote.enabledLocalInjectorIstiod)) }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/charts/istio-control/istio-discovery/templates/clusterrolebinding.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 # Created if cluster resources are not omitted
-{{- if not .Values.global.omitClusterResources }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "cluster") }}
 # Created if this is not a remote istiod, OR if it is and is also a config cluster
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled (or .Values.global.configCluster .Values.istiodRemote.enabledLocalInjectorIstiod)) }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/charts/istio-control/istio-discovery/templates/clusterrolebinding.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 # Created if cluster resources are not omitted
-{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "cluster") }}
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "CLUSTER") }}
 # Created if this is not a remote istiod, OR if it is and is also a config cluster
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled (or .Values.global.configCluster .Values.istiodRemote.enabledLocalInjectorIstiod)) }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/charts/istio-control/istio-discovery/templates/configmap-jwks.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap-jwks.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
 # Not created if istiod is running remotely
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled .Values.istiodRemote.enabledLocalInjectorIstiod) }}
 {{- if .Values.jwksResolverExtraRootCA }}

--- a/manifests/charts/istio-control/istio-discovery/templates/configmap-jwks.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap-jwks.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 # Not created if istiod is running remotely
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled .Values.istiodRemote.enabledLocalInjectorIstiod) }}
 {{- if .Values.jwksResolverExtraRootCA }}

--- a/manifests/charts/istio-control/istio-discovery/templates/configmap-jwks.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap-jwks.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 # Not created if istiod is running remotely
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled .Values.istiodRemote.enabledLocalInjectorIstiod) }}
 {{- if .Values.jwksResolverExtraRootCA }}
@@ -15,5 +16,6 @@ metadata:
     {{- include "istio.labels" . | nindent 4 }}
 data:
   extra.pem: {{ .Values.jwksResolverExtraRootCA | quote }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/configmap-values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap-values.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/manifests/charts/istio-control/istio-discovery/templates/configmap-values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap-values.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -18,3 +19,4 @@ data:
 {{- $_ := unset $.Values "_original" }}
   merged-values: |-
 {{ .Values | toPrettyJson | indent 4 }}
+{{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/configmap-values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap-values.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
@@ -78,7 +78,7 @@
 {{- $originalMesh := include "mesh" . | fromYaml }}
 {{- $mesh := mergeOverwrite $originalMesh .Values.meshConfig }}
 
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 {{- if .Values.configMap }}
 apiVersion: v1
 kind: ConfigMap

--- a/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
@@ -78,6 +78,7 @@
 {{- $originalMesh := include "mesh" . | fromYaml }}
 {{- $mesh := mergeOverwrite $originalMesh .Values.meshConfig }}
 
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 {{- if .Values.configMap }}
 apiVersion: v1
 kind: ConfigMap
@@ -109,4 +110,5 @@ data:
 {{- include "mesh" . }}
 {{- end }}
 ---
+{{- end }}
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
@@ -78,7 +78,7 @@
 {{- $originalMesh := include "mesh" . | fromYaml }}
 {{- $mesh := mergeOverwrite $originalMesh .Values.meshConfig }}
 
-{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
 {{- if .Values.configMap }}
 apiVersion: v1
 kind: ConfigMap

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
 # Not created if istiod is running remotely
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled .Values.istiodRemote.enabledLocalInjectorIstiod) }}
 apiVersion: apps/v1

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 # Not created if istiod is running remotely
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled .Values.istiodRemote.enabledLocalInjectorIstiod) }}
 apiVersion: apps/v1

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 # Not created if istiod is running remotely
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled .Values.istiodRemote.enabledLocalInjectorIstiod) }}
 apiVersion: apps/v1
@@ -311,4 +312,5 @@ spec:
       {{- end }}
 
 ---
+{{- end }}
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/gateway-class-configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/gateway-class-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
 {{ range $key, $value := .Values.gatewayClasses }}
 apiVersion: v1
 kind: ConfigMap

--- a/manifests/charts/istio-control/istio-discovery/templates/gateway-class-configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/gateway-class-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 {{ range $key, $value := .Values.gatewayClasses }}
 apiVersion: v1
 kind: ConfigMap
@@ -19,3 +20,4 @@ data:
 {{ end }}
 ---
 {{ end }}
+{{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/gateway-class-configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/gateway-class-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 {{ range $key, $value := .Values.gatewayClasses }}
 apiVersion: v1
 kind: ConfigMap

--- a/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
 {{- if not .Values.global.omitSidecarInjectorConfigMap }}
 apiVersion: v1
 kind: ConfigMap

--- a/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 {{- if not .Values.global.omitSidecarInjectorConfigMap }}
 apiVersion: v1
 kind: ConfigMap
@@ -79,4 +80,5 @@ data:
 {{ toYaml . | trim | indent 6 }}
 {{- end }}
 
+{{- end }}
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 {{- if not .Values.global.omitSidecarInjectorConfigMap }}
 apiVersion: v1
 kind: ConfigMap

--- a/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -36,7 +36,7 @@ a unique prefix to each. */}}
   admissionReviewVersions: ["v1"]
 {{- end }}
 
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "CLUSTER") }}
 {{- /* Installed for each revision - not installed for cluster resources ( cluster roles, bindings, crds) */}}
 {{- if not .Values.global.operatorManageWebhooks }}
 apiVersion: admissionregistration.k8s.io/v1

--- a/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -35,6 +35,8 @@ a unique prefix to each. */}}
   reinvocationPolicy: "{{ .reinvocationPolicy }}"
   admissionReviewVersions: ["v1"]
 {{- end }}
+
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 {{- /* Installed for each revision - not installed for cluster resources ( cluster roles, bindings, crds) */}}
 {{- if not .Values.global.operatorManageWebhooks }}
 apiVersion: admissionregistration.k8s.io/v1
@@ -161,5 +163,6 @@ webhooks:
       operator: DoesNotExist
 {{- end }}
 
+{{- end }}
 {{- end }}
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -36,7 +36,7 @@ a unique prefix to each. */}}
   admissionReviewVersions: ["v1"]
 {{- end }}
 
-{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
 {{- /* Installed for each revision - not installed for cluster resources ( cluster roles, bindings, crds) */}}
 {{- if not .Values.global.operatorManageWebhooks }}
 apiVersion: admissionregistration.k8s.io/v1

--- a/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -36,7 +36,7 @@ a unique prefix to each. */}}
   admissionReviewVersions: ["v1"]
 {{- end }}
 
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "CLUSTER") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "cluster") }}
 {{- /* Installed for each revision - not installed for cluster resources ( cluster roles, bindings, crds) */}}
 {{- if not .Values.global.operatorManageWebhooks }}
 apiVersion: admissionregistration.k8s.io/v1

--- a/manifests/charts/istio-control/istio-discovery/templates/networkpolicy.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
 {{- if (.Values.global.networkPolicy).enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/manifests/charts/istio-control/istio-discovery/templates/networkpolicy.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 {{- if (.Values.global.networkPolicy).enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/manifests/charts/istio-control/istio-discovery/templates/networkpolicy.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/networkpolicy.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 {{- if (.Values.global.networkPolicy).enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -43,4 +44,5 @@ spec:
   # Allow all egress (needed because features like JWKS require connections to user-defined endpoints)
   egress:
   - {}
+{{- end }}
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/poddisruptionbudget.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 # Not created if istiod is running remotely
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled .Values.istiodRemote.enabledLocalInjectorIstiod) }}
 {{- if .Values.global.defaultPodDisruptionBudget.enabled }}

--- a/manifests/charts/istio-control/istio-discovery/templates/poddisruptionbudget.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
 # Not created if istiod is running remotely
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled .Values.istiodRemote.enabledLocalInjectorIstiod) }}
 {{- if .Values.global.defaultPodDisruptionBudget.enabled }}

--- a/manifests/charts/istio-control/istio-discovery/templates/poddisruptionbudget.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/poddisruptionbudget.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 # Not created if istiod is running remotely
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled .Values.istiodRemote.enabledLocalInjectorIstiod) }}
 {{- if .Values.global.defaultPodDisruptionBudget.enabled }}
@@ -35,6 +36,7 @@ spec:
       istio: pilot
       {{- end }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/reader-clusterrole.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/reader-clusterrole.yaml
@@ -1,3 +1,5 @@
+# Created if cluster resources are not omitted
+{{- if not .Values.global.omitClusterResources }}
 {{ $mcsAPIGroup := or .Values.env.MCS_API_GROUP "multicluster.x-k8s.io" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -60,3 +62,4 @@ rules:
     resources: ["validatingwebhookconfigurations"]
     verbs: ["get", "list", "watch", "update"]
 {{- end}}
+{{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/reader-clusterrole.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/reader-clusterrole.yaml
@@ -1,5 +1,5 @@
 # Created if cluster resources are not omitted
-{{- if not .Values.global.omitClusterResources }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "cluster") }}
 {{ $mcsAPIGroup := or .Values.env.MCS_API_GROUP "multicluster.x-k8s.io" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/manifests/charts/istio-control/istio-discovery/templates/reader-clusterrole.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/reader-clusterrole.yaml
@@ -1,5 +1,5 @@
 # Created if cluster resources are not omitted
-{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "cluster") }}
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "CLUSTER") }}
 {{ $mcsAPIGroup := or .Values.env.MCS_API_GROUP "multicluster.x-k8s.io" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/manifests/charts/istio-control/istio-discovery/templates/reader-clusterrole.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/reader-clusterrole.yaml
@@ -1,5 +1,5 @@
 # Created if cluster resources are not omitted
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "CLUSTER") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "cluster") }}
 {{ $mcsAPIGroup := or .Values.env.MCS_API_GROUP "multicluster.x-k8s.io" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/manifests/charts/istio-control/istio-discovery/templates/reader-clusterrolebinding.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/reader-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 # Created if cluster resources are not omitted
-{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "cluster") }}
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "CLUSTER") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/manifests/charts/istio-control/istio-discovery/templates/reader-clusterrolebinding.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/reader-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 # Created if cluster resources are not omitted
-{{- if not .Values.global.omitClusterResources }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "cluster") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/manifests/charts/istio-control/istio-discovery/templates/reader-clusterrolebinding.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/reader-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 # Created if cluster resources are not omitted
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "CLUSTER") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "cluster") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/manifests/charts/istio-control/istio-discovery/templates/reader-clusterrolebinding.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/reader-clusterrolebinding.yaml
@@ -1,3 +1,5 @@
+# Created if cluster resources are not omitted
+{{- if not .Values.global.omitClusterResources }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -15,3 +17,4 @@ subjects:
   - kind: ServiceAccount
     name: istio-reader-service-account
     namespace: {{ .Values.global.istioNamespace }}
+{{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/remote-istiod-endpointslices.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/remote-istiod-endpointslices.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
 {{- if and .Values.global.remotePilotAddress .Values.istiodRemote.enabled }}
 # if the remotePilotAddress is an IP addr
 {{- if regexMatch "^([0-9]*\\.){3}[0-9]*$" .Values.global.remotePilotAddress }}

--- a/manifests/charts/istio-control/istio-discovery/templates/remote-istiod-endpointslices.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/remote-istiod-endpointslices.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 {{- if and .Values.global.remotePilotAddress .Values.istiodRemote.enabled }}
 # if the remotePilotAddress is an IP addr
 {{- if regexMatch "^([0-9]*\\.){3}[0-9]*$" .Values.global.remotePilotAddress }}
@@ -36,5 +37,6 @@ ports:
   name: tcp-webhook
   protocol: TCP
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/remote-istiod-endpointslices.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/remote-istiod-endpointslices.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 {{- if and .Values.global.remotePilotAddress .Values.istiodRemote.enabled }}
 # if the remotePilotAddress is an IP addr
 {{- if regexMatch "^([0-9]*\\.){3}[0-9]*$" .Values.global.remotePilotAddress }}

--- a/manifests/charts/istio-control/istio-discovery/templates/remote-istiod-service.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/remote-istiod-service.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 # This file is only used for remote
 {{- if and .Values.global.remotePilotAddress .Values.istiodRemote.enabled }}
 apiVersion: v1

--- a/manifests/charts/istio-control/istio-discovery/templates/remote-istiod-service.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/remote-istiod-service.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 # This file is only used for remote
 {{- if and .Values.global.remotePilotAddress .Values.istiodRemote.enabled }}
 apiVersion: v1
@@ -38,4 +39,5 @@ spec:
 {{- end }}
 {{- end }}
 ---
+{{- end }}
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/remote-istiod-service.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/remote-istiod-service.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
 # This file is only used for remote
 {{- if and .Values.global.remotePilotAddress .Values.istiodRemote.enabled }}
 apiVersion: v1

--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags-mwc.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags-mwc.yaml
@@ -33,6 +33,8 @@ a unique prefix to each. */}}
   reinvocationPolicy: "{{ .reinvocationPolicy }}"
   admissionReviewVersions: ["v1"]
 {{- end }}
+
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 {{- if not .Values.global.operatorManageWebhooks }}
 {{- range $tagName := $.Values.revisionTags }}
 apiVersion: admissionregistration.k8s.io/v1
@@ -148,5 +150,6 @@ webhooks:
 
 {{- end }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags-mwc.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags-mwc.yaml
@@ -34,7 +34,7 @@ a unique prefix to each. */}}
   admissionReviewVersions: ["v1"]
 {{- end }}
 
-{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
 {{- if not .Values.global.operatorManageWebhooks }}
 {{- range $tagName := $.Values.revisionTags }}
 apiVersion: admissionregistration.k8s.io/v1

--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags-mwc.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags-mwc.yaml
@@ -34,7 +34,7 @@ a unique prefix to each. */}}
   admissionReviewVersions: ["v1"]
 {{- end }}
 
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "CLUSTER") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "cluster") }}
 {{- if not .Values.global.operatorManageWebhooks }}
 {{- range $tagName := $.Values.revisionTags }}
 apiVersion: admissionregistration.k8s.io/v1

--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags-mwc.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags-mwc.yaml
@@ -34,7 +34,7 @@ a unique prefix to each. */}}
   admissionReviewVersions: ["v1"]
 {{- end }}
 
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "CLUSTER") }}
 {{- if not .Values.global.operatorManageWebhooks }}
 {{- range $tagName := $.Values.revisionTags }}
 apiVersion: admissionregistration.k8s.io/v1

--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags-svc.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags-svc.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 # Adapted from istio-discovery/templates/service.yaml
 {{- range $tagName := .Values.revisionTags }}
 apiVersion: v1

--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags-svc.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags-svc.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
 # Adapted from istio-discovery/templates/service.yaml
 {{- range $tagName := .Values.revisionTags }}
 apiVersion: v1

--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags-svc.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags-svc.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 # Adapted from istio-discovery/templates/service.yaml
 {{- range $tagName := .Values.revisionTags }}
 apiVersion: v1
@@ -54,3 +55,4 @@ spec:
   {{- end }}
 ---
 {{- end -}}
+{{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/role.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 # Created if this is not a remote istiod, OR if it is and is also a config cluster
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled (or .Values.global.configCluster .Values.istiodRemote.enabledLocalInjectorIstiod)) }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/charts/istio-control/istio-discovery/templates/role.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/role.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 # Created if this is not a remote istiod, OR if it is and is also a config cluster
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled (or .Values.global.configCluster .Values.istiodRemote.enabledLocalInjectorIstiod)) }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -32,4 +33,5 @@ rules:
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
   verbs: ["get", "update", "patch", "create"]
+{{- end }}
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/role.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
 # Created if this is not a remote istiod, OR if it is and is also a config cluster
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled (or .Values.global.configCluster .Values.istiodRemote.enabledLocalInjectorIstiod)) }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/charts/istio-control/istio-discovery/templates/rolebinding.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 # Created if this is not a remote istiod, OR if it is and is also a config cluster
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled (or .Values.global.configCluster .Values.istiodRemote.enabledLocalInjectorIstiod)) }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/charts/istio-control/istio-discovery/templates/rolebinding.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
 # Created if this is not a remote istiod, OR if it is and is also a config cluster
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled (or .Values.global.configCluster .Values.istiodRemote.enabledLocalInjectorIstiod)) }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/charts/istio-control/istio-discovery/templates/rolebinding.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 # Created if this is not a remote istiod, OR if it is and is also a config cluster
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled (or .Values.global.configCluster .Values.istiodRemote.enabledLocalInjectorIstiod)) }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -18,4 +19,5 @@ subjects:
   - kind: ServiceAccount
     name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
     namespace: {{ .Values.global.istioNamespace }}
+{{- end }}
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/service.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 # Not created if istiod is running remotely
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled .Values.istiodRemote.enabledLocalInjectorIstiod) }}
 apiVersion: v1
@@ -55,4 +56,5 @@ spec:
   trafficDistribution: {{ .Values.trafficDistribution }}
   {{- end }}
 ---
+{{- end }}
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/service.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 # Not created if istiod is running remotely
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled .Values.istiodRemote.enabledLocalInjectorIstiod) }}
 apiVersion: v1

--- a/manifests/charts/istio-control/istio-discovery/templates/service.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
 # Not created if istiod is running remotely
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled .Values.istiodRemote.enabledLocalInjectorIstiod) }}
 apiVersion: v1

--- a/manifests/charts/istio-control/istio-discovery/templates/serviceaccount.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
 # Created if this is not a remote istiod, OR if it is and is also a config cluster
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled (or .Values.global.configCluster .Values.istiodRemote.enabledLocalInjectorIstiod)) }}
 apiVersion: v1

--- a/manifests/charts/istio-control/istio-discovery/templates/serviceaccount.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 # Created if this is not a remote istiod, OR if it is and is also a config cluster
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled (or .Values.global.configCluster .Values.istiodRemote.enabledLocalInjectorIstiod)) }}
 apiVersion: v1

--- a/manifests/charts/istio-control/istio-discovery/templates/serviceaccount.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 # Created if this is not a remote istiod, OR if it is and is also a config cluster
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled (or .Values.global.configCluster .Values.istiodRemote.enabledLocalInjectorIstiod)) }}
 apiVersion: v1
@@ -22,3 +23,4 @@ metadata:
   {{- end }}
 {{- end }}
 ---
+{{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/validatingadmissionpolicy.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/validatingadmissionpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 # Created if this is not a remote istiod, OR if it is and is also a config cluster
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled (or .Values.global.configCluster .Values.istiodRemote.enabledLocalInjectorIstiod)) }}
 {{- if .Values.experimental.stableValidationPolicy }}

--- a/manifests/charts/istio-control/istio-discovery/templates/validatingadmissionpolicy.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/validatingadmissionpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
 # Created if this is not a remote istiod, OR if it is and is also a config cluster
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled (or .Values.global.configCluster .Values.istiodRemote.enabledLocalInjectorIstiod)) }}
 {{- if .Values.experimental.stableValidationPolicy }}

--- a/manifests/charts/istio-control/istio-discovery/templates/validatingadmissionpolicy.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/validatingadmissionpolicy.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 # Created if this is not a remote istiod, OR if it is and is also a config cluster
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled (or .Values.global.configCluster .Values.istiodRemote.enabledLocalInjectorIstiod)) }}
 {{- if .Values.experimental.stableValidationPolicy }}
@@ -59,5 +60,6 @@ metadata:
 spec:
   policyName: "stable-channel-policy{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}-{{ .Values.global.istioNamespace }}.istio.io"
   validationActions: [Deny]
+{{- end }}
 {{- end }}
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "CLUSTER") }}
 # Created if this is not a remote istiod, OR if it is and is also a config cluster
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled (or .Values.global.configCluster .Values.istiodRemote.enabledLocalInjectorIstiod)) }}
 {{- if .Values.global.configValidation }}

--- a/manifests/charts/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
 # Created if this is not a remote istiod, OR if it is and is also a config cluster
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled (or .Values.global.configCluster .Values.istiodRemote.enabledLocalInjectorIstiod)) }}
 {{- if .Values.global.configValidation }}

--- a/manifests/charts/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "CLUSTER") }}
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "cluster") }}
 # Created if this is not a remote istiod, OR if it is and is also a config cluster
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled (or .Values.global.configCluster .Values.istiodRemote.enabledLocalInjectorIstiod)) }}
 {{- if .Values.global.configValidation }}

--- a/manifests/charts/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 # Created if this is not a remote istiod, OR if it is and is also a config cluster
 {{- if or (not .Values.istiodRemote.enabled) (and .Values.istiodRemote.enabled (or .Values.global.configCluster .Values.istiodRemote.enabledLocalInjectorIstiod)) }}
 {{- if .Values.global.configValidation }}
@@ -64,5 +65,6 @@ webhooks:
           - "{{ .Values.revision }}"
           {{- end }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/zzy_descope_legacy.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/zzy_descope_legacy.yaml
@@ -1,5 +1,3 @@
-{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 {{/* Copy anything under `.pilot` to `.`, to avoid the need to specify a redundant prefix.
 Due to the file naming, this always happens after zzz_profile.yaml */}}
 {{- $_ := mustMergeOverwrite $.Values (index $.Values "pilot") }}
-{{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/zzy_descope_legacy.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/zzy_descope_legacy.yaml
@@ -1,3 +1,5 @@
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "namespace") }}
 {{/* Copy anything under `.pilot` to `.`, to avoid the need to specify a redundant prefix.
 Due to the file naming, this always happens after zzz_profile.yaml */}}
 {{- $_ := mustMergeOverwrite $.Values (index $.Values "pilot") }}
+{{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/zzz_profile.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/zzz_profile.yaml
@@ -73,3 +73,4 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end -}}
+

--- a/manifests/charts/istio-control/istio-discovery/templates/zzz_profile.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/zzz_profile.yaml
@@ -73,4 +73,3 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end -}}
-

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -293,8 +293,13 @@ _internal_defaults_do_not_set:
 
     omitSidecarInjectorConfigMap: false
 
-    # Whether to omit cluster resources for persona-based installations
-    omitClusterResources: false
+    # resourceScope controls what resources will be processed by helm.
+    # This is useful when installing Istio on a cluster where some resources need to be owned by a cluster administrator and some can be owned by the mesh administrator.
+    # It can be one of:
+    # - all: all resources are processed
+    # - cluster: only cluster-scoped resources are processed
+    # - namespace: only namespace-scoped resources are processed
+    resourceScope: all
 
     # Configure whether Operator manages webhook configurations. The current behavior
     # of Istiod is to manage its own webhook configurations.

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -296,10 +296,10 @@ _internal_defaults_do_not_set:
     # resourceScope controls what resources will be processed by helm.
     # This is useful when installing Istio on a cluster where some resources need to be owned by a cluster administrator and some can be owned by the mesh administrator.
     # It can be one of:
-    # - ALL: all resources are processed
-    # - CLUSTER: only cluster-scoped resources are processed
-    # - NAMESPACE: only namespace-scoped resources are processed
-    resourceScope: ALL
+    # - all: all resources are processed
+    # - cluster: only cluster-scoped resources are processed
+    # - namespace: only namespace-scoped resources are processed
+    resourceScope: all
 
     # Configure whether Operator manages webhook configurations. The current behavior
     # of Istiod is to manage its own webhook configurations.

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -296,10 +296,10 @@ _internal_defaults_do_not_set:
     # resourceScope controls what resources will be processed by helm.
     # This is useful when installing Istio on a cluster where some resources need to be owned by a cluster administrator and some can be owned by the mesh administrator.
     # It can be one of:
-    # - all: all resources are processed
-    # - cluster: only cluster-scoped resources are processed
-    # - namespace: only namespace-scoped resources are processed
-    resourceScope: all
+    # - ALL: all resources are processed
+    # - CLUSTER: only cluster-scoped resources are processed
+    # - NAMESPACE: only namespace-scoped resources are processed
+    resourceScope: ALL
 
     # Configure whether Operator manages webhook configurations. The current behavior
     # of Istiod is to manage its own webhook configurations.

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -293,6 +293,9 @@ _internal_defaults_do_not_set:
 
     omitSidecarInjectorConfigMap: false
 
+    # Whether to omit cluster resources for persona-based installations
+    omitClusterResources: false
+
     # Configure whether Operator manages webhook configurations. The current behavior
     # of Istiod is to manage its own webhook configurations.
     # When this option is set as true, Istio Operator, instead of webhooks, manages the

--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.resourceScope "ALL") (eq .Values.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.resourceScope "all") (eq .Values.resourceScope "namespace") }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.resourceScope "ALL") (eq .Values.resourceScope "NAMESPACE") }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -208,3 +209,4 @@ spec:
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 6}}
       {{- end }}
+{{- end }}

--- a/manifests/charts/ztunnel/templates/rbac.yaml
+++ b/manifests/charts/ztunnel/templates/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "CLUSTER") }}
+{{- if or (eq .Values.resourceScope "ALL") (eq .Values.resourceScope "CLUSTER") }}
 {{- if (eq (.Values.platform | default "") "openshift") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/manifests/charts/ztunnel/templates/rbac.yaml
+++ b/manifests/charts/ztunnel/templates/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.resourceScope "ALL") (eq .Values.resourceScope "CLUSTER") }}
+{{- if or (eq .Values.resourceScope "all") (eq .Values.resourceScope "cluster") }}
 {{- if (eq (.Values.platform | default "") "openshift") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/manifests/charts/ztunnel/templates/rbac.yaml
+++ b/manifests/charts/ztunnel/templates/rbac.yaml
@@ -1,26 +1,4 @@
-apiVersion: v1
-kind: ServiceAccount
-  {{- with .Values.imagePullSecrets }}
-imagePullSecrets:
-  {{- range . }}
-  - name: {{ . }}
-  {{- end }}
-  {{- end }}
-metadata:
-  name: {{ include "ztunnel.release-name" . }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app.kubernetes.io/name: ztunnel
-    {{- include "istio.labels" . | nindent 4}}
-    {{ with .Values.labels -}}{{ toYaml . | nindent 4}}{{ end }}
-  annotations:
-{{- if .Values.revision }}
-    {{- $annos := set $.Values.annotations "istio.io/rev" .Values.revision }}
-    {{- toYaml $annos | nindent 4}}
-{{- else }}
-    {{- .Values.annotations | toYaml | nindent 4 }}
-{{- end }}
----
+{{- if not .Values.omitClusterResources }}
 {{- if (eq (.Values.platform | default "") "openshift") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -72,3 +50,4 @@ subjects:
   namespace: {{ .Release.Namespace }}
 {{- end }}
 ---
+{{- end }}

--- a/manifests/charts/ztunnel/templates/rbac.yaml
+++ b/manifests/charts/ztunnel/templates/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.omitClusterResources }}
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "CLUSTER") }}
 {{- if (eq (.Values.platform | default "") "openshift") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/manifests/charts/ztunnel/templates/resourcequota.yaml
+++ b/manifests/charts/ztunnel/templates/resourcequota.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
 {{- if .Values.resourceQuotas.enabled }}
 apiVersion: v1
 kind: ResourceQuota
@@ -17,4 +18,5 @@ spec:
       scopeName: PriorityClass
       values:
       - system-node-critical
+{{- end }}
 {{- end }}

--- a/manifests/charts/ztunnel/templates/resourcequota.yaml
+++ b/manifests/charts/ztunnel/templates/resourcequota.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.resourceScope "ALL") (eq .Values.resourceScope "NAMESPACE") }}
 {{- if .Values.resourceQuotas.enabled }}
 apiVersion: v1
 kind: ResourceQuota

--- a/manifests/charts/ztunnel/templates/resourcequota.yaml
+++ b/manifests/charts/ztunnel/templates/resourcequota.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.resourceScope "ALL") (eq .Values.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.resourceScope "all") (eq .Values.resourceScope "namespace") }}
 {{- if .Values.resourceQuotas.enabled }}
 apiVersion: v1
 kind: ResourceQuota

--- a/manifests/charts/ztunnel/templates/serviceaccount.yaml
+++ b/manifests/charts/ztunnel/templates/serviceaccount.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ServiceAccount
+  {{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- range . }}
+  - name: {{ . }}
+  {{- end }}
+  {{- end }}
+metadata:
+  name: {{ include "ztunnel.release-name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: ztunnel
+    {{- include "istio.labels" . | nindent 4}}
+    {{ with .Values.labels -}}{{ toYaml . | nindent 4}}{{ end }}
+  annotations:
+{{- if .Values.revision }}
+    {{- $annos := set $.Values.annotations "istio.io/rev" .Values.revision }}
+    {{- toYaml $annos | nindent 4}}
+{{- else }}
+    {{- .Values.annotations | toYaml | nindent 4 }}
+{{- end }}

--- a/manifests/charts/ztunnel/templates/serviceaccount.yaml
+++ b/manifests/charts/ztunnel/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.resourceScope "ALL") (eq .Values.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.resourceScope "all") (eq .Values.resourceScope "namespace") }}
 apiVersion: v1
 kind: ServiceAccount
   {{- with .Values.imagePullSecrets }}

--- a/manifests/charts/ztunnel/templates/serviceaccount.yaml
+++ b/manifests/charts/ztunnel/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
+{{- if or (eq .Values.resourceScope "ALL") (eq .Values.resourceScope "NAMESPACE") }}
 apiVersion: v1
 kind: ServiceAccount
   {{- with .Values.imagePullSecrets }}

--- a/manifests/charts/ztunnel/templates/serviceaccount.yaml
+++ b/manifests/charts/ztunnel/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.global.resourceScope "ALL") (eq .Values.global.resourceScope "NAMESPACE") }}
 apiVersion: v1
 kind: ServiceAccount
   {{- with .Values.imagePullSecrets }}
@@ -19,4 +20,5 @@ metadata:
     {{- toYaml $annos | nindent 4}}
 {{- else }}
     {{- .Values.annotations | toYaml | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/manifests/charts/ztunnel/values.yaml
+++ b/manifests/charts/ztunnel/values.yaml
@@ -17,14 +17,6 @@ _internal_defaults_do_not_set:
   # corresponds to the networks in the map of mesh networks.
   network: ""
 
-    # resourceScope controls what resources will be processed by helm.
-    # This is useful when installing Istio on a cluster where some resources need to be owned by a cluster administrator and some can be owned by the mesh administrator.
-    # It can be one of:
-    # - ALL: all resources are processed
-    # - CLUSTER: only cluster-scoped resources are processed
-    # - NAMESPACE: only namespace-scoped resources are processed
-    resourceScope: ALL
-
   # resourceName, if set, will override the naming of resources. If not set, will default to 'ztunnel'.
   # If you set this, you MUST also set `trustedZtunnelName` in the `istiod` chart.
   resourceName: ""
@@ -126,9 +118,14 @@ _internal_defaults_do_not_set:
   # TODO Ambient inpod - for OpenShift, set to the following to get writable sockets in hostmounts to work, eventually consider CSI driver instead
   #seLinuxOptions:
   #  type: spc_t
-
-  # Whether to omit cluster resources for persona-based installations
-  omitClusterResources: false
+  
+  # resourceScope controls what resources will be processed by helm.
+  # This is useful when installing Istio on a cluster where some resources need to be owned by a cluster administrator and some can be owned by the mesh administrator.
+  # It can be one of:
+  # - ALL: all resources are processed
+  # - CLUSTER: only cluster-scoped resources are processed
+  # - NAMESPACE: only namespace-scoped resources are processed
+  resourceScope: ALL
 
   # K8s DaemonSet update strategy.
   # https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/#DaemonSetSpec).

--- a/manifests/charts/ztunnel/values.yaml
+++ b/manifests/charts/ztunnel/values.yaml
@@ -17,6 +17,14 @@ _internal_defaults_do_not_set:
   # corresponds to the networks in the map of mesh networks.
   network: ""
 
+    # resourceScope controls what resources will be processed by helm.
+    # This is useful when installing Istio on a cluster where some resources need to be owned by a cluster administrator and some can be owned by the mesh administrator.
+    # It can be one of:
+    # - ALL: all resources are processed
+    # - CLUSTER: only cluster-scoped resources are processed
+    # - NAMESPACE: only namespace-scoped resources are processed
+    resourceScope: ALL
+
   # resourceName, if set, will override the naming of resources. If not set, will default to 'ztunnel'.
   # If you set this, you MUST also set `trustedZtunnelName` in the `istiod` chart.
   resourceName: ""

--- a/manifests/charts/ztunnel/values.yaml
+++ b/manifests/charts/ztunnel/values.yaml
@@ -119,6 +119,9 @@ _internal_defaults_do_not_set:
   #seLinuxOptions:
   #  type: spc_t
 
+  # Whether to omit cluster resources for persona-based installations
+  omitClusterResources: false
+
   # K8s DaemonSet update strategy.
   # https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/#DaemonSetSpec).
   updateStrategy:

--- a/manifests/charts/ztunnel/values.yaml
+++ b/manifests/charts/ztunnel/values.yaml
@@ -122,10 +122,10 @@ _internal_defaults_do_not_set:
   # resourceScope controls what resources will be processed by helm.
   # This is useful when installing Istio on a cluster where some resources need to be owned by a cluster administrator and some can be owned by the mesh administrator.
   # It can be one of:
-  # - ALL: all resources are processed
-  # - CLUSTER: only cluster-scoped resources are processed
-  # - NAMESPACE: only namespace-scoped resources are processed
-  resourceScope: ALL
+  # - all: all resources are processed
+  # - cluster: only cluster-scoped resources are processed
+  # - namespace: only namespace-scoped resources are processed
+  resourceScope: all
 
   # K8s DaemonSet update strategy.
   # https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/#DaemonSetSpec).

--- a/operator/pkg/apis/values_types.pb.go
+++ b/operator/pkg/apis/values_types.pb.go
@@ -44,25 +44,25 @@ const (
 type ResourceScope int32
 
 const (
-	ResourceScope_UNDEFINED ResourceScope = 0
-	ResourceScope_ALL       ResourceScope = 1
-	ResourceScope_CLUSTER   ResourceScope = 2
-	ResourceScope_NAMESPACE ResourceScope = 3
+	ResourceScope_undefined ResourceScope = 0
+	ResourceScope_all       ResourceScope = 1
+	ResourceScope_cluster   ResourceScope = 2
+	ResourceScope_namespace ResourceScope = 3
 )
 
 // Enum value maps for ResourceScope.
 var (
 	ResourceScope_name = map[int32]string{
-		0: "UNDEFINED",
-		1: "ALL",
-		2: "CLUSTER",
-		3: "NAMESPACE",
+		0: "undefined",
+		1: "all",
+		2: "cluster",
+		3: "namespace",
 	}
 	ResourceScope_value = map[string]int32{
-		"UNDEFINED": 0,
-		"ALL":       1,
-		"CLUSTER":   2,
-		"NAMESPACE": 3,
+		"undefined": 0,
+		"all":       1,
+		"cluster":   2,
+		"namespace": 3,
 	}
 )
 
@@ -2266,7 +2266,7 @@ func (x *GlobalConfig) GetResourceScope() ResourceScope {
 	if x != nil {
 		return x.ResourceScope
 	}
-	return ResourceScope_UNDEFINED
+	return ResourceScope_undefined
 }
 
 // Configuration for Security Token Service (STS) server.
@@ -5936,10 +5936,10 @@ const file_pkg_apis_values_types_proto_rawDesc = "" +
 	"\x13NetworkPolicyConfig\x124\n" +
 	"\aenabled\x18\x01 \x01(\v2\x1a.google.protobuf.BoolValueR\aenabled*C\n" +
 	"\rResourceScope\x12\r\n" +
-	"\tUNDEFINED\x10\x00\x12\a\n" +
-	"\x03ALL\x10\x01\x12\v\n" +
-	"\aCLUSTER\x10\x02\x12\r\n" +
-	"\tNAMESPACE\x10\x03*J\n" +
+	"\tundefined\x10\x00\x12\a\n" +
+	"\x03all\x10\x01\x12\v\n" +
+	"\acluster\x10\x02\x12\r\n" +
+	"\tnamespace\x10\x03*J\n" +
 	"\x15ingressControllerMode\x12\x0f\n" +
 	"\vUNSPECIFIED\x10\x00\x12\v\n" +
 	"\aDEFAULT\x10\x01\x12\n" +

--- a/operator/pkg/apis/values_types.pb.go
+++ b/operator/pkg/apis/values_types.pb.go
@@ -1851,9 +1851,14 @@ type GlobalConfig struct {
 	// Specifies whether native nftables rules should be used instead of iptables rules for traffic redirection.
 	NativeNftables *wrapperspb.BoolValue `protobuf:"bytes,74,opt,name=nativeNftables,proto3" json:"nativeNftables,omitempty"`
 	// Settings related to Kubernetes NetworkPolicy.
-	NetworkPolicy *NetworkPolicyConfig `protobuf:"bytes,75,opt,name=networkPolicy,proto3" json:"networkPolicy,omitempty"` // The next available key is 76
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	NetworkPolicy *NetworkPolicyConfig `protobuf:"bytes,75,opt,name=networkPolicy,proto3" json:"networkPolicy,omitempty"`
+	// Specifies whether resources such as ClusterRole and ClusterRoleBinding are installed.
+	// This is useful when Mesh Administrator and Kubernetes Administrator are different rolls
+	// and cluster-scope resources cannot be applied by a Mesh Administrator.
+	// Cluster-scope resources would need to be templated or installed using helm.
+	OmitClusterResources *wrapperspb.BoolValue `protobuf:"bytes,76,opt,name=omitClusterResources,proto3" json:"omitClusterResources,omitempty"` // The next available key is 77
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *GlobalConfig) Reset() {
@@ -2203,6 +2208,13 @@ func (x *GlobalConfig) GetNativeNftables() *wrapperspb.BoolValue {
 func (x *GlobalConfig) GetNetworkPolicy() *NetworkPolicyConfig {
 	if x != nil {
 		return x.NetworkPolicy
+	}
+	return nil
+}
+
+func (x *GlobalConfig) GetOmitClusterResources() *wrapperspb.BoolValue {
+	if x != nil {
+		return x.OmitClusterResources
 	}
 	return nil
 }
@@ -5562,7 +5574,7 @@ const file_pkg_apis_values_types_proto_rawDesc = "" +
 	"\x14istio_ingressgateway\x18\x04 \x01(\v2-.istio.operator.v1alpha1.IngressGatewayConfigR\x14istio-ingressgateway\x12@\n" +
 	"\x0fsecurityContext\x18\n" +
 	" \x01(\v2\x16.google.protobuf.ValueR\x0fsecurityContext\x12>\n" +
-	"\x0eseccompProfile\x18\f \x01(\v2\x16.google.protobuf.ValueR\x0eseccompProfile\"\xdf\x13\n" +
+	"\x0eseccompProfile\x18\f \x01(\v2\x16.google.protobuf.ValueR\x0eseccompProfile\"\xaf\x14\n" +
 	"\fGlobalConfig\x12;\n" +
 	"\x04arch\x18\x01 \x01(\v2#.istio.operator.v1alpha1.ArchConfigB\x02\x18\x01R\x04arch\x12 \n" +
 	"\vcertSigners\x18D \x03(\tR\vcertSigners\x12F\n" +
@@ -5612,7 +5624,8 @@ const file_pkg_apis_values_types_proto_rawDesc = "" +
 	"\bwaypoint\x18H \x01(\v2'.istio.operator.v1alpha1.WaypointConfigR\bwaypoint\x12(\n" +
 	"\x0ftrustBundleName\x18I \x01(\tR\x0ftrustBundleName\x12B\n" +
 	"\x0enativeNftables\x18J \x01(\v2\x1a.google.protobuf.BoolValueR\x0enativeNftables\x12R\n" +
-	"\rnetworkPolicy\x18K \x01(\v2,.istio.operator.v1alpha1.NetworkPolicyConfigR\rnetworkPolicy\"-\n" +
+	"\rnetworkPolicy\x18K \x01(\v2,.istio.operator.v1alpha1.NetworkPolicyConfigR\rnetworkPolicy\x12N\n" +
+	"\x14omitClusterResources\x18L \x01(\v2\x1a.google.protobuf.BoolValueR\x14omitClusterResources\"-\n" +
 	"\tSTSConfig\x12 \n" +
 	"\vservicePort\x18\x01 \x01(\rR\vservicePort\"R\n" +
 	"\fIstiodConfig\x12B\n" +
@@ -6057,124 +6070,125 @@ var file_pkg_apis_values_types_proto_depIdxs = []int32{
 	49,  // 80: istio.operator.v1alpha1.GlobalConfig.waypoint:type_name -> istio.operator.v1alpha1.WaypointConfig
 	55,  // 81: istio.operator.v1alpha1.GlobalConfig.nativeNftables:type_name -> google.protobuf.BoolValue
 	50,  // 82: istio.operator.v1alpha1.GlobalConfig.networkPolicy:type_name -> istio.operator.v1alpha1.NetworkPolicyConfig
-	55,  // 83: istio.operator.v1alpha1.IstiodConfig.enableAnalysis:type_name -> google.protobuf.BoolValue
-	55,  // 84: istio.operator.v1alpha1.IngressGatewayConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
-	9,   // 85: istio.operator.v1alpha1.IngressGatewayConfig.memory:type_name -> istio.operator.v1alpha1.TargetUtilizationConfig
-	9,   // 86: istio.operator.v1alpha1.IngressGatewayConfig.cpu:type_name -> istio.operator.v1alpha1.TargetUtilizationConfig
-	55,  // 87: istio.operator.v1alpha1.IngressGatewayConfig.customService:type_name -> google.protobuf.BoolValue
-	55,  // 88: istio.operator.v1alpha1.IngressGatewayConfig.enabled:type_name -> google.protobuf.BoolValue
-	58,  // 89: istio.operator.v1alpha1.IngressGatewayConfig.env:type_name -> google.protobuf.Struct
-	54,  // 90: istio.operator.v1alpha1.IngressGatewayConfig.labels:type_name -> istio.operator.v1alpha1.IngressGatewayConfig.LabelsEntry
-	58,  // 91: istio.operator.v1alpha1.IngressGatewayConfig.nodeSelector:type_name -> google.protobuf.Struct
-	58,  // 92: istio.operator.v1alpha1.IngressGatewayConfig.podAnnotations:type_name -> google.protobuf.Struct
-	60,  // 93: istio.operator.v1alpha1.IngressGatewayConfig.podAntiAffinityLabelSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
-	60,  // 94: istio.operator.v1alpha1.IngressGatewayConfig.podAntiAffinityTermLabelSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
-	31,  // 95: istio.operator.v1alpha1.IngressGatewayConfig.ports:type_name -> istio.operator.v1alpha1.PortsConfig
-	58,  // 96: istio.operator.v1alpha1.IngressGatewayConfig.resources:type_name -> google.protobuf.Struct
-	37,  // 97: istio.operator.v1alpha1.IngressGatewayConfig.secretVolumes:type_name -> istio.operator.v1alpha1.SecretVolume
-	58,  // 98: istio.operator.v1alpha1.IngressGatewayConfig.serviceAnnotations:type_name -> google.protobuf.Struct
-	48,  // 99: istio.operator.v1alpha1.IngressGatewayConfig.rollingMaxSurge:type_name -> istio.operator.v1alpha1.IntOrString
-	48,  // 100: istio.operator.v1alpha1.IngressGatewayConfig.rollingMaxUnavailable:type_name -> istio.operator.v1alpha1.IntOrString
-	61,  // 101: istio.operator.v1alpha1.IngressGatewayConfig.tolerations:type_name -> k8s.io.api.core.v1.Toleration
-	58,  // 102: istio.operator.v1alpha1.IngressGatewayConfig.ingressPorts:type_name -> google.protobuf.Struct
-	58,  // 103: istio.operator.v1alpha1.IngressGatewayConfig.additionalContainers:type_name -> google.protobuf.Struct
-	58,  // 104: istio.operator.v1alpha1.IngressGatewayConfig.configVolumes:type_name -> google.protobuf.Struct
-	55,  // 105: istio.operator.v1alpha1.IngressGatewayConfig.runAsRoot:type_name -> google.protobuf.BoolValue
-	11,  // 106: istio.operator.v1alpha1.IngressGatewayConfig.serviceAccount:type_name -> istio.operator.v1alpha1.ServiceAccount
-	55,  // 107: istio.operator.v1alpha1.MultiClusterConfig.enabled:type_name -> google.protobuf.BoolValue
-	55,  // 108: istio.operator.v1alpha1.MultiClusterConfig.includeEnvoyFilter:type_name -> google.protobuf.BoolValue
-	2,   // 109: istio.operator.v1alpha1.OutboundTrafficPolicyConfig.mode:type_name -> istio.operator.v1alpha1.OutboundTrafficPolicyConfig.Mode
-	55,  // 110: istio.operator.v1alpha1.PilotConfig.enabled:type_name -> google.protobuf.BoolValue
-	55,  // 111: istio.operator.v1alpha1.PilotConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
-	58,  // 112: istio.operator.v1alpha1.PilotConfig.autoscaleBehavior:type_name -> google.protobuf.Struct
-	10,  // 113: istio.operator.v1alpha1.PilotConfig.resources:type_name -> istio.operator.v1alpha1.Resources
-	9,   // 114: istio.operator.v1alpha1.PilotConfig.cpu:type_name -> istio.operator.v1alpha1.TargetUtilizationConfig
-	58,  // 115: istio.operator.v1alpha1.PilotConfig.nodeSelector:type_name -> google.protobuf.Struct
-	62,  // 116: istio.operator.v1alpha1.PilotConfig.keepaliveMaxServerConnectionAge:type_name -> google.protobuf.Duration
-	58,  // 117: istio.operator.v1alpha1.PilotConfig.deploymentLabels:type_name -> google.protobuf.Struct
-	58,  // 118: istio.operator.v1alpha1.PilotConfig.podLabels:type_name -> google.protobuf.Struct
-	55,  // 119: istio.operator.v1alpha1.PilotConfig.configMap:type_name -> google.protobuf.BoolValue
-	58,  // 120: istio.operator.v1alpha1.PilotConfig.env:type_name -> google.protobuf.Struct
-	57,  // 121: istio.operator.v1alpha1.PilotConfig.affinity:type_name -> k8s.io.api.core.v1.Affinity
-	48,  // 122: istio.operator.v1alpha1.PilotConfig.rollingMaxSurge:type_name -> istio.operator.v1alpha1.IntOrString
-	48,  // 123: istio.operator.v1alpha1.PilotConfig.rollingMaxUnavailable:type_name -> istio.operator.v1alpha1.IntOrString
-	61,  // 124: istio.operator.v1alpha1.PilotConfig.tolerations:type_name -> k8s.io.api.core.v1.Toleration
-	58,  // 125: istio.operator.v1alpha1.PilotConfig.podAnnotations:type_name -> google.protobuf.Struct
-	58,  // 126: istio.operator.v1alpha1.PilotConfig.serviceAnnotations:type_name -> google.protobuf.Struct
-	58,  // 127: istio.operator.v1alpha1.PilotConfig.serviceAccountAnnotations:type_name -> google.protobuf.Struct
-	56,  // 128: istio.operator.v1alpha1.PilotConfig.tag:type_name -> google.protobuf.Value
-	59,  // 129: istio.operator.v1alpha1.PilotConfig.seccompProfile:type_name -> k8s.io.api.core.v1.SeccompProfile
-	63,  // 130: istio.operator.v1alpha1.PilotConfig.topologySpreadConstraints:type_name -> k8s.io.api.core.v1.TopologySpreadConstraint
-	58,  // 131: istio.operator.v1alpha1.PilotConfig.extraContainerArgs:type_name -> google.protobuf.Struct
-	64,  // 132: istio.operator.v1alpha1.PilotConfig.volumeMounts:type_name -> k8s.io.api.core.v1.VolumeMount
-	65,  // 133: istio.operator.v1alpha1.PilotConfig.volumes:type_name -> k8s.io.api.core.v1.Volume
-	9,   // 134: istio.operator.v1alpha1.PilotConfig.memory:type_name -> istio.operator.v1alpha1.TargetUtilizationConfig
-	5,   // 135: istio.operator.v1alpha1.PilotConfig.cni:type_name -> istio.operator.v1alpha1.CNIUsageConfig
-	24,  // 136: istio.operator.v1alpha1.PilotConfig.taint:type_name -> istio.operator.v1alpha1.PilotTaintControllerConfig
-	45,  // 137: istio.operator.v1alpha1.PilotConfig.istiodRemote:type_name -> istio.operator.v1alpha1.IstiodRemoteConfig
-	58,  // 138: istio.operator.v1alpha1.PilotConfig.envVarFrom:type_name -> google.protobuf.Struct
-	0,   // 139: istio.operator.v1alpha1.PilotIngressConfig.ingressControllerMode:type_name -> istio.operator.v1alpha1.ingressControllerMode
-	55,  // 140: istio.operator.v1alpha1.PilotPolicyConfig.enabled:type_name -> google.protobuf.BoolValue
-	55,  // 141: istio.operator.v1alpha1.TelemetryConfig.enabled:type_name -> google.protobuf.BoolValue
-	28,  // 142: istio.operator.v1alpha1.TelemetryConfig.v2:type_name -> istio.operator.v1alpha1.TelemetryV2Config
-	55,  // 143: istio.operator.v1alpha1.TelemetryV2Config.enabled:type_name -> google.protobuf.BoolValue
-	29,  // 144: istio.operator.v1alpha1.TelemetryV2Config.prometheus:type_name -> istio.operator.v1alpha1.TelemetryV2PrometheusConfig
-	30,  // 145: istio.operator.v1alpha1.TelemetryV2Config.stackdriver:type_name -> istio.operator.v1alpha1.TelemetryV2StackDriverConfig
-	55,  // 146: istio.operator.v1alpha1.TelemetryV2PrometheusConfig.enabled:type_name -> google.protobuf.BoolValue
-	55,  // 147: istio.operator.v1alpha1.TelemetryV2StackDriverConfig.enabled:type_name -> google.protobuf.BoolValue
-	55,  // 148: istio.operator.v1alpha1.ProxyConfig.enableCoreDump:type_name -> google.protobuf.BoolValue
-	55,  // 149: istio.operator.v1alpha1.ProxyConfig.privileged:type_name -> google.protobuf.BoolValue
-	33,  // 150: istio.operator.v1alpha1.ProxyConfig.startupProbe:type_name -> istio.operator.v1alpha1.StartupProbe
-	10,  // 151: istio.operator.v1alpha1.ProxyConfig.resources:type_name -> istio.operator.v1alpha1.Resources
-	1,   // 152: istio.operator.v1alpha1.ProxyConfig.tracer:type_name -> istio.operator.v1alpha1.tracer
-	66,  // 153: istio.operator.v1alpha1.ProxyConfig.lifecycle:type_name -> k8s.io.api.core.v1.Lifecycle
-	55,  // 154: istio.operator.v1alpha1.ProxyConfig.holdApplicationUntilProxyStarts:type_name -> google.protobuf.BoolValue
-	55,  // 155: istio.operator.v1alpha1.StartupProbe.enabled:type_name -> google.protobuf.BoolValue
-	10,  // 156: istio.operator.v1alpha1.ProxyInitConfig.resources:type_name -> istio.operator.v1alpha1.Resources
-	58,  // 157: istio.operator.v1alpha1.SDSConfig.token:type_name -> google.protobuf.Struct
-	55,  // 158: istio.operator.v1alpha1.SidecarInjectorConfig.enableNamespacesByDefault:type_name -> google.protobuf.BoolValue
-	60,  // 159: istio.operator.v1alpha1.SidecarInjectorConfig.neverInjectSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
-	60,  // 160: istio.operator.v1alpha1.SidecarInjectorConfig.alwaysInjectSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
-	55,  // 161: istio.operator.v1alpha1.SidecarInjectorConfig.rewriteAppHTTPProbe:type_name -> google.protobuf.BoolValue
-	58,  // 162: istio.operator.v1alpha1.SidecarInjectorConfig.injectedAnnotations:type_name -> google.protobuf.Struct
-	58,  // 163: istio.operator.v1alpha1.SidecarInjectorConfig.templates:type_name -> google.protobuf.Struct
-	40,  // 164: istio.operator.v1alpha1.TracerConfig.datadog:type_name -> istio.operator.v1alpha1.TracerDatadogConfig
-	41,  // 165: istio.operator.v1alpha1.TracerConfig.lightstep:type_name -> istio.operator.v1alpha1.TracerLightStepConfig
-	42,  // 166: istio.operator.v1alpha1.TracerConfig.zipkin:type_name -> istio.operator.v1alpha1.TracerZipkinConfig
-	43,  // 167: istio.operator.v1alpha1.TracerConfig.stackdriver:type_name -> istio.operator.v1alpha1.TracerStackdriverConfig
-	55,  // 168: istio.operator.v1alpha1.TracerStackdriverConfig.debug:type_name -> google.protobuf.BoolValue
-	55,  // 169: istio.operator.v1alpha1.BaseConfig.enableCRDTemplates:type_name -> google.protobuf.BoolValue
-	55,  // 170: istio.operator.v1alpha1.BaseConfig.enableIstioConfigCRDs:type_name -> google.protobuf.BoolValue
-	55,  // 171: istio.operator.v1alpha1.BaseConfig.validateGateway:type_name -> google.protobuf.BoolValue
-	55,  // 172: istio.operator.v1alpha1.IstiodRemoteConfig.enabled:type_name -> google.protobuf.BoolValue
-	55,  // 173: istio.operator.v1alpha1.IstiodRemoteConfig.enabledLocalInjectorIstiod:type_name -> google.protobuf.BoolValue
-	4,   // 174: istio.operator.v1alpha1.Values.cni:type_name -> istio.operator.v1alpha1.CNIConfig
-	15,  // 175: istio.operator.v1alpha1.Values.gateways:type_name -> istio.operator.v1alpha1.GatewaysConfig
-	16,  // 176: istio.operator.v1alpha1.Values.global:type_name -> istio.operator.v1alpha1.GlobalConfig
-	23,  // 177: istio.operator.v1alpha1.Values.pilot:type_name -> istio.operator.v1alpha1.PilotConfig
-	56,  // 178: istio.operator.v1alpha1.Values.ztunnel:type_name -> google.protobuf.Value
-	27,  // 179: istio.operator.v1alpha1.Values.telemetry:type_name -> istio.operator.v1alpha1.TelemetryConfig
-	38,  // 180: istio.operator.v1alpha1.Values.sidecarInjectorWebhook:type_name -> istio.operator.v1alpha1.SidecarInjectorConfig
-	5,   // 181: istio.operator.v1alpha1.Values.istio_cni:type_name -> istio.operator.v1alpha1.CNIUsageConfig
-	56,  // 182: istio.operator.v1alpha1.Values.meshConfig:type_name -> google.protobuf.Value
-	44,  // 183: istio.operator.v1alpha1.Values.base:type_name -> istio.operator.v1alpha1.BaseConfig
-	45,  // 184: istio.operator.v1alpha1.Values.istiodRemote:type_name -> istio.operator.v1alpha1.IstiodRemoteConfig
-	47,  // 185: istio.operator.v1alpha1.Values.experimental:type_name -> istio.operator.v1alpha1.ExperimentalConfig
-	56,  // 186: istio.operator.v1alpha1.Values.gatewayClasses:type_name -> google.protobuf.Value
-	55,  // 187: istio.operator.v1alpha1.ExperimentalConfig.stableValidationPolicy:type_name -> google.protobuf.BoolValue
-	67,  // 188: istio.operator.v1alpha1.IntOrString.intVal:type_name -> google.protobuf.Int32Value
-	68,  // 189: istio.operator.v1alpha1.IntOrString.strVal:type_name -> google.protobuf.StringValue
-	10,  // 190: istio.operator.v1alpha1.WaypointConfig.resources:type_name -> istio.operator.v1alpha1.Resources
-	57,  // 191: istio.operator.v1alpha1.WaypointConfig.affinity:type_name -> k8s.io.api.core.v1.Affinity
-	63,  // 192: istio.operator.v1alpha1.WaypointConfig.topologySpreadConstraints:type_name -> k8s.io.api.core.v1.TopologySpreadConstraint
-	69,  // 193: istio.operator.v1alpha1.WaypointConfig.nodeSelector:type_name -> k8s.io.api.core.v1.NodeSelector
-	61,  // 194: istio.operator.v1alpha1.WaypointConfig.toleration:type_name -> k8s.io.api.core.v1.Toleration
-	55,  // 195: istio.operator.v1alpha1.NetworkPolicyConfig.enabled:type_name -> google.protobuf.BoolValue
-	196, // [196:196] is the sub-list for method output_type
-	196, // [196:196] is the sub-list for method input_type
-	196, // [196:196] is the sub-list for extension type_name
-	196, // [196:196] is the sub-list for extension extendee
-	0,   // [0:196] is the sub-list for field type_name
+	55,  // 83: istio.operator.v1alpha1.GlobalConfig.omitClusterResources:type_name -> google.protobuf.BoolValue
+	55,  // 84: istio.operator.v1alpha1.IstiodConfig.enableAnalysis:type_name -> google.protobuf.BoolValue
+	55,  // 85: istio.operator.v1alpha1.IngressGatewayConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
+	9,   // 86: istio.operator.v1alpha1.IngressGatewayConfig.memory:type_name -> istio.operator.v1alpha1.TargetUtilizationConfig
+	9,   // 87: istio.operator.v1alpha1.IngressGatewayConfig.cpu:type_name -> istio.operator.v1alpha1.TargetUtilizationConfig
+	55,  // 88: istio.operator.v1alpha1.IngressGatewayConfig.customService:type_name -> google.protobuf.BoolValue
+	55,  // 89: istio.operator.v1alpha1.IngressGatewayConfig.enabled:type_name -> google.protobuf.BoolValue
+	58,  // 90: istio.operator.v1alpha1.IngressGatewayConfig.env:type_name -> google.protobuf.Struct
+	54,  // 91: istio.operator.v1alpha1.IngressGatewayConfig.labels:type_name -> istio.operator.v1alpha1.IngressGatewayConfig.LabelsEntry
+	58,  // 92: istio.operator.v1alpha1.IngressGatewayConfig.nodeSelector:type_name -> google.protobuf.Struct
+	58,  // 93: istio.operator.v1alpha1.IngressGatewayConfig.podAnnotations:type_name -> google.protobuf.Struct
+	60,  // 94: istio.operator.v1alpha1.IngressGatewayConfig.podAntiAffinityLabelSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
+	60,  // 95: istio.operator.v1alpha1.IngressGatewayConfig.podAntiAffinityTermLabelSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
+	31,  // 96: istio.operator.v1alpha1.IngressGatewayConfig.ports:type_name -> istio.operator.v1alpha1.PortsConfig
+	58,  // 97: istio.operator.v1alpha1.IngressGatewayConfig.resources:type_name -> google.protobuf.Struct
+	37,  // 98: istio.operator.v1alpha1.IngressGatewayConfig.secretVolumes:type_name -> istio.operator.v1alpha1.SecretVolume
+	58,  // 99: istio.operator.v1alpha1.IngressGatewayConfig.serviceAnnotations:type_name -> google.protobuf.Struct
+	48,  // 100: istio.operator.v1alpha1.IngressGatewayConfig.rollingMaxSurge:type_name -> istio.operator.v1alpha1.IntOrString
+	48,  // 101: istio.operator.v1alpha1.IngressGatewayConfig.rollingMaxUnavailable:type_name -> istio.operator.v1alpha1.IntOrString
+	61,  // 102: istio.operator.v1alpha1.IngressGatewayConfig.tolerations:type_name -> k8s.io.api.core.v1.Toleration
+	58,  // 103: istio.operator.v1alpha1.IngressGatewayConfig.ingressPorts:type_name -> google.protobuf.Struct
+	58,  // 104: istio.operator.v1alpha1.IngressGatewayConfig.additionalContainers:type_name -> google.protobuf.Struct
+	58,  // 105: istio.operator.v1alpha1.IngressGatewayConfig.configVolumes:type_name -> google.protobuf.Struct
+	55,  // 106: istio.operator.v1alpha1.IngressGatewayConfig.runAsRoot:type_name -> google.protobuf.BoolValue
+	11,  // 107: istio.operator.v1alpha1.IngressGatewayConfig.serviceAccount:type_name -> istio.operator.v1alpha1.ServiceAccount
+	55,  // 108: istio.operator.v1alpha1.MultiClusterConfig.enabled:type_name -> google.protobuf.BoolValue
+	55,  // 109: istio.operator.v1alpha1.MultiClusterConfig.includeEnvoyFilter:type_name -> google.protobuf.BoolValue
+	2,   // 110: istio.operator.v1alpha1.OutboundTrafficPolicyConfig.mode:type_name -> istio.operator.v1alpha1.OutboundTrafficPolicyConfig.Mode
+	55,  // 111: istio.operator.v1alpha1.PilotConfig.enabled:type_name -> google.protobuf.BoolValue
+	55,  // 112: istio.operator.v1alpha1.PilotConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
+	58,  // 113: istio.operator.v1alpha1.PilotConfig.autoscaleBehavior:type_name -> google.protobuf.Struct
+	10,  // 114: istio.operator.v1alpha1.PilotConfig.resources:type_name -> istio.operator.v1alpha1.Resources
+	9,   // 115: istio.operator.v1alpha1.PilotConfig.cpu:type_name -> istio.operator.v1alpha1.TargetUtilizationConfig
+	58,  // 116: istio.operator.v1alpha1.PilotConfig.nodeSelector:type_name -> google.protobuf.Struct
+	62,  // 117: istio.operator.v1alpha1.PilotConfig.keepaliveMaxServerConnectionAge:type_name -> google.protobuf.Duration
+	58,  // 118: istio.operator.v1alpha1.PilotConfig.deploymentLabels:type_name -> google.protobuf.Struct
+	58,  // 119: istio.operator.v1alpha1.PilotConfig.podLabels:type_name -> google.protobuf.Struct
+	55,  // 120: istio.operator.v1alpha1.PilotConfig.configMap:type_name -> google.protobuf.BoolValue
+	58,  // 121: istio.operator.v1alpha1.PilotConfig.env:type_name -> google.protobuf.Struct
+	57,  // 122: istio.operator.v1alpha1.PilotConfig.affinity:type_name -> k8s.io.api.core.v1.Affinity
+	48,  // 123: istio.operator.v1alpha1.PilotConfig.rollingMaxSurge:type_name -> istio.operator.v1alpha1.IntOrString
+	48,  // 124: istio.operator.v1alpha1.PilotConfig.rollingMaxUnavailable:type_name -> istio.operator.v1alpha1.IntOrString
+	61,  // 125: istio.operator.v1alpha1.PilotConfig.tolerations:type_name -> k8s.io.api.core.v1.Toleration
+	58,  // 126: istio.operator.v1alpha1.PilotConfig.podAnnotations:type_name -> google.protobuf.Struct
+	58,  // 127: istio.operator.v1alpha1.PilotConfig.serviceAnnotations:type_name -> google.protobuf.Struct
+	58,  // 128: istio.operator.v1alpha1.PilotConfig.serviceAccountAnnotations:type_name -> google.protobuf.Struct
+	56,  // 129: istio.operator.v1alpha1.PilotConfig.tag:type_name -> google.protobuf.Value
+	59,  // 130: istio.operator.v1alpha1.PilotConfig.seccompProfile:type_name -> k8s.io.api.core.v1.SeccompProfile
+	63,  // 131: istio.operator.v1alpha1.PilotConfig.topologySpreadConstraints:type_name -> k8s.io.api.core.v1.TopologySpreadConstraint
+	58,  // 132: istio.operator.v1alpha1.PilotConfig.extraContainerArgs:type_name -> google.protobuf.Struct
+	64,  // 133: istio.operator.v1alpha1.PilotConfig.volumeMounts:type_name -> k8s.io.api.core.v1.VolumeMount
+	65,  // 134: istio.operator.v1alpha1.PilotConfig.volumes:type_name -> k8s.io.api.core.v1.Volume
+	9,   // 135: istio.operator.v1alpha1.PilotConfig.memory:type_name -> istio.operator.v1alpha1.TargetUtilizationConfig
+	5,   // 136: istio.operator.v1alpha1.PilotConfig.cni:type_name -> istio.operator.v1alpha1.CNIUsageConfig
+	24,  // 137: istio.operator.v1alpha1.PilotConfig.taint:type_name -> istio.operator.v1alpha1.PilotTaintControllerConfig
+	45,  // 138: istio.operator.v1alpha1.PilotConfig.istiodRemote:type_name -> istio.operator.v1alpha1.IstiodRemoteConfig
+	58,  // 139: istio.operator.v1alpha1.PilotConfig.envVarFrom:type_name -> google.protobuf.Struct
+	0,   // 140: istio.operator.v1alpha1.PilotIngressConfig.ingressControllerMode:type_name -> istio.operator.v1alpha1.ingressControllerMode
+	55,  // 141: istio.operator.v1alpha1.PilotPolicyConfig.enabled:type_name -> google.protobuf.BoolValue
+	55,  // 142: istio.operator.v1alpha1.TelemetryConfig.enabled:type_name -> google.protobuf.BoolValue
+	28,  // 143: istio.operator.v1alpha1.TelemetryConfig.v2:type_name -> istio.operator.v1alpha1.TelemetryV2Config
+	55,  // 144: istio.operator.v1alpha1.TelemetryV2Config.enabled:type_name -> google.protobuf.BoolValue
+	29,  // 145: istio.operator.v1alpha1.TelemetryV2Config.prometheus:type_name -> istio.operator.v1alpha1.TelemetryV2PrometheusConfig
+	30,  // 146: istio.operator.v1alpha1.TelemetryV2Config.stackdriver:type_name -> istio.operator.v1alpha1.TelemetryV2StackDriverConfig
+	55,  // 147: istio.operator.v1alpha1.TelemetryV2PrometheusConfig.enabled:type_name -> google.protobuf.BoolValue
+	55,  // 148: istio.operator.v1alpha1.TelemetryV2StackDriverConfig.enabled:type_name -> google.protobuf.BoolValue
+	55,  // 149: istio.operator.v1alpha1.ProxyConfig.enableCoreDump:type_name -> google.protobuf.BoolValue
+	55,  // 150: istio.operator.v1alpha1.ProxyConfig.privileged:type_name -> google.protobuf.BoolValue
+	33,  // 151: istio.operator.v1alpha1.ProxyConfig.startupProbe:type_name -> istio.operator.v1alpha1.StartupProbe
+	10,  // 152: istio.operator.v1alpha1.ProxyConfig.resources:type_name -> istio.operator.v1alpha1.Resources
+	1,   // 153: istio.operator.v1alpha1.ProxyConfig.tracer:type_name -> istio.operator.v1alpha1.tracer
+	66,  // 154: istio.operator.v1alpha1.ProxyConfig.lifecycle:type_name -> k8s.io.api.core.v1.Lifecycle
+	55,  // 155: istio.operator.v1alpha1.ProxyConfig.holdApplicationUntilProxyStarts:type_name -> google.protobuf.BoolValue
+	55,  // 156: istio.operator.v1alpha1.StartupProbe.enabled:type_name -> google.protobuf.BoolValue
+	10,  // 157: istio.operator.v1alpha1.ProxyInitConfig.resources:type_name -> istio.operator.v1alpha1.Resources
+	58,  // 158: istio.operator.v1alpha1.SDSConfig.token:type_name -> google.protobuf.Struct
+	55,  // 159: istio.operator.v1alpha1.SidecarInjectorConfig.enableNamespacesByDefault:type_name -> google.protobuf.BoolValue
+	60,  // 160: istio.operator.v1alpha1.SidecarInjectorConfig.neverInjectSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
+	60,  // 161: istio.operator.v1alpha1.SidecarInjectorConfig.alwaysInjectSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
+	55,  // 162: istio.operator.v1alpha1.SidecarInjectorConfig.rewriteAppHTTPProbe:type_name -> google.protobuf.BoolValue
+	58,  // 163: istio.operator.v1alpha1.SidecarInjectorConfig.injectedAnnotations:type_name -> google.protobuf.Struct
+	58,  // 164: istio.operator.v1alpha1.SidecarInjectorConfig.templates:type_name -> google.protobuf.Struct
+	40,  // 165: istio.operator.v1alpha1.TracerConfig.datadog:type_name -> istio.operator.v1alpha1.TracerDatadogConfig
+	41,  // 166: istio.operator.v1alpha1.TracerConfig.lightstep:type_name -> istio.operator.v1alpha1.TracerLightStepConfig
+	42,  // 167: istio.operator.v1alpha1.TracerConfig.zipkin:type_name -> istio.operator.v1alpha1.TracerZipkinConfig
+	43,  // 168: istio.operator.v1alpha1.TracerConfig.stackdriver:type_name -> istio.operator.v1alpha1.TracerStackdriverConfig
+	55,  // 169: istio.operator.v1alpha1.TracerStackdriverConfig.debug:type_name -> google.protobuf.BoolValue
+	55,  // 170: istio.operator.v1alpha1.BaseConfig.enableCRDTemplates:type_name -> google.protobuf.BoolValue
+	55,  // 171: istio.operator.v1alpha1.BaseConfig.enableIstioConfigCRDs:type_name -> google.protobuf.BoolValue
+	55,  // 172: istio.operator.v1alpha1.BaseConfig.validateGateway:type_name -> google.protobuf.BoolValue
+	55,  // 173: istio.operator.v1alpha1.IstiodRemoteConfig.enabled:type_name -> google.protobuf.BoolValue
+	55,  // 174: istio.operator.v1alpha1.IstiodRemoteConfig.enabledLocalInjectorIstiod:type_name -> google.protobuf.BoolValue
+	4,   // 175: istio.operator.v1alpha1.Values.cni:type_name -> istio.operator.v1alpha1.CNIConfig
+	15,  // 176: istio.operator.v1alpha1.Values.gateways:type_name -> istio.operator.v1alpha1.GatewaysConfig
+	16,  // 177: istio.operator.v1alpha1.Values.global:type_name -> istio.operator.v1alpha1.GlobalConfig
+	23,  // 178: istio.operator.v1alpha1.Values.pilot:type_name -> istio.operator.v1alpha1.PilotConfig
+	56,  // 179: istio.operator.v1alpha1.Values.ztunnel:type_name -> google.protobuf.Value
+	27,  // 180: istio.operator.v1alpha1.Values.telemetry:type_name -> istio.operator.v1alpha1.TelemetryConfig
+	38,  // 181: istio.operator.v1alpha1.Values.sidecarInjectorWebhook:type_name -> istio.operator.v1alpha1.SidecarInjectorConfig
+	5,   // 182: istio.operator.v1alpha1.Values.istio_cni:type_name -> istio.operator.v1alpha1.CNIUsageConfig
+	56,  // 183: istio.operator.v1alpha1.Values.meshConfig:type_name -> google.protobuf.Value
+	44,  // 184: istio.operator.v1alpha1.Values.base:type_name -> istio.operator.v1alpha1.BaseConfig
+	45,  // 185: istio.operator.v1alpha1.Values.istiodRemote:type_name -> istio.operator.v1alpha1.IstiodRemoteConfig
+	47,  // 186: istio.operator.v1alpha1.Values.experimental:type_name -> istio.operator.v1alpha1.ExperimentalConfig
+	56,  // 187: istio.operator.v1alpha1.Values.gatewayClasses:type_name -> google.protobuf.Value
+	55,  // 188: istio.operator.v1alpha1.ExperimentalConfig.stableValidationPolicy:type_name -> google.protobuf.BoolValue
+	67,  // 189: istio.operator.v1alpha1.IntOrString.intVal:type_name -> google.protobuf.Int32Value
+	68,  // 190: istio.operator.v1alpha1.IntOrString.strVal:type_name -> google.protobuf.StringValue
+	10,  // 191: istio.operator.v1alpha1.WaypointConfig.resources:type_name -> istio.operator.v1alpha1.Resources
+	57,  // 192: istio.operator.v1alpha1.WaypointConfig.affinity:type_name -> k8s.io.api.core.v1.Affinity
+	63,  // 193: istio.operator.v1alpha1.WaypointConfig.topologySpreadConstraints:type_name -> k8s.io.api.core.v1.TopologySpreadConstraint
+	69,  // 194: istio.operator.v1alpha1.WaypointConfig.nodeSelector:type_name -> k8s.io.api.core.v1.NodeSelector
+	61,  // 195: istio.operator.v1alpha1.WaypointConfig.toleration:type_name -> k8s.io.api.core.v1.Toleration
+	55,  // 196: istio.operator.v1alpha1.NetworkPolicyConfig.enabled:type_name -> google.protobuf.BoolValue
+	197, // [197:197] is the sub-list for method output_type
+	197, // [197:197] is the sub-list for method input_type
+	197, // [197:197] is the sub-list for extension type_name
+	197, // [197:197] is the sub-list for extension extendee
+	0,   // [0:197] is the sub-list for field type_name
 }
 
 func init() { file_pkg_apis_values_types_proto_init() }

--- a/operator/pkg/apis/values_types.pb.go
+++ b/operator/pkg/apis/values_types.pb.go
@@ -41,6 +41,58 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type ResourceScope int32
+
+const (
+	ResourceScope_UNDEFINED ResourceScope = 0
+	ResourceScope_ALL       ResourceScope = 1
+	ResourceScope_CLUSTER   ResourceScope = 2
+	ResourceScope_NAMESPACE ResourceScope = 3
+)
+
+// Enum value maps for ResourceScope.
+var (
+	ResourceScope_name = map[int32]string{
+		0: "UNDEFINED",
+		1: "ALL",
+		2: "CLUSTER",
+		3: "NAMESPACE",
+	}
+	ResourceScope_value = map[string]int32{
+		"UNDEFINED": 0,
+		"ALL":       1,
+		"CLUSTER":   2,
+		"NAMESPACE": 3,
+	}
+)
+
+func (x ResourceScope) Enum() *ResourceScope {
+	p := new(ResourceScope)
+	*p = x
+	return p
+}
+
+func (x ResourceScope) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ResourceScope) Descriptor() protoreflect.EnumDescriptor {
+	return file_pkg_apis_values_types_proto_enumTypes[0].Descriptor()
+}
+
+func (ResourceScope) Type() protoreflect.EnumType {
+	return &file_pkg_apis_values_types_proto_enumTypes[0]
+}
+
+func (x ResourceScope) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ResourceScope.Descriptor instead.
+func (ResourceScope) EnumDescriptor() ([]byte, []int) {
+	return file_pkg_apis_values_types_proto_rawDescGZIP(), []int{0}
+}
+
 // Mode for the ingress controller.
 type IngressControllerMode int32
 
@@ -82,11 +134,11 @@ func (x IngressControllerMode) String() string {
 }
 
 func (IngressControllerMode) Descriptor() protoreflect.EnumDescriptor {
-	return file_pkg_apis_values_types_proto_enumTypes[0].Descriptor()
+	return file_pkg_apis_values_types_proto_enumTypes[1].Descriptor()
 }
 
 func (IngressControllerMode) Type() protoreflect.EnumType {
-	return &file_pkg_apis_values_types_proto_enumTypes[0]
+	return &file_pkg_apis_values_types_proto_enumTypes[1]
 }
 
 func (x IngressControllerMode) Number() protoreflect.EnumNumber {
@@ -95,7 +147,7 @@ func (x IngressControllerMode) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use IngressControllerMode.Descriptor instead.
 func (IngressControllerMode) EnumDescriptor() ([]byte, []int) {
-	return file_pkg_apis_values_types_proto_rawDescGZIP(), []int{0}
+	return file_pkg_apis_values_types_proto_rawDescGZIP(), []int{1}
 }
 
 // Specifies which tracer to use.
@@ -141,11 +193,11 @@ func (x Tracer) String() string {
 }
 
 func (Tracer) Descriptor() protoreflect.EnumDescriptor {
-	return file_pkg_apis_values_types_proto_enumTypes[1].Descriptor()
+	return file_pkg_apis_values_types_proto_enumTypes[2].Descriptor()
 }
 
 func (Tracer) Type() protoreflect.EnumType {
-	return &file_pkg_apis_values_types_proto_enumTypes[1]
+	return &file_pkg_apis_values_types_proto_enumTypes[2]
 }
 
 func (x Tracer) Number() protoreflect.EnumNumber {
@@ -154,7 +206,7 @@ func (x Tracer) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use Tracer.Descriptor instead.
 func (Tracer) EnumDescriptor() ([]byte, []int) {
-	return file_pkg_apis_values_types_proto_rawDescGZIP(), []int{1}
+	return file_pkg_apis_values_types_proto_rawDescGZIP(), []int{2}
 }
 
 // Specifies the sidecar's default behavior when handling outbound traffic from the application.
@@ -190,11 +242,11 @@ func (x OutboundTrafficPolicyConfig_Mode) String() string {
 }
 
 func (OutboundTrafficPolicyConfig_Mode) Descriptor() protoreflect.EnumDescriptor {
-	return file_pkg_apis_values_types_proto_enumTypes[2].Descriptor()
+	return file_pkg_apis_values_types_proto_enumTypes[3].Descriptor()
 }
 
 func (OutboundTrafficPolicyConfig_Mode) Type() protoreflect.EnumType {
-	return &file_pkg_apis_values_types_proto_enumTypes[2]
+	return &file_pkg_apis_values_types_proto_enumTypes[3]
 }
 
 func (x OutboundTrafficPolicyConfig_Mode) Number() protoreflect.EnumNumber {
@@ -1852,13 +1904,11 @@ type GlobalConfig struct {
 	NativeNftables *wrapperspb.BoolValue `protobuf:"bytes,74,opt,name=nativeNftables,proto3" json:"nativeNftables,omitempty"`
 	// Settings related to Kubernetes NetworkPolicy.
 	NetworkPolicy *NetworkPolicyConfig `protobuf:"bytes,75,opt,name=networkPolicy,proto3" json:"networkPolicy,omitempty"`
-	// Specifies whether resources such as ClusterRole and ClusterRoleBinding are installed.
-	// This is useful when Mesh Administrator and Kubernetes Administrator are different rolls
-	// and cluster-scope resources cannot be applied by a Mesh Administrator.
-	// Cluster-scope resources would need to be templated or installed using helm.
-	OmitClusterResources *wrapperspb.BoolValue `protobuf:"bytes,76,opt,name=omitClusterResources,proto3" json:"omitClusterResources,omitempty"` // The next available key is 77
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
+	// Specifies resource scope for discovery selectors.
+	// This is useful when installing Istio on a cluster where some resources need to be owned by a cluster administrator and some can be owned by the mesh administrator.
+	ResourceScope ResourceScope `protobuf:"varint,76,opt,name=resourceScope,proto3,enum=istio.operator.v1alpha1.ResourceScope" json:"resourceScope,omitempty"` // The next available key is 77
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GlobalConfig) Reset() {
@@ -2212,11 +2262,11 @@ func (x *GlobalConfig) GetNetworkPolicy() *NetworkPolicyConfig {
 	return nil
 }
 
-func (x *GlobalConfig) GetOmitClusterResources() *wrapperspb.BoolValue {
+func (x *GlobalConfig) GetResourceScope() ResourceScope {
 	if x != nil {
-		return x.OmitClusterResources
+		return x.ResourceScope
 	}
-	return nil
+	return ResourceScope_UNDEFINED
 }
 
 // Configuration for Security Token Service (STS) server.
@@ -5574,7 +5624,7 @@ const file_pkg_apis_values_types_proto_rawDesc = "" +
 	"\x14istio_ingressgateway\x18\x04 \x01(\v2-.istio.operator.v1alpha1.IngressGatewayConfigR\x14istio-ingressgateway\x12@\n" +
 	"\x0fsecurityContext\x18\n" +
 	" \x01(\v2\x16.google.protobuf.ValueR\x0fsecurityContext\x12>\n" +
-	"\x0eseccompProfile\x18\f \x01(\v2\x16.google.protobuf.ValueR\x0eseccompProfile\"\xaf\x14\n" +
+	"\x0eseccompProfile\x18\f \x01(\v2\x16.google.protobuf.ValueR\x0eseccompProfile\"\xad\x14\n" +
 	"\fGlobalConfig\x12;\n" +
 	"\x04arch\x18\x01 \x01(\v2#.istio.operator.v1alpha1.ArchConfigB\x02\x18\x01R\x04arch\x12 \n" +
 	"\vcertSigners\x18D \x03(\tR\vcertSigners\x12F\n" +
@@ -5624,8 +5674,8 @@ const file_pkg_apis_values_types_proto_rawDesc = "" +
 	"\bwaypoint\x18H \x01(\v2'.istio.operator.v1alpha1.WaypointConfigR\bwaypoint\x12(\n" +
 	"\x0ftrustBundleName\x18I \x01(\tR\x0ftrustBundleName\x12B\n" +
 	"\x0enativeNftables\x18J \x01(\v2\x1a.google.protobuf.BoolValueR\x0enativeNftables\x12R\n" +
-	"\rnetworkPolicy\x18K \x01(\v2,.istio.operator.v1alpha1.NetworkPolicyConfigR\rnetworkPolicy\x12N\n" +
-	"\x14omitClusterResources\x18L \x01(\v2\x1a.google.protobuf.BoolValueR\x14omitClusterResources\"-\n" +
+	"\rnetworkPolicy\x18K \x01(\v2,.istio.operator.v1alpha1.NetworkPolicyConfigR\rnetworkPolicy\x12L\n" +
+	"\rresourceScope\x18L \x01(\x0e2&.istio.operator.v1alpha1.ResourceScopeR\rresourceScope\"-\n" +
 	"\tSTSConfig\x12 \n" +
 	"\vservicePort\x18\x01 \x01(\rR\vservicePort\"R\n" +
 	"\fIstiodConfig\x12B\n" +
@@ -5884,7 +5934,12 @@ const file_pkg_apis_values_types_proto_rawDesc = "" +
 	"toleration\x18\x05 \x03(\v2\x1e.k8s.io.api.core.v1.TolerationR\n" +
 	"toleration\"K\n" +
 	"\x13NetworkPolicyConfig\x124\n" +
-	"\aenabled\x18\x01 \x01(\v2\x1a.google.protobuf.BoolValueR\aenabled*J\n" +
+	"\aenabled\x18\x01 \x01(\v2\x1a.google.protobuf.BoolValueR\aenabled*C\n" +
+	"\rResourceScope\x12\r\n" +
+	"\tUNDEFINED\x10\x00\x12\a\n" +
+	"\x03ALL\x10\x01\x12\v\n" +
+	"\aCLUSTER\x10\x02\x12\r\n" +
+	"\tNAMESPACE\x10\x03*J\n" +
 	"\x15ingressControllerMode\x12\x0f\n" +
 	"\vUNSPECIFIED\x10\x00\x12\v\n" +
 	"\aDEFAULT\x10\x01\x12\n" +
@@ -5912,278 +5967,279 @@ func file_pkg_apis_values_types_proto_rawDescGZIP() []byte {
 	return file_pkg_apis_values_types_proto_rawDescData
 }
 
-var file_pkg_apis_values_types_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
+var file_pkg_apis_values_types_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
 var file_pkg_apis_values_types_proto_msgTypes = make([]protoimpl.MessageInfo, 52)
 var file_pkg_apis_values_types_proto_goTypes = []any{
-	(IngressControllerMode)(0),               // 0: istio.operator.v1alpha1.ingressControllerMode
-	(Tracer)(0),                              // 1: istio.operator.v1alpha1.tracer
-	(OutboundTrafficPolicyConfig_Mode)(0),    // 2: istio.operator.v1alpha1.OutboundTrafficPolicyConfig.Mode
-	(*ArchConfig)(nil),                       // 3: istio.operator.v1alpha1.ArchConfig
-	(*CNIConfig)(nil),                        // 4: istio.operator.v1alpha1.CNIConfig
-	(*CNIUsageConfig)(nil),                   // 5: istio.operator.v1alpha1.CNIUsageConfig
-	(*CNIAmbientConfig)(nil),                 // 6: istio.operator.v1alpha1.CNIAmbientConfig
-	(*CNIRepairConfig)(nil),                  // 7: istio.operator.v1alpha1.CNIRepairConfig
-	(*ResourceQuotas)(nil),                   // 8: istio.operator.v1alpha1.ResourceQuotas
-	(*TargetUtilizationConfig)(nil),          // 9: istio.operator.v1alpha1.TargetUtilizationConfig
-	(*Resources)(nil),                        // 10: istio.operator.v1alpha1.Resources
-	(*ServiceAccount)(nil),                   // 11: istio.operator.v1alpha1.ServiceAccount
-	(*DefaultPodDisruptionBudgetConfig)(nil), // 12: istio.operator.v1alpha1.DefaultPodDisruptionBudgetConfig
-	(*DefaultResourcesConfig)(nil),           // 13: istio.operator.v1alpha1.DefaultResourcesConfig
-	(*EgressGatewayConfig)(nil),              // 14: istio.operator.v1alpha1.EgressGatewayConfig
-	(*GatewaysConfig)(nil),                   // 15: istio.operator.v1alpha1.GatewaysConfig
-	(*GlobalConfig)(nil),                     // 16: istio.operator.v1alpha1.GlobalConfig
-	(*STSConfig)(nil),                        // 17: istio.operator.v1alpha1.STSConfig
-	(*IstiodConfig)(nil),                     // 18: istio.operator.v1alpha1.IstiodConfig
-	(*GlobalLoggingConfig)(nil),              // 19: istio.operator.v1alpha1.GlobalLoggingConfig
-	(*IngressGatewayConfig)(nil),             // 20: istio.operator.v1alpha1.IngressGatewayConfig
-	(*MultiClusterConfig)(nil),               // 21: istio.operator.v1alpha1.MultiClusterConfig
-	(*OutboundTrafficPolicyConfig)(nil),      // 22: istio.operator.v1alpha1.OutboundTrafficPolicyConfig
-	(*PilotConfig)(nil),                      // 23: istio.operator.v1alpha1.PilotConfig
-	(*PilotTaintControllerConfig)(nil),       // 24: istio.operator.v1alpha1.PilotTaintControllerConfig
-	(*PilotIngressConfig)(nil),               // 25: istio.operator.v1alpha1.PilotIngressConfig
-	(*PilotPolicyConfig)(nil),                // 26: istio.operator.v1alpha1.PilotPolicyConfig
-	(*TelemetryConfig)(nil),                  // 27: istio.operator.v1alpha1.TelemetryConfig
-	(*TelemetryV2Config)(nil),                // 28: istio.operator.v1alpha1.TelemetryV2Config
-	(*TelemetryV2PrometheusConfig)(nil),      // 29: istio.operator.v1alpha1.TelemetryV2PrometheusConfig
-	(*TelemetryV2StackDriverConfig)(nil),     // 30: istio.operator.v1alpha1.TelemetryV2StackDriverConfig
-	(*PortsConfig)(nil),                      // 31: istio.operator.v1alpha1.PortsConfig
-	(*ProxyConfig)(nil),                      // 32: istio.operator.v1alpha1.ProxyConfig
-	(*StartupProbe)(nil),                     // 33: istio.operator.v1alpha1.StartupProbe
-	(*ProxyInitConfig)(nil),                  // 34: istio.operator.v1alpha1.ProxyInitConfig
-	(*ResourcesRequestsConfig)(nil),          // 35: istio.operator.v1alpha1.ResourcesRequestsConfig
-	(*SDSConfig)(nil),                        // 36: istio.operator.v1alpha1.SDSConfig
-	(*SecretVolume)(nil),                     // 37: istio.operator.v1alpha1.SecretVolume
-	(*SidecarInjectorConfig)(nil),            // 38: istio.operator.v1alpha1.SidecarInjectorConfig
-	(*TracerConfig)(nil),                     // 39: istio.operator.v1alpha1.TracerConfig
-	(*TracerDatadogConfig)(nil),              // 40: istio.operator.v1alpha1.TracerDatadogConfig
-	(*TracerLightStepConfig)(nil),            // 41: istio.operator.v1alpha1.TracerLightStepConfig
-	(*TracerZipkinConfig)(nil),               // 42: istio.operator.v1alpha1.TracerZipkinConfig
-	(*TracerStackdriverConfig)(nil),          // 43: istio.operator.v1alpha1.TracerStackdriverConfig
-	(*BaseConfig)(nil),                       // 44: istio.operator.v1alpha1.BaseConfig
-	(*IstiodRemoteConfig)(nil),               // 45: istio.operator.v1alpha1.IstiodRemoteConfig
-	(*Values)(nil),                           // 46: istio.operator.v1alpha1.Values
-	(*ExperimentalConfig)(nil),               // 47: istio.operator.v1alpha1.ExperimentalConfig
-	(*IntOrString)(nil),                      // 48: istio.operator.v1alpha1.IntOrString
-	(*WaypointConfig)(nil),                   // 49: istio.operator.v1alpha1.WaypointConfig
-	(*NetworkPolicyConfig)(nil),              // 50: istio.operator.v1alpha1.NetworkPolicyConfig
-	nil,                                      // 51: istio.operator.v1alpha1.Resources.LimitsEntry
-	nil,                                      // 52: istio.operator.v1alpha1.Resources.RequestsEntry
-	nil,                                      // 53: istio.operator.v1alpha1.EgressGatewayConfig.LabelsEntry
-	nil,                                      // 54: istio.operator.v1alpha1.IngressGatewayConfig.LabelsEntry
-	(*wrapperspb.BoolValue)(nil),             // 55: google.protobuf.BoolValue
-	(*structpb.Value)(nil),                   // 56: google.protobuf.Value
-	(*v1.Affinity)(nil),                      // 57: k8s.io.api.core.v1.Affinity
-	(*structpb.Struct)(nil),                  // 58: google.protobuf.Struct
-	(*v1.SeccompProfile)(nil),                // 59: k8s.io.api.core.v1.SeccompProfile
-	(*v11.LabelSelector)(nil),                // 60: k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
-	(*v1.Toleration)(nil),                    // 61: k8s.io.api.core.v1.Toleration
-	(*durationpb.Duration)(nil),              // 62: google.protobuf.Duration
-	(*v1.TopologySpreadConstraint)(nil),      // 63: k8s.io.api.core.v1.TopologySpreadConstraint
-	(*v1.VolumeMount)(nil),                   // 64: k8s.io.api.core.v1.VolumeMount
-	(*v1.Volume)(nil),                        // 65: k8s.io.api.core.v1.Volume
-	(*v1.Lifecycle)(nil),                     // 66: k8s.io.api.core.v1.Lifecycle
-	(*wrapperspb.Int32Value)(nil),            // 67: google.protobuf.Int32Value
-	(*wrapperspb.StringValue)(nil),           // 68: google.protobuf.StringValue
-	(*v1.NodeSelector)(nil),                  // 69: k8s.io.api.core.v1.NodeSelector
+	(ResourceScope)(0),                       // 0: istio.operator.v1alpha1.ResourceScope
+	(IngressControllerMode)(0),               // 1: istio.operator.v1alpha1.ingressControllerMode
+	(Tracer)(0),                              // 2: istio.operator.v1alpha1.tracer
+	(OutboundTrafficPolicyConfig_Mode)(0),    // 3: istio.operator.v1alpha1.OutboundTrafficPolicyConfig.Mode
+	(*ArchConfig)(nil),                       // 4: istio.operator.v1alpha1.ArchConfig
+	(*CNIConfig)(nil),                        // 5: istio.operator.v1alpha1.CNIConfig
+	(*CNIUsageConfig)(nil),                   // 6: istio.operator.v1alpha1.CNIUsageConfig
+	(*CNIAmbientConfig)(nil),                 // 7: istio.operator.v1alpha1.CNIAmbientConfig
+	(*CNIRepairConfig)(nil),                  // 8: istio.operator.v1alpha1.CNIRepairConfig
+	(*ResourceQuotas)(nil),                   // 9: istio.operator.v1alpha1.ResourceQuotas
+	(*TargetUtilizationConfig)(nil),          // 10: istio.operator.v1alpha1.TargetUtilizationConfig
+	(*Resources)(nil),                        // 11: istio.operator.v1alpha1.Resources
+	(*ServiceAccount)(nil),                   // 12: istio.operator.v1alpha1.ServiceAccount
+	(*DefaultPodDisruptionBudgetConfig)(nil), // 13: istio.operator.v1alpha1.DefaultPodDisruptionBudgetConfig
+	(*DefaultResourcesConfig)(nil),           // 14: istio.operator.v1alpha1.DefaultResourcesConfig
+	(*EgressGatewayConfig)(nil),              // 15: istio.operator.v1alpha1.EgressGatewayConfig
+	(*GatewaysConfig)(nil),                   // 16: istio.operator.v1alpha1.GatewaysConfig
+	(*GlobalConfig)(nil),                     // 17: istio.operator.v1alpha1.GlobalConfig
+	(*STSConfig)(nil),                        // 18: istio.operator.v1alpha1.STSConfig
+	(*IstiodConfig)(nil),                     // 19: istio.operator.v1alpha1.IstiodConfig
+	(*GlobalLoggingConfig)(nil),              // 20: istio.operator.v1alpha1.GlobalLoggingConfig
+	(*IngressGatewayConfig)(nil),             // 21: istio.operator.v1alpha1.IngressGatewayConfig
+	(*MultiClusterConfig)(nil),               // 22: istio.operator.v1alpha1.MultiClusterConfig
+	(*OutboundTrafficPolicyConfig)(nil),      // 23: istio.operator.v1alpha1.OutboundTrafficPolicyConfig
+	(*PilotConfig)(nil),                      // 24: istio.operator.v1alpha1.PilotConfig
+	(*PilotTaintControllerConfig)(nil),       // 25: istio.operator.v1alpha1.PilotTaintControllerConfig
+	(*PilotIngressConfig)(nil),               // 26: istio.operator.v1alpha1.PilotIngressConfig
+	(*PilotPolicyConfig)(nil),                // 27: istio.operator.v1alpha1.PilotPolicyConfig
+	(*TelemetryConfig)(nil),                  // 28: istio.operator.v1alpha1.TelemetryConfig
+	(*TelemetryV2Config)(nil),                // 29: istio.operator.v1alpha1.TelemetryV2Config
+	(*TelemetryV2PrometheusConfig)(nil),      // 30: istio.operator.v1alpha1.TelemetryV2PrometheusConfig
+	(*TelemetryV2StackDriverConfig)(nil),     // 31: istio.operator.v1alpha1.TelemetryV2StackDriverConfig
+	(*PortsConfig)(nil),                      // 32: istio.operator.v1alpha1.PortsConfig
+	(*ProxyConfig)(nil),                      // 33: istio.operator.v1alpha1.ProxyConfig
+	(*StartupProbe)(nil),                     // 34: istio.operator.v1alpha1.StartupProbe
+	(*ProxyInitConfig)(nil),                  // 35: istio.operator.v1alpha1.ProxyInitConfig
+	(*ResourcesRequestsConfig)(nil),          // 36: istio.operator.v1alpha1.ResourcesRequestsConfig
+	(*SDSConfig)(nil),                        // 37: istio.operator.v1alpha1.SDSConfig
+	(*SecretVolume)(nil),                     // 38: istio.operator.v1alpha1.SecretVolume
+	(*SidecarInjectorConfig)(nil),            // 39: istio.operator.v1alpha1.SidecarInjectorConfig
+	(*TracerConfig)(nil),                     // 40: istio.operator.v1alpha1.TracerConfig
+	(*TracerDatadogConfig)(nil),              // 41: istio.operator.v1alpha1.TracerDatadogConfig
+	(*TracerLightStepConfig)(nil),            // 42: istio.operator.v1alpha1.TracerLightStepConfig
+	(*TracerZipkinConfig)(nil),               // 43: istio.operator.v1alpha1.TracerZipkinConfig
+	(*TracerStackdriverConfig)(nil),          // 44: istio.operator.v1alpha1.TracerStackdriverConfig
+	(*BaseConfig)(nil),                       // 45: istio.operator.v1alpha1.BaseConfig
+	(*IstiodRemoteConfig)(nil),               // 46: istio.operator.v1alpha1.IstiodRemoteConfig
+	(*Values)(nil),                           // 47: istio.operator.v1alpha1.Values
+	(*ExperimentalConfig)(nil),               // 48: istio.operator.v1alpha1.ExperimentalConfig
+	(*IntOrString)(nil),                      // 49: istio.operator.v1alpha1.IntOrString
+	(*WaypointConfig)(nil),                   // 50: istio.operator.v1alpha1.WaypointConfig
+	(*NetworkPolicyConfig)(nil),              // 51: istio.operator.v1alpha1.NetworkPolicyConfig
+	nil,                                      // 52: istio.operator.v1alpha1.Resources.LimitsEntry
+	nil,                                      // 53: istio.operator.v1alpha1.Resources.RequestsEntry
+	nil,                                      // 54: istio.operator.v1alpha1.EgressGatewayConfig.LabelsEntry
+	nil,                                      // 55: istio.operator.v1alpha1.IngressGatewayConfig.LabelsEntry
+	(*wrapperspb.BoolValue)(nil),             // 56: google.protobuf.BoolValue
+	(*structpb.Value)(nil),                   // 57: google.protobuf.Value
+	(*v1.Affinity)(nil),                      // 58: k8s.io.api.core.v1.Affinity
+	(*structpb.Struct)(nil),                  // 59: google.protobuf.Struct
+	(*v1.SeccompProfile)(nil),                // 60: k8s.io.api.core.v1.SeccompProfile
+	(*v11.LabelSelector)(nil),                // 61: k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
+	(*v1.Toleration)(nil),                    // 62: k8s.io.api.core.v1.Toleration
+	(*durationpb.Duration)(nil),              // 63: google.protobuf.Duration
+	(*v1.TopologySpreadConstraint)(nil),      // 64: k8s.io.api.core.v1.TopologySpreadConstraint
+	(*v1.VolumeMount)(nil),                   // 65: k8s.io.api.core.v1.VolumeMount
+	(*v1.Volume)(nil),                        // 66: k8s.io.api.core.v1.Volume
+	(*v1.Lifecycle)(nil),                     // 67: k8s.io.api.core.v1.Lifecycle
+	(*wrapperspb.Int32Value)(nil),            // 68: google.protobuf.Int32Value
+	(*wrapperspb.StringValue)(nil),           // 69: google.protobuf.StringValue
+	(*v1.NodeSelector)(nil),                  // 70: k8s.io.api.core.v1.NodeSelector
 }
 var file_pkg_apis_values_types_proto_depIdxs = []int32{
-	55,  // 0: istio.operator.v1alpha1.CNIConfig.enabled:type_name -> google.protobuf.BoolValue
-	56,  // 1: istio.operator.v1alpha1.CNIConfig.tag:type_name -> google.protobuf.Value
-	57,  // 2: istio.operator.v1alpha1.CNIConfig.affinity:type_name -> k8s.io.api.core.v1.Affinity
-	58,  // 3: istio.operator.v1alpha1.CNIConfig.env:type_name -> google.protobuf.Struct
-	58,  // 4: istio.operator.v1alpha1.CNIConfig.daemonSetLabels:type_name -> google.protobuf.Struct
-	58,  // 5: istio.operator.v1alpha1.CNIConfig.podAnnotations:type_name -> google.protobuf.Struct
-	58,  // 6: istio.operator.v1alpha1.CNIConfig.podLabels:type_name -> google.protobuf.Struct
-	19,  // 7: istio.operator.v1alpha1.CNIConfig.logging:type_name -> istio.operator.v1alpha1.GlobalLoggingConfig
-	7,   // 8: istio.operator.v1alpha1.CNIConfig.repair:type_name -> istio.operator.v1alpha1.CNIRepairConfig
-	55,  // 9: istio.operator.v1alpha1.CNIConfig.chained:type_name -> google.protobuf.BoolValue
-	8,   // 10: istio.operator.v1alpha1.CNIConfig.resource_quotas:type_name -> istio.operator.v1alpha1.ResourceQuotas
-	10,  // 11: istio.operator.v1alpha1.CNIConfig.resources:type_name -> istio.operator.v1alpha1.Resources
-	55,  // 12: istio.operator.v1alpha1.CNIConfig.privileged:type_name -> google.protobuf.BoolValue
-	59,  // 13: istio.operator.v1alpha1.CNIConfig.seccompProfile:type_name -> k8s.io.api.core.v1.SeccompProfile
-	6,   // 14: istio.operator.v1alpha1.CNIConfig.ambient:type_name -> istio.operator.v1alpha1.CNIAmbientConfig
-	48,  // 15: istio.operator.v1alpha1.CNIConfig.rollingMaxUnavailable:type_name -> istio.operator.v1alpha1.IntOrString
-	55,  // 16: istio.operator.v1alpha1.CNIConfig.istioOwnedCNIConfig:type_name -> google.protobuf.BoolValue
-	55,  // 17: istio.operator.v1alpha1.CNIUsageConfig.enabled:type_name -> google.protobuf.BoolValue
-	55,  // 18: istio.operator.v1alpha1.CNIUsageConfig.chained:type_name -> google.protobuf.BoolValue
-	55,  // 19: istio.operator.v1alpha1.CNIAmbientConfig.enabled:type_name -> google.protobuf.BoolValue
-	55,  // 20: istio.operator.v1alpha1.CNIAmbientConfig.dnsCapture:type_name -> google.protobuf.BoolValue
-	55,  // 21: istio.operator.v1alpha1.CNIAmbientConfig.ipv6:type_name -> google.protobuf.BoolValue
-	55,  // 22: istio.operator.v1alpha1.CNIAmbientConfig.reconcileIptablesOnStartup:type_name -> google.protobuf.BoolValue
-	55,  // 23: istio.operator.v1alpha1.CNIRepairConfig.enabled:type_name -> google.protobuf.BoolValue
-	56,  // 24: istio.operator.v1alpha1.CNIRepairConfig.tag:type_name -> google.protobuf.Value
-	55,  // 25: istio.operator.v1alpha1.ResourceQuotas.enabled:type_name -> google.protobuf.BoolValue
-	51,  // 26: istio.operator.v1alpha1.Resources.limits:type_name -> istio.operator.v1alpha1.Resources.LimitsEntry
-	52,  // 27: istio.operator.v1alpha1.Resources.requests:type_name -> istio.operator.v1alpha1.Resources.RequestsEntry
-	58,  // 28: istio.operator.v1alpha1.ServiceAccount.annotations:type_name -> google.protobuf.Struct
-	55,  // 29: istio.operator.v1alpha1.DefaultPodDisruptionBudgetConfig.enabled:type_name -> google.protobuf.BoolValue
-	35,  // 30: istio.operator.v1alpha1.DefaultResourcesConfig.requests:type_name -> istio.operator.v1alpha1.ResourcesRequestsConfig
-	55,  // 31: istio.operator.v1alpha1.EgressGatewayConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
-	9,   // 32: istio.operator.v1alpha1.EgressGatewayConfig.memory:type_name -> istio.operator.v1alpha1.TargetUtilizationConfig
-	9,   // 33: istio.operator.v1alpha1.EgressGatewayConfig.cpu:type_name -> istio.operator.v1alpha1.TargetUtilizationConfig
-	55,  // 34: istio.operator.v1alpha1.EgressGatewayConfig.customService:type_name -> google.protobuf.BoolValue
-	55,  // 35: istio.operator.v1alpha1.EgressGatewayConfig.enabled:type_name -> google.protobuf.BoolValue
-	58,  // 36: istio.operator.v1alpha1.EgressGatewayConfig.env:type_name -> google.protobuf.Struct
-	53,  // 37: istio.operator.v1alpha1.EgressGatewayConfig.labels:type_name -> istio.operator.v1alpha1.EgressGatewayConfig.LabelsEntry
-	58,  // 38: istio.operator.v1alpha1.EgressGatewayConfig.nodeSelector:type_name -> google.protobuf.Struct
-	58,  // 39: istio.operator.v1alpha1.EgressGatewayConfig.podAnnotations:type_name -> google.protobuf.Struct
-	60,  // 40: istio.operator.v1alpha1.EgressGatewayConfig.podAntiAffinityLabelSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
-	60,  // 41: istio.operator.v1alpha1.EgressGatewayConfig.podAntiAffinityTermLabelSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
-	31,  // 42: istio.operator.v1alpha1.EgressGatewayConfig.ports:type_name -> istio.operator.v1alpha1.PortsConfig
-	10,  // 43: istio.operator.v1alpha1.EgressGatewayConfig.resources:type_name -> istio.operator.v1alpha1.Resources
-	37,  // 44: istio.operator.v1alpha1.EgressGatewayConfig.secretVolumes:type_name -> istio.operator.v1alpha1.SecretVolume
-	58,  // 45: istio.operator.v1alpha1.EgressGatewayConfig.serviceAnnotations:type_name -> google.protobuf.Struct
-	61,  // 46: istio.operator.v1alpha1.EgressGatewayConfig.tolerations:type_name -> k8s.io.api.core.v1.Toleration
-	48,  // 47: istio.operator.v1alpha1.EgressGatewayConfig.rollingMaxSurge:type_name -> istio.operator.v1alpha1.IntOrString
-	48,  // 48: istio.operator.v1alpha1.EgressGatewayConfig.rollingMaxUnavailable:type_name -> istio.operator.v1alpha1.IntOrString
-	58,  // 49: istio.operator.v1alpha1.EgressGatewayConfig.configVolumes:type_name -> google.protobuf.Struct
-	58,  // 50: istio.operator.v1alpha1.EgressGatewayConfig.additionalContainers:type_name -> google.protobuf.Struct
-	55,  // 51: istio.operator.v1alpha1.EgressGatewayConfig.runAsRoot:type_name -> google.protobuf.BoolValue
-	11,  // 52: istio.operator.v1alpha1.EgressGatewayConfig.serviceAccount:type_name -> istio.operator.v1alpha1.ServiceAccount
-	14,  // 53: istio.operator.v1alpha1.GatewaysConfig.istio_egressgateway:type_name -> istio.operator.v1alpha1.EgressGatewayConfig
-	55,  // 54: istio.operator.v1alpha1.GatewaysConfig.enabled:type_name -> google.protobuf.BoolValue
-	20,  // 55: istio.operator.v1alpha1.GatewaysConfig.istio_ingressgateway:type_name -> istio.operator.v1alpha1.IngressGatewayConfig
-	56,  // 56: istio.operator.v1alpha1.GatewaysConfig.securityContext:type_name -> google.protobuf.Value
-	56,  // 57: istio.operator.v1alpha1.GatewaysConfig.seccompProfile:type_name -> google.protobuf.Value
-	3,   // 58: istio.operator.v1alpha1.GlobalConfig.arch:type_name -> istio.operator.v1alpha1.ArchConfig
-	55,  // 59: istio.operator.v1alpha1.GlobalConfig.configValidation:type_name -> google.protobuf.BoolValue
-	58,  // 60: istio.operator.v1alpha1.GlobalConfig.defaultNodeSelector:type_name -> google.protobuf.Struct
-	12,  // 61: istio.operator.v1alpha1.GlobalConfig.defaultPodDisruptionBudget:type_name -> istio.operator.v1alpha1.DefaultPodDisruptionBudgetConfig
-	13,  // 62: istio.operator.v1alpha1.GlobalConfig.defaultResources:type_name -> istio.operator.v1alpha1.DefaultResourcesConfig
-	61,  // 63: istio.operator.v1alpha1.GlobalConfig.defaultTolerations:type_name -> k8s.io.api.core.v1.Toleration
-	55,  // 64: istio.operator.v1alpha1.GlobalConfig.logAsJson:type_name -> google.protobuf.BoolValue
-	19,  // 65: istio.operator.v1alpha1.GlobalConfig.logging:type_name -> istio.operator.v1alpha1.GlobalLoggingConfig
-	58,  // 66: istio.operator.v1alpha1.GlobalConfig.meshNetworks:type_name -> google.protobuf.Struct
-	21,  // 67: istio.operator.v1alpha1.GlobalConfig.multiCluster:type_name -> istio.operator.v1alpha1.MultiClusterConfig
-	55,  // 68: istio.operator.v1alpha1.GlobalConfig.omitSidecarInjectorConfigMap:type_name -> google.protobuf.BoolValue
-	55,  // 69: istio.operator.v1alpha1.GlobalConfig.operatorManageWebhooks:type_name -> google.protobuf.BoolValue
-	32,  // 70: istio.operator.v1alpha1.GlobalConfig.proxy:type_name -> istio.operator.v1alpha1.ProxyConfig
-	34,  // 71: istio.operator.v1alpha1.GlobalConfig.proxy_init:type_name -> istio.operator.v1alpha1.ProxyInitConfig
-	36,  // 72: istio.operator.v1alpha1.GlobalConfig.sds:type_name -> istio.operator.v1alpha1.SDSConfig
-	56,  // 73: istio.operator.v1alpha1.GlobalConfig.tag:type_name -> google.protobuf.Value
-	39,  // 74: istio.operator.v1alpha1.GlobalConfig.tracer:type_name -> istio.operator.v1alpha1.TracerConfig
-	18,  // 75: istio.operator.v1alpha1.GlobalConfig.istiod:type_name -> istio.operator.v1alpha1.IstiodConfig
-	17,  // 76: istio.operator.v1alpha1.GlobalConfig.sts:type_name -> istio.operator.v1alpha1.STSConfig
-	55,  // 77: istio.operator.v1alpha1.GlobalConfig.mountMtlsCerts:type_name -> google.protobuf.BoolValue
-	55,  // 78: istio.operator.v1alpha1.GlobalConfig.externalIstiod:type_name -> google.protobuf.BoolValue
-	55,  // 79: istio.operator.v1alpha1.GlobalConfig.configCluster:type_name -> google.protobuf.BoolValue
-	49,  // 80: istio.operator.v1alpha1.GlobalConfig.waypoint:type_name -> istio.operator.v1alpha1.WaypointConfig
-	55,  // 81: istio.operator.v1alpha1.GlobalConfig.nativeNftables:type_name -> google.protobuf.BoolValue
-	50,  // 82: istio.operator.v1alpha1.GlobalConfig.networkPolicy:type_name -> istio.operator.v1alpha1.NetworkPolicyConfig
-	55,  // 83: istio.operator.v1alpha1.GlobalConfig.omitClusterResources:type_name -> google.protobuf.BoolValue
-	55,  // 84: istio.operator.v1alpha1.IstiodConfig.enableAnalysis:type_name -> google.protobuf.BoolValue
-	55,  // 85: istio.operator.v1alpha1.IngressGatewayConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
-	9,   // 86: istio.operator.v1alpha1.IngressGatewayConfig.memory:type_name -> istio.operator.v1alpha1.TargetUtilizationConfig
-	9,   // 87: istio.operator.v1alpha1.IngressGatewayConfig.cpu:type_name -> istio.operator.v1alpha1.TargetUtilizationConfig
-	55,  // 88: istio.operator.v1alpha1.IngressGatewayConfig.customService:type_name -> google.protobuf.BoolValue
-	55,  // 89: istio.operator.v1alpha1.IngressGatewayConfig.enabled:type_name -> google.protobuf.BoolValue
-	58,  // 90: istio.operator.v1alpha1.IngressGatewayConfig.env:type_name -> google.protobuf.Struct
-	54,  // 91: istio.operator.v1alpha1.IngressGatewayConfig.labels:type_name -> istio.operator.v1alpha1.IngressGatewayConfig.LabelsEntry
-	58,  // 92: istio.operator.v1alpha1.IngressGatewayConfig.nodeSelector:type_name -> google.protobuf.Struct
-	58,  // 93: istio.operator.v1alpha1.IngressGatewayConfig.podAnnotations:type_name -> google.protobuf.Struct
-	60,  // 94: istio.operator.v1alpha1.IngressGatewayConfig.podAntiAffinityLabelSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
-	60,  // 95: istio.operator.v1alpha1.IngressGatewayConfig.podAntiAffinityTermLabelSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
-	31,  // 96: istio.operator.v1alpha1.IngressGatewayConfig.ports:type_name -> istio.operator.v1alpha1.PortsConfig
-	58,  // 97: istio.operator.v1alpha1.IngressGatewayConfig.resources:type_name -> google.protobuf.Struct
-	37,  // 98: istio.operator.v1alpha1.IngressGatewayConfig.secretVolumes:type_name -> istio.operator.v1alpha1.SecretVolume
-	58,  // 99: istio.operator.v1alpha1.IngressGatewayConfig.serviceAnnotations:type_name -> google.protobuf.Struct
-	48,  // 100: istio.operator.v1alpha1.IngressGatewayConfig.rollingMaxSurge:type_name -> istio.operator.v1alpha1.IntOrString
-	48,  // 101: istio.operator.v1alpha1.IngressGatewayConfig.rollingMaxUnavailable:type_name -> istio.operator.v1alpha1.IntOrString
-	61,  // 102: istio.operator.v1alpha1.IngressGatewayConfig.tolerations:type_name -> k8s.io.api.core.v1.Toleration
-	58,  // 103: istio.operator.v1alpha1.IngressGatewayConfig.ingressPorts:type_name -> google.protobuf.Struct
-	58,  // 104: istio.operator.v1alpha1.IngressGatewayConfig.additionalContainers:type_name -> google.protobuf.Struct
-	58,  // 105: istio.operator.v1alpha1.IngressGatewayConfig.configVolumes:type_name -> google.protobuf.Struct
-	55,  // 106: istio.operator.v1alpha1.IngressGatewayConfig.runAsRoot:type_name -> google.protobuf.BoolValue
-	11,  // 107: istio.operator.v1alpha1.IngressGatewayConfig.serviceAccount:type_name -> istio.operator.v1alpha1.ServiceAccount
-	55,  // 108: istio.operator.v1alpha1.MultiClusterConfig.enabled:type_name -> google.protobuf.BoolValue
-	55,  // 109: istio.operator.v1alpha1.MultiClusterConfig.includeEnvoyFilter:type_name -> google.protobuf.BoolValue
-	2,   // 110: istio.operator.v1alpha1.OutboundTrafficPolicyConfig.mode:type_name -> istio.operator.v1alpha1.OutboundTrafficPolicyConfig.Mode
-	55,  // 111: istio.operator.v1alpha1.PilotConfig.enabled:type_name -> google.protobuf.BoolValue
-	55,  // 112: istio.operator.v1alpha1.PilotConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
-	58,  // 113: istio.operator.v1alpha1.PilotConfig.autoscaleBehavior:type_name -> google.protobuf.Struct
-	10,  // 114: istio.operator.v1alpha1.PilotConfig.resources:type_name -> istio.operator.v1alpha1.Resources
-	9,   // 115: istio.operator.v1alpha1.PilotConfig.cpu:type_name -> istio.operator.v1alpha1.TargetUtilizationConfig
-	58,  // 116: istio.operator.v1alpha1.PilotConfig.nodeSelector:type_name -> google.protobuf.Struct
-	62,  // 117: istio.operator.v1alpha1.PilotConfig.keepaliveMaxServerConnectionAge:type_name -> google.protobuf.Duration
-	58,  // 118: istio.operator.v1alpha1.PilotConfig.deploymentLabels:type_name -> google.protobuf.Struct
-	58,  // 119: istio.operator.v1alpha1.PilotConfig.podLabels:type_name -> google.protobuf.Struct
-	55,  // 120: istio.operator.v1alpha1.PilotConfig.configMap:type_name -> google.protobuf.BoolValue
-	58,  // 121: istio.operator.v1alpha1.PilotConfig.env:type_name -> google.protobuf.Struct
-	57,  // 122: istio.operator.v1alpha1.PilotConfig.affinity:type_name -> k8s.io.api.core.v1.Affinity
-	48,  // 123: istio.operator.v1alpha1.PilotConfig.rollingMaxSurge:type_name -> istio.operator.v1alpha1.IntOrString
-	48,  // 124: istio.operator.v1alpha1.PilotConfig.rollingMaxUnavailable:type_name -> istio.operator.v1alpha1.IntOrString
-	61,  // 125: istio.operator.v1alpha1.PilotConfig.tolerations:type_name -> k8s.io.api.core.v1.Toleration
-	58,  // 126: istio.operator.v1alpha1.PilotConfig.podAnnotations:type_name -> google.protobuf.Struct
-	58,  // 127: istio.operator.v1alpha1.PilotConfig.serviceAnnotations:type_name -> google.protobuf.Struct
-	58,  // 128: istio.operator.v1alpha1.PilotConfig.serviceAccountAnnotations:type_name -> google.protobuf.Struct
-	56,  // 129: istio.operator.v1alpha1.PilotConfig.tag:type_name -> google.protobuf.Value
-	59,  // 130: istio.operator.v1alpha1.PilotConfig.seccompProfile:type_name -> k8s.io.api.core.v1.SeccompProfile
-	63,  // 131: istio.operator.v1alpha1.PilotConfig.topologySpreadConstraints:type_name -> k8s.io.api.core.v1.TopologySpreadConstraint
-	58,  // 132: istio.operator.v1alpha1.PilotConfig.extraContainerArgs:type_name -> google.protobuf.Struct
-	64,  // 133: istio.operator.v1alpha1.PilotConfig.volumeMounts:type_name -> k8s.io.api.core.v1.VolumeMount
-	65,  // 134: istio.operator.v1alpha1.PilotConfig.volumes:type_name -> k8s.io.api.core.v1.Volume
-	9,   // 135: istio.operator.v1alpha1.PilotConfig.memory:type_name -> istio.operator.v1alpha1.TargetUtilizationConfig
-	5,   // 136: istio.operator.v1alpha1.PilotConfig.cni:type_name -> istio.operator.v1alpha1.CNIUsageConfig
-	24,  // 137: istio.operator.v1alpha1.PilotConfig.taint:type_name -> istio.operator.v1alpha1.PilotTaintControllerConfig
-	45,  // 138: istio.operator.v1alpha1.PilotConfig.istiodRemote:type_name -> istio.operator.v1alpha1.IstiodRemoteConfig
-	58,  // 139: istio.operator.v1alpha1.PilotConfig.envVarFrom:type_name -> google.protobuf.Struct
-	0,   // 140: istio.operator.v1alpha1.PilotIngressConfig.ingressControllerMode:type_name -> istio.operator.v1alpha1.ingressControllerMode
-	55,  // 141: istio.operator.v1alpha1.PilotPolicyConfig.enabled:type_name -> google.protobuf.BoolValue
-	55,  // 142: istio.operator.v1alpha1.TelemetryConfig.enabled:type_name -> google.protobuf.BoolValue
-	28,  // 143: istio.operator.v1alpha1.TelemetryConfig.v2:type_name -> istio.operator.v1alpha1.TelemetryV2Config
-	55,  // 144: istio.operator.v1alpha1.TelemetryV2Config.enabled:type_name -> google.protobuf.BoolValue
-	29,  // 145: istio.operator.v1alpha1.TelemetryV2Config.prometheus:type_name -> istio.operator.v1alpha1.TelemetryV2PrometheusConfig
-	30,  // 146: istio.operator.v1alpha1.TelemetryV2Config.stackdriver:type_name -> istio.operator.v1alpha1.TelemetryV2StackDriverConfig
-	55,  // 147: istio.operator.v1alpha1.TelemetryV2PrometheusConfig.enabled:type_name -> google.protobuf.BoolValue
-	55,  // 148: istio.operator.v1alpha1.TelemetryV2StackDriverConfig.enabled:type_name -> google.protobuf.BoolValue
-	55,  // 149: istio.operator.v1alpha1.ProxyConfig.enableCoreDump:type_name -> google.protobuf.BoolValue
-	55,  // 150: istio.operator.v1alpha1.ProxyConfig.privileged:type_name -> google.protobuf.BoolValue
-	33,  // 151: istio.operator.v1alpha1.ProxyConfig.startupProbe:type_name -> istio.operator.v1alpha1.StartupProbe
-	10,  // 152: istio.operator.v1alpha1.ProxyConfig.resources:type_name -> istio.operator.v1alpha1.Resources
-	1,   // 153: istio.operator.v1alpha1.ProxyConfig.tracer:type_name -> istio.operator.v1alpha1.tracer
-	66,  // 154: istio.operator.v1alpha1.ProxyConfig.lifecycle:type_name -> k8s.io.api.core.v1.Lifecycle
-	55,  // 155: istio.operator.v1alpha1.ProxyConfig.holdApplicationUntilProxyStarts:type_name -> google.protobuf.BoolValue
-	55,  // 156: istio.operator.v1alpha1.StartupProbe.enabled:type_name -> google.protobuf.BoolValue
-	10,  // 157: istio.operator.v1alpha1.ProxyInitConfig.resources:type_name -> istio.operator.v1alpha1.Resources
-	58,  // 158: istio.operator.v1alpha1.SDSConfig.token:type_name -> google.protobuf.Struct
-	55,  // 159: istio.operator.v1alpha1.SidecarInjectorConfig.enableNamespacesByDefault:type_name -> google.protobuf.BoolValue
-	60,  // 160: istio.operator.v1alpha1.SidecarInjectorConfig.neverInjectSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
-	60,  // 161: istio.operator.v1alpha1.SidecarInjectorConfig.alwaysInjectSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
-	55,  // 162: istio.operator.v1alpha1.SidecarInjectorConfig.rewriteAppHTTPProbe:type_name -> google.protobuf.BoolValue
-	58,  // 163: istio.operator.v1alpha1.SidecarInjectorConfig.injectedAnnotations:type_name -> google.protobuf.Struct
-	58,  // 164: istio.operator.v1alpha1.SidecarInjectorConfig.templates:type_name -> google.protobuf.Struct
-	40,  // 165: istio.operator.v1alpha1.TracerConfig.datadog:type_name -> istio.operator.v1alpha1.TracerDatadogConfig
-	41,  // 166: istio.operator.v1alpha1.TracerConfig.lightstep:type_name -> istio.operator.v1alpha1.TracerLightStepConfig
-	42,  // 167: istio.operator.v1alpha1.TracerConfig.zipkin:type_name -> istio.operator.v1alpha1.TracerZipkinConfig
-	43,  // 168: istio.operator.v1alpha1.TracerConfig.stackdriver:type_name -> istio.operator.v1alpha1.TracerStackdriverConfig
-	55,  // 169: istio.operator.v1alpha1.TracerStackdriverConfig.debug:type_name -> google.protobuf.BoolValue
-	55,  // 170: istio.operator.v1alpha1.BaseConfig.enableCRDTemplates:type_name -> google.protobuf.BoolValue
-	55,  // 171: istio.operator.v1alpha1.BaseConfig.enableIstioConfigCRDs:type_name -> google.protobuf.BoolValue
-	55,  // 172: istio.operator.v1alpha1.BaseConfig.validateGateway:type_name -> google.protobuf.BoolValue
-	55,  // 173: istio.operator.v1alpha1.IstiodRemoteConfig.enabled:type_name -> google.protobuf.BoolValue
-	55,  // 174: istio.operator.v1alpha1.IstiodRemoteConfig.enabledLocalInjectorIstiod:type_name -> google.protobuf.BoolValue
-	4,   // 175: istio.operator.v1alpha1.Values.cni:type_name -> istio.operator.v1alpha1.CNIConfig
-	15,  // 176: istio.operator.v1alpha1.Values.gateways:type_name -> istio.operator.v1alpha1.GatewaysConfig
-	16,  // 177: istio.operator.v1alpha1.Values.global:type_name -> istio.operator.v1alpha1.GlobalConfig
-	23,  // 178: istio.operator.v1alpha1.Values.pilot:type_name -> istio.operator.v1alpha1.PilotConfig
-	56,  // 179: istio.operator.v1alpha1.Values.ztunnel:type_name -> google.protobuf.Value
-	27,  // 180: istio.operator.v1alpha1.Values.telemetry:type_name -> istio.operator.v1alpha1.TelemetryConfig
-	38,  // 181: istio.operator.v1alpha1.Values.sidecarInjectorWebhook:type_name -> istio.operator.v1alpha1.SidecarInjectorConfig
-	5,   // 182: istio.operator.v1alpha1.Values.istio_cni:type_name -> istio.operator.v1alpha1.CNIUsageConfig
-	56,  // 183: istio.operator.v1alpha1.Values.meshConfig:type_name -> google.protobuf.Value
-	44,  // 184: istio.operator.v1alpha1.Values.base:type_name -> istio.operator.v1alpha1.BaseConfig
-	45,  // 185: istio.operator.v1alpha1.Values.istiodRemote:type_name -> istio.operator.v1alpha1.IstiodRemoteConfig
-	47,  // 186: istio.operator.v1alpha1.Values.experimental:type_name -> istio.operator.v1alpha1.ExperimentalConfig
-	56,  // 187: istio.operator.v1alpha1.Values.gatewayClasses:type_name -> google.protobuf.Value
-	55,  // 188: istio.operator.v1alpha1.ExperimentalConfig.stableValidationPolicy:type_name -> google.protobuf.BoolValue
-	67,  // 189: istio.operator.v1alpha1.IntOrString.intVal:type_name -> google.protobuf.Int32Value
-	68,  // 190: istio.operator.v1alpha1.IntOrString.strVal:type_name -> google.protobuf.StringValue
-	10,  // 191: istio.operator.v1alpha1.WaypointConfig.resources:type_name -> istio.operator.v1alpha1.Resources
-	57,  // 192: istio.operator.v1alpha1.WaypointConfig.affinity:type_name -> k8s.io.api.core.v1.Affinity
-	63,  // 193: istio.operator.v1alpha1.WaypointConfig.topologySpreadConstraints:type_name -> k8s.io.api.core.v1.TopologySpreadConstraint
-	69,  // 194: istio.operator.v1alpha1.WaypointConfig.nodeSelector:type_name -> k8s.io.api.core.v1.NodeSelector
-	61,  // 195: istio.operator.v1alpha1.WaypointConfig.toleration:type_name -> k8s.io.api.core.v1.Toleration
-	55,  // 196: istio.operator.v1alpha1.NetworkPolicyConfig.enabled:type_name -> google.protobuf.BoolValue
+	56,  // 0: istio.operator.v1alpha1.CNIConfig.enabled:type_name -> google.protobuf.BoolValue
+	57,  // 1: istio.operator.v1alpha1.CNIConfig.tag:type_name -> google.protobuf.Value
+	58,  // 2: istio.operator.v1alpha1.CNIConfig.affinity:type_name -> k8s.io.api.core.v1.Affinity
+	59,  // 3: istio.operator.v1alpha1.CNIConfig.env:type_name -> google.protobuf.Struct
+	59,  // 4: istio.operator.v1alpha1.CNIConfig.daemonSetLabels:type_name -> google.protobuf.Struct
+	59,  // 5: istio.operator.v1alpha1.CNIConfig.podAnnotations:type_name -> google.protobuf.Struct
+	59,  // 6: istio.operator.v1alpha1.CNIConfig.podLabels:type_name -> google.protobuf.Struct
+	20,  // 7: istio.operator.v1alpha1.CNIConfig.logging:type_name -> istio.operator.v1alpha1.GlobalLoggingConfig
+	8,   // 8: istio.operator.v1alpha1.CNIConfig.repair:type_name -> istio.operator.v1alpha1.CNIRepairConfig
+	56,  // 9: istio.operator.v1alpha1.CNIConfig.chained:type_name -> google.protobuf.BoolValue
+	9,   // 10: istio.operator.v1alpha1.CNIConfig.resource_quotas:type_name -> istio.operator.v1alpha1.ResourceQuotas
+	11,  // 11: istio.operator.v1alpha1.CNIConfig.resources:type_name -> istio.operator.v1alpha1.Resources
+	56,  // 12: istio.operator.v1alpha1.CNIConfig.privileged:type_name -> google.protobuf.BoolValue
+	60,  // 13: istio.operator.v1alpha1.CNIConfig.seccompProfile:type_name -> k8s.io.api.core.v1.SeccompProfile
+	7,   // 14: istio.operator.v1alpha1.CNIConfig.ambient:type_name -> istio.operator.v1alpha1.CNIAmbientConfig
+	49,  // 15: istio.operator.v1alpha1.CNIConfig.rollingMaxUnavailable:type_name -> istio.operator.v1alpha1.IntOrString
+	56,  // 16: istio.operator.v1alpha1.CNIConfig.istioOwnedCNIConfig:type_name -> google.protobuf.BoolValue
+	56,  // 17: istio.operator.v1alpha1.CNIUsageConfig.enabled:type_name -> google.protobuf.BoolValue
+	56,  // 18: istio.operator.v1alpha1.CNIUsageConfig.chained:type_name -> google.protobuf.BoolValue
+	56,  // 19: istio.operator.v1alpha1.CNIAmbientConfig.enabled:type_name -> google.protobuf.BoolValue
+	56,  // 20: istio.operator.v1alpha1.CNIAmbientConfig.dnsCapture:type_name -> google.protobuf.BoolValue
+	56,  // 21: istio.operator.v1alpha1.CNIAmbientConfig.ipv6:type_name -> google.protobuf.BoolValue
+	56,  // 22: istio.operator.v1alpha1.CNIAmbientConfig.reconcileIptablesOnStartup:type_name -> google.protobuf.BoolValue
+	56,  // 23: istio.operator.v1alpha1.CNIRepairConfig.enabled:type_name -> google.protobuf.BoolValue
+	57,  // 24: istio.operator.v1alpha1.CNIRepairConfig.tag:type_name -> google.protobuf.Value
+	56,  // 25: istio.operator.v1alpha1.ResourceQuotas.enabled:type_name -> google.protobuf.BoolValue
+	52,  // 26: istio.operator.v1alpha1.Resources.limits:type_name -> istio.operator.v1alpha1.Resources.LimitsEntry
+	53,  // 27: istio.operator.v1alpha1.Resources.requests:type_name -> istio.operator.v1alpha1.Resources.RequestsEntry
+	59,  // 28: istio.operator.v1alpha1.ServiceAccount.annotations:type_name -> google.protobuf.Struct
+	56,  // 29: istio.operator.v1alpha1.DefaultPodDisruptionBudgetConfig.enabled:type_name -> google.protobuf.BoolValue
+	36,  // 30: istio.operator.v1alpha1.DefaultResourcesConfig.requests:type_name -> istio.operator.v1alpha1.ResourcesRequestsConfig
+	56,  // 31: istio.operator.v1alpha1.EgressGatewayConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
+	10,  // 32: istio.operator.v1alpha1.EgressGatewayConfig.memory:type_name -> istio.operator.v1alpha1.TargetUtilizationConfig
+	10,  // 33: istio.operator.v1alpha1.EgressGatewayConfig.cpu:type_name -> istio.operator.v1alpha1.TargetUtilizationConfig
+	56,  // 34: istio.operator.v1alpha1.EgressGatewayConfig.customService:type_name -> google.protobuf.BoolValue
+	56,  // 35: istio.operator.v1alpha1.EgressGatewayConfig.enabled:type_name -> google.protobuf.BoolValue
+	59,  // 36: istio.operator.v1alpha1.EgressGatewayConfig.env:type_name -> google.protobuf.Struct
+	54,  // 37: istio.operator.v1alpha1.EgressGatewayConfig.labels:type_name -> istio.operator.v1alpha1.EgressGatewayConfig.LabelsEntry
+	59,  // 38: istio.operator.v1alpha1.EgressGatewayConfig.nodeSelector:type_name -> google.protobuf.Struct
+	59,  // 39: istio.operator.v1alpha1.EgressGatewayConfig.podAnnotations:type_name -> google.protobuf.Struct
+	61,  // 40: istio.operator.v1alpha1.EgressGatewayConfig.podAntiAffinityLabelSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
+	61,  // 41: istio.operator.v1alpha1.EgressGatewayConfig.podAntiAffinityTermLabelSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
+	32,  // 42: istio.operator.v1alpha1.EgressGatewayConfig.ports:type_name -> istio.operator.v1alpha1.PortsConfig
+	11,  // 43: istio.operator.v1alpha1.EgressGatewayConfig.resources:type_name -> istio.operator.v1alpha1.Resources
+	38,  // 44: istio.operator.v1alpha1.EgressGatewayConfig.secretVolumes:type_name -> istio.operator.v1alpha1.SecretVolume
+	59,  // 45: istio.operator.v1alpha1.EgressGatewayConfig.serviceAnnotations:type_name -> google.protobuf.Struct
+	62,  // 46: istio.operator.v1alpha1.EgressGatewayConfig.tolerations:type_name -> k8s.io.api.core.v1.Toleration
+	49,  // 47: istio.operator.v1alpha1.EgressGatewayConfig.rollingMaxSurge:type_name -> istio.operator.v1alpha1.IntOrString
+	49,  // 48: istio.operator.v1alpha1.EgressGatewayConfig.rollingMaxUnavailable:type_name -> istio.operator.v1alpha1.IntOrString
+	59,  // 49: istio.operator.v1alpha1.EgressGatewayConfig.configVolumes:type_name -> google.protobuf.Struct
+	59,  // 50: istio.operator.v1alpha1.EgressGatewayConfig.additionalContainers:type_name -> google.protobuf.Struct
+	56,  // 51: istio.operator.v1alpha1.EgressGatewayConfig.runAsRoot:type_name -> google.protobuf.BoolValue
+	12,  // 52: istio.operator.v1alpha1.EgressGatewayConfig.serviceAccount:type_name -> istio.operator.v1alpha1.ServiceAccount
+	15,  // 53: istio.operator.v1alpha1.GatewaysConfig.istio_egressgateway:type_name -> istio.operator.v1alpha1.EgressGatewayConfig
+	56,  // 54: istio.operator.v1alpha1.GatewaysConfig.enabled:type_name -> google.protobuf.BoolValue
+	21,  // 55: istio.operator.v1alpha1.GatewaysConfig.istio_ingressgateway:type_name -> istio.operator.v1alpha1.IngressGatewayConfig
+	57,  // 56: istio.operator.v1alpha1.GatewaysConfig.securityContext:type_name -> google.protobuf.Value
+	57,  // 57: istio.operator.v1alpha1.GatewaysConfig.seccompProfile:type_name -> google.protobuf.Value
+	4,   // 58: istio.operator.v1alpha1.GlobalConfig.arch:type_name -> istio.operator.v1alpha1.ArchConfig
+	56,  // 59: istio.operator.v1alpha1.GlobalConfig.configValidation:type_name -> google.protobuf.BoolValue
+	59,  // 60: istio.operator.v1alpha1.GlobalConfig.defaultNodeSelector:type_name -> google.protobuf.Struct
+	13,  // 61: istio.operator.v1alpha1.GlobalConfig.defaultPodDisruptionBudget:type_name -> istio.operator.v1alpha1.DefaultPodDisruptionBudgetConfig
+	14,  // 62: istio.operator.v1alpha1.GlobalConfig.defaultResources:type_name -> istio.operator.v1alpha1.DefaultResourcesConfig
+	62,  // 63: istio.operator.v1alpha1.GlobalConfig.defaultTolerations:type_name -> k8s.io.api.core.v1.Toleration
+	56,  // 64: istio.operator.v1alpha1.GlobalConfig.logAsJson:type_name -> google.protobuf.BoolValue
+	20,  // 65: istio.operator.v1alpha1.GlobalConfig.logging:type_name -> istio.operator.v1alpha1.GlobalLoggingConfig
+	59,  // 66: istio.operator.v1alpha1.GlobalConfig.meshNetworks:type_name -> google.protobuf.Struct
+	22,  // 67: istio.operator.v1alpha1.GlobalConfig.multiCluster:type_name -> istio.operator.v1alpha1.MultiClusterConfig
+	56,  // 68: istio.operator.v1alpha1.GlobalConfig.omitSidecarInjectorConfigMap:type_name -> google.protobuf.BoolValue
+	56,  // 69: istio.operator.v1alpha1.GlobalConfig.operatorManageWebhooks:type_name -> google.protobuf.BoolValue
+	33,  // 70: istio.operator.v1alpha1.GlobalConfig.proxy:type_name -> istio.operator.v1alpha1.ProxyConfig
+	35,  // 71: istio.operator.v1alpha1.GlobalConfig.proxy_init:type_name -> istio.operator.v1alpha1.ProxyInitConfig
+	37,  // 72: istio.operator.v1alpha1.GlobalConfig.sds:type_name -> istio.operator.v1alpha1.SDSConfig
+	57,  // 73: istio.operator.v1alpha1.GlobalConfig.tag:type_name -> google.protobuf.Value
+	40,  // 74: istio.operator.v1alpha1.GlobalConfig.tracer:type_name -> istio.operator.v1alpha1.TracerConfig
+	19,  // 75: istio.operator.v1alpha1.GlobalConfig.istiod:type_name -> istio.operator.v1alpha1.IstiodConfig
+	18,  // 76: istio.operator.v1alpha1.GlobalConfig.sts:type_name -> istio.operator.v1alpha1.STSConfig
+	56,  // 77: istio.operator.v1alpha1.GlobalConfig.mountMtlsCerts:type_name -> google.protobuf.BoolValue
+	56,  // 78: istio.operator.v1alpha1.GlobalConfig.externalIstiod:type_name -> google.protobuf.BoolValue
+	56,  // 79: istio.operator.v1alpha1.GlobalConfig.configCluster:type_name -> google.protobuf.BoolValue
+	50,  // 80: istio.operator.v1alpha1.GlobalConfig.waypoint:type_name -> istio.operator.v1alpha1.WaypointConfig
+	56,  // 81: istio.operator.v1alpha1.GlobalConfig.nativeNftables:type_name -> google.protobuf.BoolValue
+	51,  // 82: istio.operator.v1alpha1.GlobalConfig.networkPolicy:type_name -> istio.operator.v1alpha1.NetworkPolicyConfig
+	0,   // 83: istio.operator.v1alpha1.GlobalConfig.resourceScope:type_name -> istio.operator.v1alpha1.ResourceScope
+	56,  // 84: istio.operator.v1alpha1.IstiodConfig.enableAnalysis:type_name -> google.protobuf.BoolValue
+	56,  // 85: istio.operator.v1alpha1.IngressGatewayConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
+	10,  // 86: istio.operator.v1alpha1.IngressGatewayConfig.memory:type_name -> istio.operator.v1alpha1.TargetUtilizationConfig
+	10,  // 87: istio.operator.v1alpha1.IngressGatewayConfig.cpu:type_name -> istio.operator.v1alpha1.TargetUtilizationConfig
+	56,  // 88: istio.operator.v1alpha1.IngressGatewayConfig.customService:type_name -> google.protobuf.BoolValue
+	56,  // 89: istio.operator.v1alpha1.IngressGatewayConfig.enabled:type_name -> google.protobuf.BoolValue
+	59,  // 90: istio.operator.v1alpha1.IngressGatewayConfig.env:type_name -> google.protobuf.Struct
+	55,  // 91: istio.operator.v1alpha1.IngressGatewayConfig.labels:type_name -> istio.operator.v1alpha1.IngressGatewayConfig.LabelsEntry
+	59,  // 92: istio.operator.v1alpha1.IngressGatewayConfig.nodeSelector:type_name -> google.protobuf.Struct
+	59,  // 93: istio.operator.v1alpha1.IngressGatewayConfig.podAnnotations:type_name -> google.protobuf.Struct
+	61,  // 94: istio.operator.v1alpha1.IngressGatewayConfig.podAntiAffinityLabelSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
+	61,  // 95: istio.operator.v1alpha1.IngressGatewayConfig.podAntiAffinityTermLabelSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
+	32,  // 96: istio.operator.v1alpha1.IngressGatewayConfig.ports:type_name -> istio.operator.v1alpha1.PortsConfig
+	59,  // 97: istio.operator.v1alpha1.IngressGatewayConfig.resources:type_name -> google.protobuf.Struct
+	38,  // 98: istio.operator.v1alpha1.IngressGatewayConfig.secretVolumes:type_name -> istio.operator.v1alpha1.SecretVolume
+	59,  // 99: istio.operator.v1alpha1.IngressGatewayConfig.serviceAnnotations:type_name -> google.protobuf.Struct
+	49,  // 100: istio.operator.v1alpha1.IngressGatewayConfig.rollingMaxSurge:type_name -> istio.operator.v1alpha1.IntOrString
+	49,  // 101: istio.operator.v1alpha1.IngressGatewayConfig.rollingMaxUnavailable:type_name -> istio.operator.v1alpha1.IntOrString
+	62,  // 102: istio.operator.v1alpha1.IngressGatewayConfig.tolerations:type_name -> k8s.io.api.core.v1.Toleration
+	59,  // 103: istio.operator.v1alpha1.IngressGatewayConfig.ingressPorts:type_name -> google.protobuf.Struct
+	59,  // 104: istio.operator.v1alpha1.IngressGatewayConfig.additionalContainers:type_name -> google.protobuf.Struct
+	59,  // 105: istio.operator.v1alpha1.IngressGatewayConfig.configVolumes:type_name -> google.protobuf.Struct
+	56,  // 106: istio.operator.v1alpha1.IngressGatewayConfig.runAsRoot:type_name -> google.protobuf.BoolValue
+	12,  // 107: istio.operator.v1alpha1.IngressGatewayConfig.serviceAccount:type_name -> istio.operator.v1alpha1.ServiceAccount
+	56,  // 108: istio.operator.v1alpha1.MultiClusterConfig.enabled:type_name -> google.protobuf.BoolValue
+	56,  // 109: istio.operator.v1alpha1.MultiClusterConfig.includeEnvoyFilter:type_name -> google.protobuf.BoolValue
+	3,   // 110: istio.operator.v1alpha1.OutboundTrafficPolicyConfig.mode:type_name -> istio.operator.v1alpha1.OutboundTrafficPolicyConfig.Mode
+	56,  // 111: istio.operator.v1alpha1.PilotConfig.enabled:type_name -> google.protobuf.BoolValue
+	56,  // 112: istio.operator.v1alpha1.PilotConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
+	59,  // 113: istio.operator.v1alpha1.PilotConfig.autoscaleBehavior:type_name -> google.protobuf.Struct
+	11,  // 114: istio.operator.v1alpha1.PilotConfig.resources:type_name -> istio.operator.v1alpha1.Resources
+	10,  // 115: istio.operator.v1alpha1.PilotConfig.cpu:type_name -> istio.operator.v1alpha1.TargetUtilizationConfig
+	59,  // 116: istio.operator.v1alpha1.PilotConfig.nodeSelector:type_name -> google.protobuf.Struct
+	63,  // 117: istio.operator.v1alpha1.PilotConfig.keepaliveMaxServerConnectionAge:type_name -> google.protobuf.Duration
+	59,  // 118: istio.operator.v1alpha1.PilotConfig.deploymentLabels:type_name -> google.protobuf.Struct
+	59,  // 119: istio.operator.v1alpha1.PilotConfig.podLabels:type_name -> google.protobuf.Struct
+	56,  // 120: istio.operator.v1alpha1.PilotConfig.configMap:type_name -> google.protobuf.BoolValue
+	59,  // 121: istio.operator.v1alpha1.PilotConfig.env:type_name -> google.protobuf.Struct
+	58,  // 122: istio.operator.v1alpha1.PilotConfig.affinity:type_name -> k8s.io.api.core.v1.Affinity
+	49,  // 123: istio.operator.v1alpha1.PilotConfig.rollingMaxSurge:type_name -> istio.operator.v1alpha1.IntOrString
+	49,  // 124: istio.operator.v1alpha1.PilotConfig.rollingMaxUnavailable:type_name -> istio.operator.v1alpha1.IntOrString
+	62,  // 125: istio.operator.v1alpha1.PilotConfig.tolerations:type_name -> k8s.io.api.core.v1.Toleration
+	59,  // 126: istio.operator.v1alpha1.PilotConfig.podAnnotations:type_name -> google.protobuf.Struct
+	59,  // 127: istio.operator.v1alpha1.PilotConfig.serviceAnnotations:type_name -> google.protobuf.Struct
+	59,  // 128: istio.operator.v1alpha1.PilotConfig.serviceAccountAnnotations:type_name -> google.protobuf.Struct
+	57,  // 129: istio.operator.v1alpha1.PilotConfig.tag:type_name -> google.protobuf.Value
+	60,  // 130: istio.operator.v1alpha1.PilotConfig.seccompProfile:type_name -> k8s.io.api.core.v1.SeccompProfile
+	64,  // 131: istio.operator.v1alpha1.PilotConfig.topologySpreadConstraints:type_name -> k8s.io.api.core.v1.TopologySpreadConstraint
+	59,  // 132: istio.operator.v1alpha1.PilotConfig.extraContainerArgs:type_name -> google.protobuf.Struct
+	65,  // 133: istio.operator.v1alpha1.PilotConfig.volumeMounts:type_name -> k8s.io.api.core.v1.VolumeMount
+	66,  // 134: istio.operator.v1alpha1.PilotConfig.volumes:type_name -> k8s.io.api.core.v1.Volume
+	10,  // 135: istio.operator.v1alpha1.PilotConfig.memory:type_name -> istio.operator.v1alpha1.TargetUtilizationConfig
+	6,   // 136: istio.operator.v1alpha1.PilotConfig.cni:type_name -> istio.operator.v1alpha1.CNIUsageConfig
+	25,  // 137: istio.operator.v1alpha1.PilotConfig.taint:type_name -> istio.operator.v1alpha1.PilotTaintControllerConfig
+	46,  // 138: istio.operator.v1alpha1.PilotConfig.istiodRemote:type_name -> istio.operator.v1alpha1.IstiodRemoteConfig
+	59,  // 139: istio.operator.v1alpha1.PilotConfig.envVarFrom:type_name -> google.protobuf.Struct
+	1,   // 140: istio.operator.v1alpha1.PilotIngressConfig.ingressControllerMode:type_name -> istio.operator.v1alpha1.ingressControllerMode
+	56,  // 141: istio.operator.v1alpha1.PilotPolicyConfig.enabled:type_name -> google.protobuf.BoolValue
+	56,  // 142: istio.operator.v1alpha1.TelemetryConfig.enabled:type_name -> google.protobuf.BoolValue
+	29,  // 143: istio.operator.v1alpha1.TelemetryConfig.v2:type_name -> istio.operator.v1alpha1.TelemetryV2Config
+	56,  // 144: istio.operator.v1alpha1.TelemetryV2Config.enabled:type_name -> google.protobuf.BoolValue
+	30,  // 145: istio.operator.v1alpha1.TelemetryV2Config.prometheus:type_name -> istio.operator.v1alpha1.TelemetryV2PrometheusConfig
+	31,  // 146: istio.operator.v1alpha1.TelemetryV2Config.stackdriver:type_name -> istio.operator.v1alpha1.TelemetryV2StackDriverConfig
+	56,  // 147: istio.operator.v1alpha1.TelemetryV2PrometheusConfig.enabled:type_name -> google.protobuf.BoolValue
+	56,  // 148: istio.operator.v1alpha1.TelemetryV2StackDriverConfig.enabled:type_name -> google.protobuf.BoolValue
+	56,  // 149: istio.operator.v1alpha1.ProxyConfig.enableCoreDump:type_name -> google.protobuf.BoolValue
+	56,  // 150: istio.operator.v1alpha1.ProxyConfig.privileged:type_name -> google.protobuf.BoolValue
+	34,  // 151: istio.operator.v1alpha1.ProxyConfig.startupProbe:type_name -> istio.operator.v1alpha1.StartupProbe
+	11,  // 152: istio.operator.v1alpha1.ProxyConfig.resources:type_name -> istio.operator.v1alpha1.Resources
+	2,   // 153: istio.operator.v1alpha1.ProxyConfig.tracer:type_name -> istio.operator.v1alpha1.tracer
+	67,  // 154: istio.operator.v1alpha1.ProxyConfig.lifecycle:type_name -> k8s.io.api.core.v1.Lifecycle
+	56,  // 155: istio.operator.v1alpha1.ProxyConfig.holdApplicationUntilProxyStarts:type_name -> google.protobuf.BoolValue
+	56,  // 156: istio.operator.v1alpha1.StartupProbe.enabled:type_name -> google.protobuf.BoolValue
+	11,  // 157: istio.operator.v1alpha1.ProxyInitConfig.resources:type_name -> istio.operator.v1alpha1.Resources
+	59,  // 158: istio.operator.v1alpha1.SDSConfig.token:type_name -> google.protobuf.Struct
+	56,  // 159: istio.operator.v1alpha1.SidecarInjectorConfig.enableNamespacesByDefault:type_name -> google.protobuf.BoolValue
+	61,  // 160: istio.operator.v1alpha1.SidecarInjectorConfig.neverInjectSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
+	61,  // 161: istio.operator.v1alpha1.SidecarInjectorConfig.alwaysInjectSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
+	56,  // 162: istio.operator.v1alpha1.SidecarInjectorConfig.rewriteAppHTTPProbe:type_name -> google.protobuf.BoolValue
+	59,  // 163: istio.operator.v1alpha1.SidecarInjectorConfig.injectedAnnotations:type_name -> google.protobuf.Struct
+	59,  // 164: istio.operator.v1alpha1.SidecarInjectorConfig.templates:type_name -> google.protobuf.Struct
+	41,  // 165: istio.operator.v1alpha1.TracerConfig.datadog:type_name -> istio.operator.v1alpha1.TracerDatadogConfig
+	42,  // 166: istio.operator.v1alpha1.TracerConfig.lightstep:type_name -> istio.operator.v1alpha1.TracerLightStepConfig
+	43,  // 167: istio.operator.v1alpha1.TracerConfig.zipkin:type_name -> istio.operator.v1alpha1.TracerZipkinConfig
+	44,  // 168: istio.operator.v1alpha1.TracerConfig.stackdriver:type_name -> istio.operator.v1alpha1.TracerStackdriverConfig
+	56,  // 169: istio.operator.v1alpha1.TracerStackdriverConfig.debug:type_name -> google.protobuf.BoolValue
+	56,  // 170: istio.operator.v1alpha1.BaseConfig.enableCRDTemplates:type_name -> google.protobuf.BoolValue
+	56,  // 171: istio.operator.v1alpha1.BaseConfig.enableIstioConfigCRDs:type_name -> google.protobuf.BoolValue
+	56,  // 172: istio.operator.v1alpha1.BaseConfig.validateGateway:type_name -> google.protobuf.BoolValue
+	56,  // 173: istio.operator.v1alpha1.IstiodRemoteConfig.enabled:type_name -> google.protobuf.BoolValue
+	56,  // 174: istio.operator.v1alpha1.IstiodRemoteConfig.enabledLocalInjectorIstiod:type_name -> google.protobuf.BoolValue
+	5,   // 175: istio.operator.v1alpha1.Values.cni:type_name -> istio.operator.v1alpha1.CNIConfig
+	16,  // 176: istio.operator.v1alpha1.Values.gateways:type_name -> istio.operator.v1alpha1.GatewaysConfig
+	17,  // 177: istio.operator.v1alpha1.Values.global:type_name -> istio.operator.v1alpha1.GlobalConfig
+	24,  // 178: istio.operator.v1alpha1.Values.pilot:type_name -> istio.operator.v1alpha1.PilotConfig
+	57,  // 179: istio.operator.v1alpha1.Values.ztunnel:type_name -> google.protobuf.Value
+	28,  // 180: istio.operator.v1alpha1.Values.telemetry:type_name -> istio.operator.v1alpha1.TelemetryConfig
+	39,  // 181: istio.operator.v1alpha1.Values.sidecarInjectorWebhook:type_name -> istio.operator.v1alpha1.SidecarInjectorConfig
+	6,   // 182: istio.operator.v1alpha1.Values.istio_cni:type_name -> istio.operator.v1alpha1.CNIUsageConfig
+	57,  // 183: istio.operator.v1alpha1.Values.meshConfig:type_name -> google.protobuf.Value
+	45,  // 184: istio.operator.v1alpha1.Values.base:type_name -> istio.operator.v1alpha1.BaseConfig
+	46,  // 185: istio.operator.v1alpha1.Values.istiodRemote:type_name -> istio.operator.v1alpha1.IstiodRemoteConfig
+	48,  // 186: istio.operator.v1alpha1.Values.experimental:type_name -> istio.operator.v1alpha1.ExperimentalConfig
+	57,  // 187: istio.operator.v1alpha1.Values.gatewayClasses:type_name -> google.protobuf.Value
+	56,  // 188: istio.operator.v1alpha1.ExperimentalConfig.stableValidationPolicy:type_name -> google.protobuf.BoolValue
+	68,  // 189: istio.operator.v1alpha1.IntOrString.intVal:type_name -> google.protobuf.Int32Value
+	69,  // 190: istio.operator.v1alpha1.IntOrString.strVal:type_name -> google.protobuf.StringValue
+	11,  // 191: istio.operator.v1alpha1.WaypointConfig.resources:type_name -> istio.operator.v1alpha1.Resources
+	58,  // 192: istio.operator.v1alpha1.WaypointConfig.affinity:type_name -> k8s.io.api.core.v1.Affinity
+	64,  // 193: istio.operator.v1alpha1.WaypointConfig.topologySpreadConstraints:type_name -> k8s.io.api.core.v1.TopologySpreadConstraint
+	70,  // 194: istio.operator.v1alpha1.WaypointConfig.nodeSelector:type_name -> k8s.io.api.core.v1.NodeSelector
+	62,  // 195: istio.operator.v1alpha1.WaypointConfig.toleration:type_name -> k8s.io.api.core.v1.Toleration
+	56,  // 196: istio.operator.v1alpha1.NetworkPolicyConfig.enabled:type_name -> google.protobuf.BoolValue
 	197, // [197:197] is the sub-list for method output_type
 	197, // [197:197] is the sub-list for method input_type
 	197, // [197:197] is the sub-list for extension type_name
@@ -6201,7 +6257,7 @@ func file_pkg_apis_values_types_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_apis_values_types_proto_rawDesc), len(file_pkg_apis_values_types_proto_rawDesc)),
-			NumEnums:      3,
+			NumEnums:      4,
 			NumMessages:   52,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/operator/pkg/apis/values_types.proto
+++ b/operator/pkg/apis/values_types.proto
@@ -645,7 +645,13 @@ message GlobalConfig {
 
   // Settings related to Kubernetes NetworkPolicy.
   NetworkPolicyConfig networkPolicy = 75;
-  // The next available key is 76
+
+  // Specifies whether resources such as ClusterRole and ClusterRoleBinding are installed.
+  // This is useful when Mesh Administrator and Kubernetes Administrator are different rolls
+  // and cluster-scope resources cannot be applied by a Mesh Administrator.
+  // Cluster-scope resources would need to be templated or installed using helm.
+  google.protobuf.BoolValue omitClusterResources = 76;
+  // The next available key is 77
 }
 
 // Configuration for Security Token Service (STS) server.

--- a/operator/pkg/apis/values_types.proto
+++ b/operator/pkg/apis/values_types.proto
@@ -653,10 +653,10 @@ message GlobalConfig {
 }
 
 enum ResourceScope {
-  UNDEFINED = 0;
-  ALL = 1;
-  CLUSTER = 2;
-  NAMESPACE = 3;
+  undefined = 0;
+  all = 1;
+  cluster = 2;
+  namespace = 3;
 }
 
 

--- a/operator/pkg/apis/values_types.proto
+++ b/operator/pkg/apis/values_types.proto
@@ -646,13 +646,19 @@ message GlobalConfig {
   // Settings related to Kubernetes NetworkPolicy.
   NetworkPolicyConfig networkPolicy = 75;
 
-  // Specifies whether resources such as ClusterRole and ClusterRoleBinding are installed.
-  // This is useful when Mesh Administrator and Kubernetes Administrator are different rolls
-  // and cluster-scope resources cannot be applied by a Mesh Administrator.
-  // Cluster-scope resources would need to be templated or installed using helm.
-  google.protobuf.BoolValue omitClusterResources = 76;
+  // Specifies resource scope for discovery selectors.
+  // This is useful when installing Istio on a cluster where some resources need to be owned by a cluster administrator and some can be owned by the mesh administrator.
+  ResourceScope resourceScope = 76;
   // The next available key is 77
 }
+
+enum ResourceScope {
+  UNDEFINED = 0;
+  ALL = 1;
+  CLUSTER = 2;
+  NAMESPACE = 3;
+}
+
 
 // Configuration for Security Token Service (STS) server.
 //

--- a/releasenotes/notes/57559.yaml
+++ b/releasenotes/notes/57559.yaml
@@ -1,0 +1,19 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+
+# issue is a list of GitHub issues resolved in this note.
+# If issue is not in the current repo, specify its full URL instead.
+issue:
+- 57530
+
+# releaseNotes is a markdown listing of any user facing changes. This will appear in the
+# release notes.
+releaseNotes:
+  - |
+    **Added** support for "persona-based" installations to our Helm charts based on the scope of generated/applied resources.
+    If no `resourceScope` is set, all resources will be installed. This is the same behavior a user would expect from 1.27 charts.
+    If `resourceScope` is set to `namespace`, only namespace-scoped resources will be installed.
+    If `resourceScope` is set to `cluster`, only cluster-scoped resources will be installed.
+    This can enable a kubernetes administrator to manage the resources in the cluster and the mesh administrator to manage the resources in the mesh.
+    For the ztunnel chart, `resourceScope` is a top-level field. For all other charts, it is a field under `global`.


### PR DESCRIPTION
**Please provide a description of this PR:**

Adds support for omitting sensitive cluster-scope resources during install. The goal is to divide the helm install into 2 portions:

1. Kubernetes Owner - The resources which provide cluster-scope permissions. Other resources where permission to write is analogous to owning the cluster could be included here.
1. Mesh Owner - The bulk of the configuration. Most decisions and settings should live here.

The likely UX would be for the Mesh owner to template the cluster-scope resources for review to the Kubernetes owner.