### PR TITLE
gateway: do not fail to startup when alpha BackendTLSPolicy is installed

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion_test.go
+++ b/pilot/pkg/config/kube/gateway/conversion_test.go
@@ -795,7 +795,7 @@ func setupClientCRDs(t *testing.T, kc kube.CLIClient) {
 		gvr.InferencePool,
 	} {
 		clienttest.MakeCRDWithAnnotations(t, kc, crd, map[string]string{
-			consts.BundleVersionAnnotation: "v1.1.0",
+			consts.BundleVersionAnnotation: consts.BundleVersion,
 		})
 	}
 }

--- a/pkg/kube/kclient/crdwatcher.go
+++ b/pkg/kube/kclient/crdwatcher.go
@@ -64,7 +64,8 @@ func newCrdWatcher(client kube.Client) kubetypes.CrdWatcher {
 }
 
 var minimumCRDVersions = map[string]*semver.Version{
-	"grpcroutes.gateway.networking.k8s.io": semver.New(1, 1, 0, "", ""),
+	"grpcroutes.gateway.networking.k8s.io":         semver.New(1, 1, 0, "", ""),
+	"backendtlspolicies.gateway.networking.k8s.io": semver.New(1, 4, 0, "", ""),
 }
 
 // minimumVersionFilter filters CRDs that do not meet a minimum "version".


### PR DESCRIPTION
This fixes a gap on the 1.4 upgrade. We need to mirror what we did when
GRPCRoute was promoted.

Today, we detect if a CRD exists and watch it only if it does. However,
this needs to be version aware, so the presence of the alpha-only CRD
does not mean we should attempt to read v1, since it doesn't exist.

A known and intended risk of this is a user has alpha policies, upgrades
Istio without installing v1, and they stop working. THIS IS INTENDED and
known; this is exactly why we make users explicitly opt-in to the
experimental support for alpha.
