### PR TITLE
Enable ambient untaint test for dualstack

### DIFF
--- a/tests/integration/ambient/cniupgrade/main_test.go
+++ b/tests/integration/ambient/cniupgrade/main_test.go
@@ -30,6 +30,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo/match"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/namespace"
+	testlabel "istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/test/shell"
@@ -68,6 +69,7 @@ func TestMain(m *testing.M) {
 		NewSuite(m).
 		RequireMinVersion(24).
 		RequireSingleCluster().
+		Label(testlabel.IPv4). // https://github.com/istio/istio/issues/41008
 		Setup(func(t resource.Context) error {
 			t.Settings().Ambient = true
 			return nil


### PR DESCRIPTION
This PR enables the untaint tests in ambient for an IPv6/dualstack env
