### PR TITLE
Add helm chart support to override webhook service names

### DIFF
--- a/manifests/charts/base/templates/defaultrevision-validatingwebhookconfiguration.yaml
+++ b/manifests/charts/base/templates/defaultrevision-validatingwebhookconfiguration.yaml
@@ -17,11 +17,11 @@ webhooks:
       url: {{ .Values.base.validationURL }}
       {{- else }}
       service:
-        {{- if (eq .Values.defaultRevision "default") }}
-        name: istiod
-        {{- else }}
-        name: istiod-{{ .Values.defaultRevision }}
-        {{- end }}
+      {{- if .Values.base.validationService }}
+      name: {{ .Values.base.validationService }}
+      {{- else }}
+      name: istiod{{- if not (eq .Values.defaultRevision "default") }}-{{ .Values.defaultRevision }}{{- end }}
+      {{- end }}
         namespace: {{ .Values.global.istioNamespace }}
         path: "/validate"
       {{- end }}

--- a/manifests/charts/base/templates/defaultrevision-validatingwebhookconfiguration.yaml
+++ b/manifests/charts/base/templates/defaultrevision-validatingwebhookconfiguration.yaml
@@ -17,11 +17,11 @@ webhooks:
       url: {{ .Values.base.validationURL }}
       {{- else }}
       service:
-      {{- if .Values.base.validationService }}
-      name: {{ .Values.base.validationService }}
-      {{- else }}
-      name: istiod{{- if not (eq .Values.defaultRevision "default") }}-{{ .Values.defaultRevision }}{{- end }}
-      {{- end }}
+        {{- if .Values.base.validationService }}
+        name: {{ .Values.base.validationService }}
+        {{- else }}
+        name: istiod{{- if not (eq .Values.defaultRevision "default") }}-{{ .Values.defaultRevision }}{{- end }}
+        {{- end }}
         namespace: {{ .Values.global.istioNamespace }}
         path: "/validate"
       {{- end }}

--- a/manifests/charts/base/values.yaml
+++ b/manifests/charts/base/values.yaml
@@ -26,6 +26,11 @@ _internal_defaults_do_not_set:
     # Validation webhook configuration url
     # For example: https://$remotePilotAddress:15017/validate
     validationURL: ""
+
+    # Validation webhook configuration service name
+    # For example: istiod
+    validationService: ""
+
     # Validation webhook caBundle value. Useful when running pilot with a well known cert
     validationCABundle: ""
 

--- a/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -4,6 +4,7 @@
 {{- $whv := dict
 "revision" .Values.revision
   "injectionPath" .Values.istiodRemote.injectionPath
+  "injectionService" .Values.istiodRemote.injectionService
   "injectionURL" .Values.istiodRemote.injectionURL
   "reinvocationPolicy" .Values.sidecarInjectorWebhook.reinvocationPolicy
   "caBundle" .Values.istiodRemote.injectionCABundle
@@ -17,7 +18,11 @@ a unique prefix to each. */}}
     url: "{{ .injectionURL }}"
     {{- else }}
     service:
+      {{- if .injectionService }}
+      name: {{ .injectionService }}
+      {{- else }}
       name: istiod{{- if not (eq .revision "") }}-{{ .revision }}{{- end }}
+      {{- end }}
       namespace: {{ .namespace }}
       path: "{{ .injectionPath }}"
       port: 443

--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags-mwc.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags-mwc.yaml
@@ -5,6 +5,7 @@
 {{- $whv := dict
 "revision" .Values.revision
   "injectionPath" .Values.istiodRemote.injectionPath
+  "injectionService" .Values.istiodRemote.injectionService
   "injectionURL" .Values.istiodRemote.injectionURL
   "reinvocationPolicy" .Values.sidecarInjectorWebhook.reinvocationPolicy
   "caBundle" .Values.istiodRemote.injectionCABundle
@@ -18,7 +19,11 @@ a unique prefix to each. */}}
     url: "{{ .injectionURL }}"
     {{- else }}
     service:
+      {{- if .injectionService }}
+      name: {{ .injectionService }}
+      {{- else }}
       name: istiod{{- if not (eq .revision "") }}-{{ .revision }}{{- end }}
+      {{- end }}
       namespace: {{ .namespace }}
       path: "{{ .injectionPath }}"
       port: 443

