### PR TITLE
fix: log unset / mismatching cniConfigFilePath only as debug avoid log noise

### DIFF
--- a/cni/pkg/install/install.go
+++ b/cni/pkg/install/install.go
@@ -304,7 +304,7 @@ func checkValidCNIConfig(ctx context.Context, cfg *config.InstallConfig, cniConf
 	// first call of checkValidCNIConfig and we will return an error so the cni config file can be
 	// created or rewritten
 	if defaultCNIConfigFilepath != cniConfigFilepath {
-		log.Infof("cniConfigFilePath mismatch: expected %s but found %s", defaultCNIConfigFilepath, cniConfigFilepath)
+		log.Debugf("cniConfigFilePath mismatch: expected %s but found %s", defaultCNIConfigFilepath, cniConfigFilepath)
 		if len(cfg.CNIConfName) > 0 || !cfg.ChainedCNIPlugin {
 			// Install was run with overridden CNI config file so don't error out on preempt check
 			// Likely the only use for this is testing the script


### PR DESCRIPTION


**Please provide a description of this PR:**
This follows a discussion with @jaellio  (https://github.com/istio/istio/pull/56972#issuecomment-3522763940) 
about observed logs like

```
{"level":"info","time":"2025-11-12T15:21:24.588593Z","msg":"cniConfigFilePath mismatch: expected /host/etc/cni/net.d/10-aws.conflist but found "}
```
on every CNI startup. This condition is actually expected on the first iteration, so it's better to only log it on debug log level.