### PR TITLE
feat(ztunnel): add ServiceAccount configuration fields

### DIFF
--- a/manifests/charts/ztunnel/templates/_helpers.tpl
+++ b/manifests/charts/ztunnel/templates/_helpers.tpl
@@ -1,4 +1,4 @@
-{{ define "ztunnel.release-name" }}{{ .Values.resourceName| default "ztunnel" }}{{ end }}
+{{ define "ztunnel.release-name" }}{{ .Values.resourceName | default "ztunnel" }}{{ end }}
 
 {{ define "ztunnel.service-account-name" }}{{ .Values.serviceAccount.name | default (include "ztunnel.release-name" .) }}{{ end }}
 

--- a/manifests/charts/ztunnel/templates/_helpers.tpl
+++ b/manifests/charts/ztunnel/templates/_helpers.tpl
@@ -1,1 +1,29 @@
 {{ define "ztunnel.release-name" }}{{ .Values.resourceName| default "ztunnel" }}{{ end }}
+
+{{ define "ztunnel.service-account-name" }}{{ .Values.serviceAccount.name | default (include "ztunnel.release-name" .) }}{{ end }}
+
+{{/*
+Merge common annotations with revision
+*/}}
+{{- define "ztunnel.common-annotations" -}}
+{{- $mergedAnnotations := dict }}
+{{- if .Values.annotations }}
+  {{- $mergedAnnotations = merge $mergedAnnotations .Values.annotations }}
+{{- end }}
+{{- if .Values.revision }}
+  {{- $mergedAnnotations = set $mergedAnnotations "istio.io/rev" .Values.revision }}
+{{- end }}
+{{- toYaml $mergedAnnotations }}
+{{- end }}
+
+{{/*
+Merge annotations for ServiceAccount (includes serviceAccount.annotations)
+*/}}
+{{- define "ztunnel.serviceaccount-annotations" -}}
+{{- $commonAnnotations := include "ztunnel.common-annotations" . | fromYaml }}
+{{- $mergedAnnotations := $commonAnnotations | default dict }}
+{{- if .Values.serviceAccount.annotations }}
+  {{- $mergedAnnotations = merge $mergedAnnotations .Values.serviceAccount.annotations }}
+{{- end }}
+{{- toYaml $mergedAnnotations }}
+{{- end }}

--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -7,13 +7,10 @@ metadata:
     app.kubernetes.io/name: ztunnel
     {{- include "istio.labels" . | nindent 4}}
     {{ with .Values.labels -}}{{ toYaml . | nindent 4}}{{ end }}
+  {{- with (include "ztunnel.common-annotations" .) }}
   annotations:
-{{- if .Values.revision }}
-    {{- $annos := set $.Values.annotations "istio.io/rev" .Values.revision }}
-    {{- toYaml $annos | nindent 4}}
-{{- else }}
-    {{- .Values.annotations | toYaml | nindent 4 }}
-{{- end }}
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   {{- with .Values.updateStrategy }}
   updateStrategy:

--- a/manifests/charts/ztunnel/templates/rbac.yaml
+++ b/manifests/charts/ztunnel/templates/rbac.yaml
@@ -1,44 +1,18 @@
-apiVersion: v1
-kind: ServiceAccount
-  {{- with .Values.imagePullSecrets }}
-imagePullSecrets:
-  {{- range . }}
-  - name: {{ . }}
-  {{- end }}
-  {{- end }}
-metadata:
-  name: {{ include "ztunnel.release-name" . }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app.kubernetes.io/name: ztunnel
-    {{- include "istio.labels" . | nindent 4}}
-    {{ with .Values.labels -}}{{ toYaml . | nindent 4}}{{ end }}
-  annotations:
-{{- if .Values.revision }}
-    {{- $annos := set $.Values.annotations "istio.io/rev" .Values.revision }}
-    {{- toYaml $annos | nindent 4}}
-{{- else }}
-    {{- .Values.annotations | toYaml | nindent 4 }}
-{{- end }}
----
-{{- if (eq (.Values.platform | default "") "openshift") }}
+{{- if and .Values.rbac.enabled (eq (.Values.platform | default "") "openshift") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "ztunnel.release-name" . }}
+  name: {{ include "ztunnel.service-account-name" . }}
   labels:
     app: ztunnel
     release: {{ include "ztunnel.release-name" . }}
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     app.kubernetes.io/name: ztunnel
     {{- include "istio.labels" . | nindent 4}}
+  {{- with (include "ztunnel.common-annotations" .) }}
   annotations:
-{{- if .Values.revision }}
-    {{- $annos := set $.Values.annotations "istio.io/rev" .Values.revision }}
-    {{- toYaml $annos | nindent 4}}
-{{- else }}
-    {{- .Values.annotations | toYaml | nindent 4 }}
-{{- end }}
+    {{- . | nindent 4 }}
+  {{- end }}
 rules:
 - apiGroups: ["security.openshift.io"]
   resources: ["securitycontextconstraints"]
@@ -48,27 +22,24 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "ztunnel.release-name" . }}
+  name: {{ include "ztunnel.service-account-name" . }}
   labels:
     app: ztunnel
     release: {{ include "ztunnel.release-name" . }}
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     app.kubernetes.io/name: ztunnel
     {{- include "istio.labels" . | nindent 4}}
