### PR TITLE
installation: fix GKE CNI detection with Helm 3.19.0+

### DIFF
--- a/manifests/charts/base/files/profile-platform-gke.yaml
+++ b/manifests/charts/base/files/profile-platform-gke.yaml
@@ -3,7 +3,7 @@
 # If you want to make a change in this file, edit the original one and run "make gen".
 
 cni:
-  cniBinDir: "" # intentionally unset for gke to allow template-based autodetection to work
+  cniBinDir: /home/kubernetes/bin
   resourceQuotas:
     enabled: true
 resourceQuotas:

--- a/manifests/charts/default/files/profile-platform-gke.yaml
+++ b/manifests/charts/default/files/profile-platform-gke.yaml
@@ -3,7 +3,7 @@
 # If you want to make a change in this file, edit the original one and run "make gen".
 
 cni:
-  cniBinDir: "" # intentionally unset for gke to allow template-based autodetection to work
+  cniBinDir: /home/kubernetes/bin
   resourceQuotas:
     enabled: true
 resourceQuotas:

--- a/manifests/charts/gateway/files/profile-platform-gke.yaml
+++ b/manifests/charts/gateway/files/profile-platform-gke.yaml
@@ -3,7 +3,7 @@
 # If you want to make a change in this file, edit the original one and run "make gen".
 
 cni:
-  cniBinDir: "" # intentionally unset for gke to allow template-based autodetection to work
+  cniBinDir: /home/kubernetes/bin
   resourceQuotas:
     enabled: true
 resourceQuotas:

--- a/manifests/charts/gateways/istio-egress/files/profile-platform-gke.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-platform-gke.yaml
@@ -3,7 +3,7 @@
 # If you want to make a change in this file, edit the original one and run "make gen".
 
 cni:
-  cniBinDir: "" # intentionally unset for gke to allow template-based autodetection to work
+  cniBinDir: /home/kubernetes/bin
   resourceQuotas:
     enabled: true
 resourceQuotas:

--- a/manifests/charts/gateways/istio-ingress/files/profile-platform-gke.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-platform-gke.yaml
@@ -3,7 +3,7 @@
 # If you want to make a change in this file, edit the original one and run "make gen".
 
 cni:
-  cniBinDir: "" # intentionally unset for gke to allow template-based autodetection to work
+  cniBinDir: /home/kubernetes/bin
   resourceQuotas:
     enabled: true
 resourceQuotas:

--- a/manifests/charts/istio-cni/README.md
+++ b/manifests/charts/istio-cni/README.md
@@ -63,3 +63,5 @@ On GKE, 'kube-system' is required.
 
 If using `helm template`, `--set cni.cniBinDir=/home/kubernetes/bin` is required - with `helm install`
 it is auto-detected.
+
+Helm 3.19.0+ breaks auto-detection due to version normalization. Use `--set profile=platform-gke` or manually set `--set cni.cniBinDir=/home/kubernetes/bin`.

--- a/manifests/charts/istio-cni/files/profile-platform-gke.yaml
+++ b/manifests/charts/istio-cni/files/profile-platform-gke.yaml
@@ -3,7 +3,7 @@
 # If you want to make a change in this file, edit the original one and run "make gen".
 
 cni:
-  cniBinDir: "" # intentionally unset for gke to allow template-based autodetection to work
+  cniBinDir: /home/kubernetes/bin
   resourceQuotas:
     enabled: true
 resourceQuotas:

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -5,6 +5,7 @@
 #
 # $detectedBinDir exists to support a GKE-specific platform override,
 # and is deprecated in favor of using the explicit `gke` platform profile.
+# NOTE: Auto-detection is broken with Helm 3.19.0+ due to version normalization.
 {{- $detectedBinDir := (.Capabilities.KubeVersion.GitVersion | contains "-gke") | ternary
     "/home/kubernetes/bin"
     "/opt/cni/bin"

--- a/manifests/charts/istio-control/istio-discovery/files/profile-platform-gke.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-platform-gke.yaml
@@ -3,7 +3,7 @@
 # If you want to make a change in this file, edit the original one and run "make gen".
 
 cni:
-  cniBinDir: "" # intentionally unset for gke to allow template-based autodetection to work
+  cniBinDir: /home/kubernetes/bin
   resourceQuotas:
     enabled: true
 resourceQuotas:

--- a/manifests/charts/ztunnel/files/profile-platform-gke.yaml
+++ b/manifests/charts/ztunnel/files/profile-platform-gke.yaml
@@ -3,7 +3,7 @@
 # If you want to make a change in this file, edit the original one and run "make gen".
 
 cni:
-  cniBinDir: "" # intentionally unset for gke to allow template-based autodetection to work
+  cniBinDir: /home/kubernetes/bin
   resourceQuotas:
     enabled: true
 resourceQuotas:

--- a/manifests/helm-profiles/platform-gke.yaml
+++ b/manifests/helm-profiles/platform-gke.yaml
@@ -1,5 +1,5 @@
 cni:
-  cniBinDir: "" # intentionally unset for gke to allow template-based autodetection to work
+  cniBinDir: /home/kubernetes/bin
   resourceQuotas:
     enabled: true
 resourceQuotas:

--- a/releasenotes/notes/58094.yaml
+++ b/releasenotes/notes/58094.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue: [58094]
+releaseNotes:
+- |
+  **Fixed** GKE CNI bin directory detection broken by Helm 3.19.0+ version normalization.
+  GKE users should use `--set profile=platform-gke` or manually set `--set cni.cniBinDir="/home/kubernetes/bin"`.


### PR DESCRIPTION
**Please provide a description of this PR:**
Helm 3.19.0+ normalizes .Capabilities.KubeVersion.GitVersion, removing the '-gke' suffix that the CNI chart uses for platform detection.

This updates the GKE platform profile to explicitly set cniBinDir instead of relying on broken auto-detection.
