### PR TITLE
Gateway API frontend mTLS mode support with legacy tls-terminate-mode compatibility

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -2098,6 +2098,35 @@ func resolveGatewayTLS(port k8s.PortNumber, gw *k8s.GatewayTLSConfig) *k8s.TLSCo
 	return &f.Default
 }
 
+func applyTLSTerminateModeOptionOverride(out *istio.ServerTLSSettings, options map[k8s.AnnotationKey]k8s.AnnotationValue) bool {
+	if options == nil {
+		return false
+	}
+	switch options[gatewaycommon.GatewayTLSTerminateModeKey] {
+	case "MUTUAL":
+		out.Mode = istio.ServerTLSSettings_MUTUAL
+	case "OPTIONAL_MUTUAL":
+		out.Mode = istio.ServerTLSSettings_OPTIONAL_MUTUAL
+	case "ISTIO_SIMPLE":
+		// Simple TLS but with builtin workload certificate.
+		// equivalent to `credentialName: builtin://
+		out.Mode = istio.ServerTLSSettings_SIMPLE
+		out.CredentialName = creds.BuiltinGatewaySecretTypeURI
+		return true
+	case "ISTIO_MUTUAL":
+		out.Mode = istio.ServerTLSSettings_ISTIO_MUTUAL
+		return true
+	}
+	return false
+}
+
+func serverTLSModeFromFrontendValidationMode(mode k8s.FrontendValidationModeType) istio.ServerTLSSettings_TLSmode {
+	if mode == k8s.AllowInsecureFallback {
+		return istio.ServerTLSSettings_OPTIONAL_MUTUAL
+	}
+	return istio.ServerTLSSettings_MUTUAL
+}
+
 func buildTLS(
 	ctx krt.HandlerContext,
 	configMaps krt.Collection[*corev1.ConfigMap],
@@ -2124,22 +2153,8 @@ func buildTLS(
 	switch mode {
 	case k8s.TLSModeTerminate:
 		out.Mode = istio.ServerTLSSettings_SIMPLE
-		if tls.Options != nil {
-			switch tls.Options[gatewaycommon.GatewayTLSTerminateModeKey] {
-			case "MUTUAL":
-				out.Mode = istio.ServerTLSSettings_MUTUAL
-			case "OPTIONAL_MUTUAL":
-				out.Mode = istio.ServerTLSSettings_OPTIONAL_MUTUAL
-			case "ISTIO_SIMPLE":
-				// Simple TLS but with builtin workload certificate.
-				// equivalent to `credentialName: builtin://
-				out.Mode = istio.ServerTLSSettings_SIMPLE
-				out.CredentialName = creds.BuiltinGatewaySecretTypeURI
-				return out, nil
-			case "ISTIO_MUTUAL":
-				out.Mode = istio.ServerTLSSettings_ISTIO_MUTUAL
-				return out, nil
-			}
+		if applyTLSTerminateModeOptionOverride(out, tls.Options) {
+			return out, nil
 		}
 		if len(tls.CertificateRefs) > 2 {
 			return out, &ConfigError{
@@ -2183,7 +2198,6 @@ func buildTLS(
 		}
 
 		if gatewayTLS != nil && gatewayTLS.Validation != nil && len(gatewayTLS.Validation.CACertificateRefs) > 0 {
-			// TODO: add 'Mode'
 			if len(gatewayTLS.Validation.CACertificateRefs) > 1 {
 				return out, &ConfigError{
 					Reason:  InvalidTLS,
@@ -2204,15 +2218,11 @@ func buildTLS(
 					),
 				}
 			}
-			out.Mode = istio.ServerTLSSettings_MUTUAL
+			out.Mode = serverTLSModeFromFrontendValidationMode(gatewayTLS.Validation.Mode)
 			out.CaCertCredentialName = cred.ResourceName
-			if tls.Options != nil {
-				switch tls.Options[gatewaycommon.GatewayTLSTerminateModeKey] {
-				case "MUTUAL":
-					out.Mode = istio.ServerTLSSettings_MUTUAL
-				case "OPTIONAL_MUTUAL":
-					out.Mode = istio.ServerTLSSettings_OPTIONAL_MUTUAL
-				}
+			// Backward-compatibility: keep honoring legacy listener option even when frontend validation is configured.
+			if applyTLSTerminateModeOptionOverride(out, tls.Options) {
+				return out, nil
 			}
 		}
 	case k8s.TLSModePassthrough:

--- a/pilot/pkg/config/kube/gateway/conversion_test.go
+++ b/pilot/pkg/config/kube/gateway/conversion_test.go
@@ -57,6 +57,7 @@ import (
 	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/util/sets"
 )
 
@@ -1354,6 +1355,86 @@ func TestSortHTTPRoutes(t *testing.T) {
 			if !reflect.DeepEqual(tt.in, tt.out) {
 				t.Fatalf("expected %v, got %v", tt.out, tt.in)
 			}
+		})
+	}
+}
+
+func TestServerTLSModeFromFrontendValidationMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		mode     k8s.FrontendValidationModeType
+		expected istio.ServerTLSSettings_TLSmode
+	}{
+		{
+			name:     "defaults to mutual",
+			mode:     "",
+			expected: istio.ServerTLSSettings_MUTUAL,
+		},
+		{
+			name:     "allow valid only maps to mutual",
+			mode:     k8s.AllowValidOnly,
+			expected: istio.ServerTLSSettings_MUTUAL,
+		},
+		{
+			name:     "allow insecure fallback maps to optional mutual",
+			mode:     k8s.AllowInsecureFallback,
+			expected: istio.ServerTLSSettings_OPTIONAL_MUTUAL,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, serverTLSModeFromFrontendValidationMode(tt.mode), tt.expected)
+		})
+	}
+}
+
+func TestApplyTLSTerminateModeOptionOverride(t *testing.T) {
+	tests := []struct {
+		name               string
+		options            map[k8s.AnnotationKey]k8s.AnnotationValue
+		expectedMode       istio.ServerTLSSettings_TLSmode
+		expectedCredential string
+		expectedTerminal   bool
+	}{
+		{
+			name:             "mutual override",
+			options:          map[k8s.AnnotationKey]k8s.AnnotationValue{gatewaycommon.GatewayTLSTerminateModeKey: "MUTUAL"},
+			expectedMode:     istio.ServerTLSSettings_MUTUAL,
+			expectedTerminal: false,
+		},
+		{
+			name:             "optional mutual override",
+			options:          map[k8s.AnnotationKey]k8s.AnnotationValue{gatewaycommon.GatewayTLSTerminateModeKey: "OPTIONAL_MUTUAL"},
+			expectedMode:     istio.ServerTLSSettings_OPTIONAL_MUTUAL,
+			expectedTerminal: false,
+		},
+		{
+			name:               "istio simple override",
+			options:            map[k8s.AnnotationKey]k8s.AnnotationValue{gatewaycommon.GatewayTLSTerminateModeKey: "ISTIO_SIMPLE"},
+			expectedMode:       istio.ServerTLSSettings_SIMPLE,
+			expectedCredential: "builtin://",
+			expectedTerminal:   true,
+		},
+		{
+			name:             "istio mutual override",
+			options:          map[k8s.AnnotationKey]k8s.AnnotationValue{gatewaycommon.GatewayTLSTerminateModeKey: "ISTIO_MUTUAL"},
+			expectedMode:     istio.ServerTLSSettings_ISTIO_MUTUAL,
+			expectedTerminal: true,
+		},
+		{
+			name:             "no override",
+			options:          nil,
+			expectedMode:     istio.ServerTLSSettings_SIMPLE,
+			expectedTerminal: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			settings := &istio.ServerTLSSettings{Mode: istio.ServerTLSSettings_SIMPLE}
+			terminal := applyTLSTerminateModeOptionOverride(settings, tt.options)
+			assert.Equal(t, settings.Mode, tt.expectedMode)
+			assert.Equal(t, settings.CredentialName, tt.expectedCredential)
+			assert.Equal(t, terminal, tt.expectedTerminal)
 		})
 	}
 }

