### PR TITLE
charts/gateway: allow "enabled" field in the schema

### DIFF
--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -11,6 +11,10 @@
         "global": {
           "type": "object"
         },
+        "enabled": {
+          "description": "Field used as a condition when this chart is included as a dependency. It's allowed in the schema, but the chart itself does not read it. For more information see: https://helm.sh/docs/chart_best_practices/dependencies/#conditions-and-tags.",
+          "type": "boolean"
+        },
         "affinity": {
           "type": "object"
         },

--- a/releasenotes/notes/helm-values-shema-enabled-field.yaml
+++ b/releasenotes/notes/helm-values-shema-enabled-field.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+
+kind: bug-fix
+area: installation
+issue:
+  - 58277
+releaseNotes:
+- |
+  **Fixed** `istio-gateway` helm chart values schema to allow top-level `enabled` field.


### PR DESCRIPTION
**Please provide a description of this PR:**

Allow `enabled` field in the chart values schema. See https://github.com/istio/istio/issues/58277.