### PR TITLE
Revert "krt: aggregate Join events for conflicting keys (#58324)"

### DIFF
--- a/pilot/pkg/config/kube/gateway/backend_policies.go
+++ b/pilot/pkg/config/kube/gateway/backend_policies.go
@@ -143,7 +143,7 @@ func DestinationRuleCollection(
 	status.RegisterStatus(c.status, tlsPolicyStatus, GetStatus, c.tagWatcher.AccessUnprotected())
 
 	// We need to merge these by hostname into a single DR
-	allPolicies := krt.JoinCollection([]krt.Collection[BackendPolicy]{backendTrafficPolicies, backendTLSPolicies}, opts.WithName("AllBackendPolicies")...)
+	allPolicies := krt.JoinCollection([]krt.Collection[BackendPolicy]{backendTrafficPolicies, backendTLSPolicies})
 	byTargetAndHost := krt.NewIndex(allPolicies, "targetAndHost", func(o BackendPolicy) []TypedNamespacedNamePerHost {
 		return []TypedNamespacedNamePerHost{{Target: o.Target, Host: o.Host}}
 	})

--- a/pkg/kube/krt/conformance_test.go
+++ b/pkg/kube/krt/conformance_test.go
@@ -136,8 +136,8 @@ func TestConformance(t *testing.T) {
 		runConformance[Named](t, rig)
 	})
 	t.Run("join", func(t *testing.T) {
-		col1 := krt.NewStaticCollection[Named](nil, nil, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler), krt.WithName("a"))
-		col2 := krt.NewStaticCollection[Named](nil, nil, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler), krt.WithName("b"))
+		col1 := krt.NewStaticCollection[Named](nil, nil, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler))
+		col2 := krt.NewStaticCollection[Named](nil, nil, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler))
 		j := krt.JoinCollection(
 			[]krt.Collection[Named]{col1, col2},
 			krt.WithStop(test.NewStop(t)),

--- a/pkg/kube/krt/internal.go
+++ b/pkg/kube/krt/internal.go
@@ -64,11 +64,6 @@ func buildCollectionOptions(opts ...CollectionOption) collectionOptions {
 		o(c)
 	}
 	if c.stop == nil {
-		if len(opts) > 0 {
-			log.Debugf("collection %s did not have a stop channel in opts, creating a default which may cause goroutines to leak", c.name)
-		} else {
-			log.Debugf("collection was created with no opts, creating a default stop channel which may cause goroutines to leak")
-		}
 		c.stop = make(chan struct{})
 	}
 	return *c

--- a/pkg/kube/krt/join.go
+++ b/pkg/kube/krt/join.go
@@ -16,14 +16,13 @@ package krt
 
 import (
 	"fmt"
-	"sync"
 
-	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/sets"
 )
 
+// TODO: Implement with merging
 type join[T any] struct {
 	collectionName   string
 	id               collectionUID
@@ -32,17 +31,6 @@ type join[T any] struct {
 	uncheckedOverlap bool
 	syncer           Syncer
 	metadata         Metadata
-
-	// mu protects both eventHandlers and processedState
-	// but mu and processedState are ignored when uncheckedOverlap is true
-	mu sync.RWMutex
-	// processedState tracks objects we've processed via handleSubCollectionEvents
-	// This ensures RegisterBatch only sends events for objects that have been fully processed,
-	// avoiding duplicates from in-flight sub-collection events
-	processedState map[string]*T
-	eventHandlers  *handlerSet[T]
-
-	stop <-chan struct{}
 }
 
 func (j *join[T]) GetKey(k string) *T {
@@ -102,177 +90,28 @@ func (j *join[T]) Register(f func(o Event[T])) HandlerRegistration {
 }
 
 func (j *join[T]) RegisterBatch(f func(o []Event[T]), runExistingState bool) HandlerRegistration {
-	// Fast path for unchecked overlap: use List() directly without locking or tracking processedState
-	if j.uncheckedOverlap {
-		var initialEvents []Event[T]
-		if runExistingState {
-			for _, obj := range j.List() {
-				objCopy := obj
-				initialEvents = append(initialEvents, Event[T]{
-					New:   &objCopy,
-					Event: controllers.EventAdd,
-				})
-			}
-		}
-		reg := j.eventHandlers.Insert(f, j, initialEvents, j.stop)
-		return reg
+	sync := multiSyncer{}
+	removes := []func(){}
+	for _, c := range j.collections {
+		reg := c.RegisterBatch(f, runExistingState)
+		removes = append(removes, reg.UnregisterHandler)
+		sync.syncers = append(sync.syncers, reg)
 	}
-
-	j.mu.Lock()
-	defer j.mu.Unlock()
-
-	// If we need to run existing state, gather it from processedState instead of List()
-	// This prevents race where we send events for objects that haven't been processed
-	// by handleSubCollectionEvents yet (they're in sub-collection state but event is in-flight)
-	var initialEvents []Event[T]
-	if runExistingState {
-		for _, obj := range j.processedState {
-			initialEvents = append(initialEvents, Event[T]{
-				New:   obj,
-				Event: controllers.EventAdd,
-			})
-		}
+	return joinHandlerRegistration{
+		Syncer:  sync,
+		removes: removes,
 	}
-
-	// Register the handler and send initial events if needed
-	// eventHandlers has its own lock, sub-collection handlers are already registered in the constructor
-	reg := j.eventHandlers.Insert(f, j, initialEvents, j.stop)
-	return reg
 }
 
-// handleSubCollectionEvents processes events from a sub-collection, refreshing them
-// based on the current state of all collections, then distributes to registered handlers.
-func (j *join[T]) handleSubCollectionEvents(events []Event[T], sourceCollectionIdx int) {
-	// Fast path for unchecked overlap: no conflict resolution, no state tracking, no locking
-	if j.uncheckedOverlap {
-		j.eventHandlers.Distribute(events, !j.HasSynced())
-		return
-	}
-
-	j.mu.Lock()
-	defer j.mu.Unlock()
-
-	refreshedEvents := j.refreshEvents(events, sourceCollectionIdx)
-
-	if len(refreshedEvents) == 0 {
-		return
-	}
-
-	// Update processedState to track what we've processed
-	// This is used by RegisterBatch to provide consistent initial state
-	for _, ev := range refreshedEvents {
-		key := GetKey(ev.Latest())
-		if ev.Event == controllers.EventDelete {
-			delete(j.processedState, key)
-		} else {
-			// For Add and Update, store the new object pointer (no copy)
-			j.processedState[key] = ev.New
-		}
-	}
-
-	j.eventHandlers.Distribute(refreshedEvents, !j.HasSynced())
+type joinHandlerRegistration struct {
+	Syncer
+	removes []func()
 }
 
-func (j *join[T]) getFromColIdx(idx int, key string) *T {
-	if idx < 0 || idx >= len(j.collections) {
-		if EnableAssertions {
-			panic("join: getFromColIdx: index out of range:" + fmt.Sprint(idx) + " len: " + fmt.Sprint(len(j.collections)))
-		}
-		return nil
+func (j joinHandlerRegistration) UnregisterHandler() {
+	for _, remover := range j.removes {
+		remover()
 	}
-	obj := j.collections[idx].GetKey(key)
-	if obj == nil {
-		return nil
-	}
-
-	// HACK: StaticCollectoin (which we use in test) does not care what key you pass to Get
-	if GetKey(*obj) != key {
-		if EnableAssertions {
-			panic("join: getFromColIdx: collection returned object with wrong key. Wanted: " + key + " got: " + GetKey(*obj))
-		}
-		return nil
-	}
-
-	return obj
-}
-
-// refreshEvents refreshes events by checking the current state of all collections
-// to determine which collection is authoritative for each key. This implements
-// conflict resolution without storing objects.
-func (j *join[T]) refreshEvents(events []Event[T], sourceCollectionIdx int) []Event[T] {
-	var result []Event[T]
-
-	for _, ev := range events {
-		key := GetKey(ev.Latest())
-
-		// Check if any higher-priority collection (0...sourceCollectionIdx-1) has this key
-		hasHigherPriority := false
-
-		for i := range sourceCollectionIdx {
-			if o := j.getFromColIdx(i, key); o != nil {
-				hasHigherPriority = true
-				break
-			}
-		}
-
-		if ev.Event == controllers.EventDelete {
-			if hasHigherPriority {
-				// Drop delete event - we weren't using this collection's version anyway
-				continue
-			}
-
-			// Collection sourceCollectionIdx was authoritative. Check for fallback in lower-priority collections.
-			var fallbackObj *T
-			for i := sourceCollectionIdx + 1; i < len(j.collections); i++ {
-				if obj := j.getFromColIdx(i, key); obj != nil {
-					fallbackObj = obj
-					break
-				}
-			}
-
-			if fallbackObj != nil {
-				// Convert DELETE to UPDATE - fallback to lower-priority collection's version
-				result = append(result, Event[T]{
-					Event: controllers.EventUpdate,
-					Old:   ev.Old,
-					New:   fallbackObj, // pointer from collection, not a copy!
-				})
-			} else {
-				// No fallback found, send DELETE
-				result = append(result, ev)
-			}
-		} else {
-			// ADD or UPDATE event
-			if hasHigherPriority {
-				// Drop event - higher priority collection owns this key
-				continue
-			}
-
-			// No higher-priority collection has it, so this collection is now authoritative
-			// Check if a lower-priority collection had this key before
-			var oldObj *T
-			for i := sourceCollectionIdx + 1; i < len(j.collections); i++ {
-				if obj := j.getFromColIdx(i, key); obj != nil {
-					oldObj = obj
-					break
-				}
-			}
-
-			if oldObj != nil && ev.Event == controllers.EventAdd {
-				// Convert ADD to UPDATE - we're replacing a lower-priority collection's version
-				result = append(result, Event[T]{
-					Event: controllers.EventUpdate,
-					Old:   oldObj,
-					New:   ev.New,
-				})
-			} else {
-				// Forward the event as-is
-				result = append(result, ev)
-			}
-		}
-	}
-
-	return result
 }
 
 // nolint: unused // (not true, its to implement an interface)
@@ -345,8 +184,8 @@ func (j *join[T]) Metadata() Metadata {
 }
 
 // JoinCollection combines multiple Collection[T] into a single
-// Collection[T]. Key conflicts are resolved by picking the item
-// produced by the first collections in the list of input collections.
+// Collection[T] merging equal objects into one record
+// in the resulting Collection
 func JoinCollection[T any](cs []Collection[T], opts ...CollectionOption) Collection[T] {
 	o := buildCollectionOptions(opts...)
 	if o.name == "" {
@@ -365,18 +204,13 @@ func JoinCollection[T any](cs []Collection[T], opts ...CollectionOption) Collect
 		close(synced)
 		log.Infof("%v synced", o.name)
 	}()
-	if o.stop == nil {
-		panic("no stop channel")
-	}
+	// TODO: in the future, we could have a custom merge function. For now, since we just take the first, we optimize around that case
 	j := &join[T]{
 		collectionName:   o.name,
 		id:               nextUID(),
 		synced:           synced,
 		collections:      c,
 		uncheckedOverlap: o.joinUnchecked,
-		eventHandlers:    newHandlerSet[T](),
-		processedState:   make(map[string]*T),
-		stop:             o.stop,
 		syncer: channelSyncer{
 			name:   o.name,
 			synced: synced,
@@ -386,27 +220,6 @@ func JoinCollection[T any](cs []Collection[T], opts ...CollectionOption) Collect
 	if o.metadata != nil {
 		j.metadata = o.metadata
 	}
-
-	// Register handlers on sub-collections ONCE during construction
-	// These handlers will process events from sub-collections and distribute to registered handlers
-	var subHandlerRegs []HandlerRegistration
-	for idx, subCol := range c {
-		collectionIdx := idx // capture for closure
-		handler := func(events []Event[T]) {
-			j.handleSubCollectionEvents(events, collectionIdx)
-		}
-		// Don't run existing state - we handle that in RegisterBatch
-		reg := subCol.RegisterBatch(handler, false)
-		subHandlerRegs = append(subHandlerRegs, reg)
-	}
-
-	// Clean up sub-collection handlers when this collection's stop is closed
-	go func() {
-		<-o.stop
-		for _, reg := range subHandlerRegs {
-			reg.UnregisterHandler()
-		}
-	}()
 
 	return j
 }

--- a/pkg/kube/krt/join_test.go
+++ b/pkg/kube/krt/join_test.go
@@ -15,7 +15,6 @@
 package krt_test
 
 import (
-	"sync"
 	"testing"
 
 	"go.uber.org/atomic"
@@ -25,7 +24,6 @@ import (
 	istio "istio.io/api/networking/v1alpha3"
 	istioclient "istio.io/client-go/pkg/apis/networking/v1"
 	"istio.io/istio/pkg/kube"
-	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/kube/kclient/clienttest"
 	"istio.io/istio/pkg/kube/krt"
@@ -34,32 +32,14 @@ import (
 	"istio.io/istio/pkg/test/util/assert"
 )
 
-// NamedValue has the same resource name (from Named) but different values
-// for testing conflict resolution with overlapping keys
-type NamedValue struct {
-	Named
-	Value string
-}
-
 func TestJoinCollection(t *testing.T) {
-	t.Run("checked", func(t *testing.T) {
-		testJoinInner(t)
-	})
-	t.Run("unchecked", func(t *testing.T) {
-		testJoinInner(t, krt.WithJoinUnchecked())
-	})
-}
-
-func testJoinInner(t *testing.T, options ...krt.CollectionOption) {
-	options = append(options, krt.WithName("JoinTest"))
-	opts := testOptions(t).With(options...)
-
-	c1 := krt.NewStatic[Named](nil, true, krt.WithName("c1"))
-	c2 := krt.NewStatic[Named](nil, true, krt.WithName("c2"))
-	c3 := krt.NewStatic[Named](nil, true, krt.WithName("c3"))
+	opts := testOptions(t)
+	c1 := krt.NewStatic[Named](nil, true)
+	c2 := krt.NewStatic[Named](nil, true)
+	c3 := krt.NewStatic[Named](nil, true)
 	j := krt.JoinCollection(
 		[]krt.Collection[Named]{c1.AsCollection(), c2.AsCollection(), c3.AsCollection()},
-		opts...,
+		opts.WithName("Join")...,
 	)
 	last := atomic.NewString("")
 	j.Register(func(o krt.Event[Named]) {
@@ -225,103 +205,4 @@ func TestCollectionJoinSync(t *testing.T) {
 		{Named{"namespace", "name"}, NewLabeled(map[string]string{"app": "foo"}), "1.2.3.4"},
 		{Named{"namespace", "name-static"}, NewLabeled(map[string]string{"app": "foo"}), "9.9.9.9"},
 	})
-}
-
-// TestJoinCollectionConflictResolution tests conflict resolution with overlapping keys.
-// Priority order: c1 > c2 > c3 (first collection wins)
-func TestJoinCollectionConflictResolution(t *testing.T) {
-	opts := testOptions(t)
-	c1 := krt.NewStatic[NamedValue](nil, true, krt.WithName("c1"))
-	c2 := krt.NewStatic[NamedValue](nil, true, krt.WithName("c2"))
-	c3 := krt.NewStatic[NamedValue](nil, true, krt.WithName("c3"))
-
-	j := krt.JoinCollection(
-		[]krt.Collection[NamedValue]{c1.AsCollection(), c2.AsCollection(), c3.AsCollection()},
-		opts.WithName("Join")...,
-	)
-
-	var mu sync.Mutex
-	events := []krt.Event[NamedValue]{}
-	j.Register(func(o krt.Event[NamedValue]) {
-		mu.Lock()
-		defer mu.Unlock()
-		events = append(events, o)
-	})
-
-	getEventsLen := func() int {
-		mu.Lock()
-		defer mu.Unlock()
-		return len(events)
-	}
-	getEvent := func(i int) krt.Event[NamedValue] {
-		mu.Lock()
-		defer mu.Unlock()
-		return events[i]
-	}
-	clearEvents := func() {
-		mu.Lock()
-		defer mu.Unlock()
-		events = nil
-	}
-
-	// Test 1: c2 adds key "a" first - should see ADD
-	c2.Set(&NamedValue{Named{"ns", "a"}, "c2-value"})
-	assert.EventuallyEqual(t, getEventsLen, 1)
-	assert.Equal(t, getEvent(0).Event, controllers.EventAdd)
-	assert.Equal(t, getEvent(0).New.Value, "c2-value")
-
-	// Test 2: c1 adds same key - should see UPDATE (c1 has higher priority)
-	clearEvents()
-	c1.Set(&NamedValue{Named{"ns", "a"}, "c1-value"})
-	assert.EventuallyEqual(t, getEventsLen, 1)
-	assert.Equal(t, getEvent(0).Event, controllers.EventUpdate)
-	assert.Equal(t, getEvent(0).Old.Value, "c2-value")
-	assert.Equal(t, getEvent(0).New.Value, "c1-value")
-
-	// Test 3: c3 adds same key - should see NO event (c1 has priority)
-	clearEvents()
-	c3.Set(&NamedValue{Named{"ns", "a"}, "c3-value"})
-	assert.Consistently(t, getEventsLen, 0)
-	assert.Equal(t, j.GetKey("ns/a").Value, "c1-value")
-
-	// Test 4: c2 updates - should see NO event (c1 still owns it)
-	clearEvents()
-	c2.Set(&NamedValue{Named{"ns", "a"}, "c2-updated"})
-	assert.Consistently(t, getEventsLen, 0)
-
-	// Test 5: c1 deletes - should see UPDATE to c2's version (fallback)
-	clearEvents()
-	c1.Set(nil)
-	assert.EventuallyEqual(t, getEventsLen, 1)
-	assert.Equal(t, getEvent(0).Event, controllers.EventUpdate)
-	assert.Equal(t, getEvent(0).Old.Value, "c1-value")
-	assert.Equal(t, getEvent(0).New.Value, "c2-updated")
-
-	// Test 6: c2 deletes - should see UPDATE to c3's version
-	clearEvents()
-	c2.Set(nil)
-	assert.EventuallyEqual(t, getEventsLen, 1)
-	assert.Equal(t, getEvent(0).Event, controllers.EventUpdate)
-	assert.Equal(t, getEvent(0).Old.Value, "c2-updated")
-	assert.Equal(t, getEvent(0).New.Value, "c3-value")
-
-	// Test 7: c3 deletes - should see DELETE (no more fallbacks)
-	clearEvents()
-	c3.Set(nil)
-	assert.EventuallyEqual(t, getEventsLen, 1)
-	assert.Equal(t, getEvent(0).Event, controllers.EventDelete)
-	assert.Equal(t, getEvent(0).Old.Value, "c3-value")
-
-	// Test 8: Delete from lower priority collection when higher priority owns it - NO event
-	clearEvents()
-	c1.Set(&NamedValue{Named{"ns", "b"}, "c1-b"})
-	assert.EventuallyEqual(t, getEventsLen, 1) // Wait for c1's ADD
-
-	clearEvents()
-	c2.Set(&NamedValue{Named{"ns", "b"}, "c2-b"})
-	assert.Consistently(t, getEventsLen, 0) // c2 adding should be ignored
-
-	c2.Set(nil)                             // c2 deletes but c1 still owns it
-	assert.Consistently(t, getEventsLen, 0) // c2 delete should be ignored
-	assert.Equal(t, j.GetKey("ns/b").Value, "c1-b")
 }

--- a/pkg/test/util/assert/assert.go
+++ b/pkg/test/util/assert/assert.go
@@ -111,28 +111,6 @@ func EventuallyEqual[T any](t test.Failer, fetch func() T, expected T, retryOpts
 	}
 }
 
-// Consistently polls the fetch function for a duration and fails if the value ever changes from the expected value.
-// Use sparingly to avoid flakiness, as this is inherently timing-dependent.
-// This is useful for asserting that no events occur (e.g., that a value stays at 0).
-// Default duration is 20ms with 2ms polling interval.
-func Consistently[T any](t test.Failer, fetch func() T, expected T, duration ...time.Duration) {
-	t.Helper()
-	d := time.Millisecond * 20
-	if len(duration) > 0 {
-		d = duration[0]
-	}
-	interval := time.Millisecond * 2
-	deadline := time.Now().Add(d)
-
-	for time.Now().Before(deadline) {
-		a := fetch()
-		if !cmp.Equal(a, expected, opts(expected)...) {
-			t.Fatalf("value changed unexpectedly: %v\nGot: %v\nWant: %v", cmp.Diff(a, expected, opts(expected)...), a, expected)
-		}
-		time.Sleep(interval)
-	}
-}
-
 // Error asserts the provided err is non-nil
 func Error(t test.Failer, err error) {
 	t.Helper()

--- a/releasenotes/notes/58324.yaml
+++ b/releasenotes/notes/58324.yaml
@@ -1,9 +1,0 @@
-apiVersion: release-notes/v2
-kind: bug-fix
-area: traffic-management
-releaseNotes:
-- |
-  **Fixed** rare race condition where deleting a ServiceEntry that shares a
-  hostname with another ServiceEntry in the same namespace occasionally causing
-  ambient clients to lose the ability to send traffic to that hostname until
-  istiod restarts.


### PR DESCRIPTION
This reverts commit 5245b4cfcc635a8aa4284da60acd6014e5b074b8.

The new join misses events for objects that existed during the object creation. 