### PR TITLE
Do not run Envoy in Prometheus TLS sidecar mode

### DIFF
--- a/manifests/addons/values-prometheus.yaml
+++ b/manifests/addons/values-prometheus.yaml
@@ -10,6 +10,18 @@ prometheus-node-exporter:
 server:
   podLabels:
     sidecar.istio.io/inject: "false"
+  # To enable TLS scraping of application metrics with Strict mTLS, change
+  # sidecar.istio.io/inject above to "true" and uncomment the podAnnotations below.
+  # This injects a lightweight sidecar (pilot-agent only, no Envoy) which provisions
+  # Istio certificates for Prometheus to use when scraping over mTLS.
+  # podAnnotations:
+  #   traffic.sidecar.istio.io/includeInboundPorts: ""
+  #   traffic.sidecar.istio.io/includeOutboundIPRanges: ""
+  #   proxy.istio.io/config: |
+  #     proxyMetadata:
+  #       OUTPUT_CERTS: /etc/istio-output-certs
+  #       DISABLE_ENVOY: "true"
+  #   sidecar.istio.io/userVolumeMount: '[{"name": "istio-certs", "mountPath": "/etc/istio-output-certs"}]'
   persistentVolume:
     enabled: false
   # Use port 9090 to match Istio documentation

--- a/samples/addons/prometheus.yaml
+++ b/samples/addons/prometheus.yaml
@@ -12,8 +12,7 @@ metadata:
     app.kubernetes.io/part-of: prometheus
   name: prometheus
   namespace: istio-system
-  annotations:
-    {}
+  annotations: {}
 ---
 # Source: prometheus/templates/cm.yaml
 apiVersion: v1
@@ -476,8 +475,22 @@ spec:
         app.kubernetes.io/version: v3.9.1
         helm.sh/chart: prometheus-28.6.0
         app.kubernetes.io/part-of: prometheus
-        
+        # To scrape application metrics with Strict mTLS enabled, change this to "true"
+        # and uncomment the annotations below. This will inject a lightweight sidecar
+        # (pilot-agent only, no Envoy) to provision Istio certificates for Prometheus.
         sidecar.istio.io/inject: "false"
+      # Uncomment the following annotations to enable TLS scraping of application metrics.
+      # This runs pilot-agent without Envoy (DISABLE_ENVOY) to output SDS certificates
+      # to a shared volume, which Prometheus then uses for mTLS scraping.
+      # See https://istio.io/latest/docs/ops/integrations/prometheus/#tls-settings
+      # annotations:
+      #   traffic.sidecar.istio.io/includeInboundPorts: ""   # do not intercept any inbound ports
+      #   traffic.sidecar.istio.io/includeOutboundIPRanges: "" # do not intercept any outbound traffic
+      #   proxy.istio.io/config: |
+      #     proxyMetadata:
+      #       OUTPUT_CERTS: /etc/istio-output-certs
+      #       DISABLE_ENVOY: "true"
+      #   sidecar.istio.io/userVolumeMount: '[{"name": "istio-certs", "mountPath": "/etc/istio-output-certs"}]'
     spec:
       enableServiceLinks: true
       serviceAccountName: prometheus
@@ -548,6 +561,10 @@ spec:
             - name: storage-volume
               mountPath: /data
               subPath: ""
+            # Uncomment to mount Istio certificates for TLS scraping.
+            # - name: istio-certs
+            #   mountPath: /etc/prom-certs/
+            #   readOnly: true
       dnsPolicy: ClusterFirst
       terminationGracePeriodSeconds: 300
       volumes:
@@ -555,5 +572,9 @@ spec:
           configMap:
             name: prometheus
         - name: storage-volume
-          emptyDir:
-            {}
+          emptyDir: {}
+        # Uncomment to create the shared volume for Istio certificates.
+        # The sidecar will write certs here, and Prometheus will read them.
+        # - name: istio-certs
+        #   emptyDir:
+        #     medium: Memory

