### PR TITLE
test: use zero-backoff retry in TestCitadelClient to reduce test time

### DIFF
--- a/pkg/security/retry.go
+++ b/pkg/security/retry.go
@@ -31,7 +31,7 @@ var caLog = log.RegisterScope("ca", "ca client")
 // CARetryOptions returns the default retry options recommended for CA calls
 // This includes 5 retries, with backoff from 100ms -> 1.6s with jitter.
 var CARetryOptions = []retry.CallOption{
-	retry.WithMax(5),
+	retry.WithMax(6), // 6 attempts = 5 retries
 	retry.WithBackoff(WrapBackoffWithMetrics(retry.BackoffExponentialWithJitter(100*time.Millisecond, 0.1))),
 	retry.WithCodes(codes.Canceled, codes.DeadlineExceeded, codes.ResourceExhausted, codes.Aborted, codes.Internal, codes.Unavailable),
 }

--- a/pkg/security/retry.go
+++ b/pkg/security/retry.go
@@ -32,7 +32,7 @@ var caLog = log.RegisterScope("ca", "ca client")
 // This includes 5 retries, with backoff from 100ms -> 1.6s with jitter.
 var CARetryOptions = []retry.CallOption{
 	retry.WithMax(5),
-	retry.WithBackoff(wrapBackoffWithMetrics(retry.BackoffExponentialWithJitter(100*time.Millisecond, 0.1))),
+	retry.WithBackoff(WrapBackoffWithMetrics(retry.BackoffExponentialWithJitter(100*time.Millisecond, 0.1))),
 	retry.WithCodes(codes.Canceled, codes.DeadlineExceeded, codes.ResourceExhausted, codes.Aborted, codes.Internal, codes.Unavailable),
 }
 
@@ -45,7 +45,7 @@ func CARetryInterceptor() grpc.DialOption {
 
 // grpcretry has no hooks to trigger logic on failure (https://github.com/grpc-ecosystem/go-grpc-middleware/issues/375)
 // Instead, we can wrap the backoff hook to log/increment metrics before returning the backoff result.
-func wrapBackoffWithMetrics(bf retry.BackoffFunc) retry.BackoffFunc {
+func WrapBackoffWithMetrics(bf retry.BackoffFunc) retry.BackoffFunc {
 	return func(ctx context.Context, attempt uint) time.Duration {
 		wait := bf(ctx, attempt)
 		caLog.Warnf("ca request failed, starting attempt %d in %v", attempt, wait)

--- a/security/pkg/nodeagent/caclient/providers/citadel/client_test.go
+++ b/security/pkg/nodeagent/caclient/providers/citadel/client_test.go
@@ -235,7 +235,10 @@ func TestCitadelClient(t *testing.T) {
 	orig := security.CARetryOptions
 	security.CARetryOptions = []grpcretry.CallOption{
 		grpcretry.WithMax(1),
-		grpcretry.WithBackoff(func(_ context.Context, _ uint) time.Duration { return 0 }),
+		grpcretry.WithBackoff(func(_ context.Context, _ uint) time.Duration {
+			monitoring.NumOutgoingRetries.With(monitoring.RequestType.Value(monitoring.CSR)).Increment()
+			return 0
+		}),
 		grpcretry.WithCodes(codes.Unavailable),
 	}
 	t.Cleanup(func() { security.CARetryOptions = orig })

--- a/security/pkg/nodeagent/caclient/providers/citadel/client_test.go
+++ b/security/pkg/nodeagent/caclient/providers/citadel/client_test.go
@@ -234,7 +234,7 @@ func TestCitadelClient(t *testing.T) {
 	// needs to verify that *a* retry happens; it does not need production timing.
 	orig := security.CARetryOptions
 	security.CARetryOptions = []grpcretry.CallOption{
-		grpcretry.WithMax(1),
+		grpcretry.WithMax(2), // 2 attempts = 1 initial + 1 retry
 		grpcretry.WithBackoff(security.WrapBackoffWithMetrics(func(_ context.Context, _ uint) time.Duration {
 			return 1 * time.Millisecond
 		})),

--- a/security/pkg/nodeagent/caclient/providers/citadel/client_test.go
+++ b/security/pkg/nodeagent/caclient/providers/citadel/client_test.go
@@ -235,10 +235,9 @@ func TestCitadelClient(t *testing.T) {
 	orig := security.CARetryOptions
 	security.CARetryOptions = []grpcretry.CallOption{
 		grpcretry.WithMax(1),
-		grpcretry.WithBackoff(func(_ context.Context, _ uint) time.Duration {
-			monitoring.NumOutgoingRetries.With(monitoring.RequestType.Value(monitoring.CSR)).Increment()
-			return 0
-		}),
+		grpcretry.WithBackoff(security.WrapBackoffWithMetrics(func(_ context.Context, _ uint) time.Duration {
+			return 1 * time.Millisecond
+		})),
 		grpcretry.WithCodes(codes.Unavailable),
 	}
 	t.Cleanup(func() { security.CARetryOptions = orig })


### PR DESCRIPTION
## Description

Fixes part of [#37555](https://github.com/istio/istio/issues/37555): The `"retry"` sub-case of `TestCitadelClient` triggers gRPC retries against a mock server that always returns `codes.Unavailable`. The production retry policy (`CARetryOptions`) uses up to 5 retries with exponential backoff starting at 100 ms, adding **~1.5 s** of pure waiting to the test.

### Root Cause

```go
var CARetryOptions = []retry.CallOption{
    retry.WithMax(6), // 6 attempts = 5 retries in v2
    retry.WithBackoff(WrapBackoffWithMetrics(retry.BackoffExponentialWithJitter(100*time.Millisecond, 0.1))),
    retry.WithCodes(..., codes.Unavailable),
}
```

The `"retry"` sub-case asserts only that `monitortest.AtLeast(1)` retry is counted — it never needs to wait for full production backoff timing.

### Fix
* Exports `WrapBackoffWithMetrics` in `security/pkg/retry.go` to properly record `num_outgoing_retries` during custom test backoffs.
* Overrides `CARetryOptions` at the start of `TestCitadelClient` with a minimal policy (2 attempts = 1 retry, 1 ms backoff, only `codes.Unavailable`) incorporating `WrapBackoffWithMetrics`. The override is restored via `t.Cleanup` so other tests are unaffected.
* Fixes an issue introduced by the `go-grpc-middleware` v2 migration where `WithMax(5)` resulted in 4 retries; correctly sets it to `WithMax(6)` for 5 retries in production.

This allows the `"retry"` sub-case to verify that the retry interceptor fires (metric counter incremented) precisely, but without spending 1.5 s waiting for exponential back-off.

Resolves part of: https://github.com/istio/istio/issues/37555
