### PR TITLE
Add gatewayapi only profile

### DIFF
--- a/manifests/charts/base/files/profile-gatewayapi.yaml
+++ b/manifests/charts/base/files/profile-gatewayapi.yaml
@@ -1,0 +1,8 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+# The gateway api profile makes pilot ignore any Istio resource and reconciles just GatewayAPI resources
+pilot:
+  env:
+    PILOT_IGNORE_RESOURCES: "*.istio.io"

--- a/manifests/charts/default/files/profile-gatewayapi.yaml
+++ b/manifests/charts/default/files/profile-gatewayapi.yaml
@@ -1,0 +1,8 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+# The gateway api profile makes pilot ignore any Istio resource and reconciles just GatewayAPI resources
+pilot:
+  env:
+    PILOT_IGNORE_RESOURCES: "*.istio.io"

--- a/manifests/charts/gateway/files/profile-gatewayapi.yaml
+++ b/manifests/charts/gateway/files/profile-gatewayapi.yaml
@@ -1,0 +1,8 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+# The gateway api profile makes pilot ignore any Istio resource and reconciles just GatewayAPI resources
+pilot:
+  env:
+    PILOT_IGNORE_RESOURCES: "*.istio.io"

--- a/manifests/charts/gateways/istio-egress/files/profile-gatewayapi.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-gatewayapi.yaml
@@ -1,0 +1,8 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+# The gateway api profile makes pilot ignore any Istio resource and reconciles just GatewayAPI resources
+pilot:
+  env:
+    PILOT_IGNORE_RESOURCES: "*.istio.io"

--- a/manifests/charts/gateways/istio-ingress/files/profile-gatewayapi.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-gatewayapi.yaml
@@ -1,0 +1,8 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+# The gateway api profile makes pilot ignore any Istio resource and reconciles just GatewayAPI resources
+pilot:
+  env:
+    PILOT_IGNORE_RESOURCES: "*.istio.io"

--- a/manifests/charts/istio-cni/files/profile-gatewayapi.yaml
+++ b/manifests/charts/istio-cni/files/profile-gatewayapi.yaml
@@ -1,0 +1,8 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+# The gateway api profile makes pilot ignore any Istio resource and reconciles just GatewayAPI resources
+pilot:
+  env:
+    PILOT_IGNORE_RESOURCES: "*.istio.io"

--- a/manifests/charts/istio-control/istio-discovery/files/profile-gatewayapi.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-gatewayapi.yaml
@@ -1,0 +1,8 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+# The gateway api profile makes pilot ignore any Istio resource and reconciles just GatewayAPI resources
+pilot:
+  env:
+    PILOT_IGNORE_RESOURCES: "*.istio.io"

--- a/manifests/charts/ztunnel/files/profile-gatewayapi.yaml
+++ b/manifests/charts/ztunnel/files/profile-gatewayapi.yaml
@@ -1,0 +1,8 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+# The gateway api profile makes pilot ignore any Istio resource and reconciles just GatewayAPI resources
+pilot:
+  env:
+    PILOT_IGNORE_RESOURCES: "*.istio.io"

--- a/manifests/helm-profiles/gatewayapi.yaml
+++ b/manifests/helm-profiles/gatewayapi.yaml
@@ -1,0 +1,4 @@
+# The gateway api profile makes pilot ignore any Istio resource and reconciles just GatewayAPI resources
+pilot:
+  env:
+    PILOT_IGNORE_RESOURCES: "*.istio.io"

--- a/manifests/profiles/gatewayapi.yaml
+++ b/manifests/profiles/gatewayapi.yaml
@@ -1,0 +1,22 @@
+# The Gateway API profile will install Istio supporting just Gateway API resources.
+# This profile forces pilot to ignore any istio.io resource and reconcile just Gateway API
+# resources. In case you want to add specific resources groups, you can add the following
+# to this profile:
+# spec:
+#   values:
+#     pilot:
+#        env:
+#         PILOT_INCLUDE_RESOURCES: "*.security.istio.io,wasmplugins.extensions.istio.io"
+# 
+# Multi-cluster environments may need: 
+#  PILOT_INCLUDE_RESOURCES: "virtualservices.networking.istio.io", "gateways.networking.istio.io"
+
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  values:
+    profile: gatewayapi
+  components:
+    ingressGateways:
+    - name: istio-ingressgateway
+      enabled: false

--- a/releasenotes/notes/58425.yaml
+++ b/releasenotes/notes/58425.yaml
@@ -10,3 +10,4 @@ releaseNotes:
     using the variable `PILOT_INCLUDE_RESOURCES`.
     This feature enables administrators that want to deploy Istio as a Gateway API only controller, ignoring mesh resources, 
     or allowing the deployment of Istio with support only for Gateway API HTTPRoutes (eg.: GAMMA support).
+    **Added** a new `gatewayapi` profile that will make Istio operate as a Gateway API controller only


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR adds a new profile to istioctl that will configure Pilot to reconcile just Gateway API resources, and ignore any `*.istio.io` resource