### PR TITLE
correctly filter services for service targets

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -560,7 +560,7 @@ func (node *Proxy) SetGatewaysForProxy(ps *PushContext) {
 func (node *Proxy) ShouldUpdateServiceTargets(updates sets.Set[ConfigKey]) bool {
 	// we only care for services which can actually select this proxy
 	for config := range updates {
-		if config.Kind == kind.ServiceEntry || config.Namespace == node.Metadata.Namespace {
+		if config.Kind == kind.ServiceEntry && config.Namespace == node.Metadata.Namespace {
 			return true
 		}
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**
Fix a logic bug introduced in #55476 which used `||` instead of `&&`. Note that using `||` doesn't really make sense since we're producing the opposite of what was meant, we made `ShouldUpdateServiceTargets` more general instead of more specific.

This should be `&&` instead, since we're only interested in ServiceEntries in the proxy namespace, which are the only ones that can actually select the proxy.