### PR TITLE
Bugfix dst NS DR not applying when no src NS DR matches a workload

### DIFF
--- a/releasenotes/notes/57719.yaml
+++ b/releasenotes/notes/57719.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 57719
+releaseNotes:
+  - |
+    **Fixed** a bug where DRs without workload selectors in the destination/root namespace were not applied if the source namespace only contained DRs with workloadselectors.
+    This fix does not apply merging across namespaces. For example, if a DR in the source namespace has a workload selector and a DR in the destination namespace has no workload 
+    selector, the fields of the DR in the destination namespace will not be merged with the DR in the source namespace.


### PR DESCRIPTION
**Please provide a description of this PR:**
Since selecting the list of dependent destination rules for a sidecar scope is done typically at the namespace level, and the current logic returns the list of DRs in the source namespace if it is non-empty, this can result in the edge case where:
1. only DRs with workload selectors exist in the client namespace
2. the DR in the destination namespace is not applied

Fixes #57719 