### PR TITLE
Pin curl version

### DIFF
--- a/samples/curl/curl.yaml
+++ b/samples/curl/curl.yaml
@@ -52,7 +52,7 @@ spec:
       serviceAccountName: curl
       containers:
       - name: curl
-        image: curlimages/curl
+        image: curlimages/curl:8.16.0
         command: ["/bin/sleep", "infinity"]
         imagePullPolicy: IfNotPresent
         volumeMounts:

--- a/samples/security/spire/curl-spire.yaml
+++ b/samples/security/spire/curl-spire.yaml
@@ -56,7 +56,7 @@ spec:
       serviceAccountName: curl
       containers:
       - name: curl
-        image: curlimages/curl
+        image: curlimages/curl:8.16.0
         command: ["/bin/sleep", "infinity"]
         imagePullPolicy: IfNotPresent
         volumeMounts:

--- a/samples/security/spire/sleep-spire.yaml
+++ b/samples/security/spire/sleep-spire.yaml
@@ -56,7 +56,7 @@ spec:
       serviceAccountName: sleep
       containers:
       - name: sleep
-        image: curlimages/curl
+        image: curlimages/curl:8.16.0
         command: ["/bin/sleep", "infinity"]
         imagePullPolicy: IfNotPresent
         volumeMounts:

--- a/samples/sleep/sleep.yaml
+++ b/samples/sleep/sleep.yaml
@@ -52,7 +52,7 @@ spec:
       serviceAccountName: sleep
       containers:
       - name: sleep
-        image: curlimages/curl
+        image: curlimages/curl:8.16.0
         command: ["/bin/sleep", "infinity"]
         imagePullPolicy: IfNotPresent
         volumeMounts:


### PR DESCRIPTION
**Please provide a description of this PR:**

I think a month ago curl had some changes that changed the formatting of its output. This caused our docs tests to fail, since they deploy samples/curl/curl.yaml:

* https://github.com/istio/istio.io/pull/16923
* https://github.com/istio/istio.io/pull/16924