### PR TITLE
[WIP] fix: waypoint proxies should respect COMPLIANCE_POLICY

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
@@ -186,6 +186,10 @@ spec:
             resourceFieldRef:
               resource: limits.cpu
               divisor: "1"
+        {{- if .CompliancePolicy }}
+        - name: COMPLIANCE_POLICY
+          value: "{{ .CompliancePolicy }}"
+        {{- end }}
         - name: ISTIO_META_CLUSTER_ID
           value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
         {{- $network := valueOrDefault (index .InfrastructureLabels `topology.istio.io/network`) .Values.global.network }}

--- a/pilot/pkg/networking/core/listener_waypoint.go
+++ b/pilot/pkg/networking/core/listener_waypoint.go
@@ -50,6 +50,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/plugin/authz"
 	"istio.io/istio/pilot/pkg/networking/telemetry"
 	"istio.io/istio/pilot/pkg/networking/util"
+	authnutils "istio.io/istio/pilot/pkg/security/authn/utils"
 	security "istio.io/istio/pilot/pkg/security/model"
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
@@ -1258,6 +1259,9 @@ func buildCommonConnectTLSContext(proxy *model.Proxy, push *model.PushContext) *
 		// Ensure TLS 1.3 is used everywhere
 		TlsMaximumProtocolVersion: tls.TlsParameters_TLSv1_3,
 		TlsMinimumProtocolVersion: tls.TlsParameters_TLSv1_3,
+		// Cipher suites must be set for compatibility when FIPS compliance enforcement
+		// downgrades the connection to TLS 1.2.
+		CipherSuites: authnutils.SupportedCiphers,
 	}
 	// Compliance for Envoy tunnel TLS contexts.
 	security.EnforceCompliance(ctx)


### PR DESCRIPTION
**Please provide a description of this PR:**
Apply COMPLIANCE_POLICY properly to waypoint proxies. One example where this is required is when using ZTunnel's TLSv1.2 support (as per https://github.com/istio/ztunnel/pull/1711). It will also be needed for PQC support in waypoint proxies.