### PR TITLE
allow disabling overload manager on sidecar outbound listeners

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -352,6 +352,9 @@ var (
 		}
 		return blockedCIDRs
 	}()
+
+	BypassOverloadManagerForSidecarOutboundListeners = env.Register("BYPASS_OVERLOAD_MANAGER_FOR_SIDECAR_OUTBOUND_LISTENERS", false,
+		"If enabled, the overload manager will be bypassed for sidecar outbound listeners.").Get()
 )
 
 // UnsafeFeaturesEnabled returns true if any unsafe features are enabled.

--- a/pilot/pkg/networking/core/listener.go
+++ b/pilot/pkg/networking/core/listener.go
@@ -564,6 +564,7 @@ func buildListenerFromEntry(builder *ListenerBuilder, le *outboundListenerEntry,
 		Address:                          util.BuildAddress(le.bind.Primary(), uint32(le.servicePort.Port)),
 		AdditionalAddresses:              util.BuildAdditionalAddresses(le.bind.Extra(), uint32(le.servicePort.Port)),
 		TrafficDirection:                 core.TrafficDirection_OUTBOUND,
+		BypassOverloadManager:            features.BypassOverloadManagerForSidecarOutboundListeners,
 		ContinueOnListenerFiltersTimeout: true,
 	}
 	if builder.node.Metadata.OutboundListenerExactBalance {

--- a/pilot/pkg/networking/core/listener_builder.go
+++ b/pilot/pkg/networking/core/listener_builder.go
@@ -142,6 +142,7 @@ func (lb *ListenerBuilder) buildVirtualOutboundListener() *ListenerBuilder {
 		UseOriginalDst:                       proto.BoolTrue,
 		FilterChains:                         filterChains,
 		TrafficDirection:                     core.TrafficDirection_OUTBOUND,
+		BypassOverloadManager:                features.BypassOverloadManagerForSidecarOutboundListeners,
 		MaxConnectionsToAcceptPerSocketEvent: maxConnectionsToAcceptPerSocketEvent(),
 	}
 	// add extra addresses for the listener


### PR DESCRIPTION
**Please provide a description of this PR:**
It's most likely that people want outbound traffic not to be affected on sidecars whenever OverloadManager is triggered, this should probably be the default behavior too.