### PR TITLE
rework how service namespaces for sidecar are chosen

### DIFF
--- a/manifests/charts/base/files/profile-compatibility-version-1.25.yaml
+++ b/manifests/charts/base/files/profile-compatibility-version-1.25.yaml
@@ -11,6 +11,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
      # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/base/files/profile-compatibility-version-1.26.yaml
+++ b/manifests/charts/base/files/profile-compatibility-version-1.26.yaml
@@ -11,6 +11,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/base/files/profile-compatibility-version-1.27.yaml
+++ b/manifests/charts/base/files/profile-compatibility-version-1.27.yaml
@@ -9,6 +9,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/base/files/profile-compatibility-version-1.29.yaml
+++ b/manifests/charts/base/files/profile-compatibility-version-1.29.yaml
@@ -4,12 +4,5 @@
 
 pilot:
   env:
-    # 1.29 behavioral changes
-    DISABLE_TRACK_REMAINING_CB_METRICS: "false"
     # 1.30 behavioral changes
     PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
-
-cni:
-  ambient:
-    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.28
-    reconcileIptablesOnStartup: false

--- a/manifests/charts/default/files/profile-compatibility-version-1.25.yaml
+++ b/manifests/charts/default/files/profile-compatibility-version-1.25.yaml
@@ -11,6 +11,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
      # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/default/files/profile-compatibility-version-1.26.yaml
+++ b/manifests/charts/default/files/profile-compatibility-version-1.26.yaml
@@ -11,6 +11,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/default/files/profile-compatibility-version-1.27.yaml
+++ b/manifests/charts/default/files/profile-compatibility-version-1.27.yaml
@@ -9,6 +9,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/default/files/profile-compatibility-version-1.28.yaml
+++ b/manifests/charts/default/files/profile-compatibility-version-1.28.yaml
@@ -6,6 +6,8 @@ pilot:
   env:
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/default/files/profile-compatibility-version-1.29.yaml
+++ b/manifests/charts/default/files/profile-compatibility-version-1.29.yaml
@@ -4,12 +4,5 @@
 
 pilot:
   env:
-    # 1.29 behavioral changes
-    DISABLE_TRACK_REMAINING_CB_METRICS: "false"
     # 1.30 behavioral changes
     PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
-
-cni:
-  ambient:
-    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.28
-    reconcileIptablesOnStartup: false

--- a/manifests/charts/gateway/files/profile-compatibility-version-1.25.yaml
+++ b/manifests/charts/gateway/files/profile-compatibility-version-1.25.yaml
@@ -11,6 +11,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
      # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/gateway/files/profile-compatibility-version-1.26.yaml
+++ b/manifests/charts/gateway/files/profile-compatibility-version-1.26.yaml
@@ -11,6 +11,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/gateway/files/profile-compatibility-version-1.27.yaml
+++ b/manifests/charts/gateway/files/profile-compatibility-version-1.27.yaml
@@ -9,6 +9,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/gateway/files/profile-compatibility-version-1.28.yaml
+++ b/manifests/charts/gateway/files/profile-compatibility-version-1.28.yaml
@@ -6,6 +6,8 @@ pilot:
   env:
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/gateway/files/profile-compatibility-version-1.29.yaml
+++ b/manifests/charts/gateway/files/profile-compatibility-version-1.29.yaml
@@ -4,12 +4,5 @@
 
 pilot:
   env:
-    # 1.29 behavioral changes
-    DISABLE_TRACK_REMAINING_CB_METRICS: "false"
     # 1.30 behavioral changes
     PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
-
-cni:
-  ambient:
-    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.28
-    reconcileIptablesOnStartup: false

--- a/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.25.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.25.yaml
@@ -11,6 +11,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
      # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.26.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.26.yaml
@@ -11,6 +11,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.27.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.27.yaml
@@ -9,6 +9,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.28.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.28.yaml
@@ -6,6 +6,8 @@ pilot:
   env:
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.29.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.29.yaml
@@ -4,12 +4,5 @@
 
 pilot:
   env:
