### PR TITLE
fuzzing: add nodetype fallback for Proxy

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -912,7 +912,7 @@ func (node *Proxy) FuzzValidate() bool {
 		}
 	}
 	if !found {
-		return false
+		node.Type = NodeTypes[0]
 	}
 	return len(node.IPAddresses) != 0
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

This mutates the nodetype instead of rejecting the proxy entirely. It is a bit of a tall order to require the fuzzer to create the correct nodetype from a string every time, and if it has created a good Proxy with the wrong nodetype, the validator can fall back on a default node type.