### PR TITLE
[release-1.28] fix: cross-network WE panic when ambient is enabled without multicluster flag

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_workloadentry_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_workloadentry_test.go
@@ -21,6 +21,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/api/label"
+	"istio.io/api/networking/v1alpha3"
+	apiv1alpha3 "istio.io/client-go/pkg/apis/networking/v1"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/constants"
@@ -474,4 +476,43 @@ func TestAmbientIndex_WorkloadEntries_DisableK8SServiceSelectWorkloadEntries(t *
 			s.assertWorkloads(t, s.addrXdsName("10.0.0.1"), workloadapi.WorkloadStatus_HEALTHY, "pod1")
 		})
 	}
+}
+
+// TestAmbientIndex_CrossNetworkWorkloadEntry verifies that a WorkloadEntry with a non-local
+// network is properly precomputed when AMBIENT_ENABLE_MULTI_NETWORK is disabled.
+// This is a regression test for https://github.com/istio/istio/issues/59321 where
+// a cross-network WE would skip precomputation, causing a nil-pointer panic in XDS.
+func TestAmbientIndex_CrossNetworkWorkloadEntry(t *testing.T) {
+	// Explicitly disable multi-network ambient; this is the default but be explicit for clarity
+	test.SetForTest(t, &features.EnableAmbientMultiNetwork, false)
+	s := newAmbientTestServer(t, testC, testNW, "")
+
+	// Create a WorkloadEntry with a network different from the local cluster network
+	s.we.CreateOrUpdate(&apiv1alpha3.WorkloadEntry{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cross-net-wle",
+			Namespace: testNS,
+			Labels:    map[string]string{"app": "cross-net"},
+		},
+		Spec: v1alpha3.WorkloadEntry{
+			Address:        "10.10.10.1",
+			ServiceAccount: "sa-cross",
+			Labels:         map[string]string{"app": "cross-net"},
+			Network:        "other-network",
+		},
+	})
+
+	// The workload should appear and be fully functional (precomputed) despite being on a different network.
+	// Before the fix, this would panic because precomputation was skipped for cross-network WEs
+	// even when there was no coalescing path to handle them.
+	s.assertEvent(t, s.wleXdsName("cross-net-wle"))
+	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "cross-net-wle")
+
+	// Verify the workload is properly addressable (this exercises AsAddress which requires precomputation).
+	// Use the WE's network for the lookup key, not the local network.
+	addrs := s.lookup("other-network/10.10.10.1")
+	assert.Equal(t, len(addrs), 1)
+	wl := addrs[0].GetWorkload()
+	assert.Equal(t, wl.GetName(), "cross-net-wle")
+	assert.Equal(t, wl.GetNetwork(), "other-network")
 }

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
@@ -186,6 +186,7 @@ func MergedGlobalWorkloadsCollection(
 			globalNetworks.NetworkGateways,
 			globalNetworks.GatewaysByNetwork,
 			flags,
+			true, // Remote network workloads will be coalesced; safe to skip precompute
 		),
 		opts.WithName("LocalPodWorkloads")...,
 	)
@@ -210,6 +211,7 @@ func MergedGlobalWorkloadsCollection(
 			globalNetworks.NetworkGateways,
 			globalNetworks.GatewaysByNetwork,
 			flags,
+			true, // Remote network workloads will be coalesced; safe to skip precompute
 		),
 		opts.WithName("LocalWorkloadEntryWorkloads")...,
 	)
