### PR TITLE
ambient: add opt-in filter for kubelet cgroup

### DIFF
--- a/cni/pkg/cmd/root.go
+++ b/cni/pkg/cmd/root.go
@@ -128,6 +128,7 @@ var rootCmd = &cobra.Command{
 					ReconcilePodRulesOnStartup: cfg.InstallConfig.AmbientReconcilePodRulesOnStartup,
 					NativeNftables:             cfg.InstallConfig.NativeNftables,
 					ForceIptablesBinary:        cfg.InstallConfig.ForceIptablesBinary,
+					KubeletCgroup:              cfg.InstallConfig.KubeletCgroup,
 				})
 			if err != nil {
 				return fmt.Errorf("failed to create ambient nodeagent service: %v", err)
@@ -332,6 +333,7 @@ func constructConfig() (*config.Config, error) {
 
 		NativeNftables:      viper.GetBool(constants.NativeNftables),
 		ForceIptablesBinary: os.Getenv("FORCE_IPTABLES_BINARY"),
+		KubeletCgroup:       viper.GetString(constants.KubeletCgroup),
 	}
 
 	if len(installCfg.K8sNodeName) == 0 {

--- a/cni/pkg/config/config.go
+++ b/cni/pkg/config/config.go
@@ -67,6 +67,7 @@ type AmbientConfig struct {
 	Reconcile              bool       `json:"RECONCILE"`
 	CleanupOnly            bool       `json:"CLEANUP_ONLY"`
 	ForceApply             bool       `json:"FORCE_APPLY"`
+	KubeletCgroup          string     `json:"KUBELET_CGROUP"`
 }
 
 // GetConfig converts AmbientConfig to tools common config format
@@ -161,6 +162,10 @@ type InstallConfig struct {
 
 	// Choose which iptables binary to use (legacy or nft)
 	ForceIptablesBinary string
+
+	// Cgroup that kubelet runs in, used to identify health check traffic. If left unset, all host network traffic is considered
+	// health check traffic and will bypass the proxy.
+	KubeletCgroup string
 }
 
 // RepairConfig struct defines the Istio CNI race repair configuration
@@ -238,6 +243,7 @@ func (c InstallConfig) String() string {
 
 	b.WriteString("NativeNftables: " + fmt.Sprint(c.NativeNftables) + "\n")
 	b.WriteString("ForceIptablesBinary: " + fmt.Sprint(c.ForceIptablesBinary) + "\n")
+	b.WriteString("KubeletCgroup: " + fmt.Sprint(c.KubeletCgroup) + "\n")
 	return b.String()
 }
 

--- a/cni/pkg/constants/constants.go
+++ b/cni/pkg/constants/constants.go
@@ -48,6 +48,7 @@ const (
 	AmbientReconcilePodRulesOnStartup = "ambient-reconcile-pod-rules-on-startup"
 
 	NativeNftables = "native-nftables"
+	KubeletCgroup  = "kubelet-cgroup"
 
 	// Repair
 	RepairEnabled            = "repair-enabled"

--- a/cni/pkg/constants/constants.go
+++ b/cni/pkg/constants/constants.go
@@ -84,6 +84,7 @@ const (
 	ReadinessPort                      = "8000"
 	ServiceAccountPath                 = "/var/run/secrets/kubernetes.io/serviceaccount"
 	SelfNetNSPath                      = "/proc/self/ns/net"
+	SelfCgroupNSPath                      = "/proc/self/ns/cgroup"
 	DefaultIstioOwnedCNIConfigFilename = "02-istio-cni.conflist"
 )
 
@@ -99,10 +100,12 @@ var (
 	// environment variable is set to true (see CNI daemonset), which updates it to "/host/proc/1/ns/net" to align with the actual
 	// host network namespace.
 	HostNetNSPath = SelfNetNSPath
+	HostCgroupNSPath = SelfCgroupNSPath
 )
 
 func init() {
 	if allowSwitch, err := strconv.ParseBool(os.Getenv("ALLOW_SWITCH_TO_HOST_NS")); err == nil && allowSwitch {
 		HostNetNSPath = HostMountsPath + "/proc/1/ns/net"
+		HostCgroupNSPath = HostMountsPath + "/proc/1/ns/cgroup"
 	}
 }

--- a/cni/pkg/install/install.go
+++ b/cni/pkg/install/install.go
@@ -288,7 +288,7 @@ func checkValidCNIConfig(ctx context.Context, cfg *config.InstallConfig, cniConf
 			}
 			if len(cfg.CNIConfName) == 0 {
 				// We found the primary CNI config file (or the highest priority config file).
-				// Set the filename to the CNIConfName if it isn't set
+				// SetCgroup the filename to the CNIConfName if it isn't set
 				cfg.CNIConfName = firstCNIConfigFilename
 			}
 			return fmt.Errorf("istio owned CNI config does not exist or is not the highest priority. Got %s instead", firstCNIConfigFilename)

--- a/cni/pkg/nodeagent/options.go
+++ b/cni/pkg/nodeagent/options.go
@@ -56,4 +56,5 @@ type AmbientArgs struct {
 	ReconcilePodRulesOnStartup bool
 	NativeNftables             bool
 	ForceIptablesBinary        string
+	KubeletCgroup              string
 }

--- a/cni/pkg/nodeagent/server_linux.go
+++ b/cni/pkg/nodeagent/server_linux.go
@@ -36,6 +36,7 @@ func initMeshDataplane(client kube.Client, args AmbientArgs) (*meshDataplane, er
 		EnableIPv6:             args.EnableIPv6,
 		HostProbeSNATAddress:   HostProbeSNATIP,
 		HostProbeV6SNATAddress: HostProbeSNATIPV6,
+		KubeletCgroup:          args.KubeletCgroup,
 	}
 
 	podCfg := &config.AmbientConfig{

--- a/cni/pkg/util/netnsutil_linux.go
+++ b/cni/pkg/util/netnsutil_linux.go
@@ -15,7 +15,15 @@
 package util
 
 import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"sync"
+
 	netns "github.com/containernetworking/plugins/pkg/ns"
+	"golang.org/x/sys/unix"
+	"istio.io/istio/pkg/log"
 
 	pconstants "istio.io/istio/cni/pkg/constants"
 )
@@ -26,11 +34,158 @@ func RunAsHost(f func() error) error {
 		return nil
 	}
 
+	rl("EARLY", "/proc/self/ns/cgroup")
 	// A network namespace switch is definitely not required in this case, which helps with testing
 	if pconstants.HostNetNSPath == pconstants.SelfNetNSPath {
 		return f()
 	}
-	return netns.WithNetNSPath(pconstants.HostNetNSPath, func(_ netns.NetNS) error {
+	rl("self pre", "/proc/self/ns/cgroup")
+	return DoInCgroupNetNamespace(pconstants.HostCgroupNSPath, pconstants.HostNetNSPath, func() error {
+		rl("self post", "/proc/self/ns/cgroup")
+		//return netns.WithNetNSPath(pconstants.HostNetNSPath, func(_ netns.NetNS) error {
+		//	rl("self in netns", "/proc/self/ns/cgroup")
 		return f()
+		//})
 	})
+}
+
+func rl(name string, s string) {
+	l, _ := os.Readlink(s)
+	log.Errorf("howardjohn: LINK %v=%v", name, l)
+	cmd := exec.Command("readlink", s)
+	out, err := cmd.Output()
+	log.Errorf("howardjohn: LINK exec %v=%v/%v", name, string(out), err)
+}
+
+func DoInCgroupNetNamespace(nsPath string, netnsPath string, toRun func() error) error {
+	ns, err := netns.GetNS(nsPath)
+	if err != nil {
+		return err
+	}
+	defer ns.Close()
+	nsnet, err := netns.GetNS(netnsPath)
+	if err != nil {
+		return err
+	}
+	defer nsnet.Close()
+	log.Errorf("howardjohn: enter %v %v", nsPath, netnsPath)
+	//if err := ns.errorIfClosed(); err != nil {
+	//	return err
+	//}
+
+	containedCall := func() error {
+		threadNS, err := getCurrentNSNoLock()
+		if err != nil {
+			return fmt.Errorf("failed to open current netns: %v", err)
+		}
+		threadNetNS, err := getCurrentNetNSNoLock()
+		if err != nil {
+			return fmt.Errorf("failed to open current netns: %v", err)
+		}
+		log.Errorf("howardjohn: current=%v new=%v", threadNS, ns)
+		rl("cur pre", "/proc/self/ns/cgroup")
+		rl("host pre", nsPath)
+		defer threadNS.Close()
+		defer threadNetNS.Close()
+
+		// switch to target namespace
+		if err = SetCgroup(ns); err != nil {
+			return fmt.Errorf("error switching to ns %v: %v", nsPath, err)
+		}
+		if err = SetNet(nsnet); err != nil {
+			return fmt.Errorf("error switching to ns %v: %v", nsPath, err)
+		}
+		defer func() {
+			log.Errorf("howardjohn: set back...")
+			err := SetCgroup(threadNS)  // switch back
+			err2 := SetNet(threadNetNS) // switch back
+			if err == nil && err2 == nil {
+				// Unlock the current thread only when we successfully switched back
+				// to the original namespace; otherwise leave the thread locked which
+				// will force the runtime to scrap the current thread, that is maybe
+				// not as optimal but at least always safe to do.
+				runtime.UnlockOSThread()
+			}
+			rl("cur post switch", "/proc/self/ns/cgroup")
+			log.Errorf("howardjohn: switch back... %v %v", err, err2)
+		}()
+
+		log.Errorf("howardjohn: RUN")
+		return toRun()
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// Start the callback in a new green thread so that if we later fail
+	// to switch the namespace back to the original one, we can safely
+	// leave the thread locked to die without a risk of the current thread
+	// left lingering with incorrect namespace.
+	var innerError error
+	go func() {
+		defer wg.Done()
+		runtime.LockOSThread()
+		innerError = containedCall()
+	}()
+	wg.Wait()
+
+	return innerError
+}
+
+func getCurrentNSNoLock() (netns.NetNS, error) {
+	return netns.GetNS(getCurrentThreadCgroupNSPath())
+}
+
+func getCurrentThreadCgroupNSPath() string {
+	// /proc/self/ns/net returns the namespace of the main thread, not
+	// of whatever thread this goroutine is running on.  Make sure we
+	// use the thread's net namespace since the thread is switching around
+	return fmt.Sprintf("/proc/%d/task/%d/ns/cgroup", os.Getpid(), unix.Gettid())
+}
+
+func getCurrentNetNSNoLock() (netns.NetNS, error) {
+	return netns.GetNS(getCurrentThreadNetNSPath())
+}
+
+func getCurrentThreadNetNSPath() string {
+	// /proc/self/ns/net returns the namespace of the main thread, not
+	// of whatever thread this goroutine is running on.  Make sure we
+	// use the thread's net namespace since the thread is switching around
+	return fmt.Sprintf("/proc/%d/task/%d/ns/net", os.Getpid(), unix.Gettid())
+}
+
+func SetCgroup(ns netns.NetNS) error {
+	//if err := ns.errorIfClosed(); err != nil {
+	//	return err
+	//}
+
+	log.Errorf("howardjohn: ready to set!")
+	//time.Sleep(time.Second*5)
+	log.Errorf("howardjohn: setting! to fd %v", ns.Fd())
+	rl("set to FD", fmt.Sprintf("/proc/self/fd/%d", ns.Fd()))
+
+	if err := unix.Setns(int(ns.Fd()), unix.CLONE_NEWCGROUP); err != nil {
+		return fmt.Errorf("Error switching to ns %v: %v", "WIP", err)
+	}
+	rl("self in SetCgroup", "/proc/self/ns/cgroup")
+
+	return nil
+}
+
+func SetNet(ns netns.NetNS) error {
+	//if err := ns.errorIfClosed(); err != nil {
+	//	return err
+	//}
+
+	log.Errorf("howardjohn: ready to set!")
+	//time.Sleep(time.Second*5)
+	log.Errorf("howardjohn: setting! to fd %v", ns.Fd())
+	rl("set to FD", fmt.Sprintf("/proc/self/fd/%d", ns.Fd()))
+
+	if err := unix.Setns(int(ns.Fd()), unix.CLONE_NEWNET); err != nil {
+		return fmt.Errorf("Error switching to ns %v: %v", "WIP", err)
+	}
+	rl("self in SetCgroup", "/proc/self/ns/cgroup")
+
+	return nil
 }


### PR DESCRIPTION
This hardens the health check iptables to more precisely identify
kubelet traffic
