### PR TITLE
Fix grpcgen RDS over-scoping for proxyless gRPC-xDS clients

### DIFF
--- a/pilot/pkg/networking/grpcgen/grpcgen_test.go
+++ b/pilot/pkg/networking/grpcgen/grpcgen_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	statefulsession "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/stateful_session/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	cookiev3 "github.com/envoyproxy/go-control-plane/envoy/extensions/http/stateful_session/cookie/v3"
@@ -57,11 +58,13 @@ import (
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/istio-agent/grpcxds"
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/echo/common"
 	echoproto "istio.io/istio/pkg/test/echo/proto"
 	"istio.io/istio/pkg/test/echo/server/endpoint"
 	"istio.io/istio/pkg/test/env"
+	"istio.io/istio/pkg/test/util/retry"
 )
 
 // Address of the test gRPC service, used in tests.
@@ -576,4 +579,519 @@ func (t *testClientConn) ParseServiceConfig(jsonSC string) *serviceconfig.ParseR
 	//          {"cds_experimental":
 	//         		{"cluster":"outbound|14057||istiod.istio-system.svc.cluster.local"}}]}}}}]}
 	return &serviceconfig.ParseResult{}
+}
+
+// TestGRPCRDSVirtualHostFiltering verifies that the gRPC generator's RDS
+// response contains only the virtual host matching the requested route name,
+// not all services sharing the same port.
+func TestGRPCRDSVirtualHostFiltering(t *testing.T) {
+	t.Parallel()
+
+	var (
+		sharedPort = 8080
+
+		// Create three services on the same port.
+		svcA = "svc-a.test.svc.cluster.local"
+		svcB = "svc-b.test.svc.cluster.local"
+		svcC = "svc-c.test.svc.cluster.local"
+
+		ds = xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+		sd = ds.MemRegistry
+	)
+
+	for _, svc := range []struct {
+		name     string
+		hostname string
+		ip       string
+	}{
+		{"svc-a", svcA, "10.0.0.1"},
+		{"svc-b", svcB, "10.0.0.2"},
+		{"svc-c", svcC, "10.0.0.3"},
+	} {
+		sd.AddService(&model.Service{
+			Attributes: model.ServiceAttributes{
+				Name:      svc.name,
+				Namespace: "test",
+			},
+			Hostname:       host.Name(svc.hostname),
+			DefaultAddress: svc.ip,
+			Ports: model.PortList{
+				{
+					Name:     "grpc-main",
+					Port:     sharedPort,
+					Protocol: protocol.GRPC,
+				},
+			},
+		})
+		sd.SetEndpoints(svc.hostname, "test", []*model.IstioEndpoint{
+			{
+				Addresses:       []string{"127.0.0.1"},
+				EndpointPort:    uint32(sharedPort),
+				ServicePortName: "grpc-main",
+			},
+		})
+	}
+
+	routeName := fmt.Sprintf("outbound|%d||%s", sharedPort, svcA)
+	proxy := ds.SetupProxy(&model.Proxy{
+		Metadata: &model.NodeMetadata{
+			Generator: "grpc",
+			Namespace: "test",
+		},
+	})
+	adscConn := ds.Connect(proxy, []string{}, []string{})
+	defer adscConn.Close()
+
+	adscConn.Send(&discovery.DiscoveryRequest{
+		TypeUrl:       v3.RouteType,
+		ResourceNames: []string{routeName},
+	})
+
+	var rc *route.RouteConfiguration
+	retry.UntilOrFail(t, func() bool {
+		if _, err := adscConn.Wait(5*time.Second, v3.RouteType); err != nil {
+			return false
+		}
+		routes := adscConn.GetRoutes()
+		r, ok := routes[routeName]
+		if !ok || len(r.GetVirtualHosts()) != 1 {
+			return false
+		}
+		rc = r
+		return true
+	}, retry.Timeout(10*time.Second))
+
+	vh := rc.GetVirtualHosts()[0]
+	if !slices.Contains(vh.Domains, svcA) {
+		t.Errorf("expected virtual host domains %v to contain %s", vh.Domains, svcA)
+	}
+}
+
+// TestGRPCRDSWithVirtualService verifies that virtual host filtering works
+// correctly when a VirtualService is present. The VS changes routing behavior
+// (e.g., routing svc-a traffic to svc-b) but should not affect which virtual
+// hosts are returned — only the VH matching the requested hostname.
+func TestGRPCRDSWithVirtualService(t *testing.T) {
+	t.Parallel()
+
+	var (
+		sharedPort = 8080
+
+		svcA = "svc-a.test.svc.cluster.local"
+		svcB = "svc-b.test.svc.cluster.local"
+
+		ds = xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
+			Configs: []config.Config{
+				{
+					Meta: config.Meta{
+						GroupVersionKind: gvk.VirtualService,
+						Name:             "route-a-to-b",
+						Namespace:        "test",
+					},
+					Spec: &networking.VirtualService{
+						Hosts: []string{svcA},
+						Http: []*networking.HTTPRoute{
+							{
+								Route: []*networking.HTTPRouteDestination{
+									{
+										Destination: &networking.Destination{
+											Host: svcB,
+											Port: &networking.PortSelector{Number: uint32(sharedPort)},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+		sd = ds.MemRegistry
+	)
+
+	for _, svc := range []struct {
+		name     string
+		hostname string
+		ip       string
+	}{
+		{"svc-a", svcA, "10.0.0.1"},
+		{"svc-b", svcB, "10.0.0.2"},
+	} {
+		sd.AddService(&model.Service{
+			Attributes: model.ServiceAttributes{
+				Name:      svc.name,
+				Namespace: "test",
+			},
+			Hostname:       host.Name(svc.hostname),
+			DefaultAddress: svc.ip,
+			Ports: model.PortList{
+				{
+					Name:     "grpc-main",
+					Port:     sharedPort,
+					Protocol: protocol.GRPC,
+				},
+			},
+		})
+		sd.SetEndpoints(svc.hostname, "test", []*model.IstioEndpoint{
+			{
+				Addresses:       []string{"127.0.0.1"},
+				EndpointPort:    uint32(sharedPort),
+				ServicePortName: "grpc-main",
+			},
+		})
+	}
+
+	proxy := ds.SetupProxy(&model.Proxy{
+		Metadata: &model.NodeMetadata{
+			Generator: "grpc",
+			Namespace: "test",
+		},
+	})
+	adscConn := ds.Connect(proxy, []string{}, []string{})
+	defer adscConn.Close()
+
+	routeName := fmt.Sprintf("outbound|%d||%s", sharedPort, svcA)
+	adscConn.Send(&discovery.DiscoveryRequest{
+		TypeUrl:       v3.RouteType,
+		ResourceNames: []string{routeName},
+	})
+
+	var rc *route.RouteConfiguration
+	retry.UntilOrFail(t, func() bool {
+		if _, err := adscConn.Wait(5*time.Second, v3.RouteType); err != nil {
+			return false
+		}
+		routes := adscConn.GetRoutes()
+		r, ok := routes[routeName]
+		if !ok || len(r.GetVirtualHosts()) != 1 {
+			return false
+		}
+		rc = r
+		return true
+	}, retry.Timeout(10*time.Second))
+
+	vh := rc.GetVirtualHosts()[0]
+	if !slices.Contains(vh.Domains, svcA) {
+		t.Errorf("virtual host domains %v do not contain %s", vh.Domains, svcA)
+	}
+
+	// Verify the routing goes to svc-b (VirtualService effect).
+	if len(vh.Routes) == 0 {
+		t.Fatal("expected at least one route in the virtual host")
+	}
+	cluster := vh.Routes[0].GetRoute().GetCluster()
+	wantCluster := fmt.Sprintf("outbound|%d||%s", sharedPort, svcB)
+	if cluster != wantCluster {
+		t.Errorf("expected route cluster %q, got %q", wantCluster, cluster)
+	}
+}
+
+// TestGRPCRDSWithWildcardVirtualServiceHost verifies wildcard VirtualService
+// hosts are matched for the requested route hostname and returned as the only
+// virtual host for gRPC RDS.
+func TestGRPCRDSWithWildcardVirtualServiceHost(t *testing.T) {
+	t.Parallel()
+
+	var (
+		sharedPort = 80
+
+		requestedHost   = "foo.example.com"
+		wildcardHost    = "*.example.com"
+		destinationHost = "api.example.net"
+
+		routeName = fmt.Sprintf("outbound|%d||%s", sharedPort, requestedHost)
+
+		ds = xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
+			Configs: []config.Config{
+				{
+					Meta: config.Meta{
+						GroupVersionKind: gvk.VirtualService,
+						Name:             "wildcard-host-route",
+						Namespace:        "test",
+					},
+					Spec: &networking.VirtualService{
+						Hosts: []string{wildcardHost},
+						Http: []*networking.HTTPRoute{
+							{
+								Route: []*networking.HTTPRouteDestination{
+									{
+										Destination: &networking.Destination{
+											Host: destinationHost,
+											Port: &networking.PortSelector{Number: uint32(sharedPort)},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		proxy = ds.SetupProxy(&model.Proxy{
+			Metadata: &model.NodeMetadata{
+				Generator: "grpc",
+				Namespace: "test",
+			},
+		})
+	)
+
+	adscConn := ds.Connect(proxy, []string{}, []string{})
+	defer adscConn.Close()
+
+	adscConn.Send(&discovery.DiscoveryRequest{
+		TypeUrl:       v3.RouteType,
+		ResourceNames: []string{routeName},
+	})
+
+	var rc *route.RouteConfiguration
+	retry.UntilOrFail(t, func() bool {
+		if _, err := adscConn.Wait(5*time.Second, v3.RouteType); err != nil {
+			return false
+		}
+		routes := adscConn.GetRoutes()
+		r, ok := routes[routeName]
+		if !ok || len(r.GetVirtualHosts()) != 1 {
+			return false
+		}
+		rc = r
+		return true
+	}, retry.Timeout(10*time.Second))
+
+	vh := rc.GetVirtualHosts()[0]
+	hasWildcard := false
+	hasRequestedHost := false
+	for _, d := range vh.Domains {
+		if d == wildcardHost || d == wildcardHost+":80" {
+			hasWildcard = true
+		}
+		if d == requestedHost || d == requestedHost+":80" {
+			hasRequestedHost = true
+		}
+	}
+	if !hasWildcard {
+		t.Errorf("virtual host domains %v do not contain wildcard host %q", vh.Domains, wildcardHost)
+	}
+	if hasRequestedHost {
+		t.Errorf(
+			"virtual host domains %v unexpectedly contain requested host %q", vh.Domains, requestedHost,
+		)
+	}
+
+	if len(vh.Routes) == 0 {
+		t.Fatal("expected at least one route in the virtual host")
+	}
+	wantCluster := fmt.Sprintf("outbound|%d||%s", sharedPort, destinationHost)
+	cluster := vh.Routes[0].GetRoute().GetCluster()
+	if cluster != wantCluster {
+		t.Errorf("expected route cluster %q, got %q", wantCluster, cluster)
+	}
+}
+
+// TestGRPCRDSSubsetRouteFiltering verifies that requesting a subset route name
+// (e.g. "outbound|8080|v1|svc.ns.svc.cluster.local") still returns the correct
+// virtual host for the hostname.
+func TestGRPCRDSSubsetRouteFiltering(t *testing.T) {
+	t.Parallel()
+
+	var (
+		sharedPort = 8080
+
+		svcA = "svc-a.test.svc.cluster.local"
+		svcB = "svc-b.test.svc.cluster.local"
+
+		ds = xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
+			Configs: []config.Config{
+				{
+					Meta: config.Meta{
+						GroupVersionKind: gvk.DestinationRule,
+						Name:             "svc-a-subsets",
+						Namespace:        "test",
+					},
+					Spec: &networking.DestinationRule{
+						Host: svcA,
+						Subsets: []*networking.Subset{
+							{
+								Name:   "v1",
+								Labels: map[string]string{"version": "v1"},
+							},
+						},
+					},
+				},
+			},
+		})
+		sd = ds.MemRegistry
+	)
+
+	for _, svc := range []struct {
+		name     string
+		hostname string
+		ip       string
+	}{
+		{"svc-a", svcA, "10.0.0.1"},
+		{"svc-b", svcB, "10.0.0.2"},
+	} {
+		sd.AddService(&model.Service{
+			Attributes: model.ServiceAttributes{
+				Name:      svc.name,
+				Namespace: "test",
+			},
+			Hostname:       host.Name(svc.hostname),
+			DefaultAddress: svc.ip,
+			Ports: model.PortList{
+				{
+					Name:     "grpc-main",
+					Port:     sharedPort,
+					Protocol: protocol.GRPC,
+				},
+			},
+		})
+		sd.SetEndpoints(svc.hostname, "test", []*model.IstioEndpoint{
+			{
+				Addresses:       []string{"127.0.0.1"},
+				EndpointPort:    uint32(sharedPort),
+				ServicePortName: "grpc-main",
+			},
+		})
+	}
+
+	proxy := ds.SetupProxy(&model.Proxy{
+		Metadata: &model.NodeMetadata{
+			Generator: "grpc",
+			Namespace: "test",
+		},
+	})
+	adscConn := ds.Connect(proxy, []string{}, []string{})
+	defer adscConn.Close()
+
+	// Request with subset in the route name.
+	routeName := fmt.Sprintf("outbound|%d|v1|%s", sharedPort, svcA)
+	adscConn.Send(&discovery.DiscoveryRequest{
+		TypeUrl:       v3.RouteType,
+		ResourceNames: []string{routeName},
+	})
+
+	var rc *route.RouteConfiguration
+	retry.UntilOrFail(t, func() bool {
+		if _, err := adscConn.Wait(5*time.Second, v3.RouteType); err != nil {
+			return false
+		}
+		routes := adscConn.GetRoutes()
+		r, ok := routes[routeName]
+		if !ok || len(r.GetVirtualHosts()) != 1 {
+			return false
+		}
+		rc = r
+		return true
+	}, retry.Timeout(10*time.Second))
+
+	// Should still return only svc-a's virtual host.
+	vh := rc.GetVirtualHosts()[0]
+	hasSvcA := false
+	for _, d := range vh.Domains {
+		if d == svcA {
+			hasSvcA = true
+		}
+	}
+	if !hasSvcA {
+		t.Errorf("virtual host domains %v do not contain %s", vh.Domains, svcA)
+	}
+}
+
+// TestGRPCRDSSameShortNameDifferentNamespaces verifies that when two services
+// share the same short name but are in different namespaces, requesting a route
+// by FQDN returns only the correct service's virtual host.
+func TestGRPCRDSSameShortNameDifferentNamespaces(t *testing.T) {
+	t.Parallel()
+
+	var (
+		sharedPort = 8080
+
+		svcNS1 = "svc.ns1.svc.cluster.local"
+		svcNS2 = "svc.ns2.svc.cluster.local"
+
+		ds = xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+		sd = ds.MemRegistry
+	)
+
+	for _, svc := range []struct {
+		name      string
+		namespace string
+		hostname  string
+		ip        string
+	}{
+		{"svc", "ns1", svcNS1, "10.0.0.1"},
+		{"svc", "ns2", svcNS2, "10.0.0.2"},
+	} {
+		sd.AddService(&model.Service{
+			Attributes: model.ServiceAttributes{
+				Name:      svc.name,
+				Namespace: svc.namespace,
+			},
+			Hostname:       host.Name(svc.hostname),
+			DefaultAddress: svc.ip,
+			Ports: model.PortList{
+				{
+					Name:     "grpc-main",
+					Port:     sharedPort,
+					Protocol: protocol.GRPC,
+				},
+			},
+		})
+		sd.SetEndpoints(svc.hostname, svc.namespace, []*model.IstioEndpoint{
+			{
+				Addresses:       []string{"127.0.0.1"},
+				EndpointPort:    uint32(sharedPort),
+				ServicePortName: "grpc-main",
+			},
+		})
+	}
+
+	proxy := ds.SetupProxy(&model.Proxy{
+		Metadata: &model.NodeMetadata{
+			Generator: "grpc",
+			Namespace: "ns1",
+		},
+	})
+	adscConn := ds.Connect(proxy, []string{}, []string{})
+	defer adscConn.Close()
+
+	routeName := fmt.Sprintf("outbound|%d||%s", sharedPort, svcNS1)
+	adscConn.Send(&discovery.DiscoveryRequest{
+		TypeUrl:       v3.RouteType,
+		ResourceNames: []string{routeName},
+	})
+
+	var rc *route.RouteConfiguration
+	retry.UntilOrFail(t, func() bool {
+		if _, err := adscConn.Wait(5*time.Second, v3.RouteType); err != nil {
+			return false
+		}
+		routes := adscConn.GetRoutes()
+		r, ok := routes[routeName]
+		if !ok || len(r.GetVirtualHosts()) != 1 {
+			return false
+		}
+		rc = r
+		return true
+	}, retry.Timeout(10*time.Second))
+
+	// Should return only ns1's virtual host, not ns2's.
+	vh := rc.GetVirtualHosts()[0]
+	hasNS1 := false
+	hasNS2 := false
+	for _, d := range vh.Domains {
+		if d == svcNS1 {
+			hasNS1 = true
+		}
+		if d == svcNS2 {
+			hasNS2 = true
+		}
+	}
+	if !hasNS1 {
+		t.Errorf("virtual host domains %v do not contain %s", vh.Domains, svcNS1)
+	}
+	if hasNS2 {
+		t.Errorf("virtual host domains %v unexpectedly contain %s", vh.Domains, svcNS2)
+	}
 }

--- a/pilot/pkg/networking/grpcgen/rds.go
+++ b/pilot/pkg/networking/grpcgen/rds.go
@@ -15,12 +15,18 @@
 package grpcgen
 
 import (
+	"net"
+	"strconv"
+	"strings"
+
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core"
+	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/util/protoconv"
+	"istio.io/istio/pkg/config/host"
 )
 
 // BuildHTTPRoutes supports per-VIP routes, as used by GRPC.
@@ -49,10 +55,67 @@ func buildHTTPRoute(node *model.Proxy, push *model.PushContext, routeName string
 
 	virtualHosts, _, _ := core.BuildSidecarOutboundVirtualHosts(node, push, routeName, port, nil, &model.DisabledCache{})
 
-	// Only generate the required route for grpc. Will need to generate more
-	// as GRPC adds more features.
+	// gRPC-xDS clients self-filter by subscribing to individual route configs by name (e.g.
+	// "outbound|443||svc.ns.svc.cluster.local"). Filter the returned virtual hosts to only include
+	// the one matching the requested. Without this, the RouteConfiguration contains every service on
+	// the port from around the mesh, causing unnecessary churn pushes when unrelated services change.
+	virtualHosts = filterVirtualHostsForHostname(virtualHosts, string(hostname), port)
+
 	return &route.RouteConfiguration{
 		Name:         routeName,
 		VirtualHosts: virtualHosts,
 	}
+}
+
+// filterVirtualHostsForHostname returns only the virtual hosts whose domains contain the given
+// hostname or hostname:port. Wildcard domains are matched using host.Name semantics. Uses the same
+// formatting as domain generation (util.IPv6Compliant, util.DomainName) to handle IPv6 addresses
+// correctly.
+func filterVirtualHostsForHostname(
+	virtualHosts []*route.VirtualHost,
+	hostname string,
+	port int,
+) []*route.VirtualHost {
+	var (
+		h            = strings.ToLower(hostname)
+		wantHost     = util.IPv6Compliant(h)
+		wantHostPort = util.DomainName(h, port)
+		wantHostName = host.Name(h)
+		wantPort     = strconv.Itoa(port)
+		filtered     []*route.VirtualHost
+	)
+
+	for _, vh := range virtualHosts {
+		for _, d := range vh.Domains {
+			domain := strings.ToLower(d)
+			if domain == wantHost || domain == wantHostPort {
+				filtered = append(filtered, vh)
+				break
+			}
+
+			domainHost, domainPort, err := net.SplitHostPort(domain)
+			if err != nil {
+				domainHost = domain
+				domainPort = ""
+			}
+
+			domainHostName := host.Name(domainHost)
+			if domainHostName.IsWildCarded() {
+				if domainPort != "" && domainPort != wantPort {
+					continue
+				}
+				if domainHostName.Matches(wantHostName) {
+					filtered = append(filtered, vh)
+					break
+				}
+			}
+
+			if domainHost == wantHost && (domainPort == "" || domainPort == wantPort) {
+				filtered = append(filtered, vh)
+				break
+			}
+		}
+	}
+
+	return filtered
 }

--- a/pilot/pkg/networking/grpcgen/rds_test.go
+++ b/pilot/pkg/networking/grpcgen/rds_test.go
@@ -1,0 +1,124 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpcgen
+
+import (
+	"testing"
+
+	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFilterVirtualHostsForHostname(t *testing.T) {
+	t.Parallel()
+
+	const service = "svc-a.test.svc.cluster.local"
+	const port = 8080
+
+	tests := []struct {
+		name         string
+		virtualHosts []*route.VirtualHost
+		hostname     string
+		port         int
+		wantNames    []string
+	}{
+		{
+			name: "exact host domain",
+			virtualHosts: []*route.VirtualHost{
+				{Name: "svc-a", Domains: []string{service}},
+				{Name: "svc-b", Domains: []string{"svc-b.test.svc.cluster.local"}},
+			},
+			hostname:  service,
+			port:      port,
+			wantNames: []string{"svc-a"},
+		},
+		{
+			name: "exact hostport domain",
+			virtualHosts: []*route.VirtualHost{
+				{Name: "svc-a", Domains: []string{service + ":8080"}},
+				{Name: "wrong-port", Domains: []string{service + ":9090"}},
+				{Name: "svc-b", Domains: []string{"svc-b.test.svc.cluster.local:8080"}},
+			},
+			hostname:  service,
+			port:      port,
+			wantNames: []string{"svc-a"},
+		},
+		{
+			name: "wildcard domain",
+			virtualHosts: []*route.VirtualHost{
+				{Name: "wildcard", Domains: []string{"*.test.svc.cluster.local"}},
+				{Name: "other", Domains: []string{"*.other.svc.cluster.local"}},
+			},
+			hostname:  service,
+			port:      port,
+			wantNames: []string{"wildcard"},
+		},
+		{
+			name: "wildcard hostport domain",
+			virtualHosts: []*route.VirtualHost{
+				{Name: "wildcard", Domains: []string{"*.test.svc.cluster.local:8080"}},
+				{Name: "wrong-port", Domains: []string{"*.test.svc.cluster.local:9090"}},
+			},
+			hostname:  service,
+			port:      port,
+			wantNames: []string{"wildcard"},
+		},
+		{
+			name: "ipv6 exact host and hostport",
+			virtualHosts: []*route.VirtualHost{
+				{Name: "ipv6-host", Domains: []string{"[2001:db8::1]"}},
+				{Name: "ipv6-hostport", Domains: []string{"[2001:db8::1]:8080"}},
+				{Name: "other", Domains: []string{"[2001:db8::2]:8080"}},
+			},
+			hostname:  "2001:db8::1",
+			port:      port,
+			wantNames: []string{"ipv6-host", "ipv6-hostport"},
+		},
+		{
+			name: "domain matching is case insensitive",
+			virtualHosts: []*route.VirtualHost{
+				{Name: "svc-a", Domains: []string{"SVC-A.TEST.SVC.CLUSTER.LOCAL"}},
+				{Name: "svc-b", Domains: []string{"SVC-B.TEST.SVC.CLUSTER.LOCAL"}},
+			},
+			hostname:  service,
+			port:      port,
+			wantNames: []string{"svc-a"},
+		},
+		{
+			name: "no match",
+			virtualHosts: []*route.VirtualHost{
+				{Name: "svc-b", Domains: []string{"svc-b.test.svc.cluster.local"}},
+			},
+			hostname: service,
+			port:     port,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := filterVirtualHostsForHostname(test.virtualHosts, test.hostname, test.port)
+			var gotNames []string
+			for _, vh := range got {
+				gotNames = append(gotNames, vh.Name)
+			}
+
+			if diff := cmp.Diff(test.wantNames, gotNames); diff != "" {
+				t.Fatalf("unexpected filtered virtual hosts (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/releasenotes/notes/grpcgen-rds-route-scope.yaml
+++ b/releasenotes/notes/grpcgen-rds-route-scope.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+releaseNotes:
+  - |
+    **Fixed** an issue where proxyless gRPC xDS clients could receive over-broad RDS `RouteConfiguration` responses from Istiod.


### PR DESCRIPTION
**Please provide a description of this PR:**

When a gRPC-xDS client requests a specific route config (e.g., `outbound|443||name.ns.svc.cluster.local`), Istio returns a `RouteConfiguration` containing virtual hosts for all services on that 443 port from across the entire mesh. This produces unnecessary RDS pushes during unrelated service churn and is particularly rough in large multi-cluster environments.

This CR applies filtering in `pilot/pkg/networking/grpcgen/rds.go` such that after building outbound virtual hosts, grpcgen now returns only the virtual host the client actually asked for.

It also adds significant unit and integration tests to test the feature.