### PR TITLE
optimize configmeta generation

### DIFF
--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -368,26 +368,15 @@ func BuildConfigInfoMetadata(config config.Meta) *core.Metadata {
 
 // AddConfigInfoMetadata adds name.namespace of the config, the type, etc
 // to the given core.Metadata struct, if metadata is not initialized, build a new metadata.
-func AddConfigInfoMetadata(metadata *core.Metadata, cfg config.Meta) *core.Metadata {
+func AddConfigInfoMetadata(metadata *core.Metadata, config config.Meta) *core.Metadata {
 	if metadata == nil {
 		metadata = &core.Metadata{
 			FilterMetadata: make(map[string]*structpb.Struct, 1),
 		}
 	}
 
-	// Use strings.Builder to avoid intermediate string allocations
-	var sb strings.Builder
-	sb.Grow(128) // Pre-allocate reasonable capacity for the path
-	sb.WriteString("/apis/")
-	sb.WriteString(cfg.GroupVersionKind.Group)
-	sb.WriteByte('/')
-	sb.WriteString(cfg.GroupVersionKind.Version)
-	sb.WriteString("/namespaces/")
-	sb.WriteString(cfg.Namespace)
-	sb.WriteByte('/')
-	sb.WriteString(getKebabKind(cfg.GroupVersionKind.Kind)) // Use cached conversion
-	sb.WriteByte('/')
-	sb.WriteString(cfg.Name)
+	s := "/apis/" + config.GroupVersionKind.Group + "/" + config.GroupVersionKind.Version + "/namespaces/" + config.Namespace + "/" +
+		getKebabKind(config.GroupVersionKind.Kind) + "/" + config.Name
 
 	istioMeta, ok := metadata.FilterMetadata[IstioMetadataKey]
 	if !ok {
@@ -398,7 +387,7 @@ func AddConfigInfoMetadata(metadata *core.Metadata, cfg config.Meta) *core.Metad
 	}
 	istioMeta.Fields["config"] = &structpb.Value{
 		Kind: &structpb.Value_StringValue{
-			StringValue: sb.String(),
+			StringValue: s,
 		},
 	}
 	return metadata

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -1904,4 +1904,14 @@ func BenchmarkAddConfigInfoMetadata(b *testing.B) {
 			_ = AddConfigInfoMetadata(meta, cfg)
 		}
 	})
+
+	b.Run("MultipleConfigs", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			for _, cfg := range configs {
+				_ = AddConfigInfoMetadata(nil, cfg)
+			}
+		}
+	})
 }


### PR DESCRIPTION
This is another hot area highlighted in https://github.com/istio/istio/issues/58180#issuecomment-3600100549
```
Before
=====
BenchmarkAddConfigInfoMetadata/NilMetadata-16         	 4707439	       251.0 ns/op	     880 B/op	      11 allocs/op
BenchmarkAddConfigInfoMetadata/ExistingMetadata-16    	 6112737	       196.2 ns/op	     560 B/op	       8 allocs/op
BenchmarkAddConfigInfoMetadata/MultipleConfigs-16     	 1574654	       768.8 ns/op	    2616 B/op	      33 allocs/op

After
====
BenchmarkAddConfigInfoMetadata/NilMetadata-16         	 5645382	       205.7 ns/op	     800 B/op	       9 allocs/op
BenchmarkAddConfigInfoMetadata/ExistingMetadata-16    	 8008394	       150.9 ns/op	     480 B/op	       6 allocs/op
BenchmarkAddConfigInfoMetadata/MultipleConfigs-16     	 1830937	       649.2 ns/op	    2384 B/op	      27 allocs/op
```

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions