### PR TITLE
chore: removes unused env vars

### DIFF
--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -168,12 +168,8 @@ spec:
         {{- end }}
         {{- end }}
         {{- if .Values.peerCaCrl.enabled }}
-        - name: ENABLE_CRL
-          value: "true"
         - name: CRL_PATH
           value: "/var/run/secrets/istio/crl/ca-crl.pem"
-        - name: ALLOW_EXPIRED_CRL
-          value: "false"
         {{- end }}
         volumeMounts:
         - mountPath: /var/run/secrets/istio

--- a/releasenotes/notes/58733.yaml
+++ b/releasenotes/notes/58733.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+issue:
+  - 58733
+releaseNotes:
+  - |
+    **Added** CRL support in zTunnel. When ca-crl.pen file is provided via plugged-in CA, Istiod automatically
+    distributes Certificate Revocation Lists to all participating namespaces in the cluster. This enhancement allows 
+    zTunnel to validate and reject revoked certificates, strengthening the security posture of service mesh deployments 
+    using plugged-in CAs.


### PR DESCRIPTION
**Please provide a description of this PR:**

This PR removed unsed env var from zTunnel CRL feature as implemeted in https://github.com/istio/ztunnel/pull/1660.

The above PR implements the CRL_PATH(https://github.com/istio/ztunnel/blob/c3300699eb5b686d81dc90d16e4e29637edf57ee/src/config.rs#L81)  environment variable. I had added a few environment variables earlier ([PR](https://github.com/istio/istio/pull/58132)￼) before the zTunnel implementation was finalized and merged. The final zTunnel implementation does not require any environment variables other than `CRL_PATH`. I'm opening this PR to remove those extra environment variables before releasing the feature.

fxies https://github.com/istio/istio/issues/58733