### PR TITLE
Add namespace-level traffic-distribution annotation

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/services_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/services_test.go
@@ -676,6 +676,119 @@ func TestServiceEntryServices(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "namespace annotation inheritance",
+			inputs: []any{
+				&v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ns",
+						Labels: map[string]string{
+							v1.LabelMetadataName: "ns",
+						},
+						Annotations: map[string]string{
+							"networking.istio.io/traffic-distribution": "PreferClose",
+						},
+					},
+				},
+			},
+			se: &networkingclient.ServiceEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "ns",
+				},
+				Spec: networking.ServiceEntry{
+					Addresses: []string{"1.2.3.4"},
+					Hosts:     []string{"a.example.com"},
+					Ports: []*networking.ServicePort{{
+						Number: 80,
+						Name:   "http",
+					}},
+					Resolution: networking.ServiceEntry_DNS,
+				},
+			},
+			result: []*workloadapi.Service{
+				{
+					Name:      "name",
+					Namespace: "ns",
+					Hostname:  "a.example.com",
+					Addresses: []*workloadapi.NetworkAddress{{
+						Network: testNW,
+						Address: netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice(),
+					}},
+					LoadBalancing: &workloadapi.LoadBalancing{
+						RoutingPreference: []workloadapi.LoadBalancing_Scope{
+							workloadapi.LoadBalancing_NETWORK,
+							workloadapi.LoadBalancing_REGION,
+							workloadapi.LoadBalancing_ZONE,
+						},
+						Mode: workloadapi.LoadBalancing_FAILOVER,
+					},
+					Ports: []*workloadapi.Port{{
+						ServicePort: 80,
+						TargetPort:  80,
+					}},
+				},
+			},
+		},
+		{
+			name: "serviceentry annotation overrides namespace",
+			inputs: []any{
+				&v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ns",
+						Labels: map[string]string{
+							v1.LabelMetadataName: "ns",
+						},
+						Annotations: map[string]string{
+							"networking.istio.io/traffic-distribution": "PreferClose",
+						},
+					},
+				},
+			},
+			se: &networkingclient.ServiceEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "ns",
+					Annotations: map[string]string{
+						"networking.istio.io/traffic-distribution": "PreferSameNode",
+					},
+				},
+				Spec: networking.ServiceEntry{
+					Addresses: []string{"1.2.3.4"},
+					Hosts:     []string{"a.example.com"},
+					Ports: []*networking.ServicePort{{
+						Number: 80,
+						Name:   "http",
+					}},
+					Resolution: networking.ServiceEntry_DNS,
+				},
+			},
+			result: []*workloadapi.Service{
+				{
+					Name:      "name",
+					Namespace: "ns",
+					Hostname:  "a.example.com",
+					Addresses: []*workloadapi.NetworkAddress{{
+						Network: testNW,
+						Address: netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice(),
+					}},
+					LoadBalancing: &workloadapi.LoadBalancing{
+						RoutingPreference: []workloadapi.LoadBalancing_Scope{
+							workloadapi.LoadBalancing_NETWORK,
+							workloadapi.LoadBalancing_REGION,
+							workloadapi.LoadBalancing_ZONE,
+							workloadapi.LoadBalancing_SUBZONE,
+							workloadapi.LoadBalancing_NODE,
+						},
+						Mode: workloadapi.LoadBalancing_FAILOVER,
+					},
+					Ports: []*workloadapi.Port{{
+						ServicePort: 80,
+						TargetPort:  80,
+					}},
+				},
+			},
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1093,6 +1206,113 @@ func TestServiceServices(t *testing.T) {
 					Address: netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice(),
 				}},
 				Waypoint: nil,
