### PR TITLE
Enable ambient reconcile iptables on startup bydefault

### DIFF
--- a/manifests/charts/base/files/profile-compatibility-version-1.25.yaml
+++ b/manifests/charts/base/files/profile-compatibility-version-1.25.yaml
@@ -11,6 +11,12 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
      # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.25
+    reconcileIptablesOnStartup: false
+
 ambient:
   # 1.26 behavioral changes
   shareHostNetworkNamespace: true

--- a/manifests/charts/base/files/profile-compatibility-version-1.26.yaml
+++ b/manifests/charts/base/files/profile-compatibility-version-1.26.yaml
@@ -11,3 +11,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.26
+    reconcileIptablesOnStartup: false

--- a/manifests/charts/base/files/profile-compatibility-version-1.27.yaml
+++ b/manifests/charts/base/files/profile-compatibility-version-1.27.yaml
@@ -9,3 +9,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.27
+    reconcileIptablesOnStartup: false

--- a/manifests/charts/base/files/profile-compatibility-version-1.28.yaml
+++ b/manifests/charts/base/files/profile-compatibility-version-1.28.yaml
@@ -6,3 +6,8 @@ pilot:
   env:
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.28
+    reconcileIptablesOnStartup: false

--- a/manifests/charts/default/files/profile-compatibility-version-1.25.yaml
+++ b/manifests/charts/default/files/profile-compatibility-version-1.25.yaml
@@ -11,6 +11,12 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
      # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.25
+    reconcileIptablesOnStartup: false
+
 ambient:
   # 1.26 behavioral changes
   shareHostNetworkNamespace: true

--- a/manifests/charts/default/files/profile-compatibility-version-1.26.yaml
+++ b/manifests/charts/default/files/profile-compatibility-version-1.26.yaml
@@ -11,3 +11,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.26
+    reconcileIptablesOnStartup: false

--- a/manifests/charts/default/files/profile-compatibility-version-1.27.yaml
+++ b/manifests/charts/default/files/profile-compatibility-version-1.27.yaml
@@ -9,3 +9,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.27
+    reconcileIptablesOnStartup: false

--- a/manifests/charts/default/files/profile-compatibility-version-1.28.yaml
+++ b/manifests/charts/default/files/profile-compatibility-version-1.28.yaml
@@ -6,3 +6,8 @@ pilot:
   env:
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.28
+    reconcileIptablesOnStartup: false

--- a/manifests/charts/gateway/files/profile-compatibility-version-1.25.yaml
+++ b/manifests/charts/gateway/files/profile-compatibility-version-1.25.yaml
@@ -11,6 +11,12 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
      # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.25
+    reconcileIptablesOnStartup: false
+
 ambient:
   # 1.26 behavioral changes
   shareHostNetworkNamespace: true

--- a/manifests/charts/gateway/files/profile-compatibility-version-1.26.yaml
+++ b/manifests/charts/gateway/files/profile-compatibility-version-1.26.yaml
@@ -11,3 +11,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.26
+    reconcileIptablesOnStartup: false

--- a/manifests/charts/gateway/files/profile-compatibility-version-1.27.yaml
+++ b/manifests/charts/gateway/files/profile-compatibility-version-1.27.yaml
@@ -9,3 +9,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.27
+    reconcileIptablesOnStartup: false

--- a/manifests/charts/gateway/files/profile-compatibility-version-1.28.yaml
+++ b/manifests/charts/gateway/files/profile-compatibility-version-1.28.yaml
@@ -6,3 +6,8 @@ pilot:
   env:
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.28
+    reconcileIptablesOnStartup: false

--- a/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.25.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.25.yaml
@@ -11,6 +11,12 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
      # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.25
+    reconcileIptablesOnStartup: false
+
 ambient:
   # 1.26 behavioral changes
   shareHostNetworkNamespace: true

--- a/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.26.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.26.yaml
@@ -11,3 +11,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.26
+    reconcileIptablesOnStartup: false