--- a/manifests/charts/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
@@ -22,7 +22,11 @@ webhooks:
       url: {{ .Values.base.validationURL }}
       {{- else }}
       service:
+        {{- if .Values.base.validationService }}
+        name: {{ .Values.base.validationService }}
+        {{- else }}
         name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+        {{- end }}
         namespace: {{ .Values.global.istioNamespace }}
         path: "/validate"
       {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -192,6 +192,10 @@ _internal_defaults_do_not_set:
     # Override to pass env variables, for example: /inject/cluster/remote/net/network2
     injectionPath: "/inject"
 
+    # Sidecar injector mutating webhook configuration service name value for the clientConfig.service field.
+    # Override to use a different service name for the sidecar injector webhook.
+    injectionService: ""
+
     injectionCABundle: ""
   telemetry:
     enabled: true
@@ -359,7 +363,7 @@ _internal_defaults_do_not_set:
 
       #If set to true, istio-proxy container will have privileged securityContext
       privileged: false
-      
+
       seccompProfile: {}
 
       # The number of successive failed probes before indicating readiness failure.
@@ -563,7 +567,7 @@ _internal_defaults_do_not_set:
   #         type: ClusterIP
   # Per-Gateway configuration can also be set in the `Gateway.spec.infrastructure.parametersRef` field.
   gatewayClasses: {}
-  
+
   pdb:
     # -- Minimum available pods set in PodDisruptionBudget.
     # Define either 'minAvailable' or 'maxUnavailable', never both.

--- a/operator/pkg/apis/values_types.pb.go
+++ b/operator/pkg/apis/values_types.pb.go
@@ -4792,8 +4792,10 @@ type BaseConfig struct {
 	ValidateGateway       *wrapperspb.BoolValue `protobuf:"bytes,4,opt,name=validateGateway,proto3" json:"validateGateway,omitempty"`
 	// validation webhook CA bundle
 	ValidationCABundle string `protobuf:"bytes,5,opt,name=validationCABundle,proto3" json:"validationCABundle,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// validation webhook service
+	ValidationService string `protobuf:"bytes,7,opt,name=validationService,proto3" json:"validationService,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *BaseConfig) Reset() {
@@ -4868,6 +4870,13 @@ func (x *BaseConfig) GetValidationCABundle() string {
 	return ""
 }
 
+func (x *BaseConfig) GetValidationService() string {
+	if x != nil {
+		return x.ValidationService
+	}
+	return ""
+}
+
 type IstiodRemoteConfig struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// URL to use for sidecar injector webhook.
@@ -4876,6 +4885,8 @@ type IstiodRemoteConfig struct {
 	InjectionPath string `protobuf:"bytes,2,opt,name=injectionPath,proto3" json:"injectionPath,omitempty"`
 	// injector ca bundle
 	InjectionCABundle string `protobuf:"bytes,3,opt,name=injectionCABundle,proto3" json:"injectionCABundle,omitempty"`
+	// Service name to use for sidecar injector webhook
+	InjectionService string `protobuf:"bytes,7,opt,name=injectionService,proto3" json:"injectionService,omitempty"`
 	// Indicates if this cluster/install should consume a "remote" istiod instance,
 	Enabled *wrapperspb.BoolValue `protobuf:"bytes,5,opt,name=enabled,proto3" json:"enabled,omitempty"`
 	// If `true`, indicates that this cluster/install should consume a "local istiod" installation,
@@ -4932,6 +4943,13 @@ func (x *IstiodRemoteConfig) GetInjectionPath() string {
 func (x *IstiodRemoteConfig) GetInjectionCABundle() string {
 	if x != nil {
 		return x.InjectionCABundle
+	}
+	return ""
+}
+
+func (x *IstiodRemoteConfig) GetInjectionService() string {
+	if x != nil {
+		return x.InjectionService
 	}
 	return ""
 }
@@ -5818,7 +5836,7 @@ const file_pkg_apis_values_types_proto_rawDesc = "" +
 	"\x05debug\x18\x01 \x01(\v2\x1a.google.protobuf.BoolValueR\x05debug\x124\n" +
 	"\x15maxNumberOfAttributes\x18\x02 \x01(\rR\x15maxNumberOfAttributes\x126\n" +
 	"\x16maxNumberOfAnnotations\x18\x03 \x01(\rR\x16maxNumberOfAnnotations\x12:\n" +
-	"\x18maxNumberOfMessageEvents\x18\x04 \x01(\rR\x18maxNumberOfMessageEvents\"\xea\x02\n" +
+	"\x18maxNumberOfMessageEvents\x18\x04 \x01(\rR\x18maxNumberOfMessageEvents\"\x98\x03\n" +
 	"\n" +
 	"BaseConfig\x12J\n" +
 	"\x12enableCRDTemplates\x18\x01 \x01(\v2\x1a.google.protobuf.BoolValueR\x12enableCRDTemplates\x12\"\n" +
@@ -5826,11 +5844,13 @@ const file_pkg_apis_values_types_proto_rawDesc = "" +
 	"\rvalidationURL\x18\x02 \x01(\tR\rvalidationURL\x12P\n" +
 	"\x15enableIstioConfigCRDs\x18\x03 \x01(\v2\x1a.google.protobuf.BoolValueR\x15enableIstioConfigCRDs\x12D\n" +
 	"\x0fvalidateGateway\x18\x04 \x01(\v2\x1a.google.protobuf.BoolValueR\x0fvalidateGateway\x12.\n" +
-	"\x12validationCABundle\x18\x05 \x01(\tR\x12validationCABundle\"\x9e\x02\n" +
+	"\x12validationCABundle\x18\x05 \x01(\tR\x12validationCABundle\x12,\n" +
+	"\x11validationService\x18\a \x01(\tR\x11validationService\"\xca\x02\n" +
 	"\x12IstiodRemoteConfig\x12\"\n" +
 	"\finjectionURL\x18\x01 \x01(\tR\finjectionURL\x12$\n" +
 	"\rinjectionPath\x18\x02 \x01(\tR\rinjectionPath\x12,\n" +
-	"\x11injectionCABundle\x18\x03 \x01(\tR\x11injectionCABundle\x124\n" +
+	"\x11injectionCABundle\x18\x03 \x01(\tR\x11injectionCABundle\x12*\n" +
+	"\x10injectionService\x18\a \x01(\tR\x10injectionService\x124\n" +
 	"\aenabled\x18\x05 \x01(\v2\x1a.google.protobuf.BoolValueR\aenabled\x12Z\n" +
 	"\x1aenabledLocalInjectorIstiod\x18\x06 \x01(\v2\x1a.google.protobuf.BoolValueR\x1aenabledLocalInjectorIstiod\"\xd7\b\n" +
 	"\x06Values\x124\n" +

--- a/operator/pkg/apis/values_types.proto
+++ b/operator/pkg/apis/values_types.proto
@@ -150,7 +150,7 @@ message CNIConfig {
 
   // Specifies if an Istio owned CNI config should be created.
   google.protobuf.BoolValue istioOwnedCNIConfig = 35;
-  
+
   string istioOwnedCNIConfigFileName = 36;
 }
 
@@ -1358,6 +1358,9 @@ message BaseConfig {
 
   // validation webhook CA bundle
   string validationCABundle = 5;
+
+  // validation webhook service
+  string validationService = 7;
 }
 
 message IstiodRemoteConfig {
@@ -1367,6 +1370,8 @@ message IstiodRemoteConfig {
   string injectionPath = 2;
   // injector ca bundle
   string injectionCABundle = 3;
+  // Service name to use for sidecar injector webhook
+  string injectionService = 7;
   // Indicates if this cluster/install should consume a "remote" istiod instance,
   google.protobuf.BoolValue enabled = 5;
   // If `true`, indicates that this cluster/install should consume a "local istiod" installation,

--- a/releasenotes/notes/webhook-service-name.yaml
+++ b/releasenotes/notes/webhook-service-name.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+
+# issue is a list of GitHub issues resolved in this note.
+issue: []
+
+releaseNotes:
+  - |
+    **Added** helm chart support for configuring service name for validation and injection webhooks


### PR DESCRIPTION
Adds the option to modify the service name of all webhooks. 

This is useful in implementing this [workaround](https://github.com/istio/istio/issues/45738#issuecomment-2602958354) when encountering the issue described in #45738 (in brief, when running a custom CNI on a managed control plane, webhook recipients must be on the hostNetwork)