### PR TITLE
fix: istio-init iptables-restore fails in gVisor pods — regression

### DIFF
--- a/tools/istio-iptables/pkg/capture/run.go
+++ b/tools/istio-iptables/pkg/capture/run.go
@@ -281,9 +281,27 @@ func (cfg *IptablesConfigurator) Run() error {
 
 	// Apply port based exclusions. Must be applied before connections back to self are redirected.
 	if cfg.cfg.OutboundPortsExclude != "" {
-		for _, port := range config.Split(cfg.cfg.OutboundPortsExclude) {
-			cfg.ruleBuilder.AppendRule(constants.ISTIOOUTPUT, "nat", "-p", "tcp", "--dport", port, "-j", "RETURN")
-			cfg.ruleBuilder.AppendRule(constants.ISTIOOUTPUT, "nat", "-p", "udp", "--dport", port, "-j", "RETURN")
+		ports := config.Split(cfg.cfg.OutboundPortsExclude)
+		
+		// Use multiport optimization to reduce the number of rules
+		// This helps with gVisor compatibility by reducing the total rule count
+		const maxPortsPerRule = 15 // iptables multiport limit
+		
+		for i := 0; i < len(ports); i += maxPortsPerRule {
+			end := i + maxPortsPerRule
+			if end > len(ports) {
+				end = len(ports)
+			}
+			
+			portList := strings.Join(ports[i:end], ",")
+			
+			// TCP exclusion with multiport
+			cfg.ruleBuilder.AppendRule(constants.ISTIOOUTPUT, "nat", 
+				"-p", "tcp", "-m", "multiport", "--dports", portList, "-j", "RETURN")
+			
+			// UDP exclusion with multiport
+			cfg.ruleBuilder.AppendRule(constants.ISTIOOUTPUT, "nat",
+				"-p", "udp", "-m", "multiport", "--dports", portList, "-j", "RETURN")
 		}
 	}
 


### PR DESCRIPTION
Fixes #59353

## Description
This PR addresses the iptables-restore failures in gVisor pods by optimizing the number of iptables rules generated.

## Changes
- Use multiport iptables module to batch multiple port exclusions into single rules
- Reduces the total number of rules by up to 15x when many ports are excluded
- This helps with gVisor compatibility which has stricter limits on iptables rules

## Testing
- Tested with multiple port exclusions to verify rule batching works correctly
- Maintains the same functionality while reducing rule count