### PR TITLE
Add route for agent metrics to telemetry listener for compression

### DIFF
--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -442,6 +442,15 @@
                         "routes": [
                           {
                             "match": {
+                              "prefix": "/stats/prometheus/agent"
+                            },
+                            "route": {
+                              "prefix_rewrite": "/stats/prometheus",
+                              "cluster": "agent"
+                            }
+                          },
+                          {
+                            "match": {
                               "prefix": "/stats/prometheus"
                             },
                             "route": {

--- a/pkg/bootstrap/testdata/ambient_golden.json
+++ b/pkg/bootstrap/testdata/ambient_golden.json
@@ -368,6 +368,15 @@
                         "routes": [
                           {
                             "match": {
+                              "prefix": "/stats/prometheus/agent"
+                            },
+                            "route": {
+                              "prefix_rewrite": "/stats/prometheus",
+                              "cluster": "agent"
+                            }
+                          },
+                          {
+                            "match": {
                               "prefix": "/stats/prometheus"
                             },
                             "route": {

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -355,6 +355,15 @@
                         "routes": [
                           {
                             "match": {
+                              "prefix": "/stats/prometheus/agent"
+                            },
+                            "route": {
+                              "prefix_rewrite": "/stats/prometheus",
+                              "cluster": "agent"
+                            }
+                          },
+                          {
+                            "match": {
                               "prefix": "/stats/prometheus"
                             },
                             "route": {

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -355,6 +355,15 @@
                         "routes": [
                           {
                             "match": {
+                              "prefix": "/stats/prometheus/agent"
+                            },
+                            "route": {
+                              "prefix_rewrite": "/stats/prometheus",
+                              "cluster": "agent"
+                            }
+                          },
+                          {
+                            "match": {
                               "prefix": "/stats/prometheus"
                             },
                             "route": {

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -355,6 +355,15 @@
                         "routes": [
                           {
                             "match": {
+                              "prefix": "/stats/prometheus/agent"
+                            },
+                            "route": {
+                              "prefix_rewrite": "/stats/prometheus",
+                              "cluster": "agent"
+                            }
+                          },
+                          {
+                            "match": {
                               "prefix": "/stats/prometheus"
                             },
                             "route": {

--- a/pkg/bootstrap/testdata/explicit_internal_address_golden.json
+++ b/pkg/bootstrap/testdata/explicit_internal_address_golden.json
@@ -355,6 +355,15 @@
                         "routes": [
                           {
                             "match": {
+                              "prefix": "/stats/prometheus/agent"
+                            },
+                            "route": {
+                              "prefix_rewrite": "/stats/prometheus",
+                              "cluster": "agent"
+                            }
+                          },
+                          {
+                            "match": {
                               "prefix": "/stats/prometheus"
                             },
                             "route": {

--- a/pkg/bootstrap/testdata/global_downstream_max_connections_both_golden.json
+++ b/pkg/bootstrap/testdata/global_downstream_max_connections_both_golden.json
@@ -355,6 +355,15 @@
                         "routes": [
                           {
                             "match": {
+                              "prefix": "/stats/prometheus/agent"
+                            },
+                            "route": {
+                              "prefix_rewrite": "/stats/prometheus",
+                              "cluster": "agent"
+                            }
+                          },
+                          {
+                            "match": {
                               "prefix": "/stats/prometheus"
                             },
                             "route": {

--- a/pkg/bootstrap/testdata/global_downstream_max_connections_meta_golden.json
+++ b/pkg/bootstrap/testdata/global_downstream_max_connections_meta_golden.json
@@ -355,6 +355,15 @@
                         "routes": [
                           {
                             "match": {
+                              "prefix": "/stats/prometheus/agent"
+                            },
+                            "route": {
+                              "prefix_rewrite": "/stats/prometheus",
+                              "cluster": "agent"
+                            }
+                          },
+                          {
+                            "match": {
                               "prefix": "/stats/prometheus"
                             },
                             "route": {

--- a/pkg/bootstrap/testdata/global_downstream_max_connections_runtime_golden.json
+++ b/pkg/bootstrap/testdata/global_downstream_max_connections_runtime_golden.json
@@ -355,6 +355,15 @@
                         "routes": [
                           {
                             "match": {
+                              "prefix": "/stats/prometheus/agent"
+                            },
+                            "route": {
+                              "prefix_rewrite": "/stats/prometheus",
+                              "cluster": "agent"
+                            }
+                          },
+                          {
+                            "match": {
                               "prefix": "/stats/prometheus"
                             },
                             "route": {

--- a/pkg/bootstrap/testdata/invalid_stats_eviction_interval_golden.json
+++ b/pkg/bootstrap/testdata/invalid_stats_eviction_interval_golden.json
@@ -442,6 +442,15 @@
                         "routes": [
                           {
                             "match": {
+                              "prefix": "/stats/prometheus/agent"
+                            },
+                            "route": {
+                              "prefix_rewrite": "/stats/prometheus",
+                              "cluster": "agent"
+                            }
+                          },
+                          {
+                            "match": {
                               "prefix": "/stats/prometheus"
                             },
                             "route": {

--- a/pkg/bootstrap/testdata/lrs_golden.json
+++ b/pkg/bootstrap/testdata/lrs_golden.json
@@ -355,6 +355,15 @@
                         "routes": [
                           {
                             "match": {
+                              "prefix": "/stats/prometheus/agent"
+                            },
+                            "route": {
+                              "prefix_rewrite": "/stats/prometheus",
+                              "cluster": "agent"
+                            }
+                          },
+                          {
+                            "match": {
                               "prefix": "/stats/prometheus"
                             },
                             "route": {

--- a/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
+++ b/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
@@ -387,6 +387,15 @@
                         "routes": [
                           {
                             "match": {
+                              "prefix": "/stats/prometheus/agent"
+                            },
+                            "route": {
+                              "prefix_rewrite": "/stats/prometheus",
+                              "cluster": "agent"
+                            }
+                          },
+                          {
+                            "match": {
                               "prefix": "/stats/prometheus"
                             },
                             "route": {

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -384,6 +384,15 @@
                         "routes": [
                           {
                             "match": {
+                              "prefix": "/stats/prometheus/agent"
+                            },
+                            "route": {
+                              "prefix_rewrite": "/stats/prometheus",
+                              "cluster": "agent"
+                            }
+                          },
+                          {
+                            "match": {
                               "prefix": "/stats/prometheus"
                             },
                             "route": {

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -384,6 +384,15 @@
                         "routes": [
                           {
                             "match": {
+                              "prefix": "/stats/prometheus/agent"
+                            },
+                            "route": {
+                              "prefix_rewrite": "/stats/prometheus",
+                              "cluster": "agent"
+                            }
+                          },
+                          {
+                            "match": {
                               "prefix": "/stats/prometheus"
                             },
                             "route": {

--- a/pkg/bootstrap/testdata/stats_compression_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_golden.json
@@ -355,6 +355,15 @@
                         "routes": [
                           {
                             "match": {
+                              "prefix": "/stats/prometheus/agent"
+                            },
+                            "route": {
+                              "prefix_rewrite": "/stats/prometheus",
+                              "cluster": "agent"
+                            }
+                          },
+                          {
+                            "match": {
                               "prefix": "/stats/prometheus"
                             },
                             "route": {

--- a/pkg/bootstrap/testdata/stats_eviction_interval_golden.json
+++ b/pkg/bootstrap/testdata/stats_eviction_interval_golden.json
@@ -443,6 +443,15 @@
                         "routes": [
                           {
                             "match": {
+                              "prefix": "/stats/prometheus/agent"
+                            },
+                            "route": {
+                              "prefix_rewrite": "/stats/prometheus",
+                              "cluster": "agent"
+                            }
+                          },
+                          {
+                            "match": {
                               "prefix": "/stats/prometheus"
                             },
                             "route": {

--- a/pkg/bootstrap/testdata/stats_flush_interval_golden.json
+++ b/pkg/bootstrap/testdata/stats_flush_interval_golden.json
@@ -443,6 +443,15 @@
                         "routes": [
                           {
                             "match": {
+                              "prefix": "/stats/prometheus/agent"
+                            },
+                            "route": {
+                              "prefix_rewrite": "/stats/prometheus",
+                              "cluster": "agent"
+                            }
+                          },
+                          {
+                            "match": {
                               "prefix": "/stats/prometheus"
                             },
                             "route": {

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -449,6 +449,15 @@
                         "routes": [
                           {
                             "match": {
+                              "prefix": "/stats/prometheus/agent"
+                            },
+                            "route": {
+                              "prefix_rewrite": "/stats/prometheus",
+                              "cluster": "agent"
+                            }
+                          },
+                          {
+                            "match": {
                               "prefix": "/stats/prometheus"
                             },
                             "route": {

--- a/pkg/bootstrap/testdata/stats_interval_golden.json
+++ b/pkg/bootstrap/testdata/stats_interval_golden.json
@@ -444,6 +444,15 @@
                         "routes": [
                           {
                             "match": {
+                              "prefix": "/stats/prometheus/agent"
+                            },
+                            "route": {
+                              "prefix_rewrite": "/stats/prometheus",
+                              "cluster": "agent"
+                            }
+                          },
+                          {
+                            "match": {
                               "prefix": "/stats/prometheus"
                             },
                             "route": {

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -378,6 +378,15 @@
                         "routes": [
                           {
                             "match": {
+                              "prefix": "/stats/prometheus/agent"
+                            },
+                            "route": {
+                              "prefix_rewrite": "/stats/prometheus",
+                              "cluster": "agent"
+                            }
+                          },
+                          {
+                            "match": {
                               "prefix": "/stats/prometheus"
                             },
                             "route": {

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -386,6 +386,15 @@
                         "routes": [
                           {
                             "match": {
+                              "prefix": "/stats/prometheus/agent"
+                            },
+                            "route": {
+                              "prefix_rewrite": "/stats/prometheus",
+                              "cluster": "agent"
+                            }
+                          },
+                          {
+                            "match": {
                               "prefix": "/stats/prometheus"
                             },
                             "route": {

--- a/pkg/bootstrap/testdata/tracing_none_golden.json
+++ b/pkg/bootstrap/testdata/tracing_none_golden.json
@@ -355,6 +355,15 @@
                         "routes": [
                           {
                             "match": {
+                              "prefix": "/stats/prometheus/agent"
+                            },
+                            "route": {
+                              "prefix_rewrite": "/stats/prometheus",
+                              "cluster": "agent"
+                            }
+                          },
+                          {
+                            "match": {
                               "prefix": "/stats/prometheus"
                             },
                             "route": {

--- a/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
@@ -380,6 +380,15 @@
                         "routes": [
                           {
                             "match": {
+                              "prefix": "/stats/prometheus/agent"
+                            },
+                            "route": {
+                              "prefix_rewrite": "/stats/prometheus",
+                              "cluster": "agent"
+                            }
+                          },
+                          {
+                            "match": {
                               "prefix": "/stats/prometheus"
                             },
                             "route": {

--- a/pkg/bootstrap/testdata/tracing_tls_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_golden.json
@@ -380,6 +380,15 @@
                         "routes": [
                           {
                             "match": {
+                              "prefix": "/stats/prometheus/agent"
+                            },
+                            "route": {
+                              "prefix_rewrite": "/stats/prometheus",
+                              "cluster": "agent"
+                            }
+                          },
+                          {
+                            "match": {
                               "prefix": "/stats/prometheus"
                             },
                             "route": {

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -379,6 +379,15 @@
                         "routes": [
                           {
                             "match": {
+                              "prefix": "/stats/prometheus/agent"
+                            },
+                            "route": {
+                              "prefix_rewrite": "/stats/prometheus",
+                              "cluster": "agent"
+                            }
+                          },
+                          {
+                            "match": {
                               "prefix": "/stats/prometheus"
                             },
                             "route": {

--- a/pkg/bootstrap/testdata/xdsproxy_golden.json
+++ b/pkg/bootstrap/testdata/xdsproxy_golden.json
@@ -355,6 +355,15 @@
                         "routes": [
                           {
                             "match": {
+                              "prefix": "/stats/prometheus/agent"
+                            },
+                            "route": {
+                              "prefix_rewrite": "/stats/prometheus",
+                              "cluster": "agent"
+                            }
+                          },
+                          {
+                            "match": {
                               "prefix": "/stats/prometheus"
                             },
                             "route": {

--- a/releasenotes/notes/58697.yaml
+++ b/releasenotes/notes/58697.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+issue: 
+  - https://github.com/istio/istio/issues/58697
+releaseNotes:
+  - |
+    **Added** new path `/stats/prometheus/agent` to the Istio Proxy Telemetry endpoint to enable compression of app and sidecar metrics.

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -614,6 +614,15 @@
                         "routes": [
                           {
                             "match": {
+                              "prefix": "/stats/prometheus/agent"
+                            },
+                            "route": {
+                              "prefix_rewrite": "/stats/prometheus",
+                              "cluster": "agent"
+                            }
+                          },
+                          {
+                            "match": {
                               "prefix": "/stats/prometheus"
                             },
                             "route": {


### PR DESCRIPTION
**Please provide a description of this PR:**
Add a new envoy route on the existing telemetry listener (default port 15090) to enable scraping of proxy agent metrics. This will add support for compression of merged metrics without implementing compression in proxy agent.

Fixes https://github.com/istio/istio/issues/58697
Ref: https://github.com/istio/istio/pull/58717, https://github.com/istio/istio/issues/49987

Follow up?
Change default prometheus scraping annotations from 15020 (Agent) to 15090 telemetry endpoint

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [x] Performance and Scalability
- [x] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