--- a/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.27.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.27.yaml
@@ -9,3 +9,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.27
+    reconcileIptablesOnStartup: false

--- a/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.28.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.28.yaml
@@ -6,3 +6,8 @@ pilot:
   env:
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.28
+    reconcileIptablesOnStartup: false

--- a/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.25.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.25.yaml
@@ -11,6 +11,12 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
      # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.25
+    reconcileIptablesOnStartup: false
+
 ambient:
   # 1.26 behavioral changes
   shareHostNetworkNamespace: true

--- a/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.26.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.26.yaml
@@ -11,3 +11,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.26
+    reconcileIptablesOnStartup: false

--- a/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.27.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.27.yaml
@@ -9,3 +9,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.27
+    reconcileIptablesOnStartup: false

--- a/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.28.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.28.yaml
@@ -6,3 +6,8 @@ pilot:
   env:
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.28
+    reconcileIptablesOnStartup: false

--- a/manifests/charts/istio-cni/files/profile-compatibility-version-1.25.yaml
+++ b/manifests/charts/istio-cni/files/profile-compatibility-version-1.25.yaml
@@ -11,6 +11,12 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
      # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.25
+    reconcileIptablesOnStartup: false
+
 ambient:
   # 1.26 behavioral changes
   shareHostNetworkNamespace: true

--- a/manifests/charts/istio-cni/files/profile-compatibility-version-1.26.yaml
+++ b/manifests/charts/istio-cni/files/profile-compatibility-version-1.26.yaml
@@ -11,3 +11,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.26
+    reconcileIptablesOnStartup: false

--- a/manifests/charts/istio-cni/files/profile-compatibility-version-1.27.yaml
+++ b/manifests/charts/istio-cni/files/profile-compatibility-version-1.27.yaml
@@ -9,3 +9,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.27
+    reconcileIptablesOnStartup: false

--- a/manifests/charts/istio-cni/files/profile-compatibility-version-1.28.yaml
+++ b/manifests/charts/istio-cni/files/profile-compatibility-version-1.28.yaml
@@ -6,3 +6,8 @@ pilot:
   env:
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.28
+    reconcileIptablesOnStartup: false

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -71,8 +71,8 @@ _internal_defaults_do_not_set:
     # If enabled, and ambient is enabled, enables ipv6 support
     ipv6: true
     # If enabled, and ambient is enabled, the CNI agent will reconcile incompatible iptables rules and chains at startup.
-    # This will eventually be enabled by default
-    reconcileIptablesOnStartup: false
+    # This is enabled by default
+    reconcileIptablesOnStartup: true
     # If enabled, and ambient is enabled, the CNI agent will always share the network namespace of the host node it is running on
     shareHostNetworkNamespace: false
 

--- a/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.25.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.25.yaml
@@ -11,6 +11,12 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
      # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.25
+    reconcileIptablesOnStartup: false
+
 ambient:
   # 1.26 behavioral changes
   shareHostNetworkNamespace: true

--- a/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.26.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.26.yaml
@@ -11,3 +11,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.26
+    reconcileIptablesOnStartup: false

--- a/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.27.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.27.yaml
@@ -9,3 +9,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.27
+    reconcileIptablesOnStartup: false

--- a/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.28.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.28.yaml
@@ -6,3 +6,8 @@ pilot:
   env:
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.28
+    reconcileIptablesOnStartup: false

--- a/manifests/charts/ztunnel/files/profile-compatibility-version-1.25.yaml
+++ b/manifests/charts/ztunnel/files/profile-compatibility-version-1.25.yaml
@@ -11,6 +11,12 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
      # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.25
+    reconcileIptablesOnStartup: false
+
 ambient:
   # 1.26 behavioral changes
   shareHostNetworkNamespace: true

