### PR TITLE
fix: set CNI config file permissions to 0600 for CIS benchmark compliance

### DIFF
--- a/cni/pkg/install/cniconfig.go
+++ b/cni/pkg/install/cniconfig.go
@@ -100,7 +100,7 @@ func writeCNIConfig(ctx context.Context, pluginConfig []byte, cfg *config.Instal
 		cniConfigFilepath = filepath.Join(cfg.MountedCNINetDir, cfg.IstioOwnedCNIConfigFilename)
 	}
 
-	if err = file.AtomicWrite(cniConfigFilepath, pluginConfig, os.FileMode(0o644)); err != nil {
+	if err = file.AtomicWrite(cniConfigFilepath, pluginConfig, os.FileMode(0o600)); err != nil {
 		installLog.Errorf("Failed to write CNI config file %v: %v", cniConfigFilepath, err)
 		return cniConfigFilepath, err
 	}

--- a/cni/pkg/install/cniconfig_test.go
+++ b/cni/pkg/install/cniconfig_test.go
@@ -580,6 +580,15 @@ func TestCreateCNIConfigFile(t *testing.T) {
 				goldenFilepath := filepath.Join("testdata", c.goldenConfName)
 				goldenConfig := testutils.ReadFile(t, goldenFilepath)
 				testutils.CompareBytes(t, resultConfig, goldenConfig, goldenFilepath)
+
+				// Verify the CNI config file has restrictive permissions per CIS Kubernetes benchmark
+				info, err := os.Stat(resultFilepath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if info.Mode().Perm() != 0o600 {
+					t.Fatalf("expected CNI config file permissions 0600, got %o", info.Mode().Perm())
+				}
 			}
 		}
 		t.Run("network-config-file "+c.name, test(cfgFile))

--- a/cni/pkg/install/install.go
+++ b/cni/pkg/install/install.go
@@ -160,7 +160,7 @@ func (in *Installer) Cleanup() error {
 			if err != nil {
 				return fmt.Errorf("failed to marshal CNI config map in file %s: %w", in.cniConfigFilepath, err)
 			}
-			if err = file.AtomicWrite(in.cniConfigFilepath, cniConfig, os.FileMode(0o644)); err != nil {
+			if err = file.AtomicWrite(in.cniConfigFilepath, cniConfig, os.FileMode(0o600)); err != nil {
 				return fmt.Errorf("failed to write updated CNI config to file %s: %w", in.cniConfigFilepath, err)
 			}
 		} else {


### PR DESCRIPTION
Fixes #59071

This changes CNI config file permissions from 0644 to 0600 to comply with CIS Kubernetes benchmark.