### PR TITLE
Add missing Pilot environment variable when enabling untaint controller (#52050)

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -192,6 +192,10 @@ spec:
           - name: PILOT_TRACE_SAMPLING
             value: "{{ .Values.traceSampling }}"
 {{- end }}
+{{- if .Values.taint.enabled }}
+          - name: PILOT_ENABLE_NODE_UNTAINT_CONTROLLERS
+            value: "true"
+{{- end }}
 # If externalIstiod is set via Values.Global, then enable the pilot env variable. However, if it's set via Values.pilot.env, then
 # don't set it here to avoid duplication.
 # TODO (nshankar13): Move from Helm chart to code: https://github.com/istio/istio/issues/52449

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -43,6 +43,7 @@ _internal_defaults_do_not_set:
   # It should be noted that cluster operator/owner is responsible for having the taint set by their infrastructure provider when new nodes are added to the cluster; the untaint controller does not taint nodes
   taint:
     # Controls whether or not the untaint controller is active
+    # When enabled, this automatically sets PILOT_ENABLE_NODE_UNTAINT_CONTROLLERS environment variable to true in the istiod deployment.
     enabled: false
     # What namespace the untaint controller should watch for istio-cni pods. This is only required when istio-cni is running in a different namespace than istiod
     namespace: ""
@@ -367,7 +368,7 @@ _internal_defaults_do_not_set:
 
       #If set to true, istio-proxy container will have privileged securityContext
       privileged: false
-      
+
       seccompProfile: {}
 
       # The number of successive failed probes before indicating readiness failure.
@@ -571,7 +572,7 @@ _internal_defaults_do_not_set:
   #         type: ClusterIP
   # Per-Gateway configuration can also be set in the `Gateway.spec.infrastructure.parametersRef` field.
   gatewayClasses: {}
-  
+
   pdb:
     # -- Minimum available pods set in PodDisruptionBudget.
     # Define either 'minAvailable' or 'maxUnavailable', never both.

--- a/releasenotes/notes/helm-fix-untaint-controller.yaml
+++ b/releasenotes/notes/helm-fix-untaint-controller.yaml
@@ -1,0 +1,12 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+  - 52050
+releaseNotes:
+  - |
+    **Fixed** missing `PILOT_ENABLE_NODE_UNTAINT_CONTROLLERS` environment variable in `istiod` deployment when enabling untaint controller.
+upgradeNotes:
+  - title: Untaint controller
+    content: |
+      If you enabled untaint controller using `taint.enabled` Helm value when deploying `istiod` chart, you previously also had to set the `PILOT_ENABLE_NODE_UNTAINT_CONTROLLERS` environment variable in the `istiod` deployment to `true`. This is no longer required, as the variable is now set automatically when the untaint controller is enabled.

--- a/tests/integration/ambient/untaint/main_test.go
+++ b/tests/integration/ambient/untaint/main_test.go
@@ -55,8 +55,6 @@ values:
     taint:
       enabled: true
       namespace: "%s"
-    env:
-      PILOT_ENABLE_NODE_UNTAINT_CONTROLLERS: "true"
   ztunnel:
     terminationGracePeriodSeconds: 5
     env:


### PR DESCRIPTION
**Please provide a description of this PR:**

When enabling untaint controller in istiod Helm chart (by setting `taint.enabled` to true), an environment variable is missing for it to work. This PR adds this missing environment variable.