--- a/manifests/charts/ztunnel/files/profile-compatibility-version-1.26.yaml
+++ b/manifests/charts/ztunnel/files/profile-compatibility-version-1.26.yaml
@@ -11,3 +11,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.26
+    reconcileIptablesOnStartup: false

--- a/manifests/charts/ztunnel/files/profile-compatibility-version-1.27.yaml
+++ b/manifests/charts/ztunnel/files/profile-compatibility-version-1.27.yaml
@@ -9,3 +9,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.27
+    reconcileIptablesOnStartup: false

--- a/manifests/charts/ztunnel/files/profile-compatibility-version-1.28.yaml
+++ b/manifests/charts/ztunnel/files/profile-compatibility-version-1.28.yaml
@@ -6,3 +6,8 @@ pilot:
   env:
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.28
+    reconcileIptablesOnStartup: false

--- a/manifests/helm-profiles/compatibility-version-1.25.yaml
+++ b/manifests/helm-profiles/compatibility-version-1.25.yaml
@@ -7,6 +7,12 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
      # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.25
+    reconcileIptablesOnStartup: false
+
 ambient:
   # 1.26 behavioral changes
   shareHostNetworkNamespace: true

--- a/manifests/helm-profiles/compatibility-version-1.26.yaml
+++ b/manifests/helm-profiles/compatibility-version-1.26.yaml
@@ -7,3 +7,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.26
+    reconcileIptablesOnStartup: false

--- a/manifests/helm-profiles/compatibility-version-1.27.yaml
+++ b/manifests/helm-profiles/compatibility-version-1.27.yaml
@@ -5,3 +5,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.27
+    reconcileIptablesOnStartup: false

--- a/manifests/helm-profiles/compatibility-version-1.28.yaml
+++ b/manifests/helm-profiles/compatibility-version-1.28.yaml
@@ -2,3 +2,8 @@ pilot:
   env:
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+
+cni:
+  ambient:
+    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.28
+    reconcileIptablesOnStartup: false

--- a/releasenotes/notes/ambient-dns-on.yaml
+++ b/releasenotes/notes/ambient-dns-on.yaml
@@ -8,7 +8,7 @@ releaseNotes:
     **Promoted** the `cni.ambient.dnsCapture` value to default to `true`.
     This enables the DNS proxying for workloads in ambient mesh by default, improving security, performance, and enabling
     a number of features. This can be disabled explicitly or with `compatibilityVersion=1.24`.
-    Note: only new pods will have DNS enabled. To enable for existing pods, pods must be manually restarted, or the iptables reconcilation feature must be enabled with `--set cni.ambient.reconcileIptablesOnStartup=false`.
+    Note: only new pods will have DNS enabled. To enable for existing pods, pods must be manually restarted, or the iptables reconcilation feature must be enabled with `--set cni.ambient.reconcileIptablesOnStartup=true`.
 
 upgradeNotes:
   - title: Ambient DNS capture on by default

--- a/releasenotes/notes/reconcile-iptables-default-true.yaml
+++ b/releasenotes/notes/reconcile-iptables-default-true.yaml
@@ -6,10 +6,11 @@ releaseNotes:
   **Promoted** `cni.ambient.reconcileIptablesOnStartup` to default to `true`.
   This enables automatic reconciliation of iptables rules for existing ambient pods when the `istio-cni` DaemonSet is upgraded,
   eliminating the need to manually restart pods to get updated networking configuration.
+  This can be disabled explicitly or by using `compatibilityVersion=1.28`.
 
 upgradeNotes:
   - title: Ambient iptables reconciliation enabled by default
     content: |
-        Iptables reconciliation is now enabled by default for ambient workloads in this release. When a new `istio-cni` DaemonSet pod starts up,
+        Iptables reconciliation is now enabled by default for ambient workloads in release 1.29.0. When a new `istio-cni` DaemonSet pod starts up,
         it will automatically inspect pods that were previously enrolled in the ambient mesh and upgrade their in-pod iptables rules to the current state
         if there are any differences. This feature can be disabled explicitly with `--set cni.ambient.reconcileIptablesOnStartup=false`.

