### PR TITLE
Fix TestDirect/east_west_gateway test

### DIFF
--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -3488,48 +3488,6 @@ func TestDirect(t *testing.T) {
 					// Global services are expected to be reachable via the east-west gateway
 					Check: check.OK(),
 				})
-				i = istio.GetOrFail(t)
-				ewgaddresses, ewgports = ewginstance.HBONEAddresses()
-				if len(ewgaddresses) == 0 || len(ewgports) == 0 {
-					t.Fatal("east-west gateway address or ports not found")
-				}
-				ewgaddr = ewgaddresses[0]
-				ewgport = ewgports[0]
-				cert, err = istio.CreateCertificate(t, i, apps.Captured.ServiceName(), apps.Namespace.Name())
-				if err != nil {
-					t.Fatal(err)
-				}
-				hbsvc = echo.HBONE{
-					Address:            fmt.Sprintf("%s:%v", ewgaddr, ewgport),
-					Headers:            nil,
-					Cert:               string(cert.ClientCert),
-					Key:                string(cert.Key),
-					CaCert:             string(cert.RootCert),
-					InsecureSkipVerify: true,
-				}
-				run("local service", echo.CallOptions{
-					To:          apps.Captured.ForCluster(cluster.Name()),
-					Count:       1,
-					Address:     apps.Captured.ForCluster(cluster.Name()).ClusterLocalFQDN(),
-					Port:        echo.Port{Name: ports.HTTP.Name},
-					HBONE:       hbsvc,
-					DoubleHBONE: hbsvc,
-					// Local services are not expected to be reachable via the east-west gateway
-					Check: check.Error(),
-				})
-
-				capturedSvc = apps.Captured.ForCluster(cluster.Name()).ServiceName()
-				labelServiceGlobal(t, capturedSvc, t.Clusters().Default())
-				run("global service", echo.CallOptions{
-					To:          apps.Captured.ForCluster(cluster.Name()),
-					Count:       1,
-					Address:     apps.Captured.ForCluster(cluster.Name()).ClusterLocalFQDN(),
-					Port:        echo.Port{Name: ports.HTTP.Name},
-					HBONE:       hbsvc,
-					DoubleHBONE: hbsvc,
-					// Global services are expected to be reachable via the east-west gateway
-					Check: check.OK(),
-				})
 			}
 		})
 	})


### PR DESCRIPTION
**Please provide a description of this PR:**

The test had duplicate code that caused it to fail.

The overall test logic is to reach out to a service via an E/W gateway without marking the service as global (we expect a failure in this case), then mark the service as global and repeat (we expect a success the second time around).

This flow was incorrectly repeated twice. As a result, we've been doing the following:

1. Reach out to a local service via E/W gateway (expected a failure and got a failure)
2. Mark service as global
3. Reach out to the now global service via E/W gatway (expected a success and got a success)
4. Reach out to a service that we incorrect assume local via E/W gateway (expected a failure, but got success, because the service is actually global at this point)
5. Mark service as global unnecessarily, because it's already global
6. Reach out to a service again (expect a success and got a success
7. Cleanup, removing the global label from the service

So because we marked the service as global due to duplicate code, without cleaning the label after that, the second "iteration" of the code failed.

This change fixes this test issue and the test is now passing.

Fixes #58225




+cc @therealmitchconnors @keithmattix @Stevenjin8 @jaellio 