### PR TITLE
Fix named port mapping with ServiceEntries in ambient

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
@@ -1426,14 +1426,25 @@ func constructServices(p *v1.Pod, services []model.ServiceInfo) map[string]*work
 			targetPort := port.TargetPort
 			// The svc.Ports represents the workloadapi.Service, which drops the port name info and just has numeric target Port.
 			// TargetPort can be 0 which indicates its a named port. Check if its a named port and replace with the real targetPort if so.
-			if named, f := svc.PortNames[int32(port.ServicePort)]; f && named.TargetPortName != "" {
-				// Pods only match on TargetPort names
-				tp, ok := FindPortName(p, named.TargetPortName)
-				if !ok {
-					// Port not present for this workload. Exclude the port entirely
-					continue
+			if named, f := svc.PortNames[int32(port.ServicePort)]; f {
+				if named.TargetPortName != "" {
+					// Kubernetes Service semantics: explicit named targetPort on the Service
+					// Pods only match on TargetPort names
+					tp, ok := FindPortName(p, named.TargetPortName)
+					if !ok {
+						// Port not present for this workload. Exclude the port entirely
+						continue
+					}
+					targetPort = uint32(tp)
+				} else if svc.Source.Kind == kind.ServiceEntry && named.PortName != "" {
+					// ServiceEntry semantics: no explicit named targetPort field; match by ServiceEntry port name to Pod container port name
+					if tp, ok := FindPortName(p, named.PortName); ok {
+						targetPort = uint32(tp)
+					} else if targetPort == 0 {
+						// Fallback to service port if we couldn't resolve a name and targetPort wasn't set
+						targetPort = port.ServicePort
+					}
 				}
-				targetPort = uint32(tp)
 			}
 
 			pl.Ports = append(pl.Ports, &workloadapi.Port{

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
@@ -312,6 +312,60 @@ func TestPodWorkloads(t *testing.T) {
 			},
 		},
 		{
+			name: "pod selected by ServiceEntry honors port name mapping",
+			inputs: []any{
+				model.ServiceInfo{
+					Service: &workloadapi.Service{
+						Name:      "httpbin",
+						Namespace: "httpbin2",
+						Hostname:  "httpbin.httpbin2.mesh.internal",
+						Ports: []*workloadapi.Port{{
+							ServicePort: 8002,
+							TargetPort:  0,
+						}},
+					},
+					PortNames: map[int32]model.ServicePortName{
+						8002: {PortName: "http"},
+					},
+					LabelSelector: model.NewSelector(map[string]string{"app": "httpbin"}),
+					Source:        model.TypedObject{Kind: kind.ServiceEntry},
+				},
+			},
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "httpbin-123",
+					Namespace: "httpbin2",
+					Labels:    map[string]string{"app": "httpbin"},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{Ports: []v1.ContainerPort{{
+						Name:          "http",
+						ContainerPort: 8000,
+						Protocol:      v1.ProtocolTCP,
+					}}}},
+				},
+				Status: v1.PodStatus{Phase: v1.PodRunning, Conditions: podReady, PodIP: "10.1.1.1"},
+			},
+			result: &workloadapi.Workload{
+				Uid:               "cluster0//Pod/httpbin2/httpbin-123",
+				Name:              "httpbin-123",
+				Namespace:         "httpbin2",
+				Addresses:         [][]byte{netip.MustParseAddr("10.1.1.1").AsSlice()},
+				Network:           testNW,
+				CanonicalName:     "httpbin",
+				CanonicalRevision: "latest",
+				WorkloadType:      workloadapi.WorkloadType_POD,
+				WorkloadName:      "httpbin-123",
+				Status:            workloadapi.WorkloadStatus_HEALTHY,
+				ClusterId:         testC,
+				Services: map[string]*workloadapi.PortList{
+					"httpbin2/httpbin.httpbin2.mesh.internal": {
+						Ports: []*workloadapi.Port{{ServicePort: 8002, TargetPort: 8000}},
+					},
+				},
+			},
+		},
+		{
 			name: "simple pod with locality",
 			inputs: []any{
 				Node{

--- a/releasenotes/notes/57713.yaml
+++ b/releasenotes/notes/57713.yaml
@@ -7,4 +7,4 @@ issue:
 
 releaseNotes:
 - |
-  **Fixed** ServiceEntry port-name resolution in ztunnel now matches ServiceEntry port names to pod container ports, aligning behavior with sidecars.
+  **Fixed** ServiceEntry resolution in ztunnel now matches ServiceEntry port names to pod container ports, aligning behavior with sidecars where there isn't an explicit targetPort

--- a/releasenotes/notes/57713.yaml
+++ b/releasenotes/notes/57713.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: ambient
+
+issue:
+ - https://github.com/istio/istio/issues/57713
+
+releaseNotes:
+- |
+  **Fixed** ServiceEntry port-name resolution in ztunnel now matches ServiceEntry port names to pod container ports, aligning behavior with sidecars.


### PR DESCRIPTION
**Please provide a description of this PR:**

For ServiceEntries without a numeric targetPort that are expected to match by name, ambient translation previously failed to map the ServiceEntry port name to the pod’s container port, and always used the ServiceEntry port . The change updates the ambient workload/service translation to resolve ServiceEntry port names against pod container ports, falling back to the service port if unresolved.   This aligns the ambient/ztunnel path with the existing sidecar semantics 

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
