### PR TITLE
log: format duration when doing json

### DIFF
--- a/pkg/log/scope.go
+++ b/pkg/log/scope.go
@@ -345,11 +345,19 @@ func (s *Scope) emitWithTime(level zapcore.Level, msg string, t time.Time) {
 		fields = make([]zapcore.Field, 0, len(s.labelKeys))
 		for _, k := range s.labelKeys {
 			v := s.labels[k]
-			fields = append(fields, zap.Field{
-				Key:       k,
-				Interface: v,
-				Type:      zapcore.ReflectType,
-			})
+			if d, ok := v.(time.Duration); ok {
+				fields = append(fields, zap.Field{
+					Key:     k,
+					Integer: int64(d),
+					Type:    zapcore.DurationType,
+				})
+			} else {
+				fields = append(fields, zap.Field{
+					Key:       k,
+					Interface: v,
+					Type:      zapcore.ReflectType,
+				})
+			}
 		}
 	} else if len(s.labelKeys) > 0 {
 		sb := &strings.Builder{}

--- a/pkg/log/scope_test.go
+++ b/pkg/log/scope_test.go
@@ -19,6 +19,7 @@ import (
 	"regexp"
 	"strconv"
 	"testing"
+	"time"
 
 	"go.uber.org/zap/zapcore"
 	"k8s.io/klog/v2"
@@ -269,7 +270,7 @@ func TestScopeWithLabel(t *testing.T) {
 	lines, err := captureStdout(func() {
 		Configure(DefaultOptions())
 		funcs.Store(funcs.Load().(patchTable))
-		s2 := s.WithLabels("foo", "bar").WithLabels("baz", 123, "qux", 0.123).WithLabels("foo", "override")
+		s2 := s.WithLabels("foo", "bar").WithLabels("baz", 123, "qux", 0.123, "dur", time.Millisecond*101).WithLabels("foo", "override")
 		s2.Debug("Hello")
 		// s should be unmodified.
 		s.Debug("Hello")
@@ -280,7 +281,7 @@ func TestScopeWithLabel(t *testing.T) {
 		t.Errorf("Got error '%v', expected success", err)
 	}
 
-	mustRegexMatchString(t, lines[0], `Hello	foo=override baz=123 qux=0.123`)
+	mustRegexMatchString(t, lines[0], `Hello	foo=override baz=123 qux=0.123 dur=101ms`)
 	mustRegexMatchString(t, lines[1], "Hello$")
 }
 
@@ -295,7 +296,7 @@ func TestScopeJSON(t *testing.T) {
 		o.JSONEncoding = true
 		Configure(o)
 		funcs.Store(funcs.Load().(patchTable))
-		s.WithLabels("foo", "bar", "baz", 123).Debug("Hello")
+		s.WithLabels("foo", "bar", "baz", 123, "dur", time.Millisecond*101).Debug("Hello")
 
 		_ = Sync()
 	})
@@ -303,7 +304,7 @@ func TestScopeJSON(t *testing.T) {
 		t.Errorf("Got error '%v', expected success", err)
 	}
 
-	mustRegexMatchString(t, lines[0], `{.*"msg":"Hello","foo":"bar","baz":123}`)
+	mustRegexMatchString(t, lines[0], `{.*"msg":"Hello","foo":"bar","baz":123,"dur":"101ms"}`)
 }
 
 func mustRegexMatchString(t *testing.T, got, want string) {
@@ -464,10 +465,11 @@ func TestUpdateScope(t *testing.T) {
 }
 
 func BenchmarkLog(b *testing.B) {
-	run := func(name string, f func()) {
+	runOpts := func(name string, opts func(*Options), f func()) {
 		b.Run(name, func(b *testing.B) {
 			o := testOptions()
 			o.OutputPaths = []string{"/dev/null"}
+			opts(o)
 			if err := Configure(o); err != nil {
 				b.Fatalf("Got err '%v', expecting success", err)
 			}
@@ -475,6 +477,9 @@ func BenchmarkLog(b *testing.B) {
 				f()
 			}
 		})
+	}
+	run := func(name string, f func()) {
+		runOpts(name, func(options *Options) {}, f)
 	}
 	run("default", func() {
 		Info("some message")
@@ -491,5 +496,10 @@ func BenchmarkLog(b *testing.B) {
 	})
 	run("precreated and dynamic labels", func() {
 		scope.WithLabels("fruit", "apply").Infof("some %s", "message")
+	})
+	runOpts("json", func(options *Options) {
+		options.JSONEncoding = true
+	}, func() {
+		scope.Infof("some %s", "message")
 	})
 }


### PR DESCRIPTION
No perf impact:

```
name         old time/op    new time/op    delta
Log/json-32     584ns ± 2%     559ns ± 1%  -4.41%  (p=0.000 n=10+10)

name         old alloc/op   new alloc/op   delta
Log/json-32      274B ± 0%      274B ± 0%    ~     (all equal)

name         old allocs/op  new allocs/op  delta
Log/json-32      4.00 ± 0%      4.00 ± 0%    ~     (all equal)
```

Before, it logs the number of nanoseconds which is not useful