### PR TITLE
[release-1.27] Remove use of comment module when testing kernel support for iptables…

### DIFF
--- a/tools/istio-iptables/pkg/dependencies/implementation_linux.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation_linux.go
@@ -32,7 +32,7 @@ import (
 	"istio.io/istio/tools/istio-iptables/pkg/constants"
 )
 
-var testRuleAdd = []string{"-t", "nat", "-A", "INPUT", "-p", "255", "-j", "RETURN", "-m", "comment", "--comment", `"Istio no-op iptables capability probe"`}
+var testRuleAdd = []string{"-t", "nat", "-A", "INPUT", "-p", "255", "-j", "RETURN"}
 
 // TODO the entire `istio-iptables` package is linux-specific, I'm not sure we really need
 // platform-differentiators for the `dependencies` package itself.


### PR DESCRIPTION
**Please provide a description of this PR:**
Cherry-pick of #57679

Fixes https://github.com/istio/istio/issues/57678

Use of comment module when verifying there is kernal support for the current iptables version is unnecessary, and its use prevents use of istio in gVisor.

This change removes its use, given it is unnecessary for the test.