### PR TITLE
Wildcard hostname support in sidecar mode for SE for HTTP and TLS

### DIFF
--- a/pilot/pkg/networking/core/cluster.go
+++ b/pilot/pkg/networking/core/cluster.go
@@ -373,9 +373,36 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(cb *ClusterBuilder, 
 	efKeys := cp.efw.KeysApplyingTo(networking.EnvoyFilter_CLUSTER)
 	hit, miss := 0, 0
 	for _, service := range services {
-		if service.Resolution == model.Alias || service.Resolution == model.DynamicDNS {
+		if service.Resolution == model.Alias {
 			continue
 		}
+
+		// DYNAMIC_DNS: Use Dynamic Forward Proxy for wildcard hostnames
+		if service.Hostname.IsWildCarded() && service.Resolution == model.DynamicDNS {
+			for _, port := range service.Ports {
+				if port.Protocol == protocol.UDP {
+					continue
+				}
+				// DFP supports HTTP, TLS, GRPC, and HTTP2. GRPC/HTTP2 get http2_protocol_options via setUpstreamProtocol.
+				if port.Protocol != protocol.HTTP && port.Protocol != protocol.TLS &&
+					port.Protocol != protocol.GRPC && port.Protocol != protocol.HTTP2 {
+					log.Debugf("skipping DFP cluster for unsupported protocol %s for service %s", port.Protocol, service.Hostname)
+					continue
+				}
+				clusterName := model.BuildSubsetKey(model.TrafficDirectionOutbound, "", service.Hostname, port.Port)
+				dfpCluster := cb.buildDFPCluster(clusterName, service, port)
+
+				// Apply DestinationRule settings
+				destRule := proxy.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, proxy, service.Hostname)
+				cb.applyDestinationRule(dfpCluster, DefaultClusterMode, service, port, nil, destRule.GetRule(), nil)
+
+				if patched := cp.patch([]host.Name{service.Hostname}, dfpCluster.build()); patched != nil {
+					resources = append(resources, patched)
+				}
+			}
+			continue
+		}
+
 		for i, port := range service.Ports {
 			if port.Protocol == protocol.UDP {
 				continue

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -357,7 +357,10 @@ func (cb *ClusterBuilder) applyDestinationRule(mc *clusterWrapper, clusterMode C
 
 	if clusterMode == DefaultClusterMode {
 		opts.serviceAccounts = serviceAccounts
-		opts.istioMtlsSni = model.BuildDNSSrvSubsetKey(model.TrafficDirectionOutbound, "", service.Hostname, port.Port)
+		// For DFP clusters, we use auto_sni instead of static SNI
+		if !mc.isDFPCluster {
+			opts.istioMtlsSni = model.BuildDNSSrvSubsetKey(model.TrafficDirectionOutbound, "", service.Hostname, port.Port)
+		}
 		opts.meshExternal = service.MeshExternal
 		opts.serviceRegistry = service.Attributes.ServiceRegistry
 		opts.serviceMTLSMode = cb.req.Push.BestEffortInferServiceMTLSMode(destinationRule.GetTrafficPolicy(), service, port)
@@ -396,6 +399,12 @@ func (cb *ClusterBuilder) applyDestinationRule(mc *clusterWrapper, clusterMode C
 		mc.cluster.Metadata = util.AddConfigInfoMetadata(mc.cluster.Metadata, destRule.Meta)
 		mc.cluster.Metadata = util.AddALPNOverrideToMetadata(mc.cluster.Metadata, opts.policy.GetTls().GetMode())
 	}
+
+	// DFP clusters don't support subsets - skip subset cluster creation
+	if service.Hostname.IsWildCarded() && service.Resolution == model.DynamicDNS {
+		return nil
+	}
+
 	subsetClusters := make([]*cluster.Cluster, 0)
 	for _, subset := range destinationRule.GetSubsets() {
 		subsetCluster := cb.buildSubsetCluster(opts, destRule, subset, service, eb)

--- a/pilot/pkg/networking/core/cluster_dfp_sidecar_test.go
+++ b/pilot/pkg/networking/core/cluster_dfp_sidecar_test.go
@@ -1,0 +1,327 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"fmt"
+	"testing"
+
+	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	dfpcluster "github.com/envoyproxy/go-control-plane/envoy/extensions/clusters/dynamic_forward_proxy/v3"
+	upstream "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
+	. "github.com/onsi/gomega"
+	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
+
+	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/test/xdstest"
+	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/schema/gvk"
+)
+
+// TestSidecarDynamicDNSClusters tests DFP cluster creation for sidecar proxies
+func TestSidecarDynamicDNSClusters(t *testing.T) {
+	cases := []struct {
+		name                    string
+		protocol                string
+		port                    uint32
+		destinationRule         *networking.DestinationRule
+		expectCluster           bool
+		validateTLS             bool
+		expectAutoSni           bool
+		expectAutoSanValidation bool
+		expectTransportTLS      bool
+	}{
+		{
+			name:          "HTTP protocol",
+			protocol:      "HTTP",
+			port:          80,
+			expectCluster: true,
+		},
+		{
+			name:     "HTTP with ISTIO_MUTUAL mode",
+			protocol: "HTTP",
+			port:     80,
+			destinationRule: &networking.DestinationRule{
+				Host: "*.svc.cluster.local",
+				TrafficPolicy: &networking.TrafficPolicy{
+					Tls: &networking.ClientTLSSettings{
+						Mode: networking.ClientTLSSettings_ISTIO_MUTUAL,
+					},
+				},
+			},
+			expectCluster:           true,
+			validateTLS:             true,
+			expectAutoSni:           true,
+			expectAutoSanValidation: true,
+			expectTransportTLS:      true,
+		},
+		{
+			name:          "GRPC protocol",
+			protocol:      "GRPC",
+			port:          9090,
+			expectCluster: true,
+		},
+		{
+			name:          "TLS protocol",
+			protocol:      "TLS",
+			port:          443,
+			expectCluster: true,
+		},
+		{
+			name:     "TLS with SIMPLE mode",
+			protocol: "TLS",
+			port:     443,
+			destinationRule: &networking.DestinationRule{
+				Host: "*.svc.cluster.local",
+				TrafficPolicy: &networking.TrafficPolicy{
+					Tls: &networking.ClientTLSSettings{
+						Mode: networking.ClientTLSSettings_SIMPLE,
+					},
+				},
+			},
+			expectCluster:           true,
+			validateTLS:             true,
+			expectAutoSni:           true,
+			expectAutoSanValidation: true,
+			expectTransportTLS:      true,
+		},
+		{
+			name:     "TLS with ISTIO_MUTUAL mode",
+			protocol: "TLS",
+			port:     443,
+			destinationRule: &networking.DestinationRule{
+				Host: "*.svc.cluster.local",
+				TrafficPolicy: &networking.TrafficPolicy{
+					Tls: &networking.ClientTLSSettings{
+						Mode: networking.ClientTLSSettings_ISTIO_MUTUAL,
+					},
+				},
+			},
+			expectCluster:           true,
+			validateTLS:             true,
+			expectAutoSni:           true,
+			expectAutoSanValidation: true,
+			expectTransportTLS:      true,
+		},
+		{
+			name:     "TLS with MUTUAL mode",
+			protocol: "TLS",
+			port:     443,
+			destinationRule: &networking.DestinationRule{
+				Host: "*.svc.cluster.local",
+				TrafficPolicy: &networking.TrafficPolicy{
+					Tls: &networking.ClientTLSSettings{
+						Mode:              networking.ClientTLSSettings_MUTUAL,
+						ClientCertificate: "/etc/certs/cert.pem",
+						PrivateKey:        "/etc/certs/key.pem",
+						CaCertificates:    "/etc/certs/ca.pem",
+					},
+				},
+			},
+			expectCluster:           true,
+			validateTLS:             true,
+			expectAutoSni:           true,
+			expectAutoSanValidation: true,
+			expectTransportTLS:      true,
+		},
+		{
+			name:          "Unsupported protocol TCP",
+			protocol:      "TCP",
+			port:          3306,
+			expectCluster: false,
+		},
+		{
+			name:          "Unsupported protocol HTTPS",
+			protocol:      "HTTPS",
+			port:          443,
+			expectCluster: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			serviceEntry := config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.ServiceEntry,
+					Name:             "wildcard-se",
+					Namespace:        "default",
+				},
+				Spec: &networking.ServiceEntry{
+					Hosts: []string{"*.svc.cluster.local"},
+					Ports: []*networking.ServicePort{
+						{Number: tc.port, Name: "test-port", Protocol: tc.protocol},
+					},
+					Location:   networking.ServiceEntry_MESH_EXTERNAL,
+					Resolution: networking.ServiceEntry_DYNAMIC_DNS,
+				},
+			}
+
+			configs := []config.Config{serviceEntry}
+			if tc.destinationRule != nil {
+				drConfig := config.Config{
+					Meta: config.Meta{
+						GroupVersionKind: gvk.DestinationRule,
+						Name:             "wildcard-dr",
+						Namespace:        "default",
+					},
+					Spec: tc.destinationRule,
+				}
+				configs = append(configs, drConfig)
+			}
+
+			cg := NewConfigGenTest(t, TestOptions{Configs: configs})
+			proxy := cg.SetupProxy(nil)
+			clusters := cg.Clusters(proxy)
+			xdstest.ValidateClusters(t, clusters)
+
+			clusterMap := xdstest.ExtractClusters(clusters)
+			clusterName := fmt.Sprintf("outbound|%d||*.svc.cluster.local", tc.port)
+			dfpCluster, exists := clusterMap[clusterName]
+
+			if tc.expectCluster {
+				g.Expect(exists).To(BeTrue(), "DFP cluster should be created")
+				g.Expect(dfpCluster).NotTo(BeNil())
+
+				// Verify it's a DFP cluster with CLUSTER_PROVIDED LB policy
+				g.Expect(dfpCluster.LbPolicy).To(Equal(cluster.Cluster_CLUSTER_PROVIDED))
+				clusterType, ok := dfpCluster.ClusterDiscoveryType.(*cluster.Cluster_ClusterType)
+				g.Expect(ok).To(BeTrue())
+				g.Expect(clusterType.ClusterType.Name).To(Equal("envoy.clusters.dynamic_forward_proxy"))
+
+				// Verify DNS cache config
+				dfpConfig := &dfpcluster.ClusterConfig{}
+				err := clusterType.ClusterType.TypedConfig.UnmarshalTo(dfpConfig)
+				g.Expect(err).To(BeNil())
+				g.Expect(dfpConfig.GetDnsCacheConfig()).NotTo(BeNil())
+				g.Expect(dfpConfig.GetDnsCacheConfig().Name).To(Equal("*.svc.cluster.local_dfp_dns_cache"))
+				g.Expect(dfpConfig.GetDnsCacheConfig().DnsLookupFamily).To(Equal(cluster.Cluster_V4_ONLY))
+
+				// Validate TLS settings if needed
+				if tc.validateTLS {
+					if tc.expectTransportTLS {
+						g.Expect(dfpCluster.TransportSocket).NotTo(BeNil())
+						g.Expect(dfpCluster.TransportSocket.Name).To(Equal("envoy.transport_sockets.tls"))
+					}
+
+					// For TLS with DestinationRule, validate AutoSni/AutoSanValidation if HTTP protocol options are present
+					if (tc.expectAutoSni || tc.expectAutoSanValidation) && dfpCluster.TypedExtensionProtocolOptions != nil {
+						httpOptsAny, hasHTTPOpts := dfpCluster.TypedExtensionProtocolOptions["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
+						if hasHTTPOpts {
+							httpOpts := &upstream.HttpProtocolOptions{}
+							err := httpOptsAny.UnmarshalTo(httpOpts)
+							g.Expect(err).To(BeNil())
+							if httpOpts.UpstreamHttpProtocolOptions != nil {
+								if tc.expectAutoSni {
+									g.Expect(httpOpts.UpstreamHttpProtocolOptions.AutoSni).To(BeTrue())
+								}
+								if tc.expectAutoSanValidation {
+									g.Expect(httpOpts.UpstreamHttpProtocolOptions.AutoSanValidation).To(BeTrue())
+								} else {
+									// Explicitly verify it's NOT set when not expected
+									g.Expect(httpOpts.UpstreamHttpProtocolOptions.AutoSanValidation).To(BeFalse())
+								}
+							}
+						}
+					}
+				}
+			} else {
+				g.Expect(exists).To(BeFalse(), "DFP cluster should not be created")
+			}
+		})
+	}
+}
+
+func TestSidecarDynamicDNSInsecureSkipVerify(t *testing.T) {
+	g := NewWithT(t)
+
+	serviceEntry := config.Config{
+		Meta: config.Meta{
+			GroupVersionKind: gvk.ServiceEntry,
+			Name:             "wildcard-se",
+			Namespace:        "default",
+		},
+		Spec: &networking.ServiceEntry{
+			Hosts: []string{"*.svc.cluster.local"},
+			Ports: []*networking.ServicePort{
+				{Number: 443, Name: "tls", Protocol: "TLS"},
+			},
+			Location:   networking.ServiceEntry_MESH_EXTERNAL,
+			Resolution: networking.ServiceEntry_DYNAMIC_DNS,
+		},
+	}
+
+	destinationRule := config.Config{
+		Meta: config.Meta{
+			GroupVersionKind: gvk.DestinationRule,
+			Name:             "wildcard-dr",
+			Namespace:        "default",
+		},
+		Spec: &networking.DestinationRule{
+			Host: "*.svc.cluster.local",
+			TrafficPolicy: &networking.TrafficPolicy{
+				Tls: &networking.ClientTLSSettings{
+					Mode:               networking.ClientTLSSettings_SIMPLE,
+					InsecureSkipVerify: wrappers.Bool(true),
+				},
+			},
+		},
+	}
+
+	cg := NewConfigGenTest(t, TestOptions{
+		Configs: []config.Config{serviceEntry, destinationRule},
+	})
+
+	proxy := cg.SetupProxy(nil)
+	clusters := cg.Clusters(proxy)
+	xdstest.ValidateClusters(t, clusters)
+
+	clusterMap := xdstest.ExtractClusters(clusters)
+	dfpCluster := clusterMap["outbound|443||*.svc.cluster.local"]
+	g.Expect(dfpCluster).NotTo(BeNil(), "DFP cluster should be created")
+
+	// Verify it's a DFP cluster
+	clusterType, ok := dfpCluster.ClusterDiscoveryType.(*cluster.Cluster_ClusterType)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(clusterType.ClusterType.Name).To(Equal("envoy.clusters.dynamic_forward_proxy"))
+
+	// Verify InsecureSkipVerify sets AllowInsecureClusterOptions
+	dfpConfig := &dfpcluster.ClusterConfig{}
+	err := clusterType.ClusterType.TypedConfig.UnmarshalTo(dfpConfig)
+	g.Expect(err).To(BeNil())
+	g.Expect(dfpConfig.AllowInsecureClusterOptions).To(BeTrue(),
+		"AllowInsecureClusterOptions should be true when InsecureSkipVerify is set")
+
+	// Verify TLS transport socket is still present
+	g.Expect(dfpCluster.TransportSocket).NotTo(BeNil())
+	g.Expect(dfpCluster.TransportSocket.Name).To(Equal("envoy.transport_sockets.tls"))
+
+	// Verify AutoSni and AutoSanValidation are NOT set when InsecureSkipVerify is true
+	if dfpCluster.TypedExtensionProtocolOptions != nil {
+		httpOptsAny, hasHTTPOpts := dfpCluster.TypedExtensionProtocolOptions["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
+		if hasHTTPOpts {
+			httpOpts := &upstream.HttpProtocolOptions{}
+			err := httpOptsAny.UnmarshalTo(httpOpts)
+			g.Expect(err).To(BeNil())
+			if httpOpts.UpstreamHttpProtocolOptions != nil {
+				// AutoSni should be true, but AutoSanValidation should be false with InsecureSkipVerify
+				g.Expect(httpOpts.UpstreamHttpProtocolOptions.AutoSni).To(BeTrue())
+				g.Expect(httpOpts.UpstreamHttpProtocolOptions.AutoSanValidation).To(BeFalse(),
+					"AutoSanValidation should be false when InsecureSkipVerify is true")
+			}
+		}
+	}
+}

--- a/pilot/pkg/networking/core/cluster_tls.go
+++ b/pilot/pkg/networking/core/cluster_tls.go
@@ -24,6 +24,7 @@ import (
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	http "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
@@ -147,8 +148,8 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 				ValidationContextSdsSecretConfig: sec_model.ConstructSdsSecretConfig(sec_model.SDSRootResourceName),
 			},
 		}
-		// Set default SNI of cluster name for istio_mutual if sni is not set.
-		if len(tlsContext.Sni) == 0 {
+		// Set default SNI of cluster name for istio_mutual if sni is not set and if not a DFP cluster.
+		if len(tlsContext.Sni) == 0 && !c.isDFPCluster {
 			tlsContext.Sni = c.cluster.Name
 		}
 		// `istio-peer-exchange` alpn is only used when using mtls communication between peers.
@@ -168,6 +169,10 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 			} else {
 				tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNInMesh
 			}
+		}
+		// Set auto_sni, auto_san_validation and allow_insecure_cluster_options for sidecar DFP clusters.
+		if c.isDFPCluster && opts.direction == model.TrafficDirectionOutbound {
+			setAutoSniAndAutoSanValidation(c, tls)
 		}
 	case networking.ClientTLSSettings_SIMPLE:
 		tlsContext, err = constructUpstreamTLS(opts, tls, c, false)
@@ -278,18 +283,21 @@ func setAutoSniAndAutoSanValidation(mc *clusterWrapper, tls *networking.ClientTL
 		return
 	}
 
+	insecureSkipVerify := tls.GetInsecureSkipVerify().GetValue()
 	setAutoSni := false
 	setAutoSanValidation := false
 	if len(tls.Sni) == 0 {
 		setAutoSni = true
 	}
-	// For DFP clusters, we only set auto_san_validation if insecure_skip_verify is false.
-	if (setAutoSni && len(tls.SubjectAltNames) == 0 || mc.isDFPCluster) && !tls.GetInsecureSkipVerify().GetValue() {
+
+	// If insecureSkipVerify is true, we do not set auto_san_validation in all cases.
+	// For non-DFP clusters, require auto_san_validation if auto_sni is set and there are no explicit SANs
+	if (mc.isDFPCluster || (!mc.isDFPCluster && setAutoSni && len(tls.SubjectAltNames) == 0)) && !insecureSkipVerify {
 		setAutoSanValidation = true
 	}
 
-	// For DFP clusters, we need to allow_insecure_cluster_options if insecure_skip_verify is true.
-	if mc.isDFPCluster && tls.GetInsecureSkipVerify().GetValue() {
+	// For DFP clusters, we need to allow_insecure_cluster_options if insecure_skip_verify is true or if auto_sni or auto_san_validation is not set.
+	if mc.isDFPCluster && (insecureSkipVerify || !setAutoSni || !setAutoSanValidation) {
 		clusterType, ok := mc.cluster.ClusterDiscoveryType.(*cluster.Cluster_ClusterType)
 		if !ok {
 			log.Warnf("failed to set allow_insecure_cluster_options for DFP cluster %s: invalid cluster type", mc.cluster.Name)
@@ -318,9 +326,11 @@ func setAutoSniAndAutoSanValidation(mc *clusterWrapper, tls *networking.ClientTL
 			mc.httpProtocolOptions.UpstreamHttpProtocolOptions = &core.UpstreamHttpProtocolOptions{}
 		}
 		if setAutoSni {
+			log.Debugf("set auto_sni for DFP cluster %s", mc.cluster.Name)
 			mc.httpProtocolOptions.UpstreamHttpProtocolOptions.AutoSni = true
 		}
 		if setAutoSanValidation {
+			log.Debugf("set auto_san_validation for DFP cluster %s", mc.cluster.Name)
 			mc.httpProtocolOptions.UpstreamHttpProtocolOptions.AutoSanValidation = true
 		}
 	}
@@ -429,7 +439,7 @@ func (cb *ClusterBuilder) buildUpstreamTLSSettings(
 			// When building Mutual TLS settings, we should always use user supplied SubjectAltNames and SNI
 			// in destination rule. The Service Accounts and auto computed SNI should only be used for
 			// ISTIO_MUTUAL.
-			return cb.buildMutualTLS(tls.SubjectAltNames, tls.Sni), userSupplied
+			return cb.buildMutualTLS(tls.SubjectAltNames, tls.Sni, tls.InsecureSkipVerify), userSupplied
 		}
 		if tls.Mode != networking.ClientTLSSettings_ISTIO_MUTUAL {
 			return tls, userSupplied
@@ -446,7 +456,8 @@ func (cb *ClusterBuilder) buildUpstreamTLSSettings(
 		if subjectAltNamesToUse == nil {
 			subjectAltNamesToUse = serviceAccounts
 		}
-		return cb.buildIstioMutualTLS(subjectAltNamesToUse, sniToUse), userSupplied
+		// Preserve InsecureSkipVerify from configured Destination Rule (e.g. for DFP when cert has no DNS SAN).
+		return cb.buildIstioMutualTLS(subjectAltNamesToUse, sniToUse, tls.InsecureSkipVerify), userSupplied
 	}
 
 	if meshExternal || !autoMTLSEnabled || serviceMTLSMode == model.MTLSUnknown || serviceMTLSMode == model.MTLSDisable {
@@ -455,11 +466,10 @@ func (cb *ClusterBuilder) buildUpstreamTLSSettings(
 
 	// For backward compatibility, use metadata certs if provided.
 	if cb.hasMetadataCerts() {
-		return cb.buildMutualTLS(serviceAccounts, sni), autoDetected
+		return cb.buildMutualTLS(serviceAccounts, sni, nil), autoDetected
 	}
 
-	// Build settings for auto MTLS.
-	return cb.buildIstioMutualTLS(serviceAccounts, sni), autoDetected
+	return cb.buildIstioMutualTLS(serviceAccounts, sni, nil), autoDetected
 }
 
 func (cb *ClusterBuilder) hasMetadataCerts() bool {
@@ -467,22 +477,24 @@ func (cb *ClusterBuilder) hasMetadataCerts() bool {
 }
 
 // buildMutualTLS returns a `TLSSettings` for MUTUAL mode with proxy metadata certificates.
-func (cb *ClusterBuilder) buildMutualTLS(serviceAccounts []string, sni string) *networking.ClientTLSSettings {
+func (cb *ClusterBuilder) buildMutualTLS(serviceAccounts []string, sni string, insecureSkipVerify *wrapperspb.BoolValue) *networking.ClientTLSSettings {
 	return &networking.ClientTLSSettings{
-		Mode:              networking.ClientTLSSettings_MUTUAL,
-		CaCertificates:    cb.metadataCerts.tlsClientRootCert,
-		ClientCertificate: cb.metadataCerts.tlsClientCertChain,
-		PrivateKey:        cb.metadataCerts.tlsClientKey,
-		SubjectAltNames:   serviceAccounts,
-		Sni:               sni,
+		Mode:               networking.ClientTLSSettings_MUTUAL,
+		CaCertificates:     cb.metadataCerts.tlsClientRootCert,
+		ClientCertificate:  cb.metadataCerts.tlsClientCertChain,
+		PrivateKey:         cb.metadataCerts.tlsClientKey,
+		SubjectAltNames:    serviceAccounts,
+		Sni:                sni,
+		InsecureSkipVerify: insecureSkipVerify,
 	}
 }
 
 // buildIstioMutualTLS returns a `TLSSettings` for ISTIO_MUTUAL mode.
-func (cb *ClusterBuilder) buildIstioMutualTLS(san []string, sni string) *networking.ClientTLSSettings {
+func (cb *ClusterBuilder) buildIstioMutualTLS(san []string, sni string, insecureSkipVerify *wrapperspb.BoolValue) *networking.ClientTLSSettings {
 	return &networking.ClientTLSSettings{
-		Mode:            networking.ClientTLSSettings_ISTIO_MUTUAL,
-		SubjectAltNames: san,
-		Sni:             sni,
+		Mode:               networking.ClientTLSSettings_ISTIO_MUTUAL,
+		SubjectAltNames:    san,
+		Sni:                sni,
+		InsecureSkipVerify: insecureSkipVerify,
 	}
 }

--- a/pilot/pkg/networking/core/cluster_traffic_policy.go
+++ b/pilot/pkg/networking/core/cluster_traffic_policy.go
@@ -266,6 +266,10 @@ func applyLoadBalancer(
 	meshConfig *meshconfig.MeshConfig,
 	wrappedLocalityLbEndpoints *loadbalancer.WrappedLocalityLbEndpoints,
 ) {
+	// DFP clusters (DYNAMIC_DNS ServiceEntries) use CLUSTER_PROVIDED LB policy
+	if c.LbPolicy == cluster.Cluster_CLUSTER_PROVIDED {
+		return
+	}
 	// Disable panic threshold when SendUnhealthyEndpoints is enabled as enabling it "may" send traffic to unready
 	// end points when load balancer is in panic mode.
 	if svc.SupportsUnhealthyEndpoints() {

--- a/pilot/pkg/networking/core/gateway.go
+++ b/pilot/pkg/networking/core/gateway.go
@@ -998,7 +998,7 @@ func builtAutoPassthroughFilterChains(push *model.PushContext, proxy *model.Prox
 				applicationProtocols: allIstioMtlsALPNs,
 				tlsContext:           nil, // NO TLS context because this is passthrough
 				networkFilters: lb.buildOutboundNetworkFiltersWithSingleDestination(
-					statPrefix, clusterName, "", port, destinationRule, tunnelingconfig.Skip, false),
+					statPrefix, clusterName, "", port, destinationRule, tunnelingconfig.Skip, false, nil),
 			})
 
 			// Do the same, but for each subset
@@ -1014,7 +1014,7 @@ func builtAutoPassthroughFilterChains(push *model.PushContext, proxy *model.Prox
 					applicationProtocols: allIstioMtlsALPNs,
 					tlsContext:           nil, // NO TLS context because this is passthrough
 					networkFilters: lb.buildOutboundNetworkFiltersWithSingleDestination(
-						subsetStatPrefix, subsetClusterName, subset.Name, port, destinationRule, tunnelingconfig.Skip, false),
+						subsetStatPrefix, subsetClusterName, subset.Name, port, destinationRule, tunnelingconfig.Skip, false, nil),
 				})
 			}
 		}

--- a/pilot/pkg/networking/core/httproute.go
+++ b/pilot/pkg/networking/core/httproute.go
@@ -186,9 +186,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(
 
 	if !useSniffing {
 		ph := util.GetProxyHeaders(node, req.Push, istionetworking.ListenerClassSidecarOutbound)
-		appendXForwardedHost := ph.XForwardedHost
-		includeRequestAttemptCount := ph.IncludeRequestAttemptCount
-		virtualHosts = append(virtualHosts, buildCatchAllVirtualHost(node, includeRequestAttemptCount, appendXForwardedHost))
+		virtualHosts = append(virtualHosts, buildCatchAllVirtualHost(node, ph.IncludeRequestAttemptCount, ph.XForwardedHost))
 	}
 
 	out := &route.RouteConfiguration{
@@ -554,6 +552,7 @@ func generateVirtualHostDomains(service *model.Service, listenerPort int, port i
 		// Indicate we do not need port, as we will set IgnorePortInHostMatching
 		port = portNoAppendPortSuffix
 	}
+
 	domains := []string{}
 	allAltHosts := []string{}
 	all := []string{string(service.Hostname)}

--- a/pilot/pkg/networking/core/listener.go
+++ b/pilot/pkg/networking/core/listener.go
@@ -602,6 +602,13 @@ func buildListenerFromEntry(builder *ListenerBuilder, le *outboundListenerEntry,
 		if len(chain.sniHosts) > 0 || needsALPN {
 			needTLSInspector = true
 		}
+		// SNI DFP filter needs TLS inspector to get requested server name from ClientHello for DNS resolution.
+		for _, f := range chain.networkFilters {
+			if f.Name == wellknown.SNIDynamicForwardProxy {
+				needTLSInspector = true
+				break
+			}
+		}
 		needHTTP := len(chain.applicationProtocols) > 0
 		if needHTTP {
 			needHTTPInspector = true
@@ -767,6 +774,7 @@ func buildSidecarOutboundHTTPListenerOpts(
 		skipIstioMXHeaders:        ph.SkipIstioMXHeaders,
 		protocol:                  opts.port.Protocol,
 		class:                     istionetworking.ListenerClassSidecarOutbound,
+		policySvc:                 opts.service,
 	}
 
 	if features.HTTP10 || enableHTTP10(opts.proxy.Metadata.HTTP10) {

--- a/pilot/pkg/networking/core/listener_dfp_test.go
+++ b/pilot/pkg/networking/core/listener_dfp_test.go
@@ -1,0 +1,198 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	dfp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/dynamic_forward_proxy/v3"
+	snidfp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/sni_dynamic_forward_proxy/v3"
+	. "github.com/onsi/gomega"
+
+	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/test/xdstest"
+	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/wellknown"
+)
+
+// TestSidecarDynamicDNSFilters tests DFP filter creation for sidecar proxies
+func TestSidecarDynamicDNSFilters(t *testing.T) {
+	cases := []struct {
+		name              string
+		protocol          string
+		port              uint32
+		wildcardHost      bool
+		expectHTTPFilter  bool
+		expectSNIFilter   bool
+		validateFilterCfg bool
+	}{
+		{
+			name:              "HTTP protocol with wildcard host",
+			protocol:          "HTTP",
+			port:              80,
+			wildcardHost:      true,
+			expectHTTPFilter:  true,
+			validateFilterCfg: true,
+		},
+		{
+			name:              "TLS protocol with wildcard host",
+			protocol:          "TLS",
+			port:              443,
+			wildcardHost:      true,
+			expectSNIFilter:   true,
+			validateFilterCfg: true,
+		},
+		{
+			name:             "HTTP with non-wildcard host",
+			protocol:         "HTTP",
+			port:             80,
+			wildcardHost:     false,
+			expectHTTPFilter: false,
+			expectSNIFilter:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			hostname := "example.com"
+			if tc.wildcardHost {
+				hostname = "*.svc.cluster.local"
+			}
+
+			serviceEntry := config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.ServiceEntry,
+					Name:             "test-se",
+					Namespace:        "default",
+				},
+				Spec: &networking.ServiceEntry{
+					Hosts: []string{hostname},
+					Ports: []*networking.ServicePort{
+						{Number: tc.port, Name: "test-port", Protocol: tc.protocol},
+					},
+					Location:   networking.ServiceEntry_MESH_EXTERNAL,
+					Resolution: networking.ServiceEntry_DYNAMIC_DNS,
+				},
+			}
+
+			// For non-wildcard hosts, add endpoints
+			if !tc.wildcardHost {
+				serviceEntry.Spec.(*networking.ServiceEntry).Resolution = networking.ServiceEntry_STATIC
+				serviceEntry.Spec.(*networking.ServiceEntry).Endpoints = []*networking.WorkloadEntry{
+					{Address: "1.2.3.4"},
+				}
+			}
+
+			cg := NewConfigGenTest(t, TestOptions{Configs: []config.Config{serviceEntry}})
+			proxy := cg.SetupProxy(nil)
+			listeners := cg.Listeners(proxy)
+
+			// Find the listener for the specified port
+			var targetListener *listener.Listener
+			searchPort := fmt.Sprintf("0.0.0.0_%d", tc.port)
+			for _, l := range listeners {
+				if strings.Contains(l.Name, searchPort) {
+					targetListener = l
+					break
+				}
+			}
+
+			if tc.expectHTTPFilter || tc.expectSNIFilter {
+				g.Expect(targetListener).NotTo(BeNil(), "Should find listener for port %d", tc.port)
+			}
+
+			// Validate HTTP DFP filter
+			if tc.expectHTTPFilter {
+				foundHTTPDFP := false
+				for _, fc := range targetListener.FilterChains {
+					hcm := xdstest.ExtractHTTPConnectionManager(t, fc)
+					if hcm != nil {
+						for _, filter := range hcm.HttpFilters {
+							if filter.Name == "envoy.filters.http.dynamic_forward_proxy" {
+								foundHTTPDFP = true
+
+								if tc.validateFilterCfg {
+									var dfpConfig dfp.FilterConfig
+									err := filter.GetTypedConfig().UnmarshalTo(&dfpConfig)
+									g.Expect(err).To(BeNil())
+									g.Expect(dfpConfig.GetDnsCacheConfig()).NotTo(BeNil())
+									g.Expect(dfpConfig.GetDnsCacheConfig().Name).To(Equal("*.svc.cluster.local_dfp_dns_cache"))
+								}
+								break
+							}
+						}
+					}
+					if foundHTTPDFP {
+						break
+					}
+				}
+				g.Expect(foundHTTPDFP).To(BeTrue(), "HTTP DFP filter should be present")
+			} else if targetListener != nil {
+				// Verify HTTP DFP filter is NOT present
+				for _, fc := range targetListener.FilterChains {
+					hcm := xdstest.ExtractHTTPConnectionManager(t, fc)
+					if hcm != nil {
+						for _, filter := range hcm.HttpFilters {
+							g.Expect(filter.Name).NotTo(Equal("envoy.filters.http.dynamic_forward_proxy"),
+								"HTTP DFP filter should not be present")
+						}
+					}
+				}
+			}
+
+			// Validate SNI DFP filter
+			if tc.expectSNIFilter {
+				foundSNIDFP := false
+				for _, fc := range targetListener.FilterChains {
+					for _, f := range fc.Filters {
+						if f.Name == wellknown.SNIDynamicForwardProxy {
+							foundSNIDFP = true
+
+							if tc.validateFilterCfg {
+								var sniDFPConfig snidfp.FilterConfig
+								err := f.GetTypedConfig().UnmarshalTo(&sniDFPConfig)
+								g.Expect(err).To(BeNil())
+								g.Expect(sniDFPConfig.GetDnsCacheConfig()).NotTo(BeNil())
+								g.Expect(sniDFPConfig.GetDnsCacheConfig().Name).To(Equal("*.svc.cluster.local_dfp_dns_cache"))
+								g.Expect(sniDFPConfig.GetDnsCacheConfig().DnsLookupFamily).To(Equal(cluster.Cluster_V4_ONLY))
+								g.Expect(sniDFPConfig.GetPortValue()).To(Equal(uint32(443)))
+							}
+							break
+						}
+					}
+					if foundSNIDFP {
+						break
+					}
+				}
+				g.Expect(foundSNIDFP).To(BeTrue(), "SNI DFP filter should be present")
+			} else if targetListener != nil {
+				// Verify SNI DFP filter is NOT present
+				for _, fc := range targetListener.FilterChains {
+					for _, f := range fc.Filters {
+						g.Expect(f.Name).NotTo(Equal(wellknown.SNIDynamicForwardProxy),
+							"SNI DFP filter should not be present")
+					}
+				}
+			}
+		})
+	}
+}

--- a/pilot/pkg/networking/core/tracing.go
+++ b/pilot/pkg/networking/core/tracing.go
@@ -66,7 +66,7 @@ func configureTracing(
 	svc *model.Service,
 ) *requestidextension.UUIDRequestIDExtensionContext {
 	tracingCfg := push.Telemetry.Tracing(proxy, svc)
-	return configureTracingFromTelemetry(tracingCfg, push, proxy, httpConnMgr, class, svc)
+	return configureTracingFromTelemetry(tracingCfg, push, proxy, httpConnMgr, class)
 }
 
 func configureTracingFromTelemetry(
@@ -75,7 +75,6 @@ func configureTracingFromTelemetry(
 	proxy *model.Proxy,
 	h *hcm.HttpConnectionManager,
 	class networking.ListenerClass,
-	svc *model.Service,
 ) *requestidextension.UUIDRequestIDExtensionContext {
 	proxyCfg := proxy.Metadata.ProxyConfigOrDefault(push.Mesh.DefaultConfig)
 	// If there is no telemetry config defined, fallback to legacy mesh config.
@@ -105,7 +104,7 @@ func configureTracingFromTelemetry(
 
 	var useCustomSampler bool
 	if spec.Provider != nil {
-		hcmTracing, hasCustomSampler, err := configureFromProviderConfig(push, proxy, spec.Provider, svc)
+		hcmTracing, hasCustomSampler, err := configureFromProviderConfig(push, proxy, spec.Provider)
 		if err != nil {
 			log.Warnf("Not able to configure requested tracing provider %q: %v", spec.Provider.Name, err)
 			return nil
@@ -162,7 +161,7 @@ func configureTracingFromTelemetry(
 const configureFromProviderConfigHandled = 15
 
 func configureFromProviderConfig(pushCtx *model.PushContext, proxy *model.Proxy,
-	providerCfg *meshconfig.MeshConfig_ExtensionProvider, svc *model.Service,
+	providerCfg *meshconfig.MeshConfig_ExtensionProvider,
 ) (*hcm.HttpConnectionManager_Tracing, bool, error) {
 	startChildSpan := false
 	if proxy.Type == model.Router {
@@ -173,9 +172,8 @@ func configureFromProviderConfig(pushCtx *model.PushContext, proxy *model.Proxy,
 	var maxTagLength uint32
 	var providerConfig typedConfigGenFn
 	var providerName string
-	if svc != nil {
-		serviceCluster = svc.Hostname.String()
-	} else if proxy.XdsNode != nil {
+	// Span service name must identify the producer of the span (the proxy), not the destination.
+	if proxy.XdsNode != nil {
 		serviceCluster = proxy.XdsNode.Cluster
 	}
 	switch provider := providerCfg.Provider.(type) {

--- a/pilot/pkg/networking/core/tracing_test.go
+++ b/pilot/pkg/networking/core/tracing_test.go
@@ -303,7 +303,7 @@ func TestConfigureTracing(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			hcm := &hcm.HttpConnectionManager{}
-			gotReqIDExtCtx := configureTracingFromTelemetry(tc.inSpec, tc.opts.push, tc.opts.proxy, hcm, 0, nil)
+			gotReqIDExtCtx := configureTracingFromTelemetry(tc.inSpec, tc.opts.push, tc.opts.proxy, hcm, 0)
 			if diff := cmp.Diff(tc.want, hcm.Tracing, protocmp.Transform()); diff != "" {
 				t.Fatalf("configureTracing returned unexpected diff (-want +got):\n%s", diff)
 			}
@@ -430,7 +430,7 @@ func TestConfigureDynatraceSampler(t *testing.T) {
 			want := fakeTracingConfig(fakeOtelHTTPAny, 100, 256, append(defaultTracingTags(), fakeEnvTag))
 
 			hcm := &hcm.HttpConnectionManager{}
-			configureTracingFromTelemetry(inSpec, opts.push, opts.proxy, hcm, 0, nil)
+			configureTracingFromTelemetry(inSpec, opts.push, opts.proxy, hcm, 0)
 
 			if diff := cmp.Diff(want, hcm.Tracing, protocmp.Transform()); diff != "" {
 				t.Fatalf("configureTracing returned unexpected diff (-want +got):\n%s", diff)
@@ -574,7 +574,7 @@ func TestConfigureDynatraceSamplerWithCustomHttp(t *testing.T) {
 	want := fakeTracingConfig(fakeOtelHTTPAny, 100, 256, append(defaultTracingTags(), fakeEnvTag))
 
 	hcm := &hcm.HttpConnectionManager{}
-	configureTracingFromTelemetry(inSpec, opts.push, opts.proxy, hcm, 0, nil)
+	configureTracingFromTelemetry(inSpec, opts.push, opts.proxy, hcm, 0)
 
 	if diff := cmp.Diff(want, hcm.Tracing, protocmp.Transform()); diff != "" {
 		t.Fatalf("configureTracing returned unexpected diff (-want +got):\n%s", diff)
@@ -2370,7 +2370,7 @@ func TestOtelConfigWithSemanticConventions(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			hcmCfg := &hcm.HttpConnectionManager{}
-			gotReqIDExtCtx := configureTracingFromTelemetry(tc.inSpec, tc.push, tc.proxy, hcmCfg, 0, nil)
+			gotReqIDExtCtx := configureTracingFromTelemetry(tc.inSpec, tc.push, tc.proxy, hcmCfg, 0)
 			if diff := cmp.Diff(tc.want, hcmCfg.Tracing, protocmp.Transform()); diff != "" {
 				t.Fatalf("configureTracing returned unexpected diff (-want +got):\n%s", diff)
 			}

--- a/pilot/pkg/networking/core/waypoint.go
+++ b/pilot/pkg/networking/core/waypoint.go
@@ -17,6 +17,7 @@ package core
 import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/host"
+	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/util/sets"
 )
@@ -70,6 +71,11 @@ func findWaypointResources(node *model.Proxy, push *model.PushContext) ([]model.
 		hostName := host.Name(s.Service.Hostname)
 		svc, ok := push.ServiceIndex.HostnameAndNamespace[hostName][s.Service.Namespace]
 		if !ok {
+			continue
+		}
+		// Exclude MESH_INTERNAL services with DYNAMIC_DNS resolution from waypoint.
+		if svc.Resolution == model.DynamicDNS && !svc.MeshExternal {
+			log.Warnf("DYNAMIC_DNS is supported only for MESH_EXTERNAL services; skipping waypoint service %s/%s", svc.Attributes.Namespace, svc.Hostname)
 			continue
 		}
 		if waypointServices.services == nil {

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -287,6 +287,7 @@ func convertServices(cfg config.Config, nsAnnotations map[string]string) []*mode
 	if features.CanonicalServiceForMeshExternalServiceEntry && serviceEntry.Location == networking.ServiceEntry_MESH_EXTERNAL {
 		labels = ensureCanonicalServiceLabels(cfg.Name, cfg.Labels)
 	}
+
 	for _, ha := range hostAddresses {
 		svc := &model.Service{
 			CreationTime:   creationTime,

--- a/pilot/pkg/xds/filters/filters.go
+++ b/pilot/pkg/xds/filters/filters.go
@@ -648,6 +648,18 @@ func additionalLabels(cfg map[string]any) {
 // using the specified DNS cache config name. This name must match the name used in the corresponding
 // dynamic forward proxy cluster.
 func BuildWaypointInboundDFPFilter(dnsCacheConfigName string) *hcm.HttpFilter {
+	return buildDynamicForwardProxyFilter(dnsCacheConfigName)
+}
+
+// BuildSidecarOutboundDynamicForwardProxyFilter builds a dynamic forward proxy filter for sidecar outbound listeners
+// using the specified DNS cache config name. This name must match the name used in the corresponding
+// dynamic forward proxy cluster.
+func BuildSidecarOutboundDynamicForwardProxyFilter(dnsCacheConfigName string) *hcm.HttpFilter {
+	return buildDynamicForwardProxyFilter(dnsCacheConfigName)
+}
+
+// buildDynamicForwardProxyFilter builds a DFP HTTP filter using the specified DNS cache config name.
+func buildDynamicForwardProxyFilter(dnsCacheConfigName string) *hcm.HttpFilter {
 	return &hcm.HttpFilter{
 		Name: "envoy.filters.http.dynamic_forward_proxy",
 		ConfigType: &hcm.HttpFilter_TypedConfig{

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -33,6 +33,7 @@ import (
 
 	"istio.io/api/annotation"
 	extensions "istio.io/api/extensions/v1alpha1"
+	"istio.io/api/label"
 	networking "istio.io/api/networking/v1alpha3"
 	networkingv1beta1 "istio.io/api/networking/v1beta1"
 	security_beta "istio.io/api/security/v1beta1"
@@ -3041,7 +3042,6 @@ var ValidateServiceEntry = RegisterValidateFunc("ValidateServiceEntry",
 					}
 				}
 			}
-		// Only supported by ztunnel and waypoints
 		case networking.ServiceEntry_DYNAMIC_DNS:
 			if len(serviceEntry.Hosts) == 0 {
 				errs = AppendValidation(errs, fmt.Errorf("at least one wildcard host must be provided for resolution type %s", serviceEntry.Resolution))
@@ -3065,12 +3065,17 @@ var ValidateServiceEntry = RegisterValidateFunc("ValidateServiceEntry",
 					continue
 				}
 				proto := protocol.Parse(port.Protocol)
-				if proto != protocol.HTTP && proto != protocol.TLS {
-					errs = AppendValidation(errs, fmt.Errorf("only HTTP and TLS protocol is supported for resolution type %s", serviceEntry.Resolution))
+				// DFP supports HTTP, TLS, GRPC, and HTTP2 (aligned with pilot cluster buildOutboundClusters).
+				if proto != protocol.HTTP && proto != protocol.TLS && proto != protocol.GRPC && proto != protocol.HTTP2 {
+					errs = AppendValidation(errs, fmt.Errorf("only HTTP, TLS, GRPC, and HTTP2 protocols are supported for resolution type %s", serviceEntry.Resolution))
 				}
 			}
-			if serviceEntry.Location != networking.ServiceEntry_MESH_EXTERNAL {
-				errs = AppendValidation(errs, fmt.Errorf("location must be MESH_EXTERNAL for resolution type %s", serviceEntry.Resolution))
+			// DYNAMIC_DNS supports MESH_EXTERNAL for both sidecar and waypoint mode; MESH_INTERNAL only when the ServiceEntry has no waypoint.
+			if serviceEntry.Location != networking.ServiceEntry_MESH_EXTERNAL && serviceEntry.Location != networking.ServiceEntry_MESH_INTERNAL {
+				errs = AppendValidation(errs, fmt.Errorf("location must be MESH_EXTERNAL or MESH_INTERNAL for resolution type %s", serviceEntry.Resolution))
+			}
+			if serviceEntry.Location == networking.ServiceEntry_MESH_INTERNAL && usesWaypoint(cfg) {
+				errs = AppendValidation(errs, fmt.Errorf("location MESH_INTERNAL with resolution type %s is not supported when using waypoints", serviceEntry.Resolution))
 			}
 		default:
 			errs = AppendValidation(errs, fmt.Errorf("unsupported resolution type %s",
@@ -3101,6 +3106,17 @@ var ValidateServiceEntry = RegisterValidateFunc("ValidateServiceEntry",
 		errs = AppendValidation(errs, validateExportTo(cfg.Namespace, serviceEntry.ExportTo, true, false))
 		return errs.Unwrap()
 	})
+
+// usesWaypoint returns true if the config has the use-waypoint label set to a waypoint (i.e. not "none").
+func usesWaypoint(cfg config.Config) bool {
+	if cfg.Labels == nil {
+		return false
+	}
+	if val, ok := cfg.Labels[label.IoIstioUseWaypoint.Name]; ok && val != "" && !strings.EqualFold(val, "none") {
+		return true
+	}
+	return false
+}
 
 // ValidatePortName validates a port name to DNS-1123
 func ValidatePortName(name string) error {

--- a/releasenotes/notes/se-wildcard-host-sidecar.yaml
+++ b/releasenotes/notes/se-wildcard-host-sidecar.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 58244
+releaseNotes:
+  - |
+    **Added** DYNAMIC_DNS wildcard ServiceEntry support for sidecar proxies for both MESH_INTERNAL and MESH_EXTERNAL locations. 
+    Enables L7 HTTP routing (via Host header) and L4 TLS routing (via SNI) with observability for wildcard hosts (e.g., `*.example.com`)
+    in traditional sidecar mode. Note that it is possible to spoof SNI for TLS connections that match the wildcard host. 
+    E.g. a client connecting to `foo.example.com` could connect via SE `*.example.com`  while having SNI set to `bar.example.com`.


### PR DESCRIPTION
**Please provide a description of this PR:**
Support defining ServiceEntry with `DYNAMIC_DNS` resolution in Sidecar mode.
Local E2E test setup:
1. Defines a `MESH_EXTERNAL` SE for `*.google.com` with TLS port for testing SNI DFP path. 
2. Also defines a `MESH_INTERNAL` SE +`ISTIO_MUTUAL` DR for `*.svc.cluster.local` with HTTP port for HTTP DFP path. This is achieved by applying a Sidecar to ratings pods so it is not aware of other services in the mesh (only `istio-system` is visible where the SE exists).
```
# Setup istio pilot with this image
istioctl install --set hub=docker.io/rudrakhpanigrahi056 --set tag=sidecar_se_dfp
# So SE with DYNAMIC_DNS for MESH_INTERNAL is allowed (make sure to pull this istio branch before running it)
kubectl apply -f manifests/charts/base/files/crd-all.gen.yaml
# install test services
kubectl label namespace default istio-injection=enabled
kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml
# Deploy SE + DR (wildcard for all mesh internal services) + Sidecar (to remove concrete services from XDS config)
kubectl apply -f dfp.yaml
```
Contents of `dfp.yaml`
```
apiVersion: networking.istio.io/v1
kind: ServiceEntry
metadata:
  name: internal-wildcard-http
  namespace: istio-system
spec:
  hosts:
  - "*.svc.cluster.local"
  ports:
  - name: http
    number: 9080
    protocol: HTTP
  location: MESH_INTERNAL
  resolution: DYNAMIC_DNS
  exportTo:
  - "*"
---
apiVersion: networking.istio.io/v1
kind: DestinationRule
metadata:
  name: internal-wildcard-dr
  namespace: istio-system
spec:
  host: "*.svc.cluster.local"
  trafficPolicy:
    tls:
      mode: ISTIO_MUTUAL
      insecureSkipVerify: true # no DNS SAN in cert
  exportTo:
  - "*"
---
apiVersion: networking.istio.io/v1
kind: ServiceEntry
metadata:
  name: external-wildcard-https
  namespace: istio-system
spec:
  hosts:
  - "*.google.com"
  ports:
  - name: tls
    number: 443
    protocol: TLS
  location: MESH_EXTERNAL
  resolution: DYNAMIC_DNS
  exportTo:
  - "*"
---
apiVersion: networking.istio.io/v1
kind: Sidecar
metadata:
  name: restrict-default
  namespace: default
spec:
  workloadSelector:
    labels:
      app: ratings
  egress:
  - hosts:
    - "istio-system/*"
```
Test output:
```
# Internal Mesh call
❯ POD_NAME=$(kubectl get pod -n default -l app=ratings -o jsonpath='{.items[0].metadata.name}') && echo "Making test request..." && kubectl exec $POD_NAME -n default -c ratings -- curl -sS -o /dev/null -w "HTTP %{http_code}\n" details.default.svc.cluster.local:9080/details/0 && echo "Checking stats after request..." && kubectl exec $POD_NAME -c istio-proxy -- curl -s localhost:15000/clusters | grep "outbound|9080||\*\.svc\.cluster\.local" | grep -E "rq_total|rq_success"

Making test request...
HTTP 200
Checking stats after request...
outbound|9080||*.svc.cluster.local::10.96.35.238:9080::rq_success::1
outbound|9080||*.svc.cluster.local::10.96.35.238:9080::rq_total::1

# External HTTPS call
❯ POD_NAME=$(kubectl get pod -n default -l app=ratings -o jsonpath='{.items[0].metadata.name}') && echo "Making test request..." && kubectl exec $POD_NAME -n default -c ratings -- curl -sS -o /dev/null -w "HTTP %{http_code}\n" https://www.google.com && echo "Checking stats after request..." && kubectl exec $POD_NAME -c istio-proxy -- curl -s localhost:15000/clusters | grep "outbound|443||\*\.google\.com" | grep -E "rq|cx"

Making test request...
HTTP 200
Checking stats after request...
outbound|443||*.google.com::142.251.223.228:443::cx_active::0
outbound|443||*.google.com::142.251.223.228:443::cx_connect_fail::0
outbound|443||*.google.com::142.251.223.228:443::cx_total::3
outbound|443||*.google.com::142.251.223.228:443::rq_active::0
outbound|443||*.google.com::142.251.223.228:443::rq_error::0
outbound|443||*.google.com::142.251.223.228:443::rq_success::0
outbound|443||*.google.com::142.251.223.228:443::rq_timeout::0
outbound|443||*.google.com::142.251.223.228:443::rq_total::3
```
Expected config dump: https://gist.github.com/rudrakhp/64e400bda3dc75b41b556b4218e20cdf