### PR TITLE
XDS debug endpoints to require authentication

### DIFF
--- a/releasenotes/notes/statusgen-xds-auth.yaml
+++ b/releasenotes/notes/statusgen-xds-auth.yaml
@@ -1,0 +1,21 @@
+apiVersion: release-notes/v2
+
+kind: security-fix
+
+area: security
+
+# no public issue for security vulnerability
+issue: []
+
+releaseNotes:
+- |
+  **Fixed** XDS debug endpoints (syncz, config_dump) to require authentication.
+  Previously accessible without authentication on plaintext XDS port 15010.
+  Controlled by ENABLE_DEBUG_ENDPOINT_AUTH (same flag as HTTP debug endpoints).
+
+upgradeNotes:
+- title: XDS debug endpoints now require authentication
+  content: |
+    XDS debug endpoints (syncz, config_dump) on port 15010 now require authentication.
+    This affects istioctl commands using --plaintext flag and custom tooling using plaintext XDS.
+    To restore previous behavior, set ENABLE_DEBUG_ENDPOINT_AUTH=false.


### PR DESCRIPTION
**Please provide a description of this PR:**

this is a security fix. 

- the new secured behavoir can be disabled with `ENABLE_DEBUG_ENDPOINT_AUTH=false` the same flag used for 15014 port protection https://github.com/istio/istio/pull/58925
- additionally to the `master` branch - it should be backported to all active releases 1.27-1.29