### PR TITLE
Remove redundant runAsUser/runAsGroup from gateway container securityContext

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -84,10 +84,6 @@ spec:
             allowPrivilegeEscalation: false
             privileged: false
             readOnlyRootFilesystem: true
-            {{- if not (eq (.Values.platform | default "") "openshift") }}
-            runAsUser: 1337
-            runAsGroup: 1337
-            {{- end }}
             runAsNonRoot: true
           {{- end }}
           env:

--- a/operator/pkg/helm/testdata/output/gateway-additional-containers.golden.yaml
+++ b/operator/pkg/helm/testdata/output/gateway-additional-containers.golden.yaml
@@ -57,8 +57,6 @@ spec:
             allowPrivilegeEscalation: false
             privileged: false
             readOnlyRootFilesystem: true
-            runAsUser: 1337
-            runAsGroup: 1337
             runAsNonRoot: true
           env:
           ports:

--- a/operator/pkg/helm/testdata/output/gateway-deployment.golden.yaml
+++ b/operator/pkg/helm/testdata/output/gateway-deployment.golden.yaml
@@ -57,8 +57,6 @@ spec:
             allowPrivilegeEscalation: false
             privileged: false
             readOnlyRootFilesystem: true
-            runAsUser: 1337
-            runAsGroup: 1337
             runAsNonRoot: true
           env:
           ports:

--- a/operator/pkg/helm/testdata/output/gateway-env-var-from.golden.yaml
+++ b/operator/pkg/helm/testdata/output/gateway-env-var-from.golden.yaml
@@ -57,8 +57,6 @@ spec:
             allowPrivilegeEscalation: false
             privileged: false
             readOnlyRootFilesystem: true
-            runAsUser: 1337
-            runAsGroup: 1337
             runAsNonRoot: true
           env:
           - name: TEST_ENV

--- a/operator/pkg/helm/testdata/output/gateway-init-containers.golden.yaml
+++ b/operator/pkg/helm/testdata/output/gateway-init-containers.golden.yaml
@@ -64,8 +64,6 @@ spec:
             allowPrivilegeEscalation: false
             privileged: false
             readOnlyRootFilesystem: true
-            runAsUser: 1337
-            runAsGroup: 1337
             runAsNonRoot: true
           env:
           ports:


### PR DESCRIPTION
## Summary
- Remove `runAsUser: 1337` and `runAsGroup: 1337` from the gateway chart's container-level `securityContext`.
- These values are already injected by the Istio mutating webhook via the injection template ([`injection-template.yaml:408-409`](https://github.com/istio/istio/blob/master/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml#L408-L409)), making the container-level hardcoded values redundant.
- The gateway chart's helper ([`_helpers.tpl:28`](https://github.com/istio/istio/blob/master/manifests/charts/gateway/templates/_helpers.tpl#L28)) and default values ([`values.yaml:34`](https://github.com/istio/istio/blob/master/manifests/charts/gateway/values.yaml#L34)) both set `sidecar.istio.io/inject: "true"`, so injection is effectively always enabled — there is virtually no case where the webhook does not inject these security context values.
- This resolves a spurious warning log `Could not find either istio-init or istio-validation container` ([`webhook.go:616`](https://github.com/istio/istio/blob/master/pkg/kube/inject/webhook.go#L616)) emitted by istiod during ingress gateway injection. The `adjustInitContainerUser` function treats the hardcoded container-level `runAsUser` as a user override (line 601), then attempts to find an `istio-init` or `istio-validation` init container to match — but gateway pods do not have these init containers, triggering the warning.
- This also eliminates unnecessary conflicts when users customize init containers with different `runAsUser` values, since container-level settings take precedence over pod-level defaults.

## Files changed
- `manifests/charts/gateway/templates/deployment.yaml` — removed container-level `runAsUser`/`runAsGroup`
- `operator/pkg/helm/testdata/output/*.golden.yaml` — updated 4 golden test files to reflect the change

## Test plan
- [x] Verify `go test ./operator/pkg/helm/...` passes
- [x] Verify rendered gateway pod still receives `runAsUser: 1337` via injection
- [x] Verify the `Could not find either istio-init or istio-validation container` warning no longer appears during gateway injection