### PR TITLE
fix flake: TestServiceDiscoveryWorkloadUpdate/cleanup

### DIFF
--- a/pilot/pkg/serviceregistry/serviceentry/controller_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller_test.go
@@ -992,9 +992,17 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 }
 
 func assertControllerEmpty(t *testing.T, sd *Controller) {
+	t.Helper()
 	// KRT-based controller: validate via outputs
-	assert.Equal(t, len(sd.outputs.Services.List()), 0)
-	assert.Equal(t, len(sd.outputs.ServiceInstances.List()), 0)
+	retry.UntilSuccessOrFail(t, func() error {
+		if n := len(sd.outputs.Services.List()); n != 0 {
+			return fmt.Errorf("expected 0 services, got %d", n)
+		}
+		if n := len(sd.outputs.ServiceInstances.List()); n != 0 {
+			return fmt.Errorf("expected 0 service instances, got %d", n)
+		}
+		return nil
+	}, retry.Timeout(time.Second*2))
 }
 
 func TestServiceDiscoveryWorkloadChangeLabel(t *testing.T) {


### PR DESCRIPTION
**Please provide a description of this PR:**

this was a pretty frequent flake, easy to repro

```
 33 runs so far, 1 failures (97.06% pass rate). 4.034831316s avg, 4.324045412s     
  max, 3.142178898s min                    
```

We are doing an instant assertion on async stuff coming out of krt handlers. 

cc @sschepens idk if there are other places we should look for such testing bugs, also idk if this needs to be backported to 1.29 or not , did #58951 make the release ?