### PR TITLE
[release-1.27] Fix nftables TPROXY rules when includeInboundPorts is empty

### DIFF
--- a/releasenotes/notes/58135.yaml
+++ b/releasenotes/notes/58135.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 58135
+releaseNotes:
+- |
+  **Fixed** `istio-init` failure when using native nftables with TPROXY mode and empty `traffic.sidecar.istio.io/includeInboundPorts` annotation.

--- a/tools/istio-nftables/pkg/builder/nftables_builder_test.go
+++ b/tools/istio-nftables/pkg/builder/nftables_builder_test.go
@@ -52,9 +52,10 @@ func buildRules(t *testing.T, builder *NftablesRuleBuilder) string {
 	chainRuleCount := make(map[string]int)
 	for _, rule := range builder.Rules[testTable] {
 		// In IPtables, inserting a rule at position 1 means it gets placed at the head of the chain. In contrast,
-		// nftables starts rule indexing at 0. However, nftables doesn't allow inserting a rule at index 0 if the
-		// chain is empty. So to handle this case, we check if the chain is empty, and if it is, we use appendRule instead.
-		if rule.Index != nil && chainRuleCount[rule.Chain] == 0 {
+		// nftables starts rule indexing at 0. However, nftables does not allow inserting a rule at index 0 when
+		// the chain is empty, nor does it allow inserting a rule at position N if the chain already contains N rules.
+		// To handle these cases, we check if the chain is empty and convert it to an append operation.
+		if rule.Index != nil && (chainRuleCount[rule.Chain] == 0 || *rule.Index >= chainRuleCount[rule.Chain]) {
 			rule.Index = nil
 		}
 		// When a rule includes the Index, its considered as an Insert request.

--- a/tools/istio-nftables/pkg/capture/run.go
+++ b/tools/istio-nftables/pkg/capture/run.go
@@ -819,9 +819,10 @@ func (cfg *NftablesConfigurator) addIstioTableRules(
 		chain := rule.Chain
 
 		// In IPtables, inserting a rule at position 1 means it gets placed at the head of the chain. In contrast,
-		// nftables starts rule indexing at 0. However, nftables doesn't allow inserting a rule at index 0 if the
-		// chain is empty. So to handle this case, we check if the chain is empty, and if it is, we use appendRule instead.
-		if rule.Index != nil && chainRuleCount[chain] == 0 {
+		// nftables starts rule indexing at 0. However, nftables does not allow inserting a rule at index 0 when
+		// the chain is empty, nor does it allow inserting a rule at position N if the chain already contains N rules.
+		// To handle these cases, we check if the chain is empty and convert it to an append operation.
+		if rule.Index != nil && (chainRuleCount[chain] == 0 || *rule.Index >= chainRuleCount[chain]) {
 			rule.Index = nil
 		}
 

--- a/tools/istio-nftables/pkg/capture/run_test.go
+++ b/tools/istio-nftables/pkg/capture/run_test.go
@@ -166,6 +166,13 @@ func getCommonTestCases() []struct {
 			},
 		},
 		{
+			"inbound-ports-empty-tproxy",
+			func(cfg *config.Config) {
+				cfg.InboundPortsInclude = ""
+				cfg.InboundInterceptionMode = "TPROXY"
+			},
+		},
+		{
 			"dns-uid-gid",
 			func(cfg *config.Config) {
 				cfg.RedirectDNS = true

--- a/tools/istio-nftables/pkg/capture/testdata/inbound-ports-empty-tproxy.golden
+++ b/tools/istio-nftables/pkg/capture/testdata/inbound-ports-empty-tproxy.golden
@@ -1,0 +1,32 @@
+add table inet istio-proxy-nat
+flush table inet istio-proxy-nat
+add chain inet istio-proxy-nat output { type nat hook output priority -100 ; }
+add chain inet istio-proxy-nat istio-inbound
+add chain inet istio-proxy-nat istio-redirect
+add chain inet istio-proxy-nat istio-in-redirect
+add chain inet istio-proxy-nat istio-output
+add rule inet istio-proxy-nat istio-inbound meta l4proto tcp tcp dport 15008 return
+add rule inet istio-proxy-nat istio-redirect meta l4proto tcp redirect to :15001
+add rule inet istio-proxy-nat istio-in-redirect meta l4proto tcp redirect to :15006
+add rule inet istio-proxy-nat output jump istio-output
+add rule inet istio-proxy-nat istio-output oifname lo ip saddr 127.0.0.6/32 return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skuid 1337 jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skuid != 1337 return
+add rule inet istio-proxy-nat istio-output skuid 1337 return
+add rule inet istio-proxy-nat istio-output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 tcp dport != 15008 skgid 1337 jump istio-in-redirect
+add rule inet istio-proxy-nat istio-output oifname lo skgid != 1337 return
+add rule inet istio-proxy-nat istio-output skgid 1337 return
+add rule inet istio-proxy-nat istio-output ip daddr 127.0.0.1/32 return
+add table inet istio-proxy-mangle
+flush table inet istio-proxy-mangle
+add chain inet istio-proxy-mangle prerouting { type filter hook prerouting priority -150 ; }
+add chain inet istio-proxy-mangle output { type route hook output priority -150 ; }
+add chain inet istio-proxy-mangle istio-inbound
+add rule inet istio-proxy-mangle prerouting meta l4proto tcp mark 1337 ct mark set mark
+add rule inet istio-proxy-mangle output oifname lo meta l4proto tcp mark 1337 return
+add rule inet istio-proxy-mangle output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 skuid 1337 meta mark set 1338
+add rule inet istio-proxy-mangle output oifname lo meta l4proto tcp ip daddr != 127.0.0.1/32 skgid 1337 meta mark set 1338
+add rule inet istio-proxy-mangle output meta l4proto tcp ct mark 1337 meta mark set ct mark
+add rule inet istio-proxy-mangle istio-inbound meta l4proto tcp mark 1337 return
+add rule inet istio-proxy-mangle istio-inbound iifname lo meta l4proto tcp ip saddr 127.0.0.6/32 return
+add rule inet istio-proxy-mangle istio-inbound iifname lo meta l4proto tcp mark != 1338 return


### PR DESCRIPTION
When using native nftables with TPROXY interception mode along with an empty list for traffic.sidecar.istio.io/includeInboundPorts annotation, the istio-init sidecar proxy was failing to program the nftable rules. This PR fixes the issue.

Fixes: https://github.com/istio/istio/issues/58135
(cherry picked from commit aa17d3013f692669927135472f1533079a6dd520)
