### PR TITLE
Enable Envoy's strip_trailing_host_dot for FQDN support

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -277,18 +277,6 @@ var (
 	EnableClusterTrustBundles = env.Register("ENABLE_CLUSTER_TRUST_BUNDLE_API", false,
 		"If enabled, uses the ClusterTrustBundle API instead of ConfigMaps to store the root certificate in the cluster.").Get()
 
-	// EnableAbsoluteFqdnVhostDomain controls whether the absolute FQDN (hostname followed by a dot,)
-	// e.g. my-service.my-ns.svc.cluster.local. / google.com. is added to the VirtualHost domains list.
-	// Setting this to false disables the addition.
-	// See https://github.com/istio/istio/issues/56007 for more details of this feature with examples.
-	EnableAbsoluteFqdnVhostDomain = env.Register(
-		"PILOT_ENABLE_ABSOLUTE_FQDN_VHOST_DOMAIN", // Environment variable name
-		true, // Default value (true = feature enabled by default)
-		"If set to false, Istio will not add the absolute FQDN variant"+
-			" (e.g., my-service.my-ns.svc.cluster.local.) to the domains"+
-			" list for VirtualHost entries.",
-	).Get()
-
 	EnableProxyFindPodByIP = env.Register("ENABLE_PROXY_FIND_POD_BY_IP", false,
 		"If enabled, the pod controller will allow finding pods matching proxies by IP if it fails to find them by name.").Get()
 

--- a/pilot/pkg/networking/core/httproute.go
+++ b/pilot/pkg/networking/core/httproute.go
@@ -609,44 +609,27 @@ func appendDomainPort(domains []string, domain string, port int) []string {
 // - Given foo.local.campus.net on proxy domain "" or proxy domain example.com, this
 // function returns nil
 func GenerateAltVirtualHosts(hostname string, port int, proxyDomain string) []string {
-	var vhosts []string // Initialize the slice for alternate hosts
-
-	if features.EnableAbsoluteFqdnVhostDomain {
-		// Add the absolute FQDN variant (with trailing dot) if the hostname is not an IP address.
-		// This is considered another form of alternate host representation.
-		// See https://github.com/istio/istio/issues/56007 for context.
-		// "foo.local.campus.net" -> "foo.local.campus.net."
-		// "foo.bar.svc.cluster.local" -> "foo.bar.svc.cluster.local."
-		isIP := net.ParseIP(hostname) != nil
-		if !isIP {
-			vhosts = append(vhosts, hostname+".")
-		}
-		if port != portNoAppendPortSuffix {
-			vhosts = append(vhosts, util.DomainName(hostname+".", port))
-		}
-	}
-
 	// If the dns/proxy domain contains `.svc`, only services following the <ns>.svc.<suffix>
 	// naming convention and that share a suffix with the domain should be expanded.
 	if strings.Contains(proxyDomain, ".svc.") {
 
 		if strings.HasSuffix(hostname, removeSvcNamespace(proxyDomain)) {
-			kubeSVCAltHosts := generateAltVirtualHostsForKubernetesService(hostname, port, proxyDomain)
-			return append(vhosts, kubeSVCAltHosts...)
+			return generateAltVirtualHostsForKubernetesService(hostname, port, proxyDomain)
 		}
 
 		// Hostname is not a kube service.  It is not safe to expand the
 		// hostname as non-fully-qualified names could conflict with expansion of other kube service
 		// hostnames
-		return vhosts
+		return nil
 	}
 
+	var vhosts []string
 	uniqueHostnameParts, sharedDNSDomainParts := getUniqueAndSharedDNSDomain(hostname, proxyDomain)
 
 	// If there is no shared DNS name (e.g., foobar.com service on local.net proxy domain)
 	// do not generate any alternate virtual host representations
 	if len(sharedDNSDomainParts) == 0 {
-		return vhosts
+		return nil
 	}
 
 	uniqueHostname := strings.Join(uniqueHostnameParts, ".")

--- a/pilot/pkg/networking/core/httproute_test.go
+++ b/pilot/pkg/networking/core/httproute_test.go
@@ -67,7 +67,6 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			},
 			want: []string{
 				"foo.local.campus.net",
-				"foo.local.campus.net.",
 				"foo",
 			},
 		},
@@ -83,7 +82,6 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			},
 			want: []string{
 				"foo.local.campus.net",
-				"foo.local.campus.net.",
 				"foo.local",
 				"foo.local.campus",
 			},
