### PR TITLE
test: Show output of external control plane installer when failed

### DIFF
--- a/pkg/test/framework/components/istio/cleanup.go
+++ b/pkg/test/framework/components/istio/cleanup.go
@@ -69,10 +69,15 @@ func (i *istioImpl) Close() error {
 
 	// Execute External Control Plane Cleanup Script
 	if i.cfg.ControlPlaneInstaller != "" && !i.cfg.DeployIstio {
-		scopes.Framework.Infof("============= Execute Control Plane Cleanup =============")
+		scopes.Framework.Infof("=== BEGIN: Execute Control Plane Cleanup ===")
 		cmd := exec.Command(i.cfg.ControlPlaneInstaller, "cleanup", i.workDir)
-		if err := cmd.Run(); err != nil {
-			scopes.Framework.Errorf("failed to run external control plane installer: %v", err)
+		if output, err := cmd.CombinedOutput(); err != nil {
+			// Display the installer output within the error message, but proceed with the subsequent cleanup without returning an error.
+			scopes.Framework.Errorf("Execute Control Plane Cleanup failed on: %v\nInstaller output:\n%s", err, string(output))
+			scopes.Framework.Infof("=== FAILED: Execute Control Plane Cleanup ===")
+		} else {
+			scopes.Framework.Debugf("Control Plane cleanup output:\n%s", string(output))
+			scopes.Framework.Infof("=== DONE: Execute Control Plane Cleanup ===")
 		}
 	}
 

--- a/pkg/test/framework/components/istio/kube.go
+++ b/pkg/test/framework/components/istio/kube.go
@@ -287,11 +287,16 @@ func newKube(ctx resource.Context, cfg Config) (Instance, error) {
 
 	// Execute External Control Plane Installer Script
 	if cfg.ControlPlaneInstaller != "" && !cfg.DeployIstio {
-		scopes.Framework.Infof("============= Execute Control Plane Installer =============")
+		scopes.Framework.Infof("=== BEGIN: Execute Control Plane Installer ===")
 		cmd := exec.Command(cfg.ControlPlaneInstaller, "install", workDir)
-		if err := cmd.Run(); err != nil {
-			scopes.Framework.Errorf("failed to run external control plane installer: %v", err)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			scopes.Framework.Errorf("Execute Control Plane Installer failed on: %v\nInstaller output:\n%s", err, string(output))
+			scopes.Framework.Infof("=== FAILED: Execute Control Plane Installer ===")
+			return nil, err
 		}
+		scopes.Framework.Debugf("Control Plane Installer output:\n%s", string(output))
+		scopes.Framework.Infof("=== DONE: Execute Control Plane Installer ===")
 	}
 
 	if !cfg.DeployIstio {

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -443,14 +443,20 @@ Examples will use `extinst` as script name.
 Installs the Istio control plane for this test run. Takes 1 argument, work directory of integration test.
 
 Example:
-extinst install /work/test1/integ-test
+
+```console
+$ extinst install /work/test1/integ-test
+```
 
 ##### 'cleanup' command
 
 Cleans up the previously-installed control plane. Takes 1 argument, work directory of integration test.
 
 Example:
-extinst cleanup /work/test1/integ-test
+
+```console
+$ extinst cleanup /work/test1/integ-test
+```
 
 ## Environments
 


### PR DESCRIPTION
**Please provide a description of this PR:**
When external control plane installer (script or bin) (provided via `--istio.test.kube.controlPlaneInstaller`) failed, the output contains only status code
```
2026-01-27T09:34:15.114054Z	info	tf	================================
2026-01-27T09:34:15.116112Z	info	tf	============= Execute Control Plane Installer =============
2026-01-27T09:36:31.759743Z	error	tf	failed to run external control plane installer: exit status 1
2026-01-27T09:36:31.759788Z	info	tf	skipping deployment as specified in the config
2026-01-27T09:36:31.759802Z	info	tf	=== SUCCEEDED: Deploy Istio in 2m16.645801401s
```
and test execution continues.

**Changes:**
- Added output from the installer when it failes to the error log (to gather information in the error in the external control plane installer) e.g.:

```
2026-01-27T12:43:42.098950Z	info	tf	================================
2026-01-27T12:43:42.101452Z	info	tf	=== BEGIN: Execute Control Plane Installer ===
2026-01-27T12:45:53.277973Z	error	tf	Execute Control Plane Installer failed on: exit status 1
Installer output:
[2026-01-27 13:43:42] + set -o pipefail
...
[2026-01-27 13:45:53] + oc describe pod '' -n istio-system
[2026-01-27 13:45:53] error: resource name may not be empty
[2026-01-27 13:45:53] + exit 1

2026-01-27T12:45:53.278016Z	info	tf	=== FAILED: Execute Control Plane Installer ===
2026-01-27T12:45:53.278039Z	info	tf	=== FAILED: Deploy Istio in 2m11.179150951s [Suite=ambient] ===
2026-01-27T12:45:53.278064Z	error	tf	=== Dumping Istio Deployment State for [suite(ambient)]...
```
and **terminate the test execution** since in that situation, it is pointless to continue.

- Added output from the installer when it succeeds to the debug log