### PR TITLE
adding feature flag LISTENER_DECONFLICT_BY_LENGTH

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -275,6 +275,10 @@ var (
 	MaxConnectionsToAcceptPerSocketEvent = env.Register("MAX_CONNECTIONS_PER_SOCKET_EVENT_LOOP", 1,
 		"The maximum number of connections to accept from the kernel per socket event. Set this to '0' to accept unlimited connections.").Get()
 
+	ListenerDeconflictByLength = env.Register("LISTENER_DECONFLICT_BY_LENGTH", false,
+		"If enabled, when there are conflicting inbound listener filter chains on the same port, "+
+			"the service with the shorter hostname will be used instead of the oldest service.").Get()
+
 	EnableClusterTrustBundles = env.Register("ENABLE_CLUSTER_TRUST_BUNDLE_API", false,
 		"If enabled, uses the ClusterTrustBundle API instead of ConfigMaps to store the root certificate in the cluster.").Get()
 


### PR DESCRIPTION
**Description**
We have found that deconflicting by oldest service doesn't work when there are many services... in our use case we create a servicer *per* pod, a 'pod direct service', so that each pod can be communicated with by it's name.

The oldest method doesn't work since the services are dynamically created/deleted on pod bring-up/down.

Hence adding a feature flag to use length instead of age.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [X ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions