### PR TITLE
wasm: optimize lookup in control plane

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -2204,7 +2204,7 @@ func (ps *PushContext) WasmPluginsByListenerInfo(proxy *Proxy, info WasmPluginLi
 	for _, ns := range slices.FilterDuplicates(lookupInNamespaces) {
 		if wasmPlugins, ok := ps.wasmPluginsByNamespace[ns]; ok {
 			for _, plugin := range wasmPlugins {
-				if plugin.MatchListener(selectionOpts, info) && plugin.MatchType(pluginType) {
+				if plugin.MatchType(pluginType) && plugin.MatchListener(selectionOpts, info) {
 					matchedPlugins[plugin.Phase] = append(matchedPlugins[plugin.Phase], plugin)
 				}
 			}


### PR DESCRIPTION
In a real world environment with many WasmPlugins, we saw about 10% of
CPU usage on the lookup MatchListener. 1/3 of these is spent on HTTP
lookups, while 2/3 on TCP lookups. However, the cluster only has HTTP
wasm plugins.

By flipping the condition to filter by the fast check (MatchType) we can
avoid the expensive MatchListener calls.
