### PR TITLE
pilot: config_dump of SDS corrupts XDS cache

### DIFF
--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -626,6 +626,9 @@ func (s *DiscoveryServer) getConfigDumpByResourceType(conn *Connection, req *mod
 						continue
 					}
 					if secret.GetTlsCertificate() != nil {
+						// When utilizing XDS caching, the resource object is shared, so modifying this would modify the cached item
+						// Make a clone
+						rr = protomarshal.Clone(rr)
 						secret.GetTlsCertificate().PrivateKey = &core.DataSource{
 							Specifier: &core.DataSource_InlineBytes{
 								InlineBytes: []byte("[redacted]"),


### PR DESCRIPTION
Steps to reproduce:

* Have a TLS cert
* Call config_dump
* Connect via XDS; the mutated private key is cached and returns `[redacted]` to envoy instead of the private key, giving a NO_START_LINE