### PR TITLE
Improve log message when nft binary is missing on the host

### DIFF
--- a/tools/istio-nftables/pkg/capture/run.go
+++ b/tools/istio-nftables/pkg/capture/run.go
@@ -53,7 +53,10 @@ func NewNftablesConfigurator(cfg *config.Config, nftProvider NftProviderFunc) (*
 			nftImpl, err := builder.NewNftImpl(family, table)
 			if err != nil {
 				if errors.Is(err, exec.ErrNotFound) {
-					return nil, fmt.Errorf("nativeNftables is enabled, but the nft binary is missing on the host filesystem: %w", err)
+					if cfg.HostFilesystemPodNetwork {
+						return nil, fmt.Errorf("nativeNftables is enabled, but the nft binary is missing on the host filesystem: %w", err)
+					}
+					return nil, fmt.Errorf("nativeNftables is enabled, but the nft binary is missing in the sidecar container image: %w", err)
 				}
 				return nil, err
 			}


### PR DESCRIPTION
When nativeNftables mode is enabled in sidecar mode along with IstioCNI, the CNI plugin uses the host's nft binary which may not be available on some platforms. This PR improves the logging to help users understand the exact issue.

Related to: https://github.com/istio/istio/issues/57978