### PR TITLE
Convert extproc to upstream filter for inference

### DIFF
--- a/pilot/pkg/config/kube/gateway/controller.go
+++ b/pilot/pkg/config/kube/gateway/controller.go
@@ -368,17 +368,12 @@ func NewController(
 		grpcRoutes.VirtualServices,
 	}, opts.WithName("DerivedVirtualServices")...)
 
-	InferencePoolsByGateway := krt.NewIndex(InferencePools, "byGateway", func(i InferencePool) []types.NamespacedName {
-		return i.gatewayParents.UnsortedList()
-	})
-
 	outputs := Outputs{
-		ReferenceGrants:         ReferenceGrants,
-		Gateways:                Gateways,
-		VirtualServices:         VirtualServices,
-		DestinationRules:        DestinationRules,
-		InferencePools:          InferencePools,
-		InferencePoolsByGateway: InferencePoolsByGateway,
+		ReferenceGrants:  ReferenceGrants,
+		Gateways:         Gateways,
+		VirtualServices:  VirtualServices,
+		DestinationRules: DestinationRules,
+		InferencePools:   InferencePools,
 	}
 	c.outputs = outputs
 
@@ -426,16 +421,16 @@ func NewController(
 				return
 			}
 
-			poolName, ok := obj.Labels[InferencePoolRefLabel]
+			poolName, ok := obj.Labels[model.InferencePoolRefLabel]
 			if !ok && o.Event == controllers.EventUpdate && o.Old != nil {
 				// Try and find the label from the old object
 				old := ptr.Flatten(o.Old)
-				poolName, ok = old.Labels[InferencePoolRefLabel]
+				poolName, ok = old.Labels[model.InferencePoolRefLabel]
 			}
 
 			if !ok {
 				log.Errorf("service %s/%s is missing the %s label, cannot reconcile shadow service",
-					obj.Namespace, obj.Name, InferencePoolRefLabel)
+					obj.Namespace, obj.Name, model.InferencePoolRefLabel)
 				return
 			}
 
@@ -618,10 +613,6 @@ func pushXds[T any](xds model.XDSUpdater, f func(T) model.ConfigKey) func(events
 			Reason:         model.NewReasonStats(model.ConfigUpdate),
 		})
 	}
