### PR TITLE
[release-1.29] Source and destination waypoint tags

### DIFF
--- a/pilot/pkg/networking/core/tracing.go
+++ b/pilot/pkg/networking/core/tracing.go
@@ -555,7 +555,7 @@ var optionalPolicyTags = []*tracing.CustomTag{
 // while CelState is stored under downstream_peer key for CEL expression compatibility.
 // All fields are extracted individually to support dynamic addition of new fields in WorkloadMetadataObject.
 func buildWaypointSourceTags() []*tracing.CustomTag {
-	buildFilterStateTag := func(tagName, fieldName string) *tracing.CustomTag {
+	buildDownstreamFilterStateTag := func(tagName, fieldName string) *tracing.CustomTag {
 		return &tracing.CustomTag{
 			Tag: tagName,
 			Type: &tracing.CustomTag_Value{
@@ -563,19 +563,37 @@ func buildWaypointSourceTags() []*tracing.CustomTag {
 			},
 		}
 	}
+	buildUpstreamFilterStateTag := func(tagName, fieldName string) *tracing.CustomTag {
+		return &tracing.CustomTag{
+			Tag: tagName,
+			Type: &tracing.CustomTag_Value{
+				Value: fmt.Sprintf("%%FILTER_STATE(upstream_peer_obj:FIELD:%s)%%", fieldName),
+			},
+		}
+	}
 
 	// Extract all available fields from WorkloadMetadataObject
 	// See: proxy/extensions/common/metadata_object.h for field definitions
 	return []*tracing.CustomTag{
-		buildFilterStateTag("istio.source_workload", "workload"),
-		buildFilterStateTag("istio.source_namespace", "namespace"),
-		buildFilterStateTag("istio.source_cluster_id", "cluster"),
-		buildFilterStateTag("istio.source_canonical_service", "service"),
-		buildFilterStateTag("istio.source_canonical_revision", "revision"),
-		buildFilterStateTag("istio.source_app", "app"),
-		buildFilterStateTag("istio.source_app_version", "version"),
-		buildFilterStateTag("istio.source_workload_type", "type"),
-		buildFilterStateTag("istio.source_instance_name", "name"),
+		buildUpstreamFilterStateTag("istio.destination_workload", "workload"),
+		buildUpstreamFilterStateTag("istio.destination_namespace", "namespace"),
+		buildUpstreamFilterStateTag("istio.destination_cluster_id", "cluster"),
+		buildUpstreamFilterStateTag("istio.destination_canonical_service", "service"),
+		buildUpstreamFilterStateTag("istio.destination_canonical_revision", "revision"),
+		buildUpstreamFilterStateTag("istio.destination_app", "app"),
+		buildUpstreamFilterStateTag("istio.destination_app_version", "version"),
+		buildUpstreamFilterStateTag("istio.destination_workload_type", "type"),
+		buildUpstreamFilterStateTag("istio.destination_instance_name", "name"),
+
+		buildDownstreamFilterStateTag("istio.source_workload", "workload"),
+		buildDownstreamFilterStateTag("istio.source_namespace", "namespace"),
+		buildDownstreamFilterStateTag("istio.source_cluster_id", "cluster"),
+		buildDownstreamFilterStateTag("istio.source_canonical_service", "service"),
+		buildDownstreamFilterStateTag("istio.source_canonical_revision", "revision"),
+		buildDownstreamFilterStateTag("istio.source_app", "app"),
+		buildDownstreamFilterStateTag("istio.source_app_version", "version"),
+		buildDownstreamFilterStateTag("istio.source_workload_type", "type"),
+		buildDownstreamFilterStateTag("istio.source_instance_name", "name"),
 	}
 }
 

--- a/pilot/pkg/networking/core/tracing_test.go
+++ b/pilot/pkg/networking/core/tracing_test.go
@@ -605,7 +605,17 @@ func defaultTracingTags() []*tracing.CustomTag {
 func waypointTracingTags(extra ...*tracing.CustomTag) []*tracing.CustomTag {
 	tags := append([]*tracing.CustomTag{}, defaultTracingTags()...)
 	tags = append(tags,
-		// FIELD accessor tags for waypoint source tracking (uses downstream_peer_obj key)
+		// FIELD accessor tags for waypoint source tracking (uses {downstream,upstream}_peer_obj key)
+		&tracing.CustomTag{Tag: "istio.destination_app", Type: &tracing.CustomTag_Value{Value: "%FILTER_STATE(upstream_peer_obj:FIELD:app)%"}},
+		&tracing.CustomTag{Tag: "istio.destination_app_version", Type: &tracing.CustomTag_Value{Value: "%FILTER_STATE(upstream_peer_obj:FIELD:version)%"}},
+		&tracing.CustomTag{Tag: "istio.destination_canonical_revision", Type: &tracing.CustomTag_Value{Value: "%FILTER_STATE(upstream_peer_obj:FIELD:revision)%"}},
+		&tracing.CustomTag{Tag: "istio.destination_canonical_service", Type: &tracing.CustomTag_Value{Value: "%FILTER_STATE(upstream_peer_obj:FIELD:service)%"}},
+		&tracing.CustomTag{Tag: "istio.destination_cluster_id", Type: &tracing.CustomTag_Value{Value: "%FILTER_STATE(upstream_peer_obj:FIELD:cluster)%"}},
+		&tracing.CustomTag{Tag: "istio.destination_instance_name", Type: &tracing.CustomTag_Value{Value: "%FILTER_STATE(upstream_peer_obj:FIELD:name)%"}},
+		&tracing.CustomTag{Tag: "istio.destination_namespace", Type: &tracing.CustomTag_Value{Value: "%FILTER_STATE(upstream_peer_obj:FIELD:namespace)%"}},
+		&tracing.CustomTag{Tag: "istio.destination_workload", Type: &tracing.CustomTag_Value{Value: "%FILTER_STATE(upstream_peer_obj:FIELD:workload)%"}},
+		&tracing.CustomTag{Tag: "istio.destination_workload_type", Type: &tracing.CustomTag_Value{Value: "%FILTER_STATE(upstream_peer_obj:FIELD:type)%"}},
+
 		&tracing.CustomTag{Tag: "istio.source_app", Type: &tracing.CustomTag_Value{Value: "%FILTER_STATE(downstream_peer_obj:FIELD:app)%"}},
 		&tracing.CustomTag{Tag: "istio.source_app_version", Type: &tracing.CustomTag_Value{Value: "%FILTER_STATE(downstream_peer_obj:FIELD:version)%"}},
 		&tracing.CustomTag{Tag: "istio.source_canonical_revision", Type: &tracing.CustomTag_Value{Value: "%FILTER_STATE(downstream_peer_obj:FIELD:revision)%"}},

--- a/releasenotes/notes/58348.yaml
+++ b/releasenotes/notes/58348.yaml
@@ -5,6 +5,6 @@ issue:
   - 58348
 releaseNotes:
   - |
-    **Added** source workload identification to waypoint proxy traces. Waypoint proxies now include
-    `istio.source_workload`, `istio.source_namespace`, and other source peer tags in trace spans,
-    matching the observability capabilities of sidecar proxies.
+    **Added** source and destination workload identification to waypoint proxy traces.
+    Waypoint proxies now include `istio.source_workload`, `istio.source_namespace`, `istio.destination_workload`, `istio.destination_namespace` and
+    other source peer tags in trace spans, matching the observability capabilities of sidecar proxies.


### PR DESCRIPTION
**Please provide a description of this PR:**

Joint cherry pick of #58872, #58866, #58818.

resolves #58874, #58867, #58851

We need these because otherwise,
we would change the default telemetry tags emitted by waypoints in 1.30.

cc @PetrMc