### PR TITLE
Program IPv6 nftables rules only when IPv6 is enabled

### DIFF
--- a/cni/pkg/nftables/nftables.go
+++ b/cni/pkg/nftables/nftables.go
@@ -224,7 +224,7 @@ func (cfg *NftablesConfigurator) AppendInpodRules(podOverrides config.PodLevelOv
 
 		// CLI: nft add rule inet istio-ambient-nat istio-prerouting meta l4proto tcp ip6 saddr
 		// fd16:9254:7127:1337:ffff:ffff:ffff:ffff counter accept
-		cfg.ruleBuilder.AppendRule(IstioPreroutingChain, AmbientNatTable,
+		cfg.ruleBuilder.AppendV6RuleIfSupported(IstioPreroutingChain, AmbientNatTable,
 			"meta l4proto tcp",
 			"ip6 saddr", cfg.cfg.HostProbeV6SNATAddress.String(), Counter,
 			"accept",
@@ -240,7 +240,7 @@ func (cfg *NftablesConfigurator) AppendInpodRules(podOverrides config.PodLevelOv
 	)
 
 	// CLI: nft add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr fd16:9254:7127:1337:ffff:ffff:ffff:ffff counter accept
-	cfg.ruleBuilder.AppendRule(IstioOutputChain, AmbientNatTable,
+	cfg.ruleBuilder.AppendV6RuleIfSupported(IstioOutputChain, AmbientNatTable,
 		"meta l4proto tcp",
 		"ip6 daddr", cfg.cfg.HostProbeV6SNATAddress.String(), Counter,
 		"accept",
@@ -259,7 +259,7 @@ func (cfg *NftablesConfigurator) AppendInpodRules(podOverrides config.PodLevelOv
 			"redirect to", ":"+fmt.Sprint(config.ZtunnelInboundPlaintextPort),
 		)
 
-		cfg.ruleBuilder.AppendRule(IstioPreroutingChain, AmbientNatTable,
+		cfg.ruleBuilder.AppendV6RuleIfSupported(IstioPreroutingChain, AmbientNatTable,
 			"ip6 daddr", "!=", "::1/128",
 			"tcp dport", "!=", fmt.Sprint(config.ZtunnelInboundPort),
 			"mark and 0xfff", "!=", fmt.Sprintf("0x%x", config.InpodMark), Counter,
@@ -301,7 +301,7 @@ func (cfg *NftablesConfigurator) AppendInpodRules(podOverrides config.PodLevelOv
 		)
 
 		// CLI: nft add rule inet istio-ambient-nat istio-output ip6 daddr != ::1/128 tcp dport 53 mark and 0xfff != 0x539 counter redirect to :15053
-		cfg.ruleBuilder.AppendRule(
+		cfg.ruleBuilder.AppendV6RuleIfSupported(
 			IstioOutputChain, AmbientNatTable,
 			"ip6 daddr", "!=", "::1/128",
 			"tcp dport", "53",
@@ -356,7 +356,7 @@ func (cfg *NftablesConfigurator) AppendInpodRules(podOverrides config.PodLevelOv
 	)
 
 	// CLI: nft add rule inet istio-ambient-nat istio-output oifname "lo" ip6 daddr != ::1/128 counter accept
-	cfg.ruleBuilder.AppendRule(
+	cfg.ruleBuilder.AppendV6RuleIfSupported(
 		IstioOutputChain, AmbientNatTable,
 		"oifname", "lo",
 		"ip6 daddr",
@@ -377,7 +377,7 @@ func (cfg *NftablesConfigurator) AppendInpodRules(podOverrides config.PodLevelOv
 		"redirect to", ":"+fmt.Sprintf("%d", config.ZtunnelOutboundPort),
 	)
 
-	cfg.ruleBuilder.AppendRule(
+	cfg.ruleBuilder.AppendV6RuleIfSupported(
 		IstioOutputChain, AmbientNatTable,
 		"meta l4proto tcp",
 		"ip6 daddr",
@@ -473,7 +473,7 @@ func (cfg *NftablesConfigurator) CreateHostRulesForHealthChecks() error {
 		"ip", "daddr", fmt.Sprintf("@%s-v4", config.ProbeIPSet), Counter, "snat", "to", cfg.cfg.HostProbeSNATAddress.String())
 
 	// For V6 we have to use a different set and a different SNAT IP
-	cfg.ruleBuilder.AppendRule(PostroutingChain, AmbientNatTable, "meta l4proto tcp", "skuid", kubeletUID,
+	cfg.ruleBuilder.AppendV6RuleIfSupported(PostroutingChain, AmbientNatTable, "meta l4proto tcp", "skuid", kubeletUID,
 		"ip6", "daddr", fmt.Sprintf("@%s-v6", config.ProbeIPSet), Counter, "snat", "to", cfg.cfg.HostProbeV6SNATAddress.String())
 
 	return util.RunAsHost(func() error {

--- a/cni/pkg/nftables/testdata/default.golden
+++ b/cni/pkg/nftables/testdata/default.golden
@@ -7,19 +7,13 @@ add chain inet istio-ambient-nat istio-output
 add rule inet istio-ambient-nat output jump istio-output
 add rule inet istio-ambient-nat prerouting jump istio-prerouting
 add rule inet istio-ambient-nat istio-prerouting meta l4proto tcp ip saddr 169.254.7.127 counter accept
-add rule inet istio-ambient-nat istio-prerouting meta l4proto tcp ip6 saddr e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 counter accept
 add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr 169.254.7.127 counter accept
-add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 counter accept
 add rule inet istio-ambient-nat istio-prerouting ip daddr != 127.0.0.1/32 tcp dport != 15008 mark and 0xfff  != 0x539 counter redirect to :15006
-add rule inet istio-ambient-nat istio-prerouting ip6 daddr != ::1/128 tcp dport != 15008 mark and 0xfff != 0x539 counter redirect to :15006
 add rule inet istio-ambient-nat istio-output oifname != lo mark and 0xfff != 0x539 udp dport 53 counter redirect to :15053
 add rule inet istio-ambient-nat istio-output ip daddr != 127.0.0.1/32 tcp dport 53 mark and 0xfff != 0x539 counter redirect to :15053
-add rule inet istio-ambient-nat istio-output ip6 daddr != ::1/128 tcp dport 53 mark and 0xfff != 0x539 counter redirect to :15053
 add rule inet istio-ambient-nat istio-output meta l4proto tcp mark and 0xfff == 0x111 counter accept
 add rule inet istio-ambient-nat istio-output oifname lo ip daddr != 127.0.0.1/32 counter accept
-add rule inet istio-ambient-nat istio-output oifname lo ip6 daddr != ::1/128 counter accept
 add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr != 127.0.0.1/32 mark and 0xfff != 0x539 counter redirect to :15001
-add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr != ::1/128 mark and 0xfff != 0x539 counter redirect to :15001
 add table inet istio-ambient-mangle
 flush table inet istio-ambient-mangle
 add chain inet istio-ambient-mangle prerouting { type filter hook prerouting priority -150 ; }

--- a/cni/pkg/nftables/testdata/dns_pod_disabled_and_on_globally.golden
+++ b/cni/pkg/nftables/testdata/dns_pod_disabled_and_on_globally.golden
@@ -7,16 +7,11 @@ add chain inet istio-ambient-nat istio-output
 add rule inet istio-ambient-nat output jump istio-output
 add rule inet istio-ambient-nat prerouting jump istio-prerouting
 add rule inet istio-ambient-nat istio-prerouting meta l4proto tcp ip saddr 169.254.7.127 counter accept
-add rule inet istio-ambient-nat istio-prerouting meta l4proto tcp ip6 saddr e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 counter accept
 add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr 169.254.7.127 counter accept
-add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 counter accept
 add rule inet istio-ambient-nat istio-prerouting ip daddr != 127.0.0.1/32 tcp dport != 15008 mark and 0xfff  != 0x539 counter redirect to :15006
-add rule inet istio-ambient-nat istio-prerouting ip6 daddr != ::1/128 tcp dport != 15008 mark and 0xfff != 0x539 counter redirect to :15006
 add rule inet istio-ambient-nat istio-output meta l4proto tcp mark and 0xfff == 0x111 counter accept
 add rule inet istio-ambient-nat istio-output oifname lo ip daddr != 127.0.0.1/32 counter accept
-add rule inet istio-ambient-nat istio-output oifname lo ip6 daddr != ::1/128 counter accept
 add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr != 127.0.0.1/32 mark and 0xfff != 0x539 counter redirect to :15001
-add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr != ::1/128 mark and 0xfff != 0x539 counter redirect to :15001
 add table inet istio-ambient-mangle
 flush table inet istio-ambient-mangle
 add chain inet istio-ambient-mangle prerouting { type filter hook prerouting priority -150 ; }

--- a/cni/pkg/nftables/testdata/dns_pod_enabled_and_off_globally.golden
+++ b/cni/pkg/nftables/testdata/dns_pod_enabled_and_off_globally.golden
@@ -7,19 +7,13 @@ add chain inet istio-ambient-nat istio-output
 add rule inet istio-ambient-nat output jump istio-output
 add rule inet istio-ambient-nat prerouting jump istio-prerouting
 add rule inet istio-ambient-nat istio-prerouting meta l4proto tcp ip saddr 169.254.7.127 counter accept
-add rule inet istio-ambient-nat istio-prerouting meta l4proto tcp ip6 saddr e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 counter accept
 add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr 169.254.7.127 counter accept
-add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 counter accept
 add rule inet istio-ambient-nat istio-prerouting ip daddr != 127.0.0.1/32 tcp dport != 15008 mark and 0xfff  != 0x539 counter redirect to :15006
-add rule inet istio-ambient-nat istio-prerouting ip6 daddr != ::1/128 tcp dport != 15008 mark and 0xfff != 0x539 counter redirect to :15006
 add rule inet istio-ambient-nat istio-output oifname != lo mark and 0xfff != 0x539 udp dport 53 counter redirect to :15053
 add rule inet istio-ambient-nat istio-output ip daddr != 127.0.0.1/32 tcp dport 53 mark and 0xfff != 0x539 counter redirect to :15053
-add rule inet istio-ambient-nat istio-output ip6 daddr != ::1/128 tcp dport 53 mark and 0xfff != 0x539 counter redirect to :15053
 add rule inet istio-ambient-nat istio-output meta l4proto tcp mark and 0xfff == 0x111 counter accept
 add rule inet istio-ambient-nat istio-output oifname lo ip daddr != 127.0.0.1/32 counter accept
-add rule inet istio-ambient-nat istio-output oifname lo ip6 daddr != ::1/128 counter accept
 add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr != 127.0.0.1/32 mark and 0xfff != 0x539 counter redirect to :15001
-add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr != ::1/128 mark and 0xfff != 0x539 counter redirect to :15001
 add table inet istio-ambient-mangle
 flush table inet istio-ambient-mangle
 add chain inet istio-ambient-mangle prerouting { type filter hook prerouting priority -150 ; }

--- a/cni/pkg/nftables/testdata/hostprobe.golden
+++ b/cni/pkg/nftables/testdata/hostprobe.golden
@@ -2,4 +2,3 @@ add table inet istio-ambient-nat
 flush table inet istio-ambient-nat
 add chain inet istio-ambient-nat postrouting { type nat hook postrouting priority 100 ; }
 add rule inet istio-ambient-nat postrouting meta l4proto tcp skuid 1000 ip daddr @istio-inpod-probes-v4 counter snat to 169.254.7.127
-add rule inet istio-ambient-nat postrouting meta l4proto tcp skuid 1000 ip6 daddr @istio-inpod-probes-v6 counter snat to e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164

--- a/cni/pkg/nftables/testdata/ingress.golden
+++ b/cni/pkg/nftables/testdata/ingress.golden
@@ -7,12 +7,9 @@ add chain inet istio-ambient-nat istio-output
 add rule inet istio-ambient-nat output jump istio-output
 add rule inet istio-ambient-nat prerouting jump istio-prerouting
 add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr 169.254.7.127 counter accept
-add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 counter accept
 add rule inet istio-ambient-nat istio-output meta l4proto tcp mark and 0xfff == 0x111 counter accept
 add rule inet istio-ambient-nat istio-output oifname lo ip daddr != 127.0.0.1/32 counter accept
-add rule inet istio-ambient-nat istio-output oifname lo ip6 daddr != ::1/128 counter accept
 add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr != 127.0.0.1/32 mark and 0xfff != 0x539 counter redirect to :15001
-add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr != ::1/128 mark and 0xfff != 0x539 counter redirect to :15001
 add table inet istio-ambient-mangle
 flush table inet istio-ambient-mangle
 add chain inet istio-ambient-mangle prerouting { type filter hook prerouting priority -150 ; }

--- a/cni/pkg/nftables/testdata/ingress_and_virtual_interfaces.golden
+++ b/cni/pkg/nftables/testdata/ingress_and_virtual_interfaces.golden
@@ -11,12 +11,9 @@ add rule inet istio-ambient-nat istio-prerouting iifname fake1s0f0 meta l4proto 
 add rule inet istio-ambient-nat istio-prerouting iifname fake1s0f1 meta l4proto tcp counter redirect to :15001
 add rule inet istio-ambient-nat istio-prerouting iifname fake1s0f1 meta l4proto tcp counter return
 add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr 169.254.7.127 counter accept
-add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 counter accept
 add rule inet istio-ambient-nat istio-output meta l4proto tcp mark and 0xfff == 0x111 counter accept
 add rule inet istio-ambient-nat istio-output oifname lo ip daddr != 127.0.0.1/32 counter accept
-add rule inet istio-ambient-nat istio-output oifname lo ip6 daddr != ::1/128 counter accept
 add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr != 127.0.0.1/32 mark and 0xfff != 0x539 counter redirect to :15001
-add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr != ::1/128 mark and 0xfff != 0x539 counter redirect to :15001
 add table inet istio-ambient-mangle
 flush table inet istio-ambient-mangle
 add chain inet istio-ambient-mangle prerouting { type filter hook prerouting priority -150 ; }

--- a/cni/pkg/nftables/testdata/virtual_interfaces.golden
+++ b/cni/pkg/nftables/testdata/virtual_interfaces.golden
@@ -11,16 +11,11 @@ add rule inet istio-ambient-nat istio-prerouting iifname fake1s0f0 meta l4proto 
 add rule inet istio-ambient-nat istio-prerouting iifname fake1s0f1 meta l4proto tcp counter redirect to :15001
 add rule inet istio-ambient-nat istio-prerouting iifname fake1s0f1 meta l4proto tcp counter return
 add rule inet istio-ambient-nat istio-prerouting meta l4proto tcp ip saddr 169.254.7.127 counter accept
-add rule inet istio-ambient-nat istio-prerouting meta l4proto tcp ip6 saddr e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 counter accept
 add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr 169.254.7.127 counter accept
-add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 counter accept
 add rule inet istio-ambient-nat istio-prerouting ip daddr != 127.0.0.1/32 tcp dport != 15008 mark and 0xfff  != 0x539 counter redirect to :15006
-add rule inet istio-ambient-nat istio-prerouting ip6 daddr != ::1/128 tcp dport != 15008 mark and 0xfff != 0x539 counter redirect to :15006
 add rule inet istio-ambient-nat istio-output meta l4proto tcp mark and 0xfff == 0x111 counter accept
 add rule inet istio-ambient-nat istio-output oifname lo ip daddr != 127.0.0.1/32 counter accept
-add rule inet istio-ambient-nat istio-output oifname lo ip6 daddr != ::1/128 counter accept
 add rule inet istio-ambient-nat istio-output meta l4proto tcp ip daddr != 127.0.0.1/32 mark and 0xfff != 0x539 counter redirect to :15001
-add rule inet istio-ambient-nat istio-output meta l4proto tcp ip6 daddr != ::1/128 mark and 0xfff != 0x539 counter redirect to :15001
 add table inet istio-ambient-mangle
 flush table inet istio-ambient-mangle
 add chain inet istio-ambient-mangle prerouting { type filter hook prerouting priority -150 ; }

--- a/releasenotes/notes/58249.yaml
+++ b/releasenotes/notes/58249.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 58249
+releaseNotes:
+- |
+  **Fixed** IPv6 nftables rules are no longer programmed when IPv6 is explicitly disabled in ambient mode.


### PR DESCRIPTION
The nftables code was always configuring IPv6 rules regardless of the cni.ambient.EnableIPv6 setting, which caused errors on platforms without IPv6 support. This PR ensures IPv6 rules are only configured when EnableIPv6 is set to true.

Fixes: https://github.com/istio/istio/issues/58249