### PR TITLE
bump kiali addon to v2.17.0

### DIFF
--- a/manifests/addons/gen.sh
+++ b/manifests/addons/gen.sh
@@ -33,8 +33,8 @@ GRAFANA_VERSION=${GRAFANA_VERSION:-"9.2.2"}
 {
 helm3 template kiali-server \
   --namespace istio-system \
-  --version 2.16.0 \
-  --set deployment.image_version=v2.16 \
+  --version 2.17.0 \
+  --set deployment.image_version=v2.17 \
   --include-crds \
   kiali-server \
   --repo https://kiali.org/helm-charts \

--- a/manifests/addons/values-kiali.yaml
+++ b/manifests/addons/values-kiali.yaml
@@ -6,6 +6,8 @@ deployment:
     sidecar.istio.io/inject: "false"
   ingress_enabled: false
   image_pull_policy: IfNotPresent
+  network_policy:
+    enabled: false
 login_token:
   signing_key: CHANGEME00000000
 external_services:

--- a/releasenotes/notes/kiali-update-v2.17.yaml
+++ b/releasenotes/notes/kiali-update-v2.17.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+
+releaseNotes:
+  - |
+    **Updated** Kiali addon to version v2.17.0.

--- a/samples/addons/kiali.yaml
+++ b/samples/addons/kiali.yaml
@@ -7,12 +7,12 @@ metadata:
   namespace: "istio-system"
   labels:
     
-    helm.sh/chart: kiali-server-2.16.0
+    helm.sh/chart: kiali-server-2.17.0
     app: kiali
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: kiali
-    version: "v2.16.0"
-    app.kubernetes.io/version: "v2.16.0"
+    version: "v2.17.0"
+    app.kubernetes.io/version: "v2.17.0"
     app.kubernetes.io/part-of: "kiali"
 ...
 ---
@@ -24,12 +24,12 @@ metadata:
   namespace: "istio-system"
   labels:
     
-    helm.sh/chart: kiali-server-2.16.0
+    helm.sh/chart: kiali-server-2.17.0
     app: kiali
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: kiali
-    version: "v2.16.0"
-    app.kubernetes.io/version: "v2.16.0"
+    version: "v2.17.0"
+    app.kubernetes.io/version: "v2.17.0"
     app.kubernetes.io/part-of: "kiali"
 data:
   config.yaml: |
@@ -69,7 +69,7 @@ data:
       image_name: quay.io/kiali/kiali
       image_pull_policy: IfNotPresent
       image_pull_secrets: []
-      image_version: v2.16
+      image_version: v2.17
       ingress:
         additional_labels: {}
         class_name: nginx
@@ -83,6 +83,8 @@ data:
         sampler_rate: "1"
         time_field_format: 2006-01-02T15:04:05Z07:00
       namespace: istio-system
+      network_policy:
+        enabled: false
       node_selector: {}
       pod_annotations:
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
@@ -114,7 +116,7 @@ data:
       service_type: ""
       tolerations: []
       topology_spread_constraints: []
-      version_label: v2.16.0
+      version_label: v2.17.0
       view_only_mode: false
     external_services:
       custom_dashboards:
@@ -127,6 +129,7 @@ data:
       cert_file: ""
       private_key_file: ""
     kiali_feature_flags:
+      custom_workload_types: []
       disabled_features: []
       validations:
         ignore:
@@ -150,12 +153,12 @@ metadata:
   name: kiali
   labels:
     
-    helm.sh/chart: kiali-server-2.16.0
+    helm.sh/chart: kiali-server-2.17.0
     app: kiali
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: kiali
-    version: "v2.16.0"
-    app.kubernetes.io/version: "v2.16.0"
+    version: "v2.17.0"
+    app.kubernetes.io/version: "v2.17.0"
     app.kubernetes.io/part-of: "kiali"
 rules:
 - apiGroups: [""]
@@ -210,7 +213,7 @@ rules:
   - extensions.istio.io
   - telemetry.istio.io
   - gateway.networking.k8s.io
-  - inference.networking.x-k8s.io
+  - inference.networking.k8s.io
   resources: ["*"]
   verbs:
   - get
@@ -260,12 +263,12 @@ metadata:
   name: kiali
   labels:
     
-    helm.sh/chart: kiali-server-2.16.0
+    helm.sh/chart: kiali-server-2.17.0
     app: kiali
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: kiali
-    version: "v2.16.0"
-    app.kubernetes.io/version: "v2.16.0"
+    version: "v2.17.0"
+    app.kubernetes.io/version: "v2.17.0"
     app.kubernetes.io/part-of: "kiali"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -285,12 +288,12 @@ metadata:
   namespace: "istio-system"
   labels:
     
-    helm.sh/chart: kiali-server-2.16.0
+    helm.sh/chart: kiali-server-2.17.0
     app: kiali
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: kiali
-    version: "v2.16.0"
-    app.kubernetes.io/version: "v2.16.0"
+    version: "v2.17.0"
+    app.kubernetes.io/version: "v2.17.0"
     app.kubernetes.io/part-of: "kiali"
   annotations:
 spec:
@@ -316,12 +319,12 @@ metadata:
   namespace: "istio-system"
   labels:
     
-    helm.sh/chart: kiali-server-2.16.0
+    helm.sh/chart: kiali-server-2.17.0
     app: kiali
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: kiali
-    version: "v2.16.0"
-    app.kubernetes.io/version: "v2.16.0"
+    version: "v2.17.0"
+    app.kubernetes.io/version: "v2.17.0"
     app.kubernetes.io/part-of: "kiali"
 spec:
   replicas: 1
@@ -339,16 +342,16 @@ spec:
       name: kiali
       labels:
         
-        helm.sh/chart: kiali-server-2.16.0
+        helm.sh/chart: kiali-server-2.17.0
         app: kiali
         app.kubernetes.io/name: kiali
         app.kubernetes.io/instance: kiali
-        version: "v2.16.0"
-        app.kubernetes.io/version: "v2.16.0"
+        version: "v2.17.0"
+        app.kubernetes.io/version: "v2.17.0"
         app.kubernetes.io/part-of: "kiali"
         sidecar.istio.io/inject: "false"
       annotations:
-        checksum/config: 580a9fd573cf01d964d19ff5c3659dba6c86e70ba728e5ce4f32e679d216cec2
+        checksum/config: 5129658cb79b9fbbb9b7745ea8ff77c611538e6ce760b6ad5554d7c85a6b79c1
         prometheus.io/scrape: "true"
         prometheus.io/port: "9090"
         kiali.io/dashboards: go,kiali
@@ -356,7 +359,7 @@ spec:
     spec:
       serviceAccountName: kiali
       containers:
-      - image: "quay.io/kiali/kiali:v2.16"
+      - image: "quay.io/kiali/kiali:v2.17"
         imagePullPolicy: IfNotPresent
         name: kiali
         command:


### PR DESCRIPTION
Kiali v2.17.0 is the appropriate version for the next Istio v1.28 release. This PR bumps up the addon version of Kiali to that version.