### PR TITLE
chart(cni): add minReadySeconds configuration

### DIFF
--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -34,6 +34,9 @@ spec:
   selector:
     matchLabels:
       k8s-app: {{ template "name" . }}-node
+  {{- if .Values.minReadySeconds }}
+  minReadySeconds: {{ .Values.minReadySeconds }}
+  {{- end }}
   {{- with .Values.updateStrategy }}
   updateStrategy:
     {{- toYaml . | nindent 4 }}

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -136,6 +136,10 @@ _internal_defaults_do_not_set:
     rollingUpdate:
       maxUnavailable: 1
 
+  # The minimum number of seconds for which a newly created DaemonSet pod should be ready without any of its container crashing, for it to be considered available.
+  # Defaults to 0 (pod will be considered available as soon as it is ready).
+  minReadySeconds: 0
+
   # Sets the per-pod terminationGracePeriodSeconds setting.
   # A higher value gives more time for CNI cleanup during rolling updates,
   # preventing "failed to find plugin istio-cni" errors.

--- a/releasenotes/notes/istio-cni-min-ready-seconds.yaml
+++ b/releasenotes/notes/istio-cni-min-ready-seconds.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue: []
+
+releaseNotes:
+  - |
+    **Added** Allow setting minReadySeconds for istio-cni pod via Helm chart.


### PR DESCRIPTION
## Summary
Adds `minReadySeconds` configuration to the `istio-cni` Helm chart. This allows users to specify the minimum number of seconds for which a newly created DaemonSet pod should be ready without any of its container crashing, for it to be considered available.

## Test plan
Verified by running `helm template` with and without the `minReadySeconds` value set.
- Default value (0) results in the field being omitted (default K8s behavior).
- Setting a value (e.g., 5) correctly adds `minReadySeconds: 5` to the DaemonSet spec.