### PR TITLE
refactor: replace context.WithCancel with t.Context

### DIFF
--- a/cni/pkg/install/cniconfig_test.go
+++ b/cni/pkg/install/cniconfig_test.go
@@ -227,8 +227,7 @@ func TestGetCNIConfigFilepath(t *testing.T) {
 
 			// Handle chained CNI plugin cases
 			// Call with goroutine to test fsnotify watcher
-			parent, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			parent := t.Context()
 			resultChan, errChan := make(chan string, 1), make(chan error, 1)
 			go func(resultChan chan string, errChan chan error, ctx context.Context, cniConfName, mountedCNINetDir string, chained bool) {
 				result, err := getCNIConfigFilepath(ctx, cniConfName, mountedCNINetDir, chained)

--- a/cni/pkg/install/install_test.go
+++ b/cni/pkg/install/install_test.go
@@ -220,8 +220,7 @@ func TestSleepCheckInstall(t *testing.T) {
 			tempDir := t.TempDir()
 
 			// Initialize parameters
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			if c.istioOwnedCNIConfig && len(c.istioOwnedCNIConfigFilename) == 0 {
 				c.istioOwnedCNIConfigFilename = "02-istio-conf.conflist"

--- a/pilot/cmd/pilot-agent/status/ready/probe_test.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe_test.go
@@ -36,8 +36,7 @@ func TestEnvoyStatsCompleteAndSuccessful(t *testing.T) {
 
 	server := testserver.CreateAndStartServer(liveServerStats)
 	defer server.Close()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	probe := Probe{AdminPort: uint16(server.Listener.Addr().(*net.TCPAddr).Port)}
 	probe.Context = ctx
 
@@ -111,8 +110,7 @@ server.state: 0`,
 		t.Run(tt.name, func(t *testing.T) {
 			server := testserver.CreateAndStartServer(tt.stats)
 			defer server.Close()
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 			probe := Probe{AdminPort: uint16(server.Listener.Addr().(*net.TCPAddr).Port)}
 			probe.Context = ctx
 			err := probe.Check()
@@ -137,8 +135,7 @@ func TestEnvoyInitializing(t *testing.T) {
 
 	server := testserver.CreateAndStartServer(initServerStats)
 	defer server.Close()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	probe := Probe{AdminPort: uint16(server.Listener.Addr().(*net.TCPAddr).Port)}
 	probe.Context = ctx
 	err := probe.Check()
@@ -151,8 +148,7 @@ func TestEnvoyNoClusterManagerStats(t *testing.T) {
 
 	server := testserver.CreateAndStartServer(onlyServerStats)
 	defer server.Close()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	probe := Probe{AdminPort: uint16(server.Listener.Addr().(*net.TCPAddr).Port)}
 	probe.Context = ctx
 	err := probe.Check()
@@ -165,8 +161,7 @@ func TestEnvoyNoServerStats(t *testing.T) {
 
 	server := testserver.CreateAndStartServer(noServerStats)
 	defer server.Close()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	probe := Probe{AdminPort: uint16(server.Listener.Addr().(*net.TCPAddr).Port)}
 	probe.Context = ctx
 	err := probe.Check()
@@ -178,8 +173,7 @@ func TestEnvoyReadinessCache(t *testing.T) {
 	g := NewWithT(t)
 
 	server := testserver.CreateAndStartServer(noServerStats)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	probe := Probe{AdminPort: uint16(server.Listener.Addr().(*net.TCPAddr).Port)}
 	probe.Context = ctx
 	err := probe.Check()

--- a/pilot/pkg/model/jwks_resolver_test.go
+++ b/pilot/pkg/model/jwks_resolver_test.go
@@ -15,7 +15,6 @@
 package model
 
 import (
-	"context"
 	"fmt"
 	"sync/atomic"
 	"testing"
@@ -656,8 +655,7 @@ func TestJwtPubKeyRefreshedWhenErrorsGettingOtherURLs(t *testing.T) {
 	}
 
 	// Start a goroutine that requests an invalid URL repeatedly
-	goroutineCtx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	goroutineCtx := t.Context()
 	go func() {
 		for {
 			select {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/authorization_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/authorization_test.go
@@ -15,7 +15,6 @@
 package ambient
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -223,8 +222,7 @@ func TestWaypointPolicyStatusCollection(t *testing.T) {
 	stop := test.NewStop(t)
 	opts := krt.NewOptionsBuilder(stop, "", krt.GlobalDebugHandler)
 	c := kube.NewFakeClient()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	clientAuthzPol := kclient.New[*securityclient.AuthorizationPolicy](c)
 	authzPolCol := krt.WrapClient(clientAuthzPol, opts.WithName("authzPolCol")...)

--- a/security/pkg/pki/ca/ca_test.go
+++ b/security/pkg/pki/ca/ca_test.go
@@ -304,8 +304,7 @@ func TestCreateSelfSignedIstioCAReadSigningCertOnly(t *testing.T) {
 	}
 	signingCertPem := secret.Data[CACertFile]
 
-	ctx1, cancel1 := context.WithCancel(context.Background())
-	defer cancel1()
+	ctx1 := t.Context()
 	caopts, err := NewSelfSignedIstioCAOptions(ctx1, 0,
 		caCertTTL, defaultCertTTL, rootCertCheckInverval, maxCertTTL, org, false, false,
 		caNamespace, client.CoreV1(), rootCertFile, false, rsaKeySize)


### PR DESCRIPTION
**Please provide a description of this PR:**

The addition of the Context method to Go's testing.T provides significant improvements for writing concurrent tests. It allows better management of goroutines, ensuring they properly exit and preventing issues like deadlocks and unfinished processes. 

By using Context, errors and cancellations can be handled more effectively, making tests more robust and easier to reason about. This change also enables tighter integration between tests and the application code, especially for systems that span multiple concurrent components. Overall, it simplifies test code and enhances test stability and maintainability.


More info: https://github.com/golang/go/issues/18368