### PR TITLE
pilot: fix data race in hostname modification

### DIFF
--- a/pilot/pkg/model/gateway.go
+++ b/pilot/pkg/model/gateway.go
@@ -27,6 +27,7 @@ import (
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/monitoring"
+	"istio.io/istio/pkg/util/protomarshal"
 	"istio.io/istio/pkg/util/sets"
 )
 
@@ -191,7 +192,7 @@ func mergeGateways(gateways []gatewayWithInstances, proxy *Proxy, ps *PushContex
 				RecordRejectedConfig(gatewayName)
 				continue
 			}
-			sanitizeServerHostNamespace(s, gatewayConfig.Namespace)
+			s := sanitizeServerHostNamespace(s, gatewayConfig.Namespace)
 			gatewayNameForServer[s] = gatewayName
 			log.Debugf("mergeGateways: gateway %q processing server %s :%v", gatewayName, s.Name, s.Hosts)
 
@@ -573,21 +574,27 @@ func ParseGatewayRDSRouteName(name string) (portNumber int, portName, gatewayNam
 // convert ./host to currentNamespace/Host
 // */host to just host
 // */* to just *
-func sanitizeServerHostNamespace(server *networking.Server, namespace string) {
+func sanitizeServerHostNamespace(server *networking.Server, namespace string) *networking.Server {
+	needsClone := true
 	for i, h := range server.Hosts {
 		if strings.Contains(h, "/") {
 			parts := strings.Split(h, "/")
+			if needsClone {
+				server = protomarshal.Clone(server)
+				needsClone = false
+			}
 			if parts[0] == "." {
 				server.Hosts[i] = namespace + "/" + parts[1] // format: %s/%s
 			} else if parts[0] == "*" {
 				if parts[1] == "*" {
 					server.Hosts = []string{"*"}
-					return
+					continue
 				}
 				server.Hosts[i] = parts[1]
 			}
 		}
 	}
+	return server
 }
 
 type GatewayPortMap map[int]sets.Set[int]


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/57449

The problem is multiple threads can concurrently enter mergeGateways, and then attempt to modify the shared *gateway.Server object. This is a shared object from the informer cache, so whatever we change once sticks around permanently (so, regardless of race, we should never have done this).

In the original issue, we saw 2 charecters trunacated off the end. This is due to us removing 2 chars from the front (`*/`); I think due to the race we end up setting the length of the resulting array wrong or something like that.

For testing, I applied the original configs from the issue in a loop. It was very very hard to get a case with the truncation, but I got it a few times. I then found the bug by code inspection and realized I should turn on `-race`; this immediately found the bug I identified. Fixing the bug and keeping `-race` shows no issues.

**Please provide a description of this PR:**