-    # 1.29 behavioral changes
-    DISABLE_TRACK_REMAINING_CB_METRICS: "false"
     # 1.30 behavioral changes
     PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
-
-cni:
-  ambient:
-    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.28
-    reconcileIptablesOnStartup: false

--- a/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.25.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.25.yaml
@@ -11,6 +11,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
      # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.26.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.26.yaml
@@ -11,6 +11,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.27.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.27.yaml
@@ -9,6 +9,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.28.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.28.yaml
@@ -6,6 +6,8 @@ pilot:
   env:
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.29.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.29.yaml
@@ -4,12 +4,5 @@
 
 pilot:
   env:
-    # 1.29 behavioral changes
-    DISABLE_TRACK_REMAINING_CB_METRICS: "false"
     # 1.30 behavioral changes
     PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
-
-cni:
-  ambient:
-    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.28
-    reconcileIptablesOnStartup: false

--- a/manifests/charts/istio-cni/files/profile-compatibility-version-1.25.yaml
+++ b/manifests/charts/istio-cni/files/profile-compatibility-version-1.25.yaml
@@ -11,6 +11,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
      # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/istio-cni/files/profile-compatibility-version-1.26.yaml
+++ b/manifests/charts/istio-cni/files/profile-compatibility-version-1.26.yaml
@@ -11,6 +11,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/istio-cni/files/profile-compatibility-version-1.27.yaml
+++ b/manifests/charts/istio-cni/files/profile-compatibility-version-1.27.yaml
@@ -9,6 +9,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/istio-cni/files/profile-compatibility-version-1.28.yaml
+++ b/manifests/charts/istio-cni/files/profile-compatibility-version-1.28.yaml
@@ -6,6 +6,8 @@ pilot:
   env:
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/istio-cni/files/profile-compatibility-version-1.29.yaml
+++ b/manifests/charts/istio-cni/files/profile-compatibility-version-1.29.yaml
@@ -4,12 +4,5 @@
 
 pilot:
   env:
-    # 1.29 behavioral changes
-    DISABLE_TRACK_REMAINING_CB_METRICS: "false"
     # 1.30 behavioral changes
     PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
-
-cni:
-  ambient:
-    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.28
-    reconcileIptablesOnStartup: false

--- a/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.25.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.25.yaml
@@ -11,6 +11,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
      # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.26.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.26.yaml
@@ -11,6 +11,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.27.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.27.yaml
@@ -9,6 +9,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.28.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.28.yaml
@@ -6,6 +6,8 @@ pilot:
   env:
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.29.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.29.yaml
@@ -4,12 +4,5 @@
 
 pilot:
   env:
-    # 1.29 behavioral changes
-    DISABLE_TRACK_REMAINING_CB_METRICS: "false"
     # 1.30 behavioral changes
     PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
-
-cni:
-  ambient:
-    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.28
-    reconcileIptablesOnStartup: false

--- a/manifests/charts/ztunnel/files/profile-compatibility-version-1.25.yaml
+++ b/manifests/charts/ztunnel/files/profile-compatibility-version-1.25.yaml
@@ -11,6 +11,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
      # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/ztunnel/files/profile-compatibility-version-1.26.yaml
+++ b/manifests/charts/ztunnel/files/profile-compatibility-version-1.26.yaml
@@ -11,6 +11,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/ztunnel/files/profile-compatibility-version-1.27.yaml
+++ b/manifests/charts/ztunnel/files/profile-compatibility-version-1.27.yaml
@@ -9,6 +9,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/ztunnel/files/profile-compatibility-version-1.28.yaml
+++ b/manifests/charts/ztunnel/files/profile-compatibility-version-1.28.yaml
@@ -6,6 +6,8 @@ pilot:
   env:
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/charts/ztunnel/files/profile-compatibility-version-1.29.yaml
+++ b/manifests/charts/ztunnel/files/profile-compatibility-version-1.29.yaml
@@ -4,12 +4,5 @@
 
 pilot:
   env:
