### PR TITLE
chore: remove comments about MaxRequests or MaxPendingRequests only applying to particular HTTP version

### DIFF
--- a/pilot/pkg/networking/core/cluster_traffic_policy.go
+++ b/pilot/pkg/networking/core/cluster_traffic_policy.go
@@ -109,11 +109,9 @@ func (cb *ClusterBuilder) applyConnectionPool(mesh *meshconfig.MeshConfig,
 
 	if settings.Http != nil {
 		if settings.Http.Http2MaxRequests > 0 {
-			// Envoy only applies MaxRequests in HTTP/2 clusters
 			threshold.MaxRequests = &wrapperspb.UInt32Value{Value: uint32(settings.Http.Http2MaxRequests)}
 		}
 		if settings.Http.Http1MaxPendingRequests > 0 {
-			// Envoy only applies MaxPendingRequests in HTTP/1.1 clusters
 			threshold.MaxPendingRequests = &wrapperspb.UInt32Value{Value: uint32(settings.Http.Http1MaxPendingRequests)}
 		}
 


### PR DESCRIPTION
**Please provide a description of this PR:**

The circuit-breaker connection pool settings `MaxRequests`and `MaxPendingRequests` apply to HTTP/1.1 as well as HTTP/2 since [1] and [2].

This was actually changed in the Istio docs via [3], but these source code comments were left, potentially causing confusion.

[1] https://github.com/envoyproxy/envoy/issues/9215
[2] https://github.com/envoyproxy/envoy/pull/9668
[3] https://github.com/istio/api/pull/2428

