### PR TITLE
Return back peer metadata filter in inner_connect_originate listener

### DIFF
--- a/pilot/pkg/networking/core/listener.go
+++ b/pilot/pkg/networking/core/listener.go
@@ -1439,44 +1439,60 @@ func buildInnerConnectOriginateListener(push *model.PushContext, proxy *model.Pr
 			},
 		},
 	}
+	tunnel := &tcp.TcpProxy_TunnelingConfig{
+		Hostname: "%FILTER_STATE(istio.double_hbone.hbone_target_address:PLAIN)%",
+	}
+
+	headers := []*core.HeaderValueOption{{
+		AppendAction: core.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
+		Header: &core.HeaderValue{
+			Key:   downstreamOriginNetworkHeader,
+			Value: string(proxy.Metadata.Network),
+		},
+	}}
+
+	if features.EnableAmbientBaggage {
+		tunnel.PropagateResponseHeaders = true
+		headers = append(headers, &core.HeaderValueOption{
+			AppendAction: core.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
+			Header: &core.HeaderValue{
+				Key:   "baggage",
+				Value: "%FILTER_STATE(io.istio.baggage:PLAIN)%",
+			},
+		})
+	}
+	tunnel.HeadersToAdd = headers
+
 	tcpProxy := &tcp.TcpProxy{
 		StatPrefix:       DoubleHBONEInnerConnectOriginate,
 		ClusterSpecifier: &tcp.TcpProxy_Cluster{Cluster: DoubleHBONEInnerConnectOriginate},
-		TunnelingConfig: &tcp.TcpProxy_TunnelingConfig{
-			Hostname: "%FILTER_STATE(istio.double_hbone.hbone_target_address:PLAIN)%",
-			HeadersToAdd: []*core.HeaderValueOption{
-				// Set x-forwarded-network header to the value of the proxy's network
-				{
-					AppendAction: core.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
-					Header: &core.HeaderValue{
-						Key:   downstreamOriginNetworkHeader,
-						Value: string(proxy.Metadata.Network),
-					},
-				},
-			},
-		},
+		TunnelingConfig:  tunnel,
 	}
 	accessLogBuilder.setHboneOriginationAccessLog(push, proxy, tcpProxy, istionetworking.ListenerClassSidecarInbound)
+
+	sfs := &listener.Filter{
+		Name: "propagate_endpoint_metadata",
+		ConfigType: &listener.Filter_TypedConfig{
+			TypedConfig: protoconv.MessageToAny(setFilterState),
+		},
+	}
+	tcp := &listener.Filter{
+		Name: wellknown.TCPProxy,
+		ConfigType: &listener.Filter_TypedConfig{
+			TypedConfig: protoconv.MessageToAny(tcpProxy),
+		},
+	}
+	filters := []*listener.Filter{sfs, tcp}
+	if features.EnableAmbientBaggage {
+		filters = []*listener.Filter{sfs, xdsfilters.WaypointListenerBaggagePeerMetadata, tcp}
+	}
 
 	l := &listener.Listener{
 		Name:              DoubleHBONEInnerConnectOriginate,
 		UseOriginalDst:    wrappers.Bool(false),
 		ListenerSpecifier: &listener.Listener_InternalListener{InternalListener: &listener.Listener_InternalListenerConfig{}},
 		FilterChains: []*listener.FilterChain{{
-			Filters: []*listener.Filter{
-				{
-					Name: "propagate_endpoint_metadata",
-					ConfigType: &listener.Filter_TypedConfig{
-						TypedConfig: protoconv.MessageToAny(setFilterState),
-					},
-				},
-				{
-					Name: wellknown.TCPProxy,
-					ConfigType: &listener.Filter_TypedConfig{
-						TypedConfig: protoconv.MessageToAny(tcpProxy),
-					},
-				},
-			},
+			Filters: filters,
 		}},
 	}
 	accessLogBuilder.setListenerAccessLog(push, proxy, l, istionetworking.ListenerClassSidecarInbound)

--- a/pilot/test/xdstest/extract.go
+++ b/pilot/test/xdstest/extract.go
@@ -264,6 +264,14 @@ func ExtractFilterNames(t test.Failer, fcs *listener.FilterChain) ([]string, []s
 	return nwFilters, httpFilters
 }
 
+func ExtractClusterFilterNames(filters []*cluster.Filter) []string {
+	names := []string{}
+	for _, f := range filters {
+		names = append(names, f.Name)
+	}
+	return names
+}
+
 func ExtractTCPProxy(t test.Failer, fcs *listener.FilterChain) *tcpproxy.TcpProxy {
 	for _, fc := range fcs.Filters {
 		if fc.Name == wellknown.TCPProxy {


### PR DESCRIPTION
**Please provide a description of this PR:**

This filter is needed for peer metadata discovery and telemetry to work properly in multi-network environments. We had it at some point, but with more recent reworks and merges we lost it.

Unfortunately, we didn't create any automatic tests to catch this issue. No customer impact though - it's a new code path disabled by default.

This time I'm adding some unit tests that checks that all the right filters are generated in different configurations.





+cc @keithmattix @Stevenjin8 @grnmeira 