### PR TITLE
limit decompressed size in wasm gzip fetch path

### DIFF
--- a/pkg/wasm/httpfetcher.go
+++ b/pkg/wasm/httpfetcher.go
@@ -173,7 +173,7 @@ func getFileFromGZ(b []byte) []byte {
 		return nil
 	}
 
-	ret, err := io.ReadAll(zr)
+	ret, err := io.ReadAll(io.LimitReader(zr, features.MaxWasmBinarySizeBytes))
 	if err != nil {
 		return nil
 	}

--- a/releasenotes/notes/wasm-gzip-decompression-limit.yaml
+++ b/releasenotes/notes/wasm-gzip-decompression-limit.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: extensibility
+issue: []
+releaseNotes:
+  - |
+    **Fixed** missing size limit on gzip-decompressed WASM binaries fetched over HTTP, consistent with
+    the limits already applied to other fetch paths.


### PR DESCRIPTION
`getFileFromGZ` was missing the `io.LimitReader` size cap that all sibling functions already apply. Without it a small gzipped payload can decompress to arbitrary size and OOM istiod.