### PR TITLE
cni: add k3s process names to nftables kubelet UID detection (#59187)

### DIFF
--- a/cni/pkg/nftables/kubeletuid_linux.go
+++ b/cni/pkg/nftables/kubeletuid_linux.go
@@ -37,7 +37,7 @@ func getKubeletUIDFromPath(procPath string) (string, error) {
 	}
 
 	// List of process names to search for, in order of preference
-	processNames := []string{"kubelet", "kubelite"}
+	processNames := []string{"kubelet", "kubelite", "k3s", "k3s-server", "k3s-agent"}
 
 	for _, proc := range procs {
 		comm, err := proc.Comm()


### PR DESCRIPTION
Fixes #59187

Extends the processNames list in kubeletuid_linux.go to include k3s 
process names (k3s, k3s-server, k3s-agent). On k3s, the kubelet is 
embedded in the k3s binary so the process comm is never "kubelet".

Related to #58185 (same issue on MicroK8s, fixed in #58314).



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ x] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions