### PR TITLE
support krt.Named as Index key

### DIFF
--- a/pkg/kube/krt/helpers.go
+++ b/pkg/kube/krt/helpers.go
@@ -133,6 +133,10 @@ func (n Named) GetNamespace() string {
 	return n.Namespace
 }
 
+func (n Named) String() string {
+	return n.ResourceName()
+}
+
 // GetApplyConfigKey returns the key for the ApplyConfig.
 // If there is none, this will return nil.
 func GetApplyConfigKey[O any](a O) *string {


### PR DESCRIPTION
krt.Index requires keys to either be strings or implement Stringer.  Adding Stringer support to krt.Named makes it possible to create an index based on object name, such as an index of services owned by different gateways.