### PR TITLE
Filter `DefaultAddress` fallback by IP family in `getAllAddressesForProxy`

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1802,6 +1802,21 @@ func (s *Service) getAllAddressesForProxy(node *Proxy) []string {
 	}
 
 	if a := s.DefaultAddress; len(a) > 0 {
+		// If the service has ClusterVIPs (from a K8s service) but none for this proxy's cluster, the
+		// DefaultAddress is a remote cluster's ClusterIP. Filter it by IP family to avoid returning an
+		// unreachable address (e.g. IPv6 ClusterIP to an IPv4-only proxy).
+		//
+		// Conversely, ServiceEntries with explicit addresses have empty ClusterVIPs and rely on
+		// DefaultAddress for routing (Envoy matches on the VIP regardless of IP family), so leave them
+		// alone.
+		if s.ClusterVIPs.Len() > 0 {
+			if filtered := netutil.FilterAddressesByIPFamily(
+				[]string{a}, node.SupportsIPv4(), node.SupportsIPv6(),
+			); len(filtered) > 0 {
+				return filtered
+			}
+			return nil
+		}
 		return []string{a}
 	}
 	return nil

--- a/pilot/pkg/model/service_test.go
+++ b/pilot/pkg/model/service_test.go
@@ -691,6 +691,89 @@ func TestGetAllAddresses(t *testing.T) {
 			expectedAddresses:      []string{"2001:2::f0f0:e351"},
 			expectedExtraAddresses: []string{},
 		},
+		{
+			name: "IPv4 mode, no ClusterVIPs for local cluster, IPv6 DefaultAddress, expected no addresses",
+			service: &Service{
+				DefaultAddress: "fdce:e254:471d::52c8",
+				ClusterVIPs: AddressMap{
+					Addresses: map[cluster.ID][]string{
+						"other-cluster": {"fdce:e254:471d::52c8"},
+					},
+				},
+			},
+			ipMode:                 IPv4,
+			expectedAddresses:      nil,
+			expectedExtraAddresses: nil,
+		},
+		{
+			name: "IPv6 mode, no ClusterVIPs for local cluster, IPv4 DefaultAddress, expected no addresses",
+			service: &Service{
+				DefaultAddress: "10.96.0.50",
+				ClusterVIPs: AddressMap{
+					Addresses: map[cluster.ID][]string{
+						"other-cluster": {"10.96.0.50"},
+					},
+				},
+			},
+			ipMode:                 IPv6,
+			expectedAddresses:      nil,
+			expectedExtraAddresses: nil,
+		},
+		{
+			name:             "dual mode, ISTIO_DUAL_STACK enabled, no ClusterVIPs for local cluster, IPv6 DefaultAddress, expected IPv6",
+			dualStackEnabled: true,
+			service: &Service{
+				DefaultAddress: "fdce:e254:471d::52c8",
+				ClusterVIPs: AddressMap{
+					Addresses: map[cluster.ID][]string{
+						"other-cluster": {"fdce:e254:471d::52c8"},
+					},
+				},
+			},
+			ipMode:                 Dual,
+			expectedAddresses:      []string{"fdce:e254:471d::52c8"},
+			expectedExtraAddresses: nil,
+		},
+		{
+			name: "IPv4 mode, no ClusterVIPs for local cluster, IPv4 DefaultAddress, expected IPv4",
+			service: &Service{
+				DefaultAddress: "10.96.0.50",
+				ClusterVIPs: AddressMap{
+					Addresses: map[cluster.ID][]string{
+						"other-cluster": {"10.96.0.50"},
+					},
+				},
+			},
+			ipMode:                 IPv4,
+			expectedAddresses:      []string{"10.96.0.50"},
+			expectedExtraAddresses: nil,
+		},
+		{
+			name: "IPv6 mode, no ClusterVIPs for local cluster, IPv6 DefaultAddress, expected IPv6",
+			service: &Service{
+				DefaultAddress: "fdce:e254:471d::52c8",
+				ClusterVIPs: AddressMap{
+					Addresses: map[cluster.ID][]string{
+						"other-cluster": {"fdce:e254:471d::52c8"},
+					},
+				},
+			},
+			ipMode:                 IPv6,
+			expectedAddresses:      []string{"fdce:e254:471d::52c8"},
+			expectedExtraAddresses: nil,
+		},
+		{
+			// ServiceEntry with explicit IPv6 address and no ClusterVIPs. IPv4-only proxy should still
+			// receive the address—Envoy matches on the VIP in its listener regardless of IP family when
+			// DNS capture is on. Family filtering only applies to K8s services (ClusterVIPs.Len() > 0).
+			name: "IPv4 mode, ServiceEntry with IPv6 address (no ClusterVIPs), expected IPv6 returned",
+			service: &Service{
+				DefaultAddress: "1234:1234:1234::1234:1234:1234",
+			},
+			ipMode:                 IPv4,
+			expectedAddresses:      []string{"1234:1234:1234::1234:1234:1234"},
+			expectedExtraAddresses: nil,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/releasenotes/notes/nds-cross-cluster-ip-family-filter.yaml
+++ b/releasenotes/notes/nds-cross-cluster-ip-family-filter.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+releaseNotes:
+  - |
+    **Fixed** `GetAllAddressesForProxy` returning unreachable service addresses to proxies when the
+    `DefaultAddress` IP family does not match the proxy's supported IP family.


### PR DESCRIPTION
`getAllAddressesForProxy()` falls back to `DefaultAddress` unconditionally when no `ClusterVIPs` exist for the proxy's cluster. This bypasses IP family filtering, causing an IPv4-only proxy to receive an unreachable IPv6 ClusterIP in its NDS NameTable for services that only exist on a remote IPv6-only cluster.

With this CR, the `DefaultAddress` fallback now passes through `filterAddresses()` before returning. When no family-compatible address exists, `nil` is returned and the NameTable entry is omitted.

EDS already routes correctly via east-west gateways for these services. This fix makes NDS consistent by not advertising unreachable addresses.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [x] Dual Stack
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [x] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
