### PR TITLE
test: fix index out of range error in ingressImpl.callEcho

### DIFF
--- a/pkg/test/framework/components/istio/ingress.go
+++ b/pkg/test/framework/components/istio/ingress.go
@@ -256,8 +256,8 @@ func (c *ingressImpl) callEcho(opts echo.CallOptions) (echo.CallResult, error) {
 	} else {
 		addrs, ports = c.AddressesForPort(opts.Port.ServicePort)
 	}
-	if addrs == nil || ports == nil {
-		scopes.Framework.Warnf("failed to get host and port for %s/%d", opts.Port.Protocol, opts.Port.ServicePort)
+	if len(addrs) == 0 || len(ports) == 0 {
+		return echo.CallResult{}, fmt.Errorf("ingress: failed to get host and port for %s/%d", opts.Port.Protocol, opts.Port.ServicePort)
 	}
 	addr = addrs[0]
 	port = ports[0]


### PR DESCRIPTION
`addrs` and `ports` could be empty, and then accessing `addrs[0]` results in:
```
panic: runtime error: index out of range [0] with length 0 [recovered, repanicked]
```