### PR TITLE
krt: Join aggregate duplicate events keeping old fastpath

### DIFF
--- a/pilot/pkg/config/kube/gateway/backend_policies.go
+++ b/pilot/pkg/config/kube/gateway/backend_policies.go
@@ -143,7 +143,7 @@ func DestinationRuleCollection(
 	status.RegisterStatus(c.status, tlsPolicyStatus, GetStatus, c.tagWatcher.AccessUnprotected())
 
 	// We need to merge these by hostname into a single DR
-	allPolicies := krt.JoinCollection([]krt.Collection[BackendPolicy]{backendTrafficPolicies, backendTLSPolicies})
+	allPolicies := krt.JoinCollection([]krt.Collection[BackendPolicy]{backendTrafficPolicies, backendTLSPolicies}, opts.WithName("AllBackendPolicies")...)
 	byTargetAndHost := krt.NewIndex(allPolicies, "targetAndHost", func(o BackendPolicy) []TypedNamespacedNamePerHost {
 		return []TypedNamespacedNamePerHost{{Target: o.Target, Host: o.Host}}
 	})

--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"sync"
 
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/kube/controllers"
 	istiolog "istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/maps"
@@ -36,7 +37,7 @@ const (
 )
 
 // EnableAssertions, if true, will enable assertions. These typically are violations of the krt collection requirements.
-const EnableAssertions = false
+var EnableAssertions = features.EnableUnsafeAssertions
 
 type dependencyState[I any] struct {
 	// collectionDependencies specifies the set of collections we depend on from within the transformation functions (via Fetch).

--- a/pkg/kube/krt/conformance_test.go
+++ b/pkg/kube/krt/conformance_test.go
@@ -136,8 +136,8 @@ func TestConformance(t *testing.T) {
 		runConformance[Named](t, rig)
 	})
 	t.Run("join", func(t *testing.T) {
-		col1 := krt.NewStaticCollection[Named](nil, nil, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler))
-		col2 := krt.NewStaticCollection[Named](nil, nil, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler))
+		col1 := krt.NewStaticCollection[Named](nil, nil, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler), krt.WithName("join-conformance-1"))
+		col2 := krt.NewStaticCollection[Named](nil, nil, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler), krt.WithName("join-conformance-2"))
 		j := krt.JoinCollection(
 			[]krt.Collection[Named]{col1, col2},
 			krt.WithStop(test.NewStop(t)),

--- a/pkg/kube/krt/internal.go
+++ b/pkg/kube/krt/internal.go
@@ -64,6 +64,14 @@ func buildCollectionOptions(opts ...CollectionOption) collectionOptions {
 		o(c)
 	}
 	if c.stop == nil {
+		if EnableAssertions {
+			panic("collection " + c.name + " created with no stop channel provided; will likely cause goroutine leaks")
+		}
+		if len(opts) > 0 {
+			log.Debugf("collection %s did not have a stop channel in opts, creating a default which may cause goroutines to leak", c.name)
+		} else {
+			log.Debugf("collection was created with no opts, creating a default stop channel which may cause goroutines to leak")
+		}
 		c.stop = make(chan struct{})
 	}
 	return *c

--- a/pkg/kube/krt/join.go
+++ b/pkg/kube/krt/join.go
@@ -16,13 +16,14 @@ package krt
 
 import (
 	"fmt"
+	"sync"
 
+	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/sets"
 )
 
-// TODO: Implement with merging
 type join[T any] struct {
 	collectionName   string
 	id               collectionUID
@@ -31,6 +32,17 @@ type join[T any] struct {
 	uncheckedOverlap bool
 	syncer           Syncer
 	metadata         Metadata
+
+	// mu protects both eventHandlers and processedState
+	// but mu and processedState are ignored when uncheckedOverlap is true
+	mu sync.RWMutex
+	// processedState tracks objects we've processed via handleSubCollectionEvents
+	// This ensures RegisterBatch only sends events for objects that have been fully processed,
+	// avoiding duplicates from in-flight sub-collection events
+	processedState map[string]*T
+	eventHandlers  *handlerSet[T]
+
+	stop <-chan struct{}
 }
 
 func (j *join[T]) GetKey(k string) *T {
@@ -46,14 +58,31 @@ func (j *join[T]) List() []T {
 	var res []T
 	if j.uncheckedOverlap {
 		first := true
+		var seen sets.String
+		if EnableAssertions {
+			seen = sets.New[string]()
+		}
 		for _, c := range j.collections {
 			objs := c.List()
 			// As an optimization, take the first (non-empty) result as-is without copying
 			if len(objs) > 0 && first {
 				res = objs
 				first = false
+				if EnableAssertions {
+					for _, i := range objs {
+						seen.Insert(GetKey(i))
+					}
+				}
 			} else {
 				// After the first, safely merge into the result
+				if EnableAssertions {
+					for _, i := range objs {
+						key := GetKey(i)
+						if seen.InsertContains(key) {
+							panic("Join collection has overlapping keys in unchecked mode: " + key)
+						}
+					}
+				}
 				res = append(res, objs...)
 			}
 		}
@@ -86,21 +115,46 @@ func (j *join[T]) List() []T {
 }
 
 func (j *join[T]) Register(f func(o Event[T])) HandlerRegistration {
-	return registerHandlerAsBatched[T](j, f)
+	return registerHandlerAsBatched(j, f)
 }
 
 func (j *join[T]) RegisterBatch(f func(o []Event[T]), runExistingState bool) HandlerRegistration {
-	sync := multiSyncer{}
-	removes := []func(){}
-	for _, c := range j.collections {
-		reg := c.RegisterBatch(f, runExistingState)
-		removes = append(removes, reg.UnregisterHandler)
-		sync.syncers = append(sync.syncers, reg)
+	// Fast path for unchecked overlap: register directly with sub-collections (old behavior)
+	// This avoids the indirection layer of handleSubCollectionEvents and eventHandlers.Distribute
+	if j.uncheckedOverlap {
+		sync := multiSyncer{}
+		removes := []func(){}
+		for _, c := range j.collections {
+			reg := c.RegisterBatch(f, runExistingState)
+			removes = append(removes, reg.UnregisterHandler)
+			sync.syncers = append(sync.syncers, reg)
+		}
+		return joinHandlerRegistration{
+			Syncer:  sync,
+			removes: removes,
+		}
 	}
-	return joinHandlerRegistration{
-		Syncer:  sync,
-		removes: removes,
+
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	// If we need to run existing state, gather it from processedState instead of List()
+	// This prevents race where we send events for objects that haven't been processed
+	// by handleSubCollectionEvents yet (they're in sub-collection state but event is in-flight)
+	var initialEvents []Event[T]
+	if runExistingState {
+		for _, obj := range j.processedState {
+			initialEvents = append(initialEvents, Event[T]{
+				New:   obj,
+				Event: controllers.EventAdd,
+			})
+		}
 	}
+
+	// Register the handler and send initial events if needed
+	// eventHandlers has its own lock, sub-collection handlers are already registered in the constructor
+	reg := j.eventHandlers.Insert(f, j, initialEvents, j.stop)
+	return reg
 }
 
 type joinHandlerRegistration struct {
@@ -112,6 +166,136 @@ func (j joinHandlerRegistration) UnregisterHandler() {
 	for _, remover := range j.removes {
 		remover()
 	}
+}
+
+// handleSubCollectionEvents processes events from a sub-collection, refreshing them
+// based on the current state of all collections, then distributes to registered handlers.
+// This is only used for checked mode (uncheckedOverlap=false).
+func (j *join[T]) handleSubCollectionEvents(events []Event[T], sourceCollectionIdx int) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	refreshedEvents := j.refreshEvents(events, sourceCollectionIdx)
+
+	if len(refreshedEvents) == 0 {
+		return
+	}
+
+	// Update processedState to track what we've processed
+	// This is used by RegisterBatch to provide consistent initial state
+	for _, ev := range refreshedEvents {
+		key := GetKey(ev.Latest())
+		if ev.Event == controllers.EventDelete {
+			delete(j.processedState, key)
+		} else {
+			// For Add and Update, store the new object pointer (no copy)
+			j.processedState[key] = ev.New
+		}
+	}
+
+	j.eventHandlers.Distribute(refreshedEvents, !j.HasSynced())
+}
+
+func (j *join[T]) getFromColIdx(idx int, key string) *T {
+	if idx < 0 || idx >= len(j.collections) {
+		if EnableAssertions {
+			panic("join: getFromColIdx: index out of range:" + fmt.Sprint(idx) + " len: " + fmt.Sprint(len(j.collections)))
+		}
+		return nil
+	}
+	obj := j.collections[idx].GetKey(key)
+	if obj == nil {
+		return nil
+	}
+
+	// HACK: StaticCollectoin (which we use in test) does not care what key you pass to Get
+	if GetKey(*obj) != key {
+		if EnableAssertions {
+			panic("join: getFromColIdx: collection returned object with wrong key. Wanted: " + key + " got: " + GetKey(*obj))
+		}
+		return nil
+	}
+
+	return obj
+}
+
+// refreshEvents refreshes events by checking the current state of all collections
+// to determine which collection is authoritative for each key. This implements
+// conflict resolution without storing objects.
+func (j *join[T]) refreshEvents(events []Event[T], sourceCollectionIdx int) []Event[T] {
+	var result []Event[T]
+
+	for _, ev := range events {
+		key := GetKey(ev.Latest())
+
+		// Check if any higher-priority collection (0...sourceCollectionIdx-1) has this key
+		hasHigherPriority := false
+
+		for i := range sourceCollectionIdx {
+			if o := j.getFromColIdx(i, key); o != nil {
+				hasHigherPriority = true
+				break
+			}
+		}
+
+		if ev.Event == controllers.EventDelete {
+			if hasHigherPriority {
+				// Drop delete event - we weren't using this collection's version anyway
+				continue
+			}
+
+			// Collection sourceCollectionIdx was authoritative. Check for fallback in lower-priority collections.
+			var fallbackObj *T
+			for i := sourceCollectionIdx + 1; i < len(j.collections); i++ {
+				if obj := j.getFromColIdx(i, key); obj != nil {
+					fallbackObj = obj
+					break
+				}
+			}
+
+			if fallbackObj != nil {
+				// Convert DELETE to UPDATE - fallback to lower-priority collection's version
+				result = append(result, Event[T]{
+					Event: controllers.EventUpdate,
+					Old:   ev.Old,
+					New:   fallbackObj, // pointer from collection, not a copy!
+				})
+			} else {
+				// No fallback found, send DELETE
+				result = append(result, ev)
+			}
+		} else {
+			// ADD or UPDATE event
+			if hasHigherPriority {
+				// Drop event - higher priority collection owns this key
+				continue
+			}
+
+			// No higher-priority collection has it, so this collection is now authoritative
+			// Check if a lower-priority collection had this key before
+			var oldObj *T
+			for i := sourceCollectionIdx + 1; i < len(j.collections); i++ {
+				if obj := j.getFromColIdx(i, key); obj != nil {
+					oldObj = obj
+					break
+				}
+			}
+
+			if oldObj != nil && ev.Event == controllers.EventAdd {
+				// Convert ADD to UPDATE - we're replacing a lower-priority collection's version
+				result = append(result, Event[T]{
+					Event: controllers.EventUpdate,
+					Old:   oldObj,
+					New:   ev.New,
+				})
+			} else {
+				// Forward the event as-is
+				result = append(result, ev)
+			}
+		}
+	}
+
+	return result
 }
 
 // nolint: unused // (not true, its to implement an interface)
@@ -184,8 +368,8 @@ func (j *join[T]) Metadata() Metadata {
 }
 
 // JoinCollection combines multiple Collection[T] into a single
-// Collection[T] merging equal objects into one record
-// in the resulting Collection
+// Collection[T]. Key conflicts are resolved by picking the item
+// produced by the first collections in the list of input collections.
 func JoinCollection[T any](cs []Collection[T], opts ...CollectionOption) Collection[T] {
 	o := buildCollectionOptions(opts...)
 	if o.name == "" {
@@ -204,13 +388,16 @@ func JoinCollection[T any](cs []Collection[T], opts ...CollectionOption) Collect
 		close(synced)
 		log.Infof("%v synced", o.name)
 	}()
-	// TODO: in the future, we could have a custom merge function. For now, since we just take the first, we optimize around that case
+	if o.stop == nil {
+		panic("no stop channel")
+	}
 	j := &join[T]{
 		collectionName:   o.name,
 		id:               nextUID(),
 		synced:           synced,
 		collections:      c,
 		uncheckedOverlap: o.joinUnchecked,
+		stop:             o.stop,
 		syncer: channelSyncer{
 			name:   o.name,
 			synced: synced,
@@ -220,6 +407,37 @@ func JoinCollection[T any](cs []Collection[T], opts ...CollectionOption) Collect
 	if o.metadata != nil {
 		j.metadata = o.metadata
 	}
+
+	// For unchecked mode, we don't need the centralized event handling infrastructure.
+	// Handlers register directly with sub-collections in RegisterBatch.
+	if o.joinUnchecked {
+		return j
+	}
+
+	// Checked mode: set up centralized event handling with conflict resolution
+	j.eventHandlers = newHandlerSet[T]()
+	j.processedState = make(map[string]*T)
+
+	// Register handlers on sub-collections ONCE during construction
+	// These handlers will process events from sub-collections and distribute to registered handlers
+	var subHandlerRegs []HandlerRegistration
+	for idx, subCol := range c {
+		collectionIdx := idx // capture for closure
+		handler := func(events []Event[T]) {
+			j.handleSubCollectionEvents(events, collectionIdx)
+		}
+		// run existing state to populate processedState
+		reg := subCol.RegisterBatch(handler, true)
+		subHandlerRegs = append(subHandlerRegs, reg)
+	}
+
+	// Clean up sub-collection handlers when this collection's stop is closed
+	go func() {
+		<-o.stop
+		for _, reg := range subHandlerRegs {
+			reg.UnregisterHandler()
+		}
+	}()
 
 	return j
 }

--- a/pkg/test/util/assert/assert.go
+++ b/pkg/test/util/assert/assert.go
@@ -111,6 +111,28 @@ func EventuallyEqual[T any](t test.Failer, fetch func() T, expected T, retryOpts
 	}
 }
 
+// Consistently polls the fetch function for a duration and fails if the value ever changes from the expected value.Add a comment on  lines L114 to L119Add diff commentMarkdown input:  edit mode selected.WritePreviewHeadingBoldItalicQuoteCodeLinkUnordered listNumbered listTask listMentionReferenceSaved repliesAdd FilesPaste, drop, or click to add filesCancelCommentStart a reviewReturn to code
+// Use sparingly to avoid flakiness, as this is inherently timing-dependent.
+// This is useful for asserting that no events occur (e.g., that a value stays at 0).
+// Default duration is 20ms with 2ms polling interval.
+func Consistently[T any](t test.Failer, fetch func() T, expected T, duration ...time.Duration) {
+	t.Helper()
+	d := time.Millisecond * 20
+	if len(duration) > 0 {
+		d = duration[0]
+	}
+	interval := time.Millisecond * 2
+	deadline := time.Now().Add(d)
+
+	for time.Now().Before(deadline) {
+		a := fetch()
+		if !cmp.Equal(a, expected, opts(expected)...) {
+			t.Fatalf("value changed unexpectedly: %v\nGot: %v\nWant: %v", cmp.Diff(a, expected, opts(expected)...), a, expected)
+		}
+		time.Sleep(interval)
+	}
+}
+
 // Error asserts the provided err is non-nil
 func Error(t test.Failer, err error) {
 	t.Helper()

--- a/pkg/test/util/assert/assert.go
+++ b/pkg/test/util/assert/assert.go
@@ -111,10 +111,11 @@ func EventuallyEqual[T any](t test.Failer, fetch func() T, expected T, retryOpts
 	}
 }
 
-// Consistently polls the fetch function for a duration and fails if the value ever changes from the expected value.Add a comment on  lines L114 to L119Add diff commentMarkdown input:  edit mode selected.WritePreviewHeadingBoldItalicQuoteCodeLinkUnordered listNumbered listTask listMentionReferenceSaved repliesAdd FilesPaste, drop, or click to add filesCancelCommentStart a reviewReturn to code
-// Use sparingly to avoid flakiness, as this is inherently timing-dependent.
-// This is useful for asserting that no events occur (e.g., that a value stays at 0).
-// Default duration is 20ms with 2ms polling interval.
+// Consistently polls the fetch function for a duration and fails if the value
+// ever changes from the expected value. Use sparingly to avoid flakiness, as
+// this is inherently timing-dependent. This is useful for asserting that no
+// events occur (e.g., that a value stays at 0). Default duration is 20ms with
+// 2ms polling interval.
 func Consistently[T any](t test.Failer, fetch func() T, expected T, duration ...time.Duration) {
 	t.Helper()
 	d := time.Millisecond * 20


### PR DESCRIPTION
**Please provide a description of this PR:**

addresses the issue that caused us to #58601 
 
@howardjohn pointed out that the previous PR did impact the "unchecked" fast path a bit too much. This PR restores that path to a near zero cost abstraction/passthrough. 

This also restores what the original checked mode was, but as an assertion. Now, the `UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS` environment variable will allow any consumer to verify their assumption that keys are non-overlapping (assuming List is called on their unchecked Join somewhere). 

Finally, I added some very basic RegisterBatch tests to make sure initial state runs. Pretty confident there are no races, did a lot of `stress` with and with out `-race` checker. 