### PR TITLE
Bump down log warning

### DIFF
--- a/istioctl/pkg/cli/context.go
+++ b/istioctl/pkg/cli/context.go
@@ -233,7 +233,7 @@ func (i *instance) RevisionOrDefault(rev string) string {
 		if defaultRev := i.defaultWatcher.GetDefault(); defaultRev != "" {
 			return defaultRev
 		}
-		log.Warnf("default revision watcher not synced, falling back to \"default\"")
+		log.Debug("default revision watcher not synced, falling back to \"default\"")
 	}
 
 	return "default"


### PR DESCRIPTION
**Please provide a description of this PR:**

I added a log that assumed there was a default tag causing docs tests to fail (https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio.io/16809/doc.test.multicluster_istio.io/1985748443670253568).

This bumps down the log level.