### PR TITLE
Support retry in CNI plugin for verifying ambient enablement

### DIFF
--- a/cni/pkg/cmd/root.go
+++ b/cni/pkg/cmd/root.go
@@ -239,6 +239,7 @@ func init() {
 	registerIntegerParameter(constants.MonitoringPort, 15014, "HTTP port to serve prometheus metrics")
 	registerStringParameter(constants.ZtunnelUDSAddress, "/var/run/ztunnel/ztunnel.sock", "The UDS server address which ztunnel will connect to")
 	registerBooleanParameter(constants.AmbientEnabled, false, "Whether ambient controller is enabled")
+	registerBooleanParameter(constants.EnableAmbientDetectionRetry, false, "Whether or not is ambient check is retried on error in the cni plugin")
 	// Repair
 	registerBooleanParameter(constants.RepairEnabled, true, "Whether to enable race condition repair or not")
 	registerBooleanParameter(constants.RepairDeletePods, false, "Controller will delete pods when detecting pod broken by race condition")
@@ -329,6 +330,7 @@ func constructConfig() (*config.Config, error) {
 		AmbientIPv6:                       viper.GetBool(constants.AmbientIPv6),
 		AmbientDisableSafeUpgrade:         viper.GetBool(constants.AmbientDisableSafeUpgrade),
 		AmbientReconcilePodRulesOnStartup: viper.GetBool(constants.AmbientReconcilePodRulesOnStartup),
+		EnableAmbientDetectionRetry:       viper.GetBool(constants.EnableAmbientDetectionRetry),
 
 		NativeNftables:      viper.GetBool(constants.NativeNftables),
 		ForceIptablesBinary: os.Getenv("FORCE_IPTABLES_BINARY"),

--- a/cni/pkg/config/config.go
+++ b/cni/pkg/config/config.go
@@ -156,6 +156,9 @@ type InstallConfig struct {
 	// Whether reconciliation of iptables at post startup is enabled for Ambient workloads
 	AmbientReconcilePodRulesOnStartup bool
 
+	// Whether to retry checking if a pod is ambient in the cni plugin when there are errors
+	EnableAmbientDetectionRetry bool
+
 	// Whether native nftables should be used instead of iptable rules for traffic redirection
 	NativeNftables bool
 
@@ -235,6 +238,7 @@ func (c InstallConfig) String() string {
 	b.WriteString("AmbientIPv6: " + fmt.Sprint(c.AmbientIPv6) + "\n")
 	b.WriteString("AmbientDisableSafeUpgrade: " + fmt.Sprint(c.AmbientDisableSafeUpgrade) + "\n")
 	b.WriteString("AmbientReconcilePodRulesOnStartup: " + fmt.Sprint(c.AmbientReconcilePodRulesOnStartup) + "\n")
+	b.WriteString("EnableAmbientDetectionRetry: " + fmt.Sprint(c.EnableAmbientDetectionRetry) + "\n")
 
 	b.WriteString("NativeNftables: " + fmt.Sprint(c.NativeNftables) + "\n")
 	b.WriteString("ForceIptablesBinary: " + fmt.Sprint(c.ForceIptablesBinary) + "\n")

--- a/cni/pkg/constants/constants.go
+++ b/cni/pkg/constants/constants.go
@@ -46,6 +46,7 @@ const (
 	AmbientIPv6                       = "ambient-ipv6"
 	AmbientDisableSafeUpgrade         = "ambient-disable-safe-upgrade"
 	AmbientReconcilePodRulesOnStartup = "ambient-reconcile-pod-rules-on-startup"
+	EnableAmbientDetectionRetry       = "enable-ambient-detection-retry"
 
 	NativeNftables = "native-nftables"
 

--- a/cni/pkg/install/cniconfig.go
+++ b/cni/pkg/install/cniconfig.go
@@ -38,14 +38,14 @@ func createCNIConfigFile(ctx context.Context, cfg *config.InstallConfig) (string
 		return "", fmt.Errorf("failed to parse ambient enablement selector: %v", err)
 	}
 	pluginConfig := plugin.Config{
-		PluginLogLevel:       cfg.PluginLogLevel,
-		CNIAgentRunDir:       cfg.CNIAgentRunDir,
-		AmbientEnabled:       cfg.AmbientEnabled,
-		EnablementSelectors:  selectors,
-		ExcludeNamespaces:    strings.Split(cfg.ExcludeNamespaces, ","),
-		PodNamespace:         cfg.PodNamespace,
-		NativeNftables:       cfg.NativeNftables,
-		EnableIsAmbientRetry: cfg.IstioOwnedCNIConfig,
+		PluginLogLevel:              cfg.PluginLogLevel,
+		CNIAgentRunDir:              cfg.CNIAgentRunDir,
+		AmbientEnabled:              cfg.AmbientEnabled,
+		EnablementSelectors:         selectors,
+		ExcludeNamespaces:           strings.Split(cfg.ExcludeNamespaces, ","),
+		PodNamespace:                cfg.PodNamespace,
+		NativeNftables:              cfg.NativeNftables,
+		EnableAmbientDetectionRetry: cfg.EnableAmbientDetectionRetry,
 	}
 
 	pluginConfig.Name = "istio-cni"

--- a/cni/pkg/install/cniconfig.go
+++ b/cni/pkg/install/cniconfig.go
@@ -38,13 +38,14 @@ func createCNIConfigFile(ctx context.Context, cfg *config.InstallConfig) (string
 		return "", fmt.Errorf("failed to parse ambient enablement selector: %v", err)
 	}
 	pluginConfig := plugin.Config{
-		PluginLogLevel:      cfg.PluginLogLevel,
-		CNIAgentRunDir:      cfg.CNIAgentRunDir,
-		AmbientEnabled:      cfg.AmbientEnabled,
-		EnablementSelectors: selectors,
-		ExcludeNamespaces:   strings.Split(cfg.ExcludeNamespaces, ","),
-		PodNamespace:        cfg.PodNamespace,
-		NativeNftables:      cfg.NativeNftables,
+		PluginLogLevel:       cfg.PluginLogLevel,
+		CNIAgentRunDir:       cfg.CNIAgentRunDir,
+		AmbientEnabled:       cfg.AmbientEnabled,
+		EnablementSelectors:  selectors,
+		ExcludeNamespaces:    strings.Split(cfg.ExcludeNamespaces, ","),
+		PodNamespace:         cfg.PodNamespace,
+		NativeNftables:       cfg.NativeNftables,
+		EnableIsAmbientRetry: cfg.IstioOwnedCNIConfig,
 	}
 
 	pluginConfig.Name = "istio-cni"

--- a/cni/pkg/install/testdata/bridge.conf.golden
+++ b/cni/pkg/install/testdata/bridge.conf.golden
@@ -21,7 +21,7 @@
       "ambient_enabled": false,
       "cni_agent_run_dir": "/path/to/kubeconfig",
       "dns": {},
-      "enable_is_ambient_retry": false,
+      "enable_ambient_detection_retry": false,
       "enablement_selectors": [],
       "exclude_namespaces": [
         ""

--- a/cni/pkg/install/testdata/bridge.conf.golden
+++ b/cni/pkg/install/testdata/bridge.conf.golden
@@ -22,6 +22,7 @@
       "cni_agent_run_dir": "/path/to/kubeconfig",
       "dns": {},
       "enablement_selectors": [],
+      "enable_is_ambient_retry": false,
       "exclude_namespaces": [
         ""
       ],

--- a/cni/pkg/install/testdata/bridge.conf.golden
+++ b/cni/pkg/install/testdata/bridge.conf.golden
@@ -21,8 +21,8 @@
       "ambient_enabled": false,
       "cni_agent_run_dir": "/path/to/kubeconfig",
       "dns": {},
-      "enablement_selectors": [],
       "enable_is_ambient_retry": false,
+      "enablement_selectors": [],
       "exclude_namespaces": [
         ""
       ],

--- a/cni/pkg/install/testdata/istio-cni.conf
+++ b/cni/pkg/install/testdata/istio-cni.conf
@@ -13,5 +13,5 @@
   ],
   "pod_namespace": "my-namespace",
   "native_nftables": false,
-  "enable_is_ambient_retry": false
+  "enable_ambient_detection_retry": false
 }

--- a/cni/pkg/install/testdata/istio-cni.conf
+++ b/cni/pkg/install/testdata/istio-cni.conf
@@ -12,5 +12,6 @@
     ""
   ],
   "pod_namespace": "my-namespace",
-  "native_nftables": false
+  "native_nftables": false,
+  "enable_is_ambient_retry": false
 }

--- a/cni/pkg/install/testdata/istio-owned-bridge.conflist.golden
+++ b/cni/pkg/install/testdata/istio-owned-bridge.conflist.golden
@@ -22,6 +22,7 @@
       "cni_agent_run_dir": "/path/to/kubeconfig",
       "dns": {},
       "enablement_selectors": [],
+      "enable_is_ambient_retry": true,
       "exclude_namespaces": [
         ""
       ],

--- a/cni/pkg/install/testdata/istio-owned-bridge.conflist.golden
+++ b/cni/pkg/install/testdata/istio-owned-bridge.conflist.golden
@@ -21,7 +21,7 @@
       "ambient_enabled": true,
       "cni_agent_run_dir": "/path/to/kubeconfig",
       "dns": {},
-      "enable_ambient_detection_retry": true,
+      "enable_ambient_detection_retry": false,
       "enablement_selectors": [],
       "exclude_namespaces": [
         ""

--- a/cni/pkg/install/testdata/istio-owned-bridge.conflist.golden
+++ b/cni/pkg/install/testdata/istio-owned-bridge.conflist.golden
@@ -21,8 +21,8 @@
       "ambient_enabled": true,
       "cni_agent_run_dir": "/path/to/kubeconfig",
       "dns": {},
-      "enablement_selectors": [],
       "enable_is_ambient_retry": true,
+      "enablement_selectors": [],
       "exclude_namespaces": [
         ""
       ],

--- a/cni/pkg/install/testdata/istio-owned-bridge.conflist.golden
+++ b/cni/pkg/install/testdata/istio-owned-bridge.conflist.golden
@@ -21,7 +21,7 @@
       "ambient_enabled": true,
       "cni_agent_run_dir": "/path/to/kubeconfig",
       "dns": {},
-      "enable_is_ambient_retry": true,
+      "enable_ambient_detection_retry": true,
       "enablement_selectors": [],
       "exclude_namespaces": [
         ""

--- a/cni/pkg/install/testdata/istio-owned.conflist.golden
+++ b/cni/pkg/install/testdata/istio-owned.conflist.golden
@@ -31,8 +31,8 @@
       "ambient_enabled": true,
       "cni_agent_run_dir": "/path/to/kubeconfig",
       "dns": {},
-      "enablement_selectors": [],
       "enable_is_ambient_retry": true,
+      "enablement_selectors": [],
       "exclude_namespaces": [
         ""
       ],

--- a/cni/pkg/install/testdata/istio-owned.conflist.golden
+++ b/cni/pkg/install/testdata/istio-owned.conflist.golden
@@ -32,6 +32,7 @@
       "cni_agent_run_dir": "/path/to/kubeconfig",
       "dns": {},
       "enablement_selectors": [],
+      "enable_is_ambient_retry": true,
       "exclude_namespaces": [
         ""
       ],

--- a/cni/pkg/install/testdata/istio-owned.conflist.golden
+++ b/cni/pkg/install/testdata/istio-owned.conflist.golden
@@ -31,7 +31,7 @@
       "ambient_enabled": true,
       "cni_agent_run_dir": "/path/to/kubeconfig",
       "dns": {},
-      "enable_ambient_detection_retry": true,
+      "enable_ambient_detection_retry": false,
       "enablement_selectors": [],
       "exclude_namespaces": [
         ""

--- a/cni/pkg/install/testdata/istio-owned.conflist.golden
+++ b/cni/pkg/install/testdata/istio-owned.conflist.golden
@@ -31,7 +31,7 @@
       "ambient_enabled": true,
       "cni_agent_run_dir": "/path/to/kubeconfig",
       "dns": {},
-      "enable_is_ambient_retry": true,
+      "enable_ambient_detection_retry": true,
       "enablement_selectors": [],
       "exclude_namespaces": [
         ""

--- a/cni/pkg/install/testdata/list-with-istio.conflist.golden
+++ b/cni/pkg/install/testdata/list-with-istio.conflist.golden
@@ -31,8 +31,8 @@
       "ambient_enabled": false,
       "cni_agent_run_dir": "/path/to/kubeconfig",
       "dns": {},
-      "enablement_selectors": [],
       "enable_is_ambient_retry": false,
+      "enablement_selectors": [],
       "exclude_namespaces": [
         ""
       ],

--- a/cni/pkg/install/testdata/list-with-istio.conflist.golden
+++ b/cni/pkg/install/testdata/list-with-istio.conflist.golden
@@ -32,6 +32,7 @@
       "cni_agent_run_dir": "/path/to/kubeconfig",
       "dns": {},
       "enablement_selectors": [],
+      "enable_is_ambient_retry": false,
       "exclude_namespaces": [
         ""
       ],

--- a/cni/pkg/install/testdata/list-with-istio.conflist.golden
+++ b/cni/pkg/install/testdata/list-with-istio.conflist.golden
@@ -31,7 +31,7 @@
       "ambient_enabled": false,
       "cni_agent_run_dir": "/path/to/kubeconfig",
       "dns": {},
-      "enable_is_ambient_retry": false,
+      "enable_ambient_detection_retry": false,
       "enablement_selectors": [],
       "exclude_namespaces": [
         ""

--- a/cni/pkg/install/testdata/list.conflist.golden
+++ b/cni/pkg/install/testdata/list.conflist.golden
@@ -31,8 +31,8 @@
       "ambient_enabled": false,
       "cni_agent_run_dir": "/path/to/kubeconfig",
       "dns": {},
-      "enablement_selectors": [],
       "enable_is_ambient_retry": false,
+      "enablement_selectors": [],
       "exclude_namespaces": [
         ""
       ],

--- a/cni/pkg/install/testdata/list.conflist.golden
+++ b/cni/pkg/install/testdata/list.conflist.golden
@@ -32,6 +32,7 @@
       "cni_agent_run_dir": "/path/to/kubeconfig",
       "dns": {},
       "enablement_selectors": [],
+      "enable_is_ambient_retry": false,
       "exclude_namespaces": [
         ""
       ],

--- a/cni/pkg/install/testdata/list.conflist.golden
+++ b/cni/pkg/install/testdata/list.conflist.golden
@@ -31,7 +31,7 @@
       "ambient_enabled": false,
       "cni_agent_run_dir": "/path/to/kubeconfig",
       "dns": {},
-      "enable_is_ambient_retry": false,
+      "enable_ambient_detection_retry": false,
       "enablement_selectors": [],
       "exclude_namespaces": [
         ""

--- a/cni/pkg/plugin/plugin.go
+++ b/cni/pkg/plugin/plugin.go
@@ -72,7 +72,7 @@ type Config struct {
 	ExcludeNamespaces           []string                  `json:"exclude_namespaces"`
 	PodNamespace                string                    `json:"pod_namespace"`
 	NativeNftables              bool                      `json:"native_nftables"`
-	EnableAmbientDetectionRetry bool                      `json:"enable_is_ambient_retry"`
+	EnableAmbientDetectionRetry bool                      `json:"enable_ambient_detection_retry"`
 }
 
 // K8sArgs is the valid CNI_ARGS used for Kubernetes

--- a/cni/pkg/plugin/plugin.go
+++ b/cni/pkg/plugin/plugin.go
@@ -65,14 +65,14 @@ type Config struct {
 	types.NetConf
 
 	// Add plugin-specific flags here
-	PluginLogLevel       string                    `json:"plugin_log_level"`
-	CNIAgentRunDir       string                    `json:"cni_agent_run_dir"`
-	AmbientEnabled       bool                      `json:"ambient_enabled"`
-	EnablementSelectors  []util.EnablementSelector `json:"enablement_selectors"`
-	ExcludeNamespaces    []string                  `json:"exclude_namespaces"`
-	PodNamespace         string                    `json:"pod_namespace"`
-	NativeNftables       bool                      `json:"native_nftables"`
-	EnableIsAmbientRetry bool                      `json:"enable_is_ambient_retry"`
+	PluginLogLevel              string                    `json:"plugin_log_level"`
+	CNIAgentRunDir              string                    `json:"cni_agent_run_dir"`
+	AmbientEnabled              bool                      `json:"ambient_enabled"`
+	EnablementSelectors         []util.EnablementSelector `json:"enablement_selectors"`
+	ExcludeNamespaces           []string                  `json:"exclude_namespaces"`
+	PodNamespace                string                    `json:"pod_namespace"`
+	NativeNftables              bool                      `json:"native_nftables"`
+	EnableAmbientDetectionRetry bool                      `json:"enable_is_ambient_retry"`
 }
 
 // K8sArgs is the valid CNI_ARGS used for Kubernetes
@@ -241,12 +241,12 @@ func doAddRun(args *skel.CmdArgs, conf *Config, kClient kubernetes.Interface, ru
 	// For ambient pods, this is all the logic we need to run
 	if conf.AmbientEnabled {
 		log.Debugf("istio-cni ambient cmdAdd podName: %s - checking if ambient enabled", podName)
-		podIsAmbient, err := isAmbientPod(kClient, podName, podNamespace, conf.EnablementSelectors, conf.EnableIsAmbientRetry)
+		podIsAmbient, err := isAmbientPod(kClient, podName, podNamespace, conf.EnablementSelectors, conf.EnableAmbientDetectionRetry)
 		if err != nil {
 			log.Errorf("istio-cni cmdAdd failed to check if pod is ambient: %s", err)
 			// Conditionally return the error based on whether istio owned CNI is configured
 			// to support gradual rollout of feature in critical code path
-			if conf.EnableIsAmbientRetry {
+			if conf.EnableAmbientDetectionRetry {
 				return err
 			}
 		}

--- a/cni/pkg/plugin/plugin.go
+++ b/cni/pkg/plugin/plugin.go
@@ -397,9 +397,9 @@ func isAmbientPod(client kubernetes.Interface, podName, podNamespace string, sel
 		return false, fmt.Errorf("failed to instantiate ambient enablement selector: %v", err)
 	}
 
-	maxRetries := podRetrievalMaxRetries
-	if !enableRetry {
-		maxRetries = 1
+	maxRetries := 1
+	if enableRetry {
+		maxRetries = podRetrievalMaxRetries
 	}
 
 	var pod *v1.Pod

--- a/cni/pkg/plugin/plugin.go
+++ b/cni/pkg/plugin/plugin.go
@@ -50,8 +50,6 @@ var (
 
 	podRetrievalMaxRetries = 30
 	podRetrievalInterval   = 1 * time.Second
-
-	
 )
 
 const (

--- a/cni/pkg/plugin/plugin_dryrun_test.go
+++ b/cni/pkg/plugin/plugin_dryrun_test.go
@@ -80,6 +80,7 @@ func buildDryrunConf() string {
 		testSandboxDirectory,
 		filepath.Dir("/tmp"),
 		false,
+		false,
 		"iptables",
 	)
 }

--- a/cni/pkg/plugin/plugin_test.go
+++ b/cni/pkg/plugin/plugin_test.go
@@ -79,6 +79,7 @@ var mockConfTmpl = `{
     "plugin_log_level": "debug",
     "cni_agent_run_dir": "%s",
     "ambient_enabled": %t,
+	"enable_is_ambient_retry": %t,
 	"enablement_selectors": [
 		{
 			"podSelector": {
@@ -124,6 +125,7 @@ func buildMockConf(ambientEnabled bool) string {
 		"eth0",
 		testSandboxDirectory,
 		"", // unused here
+		ambientEnabled,
 		ambientEnabled,
 		"mock",
 	)

--- a/cni/pkg/plugin/plugin_test.go
+++ b/cni/pkg/plugin/plugin_test.go
@@ -269,17 +269,17 @@ func TestIsAmbientPod(t *testing.T) {
 	podGVR, _ := gvk.ToGVR(gvk.Pod)
 	nsGVR, _ := gvk.ToGVR(gvk.Namespace)
 	// Fail first 3 attempts to get pod/namespace, then succeed
-	client := kube.NewFakeClientWithFailures(3, sets.New(podGVR, nsGVR), pod, ns)
+	client := kube.NewFakeClientWithNFailures(3, sets.New(podGVR, nsGVR), pod, ns)
 
-	isAmbient, err := isAmbientPod(client.Kube(), pod.Name, pod.Namespace, conf.EnablementSelectors, conf.EnableIsAmbientRetry)
+	isAmbient, err := isAmbientPod(client.Kube(), pod.Name, pod.Namespace, conf.EnablementSelectors, conf.EnableAmbientDetectionRetry)
 	assert.NoError(t, err)
 	assert.Equal(t, true, isAmbient, "expected pod to be ambient")
 
 	// Fail all attempts to get pod/namespace
 	podRetrievalMaxRetries = 5
-	client = kube.NewFakeClientWithFailures(podRetrievalMaxRetries+1, sets.New(podGVR, nsGVR), pod, ns)
+	client = kube.NewFakeClientWithNFailures(podRetrievalMaxRetries+1, sets.New(podGVR, nsGVR), pod, ns)
 
-	_, err = isAmbientPod(client.Kube(), pod.Name, pod.Namespace, conf.EnablementSelectors, conf.EnableIsAmbientRetry)
+	_, err = isAmbientPod(client.Kube(), pod.Name, pod.Namespace, conf.EnablementSelectors, conf.EnableAmbientDetectionRetry)
 	assert.Error(t, err)
 }
 

--- a/cni/pkg/plugin/plugin_test.go
+++ b/cni/pkg/plugin/plugin_test.go
@@ -264,7 +264,7 @@ func TestIsAmbientPod(t *testing.T) {
 
 	client := kube.NewFakeClientWithRetries(3, pod, ns)
 
-	isAmbient, err := isAmbientPod(client.Kube(), pod.Name, pod.Namespace, conf.EnablementSelectors)
+	isAmbient, err := isAmbientPod(client.Kube(), pod.Name, pod.Namespace, conf.EnablementSelectors, conf.EnableIsAmbientRetry)
 	assert.NoError(t, err)
 	assert.Equal(t, true, isAmbient, "expected pod to be ambient")
 }

--- a/cni/pkg/plugin/plugin_test.go
+++ b/cni/pkg/plugin/plugin_test.go
@@ -81,7 +81,7 @@ var mockConfTmpl = `{
     "plugin_log_level": "debug",
     "cni_agent_run_dir": "%s",
     "ambient_enabled": %t,
-	"enable_is_ambient_retry": %t,
+	"enable_ambient_detection_retry": %t,
 	"enablement_selectors": [
 		{
 			"podSelector": {

--- a/cni/pkg/plugin/plugin_test.go
+++ b/cni/pkg/plugin/plugin_test.go
@@ -119,7 +119,7 @@ type mockInterceptRuleMgr struct {
 	lastRedirect []*Redirect
 }
 
-func buildMockConf(ambientEnabled bool) string {
+func buildMockConfWithRetryOption(ambientEnabled bool, enableAmbientDetectionRetry bool) string {
 	return fmt.Sprintf(
 		mockConfTmpl,
 		"1.0.0",
@@ -128,9 +128,13 @@ func buildMockConf(ambientEnabled bool) string {
 		testSandboxDirectory,
 		"", // unused here
 		ambientEnabled,
-		ambientEnabled,
+		enableAmbientDetectionRetry,
 		"mock",
 	)
+}
+
+func buildMockConf(ambientEnabled bool) string {
+	return buildMockConfWithRetryOption(ambientEnabled, false)
 }
 
 func buildFakePodAndNSForClient() (*corev1.Pod, *corev1.Namespace) {
@@ -255,7 +259,7 @@ func testDoAddRun(t *testing.T, stdinData, nsName string, objects ...runtime.Obj
 }
 
 func TestIsAmbientPod(t *testing.T) {
-	cniConf := buildMockConf(true)
+	cniConf := buildMockConfWithRetryOption(true, true)
 	pod, ns := buildFakePodAndNSForClient()
 	ns.ObjectMeta.Labels = map[string]string{label.IoIstioDataplaneMode.Name: constants.DataplaneModeAmbient}
 

--- a/cni/test/testdata/expected/10-calico.conflist-istioconfig
+++ b/cni/test/testdata/expected/10-calico.conflist-istioconfig
@@ -28,7 +28,7 @@
       "ambient_enabled": false,
       "cni_agent_run_dir": "/tmp",
       "dns": {},
-      "enable_is_ambient_retry": false,
+      "enable_ambient_detection_retry": false,
       "enablement_selectors": [],
       "exclude_namespaces": [
         "istio-system"

--- a/cni/test/testdata/expected/10-calico.conflist-istioconfig
+++ b/cni/test/testdata/expected/10-calico.conflist-istioconfig
@@ -29,6 +29,7 @@
       "cni_agent_run_dir": "/tmp",
       "dns": {},
       "enablement_selectors": [],
+      "enable_is_ambient_retry": false,
       "exclude_namespaces": [
         "istio-system"
       ],

--- a/cni/test/testdata/expected/10-calico.conflist-istioconfig
+++ b/cni/test/testdata/expected/10-calico.conflist-istioconfig
@@ -28,8 +28,8 @@
       "ambient_enabled": false,
       "cni_agent_run_dir": "/tmp",
       "dns": {},
-      "enablement_selectors": [],
       "enable_is_ambient_retry": false,
+      "enablement_selectors": [],
       "exclude_namespaces": [
         "istio-system"
       ],

--- a/cni/test/testdata/expected/YYY-istio-cni.conf
+++ b/cni/test/testdata/expected/YYY-istio-cni.conf
@@ -12,5 +12,6 @@
     "istio-system"
   ],
   "pod_namespace": "",
-  "native_nftables": false
+  "native_nftables": false,
+  "enable_is_ambient_retry": false
 }

--- a/cni/test/testdata/expected/YYY-istio-cni.conf
+++ b/cni/test/testdata/expected/YYY-istio-cni.conf
@@ -13,5 +13,5 @@
   ],
   "pod_namespace": "",
   "native_nftables": false,
-  "enable_is_ambient_retry": false
+  "enable_ambient_detection_retry": false
 }

--- a/cni/test/testdata/expected/minikube_cni.conflist.expected
+++ b/cni/test/testdata/expected/minikube_cni.conflist.expected
@@ -25,7 +25,7 @@
       "ambient_enabled": false,
       "cni_agent_run_dir": "/tmp",
       "dns": {},
-      "enable_is_ambient_retry": false,
+      "enable_ambient_detection_retry": false,
       "enablement_selectors": [],
       "exclude_namespaces": [
         "istio-system"

--- a/cni/test/testdata/expected/minikube_cni.conflist.expected
+++ b/cni/test/testdata/expected/minikube_cni.conflist.expected
@@ -25,8 +25,8 @@
       "ambient_enabled": false,
       "cni_agent_run_dir": "/tmp",
       "dns": {},
-      "enablement_selectors": [],
       "enable_is_ambient_retry": false,
+      "enablement_selectors": [],
       "exclude_namespaces": [
         "istio-system"
       ],

--- a/cni/test/testdata/expected/minikube_cni.conflist.expected
+++ b/cni/test/testdata/expected/minikube_cni.conflist.expected
@@ -26,6 +26,7 @@
       "cni_agent_run_dir": "/tmp",
       "dns": {},
       "enablement_selectors": [],
+      "enable_is_ambient_retry": false,
       "exclude_namespaces": [
         "istio-system"
       ],

--- a/manifests/charts/istio-cni/templates/configmap-cni.yaml
+++ b/manifests/charts/istio-cni/templates/configmap-cni.yaml
@@ -19,6 +19,7 @@ data:
   AMBIENT_DNS_CAPTURE: {{ .Values.ambient.dnsCapture | quote  }}
   AMBIENT_IPV6: {{ .Values.ambient.ipv6 | quote }}
   AMBIENT_RECONCILE_POD_RULES_ON_STARTUP: {{ .Values.ambient.reconcileIptablesOnStartup | quote }}
+  ENABLE_IS_AMBIENT_RETRY: {{ .Values.ambient.enableIsAmbientRetry | quote }}
   {{- if .Values.cniConfFileName }} # K8S < 1.24 doesn't like empty values
   CNI_CONF_NAME: {{ .Values.cniConfFileName }} # Name of the CNI config file to create. Only override if you know the exact path your CNI requires..
   {{- end }}

--- a/manifests/charts/istio-cni/templates/configmap-cni.yaml
+++ b/manifests/charts/istio-cni/templates/configmap-cni.yaml
@@ -19,7 +19,7 @@ data:
   AMBIENT_DNS_CAPTURE: {{ .Values.ambient.dnsCapture | quote  }}
   AMBIENT_IPV6: {{ .Values.ambient.ipv6 | quote }}
   AMBIENT_RECONCILE_POD_RULES_ON_STARTUP: {{ .Values.ambient.reconcileIptablesOnStartup | quote }}
-  ENABLE_IS_AMBIENT_RETRY: {{ .Values.ambient.enableIsAmbientRetry | quote }}
+  ENABLE_AMBIENT_DETECTION_RETRY: {{ .Values.ambient.enableAmbientDetectionRetry | quote }}
   {{- if .Values.cniConfFileName }} # K8S < 1.24 doesn't like empty values
   CNI_CONF_NAME: {{ .Values.cniConfFileName }} # Name of the CNI config file to create. Only override if you know the exact path your CNI requires..
   {{- end }}

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -76,7 +76,7 @@ _internal_defaults_do_not_set:
     # If enabled, and ambient is enabled, the CNI agent will always share the network namespace of the host node it is running on
     shareHostNetworkNamespace: false
     # If enabled, the CNI agent will retry checking if a pod is ambient enabled when there are errors
-    enableIsAmbientRetry: false
+    enableAmbientDetectionRetry: false
 
 
   repair:

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -75,6 +75,8 @@ _internal_defaults_do_not_set:
     reconcileIptablesOnStartup: true
     # If enabled, and ambient is enabled, the CNI agent will always share the network namespace of the host node it is running on
     shareHostNetworkNamespace: false
+    # If enabled, the CNI agent will retry checking if a pod is ambient enabled when there are errors
+    enableIsAmbientRetry: false
 
 
   repair:

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -464,10 +464,10 @@ func NewFakeClientWithVersion(minor string, objects ...runtime.Object) CLIClient
 	return c
 }
 
-// NewFakeClientWithFailures creates a fake client that fails for get operations on the specified
+// NewFakeClientWithNFailures creates a fake client that fails for get operations on the specified
 // resource kinds for the first failureCount attempts, then succeeds.
 // failingResources is a set of resource (e.g., "pods", "namespaces") that should fail.
-func NewFakeClientWithFailures(failureCount int, failingResources sets.Set[schema.GroupVersionResource], objects ...runtime.Object) CLIClient {
+func NewFakeClientWithNFailures(failureCount int, failingResources sets.Set[schema.GroupVersionResource], objects ...runtime.Object) CLIClient {
 	c := NewFakeClient(objects...).(*client)
 
 	// Track retry attempts per resource

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -99,6 +99,7 @@ import (
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/sleep"
 	"istio.io/istio/pkg/test/util/yml"
+	"istio.io/istio/pkg/util/sets"
 	"istio.io/istio/pkg/version"
 )
 
@@ -463,9 +464,10 @@ func NewFakeClientWithVersion(minor string, objects ...runtime.Object) CLIClient
 	return c
 }
 
-// NewFakeClientWithRetries creates a fake client that fails for pod/namespace get operations
-// for the first failureCount attempts, then succeeds.
-func NewFakeClientWithRetries(failureCount int, objects ...runtime.Object) CLIClient {
+// NewFakeClientWithFailures creates a fake client that fails for get operations on the specified
+// resource kinds for the first failureCount attempts, then succeeds.
+// failingResources is a set of resource (e.g., "pods", "namespaces") that should fail.
+func NewFakeClientWithFailures(failureCount int, failingResources sets.Set[schema.GroupVersionResource], objects ...runtime.Object) CLIClient {
 	c := NewFakeClient(objects...).(*client)
 
 	// Track retry attempts per resource
@@ -473,12 +475,12 @@ func NewFakeClientWithRetries(failureCount int, objects ...runtime.Object) CLICl
 
 	// Create a reactor that fails initially then succeeds
 	retryReactor := func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
-		// Only handle Get actions for pods and namespaces
+		// Only handle Get actions for failingResources
 		if action.GetVerb() != "get" {
 			return false, nil, nil
 		}
-		resource := action.GetResource().Resource
-		if resource != "pods" && resource != "namespaces" {
+		resource := action.GetResource()
+		if !failingResources.Contains(resource) {
 			return false, nil, nil
 		}
 
@@ -497,9 +499,10 @@ func NewFakeClientWithRetries(failureCount int, objects ...runtime.Object) CLICl
 		return false, nil, nil
 	}
 
-	// Prepend the reactor so it runs before the default handlers
-	c.kube.(*fake.Clientset).PrependReactor("get", "pods", retryReactor)
-	c.kube.(*fake.Clientset).PrependReactor("get", "namespaces", retryReactor)
+	// Prepend the reactor for each failing kind
+	for resource := range failingResources {
+		c.kube.(*fake.Clientset).PrependReactor("get", resource.Resource, retryReactor)
+	}
 
 	return c
 }

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -466,42 +466,42 @@ func NewFakeClientWithVersion(minor string, objects ...runtime.Object) CLIClient
 // NewFakeClientWithRetries creates a fake client that fails for pod/namespace get operations
 // for the first failureCount attempts, then succeeds.
 func NewFakeClientWithRetries(failureCount int, objects ...runtime.Object) CLIClient {
-    c := NewFakeClient(objects...).(*client)
+	c := NewFakeClient(objects...).(*client)
 
-    // Track retry attempts per resource
-    attempts := &sync.Map{}
+	// Track retry attempts per resource
+	attempts := &sync.Map{}
 
-    // Create a reactor that fails initially then succeeds
-    retryReactor := func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
-        // Only handle Get actions for pods and namespaces
-        if action.GetVerb() != "get" {
-            return false, nil, nil
-        }
-        resource := action.GetResource().Resource
-        if resource != "pods" && resource != "namespaces" {
-            return false, nil, nil
-        }
+	// Create a reactor that fails initially then succeeds
+	retryReactor := func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+		// Only handle Get actions for pods and namespaces
+		if action.GetVerb() != "get" {
+			return false, nil, nil
+		}
+		resource := action.GetResource().Resource
+		if resource != "pods" && resource != "namespaces" {
+			return false, nil, nil
+		}
 
-        getAction := action.(clienttesting.GetAction)
-        key := fmt.Sprintf("%s/%s/%s", resource, action.GetNamespace(), getAction.GetName())
+		getAction := action.(clienttesting.GetAction)
+		key := fmt.Sprintf("%s/%s/%s", resource, action.GetNamespace(), getAction.GetName())
 
-        val, _ := attempts.LoadOrStore(key, atomic.NewInt32(0))
-        attemptCounter := val.(*atomic.Int32)
+		val, _ := attempts.LoadOrStore(key, atomic.NewInt32(0))
+		attemptCounter := val.(*atomic.Int32)
 
-        currentAttempt := attemptCounter.Inc()
+		currentAttempt := attemptCounter.Inc()
 
-        if int(currentAttempt) <= failureCount {
-            return true, nil, kerrors.NewServiceUnavailable(fmt.Sprintf("transient error: attempt %d/%d", currentAttempt, failureCount))
-        }
+		if int(currentAttempt) <= failureCount {
+			return true, nil, kerrors.NewServiceUnavailable(fmt.Sprintf("transient error: attempt %d/%d", currentAttempt, failureCount))
+		}
 
-        return false, nil, nil
-    }
+		return false, nil, nil
+	}
 
-    // Prepend the reactor so it runs before the default handlers
-    c.kube.(*fake.Clientset).PrependReactor("get", "pods", retryReactor)
-    c.kube.(*fake.Clientset).PrependReactor("get", "namespaces", retryReactor)
+	// Prepend the reactor so it runs before the default handlers
+	c.kube.(*fake.Clientset).PrependReactor("get", "pods", retryReactor)
+	c.kube.(*fake.Clientset).PrependReactor("get", "namespaces", retryReactor)
 
-    return c
+	return c
 }
 
 type fakeClient interface {

--- a/releasenotes/notes/55968.yaml
+++ b/releasenotes/notes/55968.yaml
@@ -13,3 +13,8 @@ releaseNotes:
   cni.istioOwnedCNIConfigFilename, the Istio owned CNI config file will be named 02-istio-cni.conflist.
   The istioOwnedCNIConfigFilename must have a higher lexicographical priority than the primary CNI.
   Ambient and chained CNI plugins must be enabled for this feature to work.
+- |
+  **Added** a retry mechanism when checking if a pod is ambient enabled in istio-cni.
+  This is to address potential transient failures resulting in potential mesh bypassing. This feature
+  is disabled by default and can be enabled by setting cni.istioOwnedCNIConfig to true in the istio-cni
+  Helm chart values.

--- a/releasenotes/notes/55968.yaml
+++ b/releasenotes/notes/55968.yaml
@@ -13,8 +13,3 @@ releaseNotes:
   cni.istioOwnedCNIConfigFilename, the Istio owned CNI config file will be named 02-istio-cni.conflist.
   The istioOwnedCNIConfigFilename must have a higher lexicographical priority than the primary CNI.
   Ambient and chained CNI plugins must be enabled for this feature to work.
-- |
-  **Added** a retry mechanism when checking if a pod is ambient enabled in istio-cni.
-  This is to address potential transient failures resulting in potential mesh bypassing. This feature
-  is disabled by default and can be enabled by setting cni.istioOwnedCNIConfig to true in the istio-cni
-  Helm chart values.

--- a/releasenotes/notes/cni-retry-is-ambient-check.yaml
+++ b/releasenotes/notes/cni-retry-is-ambient-check.yaml
@@ -6,5 +6,5 @@ releaseNotes:
 - |
   **Added** a retry mechanism when checking if a pod is ambient enabled in istio-cni.
   This is to address potential transient failures resulting in potential mesh bypassing. This feature
-  is disabled by default and can be enabled by setting `ambient.enableIsAmbientRetry` in the
+  is disabled by default and can be enabled by setting `ambient.enableAmbientDetectionRetry` in the
   `istio-cni` chart.

--- a/releasenotes/notes/cni-retry-is-ambient-check.yaml
+++ b/releasenotes/notes/cni-retry-is-ambient-check.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+issues: []
+releaseNotes:
+- |
+  **Added** a retry mechanism when checking if a pod is ambient enabled in istio-cni.
+  This is to address potential transient failures resulting in potential mesh bypassing. This feature
+  is disabled by default and can be enabled by setting `ambient.enableIsAmbientRetry` in the
+  `istio-cni` chart.


### PR DESCRIPTION
**Please provide a description of this PR:**

Adds support to retry getting pod and namespace to determine if a pod is ambient enabled. Currently, if the plugin fails to determine if a pod is ambient enabled it assumes it is not. This enables potential mesh bypass.

Resolves #57985 