### PR TITLE
WIP: Support namespace selectors in webhook templates

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -8,6 +8,16 @@
   "reinvocationPolicy" .Values.sidecarInjectorWebhook.reinvocationPolicy
   "caBundle" .Values.istiodRemote.injectionCABundle
   "namespace" .Release.Namespace }}
+{{- define "additionalNamespaceSelectors" }}
+{{- range .Values.sidecarInjectorWebhook.additionalNamespaceSelectors }}
+    - key: {{ .key | quote }}
+      operator: {{ .operator }}
+      values:
+      {{- range .values }}
+      - {{ . | quote }}
+      {{- end }}
+{{- end }}
+{{- end }}
 {{- define "core" }}
 {{- /* Kubernetes unfortunately requires a unique name for the webhook in some newer versions, so we assign
 a unique prefix to each. */}}
@@ -75,6 +85,7 @@ webhooks:
       {{- end }}
     - key: istio-injection
       operator: DoesNotExist
+{{- include "additionalNamespaceSelectors" . }}
   objectSelector:
     matchExpressions:
     - key: sidecar.istio.io/inject
@@ -90,6 +101,7 @@ webhooks:
       operator: DoesNotExist
     - key: istio-injection
       operator: DoesNotExist
+{{- include "additionalNamespaceSelectors" . }}
   objectSelector:
     matchExpressions:
     - key: sidecar.istio.io/inject
@@ -117,6 +129,7 @@ webhooks:
       operator: In
       values:
       - enabled
+{{- include "additionalNamespaceSelectors" . }}
   objectSelector:
     matchExpressions:
     - key: sidecar.istio.io/inject
@@ -132,6 +145,7 @@ webhooks:
       operator: DoesNotExist
     - key: istio.io/rev
       operator: DoesNotExist
+{{- include "additionalNamespaceSelectors" . }}
   objectSelector:
     matchExpressions:
     - key: sidecar.istio.io/inject
@@ -153,6 +167,7 @@ webhooks:
     - key: "kubernetes.io/metadata.name"
       operator: "NotIn"
       values: ["kube-system","kube-public","kube-node-lease","local-path-storage"]
+{{- include "additionalNamespaceSelectors" . }}
   objectSelector:
     matchExpressions:
     - key: sidecar.istio.io/inject

--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags-mwc.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags-mwc.yaml
@@ -66,6 +66,7 @@ webhooks:
       - "{{ $tagName }}"
     - key: istio-injection
       operator: DoesNotExist
+{{- include "additionalNamespaceSelectors" $ }}
   objectSelector:
     matchExpressions:
     - key: sidecar.istio.io/inject
@@ -79,6 +80,7 @@ webhooks:
       operator: DoesNotExist
     - key: istio-injection
       operator: DoesNotExist
+{{- include "additionalNamespaceSelectors" $ }}
   objectSelector:
     matchExpressions:
     - key: sidecar.istio.io/inject
@@ -102,6 +104,7 @@ webhooks:
       operator: In
       values:
       - enabled
+{{- include "additionalNamespaceSelectors" $ }}
   objectSelector:
     matchExpressions:
     - key: sidecar.istio.io/inject
@@ -117,6 +120,7 @@ webhooks:
       operator: DoesNotExist
     - key: istio.io/rev
       operator: DoesNotExist
+{{- include "additionalNamespaceSelectors" $ }}
   objectSelector:
     matchExpressions:
     - key: sidecar.istio.io/inject
@@ -138,6 +142,7 @@ webhooks:
     - key: "kubernetes.io/metadata.name"
       operator: "NotIn"
       values: ["kube-system","kube-public","kube-node-lease","local-path-storage"]
+{{- include "additionalNamespaceSelectors" $ }}
   objectSelector:
     matchExpressions:
     - key: sidecar.istio.io/inject

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -119,6 +119,14 @@ _internal_defaults_do_not_set:
     neverInjectSelector: []
     alwaysInjectSelector: []
 
+    # additionalNamespaceSelectors allows us to specify match expressions to be added to all webhook configurations.
+    # For example, to exclude AKS-managed namespaces:
+    # additionalNamespaceSelectors:
+    #   - key: "kubernetes.azure.com/managedby"
+    #     operator: "NotIn"
+    #     values: ["aks"]
+    additionalNamespaceSelectors: []
+
     # injectedAnnotations are additional annotations that will be added to the pod spec after injection
     # This is primarily to support PSP annotations. For example, if you defined a PSP with the annotations:
     #


### PR DESCRIPTION
Currently, Istio webhook configuration only supports hardcoded namespace selectors for standard Istio labels. This PR adds support for custom ns selectors in Istio sidecar injection webhooks, enabling users to exclude specific namespaces (like AKS-managed namespaces) from sidecar injection based on custom labels.

Related to: https://github.com/istio-ecosystem/sail-operator/issues/1148