### PR TITLE
fix for istioctl waypoint status timing out when gateway resource is not programmed

### DIFF
--- a/istioctl/pkg/waypoint/testdata/waypoint/waypoint-notready-wait
+++ b/istioctl/pkg/waypoint/testdata/waypoint/waypoint-notready-wait
@@ -1,0 +1,2 @@
+Error: failed to print waypoint status: timed out while retrieving status for waypoint	default/waypoint
+

--- a/istioctl/pkg/waypoint/testdata/waypoint/waypoint-status-notready
+++ b/istioctl/pkg/waypoint/testdata/waypoint/waypoint-status-notready
@@ -1,0 +1,2 @@
+NAME         STATUS     TYPE           REASON     MESSAGE
+waypoint     False      Programmed                

--- a/istioctl/pkg/waypoint/testdata/waypoint/waypoint-status-ready
+++ b/istioctl/pkg/waypoint/testdata/waypoint/waypoint-status-ready
@@ -1,0 +1,2 @@
+NAME         STATUS     TYPE           REASON     MESSAGE
+waypoint     True       Programmed                

--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -59,6 +59,8 @@ var (
 	waypointName    = constants.DefaultNamespaceWaypoint
 	enrollNamespace bool
 	overwrite       bool
+
+	statusWaitReady bool
 )
 
 const waitTimeout = 90 * time.Second
@@ -465,6 +467,7 @@ func Cmd(ctx cli.Context) *cobra.Command {
 	waypointApplyCmd.Flags().DurationVar(&waypointTimeout, "waypoint-timeout", waitTimeout, "Timeout for waiting for waypoint ready")
 	waypointGenerateCmd.Flags().StringVarP(&revision, "revision", "r", "", "The revision to label the waypoint with")
 	waypointStatusCmd.Flags().DurationVar(&waypointTimeout, "waypoint-timeout", waitTimeout, "Timeout for retrieving status for waypoint")
+	waypointStatusCmd.Flags().BoolVarP(&statusWaitReady, "wait", "w", true, "Wait for waypoint to be programmed before reporting status")
 	waypointCmd.AddCommand(waypointGenerateCmd)
 	waypointCmd.AddCommand(waypointDeleteCmd)
 	waypointCmd.AddCommand(waypointListCmd)
@@ -629,7 +632,7 @@ func printWaypointStatus(ctx cli.Context, w *tabwriter.Writer, kubeClient kube.C
 				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", gwc.Name, cond.Status, cond.Type, cond.Reason, cond.Message)
 			}
 
-			if programmed {
+			if !statusWaitReady || programmed {
 				break
 			}
 

--- a/istioctl/pkg/waypoint/waypoint_test.go
+++ b/istioctl/pkg/waypoint/waypoint_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gateway "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -109,6 +110,103 @@ func TestWaypointList(t *testing.T) {
 			if fErr != nil {
 				t.Fatal(fErr)
 			}
+			output := out.String()
+			if output != expectedOut {
+				t.Fatalf("expected %s, got %s", expectedOut, output)
+			}
+		})
+	}
+}
+
+func TestWaypointStatus(t *testing.T) {
+	cases := []struct {
+		name            string
+		args            []string
+		gateways        []*gateway.Gateway
+		expectedOutFile string
+	}{
+		{
+			name: "waypoint ready",
+			args: strings.Split("status", " "),
+			gateways: []*gateway.Gateway{
+				makeGateway(constants.DefaultNamespaceWaypoint, "default", true, true),
+			},
+			expectedOutFile: "waypoint-status-ready",
+		},
+		{
+			name: "waypoint ready with --wait",
+			args: strings.Split("status --wait=true", " "),
+			gateways: []*gateway.Gateway{
+				makeGateway(constants.DefaultNamespaceWaypoint, "default", true, true),
+			},
+			expectedOutFile: "waypoint-status-ready",
+		},
+		{
+			name: "waypoint ready with --wait=false",
+			args: strings.Split("status --wait=false", " "),
+			gateways: []*gateway.Gateway{
+				makeGateway(constants.DefaultNamespaceWaypoint, "default", true, true),
+			},
+			expectedOutFile: "waypoint-status-ready",
+		},
+		{
+			name: "waypoint not ready without --wait",
+			args: strings.Split("status --waypoint-timeout 0.5s", " "),
+			gateways: []*gateway.Gateway{
+				makeGateway(constants.DefaultNamespaceWaypoint, "default", false, true),
+			},
+			expectedOutFile: "waypoint-notready-wait",
+		},
+		{
+			name: "waypoint not ready with --wait",
+			args: strings.Split("status --wait --waypoint-timeout 0.5s", " "),
+			gateways: []*gateway.Gateway{
+				makeGateway(constants.DefaultNamespaceWaypoint, "default", false, true),
+			},
+			expectedOutFile: "waypoint-notready-wait",
+		},
+		{
+			name: "waypoint not ready with --wait=false",
+			args: strings.Split("status --wait=false --waypoint-timeout 0.5s", " "),
+			gateways: []*gateway.Gateway{
+				makeGateway(constants.DefaultNamespaceWaypoint, "default", false, true),
+			},
+			expectedOutFile: "waypoint-status-notready",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := cli.NewFakeContext(&cli.NewFakeContextOption{
+				Namespace: "default",
+			})
+			client, err := ctx.CLIClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			for _, gw := range tt.gateways {
+				_, _ = client.GatewayAPI().GatewayV1().Gateways(gw.Namespace).Create(context.Background(), gw, metav1.CreateOptions{})
+			}
+			defaultFile, err := os.ReadFile(fmt.Sprintf("testdata/waypoint/%s", tt.expectedOutFile))
+			if err != nil {
+				t.Fatal(err)
+			}
+			expectedOut := string(defaultFile)
+			if len(expectedOut) == 0 {
+				t.Fatal("expected output is empty")
+			}
+
+			var out bytes.Buffer
+			rootCmd := Cmd(ctx)
+			rootCmd.SetArgs(tt.args)
+			rootCmd.SetOut(&out)
+			rootCmd.SetErr(&out)
+			// disable Usage
+			rootCmd.SetUsageFunc(func(cmd *cobra.Command) error {
+				return nil
+			})
+
+			rootCmd.Execute()
 			output := out.String()
 			if output != expectedOut {
 				t.Fatalf("expected %s, got %s", expectedOut, output)

--- a/releasenotes/notes/57075.yml
+++ b/releasenotes/notes/57075.yml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+issue:
+- 57075
+releaseNotes:
+- |
+    **Fixed** an issue where istioctl waypoint status always timed out if the waypoint did not reach a programmed state. This adds a new --wait flag, which defaults to true if not specified but allows a user to disable the original wait behavior and view the status for all waypoint states.


### PR DESCRIPTION
…not programmed

**Please provide a description of this PR:**
**Fixed** an issue where istioctl waypoint status always timed out if the waypoint did not reach a programmed state. This adds a new --wait flag, which defaults to true if not specified but allows a user to disable the original wait behavior and view the status for all waypoint states.