### PR TITLE
fix: use 'default' revision for non-revisioned installs

### DIFF
--- a/istioctl/pkg/admin/istiodconfig.go
+++ b/istioctl/pkg/admin/istiodconfig.go
@@ -485,10 +485,15 @@ func istiodLogCmd(ctx cli.Context) *cobra.Command {
 			var podName, ns string
 			if len(args) == 0 {
 				// resolvedRevision is already set by ctx.RevisionOrDefault(opts.Revision)
+				// For non-revisioned installs, if resolvedRevision is empty, use "default"
+				revisionForSelector := resolvedRevision
+				if revisionForSelector == "" {
+					revisionForSelector = "default"
+				}
 				if len(istiodLabelSelector) > 0 {
-					istiodLabelSelector = fmt.Sprintf("%s,%s=%s", istiodLabelSelector, label.IoIstioRev.Name, resolvedRevision)
+					istiodLabelSelector = fmt.Sprintf("%s,%s=%s", istiodLabelSelector, label.IoIstioRev.Name, revisionForSelector)
 				} else {
-					istiodLabelSelector = fmt.Sprintf("%s=%s", label.IoIstioRev.Name, resolvedRevision)
+					istiodLabelSelector = fmt.Sprintf("%s=%s", label.IoIstioRev.Name, revisionForSelector)
 				}
 				pl, err := client.PodsForSelector(context.TODO(), ctx.NamespaceOrDefault(ctx.IstioNamespace()), istiodLabelSelector)
 				if err != nil {


### PR DESCRIPTION

**Please provide a description of this PR:**

https://github.com/istio/istio/pull/56874#issuecomment-3403790365
Fix istioctl admin log for non-revisioned installs