### PR TITLE
support custom CRL ConfigMap name

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -516,7 +516,7 @@ spec:
   {{- end }}
   - name: istio-ca-crl
     configMap:
-      name: istio-ca-crl
+      name: {{ .Values.global.crlConfigMapName | default "istio-ca-crl" }}
       optional: true
   {{- if .Values.global.mountMtlsCerts }}
   # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -516,7 +516,7 @@ spec:
   {{- end }}
   - name: istio-ca-crl
     configMap:
-      name: {{ .Values.global.crlConfigMapName | default "istio-ca-crl" }}
+      name: {{ .Values.pilot.crlConfigMapName | default "istio-ca-crl" }}
       optional: true
   {{- if .Values.global.mountMtlsCerts }}
   # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -202,6 +202,10 @@ spec:
           - name: PILOT_CA_CERT_CONFIGMAP
             value: "{{ .Values.global.trustBundleName }}"
 {{- end }}
+{{- if .Values.global.crlConfigMapName }}
+          - name: PILOT_CRL_CONFIGMAP
+            value: "{{ .Values.global.crlConfigMapName }}"
+{{- end }}
           - name: PILOT_ENABLE_ANALYSIS
             value: "{{ .Values.global.istiod.enableAnalysis }}"
           - name: CLUSTER_ID

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -202,9 +202,9 @@ spec:
           - name: PILOT_CA_CERT_CONFIGMAP
             value: "{{ .Values.global.trustBundleName }}"
 {{- end }}
-{{- if .Values.global.crlConfigMapName }}
+{{- if .Values.crlConfigMapName }}
           - name: PILOT_CRL_CONFIGMAP
-            value: "{{ .Values.global.crlConfigMapName }}"
+            value: "{{ .Values.crlConfigMapName }}"
 {{- end }}
           - name: PILOT_ENABLE_ANALYSIS
             value: "{{ .Values.global.istiod.enableAnalysis }}"

--- a/operator/pkg/apis/values_types.pb.go
+++ b/operator/pkg/apis/values_types.pb.go
@@ -1851,9 +1851,11 @@ type GlobalConfig struct {
 	// Specifies whether native nftables rules should be used instead of iptables rules for traffic redirection.
 	NativeNftables *wrapperspb.BoolValue `protobuf:"bytes,74,opt,name=nativeNftables,proto3" json:"nativeNftables,omitempty"`
 	// Settings related to Kubernetes NetworkPolicy.
-	NetworkPolicy *NetworkPolicyConfig `protobuf:"bytes,75,opt,name=networkPolicy,proto3" json:"networkPolicy,omitempty"` // The next available key is 76
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	NetworkPolicy *NetworkPolicyConfig `protobuf:"bytes,75,opt,name=networkPolicy,proto3" json:"networkPolicy,omitempty"`
+	// Select a custom name for istiod's plugged-in CA CRL ConfigMap.
+	CrlConfigMapName string `protobuf:"bytes,76,opt,name=crlConfigMapName,proto3" json:"crlConfigMapName,omitempty"` // The next available key is 77
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *GlobalConfig) Reset() {
@@ -2205,6 +2207,13 @@ func (x *GlobalConfig) GetNetworkPolicy() *NetworkPolicyConfig {
 		return x.NetworkPolicy
 	}
 	return nil
+}
+
+func (x *GlobalConfig) GetCrlConfigMapName() string {
+	if x != nil {
+		return x.CrlConfigMapName
+	}
+	return ""
 }
 
 // Configuration for Security Token Service (STS) server.
@@ -5562,7 +5571,7 @@ const file_pkg_apis_values_types_proto_rawDesc = "" +
 	"\x14istio_ingressgateway\x18\x04 \x01(\v2-.istio.operator.v1alpha1.IngressGatewayConfigR\x14istio-ingressgateway\x12@\n" +
 	"\x0fsecurityContext\x18\n" +
 	" \x01(\v2\x16.google.protobuf.ValueR\x0fsecurityContext\x12>\n" +
