### PR TITLE
chart(ztunnel): add minReadySeconds configuration

### DIFF
--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -16,6 +16,9 @@ metadata:
     {{- .Values.annotations | toYaml | nindent 4 }}
 {{- end }}
 spec:
+  {{- if .Values.minReadySeconds }}
+  minReadySeconds: {{ .Values.minReadySeconds }}
+  {{- end }}
   {{- with .Values.updateStrategy }}
   updateStrategy:
     {{- toYaml . | nindent 4 }}

--- a/manifests/charts/ztunnel/values.yaml
+++ b/manifests/charts/ztunnel/values.yaml
@@ -145,6 +145,10 @@ _internal_defaults_do_not_set:
       maxSurge: 1
       maxUnavailable: 0
 
+  # The minimum number of seconds for which a newly created DaemonSet pod should be ready without any of its container crashing, for it to be considered available.
+  # Defaults to 0 (pod will be considered available as soon as it is ready).
+  minReadySeconds: 0
+
   # DNS policy for the ztunnel pod
   # https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
   dnsPolicy: ""

--- a/releasenotes/notes/ztunnel-min-ready-seconds.yaml
+++ b/releasenotes/notes/ztunnel-min-ready-seconds.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue: []
+
+releaseNotes:
+  - |
+    **Added** Allow setting minReadySeconds for ztunnel pod via Helm chart.


### PR DESCRIPTION
## Summary
Adds `minReadySeconds` configuration to the ztunnel Helm chart. This allows users to specify the minimum number of seconds for which a newly created DaemonSet pod should be ready without any of its container crashing, for it to be considered available.

## Test plan
Verified by running `helm template` with and without the `minReadySeconds` value set.
- Default value (0) results in the field being omitted (default K8s behavior).
- Setting a value (e.g., 5) correctly adds `minReadySeconds: 5` to the DaemonSet spec.