### PR TITLE
Update skipped tests in Gateway API conformance test

### DIFF
--- a/tests/integration/ambient/gateway_conformance_test.go
+++ b/tests/integration/ambient/gateway_conformance_test.go
@@ -70,7 +70,6 @@ var skippedTests = map[string]string{
 	"BackendTLSPolicyConflictResolution": "https://github.com/istio/istio/issues/57817",
 
 	// The following tests were added in v1.5.0
-	"GatewayTLSBackendClientCertificate":                         "TODO",
 	"GatewayFrontendInvalidDefaultClientCertificateValidation":   "TODO",
 	"GatewayInvalidTLSBackendConfiguration":                      "TODO",
 	"GatewayTLSBackendClientCertificate":                         "TODO",

--- a/tests/integration/ambient/gateway_conformance_test.go
+++ b/tests/integration/ambient/gateway_conformance_test.go
@@ -70,7 +70,7 @@ var skippedTests = map[string]string{
 	"BackendTLSPolicyConflictResolution": "https://github.com/istio/istio/issues/57817",
 
 	// The following tests were added in v1.5.0
-	"GatewayBackendClientCertificateFeature":                     "TODO",
+	"GatewayTLSBackendClientCertificate":                         "TODO",
 	"GatewayFrontendInvalidDefaultClientCertificateValidation":   "TODO",
 	"GatewayInvalidTLSBackendConfiguration":                      "TODO",
 	"GatewayTLSBackendClientCertificate":                         "TODO",


### PR DESCRIPTION
**Please provide a description of this PR:**

The name of this test changed in upstream Gateway API, see https://github.com/kubernetes-sigs/gateway-api/pull/4619#discussion_r2872124734.

Should not be backported unless an existing minor version updates to a newer (as of yet unreleased) Gateway API version.