### PR TITLE
honor ambient.istio.io/bypass-inbound-capture for WDS workloads

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
@@ -1337,7 +1337,8 @@ func (a *index) endpointSlicesBuilder(
 }
 
 func setTunnelProtocol(labels, annotations map[string]string, w *workloadapi.Workload) {
-	if annotations[annotation.AmbientRedirection.Name] == constants.AmbientRedirectionEnabled {
+	if annotations[annotation.AmbientRedirection.Name] == constants.AmbientRedirectionEnabled &&
+		annotations[annotation.AmbientBypassInboundCapture.Name] != "true" {
 		// Configured for override
 		w.TunnelProtocol = workloadapi.TunnelProtocol_HBONE
 	}


### PR DESCRIPTION
I started a quick fix, but after a bit of thought I'm actually not entirely sure this is the path we want to take. I will toss out a PR anyway and we can discuss. I think it should be fine for inbound HBONE to function when bypass-inbound-capture is true. Incoming HBONE is addressed to 15008 and that listener exists, so ztunnel should get the traffic. I think it should really only be inbound passthrough that we are not concerned with. Is this just a CNI bug and the packets are getting caught in netfilter after ztunnel decaps?

**Please provide a description of this PR:**

fixes #58546 

Honor `ambient.istio.io/bypass-inbound-capture` annotation when computing wds Workloads. Presently, a workload using this annotation is marked as `protocol: HBONE` because it is annotated with `ambient.istio.io/redirection: enabled` by the CNI and we do not consider `ambient.istio.io/bypass-inbound-capture` when determining whether or not it can accept HBONE connections. This prevents an in-mesh application from being able to communicate with the pod, since ztunnel thinks it should send HBONE even though the pod cannot accept inbound-HBONE