### PR TITLE
fix: use 2048-bit RSA keys in OIDC test

### DIFF
--- a/security/pkg/server/ca/authenticate/oidc_test.go
+++ b/security/pkg/server/ca/authenticate/oidc_test.go
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Allow a smaller key since large keys + race detector is pretty slow
-//
-//go:debug rsa1024min=0
 package authenticate
 
 import (
@@ -130,7 +127,7 @@ func TestCheckAudience(t *testing.T) {
 
 func TestOIDCAuthenticate(t *testing.T) {
 	// Create a JWKS server
-	rsaKey, err := rsa.GenerateKey(rand.Reader, 512)
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		t.Fatalf("failed to generate a private key: %v", err)
 	}


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/58653

Go 1.24.6+ rejects 512-bit RSA keys as insecure. Update test to use 2048-bit keys.