### PR TITLE
dns: remove TODO about skipping node's own IP

### DIFF
--- a/pkg/dns/server/name_table.go
+++ b/pkg/dns/server/name_table.go
@@ -113,7 +113,6 @@ func BuildNameTable(cfg Config) *dnsProto.NameTable {
 							// This ends up matching the behavior of Kubernetes DNS.
 							continue
 						}
-						// TODO: should we skip the node's own IP like we do in listener?
 						addressList = append(addressList, instance.Addresses...)
 					}
 					// Write local cluster entries first


### PR DESCRIPTION
This PR removes an open TODO questioning whether we should skip the node's own IP in the DNS name table, identical to how it's handled for outbound listeners.

As pointed out in the reviews, for Headless Services, many applications (e.g. StatefulSets) expect to be able to resolve their own IP to discover their peers or identity. Skipping the self node IP diverges from Kubernetes' default DNS behavior and breaks these applications.

Therefore, we intentionally leave the proxy's own IP in the DNS name table and remove the TODO comment.