### PR TITLE
Fix per-revision namespace controller election

### DIFF
--- a/releasenotes/notes/56594-root-ca-configmap-per-revision.yaml
+++ b/releasenotes/notes/56594-root-ca-configmap-per-revision.yaml
@@ -1,0 +1,13 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+issue:
+  - https://github.com/istio/istio/issues/56594
+  - https://github.com/istio/istio/issues/52988
+
+releaseNotes:
+  - |
+    **Fixed** namespace controller leader election being shared across revisions, which could prevent
+    `istio-ca-root-cert` ConfigMaps from being created for namespaces selected by other revisions when
+    `meshConfig.discoverySelectors` differ.


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix namespace controller leader election to be per-revision (revision-suffixed election ID) so `istio-ca-root-cert` ConfigMaps are created for namespaces selected by each revision when discovery selectors differ.

Fixes #56594
Refs #52988

Tests:
- `go test ./pilot/pkg/serviceregistry/kube/controller`