### PR TITLE
Set tunnel metadata on double-HBONE endpoints

### DIFF
--- a/tests/integration/ambient/waypoint_test.go
+++ b/tests/integration/ambient/waypoint_test.go
@@ -957,6 +957,14 @@ spec:
           port: 9093
           weight: 1
 `).ApplyOrFail(t)
+		if t.Settings().AmbientMultiNetwork {
+			labelServiceGlobal(t, apps.Captured.ServiceName(), t.AllClusters()...)
+			labelServiceGlobal(t, apps.ServiceAddressedWaypoint.ServiceName(), t.AllClusters()...)
+			t.Cleanup(func() {
+				unlabelServiceGlobal(t, apps.ServiceAddressedWaypoint.ServiceName(), t.AllClusters()...)
+				unlabelServiceGlobal(t, apps.Captured.ServiceName(), t.AllClusters()...)
+			})
+		}
 		apps.Captured[0].CallOrFail(t, echo.CallOptions{
 			To:    apps.ServiceAddressedWaypoint,
 			Port:  ports.TCP,
@@ -1010,6 +1018,14 @@ spec:
           port: 9093
           weight: 1
 `).ApplyOrFail(t)
+		if t.Settings().AmbientMultiNetwork {
+			labelServiceGlobal(t, apps.Captured.ServiceName(), t.AllClusters()...)
+			labelServiceGlobal(t, apps.ServiceAddressedWaypoint.ServiceName(), t.AllClusters()...)
+			t.Cleanup(func() {
+				unlabelServiceGlobal(t, apps.ServiceAddressedWaypoint.ServiceName(), t.AllClusters()...)
+				unlabelServiceGlobal(t, apps.Captured.ServiceName(), t.AllClusters()...)
+			})
+		}
 		apps.Captured[0].CallOrFail(t, echo.CallOptions{
 			To:    apps.ServiceAddressedWaypoint,
 			Port:  ports.TCP,


### PR DESCRIPTION
**Please provide a description of this PR:**

When there are multiple transport sockets available for the cluster, we need to provide metadata required to pick the right transport socket. This was overlooked before and this PR fixes that.

The issue was coincidently caught by `TestTLSRoute` and `TestTCPRoute` integration tests. Those tests triggered the issue due to missing global label cleanup from one of the `TestDirect` test cases. This PR adds the missing cleanup step to avoid environmental issues causing issues for other tests.

However, with `TestDirect` test fixed, we now don't have any tests that catch the root cause issue. So this PR also modifies `TestTLSRoute` and `TestTCPRoute` tests by labeling services as global there explicitly. This will catch the issue, but this time it would do so purposefully and consistently and not coincidentally due to environment state.

Fixes #58229 
Fixes #58230

NOTE: This issue could have affected other test cases, but I didn't re-run the whole test suite enough times to conclusively confirm that other multicluster tests are fixed by this change - I will do that separately and will send PRs to stop skip tests if they are indeed fixed now.

+cc @therealmitchconnors @keithmattix @jaellio @Stevenjin8 