### PR TITLE
Improve traffic management support for gRPC proxyless clients

### DIFF
--- a/pilot/pkg/networking/grpcgen/cds_test.go
+++ b/pilot/pkg/networking/grpcgen/cds_test.go
@@ -1,0 +1,237 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpcgen
+
+import (
+	"testing"
+
+	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+
+	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/model"
+)
+
+func TestApplyCircuitBreakers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		policy      *networking.TrafficPolicy
+		wantNil     bool
+		wantMaxReqs uint32
+	}{
+		{
+			name: "nil connection pool",
+			policy: &networking.TrafficPolicy{
+				ConnectionPool: nil,
+			},
+			wantNil: true,
+		},
+		{
+			name: "no http2MaxRequests",
+			policy: &networking.TrafficPolicy{
+				ConnectionPool: &networking.ConnectionPoolSettings{
+					Http: &networking.ConnectionPoolSettings_HTTPSettings{},
+				},
+			},
+			wantNil: true,
+		},
+		{
+			name: "http2MaxRequests set",
+			policy: &networking.TrafficPolicy{
+				ConnectionPool: &networking.ConnectionPoolSettings{
+					Http: &networking.ConnectionPoolSettings_HTTPSettings{
+						Http2MaxRequests: 100,
+					},
+				},
+			},
+			wantMaxReqs: 100,
+		},
+		{
+			name: "only tcp maxConnections set - should be ignored",
+			policy: &networking.TrafficPolicy{
+				ConnectionPool: &networking.ConnectionPoolSettings{
+					Tcp: &networking.ConnectionPoolSettings_TCPSettings{
+						MaxConnections: 50,
+					},
+				},
+			},
+			wantNil: true, // No circuit breakers since only max_requests is supported.
+		},
+		{
+			name: "other http fields ignored - only max_requests used",
+			policy: &networking.TrafficPolicy{
+				ConnectionPool: &networking.ConnectionPoolSettings{
+					Http: &networking.ConnectionPoolSettings_HTTPSettings{
+						Http2MaxRequests:        100,
+						Http1MaxPendingRequests: 200, // Ignored.
+						MaxRetries:              3,   // Ignored.
+					},
+					Tcp: &networking.ConnectionPoolSettings_TCPSettings{
+						MaxConnections: 50, // Ignored.
+					},
+				},
+			},
+			wantMaxReqs: 100, // Only max_requests is set.
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := &cluster.Cluster{}
+			b := &clusterBuilder{
+				node: &model.Proxy{ID: "test-node"},
+			}
+			b.applyCircuitBreakers(c, test.policy)
+
+			if test.wantNil {
+				if c.CircuitBreakers != nil {
+					t.Errorf("expected nil CircuitBreakers, got %v", c.CircuitBreakers)
+				}
+				return
+			}
+
+			if c.CircuitBreakers == nil {
+				t.Fatal("CircuitBreakers should not be nil")
+			}
+			if len(c.CircuitBreakers.Thresholds) != 1 {
+				t.Fatalf("expected 1 threshold, got %d", len(c.CircuitBreakers.Thresholds))
+			}
+
+			th := c.CircuitBreakers.Thresholds[0]
+			if th.MaxRequests.Value != test.wantMaxReqs {
+				t.Errorf("MaxRequests: got %d, want %d", th.MaxRequests.Value, test.wantMaxReqs)
+			}
+
+			// Verify other fields are NOT set (per gRFC A32).
+			if th.MaxConnections != nil {
+				t.Errorf("MaxConnections should not be set, got %d", th.MaxConnections.Value)
+			}
+			if th.MaxRetries != nil {
+				t.Errorf("MaxRetries should not be set, got %d", th.MaxRetries.Value)
+			}
+			if th.MaxPendingRequests != nil {
+				t.Errorf("MaxPendingRequests should not be set, got %d", th.MaxPendingRequests.Value)
+			}
+			if th.TrackRemaining {
+				t.Error("TrackRemaining should not be set")
+			}
+		})
+	}
+}
+
+func TestApplyLoadBalancing(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		policy       *networking.TrafficPolicy
+		wantLbPolicy cluster.Cluster_LbPolicy
+	}{
+		{
+			name:         "nil policy",
+			policy:       nil,
+			wantLbPolicy: cluster.Cluster_ROUND_ROBIN, // Default is ROUND_ROBIN.
+		},
+		{
+			name: "ROUND_ROBIN",
+			policy: &networking.TrafficPolicy{
+				LoadBalancer: &networking.LoadBalancerSettings{
+					LbPolicy: &networking.LoadBalancerSettings_Simple{
+						Simple: networking.LoadBalancerSettings_ROUND_ROBIN,
+					},
+				},
+			},
+			wantLbPolicy: cluster.Cluster_ROUND_ROBIN, // Default gRPC behavior.
+		},
+		{
+			name: "LEAST_REQUEST",
+			policy: &networking.TrafficPolicy{
+				LoadBalancer: &networking.LoadBalancerSettings{
+					LbPolicy: &networking.LoadBalancerSettings_Simple{
+						Simple: networking.LoadBalancerSettings_LEAST_REQUEST,
+					},
+				},
+			},
+			wantLbPolicy: cluster.Cluster_LEAST_REQUEST,
+		},
+		{
+			name: "RING_HASH with consistent hash",
+			policy: &networking.TrafficPolicy{
+				LoadBalancer: &networking.LoadBalancerSettings{
+					LbPolicy: &networking.LoadBalancerSettings_ConsistentHash{
+						ConsistentHash: &networking.LoadBalancerSettings_ConsistentHashLB{
+							HashKey: &networking.LoadBalancerSettings_ConsistentHashLB_HttpHeaderName{
+								HttpHeaderName: "x-session-id",
+							},
+						},
+					},
+				},
+			},
+			wantLbPolicy: cluster.Cluster_RING_HASH,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := &cluster.Cluster{}
+			b := &clusterBuilder{}
+			b.applyLoadBalancing(c, test.policy)
+
+			if c.LbPolicy != test.wantLbPolicy {
+				t.Errorf("LbPolicy: got %v, want %v", c.LbPolicy, test.wantLbPolicy)
+			}
+		})
+	}
+}
+
+func TestApplyTrafficPolicy(t *testing.T) {
+	t.Parallel()
+
+	t.Run("calls all sub-functions", func(t *testing.T) {
+		t.Parallel()
+
+		c := &cluster.Cluster{}
+		b := &clusterBuilder{}
+		policy := &networking.TrafficPolicy{
+			ConnectionPool: &networking.ConnectionPoolSettings{
+				Http: &networking.ConnectionPoolSettings_HTTPSettings{
+					Http2MaxRequests: 100,
+				},
+			},
+			LoadBalancer: &networking.LoadBalancerSettings{
+				LbPolicy: &networking.LoadBalancerSettings_Simple{
+					Simple: networking.LoadBalancerSettings_LEAST_REQUEST,
+				},
+			},
+		}
+
+		b.applyTrafficPolicy(c, policy)
+
+		// Verify circuit breakers were applied.
+		if c.CircuitBreakers == nil {
+			t.Error("CircuitBreakers should be set")
+		}
+
+		// Verify load balancing was applied.
+		if c.LbPolicy != cluster.Cluster_LEAST_REQUEST {
+			t.Errorf("LbPolicy should be LEAST_REQUEST, got %v", c.LbPolicy)
+		}
+	})
+}

