### PR TITLE
Make TestZipkinConfigDump compatible with legacy config

### DIFF
--- a/tests/integration/telemetry/tracing/zipkin/config_test.go
+++ b/tests/integration/telemetry/tracing/zipkin/config_test.go
@@ -121,7 +121,16 @@ func verifyZipkinTracingExists(t framework.TestContext, configDump *admin.Config
 					// Verify HttpService with timeout and headers
 					httpService := zipkinConfig.GetCollectorService()
 					if httpService == nil {
-						t.Fatal("HttpService is nil - timeout and headers not configured")
+						// Check if this is legacy configuration (proxy < 1.29)
+						if zipkinConfig.CollectorCluster != "" || zipkinConfig.CollectorEndpoint != "" || zipkinConfig.CollectorHostname != "" {
+							t.Log("Using legacy Zipkin configuration (proxy < 1.29) - timeout and headers not supported")
+							t.Logf("CollectorCluster: %s", zipkinConfig.CollectorCluster)
+							t.Logf("CollectorEndpoint: %s", zipkinConfig.CollectorEndpoint)
+							t.Logf("CollectorHostname: %s", zipkinConfig.CollectorHostname)
+							// Legacy configuration is valid, just skip timeout/headers validation
+							break
+						}
+						t.Fatal("HttpService is nil and no legacy fields configured")
 						return // Satisfy static analyzer (unreachable but makes linter happy)
 					}
 					t.Log("Using HttpService (supports timeout/headers)")


### PR DESCRIPTION
**Please provide a description of this PR:**
The TestZipkinConfigDump test fails when running with proxy versions < 1.29 because it expected HttpService to be configured, but legacy Zipkin configuration (used for proxy < 1.29) uses CollectorCluster, CollectorEndpoint, and CollectorHostname fields instead.
If HttpService is not detected, but CollectorCluster, CollectorEndpoint and CollectorHostname fields are detected, use legacy config.

This change:
- Detects when HttpService is nil and checks for legacy Zipkin fields
- Logs legacy configuration details instead of failing the test
- Maintains backward compatibility while still validating modern HttpService configuration for newer proxies (≥ 1.29)