### PR TITLE
[release-1.28] Manual cherry-pick wasm gzip fetch path

### DIFF
--- a/pkg/wasm/httpfetcher.go
+++ b/pkg/wasm/httpfetcher.go
@@ -175,7 +175,8 @@ func getFileFromGZ(b []byte) []byte {
 		return nil
 	}
 
-	ret, err := io.ReadAll(zr)
+	// Limit wasm module to 256mb; in reality it must be much smaller
+	ret, err := io.ReadAll(io.LimitReader(zr, 1024*1024*256))
 	if err != nil {
 		return nil
 	}

--- a/releasenotes/notes/wasm-gzip-decompression-limit.yaml
+++ b/releasenotes/notes/wasm-gzip-decompression-limit.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: extensibility
+issue: []
+releaseNotes:
+  - |
+    **Fixed** missing size limit on gzip-decompressed WASM binaries fetched over HTTP, consistent with
+    the limits already applied to other fetch paths.


### PR DESCRIPTION
Manual cherry-pick of #59395 to release-1.28. Replaces #59465