### PR TITLE
feat: add clusterIP configuration to the gateway chart service template and values.yaml

### DIFF
--- a/manifests/charts/gateway/templates/service.yaml
+++ b/manifests/charts/gateway/templates/service.yaml
@@ -45,6 +45,9 @@ spec:
   internalTrafficPolicy: "{{ . }}"
 {{- end }}
   type: {{ .Values.service.type }}
+{{- if not (eq  .Values.service.clusterIP "") }}
+  clusterIP: {{ .Values.service.clusterIP }}
+{{- end }}
   ports:
 {{- if .Values.networkGateway }}
   - name: status-port

--- a/manifests/charts/gateway/templates/service.yaml
+++ b/manifests/charts/gateway/templates/service.yaml
@@ -45,7 +45,7 @@ spec:
   internalTrafficPolicy: "{{ . }}"
 {{- end }}
   type: {{ .Values.service.type }}
-{{- if not (eq  .Values.service.clusterIP "") }}
+{{- if not (eq .Values.service.clusterIP "") }}
   clusterIP: {{ .Values.service.clusterIP }}
 {{- end }}
   ports:

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -42,6 +42,8 @@ _internal_defaults_do_not_set:
   service:
     # Type of service. Set to "None" to disable the service entirely
     type: LoadBalancer
+    # Set to a specific ClusterIP, or "" for automatic assignment
+    clusterIP: ""
     ports:
     - name: status-port
       port: 15021

--- a/releasenotes/notes/clusterIP-gateway-chart.yaml
+++ b/releasenotes/notes/clusterIP-gateway-chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+
+releaseNotes:
+  - |
+    **Added** service.clusterIP configuration to Gateway chart to support overriding the `spec.spec.clusterIP` of the Service resource. This 
+    could be useful in cases where the user wants to set a specific ClusterIP for the Gateway Service instead of relying on automatic assignment.

--- a/releasenotes/notes/clusterIP-gateway-chart.yaml
+++ b/releasenotes/notes/clusterIP-gateway-chart.yaml
@@ -4,5 +4,5 @@ area: installation
 
 releaseNotes:
   - |
-    **Added** service.clusterIP configuration to Gateway chart to support overriding the `spec.spec.clusterIP` of the Service resource. This 
+    **Added** service.clusterIP configuration to Gateway chart to support overriding the `spec.clusterIP` of the Service resource. This 
     could be useful in cases where the user wants to set a specific ClusterIP for the Gateway Service instead of relying on automatic assignment.


### PR DESCRIPTION
**Please provide a description of this PR:**

Exposes a service.spec.clusterIP in the values of the gateway chart, enabling to user to set the value as alternative to automatic assignment.