-	"\x0eseccompProfile\x18\f \x01(\v2\x16.google.protobuf.ValueR\x0eseccompProfile\"\xdf\x13\n" +
+	"\x0eseccompProfile\x18\f \x01(\v2\x16.google.protobuf.ValueR\x0eseccompProfile\"\x8b\x14\n" +
 	"\fGlobalConfig\x12;\n" +
 	"\x04arch\x18\x01 \x01(\v2#.istio.operator.v1alpha1.ArchConfigB\x02\x18\x01R\x04arch\x12 \n" +
 	"\vcertSigners\x18D \x03(\tR\vcertSigners\x12F\n" +
@@ -5612,7 +5621,8 @@ const file_pkg_apis_values_types_proto_rawDesc = "" +
 	"\bwaypoint\x18H \x01(\v2'.istio.operator.v1alpha1.WaypointConfigR\bwaypoint\x12(\n" +
 	"\x0ftrustBundleName\x18I \x01(\tR\x0ftrustBundleName\x12B\n" +
 	"\x0enativeNftables\x18J \x01(\v2\x1a.google.protobuf.BoolValueR\x0enativeNftables\x12R\n" +
-	"\rnetworkPolicy\x18K \x01(\v2,.istio.operator.v1alpha1.NetworkPolicyConfigR\rnetworkPolicy\"-\n" +
+	"\rnetworkPolicy\x18K \x01(\v2,.istio.operator.v1alpha1.NetworkPolicyConfigR\rnetworkPolicy\x12*\n" +
+	"\x10crlConfigMapName\x18L \x01(\tR\x10crlConfigMapName\"-\n" +
 	"\tSTSConfig\x12 \n" +
 	"\vservicePort\x18\x01 \x01(\rR\vservicePort\"R\n" +
 	"\fIstiodConfig\x12B\n" +

--- a/operator/pkg/apis/values_types.pb.go
+++ b/operator/pkg/apis/values_types.pb.go
@@ -1851,11 +1851,9 @@ type GlobalConfig struct {
 	// Specifies whether native nftables rules should be used instead of iptables rules for traffic redirection.
 	NativeNftables *wrapperspb.BoolValue `protobuf:"bytes,74,opt,name=nativeNftables,proto3" json:"nativeNftables,omitempty"`
 	// Settings related to Kubernetes NetworkPolicy.
-	NetworkPolicy *NetworkPolicyConfig `protobuf:"bytes,75,opt,name=networkPolicy,proto3" json:"networkPolicy,omitempty"`
-	// Select a custom name for istiod's plugged-in CA CRL ConfigMap.
-	CrlConfigMapName string `protobuf:"bytes,76,opt,name=crlConfigMapName,proto3" json:"crlConfigMapName,omitempty"` // The next available key is 77
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	NetworkPolicy *NetworkPolicyConfig `protobuf:"bytes,75,opt,name=networkPolicy,proto3" json:"networkPolicy,omitempty"` // The next available key is 76
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GlobalConfig) Reset() {
@@ -2207,13 +2205,6 @@ func (x *GlobalConfig) GetNetworkPolicy() *NetworkPolicyConfig {
 		return x.NetworkPolicy
 	}
 	return nil
-}
-
-func (x *GlobalConfig) GetCrlConfigMapName() string {
-	if x != nil {
-		return x.CrlConfigMapName
-	}
-	return ""
 }
 
 // Configuration for Security Token Service (STS) server.
