### PR TITLE
fix: update Go version to 1.25.7 to address CVE-2025-68121

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module istio.io/istio
 
-go 1.25.0
+go 1.25.7
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0


### PR DESCRIPTION
## Summary

This PR updates the Go version from 1.25.0 to 1.25.7 to address critical security vulnerabilities.

## Security Fixes

This update fixes the following vulnerabilities in the Go standard library:

| CVE | Severity | Description |
|-----|----------|-------------|
| CVE-2025-68121 | **CRITICAL** | crypto/tls: Unexpected session resumption |
| CVE-2025-61726 | HIGH | net/url: Memory exhaustion in query parameter parsing |
| CVE-2025-61728 | HIGH | archive/zip: Excessive CPU consumption |
| CVE-2025-61729 | HIGH | crypto/x509: DoS via crafted X.509 certificates |
| CVE-2025-61730 | HIGH | TLS 1.3 handshake vulnerability |

## Changes

- Updated `go` directive in `go.mod` from `1.25.0` to `1.25.7`

## Testing

- [x] `go mod tidy` runs successfully
- [x] No breaking changes to dependencies

## References

- https://go.dev/doc/devel/release#go1.25.7
- https://pkg.go.dev/vuln

---

This is a minimal security fix with low risk. The Go 1.25.7 release contains only security fixes with no API changes.