+				Ports: []*workloadapi.Port{{
+					ServicePort: 80,
+					AppProtocol: workloadapi.AppProtocol_HTTP11,
+				}},
+				Canonical: true,
+			},
+		},
+		{
+			name: "namespace annotation inheritance",
+			inputs: []any{
+				&v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ns",
+						Labels: map[string]string{
+							v1.LabelMetadataName: "ns",
+						},
+						Annotations: map[string]string{
+							"networking.istio.io/traffic-distribution": "PreferClose",
+						},
+					},
+				},
+			},
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "ns",
+				},
+				Spec: v1.ServiceSpec{
+					ClusterIP: "1.2.3.4",
+					Ports: []v1.ServicePort{{
+						Port: 80,
+						Name: "http",
+					}},
+				},
+			},
+			result: &workloadapi.Service{
+				Name:      "name",
+				Namespace: "ns",
+				Hostname:  "name.ns.svc.domain.suffix",
+				Addresses: []*workloadapi.NetworkAddress{{
+					Network: testNW,
+					Address: netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice(),
+				}},
+				LoadBalancing: &workloadapi.LoadBalancing{
+					RoutingPreference: []workloadapi.LoadBalancing_Scope{
+						workloadapi.LoadBalancing_NETWORK,
+						workloadapi.LoadBalancing_REGION,
+						workloadapi.LoadBalancing_ZONE,
+					},
+					Mode: workloadapi.LoadBalancing_FAILOVER,
+				},
+				Ports: []*workloadapi.Port{{
+					ServicePort: 80,
+					AppProtocol: workloadapi.AppProtocol_HTTP11,
+				}},
+				Canonical: true,
+			},
+		},
+		{
+			name: "service annotation overrides namespace",
+			inputs: []any{
+				&v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ns",
+						Labels: map[string]string{
+							v1.LabelMetadataName: "ns",
+						},
+						Annotations: map[string]string{
+							"networking.istio.io/traffic-distribution": "PreferClose",
+						},
+					},
+				},
+			},
+			svc: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "ns",
+					Annotations: map[string]string{
+						"networking.istio.io/traffic-distribution": "PreferSameNode",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					ClusterIP: "1.2.3.4",
+					Ports: []v1.ServicePort{{
+						Port: 80,
+						Name: "http",
+					}},
+				},
+			},
+			result: &workloadapi.Service{
+				Name:      "name",
+				Namespace: "ns",
+				Hostname:  "name.ns.svc.domain.suffix",
+				Addresses: []*workloadapi.NetworkAddress{{
+					Network: testNW,
+					Address: netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice(),
+				}},
+				LoadBalancing: &workloadapi.LoadBalancing{
+					RoutingPreference: []workloadapi.LoadBalancing_Scope{
+						workloadapi.LoadBalancing_NETWORK,
+						workloadapi.LoadBalancing_REGION,
+						workloadapi.LoadBalancing_ZONE,
+						workloadapi.LoadBalancing_SUBZONE,
+						workloadapi.LoadBalancing_NODE,
+					},
+					Mode: workloadapi.LoadBalancing_FAILOVER,
+				},
 				Ports: []*workloadapi.Port{{
 					ServicePort: 80,
 					AppProtocol: workloadapi.AppProtocol_HTTP11,

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 
+	"istio.io/api/annotation"
 	"istio.io/api/label"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
@@ -279,6 +280,25 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 		)
 	}
 
+	// Namespace annotation handler for traffic-distribution inheritance
+	// When namespace annotations change, reprocess all services in that namespace
+	registerHandlers[*v1.Namespace](
+		c,
+		c.namespaces,
+		"Namespaces-TrafficDistribution",
+		func(old *v1.Namespace, cur *v1.Namespace, event model.Event) error {
+			if event == model.EventUpdate && old != nil {
+				oldTrafficDist := old.Annotations[annotation.NetworkingTrafficDistribution.Name]
+				curTrafficDist := cur.Annotations[annotation.NetworkingTrafficDistribution.Name]
+				if oldTrafficDist != curTrafficDist {
+					c.reprocessServicesInNamespace(cur.Name)
+				}
+			}
+			return nil
+		},
+		nil,
+	)
+
 	c.services = kclient.NewFiltered[*v1.Service](kubeClient, kclient.Filter{ObjectFilter: kubeClient.ObjectFilter()})
 
 	registerHandlers(c, c.services, "Services", c.onServiceEvent, nil)
@@ -418,8 +438,15 @@ func (c *Controller) Cleanup() error {
 func (c *Controller) onServiceEvent(pre, curr *v1.Service, event model.Event) error {
 	log.Debugf("Handle event %s for service %s in namespace %s", event, curr.Name, curr.Namespace)
 
+	// Get namespace annotations for traffic distribution inheritance
+	var nsAnnotations map[string]string
+	ns := c.namespaces.Get(curr.Namespace, "")
+	if ns != nil {
+		nsAnnotations = ns.Annotations
+	}
+
 	// Create the standard (cluster.local) service.
-	svcConv := kube.ConvertService(*curr, c.opts.DomainSuffix, c.Cluster(), c.meshWatcher.TrustDomain())
+	svcConv := kube.ConvertService(*curr, nsAnnotations, c.opts.DomainSuffix, c.Cluster(), c.meshWatcher.TrustDomain())
 
 	switch event {
 	case model.EventDelete:
@@ -429,6 +456,16 @@ func (c *Controller) onServiceEvent(pre, curr *v1.Service, event model.Event) er
 	}
 
 	return nil
+}
+
+// reprocessServicesInNamespace triggers an update event for all services in a namespace.
+func (c *Controller) reprocessServicesInNamespace(namespace string) {
+	allServices := c.services.List(namespace, klabels.Everything())
+	for _, svc := range allServices {
+		if err := c.onServiceEvent(svc, svc, model.EventUpdate); err != nil {
+			log.Warnf("failed to reprocess service %s/%s: %v", namespace, svc.Name, err)
+		}
+	}
 }
 
 func (c *Controller) deleteService(svc *model.Service) {

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -2813,16 +2813,16 @@ func TestServiceUpdateNeedsPush(t *testing.T) {
 			name:     "target ports changed",
 			prev:     &svc,
 			curr:     &updatedSvc,
-			prevConv: kube.ConvertService(svc, constants.DefaultClusterLocalDomain, "", ""),
-			currConv: kube.ConvertService(updatedSvc, constants.DefaultClusterLocalDomain, "", ""),
+			prevConv: kube.ConvertService(svc, nil, constants.DefaultClusterLocalDomain, "", ""),
+			currConv: kube.ConvertService(updatedSvc, nil, constants.DefaultClusterLocalDomain, "", ""),
 			expect:   true,
 		},
 		testcase{
 			name:     "target ports unchanged",
 			prev:     &svc,
 			curr:     &svc,
-			prevConv: kube.ConvertService(svc, constants.DefaultClusterLocalDomain, "", ""),
-			currConv: kube.ConvertService(svc, constants.DefaultClusterLocalDomain, "", ""),
+			prevConv: kube.ConvertService(svc, nil, constants.DefaultClusterLocalDomain, "", ""),
+			currConv: kube.ConvertService(svc, nil, constants.DefaultClusterLocalDomain, "", ""),
 			expect:   false,
 		})
 

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -179,6 +179,11 @@ func (m *Multicluster) initializeCluster(cluster *multicluster.Cluster, kubeCont
 		kubeRegistry.AppendWorkloadHandler(m.serviceEntryController.WorkloadInstanceHandler)
 	}
 
+	// Set namespace client for traffic distribution inheritance (config cluster only)
+	if m.serviceEntryController != nil && configCluster {
+		m.serviceEntryController.SetNamespaces(kubeRegistry.namespaces)
+	}
+
 	// TODO implement deduping in aggregate registry to allow multiple k8s registries to handle WorkloadEntry
 	if features.EnableK8SServiceSelectWorkloadEntries {
 		if m.serviceEntryController != nil && configCluster {

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -44,7 +44,7 @@ func convertPort(port corev1.ServicePort) *model.Port {
 	}
 }
 
-func ConvertService(svc corev1.Service, domainSuffix string, clusterID cluster.ID, trustDomain string) *model.Service {
+func ConvertService(svc corev1.Service, nsAnnotations map[string]string, domainSuffix string, clusterID cluster.ID, trustDomain string) *model.Service {
 	addrs := []string{constants.UnspecifiedIP}
 	resolution := model.ClientSideLB
 	externalName := ""
@@ -151,7 +151,7 @@ func ConvertService(svc corev1.Service, domainSuffix string, clusterID cluster.I
 
 	istioService.Attributes.Type = string(svc.Spec.Type)
 	istioService.Attributes.ExternalName = externalName
-	istioService.Attributes.TrafficDistribution = model.GetTrafficDistribution(svc.Spec.TrafficDistribution, svc.Annotations)
+	istioService.Attributes.TrafficDistribution = model.GetTrafficDistribution(svc.Spec.TrafficDistribution, svc.Annotations, nsAnnotations)
 	istioService.Attributes.NodeLocal = nodeLocal
 	istioService.Attributes.PublishNotReadyAddresses = svc.Spec.PublishNotReadyAddresses
 	if len(svc.Spec.ExternalIPs) > 0 {

--- a/pilot/pkg/serviceregistry/kube/conversion_test.go
+++ b/pilot/pkg/serviceregistry/kube/conversion_test.go
@@ -168,7 +168,7 @@ func TestServiceConversion(t *testing.T) {
 		},
 	}
 
-	service := ConvertService(localSvc, domainSuffix, clusterID, domainSuffix)
+	service := ConvertService(localSvc, nil, domainSuffix, clusterID, domainSuffix)
 	if service == nil {
 		t.Fatal("could not convert service")
 	}
@@ -254,7 +254,7 @@ func TestServiceConversionWithEmptyServiceAccountsAnnotation(t *testing.T) {
 		},
 	}
 
-	service := ConvertService(localSvc, domainSuffix, clusterID, "")
+	service := ConvertService(localSvc, nil, domainSuffix, clusterID, "")
 	if service == nil {
 		t.Fatal("could not convert service")
 	}
@@ -309,7 +309,7 @@ func TestServiceConversionWithExportToAnnotation(t *testing.T) {
 	}
 	for _, test := range tests {
 		localSvc.Annotations[annotation.NetworkingExportTo.Name] = test.Annotation
-		service := ConvertService(localSvc, domainSuffix, clusterID, "")
+		service := ConvertService(localSvc, nil, domainSuffix, clusterID, "")
 		if service == nil {
 			t.Fatal("could not convert service")
 		}
@@ -342,7 +342,7 @@ func TestExternalServiceConversion(t *testing.T) {
 		},
 	}
 
-	service := ConvertService(extSvc, domainSuffix, clusterID, "")
+	service := ConvertService(extSvc, nil, domainSuffix, clusterID, "")
 	if service == nil {
 		t.Fatal("could not convert external service")
 	}
@@ -392,7 +392,7 @@ func TestExternalClusterLocalServiceConversion(t *testing.T) {
 
 	domainSuffix := "cluster.local"
 
-	service := ConvertService(extSvc, domainSuffix, clusterID, "")
+	service := ConvertService(extSvc, nil, domainSuffix, clusterID, "")
 	if service == nil {
 		t.Fatal("could not convert external service")
 	}
@@ -453,7 +453,7 @@ func TestLBServiceConversion(t *testing.T) {
 		},
 	}
 
-	service := ConvertService(extSvc, domainSuffix, clusterID, "")
+	service := ConvertService(extSvc, nil, domainSuffix, clusterID, "")
 	if service == nil {
 		t.Fatal("could not convert external service")
 	}
@@ -499,7 +499,7 @@ func TestInternalTrafficPolicyServiceConversion(t *testing.T) {
 		},
 	}
 
-	service := ConvertService(svc, domainSuffix, clusterID, "")
+	service := ConvertService(svc, nil, domainSuffix, clusterID, "")
 	if service == nil {
 		t.Fatal("could not convert service")
 	}

--- a/pilot/pkg/serviceregistry/serviceentry/controller_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller_test.go
@@ -1639,7 +1639,7 @@ func expectEvents(t testing.TB, ch *xdsfake.Updater, events ...Event) {
 
 func expectServiceInstances(t testing.TB, sd *Controller, cfg *config.Config, port int, expected ...[]*model.ServiceInstance) {
 	t.Helper()
-	svcs := convertServices(*cfg)
+	svcs := convertServices(*cfg, nil)
 	if len(svcs) != len(expected) {
 		t.Fatalf("got more services than expected: %v vs %v", len(svcs), len(expected))
 	}
@@ -1873,8 +1873,8 @@ func TestServicesDiff(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			as := convertServices(*tt.current)
-			bs := convertServices(*tt.new)
+			as := convertServices(*tt.current, nil)
+			bs := convertServices(*tt.new, nil)
 			added, deleted, updated, unchanged := servicesDiff(as, bs)
 			for i, item := range []struct {
 				hostnames []host.Name

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -157,7 +157,8 @@ func ServiceToServiceEntry(svc *model.Service, proxy *model.Proxy) *config.Confi
 }
 
 // convertServices transforms a ServiceEntry config to a list of internal Service objects.
-func convertServices(cfg config.Config) []*model.Service {
+// nsAnnotations are the namespace annotations for traffic distribution inheritance.
+func convertServices(cfg config.Config, nsAnnotations map[string]string) []*model.Service {
 	serviceEntry := cfg.Spec.(*networking.ServiceEntry)
 	// ShouldV2AutoAllocateIP already checks that there are no addresses in the spec however this is critical enough to likely be worth checking
 	// explicitly as well in case the logic changes. We never want to overwrite addresses in the spec if there are any
@@ -183,8 +184,7 @@ func convertServices(cfg config.Config) []*model.Service {
 		resolution = model.DynamicDNS
 	}
 
-	// ServiceEntry doesn't have namespace-level inheritance for traffic distribution
-	trafficDistribution := model.GetTrafficDistribution(nil, cfg.Annotations, nil)
+	trafficDistribution := model.GetTrafficDistribution(nil, cfg.Annotations, nsAnnotations)
 
 	svcPorts := make(model.PortList, 0, len(serviceEntry.Ports))
 	var portOverrides map[uint32]uint32
@@ -368,7 +368,7 @@ func (s *Controller) convertServiceEntryToInstances(cfg config.Config, services 
 		return nil
 	}
 	if services == nil {
-		services = convertServices(cfg)
+		services = convertServices(cfg, s.getNamespaceAnnotations(cfg.Namespace))
 	}
 
 	endpointsNum := len(serviceEntry.Endpoints)

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -183,7 +183,8 @@ func convertServices(cfg config.Config) []*model.Service {
 		resolution = model.DynamicDNS
 	}
 
-	trafficDistribution := model.GetTrafficDistribution(nil, cfg.Annotations)
+	// ServiceEntry doesn't have namespace-level inheritance for traffic distribution
+	trafficDistribution := model.GetTrafficDistribution(nil, cfg.Annotations, nil)
 
 	svcPorts := make(model.PortList, 0, len(serviceEntry.Ports))
 	var portOverrides map[uint32]uint32

--- a/releasenotes/notes/namespace-traffic-distribution.yaml
+++ b/releasenotes/notes/namespace-traffic-distribution.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+releaseNotes:
+- |
+  **Added** namespace-level traffic distribution annotation. Services inherit traffic distribution from namespace annotation when not explicitly set on the service.


### PR DESCRIPTION
**Please provide a description of this PR:**

Add namespace-level traffic-distribution annotation. Services inherit from their namespace when not explicitly configured, with the usual precedence: spec field > service annotation > namespace annotation > default. Added a namespace watcher to trigger service updates when the annotation changes, and tests cover the inheritance and override scenarios.