### PR TITLE
Add "ZtunnelNamespace" flag to specify Ztunnel deployment location

### DIFF
--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -93,6 +93,7 @@ var (
 	settingsFromCommandline = &Config{
 		SystemNamespace:               DefaultSystemNamespace,
 		TelemetryNamespace:            DefaultSystemNamespace,
+		ZtunnelNamespace:              DefaultSystemNamespace,
 		DeployIstio:                   true,
 		PrimaryClusterIOPFile:         IntegrationTestDefaultsIOP,
 		ConfigClusterIOPFile:          IntegrationTestDefaultsIOP,
@@ -116,6 +117,9 @@ type Config struct {
 
 	// The namespace in which kiali, tracing providers, graphana, prometheus are deployed.
 	TelemetryNamespace string
+
+	// The namespace where the ztunnel daemonset resides (default: "istio-system").
+	ZtunnelNamespace string
 
 	// The IstioOperator spec file to be used for Control plane cluster by default
 	PrimaryClusterIOPFile string

--- a/pkg/test/framework/components/istio/flags.go
+++ b/pkg/test/framework/components/istio/flags.go
@@ -24,6 +24,8 @@ func init() {
 		"Specifies the namespace where the istiod resides in a typical deployment. Defaults to istio-system")
 	flag.StringVar(&settingsFromCommandline.TelemetryNamespace, "istio.test.kube.telemetryNamespace", settingsFromCommandline.TelemetryNamespace,
 		"Specifies the namespace in which kiali, tracing providers, graphana, prometheus are deployed.")
+	flag.StringVar(&settingsFromCommandline.ZtunnelNamespace, "istio.test.kube.ztunnelNamespace", settingsFromCommandline.ZtunnelNamespace,
+		"Specifies the namespace where the ztunnel daemonset resides. Defaults to istio-system")
 	flag.BoolVar(&settingsFromCommandline.DeployIstio, "istio.test.kube.deploy", settingsFromCommandline.DeployIstio,
 		"Deploy Istio into the target Kubernetes environment.")
 	flag.StringVar(&settingsFromCommandline.BaseIOPFile, "istio.test.kube.helm.baseIopFile", settingsFromCommandline.BaseIOPFile,

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -3714,7 +3714,8 @@ func restartZtunnel(t framework.TestContext, c cluster.Cluster) {
 				}
 			}
 		}`, time.Now().Format(time.RFC3339)) // e.g., “2006-01-02T15:04:05Z07:00”
-	ds := c.Kube().AppsV1().DaemonSets(i.Settings().SystemNamespace)
+	ztunnelNS := i.Settings().ZtunnelNamespace
+	ds := c.Kube().AppsV1().DaemonSets(ztunnelNS)
 	_, err := ds.Patch(context.Background(), "ztunnel", types.StrategicMergePatchType, []byte(patchData), patchOpts)
 	if err != nil {
 		t.Fatal(err)
@@ -3732,7 +3733,7 @@ func restartZtunnel(t framework.TestContext, c cluster.Cluster) {
 	}, retry.Timeout(60*time.Second), retry.Delay(2*time.Second)); err != nil {
 		t.Fatalf("failed to wait for ztunnel rollout status for: %v", err)
 	}
-	if _, err := kubetest.CheckPodsAreReady(kubetest.NewPodFetch(t.AllClusters()[0], i.Settings().SystemNamespace, "app=ztunnel")); err != nil {
+	if _, err := kubetest.CheckPodsAreReady(kubetest.NewPodFetch(t.AllClusters()[0], ztunnelNS, "app=ztunnel")); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -3850,8 +3851,8 @@ func TestZtunnelSecureMetrics(t *testing.T) {
 					tc.Fatal("No captured client instance found for ZtunnelSecureMetrics test")
 				}
 
-				istioSystemNS := i.Settings().SystemNamespace
-				k8sPods := c.Kube().CoreV1().Pods(istioSystemNS)
+				ztunnelNS := i.Settings().ZtunnelNamespace
+				k8sPods := c.Kube().CoreV1().Pods(ztunnelNS)
 
 				// Get ztunnel pod info
 				ztunnelPods, err := k8sPods.List(context.TODO(), metav1.ListOptions{LabelSelector: "app=ztunnel"})
@@ -3862,7 +3863,7 @@ func TestZtunnelSecureMetrics(t *testing.T) {
 				ztunnelPodIP := ztunnelPod.Status.PodIP
 				ztunnelMetricsPort := 15020 // Default ztunnel metrics port
 				ztunnelServiceAccount := ztunnelPod.Spec.ServiceAccountName
-				trustDomain := util.GetTrustDomain(c, istioSystemNS)
+				trustDomain := util.GetTrustDomain(c, ztunnelNS)
 				// Extract ztunnel app labels for canonical service/revision
 				ztunnelAppLabel := ztunnelPod.Labels["app"]
 				ztunnelVersionLabel := ztunnelPod.Labels["app.kubernetes.io/version"]
@@ -3896,9 +3897,9 @@ func TestZtunnelSecureMetrics(t *testing.T) {
 					Labels: map[string]string{
 						"reporter":                       "destination",
 						"connection_security_policy":     "mutual_tls",
-						"destination_workload_namespace": istioSystemNS,
+						"destination_workload_namespace": ztunnelNS,
 						"destination_workload":           "ztunnel",
-						"destination_principal":          fmt.Sprintf("spiffe://%s/ns/%s/sa/%s", trustDomain, istioSystemNS, ztunnelServiceAccount),
+						"destination_principal":          fmt.Sprintf("spiffe://%s/ns/%s/sa/%s", trustDomain, ztunnelNS, ztunnelServiceAccount),
 						"destination_canonical_service":  ztunnelAppLabel,
 						"destination_canonical_revision": ztunnelVersionLabel,
 						"source_workload_namespace":      sourceNamespace,

--- a/tests/integration/ambient/cacert_rotation_test.go
+++ b/tests/integration/ambient/cacert_rotation_test.go
@@ -49,11 +49,12 @@ func TestIntermediateCertificateRefresh(t *testing.T) {
 			istioCtl := istioctl.NewOrFail(t, istioctl.Config{})
 			namespace.ClaimOrFail(t, istioCfg.SystemNamespace)
 			newX509 := getX509FromFile(t, "ca-cert-alt-2.pem")
+			ztunnelNS := istioCfg.ZtunnelNamespace
 
 			sa := apps.Captured[0].SpiffeIdentity()
 
 			// we do not know which ztunnel instance is located on the node as the workload, so we need to check all of them initially
-			ztunnelPods, err := kubetest.NewPodFetch(t.AllClusters()[0], istioCfg.SystemNamespace, "app=ztunnel")()
+			ztunnelPods, err := kubetest.NewPodFetch(t.AllClusters()[0], ztunnelNS, "app=ztunnel")()
 			assert.NoError(t, err)
 
 			originalWorkloadSecret, ztunnelPod, err := getWorkloadSecret(t, ztunnelPods, sa, istioCtl)

--- a/tests/integration/ambient/istioctl_test.go
+++ b/tests/integration/ambient/istioctl_test.go
@@ -40,7 +40,8 @@ func TestZtunnelConfig(t *testing.T) {
 			istioCtl := istioctl.NewOrFail(t, istioctl.Config{})
 			istioCfg := istio.DefaultConfigOrFail(t, t)
 			g := NewWithT(t)
-			ztunnelPods, err := kubetest.NewPodFetch(t.AllClusters()[0], istioCfg.SystemNamespace, "app=ztunnel")()
+			ztunnelNS := istioCfg.ZtunnelNamespace
+			ztunnelPods, err := kubetest.NewPodFetch(t.AllClusters()[0], ztunnelNS, "app=ztunnel")()
 			assert.NoError(t, err)
 			podName, err := getPodName(ztunnelPods)
 			if err != nil {
@@ -48,7 +49,7 @@ func TestZtunnelConfig(t *testing.T) {
 			}
 
 			args := []string{
-				"zc", "all", podName, "-o", "json",
+				"zc", "all", podName, "--namespace", ztunnelNS, "-o", "json",
 			}
 			var zDumpAll configdump.ZtunnelDump
 			out, _ := istioCtl.InvokeOrFail(t, args)
@@ -62,7 +63,7 @@ func TestZtunnelConfig(t *testing.T) {
 
 			var zDump configdump.ZtunnelDump
 			args = []string{
-				"zc", "services", podName, "-o", "json",
+				"zc", "services", podName, "--namespace", ztunnelNS, "-o", "json",
 			}
 			out, _ = istioCtl.InvokeOrFail(t, args)
 			err = unmarshalListOrMap([]byte(out), &zDump.Services)
@@ -70,7 +71,7 @@ func TestZtunnelConfig(t *testing.T) {
 			g.Expect(zDump.Services).To(Not(BeNil()))
 
 			args = []string{
-				"zc", "workloads", podName, "-o", "json",
+				"zc", "workloads", podName, "--namespace", ztunnelNS, "-o", "json",
 			}
 			out, _ = istioCtl.InvokeOrFail(t, args)
 			err = unmarshalListOrMap([]byte(out), &zDump.Workloads)
@@ -78,7 +79,7 @@ func TestZtunnelConfig(t *testing.T) {
 			g.Expect(zDump.Workloads).To(Not(BeNil()))
 
 			args = []string{
-				"zc", "policies", podName, "-o", "json",
+				"zc", "policies", podName, "--namespace", ztunnelNS, "-o", "json",
 			}
 			out, _ = istioCtl.InvokeOrFail(t, args)
 			err = unmarshalListOrMap([]byte(out), &zDump.Policies)
@@ -86,7 +87,7 @@ func TestZtunnelConfig(t *testing.T) {
 			g.Expect(zDump.Policies).To(Not(BeNil()))
 
 			args = []string{
-				"zc", "certificates", podName, "-o", "json",
+				"zc", "certificates", podName, "--namespace", ztunnelNS, "-o", "json",
 			}
 			out, _ = istioCtl.InvokeOrFail(t, args)
 			err = unmarshalListOrMap([]byte(out), &zDump.Certificates)


### PR DESCRIPTION
**Please provide a description of this PR:**
Add "ZtunnelNamespace" flag to specify Ztunnel deployment location

During deployment of Ambient mode, Ztunnel resource could be deployed to a namespace other that "istio-system".
When executing TestZtunnelConfig and TestZtunnelRestart integration tests,
while Ztunnel resource deployment in a separate NS, the test will fail as will not be able to locate the required resource.

Add "ZtunnelNamespace" flag to specify Ztunnel deployment location.
Defaults to - "istio-system".