### PR TITLE
Use fully qualified names for images in samples

### DIFF
--- a/samples/curl/curl.yaml
+++ b/samples/curl/curl.yaml
@@ -52,7 +52,7 @@ spec:
       serviceAccountName: curl
       containers:
       - name: curl
-        image: curlimages/curl:8.16.0
+        image: docker.io/curlimages/curl:8.16.0
         command: ["/bin/sleep", "infinity"]
         imagePullPolicy: IfNotPresent
         volumeMounts:

--- a/samples/httpbin/sample-client/fortio-deploy.yaml
+++ b/samples/httpbin/sample-client/fortio-deploy.yaml
@@ -40,7 +40,7 @@ spec:
     spec:
       containers:
       - name: fortio
-        image: fortio/fortio:latest_release
+        image: docker.io/fortio/fortio:latest_release
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/samples/open-telemetry/loki/otel.yaml
+++ b/samples/open-telemetry/loki/otel.yaml
@@ -87,7 +87,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
-          image: otel/opentelemetry-collector-contrib:0.73.0
+          image: docker.io/otel/opentelemetry-collector-contrib:0.73.0
           imagePullPolicy: IfNotPresent
           name: opentelemetry-collector
           ports:

--- a/samples/open-telemetry/otel.yaml
+++ b/samples/open-telemetry/otel.yaml
@@ -120,7 +120,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
-          image: otel/opentelemetry-collector-contrib:0.123.0
+          image: docker.io/otel/opentelemetry-collector-contrib:0.123.0
           imagePullPolicy: IfNotPresent
           name: opentelemetry-collector
           ports:

--- a/samples/proxy-coredump/daemonset.yaml
+++ b/samples/proxy-coredump/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
             - sh
             - -c
             - sysctl -w kernel.core_pattern=/var/lib/istio/data/core.proxy && ulimit -c unlimited
-          image: alpine
+          image: docker.io/library/alpine
           imagePullPolicy: IfNotPresent
           resources: {}
           securityContext:
@@ -36,7 +36,7 @@ spec:
           resources:
             requests:
               cpu: 1m
-          image: alpine
+          image: docker.io/library/alpine
           command: ["tail"]
           args: ["-f", "/dev/null"]
       volumes:

--- a/samples/ratelimit/rate-limit-service.yaml
+++ b/samples/ratelimit/rate-limit-service.yaml
@@ -113,7 +113,7 @@ spec:
         app: ratelimit
     spec:
       containers:
-      - image: envoyproxy/ratelimit:30a4ce1a # 2024/08/01
+      - image: docker.io/envoyproxy/ratelimit:30a4ce1a # 2024/08/01
         imagePullPolicy: IfNotPresent
         name: ratelimit
         command: ["/bin/ratelimit"]

--- a/samples/security/spire/curl-spire.yaml
+++ b/samples/security/spire/curl-spire.yaml
@@ -56,7 +56,7 @@ spec:
       serviceAccountName: curl
       containers:
       - name: curl
-        image: curlimages/curl:8.16.0
+        image: docker.io/curlimages/curl:8.16.0
         command: ["/bin/sleep", "infinity"]
         imagePullPolicy: IfNotPresent
         volumeMounts:

--- a/samples/security/spire/istio-spire-config.yaml
+++ b/samples/security/spire/istio-spire-config.yaml
@@ -49,7 +49,7 @@ spec:
                 - path: spec.template.spec.initContainers
                   value:
                     - name: wait-for-spire-socket
-                      image: busybox:1.28
+                      image: docker.io/library/busybox:1.28
                       volumeMounts:
                         - name: workload-socket
                           mountPath: /run/secrets/workload-spiffe-uds

--- a/samples/security/spire/sleep-spire.yaml
+++ b/samples/security/spire/sleep-spire.yaml
@@ -56,7 +56,7 @@ spec:
       serviceAccountName: sleep
       containers:
       - name: sleep
-        image: curlimages/curl:8.16.0
+        image: docker.io/curlimages/curl:8.16.0
         command: ["/bin/sleep", "infinity"]
         imagePullPolicy: IfNotPresent
         volumeMounts:

--- a/samples/sleep/sleep.yaml
+++ b/samples/sleep/sleep.yaml
@@ -52,7 +52,7 @@ spec:
       serviceAccountName: sleep
       containers:
       - name: sleep
-        image: curlimages/curl:8.16.0
+        image: docker.io/curlimages/curl:8.16.0
         command: ["/bin/sleep", "infinity"]
         imagePullPolicy: IfNotPresent
         volumeMounts:

--- a/samples/websockets/app.yaml
+++ b/samples/websockets/app.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: tornado
-        image: hiroakis/tornado-websocket-example
+        image: docker.io/hiroakis/tornado-websocket-example
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8888


### PR DESCRIPTION
**Please provide a description of this PR:**
Use fully qualified names for images in samples

Some Kubernetes container runtimes, like cri-o (from [v1.34.0](https://github.com/cri-o/cri-o/releases/tag/v1.34.0)) , disallow short image names at all or disallow them when it is ambiguous across multiple registries. ( see https://github.com/cri-o/cri-o/pull/9401 )