### PR TITLE
Fix source_app/destination_app to respect app.kubernetes.io/name label (#58436)

### DIFF
--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -447,7 +447,7 @@ func serviceClusterOrDefault(name string, metadata *model.BootstrapNodeMetadata)
 	if name != "" && name != "istio-proxy" {
 		return name
 	}
-	if app, ok := metadata.Labels["app"]; ok {
+	if app, ok := labels.GetAppName(metadata.Labels); ok {
 		return app + "." + metadata.Namespace
 	}
 	if metadata.WorkloadName != "" {

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -447,7 +447,7 @@ func serviceClusterOrDefault(name string, metadata *model.BootstrapNodeMetadata)
 	if name != "" && name != "istio-proxy" {
 		return name
 	}
-	if app, ok := labels.GetAppName(metadata.Labels); ok {
+	if app, ok := labels.GetAppNameBackwardCompatible(metadata.Labels); ok {
 		return app + "." + metadata.Namespace
 	}
 	if metadata.WorkloadName != "" {

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -447,7 +447,7 @@ func serviceClusterOrDefault(name string, metadata *model.BootstrapNodeMetadata)
 	if name != "" && name != "istio-proxy" {
 		return name
 	}
-	if app, ok := labels.GetAppNameBackwardCompatible(metadata.Labels); ok {
+	if app, ok := labels.GetApp(metadata.Labels); ok {
 		return app + "." + metadata.Namespace
 	}
 	if metadata.WorkloadName != "" {

--- a/pkg/bootstrap/config_test.go
+++ b/pkg/bootstrap/config_test.go
@@ -200,3 +200,113 @@ func TestRequiredEnvoyStatsMatcherInclusionRegexes(t *testing.T) {
 		t.Fatal("requiredEnvoyStatsMatcherInclusionRegexes doesn't match the route's stat_prefix")
 	}
 }
+
+func TestServiceClusterOrDefault(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		metadata *model.BootstrapNodeMetadata
+		expected string
+	}{
+		{
+			name:  "non-empty name that is not istio-proxy",
+			input: "my-service",
+			metadata: &model.BootstrapNodeMetadata{
+				NodeMetadata: model.NodeMetadata{
+					Namespace: "default",
+					Labels:    map[string]string{"app": "test"},
+				},
+			},
+			expected: "my-service",
+		},
+		{
+			name:  "empty name with app.kubernetes.io/name label",
+			input: "",
+			metadata: &model.BootstrapNodeMetadata{
+				NodeMetadata: model.NodeMetadata{
+					Namespace: "default",
+					Labels: map[string]string{
+						"app.kubernetes.io/name": "k8s-app",
+						"app":                    "legacy-app",
+					},
+				},
+			},
+			expected: "k8s-app.default",
+		},
+		{
+			name:  "empty name with only app label",
+			input: "",
+			metadata: &model.BootstrapNodeMetadata{
+				NodeMetadata: model.NodeMetadata{
+					Namespace: "default",
+					Labels:    map[string]string{"app": "legacy-app"},
+				},
+			},
+			expected: "legacy-app.default",
+		},
+		{
+			name:  "empty name with canonical service label",
+			input: "",
+			metadata: &model.BootstrapNodeMetadata{
+				NodeMetadata: model.NodeMetadata{
+					Namespace: "default",
+					Labels: map[string]string{
+						model.IstioCanonicalServiceLabelName: "canonical-name",
+						"app.kubernetes.io/name":             "k8s-app",
+						"app":                                "legacy-app",
+					},
+				},
+			},
+			expected: "canonical-name.default",
+		},
+		{
+			name:  "istio-proxy name falls back to labels",
+			input: "istio-proxy",
+			metadata: &model.BootstrapNodeMetadata{
+				NodeMetadata: model.NodeMetadata{
+					Namespace: "default",
+					Labels:    map[string]string{"app.kubernetes.io/name": "k8s-app"},
+				},
+			},
+			expected: "k8s-app.default",
+		},
+		{
+			name:  "no labels falls back to workload name",
+			input: "",
+			metadata: &model.BootstrapNodeMetadata{
+				NodeMetadata: model.NodeMetadata{
+					Namespace:    "default",
+					WorkloadName: "my-workload",
+				},
+			},
+			expected: "my-workload.default",
+		},
+		{
+			name:  "no labels and no workload name falls back to istio-proxy",
+			input: "",
+			metadata: &model.BootstrapNodeMetadata{
+				NodeMetadata: model.NodeMetadata{
+					Namespace: "default",
+				},
+			},
+			expected: "istio-proxy.default",
+		},
+		{
+			name:  "no namespace returns just istio-proxy",
+			input: "",
+			metadata: &model.BootstrapNodeMetadata{
+				NodeMetadata: model.NodeMetadata{},
+			},
+			expected: "istio-proxy",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := serviceClusterOrDefault(tt.input, tt.metadata)
+			if result != tt.expected {
+				t.Errorf("serviceClusterOrDefault() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/kube/labels/labels.go
+++ b/pkg/kube/labels/labels.go
@@ -35,6 +35,14 @@ var (
 		"app.kubernetes.io/version",
 		"version",
 	}
+	// nameLabelsBackwardCompatible is the reverse order of nameLabels for backward compatibility.
+	// It checks app first, then app.kubernetes.io/name, and finally service.istio.io/canonical-name.
+	// This is used in serviceClusterOrDefault to maintain backward compatibility.
+	nameLabelsBackwardCompatible = []string{
+		"app",
+		"app.kubernetes.io/name",
+		model.IstioCanonicalServiceLabelName,
+	}
 )
 
 // WorkloadNameFromWorkloadEntry derives the workload name from a WorkloadEntry
@@ -104,4 +112,16 @@ func canonicalServiceName(labels map[string]string, workloadName string) string 
 // Returns the value and true if found, or empty string and false if none of the labels are present.
 func GetAppName(labels map[string]string) (string, bool) {
 	return lookupLabelValue(labels, nameLabels...)
+}
+
+// GetAppNameBackwardCompatible returns the app name from labels using a backward-compatible
+// priority order that checks "app" first for backward compatibility:
+// 1. app
+// 2. app.kubernetes.io/name
+// 3. service.istio.io/canonical-name
+// This is used in serviceClusterOrDefault to maintain backward compatibility for existing users
+// who have both "app" and "app.kubernetes.io/name" labels with different values.
+// Returns the value and true if found, or empty string and false if none of the labels are present.
+func GetAppNameBackwardCompatible(labels map[string]string) (string, bool) {
+	return lookupLabelValue(labels, nameLabelsBackwardCompatible...)
 }

--- a/pkg/kube/labels/labels.go
+++ b/pkg/kube/labels/labels.go
@@ -96,3 +96,12 @@ func canonicalServiceName(labels map[string]string, workloadName string) string 
 	}
 	return value
 }
+
+// GetAppName returns the app name from labels, checking the following labels in order:
+// 1. service.istio.io/canonical-name
+// 2. app.kubernetes.io/name
+// 3. app
+// Returns the value and true if found, or empty string and false if none of the labels are present.
+func GetAppName(labels map[string]string) (string, bool) {
+	return lookupLabelValue(labels, nameLabels...)
+}

--- a/pkg/kube/labels/labels.go
+++ b/pkg/kube/labels/labels.go
@@ -105,16 +105,7 @@ func canonicalServiceName(labels map[string]string, workloadName string) string 
 	return value
 }
 
-// GetAppName returns the app name from labels, checking the following labels in order:
-// 1. service.istio.io/canonical-name
-// 2. app.kubernetes.io/name
-// 3. app
-// Returns the value and true if found, or empty string and false if none of the labels are present.
-func GetAppName(labels map[string]string) (string, bool) {
-	return lookupLabelValue(labels, nameLabels...)
-}
-
-// GetAppNameBackwardCompatible returns the app name from labels using a backward-compatible
+// GetApp returns the app name from labels using a backward-compatible
 // priority order that checks "app" first for backward compatibility:
 // 1. app
 // 2. app.kubernetes.io/name
@@ -122,6 +113,6 @@ func GetAppName(labels map[string]string) (string, bool) {
 // This is used in serviceClusterOrDefault to maintain backward compatibility for existing users
 // who have both "app" and "app.kubernetes.io/name" labels with different values.
 // Returns the value and true if found, or empty string and false if none of the labels are present.
-func GetAppNameBackwardCompatible(labels map[string]string) (string, bool) {
+func GetApp(labels map[string]string) (string, bool) {
 	return lookupLabelValue(labels, nameLabelsBackwardCompatible...)
 }

--- a/pkg/kube/labels/labels_test.go
+++ b/pkg/kube/labels/labels_test.go
@@ -1,0 +1,270 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package labels
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/model"
+)
+
+func TestCanonicalService(t *testing.T) {
+	tests := []struct {
+		name             string
+		labels           map[string]string
+		workloadName     string
+		expectedName     string
+		expectedRevision string
+	}{
+		{
+			name:             "empty labels, fallback to workload name and latest",
+			labels:           map[string]string{},
+			workloadName:     "my-workload",
+			expectedName:     "my-workload",
+			expectedRevision: "latest",
+		},
+		{
+			name: "canonical service labels take priority",
+			labels: map[string]string{
+				model.IstioCanonicalServiceLabelName:         "canonical-name",
+				model.IstioCanonicalServiceRevisionLabelName: "canonical-revision",
+				"app.kubernetes.io/name":                     "k8s-name",
+				"app.kubernetes.io/version":                  "k8s-version",
+				"app":                                        "legacy-app",
+				"version":                                    "legacy-version",
+			},
+			workloadName:     "my-workload",
+			expectedName:     "canonical-name",
+			expectedRevision: "canonical-revision",
+		},
+		{
+			name: "app.kubernetes.io/name takes priority over app",
+			labels: map[string]string{
+				"app.kubernetes.io/name":    "k8s-name",
+				"app.kubernetes.io/version": "k8s-version",
+				"app":                       "legacy-app",
+				"version":                   "legacy-version",
+			},
+			workloadName:     "my-workload",
+			expectedName:     "k8s-name",
+			expectedRevision: "k8s-version",
+		},
+		{
+			name: "legacy app and version labels work as fallback",
+			labels: map[string]string{
+				"app":     "legacy-app",
+				"version": "legacy-version",
+			},
+			workloadName:     "my-workload",
+			expectedName:     "legacy-app",
+			expectedRevision: "legacy-version",
+		},
+		{
+			name: "mixed labels - k8s name with legacy version",
+			labels: map[string]string{
+				"app.kubernetes.io/name": "k8s-name",
+				"version":                "legacy-version",
+			},
+			workloadName:     "my-workload",
+			expectedName:     "k8s-name",
+			expectedRevision: "legacy-version",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, revision := CanonicalService(tt.labels, tt.workloadName)
+			if name != tt.expectedName {
+				t.Errorf("CanonicalService() name = %v, want %v", name, tt.expectedName)
+			}
+			if revision != tt.expectedRevision {
+				t.Errorf("CanonicalService() revision = %v, want %v", revision, tt.expectedRevision)
+			}
+		})
+	}
+}
+
+func TestGetAppName(t *testing.T) {
+	tests := []struct {
+		name          string
+		labels        map[string]string
+		expectedValue string
+		expectedOk    bool
+	}{
+		{
+			name:          "empty labels",
+			labels:        map[string]string{},
+			expectedValue: "",
+			expectedOk:    false,
+		},
+		{
+			name: "canonical service label takes priority",
+			labels: map[string]string{
+				model.IstioCanonicalServiceLabelName: "canonical-name",
+				"app.kubernetes.io/name":             "k8s-name",
+				"app":                                "legacy-app",
+			},
+			expectedValue: "canonical-name",
+			expectedOk:    true,
+		},
+		{
+			name: "app.kubernetes.io/name takes priority over app",
+			labels: map[string]string{
+				"app.kubernetes.io/name": "k8s-name",
+				"app":                    "legacy-app",
+			},
+			expectedValue: "k8s-name",
+			expectedOk:    true,
+		},
+		{
+			name: "legacy app label works as fallback",
+			labels: map[string]string{
+				"app": "legacy-app",
+			},
+			expectedValue: "legacy-app",
+			expectedOk:    true,
+		},
+		{
+			name: "only app.kubernetes.io/name set",
+			labels: map[string]string{
+				"app.kubernetes.io/name": "k8s-name",
+			},
+			expectedValue: "k8s-name",
+			expectedOk:    true,
+		},
+		{
+			name: "unrelated labels only",
+			labels: map[string]string{
+				"foo": "bar",
+			},
+			expectedValue: "",
+			expectedOk:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, ok := GetAppName(tt.labels)
+			if value != tt.expectedValue {
+				t.Errorf("GetAppName() value = %v, want %v", value, tt.expectedValue)
+			}
+			if ok != tt.expectedOk {
+				t.Errorf("GetAppName() ok = %v, want %v", ok, tt.expectedOk)
+			}
+		})
+	}
+}
+
+func TestHasCanonicalServiceName(t *testing.T) {
+	tests := []struct {
+		name     string
+		labels   map[string]string
+		expected bool
+	}{
+		{
+			name:     "empty labels",
+			labels:   map[string]string{},
+			expected: false,
+		},
+		{
+			name: "has canonical service label",
+			labels: map[string]string{
+				model.IstioCanonicalServiceLabelName: "name",
+			},
+			expected: true,
+		},
+		{
+			name: "has app.kubernetes.io/name",
+			labels: map[string]string{
+				"app.kubernetes.io/name": "name",
+			},
+			expected: true,
+		},
+		{
+			name: "has app label",
+			labels: map[string]string{
+				"app": "name",
+			},
+			expected: true,
+		},
+		{
+			name: "has unrelated labels",
+			labels: map[string]string{
+				"foo": "bar",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := HasCanonicalServiceName(tt.labels)
+			if got != tt.expected {
+				t.Errorf("HasCanonicalServiceName() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestHasCanonicalServiceRevision(t *testing.T) {
+	tests := []struct {
+		name     string
+		labels   map[string]string
+		expected bool
+	}{
+		{
+			name:     "empty labels",
+			labels:   map[string]string{},
+			expected: false,
+		},
+		{
+			name: "has canonical service revision label",
+			labels: map[string]string{
+				model.IstioCanonicalServiceRevisionLabelName: "revision",
+			},
+			expected: true,
+		},
+		{
+			name: "has app.kubernetes.io/version",
+			labels: map[string]string{
+				"app.kubernetes.io/version": "version",
+			},
+			expected: true,
+		},
+		{
+			name: "has version label",
+			labels: map[string]string{
+				"version": "v1",
+			},
+			expected: true,
+		},
+		{
+			name: "has unrelated labels",
+			labels: map[string]string{
+				"foo": "bar",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := HasCanonicalServiceRevision(tt.labels)
+			if got != tt.expected {
+				t.Errorf("HasCanonicalServiceRevision() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/kube/labels/labels_test.go
+++ b/pkg/kube/labels/labels_test.go
@@ -96,78 +96,7 @@ func TestCanonicalService(t *testing.T) {
 	}
 }
 
-func TestGetAppName(t *testing.T) {
-	tests := []struct {
-		name          string
-		labels        map[string]string
-		expectedValue string
-		expectedOk    bool
-	}{
-		{
-			name:          "empty labels",
-			labels:        map[string]string{},
-			expectedValue: "",
-			expectedOk:    false,
-		},
-		{
-			name: "canonical service label takes priority",
-			labels: map[string]string{
-				model.IstioCanonicalServiceLabelName: "canonical-name",
-				"app.kubernetes.io/name":             "k8s-name",
-				"app":                                "legacy-app",
-			},
-			expectedValue: "canonical-name",
-			expectedOk:    true,
-		},
-		{
-			name: "app.kubernetes.io/name takes priority over app",
-			labels: map[string]string{
-				"app.kubernetes.io/name": "k8s-name",
-				"app":                    "legacy-app",
-			},
-			expectedValue: "k8s-name",
-			expectedOk:    true,
-		},
-		{
-			name: "legacy app label works as fallback",
-			labels: map[string]string{
-				"app": "legacy-app",
-			},
-			expectedValue: "legacy-app",
-			expectedOk:    true,
-		},
-		{
-			name: "only app.kubernetes.io/name set",
-			labels: map[string]string{
-				"app.kubernetes.io/name": "k8s-name",
-			},
-			expectedValue: "k8s-name",
-			expectedOk:    true,
-		},
-		{
-			name: "unrelated labels only",
-			labels: map[string]string{
-				"foo": "bar",
-			},
-			expectedValue: "",
-			expectedOk:    false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			value, ok := GetAppName(tt.labels)
-			if value != tt.expectedValue {
-				t.Errorf("GetAppName() value = %v, want %v", value, tt.expectedValue)
-			}
-			if ok != tt.expectedOk {
-				t.Errorf("GetAppName() ok = %v, want %v", ok, tt.expectedOk)
-			}
-		})
-	}
-}
-
-func TestGetAppNameBackwardCompatible(t *testing.T) {
+func TestGetApp(t *testing.T) {
 	tests := []struct {
 		name          string
 		labels        map[string]string
@@ -235,12 +164,12 @@ func TestGetAppNameBackwardCompatible(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			value, ok := GetAppNameBackwardCompatible(tt.labels)
+			value, ok := GetApp(tt.labels)
 			if value != tt.expectedValue {
-				t.Errorf("GetAppNameBackwardCompatible() value = %v, want %v", value, tt.expectedValue)
+				t.Errorf("GetApp() value = %v, want %v", value, tt.expectedValue)
 			}
 			if ok != tt.expectedOk {
-				t.Errorf("GetAppNameBackwardCompatible() ok = %v, want %v", ok, tt.expectedOk)
+				t.Errorf("GetApp() ok = %v, want %v", ok, tt.expectedOk)
 			}
 		})
 	}

--- a/releasenotes/notes/58436.yaml
+++ b/releasenotes/notes/58436.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+issue:
+  - 58436
+releaseNotes:
+  - |
+    **Added** support for `app.kubernetes.io/name` and `service.istio.io/canonical-name` labels
+    when populating `source_app` and `destination_app` metric labels. The priority order is:
+    `app` (for backward compatibility), then `app.kubernetes.io/name`, then `service.istio.io/canonical-name`.
+    This allows users who only have `app.kubernetes.io/name` labels to have their metrics properly populated.


### PR DESCRIPTION
**Please provide a description of this PR:**
This change ensures that source_app, destination_app, source_version, and destination_version metric labels properly respect Kubernetes well-known labels (app.kubernetes.io/name and app.kubernetes.io/version) with the correct priority order:

For app name:
1. service.istio.io/canonical-name
2. app.kubernetes.io/name
3. app

For version:
1. service.istio.io/canonical-revision
2. app.kubernetes.io/version
3. version

The fix adds a GetAppName function to the labels package that uses the existing label priority lookup mechanism, and updates serviceClusterOrDefault in bootstrap/config.go to use this function instead of directly accessing the 'app' label.

This maintains backward compatibility while allowing users who only have app.kubernetes.io/name or app.kubernetes.io/version labels to have their metric labels properly populated.

Fixes #58436