### PR TITLE
Fix racy test

### DIFF
--- a/tests/integration/ambient/traffic_test.go
+++ b/tests/integration/ambient/traffic_test.go
@@ -31,7 +31,7 @@ func TestTraffic(t *testing.T) {
 			deployments := deployment.NewOrFail(t, deployment.Config{
 				IncludeExtAuthz: false,
 			})
-			SetWaypointServiceEntry(t, "external-service", apps.Namespace.Name(), "waypoint")
+			SetWaypointServiceEntry(t, "external-service", deployments.NS[0].Namespace.Name(), "waypoint")
 			common.RunAllTrafficTests(t, i, deployments.SingleNamespaceView())
 		})
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
Small change to ensure that the external traffic service test consistently runs after the common external ServiceEntry has a waypoint configured for it.