### PR TITLE
disable trailing dots on hostnames for java-grpc clients

### DIFF
--- a/pilot/pkg/networking/core/tls.go
+++ b/pilot/pkg/networking/core/tls.go
@@ -209,7 +209,7 @@ func buildSidecarOutboundTLSFilterChainOpts(node *model.Proxy, push *model.PushC
 		if len(destinationCIDRs) > 0 || len(svcListenAddress) == 0 || (svcListenAddress == actualWildcard && bind == actualWildcard) {
 			sniHosts = []string{string(service.Hostname)}
 			for _, a := range service.Attributes.Aliases {
-				alt := GenerateAltVirtualHosts(a.Hostname.String(), 0, node.DNSDomain)
+				alt := GenerateAltVirtualHosts(a.Hostname.String(), 0, node.DNSDomain, node)
 				sniHosts = append(sniHosts, a.Hostname.String())
 				sniHosts = append(sniHosts, alt...)
 			}

--- a/pkg/model/proxy.go
+++ b/pkg/model/proxy.go
@@ -284,6 +284,10 @@ type NodeMetadata struct {
 	// Generator indicates the client wants to use a custom Generator plugin.
 	Generator string `json:"GENERATOR,omitempty"`
 
+	// EnableTrailingDot indicates whether to add trailing dots to virtual host domains.
+	// Computed by Istiod based on: client metadata > user agent > system default.
+	EnableTrailingDot StringBool `json:"ENABLE_TRAILING_DOT,omitempty"`
+
 	// DNSCapture indicates whether the workload has enabled dns capture
 	DNSCapture StringBool `json:"DNS_CAPTURE,omitempty"`
 

--- a/releasenotes/notes/grpc-java-trailing-dot-compatibility.yaml
+++ b/releasenotes/notes/grpc-java-trailing-dot-compatibility.yaml
@@ -1,0 +1,15 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+issue:
+  - https://github.com/istio/istio/issues/56007
+
+releaseNotes:
+- |
+  **Added** automatic gRPC Java compatibility for trailing dot virtual hosts. gRPC Java clients are now 
+  auto-detected and receive hostnames without trailing dots (e.g., `foo.svc.cluster.local` instead of 
+  `foo.svc.cluster.local.`), as gRPC Java's hostname validation rejects trailing dots. Override per-client 
+  by setting `TRAILING_DOT: "true"` or `TRAILING_DOT: "false"` in xDS node metadata.
+
+


### PR DESCRIPTION
The fix for #56007 enabled trailing dots by default, but gRPC Java's hostname validation rejects them.

The fix is to auto-detect gRPC Java clients and disable trailing dots, while keeping trailing dots for other clients.

**Changes:**
- Add `computeEnableTrailingDot()` to detect gRPC Java via user agent
- Cache decision in `Metadata.EnableTrailingDot` 
- Support client override via `TRAILING_DOT` metadata 

**Precedence:** client metadata > user-agent detection > system default

---

**Areas affected:**
- [x] Networking