### PR TITLE
fix: flaky unit tests for sidecar dfp

### DIFF
--- a/pilot/pkg/networking/core/fake.go
+++ b/pilot/pkg/networking/core/fake.go
@@ -226,12 +226,14 @@ func (f *ConfigGenTest) Run() {
 		}
 	}
 
-	go f.Registry.Run(f.stop)
+	// Start store first and wait for it to sync at least once before registry starts
 	go f.store.Run(f.stop)
 
 	// TODO allow passing event handlers for controller
 
 	retry.UntilOrFail(f.t, f.store.HasSynced, retry.Delay(time.Millisecond))
+
+	go f.Registry.Run(f.stop)
 	retry.UntilOrFail(f.t, f.Registry.HasSynced, retry.Delay(time.Millisecond))
 
 	f.ServiceEntryRegistry.ResyncEDS()

--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -19,6 +19,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 
+	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
@@ -501,6 +502,21 @@ func (s *Controller) HasSynced() bool {
 			!s.outputs.ServiceInstances.HasSynced() ||
 			!s.outputs.ServiceInstancesByNamespaceHost.HasSynced() {
 			return false
+		}
+		// KRT can report output synced after a first run with empty input (event ordering).
+		// Don't report synced until every ServiceEntry host has a corresponding service in the output.
+		if s.inputs.ServiceEntries.HasSynced() {
+			for _, cfg := range s.inputs.ServiceEntries.List() {
+				se, ok := cfg.Spec.(*networking.ServiceEntry)
+				if !ok {
+					continue
+				}
+				for _, h := range se.Hosts {
+					if len(s.outputs.ServicesByHost.Lookup(h)) == 0 {
+						return false
+					}
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
**Please provide a description of this PR:**
Observed test flakiness: https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/59330/unit-tests_istio/2031466035986567168

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
