### PR TITLE
Fix typo proivde -> provide , dependant -> dependent

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/nodes.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/nodes.go
@@ -86,7 +86,7 @@ func GlobalNodesCollection(
 
 // NodesCollection maps a node to it's locality.
 // In many environments, nodes change frequently causing excessive recomputation of workloads.
-// By making an intermediate collection we can reduce the times we need to trigger dependants (locality should ~never change).
+// By making an intermediate collection we can reduce the times we need to trigger dependents (locality should ~never change).
 func NodesCollection(nodes krt.Collection[*v1.Node], opts ...krt.CollectionOption) krt.Collection[Node] {
 	return krt.NewCollection(nodes, func(ctx krt.HandlerContext, k *v1.Node) *Node {
 		node := &Node{

--- a/pkg/kube/krt/recomputetrigger.go
+++ b/pkg/kube/krt/recomputetrigger.go
@@ -31,7 +31,7 @@ func (c RecomputeProtected[T]) Get(ctx HandlerContext) T {
 	return c.data
 }
 
-// TriggerRecomputation tells all dependants to recompute
+// TriggerRecomputation tells all dependents to recompute
 func (c RecomputeProtected[T]) TriggerRecomputation() {
 	c.trigger.TriggerRecomputation()
 }
@@ -82,7 +82,7 @@ func NewRecomputeTrigger(startSynced bool, opts ...CollectionOption) *RecomputeT
 	return &RecomputeTrigger{inner: inner, i: atomic.NewInt32(0)}
 }
 
-// TriggerRecomputation tells all dependants to recompute
+// TriggerRecomputation tells all dependents to recompute
 func (r *RecomputeTrigger) TriggerRecomputation() {
 	v := r.i.Inc()
 	r.inner.Set(ptr.Of(v))

--- a/pkg/monitoring/monitoring_test.go
+++ b/pkg/monitoring/monitoring_test.go
@@ -102,7 +102,7 @@ func TestRegisterIfSum(t *testing.T) {
 	mt.Assert(testConditionalSum.Name(), map[string]string{"name": "foo", "kind": "bar"}, monitortest.Exactly(1))
 }
 
-// Create distinct metrics for this test, otherwise we are order-dependant since they are globals
+// Create distinct metrics for this test, otherwise we are order-dependent since they are globals
 var (
 	testEmptyGauge = monitoring.NewGauge(
 		"test_empty_gauge",

--- a/samples/kind-lb/README.md
+++ b/samples/kind-lb/README.md
@@ -41,7 +41,7 @@ is hard coded as 200-240. As you might have guessed, for each k8s cluster one ca
 create at most 40 public IP v4 addresses.
 
 The `ip-space` parameter is not required when you create just one cluster, however, when
-running multiple k8s clusters it is important to proivde different values for each cluster
+running multiple k8s clusters it is important to provide different values for each cluster
 to avoid overlapping addresses.
 
 For example, to create two clusters, run the script two times with the following


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix typo : proivde -> provide
- `samples/kind-lb/README.md`

Fix typo : dependant -> dependent
- `pilot/pkg/serviceregistry/kube/controller/ambient/nodes.go`
- `pkg/kube/krt/recomputetrigger.go`
- `pkg/monitoring/monitoring_test.go`