### PR TITLE
fix: Correct behavior when creating an Envoy route from a Gateway HTTPRoute that reference an InferencePool

### DIFF
--- a/pilot/pkg/networking/core/route/route.go
+++ b/pilot/pkg/networking/core/route/route.go
@@ -366,7 +366,7 @@ func GetDestinationCluster(destination *networking.Destination, service *model.S
 		if service.UseInferenceSemantics() {
 			// If this is a service created from a GIE InferencePool, use the first port
 			port = service.Ports[0].Port
-		} else if  len(service.Ports) == 1 {
+		} else if len(service.Ports) == 1 {
 			// if service only has one port defined, use that as the port, otherwise use default listenerPort
 			port = service.Ports[0].Port
 		}

--- a/pilot/pkg/networking/core/route/route_test.go
+++ b/pilot/pkg/networking/core/route/route_test.go
@@ -1490,7 +1490,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 			},
 			Hostname: "test-inference-pool-ip",
 			Attributes: model.ServiceAttributes{
-				Labels: map[string]string {
+				Labels: map[string]string{
 					constants.InternalServiceSemantics: constants.ServiceSemanticsInferencePool,
 				},
 			},


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR corrects the problem in which an Envoy route is not created correctly if the HTTPRoute referenced a Gateway Inference Extension InferencePool that had more than one targetPort in it. This caused configuration errors as none of the created clusters were using port 80.

Specifically rather than using port 80 in such situations, this PR causes the route to be created using the first targetPort in the InferencePool/Shadow service.

This PR partially fixes #57638. The complete solution to #57638 includes creating only one cluster from an InferencePool that has multiple targetPorts. This fix is needed as well and enables work arounds in llm-d.