### PR TITLE
add tls-inspector for listener with only TLS ports

### DIFF
--- a/releasenotes/notes/59028.yaml
+++ b/releasenotes/notes/59028.yaml
@@ -5,6 +5,6 @@ issue:
   - 59024
 releaseNotes:
   - |
-    **Fixed** an issue where waypoints failed to dynamically resolve hostnames
-    for wildcard ServiceEntry with `resolution: DYNAMIC_DNS` because SNI way
-    not always being extracted from TLS connections.
+    **Fixed** an issue where waypoints failed to add the TLS inspector
+    listener filter when only TLS ports existed, causing SNI-based routing
+    to fail for wildcard ServiceEntry with `resolution: DYNAMIC_DNS`.

--- a/releasenotes/notes/59028.yaml
+++ b/releasenotes/notes/59028.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 59024
+releaseNotes:
+  - |
+    **Fixed** an issue where waypoints failed to dynamically resolve hostnames
+    for wildcard ServiceEntry with `resolution: DYNAMIC_DNS` because SNI way
+    not always being extracted from TLS connections.


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes a bug where the tls-inspector was not being included when we had zero non-TLS ports defined.

fixes #59024