--- a/samples/addons/prometheus.yaml
+++ b/samples/addons/prometheus.yaml
@@ -12,7 +12,8 @@ metadata:
     app.kubernetes.io/part-of: prometheus
   name: prometheus
   namespace: istio-system
-  annotations: {}
+  annotations:
+    {}
 ---
 # Source: prometheus/templates/cm.yaml
 apiVersion: v1
@@ -475,22 +476,8 @@ spec:
         app.kubernetes.io/version: v3.9.1
         helm.sh/chart: prometheus-28.6.0
         app.kubernetes.io/part-of: prometheus
-        # To scrape application metrics with Strict mTLS enabled, change this to "true"
-        # and uncomment the annotations below. This will inject a lightweight sidecar
-        # (pilot-agent only, no Envoy) to provision Istio certificates for Prometheus.
+        
         sidecar.istio.io/inject: "false"
-      # Uncomment the following annotations to enable TLS scraping of application metrics.
-      # This runs pilot-agent without Envoy (DISABLE_ENVOY) to output SDS certificates
-      # to a shared volume, which Prometheus then uses for mTLS scraping.
-      # See https://istio.io/latest/docs/ops/integrations/prometheus/#tls-settings
-      # annotations:
-      #   traffic.sidecar.istio.io/includeInboundPorts: ""   # do not intercept any inbound ports
-      #   traffic.sidecar.istio.io/includeOutboundIPRanges: "" # do not intercept any outbound traffic
-      #   proxy.istio.io/config: |
-      #     proxyMetadata:
-      #       OUTPUT_CERTS: /etc/istio-output-certs
-      #       DISABLE_ENVOY: "true"
-      #   sidecar.istio.io/userVolumeMount: '[{"name": "istio-certs", "mountPath": "/etc/istio-output-certs"}]'
     spec:
       enableServiceLinks: true
       serviceAccountName: prometheus
@@ -561,10 +548,6 @@ spec:
             - name: storage-volume
               mountPath: /data
               subPath: ""
-            # Uncomment to mount Istio certificates for TLS scraping.
-            # - name: istio-certs
-            #   mountPath: /etc/prom-certs/
-            #   readOnly: true
       dnsPolicy: ClusterFirst
       terminationGracePeriodSeconds: 300
       volumes:
@@ -572,9 +555,5 @@ spec:
           configMap:
             name: prometheus
         - name: storage-volume
-          emptyDir: {}
-        # Uncomment to create the shared volume for Istio certificates.
-        # The sidecar will write certs here, and Prometheus will read them.
-        # - name: istio-certs
-        #   emptyDir:
-        #     medium: Memory
+          emptyDir:
+            {}


### PR DESCRIPTION
**Description:**

Addresses #34768 — the Prometheus addon sample manifests currently don't include configuration for lightweight TLS cert provisioning. When users need to scrape application metrics in Strict mTLS mode, they must inject a full Envoy sidecar alongside Prometheus, which is unnecessarily heavy.

This PR adds commented-out configuration blocks to both Prometheus addon files that use `DISABLE_ENVOY=true` with `OUTPUT_CERTS`, so only `pilot-agent` runs (no Envoy process) to provision Istio certificates. Users can uncomment these blocks to enable lightweight TLS cert provisioning.

**Changes:**

- `samples/addons/prometheus.yaml`: Added commented-out TLS annotations (`DISABLE_ENVOY`, `OUTPUT_CERTS`), cert volume, and volumeMount.
- `manifests/addons/values-prometheus.yaml`: Added equivalent Helm `podAnnotations` as commented-out values.

**Testing:**

- Verified YAML syntax is valid.
- Verified the commented-out blocks match the pattern documented at https://istio.io/latest/docs/ops/integrations/prometheus/#tls-settings but with the addition of `DISABLE_ENVOY: "true"`.

**Note:** A follow-up PR to the `istio/istio.io` docs repo will update the TLS settings documentation to recommend `DISABLE_ENVOY: "true"` as well.

Fixes #34768