### PR TITLE
Fix shadow service issues when an InferencePool has more than one TargetPort

### DIFF
--- a/pilot/pkg/config/kube/gateway/inferencepool_collection.go
+++ b/pilot/pkg/config/kube/gateway/inferencepool_collection.go
@@ -509,6 +509,7 @@ func translateShadowServiceToService(existingLabels map[string]string, shadow sh
 	dummyPort := int32(54320) // Dummy port, not used for anything
 	for i, port := range shadow.targetPorts {
 		ports = append(ports, corev1.ServicePort{
+			Name:       "port" + intstr.FromInt(i),
 			Protocol:   corev1.ProtocolTCP,
 			Port:       dummyPort + int32(i),
 			TargetPort: intstr.FromInt(int(port.port)),


### PR DESCRIPTION
Added the Name parameter to ports created for the InferencePool shado…w service

**Please provide a description of this PR:**

Istiod/pilot creates a shadow service when an HTTPRoute references an Inference Gateway InferencePool object. If there are more than one TargetPorts in the InferencePool object, the shadow service is created with multiple ports, but they are missing the name parameter.

This PR fixes the problem by adding a name to each of the ports on the shadow service. Each port in the shadow service is given a name of the form `portN`, where N is a number between zero and the number of TargetPorts minus one.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
