### PR TITLE
Switch default iptables to nft in Docker images

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -27,8 +27,8 @@ RUN apt-get update && \
   && apt-get upgrade -y \
   && apt-get clean \
   && rm -rf  /var/log/*log /var/lib/apt/lists/* /var/log/apt/* /var/lib/dpkg/*-old /var/cache/debconf/*-old \
-  && update-alternatives --set iptables /usr/sbin/iptables-legacy \
-  && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+  && update-alternatives --set iptables /usr/sbin/iptables-nft \
+  && update-alternatives --set ip6tables /usr/sbin/ip6tables-nft
 
 # Sudoers used to allow tcpdump and other debug utilities.
 RUN useradd -m --uid 1337 istio-proxy && \

--- a/pkg/test/echo/docker/Dockerfile.app_sidecar_base
+++ b/pkg/test/echo/docker/Dockerfile.app_sidecar_base
@@ -28,9 +28,9 @@ RUN apt-get update && \
     && apt-get clean \
     && rm -rf  /var/log/*log /var/lib/apt/lists/* /var/log/apt/* /var/lib/dpkg/*-old /var/cache/debconf/*-old
 
-RUN if [ -f /usr/sbin/iptables-legacy ]; then \
-    update-alternatives --set iptables /usr/sbin/iptables-legacy && \
-    update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy; fi
+RUN if [ -f /usr/sbin/iptables-nft ]; then \
+    update-alternatives --set iptables /usr/sbin/iptables-nft && \
+    update-alternatives --set ip6tables /usr/sbin/ip6tables-nft; fi
 
 # Add a user that will run the application. This allows running as this user and capture iptables
 RUN useradd -m --uid 1338 application && \


### PR DESCRIPTION
This PR replaces iptables-legacy with iptables-nft as the default iptables backend in Dockerfile.base and Dockerfile.app_sidecar_base. Modern Linux kernels and distributions favor the nftables backend, so using iptables-nft ensures better compatibility with nft-based host systems. At runtime, the Istio code can still select the iptables-legacy variant if it detects legacy rules.
