### PR TITLE
chore: make the gen file more firendly to gofumpt

### DIFF
--- a/pkg/config/xds/filter_types.gen.go
+++ b/pkg/config/xds/filter_types.gen.go
@@ -1,4 +1,5 @@
 //go:build !agent
+
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/config/xds/filter_types.go
+++ b/pkg/config/xds/filter_types.go
@@ -15,6 +15,7 @@
 // nolint: lll
 //
 //go:generate sh -c "echo '//go:build !agent' > filter_types.gen.go"
+//go:generate sh -c "echo '' >> filter_types.gen.go"
 //go:generate sh -c "echo '// Copyright Istio Authors' >> filter_types.gen.go"
 //go:generate sh -c "echo '//' >> filter_types.gen.go"
 //go:generate sh -c "echo '// Licensed under the Apache License, Version 2.0 (the \"License\");' >> filter_types.gen.go"


### PR DESCRIPTION
**Please provide a description of this PR:**

with this `gofumpt -l -w .` won't change the `fiter_types.gen.go`