### PR TITLE
Fix envoyfilter not working when virtualservice configured

### DIFF
--- a/pilot/pkg/networking/core/listener_waypoint.go
+++ b/pilot/pkg/networking/core/listener_waypoint.go
@@ -42,6 +42,7 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	istionetworking "istio.io/istio/pilot/pkg/networking"
+	"istio.io/istio/pilot/pkg/networking/core/envoyfilter"
 	"istio.io/istio/pilot/pkg/networking/core/extension"
 	"istio.io/istio/pilot/pkg/networking/core/match"
 	istio_route "istio.io/istio/pilot/pkg/networking/core/route"
@@ -862,11 +863,14 @@ func buildWaypointInboundHTTPRouteConfig(lb *ListenerBuilder, svc *model.Service
 		Routes:  routes,
 	}
 
-	return &route.RouteConfiguration{
-		Name:             cc.clusterName,
-		VirtualHosts:     []*route.VirtualHost{inboundVHost},
-		ValidateClusters: proto.BoolFalse,
-	}
+	// Serviceentries should be patched when virtualservice exists.
+	return envoyfilter.ApplyRouteConfigurationPatches(networking.EnvoyFilter_SIDECAR_INBOUND, lb.node,
+		lb.push.EnvoyFilters(lb.node),
+		&route.RouteConfiguration{
+			Name:             cc.clusterName,
+			VirtualHosts:     []*route.VirtualHost{inboundVHost},
+			ValidateClusters: proto.BoolFalse,
+		})
 }
 
 // Select the config pertaining to the service being processed.


### PR DESCRIPTION
**Please provide a description of this PR:**

The envoyfilter would be patched correctly until virtualservice removed.

Here is my vs and envoyfilter configuration:

```yaml
apiVersion: networking.istio.io/v1
kind: VirtualService
metadata:
  name: podinfo
spec:
  hosts:
  - podinfo
  http:
  - match:
    - uri:
        exact: /headers
      port: 9898
    route:
    - destination:
        host: podinfo
        port:
          number: 9898
    name: api-headers
  - route:
    - destination:
        host: podinfo
```

```yaml
apiVersion: networking.istio.io/v1alpha3
kind: EnvoyFilter
metadata:
  name: filter-local-ratelimit-svc
  namespace: default
spec:
  workloadSelector:
    labels:
      gateway.networking.k8s.io/gateway-name: waypoint
      # app: nginx
  configPatches:
    - applyTo: HTTP_FILTER
      match:
        context: SIDECAR_INBOUND
        listener:
          filterChain:
            filter:
              name: "envoy.filters.network.http_connection_manager"
      patch:
        operation: INSERT_BEFORE
        value:
          name: envoy.filters.http.local_ratelimit
          typed_config:
            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
            type_url: type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
            value:
              stat_prefix: http_local_rate_limiter
    - applyTo: HTTP_ROUTE
      match:
        context: SIDECAR_INBOUND
        routeConfiguration:
          vhost:
            name: inbound|http|9898
            route:
              name: "api-headers"
      patch:
        operation: MERGE
        value:
          typed_per_filter_config:
            envoy.filters.http.local_ratelimit:
              "@type": type.googleapis.com/udpa.type.v1.TypedStruct
              type_url: type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
              value:
                stat_prefix: http_local_rate_limiter
                token_bucket:
                  max_tokens: 4
                  tokens_per_fill: 4
                  fill_interval: 60s
                filter_enabled:
                  runtime_key: local_rate_limit_enabled
                  default_value:
                    numerator: 100
                    denominator: HUNDRED
                filter_enforced:
                  runtime_key: local_rate_limit_enforced
                  default_value:
                    numerator: 100
                    denominator: HUNDRED
                response_headers_to_add:
                  - append: false
                    header:
                      key: x-local-rate-limit
                      value: 'true'
```

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Ambient