### PR TITLE
Adapt TestInferencePoolMultipleTargetPorts test to Openshift

### DIFF
--- a/pkg/test/framework/components/crd/gateway.go
+++ b/pkg/test/framework/components/crd/gateway.go
@@ -109,7 +109,9 @@ func DeployGatewayAPIInferenceExtensionOrSkip(ctx framework.TestContext) {
 
 func DeployGatewayAPIInferenceExtension(ctx resource.Context) error {
 	cfg, _ := istio.DefaultConfig(ctx)
-	if !cfg.DeployGatewayAPI {
+	// Starting from Openshift 4.19 (1.32), GW API comes pre-installed and should not be deployed.
+	// But GatewayAPIInferenceExtension should be deployed on Openshift in any condition.
+	if !cfg.DeployGatewayAPI && !ctx.Settings().OpenShift {
 		return nil
 	}
 	if !SupportsGatewayAPI(ctx) {


### PR DESCRIPTION
**Please provide a description of this PR:**
Starting from Openshift 4.19 (1.32), GW API comes pre-installed and should not be deployed.
But GatewayAPIInferenceExtension should be deployed on Openshift in any condition.

Adding condition to make sure GatewayAPIInferenceExtension CRDs are being deployed during the test execution.