### PR TITLE
Add configurable idle timeout for HBONE connections

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -603,8 +603,6 @@ istio.io/api v1.28.0-alpha.0.0.20260111101934-ef92f547ede5 h1:+4TtGsM6rpAwp7o3eE
 istio.io/api v1.28.0-alpha.0.0.20260111101934-ef92f547ede5/go.mod h1:+brQWcBHoROuyA6fv8rbgg8Kfn0RCGuqoY0duCMuSLA=
 istio.io/client-go v1.28.0-alpha.0.0.20260111102334-0a4054ecb369 h1:P+549Epko0e0prk13+tK+6f+WF3eUs/DlV1brzJNa94=
 istio.io/client-go v1.28.0-alpha.0.0.20260111102334-0a4054ecb369/go.mod h1:R5jRUuzBJpfSQuLuod6SVR98LOpcW6TtbaJcuqSBXvE=
-istio.io/client-go v1.28.0-alpha.0.0.20260106110844-8dd17c61b14f h1:5CYS2nBL6x2KL3J1I7DUP8BO1aNYyERGpgzJnL1Vnkk=
-istio.io/client-go v1.28.0-alpha.0.0.20260106110844-8dd17c61b14f/go.mod h1:d5lfv9uJyfX+hPvCirKknqf7bx0Ve6E6d7ReLJ1ZpDE=
 k8s.io/api v0.35.0 h1:iBAU5LTyBI9vw3L5glmat1njFK34srdLmktWwLTprlY=
 k8s.io/api v0.35.0/go.mod h1:AQ0SNTzm4ZAczM03QH42c7l3bih1TbAXYo0DkF8ktnA=
 k8s.io/apiextensions-apiserver v0.35.0 h1:3xHk2rTOdWXXJM+RDQZJvdx0yEOgC0FgQ1PlJatA5T4=


### PR DESCRIPTION
**Please provide a description of this PR:**

## Summary

This PR adds a new environment variable `PILOT_CONNECT_ORIGINATE_IDLE_TIMEOUT` to configure the idle timeout for HBONE connections from proxies (ingress gateway, waypoint) to ztunnel. This prevents 503 errors caused by stale connection reuse when pod IPs are recycled.

## Problem Description

In Istio ambient mesh deployments on environments with IP reuse (e.g., AWS EKS with VPC CNI), sporadic 503 errors occur during pod churn due to stale HBONE connections.

### Root Cause

The `connect_originate` cluster used for HBONE connections has no explicit idle timeout, defaulting to Envoy's 1-hour timeout. When IPs are
reused after a CNI cooldown period (e.g., AWS VPC CNI's default 30 seconds), proxies may reuse stale connections from their pool, resulting
in connection failures.

**Timeline of the issue:**
1. Pod A is deleted, IP released (t=0)
2. CNI waits for cooldown period (e.g., 30s for AWS VPC CNI)
3. Pod B gets the same IP (t=30+)
4. Proxy still has a connection in its pool pointing to the old pod (1-hour default idle timeout)
5. When traffic arrives for that IP, the proxy reuses the stale connection -> RST -> 503 UC error

**Key observations:**
- Errors only occur after pod churn
- Pattern is sporadic (depends on timing and whether stale connection is in pool)
- DestinationRules don't help (they don't affect the `connect_originate` cluster)
- Errors correlate with pod deletions but can persist for minutes afterward

### Error Pattern

```json
{
  "upstream_host": "envoy://connect_originate/[2a05:d014:17ac:fa08:c524::23]:8000",
  "upstream_cluster": "inbound-vip|80|http|service.namespace.svc.cluster.local",
  "response_code": 503,
  "response_flags": "UC",
  "details": "upstream_reset_before_response_started{connection_termination}"
}
```

## Solution

Added a configurable idle timeout to the `connect_originate` cluster that can be set lower than the IP cooldown period, ensuring connections are closed before IPs can be reused.

**Opt-in approach:**
- Default is 0 (disabled) to preserve backward compatibility
- Users must explicitly enable via environment variable
- No behavior change for existing deployments

## Testing

This fix has been extensively tested in a real-world AWS EKS IPv6 environment:

- No more 503 UC errors during pod churn
- Configuration validated via `istioctl proxy-config`: confirmed `idle_timeout: 15s` present in `connect_originate` cluster

### Why Automated Testing Is Impractical

Comprehensive automated testing for this specific bug is not feasible due to the following challenges:

1. **Timing-dependent race condition:**
   - Requires precise coordination between pod deletion, CNI cooldown period, connection timeout, IP reassignment, and request timing
   - Impossible to reliably reproduce in a fast, deterministic test

2. **Infrastructure-specific behavior:**
   - Depends on CNI-specific IP reuse behavior
   - Requires actual IP address reuse, which can't be easily mocked
   - Would need real cloud infrastructure (AWS EKS) to test properly

3. **Test complexity:**
   - E2E test would require: real cloud infrastructure, timed pod deletion, forced IP reuse, traffic generation, and error detection
   - The test setup would be more complex than the fix itself

## Related Issues

Fixes:

https://github.com/istio/ztunnel/issues/1637
https://github.com/istio/ztunnel/issues/1662

## Upgrade Notes

This change is fully backward compatible:
- Default behavior unchanged (idle timeout disabled)
- Opt-in via environment variable
- No breaking changes