### PR TITLE
Add tpl to affinity and topologySpreadConstraints in "gateway" chart

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -129,7 +129,7 @@ spec:
       {{- end }}
       {{- with .Values.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- tpl ( toYaml . ) $ | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
@@ -137,7 +137,7 @@ spec:
       {{- end }}
       {{- with .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
-        {{- toYaml . | nindent 8 }}
+        {{- tpl ( toYaml . ) $ | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ $.Values.terminationGracePeriodSeconds }}
       {{- with .Values.priorityClassName }}


### PR DESCRIPTION
**Please provide a description of this PR:**

This PR adds a Helm `tpl` function around the template rendering the `affinity` and `topologySpreadConstraints` in the `Deployment` manifest in the `gateway` chart.

The `gateways/istio-ingress` `gateways/istio-egress` charts are not touched in this PR as they have their own special templating logic rendering the same fields.

Fixes https://github.com/istio/istio/issues/56930