### PR TITLE
krt: fix static collection register syncing

### DIFF
--- a/pkg/kube/krt/static.go
+++ b/pkg/kube/krt/static.go
@@ -330,8 +330,7 @@ func (s *staticList[T]) WaitUntilSynced(stop <-chan struct{}) bool {
 }
 
 func (s *staticList[T]) Synced() Syncer {
-	// We are always synced in the static collection since the initial state must be provided upfront
-	return alwaysSynced{}
+	return s.syncer
 }
 
 func (s *staticList[T]) RegisterBatch(f func(o []Event[T]), runExistingState bool) HandlerRegistration {


### PR DESCRIPTION
**Please provide a description of this PR:**
follow up of #59385 

`Synced()` ends up being [passed into](https://github.com/istio/istio/blob/master/pkg/kube/krt/static.go#L349) `eventHandlers` in `RegisterBatch`

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
