### PR TITLE
Make gateway transport socket connect timeout configurable

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -355,6 +355,16 @@ var (
 		}
 		return blockedCIDRs
 	}()
+
+	// GatewayTransportSocketConnectTimeout specifies the timeout for transport socket (e.g., TLS
+	// handshake) connections on gateway listeners. This protects against slow or incomplete TLS
+	// handshakes consuming resources. Set to 0s to disable the timeout entirely.
+	GatewayTransportSocketConnectTimeout = env.Register(
+		"PILOT_GATEWAY_TRANSPORT_SOCKET_CONNECT_TIMEOUT",
+		15*time.Second,
+		"The timeout for transport socket (e.g., TLS handshake) connections on gateway listeners. "+
+			"This helps protect against slow TLS handshake attacks. Set to 0s to disable.",
+	).Get()
 )
 
 // UnsafeFeaturesEnabled returns true if any unsafe features are enabled.

--- a/pilot/pkg/networking/core/listener.go
+++ b/pilot/pkg/networking/core/listener.go
@@ -101,6 +101,16 @@ var (
 	defaultGatewayTransportSocketConnectTimeout = 15 * time.Second
 )
 
+// gatewayTransportSocketConnectTimeout returns the configured transport socket connect timeout
+// for gateway listeners. Returns nil if the timeout is set to 0 (disabled).
+func gatewayTransportSocketConnectTimeout() *durationpb.Duration {
+	timeout := features.GatewayTransportSocketConnectTimeout
+	if timeout == 0 {
+		return nil
+	}
+	return durationpb.New(timeout)
+}
+
 // BuildListeners produces a list of listeners and referenced clusters for all proxies
 func (configgen *ConfigGeneratorImpl) BuildListeners(node *model.Proxy,
 	push *model.PushContext,
@@ -621,7 +631,7 @@ func buildListenerFromEntry(builder *ListenerBuilder, le *outboundListenerEntry,
 			TransportSocket: buildDownstreamTLSTransportSocket(opt.tlsContext),
 			// Setting this timeout enables the proxy to enhance its resistance against memory exhaustion attacks,
 			// such as slow TLS Handshake attacks.
-			TransportSocketConnectTimeout: durationpb.New(defaultGatewayTransportSocketConnectTimeout),
+			TransportSocketConnectTimeout: gatewayTransportSocketConnectTimeout(),
 		}
 		if opt.httpOpts == nil {
 			// we are building a network filter chain (no http connection manager) for this filter chain
@@ -1128,7 +1138,7 @@ func buildGatewayListener(opts gatewayListenerOpts, transport istionetworking.Tr
 			TransportSocket:  transportSocket,
 			// Setting this timeout enables the proxy to enhance its resistance against memory exhaustion attacks,
 			// such as slow TLS Handshake attacks.
-			TransportSocketConnectTimeout: durationpb.New(defaultGatewayTransportSocketConnectTimeout),
+			TransportSocketConnectTimeout: gatewayTransportSocketConnectTimeout(),
 		})
 	}
 

--- a/releasenotes/notes/56320.yaml
+++ b/releasenotes/notes/56320.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 56320
+releaseNotes:
+  - |
+    **Added** `PILOT_GATEWAY_TRANSPORT_SOCKET_CONNECT_TIMEOUT` environment variable to configure the
+    transport socket connect timeout on gateway listeners. The default remains 15 seconds. Set to `0s`
+    to disable the timeout for workloads that require longer TLS handshake times.


### PR DESCRIPTION
**Fixes #56320**

## Problem

PR #52852 introduced a hardcoded 15-second `transportSocketConnectTimeout` on gateway listener filter chains to protect against slow TLS handshake attacks. However, this breaks clients that legitimately need more than 15 seconds after the TLS handshake before sending data (e.g., certain IoT devices).

## Root Cause

The timeout value was set as a compile-time constant (`defaultGatewayTransportSocketConnectTimeout = 15 * time.Second`) with no way to configure it. This applies to both sidecar outbound listeners and gateway listeners.

## Solution

Added a new environment variable `PILOT_GATEWAY_TRANSPORT_SOCKET_CONNECT_TIMEOUT` (configured on istiod) that allows operators to customize this timeout:

- **Default**: `15s` (preserves existing behavior)
- **Set to `0s`**: Disables the timeout entirely
- **Set to any duration**: Uses that value (e.g., `30s`, `60s`)

This follows the same pattern used by other configurable timeouts in Istio's pilot (e.g., `PILOT_DNS_JITTER_DURATION`, `PILOT_WORKLOAD_ENTRY_GRACE_PERIOD`).

## Usage

```yaml
apiVersion: install.istio.io/v1alpha1
kind: IstioOperator
spec:
  values:
    pilot:
      env:
        PILOT_GATEWAY_TRANSPORT_SOCKET_CONNECT_TIMEOUT: "30s"
```

## Changes

- `pilot/pkg/features/pilot.go`: Added `GatewayTransportSocketConnectTimeout` feature flag
- `pilot/pkg/networking/core/listener.go`: Added helper function `gatewayTransportSocketConnectTimeout()` that returns the configured timeout (or nil when disabled), replaced hardcoded usages
- `pilot/pkg/networking/core/listener_test.go`: Added test cases for custom timeout and disabled timeout
- `pilot/pkg/networking/core/gateway_test.go`: Added test cases for custom timeout and disabled timeout
- `releasenotes/notes/56320.yaml`: Release note

## Testing

All existing and new tests pass:
- `TestListenerTransportSocketConnectTimeoutForSidecar` — default, custom, and disabled cases
- `TestListenerTransportSocketConnectTimeoutForGateway` — default, custom, and disabled cases
