### PR TITLE
ip allocator: Fix rate TOCTOU race condition

### DIFF
--- a/pilot/pkg/controllers/ipallocate/ipallocate.go
+++ b/pilot/pkg/controllers/ipallocate/ipallocate.go
@@ -390,6 +390,13 @@ func (c *IPAllocator) statusPatchForAddresses(se *networkingv1.ServiceEntry, for
 	}
 
 	replaceAddresses, err := json.Marshal([]jsonPatch{
+		// Ensure the existing status we are acting on has not changed since we decided to allocate.
+		// This avoids TOCTOU race conditions
+		{
+			Operation: "test",
+			Path:      "/status/addresses",
+			Value:     se.Status.Addresses,
+		},
 		{
 			Operation: "replace",
 			Path:      "/status/addresses",


### PR DESCRIPTION
Example test failure that legitimately catches the bug of re-assigning
an IP:
https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/57728/unit-tests_istio/1970226912013848576.

Basically its a race: I make 2 changes to a SE, triggering 2 reconcile() calls

Reconcile 1: allocate ip1, write
Reconcile 2: read from cache, the state before the write, allocate ip2, write (overwriting ip1)