--- a/releasenotes/notes/grpc-proxyless-traffic-management.yaml
+++ b/releasenotes/notes/grpc-proxyless-traffic-management.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+releaseNotes:
+  - |
+    **Added** support for `LEAST_REQUEST` load balancing policy in gRPC proxyless clients.
+  - |
+    **Fixed** warning about `CONSISTENT_HASH` load balancing policy in gRPC proxyless clients.
+  - |
+    **Added** support for circuit breaking (`http2MaxRequests`) in gRPC proxyless clients.


### PR DESCRIPTION
**Please provide a description of this PR:**

I'm in the middle of an Istio rollout and also evaluating proxyless support. I
noticed package `grpcgen` has fallen behind a little bit on what is supported in
gRPC xDS now.

This hopefully uncontroversial[^1] PR enables LEAST_REQUEST load balancing,
circuit breaking (max requests), and fixes a warning about correct usage of
RING_HASH for proxyless gRPC clients.

In addition to the new unit tests, I have tested a build of this and the
features work with a proxyless (`grpc-go`) client in my environment.

Changes:

Purely constrained to passing the correct messages down the xDS stream that
modern gRPC xDS libraries will obey. Also adds some unit tests.

1. Load Balancing: 
a) LEAST_REQUEST: sets `lb_policy: LEAST_REQUEST` when configured in
DestinationRule.
b) RING_HASH: calls existing `ApplyRingHashLoadBalancer` helper to do
similar but relocated to avoid logging a confusing warning.

1. Circuit Breaking:
a) Sets `circuit_breakers.max_requests` from `http2MaxRequests`.

[^1]: I am also keen on adding outlier detection because it really brings Istio's proxyless support back upto scratch IMO. However, gRPC xDS libraries evolved to only support statistical success rate algorithms (gRFC [A50](https://github.com/grpc/proposal/blob/master/A50-xds-outlier-detection.md)) and I found a previous attempt to support it in Istio was already made and challenged in [API #30001](https://github.com/istio/api/issues/3001) / [API #3000](https://github.com/istio/api/pull/3000) / [Istio #48022](https://github.com/istio/istio/issues/48022) / [Istio #47928](https://github.com/istio/istio/pull/47928). If I proceed with Istio/proxyless gRPC I may try to pick that up with the project in due time to see if we can reach an acceptable changeset.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [X] Networking