### PR TITLE
feat: Make automountServiceAccountToken configurable in istiod Helm chart

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -86,6 +86,9 @@ spec:
 {{- toYaml . | nindent 8 }}
 {{- end }}
       serviceAccountName: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+{{- if ne .Values.automountServiceAccountToken nil }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+{{- end }}
 {{- if .Values.global.priorityClassName }}
       priorityClassName: "{{ .Values.global.priorityClassName }}"
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/serviceaccount.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/serviceaccount.yaml
@@ -9,6 +9,9 @@ imagePullSecrets:
   - name: {{ . }}
   {{- end }}
   {{- end }}
+{{- if ne .Values.automountServiceAccountToken nil }}
+automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+{{- end }}
 metadata:
   name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   namespace: {{ .Values.global.istioNamespace }}

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -26,6 +26,10 @@ _internal_defaults_do_not_set:
   # Set to `type: RuntimeDefault` to use the default profile if available.
   seccompProfile: {}
 
+  # Specifies whether a service account token should be automatically mounted into pods
+  # Defaults to true when unspecified. Set to 'false' if you are using projected tokens.
+  automountServiceAccountToken:
+
   # Whether to use an existing CNI installation
   cni:
     enabled: false


### PR DESCRIPTION
**Please provide a description of this PR:**

automountServiceAccountToken is often enforced by security policies and it has to be explicitly set to false in many enterprize clusters (instead sa token is defined in a [projected volume](https://kubernetes.io/docs/concepts/storage/projected-volumes/#serviceaccounttoken)). This PR adds configurable automountServiceAccountToken to helm values. The default behavior does not change and automountServiceAccountToken is not added to templates unless explicitly set in Helm values.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**


- [x] Installation