### PR TITLE
test: add TargetPortName support to echo framework

### DIFF
--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -708,8 +708,17 @@ func getContainerPorts(cfg echo.Config) echoCommon.PortList {
 	var readyPort *echoCommon.Port
 	for _, p := range ports {
 		// Add the port to the set of application ports.
+		portName := p.Name
+		// If a named target port is specified, use it as the container port name
+		// Truncate to 15 chars max (Kubernetes limit)
+		if p.TargetPortName != "" {
+			portName = p.TargetPortName
+			if len(portName) > 15 {
+				portName = portName[:15]
+			}
+		}
 		cport := &echoCommon.Port{
-			Name:              p.Name,
+			Name:              portName,
 			Protocol:          p.Protocol,
 			Port:              p.WorkloadPort,
 			TLS:               p.TLS,

--- a/pkg/test/framework/components/echo/kube/templates/deployment.yaml
+++ b/pkg/test/framework/components/echo/kube/templates/deployment.yaml
@@ -162,6 +162,8 @@ spec:
           name: tcp-health-port
 {{- else if and ($appContainer.ImageFullPath) (eq .Port 17171) }}
           name: tcp-health-port
+{{- else if and $p.Name (le (len $p.Name) 15) }}
+          name: {{ $p.Name }}
 {{- end }}
 {{- end }}
         env:

--- a/pkg/test/framework/components/echo/kube/templates/service.yaml
+++ b/pkg/test/framework/components/echo/kube/templates/service.yaml
@@ -54,7 +54,11 @@ spec:
 {{- range $i, $p := .ServicePorts }}
   - name: {{ $p.Name }}
     port: {{ $p.ServicePort }}
+{{- if $p.TargetPortName }}
+    targetPort: {{ $p.TargetPortName }}
+{{- else }}
     targetPort: {{ $p.WorkloadPort }}
+{{- end }}
 {{- end }}
   selector:
     app: {{ .Service }}

--- a/pkg/test/framework/components/echo/port.go
+++ b/pkg/test/framework/components/echo/port.go
@@ -43,6 +43,11 @@ type Port struct {
 	// This need not be the same as the ServicePort where the service is accessed.
 	WorkloadPort int
 
+	// TargetPortName is the name of the container port to use as the target port.
+	// If set, this will be used instead of WorkloadPort in the Service targetPort field.
+	// This enables testing services that reference container ports by name rather than number.
+	TargetPortName string
+
 	// TLS determines whether the connection will be plain text or TLS. By default this is false (plain text).
 	TLS bool
 


### PR DESCRIPTION
**Please provide a description of this PR:**
Enable testing services that use named target ports by adding TargetPortName field to echo.Port. When set, this uses the port name in Service targetPort instead of the numeric WorkloadPort.

This supports standard Kubernetes behavior where Services can reference container ports by name rather than number.