### PR TITLE
[release-1.27] Allow overriding gateway Service selector labels via Helm values

### DIFF
--- a/manifests/charts/gateway/templates/service.yaml
+++ b/manifests/charts/gateway/templates/service.yaml
@@ -66,4 +66,7 @@ spec:
 {{- end }}
   selector:
     {{- include "gateway.selectorLabels" . | nindent 4 }}
+    {{- with .Values.service.selectorLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -178,6 +178,12 @@
             "annotations": {
               "type": "object"
             },
+            "selectorLabels": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
             "externalTrafficPolicy": {
               "type": "string"
             },

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -42,6 +42,8 @@ _internal_defaults_do_not_set:
   service:
     # Type of service. Set to "None" to disable the service entirely
     type: LoadBalancer
+    # Additional labels to add to the service selector
+    selectorLabels: {}
     ports:
     - name: status-port
       port: 15021

--- a/operator/pkg/helm/helm_test.go
+++ b/operator/pkg/helm/helm_test.go
@@ -68,6 +68,13 @@ func TestRender(t *testing.T) {
 			diffSelect:  "Deployment:*:istio-ingress",
 		},
 		{
+			desc:        "gateway-service-selector-labels",
+			releaseName: "istio-ingress",
+			namespace:   "istio-ingress",
+			chartName:   "gateway",
+			diffSelect:  "Service:*:istio-ingress",
+		},
+		{
 			desc:        "istiod-traffic-distribution",
 			releaseName: "istiod",
 			namespace:   "istio-system",

--- a/operator/pkg/helm/testdata/input/gateway-service-selector-labels.yaml
+++ b/operator/pkg/helm/testdata/input/gateway-service-selector-labels.yaml
@@ -1,0 +1,6 @@
+spec:
+  values:
+    service:
+      selectorLabels:
+        istio.io/rev: canary
+        custom-label: custom-value

--- a/operator/pkg/helm/testdata/output/gateway-service-selector-labels.golden.yaml
+++ b/operator/pkg/helm/testdata/output/gateway-service-selector-labels.golden.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-ingress
+  namespace: istio-ingress
+  labels:
+    app.kubernetes.io/name: istio-ingress
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "istio-ingress"
+    app.kubernetes.io/part-of: "istio"
+    app.kubernetes.io/version: "1.0.0"
+    helm.sh/chart: gateway-1.0.0
+    app: istio-ingress
+    istio: ingress
+    "istio.io/dataplane-mode": "none"
+  annotations:
+    {}
+spec:
+  type: LoadBalancer
+  ports:
+    - name: status-port
+      port: 15021
+      protocol: TCP
+      targetPort: 15021
+    - name: http2
+      port: 80
+      protocol: TCP
+      targetPort: 80
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 443
+  selector:
+    app: istio-ingress
+    istio: ingress
+    custom-label: custom-value
+    istio.io/rev: canary

--- a/releasenotes/notes/gateway-service-selector-labels.yaml
+++ b/releasenotes/notes/gateway-service-selector-labels.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+
+kind: feature
+
+area: installation
+
+releaseNotes:
+- |
+  **Added** `service.selectorLabels` field to gateway Helm chart for custom service selector labels during revision-based migrations.


### PR DESCRIPTION
Cherry-pick of #58562 to release-1.27. Adds support for service.selectorLabels in gateway Helm chart https://github.com/istio/istio/issues/58561.