### PR TITLE
Ambient-Sidecar-Interop: Opt-in support to route sidecar traffic to ambient via waypoint

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1095,6 +1095,7 @@ func (i AddressInfo) ResourceName() string {
 type ServiceWaypointInfo struct {
 	Service            *workloadapi.Service
 	IngressUseWaypoint bool
+	SidecarUseWaypoint bool
 	WaypointHostname   string
 }
 
@@ -1176,6 +1177,11 @@ func (i ServiceInfo) GetConditions() ConditionSet {
 		} else if i.Waypoint.IngressLabelPresent {
 			buildMsg.WriteString(". Ingress traffic is not using the waypoint, set the istio.io/ingress-use-waypoint label to true if desired.")
 		}
+		if i.Waypoint.SidecarUseWaypoint {
+			buildMsg.WriteString(". Sidecar traffic will traverse the waypoint")
+		} else if i.Waypoint.SidecarLabelPresent {
+			buildMsg.WriteString(". Sidecar traffic is not using the waypoint, set the istio.io/sidecar-use-waypoint label to true if desired.")
+		}
 
 		set[WaypointBound] = &Condition{
 			Status:  true,
@@ -1200,6 +1206,8 @@ type WaypointBindingStatus struct {
 	IngressUseWaypoint bool
 	// IngressLabelPresent specifies whether the istio.io/ingress-use-waypoint label is set on the service.
 	IngressLabelPresent bool
+	SidecarUseWaypoint  bool
+	SidecarLabelPresent bool
 	// Error represents some error
 	Error *StatusMessage
 }
@@ -1213,6 +1221,8 @@ func (i WaypointBindingStatus) Equals(other WaypointBindingStatus) bool {
 	return i.ResourceName == other.ResourceName &&
 		i.IngressUseWaypoint == other.IngressUseWaypoint &&
 		i.IngressLabelPresent == other.IngressLabelPresent &&
+		i.SidecarUseWaypoint == other.SidecarUseWaypoint &&
+		i.SidecarLabelPresent == other.SidecarLabelPresent &&
 		ptr.Equal(i.Error, other.Error)
 }
 
@@ -1485,6 +1495,7 @@ func SortWorkloadsByCreationTime(workloads []WorkloadInfo) []WorkloadInfo {
 type NamespaceInfo struct {
 	Name               string
 	IngressUseWaypoint bool
+	SidecarUseWaypoint bool
 }
 
 func (i NamespaceInfo) ResourceName() string {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
@@ -208,6 +208,10 @@ func serviceServiceBuilder(
 				waypointStatus.IngressLabelPresent = true
 				waypointStatus.IngressUseWaypoint = strings.EqualFold(val, "true")
 			}
+			if val, ok := s.Labels["istio.io/sidecar-use-waypoint"]; ok {
+				waypointStatus.SidecarLabelPresent = true
+				waypointStatus.SidecarUseWaypoint = strings.EqualFold(val, "true")
+			}
 		}
 		waypointStatus.Error = wperr
 

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/sidecar_interop.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/sidecar_interop.go
@@ -115,9 +115,11 @@ func (a *index) ServicesWithWaypoint(key string) []model.ServiceWaypointInfo {
 	for _, s := range svcs {
 		wp := s.Service.GetWaypoint()
 		useWaypoint := ingressUseWaypoint(s, a.namespaces.GetKey(s.Service.Namespace))
+		sidecarUseWaypoint := sidecarUseWaypoint(s, a.namespaces.GetKey(s.Service.Namespace))
 		wi := model.ServiceWaypointInfo{
 			Service:            s.Service,
 			IngressUseWaypoint: useWaypoint,
+			SidecarUseWaypoint: sidecarUseWaypoint,
 		}
 		if wp == nil {
 			continue
@@ -151,6 +153,16 @@ func ingressUseWaypoint(s model.ServiceInfo, ns *model.NamespaceInfo) bool {
 	}
 	if ns != nil {
 		return ns.IngressUseWaypoint
+	}
+	return false
+}
+
+func sidecarUseWaypoint(s model.ServiceInfo, ns *model.NamespaceInfo) bool {
+	if s.Waypoint.SidecarLabelPresent {
+		return s.Waypoint.SidecarUseWaypoint
+	}
+	if ns != nil {
+		return ns.SidecarUseWaypoint
 	}
 	return false
 }

--- a/pilot/pkg/xds/endpoints/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder.go
@@ -864,7 +864,7 @@ func getSubSetLabels(dr *v1alpha3.DestinationRule, subsetName string) labels.Ins
 // Lookup the service, find its waypoint, then find the waypoint's endpoints.
 func (b *EndpointBuilder) findServiceWaypoint(endpointIndex *model.EndpointIndex) ([]*model.IstioEndpoint, bool) {
 	// Currently we only support routers (gateways)
-	if b.nodeType != model.Router && !isEastWestGateway(b.proxy) {
+	if b.nodeType != model.Router && !isEastWestGateway(b.proxy) && b.nodeType != model.SidecarProxy {
 		// Currently only ingress and e/w gateway will call waypoints
 		return nil, false
 	}
@@ -883,9 +883,10 @@ func (b *EndpointBuilder) findServiceWaypoint(endpointIndex *model.EndpointIndex
 	}
 	svc := svcs[0]
 	// They need to explicitly opt-in on the service to send from ingress -> waypoint
-	if !svc.IngressUseWaypoint && !isEastWestGateway(b.proxy) {
+	if !svc.IngressUseWaypoint && !isEastWestGateway(b.proxy) && !svc.SidecarUseWaypoint {
 		return nil, false
 	}
+
 	waypointClusterName := model.BuildSubsetKey(
 		model.TrafficDirectionOutbound,
 		"",


### PR DESCRIPTION
related https://github.com/istio/istio/issues/57213
**Please provide a description of this PR:**
Currently sidecar traffic by-passes waypoint while going to ambient service, which results in skipping any policies applied at the waypoint. This skip of waypoint happens for traffic coming from gateway as well but we have `istio.io/ingress-use-waypoint` svc label in that case which users can apply at ambient svc.

Similar to existing opt-in service label `istio.io/ingress-use-waypoint`, this PR is proposing to add another similar opt-in label `istio.io/sidecar-use-waypoint` for sidecar to ambient svc as well.

There is a possibility of double processing of client side configs like retries at sidecar and waypoint, but similar to ingress case, users who are aware can enable this feature optionally. 