### PR TITLE
`istioctl`: Display proxy cert serial numbers with trailing zeros

### DIFF
--- a/istioctl/pkg/proxyconfig/testdata/config_dump_summary.txt
+++ b/istioctl/pkg/proxyconfig/testdata/config_dump_summary.txt
@@ -19,7 +19,7 @@ route/inbound-vip|8000|http|httpbin.default.svc.cluster.local     inbound|http|8
 
 RESOURCE NAME      TYPE           STATUS     VALID CERT     SERIAL NUMBER                        NOT AFTER                NOT BEFORE
 secret/default     Cert Chain     ACTIVE     false          6fbee254c22900615cb1f74e3d2f1713     2023-05-16T01:32:52Z     2023-05-15T01:30:52Z
-secret/ROOTCA      CA             ACTIVE     true           193a543fe2b0d9cd4847675394dfc54      2033-05-02T03:41:33Z     2023-05-05T03:41:33Z
+secret/ROOTCA      CA             ACTIVE     true           0193a543fe2b0d9cd4847675394dfc54     2033-05-02T03:41:33Z     2023-05-05T03:41:33Z
 
 NAME                                                       STATUS      LOCALITY     CLUSTER
 endpoint/envoy://connect_originate/192.168.195.248:800     HEALTHY                  inbound-vip|8100|http|httpbin.default.svc.cluster.local

--- a/istioctl/pkg/writer/compare/sds/util.go
+++ b/istioctl/pkg/writer/compare/sds/util.go
@@ -251,7 +251,7 @@ func secretMetaFromCert(rawCert []byte, trustDomain string) (SecretMeta, error) 
 
 	today := time.Now()
 	return SecretMeta{
-		SerialNumber: fmt.Sprintf("%x", cert.SerialNumber),
+		SerialNumber: fmt.Sprintf("%032x", cert.SerialNumber),
 		NotAfter:     cert.NotAfter.Format(time.RFC3339),
 		NotBefore:    cert.NotBefore.Format(time.RFC3339),
 		Type:         certType,

--- a/istioctl/pkg/writer/envoy/configdump/testdata/secret/istio/output
+++ b/istioctl/pkg/writer/envoy/configdump/testdata/secret/istio/output
@@ -1,4 +1,4 @@
 RESOURCE NAME              TYPE           STATUS      VALID CERT     SERIAL NUMBER                        NOT AFTER                NOT BEFORE
 configmap://some/thing                    WARMING     false                                                                        
 default                    Cert Chain     ACTIVE      false          6fbee254c22900615cb1f74e3d2f1713     2023-05-16T01:32:52Z     2023-05-15T01:30:52Z
-ROOTCA                     CA             ACTIVE      true           193a543fe2b0d9cd4847675394dfc54      2033-05-02T03:41:33Z     2023-05-05T03:41:33Z
+ROOTCA                     CA             ACTIVE      true           0193a543fe2b0d9cd4847675394dfc54     2033-05-02T03:41:33Z     2023-05-05T03:41:33Z


### PR DESCRIPTION
Updating `istioctl` formatting logic for proxy certificate serial numbers to have a consistent 32-character wide hex representation.

Fixes https://github.com/istio/istio/issues/58374.

### Before:
```bash
$ istioctl proxy-config secret <pod-name>
RESOURCE NAME     TYPE           STATUS     VALID CERT     SERIAL NUMBER                        NOT AFTER                NOT BEFORE
default           Cert Chain     ACTIVE     true           ee7d716482863d8695df536017081221     2025-12-02T09:50:29Z     2025-12-01T09:48:29Z
ROOTCA            CA             ACTIVE     true           6455047a209b71f9b068034c0311167      2035-09-23T08:56:50Z     2025-09-25T08:56:50Z
```

### After:
### Before:
```bash
$ istioctl proxy-config secret <pod-name>
RESOURCE NAME     TYPE           STATUS     VALID CERT     SERIAL NUMBER                        NOT AFTER                NOT BEFORE
default           Cert Chain     ACTIVE     true           ee7d716482863d8695df536017081221     2025-12-02T09:50:29Z     2025-12-01T09:48:29Z
ROOTCA            CA             ACTIVE     true           06455047a209b71f9b068034c0311167     2035-09-23T08:56:50Z     2025-09-25T08:56:50Z
```

**Please check any characteristics that apply to this pull request.**

Not sure if such a minor change warrants a release note 🤔 Let me know if I should add one.