### PR TITLE
Drop gogo usage

### DIFF
--- a/pilot/pkg/bootstrap/config_compare.go
+++ b/pilot/pkg/bootstrap/config_compare.go
@@ -17,7 +17,6 @@ package bootstrap
 import (
 	"strings"
 
-	gogoproto "github.com/gogo/protobuf/proto" // nolint: depguard
 	"google.golang.org/protobuf/proto"
 
 	"istio.io/istio/pkg/config"
@@ -60,11 +59,6 @@ func needsPush(prev config.Config, curr config.Config) bool {
 	currspecProto, okProtoC := curr.Spec.(proto.Message)
 	if okProtoP && okProtoC {
 		return !proto.Equal(prevspecProto, currspecProto)
-	}
-	prevspecGogo, okGogoP := prev.Spec.(gogoproto.Message)
-	currspecGogo, okGogoC := curr.Spec.(gogoproto.Message)
-	if okGogoP && okGogoC {
-		return !gogoproto.Equal(prevspecGogo, currspecGogo)
 	}
 	return true
 }

--- a/pkg/config/model_test.go
+++ b/pkg/config/model_test.go
@@ -257,7 +257,7 @@ func TestToJSON(t *testing.T) {
 		// Kubernetes type
 		{
 			input: &corev1.PodSpec{ServiceAccountName: "foobar"},
-			json:  `{"serviceAccountName":"foobar"}`,
+			json:  `{"containers":null,"serviceAccountName":"foobar"}`,
 		},
 		// gateway-api type
 		{


### PR DESCRIPTION
Per https://github.com/istio/istio/pull/57883, we no longer need any gogo usage

* Istio types are golang proto, not gogo
* gateway API types have no protos
* K8s types are gogoproto, but they essentially won't be in the next release, and we shouldn't use them as such anyways