### PR TITLE
Bugfix enhanced DR merging where some DRs with the same sidecar scope fail to apply

### DIFF
--- a/releasenotes/notes/bugfix-dr-merging-missing-no-selector.yaml
+++ b/releasenotes/notes/bugfix-dr-merging-missing-no-selector.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+- |
+  **Fixed** an issue where DestinationRules with no selector would no longer apply if a DestinationRule with a selector is present and
+  `ENABLE_ENHANCED_DESTINATIONRULE_MERGE` is set to true.


### PR DESCRIPTION
**Please provide a description of this PR:**
With two destination rules with the same exportTo scope, one with a workload selector and one without, the DR without a workload selector no longer applies to workloads that do not match the DR with the workload selector. This is because the feature `ENABLE_ENHANCED_DESTINATIONRULE_MERGE` will set `appendSeparately` to false and the following lines of code won't set it back to true if the workload selectors don't match.

We have tested with `ENABLE_ENHANCED_DESTINATIONRULE_MERGE=true` and `ENABLE_ENHANCED_DESTINATIONRULE_MERGE=false`. False applies the DR w/o a workload selector correctly while true does not. 

This was discovered while trying out the mitigation I proposed for #57719:
> A mitigation (to be confirmed) would be to copy over the DR in the destination namespace with no workload selector into the client namespace.