### PR TITLE
Cherry_pick: Fixes panic due to uninitialized pointer when ClusterID is misconfigure

### DIFF
--- a/security/pkg/server/ca/authenticate/kubeauth/kube_jwt.go
+++ b/security/pkg/server/ca/authenticate/kubeauth/kube_jwt.go
@@ -119,8 +119,12 @@ func (a *KubeJWTAuthenticator) authenticateGrpc(ctx context.Context) (*security.
 func (a *KubeJWTAuthenticator) authenticate(targetJWT string, clusterID cluster.ID) (*security.Caller, error) {
 	kubeClient := a.getKubeClient(clusterID)
 	if kubeClient == nil {
+		var clusterList []cluster.ID
+		if a.remoteKubeClientGetter != nil {
+			clusterList = a.remoteKubeClientGetter.ListClusters()
+		}
 		return nil, fmt.Errorf("client claims to be in cluster %q, but we only know about local cluster %q and remote clusters %v",
-			clusterID, a.clusterID, a.remoteKubeClientGetter.ListClusters())
+			clusterID, a.clusterID, clusterList)
 	}
 
 	id, err := tokenreview.ValidateK8sJwt(kubeClient, targetJWT, security.TokenAudiences)


### PR DESCRIPTION
…red (#57469)

(cherry-picked from commit 261987ad519b0216f3207b550060d8ba23e69c10)

This MR: https://github.com/istio/istio/pull/57469
 has the cherry-pick label for release-1.27, but the automation failed. As a result, the changes are not currently available in the release-1.27 branch.