--- a/releasenotes/notes/gateway-api-frontend-validation-mode.yaml
+++ b/releasenotes/notes/gateway-api-frontend-validation-mode.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+releaseNotes:
+  - |
+    **Added** Gateway API frontend mTLS mode support by honoring `spec.tls.frontend.{default,perPort}.validation.mode`
+    (`AllowValidOnly` and `AllowInsecureFallback`) when converting `Gateway` listeners.
+  - |
+    **Updated** Gateway API listener TLS conversion to keep backward compatibility with
+    `tls.options["gateway.istio.io/tls-terminate-mode"]` so existing configurations continue to work.


### PR DESCRIPTION
**Summary**
This PR adds Gateway API frontend mTLS mode handling for Gateway listeners and preserves backward compatibility with Istio’s legacy listener option.
Specifically, Gateway API frontend validation mode is translated into Istio server TLS mode while keeping existing tls.options override behavior unchanged.

**What changed**

Added mapping from Gateway API frontend validation mode to Istio TLS mode:
- AllowValidOnly → MUTUAL
- AllowInsecureFallback → OPTIONAL_MUTUAL

Preserved compatibility with tls.options["gateway.istio.io/tls-terminate-mode"]
- Legacy option still overrides mode when present
- Existing ISTIO_MUTUAL / ISTIO_SIMPLE behavior remains intact

Refactored TLS terminate option override handling into a shared helper for consistency.
Added/updated unit tests covering:
- frontend validation mode mapping
- legacy option override behavior

Added release note for Gateway API frontend mTLS support and compatibility guarantees.

**Why**
Aligns Istio Gateway API behavior with GEP-91 frontend client certificate validation semantics.
Ensures users can migrate to standard Gateway API fields without breaking existing Istio-specific configurations.
Maintains operational safety and smooth upgrade path for current deployments.