--- a/releasenotes/notes/reconcile-iptables-default-true.yaml
+++ b/releasenotes/notes/reconcile-iptables-default-true.yaml
@@ -1,0 +1,15 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+- |
+  **Promoted** `cni.ambient.reconcileIptablesOnStartup` to default to `true`.
+  This enables automatic reconciliation of iptables rules for existing ambient pods when the `istio-cni` DaemonSet is upgraded,
+  eliminating the need to manually restart pods to get updated networking configuration.
+
+upgradeNotes:
+  - title: Ambient iptables reconciliation enabled by default
+    content: |
+        Iptables reconciliation is now enabled by default for ambient workloads in this release. When a new `istio-cni` DaemonSet pod starts up,
+        it will automatically inspect pods that were previously enrolled in the ambient mesh and upgrade their in-pod iptables rules to the current state
+        if there are any differences. This feature can be disabled explicitly with `--set cni.ambient.reconcileIptablesOnStartup=false`.

--- a/releasenotes/notes/reconcile-iptables-default-true.yaml
+++ b/releasenotes/notes/reconcile-iptables-default-true.yaml
@@ -4,7 +4,7 @@ area: traffic-management
 releaseNotes:
 - |
   **Promoted** `cni.ambient.reconcileIptablesOnStartup` to default to `true`.
-  This enables automatic reconciliation of iptables rules for existing ambient pods when the `istio-cni` DaemonSet is upgraded,
+  This enables automatic reconciliation of iptables/nftables rules for existing ambient pods when the `istio-cni` DaemonSet is upgraded,
   eliminating the need to manually restart pods to get updated networking configuration.
   This can be disabled explicitly or by using `compatibilityVersion=1.28`.
 
@@ -12,5 +12,5 @@ upgradeNotes:
   - title: Ambient iptables reconciliation enabled by default
     content: |
         Iptables reconciliation is now enabled by default for ambient workloads in release 1.29.0. When a new `istio-cni` DaemonSet pod starts up,
-        it will automatically inspect pods that were previously enrolled in the ambient mesh and upgrade their in-pod iptables rules to the current state
+        it will automatically inspect pods that were previously enrolled in the ambient mesh and upgrade their in-pod iptables/nftables rules to the current state
         if there are any differences. This feature can be disabled explicitly with `--set cni.ambient.reconcileIptablesOnStartup=false`.


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR changes the default value of `cni.ambient.reconcileIptablesOnStartup` from false to true, enabling automatic iptables reconciliation for existing ambient pods when istio-cni is upgraded.

As documented in issue #56729, the current default behaviour (false) causes connectivity loss in ambient mesh during common infrastructure events like node reboots. The failure consistently occurs when ambient-enabled application pods and the istio-cni DaemonSet pod restart on the same worker node after OS reboots.

The root cause is the loss of in-pod iptables rules necessary for Ambient Mesh redirection. When `reconcileIptablesOnStartup` is false (current default), the istio-cni agent does not inspect or re-apply network configuration to existing ambient pods upon startup, resulting in broken data plane connectivity when the pod's network namespace state is reset.

Since this breaks core Ambient Mesh functionality during some regular cluster maintenance scenarios, this PR enables the reconciliation feature by default to ensure ambient mesh reliability, also the original release note from [1.25.0](https://istio.io/latest/news/releases/1.25.x/announcing-1.25/upgrade-notes/#ambient-mode-pod-upgrade-reconciliation) mentions that this will be enable by default in the future, it passed already 3 minor releases, so I think is safe to enable by default.

Changes done:
  - Set `reconcileIptablesOnStartup: true` in CNI values.yaml
  - Add release notes documenting the change
  - Fix typo in ambient-dns-on.yaml release notes (false → true)

Fixes #56729