### PR TITLE
Allow ambinet E/W gateway to conditionally skip waypoints (#58065)

### DIFF
--- a/pilot/pkg/features/ambient.go
+++ b/pilot/pkg/features/ambient.go
@@ -67,8 +67,8 @@ var (
 	// While we don't provide much guarantees for alpha features like ambient multi-network, if it's easy to avoid breaking users unnecessarily
 	// we should do that.
 	//
-	// TODO(krinkin.m.u): set default to true once all the changes required to enable waypoints to talk cross network land.
-	EnableAmbientWaypointMultiNetwork = registerAmbient("AMBIENT_ENABLE_MULTI_NETWORK_WAYPOINT", false, false,
+	// NOTE: This flag does nothing when AMBIENT_ENABLE_MULTI_NETWORK is false.
+	EnableAmbientWaypointMultiNetwork = registerAmbient("AMBIENT_ENABLE_MULTI_NETWORK_WAYPOINT", true, false,
 		"If true and AMBIENT_ENABLE_MULTI_NETWORK is also true, it will enable waypoints to route requests to clusters on remote networks, "+
 			"while by default waypoints will keep traffic local.")
 

--- a/pilot/pkg/networking/core/match/match.go
+++ b/pilot/pkg/networking/core/match/match.go
@@ -57,6 +57,12 @@ var (
 			Key: filters.AuthorityFilterStateKey,
 		}),
 	}
+	RequestSourceFilterStateInput = &xds.TypedExtensionConfig{
+		Name: "request-source-filter-state",
+		TypedConfig: protoconv.MessageToAny(&network.FilterStateInput{
+			Key: filters.RequestSourceFilterStateKey,
+		}),
+	}
 )
 
 type Mapper struct {
@@ -92,6 +98,10 @@ func NewSourceIP() Mapper {
 
 func NewDestinationPort() Mapper {
 	return newMapper(DestinationPort)
+}
+
+func NewRequestSource() Mapper {
+	return newMapper(RequestSourceFilterStateInput)
 }
 
 type ProtocolMatch struct {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -659,20 +659,6 @@ func (a *index) AllLocalNetworkGlobalServices(key model.WaypointKey) []model.Ser
 	// TODO(jaellio): Improve this to use a more efficient lookup/index since this is in the
 	// hot path for east west gateway updates/configuration.
 	for _, svc := range a.services.List() {
-		workloads := a.workloads.ByServiceKey.Lookup(svc.ResourceName())
-		localWorkloads := false
-		for _, wl := range workloads {
-			if wl.Workload.Network == key.Network {
-				localWorkloads = true
-				break
-			}
-		}
-		if !localWorkloads {
-			log.Debugf("Skipping service %s/%s in network %s, as it has no local workloads in the network %s",
-				svc.Service.Namespace, svc.Service.Name, key.Network, key.Network)
-			continue
-		}
-
 		if svc.Scope != model.Global {
 			// Check if the service is a waypoint. If the service is not a waypoint
 			// or it's a waypoint containing no services then the Lookup will return

--- a/pilot/pkg/xds/endpoints/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder.go
@@ -340,19 +340,10 @@ func (b *EndpointBuilder) BuildClusterLoadAssignment(endpointIndex *model.Endpoi
 		return buildEmptyClusterLoadAssignment(b.clusterName)
 	}
 
-	if features.EnableIngressWaypointRouting {
-		if waypointEps, f := b.findServiceWaypoint(endpointIndex); f {
-			// endpoints are from waypoint service but the envoy endpoint is different envoy cluster
-			locLbEps := b.generate(waypointEps, true)
-			return b.createClusterLoadAssignment(locLbEps)
-		}
-	}
-
-	// If we're an east west gateway, then we also want to send to waypoints
-	// TODO: depending on the final design, there will be times we DON'T want
-	// the e/w gateway to send to waypoints. That conditional logic will either live
-	// here or in the listener logic.
-	if features.EnableAmbientMultiNetwork && isEastWestGateway(b.proxy) {
+	// features.EnableIngressWaypointRouting only makes sense for ingress gateways and for E/W gateways
+	// we don't want this behavior, so additionally check that we are not generating endpoints for the
+	// E/W gateway.
+	if features.EnableIngressWaypointRouting && !isEastWestGateway(b.proxy) {
 		if waypointEps, f := b.findServiceWaypoint(endpointIndex); f {
 			// endpoints are from waypoint service but the envoy endpoint is different envoy cluster
 			locLbEps := b.generate(waypointEps, true)

--- a/pilot/pkg/xds/filters/filters.go
+++ b/pilot/pkg/xds/filters/filters.go
@@ -76,6 +76,11 @@ const (
 	// Authority Key is another filter state key where we store :authority. Because this is not a
 	// well-known filter state key, we can store non-IP address :authorities in here
 	AuthorityFilterStateKey = "io.istio.connect_authority"
+
+	// RequestSourceFilterStateKey is a filter state key where we store the value of x-istio-source header
+	// for incoming HBONE connections. This header when set to waypoint indicates that request has been processed
+	// by a waypoint already and therfore L7 policies have been applied already and we should skip them.
+	RequestSourceFilterStateKey = "io.istio.source"
 )
 
 // Define static filters to be reused across the codebase. This avoids duplicate marshaling/unmarshaling
@@ -239,6 +244,40 @@ var (
 						},
 					},
 				}),
+		},
+	}
+
+	// This filter is used to capture value of istio-l7-policies-applied header from the HBONE connect request in the filter state.
+	// This header in multi-network ambient mode indicates whether L7 policies have been applied already to the
+	// request. For example, if the request went from ztunnel to waypoint and then to E/W gateway, then waypoint would have already
+	// applied L7 policies to the request, so E/W gateway should not send the request to waypoint to avoid applying the L7 policies
+	// again. On the other hand, if ztunnel directly sent the request to the E/W gateway, then the request still needs L7 policies
+	// to be applied and so has to be routed to the waypoint if the service has one.
+	RequestSourceFilter = &hcm.HttpFilter{
+		Name: "request_source",
+		ConfigType: &hcm.HttpFilter_TypedConfig{
+			TypedConfig: protoconv.MessageToAny(&sfs.Config{
+				OnRequestHeaders: []*sfsvalue.FilterStateValue{
+					{
+						Key: &sfsvalue.FilterStateValue_ObjectKey{
+							ObjectKey: RequestSourceFilterStateKey,
+						},
+						Value: &sfsvalue.FilterStateValue_FormatString{
+							FormatString: &core.SubstitutionFormatString{
+								Format: &core.SubstitutionFormatString_TextFormatSource{
+									TextFormatSource: &core.DataSource{
+										Specifier: &core.DataSource_InlineString{
+											InlineString: "%REQ(x-istio-source)%",
+										},
+									},
+								},
+							},
+						},
+						FactoryKey:         "envoy.string",
+						SharedWithUpstream: sfsvalue.FilterStateValue_ONCE,
+					},
+				},
+			}),
 		},
 	}
 

--- a/pkg/test/framework/components/istio/eastwest.go
+++ b/pkg/test/framework/components/istio/eastwest.go
@@ -28,6 +28,7 @@ import (
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework/components/cluster"
+	applyopt "istio.io/istio/pkg/test/framework/resource/config/apply"
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/test/util/tmpl"
@@ -146,7 +147,7 @@ func (i *istioImpl) deployAmbientEastWestGateway(cluster cluster.Cluster) error 
 	if err != nil {
 		return fmt.Errorf("failed generating eastwest gateway yaml: %v: %v", err, string(gw))
 	}
-	if err = i.ctx.ConfigKube(cluster).YAML(i.cfg.SystemNamespace, string(gw)).Apply(); err != nil {
+	if err = i.ctx.ConfigKube(cluster).YAML(i.cfg.SystemNamespace, string(gw)).Apply(applyopt.NoCleanup); err != nil {
 		return fmt.Errorf("failed applying eastwest gateway yaml: %v", err)
 	}
 

--- a/releasenotes/notes/57537.yaml
+++ b/releasenotes/notes/57537.yaml
@@ -1,0 +1,12 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+# issue is a list of GitHub issues resolved in this note.
+# If issue is not in the current repo, specify its full URL instead.
+issue:
+  - 57537
+
+releaseNotes:
+  - |
+    **Enabled** waypoints to route traffic to remote networks in ambient multi-cluster.

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -46,6 +46,7 @@ import (
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/ambient"
+	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/check"
 	"istio.io/istio/pkg/test/framework/components/echo/common"
@@ -3364,7 +3365,7 @@ func TestDirect(t *testing.T) {
 			})
 
 			capturedSvc := apps.Captured.ForCluster(cluster.Name()).ServiceName()
-			labelService(t, capturedSvc, "istio.io/global", "true")
+			labelService(t, apps.Namespace.Name(), capturedSvc, "istio.io/global", "true", t.Clusters().Default())
 			run("global service", echo.CallOptions{
 				To:          apps.Captured.ForCluster(cluster.Name()),
 				Count:       1,
@@ -3530,14 +3531,22 @@ func labelWorkload(t framework.TestContext, w echo.Workload, k, v string) {
 	}
 }
 
-func labelService(t framework.TestContext, svcName, k, v string) {
+func labelService(t framework.TestContext, ns, svcName, k, v string, cs ...cluster.Cluster) {
+	t.Helper()
+
+	for _, c := range cs {
+		labelServiceInCluster(t, c, ns, svcName, k, v)
+	}
+}
+
+func labelServiceInCluster(t framework.TestContext, c cluster.Cluster, ns, svcName, k, v string) {
 	patchOpts := metav1.PatchOptions{}
 	patchData := fmt.Sprintf(`{"metadata":{"labels": {%q: %q}}}`, k, v)
 	if v == "" {
 		patchData = fmt.Sprintf(`{"metadata":{"labels": {%q: null}}}`, k)
 	}
-	s := t.Clusters().Default().Kube().CoreV1().Services(apps.Namespace.Name())
-	_, err := s.Patch(context.Background(), svcName, types.StrategicMergePatchType, []byte(patchData), patchOpts)
+	s := c.Kube().CoreV1().Services(ns)
+	_, err := s.Patch(t.Context(), svcName, types.StrategicMergePatchType, []byte(patchData), patchOpts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/integration/ambient/main_test.go
+++ b/tests/integration/ambient/main_test.go
@@ -155,9 +155,7 @@ func TestMain(m *testing.M) {
 				cfg.DeployEastWestGW = true
 				cfg.DeployGatewayAPI = true
 				cfg.ControlPlaneValues = ambientMultiNetworkControlPlaneValues
-				// TODO: Remove once we're actually ready to test the multi-cluster
-				// features
-				cfg.SkipDeployCrossClusterSecrets = true
+				cfg.SkipDeployCrossClusterSecrets = false
 			}
 		}, cert.CreateCASecretAlt)).
 		Setup(func(t resource.Context) error {

--- a/tests/integration/ambient/multinetwork_test.go
+++ b/tests/integration/ambient/multinetwork_test.go
@@ -1,0 +1,223 @@
+//go:build integ
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ambient
+
+import (
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"istio.io/api/label"
+	"istio.io/istio/pkg/test/echo/common/scheme"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/ambient"
+	"istio.io/istio/pkg/test/framework/components/cluster"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/check"
+	"istio.io/istio/pkg/test/framework/components/echo/common/ports"
+	"istio.io/istio/pkg/test/framework/components/echo/deployment"
+	"istio.io/istio/pkg/test/framework/components/echo/match"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/util/retry"
+)
+
+func TestMultinetworkFailover(t *testing.T) {
+	const brokenService = "broken"
+
+	runTest := func(t framework.TestContext, healthy, unhealthy cluster.Cluster, ns namespace.Instance) {
+		clients := deployEchoOrFail(t, brokenService, healthy, unhealthy, ns)
+		for _, src := range clients {
+			// This service is partially broken, but because we can failover to remote network the request
+			// should still succeed.
+			src.CallOrFail(t, echo.CallOptions{
+				Address: fmt.Sprintf("%s.%s.svc.cluster.local", brokenService, ns.Name()),
+				Port:    ports.HTTP,
+				Scheme:  scheme.HTTP,
+				Check:   check.OK(),
+			})
+		}
+	}
+	framework.NewTest(t).Run(func(t framework.TestContext) {
+		t.NewSubTest("without-waypoint").Run(func(t framework.TestContext) {
+			if !t.Settings().Ambient || !t.Settings().AmbientMultiNetwork {
+				t.Skip("this test is ambient multi-network specific")
+			}
+
+			if len(t.Clusters()) < 2 {
+				t.Fatal("ambient multi-network failover test requires at least 2 clusters")
+			}
+
+			allClusters := t.Clusters()
+			local := allClusters[0]
+			remote := allClusters[1]
+
+			nsConfig := namespace.NewOrFail(t, namespace.Config{
+				Prefix: "without-waypoint",
+				Inject: false,
+				Labels: map[string]string{
+					label.IoIstioDataplaneMode.Name: "ambient",
+				},
+			})
+
+			runTest(t, local, remote, nsConfig)
+		})
+		t.NewSubTest("with-waypoints").Run(func(t framework.TestContext) {
+			if !t.Settings().Ambient || !t.Settings().AmbientMultiNetwork {
+				t.Skip("this test is ambient multi-network specific")
+			}
+
+			if len(t.Clusters()) < 2 {
+				t.Fatal("ambient multi-network failover test requires at least 2 clusters")
+			}
+
+			allClusters := t.Clusters()
+			local := allClusters[0]
+			remote := allClusters[1]
+
+			nsConfig := namespace.NewOrFail(t, namespace.Config{
+				Prefix: "with-waypoint",
+				Inject: false,
+				Labels: map[string]string{
+					label.IoIstioDataplaneMode.Name: "ambient",
+				},
+			})
+
+			waypointName := "waypoint"
+			deployWaypointsOrFail(t, local, waypointName, nsConfig)
+
+			runTest(t, local, remote, nsConfig)
+		})
+	})
+}
+
+// deployEchoOrFail deploys global (a.k.a. multi-network) Echo servers and local clients in provided clusters.
+// One of the clusters is designated as unhealthy and one as healthy.
+// This function will deploy an "unhealthy" version of the service in the unhealthy cluster and a "healthy" version in
+// the healthy cluster.
+func deployEchoOrFail(t framework.TestContext, serviceName string, healthy, unhealthy cluster.Cluster, ns namespace.Instance) echo.Instances {
+	t.Helper()
+
+	broken := serviceName
+	client := "client"
+
+	builder := deployment.New(t).
+		WithConfig(echo.Config{
+			Service:   broken,
+			Namespace: ns,
+			Cluster:   unhealthy,
+			Ports:     ports.All(),
+			ServiceLabels: map[string]string{
+				"istio.io/global": "true",
+			},
+			Subsets: []echo.SubsetConfig{
+				{
+					Version: broken,
+				},
+			},
+		}).
+		WithConfig(echo.Config{
+			Service:   broken,
+			Namespace: ns,
+			Cluster:   healthy,
+			Ports:     ports.All(),
+			ServiceLabels: map[string]string{
+				"istio.io/global": "true",
+			},
+			Subsets: []echo.SubsetConfig{
+				{
+					Version: broken,
+				},
+			},
+		}).
+		// This is the client, we deploy it in all clusters and use clients in different clusters to validate
+		// different traffic paths.
+		WithConfig(echo.Config{
+			Service:   client,
+			Namespace: ns,
+			Cluster:   unhealthy,
+			Ports:     ports.All(),
+			Subsets: []echo.SubsetConfig{
+				{
+					Version: client,
+				},
+			},
+		}).
+		WithConfig(echo.Config{
+			Service:   client,
+			Namespace: ns,
+			Cluster:   healthy,
+			Ports:     ports.All(),
+			Subsets: []echo.SubsetConfig{
+				{
+					Version: client,
+				},
+			},
+		})
+
+	echos := builder.BuildOrFail(t)
+
+	// NOTE: We cannot just specify replicas 0, because the way the Deployment config template is written
+	// it treats 0 as unset value and defaults to 1 replica in that case defeating the point of setting
+	// replicas to 0 explicitly.
+	scaleDeploymentOrFail(t, unhealthy, ns.Name(), fmt.Sprintf("%s-%s", broken, broken), 0)
+
+	return match.ServiceName(echo.NamespacedName{Name: client, Namespace: ns}).GetMatches(echos)
+}
+
+// deployWaypointsOrFail deploys global (a.k.a. multi-network) waypoints in two clusters.
+// One of the clusters designated as unhealthy the deployed waypoint will be unhealthy there.
+// The other cluster is designated as healthy and deployed waypoint will be healthy there.
+func deployWaypointsOrFail(t framework.TestContext, unhealthy cluster.Cluster, waypoint string, ns namespace.Instance) {
+	t.Helper()
+
+	_ = ambient.NewWaypointProxyOrFail(t, ns, waypoint)
+	ambient.SetWaypointForNamespace(t, ns, waypoint)
+	labelService(t, ns.Name(), waypoint, "istio.io/global", "true", t.AllClusters()...)
+
+	scaleDeploymentOrFail(t, unhealthy, ns.Name(), waypoint, 0)
+}
+
+func scaleDeploymentOrFail(t framework.TestContext, c cluster.Cluster, namespace, name string, scale int32) {
+	t.Helper()
+
+	s, err := c.Kube().AppsV1().Deployments(namespace).GetScale(t.Context(), name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to find deployment %s in namespace %s: %w", name, namespace, err)
+	}
+
+	s.Spec.Replicas = scale
+	_, err = c.Kube().AppsV1().Deployments(namespace).UpdateScale(t.Context(), name, s, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("failed to scale deployment %s in namespace %s to %d replicas: %w", name, namespace, scale, err)
+	}
+
+	retry.UntilSuccessOrFail(t, func() error {
+		s, err := c.Kube().AppsV1().Deployments(namespace).GetScale(t.Context(), name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to find deployment %s in namespace %s: %w", name, namespace, err)
+		}
+		pods, err := c.PodsForSelector(t.Context(), namespace, s.Status.Selector)
+		if err != nil {
+			return fmt.Errorf("failed to query pods matching selector %s in namespace %s: %w", s.Status.Selector, namespace, err)
+		}
+		if s.Status.Replicas == scale && len(pods.Items) == int(scale) {
+			return nil
+		}
+		return fmt.Errorf("deployment still has different number of pods, want %d, got %d", scale, len(pods.Items))
+	})
+}

--- a/tests/integration/ambient/waypoint_test.go
+++ b/tests/integration/ambient/waypoint_test.go
@@ -37,6 +37,7 @@ import (
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/check"
 	"istio.io/istio/pkg/test/framework/components/echo/common/ports"
@@ -211,7 +212,11 @@ func TestWaypoint(t *testing.T) {
 }
 
 func checkWaypointIsReady(t framework.TestContext, ns, name string) error {
-	fetch := kubetest.NewPodFetch(t.AllClusters()[0], ns, label.IoK8sNetworkingGatewayGatewayName.Name+"="+name)
+	return checkWaypointIsReadyInCluster(t.AllClusters()[0], ns, name)
+}
+
+func checkWaypointIsReadyInCluster(c cluster.Cluster, ns, name string) error {
+	fetch := kubetest.NewPodFetch(c, ns, label.IoK8sNetworkingGatewayGatewayName.Name+"="+name)
 	_, err := kubetest.CheckPodsAreReady(fetch)
 	return err
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

* Enable waypoints to route to a remote network

This change makes the following changes to the waypoint config generation code:

1. It creates new Envoy listeners and clusters (inner_connect_originate and outer_connect_originate) that wrap requests in double-HBONE tunnel (e.g., CONNECT inside CONNECT) when used
2. It generates EDS endpoints for ambient E/W gateways for services that have endpoints on a remote network; these endpoints will send traffic through the listeners and clusters mentioned above to wrap requests into double-HBONE tunnel
3. Populate istio-l7-policies-applied HTTP header for the outer HBONE tunnel to indicate that L7 policies have been applied by waypoint and therefore those should be skipped in remote network.

It's part of the changes described in
https://docs.google.com/document/d/1MM0Oilp8kJ0IMXv8m5nAG1JCfozJHpz8yI8uXxNZpSI/edit?usp=sharing that enabled waypoints to communicate across networks.

This particular change is only concerned with changes on the waypoint side, we also need to make changes on the E/W gateway side for the whole thing to work end-to-end.

NOTE: Even without E/W gateway changes we can still test these changes e2e, we just have to limit ourselves to empty or idempotent L7 policies that could be safely applied twice.

Given that without E/W gateway changes it would not be correct to enable this logic (i.e., because it may result in applying L7 policies twice) these changes only take effect if
AMBIENT_ENABLE_MULTI_NETWORK_WAYPOINT environment variable is explicitly set in pilot environment.

Background: currently in ambient multinetwork waypoints cannot communicate across networks - this means that one we send a request to a waypoint it will stay on the network of that waypoint. On the other hand, ztunnel, when L7 policies are involved, does not have enough visibility to tell where (as if in which network) we have healthy backends and, consequently, it can send request to a network where there are no healthy backends to serve it.

Given that we don't want to enable L7 capabilities in ztunnel, we decided to let waypoint handle that. ztunnel will route the request to a waypoint (either local or remote, it will pick a sensible waypoint endpoints because it's aware of the waypoint health status) and then waypoint, with visibility into the health of the actual service endpoints, will pick the right endpoint for the request. That's what these changes intend to achieve.



* Don't add L7 policies header to the inner CONNECT because it's not currently needed for anything



* Tests for EDS endpoint generation for waypoints in ambient multi-network

In particular this test capture differences from sidecar mode. In sidecar mode when pilot sees an endpoint on a remote network and no appropriate E/W gateway, it will consider that endpoint reachable without a gateway.

This behavior has been around for a while, but it's not the most intuitive, alas changing it now might actually break some users, so we will have to live with this.

In ambient multi-network/multi-cluster is a new alpha feature, not to mention that waypoint hasn't been able to route requests to remote networks, so we are free to pick a different behavour here.

Additionally, we ignore E/W gateways that don't have a valid HBONE port, so this test also covers that filtering.



* fix formatting in the newly added test



* Fix formatting of the newly added test



* Fix formatting of newly added tests



* Replace {Inner|Outer}ConnectOriginate with DoubleHBONE{Inner|Outer}ConnectOriginate to be more descriptive



* Replace APPEND_IF_EXISTS_OR_ADD with OVERWRITE_IF_EXISTS_OR_ADD when adding L7 policy status header

It does not make any functional difference in this case, but during PR review I got a comment indicating that APPEND_IF_EXISTS_OR_ADD is surprising and people expect to see OVERWRITE_IF_EXISTS_OR_ADD instead. So let's go with an option that is least suprising to people.



* Disable connection pooling on the inner/outer connect originate clusters

This is a hack that allows us to avoid lasering a single backend in the remote network all the time due to connection pooling and how it interacts with double HBONE.

This does not allow us to distribute the load between backends in the remote network reasonably well, because at a higher level some pooling still takes place (e.g., at the level of the service cluster).

I'm deploying this hack as a short term mitigation that would allow us to get the best behavior out of what currently possible, but we are discussing a better approach to solve this problem in the near future.



* Fix formatting



* Use x-istio-source header to indicate that L7 policies have been applied already



* Rename metadata/filter state keys used for double HBONE

Before I used waypoint or istio.waypoint. Now I'm changing everything to always use istio.double_hbone as a root of all related configs.



* Don't generate double-HBONE clusters/listeners in E/W gateway

More specifically generate those only for waypoints where they are actually being used.



* Add a TODO to change default for the multi-network waypoint feature flag



* Change comment into TODO and link relanvant feature request



* An empty commit to re-trigger CI



* Allow ambinet E/W gateway to conditionally skip waypoints

In ambient muilti-network we want to allow waypoints to route requests to remote network. Short background here is that ztunnels don't have much visibility if behind waypoint we have any healthy service endpoints. So when it picks a cluster/network and sends a request to a waypoint there it does not actually know if there are any healthy service endpoints that can ultimately serve the request. Waypoints on the other hand are aware of service endpoint health. So it's important for waypoints to be able to failover to a remote network when there are no locally available endpoints.

In a separate PR I added support for the double-HBONE client to waypoints, so waypoint now can route requests through E/W gateway to endpoints in remote networks.

However, because waypoint also applies L7 policies, if we don't change anything and E/W gateway will route the request to a waypoint in a remote network cluster we'd apply L7 policies twice. That, depending on the specific configuration could result in an incorrect behavior.

https://docs.google.com/document/d/1MM0Oilp8kJ0IMXv8m5nAG1JCfozJHpz8yI8uXxNZpSI/edit?usp=sharing outlines the design for the whole solution.

This particular change enables E/W gateway to check if the request already went through a waypoint and if so skip the waypoint and route it directly to the service endpoint.

The check itself is done by looking at the headers in the outer HBONE tunnel CONNECT request. When request comes from waypoint we'd see there x-istio-source header with value "waypoint".

We preserve the value of that header in the filter state and then use that filter state as input for the filter chain matching. If the filter state contains value "waypoint" we match with the filter chain that routes the request to the actual service cluster, otherwise it would route to the waypoint cluster.

All-in-all, to skip L7 policies we skip waypoint alltogether.



* Fix spelling



* Add release note for the PR



* Fix release notes format



* Add an integration test that verifies that we can failover to remote network



* No need to check IngressUseWaypoint flag or that we are generating for E/W gateway when looking up waypoint



* Fix lints



* Drop all unnecessary checks when looking up waypoint for a service



* Address review comments



* Refactor labelService a bit



---------

+cc @therealmitchconnors and @keithmattix 

Fixes #58105