### PR TITLE
fix TestInformerExistingPodAddErrorAnnotatesWithPartialStatusOnRetry

### DIFF
--- a/cni/pkg/nodeagent/informers_test.go
+++ b/cni/pkg/nodeagent/informers_test.go
@@ -176,7 +176,7 @@ func TestInformerExistingPodAddErrorAnnotatesWithPartialStatusOnRetry(t *testing
 	client := kube.NewFakeClient(ns, pod)
 	fs := &fakeServer{}
 
-	fs.On("AddPodToMesh",
+	call := fs.On("AddPodToMesh",
 		ctx,
 		mock.IsType(pod),
 		util.GetPodIPsIfPresent(pod),
@@ -200,6 +200,11 @@ func TestInformerExistingPodAddErrorAnnotatesWithPartialStatusOnRetry(t *testing
 	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.AtLeast(6))
 
 	assertPodAnnotatedPending(t, client, pod)
+
+	// allow the call to succeed, this will stop further retry events from occurring
+	call.Return(nil)
+	// assert that the pod has been annotated before we proceed
+	assertPodAnnotated(t, client, pod)
 
 	// Assert expected calls actually made
 	fs.AssertExpectations(t)


### PR DESCRIPTION
The reconcile loop will constantly retry given an error. This can affect further tests since the reconcile event counter is a global. Allow the pod to be added to the mesh and no more update events occur.

**Please provide a description of this PR:**
What tends to happen is that the next test
`TestInformerExistingPodAddErrorDoesNotRetryIfNotRetryable` fails with 
```
informers_test.go:1295: Metric nodeagent_reconcile_events_total/map[type:update] not matched (timeout while waiting after 35 attempts (last             │ │ error: got unexpected val 4: want 1, got 4)); 
```
All tests after will fail, and all tests pass if the PartialStatusOnRetry is skipped.