### PR TITLE
Fix ambient mc test flake

### DIFF
--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -2857,7 +2857,7 @@ func runTestContextForCalls(
 				}
 			}
 			for name := range apps.WaypointProxies {
-				labelServiceGlobal(t, name, t.Clusters()...) 
+				labelServiceGlobal(t, name, t.Clusters()...)
 			}
 		})
 		// Pilot delays pushing changes to be able to batch multiple incoming changes together and push them
@@ -2869,7 +2869,7 @@ func runTestContextForCalls(
 		// service labels it does not mean that pilot will immediately see them - there is a race condition here,
 		// but we do expect pilot to notice the update rather quickly, so we double the DebounceAfter time here
 		// to account for this issue.
-		time.Sleep(2*features.DebounceAfter)
+		time.Sleep(2 * features.DebounceAfter)
 	}
 	for _, src := range svcs {
 		t.NewSubTestf("from %v %v", src.Config().Cluster.Name(), src.Config().Service).Run(func(t framework.TestContext) {


### PR DESCRIPTION
**Please provide a description of this PR:**

Part of the multicluster setup is to mark services as global. It takes some time for the labels to get noticed, but it's usually happens pretty quickly. However, pilot implements batching of xDS updates - it does not try to push a change immediately when it sees it, but waits for a bit for potential other changes to arrive, so that all of the changes are pushed together in one batch saving some effort.

There are two time limits involved into this batching process:

1. How long we are willing to wait for new events after the last event we received before we decide to push - DebounceAfter
2. What is the maximum total time we can delay the push of an event, even if we have new events coming all the time - DebounceMax

With those two in mind, after we label services as global, we might want to wait for DebounceMax time to make sure that those changes were pushed. DebounceMax by default is set at 10s, which is a bit too long.

Given that we control the test environment reasonably well, I think we can get away with waiting for just DebounceAfter, which is by default just 100ms, assuming that no changes that will require an xDS push happen during the wait.

Naturally, waiting for some time does not completely eliminate the race condition in the tests, so I'm doubling DebounceAfter to account for reasonable levels of variablity.

Also, I noted that in the tests we label the same services as global twice. I think it was the mistake, and the actual intention was not to lable the services second time, but to label waypoints used by those services and workloads. So I fix that along the way here.

Fixes #58780