### PR TITLE
Bugfix: HTTP/2 connection pool settings not applied when enabling HTTP/2 upgrade policies

### DIFF
--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -672,7 +672,7 @@ func setH2Options(mc *clusterWrapper) {
 		mc.httpProtocolOptions = &http.HttpProtocolOptions{}
 	}
 	options := mc.httpProtocolOptions
-	if options.UpstreamHttpProtocolOptions == nil {
+	if options.UpstreamProtocolOptions == nil {
 		options.UpstreamProtocolOptions = &http.HttpProtocolOptions_ExplicitHttpConfig_{
 			ExplicitHttpConfig: &http.HttpProtocolOptions_ExplicitHttpConfig{
 				ProtocolConfig: &http.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{

--- a/pilot/pkg/networking/core/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/cluster_builder_test.go
@@ -414,6 +414,46 @@ func TestApplyDestinationRule(t *testing.T) {
 			expectedSubsetClusters: []*cluster.Cluster{},
 		},
 		{
+			name:        "destination rule with http2UpgradePolicy and maxConcurrentStreams",
+			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
+			clusterMode: DefaultClusterMode,
+			service:     service,
+			port:        servicePort[0],
+			proxyView:   model.ProxyViewAll,
+			destRule: &networking.DestinationRule{
+				Host: "foo.default.svc.cluster.local",
+				TrafficPolicy: &networking.TrafficPolicy{
+					ConnectionPool: &networking.ConnectionPoolSettings{
+						Http: &networking.ConnectionPoolSettings_HTTPSettings{
+							MaxConcurrentStreams: 200,
+							H2UpgradePolicy:      networking.ConnectionPoolSettings_HTTPSettings_UPGRADE,
+						},
+					},
+				},
+			},
+			expectedSubsetClusters: []*cluster.Cluster{},
+		},
+		{
+			name:        "destination rule with no-op http2UpgradePolicy and maxConcurrentStreams",
+			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
+			clusterMode: DefaultClusterMode,
+			service:     http2Service,
+			port:        http2ServicePort[0],
+			proxyView:   model.ProxyViewAll,
+			destRule: &networking.DestinationRule{
+				Host: "foo.default.svc.cluster.local",
+				TrafficPolicy: &networking.TrafficPolicy{
+					ConnectionPool: &networking.ConnectionPoolSettings{
+						Http: &networking.ConnectionPoolSettings_HTTPSettings{
+							MaxConcurrentStreams: 200,
+							H2UpgradePolicy:      networking.ConnectionPoolSettings_HTTPSettings_UPGRADE,
+						},
+					},
+				},
+			},
+			expectedSubsetClusters: []*cluster.Cluster{},
+		},
+		{
 			name:        "subset without labels in both",
 			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_STRICT_DNS}},
 			clusterMode: DefaultClusterMode,

--- a/pilot/pkg/networking/core/cluster_traffic_policy.go
+++ b/pilot/pkg/networking/core/cluster_traffic_policy.go
@@ -46,9 +46,12 @@ func (cb *ClusterBuilder) applyTrafficPolicy(service *model.Service, opts buildC
 	if connectionPool == nil {
 		connectionPool = &networking.ConnectionPoolSettings{}
 	}
-	cb.applyConnectionPool(opts.mesh, opts.mutable, connectionPool, retryBudget)
+	// Apply h2 upgrade s.t. h2 connection pool settings can be applied to the cluster.
 	if opts.direction != model.TrafficDirectionInbound {
 		cb.applyH2Upgrade(opts.mutable, opts.port, opts.mesh, connectionPool)
+	}
+	cb.applyConnectionPool(opts.mesh, opts.mutable, connectionPool, retryBudget)
+	if opts.direction != model.TrafficDirectionInbound {
 		applyOutlierDetection(service, opts.mutable.cluster, outlierDetection)
 		applyLoadBalancer(service, opts.mutable.cluster, loadBalancer, opts.port, cb.locality, cb.proxyLabels, opts.mesh)
 		if opts.clusterMode != SniDnatClusterMode {

--- a/releasenotes/notes/bugfix-http2-upgrade-policy.yaml
+++ b/releasenotes/notes/bugfix-http2-upgrade-policy.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed** an issue where HTTP/2 connection pool settings was not being applied to clusters when enabling HTTP/2 upgrade policies.

--- a/releasenotes/notes/bugfix-http2-upgrade-policy.yaml
+++ b/releasenotes/notes/bugfix-http2-upgrade-policy.yaml
@@ -3,4 +3,4 @@ kind: bug-fix
 area: traffic-management
 releaseNotes:
   - |
-    **Fixed** an issue where HTTP/2 connection pool settings was not being applied to clusters when enabling HTTP/2 upgrade policies.
+    **Fixed** an issue where HTTP/2 connection pool settings are not applied when enabling HTTP/2 upgrades


### PR DESCRIPTION
**Please provide a description of this PR:**
* Bugfix where `UpstreamHTTPProtocolOptions` was mistaken for `UpstreamProtocolOptions` in `setH2Options()`
* For http1 clusters that have been upgraded to http2, it may still be useful to apply http2 connection pool settings. This currently won't happen due to the `http2ProtocolOptions` being `nil` when `applyConnectionPool` is called. 


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
