### PR TITLE
dedupe ServiceEntry with overlapping hosts

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1124,7 +1124,10 @@ type ServiceInfo struct {
 	MarshaledAddress *anypb.Any
 	// AsAddress contains a pre-created AddressInfo representation. This ensures we do not need repeated conversions on
 	// the hotpath
-	AsAddress AddressInfo
+	AsAddress    AddressInfo
+	// CreationTime is the time when the service was created. Note this is used internally only
+	// for conflict resolution.
+	CreationTime time.Time
 }
 
 func (i ServiceInfo) GetLabelSelector() map[string]string {
@@ -1218,6 +1221,10 @@ func (i WaypointBindingStatus) Equals(other WaypointBindingStatus) bool {
 
 func (i ServiceInfo) NamespacedName() types.NamespacedName {
 	return types.NamespacedName{Name: i.Service.Name, Namespace: i.Service.Namespace}
+}
+
+func (i ServiceInfo) GetName() string {
+	return i.Service.Name
 }
 
 func (i ServiceInfo) GetNamespace() string {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/multicluster.go
@@ -486,8 +486,9 @@ func (a *index) buildGlobalCollections(
 			sans = sans.Union(sets.New(svc.Service.SubjectAltNames...))
 
 			newSvcInfo := &model.ServiceInfo{
-				Service: protomarshal.Clone(svc.Service),
-				Scope:   svc.Scope,
+				Service:      protomarshal.Clone(svc.Service),
+				Scope:        svc.Scope,
+				CreationTime: svc.CreationTime,
 			}
 			newSvcInfo.Service.SubjectAltNames = sans.UnsortedList()
 			return precomputeServicePtr(newSvcInfo)

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
@@ -38,6 +38,7 @@ import (
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/config/schema/kubetypes"
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/krt"
@@ -65,6 +66,7 @@ func (a *index) ServicesCollection(
 				multicluster.ClusterKRTMetadataKey: clusterID,
 			}),
 		)...)
+
 	ServiceEntriesInfo := krt.NewManyCollection(serviceEntries, a.serviceEntryServiceBuilder(waypoints, namespaces),
 		append(
 			opts.WithName("ServiceEntriesInfo"),
@@ -72,8 +74,36 @@ func (a *index) ServicesCollection(
 				multicluster.ClusterKRTMetadataKey: clusterID,
 			}),
 		)...)
-	WorkloadServices := krt.JoinCollection(
-		[]krt.Collection[model.ServiceInfo]{ServicesInfo, ServiceEntriesInfo},
+	serviceEntryByHostname := krt.NewIndex(ServiceEntriesInfo, "serviceEntryByHostname", func(se ServiceEntryInfo) []string {
+		return []string{se.Service.Hostname}
+	})
+	DedupedServiceEntriesInfo := krt.NewCollection(ServiceEntriesInfo, func(ctx krt.HandlerContext, se ServiceEntryInfo) *model.ServiceInfo {
+		byHostname := krt.Fetch(ctx, ServiceEntriesInfo, krt.FilterIndex(serviceEntryByHostname, se.Service.Hostname))
+		if len(byHostname) > 1 {
+			for _, other := range byHostname {
+				if other.NamespacedName() != se.NamespacedName() && other.CreationTime.Before(se.CreationTime) {
+					// another ServiceEntry exists with the same hostname and is older
+					return nil
+				}
+			}
+		}
+		return &se.ServiceInfo
+	})
+	WorkloadServices := krt.JoinWithMergeCollection(
+		[]krt.Collection[model.ServiceInfo]{
+			ServicesInfo,
+			DedupedServiceEntriesInfo,
+		},
+		func(conflicting []model.ServiceInfo) *model.ServiceInfo {
+			// we'll never have more than 2 here - Service can't have hostname conflict
+			// we already de-duplicated ServiceEntries above
+			for _, c := range conflicting {
+				if c.Source.Kind == kind.Service {
+					return &c
+				}
+			}
+			return &conflicting[0]
+		},
 		append(opts.WithName("WorkloadService"), krt.WithMetadata(
 			krt.Metadata{
 				multicluster.ClusterKRTMetadataKey: clusterID,
@@ -227,6 +257,7 @@ func serviceServiceBuilder(
 			Source:        MakeSource(s),
 			Waypoint:      waypointStatus,
 			Scope:         serviceScope,
+			CreationTime:  s.CreationTimestamp.Time,
 		}
 		if precompute {
 			return precomputeServicePtr(svcInfo)
@@ -352,14 +383,27 @@ func MakeSource(o controllers.Object) model.TypedObject {
 	}
 }
 
+// ServiceEntryInfo is a wrapper around ServiceInfo that handles key conflicts
+// on hostname.
+type ServiceEntryInfo struct {
+	model.ServiceInfo
+}
+
+func (s ServiceEntryInfo) ResourceName() string {
+	return s.GetNamespace() + "/" + s.GetName()
+}
+
 func (a *index) serviceEntryServiceBuilder(
 	waypoints krt.Collection[Waypoint],
 	namespaces krt.Collection[*v1.Namespace],
-) krt.TransformationMulti[*networkingclient.ServiceEntry, model.ServiceInfo] {
-	return func(ctx krt.HandlerContext, s *networkingclient.ServiceEntry) []model.ServiceInfo {
+) krt.TransformationMulti[*networkingclient.ServiceEntry, ServiceEntryInfo] {
+	return func(ctx krt.HandlerContext, s *networkingclient.ServiceEntry) []ServiceEntryInfo {
 		waypoint, waypointError := fetchWaypointForService(ctx, waypoints, namespaces, s.ObjectMeta)
-		return serviceEntriesInfo(ctx, s, waypoint, waypointError, func(ctx krt.HandlerContext) network.ID {
+		serviceInfos := serviceEntriesInfo(ctx, s, waypoint, waypointError, func(ctx krt.HandlerContext) network.ID {
 			return a.Network(ctx)
+		})
+		return slices.Map(serviceInfos, func(si model.ServiceInfo) ServiceEntryInfo {
+			return ServiceEntryInfo{ServiceInfo: si}
 		})
 	}
 }
@@ -396,6 +440,7 @@ func serviceEntriesInfo(
 			LabelSelector: sel,
 			Source:        MakeSource(s),
 			Waypoint:      waypoint,
+			CreationTime:  s.CreationTimestamp.Time,
 		})
 	})
 }

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/services_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/services_test.go
@@ -589,7 +589,7 @@ func TestServiceEntryServices(t *testing.T) {
 				krttest.GetMockCollection[*v1.Namespace](mock),
 			)
 			wrapper := builder(krt.TestingDummyContext{}, tt.se)
-			res := slices.Map(wrapper, func(e model.ServiceInfo) *workloadapi.Service {
+			res := slices.Map(wrapper, func(e ServiceEntryInfo) *workloadapi.Service {
 				return e.Service
 			})
 			assert.Equal(t, res, tt.result)

--- a/pkg/kube/krt/join.go
+++ b/pkg/kube/krt/join.go
@@ -16,13 +16,15 @@ package krt
 
 import (
 	"fmt"
+	"strconv"
+	"sync"
 
+	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/sets"
 )
 
-// TODO: Implement with merging
 type join[T any] struct {
 	collectionName   string
 	id               collectionUID
@@ -31,9 +33,31 @@ type join[T any] struct {
 	uncheckedOverlap bool
 	syncer           Syncer
 	metadata         Metadata
+	merge            func(ts []T) *T
+
+	// mergedCache is a cache of the merged results for each key
+	// This is used to ensure we have accurate eventing when dealing
+	// with merged collections (e.g. that event.Old is set correctly).
+	// This will prevent unnecessary xDS pushes; without it, we'd
+	// Old != New (merged) would always be true and we'd push.
+	mergedCache  map[mergedCacheKey]mergedCacheEntry[T]
+	sync.RWMutex // protects mergedCache
 }
 
-func (j *join[T]) GetKey(k string) *T {
+type mergedCacheKey struct {
+	handlerID string // An empty handler id corresponds to the collection itself (e.g. during GetKey() or List())
+	key       string
+}
+
+type mergedCacheEntry[T any] struct {
+	prev    *T
+	current *T // Must always be set of there's an entry in the map
+}
+
+func (j *join[T]) quickGetKey(k string) *T {
+	if j.merge != nil {
+		return nil
+	}
 	for _, c := range j.collections {
 		if r := c.GetKey(k); r != nil {
 			return r
@@ -42,7 +66,24 @@ func (j *join[T]) GetKey(k string) *T {
 	return nil
 }
 
-func (j *join[T]) List() []T {
+func (j *join[T]) GetKey(k string) *T {
+	if j.merge == nil {
+		return j.quickGetKey(k)
+	}
+
+	j.RLock()
+	defer j.RUnlock()
+	// Check the cache first
+	if entry, ok := j.mergedCache[mergedCacheKey{key: k, handlerID: ""}]; ok {
+		if entry.current != nil {
+			return entry.current
+		}
+		log.Warnf("Merged key %s in collection %s is nil in the cache during a get operation", k, j.collectionName)
+	}
+	return nil
+}
+
+func (j *join[T]) quickList() []T {
 	var res []T
 	if j.uncheckedOverlap {
 		first := true
@@ -85,15 +126,187 @@ func (j *join[T]) List() []T {
 	return res
 }
 
+func (j *join[T]) mergeList() []T {
+	j.RLock()
+	defer j.RUnlock()
+
+	// TODO: Should we fall back to manually computing the merge and saving it in the cache?
+	// My gut says no; we want one source of truth
+	var l []T
+	for key, item := range j.mergedCache {
+		if key.handlerID != "" {
+			continue
+		}
+		if item.current != nil {
+			l = append(l, *item.current)
+		} else {
+			log.Warnf("Merged key %s in collection %s is nil in the cache during a list operation", key, j.collectionName)
+		}
+	}
+	return l
+}
+
+func (j *join[T]) List() []T {
+	if j.merge != nil {
+		return j.mergeList()
+	}
+
+	return j.quickList()
+}
+
 func (j *join[T]) Register(f func(o Event[T])) HandlerRegistration {
 	return registerHandlerAsBatched[T](j, f)
 }
 
-func (j *join[T]) RegisterBatch(f func(o []Event[T]), runExistingState bool) HandlerRegistration {
+func (j *join[T]) registerBatchUnmerged(f func(o []Event[T]), runExistingState bool) HandlerRegistration {
 	sync := multiSyncer{}
 	removes := []func(){}
 	for _, c := range j.collections {
 		reg := c.RegisterBatch(f, runExistingState)
+		removes = append(removes, reg.UnregisterHandler)
+		sync.syncers = append(sync.syncers, reg)
+	}
+	return joinHandlerRegistration{
+		Syncer:  sync,
+		removes: removes,
+	}
+}
+
+func (j *join[T]) calculateMerged(k string) *T {
+	var found []T
+	for _, c := range j.collections {
+		if r := c.GetKey(k); r != nil {
+			found = append(found, *r)
+		}
+	}
+	if len(found) == 0 {
+		return nil
+	}
+	return j.merge(found)
+}
+
+func maybeInitMergeCacheForHandlerLocked[T any](cache map[mergedCacheKey]mergedCacheEntry[T], handlerID string) {
+	// First check to see if there's been any merge cache entry before us
+	// by checking the empty handler mergeKey
+	for key, entry := range cache {
+		// no-op
+		if key.handlerID != "" {
+			continue
+		}
+
+		// There are entries in the cache; copy them to our handlerID
+		cache[mergedCacheKey{key: key.key, handlerID: handlerID}] = entry
+	}
+}
+
+func updateMergeCacheLocked[T any](cache map[mergedCacheKey]mergedCacheEntry[T], merged *T, key, handlerID string) mergedCacheEntry[T] {
+	if merged == nil {
+		// First get the existing value from the cache (if it exists)
+		var old *T
+		entry, ok := cache[mergedCacheKey{key: key, handlerID: handlerID}]
+		if ok && entry.current != nil {
+			old = entry.current
+		}
+
+		delete(cache, mergedCacheKey{key: key, handlerID: handlerID})
+		// Eagerly keep collection reads up to date; delete the collection entry too
+		delete(cache, mergedCacheKey{key: key})
+		return mergedCacheEntry[T]{prev: old}
+	}
+	// Now we know this is either an add or an update
+	var updatedEntry mergedCacheEntry[T]
+	if entry, ok := cache[mergedCacheKey{key: key, handlerID: handlerID}]; ok {
+		if entry.current != nil {
+			entry.prev = entry.current
+			entry.current = merged
+			updatedEntry = entry
+		}
+	} else {
+		updatedEntry = mergedCacheEntry[T]{current: merged}
+	}
+
+	cache[mergedCacheKey{key: key, handlerID: handlerID}] = updatedEntry
+	// It's probably simpler to just always set the collection entry multiple times
+	// TODO: Ensure old vlues don't stick around for too long and prevent garbage collection
+	cache[mergedCacheKey{key: key}] = updatedEntry
+	return updatedEntry
+}
+
+func (j *join[T]) updateMergedCache(key, handlerID string, merged *T) mergedCacheEntry[T] {
+	j.Lock()
+	defer j.Unlock()
+	return updateMergeCacheLocked(j.mergedCache, merged, key, handlerID)
+}
+
+func handleInnerCollectionEvent[T any](
+	handler func(o []Event[T]),
+	handlerID string,
+	getMergedForKey func(key string) *T,
+	updateMergedCache func(key, handlerID string, merged *T) mergedCacheEntry[T],
+) func(o []Event[T]) {
+	return func(events []Event[T]) {
+		mergedEvents := make([]Event[T], 0, len(events))
+		changedKeys := make(map[string]struct{}, len(events))
+		// When we calculate the merged value for a given key, we're looking at the present state
+		// of our set of collections, not the state at the time of the event. Therefore, it's possible
+		// that the event state is stale and the merged value is different. Therefore, we should just
+		// operate on the key and not the event itself.
+		for _, i := range events {
+			key := GetKey(i.Latest())
+			changedKeys[key] = struct{}{}
+		}
+		// Loop through all of the keys that changed and create an event based on the currente state
+		// and our cached entries.
+		for key := range changedKeys {
+			merged := getMergedForKey(key)
+			entry := updateMergedCache(key, handlerID, merged)
+			var e Event[T]
+
+			switch {
+			case entry.current == nil && entry.prev == nil:
+				msg := "Merged (nested) join collection: Received event for key %s in handler %s but it's not longer in our set of collections. Skipping..."
+				log.Warnf(msg, key, handlerID)
+				continue
+			// No current entry in our cache for this handler. This key was deleted across all our collections
+			case entry.current == nil:
+				e = Event[T]{
+					Event: controllers.EventDelete,
+					Old:   entry.prev,
+				}
+			// This key was added for the first time across all our collections.
+			case entry.prev == nil:
+				e = Event[T]{
+					Event: controllers.EventAdd,
+					New:   merged,
+				}
+			// We have both a current and previous entry in our cache for this handler.
+			// This key was updated due to a change in one of our collections
+			default:
+				e = Event[T]{
+					Event: controllers.EventUpdate,
+					Old:   entry.prev,
+					New:   merged,
+				}
+			}
+			mergedEvents = append(mergedEvents, e)
+		}
+		handler(mergedEvents)
+	}
+}
+
+func (j *join[T]) RegisterBatch(f func(o []Event[T]), runExistingState bool) HandlerRegistration {
+	if j.merge == nil {
+		return j.registerBatchUnmerged(f, runExistingState)
+	}
+	sync := multiSyncer{}
+	removes := []func(){}
+	handlerID := strconv.FormatUint(globalUIDCounter.Inc(), 10)
+	j.Lock()
+	maybeInitMergeCacheForHandlerLocked(j.mergedCache, handlerID)
+	j.Unlock()
+
+	for _, c := range j.collections {
+		reg := c.RegisterBatch(handleInnerCollectionEvent(f, handlerID, j.calculateMerged, j.updateMergedCache), runExistingState)
 		removes = append(removes, reg.UnregisterHandler)
 		sync.syncers = append(sync.syncers, reg)
 	}
@@ -184,9 +397,21 @@ func (j *join[T]) Metadata() Metadata {
 }
 
 // JoinCollection combines multiple Collection[T] into a single
-// Collection[T] merging equal objects into one record
-// in the resulting Collection
+// Collection[T], picking the first object found when duplicates are found.
+// Access operations (e.g. GetKey and List) will perform a best effort stable ordering
+// of the list of elements returned; however, this ordering will not be persistent across
+// istiod restarts.
 func JoinCollection[T any](cs []Collection[T], opts ...CollectionOption) Collection[T] {
+	return JoinWithMergeCollection[T](cs, nil, opts...)
+}
+
+// JoinWithMergeCollection combines multiple Collection[T] into a single
+// Collection[T] merging equal objects into one record
+// in the resulting Collection based on the provided merge function.
+//
+// The merge function *cannot* assume a stable ordering of the list of elements passed to it. Therefore, access operations (e.g. GetKey and List) will
+// will only be deterministic if the merge function is deterministic. The merge function should return nil if no value should be returned.
+func JoinWithMergeCollection[T any](cs []Collection[T], merge func(ts []T) *T, opts ...CollectionOption) Collection[T] {
 	o := buildCollectionOptions(opts...)
 	if o.name == "" {
 		o.name = fmt.Sprintf("Join[%v]", ptr.TypeName[T]())
@@ -204,7 +429,11 @@ func JoinCollection[T any](cs []Collection[T], opts ...CollectionOption) Collect
 		close(synced)
 		log.Infof("%v synced", o.name)
 	}()
-	// TODO: in the future, we could have a custom merge function. For now, since we just take the first, we optimize around that case
+
+	if o.joinUnchecked && merge != nil {
+		log.Warn("JoinWithMergeCollection: unchecked overlap is ineffective with a merge function")
+		o.joinUnchecked = false
+	}
 	j := &join[T]{
 		collectionName:   o.name,
 		id:               nextUID(),
@@ -215,6 +444,8 @@ func JoinCollection[T any](cs []Collection[T], opts ...CollectionOption) Collect
 			name:   o.name,
 			synced: synced,
 		},
+		merge:       merge,
+		mergedCache: make(map[mergedCacheKey]mergedCacheEntry[T]),
 	}
 
 	if o.metadata != nil {


### PR DESCRIPTION
**Please provide a description of this PR:**

If you create a ServiceEntry with an overlapping hostname with one in the same namespace, it will overwrite the key in our ambientindexes. If it goes away, the original is not recovered unless we reprocess everything (e.g. istiod restarts). 

This PR adds 2 things:
1. A de-duping step based on creation timestamp for ServiceEntry only
2. A merging step with Service to always pick k8s Service over ServiceEntry when ServiceEntry tries to takeover that hostname. 

We could also base (2) on creation timestamp. 

```
istio/repro$ istioctl zc services | grep overlap
istio/repro$ k apply -f a.yaml
serviceentry.networking.istio.io/overlap-repro-a created
istio/repro$ istioctl zc services | grep overlap
default        overlap-repro-a                                   240.1.1.1               None                               1/1

# second SE overwrites the key
istio/repro$ k apply -f b.yaml
serviceentry.networking.istio.io/overlap-repro-b created
istio/repro$ istioctl zc services | grep overlap
default        overlap-repro-b                                   240.2.2.2               None                               2/2

# delete does not recover the first one
istio/repro$ k delete -f b.yaml
serviceentry.networking.istio.io "overlap-repro-b" deleted
istio/repro$ istioctl zc services | grep overlap
istio/repro$ istioctl zc services | grep overlap
istio/repro$ istioctl zc services | grep overlap

# istiod restart recovers it
istio/repro$ k delete po -n istio-system istiod-64b7f6cddd-x42nm
pod "istiod-64b7f6cddd-x42nm" deleted
istio/repro$ istioctl zc services | grep overlap
default        overlap-repro-a                                   240.1.1.1               None                               1/1
```

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [X] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
