### PR TITLE
tests: refactor ambient test suite setup

### DIFF
--- a/tests/integration/ambient/main_test.go
+++ b/tests/integration/ambient/main_test.go
@@ -18,7 +18,6 @@ package ambient
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -74,11 +73,6 @@ values:
     podLabels:
       networking.istio.io/tunnel: "http"
 `
-
-	nativeNftablesValues = `
-  global:
-    nativeNftables: true
-`
 )
 
 type EchoDeployments struct {
@@ -133,7 +127,7 @@ func TestMain(m *testing.M) {
 
 			if ctx.Settings().NativeNftables {
 				scopes.Framework.Infof("Running the integration tests with nativeNftables enabled")
-				cfg.ControlPlaneValues = strings.TrimRight(ambientControlPlaneValues, "\n") + nativeNftablesValues
+				cfg.Values["global.nativeNftables"] = "true"
 			}
 
 			if ctx.Settings().AmbientMultiNetwork {


### PR DESCRIPTION
**Please provide a description of this PR:**

Instead of duplicating all helm values for multi-cluster setup, we can easily append only the necessary ones to the base config. Additionally, with the previous approach, we would need an additional condition to enable native nftables in multi-cluster topology.