### PR TITLE
xds: fix cache key for cluster

### DIFF
--- a/pilot/pkg/networking/core/cluster_cache.go
+++ b/pilot/pkg/networking/core/cluster_cache.go
@@ -42,7 +42,7 @@ type clusterCache struct {
 	locality                *core.Locality // identifies the locality the cluster is generated for
 	preserveHTTP1HeaderCase bool           // indicates whether the original case of HTTP/1.x headers should be preserved
 	proxyClusterID          string         // identifies the kubernetes cluster a proxy is in
-	proxySidecar            bool           // identifies if this proxy is a Sidecar
+	proxyType               model.NodeType // identifies this proxy type
 	hbone                   bool
 	proxyView               model.ProxyView
 	metadataCerts           *metadataCerts // metadata certificates of proxy
@@ -77,7 +77,7 @@ func (t *clusterCache) Key() any {
 	h.Write(Separator)
 	h.WriteString(t.proxyClusterID)
 	h.Write(Separator)
-	h.WriteString(strconv.FormatBool(t.proxySidecar))
+	h.WriteString(string(t.proxyType))
 	h.Write(Separator)
 	h.WriteString(strconv.FormatBool(t.http2))
 	h.Write(Separator)
@@ -197,7 +197,7 @@ func buildClusterKey(service *model.Service, port *model.Port, cb *ClusterBuilde
 		locality:                cb.locality,
 		preserveHTTP1HeaderCase: shouldPreserveHeaderCase(cb.proxyMetadata, cb.req.Push),
 		proxyClusterID:          cb.clusterID,
-		proxySidecar:            cb.sidecarProxy(),
+		proxyType:               cb.proxyType,
 		proxyView:               cb.proxyView,
 		hbone:                   cb.sendHbone,
 		http2:                   port.Protocol.IsHTTP2(),


### PR DESCRIPTION
https://storage.googleapis.com/istio-prow/logs/integ-assertion_istio_postsubmit/1991626385549955072/artifacts/ambient-1000a77ac823425cb81d309/_suite_context/istio-state-882031679/primary-0/istiod-66599dbf4b-knz5h_discovery.previous.log

I believe this is because waypoint has different config from gateways

```
	if (cb.sidecarProxy() || cb.proxyType == model.Waypoint) && isAutoProtocol {
		// Use downstream protocol. If the incoming traffic use HTTP 1.1, the
		// upstream cluster will use HTTP 1.1, if incoming traffic use HTTP2,
		// the upstream cluster will use HTTP2.
		cb.setUseDownstreamProtocol(cluster)
	}
```

so we need to take this into account