+  {{- with (include "ztunnel.common-annotations" .) }}
   annotations:
-{{- if .Values.revision }}
-    {{- $annos := set $.Values.annotations "istio.io/rev" .Values.revision }}
-    {{- toYaml $annos | nindent 4}}
-{{- else }}
-    {{- .Values.annotations | toYaml | nindent 4 }}
-{{- end }}
+    {{- . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "ztunnel.release-name" . }}
+  name: {{ include "ztunnel.service-account-name" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "ztunnel.release-name" . }}
+  name: {{ include "ztunnel.service-account-name" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
 ---

--- a/manifests/charts/ztunnel/templates/serviceaccount.yaml
+++ b/manifests/charts/ztunnel/templates/serviceaccount.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+  {{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- range . }}
+  - name: {{ . }}
+  {{- end }}
+  {{- end }}
+metadata:
+  name: {{ include "ztunnel.service-account-name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: ztunnel
+    {{- include "istio.labels" . | nindent 4}}
+    {{- with .Values.labels }}{{ toYaml . | nindent 4}}{{- end }}
+  {{- with (include "ztunnel.serviceaccount-annotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/manifests/charts/ztunnel/values.yaml
+++ b/manifests/charts/ztunnel/values.yaml
@@ -22,6 +22,20 @@ _internal_defaults_do_not_set:
   # If you set this, you MUST also set `trustedZtunnelName` in the `istiod` chart.
   resourceName: ""
 
+  rbac:
+    # If enabled, roles/role bindings will be created to enable ztunnel to function.
+    # This is required for OpenShift support, as it needs additional permissions.
+    enabled: true
+
+  serviceAccount:
+    # If set, a service account will be created. Otherwise, the default is used
+    create: true
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set, the release name is used
+    name: ""
+
   # Labels to apply to all top level resources
   labels: {}
   # Annotations to apply to all top level resources
@@ -32,7 +46,7 @@ _internal_defaults_do_not_set:
 
   # Additional volumes to the ztunnel pod
   volumes: []
-  
+
   # Tolerations for the ztunnel pod
   tolerations:
     - effect: NoSchedule

--- a/manifests/charts/ztunnel/values.yaml
+++ b/manifests/charts/ztunnel/values.yaml
@@ -19,7 +19,8 @@ _internal_defaults_do_not_set:
     network: ""
 
   # resourceName, if set, will override the naming of resources. If not set, will default to 'ztunnel'.
-  # If you set this, you MUST also set `trustedZtunnelName` in the `istiod` chart.
+  # IMPORTANT: If you set this, you MUST also set `trustedZtunnelName` in the `istiod` chart to match this value.
+  # This ensures proper authentication between ztunnel and istiod components.
   resourceName: ""
 
   rbac:
@@ -33,7 +34,9 @@ _internal_defaults_do_not_set:
     # Annotations to add to the service account
     annotations: {}
     # The name of the service account to use.
-    # If not set, the release name is used
+    # If not set, defaults to the value of .Values.resourceName (which defaults to 'ztunnel' if not set).
+    # IMPORTANT: If you set this value, you MUST also set `trustedZtunnelName` in the `istiod` chart to match this name.
+    # This ensures proper authentication between ztunnel and istiod components.
     name: ""
 
   # Labels to apply to all top level resources

--- a/releasenotes/notes/ztunnel-serviceaccount-config.yaml
+++ b/releasenotes/notes/ztunnel-serviceaccount-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue:
+  - 57682
+releaseNotes:
+  - |
+    **Added** ServiceAccount configuration fields for ztunnel Helm chart. This allows customization of the ServiceAccount name and annotations, providing more flexibility for different deployment scenarios.


### PR DESCRIPTION
**Please provide a description of this PR:**

Add ServiceAccount configuration fields to ztunnel Helm chart.

Fixed #57682

This allows users to:
- Control ServiceAccount creation with `serviceAccount.create`
- Customize ServiceAccount name with `serviceAccount.name`
- Add custom annotations with `serviceAccount.annotations`

These changes provide more flexibility for environments with specific ServiceAccount requirements or naming conventions.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.