### PR TITLE
autoregistration unhealthy status race

### DIFF
--- a/pilot/pkg/autoregistration/controller_test.go
+++ b/pilot/pkg/autoregistration/controller_test.go
@@ -920,7 +920,7 @@ func checkEntryHealth(store model.ConfigStoreController, proxy *model.Proxy, hea
 func checkHealthOrFail(t test.Failer, store model.ConfigStoreController, proxy *model.Proxy, healthy bool) {
 	retry.UntilSuccessOrFail(t, func() error {
 		return checkEntryHealth(store, proxy, healthy)
-	})
+	}, retry.Timeout(5*time.Second))
 }
 
 func checkEntryDisconnected(store model.ConfigStoreController, we config.Config) error {


### PR DESCRIPTION
**Please provide a description of this PR:**

This fixes a rare flake in the `TestUpdateHealthCondition` test for workloadentry autoregistration. Unnecessary updates in one place overwrite the health updates.

I also reduce the timeout from 30s to 5s, as the tests pass under `stress` at around ~200ms per run max