@@ -98,10 +96,7 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			node: &model.Proxy{
 				DNSDomain: "example.com",
 			},
-			want: []string{
-				"foo.local.campus.net",
-				"foo.local.campus.net.",
-			},
+			want: []string{"foo.local.campus.net"},
 		},
 		{
 			name: "k8s service with default domain",
@@ -115,7 +110,6 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			},
 			want: []string{
 				"echo.default.svc.cluster.local",
-				"echo.default.svc.cluster.local.",
 				"echo",
 				"echo.default.svc",
 				"echo.default",
@@ -133,7 +127,6 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			},
 			want: []string{
 				"foo.default.svc.bar.baz",
-				"foo.default.svc.bar.baz.",
 			},
 		},
 		{
@@ -148,7 +141,6 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			},
 			want: []string{
 				"echo.default.svc.cluster.local",
-				"echo.default.svc.cluster.local.",
 				"echo.default",
 				"echo.default.svc",
 			},
@@ -163,10 +155,7 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			node: &model.Proxy{
 				DNSDomain: "foo.svc.custom.k8s.local",
 			},
-			want: []string{
-				"google.local",
-				"google.local.",
-			},
+			want: []string{"google.local"},
 		},
 		{
 			name: "ipv4 domain",
@@ -202,10 +191,7 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			node: &model.Proxy{
 				DNSDomain: "tests.svc.cluster.local",
 			},
-			want: []string{
-				"aaa.example.local",
-				"aaa.example.local.",
-			},
+			want: []string{"aaa.example.local"},
 		},
 		{
 			name: "front subset of cluster domain in address",
@@ -217,10 +203,7 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			node: &model.Proxy{
 				DNSDomain: "tests.svc.my.long.domain.suffix",
 			},
-			want: []string{
-				"aaa.example.my",
-				"aaa.example.my.",
-			},
+			want: []string{"aaa.example.my"},
 		},
 		{
 			name: "large subset of cluster domain in address",
@@ -232,10 +215,7 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			node: &model.Proxy{
 				DNSDomain: "tests.svc.my.long.domain.suffix",
 			},
-			want: []string{
-				"aaa.example.my.long",
-				"aaa.example.my.long.",
-			},
+			want: []string{"aaa.example.my.long"},
 		},
 		{
 			name: "no overlap of cluster domain in address",
@@ -247,10 +227,7 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			node: &model.Proxy{
 				DNSDomain: "tests.svc.cluster.local",
 			},
-			want: []string{
-				"aaa.example.com",
-				"aaa.example.com.",
-			},
+			want: []string{"aaa.example.com"},
 		},
 		{
 			name: "wildcard",
@@ -266,12 +243,10 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			},
 			want: []string{
 				"headless.default.svc.cluster.local",
-				"headless.default.svc.cluster.local.",
 				"headless",
 				"headless.default.svc",
 				"headless.default",
 				"*.headless.default.svc.cluster.local",
-				"*.headless.default.svc.cluster.local.",
 				"*.headless",
 				"*.headless.default.svc",
 				"*.headless.default",
@@ -299,7 +274,6 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			},
 			want: []string{
 				"echo.default.svc.cluster.local",
-				"echo.default.svc.cluster.local.",
 				"echo",
 				"echo.default.svc",
 				"echo.default",
@@ -331,7 +305,6 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			},
 			want: []string{
 				"echo.default.svc.cluster.local",
-				"echo.default.svc.cluster.local.",
 				"echo",
 				"echo.default.svc",
 				"echo.default",
@@ -362,7 +335,6 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			},
 			want: []string{
 				"echo.default.svc.cluster.local",
-				"echo.default.svc.cluster.local.",
 				"echo",
 				"echo.default.svc",
 				"echo.default",
@@ -383,10 +355,8 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			},
 			want: []string{
 				"foo.local.campus.net",
-				"foo.local.campus.net.",
 				"foo",
 				"alias.local.campus.net",
-				"alias.local.campus.net.",
 				"alias",
 			},
 		},
