### PR TITLE
Set x-forwarded-network header for double HBONE

### DIFF
--- a/pilot/pkg/networking/core/listener.go
+++ b/pilot/pkg/networking/core/listener.go
@@ -1444,6 +1444,16 @@ func buildInnerConnectOriginateListener(push *model.PushContext, proxy *model.Pr
 		ClusterSpecifier: &tcp.TcpProxy_Cluster{Cluster: DoubleHBONEInnerConnectOriginate},
 		TunnelingConfig: &tcp.TcpProxy_TunnelingConfig{
 			Hostname: "%FILTER_STATE(istio.double_hbone.hbone_target_address:PLAIN)%",
+			HeadersToAdd: []*core.HeaderValueOption{
+				// Set x-forwarded-network header to the value of the proxy's network
+				{
+					AppendAction: core.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
+					Header: &core.HeaderValue{
+						Key:   downstreamOriginNetworkHeader,
+						Value: string(proxy.Metadata.Network),
+					},
+				},
+			},
 		},
 	}
 	accessLogBuilder.setHboneOriginationAccessLog(push, proxy, tcpProxy, istionetworking.ListenerClassSidecarInbound)

--- a/pilot/pkg/networking/core/listener_waypoint.go
+++ b/pilot/pkg/networking/core/listener_waypoint.go
@@ -71,7 +71,8 @@ const (
 	// We use this header to indicate to the next proxy (e.g., E/W gateway), that the request
 	// came from a waypoint and the next proxy then can infer that L7 policies have been
 	// applied already.
-	downstreamSourceHeader = "x-istio-source"
+	downstreamSourceHeader        = "x-istio-source"
+	downstreamOriginNetworkHeader = "x-forwarded-network"
 )
 
 func (lb *ListenerBuilder) serviceForHostname(name host.Name) *model.Service {


### PR DESCRIPTION
**Please provide a description of this PR:**
Fixes #58809. This forwarded network header in the inner connect tunnel will help HBONE servers know:
1. Which network the request came from
2. That they should report unknown labels if their only available metadata discovery method is workload discovery (i.e. WDS).

The philosophy behind point 2) is that it's better to explicitly say that the value is unknown vs. reporting unreliable data (e.g. in the scenario where there the source client in another network has the same ip as a local workload; workload based metadata discovery would return the local workload's data and it would be completely wrong). We'll update the peer metadata logic in #58799