-    # 1.29 behavioral changes
-    DISABLE_TRACK_REMAINING_CB_METRICS: "false"
     # 1.30 behavioral changes
     PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
-
-cni:
-  ambient:
-    # 1.29 behavioral changes - reconcileIptablesOnStartup was false by default in 1.28
-    reconcileIptablesOnStartup: false

--- a/manifests/helm-profiles/compatibility-version-1.25.yaml
+++ b/manifests/helm-profiles/compatibility-version-1.25.yaml
@@ -7,6 +7,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
      # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/helm-profiles/compatibility-version-1.26.yaml
+++ b/manifests/helm-profiles/compatibility-version-1.26.yaml
@@ -7,6 +7,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/helm-profiles/compatibility-version-1.27.yaml
+++ b/manifests/helm-profiles/compatibility-version-1.27.yaml
@@ -5,6 +5,8 @@ pilot:
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/helm-profiles/compatibility-version-1.28.yaml
+++ b/manifests/helm-profiles/compatibility-version-1.28.yaml
@@ -2,6 +2,8 @@ pilot:
   env:
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
 
 cni:
   ambient:

--- a/manifests/helm-profiles/compatibility-version-1.29.yaml
+++ b/manifests/helm-profiles/compatibility-version-1.29.yaml
@@ -1,0 +1,4 @@
+pilot:
+  env:
+    # 1.30 behavioral changes
+    PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -380,6 +380,13 @@ var (
 		1024*1024*256,
 		"Maximum size of a Wasm binary in bytes. Default is 256MB.",
 	).Get()
+
+	SidecarPickBestServiceNamespace = env.Register(
+		"PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE",
+		true,
+		"If enabled, when a sidecar needs to pick a service namespace for a hostname, it will prefer Kubernetes services "+
+			"and fall back to the oldest non-Kubernetes service. When disabled, the first visible namespace alphabetically is used.",
+	).Get()
 )
 
 // UnsafeFeaturesEnabled returns true if any unsafe features are enabled.

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	"encoding/json"
+	"sort"
 	"strings"
 	"sync"
 
@@ -396,7 +397,11 @@ func (sc *SidecarScope) collectImportedServices(ps *PushContext, configNamespace
 						continue
 					}
 					// This won't overwrite hostnames that have already been found eg because they were requested in hosts
