### PR TITLE
Add TraceContextOption support for Zipkin tracing provider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/docker/cli v28.3.3+incompatible
 	github.com/envoyproxy/go-control-plane/contrib v1.32.5-0.20250627145903-197b96a9c7f8
-	github.com/envoyproxy/go-control-plane/envoy v1.32.5-0.20250627145903-197b96a9c7f8
+	github.com/envoyproxy/go-control-plane/envoy v1.32.5-0.20250918175225-9957682f726b
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/fatih/color v1.18.0
 	github.com/felixge/fgprof v0.9.5

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/envoyproxy/go-control-plane v0.13.5-0.20250705082150-f8f2cd45490a h1:
 github.com/envoyproxy/go-control-plane v0.13.5-0.20250705082150-f8f2cd45490a/go.mod h1:whHrEUXbTAzBJlzd3Gz4us5zEFP1gL6o3LbfA+a/xbg=
 github.com/envoyproxy/go-control-plane/contrib v1.32.5-0.20250627145903-197b96a9c7f8 h1:KXgXPtBofHkRHr+8dO058dGZnLHapW7m0yJEgSYdAFA=
 github.com/envoyproxy/go-control-plane/contrib v1.32.5-0.20250627145903-197b96a9c7f8/go.mod h1:Nx/YcyEeIcgjT13QwKHdcPmS060urxZ835MeO8cLOrg=
-github.com/envoyproxy/go-control-plane/envoy v1.32.5-0.20250627145903-197b96a9c7f8 h1:/F9jLyfDeNr4iZxyibtKlZxCDqCFEhoYiLdc9VOZT2E=
-github.com/envoyproxy/go-control-plane/envoy v1.32.5-0.20250627145903-197b96a9c7f8/go.mod h1:09qwbGVuSWWAyN5t/b3iyVfz5+z8QWGrzkoqm/8SbEs=
+github.com/envoyproxy/go-control-plane/envoy v1.32.5-0.20250918175225-9957682f726b h1:xw6sdEUsSpjE6QidXaeTP7zUJxB2gEg5m4nyaWID+54=
+github.com/envoyproxy/go-control-plane/envoy v1.32.5-0.20250918175225-9957682f726b/go.mod h1:2LcmvJoXsDSrsGZIxGM0Gah9ykiwTn/kgjyQdnNH8Jc=
 github.com/envoyproxy/go-control-plane/ratelimit v0.1.0 h1:/G9QYbddjL25KvtKTv3an9lx6VBE2cnb8wp1vEGNYGI=
 github.com/envoyproxy/go-control-plane/ratelimit v0.1.0/go.mod h1:Wk+tMFAFbCXaJPzVVHnPgRKdUdwW/KdbRt94AzgRee4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=

--- a/pilot/pkg/networking/core/tracing_test.go
+++ b/pilot/pkg/networking/core/tracing_test.go
@@ -240,6 +240,22 @@ func TestConfigureTracing(t *testing.T) {
 				99.999, 256, append(defaultTracingTags(), fakeEnvTag)),
 			wantReqIDExtCtx: &defaultUUIDExtensionCtx,
 		},
