### PR TITLE
telemetry: fix stats eviction interval format

### DIFF
--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"istio.io/api/annotation"
@@ -343,7 +344,8 @@ func getStatsOptions(meta *model.BootstrapNodeMetadata) []option.Instance {
 		} else if statsEvictionInterval%statsFlushInterval != 0 {
 			log.Warnf("StatsEvictionInterval must be a multiple of the StatsFlushInterval")
 		} else {
-			options = append(options, option.EnvoyStatsEvictionInterval(statsEvictionInterval))
+			duration := &durationpb.Duration{Seconds: int64(statsEvictionInterval.Seconds())}
+			options = append(options, option.EnvoyStatsEvictionInterval(duration))
 		}
 	}
 

--- a/pkg/bootstrap/option/instance.go
+++ b/pkg/bootstrap/option/instance.go
@@ -123,8 +123,15 @@ func newOptionOrSkipIfZero(name Name, value any) *instance {
 	return newOption(name, value)
 }
 
+// Create an option with a time.Duration-compatible stringified format (hours, minutes, seconds, etc)
 func newDurationOption(name Name, value *durationpb.Duration) *instance {
 	return newOptionOrSkipIfZero(name, value).withConvert(durationConverter(value))
+}
+
+// Create an option with a protobuf Duration-compatible stringified format
+// (seconds and nanoseconds) as accepted by Envoy's protobuf json parser
+func newEnvoyDurationOption(name Name, value *durationpb.Duration) *instance {
+	return newOptionOrSkipIfZero(name, value).withConvert(envoyDurationConverter(value))
 }
 
 func newTCPKeepaliveOption(name Name, value *networkingAPI.ConnectionPoolSettings_TCPSettings_TcpKeepalive) *instance {

--- a/pkg/bootstrap/option/instances.go
+++ b/pkg/bootstrap/option/instances.go
@@ -308,6 +308,6 @@ func EnvoyStatsFlushInterval(interval time.Duration) Instance {
 	return newOption("stats_flush_interval", interval)
 }
 
-func EnvoyStatsEvictionInterval(interval time.Duration) Instance {
-	return newOption("stats_eviction_interval", interval)
+func EnvoyStatsEvictionInterval(interval *durationpb.Duration) Instance {
+	return newEnvoyDurationOption("stats_eviction_interval", interval)
 }

--- a/pkg/bootstrap/option/instances_test.go
+++ b/pkg/bootstrap/option/instances_test.go
@@ -647,6 +647,24 @@ func TestOptions(t *testing.T) {
 			}, &model.BootstrapNodeMetadata{}, false),
 			expected: `{"name":"envoy.transport_sockets.tls","typed_config":{"@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext","common_tls_context":{"combined_validation_context":{"default_validation_context":{},"validation_context_sds_secret_config":{"name":"file-root:/etc/tracing/ca.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}}}}}`,
 		},
+		{
+			testName: "stats eviction interval normal",
+			key:      "stats_eviction_interval",
+			option:   option.EnvoyStatsEvictionInterval(durationpb.New(time.Second * 10)),
+			expected: "10s",
+		},
+		{
+			testName: "stats eviction interval fractional",
+			key:      "stats_eviction_interval",
+			option:   option.EnvoyStatsEvictionInterval(durationpb.New(time.Second*2 + time.Millisecond*5)),
+			expected: "2.005000000s",
+		},
+		{
+			testName: "stats eviction interval longer than 60s",
+			key:      "stats_eviction_interval",
+			option:   option.EnvoyStatsEvictionInterval(durationpb.New(time.Second * 120)),
+			expected: "120s",
+		},
 	}
 
 	for _, c := range cases {

--- a/releasenotes/notes/58518.yaml
+++ b/releasenotes/notes/58518.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: telemetry
+issue:
+  - https://github.com/istio/istio/issues/58500
+releaseNotes:
+- |
+  **Fixed** `sidecar.istio.io/statsEvictionInterval` annotation with values >= 60s
+  causing `istio-proxy` sidecars to fail to start.


### PR DESCRIPTION
**Please provide a description of this PR:**

The annotation `sidecar.istio.io/statsEvictionInterval` added in #57736 is incorrectly translated to Envoy bootstrap configuration `stats_eviction_interval` if it is set to a value >= 60s.

Istio will translate an annotation value like "120s" or "2m" into an Envoy `stats_eviction_interval` option of "2m0s". But Envoy expects a protocol buffers Duration type that only supports a "s" suffix so parsing fails with an error like:

    error `Unable to parse JSON as proto (INVALID_ARGUMENT: invalid JSON in envoy.config.bootstrap.v3.Bootstrap @ stats_eviction_interval:   message google.protobuf.Duration, near  39:30 (offset 4137): duration must end with a single 's'): {

Fix by adding a new `envoyDurationConverter` that emits values in the desired format.

Also change the option to use a protocol buffers duration type for consistency with existing `ConnectTimeout` option and its `newDurationOption` helper.

Fixes istio/istio#58500

Added a few simple tests that pass

```
➜  istio git:(fix-stats-eviction-interval-durations) go test --timeout=0 ./pkg/bootstrap/option/...
ok  	istio.io/istio/pkg/bootstrap/option	0.030s
```