-}
-
-func (c *Controller) HasInferencePool(gw types.NamespacedName) bool {
-	return len(c.outputs.InferencePoolsByGateway.Lookup(gw)) > 0
 }
 
 func (c *Controller) inRevision(obj any) bool {

--- a/pilot/pkg/config/kube/gateway/conversion_test.go
+++ b/pilot/pkg/config/kube/gateway/conversion_test.go
@@ -130,9 +130,9 @@ var services = []*model.Service{
 		Attributes: model.ServiceAttributes{
 			Namespace: "default",
 			Labels: map[string]string{
-				InferencePoolExtensionRefSvc:         "ext-proc-svc",
-				InferencePoolExtensionRefPort:        "9002",
-				InferencePoolExtensionRefFailureMode: "FailClose",
+				model.InferencePoolExtensionRefSvc:         "ext-proc-svc",
+				model.InferencePoolExtensionRefPort:        "9002",
+				model.InferencePoolExtensionRefFailureMode: "FailClose",
 			},
 		},
 		Ports:    ports,
@@ -142,9 +142,9 @@ var services = []*model.Service{
 		Attributes: model.ServiceAttributes{
 			Namespace: "default",
 			Labels: map[string]string{
-				InferencePoolExtensionRefSvc:         "ext-proc-svc-2",
-				InferencePoolExtensionRefPort:        "9002",
-				InferencePoolExtensionRefFailureMode: "FailClose",
+				model.InferencePoolExtensionRefSvc:         "ext-proc-svc-2",
+				model.InferencePoolExtensionRefPort:        "9002",
+				model.InferencePoolExtensionRefFailureMode: "FailClose",
 			},
 		},
 		Ports:    ports,

--- a/pilot/pkg/config/kube/gateway/inferencepool_collection.go
+++ b/pilot/pkg/config/kube/gateway/inferencepool_collection.go
@@ -27,6 +27,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gateway "sigs.k8s.io/gateway-api/apis/v1beta1"
 
+	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/kube/kclient"
@@ -38,12 +39,8 @@ import (
 )
 
 const (
-	maxServiceNameLength                 = 63
-	hashSize                             = 8
-	InferencePoolRefLabel                = "istio.io/inferencepool-name"
-	InferencePoolExtensionRefSvc         = "istio.io/inferencepool-extension-service"
-	InferencePoolExtensionRefPort        = "istio.io/inferencepool-extension-port"
-	InferencePoolExtensionRefFailureMode = "istio.io/inferencepool-extension-failure-mode"
+	maxServiceNameLength = 63
+	hashSize             = 8
 )
 
 // // ManagedLabel is the label used to identify resources managed by this controller
@@ -522,11 +519,11 @@ func translateShadowServiceToService(existingLabels map[string]string, shadow sh
 			Name:      shadow.key.Name,
 			Namespace: shadow.key.Namespace,
 			Labels: maps.MergeCopy(map[string]string{
-				InferencePoolRefLabel:                shadow.poolName,
-				InferencePoolExtensionRefSvc:         extRef.name,
-				InferencePoolExtensionRefPort:        strconv.Itoa(int(extRef.port)),
-				InferencePoolExtensionRefFailureMode: extRef.failureMode,
-				constants.InternalServiceSemantics:   constants.ServiceSemanticsInferencePool,
+				model.InferencePoolRefLabel:                shadow.poolName,
+				model.InferencePoolExtensionRefSvc:         extRef.name,
+				model.InferencePoolExtensionRefPort:        strconv.Itoa(int(extRef.port)),
+				model.InferencePoolExtensionRefFailureMode: extRef.failureMode,
+				constants.InternalServiceSemantics:         constants.ServiceSemanticsInferencePool,
 			}, existingLabels),
 		},
 		Spec: corev1.ServiceSpec{
@@ -601,8 +598,8 @@ func (c *Controller) canManageShadowServiceForInference(obj *corev1.Service) (bo
 		return true, ""
 	}
 
-	_, inferencePoolManaged := obj.GetLabels()[InferencePoolRefLabel]
-	// We can manage if it has no manager or if we are the manager
+	_, inferencePoolManaged := obj.GetLabels()[model.InferencePoolRefLabel]
+	// We can manage if it has no manager or ifmodel. we are the manager
 	return inferencePoolManaged, obj.GetResourceVersion()
 }
 

--- a/pilot/pkg/config/kube/gateway/inferencepool_test.go
+++ b/pilot/pkg/config/kube/gateway/inferencepool_test.go
@@ -22,6 +22,7 @@ import (
 	inferencev1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 
 	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/test"
@@ -80,7 +81,7 @@ func TestReconcileInferencePool(t *testing.T) {
 	}, true)
 
 	assert.Equal(t, service.ObjectMeta.Labels[constants.InternalServiceSemantics], constants.ServiceSemanticsInferencePool)
-	assert.Equal(t, service.ObjectMeta.Labels[InferencePoolRefLabel], pool.Name)
+	assert.Equal(t, service.ObjectMeta.Labels[model.InferencePoolRefLabel], pool.Name)
 	assert.Equal(t, service.OwnerReferences[0].Name, pool.Name)
 	assert.Equal(t, service.Spec.Ports[0].TargetPort.IntVal, int32(8080))
 	assert.Equal(t, service.Spec.Ports[0].Port, int32(54321)) // dummyPort + i

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -29,7 +29,6 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	anypb "google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/structpb"
-	"k8s.io/apimachinery/pkg/types"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/credentials"
@@ -1063,14 +1062,8 @@ func (node *Proxy) DeleteWatchedResource(typeURL string) {
 	delete(node.WatchedResources, typeURL)
 }
 
-type InferenceGatewayContext interface {
-	// HasInferencePool returns whether or not a given gateway has a reference to an InferencePool
-	HasInferencePool(types.NamespacedName) bool
-}
-
 type GatewayController interface {
 	ConfigStoreController
-	InferenceGatewayContext
 	// Reconcile updates the internal state of the gateway controller for a given input. This should be
 	// called before any List/Get calls if the state has changed
 	Reconcile(ctx *PushContext)

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -127,6 +127,14 @@ type Service struct {
 	ResourceVersion string
 }
 
+// Constants for the Inference Extension
+const (
+	InferencePoolRefLabel                = "istio.io/inferencepool-name"
+	InferencePoolExtensionRefSvc         = "istio.io/inferencepool-extension-service"
+	InferencePoolExtensionRefPort        = "istio.io/inferencepool-extension-port"
+	InferencePoolExtensionRefFailureMode = "istio.io/inferencepool-extension-failure-mode"
+)
+
 // UseInferenceSemantics determines which logic we should use for Service
 // This allows InferencePools and Services to both be represented by Service, but have different
 // semantics.

--- a/pilot/pkg/networking/core/cluster.go
+++ b/pilot/pkg/networking/core/cluster.go
@@ -363,6 +363,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(cb *ClusterBuilder, 
 
 			if service.UseInferenceSemantics() && proxy.Type == model.Router {
 				cb.applyOverrideHostPolicy(defaultCluster)
+				cb.applyExtProcUpstreamFilter(defaultCluster, service)
 			}
 			if patched := cp.patch(nil, defaultCluster.build()); patched != nil {
 				resources = append(resources, patched)

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -44,7 +44,6 @@ import (
 	networkutil "istio.io/istio/pilot/pkg/util/network"
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pilot/pkg/xds/endpoints"
-	"istio.io/istio/pilot/pkg/xds/filters"
 	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pkg/config"
@@ -225,9 +224,8 @@ func (cb *ClusterBuilder) applyExtProcUpstreamFilter(cw *clusterWrapper, svc *mo
 	extProcFailureMode := svc.Attributes.Labels[model.InferencePoolExtensionRefFailureMode]
 	failureModeAllow := extProcFailureMode == string(inferencev1.EndpointPickerFailOpen)
 	extProcCluster := model.BuildSubsetKey(model.TrafficDirectionOutbound, "", extSvcHost, extPortNum)
-	rawOpts.HttpFilters = append(rawOpts.HttpFilters, filters.BuildInferencePoolExtProcFilter(extProcCluster, failureModeAllow))
 	// Must end with the codec filter
-	rawOpts.HttpFilters = append(rawOpts.HttpFilters, filters.UpstreamCodecFilter)
+	rawOpts.HttpFilters = append(rawOpts.HttpFilters, xdsfilters.BuildInferencePoolExtProcFilter(extProcCluster, failureModeAllow), xdsfilters.UpstreamCodecFilter)
 
 	cw.cluster.TypedExtensionProtocolOptions[v3.HttpProtocolOptionsType] = protoconv.MessageToAny(rawOpts)
 }

--- a/pilot/pkg/networking/core/gateway.go
+++ b/pilot/pkg/networking/core/gateway.go
@@ -443,8 +443,6 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 				gatewayRoutes[gatewayName] = make(map[string][]*route.Route)
 			}
 
-			infPoolConfigs := istio_route.CheckAndGetInferencePoolConfigs(virtualService)
-
 			vskey := virtualService.Name + "/" + virtualService.Namespace
 
 			if routes, exists = gatewayRoutes[gatewayName][vskey]; !exists {
@@ -461,7 +459,6 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 					LookupHash: func(destination *networking.HTTPRouteDestination) *networking.LoadBalancerSettings_ConsistentHashLB {
 						return hashByDestination[destination]
 					},
-					InferencePoolExtensionRefs: infPoolConfigs,
 				}
 				routes, err = istio_route.BuildHTTPRoutesForVirtualService(node, virtualService, port, sets.New(gatewayName), opts)
 				if err != nil {

--- a/pilot/pkg/networking/core/listener_builder.go
+++ b/pilot/pkg/networking/core/listener_builder.go
@@ -24,10 +24,8 @@ import (
 	tcp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	"google.golang.org/protobuf/types/known/durationpb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
-	"k8s.io/apimachinery/pkg/types"
 
 	extensions "istio.io/api/extensions/v1alpha1"
-	"istio.io/api/label"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
@@ -411,12 +409,6 @@ func (lb *ListenerBuilder) buildHTTPConnectionManager(httpOpts *httpListenerOpts
 		// TODO: these feel like the wrong place to insert, but this retains backwards compatibility with the original implementation
 		filters = extension.PopAppendHTTP(filters, wasm, extensions.PluginPhase_STATS)
 		filters = extension.PopAppendHTTP(filters, wasm, extensions.PluginPhase_UNSPECIFIED_PHASE)
-		// Add ExtProc per listener only if the Gateway has any inferencePool attached to it
-		if kubeGwName, ok := lb.node.Labels[label.IoK8sNetworkingGatewayGatewayName.Name]; ok {
-			if lb.push.GatewayAPIController.HasInferencePool(types.NamespacedName{Name: kubeGwName, Namespace: lb.node.GetNamespace()}) {
-				filters = append(filters, xdsfilters.InferencePoolExtProc)
-			}
-		}
 	}
 
 	if httpOpts.protocol == protocol.GRPCWeb {

--- a/pilot/pkg/networking/core/listener_builder_test.go
+++ b/pilot/pkg/networking/core/listener_builder_test.go
@@ -25,7 +25,6 @@ import (
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
-	"k8s.io/apimachinery/pkg/types"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
@@ -37,11 +36,9 @@ import (
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
-	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/util/protomarshal"
-	"istio.io/istio/pkg/util/sets"
 	"istio.io/istio/pkg/wellknown"
 )
 
@@ -986,32 +983,6 @@ func TestAdditionalAddressesForIPv6(t *testing.T) {
 	if vo.AdditionalAddresses == nil || len(vo.AdditionalAddresses) != 1 {
 		t.Fatal("expected additional ipv4 bind addresses")
 	}
-}
-
-func TestExtProcExistForInferencePoolEnabledGateway(t *testing.T) {
-	test.SetForTest(t, &features.EnableGatewayAPIInferenceExtension, true)
-
-	cg := NewConfigGenTest(t, TestOptions{
-		Services: testServices,
-	})
-	proxy := cg.SetupProxy(&model.Proxy{Labels: map[string]string{"gateway.networking.k8s.io/gateway-name": "foo-gateway"}, ConfigNamespace: "not-default"})
-	fakeGatewayController := model.FakeController{
-		GatewaysWithInferencePools: sets.New(types.NamespacedName{Name: "foo-gateway", Namespace: "not-default"}),
-	}
-	cg.env.PushContext().GatewayAPIController = fakeGatewayController
-
-	lstnrs := cg.Listeners(proxy)
-	vo := xdstest.ExtractListener("0.0.0.0_8080", lstnrs)
-	if vo == nil {
-		t.Fatal("didn't find virtual outbound listener")
-	}
-	for _, fc := range vo.GetFilterChains() {
-		_, httpFilters := xdstest.ExtractFilterNames(t, fc)
-		if slices.Contains(httpFilters, wellknown.HTTPExternalProcessing) {
-			return
-		}
-	}
-	t.Fatal("expected ext proc filter to be added")
 }
 
 func TestPreserveHeader(t *testing.T) {

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -108,9 +108,6 @@ type Config struct {
 
 	// Status holds long-running status.
 	Status Status
-
-	// Extra holds additional, non-spec information for internal processing.
-	Extra map[string]any
 }
 
 func LabelsInRevision(lbls map[string]string, rev string) bool {
@@ -395,10 +392,6 @@ func (c *Config) Equals(other *Config) bool {
 	if !equals(c.Status, other.Status) {
 		return false
 	}
-	// Can't use map.Equal because store maps as the value
-	if !equals(c.Extra, other.Extra) {
-		return false
-	}
 	return true
 }
 
@@ -454,10 +447,6 @@ func (c Config) DeepCopy() Config {
 	clone.Spec = DeepCopy(c.Spec)
 	if c.Status != nil {
 		clone.Status = DeepCopy(c.Status)
-	}
-	// Note that this is effectively a shallow clone, but this is fine as it is not manipulated.
-	if c.Extra != nil {
-		clone.Extra = maps.Clone(c.Extra)
 	}
 	return clone
 }

--- a/pkg/wellknown/wellknown.go
+++ b/pkg/wellknown/wellknown.go
@@ -61,6 +61,8 @@ const (
 	EnvoyOverrideHostLbPolicy = "envoy.load_balancing_policies.override_host"
 	// ROUND_ROBIN envoy lb policy
 	EnvoyRoundRobinLbPolicy = "envoy.load_balancing_policies.round_robin"
+	// Upstream codec filter
+	HTTPUpstreamCodec = "envoy.filters.http.upstream_codec"
 )
 
 // Network filter names


### PR DESCRIPTION
**Please provide a description of this PR:**
Currently, we use an ExtProcPerRoute in order to call the EPP during inference. However, this model doesn't scale well to multicluster inference since the upstream spec doesn't require namespace sameness among EPP services (if the EPP for a remote inference pool has a different name, we won't know its name until we pick the cluster and the ext proc filter gets executed before then). This PR removes all of the route propagation for inference pools and instead calls the EPP as an ext-proc on the cluster. Upstream clusters are technically alpha in Envoy, but it's been around for two years (and inference extension support is alpha in Istio as well)