### PR TITLE
Distroless base image: install nftables-1.1.1

### DIFF
--- a/docker/iptables.yaml
+++ b/docker/iptables.yaml
@@ -12,7 +12,7 @@ contents:
     - libnfnetlink
     - libmnl
     - libgcc
-    - nftables-slim
+    - nftables=1.1.1-r40
 archs:
   - x86_64
   - aarch64

--- a/tools/build-base-images.sh
+++ b/tools/build-base-images.sh
@@ -77,7 +77,15 @@ unexpectedFiles="$(
     grep -v '^usr/bin/nft' | \
     grep -v '^usr/share/doc/nftables/examples/.*.nft' | \
     grep -v '^etc/apk/commit_hooks.d/ldconfig-commit.sh$' | \
-    grep -v '.*\.so[0-9\.]*' || true
+    grep -v '.*\.so[0-9\.]*' | \
+    # TODO: Remove the following test files when getting a nftables-slim=1.1.1 package from packages.wolfi.dev/os
+    grep -v '^usr/bin/clear' | \
+    grep -v '^usr/bin/infocmp' | \
+    grep -v '^usr/bin/tabs' | \
+    grep -v '^usr/bin/tic' | \
+    grep -v '^usr/bin/toe' | \
+    grep -v '^usr/bin/tput' | \
+    grep -v '^usr/bin/tset' || true
 )"
 expectedFiles=(
   "usr/bin/xtables-legacy-multi"


### PR DESCRIPTION

This PR changes the distroless base image nft package. It replaces the `nftables-slim` latest with `nftables=1.1.1-r40`.
The `nftables-slim` and `nftables` package version latest or 1.1.2+ are causing an segmentation fault in https://github.com/istio/istio/issues/58492

Currently, there is no `nftables-slim`=1.1.1 package in the wolfi repo.  There is only a `nftables` 1.1.1 package available so far.

When install `nftables` package, it includes seven sample test files in the usr/bin directory. There is no way to run additional remove command when using apko image build from that.
When install `nftables-slim` package, it does not include those sample test files.

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