-					if ns := pickBestVisibleNamespace(ps, byNamespace, configNamespace); ns != "" {
+					pickNamespace := pickFirstVisibleNamespace
+					if features.SidecarPickBestServiceNamespace {
+						pickNamespace = pickBestVisibleNamespace
+					}
+					if ns := pickNamespace(ps, byNamespace, configNamespace); ns != "" {
 						if matchedSvc := serviceMatchingPort(byNamespace[ns], ilw, ports); matchedSvc != nil {
 							sc.appendSidecarServices(servicesAdded, matchedSvc)
 						}
@@ -1035,6 +1040,23 @@ func canMergeServices(s1, s2 *Service) bool {
 	}
 
 	return true
+}
+
+// Pick the Service namespace visible to the configNamespace namespace.
+// If it does not exist, return an empty string,
+// If there are more than one, pick the first alphabetically.
+func pickFirstVisibleNamespace(ps *PushContext, byNamespace map[string]*Service, configNamespace string) string {
+	nss := make([]string, 0, len(byNamespace))
+	for ns := range byNamespace {
+		if ps.IsServiceVisible(byNamespace[ns], configNamespace) {
+			nss = append(nss, ns)
+		}
+	}
+	if len(nss) > 0 {
+		sort.Strings(nss)
+		return nss[0]
+	}
+	return ""
 }
 
 // Pick the best Service namespace visible to the configNamespace namespace.

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -16,7 +16,6 @@ package model
 
 import (
 	"encoding/json"
-	"sort"
 	"strings"
 	"sync"
 
@@ -397,7 +396,7 @@ func (sc *SidecarScope) collectImportedServices(ps *PushContext, configNamespace
 						continue
 					}
 					// This won't overwrite hostnames that have already been found eg because they were requested in hosts
-					if ns := pickFirstVisibleNamespace(ps, byNamespace, configNamespace); ns != "" {
+					if ns := pickBestVisibleNamespace(ps, byNamespace, configNamespace); ns != "" {
 						if matchedSvc := serviceMatchingPort(byNamespace[ns], ilw, ports); matchedSvc != nil {
 							sc.appendSidecarServices(servicesAdded, matchedSvc)
 						}
@@ -1038,19 +1037,29 @@ func canMergeServices(s1, s2 *Service) bool {
 	return true
 }
 
-// Pick the Service namespace visible to the configNamespace namespace.
-// If it does not exist, return an empty string,
-// If there are more than one, pick the first alphabetically.
-func pickFirstVisibleNamespace(ps *PushContext, byNamespace map[string]*Service, configNamespace string) string {
-	nss := make([]string, 0, len(byNamespace))
-	for ns := range byNamespace {
-		if ps.IsServiceVisible(byNamespace[ns], configNamespace) {
-			nss = append(nss, ns)
+// Pick the best Service namespace visible to the configNamespace namespace.
+// If it does not exist, return an empty string.
+// Best is defined as:
+// 1. contains a Kubernetes service and is visible to configNamespace
+// 2. contains the oldest non-Kubernetes service which is visible to configNamespace
+// This does not consider whether a svc is in the configNamespace,
+// the calling logic has already attempted a direct lookup of byNamespace[configNamespace]
+func pickBestVisibleNamespace(ps *PushContext, byNamespace map[string]*Service, configNamespace string) string {
+	var currentBestService *Service
+	for _, svc := range byNamespace {
+		if ps.IsServiceVisible(svc, configNamespace) {
+			// if we have a visible kube service, use it
+			if svc.Attributes.ServiceRegistry == provider.Kubernetes {
+				return svc.NamespacedName().Namespace
+			}
+			// if this is the first visible service, or it's older than our current best, then it is the new best that we have seen
+			if currentBestService == nil || svc.CreationTime.Before(currentBestService.CreationTime) {
+				currentBestService = svc
+			}
 		}
 	}
-	if len(nss) > 0 {
-		sort.Strings(nss)
-		return nss[0]
+	if currentBestService != nil {
+		return currentBestService.NamespacedName().Namespace
 	}
 	return ""
 }

--- a/releasenotes/notes/sidecar-pick-best-service-namespace.yaml
+++ b/releasenotes/notes/sidecar-pick-best-service-namespace.yaml
@@ -1,0 +1,22 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue: []
+releaseNotes:
+  - |
+    **Improved** sidecar proxy service namespace selection. When configuring sidecar proxies if a hostname exists
+    in multiple namespaces, Istio now prefers Kubernetes services and falls back to the oldest non-Kubernetes
+    service (e.g. `ServiceEntry`) by creation time. Previously, the first visible namespace alphabetically was
+    chosen. 
+upgradeNotes:
+  - title: Sidecar proxy service namespace selection changed
+    content: |
+      When configuring sidecar proxies if a hostname exists in multiple namespaces, Istio now prefers Kubernetes
+      services and falls back to the oldest non-Kubernetes service by creation time. Previously, the first visible
+      namespace alphabetically was chosen.
+
+      This may cause traffic to route to a different service instance if you have the same hostname across multiple
+      namespaces with mixed service types (e.g. a Kubernetes service and a `ServiceEntry`).
+
+      If this is not desired, set the `PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE` environment variable to `false`
+      in Istiod, or use `compatibilityVersion` 1.28 or earlier to restore the previous behavior.


### PR DESCRIPTION
**Please provide a description of this PR:**

Replaces #58879 which I let go stale :pensive:

Context about where the older PR was left. @keithmattix and @ramaraochavali had expressed concerns that this may break users who had become dependent on the alphabetical sorting. A feature gate has been added to address this (default to true for 1.30, compatibility profiles for older releases setting it to false).