### PR TITLE
Reduce flakiness of the TestServiceRestart test

### DIFF
--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -3499,18 +3499,18 @@ func TestDirect(t *testing.T) {
 func TestServiceRestart(t *testing.T) {
 	// Keep the call interval small - it reduces test flakiness.
 	//
-	// echo app after it recieved SIGTERM will wait for 1 second before shutting down.
+	// echo app after it received SIGTERM will wait for 1 second before shutting down.
 	// If during this one second it gets a new request, it rests the timer and waits for another
 	// second and so on, until it gets forcefully terminated or until it gets no request during
 	// the 1 second wait time.
 	//
-	// We need to wait after receving SIGTERM before terminating, because k8s may start pod
+	// We need to wait after receiving SIGTERM before terminating, because k8s may start pod
 	// shutdown sequence, before the pod was removed from the service endpoints list. That race
 	// condition creates a situation where request can be routed to a pod that is being shut down
 	// and does not accept new requests anymore.
 	//
 	// Normally for the destination service we have 2 deployments with 1 pod each, however during
-	// the restart of one of the deployments in this test we can temporarly have 3 pods backing
+	// the restart of one of the deployments in this test we can temporary have 3 pods backing
 	// the service, assuming some level of uniformity each pod for each request is chosen with
 	// probability of 1/3 and not chosen with probability 2/3.
 	//
@@ -3522,7 +3522,7 @@ func TestServiceRestart(t *testing.T) {
 	// flakes.
 	//
 	// To reduce the possibility of such flakes we changed the call interval from 100ms to 40ms
-	// in the past, so please do not increase the call interval. 
+	// in the past, so please do not increase the call interval.
 	const callInterval = 40 * time.Millisecond
 	successThreshold := 1.0
 	if os.Getenv("KUBERNETES_CNI") == "calico" {


### PR DESCRIPTION
**Please provide a description of this PR:**

In my local environment the test flakes 2-3 times per 1000 runs. Looking at the causes of the flakes I found two:

1. The echo process gets terminated prematurely - before the pod is removed from the list of service endpoints
2. DNS resolution fails with timeout - I've only seen this once, so it's quite rare and it's not an Istio issue, so I'm going to ignore this cause for now (we can potentially harden echo implementation by allowing retries of DNS failures, though)

The way a restart works in k8s deployment is roughly happens in the following order:

- deployment brings up a new pod
- deployment waits for the new pod to become healthy
- deployment terminates the old pod

In parallel with termination of the new pod, if deployment pods are behind a service, the terminating pod gets removed from the list of the service endpoints.

The important thing here is that terminating pod and removing it from the service endpoints list happens concurrently, so you could end up in a situation, when the processes in the pod already terminated, but the pod is still listed as a service endpoint and can get requests routed to it. Obviously, such requests will fail.

In echo app implementation used in our tests we protect against that by delaying echo process termination. The way it works is roughly as follows:

1. Echo receives a SIGTERM from Kubelet - this is Kubelet's way to ask the pod politely to shut down.
2. Echo starts a 1 second timer:
   - if during this 1 second interval echo receives a request it rests the timer and start waiting for another 1 second
3. If Echo does not receive a request before timer elapses, Echo shuts down.

And basically the intention here is to wait for as long as we get requests routed to the pod. Once requests stop, we assume that the pod has been deleted from service endpoints list and it's safe to shut down.

The `TestServiceRestart` test currently sends a request every 100ms, so during the 1 second the Echo waits for requests to come we will have ~10 attempts - that seems like enough, but let's count.

In the test setup normally we have 2 deployments (v1 and v2) each with 1 pod, so 2 pods in total. However, during the restart in one of the deployments we first bring up a new pod and only after that start terminating the old pod, so for a period of time we will have 3 pods to choose from.

That means that each request, assuming uniformity, has about 2/3 chance of *not* getting routed to the terminating pod. And assuming independence all ~10 attempts can miss the terminating pod with about 1-2% chance, so it's small, but not insignificant.

If all 10 attempts miss the terminating pod, it will stop listening on its ports and shut down. If by the time it happens the pod is not yet removed from the service endpoint list it can still get new requests and those requests, if routed to the pod, will fail, failing the test along the way. So roughly we get a 0.5 - 0.6% chance of flaking (very roughly, but it's close enough to what I actually observe in my local environment).

This PR changes the call interval from 100ms to 40ms. Due to an exponential nature of the probaility calculation function, this change results in a significantly lower chance of hitting the flake (e.g. more than 100 times lower chance, though the calculations I did are rather rough).

We can also just increase the shutdown time interval in echo from 1 second to something higher to get a similar effect, but given that this is the only test where I observed this failure mode, I'd rather adjust the test then the echo binary.

Related to #58226