### PR TITLE
fix: clean stale ips for SE

### DIFF
--- a/releasenotes/notes/stale-serviceentry-address-cleanup.yaml
+++ b/releasenotes/notes/stale-serviceentry-address-cleanup.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 58974
+releaseNotes:
+  - |
+    **Fixed** stale `status.addresses` not being cleared when a ServiceEntry is updated
+    such that it no longer qualifies for IP auto-allocation.


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix behavior where IPs allocated to SE in last reconcile were not freed if it should not be allocated in current reconcile. 
Fixes #58974 