### PR TITLE
Support safe migration from iptables to nftables in Ambient

### DIFF
--- a/cni/pkg/nodeagent/detect_artifacts_linux.go
+++ b/cni/pkg/nodeagent/detect_artifacts_linux.go
@@ -1,0 +1,102 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodeagent
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/vishvananda/netlink"
+
+	"istio.io/istio/cni/pkg/config"
+	"istio.io/istio/cni/pkg/ipset"
+	"istio.io/istio/cni/pkg/util"
+)
+
+// detectIptablesArtifacts checks for the presence of Istio iptables artifacts (specifically IPsets)
+// on the host network to determine if a previous iptables-based deployment exists.
+// Returns:
+//   - true if iptables artifacts (IPsets) are detected
+//   - false if no artifacts are detected or if detection fails
+//   - error if there was a failure during detection
+func detectIptablesArtifacts(enableIPv6 bool) (bool, error) {
+	var detected bool
+	var detectionErr error
+
+	// Run the detection in the host network namespace
+	err := util.RunAsHost(func() error {
+		// Check if the IPv4 IPset exists
+		v4Name := fmt.Sprintf(ipset.V4Name, config.ProbeIPSet)
+		v4Exists, err := ipsetExists(v4Name)
+		if err != nil {
+			log.Debugf("failed to check for v4 IPset %s: %v", v4Name, err)
+			detectionErr = fmt.Errorf("v4 IPset detection failed: %w", err)
+			// Lets continue checking for v6 (if enabled)
+		}
+
+		if v4Exists {
+			log.Infof("detected iptables artifact: IPset %s exists", v4Name)
+			detected = true
+			// Found v4 artifact, no need to check for v6
+			return nil
+		}
+
+		// Check if the IPv6 IPset exists
+		if enableIPv6 {
+			v6Name := fmt.Sprintf(ipset.V6Name, config.ProbeIPSet)
+			v6Exists, err := ipsetExists(v6Name)
+			if err != nil {
+				log.Debugf("failed to check for v6 IPset %s: %v", v6Name, err)
+				if detectionErr != nil {
+					detectionErr = fmt.Errorf("%w; v6 IPset detection failed: %w", detectionErr, err)
+				} else {
+					detectionErr = fmt.Errorf("v6 IPset detection failed: %w", err)
+				}
+			}
+
+			if v6Exists {
+				log.Infof("detected iptables artifact: IPset %s exists", v6Name)
+				detected = true
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to run detection in host namespace: %w", err)
+	}
+
+	return detected, detectionErr
+}
+
+// ipsetExists checks if an IPset with the given name exists on the host.
+// Returns:
+//   - true, nil if the IPset exists
+//   - false, nil if the IPset does not exist (expected for clean/fresh setup)
+//   - false, error for any errors
+func ipsetExists(name string) (bool, error) {
+	_, err := netlink.IpsetList(name)
+	if err == nil {
+		// IPset exists
+		return true, nil
+	}
+
+	if strings.Contains(err.Error(), "no such file") {
+		// IPSet does not exist
+		return false, nil
+	}
+
+	return false, err
+}

--- a/cni/pkg/nodeagent/detect_artifacts_linux_test.go
+++ b/cni/pkg/nodeagent/detect_artifacts_linux_test.go
@@ -1,0 +1,154 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodeagent
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	// Create a new network namespace. This will have the 'lo' interface ready but nothing else.
+	_ "github.com/howardjohn/unshare-go/netns"
+	// Create a new user namespace. This will map the current UID/GID to 0.
+	"github.com/howardjohn/unshare-go/userns"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+
+	"istio.io/istio/cni/pkg/config"
+	"istio.io/istio/cni/pkg/ipset"
+	"istio.io/istio/pkg/test/util/assert"
+)
+
+// TestDetectIptablesArtifacts is an e2e test that validates the iptable artifacts on the network.
+// It runs in an isolated network namespace created by unshare-go, which provides a clean environment
+// with root-like capabilities for netlink operations. It validates the upgrade path from iptables to
+// nftables backend by simulating various scenarios.
+func TestDetectIptablesArtifacts(t *testing.T) {
+	setup(t)
+
+	tests := []struct {
+		name             string
+		enableIPv6       bool
+		setupFunc        func(t *testing.T)
+		cleanupFunc      func(t *testing.T)
+		expectedDetected bool
+		description      string
+	}{
+		{
+			name:       "v4_ipset_exists",
+			enableIPv6: false,
+			setupFunc: func(t *testing.T) {
+				v4Name := fmt.Sprintf(ipset.V4Name, config.ProbeIPSet)
+				err := netlink.IpsetCreate(v4Name, "hash:ip", netlink.IpsetCreateOptions{Replace: true})
+				if err != nil && !strings.Contains(err.Error(), "exist") {
+					t.Fatalf("failed to create v4 ipset: %v", err)
+				}
+				t.Logf("Created v4 IPset: %s", v4Name)
+			},
+			cleanupFunc: func(t *testing.T) {
+				v4Name := fmt.Sprintf(ipset.V4Name, config.ProbeIPSet)
+				_ = netlink.IpsetDestroy(v4Name)
+			},
+			expectedDetected: true,
+			description:      "Should detect when v4 IPset exists (simulates an existing iptables deployment)",
+		},
+		{
+			name:       "v6_ipset_exists",
+			enableIPv6: true,
+			setupFunc: func(t *testing.T) {
+				v6Name := fmt.Sprintf(ipset.V6Name, config.ProbeIPSet)
+				err := netlink.IpsetCreate(v6Name, "hash:ip", netlink.IpsetCreateOptions{
+					Family:  unix.AF_INET6,
+					Replace: true,
+				})
+				if err != nil && !strings.Contains(err.Error(), "exist") {
+					t.Fatalf("failed to create v6 ipset: %v", err)
+				}
+				t.Logf("Created v6 IPset: %s", v6Name)
+			},
+			cleanupFunc: func(t *testing.T) {
+				v6Name := fmt.Sprintf(ipset.V6Name, config.ProbeIPSet)
+				_ = netlink.IpsetDestroy(v6Name)
+			},
+			expectedDetected: true,
+			description:      "Should detect when v6 IPset exists",
+		},
+		{
+			name:       "both_v4_and_v6_ipsets_exist",
+			enableIPv6: true,
+			setupFunc: func(t *testing.T) {
+				v4Name := fmt.Sprintf(ipset.V4Name, config.ProbeIPSet)
+				v6Name := fmt.Sprintf(ipset.V6Name, config.ProbeIPSet)
+
+				err := netlink.IpsetCreate(v4Name, "hash:ip", netlink.IpsetCreateOptions{Replace: true})
+				if err != nil && !strings.Contains(err.Error(), "exist") {
+					t.Fatalf("failed to create v4 ipset: %v", err)
+				}
+
+				err = netlink.IpsetCreate(v6Name, "hash:ip", netlink.IpsetCreateOptions{
+					Family:  unix.AF_INET6,
+					Replace: true,
+				})
+				if err != nil && !strings.Contains(err.Error(), "exist") {
+					t.Fatalf("failed to create v6 ipset: %v", err)
+				}
+				t.Logf("Created both v4 and v6 IPsets")
+			},
+			cleanupFunc: func(t *testing.T) {
+				v4Name := fmt.Sprintf(ipset.V4Name, config.ProbeIPSet)
+				v6Name := fmt.Sprintf(ipset.V6Name, config.ProbeIPSet)
+				_ = netlink.IpsetDestroy(v4Name)
+				_ = netlink.IpsetDestroy(v6Name)
+			},
+			expectedDetected: true,
+			description:      "Should detect when both v4 and v6 IPsets exist",
+		},
+		{
+			name:             "no_ipsets_exist",
+			enableIPv6:       true,
+			setupFunc:        func(t *testing.T) {},
+			cleanupFunc:      func(t *testing.T) {},
+			expectedDetected: false,
+			description:      "Should not detect artifacts in clean state (simulates a fresh setup)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log(tt.description)
+
+			tt.setupFunc(t)
+			defer tt.cleanupFunc(t)
+
+			detected, _ := detectIptablesArtifacts(tt.enableIPv6)
+			assert.Equal(t, detected, tt.expectedDetected)
+		})
+	}
+}
+
+var initialized = &sync.Once{}
+
+// setup initializes the test environment using unshare-go.
+// Importing "github.com/howardjohn/unshare-go/netns" causes the test to run in an isolated network
+// namespace and userns provides user namespace mapping.
+func setup(t *testing.T) {
+	initialized.Do(func() {
+		// Map current GID to root (0) in the user namespace
+		// This gives us the necessary privileges for netlink operations (CAP_NET_ADMIN)
+		assert.NoError(t, userns.WriteGroupMap(map[uint32]uint32{userns.OriginalGID(): 0}))
+		t.Log("Successfully initialized an isolated test network namespace with root capabilities")
+	})
+}

--- a/releasenotes/notes/58353.yaml
+++ b/releasenotes/notes/58353.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 58353
+releaseNotes:
+- |
+  **Fixed** use cases where upgrading from the iptables backend to the nftables backend in ambient created stale iptables rules on the network. The code now continues to use iptables on the node until it is rebooted.


### PR DESCRIPTION
When an existing Istio Ambient deployment using the iptables backend is upgraded to the nftables backend, IstioCNI shouldn’t switch to nftables silently. Doing so leaves stale iptables rules/IPsets on the host. If this happens along with `reconcileIptablesOnStartup` setting, the pod network namespaces end up with both nftables rules and the old iptables rules.

In both cases, the stale iptables rules can cause issues until the node is rebooted. This PR updates the IstioCNI initialization code to detect any iptables artifacts on the host. If it finds them, it overrides the nftables setting, keeps using the iptables backend, and logs a message telling users to reboot the node to complete the migration. This allows safe upgrades with no pod disruption in Ambient mode. After a reboot, the old iptables artifacts are cleared and pods come up with clean namespaces, completing the migration automatically.

Fixes: https://github.com/istio/istio/issues/58353
- [x] Ambient
- [x] Networking