@@ -469,8 +439,8 @@ func TestSidecarOutboundHTTPRouteConfigWithDuplicateHosts(t *testing.T) {
 			nil,
 			map[string][]string{
 				"allow_any":     {"*"},
-				"test.local:80": {"test.local", "test.local."},
-				"test:80":       {"test", "test."},
+				"test.local:80": {"test.local"},
+				"test:80":       {"test"},
 			},
 			map[string]string{
 				"allow_any":     "PassthroughCluster",
@@ -489,11 +459,10 @@ func TestSidecarOutboundHTTPRouteConfigWithDuplicateHosts(t *testing.T) {
 				"allow_any": {"*"},
 				"test.default.svc.cluster.local:80": {
 					"test.default.svc.cluster.local",
-					"test.default.svc.cluster.local.",
 					"test.default.svc",
 					"test.default",
 				},
-				"test:80": {"test", "test."},
+				"test:80": {"test"},
 			},
 			map[string]string{
 				"allow_any":                         "PassthroughCluster",
@@ -510,8 +479,8 @@ func TestSidecarOutboundHTTPRouteConfigWithDuplicateHosts(t *testing.T) {
 			nil,
 			map[string][]string{
 				"allow_any":     {"*"},
-				"test.local:80": {"test.local", "test.local."},
-				"test:80":       {"test", "test."},
+				"test.local:80": {"test.local"},
+				"test:80":       {"test"},
 			},
 			map[string]string{
 				"allow_any":     "PassthroughCluster",
@@ -535,7 +504,6 @@ func TestSidecarOutboundHTTPRouteConfigWithDuplicateHosts(t *testing.T) {
 				"allow_any": {"*"},
 				"test-duplicate-domains.default.svc.cluster.local:80": {
 					"test-duplicate-domains.default.svc.cluster.local",
-					"test-duplicate-domains.default.svc.cluster.local.",
 					"test-duplicate-domains",
 					"test-duplicate-domains.default.svc",
 				},
@@ -573,7 +541,6 @@ func TestSidecarOutboundHTTPRouteConfigWithDuplicateHosts(t *testing.T) {
 				"allow_any": {"*"},
 				"test-duplicate-domains.default.svc.cluster.local:80": {
 					"test-duplicate-domains.default.svc.cluster.local",
-					"test-duplicate-domains.default.svc.cluster.local.",
 					"test-duplicate-domains",
 					"test-duplicate-domains.default.svc",
 				},
@@ -602,7 +569,6 @@ func TestSidecarOutboundHTTPRouteConfigWithDuplicateHosts(t *testing.T) {
 				"allow_any": {"*"},
 				"test.default.svc.cluster.local:80": {
 					"test.default.svc.cluster.local",
-					"test.default.svc.cluster.local.",
 					"test",
 					"test.default.svc",
 				},
@@ -623,7 +589,7 @@ func TestSidecarOutboundHTTPRouteConfigWithDuplicateHosts(t *testing.T) {
 			nil,
 			map[string][]string{
 				"allow_any":     {"*"},
-				"test.local:80": {"test.local", "test.local."},
+				"test.local:80": {"test.local"},
 			},
 			map[string]string{
 				"allow_any":     "PassthroughCluster",
@@ -1055,26 +1021,6 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			},
 		},
 	}
-	// Copy of virtualServiceSpec2
-	wildcardVirtualServiceSpec := &networking.VirtualService{
-		Hosts:    []string{"*-private-2.COM"},
-		Gateways: []string{"mesh"},
-		Http: []*networking.HTTPRoute{
-			{
-				Route: []*networking.HTTPRouteDestination{
-					{
-						Destination: &networking.Destination{
-							Host: "test.org",
-							Port: &networking.PortSelector{
-								Number: 62,
-							},
-						},
-						Weight: 100,
-					},
-				},
-			},
-		},
-	}
 	virtualServiceSpec3 := &networking.VirtualService{
 		Hosts:    []string{"test-private-3.com"},
 		Gateways: []string{"mesh"},
@@ -1197,14 +1143,6 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 		},
 		Spec: virtualServiceSpec2,
 	}
-	wildcardVirtualService2 := config.Config{
-		Meta: config.Meta{
-			GroupVersionKind: gvk.VirtualService,
-			Name:             "acme-v2",
-			Namespace:        "not-default",
-		},
-		Spec: wildcardVirtualServiceSpec,
-	}
 	virtualService3 := config.Config{
 		Meta: config.Meta{
 			GroupVersionKind: gvk.VirtualService,
@@ -1287,8 +1225,8 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			sidecarConfig:         sidecarConfig,
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
-				"bookinfo.com:9999": {"bookinfo.com:9999": true, "*.bookinfo.com:9999": true, "bookinfo.com.:9999": true, "*.bookinfo.com.:9999": true},
-				"bookinfo.com:70":   {"bookinfo.com:70": true, "*.bookinfo.com:70": true, "bookinfo.com.:70": true, "*.bookinfo.com.:70": true},
+				"bookinfo.com:9999": {"bookinfo.com:9999": true, "*.bookinfo.com:9999": true},
+				"bookinfo.com:70":   {"bookinfo.com:70": true, "*.bookinfo.com:70": true},
 				"allow_any": {
 					"*": true,
 				},
@@ -1300,7 +1238,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			sidecarConfig:         sidecarConfig,
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
-				"test.com:8080": {"test.com": true, "8.8.8.8": true, "test.com.": true},
+				"test.com:8080": {"test.com": true, "8.8.8.8": true},
 				"block_all": {
 					"*": true,
 				},
@@ -1314,7 +1252,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"test-private.com:80": {
-					"test-private.com": true, "9.9.9.9": true, "test-private.com.": true,
+					"test-private.com": true, "9.9.9.9": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1329,7 +1267,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"test-private.com:80": {
-					"test-private.com": true, "9.9.9.9": true, "test-private.com.": true,
+					"test-private.com": true, "9.9.9.9": true,
 				},
 				"allow_any": {
 					"*": true,
@@ -1346,7 +1284,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			expectedHosts: map[string]map[string]bool{
 				// does not include `match-no-service`
 				"test-private.com:80": {
-					"test-private.com": true, "9.9.9.9": true, "test-private.com.": true,
+					"test-private.com": true, "9.9.9.9": true,
 				},
 				"match-no-service.not-default:80": {"match-no-service.not-default": true},
 				"allow_any": {
@@ -1364,7 +1302,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			expectedHosts: map[string]map[string]bool{
 				// does not include `match-no-service`
 				"test-private.com:80": {
-					"test-private.com": true, "9.9.9.9": true, "test-private.com.": true,
+					"test-private.com": true, "9.9.9.9": true,
 				},
 				"match-no-service.not-default:80": {"match-no-service.not-default": true},
 				"allow_any": {
@@ -1381,10 +1319,8 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"bookinfo.com:9999": {
-					"bookinfo.com":    true,
-					"*.bookinfo.com":  true,
-					"bookinfo.com.":   true,
-					"*.bookinfo.com.": true,
+					"bookinfo.com":   true,
+					"*.bookinfo.com": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1399,7 +1335,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"test-private.com:80": {
-					"test-private.com": true, "9.9.9.9": true, "test-private.com.": true,
+					"test-private.com": true, "9.9.9.9": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1414,13 +1350,11 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"test-private.com:70": {
-					"test-private.com": true, "9.9.9.9": true, "test-private.com.": true,
+					"test-private.com": true, "9.9.9.9": true,
 				},
 				"bookinfo.com:70": {
-					"bookinfo.com":    true,
-					"*.bookinfo.com":  true,
-					"bookinfo.com.":   true,
-					"*.bookinfo.com.": true,
+					"bookinfo.com":   true,
+					"*.bookinfo.com": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1435,10 +1369,8 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"bookinfo.com:9999": {
-					"bookinfo.com":    true,
-					"*.bookinfo.com":  true,
-					"bookinfo.com.":   true,
-					"*.bookinfo.com.": true,
+					"bookinfo.com":   true,
+					"*.bookinfo.com": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1453,7 +1385,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"test.com:8080": {
-					"test.com": true, "8.8.8.8": true, "test.com.": true,
+					"test.com": true, "8.8.8.8": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1468,7 +1400,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"test-private.com:80": {
-					"test-private.com": true, "9.9.9.9": true, "test-private.com.": true,
+					"test-private.com": true, "9.9.9.9": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1483,13 +1415,11 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"test-private.com:70": {
-					"test-private.com": true, "9.9.9.9": true, "test-private.com.": true,
+					"test-private.com": true, "9.9.9.9": true,
 				},
 				"bookinfo.com:70": {
-					"bookinfo.com":    true,
-					"*.bookinfo.com":  true,
-					"bookinfo.com.":   true,
-					"*.bookinfo.com.": true,
+					"bookinfo.com":   true,
+					"*.bookinfo.com": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1516,7 +1446,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"test-private.com:80": {
-					"test-private.com": true, "9.9.9.9": true, "test-private.com.": true,
+					"test-private.com": true, "9.9.9.9": true,
 				},
 				"allow_any": {
 					"*": true,
@@ -1531,7 +1461,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"test-private.com:80": {
-					"test-private.com": true, "9.9.9.9": true, "test-private.com.": true,
+					"test-private.com": true, "9.9.9.9": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1546,22 +1476,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: []*config.Config{&virtualService1, &virtualService2},
 			expectedHosts: map[string]map[string]bool{
 				"test-private-2.com:60": {
-					"test-private-2.com": true, "9.9.9.10": true, "test-private-2.com.": true,
-				},
-				"block_all": {
-					"*": true,
-				},
-			},
-			registryOnly: true,
-		},
-		{
-			name:                  "no sidecar config with virtual services with wildcard",
-			routeName:             "60",
-			sidecarConfig:         nil,
-			virtualServiceConfigs: []*config.Config{&wildcardVirtualService2},
-			expectedHosts: map[string]map[string]bool{
-				"test-private-2.com:60": {
-					"test-private-2.com": true, "9.9.9.10": true, "test-private-2.com.": true,
+					"test-private-2.com": true, "9.9.9.10": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1576,7 +1491,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: []*config.Config{&virtualService3},
 			expectedHosts: map[string]map[string]bool{
 				"test-private.com:80": {
-					"test-private.com": true, "9.9.9.9": true, "test-private.com.": true,
+					"test-private.com": true, "9.9.9.9": true,
 				},
 				"test-private-3.com:80": {
 					"test-private-3.com": true,
@@ -1594,8 +1509,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
 				"test-headless.com:8888": {
-					"test-headless.com": true, "*.test-headless.com": true, "test-headless.com.": true,
-					"*.test-headless.com.": true,
+					"test-headless.com": true, "*.test-headless.com": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1610,8 +1524,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			virtualServiceConfigs: []*config.Config{&virtualService4},
 			expectedHosts: map[string]map[string]bool{
 				"test-headless.com:8888": {
-					"test-headless.com": true, "*.test-headless.com": true, "test-headless.com.": true,
-					"*.test-headless.com.": true,
+					"test-headless.com": true, "*.test-headless.com": true,
 				},
 				"example.com:8888": {
 					"example.com": true,
@@ -1628,12 +1541,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			sidecarConfig:         sidecarConfig,
 			virtualServiceConfigs: nil,
 			expectedHosts: map[string]map[string]bool{
-				"test-headless.com:8888": {
-					"test-headless.com:8888":    true,
-					"*.test-headless.com:8888":  true,
-					"test-headless.com.:8888":   true,
-					"*.test-headless.com.:8888": true,
-				},
+				"test-headless.com:8888": {"test-headless.com:8888": true, "*.test-headless.com:8888": true},
 				"block_all": {
 					"*": true,
 				},
@@ -1670,50 +1578,23 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			sidecarConfig:         sidecarConfigWitHTTPProxy,
 			virtualServiceConfigs: []*config.Config{&virtualService5},
 			expectedHosts: map[string]map[string]bool{
-				"bookinfo.com:9999": {
-					"bookinfo.com:9999":    true,
-					"*.bookinfo.com:9999":  true,
-					"bookinfo.com.:9999":   true,
-					"*.bookinfo.com.:9999": true,
-				},
-				"bookinfo.com:70": {
-					"bookinfo.com:70":    true,
-					"*.bookinfo.com:70":  true,
-					"bookinfo.com.:70":   true,
-					"*.bookinfo.com.:70": true,
-				},
-				"test-headless.com:8888": {
-					"test-headless.com:8888":    true,
-					"*.test-headless.com:8888":  true,
-					"test-headless.com.:8888":   true,
-					"*.test-headless.com.:8888": true,
-				},
+				"bookinfo.com:9999":      {"bookinfo.com:9999": true, "*.bookinfo.com:9999": true},
+				"bookinfo.com:70":        {"bookinfo.com:70": true, "*.bookinfo.com:70": true},
+				"test-headless.com:8888": {"test-headless.com:8888": true, "*.test-headless.com:8888": true},
 				"test-private-2.com:60": {
-					"test-private-2.com:60":  true,
-					"9.9.9.10:60":            true,
-					"test-private-2.com.:60": true,
+					"test-private-2.com:60": true, "9.9.9.10:60": true,
 				},
 				"test-private.com:70": {
-					"test-private.com:70":  true,
-					"9.9.9.9:70":           true,
-					"test-private.com.:70": true,
+					"test-private.com:70": true, "9.9.9.9:70": true,
 				},
 				"test-private.com:80": {
-					"test-private.com":     true,
-					"test-private.com:80":  true,
-					"9.9.9.9":              true,
-					"9.9.9.9:80":           true,
-					"test-private.com.":    true,
-					"test-private.com.:80": true,
+					"test-private.com": true, "test-private.com:80": true, "9.9.9.9": true, "9.9.9.9:80": true,
 				},
 				"test.com:8080": {
-					"test.com:8080":  true,
-					"8.8.8.8:8080":   true,
-					"test.com.:8080": true,
+					"test.com:8080": true, "8.8.8.8:8080": true,
 				},
 				"service-A.default.svc.cluster.local:7777": {
-					"service-A.default.svc.cluster.local:7777":  true,
-					"service-A.default.svc.cluster.local.:7777": true,
+					"service-A.default.svc.cluster.local:7777": true,
 				},
 				"block_all": {
 					"*": true,
@@ -1731,8 +1612,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 					"*": true,
 				},
 				"service-a.default.svc.cluster.local:7777": {
-					"service-a.default.svc.cluster.local":  true,
-					"service-a.default.svc.cluster.local.": true,
+					"service-a.default.svc.cluster.local": true,
 				},
 				"service-a.v2:7777": {
 					"service-a.v2": true,

--- a/pilot/pkg/networking/core/listener_builder.go
+++ b/pilot/pkg/networking/core/listener_builder.go
@@ -352,6 +352,10 @@ func (lb *ListenerBuilder) buildHTTPConnectionManager(httpOpts *httpListenerOpts
 		connectionManager.PathWithEscapedSlashesAction = hcm.HttpConnectionManager_UNESCAPE_AND_FORWARD
 	}
 
+	// Strip trailing dots from Host header to support absolute FQDNs (e.g., foo.svc.cluster.local.)
+	// See https://github.com/istio/istio/issues/56007
+	connectionManager.StripTrailingHostDot = true
+
 	if httpOpts.useRemoteAddress {
 		connectionManager.UseRemoteAddress = proto.BoolTrue
 	} else {

--- a/releasenotes/notes/strip-trailing-host-dot.yaml
+++ b/releasenotes/notes/strip-trailing-host-dot.yaml
@@ -1,0 +1,19 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+issue:
+  - https://github.com/istio/istio/issues/56007
+
+releaseNotes:
+- |
+  **Improved** handling of hostnames with trailing dots by configuring Envoy to
+   strip it. This replaces the `PILOT_ENABLE_ABSOLUTE_FQDN_VHOST_DOMAIN` feature
+   flag and reduces route configuration size.
+
+upgradeNotes:
+  - title: Trailing dot handling change
+    content: |
+      The `PILOT_ENABLE_ABSOLUTE_FQDN_VHOST_DOMAIN` environment variable has been removed
+      and will be ignored if set. This change is backwards compatible: existing requests
+      continue to work. No user action is required.

--- a/tests/integration/pilot/fqdn_test.go
+++ b/tests/integration/pilot/fqdn_test.go
@@ -1,0 +1,85 @@
+//go:build integ
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pilot
+
+import (
+	"fmt"
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/check"
+	"istio.io/istio/pkg/test/framework/components/echo/match"
+)
+
+// TestAbsoluteFQDNWithTrailingDot verifies requests with trailing dots in Host headers
+// (e.g., `foo.svc.cluster.local.`) are routed correctly.
+func TestAbsoluteFQDNWithTrailingDot(t *testing.T) {
+	framework.NewTest(t).Run(func(t framework.TestContext) {
+		src := match.ServiceName(apps.A.NamespacedName()).GetMatches(apps.A.Instances())[0]
+		dstB := apps.B.Instances()
+		dstC := apps.C.Instances()
+
+		t.NewSubTest("FQDN with trailing dot").Run(func(t framework.TestContext) {
+			src.CallOrFail(t, echo.CallOptions{
+				To:   dstB,
+				Port: echo.Port{Name: "http"},
+				HTTP: echo.HTTP{
+					Path: "/",
+					Headers: map[string][]string{
+						"Host": {dstB[0].Config().ClusterLocalFQDN() + "."},
+					},
+				},
+				Check: check.And(check.OK(), check.Host(dstB[0].Config().Service)),
+			})
+		})
+
+		t.NewSubTest("with port").Run(func(t framework.TestContext) {
+			port := dstB[0].Config().Ports.MustForName("http")
+			src.CallOrFail(t, echo.CallOptions{
+				To:   dstB,
+				Port: echo.Port{Name: "http"},
+				HTTP: echo.HTTP{
+					Path: "/",
+					Headers: map[string][]string{
+						"Host": {dstB[0].Config().ClusterLocalFQDN() + ".:" + fmt.Sprintf("%d", port.ServicePort)},
+					},
+				},
+				Check: check.And(check.OK(), check.Host(dstB[0].Config().Service)),
+			})
+		})
+
+		t.NewSubTest("service disambiguation").Run(func(t framework.TestContext) {
+			src.CallOrFail(t, echo.CallOptions{
+				To:   dstB,
+				Port: echo.Port{Name: "http"},
+				HTTP: echo.HTTP{
+					Headers: map[string][]string{"Host": {dstB[0].Config().ClusterLocalFQDN() + "."}},
+				},
+				Check: check.And(check.OK(), check.Host(dstB[0].Config().Service)),
+			})
+			src.CallOrFail(t, echo.CallOptions{
+				To:   dstC,
+				Port: echo.Port{Name: "http"},
+				HTTP: echo.HTTP{
+					Headers: map[string][]string{"Host": {dstC[0].Config().ClusterLocalFQDN() + "."}},
+				},
+				Check: check.And(check.OK(), check.Host(dstC[0].Config().Service)),
+			})
+		})
+	})
+}


### PR DESCRIPTION
Enable `strip_trailing_host_dot` in HttpConnectionManager to handle requests with trailing dots in Host headers (e.g., `foo.svc.cluster.local.`).

This simplifies the codebase by:
- Removing the `PILOT_ENABLE_ABSOLUTE_FQDN_VHOST_DOMAIN` feature flag
- Eliminating duplicate domain generation (reduces config size by ~50%)
- Moving the logic to Envoy where it belongs

Envoy strips trailing dots before route matching, so routes configured without trailing dots will match requests with them.

Fixes #56007

---

**Areas affected:**
- [x] Networking
- [x] Performance and Scalability

**Characteristics:**
- [x] Does not have any user-facing changes