### PR TITLE
gatewayapi: make the cors origin stricter with wildcards

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -1238,9 +1238,15 @@ func createCorsFilter(filter *k8s.HTTPCORSFilter) *istio.CorsPolicy {
 		// Code here is based on kgateway implementation
 		// Direct wildcard allows any origin
 		if rs == "*" {
+			// Use strict regex that only matches valid origin formats per RFC 6454
+			// Format: <scheme>://<host>(:<port>)?
+			// Allows: http://example.com, https://sub.example.com:8443, ws://localhost:3000
 			res.AllowOrigins = append(res.AllowOrigins, &istio.StringMatch{
 				MatchType: &istio.StringMatch_Regex{
-					Regex: "^.*$",
+					// Match valid origin: scheme://host(:port)?
+					// - scheme: starts with letter, followed by alphanumeric, +, -, or .
+					// - host(:port): any characters except /, whitespace, ?, #
+					Regex: `^[a-zA-Z][a-zA-Z0-9+.-]*://[^/\s?#]+$`,
 				},
 			})
 			continue

--- a/pilot/pkg/config/kube/gateway/testdata/http.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/http.yaml
@@ -373,7 +373,6 @@ spec:
           port: 80
       filters:
         - cors:
-            allowCredentials: true
             allowOrigins:
             - '*'
             allowMethods:

--- a/pilot/pkg/config/kube/gateway/testdata/http.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/http.yaml.golden
@@ -147,7 +147,6 @@ spec:
   - cors-wildcard-origin.domain.example
   http:
   - corsPolicy:
-      allowCredentials: true
       allowHeaders:
       - Accept
       - Accept-Language
@@ -159,7 +158,7 @@ spec:
       - HEAD
       - POST
       allowOrigins:
-      - regex: ^.*$
+      - regex: ^[a-zA-Z][a-zA-Z0-9+.-]*://[^/\s?#]+$
       unmatchedPreflights: IGNORE
     name: default.http-route-cors-wildcard-1.0
     route:

--- a/releasenotes/notes/59026.yaml
+++ b/releasenotes/notes/59026.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    - **Fixed** On Gateway API, make Origin parsing stricter


### PR DESCRIPTION
**Please provide a description of this PR:**
The origin validation is still too weak, and when using wildcard allows users passing any Origin header to match. This can include bad control characters, path, query strings and other undesired characters that while blocked by the browser, may be used to abuse the header.

This validation makes it stricter and compliant with CORS specification.