### PR TITLE
[release-1.27] cni repair: improve the time to find the proc (#58404)

### DIFF
--- a/cni/pkg/repair/netns_linux.go
+++ b/cni/pkg/repair/netns_linux.go
@@ -47,22 +47,15 @@ func runInHost[T any](f func() (T, error)) (T, error) {
 }
 
 func checkInterfacesForMatchingAddr(targetAddr net.IP) (match bool, err error) {
-	var interfaces []net.Interface
-	if interfaces, err = net.Interfaces(); err != nil {
-		return false, fmt.Errorf("failed to get interfaces")
+	var addrs []net.Addr
+	if addrs, err = net.InterfaceAddrs(); err != nil {
+		return match, err
 	}
-
-	for _, ief := range interfaces {
-		var addrs []net.Addr
-		if addrs, err = ief.Addrs(); err != nil {
-			return
-		}
-		for _, addr := range addrs {
-			switch v := addr.(type) {
-			case *net.IPNet:
-				if v.IP.Equal(targetAddr) {
-					return true, nil
-				}
+	for _, addr := range addrs {
+		switch v := addr.(type) {
+		case *net.IPNet:
+			if v.IP.Equal(targetAddr) {
+				return true, nil
 			}
 		}
 	}


### PR DESCRIPTION
Just get all the addresses and compare.

Asking for the addresses on an interface is just filtering all the addresses by the interface index. Rather than do it N times, just do it once.

This shaves about 20-30ms per repair. The majority of the time is still in the actual iptable repair.

**Please provide a description of this PR:**

fixes #58416