### PR TITLE
Change telemetry listeners metrics path to proxy-agent

### DIFF
--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -237,29 +237,6 @@
   "static_resources": {
     "clusters": [
       {
-        "name": "prometheus_stats",
-        "alt_stat_name": "prometheus_stats;",
-        "type": "STATIC",
-        "connect_timeout": "0.250s",
-        "lb_policy": "ROUND_ROBIN",
-        "load_assignment": {
-          "cluster_name": "prometheus_stats",
-          "endpoints": [{
-            "lb_endpoints": [{
-              "endpoint": {
-                "address":{
-                  "socket_address": {
-                    "protocol": "TCP",
-                    "address": "{{ .localhost }}",
-                    "port_value": {{ .config.ProxyAdminPort }}
-                  }
-                }
-              }
-            }]
-          }]
-        }
-      },
-      {
         "name": "agent",
         "alt_stat_name": "agent;",
         "type": "STATIC",
@@ -617,7 +594,7 @@
                               "prefix": "/stats/prometheus"
                             },
                             "route": {
-                              "cluster": "prometheus_stats"
+                              "cluster": "agent"
                             }
                           }
                         ]


### PR DESCRIPTION

**Please provide a description of this PR:**
This changes the default route from envoy to proxy agent we are preserving the existing exposed metrics, while adding istio proxy agent metrics. When merge-metrics are enabled, they will also be exposed.

Combined with #58717 this will enable by-default compression of metrics data.

Fixes https://github.com/istio/istio/issues/58697
Ref: https://github.com/istio/istio/pull/58717, https://github.com/istio/istio/issues/49987

Alternative without changing the existing behaviour: https://github.com/istio/istio/pull/58724