### PR TITLE
Add DSCP magic mark support for inbound traffic redirection

### DIFF
--- a/cni/pkg/config/config.go
+++ b/cni/pkg/config/config.go
@@ -37,6 +37,7 @@ const (
 	ZtunnelInboundPort          = 15008
 	ZtunnelOutboundPort         = 15001
 	ZtunnelInboundPlaintextPort = 15006
+	DSCPMagicMark               = 0x17 // FIXME: needs to be configurable
 	ProbeIPSet                  = "istio-inpod-probes"
 )
 

--- a/cni/pkg/iptables/iptables.go
+++ b/cni/pkg/iptables/iptables.go
@@ -333,6 +333,13 @@ func (cfg *IptablesConfigurator) AppendInpodRules(podOverrides config.PodLevelOv
 		)
 	}
 
+	iptablesBuilder.AppendRule(ChainInpodPrerouting, "nat",
+		"-p", "tcp",
+		"-m", "dscp", "--dscp", fmt.Sprintf("%#x", config.DSCPMagicMark),
+		"-j", "REDIRECT",
+		"--to-port", fmt.Sprint(config.ZtunnelInboundPort),
+	)
+
 	// CLI: -A ISTIO_OUTPUT -m connmark --mark 0x111/0xfff -j CONNMARK --restore-mark --nfmask 0xffffffff --ctmask 0xffffffff
 	//
 	// DESC: Propagate/restore connmark (if we had one) for outbound


### PR DESCRIPTION
Introduces DSCPMagicMark constant (0x17) and adds iptables rule to redirect TCP packets with matching DSCP mark to ztunnel inbound port (15008).

**Please provide a description of this PR:**