### PR TITLE
Set tunnel metadata on double-HBONE endpoints

### DIFF
--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -3366,6 +3366,9 @@ func TestDirect(t *testing.T) {
 
 			capturedSvc := apps.Captured.ForCluster(cluster.Name()).ServiceName()
 			labelService(t, apps.Namespace.Name(), capturedSvc, "istio.io/global", "true", t.Clusters().Default())
+			t.Cleanup(func() {
+				labelService(t, apps.Namespace.Name(), capturedSvc, "istio.io/global", "")
+			})
 			run("global service", echo.CallOptions{
 				To:          apps.Captured.ForCluster(cluster.Name()),
 				Count:       1,


### PR DESCRIPTION
**Please provide a description of this PR:**

NOTE: This is a partial cherry-pick of the #58248. Automatic cherry-pick didn't merge cleanly because there were significant changes to the ambient tests on the main branch, that weren't cherry-picked to the 1.28 release branch (at least at the moment).

When there are multiple transport sockets available for the cluster, we need to provide metadata required to pick the right transport socket. This was overlooked before and this PR fixes that.

The issue was coincidently caught by TestTLSRoute and TestTCPRoute integration tests. Those tests triggered the issue due to missing global label cleanup from one of the TestDirect test cases. This PR adds the missing cleanup step to avoid environmental issues causing issues for other tests.

Fixes #58253.




+cc @therealmitchconnors @keithmattix @grnmeira 