### PR TITLE
dependabot: ignore updates we don't want to update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,10 @@ updates:
     labels:
       - "release-notes-none"
     target-branch: "release-1.29"
+    # Only allow security updates on release branches
+    allow:
+      - dependency-type: "all"
+        update-type: "security"
     # We have to do some ignores here as the dependencies for these are meant to be locked to a minor version
     # and/or are updated through automation.
     ignore:
@@ -51,6 +55,10 @@ updates:
     labels:
       - "release-notes-none"
     target-branch: "release-1.28"
+    # Only allow security updates on release branches
+    allow:
+      - dependency-type: "all"
+        update-type: "security"
     # We have to do some ignores here as the dependencies for these are meant to be locked to a minor version
     # and/or are updated through automation.
     ignore:
@@ -72,6 +80,10 @@ updates:
     labels:
       - "release-notes-none"
     target-branch: "release-1.27"
+    # Only allow security updates on release branches
+    allow:
+      - dependency-type: "all"
+        update-type: "security"
     # We have to do some ignores here as the dependencies for these are meant to be locked to a minor version
     # and/or are updated through automation.
     ignore:


### PR DESCRIPTION
**Please provide a description of this PR:**

Dependabot is opening PRs for samples, likely because they are security advisories. But since we do not care about samples as they are not for production, and they are very manual in their process, we need to more explicitly ignore even the security advisory bumps.

We also need to add some ignores for things bumped through automation, or where we need to stay locked to a minor version.