### PR TITLE
Flatten "network" value in ztunnel charts

### DIFF
--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -115,9 +115,9 @@ spec:
         - name: LOG_FORMAT
           value: json
         {{- end}}
-        {{- if .Values.global.network }}
+        {{- if .Values.network }}
         - name: NETWORK
-          value: {{ .Values.global.network | quote }}
+          value: {{ .Values.network | quote }}
         {{- end }}
         - name: RUST_LOG
           value: {{ .Values.logLevel | quote }}
@@ -192,7 +192,7 @@ spec:
         projected:
           sources:
           - clusterTrustBundle:
-              name: istio.io:istiod-ca:{{ .Values.global.trustBundleName | default "root-cert" }}
+              name: istio.io:istiod-ca:{{ .Values.trustBundleName | default "root-cert" }}
               path: root-cert.pem
         {{- else }}
         configMap:

--- a/manifests/charts/ztunnel/values.yaml
+++ b/manifests/charts/ztunnel/values.yaml
@@ -12,11 +12,10 @@ _internal_defaults_do_not_set:
   # If Image contains a "/", it will replace the entire `image` in the pod.
   image: ztunnel
 
-  # We keep the global namespace around for backwards-compatibility
-  global:
-    # Network defines the network this cluster belong to. This name
-    # corresponds to the networks in the map of mesh networks.
-    network: ""
+  # Same as `global.network`, but will override it if set.
+  # Network defines the network this cluster belong to. This name
+  # corresponds to the networks in the map of mesh networks.
+  network: ""
 
   # resourceName, if set, will override the naming of resources. If not set, will default to 'ztunnel'.
   # If you set this, you MUST also set `trustedZtunnelName` in the `istiod` chart.


### PR DESCRIPTION
**Please provide a description of this PR:**
Make the "network" value flatten and configurable by both approaches:
`helm template manifests/charts/ztunnel --set network=net1`
`helm template manifests/charts/ztunnel --set global.network=net1`