### PR TITLE
Restrict endpoints visible to ambient E/W gateway to its own network

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
@@ -192,6 +192,10 @@ spec:
         {{- if $network }}
         - name: ISTIO_META_NETWORK
           value: "{{ $network }}"
+        {{- if eq .ControllerLabel "istio.io-eastwest-controller" }}
+        - name: ISTIO_META_REQUESTED_NETWORK_VIEW
+          value: "{{ $network }}"
+        {{- end }}
         {{- end }}
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/istio-east-west.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/istio-east-west.yaml
@@ -127,6 +127,8 @@ spec:
           value: Kubernetes
         - name: ISTIO_META_NETWORK
           value: network-1
+        - name: ISTIO_META_REQUESTED_NETWORK_VIEW
+          value: network-1
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
         - name: ISTIO_META_WORKLOAD_NAME

--- a/releasenotes/notes/58141.yaml
+++ b/releasenotes/notes/58141.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 58141
+releaseNotes:
+- |
+  **Fixed** the issue when EDS endpoints are generated incorrectly in ambient multi-network mode.

--- a/releasenotes/notes/58141.yaml
+++ b/releasenotes/notes/58141.yaml
@@ -5,4 +5,4 @@ issue:
 - 58141
 releaseNotes:
 - |
-  **Fixed** the issue when, due to incorrect EDS caching in pilot, ambient E/W gateway or waypoint may be configured with an unusable EDS endpoints. The issue happens when ambient E/W gateway is deployed and manifests as random request failures when Envoy selects bad endpoints.
+  **Fixed** an issue where due to incorrect EDS caching in pilot, ambient E/W gateway or waypoints would be configured with unusable EDS endpoints.

--- a/releasenotes/notes/58141.yaml
+++ b/releasenotes/notes/58141.yaml
@@ -5,4 +5,4 @@ issue:
 - 58141
 releaseNotes:
 - |
-  **Fixed** the issue when EDS endpoints are generated incorrectly in ambient multi-network mode.
+  **Fixed** the issue when, due to incorrect EDS caching in pilot, ambient E/W gateway or waypoint may be configured with an unusable EDS endpoints. The issue happens when ambient E/W gateway is deployed and manifests as random request failures when Envoy selects bad endpoints.


### PR DESCRIPTION
**Please provide a description of this PR:**

Basically without this, when we generate EDS for the E/W gateway we will
have to filter out endpoints for remote networks by some other means.

However, a bigger problem here is that we have an EDS cache. Without
specifying requested network view, regular waypoints and ambient E/W
gateways use the same cache entries, but they need different EDS endpoints.

All-in-all, we endup either with ambient E/W gateways that have
incorrect endpoints or waypoints that have incorrect endpoints, either
way it's bad.

This change modifies gateway deployment template to check if that's an
E/W gateway and if so adds ISTIO_META_REQUESTED_NETWORK_VIEW environment
variable that is later consumed by the bootstrap script to generate
metadata for Envoy.

That's exactly the same thing that regular sidecar E/W gateway does, we
just didn't do that for the ambient E/W gateway until now. With this I
was able to get the TestAuthorizationL4 test passing in the ambient
multinetwork environment passing consistently.

Fixes #58141.
Fixes #58144.




+cc @keithmattix @therealmitchconnors @Stevenjin8 @jaellio 