### PR TITLE
fix: istioctl waypoint status times out when gateway resource not pro…

### DIFF
--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -59,6 +59,8 @@ var (
 	waypointName    = constants.DefaultNamespaceWaypoint
 	enrollNamespace bool
 	overwrite       bool
+
+	statusWaitReady bool
 )
 
 const waitTimeout = 90 * time.Second
@@ -465,6 +467,7 @@ func Cmd(ctx cli.Context) *cobra.Command {
 	waypointApplyCmd.Flags().DurationVar(&waypointTimeout, "waypoint-timeout", waitTimeout, "Timeout for waiting for waypoint ready")
 	waypointGenerateCmd.Flags().StringVarP(&revision, "revision", "r", "", "The revision to label the waypoint with")
 	waypointStatusCmd.Flags().DurationVar(&waypointTimeout, "waypoint-timeout", waitTimeout, "Timeout for retrieving status for waypoint")
+	waypointStatusCmd.Flags().BoolVarP(&statusWaitReady, "wait", "w", true, "Wait for waypoint to be programmed before reporting status")
 	waypointCmd.AddCommand(waypointGenerateCmd)
 	waypointCmd.AddCommand(waypointDeleteCmd)
 	waypointCmd.AddCommand(waypointListCmd)
@@ -629,7 +632,7 @@ func printWaypointStatus(ctx cli.Context, w *tabwriter.Writer, kubeClient kube.C
 				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", gwc.Name, cond.Status, cond.Type, cond.Reason, cond.Message)
 			}
 
-			if programmed {
+			if !statusWaitReady || programmed {
 				break
 			}
 

--- a/releasenotes/notes/57075.yaml
+++ b/releasenotes/notes/57075.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+issue:
+- 57075
+releaseNotes:
+- |
+    **Fixed** an issue where istioctl waypoint status always timed out if the waypoint did not reach a programmed state. This adds a new --wait flag, which defaults to true if not specified but allows a user to disable the original wait behavior and view the status for all waypoint states.


### PR DESCRIPTION
istioctl waypoint status times out when gateway resource not programmed

Fixes #57075 by including a new "--wait" flag. The flag defaults to true to maintain previous expected behavior, but allows a user to bypass this issue using "--wait=false".

(This PR is related to a ContribFest event at KubeCon NA 2025)