### PR TITLE
use comparable to replace Parseable

### DIFF
--- a/cni/pkg/cmd/root.go
+++ b/cni/pkg/cmd/root.go
@@ -269,7 +269,7 @@ func registerBooleanParameter(name string, value bool, usage string) {
 	registerEnvironment(name, value, usage)
 }
 
-func registerEnvironment[T env.Parseable](name string, defaultValue T, usage string) {
+func registerEnvironment[T comparable](name string, defaultValue T, usage string) {
 	envName := strings.Replace(strings.ToUpper(name), "-", "_", -1)
 	// Note: we do not rely on istio env package to retrieve configuration. We relies on viper.
 	// This is just to make sure the reference doc tool can generate doc with these vars as env variable at istio.io.

--- a/pilot/pkg/features/ambient.go
+++ b/pilot/pkg/features/ambient.go
@@ -70,7 +70,7 @@ var (
 )
 
 // registerAmbient registers a variable that is allowed only if EnableAmbient is set
-func registerAmbient[T env.Parseable](name string, defaultWithAmbient, defaultWithoutAmbient T, description string) T {
+func registerAmbient[T comparable](name string, defaultWithAmbient, defaultWithoutAmbient T, description string) T {
 	if EnableAmbient {
 		return env.Register(name, defaultWithAmbient, description).Get()
 	}

--- a/pkg/env/var.go
+++ b/pkg/env/var.go
@@ -116,16 +116,12 @@ func VarDescriptions() []Var {
 	return sorted
 }
 
-type Parseable interface {
-	comparable
-}
-
-type GenericVar[T Parseable] struct {
+type GenericVar[T comparable] struct {
 	Var
 	delegate specializedVar[T]
 }
 
-func Register[T Parseable](name string, defaultValue T, description string) GenericVar[T] {
+func Register[T comparable](name string, defaultValue T, description string) GenericVar[T] {
 	// Specialized cases
 	// In the future, once only Register() remains, we can likely drop most of these.
 	// However, time.Duration is needed still as it doesn't implement json.

--- a/pkg/env/var_test.go
+++ b/pkg/env/var_test.go
@@ -65,7 +65,7 @@ func TestString(t *testing.T) {
 	}
 }
 
-func runTest[T Parseable](t *testing.T, name string, v1 T, s2 string, v2 T) {
+func runTest[T comparable](t *testing.T, name string, v1 T, s2 string, v2 T) {
 	t.Run(name, func(t *testing.T) {
 		reset()
 		ev := Register(testVar, v1, "")


### PR DESCRIPTION
**Please provide a description of this PR:**
Parseable only has one item comparable . I think we can use comparable instead of Parseable.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [x] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
