### PR TITLE
add read header and idle timeouts to webhook https server

### DIFF
--- a/pilot/pkg/bootstrap/webhook.go
+++ b/pilot/pkg/bootstrap/webhook.go
@@ -19,6 +19,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"time"
 
 	sec_model "istio.io/istio/pilot/pkg/security/model"
 	istiolog "istio.io/istio/pkg/log"
@@ -66,10 +67,12 @@ func (s *Server) initSecureWebhookServer(args *PilotArgs) {
 	// create the https server for hosting the k8s injectionWebhook handlers.
 	s.httpsMux = http.NewServeMux()
 	s.httpsServer = &http.Server{
-		Addr:      args.ServerOptions.HTTPSAddr,
-		ErrorLog:  log.New(&httpServerErrorLogWriter{}, "", 0),
-		Handler:   s.httpsMux,
-		TLSConfig: tlsConfig,
+		Addr:              args.ServerOptions.HTTPSAddr,
+		ErrorLog:          log.New(&httpServerErrorLogWriter{}, "", 0),
+		Handler:           s.httpsMux,
+		TLSConfig:         tlsConfig,
+		ReadHeaderTimeout: 30 * time.Second,
+		IdleTimeout:       90 * time.Second,
 	}
 
 	// register istiodReadyHandler on the httpsMux so that readiness can also be checked remotely

--- a/releasenotes/notes/webhook-https-timeouts.yaml
+++ b/releasenotes/notes/webhook-https-timeouts.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+releaseNotes:
+- |
+  **Fixed** missing `ReadHeaderTimeout` and `IdleTimeout` on the istiod webhook HTTPS server (port 15017),
+  aligning it with the existing timeouts on the HTTP server (port 8080).


### PR DESCRIPTION
httpsServer on port 15017 was missing ReadHeaderTimeout and IdleTimeout, unlike every other http.Server in the codebase.