+		{
+			name:   "zipkin with B3 only trace context option",
+			inSpec: fakeTracingSpec(fakeZipkinWithB3Only(), 99.999, false, true, true),
+			opts:   fakeOptsZipkinWithTraceContextOption(meshconfig.MeshConfig_ExtensionProvider_ZipkinTracingProvider_USE_B3),
+			want: fakeTracingConfig(fakeZipkinProviderWithTraceContext(clusterName, authority, DefaultZipkinEndpoint, true, tracingcfg.ZipkinConfig_USE_B3),
+				99.999, 256, append(defaultTracingTags(), fakeEnvTag)),
+			wantReqIDExtCtx: &defaultUUIDExtensionCtx,
+		},
+		{
+			name:   "zipkin with dual B3/W3C trace context option",
+			inSpec: fakeTracingSpec(fakeZipkinWithDualHeaders(), 99.999, false, true, true),
+			opts:   fakeOptsZipkinWithTraceContextOption(meshconfig.MeshConfig_ExtensionProvider_ZipkinTracingProvider_USE_B3_WITH_W3C_PROPAGATION),
+			want: fakeTracingConfig(fakeZipkinProviderWithTraceContext(clusterName, authority, DefaultZipkinEndpoint, true, tracingcfg.ZipkinConfig_USE_B3_WITH_W3C_PROPAGATION),
+				99.999, 256, append(defaultTracingTags(), fakeEnvTag)),
+			wantReqIDExtCtx: &defaultUUIDExtensionCtx,
+		},
 	}
 
 	for _, tc := range testcases {
@@ -713,6 +729,34 @@ func fakeOptsZipkinTelemetryWithEndpoint() gatewayListenerOpts {
 	return opts
 }
 
+func fakeOptsZipkinWithTraceContextOption(traceContextOption meshconfig.MeshConfig_ExtensionProvider_ZipkinTracingProvider_TraceContextOption) gatewayListenerOpts {
+	var opts gatewayListenerOpts
+	opts.push = &model.PushContext{
+		Mesh: &meshconfig.MeshConfig{
+			ExtensionProviders: []*meshconfig.MeshConfig_ExtensionProvider{
+				{
+					Name: "foo",
+					Provider: &meshconfig.MeshConfig_ExtensionProvider_Zipkin{
+						Zipkin: &meshconfig.MeshConfig_ExtensionProvider_ZipkinTracingProvider{
+							Service:            "zipkin",
+							Port:               9411,
+							MaxTagLength:       256,
+							TraceContextOption: traceContextOption,
+						},
+					},
+				},
+			},
+		},
+	}
+	opts.proxy = &model.Proxy{
+		Metadata: &model.NodeMetadata{
+			ProxyConfig: &model.NodeMetaProxyConfig{},
+		},
+	}
+
+	return opts
+}
+
 func fakeZipkin() *meshconfig.MeshConfig_ExtensionProvider {
 	return &meshconfig.MeshConfig_ExtensionProvider{
 		Name: "foo",
@@ -759,6 +803,28 @@ func fakeZipkinEnable64bitTraceID() *meshconfig.MeshConfig_ExtensionProvider {
 			},
 		},
 	}
+}
+
+func fakeZipkinWithTraceContextOption(traceContextOption meshconfig.MeshConfig_ExtensionProvider_ZipkinTracingProvider_TraceContextOption) *meshconfig.MeshConfig_ExtensionProvider {
+	return &meshconfig.MeshConfig_ExtensionProvider{
+		Name: "foo",
+		Provider: &meshconfig.MeshConfig_ExtensionProvider_Zipkin{
+			Zipkin: &meshconfig.MeshConfig_ExtensionProvider_ZipkinTracingProvider{
+				Service:            "zipkin",
+				Port:               9411,
+				MaxTagLength:       256,
+				TraceContextOption: traceContextOption,
+			},
+		},
+	}
+}
+
+func fakeZipkinWithDualHeaders() *meshconfig.MeshConfig_ExtensionProvider {
+	return fakeZipkinWithTraceContextOption(meshconfig.MeshConfig_ExtensionProvider_ZipkinTracingProvider_USE_B3_WITH_W3C_PROPAGATION)
+}
+
+func fakeZipkinWithB3Only() *meshconfig.MeshConfig_ExtensionProvider {
+	return fakeZipkinWithTraceContextOption(meshconfig.MeshConfig_ExtensionProvider_ZipkinTracingProvider_USE_B3)
 }
 
 func fakeDatadog() *meshconfig.MeshConfig_ExtensionProvider {
@@ -1215,6 +1281,10 @@ var fakeEnvTag = &tracing.CustomTag{
 }
 
 func fakeZipkinProvider(expectClusterName, expectAuthority, expectEndpoint string, enableTraceID bool) *tracingcfg.Tracing_Http {
+	return fakeZipkinProviderWithTraceContext(expectClusterName, expectAuthority, expectEndpoint, enableTraceID, tracingcfg.ZipkinConfig_USE_B3)
+}
+
+func fakeZipkinProviderWithTraceContext(expectClusterName, expectAuthority, expectEndpoint string, enableTraceID bool, traceContextOption tracingcfg.ZipkinConfig_TraceContextOption) *tracingcfg.Tracing_Http {
 	fakeZipkinProviderConfig := &tracingcfg.ZipkinConfig{
 		CollectorCluster:         expectClusterName,
 		CollectorEndpoint:        expectEndpoint,
@@ -1222,6 +1292,7 @@ func fakeZipkinProvider(expectClusterName, expectAuthority, expectEndpoint strin
 		CollectorHostname:        expectAuthority,
 		TraceId_128Bit:           enableTraceID,
 		SharedSpanContext:        wrapperspb.Bool(false),
+		TraceContextOption:       traceContextOption,
 	}
 	fakeZipkinAny := protoconv.MessageToAny(fakeZipkinProviderConfig)
 	return &tracingcfg.Tracing_Http{
@@ -1367,6 +1438,118 @@ func fakeOpenTelemetryResourceDetectorsProvider(expectClusterName, expectAuthori
 	return &tracingcfg.Tracing_Http{
 		Name:       envoyOpenTelemetry,
 		ConfigType: &tracingcfg.Tracing_Http_TypedConfig{TypedConfig: fakeOtelHTTPAny},
+	}
+}
+
+func TestConvertTraceContextOption(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    meshconfig.MeshConfig_ExtensionProvider_ZipkinTracingProvider_TraceContextOption
+		expected tracingcfg.ZipkinConfig_TraceContextOption
+	}{
+		{
+			name:     "USE_B3 option",
+			input:    meshconfig.MeshConfig_ExtensionProvider_ZipkinTracingProvider_USE_B3,
+			expected: tracingcfg.ZipkinConfig_USE_B3,
+		},
+		{
+			name:     "USE_B3_WITH_W3C_PROPAGATION option",
+			input:    meshconfig.MeshConfig_ExtensionProvider_ZipkinTracingProvider_USE_B3_WITH_W3C_PROPAGATION,
+			expected: tracingcfg.ZipkinConfig_USE_B3_WITH_W3C_PROPAGATION,
+		},
+		{
+			name:     "default fallback for unknown value",
+			input:    meshconfig.MeshConfig_ExtensionProvider_ZipkinTracingProvider_TraceContextOption(999), // Invalid enum value
+			expected: tracingcfg.ZipkinConfig_USE_B3, // Should fallback to default
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := convertTraceContextOption(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestZipkinConfig(t *testing.T) {
+	testcases := []struct {
+		name               string
+		hostname           string
+		cluster            string
+		endpoint           string
+		enable128BitTraceID bool
+		traceContextOption tracingcfg.ZipkinConfig_TraceContextOption
+		expectedConfig     *tracingcfg.ZipkinConfig
+	}{
+		{
+			name:               "basic zipkin config with USE_B3",
+			hostname:           "zipkin.istio-system.svc.cluster.local",
+			cluster:            "zipkin-cluster",
+			endpoint:           "/api/v2/spans",
+			enable128BitTraceID: true,
+			traceContextOption: tracingcfg.ZipkinConfig_USE_B3,
+			expectedConfig: &tracingcfg.ZipkinConfig{
+				CollectorCluster:         "zipkin-cluster",
+				CollectorEndpoint:        "/api/v2/spans",
+				CollectorEndpointVersion: tracingcfg.ZipkinConfig_HTTP_JSON,
+				CollectorHostname:        "zipkin.istio-system.svc.cluster.local",
+				TraceId_128Bit:           true,
+				SharedSpanContext:        wrapperspb.Bool(false),
+				TraceContextOption:       tracingcfg.ZipkinConfig_USE_B3,
+			},
+		},
+		{
+			name:               "zipkin config with dual B3/W3C headers",
+			hostname:           "zipkin.istio-system.svc.cluster.local",
+			cluster:            "zipkin-cluster",
+			endpoint:           "/api/v2/spans",
+			enable128BitTraceID: false,
+			traceContextOption: tracingcfg.ZipkinConfig_USE_B3_WITH_W3C_PROPAGATION,
+			expectedConfig: &tracingcfg.ZipkinConfig{
+				CollectorCluster:         "zipkin-cluster",
+				CollectorEndpoint:        "/api/v2/spans",
+				CollectorEndpointVersion: tracingcfg.ZipkinConfig_HTTP_JSON,
+				CollectorHostname:        "zipkin.istio-system.svc.cluster.local",
+				TraceId_128Bit:           false,
+				SharedSpanContext:        wrapperspb.Bool(false),
+				TraceContextOption:       tracingcfg.ZipkinConfig_USE_B3_WITH_W3C_PROPAGATION,
+			},
+		},
+		{
+			name:               "zipkin config with empty endpoint defaults to /api/v2/spans",
+			hostname:           "zipkin.istio-system.svc.cluster.local",
+			cluster:            "zipkin-cluster",
+			endpoint:           "",
+			enable128BitTraceID: true,
+			traceContextOption: tracingcfg.ZipkinConfig_USE_B3,
+			expectedConfig: &tracingcfg.ZipkinConfig{
+				CollectorCluster:         "zipkin-cluster",
+				CollectorEndpoint:        "/api/v2/spans",
+				CollectorEndpointVersion: tracingcfg.ZipkinConfig_HTTP_JSON,
+				CollectorHostname:        "zipkin.istio-system.svc.cluster.local",
+				TraceId_128Bit:           true,
+				SharedSpanContext:        wrapperspb.Bool(false),
+				TraceContextOption:       tracingcfg.ZipkinConfig_USE_B3,
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := zipkinConfig(tc.hostname, tc.cluster, tc.endpoint, tc.enable128BitTraceID, tc.traceContextOption)
+			assert.NoError(t, err)
+			
+			// Unmarshal the Any proto to compare the actual ZipkinConfig
+			var actualConfig tracingcfg.ZipkinConfig
+			err = result.UnmarshalTo(&actualConfig)
+			assert.NoError(t, err)
+			
+			// Compare the configurations
+			if diff := cmp.Diff(tc.expectedConfig, &actualConfig, protocmp.Transform()); diff != "" {
+				t.Fatalf("zipkinConfig returned unexpected diff (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 

--- a/releasenotes/notes/zipkin-trace-context-option.yaml
+++ b/releasenotes/notes/zipkin-trace-context-option.yaml
@@ -1,0 +1,20 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+
+# issue is a list of GitHub issues resolved in this note.
+issue:
+  # Add the actual GitHub issue number here when available
+  # - https://github.com/istio/istio/issues/XXXXX
+
+docs:
+  - '[envoy] https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/trace/v3/zipkin.proto#envoy-v3-api-enum-config-trace-v3-zipkinconfig-tracecontextoption'
+  - '[reference] https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/'
+  - '[usage] https://istio.io/latest/docs/tasks/observability/distributed-tracing/'
+
+releaseNotes:
+- |
+  **Added** support for Zipkin TraceContextOption configuration to enable dual B3/W3C header propagation.
+  Configure with `trace_context_option: USE_B3_WITH_W3C_PROPAGATION` in MeshConfig extensionProviders to
+  extract B3 headers preferentially, fall back to W3C traceparent headers, and inject both header types
+  upstream for better tracing interoperability.


### PR DESCRIPTION
## Problem
Currently, Istio's Zipkin tracing provider only supports B3 header propagation. Modern tracing systems increasingly use W3C traceparent headers, creating interoperability challenges in mixed environments.

## Solution
Implement Envoy's [TraceContextOption](cci:1://file:///Users/prashanth.chaitanya/git-workspaces/istio/pilot/pkg/networking/core/tracing.go:235:0-244:1) enum with two options:
- `USE_B3` (default): Traditional B3 header propagation
- `USE_B3_WITH_W3C_PROPAGATION`: Extract B3 headers preferentially, fall back to W3C headers, and inject both header types upstream

## Changes
- **Core Implementation**: Added [convertTraceContextOption()](cci:1://file:///Users/prashanth.chaitanya/git-workspaces/istio/pilot/pkg/networking/core/tracing.go:235:0-244:1) function and updated [zipkinConfig()](cci:1://file:///Users/prashanth.chaitanya/git-workspaces/istio/pilot/pkg/networking/core/tracing.go:20:0-20:162) in [pilot/pkg/networking/core/tracing.go](cci:7://file:///Users/prashanth.chaitanya/git-workspaces/istio/pilot/pkg/networking/core/tracing.go:0:0-0:0)
- **Configuration Support**: Extended MeshConfig with `trace_context_option` field for Zipkin providers
- **Testing**: Comprehensive unit tests covering enum conversion and configuration generation
- **Examples**: Configuration examples for both IstioOperator and Telemetry CRD approaches
- **Backward Compatibility**: Defaults to `USE_B3` when not specified

## Testing
- All existing tests pass with no regressions
- New unit tests cover [convertTraceContextOption()](cci:1://file:///Users/prashanth.chaitanya/git-workspaces/istio/pilot/pkg/networking/core/tracing.go:235:0-244:1) and [zipkinConfig()](cci:1://file:///Users/prashanth.chaitanya/git-workspaces/istio/pilot/pkg/networking/core/tracing.go:20:0-20:162) functions
- Integration tested with real Envoy config dumps showing correct `trace_context_option` application
- Tested both mesh-wide (istio-system) and namespace-specific (default) configurations

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [X] Extensions and Telemetry
- [ ] Security
- [X] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.

> **Note**: This PR has user-facing changes (new configuration option), so a release note is required and included in the PR.