@@ -433,6 +435,7 @@ func MergedGlobalWorkloadsCollection(
 					globalNetworks.NetworkGateways,
 					globalNetworks.GatewaysByNetwork,
 					flags,
+					true, // Remote network workloads will be coalesced; safe to skip precompute
 				),
 				append(
 					opts,
@@ -480,6 +483,7 @@ func MergedGlobalWorkloadsCollection(
 					globalNetworks.NetworkGateways,
 					globalNetworks.GatewaysByNetwork,
 					flags,
+					true, // Remote network workloads will be coalesced; safe to skip precompute
 				),
 				append(
 					opts,
@@ -649,6 +653,7 @@ func workloadEntryWorkloadBuilder(
 	networkGateways krt.Collection[NetworkGateway],
 	gatewaysByNetwork krt.Index[network.ID, NetworkGateway],
 	flags FeatureFlags,
+	canSkipPrecompute bool,
 ) krt.TransformationSingle[*networkingclient.WorkloadEntry, model.WorkloadInfo] {
 	return func(ctx krt.HandlerContext, wle *networkingclient.WorkloadEntry) *model.WorkloadInfo {
 		// WLE can put labels in multiple places; normalize this
@@ -705,23 +710,17 @@ func workloadEntryWorkloadBuilder(
 		w.CanonicalName, w.CanonicalRevision = kubelabels.CanonicalService(wle.Labels, w.WorkloadName)
 
 		setTunnelProtocol(wle.Labels, wle.Annotations, w)
-		localNetwork := localNetworkGetter(ctx)
-		if network != localNetwork.String() {
-			// This is a remote workload that we'll never send directly; don't precompute
-			return &model.WorkloadInfo{
-				Workload:     w,
-				Labels:       wle.Labels,
-				Source:       kind.WorkloadEntry,
-				CreationTime: wle.CreationTimestamp.Time,
-			}
-		}
-
-		return precomputeWorkloadPtr(&model.WorkloadInfo{
+		wi := &model.WorkloadInfo{
 			Workload:     w,
 			Labels:       wle.Labels,
 			Source:       kind.WorkloadEntry,
 			CreationTime: wle.CreationTimestamp.Time,
-		})
+		}
+		if canSkipPrecompute && network != localNetworkGetter(ctx).String() {
+			// Remote network workload that will be coalesced into a split-horizon workload; skip precompute
+			return wi
+		}
+		return precomputeWorkloadPtr(wi)
 	}
 }
 
@@ -753,6 +752,7 @@ func (a *index) workloadEntryWorkloadBuilder(
 		a.networks.NetworkGateways,
 		a.networks.GatewaysByNetwork,
 		a.Flags,
+		false, // No coalesced path; always precompute
 	)
 }
 
@@ -798,6 +798,7 @@ func podWorkloadBuilder(
 	networkGateways krt.Collection[NetworkGateway],
 	gatewaysByNetwork krt.Index[network.ID, NetworkGateway],
 	flags FeatureFlags,
+	canSkipPrecompute bool,
 ) krt.TransformationSingle[*v1.Pod, model.WorkloadInfo] {
 	return func(ctx krt.HandlerContext, p *v1.Pod) *model.WorkloadInfo {
 		// Pod Is Pending but have a pod IP should be a valid workload, we should build it ,
@@ -875,22 +876,17 @@ func podWorkloadBuilder(
 		w.CanonicalName, w.CanonicalRevision = kubelabels.CanonicalService(p.Labels, w.WorkloadName)
 
 		setTunnelProtocol(p.Labels, p.Annotations, w)
-		localNetwork := localNetworkGetter(ctx)
-		if network != localNetwork.String() {
-			// This is a remote workload that we'll never send directly; don't precompute
-			return &model.WorkloadInfo{
-				Workload:     w,
-				Labels:       p.Labels,
-				Source:       kind.Pod,
-				CreationTime: p.CreationTimestamp.Time,
-			}
-		}
-		return precomputeWorkloadPtr(&model.WorkloadInfo{
+		wi := &model.WorkloadInfo{
 			Workload:     w,
 			Labels:       p.Labels,
 			Source:       kind.Pod,
 			CreationTime: p.CreationTimestamp.Time,
-		})
+		}
+		if canSkipPrecompute && network != localNetworkGetter(ctx).String() {
+			// Remote network workload that will be coalesced into a split-horizon workload; skip precompute
+			return wi
+		}
+		return precomputeWorkloadPtr(wi)
 	}
 }
 
@@ -929,6 +925,7 @@ func (a *index) podWorkloadBuilder(
 		a.networks.NetworkGateways,
 		a.networks.GatewaysByNetwork,
 		a.Flags,
+		false, // No coalesced path; always precompute
 	)
 }
 

--- a/releasenotes/notes/59321.yaml
+++ b/releasenotes/notes/59321.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+
+kind: bug-fix
+
+area: traffic-management
+
+releaseNotes:
+- |
+  **Fixed** istiod crashing when `PILOT_ENABLE_AMBIENT=true`, but not
+  `AMBIENT_ENABLE_MULTI_NETWORK` is set and a WorkloadEntry resource exists
+  with a different network than the local cluster.


### PR DESCRIPTION
manual cherry-pick of #59321 