### PR TITLE
gatewayapi: support AllowInsecureFallback FrontendTLSValidation mode

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -2269,6 +2269,9 @@ func buildTLS(
 				}
 			}
 			out.Mode = istio.ServerTLSSettings_MUTUAL
+			if gatewayTLS.Validation.Mode == k8s.AllowInsecureFallback {
+				out.Mode = istio.ServerTLSSettings_OPTIONAL_MUTUAL
+			}
 			out.CaCertCredentialName = cred.ResourceName
 		}
 	case k8s.TLSModePassthrough:

--- a/releasenotes/notes/59055.yaml
+++ b/releasenotes/notes/59055.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 59055
+releaseNotes:
+  - |
+    **Fixed** When AllowInsecureFallback is specified in the Gateway TLS configuration with client certificate validation, 
+    Istio now correctly maps it to OPTIONAL_MUTUAL TLS mode instead of the default MUTUAL mode. 
+    This allows connections to succeed even when client certificate validation fails, 
+    aligning with the Gateway API v1.4 specification.


### PR DESCRIPTION
**Please provide a description of this PR:**

This PR adds support for the Gateway API `AllowInsecureFallback` FrontendTLSValidation mode, which was previously ignored by Istio.

When `AllowInsecureFallback` is specified in the Gateway TLS configuration with client certificate validation, Istio now correctly maps it to `OPTIONAL_MUTUAL` TLS mode instead of the default `MUTUAL` mode. This allows connections to succeed even when client certificate validation fails, aligning with the Gateway API v1.4 specification.

Reference: https://gateway-api.sigs.k8s.io/reference/1.4/spec/#frontendvalidationmodetype