### PR TITLE
fix goroutine leaks in ambient index DelayedInformers (backport #58479)

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -186,13 +186,19 @@ func New(options Options) Index {
 	)...)
 	authzPolicies := kclient.NewDelayedInformer[*securityclient.AuthorizationPolicy](options.Client,
 		gvr.AuthorizationPolicy, kubetypes.StandardInformer, configFilter)
+	// Start with a.stop to ensure the informer respects the index's stop channel
+	authzPolicies.Start(a.stop)
 	AuthzPolicies := krt.WrapClient[*securityclient.AuthorizationPolicy](authzPolicies, opts.WithName("informer/AuthorizationPolicies")...)
 
 	peerAuths := kclient.NewDelayedInformer[*securityclient.PeerAuthentication](options.Client,
 		gvr.PeerAuthentication, kubetypes.StandardInformer, configFilter)
+	// Start with a.stop to ensure the informer respects the index's stop channel
+	peerAuths.Start(a.stop)
 	PeerAuths := krt.WrapClient[*securityclient.PeerAuthentication](peerAuths, opts.WithName("informer/PeerAuthentications")...)
 
 	gatewayClient := kclient.NewDelayedInformer[*v1beta1.Gateway](options.Client, gvr.KubernetesGateway, kubetypes.StandardInformer, filter)
+	// Start with a.stop to ensure the informer respects the index's stop channel
+	gatewayClient.Start(a.stop)
 	Gateways := krt.WrapClient[*v1beta1.Gateway](gatewayClient, opts.With(
 		krt.WithName("informer/Gateways"),
 		krt.WithMetadata(krt.Metadata{
@@ -201,6 +207,8 @@ func New(options Options) Index {
 	)...)
 
 	gatewayClassClient := kclient.NewDelayedInformer[*v1beta1.GatewayClass](options.Client, gvr.GatewayClass, kubetypes.StandardInformer, filter)
+	// Start with a.stop to ensure the informer respects the index's stop channel
+	gatewayClassClient.Start(a.stop)
 	GatewayClasses := krt.WrapClient[*v1beta1.GatewayClass](gatewayClassClient, opts.WithName("informer/GatewayClasses")...)
 	Pods := krt.NewInformerFiltered[*corev1.Pod](options.Client, kclient.Filter{
 		ObjectFilter:    options.Client.ObjectFilter(),
@@ -214,10 +222,14 @@ func New(options Options) Index {
 
 	serviceEntries := kclient.NewDelayedInformer[*networkingclient.ServiceEntry](options.Client,
 		gvr.ServiceEntry, kubetypes.StandardInformer, configFilter)
+	// Start with a.stop to ensure the informer respects the index's stop channel
+	serviceEntries.Start(a.stop)
 	ServiceEntries := krt.WrapClient[*networkingclient.ServiceEntry](serviceEntries, opts.WithName("informer/ServiceEntries")...)
 
 	workloadEntries := kclient.NewDelayedInformer[*networkingclient.WorkloadEntry](options.Client,
 		gvr.WorkloadEntry, kubetypes.StandardInformer, configFilter)
+	// Start with a.stop to ensure the informer respects the index's stop channel
+	workloadEntries.Start(a.stop)
 	WorkloadEntries := krt.WrapClient[*networkingclient.WorkloadEntry](workloadEntries, opts.WithName("informer/WorkloadEntries")...)
 
 	servicesClient := kclient.NewFiltered[*corev1.Service](options.Client, filter)


### PR DESCRIPTION
Backport of #58479 to release-1.27. Fixes goroutine leaks in DelayedInformers by ensuring they receive the stop channel.