### PR TITLE
Modify TestAccessLogs telemetry integ tests

### DIFF
--- a/tests/integration/telemetry/api/accesslogs_test.go
+++ b/tests/integration/telemetry/api/accesslogs_test.go
@@ -55,6 +55,8 @@ func TestAccessLogs(t *testing.T) {
 				// We should not get logs from the client, since the policy only applies to the Gateway.
 				runAccessLogsTests(t, false, true)
 				deleteTelemetryResource(t, true)
+				// Clean up Gateway API resources to prevent test pollution
+				t.ConfigIstio().EvalFile(apps.Namespace.Name(), args, "./testdata/gateway-api.yaml").DeleteOrFail(t)
 			})
 			t.NewSubTest("disabled").Run(func(t framework.TestContext) {
 				applyTelemetryResource(t, false)


### PR DESCRIPTION
**Please provide a description of this PR:**
Add Gateway API resources cleanup after test execution.

The test become flaky, when executing the test on Openshift and/or using third plane control plane, and executing whole telemetry test suite, the followup tests may fail, since the TestAccessLogs does not clean up the created resource.