### PR TITLE
leaderelection: fix stealing with Lease mode

### DIFF
--- a/pilot/pkg/leaderelection/k8sleaderelection/leaderelection_test.go
+++ b/pilot/pkg/leaderelection/k8sleaderelection/leaderelection_test.go
@@ -447,14 +447,14 @@ func TestLeaseSpecToLeaderElectionRecordRoundTrip(t *testing.T) {
 		LeaseTransitions:     &leaseTransitions,
 	}
 
-	oldRecord := rl.LeaseSpecToLeaderElectionRecord(&oldSpec)
+	oldRecord := rl.LeaseToLeaderElectionRecord(&coordinationv1.Lease{Spec: oldSpec})
 	newSpec := rl.LeaderElectionRecordToLeaseSpec(oldRecord)
 
 	if !equality.Semantic.DeepEqual(oldSpec, newSpec) {
 		t.Errorf("diff: %v", diff.ObjectReflectDiff(oldSpec, newSpec))
 	}
 
-	newRecord := rl.LeaseSpecToLeaderElectionRecord(&newSpec)
+	newRecord := rl.LeaseToLeaderElectionRecord(&coordinationv1.Lease{Spec: newSpec})
 
 	if !equality.Semantic.DeepEqual(oldRecord, newRecord) {
 		t.Errorf("diff: %v", diff.ObjectReflectDiff(oldRecord, newRecord))

--- a/pilot/pkg/leaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/leaderelection.go
@@ -165,13 +165,18 @@ func (l *LeaderElection) create() (*k8sleaderelection.LeaderElector, error) {
 		},
 	}
 	if l.perRevision || l.useLeaseLock {
+		leaseKey := key
+		if l.perRevision {
+			// Per revision does not need takeover
+			// See below, where we disable KeyComparison as well
+			leaseKey = ""
+		}
 		lock = &k8sresourcelock.LeaseLock{
 			LeaseMeta: metav1.ObjectMeta{Namespace: l.namespace, Name: l.electionID},
 			Client:    l.client.CoordinationV1(),
-			// Note: Key is NOT used. This is not implemented in the library for Lease nor needed, since this is already per-revision.
-			// See below, where we disable KeyComparison
 			LockConfig: k8sresourcelock.ResourceLockConfig{
 				Identity: l.name,
+				Key:      leaseKey,
 			},
 		}
 	}
@@ -189,10 +194,7 @@ func (l *LeaderElection) create() (*k8sleaderelection.LeaderElector, error) {
 	}
 	if !l.perRevision {
 		// Function to use to decide whether this leader should steal the existing lock.
-		// This is disable when perRevision is used, as this enables the Lease. Lease doesn't have a holderKey field to place our key
-		// as holderKey is an Istio specific fork.
-		// While its possible to make it work with Lease as well (via an annotation to store it), we don't ever need prioritized
-		// for these per-revision ones anyways, since the prioritization is about preferring one revision over others.
+		// For perRevision, we don't ever need prioritized, since the prioritization is about preferring one revision over others.
 		config.KeyComparison = func(leaderKey string) bool {
 			return LocationPrioritizedComparison(leaderKey, l)
 		}


### PR DESCRIPTION
For the new-ish ambient status controller, we use a new NewLeaseLeaderElection. Unfortunately, the code explicitly states why Lease cannot be used with KeyComparison, but we didn't account for this when adding NewLeaseLeaderElection.

This means that members of the same revision will still the Lease, even if it has an owner already, constantly churning who is the leader. In real world I saw this have over 20k lease transitions in a short period of time.

There are two possible fixes:
1. Disable `KeyComparison`, breaking default-revision-wins behavior
2. Implement KeyComparison for Lease, which entails adding an annotation to Lease for our purpose

This PR implements (2)