### PR TITLE
strip proxy overrides annotation from pods

### DIFF
--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 
+	"istio.io/api/annotation"
 	"istio.io/api/label"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/util/sets"
@@ -393,7 +394,7 @@ func StripPodUnusedFields(obj any) (any, error) {
 	// ManagedFields is large and we never use it
 	t.GetObjectMeta().SetManagedFields(nil)
 	// Proxy overrides are never used in the cache and can be very big
-	delete(t.GetObjectMeta().GetAnnotations(), "proxy.istio.io/overrides")
+	delete(t.GetObjectMeta().GetAnnotations(), annotation.ProxyOverrides.Name)
 	// only container ports can be used
 	if pod := obj.(*corev1.Pod); pod != nil {
 		containers := []corev1.Container{}


### PR DESCRIPTION
**Please provide a description of this PR:**
In our case `proxy.istio.io/overrides` ends up being huge ~3kb per pod, it ends up wasting a huge amount of memory and it's only used in the injection webhook.