@@ -3009,9 +3000,11 @@ type PilotConfig struct {
 	// Configuration for the istio-discovery chart when istiod is running in a remote cluster (e.g. "remote control plane").
 	IstiodRemote *IstiodRemoteConfig `protobuf:"bytes,61,opt,name=istiodRemote,proto3" json:"istiodRemote,omitempty"`
 	// Configuration for the istio-discovery chart
-	EnvVarFrom    []*structpb.Struct `protobuf:"bytes,62,rep,name=envVarFrom,proto3" json:"envVarFrom,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	EnvVarFrom []*structpb.Struct `protobuf:"bytes,62,rep,name=envVarFrom,proto3" json:"envVarFrom,omitempty"`
+	// Select a custom name for istiod's plugged-in CA CRL ConfigMap.
+	CrlConfigMapName string `protobuf:"bytes,63,opt,name=crlConfigMapName,proto3" json:"crlConfigMapName,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *PilotConfig) Reset() {
@@ -3331,6 +3324,13 @@ func (x *PilotConfig) GetEnvVarFrom() []*structpb.Struct {
 		return x.EnvVarFrom
 	}
 	return nil
+}
+
+func (x *PilotConfig) GetCrlConfigMapName() string {
+	if x != nil {
+		return x.CrlConfigMapName
+	}
+	return ""
 }
 
 type PilotTaintControllerConfig struct {
@@ -5571,7 +5571,7 @@ const file_pkg_apis_values_types_proto_rawDesc = "" +
 	"\x14istio_ingressgateway\x18\x04 \x01(\v2-.istio.operator.v1alpha1.IngressGatewayConfigR\x14istio-ingressgateway\x12@\n" +
 	"\x0fsecurityContext\x18\n" +
 	" \x01(\v2\x16.google.protobuf.ValueR\x0fsecurityContext\x12>\n" +
-	"\x0eseccompProfile\x18\f \x01(\v2\x16.google.protobuf.ValueR\x0eseccompProfile\"\x8b\x14\n" +
+	"\x0eseccompProfile\x18\f \x01(\v2\x16.google.protobuf.ValueR\x0eseccompProfile\"\xdf\x13\n" +
 	"\fGlobalConfig\x12;\n" +
 	"\x04arch\x18\x01 \x01(\v2#.istio.operator.v1alpha1.ArchConfigB\x02\x18\x01R\x04arch\x12 \n" +
 	"\vcertSigners\x18D \x03(\tR\vcertSigners\x12F\n" +
@@ -5621,8 +5621,7 @@ const file_pkg_apis_values_types_proto_rawDesc = "" +
 	"\bwaypoint\x18H \x01(\v2'.istio.operator.v1alpha1.WaypointConfigR\bwaypoint\x12(\n" +
 	"\x0ftrustBundleName\x18I \x01(\tR\x0ftrustBundleName\x12B\n" +
 	"\x0enativeNftables\x18J \x01(\v2\x1a.google.protobuf.BoolValueR\x0enativeNftables\x12R\n" +
-	"\rnetworkPolicy\x18K \x01(\v2,.istio.operator.v1alpha1.NetworkPolicyConfigR\rnetworkPolicy\x12*\n" +
-	"\x10crlConfigMapName\x18L \x01(\tR\x10crlConfigMapName\"-\n" +
+	"\rnetworkPolicy\x18K \x01(\v2,.istio.operator.v1alpha1.NetworkPolicyConfigR\rnetworkPolicy\"-\n" +
 	"\tSTSConfig\x12 \n" +
 	"\vservicePort\x18\x01 \x01(\rR\vservicePort\"R\n" +
 	"\fIstiodConfig\x12B\n" +
@@ -5679,7 +5678,7 @@ const file_pkg_apis_values_types_proto_rawDesc = "" +
 	"\x04mode\x18\x02 \x01(\x0e29.istio.operator.v1alpha1.OutboundTrafficPolicyConfig.ModeR\x04mode\"(\n" +
 	"\x04Mode\x12\r\n" +
 	"\tALLOW_ANY\x10\x00\x12\x11\n" +
-	"\rREGISTRY_ONLY\x10\x01\"\x98\x13\n" +
+	"\rREGISTRY_ONLY\x10\x01\"\xc4\x13\n" +
 	"\vPilotConfig\x124\n" +
 	"\aenabled\x18\x01 \x01(\v2\x1a.google.protobuf.BoolValueR\aenabled\x12F\n" +
 	"\x10autoscaleEnabled\x18\x02 \x01(\v2\x1a.google.protobuf.BoolValueR\x10autoscaleEnabled\x12\"\n" +
@@ -5724,7 +5723,8 @@ const file_pkg_apis_values_types_proto_rawDesc = "" +
 	"\fistiodRemote\x18= \x01(\v2+.istio.operator.v1alpha1.IstiodRemoteConfigR\fistiodRemote\x127\n" +
 	"\n" +
 	"envVarFrom\x18> \x03(\v2\x17.google.protobuf.StructR\n" +
-	"envVarFrom\"T\n" +
+	"envVarFrom\x12*\n" +
+	"\x10crlConfigMapName\x18? \x01(\tR\x10crlConfigMapName\"T\n" +
 	"\x1aPilotTaintControllerConfig\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\x12\x1c\n" +
 	"\tnamespace\x18\x02 \x01(\tR\tnamespace\"\xc6\x01\n" +

--- a/operator/pkg/apis/values_types.proto
+++ b/operator/pkg/apis/values_types.proto
@@ -645,10 +645,7 @@ message GlobalConfig {
 
   // Settings related to Kubernetes NetworkPolicy.
   NetworkPolicyConfig networkPolicy = 75;
-
-  // Select a custom name for istiod's plugged-in CA CRL ConfigMap.
-  string crlConfigMapName = 76;
-  // The next available key is 77
+  // The next available key is 76
 }
 
 // Configuration for Security Token Service (STS) server.
@@ -984,6 +981,9 @@ message PilotConfig {
 
   // Configuration for the istio-discovery chart
   repeated google.protobuf.Struct envVarFrom = 62;
+
+  // Select a custom name for istiod's plugged-in CA CRL ConfigMap.
+  string crlConfigMapName = 63;
 }
 
 message PilotTaintControllerConfig {

--- a/operator/pkg/apis/values_types.proto
+++ b/operator/pkg/apis/values_types.proto
@@ -645,7 +645,10 @@ message GlobalConfig {
 
   // Settings related to Kubernetes NetworkPolicy.
   NetworkPolicyConfig networkPolicy = 75;
-  // The next available key is 76
+
+  // Select a custom name for istiod's plugged-in CA CRL ConfigMap.
+  string crlConfigMapName = 76;
+  // The next available key is 77
 }
 
 // Configuration for Security Token Service (STS) server.

--- a/pilot/pkg/features/experimental.go
+++ b/pilot/pkg/features/experimental.go
@@ -195,6 +195,9 @@ var (
 	CACertConfigMapName = env.Register("PILOT_CA_CERT_CONFIGMAP", "istio-ca-root-cert",
 		"The name of the ConfigMap that stores the Root CA Certificate that is used by istiod").Get()
 
+	CRLConfigMapName = env.Register("PILOT_CRL_CONFIGMAP", "istio-ca-crl",
+		"The name of the ConfigMap that stores the Certificate Revocation List (CRL) for a plugged-in CA").Get()
+
 	EnvoyStatusPortEnableProxyProtocol = env.Register("ENVOY_STATUS_PORT_ENABLE_PROXY_PROTOCOL", false,
 		"If enabled, Envoy will support requests with proxy protocol on its status port").Get()
 

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
@@ -39,14 +39,14 @@ const (
 	//
 	// 5ms, 10ms, 20ms, 40ms, 80ms
 	maxRetries = 5
-
-	// CRLNamespaceConfigMap is the name of the ConfigMap in each namespace storing the CRL of plugged in CA certificates.
-	CRLNamespaceConfigMap = "istio-ca-crl"
 )
 
 var (
 	// CACertNamespaceConfigMap is the name of the ConfigMap in each namespace storing the root cert of non-Kube CA.
 	CACertNamespaceConfigMap = features.CACertConfigMapName
+
+	// CRLNamespaceConfigMap is the name of the ConfigMap in each namespace storing the CRL of plugged in CA certificates.
+	CRLNamespaceConfigMap = features.CRLConfigMapName
 
 	configMapLabel = map[string]string{"istio.io/config": "true"}
 )

--- a/releasenotes/notes/crlconfigmapname.yaml
+++ b/releasenotes/notes/crlconfigmapname.yaml
@@ -4,4 +4,4 @@ area: installation
 
 releaseNotes:
 - |
-  **Added** a setting values.global.crlConfigMapName that allows configuring the name of the ConfigMap that istiod uses to propagate its Certificate Revocation List (CRL) in the cluster. This allows running multiple control planes with overlapping namespaces in the same cluster.
+  **Added** a setting values.pilot.crlConfigMapName that allows configuring the name of the ConfigMap that istiod uses to propagate its Certificate Revocation List (CRL) in the cluster. This allows running multiple control planes with overlapping namespaces in the same cluster.

--- a/releasenotes/notes/crlconfigmapname.yaml
+++ b/releasenotes/notes/crlconfigmapname.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+
+releaseNotes:
+- |
+  **Added** a setting values.global.crlConfigMapName that allows configuring the name of the ConfigMap that istiod uses to propagate its Certificate Revocation List (CRL) in the cluster. This allows running multiple control planes with overlapping namespaces in the same cluster.

--- a/tests/integration/pilot/multiplecontrolplanes/main_test.go
+++ b/tests/integration/pilot/multiplecontrolplanes/main_test.go
@@ -124,6 +124,7 @@ values:
   global:
     trustBundleName: usergroup-2-ca-root-cert
     istioNamespace: %s
+  pilot:
     crlConfigMapName: usergroup-2-ca-crl`, userGroup2NS.Name(), userGroup2NS.Name())
 		})).
 		SetupParallel(

--- a/tests/integration/pilot/multiplecontrolplanes/main_test.go
+++ b/tests/integration/pilot/multiplecontrolplanes/main_test.go
@@ -22,6 +22,9 @@ import (
 	"net/http"
 	"testing"
 
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/http/headers"
 	"istio.io/istio/pkg/test/echo/common/scheme"
@@ -120,7 +123,8 @@ meshConfig:
 values:
   global:
     trustBundleName: usergroup-2-ca-root-cert
-    istioNamespace: %s`, userGroup2NS.Name(), userGroup2NS.Name())
+    istioNamespace: %s
+    crlConfigMapName: usergroup-2-ca-crl`, userGroup2NS.Name(), userGroup2NS.Name())
 		})).
 		SetupParallel(
 			// application namespaces are labeled according to the required control plane ownership.
@@ -272,6 +276,55 @@ func TestCustomResourceScoping(t *testing.T) {
 							check.ErrorOrStatus(tc.statusCode),
 						),
 					})
+				})
+			}
+		})
+}
+
+// TestCRLConfigMapNames verifies that CRL ConfigMaps are correctly propagated to workload namespaces
+func TestCRLConfigMapNames(t *testing.T) {
+	framework.NewTest(t).
+		Run(func(t framework.TestContext) {
+			testCases := []struct {
+				name           string
+				namespace      namespace.Instance
+				shouldExist    []string
+				shouldNotExist []string
+			}{
+				{
+					name:           "echo1 namespace has default CRL ConfigMap",
+					namespace:      echo1NS,
+					shouldExist:    []string{"istio-ca-crl"},
+					shouldNotExist: []string{"usergroup-2-ca-crl"},
+				},
+				{
+					name:           "echo2 namespace has custom CRL ConfigMap",
+					namespace:      echo2NS,
+					shouldExist:    []string{"usergroup-2-ca-crl"},
+					shouldNotExist: []string{"istio-ca-crl"},
+				},
+				{
+					name:           "shared namespace has both CRL ConfigMaps",
+					namespace:      sharedNS,
+					shouldExist:    []string{"istio-ca-crl", "usergroup-2-ca-crl"},
+					shouldNotExist: []string{},
+				},
+			}
+
+			for _, tc := range testCases {
+				t.NewSubTest(tc.name).Run(func(t framework.TestContext) {
+					for _, cm := range tc.shouldExist {
+						_, err := t.Clusters().Default().Kube().CoreV1().ConfigMaps(tc.namespace.Name()).Get(t.Context(), cm, metav1.GetOptions{})
+						if err != nil {
+							t.Fatalf("%s should exist in %s: %v", cm, tc.namespace.Name(), err)
+						}
+					}
+					for _, cm := range tc.shouldNotExist {
+						_, err := t.Clusters().Default().Kube().CoreV1().ConfigMaps(tc.namespace.Name()).Get(t.Context(), cm, metav1.GetOptions{})
+						if err == nil || !k8serrors.IsNotFound(err) {
+							t.Fatalf("%s should not exist in %s", cm, tc.namespace.Name())
+						}
+					}
 				})
 			}
 		})


### PR DESCRIPTION
**Please provide a description of this PR:**
Adds support for a custom name for the CRL
ConfigMap that is propagated into namespaces,
for parity with #54971 which allows the same
for the CA root cert.

Part of  #53385.

cc @aslakknutsen @dgn 