### PR TITLE
fix: modify istio readiness timeout and fix a seg fault

### DIFF
--- a/pkg/istio-agent/health/health_check.go
+++ b/pkg/istio-agent/health/health_check.go
@@ -99,7 +99,9 @@ func NewWorkloadHealthChecker(cfg *v1alpha3.ReadinessProbe, envoyProbe ready.Pro
 	if envoyProbe != nil {
 		probers = append(probers, &EnvoyProber{envoyProbe})
 	}
-	probers = append(probers, prober)
+	if prober != nil {
+		probers = append(probers, prober)
+	}
 	return &WorkloadHealthChecker{
 		config: applicationHealthCheckConfig{
 			InitialDelay:   time.Duration(cfg.InitialDelaySeconds) * time.Second,

--- a/pkg/istio-agent/health/health_probers.go
+++ b/pkg/istio-agent/health/health_probers.go
@@ -292,6 +292,9 @@ var _ Prober = &AggregateProber{}
 
 func (a AggregateProber) Probe(timeout time.Duration) (ProbeResult, error) {
 	for _, probe := range a.Probes {
+		if probe == nil {
+			return Unknown, fmt.Errorf("nil probe in AggregateProber")
+		}
 		res, err := probe.Probe(timeout)
 		if err != nil || !res.IsHealthy() {
 			return res, err


### PR DESCRIPTION
**Please provide a description of this PR:**

This PR provides a way for users to modify istio readiness timeout in pilot-agent(through ISTIO_READINESS_PROBE_TIMEOUT env var). Currently users can modify readinessProbe in k8s deployment spec but it won't be getting used as underlying request times out in 1sec (not 3 second as suggested since the probe timeout getting used is from [here](https://github.com/istio/istio/blob/ec64c6713f2147b3530261d4bb5a57278bfe3c40/pkg/http/get.go#L25)).  This is useful when genuinely the proxy is taking lot of time at scale to respond to readiness probe.

This PR also fixes the below segmentation fault we observed(below lines are from 1.24 so not from the exact place in the code on master):

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xd76fea]

goroutine 130 [running]:
istio.io/istio/pkg/istio-agent/health.AggregateProber.Probe({{0xc00058b3a0?, 0x1?, 0x0?}}, 0x6fc23ac00)
	istio.io/istio/pkg/istio-agent/health/health_probers.go:211 +0x4a
istio.io/istio/pkg/istio-agent/health.(*WorkloadHealthChecker).PerformApplicationHealthCheck.func1()
	istio.io/istio/pkg/istio-agent/health/health_check.go:146 +0x5c
istio.io/istio/pkg/istio-agent/health.(*WorkloadHealthChecker).PerformApplicationHealthCheck(0xc000260840, 0xc000052520, 0xc000172d90)
	istio.io/istio/pkg/istio-agent/health/health_check.go:189 +0x1a2
created by istio.io/istio/pkg/istio-agent.initXdsProxy in goroutine 1
	istio.io/istio/pkg/istio-agent/xds_proxy.go:207 +0x705
2026-01-22T10:06:01.508740Z	warning	envoy config external/envoy/source/extensions/config_subscription/grpc/grpc_stream.h:188	StreamSecrets gRPC config stream to sds-grpc closed: 13, 	thread=23
2026-01-22T10:06:01.508784Z	warning	envoy config external/envoy/source/extensions/config_subscription/grpc/grpc_stream.h:188	StreamSecrets gRPC config stream to sds-grpc closed: 13, 	thread=23
2026-01-22T10:06:01.508904Z	warning	envoy config external/envoy/source/extensions/config_subscription/grpc/grpc_stream.h:188	StreamAggregatedResources gRPC config stream to xds-grpc closed: 13, 	thread=23
```