### PR TITLE
fix nil pointer dereference in ServiceEntry DYNAMIC_DNS validation

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -3060,6 +3060,10 @@ var ValidateServiceEntry = RegisterValidateFunc("ValidateServiceEntry",
 					"field values", serviceEntry.Resolution))
 			}
 			for _, port := range serviceEntry.Ports {
+				if port == nil {
+					errs = AppendValidation(errs, errors.New("port cannot be nil"))
+					continue
+				}
 				proto := protocol.Parse(port.Protocol)
 				if proto != protocol.HTTP && proto != protocol.TLS {
 					errs = AppendValidation(errs, fmt.Errorf("only HTTP and TLS protocol is supported for resolution type %s", serviceEntry.Resolution))

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -4477,7 +4477,7 @@ func TestValidateServiceEntries(t *testing.T) {
 		{
 			name: "nil port in ports array",
 			in: &networking.ServiceEntry{
-				Hosts:    []string{"google.com"},
+				Hosts: []string{"google.com"},
 				Ports: []*networking.ServicePort{
 					nil,
 				},

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -4462,6 +4462,41 @@ func TestValidateServiceEntries(t *testing.T) {
 			},
 			valid: false,
 		},
+		{
+			name: "discovery type DYNAMIC_DNS, nil port",
+			in: &networking.ServiceEntry{
+				Hosts:    []string{"*.google.com"},
+				Location: networking.ServiceEntry_MESH_EXTERNAL,
+				Ports: []*networking.ServicePort{
+					nil,
+				},
+				Resolution: networking.ServiceEntry_DYNAMIC_DNS,
+			},
+			valid: false,
+		},
+		{
+			name: "nil port in ports array",
+			in: &networking.ServiceEntry{
+				Hosts:    []string{"google.com"},
+				Ports: []*networking.ServicePort{
+					nil,
+				},
+				Resolution: networking.ServiceEntry_NONE,
+			},
+			valid: false,
+		},
+		{
+			name: "discovery type DNS with addresses, nil port",
+			in: &networking.ServiceEntry{
+				Hosts:     []string{"google.com"},
+				Addresses: []string{"1.2.3.4"},
+				Ports: []*networking.ServicePort{
+					nil,
+				},
+				Resolution: networking.ServiceEntry_DNS,
+			},
+			valid: false,
+		},
 	}
 
 	for _, c := range cases {

--- a/releasenotes/notes/59171.yaml
+++ b/releasenotes/notes/59171.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 59171
+releaseNotes:
+  - |
+    **Fixed** a nil pointer dereference in ServiceEntry validation for DYNAMIC_DNS resolution that could crash istiod.


### PR DESCRIPTION
Adds nil port check in DYNAMIC_DNS validation to prevent istiod crash. Adds nil pointer tests. Regression from #57972.