### PR TITLE
add namespace authorization to port 15014 debug endpoints

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -100,6 +100,9 @@ var (
 	EnableUnsafeAdminEndpoints = env.Register("UNSAFE_ENABLE_ADMIN_ENDPOINTS", false,
 		"If this is set to true, dangerous admin endpoints will be exposed on the debug interface. Not recommended for production.").Get()
 
+	EnableDebugEndpointAuth = env.Register("ENABLE_DEBUG_ENDPOINT_AUTH", true,
+		"Enforce namespace-based authorization on debug endpoints. Non-system namespaces restricted to config_dump/ndsz/edsz for same-namespace proxies only.").Get()
+
 	EnableServiceEntrySelectPods = env.Register("PILOT_ENABLE_SERVICEENTRY_SELECT_PODS", true,
 		"If enabled, service entries with selectors will select pods from the cluster. "+
 			"It is safe to disable it if you are quite sure you don't need this feature").Get()

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -15,6 +15,7 @@
 package xds
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -55,6 +56,9 @@ import (
 	"istio.io/istio/pkg/util/sets"
 	"istio.io/istio/pkg/workloadapi"
 )
+
+// CallerNamespaceKey is used to store caller namespace in request context
+type CallerNamespaceKey struct{}
 
 var indexTmpl = template.Must(template.New("index").Parse(`<html>
 <head>
@@ -264,12 +268,15 @@ func (s *DiscoveryServer) allowAuthenticatedOrLocalhost(next http.Handler) http.
 			return
 		}
 		// Check namespace-based authorization for debug endpoints
+		namespace := s.extractNamespace(ids)
 		if !s.AuthorizeDebugRequest(ids, req) {
 			istiolog.Warnf("Unauthorized debug request from %v to %s", ids, req.URL.Path)
 			w.WriteHeader(http.StatusForbidden)
 			return
 		}
-		next.ServeHTTP(w, req)
+		// Store caller namespace in context for handlers to enforce proxy-level access
+		ctx := context.WithValue(req.Context(), CallerNamespaceKey{}, namespace)
+		next.ServeHTTP(w, req.WithContext(ctx))
 	}
 }
 
@@ -283,18 +290,21 @@ func isRequestFromLocalhost(r *http.Request) bool {
 	return userIP.IsLoopback()
 }
 
-// AuthorizeDebugRequest checks if authenticated identities are authorized to access the requested debug endpoint
-func (s *DiscoveryServer) AuthorizeDebugRequest(identities []string, req *http.Request) bool {
-	// Parse identities to extract namespace
-	var namespace string
+// extractNamespace extracts namespace from authenticated identities
+func (s *DiscoveryServer) extractNamespace(identities []string) string {
 	for _, id := range identities {
 		spiffeID, err := spiffe.ParseIdentity(id)
 		if err != nil {
 			continue
 		}
-		namespace = spiffeID.Namespace
-		break
+		return spiffeID.Namespace
 	}
+	return ""
+}
+
+// AuthorizeDebugRequest checks if authenticated identities are authorized to access the requested debug endpoint
+func (s *DiscoveryServer) AuthorizeDebugRequest(identities []string, req *http.Request) bool {
+	namespace := s.extractNamespace(identities)
 
 	// deny if no valid identity found
 	if namespace == "" {
@@ -1125,9 +1135,23 @@ func (s *DiscoveryServer) handlePushRequest(w http.ResponseWriter, req *http.Req
 }
 
 // getDebugConnection fetches the Connection requested by proxyID
+// For non-system namespaces, restricts access to proxies in the caller's namespace only
 func (s *DiscoveryServer) getDebugConnection(req *http.Request) (string, *Connection) {
 	if proxyID := req.URL.Query().Get("proxyID"); proxyID != "" {
-		return proxyID, s.getProxyConnection(proxyID)
+		con := s.getProxyConnection(proxyID)
+		// Verify namespace if caller is not from system namespace
+		callerNamespace, _ := req.Context().Value(CallerNamespaceKey{}).(string)
+		if con != nil && callerNamespace != "" {
+			systemNamespace := constants.IstioSystemNamespace
+			if s.Env != nil && s.Env.Mesh() != nil && s.Env.Mesh().GetRootNamespace() != "" {
+				systemNamespace = s.Env.Mesh().GetRootNamespace()
+			}
+			// Non-system namespaces can only access proxies in their own namespace
+			if callerNamespace != systemNamespace && con.proxy.ConfigNamespace != callerNamespace {
+				return proxyID, nil // Return nil connection to deny access
+			}
+		}
+		return proxyID, con
 	}
 	return "", nil
 }

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -43,12 +43,14 @@ import (
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/istio/pkg/config/xds"
 	istiolog "istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/security"
 	"istio.io/istio/pkg/slices"
+	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/util/protomarshal"
 	"istio.io/istio/pkg/util/sets"
 	"istio.io/istio/pkg/workloadapi"
@@ -261,8 +263,12 @@ func (s *DiscoveryServer) allowAuthenticatedOrLocalhost(next http.Handler) http.
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
-		// TODO: Check that the identity contains istio-system namespace, else block or restrict to only info that
-		// is visible to the authenticated SA. Will require changes in docs and istioctl too.
+		// Check namespace-based authorization for debug endpoints
+		if !s.AuthorizeDebugRequest(ids, req) {
+			istiolog.Warnf("Unauthorized debug request from %v to %s", ids, req.URL.Path)
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
 		next.ServeHTTP(w, req)
 	}
 }
@@ -275,6 +281,41 @@ func isRequestFromLocalhost(r *http.Request) bool {
 
 	userIP, _ := netip.ParseAddr(ip)
 	return userIP.IsLoopback()
+}
+
+// AuthorizeDebugRequest checks if authenticated identities are authorized to access the requested debug endpoint
+func (s *DiscoveryServer) AuthorizeDebugRequest(identities []string, req *http.Request) bool {
+	// Parse identities to extract namespace
+	var namespace string
+	for _, id := range identities {
+		spiffeID, err := spiffe.ParseIdentity(id)
+		if err != nil {
+			continue
+		}
+		namespace = spiffeID.Namespace
+		break
+	}
+
+	// deny if no valid identity found
+	if namespace == "" {
+		return false
+	}
+
+	// get system namespace (istio-system by default, or mesh root namespace)
+	systemNamespace := constants.IstioSystemNamespace
+	if s.Env != nil && s.Env.Mesh() != nil && s.Env.Mesh().GetRootNamespace() != "" {
+		systemNamespace = s.Env.Mesh().GetRootNamespace()
+	}
+
+	// allow all if identity is from system namespace
+	if namespace == systemNamespace {
+		return true
+	}
+
+	// non-system namespace: only allow specific endpoints
+	debugPath := strings.TrimPrefix(req.URL.Path, "/debug/")
+	_, allowed := activeNamespaceDebuggers[debugPath]
+	return allowed
 }
 
 // Syncz dumps the synchronization status of all Envoys connected to this Pilot instance

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -307,7 +307,8 @@ func (s *DiscoveryServer) extractNamespace(identities []string) string {
 	return ""
 }
 
-// AuthorizeDebugRequest checks if authenticated identities are authorized to access the requested debug endpoint
+// AuthorizeDebugRequest checks if authenticated identities are authorized to access the requested debug endpoint.
+// Note: non-system namespace requests are further verified at connection time to ensure same-namespace proxy access only.
 func (s *DiscoveryServer) AuthorizeDebugRequest(identities []string, req *http.Request) bool {
 	namespace := s.extractNamespace(identities)
 

--- a/pilot/pkg/xds/debug_test.go
+++ b/pilot/pkg/xds/debug_test.go
@@ -352,7 +352,7 @@ func TestDebugProxyNamespaceRestriction(t *testing.T) {
 			wantStatus: 200,
 		},
 		{
-			name:       "cross-namespace denied - this would FAIL before fix",
+			name:       "cross-namespace denied",
 			callerNS:   "staging",
 			proxyID:    "test.production",
 			wantStatus: 404, // Returns 404 when proxy not accessible

--- a/pilot/pkg/xds/debug_test.go
+++ b/pilot/pkg/xds/debug_test.go
@@ -25,10 +25,12 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
 	"istio.io/istio/istioctl/pkg/util/configdump"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/xds"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	xdsfake "istio.io/istio/pilot/test/xds"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
 )
 
@@ -324,6 +326,7 @@ func TestDebugAuthorization(t *testing.T) {
 // TestDebugProxyNamespaceRestriction verifies that non-system namespaces can only access
 // debug info for proxies in their own namespace. This test would FAIL before the fix.
 func TestDebugProxyNamespaceRestriction(t *testing.T) {
+	test.SetForTest(t, &features.EnableDebugEndpointAuth, true)
 	s := xdsfake.NewFakeDiscoveryServer(t, xdsfake.FakeOptions{})
 
 	// Create a proxy in production namespace

--- a/releasenotes/notes/debug-endpoint-authorization.yaml
+++ b/releasenotes/notes/debug-endpoint-authorization.yaml
@@ -10,10 +10,4 @@ issue: []
 releaseNotes:
 - |
   **Fixed** unauthorized cross-namespace access to debug endpoints on port 15014. Non-system namespace service accounts
-  can now only access their own namespace debug information via config_dump, ndsz, and edsz endpoints.
-
-securityNotes:
-- |
-  Debug endpoints on port 15014 (HTTP) now enforce namespace-based authorization matching the existing port 15012 (XDS) behavior.
-  Service accounts in non-system namespaces are restricted to specific debug endpoints and cannot access debug information
-  from other namespaces.
+  are now restricted to config_dump, ndsz, and edsz endpoints for their own namespace only.

--- a/releasenotes/notes/debug-endpoint-authorization.yaml
+++ b/releasenotes/notes/debug-endpoint-authorization.yaml
@@ -1,0 +1,19 @@
+apiVersion: release-notes/v2
+
+kind: security-fix
+
+area: security
+
+# no public issue for security vulnerability
+issue: []
+
+releaseNotes:
+- |
+  **Fixed** unauthorized cross-namespace access to debug endpoints on port 15014. Non-system namespace service accounts
+  can now only access their own namespace debug information via config_dump, ndsz, and edsz endpoints.
+
+securityNotes:
+- |
+  Debug endpoints on port 15014 (HTTP) now enforce namespace-based authorization matching the existing port 15012 (XDS) behavior.
+  Service accounts in non-system namespaces are restricted to specific debug endpoints and cannot access debug information
+  from other namespaces.

--- a/releasenotes/notes/debug-endpoint-authorization.yaml
+++ b/releasenotes/notes/debug-endpoint-authorization.yaml
@@ -9,5 +9,6 @@ issue: []
 
 releaseNotes:
 - |
-  **Fixed** unauthorized cross-namespace access to debug endpoints on port 15014.
+  **Added** namespace-based authorization for debug endpoints on port 15014.
   Non-system namespaces restricted to config_dump/ndsz/edsz endpoints and same-namespace proxies only.
+  Disable with ENABLE_DEBUG_ENDPOINT_AUTH=false if needed for compatibility.

--- a/releasenotes/notes/debug-endpoint-authorization.yaml
+++ b/releasenotes/notes/debug-endpoint-authorization.yaml
@@ -12,3 +12,10 @@ releaseNotes:
   **Added** namespace-based authorization for debug endpoints on port 15014.
   Non-system namespaces restricted to config_dump/ndsz/edsz endpoints and same-namespace proxies only.
   Disable with ENABLE_DEBUG_ENDPOINT_AUTH=false if needed for compatibility.
+
+upgradeNotes:
+- title: Debug endpoint authorization is now enabled by default.
+  content: |
+    Tools accessing debug endpoints from non-system namespaces (such as Kiali or custom monitoring tools)
+    may be affected. Non-system namespaces are now restricted to config_dump, ndsz, and edsz endpoints
+    for same-namespace proxies only. To restore previous behavior, set ENABLE_DEBUG_ENDPOINT_AUTH=false.

--- a/releasenotes/notes/debug-endpoint-authorization.yaml
+++ b/releasenotes/notes/debug-endpoint-authorization.yaml
@@ -9,5 +9,5 @@ issue: []
 
 releaseNotes:
 - |
-  **Fixed** unauthorized cross-namespace access to debug endpoints on port 15014. Non-system namespace service accounts
-  are now restricted to config_dump, ndsz, and edsz endpoints for their own namespace only.
+  **Fixed** unauthorized cross-namespace access to debug endpoints on port 15014.
+  Non-system namespaces restricted to config_dump/ndsz/edsz endpoints and same-namespace proxies only.


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes cross-namespace access. Non-system namespaces now restricted to config_dump/ndsz/edsz, matching port 15012 XDS behavior.