### PR TITLE
docs: fix typos in comments

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
@@ -373,7 +373,7 @@ func MergedGlobalWorkloadsCollection(
 			}
 
 			if slices.Contains(existing, nil) {
-				// At least of of these isn't initialized yet; remove everything for this cluster
+				// At least one of these isn't initialized yet; remove everything for this cluster
 				podWorkloadInfosCache.Remove(c.ID)
 				workloadEntryWorkloadInfosCache.Remove(c.ID)
 				serviceEntryWorkloadInfosCache.Remove(c.ID)

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -1736,7 +1736,7 @@ func gatewayCases(t TrafficContext) {
 		}
 	}
 
-	// clears the To to avoid echo internals trying to match the protocol with the port on echo.Config
+	// clears the To field to avoid echo internals trying to match the protocol with the port on echo.Config
 	noTarget := func(_ echo.Caller, opts *echo.CallOptions) {
 		opts.To = nil
 	}


### PR DESCRIPTION
## Summary

Fix typos in comments:

- `of of these` → `one of these` in workloads.go
- `the To to avoid` → `the To field to avoid` in routing.go

## Files Changed

- pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
- tests/integration/pilot/common/routing.go