### PR TITLE
feat(gateway): Helm allow template expressions in name and pod scheduling fields

### DIFF
--- a/manifests/charts/gateway/templates/_helpers.tpl
+++ b/manifests/charts/gateway/templates/_helpers.tpl
@@ -1,8 +1,8 @@
 {{- define "gateway.name" -}}
 {{- if eq .Release.Name "RELEASE-NAME" -}}
-  {{- .Values.name | default "istio-ingressgateway" -}}
+  {{- tpl (.Values.name | default "istio-ingressgateway") . -}}
 {{- else -}}
-  {{- .Values.name | default .Release.Name | default "istio-ingressgateway" -}}
+  {{- tpl (.Values.name | default .Release.Name | default "istio-ingressgateway") . -}}
 {{- end -}}
 {{- end }}
 

--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -125,19 +125,19 @@ spec:
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) . | nindent 8 }}
       {{- end }}
       {{- with .Values.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) . | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) . | nindent 8 }}
       {{- end }}
       {{- with .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ $.Values.terminationGracePeriodSeconds }}
       {{- with .Values.priorityClassName }}


### PR DESCRIPTION
This PR allows template expressions in the gateway Helm chart for the gateway name and pod scheduling fields by using the tpl function.

**Changes:**

* `gateway.name` (`_helpers.tpl`): The name is now rendered with tpl, so values.name can use expressions like {{ .Release.Name }}-gateway.

* `Deployment` (`deployment.yaml`): `nodeSelector`, `affinity`, `tolerations`, and `topologySpreadConstraints` are rendered with `tpl(toYaml .) .`, so these values can contain template expressions (e.g. `{{ .Release.Name }}`, `{{ include "gateway.name" . }}`) and are evaluated at render time.

This keeps backward compatibility: values without template syntax are unchanged. It enables release- or environment-specific scheduling and naming without duplicating chart values.

**Affected product area (please put an X in all that apply)**

[ ] Ambient
[ ] Configuration Infrastructure
[ ] Docs
[ ] Dual Stack
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Extensions and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure
[ ] Upgrade
[ ] Multi Cluster
[ ] Virtual Machine
[ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

[ ] Does not have any user-facing changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.