### PR TITLE
bump kiali addon to v2.21.0

### DIFF
--- a/manifests/addons/gen.sh
+++ b/manifests/addons/gen.sh
@@ -33,8 +33,8 @@ GRAFANA_VERSION=${GRAFANA_VERSION:-"9.2.2"}
 {
 helm template kiali-server \
   --namespace istio-system \
-  --version 2.20.0 \
-  --set deployment.image_version=v2.20 \
+  --version 2.21.0 \
+  --set deployment.image_version=v2.21 \
   --include-crds \
   kiali-server \
   --repo https://kiali.org/helm-charts \

--- a/releasenotes/notes/kiali-update-v2.21.yaml
+++ b/releasenotes/notes/kiali-update-v2.21.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+
+releaseNotes:
+  - |
+    **Updated** Kiali addon to version v2.21.0.

--- a/samples/addons/kiali.yaml
+++ b/samples/addons/kiali.yaml
@@ -7,12 +7,12 @@ metadata:
   namespace: "istio-system"
   labels:
     
-    helm.sh/chart: kiali-server-2.20.0
+    helm.sh/chart: kiali-server-2.21.0
     app: kiali
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: kiali
-    version: "v2.20.0"
-    app.kubernetes.io/version: "v2.20.0"
+    version: "v2.21.0"
+    app.kubernetes.io/version: "v2.21.0"
     app.kubernetes.io/part-of: "kiali"
 ...
 ---
@@ -24,12 +24,12 @@ metadata:
   namespace: "istio-system"
   labels:
     
-    helm.sh/chart: kiali-server-2.20.0
+    helm.sh/chart: kiali-server-2.21.0
     app: kiali
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: kiali
-    version: "v2.20.0"
-    app.kubernetes.io/version: "v2.20.0"
+    version: "v2.21.0"
+    app.kubernetes.io/version: "v2.21.0"
     app.kubernetes.io/part-of: "kiali"
 data:
   config.yaml: |
@@ -72,7 +72,7 @@ data:
       image_name: quay.io/kiali/kiali
       image_pull_policy: IfNotPresent
       image_pull_secrets: []
-      image_version: v2.20
+      image_version: v2.21
       ingress:
         additional_labels: {}
         class_name: nginx
@@ -117,9 +117,14 @@ data:
       security_context: {}
       service_annotations: {}
       service_type: ""
+      tls_config:
+        cipher_suites: []
+        max_version: ""
+        min_version: ""
+        source: config
       tolerations: []
       topology_spread_constraints: []
-      version_label: v2.20.0
+      version_label: v2.21.0
       view_only_mode: false
     external_services:
       custom_dashboards:
@@ -156,12 +161,12 @@ metadata:
   name: kiali
   labels:
     
-    helm.sh/chart: kiali-server-2.20.0
+    helm.sh/chart: kiali-server-2.21.0
     app: kiali
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: kiali
-    version: "v2.20.0"
-    app.kubernetes.io/version: "v2.20.0"
+    version: "v2.21.0"
+    app.kubernetes.io/version: "v2.21.0"
     app.kubernetes.io/part-of: "kiali"
 rules:
 - apiGroups: [""]
@@ -266,12 +271,12 @@ metadata:
   name: kiali
   labels:
     
-    helm.sh/chart: kiali-server-2.20.0
+    helm.sh/chart: kiali-server-2.21.0
     app: kiali
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: kiali
-    version: "v2.20.0"
-    app.kubernetes.io/version: "v2.20.0"
+    version: "v2.21.0"
+    app.kubernetes.io/version: "v2.21.0"
     app.kubernetes.io/part-of: "kiali"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -291,12 +296,12 @@ metadata:
   namespace: "istio-system"
   labels:
     
-    helm.sh/chart: kiali-server-2.20.0
+    helm.sh/chart: kiali-server-2.21.0
     app: kiali
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: kiali
-    version: "v2.20.0"
-    app.kubernetes.io/version: "v2.20.0"
+    version: "v2.21.0"
+    app.kubernetes.io/version: "v2.21.0"
     app.kubernetes.io/part-of: "kiali"
   annotations:
 spec:
@@ -322,12 +327,12 @@ metadata:
   namespace: "istio-system"
   labels:
     
-    helm.sh/chart: kiali-server-2.20.0
+    helm.sh/chart: kiali-server-2.21.0
     app: kiali
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: kiali
-    version: "v2.20.0"
-    app.kubernetes.io/version: "v2.20.0"
+    version: "v2.21.0"
+    app.kubernetes.io/version: "v2.21.0"
     app.kubernetes.io/part-of: "kiali"
 spec:
   replicas: 1
@@ -345,24 +350,25 @@ spec:
       name: kiali
       labels:
         
-        helm.sh/chart: kiali-server-2.20.0
+        helm.sh/chart: kiali-server-2.21.0
         app: kiali
         app.kubernetes.io/name: kiali
         app.kubernetes.io/instance: kiali
-        version: "v2.20.0"
-        app.kubernetes.io/version: "v2.20.0"
+        version: "v2.21.0"
+        app.kubernetes.io/version: "v2.21.0"
         app.kubernetes.io/part-of: "kiali"
         sidecar.istio.io/inject: "false"
       annotations:
-        checksum/config: dbc20ab7b7af06baecd7908552ab787b3cfeb4f020ff4af6f751313a2cccbca6
+        checksum/config: 35ac15457de3a25040e953fa6178396e95991865aed21cb1bd8c131c5d3a81c7
         prometheus.io/scrape: "true"
         prometheus.io/port: "9090"
+        prometheus.io/scheme: "http"
         kiali.io/dashboards: go,kiali
         proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
     spec:
       serviceAccountName: kiali
       containers:
-      - image: "quay.io/kiali/kiali:v2.20"
+      - image: "quay.io/kiali/kiali:v2.21"
         imagePullPolicy: IfNotPresent
         name: kiali
         command:


### PR DESCRIPTION
**Please provide a description of this PR:**

Kiali v2.21.0 is the appropriate version for the next Istio release. This PR bumps up the Kiali addon to that version.