### PR TITLE
feat: adds crl volume to the zTunnel chart

### DIFF
--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -167,6 +167,14 @@ spec:
           value: "{{ $val }}"
         {{- end }}
         {{- end }}
+        {{- if .Values.peerCaCrl.enabled }}
+        - name: ENABLE_CRL
+          value: "true"
+        - name: CRL_PATH
+          value: "/var/run/secrets/istio/crl/ca-crl.pem"
+        - name: ALLOW_EXPIRED_CRL
+          value: "false"
+        {{- end }}
         volumeMounts:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
@@ -176,6 +184,11 @@ spec:
           name: cni-ztunnel-sock-dir
         - mountPath: /tmp
           name: tmp
+        {{- if .Values.peerCaCrl.enabled }}
+        - mountPath: /var/run/secrets/istio/crl
+          name: crl-volume
+          readOnly: true
+        {{- end }}
         {{- with .Values.volumeMounts }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -207,6 +220,13 @@ spec:
       # pprof needs a writable /tmp, and we don't have that thanks to `readOnlyRootFilesystem: true`, so mount one
       - name: tmp
         emptyDir: {}
+      {{- if .Values.peerCaCrl.enabled }}
+      # Optional CRL volume - mounts istio-ca-crl ConfigMap if it exists
+      - name: crl-volume
+        configMap:
+          name: istio-ca-crl
+          optional: true
+      {{- end }}
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 6}}
       {{- end }}

--- a/manifests/charts/ztunnel/values.yaml
+++ b/manifests/charts/ztunnel/values.yaml
@@ -66,6 +66,11 @@ _internal_defaults_do_not_set:
     enabled: false
     pods: 5000
 
+  # Certificate Revocation List (CRL) support for plugged-in CAs.
+  # When enabled, ztunnel will check certificates against the CRL
+  peerCaCrl:
+    enabled: false
+
   # List of secret names to add to the service account as image pull secrets
   imagePullSecrets: []
 


### PR DESCRIPTION
**Please provide a description of this PR:**

This PR adds the optional CRL config map mount to support [crl work](https://github.com/istio/ztunnel/pull/1660) in zTunnel.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
