### PR TITLE
add contribfest speakers to CODEOWNERS for the contribfest branch

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-*                                                                @costinm @linsun @howardjohn @stevenctl @keithmattix @hzxuzhonghu
+*                                                                @costinm @linsun @howardjohn @stevenctl @keithmattix @hzxuzhonghu @ilrudie @Stevenjin8 @kfaseela
 /.gitattributes                                                  @istio/wg-test-and-release-maintainers
 /.gitignore                                                      @istio/wg-test-and-release-maintainers
 /Makefile.core.mk                                                @istio/wg-test-and-release-maintainers


### PR DESCRIPTION
**Please provide a description of this PR:**

This is a quick branch to get a few things pre-staged for contrib fest. I added contribfest speakers as codeowners to we can do some quick work just among ourselves to prep.