### PR TITLE
ambient: expose core constructors publicly

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -2219,6 +2219,7 @@ func newAmbientTestServerFromOptions(t *testing.T, networkID network.ID, options
 		t.Cleanup(cl.Shutdown)
 		cl.RunAndWait(test.NewStop(t))
 	}
+
 	return a
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/multicluster.go
@@ -77,7 +77,7 @@ func (a *index) buildGlobalCollections(
 	LocalNamespaces := localCluster.Namespaces()
 	LocalNodes := localCluster.Nodes()
 	LocalGateways := localCluster.Gateways()
-	LocalWaypoints := a.WaypointsCollection(options.ClusterID, LocalGateways, localGatewayClasses, LocalPods, opts)
+	LocalWaypoints := a.builder.WaypointsCollection(options.ClusterID, LocalGateways, localGatewayClasses, LocalPods, opts)
 
 	LocalMeshConfig := options.MeshConfig
 	// These first collections can't be merged since the Kubernetes APIs don't have enough room
@@ -195,7 +195,7 @@ func (a *index) buildGlobalCollections(
 		opts,
 	)
 
-	LocalWorkloadServices := a.ServicesCollection(
+	LocalWorkloadServices := a.builder.ServicesCollection(
 		localCluster.ID,
 		localCluster.Services(),
 		localServiceEntries,

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/networks.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/networks.go
@@ -45,7 +45,7 @@ func (n NetworkGateway) ResourceName() string {
 	return n.Source.String() + "/" + n.Addr
 }
 
-type networkCollections struct {
+type NetworkCollections struct {
 	LocalSystemNamespace          krt.Singleton[ClusterNetwork]
 	RemoteSystemNamespaceNetworks krt.Collection[ClusterNetwork]
 	// SystemNamespaceNetworkByCluster is an index of cluster ID to the system namespace network
@@ -64,7 +64,7 @@ func (c ClusterNetwork) ResourceName() string {
 	return fmt.Sprintf("%s/%s", c.ClusterID, c.Network)
 }
 
-func (c networkCollections) HasSynced() bool {
+func (c NetworkCollections) HasSynced() bool {
 	return c.LocalSystemNamespace.AsCollection().HasSynced() &&
 		c.NetworkGateways.HasSynced()
 }
@@ -77,7 +77,7 @@ func buildGlobalNetworkCollections(
 	gatewaysByCluster krt.Index[cluster.ID, krt.Collection[krt.ObjectWithCluster[*gatewayv1.Gateway]]],
 	options Options,
 	opts krt.OptionsBuilder,
-) networkCollections {
+) NetworkCollections {
 	LocalSystemNamespaceNetwork := krt.NewSingleton(func(ctx krt.HandlerContext) *ClusterNetwork {
 		ns := ptr.Flatten(krt.FetchOne(ctx, localNamespaces, krt.FilterKey(options.SystemNamespace)))
 		if ns == nil {
@@ -190,7 +190,7 @@ func buildGlobalNetworkCollections(
 		return []network.ID{o.Network}
 	})
 
-	return networkCollections{
+	return NetworkCollections{
 		SystemNamespaceNetworkByCluster: RemoteSystemNamespaceNetworksByCluster,
 		NetworkGateways:                 MergedNetworkGateways,
 		GatewaysByNetwork:               GatewaysByNetwork,
@@ -199,12 +199,12 @@ func buildGlobalNetworkCollections(
 	}
 }
 
-func buildNetworkCollections(
+func BuildNetworkCollections(
 	namespaces krt.Collection[*v1.Namespace],
 	gateways krt.Collection[*gatewayv1.Gateway],
 	options Options,
 	opts krt.OptionsBuilder,
-) networkCollections {
+) NetworkCollections {
 	SystemNamespaceNetwork := krt.NewSingleton(func(ctx krt.HandlerContext) *ClusterNetwork {
 		ns := ptr.Flatten(krt.FetchOne(ctx, namespaces, krt.FilterKey(options.SystemNamespace)))
 		if ns == nil {
@@ -228,7 +228,7 @@ func buildNetworkCollections(
 		return []network.ID{o.Network}
 	})
 
-	return networkCollections{
+	return NetworkCollections{
 		LocalSystemNamespace: SystemNamespaceNetwork,
 		NetworkGateways:      NetworkGateways,
 		GatewaysByNetwork:    GatewaysByNetwork,

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
@@ -49,7 +49,7 @@ import (
 	"istio.io/istio/pkg/workloadapi"
 )
 
-func (a *index) ServicesCollection(
+func (a Builder) ServicesCollection(
 	clusterID cluster.ID,
 	services krt.Collection[*v1.Service],
 	serviceEntries krt.Collection[*networkingclient.ServiceEntry],
@@ -135,7 +135,7 @@ func GlobalMergedWorkloadServicesCollection(
 	globalNamespaces krt.Collection[krt.Collection[*v1.Namespace]],
 	namespacesByCluster krt.Index[cluster.ID, krt.Collection[*v1.Namespace]],
 	meshConfig krt.Singleton[MeshConfig],
-	globalNetworks networkCollections,
+	globalNetworks NetworkCollections,
 	domainSuffix string,
 	opts krt.OptionsBuilder,
 ) krt.Collection[krt.Collection[krt.ObjectWithCluster[model.ServiceInfo]]] {
@@ -365,7 +365,7 @@ func matchServiceScope(ctx krt.HandlerContext, meshCfg *MeshConfig, namespaces k
 	return model.Local
 }
 
-func (a *index) serviceServiceBuilder(
+func (a Builder) serviceServiceBuilder(
 	waypoints krt.Collection[Waypoint],
 	namespaces krt.Collection[*v1.Namespace],
 	meshConfig krt.Singleton[MeshConfig],
@@ -407,7 +407,7 @@ func (s ServiceEntryInfo) Equals(other ServiceEntryInfo) bool {
 	return s.ServiceInfo.Equals(other.ServiceInfo)
 }
 
-func (a *index) serviceEntryServiceBuilder(
+func (a Builder) serviceEntryServiceBuilder(
 	waypoints krt.Collection[Waypoint],
 	namespaces krt.Collection[*v1.Namespace],
 ) krt.TransformationMulti[*networkingclient.ServiceEntry, ServiceEntryInfo] {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/services_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/services_test.go
@@ -681,7 +681,7 @@ func TestServiceEntryServices(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := krttest.NewMock(t, tt.inputs)
 			a := newAmbientUnitTest(t)
-			builder := a.serviceEntryServiceBuilder(
+			builder := a.builder.serviceEntryServiceBuilder(
 				krttest.GetMockCollection[Waypoint](mock),
 				krttest.GetMockCollection[*v1.Namespace](mock),
 			)
@@ -1096,7 +1096,7 @@ func TestServiceServices(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := krttest.NewMock(t, tt.inputs)
 			a := newAmbientUnitTest(t)
-			builder := a.serviceServiceBuilder(
+			builder := a.builder.serviceServiceBuilder(
 				krttest.GetMockCollection[Waypoint](mock),
 				krttest.GetMockCollection[*v1.Namespace](mock),
 				krttest.GetMockSingleton[MeshConfig](mock),
@@ -1232,7 +1232,7 @@ func TestServiceConditions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := krttest.NewMock(t, tt.inputs)
 			a := newAmbientUnitTest(t)
-			builder := a.serviceServiceBuilder(
+			builder := a.builder.serviceServiceBuilder(
 				krttest.GetMockCollection[Waypoint](mock),
 				krttest.GetMockCollection[*v1.Namespace](mock),
 				krttest.GetMockSingleton[MeshConfig](mock),

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
@@ -261,7 +261,7 @@ func GlobalWaypointsCollection(
 	localWaypoints krt.Collection[Waypoint],
 	clusters krt.Collection[*multicluster.Cluster],
 	gatewayClasses krt.Collection[*gatewayv1.GatewayClass],
-	globalNetworks networkCollections,
+	globalNetworks NetworkCollections,
 	opts krt.OptionsBuilder,
 ) krt.Collection[krt.Collection[Waypoint]] {
 	return nestedCollectionFromLocalAndRemote(localWaypoints, clusters, func(ctx krt.HandlerContext, c *multicluster.Cluster) *krt.Collection[Waypoint] {
@@ -320,7 +320,7 @@ func GlobalWaypointsCollection(
 	}, "Waypoints", opts)
 }
 
-func (a *index) WaypointsCollection(
+func (a Builder) WaypointsCollection(
 	clusterID cluster.ID,
 	gateways krt.Collection[*gatewayv1.Gateway],
 	gatewayClasses krt.Collection[*gatewayv1.GatewayClass],

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"istio.io/api/annotation"
+	"istio.io/api/label"
 	networkingv1alpha3 "istio.io/api/networking/v1alpha3"
 	networkingclient "istio.io/client-go/pkg/apis/networking/v1"
 	securityclient "istio.io/client-go/pkg/apis/security/v1"
@@ -60,7 +61,7 @@ import (
 // WorkloadsCollection builds out the core Workload object type used in ambient mode.
 // A Workload represents a single addressable unit of compute -- typically a Pod or a VM.
 // Workloads can come from a variety of sources; these are joined together to build one complete `Collection[WorkloadInfo]`.
-func (a *index) WorkloadsCollection(
+func (a Builder) WorkloadsCollection(
 	pods krt.Collection[*v1.Pod],
 	nodes krt.Collection[Node],
 	meshConfig krt.Singleton[MeshConfig],
@@ -118,7 +119,8 @@ func (a *index) WorkloadsCollection(
 
 	NetworkGatewayWorkloads := krt.NewManyFromNothing[model.WorkloadInfo](func(ctx krt.HandlerContext) []model.WorkloadInfo {
 		meshCfg := krt.FetchOne(ctx, meshConfig.AsCollection())
-		return slices.Map(a.LookupAllNetworkGateway(ctx), convertGateway(meshCfg))
+		all := LookupAllNetworkGateway(ctx, a.NetworkGateways)
+		return slices.Map(all, convertGateway(meshCfg))
 	}, opts.WithName("NetworkGatewayWorkloads")...)
 
 	Workloads := krt.JoinCollection(
@@ -152,7 +154,7 @@ func MergedGlobalWorkloadsCollection(
 	localWorkloadServices krt.Collection[model.ServiceInfo],
 	globalWorkloadServices krt.Collection[krt.Collection[krt.ObjectWithCluster[model.ServiceInfo]]],
 	globalWorkloadServicesByCluster krt.Index[cluster.ID, krt.Collection[krt.ObjectWithCluster[model.ServiceInfo]]],
-	globalNetworks networkCollections,
+	globalNetworks NetworkCollections,
 	localClusterID cluster.ID,
 	flags FeatureFlags,
 	domainSuffix string,
@@ -706,7 +708,7 @@ func workloadEntryWorkloadBuilder(
 		w.WorkloadType = workloadapi.WorkloadType_POD // XXX(shashankram): HACK to impersonate pod
 		w.CanonicalName, w.CanonicalRevision = kubelabels.CanonicalService(wle.Labels, w.WorkloadName)
 
-		setTunnelProtocol(wle.Labels, wle.Annotations, w)
+		setTunnelProtocol(wle.Labels, wle.Annotations, w, flags)
 		localNetwork := localNetworkGetter(ctx)
 		if network != localNetwork.String() {
 			// This is a remote workload that we'll never send directly; don't precompute
@@ -727,7 +729,7 @@ func workloadEntryWorkloadBuilder(
 	}
 }
 
-func (a *index) workloadEntryWorkloadBuilder(
+func (a Builder) workloadEntryWorkloadBuilder(
 	meshConfig krt.Singleton[MeshConfig],
 	authorizationPolicies krt.Collection[model.WorkloadAuthorization],
 	peerAuths krt.Collection[*securityclient.PeerAuthentication],
@@ -752,8 +754,8 @@ func (a *index) workloadEntryWorkloadBuilder(
 			return a.ClusterID
 		},
 		localNetworkGetter,
-		a.networks.NetworkGateways,
-		a.networks.GatewaysByNetwork,
+		a.NetworkGateways,
+		a.GatewaysByNetwork,
 		a.Flags,
 	)
 }
@@ -876,7 +878,7 @@ func podWorkloadBuilder(
 		w.WorkloadType = workloadapi.WorkloadType_POD // backwards compatibility
 		w.CanonicalName, w.CanonicalRevision = kubelabels.CanonicalService(p.Labels, w.WorkloadName)
 
-		setTunnelProtocol(p.Labels, p.Annotations, w)
+		setTunnelProtocol(p.Labels, p.Annotations, w, flags)
 		localNetwork := localNetworkGetter(ctx)
 		if network != localNetwork.String() {
 			// This is a remote workload that we'll never send directly; don't precompute
@@ -896,7 +898,7 @@ func podWorkloadBuilder(
 	}
 }
 
-func (a *index) podWorkloadBuilder(
+func (a Builder) podWorkloadBuilder(
 	meshConfig krt.Singleton[MeshConfig],
 	authorizationPolicies krt.Collection[model.WorkloadAuthorization],
 	peerAuths krt.Collection[*securityclient.PeerAuthentication],
@@ -928,8 +930,8 @@ func (a *index) podWorkloadBuilder(
 			return a.ClusterID
 		},
 		localNetworkGetter,
-		a.networks.NetworkGateways,
-		a.networks.GatewaysByNetwork,
+		a.NetworkGateways,
+		a.GatewaysByNetwork,
 		a.Flags,
 	)
 }
@@ -1143,7 +1145,7 @@ func serviceEntryWorkloadBuilder(
 			w.WorkloadName, w.WorkloadType = se.Name, workloadapi.WorkloadType_POD // XXX(shashankram): HACK to impersonate pod
 			w.CanonicalName, w.CanonicalRevision = kubelabels.CanonicalService(se.Labels, w.WorkloadName)
 
-			setTunnelProtocol(se.Labels, se.Annotations, w)
+			setTunnelProtocol(se.Labels, se.Annotations, w, flags)
 			res = append(res, precomputeWorkload(model.WorkloadInfo{
 				Workload:     w,
 				Labels:       se.Labels,
@@ -1155,7 +1157,7 @@ func serviceEntryWorkloadBuilder(
 	}
 }
 
-func (a *index) serviceEntryWorkloadBuilder(
+func (a Builder) serviceEntryWorkloadBuilder(
 	meshConfig krt.Singleton[MeshConfig],
 	authorizationPolicies krt.Collection[model.WorkloadAuthorization],
 	peerAuths krt.Collection[*securityclient.PeerAuthentication],
@@ -1176,8 +1178,8 @@ func (a *index) serviceEntryWorkloadBuilder(
 		func(ctx krt.HandlerContext) network.ID {
 			return a.Network(ctx)
 		},
-		a.networks.NetworkGateways,
-		a.networks.GatewaysByNetwork,
+		a.NetworkGateways,
+		a.GatewaysByNetwork,
 		a.Flags,
 	)
 }
@@ -1321,7 +1323,7 @@ func endpointSlicesBuilder(
 	}
 }
 
-func (a *index) endpointSlicesBuilder(
+func (a Builder) endpointSlicesBuilder(
 	meshConfig krt.Singleton[MeshConfig],
 	workloadServices krt.Collection[model.ServiceInfo],
 ) krt.TransformationMulti[*discovery.EndpointSlice, model.WorkloadInfo] {
@@ -1338,7 +1340,10 @@ func (a *index) endpointSlicesBuilder(
 	)
 }
 
-func setTunnelProtocol(labels, annotations map[string]string, w *workloadapi.Workload) {
+func setTunnelProtocol(labels, annotations map[string]string, w *workloadapi.Workload, flags FeatureFlags) {
+	if flags.EnableMtlsTransportProtocol && labels[label.SecurityTlsMode.Name] == model.IstioMutualTLSModeLabel {
+		w.TunnelProtocol = workloadapi.TunnelProtocol_LEGACY_ISTIO_MTLS
+	}
 	if annotations[annotation.AmbientRedirection.Name] == constants.AmbientRedirectionEnabled {
 		// Configured for override
 		w.TunnelProtocol = workloadapi.TunnelProtocol_HBONE

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
@@ -834,7 +834,7 @@ func TestPodWorkloads(t *testing.T) {
 			WorkloadServicesNamespaceIndex := krt.NewNamespaceIndex(WorkloadServices)
 			EndpointSlices := krttest.GetMockCollection[*discovery.EndpointSlice](mock)
 			EndpointSlicesAddressIndex := endpointSliceAddressIndex(EndpointSlices)
-			builder := a.podWorkloadBuilder(
+			builder := a.builder.podWorkloadBuilder(
 				GetMeshConfig(mock),
 				krttest.GetMockCollection[model.WorkloadAuthorization](mock),
 				krttest.GetMockCollection[*securityclient.PeerAuthentication](mock),
@@ -1389,7 +1389,7 @@ func TestWorkloadEntryWorkloads(t *testing.T) {
 			a := newAmbientUnitTest(t)
 			WorkloadServices := krttest.GetMockCollection[model.ServiceInfo](mock)
 			WorkloadServicesNamespaceIndex := krt.NewNamespaceIndex(WorkloadServices)
-			builder := a.workloadEntryWorkloadBuilder(
+			builder := a.builder.workloadEntryWorkloadBuilder(
 				GetMeshConfig(mock),
 				krttest.GetMockCollection[model.WorkloadAuthorization](mock),
 				krttest.GetMockCollection[*securityclient.PeerAuthentication](mock),
@@ -1638,7 +1638,7 @@ func TestServiceEntryWorkloads(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := krttest.NewMock(t, tt.inputs)
 			a := newAmbientUnitTest(t)
-			builder := a.serviceEntryWorkloadBuilder(
+			builder := a.builder.serviceEntryWorkloadBuilder(
 				GetMeshConfig(mock),
 				krttest.GetMockCollection[model.WorkloadAuthorization](mock),
 				krttest.GetMockCollection[*securityclient.PeerAuthentication](mock),
@@ -1764,7 +1764,7 @@ func TestEndpointSliceWorkloads(t *testing.T) {
 			mock := krttest.NewMock(t, tt.inputs)
 			a := newAmbientUnitTest(t)
 			WorkloadServices := krttest.GetMockCollection[model.ServiceInfo](mock)
-			builder := a.endpointSlicesBuilder(
+			builder := a.builder.endpointSlicesBuilder(
 				GetMeshConfig(mock),
 				WorkloadServices,
 			)
@@ -1901,7 +1901,7 @@ func newAmbientUnitTest(t test.Failer) *index {
 			},
 		},
 	})
-	networks := buildNetworkCollections(
+	networks := BuildNetworkCollections(
 		krttest.GetMockCollection[*v1.Namespace](mock),
 		krttest.GetMockCollection[*gatewayv1.Gateway](mock),
 		Options{
@@ -1917,6 +1917,14 @@ func newAmbientUnitTest(t test.Failer) *index {
 			DefaultAllowFromWaypoint:              features.DefaultAllowFromWaypoint,
 			EnableK8SServiceSelectWorkloadEntries: features.EnableK8SServiceSelectWorkloadEntries,
 		},
+	}
+	idx.builder = Builder{
+		DomainSuffix:      idx.DomainSuffix,
+		ClusterID:         idx.ClusterID,
+		NetworkGateways:   idx.networks.NetworkGateways,
+		GatewaysByNetwork: idx.networks.GatewaysByNetwork,
+		Flags:             idx.Flags,
+		Network:           idx.Network,
 	}
 	kube.WaitForCacheSync("test", test.NewStop(t), idx.networks.HasSynced)
 	return idx


### PR DESCRIPTION
As WDS is now being used more broadly than just strictly ztunnel, this enables building it from outside of the ambient/ package