### PR TITLE
test: replace time.Sleep with retry loops in jwks_resolver_test

### DIFF
--- a/pilot/pkg/model/jwks_resolver_test.go
+++ b/pilot/pkg/model/jwks_resolver_test.go
@@ -676,13 +676,6 @@ func TestJwtPubKeyRefreshedWhenErrorsGettingOtherURLs(t *testing.T) {
 		pk, err = r.GetPublicKey("", mockCertURL, testRequestTimeout)
 		return err == nil && test.JwtPubKey2 == pk
 	}, retry.Delay(time.Millisecond*5), retry.Timeout(time.Second*5))
-	if err != nil {
-		t.Fatalf("GetPublicKey(\"\", %+v) fails: expected no error, got (%v)", mockCertURL, err)
-	}
-	// Mock server returns JwtPubKey2 for later calls
-	if test.JwtPubKey2 != pk {
-		t.Fatalf("GetPublicKey(\"\", %+v): expected (%s), got (%s)", mockCertURL, test.JwtPubKey2, pk)
-	}
 }
 
 func startMockServer(t *testing.T) *test.MockOpenIDDiscoveryServer {
@@ -736,24 +729,44 @@ func verifyKeyLastRefreshedTime(t *testing.T, r *JwksResolver, ms *test.MockOpen
 	}
 	oldRefreshedTime := e.(jwtPubKeyEntry).lastRefreshedTime
 
-	// Poll until the refresh timestamp changes (or doesn't) instead of sleeping an arbitrary duration.
-	// Use a short poll interval to minimise test time while still being robust.
-	retry.UntilSuccessOrFail(t, func() error {
+	// Capture the current refresh-cycle counts so we can wait until at least one
+	// new cycle has completed before drawing a conclusion.
+	baseChanged := atomic.LoadUint64(&r.refreshJobKeyChangedCount)
+	baseFailed := atomic.LoadUint64(&r.refreshJobFetchFailedCount)
+
+	if wantChanged {
+		// Wait until the cached timestamp is actually updated.
+		retry.UntilSuccessOrFail(t, func() error {
+			e, found = r.keyEntries.Load(key)
+			if !found {
+				return fmt.Errorf("no cached public key for %+v", key)
+			}
+			newRefreshedTime := e.(jwtPubKeyEntry).lastRefreshedTime
+			if oldRefreshedTime == newRefreshedTime {
+				return fmt.Errorf("want lastRefreshedTime changed but it has not changed yet")
+			}
+			return nil
+		}, retry.Delay(time.Millisecond*5), retry.Timeout(time.Second*5))
+	} else {
+		// Wait until at least one refresh cycle has run (key-changed or fetch-failed),
+		// then assert the timestamp did not change.
+		retry.UntilSuccessOrFail(t, func() error {
+			if atomic.LoadUint64(&r.refreshJobKeyChangedCount) == baseChanged &&
+				atomic.LoadUint64(&r.refreshJobFetchFailedCount) == baseFailed {
+				return fmt.Errorf("waiting for a refresh cycle to complete")
+			}
+			return nil
+		}, retry.Delay(time.Millisecond*5), retry.Timeout(time.Second*5))
+
 		e, found = r.keyEntries.Load(key)
 		if !found {
-			return fmt.Errorf("no cached public key for %+v", key)
+			t.Fatalf("No cached public key for %+v", key)
 		}
 		newRefreshedTime := e.(jwtPubKeyEntry).lastRefreshedTime
-		actualChanged := oldRefreshedTime != newRefreshedTime
-		if wantChanged && !actualChanged {
-			return fmt.Errorf("want lastRefreshedTime changed but it has not changed yet")
+		if oldRefreshedTime != newRefreshedTime {
+			t.Errorf("Want changed: false but lastRefreshedTime changed")
 		}
-		if !wantChanged && actualChanged {
-			// The timestamp changed when we did not expect it to; fail immediately.
-			t.Errorf("Want changed: %t but got %t", wantChanged, actualChanged)
-		}
-		return nil
-	}, retry.Delay(time.Millisecond*5), retry.Timeout(time.Second*5))
+	}
 }
 
 func TestCompareJWKSResponse(t *testing.T) {


### PR DESCRIPTION
## Description

Fixes part of [#37555](https://github.com/istio/istio/issues/37555): two unchecked slow tests in `pilot/pkg/model/jwks_resolver_test.go` that used `time.Sleep` instead of event-driven waits.

### Changes

**`pilot/pkg/model/jwks_resolver_test.go`**

| Function | Before | After | Improvement |
|---|---|---|---|
| `verifyKeyLastRefreshedTime` | `time.Sleep(200ms)` — always waits full duration | `retry.UntilSuccessOrFail` polling at 5ms intervals | Exits as soon as condition is met |
| `TestJwtPubKeyRefreshedWhenErrorsGettingOtherURLs` | `time.Sleep(2 * refreshInterval)` (100ms) — always waits | `retry.UntilOrFail` polling at 5ms intervals | Exits as soon as `JwtPubKey2` is returned |

Both changes remove fixed sleep durations and instead poll the actual condition with short intervals under a generous timeout (5s). This makes the tests more responsive and deterministic — they complete as soon as the expected state is observed.

These are unchecked items in the issue list (`TestJwtPubKeyRefreshWithNetworkError` which calls `verifyKeyLastRefreshedTime`, and `TestJwtPubKeyRefreshedWhenErrorsGettingOtherURLs`).

## Testing

- [ ] Run `go test ./pilot/pkg/model/... -run TestJwtPubKey -v -count=3` to verify tests pass and run faster

Resolves part of: https://github.com/istio/istio/issues/37555