### PR TITLE
Make terminationGracePeriodSeconds configurable in istio-cni chart

### DIFF
--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -81,9 +81,9 @@ spec:
       {{- end }}
       priorityClassName: system-node-critical
       serviceAccountName: {{ template "name" . }}
-      # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
-      # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
-      terminationGracePeriodSeconds: 5
+      # Time to allow for graceful CNI cleanup during pod termination.
+      # Configurable via values.yaml to prevent race conditions during rolling updates.
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       containers:
         # This container installs the Istio CNI binaries
         # and CNI network config file on each node.

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -134,6 +134,12 @@ _internal_defaults_do_not_set:
     rollingUpdate:
       maxUnavailable: 1
 
+  # Sets the per-pod terminationGracePeriodSeconds setting.
+  # A higher value gives more time for CNI cleanup during rolling updates,
+  # preventing "failed to find plugin istio-cni" errors.
+  # Default K8s value is 30 seconds.
+  terminationGracePeriodSeconds: 30
+
   # Revision is set as 'version' label and part of the resource names when installing multiple control planes.
   revision: ""
 

--- a/releasenotes/notes/istio-cni-chart-termgrace.yaml
+++ b/releasenotes/notes/istio-cni-chart-termgrace.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue:
+  - 58572
+
+releaseNotes:
+  - |
+    **Added** Allow setting terminationGracePeriodSeconds for istio-cni pod via Helm chart.
+


### PR DESCRIPTION
The istio-cni DaemonSet had a hardcoded terminationGracePeriodSeconds: 5 with no way to override it via Helm values. This causes a race condition during rolling updates where the CNI binary is removed before kubelet completes network cleanup, resulting in pod termination errors.

Changes:
- Add terminationGracePeriodSeconds field to values.yaml (default: 30s)
- Update daemonset.yaml template to use configurable value
- Align with ztunnel and gateway charts which already support this

This allows users to configure appropriate termination grace periods for their environment and prevents 'failed to find plugin istio-cni' errors during upgrades.

Fixes #58572