### PR TITLE
refactor: use strings.Builder to improve performance

### DIFF
--- a/istioctl/pkg/describe/describe.go
+++ b/istioctl/pkg/describe/describe.go
@@ -1496,14 +1496,14 @@ func printConfigs(writer io.Writer, configs []*config.Config) {
 		return
 	}
 	fmt.Fprintf(writer, "Applied %s:\n", configs[0].Meta.GroupVersionKind.Kind)
-	var cfgNames string
+	var cfgNames strings.Builder
 	for i, cfg := range configs {
-		cfgNames += cfg.Meta.Name + "." + cfg.Meta.Namespace
+		cfgNames.WriteString(cfg.Meta.Name + "." + cfg.Meta.Namespace)
 		if i < len(configs)-1 {
-			cfgNames += ", "
+			cfgNames.WriteString(", ")
 		}
 	}
-	fmt.Fprintf(writer, "   %s\n", cfgNames)
+	fmt.Fprintf(writer, "   %s\n", cfgNames.String())
 }
 
 func printPeerAuthentication(writer io.Writer, pa authn.MergedPeerAuthentication) {

--- a/operator/pkg/util/errs.go
+++ b/operator/pkg/util/errs.go
@@ -16,6 +16,7 @@ package util
 
 import (
 	"fmt"
+	"strings"
 )
 
 const (
@@ -115,17 +116,17 @@ func AppendErrs(errors []error, newErrs []error) Errors {
 // ToString returns a string representation of errors, with elements separated by separator string. Any nil errors in the
 // slice are skipped.
 func ToString(errors []error, separator string) string {
-	var out string
+	var out strings.Builder
 	for i, e := range errors {
 		if e == nil {
 			continue
 		}
 		if i != 0 {
-			out += separator
+			out.WriteString(separator)
 		}
-		out += e.Error()
+		out.WriteString(e.Error())
 	}
-	return out
+	return out.String()
 }
 
 // EqualErrors reports whether a and b are equal, regardless of ordering.

--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -17,6 +17,7 @@ package model
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -1721,9 +1722,10 @@ func createNonTrivialRequestAuthnTestConfigs(issuer string) []*config.Config {
 }
 
 func printConfigs(configs []*config.Config) string {
-	s := "[\n"
+	var s strings.Builder
+	s.WriteString("[\n")
 	for _, c := range configs {
-		s += fmt.Sprintf("%+v\n", c)
+		s.WriteString(fmt.Sprintf("%+v\n", c))
 	}
-	return s + "]"
+	return s.String() + "]"
 }

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -413,16 +414,16 @@ func debounce(ch chan *model.PushRequest, stopCh <-chan struct{}, opts DebounceO
 }
 
 func configsUpdated(req *model.PushRequest) string {
-	configs := ""
+	var configs strings.Builder
 	for key := range req.ConfigsUpdated {
-		configs += key.String()
+		configs.WriteString(key.String())
 		break
 	}
 	if len(req.ConfigsUpdated) > 1 {
 		more := " and " + strconv.Itoa(len(req.ConfigsUpdated)-1) + " more configs"
-		configs += more
+		configs.WriteString(more)
 	}
-	return configs
+	return configs.String()
 }
 
 func reasonsUpdated(req *model.PushRequest) string {

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -320,7 +320,7 @@ func newEndpointWithAccount(ip, account, version string) []*model.IstioEndpoint 
 }
 
 func mustReadFile(t *testing.T, fpaths ...string) string {
-	result := ""
+	var result strings.Builder
 	for _, fpath := range fpaths {
 		if !strings.HasPrefix(fpath, ".") {
 			fpath = filepath.Join(env.IstioSrc, fpath)
@@ -329,14 +329,14 @@ func mustReadFile(t *testing.T, fpaths ...string) string {
 		if err != nil {
 			t.Fatal(err)
 		}
-		result += "---\n"
-		result += string(bytes)
+		result.WriteString("---\n")
+		result.WriteString(string(bytes))
 	}
-	return result
+	return result.String()
 }
 
 func mustReadfolder(t *testing.T, folder string) string {
-	result := ""
+	var result strings.Builder
 	fpathRoot := folder
 	if !strings.HasPrefix(fpathRoot, ".") {
 		fpathRoot = filepath.Join(env.IstioSrc, folder)
@@ -350,10 +350,10 @@ func mustReadfolder(t *testing.T, folder string) string {
 		if err != nil {
 			t.Fatal(err)
 		}
-		result += "---\n"
-		result += string(bytes)
+		result.WriteString("---\n")
+		result.WriteString(string(bytes))
 	}
-	return result
+	return result.String()
 }
 
 func TestEdsWeightedServiceEntry(t *testing.T) {

--- a/pilot/pkg/xds/mesh_network_test.go
+++ b/pilot/pkg/xds/mesh_network_test.go
@@ -514,7 +514,8 @@ spec:
 					for subset, eps := range tc.expectations {
 						client.ExpectWithWeight(&workload{kind: sc.expectKind, name: name, namespace: "test", port: port}, subset, eps...)
 					}
-					configObjects := `
+					var configObjects strings.Builder
+					configObjects.WriteString(`
 ---
 apiVersion: networking.istio.io/v1
 kind: DestinationRule
@@ -533,10 +534,10 @@ spec:
   - name: v3
     labels:
       version: v3
-`
-					configObjects += sc.cfg
+`)
+					configObjects.WriteString(sc.cfg)
 					for i, entry := range tc.entries {
-						configObjects += fmt.Sprintf(`
+						configObjects.WriteString(fmt.Sprintf(`
 ---
 apiVersion: networking.istio.io/v1
 kind: WorkloadEntry
@@ -550,12 +551,12 @@ spec:
   labels:
     app: remote-we-svc
     version: %q
-`, i, entry.address, entry.sa, entry.network, entry.version)
+`, i, entry.address, entry.sa, entry.network, entry.version))
 					}
 
 					runMeshNetworkingTest(t, meshNetworkingTest{
 						workloads:       []*workload{client},
-						configYAML:      configObjects,
+						configYAML:      configObjects.String(),
 						kubeObjectsYAML: map[cluster.ID]string{constants.DefaultClusterName: sc.k8s},
 						kubeObjects: map[cluster.ID][]runtime.Object{constants.DefaultClusterName: {
 							gatewaySvc("gateway-1", "1.1.1.1", "network-1"),

--- a/pkg/config/analysis/analyzers/multicluster/service.go
+++ b/pkg/config/analysis/analyzers/multicluster/service.go
@@ -17,6 +17,7 @@ package multicluster
 import (
 	"reflect"
 	"sort"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -126,14 +127,14 @@ func findInconsistencies(services map[cluster.ID]*resource.Instance) (clusters [
 		inconsistentClusters.Insert(firstCluster.String())
 	}
 	slices.Sort(inconsistentReasons.UnsortedList())
-	errStr := ""
+	var errStr strings.Builder
 	for i, err := range inconsistentReasons.UnsortedList() {
-		errStr += err
+		errStr.WriteString(err)
 		if i < len(inconsistentReasons)-1 {
-			errStr += "; "
+			errStr.WriteString("; ")
 		}
 	}
-	return inconsistentClusters.UnsortedList(), errStr
+	return inconsistentClusters.UnsortedList(), errStr.String()
 }
 
 func compareServicePorts(a, b []corev1.ServicePort) bool {

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -292,13 +292,13 @@ func injectRequired(ignored []string, config *Config, podSpec *corev1.PodSpec, m
 
 	if log.DebugEnabled() {
 		// Build a log message for the annotations.
-		annotationStr := ""
+		var annotationStr strings.Builder
 		for name := range AnnotationValidation {
 			value, ok := annos[name]
 			if !ok {
 				value = "(unset)"
 			}
-			annotationStr += fmt.Sprintf("%s:%s ", name, value)
+			annotationStr.WriteString(fmt.Sprintf("%s:%s ", name, value))
 		}
 
 		log.Debugf("Sidecar injection policy for %v/%v: namespacePolicy:%v useDefault:%v inject:%v required:%v %s",
@@ -308,7 +308,7 @@ func injectRequired(ignored []string, config *Config, podSpec *corev1.PodSpec, m
 			useDefault,
 			inject,
 			required,
-			annotationStr)
+			annotationStr.String())
 	}
 
 	return required

--- a/pkg/test/echo/responses.go
+++ b/pkg/test/echo/responses.go
@@ -16,6 +16,7 @@ package echo
 
 import (
 	"fmt"
+	"strings"
 )
 
 // Responses is an ordered list of parsed response objects.
@@ -51,9 +52,9 @@ func (r Responses) Match(f func(r Response) bool) Responses {
 }
 
 func (r Responses) String() string {
-	out := ""
+	var out strings.Builder
 	for i, resp := range r {
-		out += fmt.Sprintf("Response[%d]:\n%s", i, resp.String())
+		out.WriteString(fmt.Sprintf("Response[%d]:\n%s", i, resp.String()))
 	}
-	return out
+	return out.String()
 }

--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -259,11 +259,11 @@ func (c *Config) fillDefaults(ctx resource.Context) {
 // Indent indents a block of text with an indent string
 func Indent(text, indent string) string {
 	if text[len(text)-1:] == "\n" {
-		result := ""
+		var result strings.Builder
 		for _, j := range strings.Split(text[:len(text)-1], "\n") {
-			result += indent + j + "\n"
+			result.WriteString(indent + j + "\n")
 		}
-		return result
+		return result.String()
 	}
 	result := ""
 	for _, j := range strings.Split(strings.TrimRight(text, "\n"), "\n") {

--- a/pkg/test/util/structpath/instance.go
+++ b/pkg/test/util/structpath/instance.go
@@ -325,13 +325,14 @@ func (i *Instance) fixPath(path string) string {
 		input = strings.Replace(input, "]", "", 1)
 		input = strings.Replace(input, "'", "", 2)
 		parts := strings.Split(input, ".")
-		output := "."
+		var output strings.Builder
+		output.WriteString(".")
 		for i := 0; i < len(parts)-1; i++ {
-			output += parts[i]
-			output += "\\."
+			output.WriteString(parts[i])
+			output.WriteString("\\.")
 		}
-		output += parts[len(parts)-1]
-		return []byte(output)
+		output.WriteString(parts[len(parts)-1])
+		return []byte(output.String())
 	}))
 
 	return result

--- a/pkg/version/cobra_test.go
+++ b/pkg/version/cobra_test.go
@@ -171,16 +171,16 @@ func printMeshVersion(meshInfo *MeshInfo, kind outputKind) string {
 		return string(res)
 	}
 
-	res := ""
+	var res strings.Builder
 	for _, info := range *meshInfo {
 		switch kind {
 		case rawOutputMock:
-			res += fmt.Sprintf("%s version: %#v\n", info.Component, info.Info)
+			res.WriteString(fmt.Sprintf("%s version: %#v\n", info.Component, info.Info))
 		case shortOutputMock:
-			res += fmt.Sprintf("%s version: %s\n", info.Component, info.Info.Version)
+			res.WriteString(fmt.Sprintf("%s version: %s\n", info.Component, info.Info.Version))
 		}
 	}
-	return res
+	return res.String()
 }
 
 func TestVersion(t *testing.T) {

--- a/tools/bug-report/pkg/cluster/cluster.go
+++ b/tools/bug-report/pkg/cluster/cluster.go
@@ -197,14 +197,14 @@ func isIncludeOrExcludeEntriesMatched(entries []string, term string) bool {
 }
 
 func entryPatternToRegexp(pattern string) string {
-	var reg string
+	var reg strings.Builder
 	for i, literal := range strings.Split(pattern, "*") {
 		if i > 0 {
-			reg += ".*"
+			reg.WriteString(".*")
 		}
-		reg += regexp.QuoteMeta(literal)
+		reg.WriteString(regexp.QuoteMeta(literal))
 	}
-	return reg
+	return reg.String()
 }
 
 // GetClusterResources returns cluster resources for the given REST config and k8s Clientset.
@@ -358,17 +358,17 @@ func (r *Resources) String() string {
 }
 
 func resourcesStringImpl(node any, prefix string) string {
-	out := ""
+	var out strings.Builder
 	if node == nil {
 		return ""
 	}
 	nv := node.(map[string]any)
 	for k, n := range nv {
-		out += prefix + k + "\n"
-		out += resourcesStringImpl(n, prefix+"  ")
+		out.WriteString(prefix + k + "\n")
+		out.WriteString(resourcesStringImpl(n, prefix+"  "))
 	}
 
-	return out
+	return out.String()
 }
 
 // PodKey returns a unique key based on the namespace and pod name.


### PR DESCRIPTION
**Please provide a description of this PR:**

strings.Builder has fewer memory allocations and better performance.
More info: [golang/go#75190](https://github.com/golang/go/issues/75190)