### PR TITLE
refactor: remove obsolete // +build tag

### DIFF
--- a/cni/pkg/ipset/nldeps_unspecified.go
+++ b/cni/pkg/ipset/nldeps_unspecified.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 // Copyright Istio Authors
 //

--- a/cni/pkg/iptables/iptables_unspecified.go
+++ b/cni/pkg/iptables/iptables_unspecified.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 // Copyright Istio Authors
 //

--- a/cni/pkg/nodeagent/netns_other.go
+++ b/cni/pkg/nodeagent/netns_other.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 // Copyright Istio Authors
 //

--- a/cni/pkg/nodeagent/podcgroupns_unspecified.go
+++ b/cni/pkg/nodeagent/podcgroupns_unspecified.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 // Copyright Istio Authors
 //

--- a/cni/pkg/nodeagent/server_unspecified.go
+++ b/cni/pkg/nodeagent/server_unspecified.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 // Copyright Istio Authors
 //

--- a/cni/pkg/nodeagent/ztunnelserver_unspecified.go
+++ b/cni/pkg/nodeagent/ztunnelserver_unspecified.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 // Copyright Istio Authors
 //

--- a/cni/pkg/plugin/sidecar_iptables_unspecified.go
+++ b/cni/pkg/plugin/sidecar_iptables_unspecified.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 // Copyright Istio Authors
 //

--- a/cni/pkg/plugin/sidecar_nftables_unspecified.go
+++ b/cni/pkg/plugin/sidecar_nftables_unspecified.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 // Copyright Istio Authors
 //

--- a/cni/pkg/repair/netns_unspecified.go
+++ b/cni/pkg/repair/netns_unspecified.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 // Copyright Istio Authors
 //

--- a/cni/pkg/repair/repaircontroller_unspecified.go
+++ b/cni/pkg/repair/repaircontroller_unspecified.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 // Copyright Istio Authors
 //

--- a/cni/pkg/util/netnsutil_unspecified.go
+++ b/cni/pkg/util/netnsutil_unspecified.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 // Copyright Istio Authors
 //

--- a/pilot/cmd/pilot-agent/status/dialer_others.go
+++ b/pilot/cmd/pilot-agent/status/dialer_others.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
 Copyright 2023 The Kubernetes Authors.

--- a/pilot/cmd/pilot-agent/status/dialer_windows.go
+++ b/pilot/cmd/pilot-agent/status/dialer_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
 Copyright 2023 The Kubernetes Authors.

--- a/pilot/pkg/networking/core/fake.go
+++ b/pilot/pkg/networking/core/fake.go
@@ -1,5 +1,4 @@
 //go:build !agent
-// +build !agent
 
 // Copyright Istio Authors
 //

--- a/pkg/collateral/cobra_agent.go
+++ b/pkg/collateral/cobra_agent.go
@@ -1,5 +1,4 @@
 //go:build agent
-// +build agent
 
 // Copyright Istio Authors
 //

--- a/pkg/config/analysis/msg/generate.main.go
+++ b/pkg/config/analysis/msg/generate.main.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/pkg/config/validation/validation_agent.go
+++ b/pkg/config/validation/validation_agent.go
@@ -1,5 +1,4 @@
 //go:build agent
-// +build agent
 
 // Copyright Istio Authors
 //

--- a/pkg/ctrlz/topics/signals_unix.go
+++ b/pkg/ctrlz/topics/signals_unix.go
@@ -1,5 +1,4 @@
 //go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
-// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
 
 // Copyright 2019 Istio Authors
 //

--- a/pkg/ctrlz/topics/signals_unspecified.go
+++ b/pkg/ctrlz/topics/signals_unspecified.go
@@ -1,5 +1,4 @@
 //go:build !unix
-// +build !unix
 
 // Copyright Istio Authors
 //

--- a/pkg/file/fadvise_unspecified.go
+++ b/pkg/file/fadvise_unspecified.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 // Copyright Istio Authors
 //

--- a/tools/common/config/config_other.go
+++ b/tools/common/config/config_other.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 // Copyright Istio Authors
 //

--- a/tools/common/tproxy/run_unspecified.go
+++ b/tools/common/tproxy/run_unspecified.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 // Copyright Istio Authors
 //

--- a/tools/istio-iptables/pkg/dependencies/implementation_unspecified.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation_unspecified.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 // Copyright Istio Authors
 //

--- a/tools/istio-iptables/pkg/validation/vld_unix.go
+++ b/tools/istio-iptables/pkg/validation/vld_unix.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
-// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package validation
 

--- a/tools/istio-iptables/pkg/validation/vld_unspecified.go
+++ b/tools/istio-iptables/pkg/validation/vld_unspecified.go
@@ -1,5 +1,4 @@
 //go:build !unix
-// +build !unix
 
 // Copyright Istio Authors
 //


### PR DESCRIPTION
**Please provide a description of this PR:**


Go 1.17 introduced a new `//go:build` syntax that replaces the legacy
`// +build` form. This change cleans up the old tag.

More info: https://github.com/golang/go/issues/41184