### PR TITLE
fix(pilot): consider native sidecar ports when scanning for inbound ports

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/helpers.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/helpers.go
@@ -170,6 +170,17 @@ func FindPortName(pod *v1.Pod, name string) (int32, bool) {
 			}
 		}
 	}
+	// Also search native sidecar init containers (restartPolicy=Always).
+	for _, container := range pod.Spec.InitContainers {
+		if container.RestartPolicy == nil || *container.RestartPolicy != v1.ContainerRestartPolicyAlways {
+			continue
+		}
+		for _, port := range container.Ports {
+			if port.Name == name && port.Protocol == v1.ProtocolTCP {
+				return port.ContainerPort, true
+			}
+		}
+	}
 	return 0, false
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -2621,6 +2621,7 @@ func TestStripNodeUnusedFields(t *testing.T) {
 }
 
 func TestStripPodUnusedFields(t *testing.T) {
+	nativeSidecarRestartPolicy := corev1.ContainerRestartPolicyAlways
 	inputPod := &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",
@@ -2646,6 +2647,27 @@ func TestStripPodUnusedFields(t *testing.T) {
 			InitContainers: []corev1.Container{
 				{
 					Name: "init-container",
+				},
+				{
+					Name:          "native-sidecar",
+					RestartPolicy: &nativeSidecarRestartPolicy,
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          "grpc",
+							ContainerPort: 8080,
+							Protocol:      corev1.ProtocolTCP,
+						},
+					},
+				},
+				{
+					Name: "init-container-with-ports",
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          "debug",
+							ContainerPort: 9090,
+							Protocol:      corev1.ProtocolTCP,
+						},
+					},
 				},
 			},
 			Containers: []corev1.Container{
@@ -2709,6 +2731,19 @@ func TestStripPodUnusedFields(t *testing.T) {
 					Ports: []corev1.ContainerPort{
 						{
 							Name: "http",
+						},
+					},
+				},
+			},
+			// Native sidecar init container with ports should be preserved.
+			InitContainers: []corev1.Container{
+				{
+					RestartPolicy: &nativeSidecarRestartPolicy,
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          "grpc",
+							ContainerPort: 8080,
+							Protocol:      corev1.ProtocolTCP,
 						},
 					},
 				},

--- a/pilot/pkg/serviceregistry/kube/controller/pod.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod.go
@@ -235,6 +235,20 @@ func getPortMap(pod *v1.Pod) map[string]uint32 {
 			}
 		}
 	}
+	// Also include ports from native sidecar init containers (restartPolicy=Always).
+	for _, c := range pod.Spec.InitContainers {
+		if c.RestartPolicy == nil || *c.RestartPolicy != v1.ContainerRestartPolicyAlways {
+			continue
+		}
+		for _, port := range c.Ports {
+			if port.Name == "" || port.Protocol != v1.ProtocolTCP {
+				continue
+			}
+			if _, f := pmap[port.Name]; !f {
+				pmap[port.Name] = uint32(port.ContainerPort)
+			}
+		}
+	}
 	return pmap
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/util.go
+++ b/pilot/pkg/serviceregistry/kube/controller/util.go
@@ -62,6 +62,17 @@ func FindPort(pod *v1.Pod, svcPort *v1.ServicePort) (int, error) {
 				}
 			}
 		}
+		// Also search native sidecar init containers (restartPolicy=Always).
+		for _, container := range pod.Spec.InitContainers {
+			if container.RestartPolicy == nil || *container.RestartPolicy != v1.ContainerRestartPolicyAlways {
+				continue
+			}
+			for _, port := range container.Ports {
+				if port.Name == name && port.Protocol == svcPort.Protocol {
+					return int(port.ContainerPort), nil
+				}
+			}
+		}
 	case intstr.Int:
 		return portName.IntValue(), nil
 	}


### PR DESCRIPTION
fixes https://github.com/istio/istio/issues/59045

**Please provide a description of this PR:**

This PR adds support for matching Service targetPorts with ports declared by native sidecars (containers in Pod `.spec.initContainers` with `restartPolicy: Always`).

This fix is for the pilot and both for ambient as well as the sidecar model.