### PR TITLE
Make node-untaint controller respect configurable taint name (PILOT_NODE_UNTAINT_CONTROLLERS_TAINT_NAME) — Fixes #57844

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -195,6 +195,8 @@ spec:
 {{- if .Values.taint.enabled }}
           - name: PILOT_ENABLE_NODE_UNTAINT_CONTROLLERS
             value: "true"
+          - name: PILOT_NODE_UNTAINT_CONTROLLERS_TAINT_NAME
+            value: {{ .Values.taint.name }}
 {{- end }}
 # If externalIstiod is set via Values.Global, then enable the pilot env variable. However, if it's set via Values.pilot.env, then
 # don't set it here to avoid duplication.

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -196,7 +196,7 @@ spec:
           - name: PILOT_ENABLE_NODE_UNTAINT_CONTROLLERS
             value: "true"
           - name: PILOT_NODE_UNTAINT_CONTROLLERS_TAINT_NAME
-            value: {{ .Values.taint.name }}
+            value: "{{ .Values.taint.name }}"
 {{- end }}
 # If externalIstiod is set via Values.Global, then enable the pilot env variable. However, if it's set via Values.pilot.env, then
 # don't set it here to avoid duplication.

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -47,6 +47,8 @@ _internal_defaults_do_not_set:
     enabled: false
     # What namespace the untaint controller should watch for istio-cni pods. This is only required when istio-cni is running in a different namespace than istiod
     namespace: ""
+    # The taint key used by the node-untaint controller to identify nodes that should be untainted.
+    name: cni.istio.io/not-ready
 
   affinity: {}
 

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -39,7 +39,7 @@ _internal_defaults_do_not_set:
   envVarFrom: []
 
   # Settings related to the untaint controller
-  # This controller will remove `cni.istio.io/not-ready` from nodes when the istio-cni pod becomes ready
+  # This controller will remove the named taint (default `cni.istio.io/not-ready`) from nodes when the istio-cni pod becomes ready.
   # It should be noted that cluster operator/owner is responsible for having the taint set by their infrastructure provider when new nodes are added to the cluster; the untaint controller does not taint nodes
   taint:
     # Controls whether or not the untaint controller is active

--- a/operator/pkg/apis/values_types.pb.go
+++ b/operator/pkg/apis/values_types.pb.go
@@ -3453,7 +3453,11 @@ type PilotTaintControllerConfig struct {
 	// added to the cluster. This is usually done by configuring the cluster infra provider.
 	Enabled bool `protobuf:"varint,1,opt,name=enabled,proto3" json:"enabled,omitempty"`
 	// The namespace of the CNI daemonset, incase it's not the same as istiod.
-	Namespace     string `protobuf:"bytes,2,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	Namespace string `protobuf:"bytes,2,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	// The taint key used by the node-untaint controller to identify nodes that should be untainted.
+	// This corresponds to the Helm chart value `values.pilot.taint.name` and the
+	// environment variable `PILOT_NODE_UNTAINT_CONTROLLERS_TAINT_NAME` used by istiod.
+	Name          string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3498,6 +3502,13 @@ func (x *PilotTaintControllerConfig) GetEnabled() bool {
 func (x *PilotTaintControllerConfig) GetNamespace() string {
 	if x != nil {
 		return x.Namespace
+	}
+	return ""
+}
+
+func (x *PilotTaintControllerConfig) GetName() string {
+	if x != nil {
+		return x.Name
 	}
 	return ""
 }
@@ -5852,10 +5863,11 @@ const file_pkg_apis_values_types_proto_rawDesc = "" +
 	"\n" +
 	"envVarFrom\x18> \x03(\v2\x17.google.protobuf.StructR\n" +
 	"envVarFrom\x12*\n" +
-	"\x10crlConfigMapName\x18? \x01(\tR\x10crlConfigMapName\"T\n" +
+	"\x10crlConfigMapName\x18? \x01(\tR\x10crlConfigMapName\"h\n" +
 	"\x1aPilotTaintControllerConfig\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\x12\x1c\n" +
-	"\tnamespace\x18\x02 \x01(\tR\tnamespace\"\xc6\x01\n" +
+	"\tnamespace\x18\x02 \x01(\tR\tnamespace\x12\x12\n" +
+	"\x04name\x18\x03 \x01(\tR\x04name\"\xc6\x01\n" +
 	"\x12PilotIngressConfig\x12&\n" +
 	"\x0eingressService\x18\x01 \x01(\tR\x0eingressService\x12d\n" +
 	"\x15ingressControllerMode\x18\x02 \x01(\x0e2..istio.operator.v1alpha1.ingressControllerModeR\x15ingressControllerMode\x12\"\n" +

--- a/operator/pkg/apis/values_types.proto
+++ b/operator/pkg/apis/values_types.proto
@@ -1010,6 +1010,10 @@ message PilotTaintControllerConfig {
 
   // The namespace of the CNI daemonset, incase it's not the same as istiod.
   string namespace = 2;
+  // The taint key used by the node-untaint controller to identify nodes that should be untainted.
+  // This corresponds to the Helm chart value `values.pilot.taint.name` and the
+  // environment variable `PILOT_NODE_UNTAINT_CONTROLLERS_TAINT_NAME` used by istiod.
+  string name = 3;
 }
 
 // Controls legacy k8s ingress. Only one pilot profile should enable ingress support.

--- a/pilot/pkg/controllers/untaint/nodeuntainter.go
+++ b/pilot/pkg/controllers/untaint/nodeuntainter.go
@@ -22,6 +22,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/config/labels"
 	kubelib "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
@@ -32,10 +33,6 @@ import (
 )
 
 var log = istiolog.RegisterScope("untaint", "CNI node-untaint controller")
-
-const (
-	TaintName = "cni.istio.io/not-ready"
-)
 
 var istioCniLabels = map[string]string{
 	"k8s-app": "istio-cni-node",
@@ -195,7 +192,7 @@ func removeReadinessTaint(nodesClient kclient.Client[*v1.Node], node *v1.Node) e
 func deleteTaint(taints []v1.Taint) []v1.Taint {
 	newTaints := []v1.Taint{}
 	for i := range taints {
-		if taints[i].Key == TaintName {
+		if taints[i].Key == features.NodeUntaintTaintName {
 			continue
 		}
 		newTaints = append(newTaints, taints[i])
@@ -205,7 +202,7 @@ func deleteTaint(taints []v1.Taint) []v1.Taint {
 
 func hasTaint(n *v1.Node) bool {
 	for _, taint := range n.Spec.Taints {
-		if taint.Key == TaintName {
+		if taint.Key == features.NodeUntaintTaintName {
 			return true
 		}
 	}

--- a/pilot/pkg/controllers/untaint/nodeuntainter.go
+++ b/pilot/pkg/controllers/untaint/nodeuntainter.go
@@ -44,7 +44,7 @@ type NodeUntainter struct {
 	cnilabels   labels.Instance
 	ourNs       string
 	queue       controllers.Queue
-	taintName    string
+	taintName   string
 }
 
 func filterNamespace(ns string) func(any) bool {
@@ -74,7 +74,7 @@ func NewNodeUntainter(stop <-chan struct{}, kubeClient kubelib.Client, cniNs, sy
 		nodesClient: nodes,
 		cnilabels:   labels.Instance(istioCniLabels),
 		ourNs:       ns,
-		taintName:    features.NodeUntaintTaintName,
+		taintName:   features.NodeUntaintTaintName,
 	}
 	nt.setup(stop, debugger)
 	return nt

--- a/pilot/pkg/controllers/untaint/nodeuntainter.go
+++ b/pilot/pkg/controllers/untaint/nodeuntainter.go
@@ -44,7 +44,7 @@ type NodeUntainter struct {
 	cnilabels   labels.Instance
 	ourNs       string
 	queue       controllers.Queue
-	taintKey    string
+	taintName    string
 }
 
 func filterNamespace(ns string) func(any) bool {
@@ -74,7 +74,7 @@ func NewNodeUntainter(stop <-chan struct{}, kubeClient kubelib.Client, cniNs, sy
 		nodesClient: nodes,
 		cnilabels:   labels.Instance(istioCniLabels),
 		ourNs:       ns,
-		taintKey:    features.NodeUntaintTaintName,
+		taintName:    features.NodeUntaintTaintName,
 	}
 	nt.setup(stop, debugger)
 	return nt
@@ -148,15 +148,15 @@ func (n *NodeUntainter) reconcileNode(key types.NamespacedName) error {
 		return nil
 	}
 
-	err := removeReadinessTaint(n.nodesClient, node, n.taintKey)
+	err := removeReadinessTaint(n.nodesClient, node, n.taintName)
 	if err != nil {
 		log.Errorf("failed to remove readiness taint from node %v: %v", node.Name, err)
 	}
 	return err
 }
 
-func removeReadinessTaint(nodesClient kclient.Client[*v1.Node], node *v1.Node, taintKey string) error {
-	updatedTaint := deleteTaint(node.Spec.Taints, taintKey)
+func removeReadinessTaint(nodesClient kclient.Client[*v1.Node], node *v1.Node, taintName string) error {
+	updatedTaint := deleteTaint(node.Spec.Taints, taintName)
 	if len(updatedTaint) == len(node.Spec.Taints) {
 		// nothing to remove..
 		return nil
@@ -191,10 +191,10 @@ func removeReadinessTaint(nodesClient kclient.Client[*v1.Node], node *v1.Node, t
 }
 
 // deleteTaint removes all the taints that have the same key and effect to given taintToDelete.
-func deleteTaint(taints []v1.Taint, taintKey string) []v1.Taint {
+func deleteTaint(taints []v1.Taint, taintName string) []v1.Taint {
 	newTaints := []v1.Taint{}
 	for i := range taints {
-		if taints[i].Key == taintKey {
+		if taints[i].Key == taintName {
 			continue
 		}
 		newTaints = append(newTaints, taints[i])
@@ -204,7 +204,7 @@ func deleteTaint(taints []v1.Taint, taintKey string) []v1.Taint {
 
 func (n *NodeUntainter) hasTaint(node *v1.Node) bool {
 	for _, taint := range node.Spec.Taints {
-		if taint.Key == n.taintKey {
+		if taint.Key == n.taintName {
 			return true
 		}
 	}

--- a/pilot/pkg/controllers/untaint/nodeuntainter.go
+++ b/pilot/pkg/controllers/untaint/nodeuntainter.go
@@ -44,6 +44,7 @@ type NodeUntainter struct {
 	cnilabels   labels.Instance
 	ourNs       string
 	queue       controllers.Queue
+	taintKey    string
 }
 
 func filterNamespace(ns string) func(any) bool {
@@ -73,6 +74,7 @@ func NewNodeUntainter(stop <-chan struct{}, kubeClient kubelib.Client, cniNs, sy
 		nodesClient: nodes,
 		cnilabels:   labels.Instance(istioCniLabels),
 		ourNs:       ns,
+		taintKey:    features.NodeUntaintTaintName,
 	}
 	nt.setup(stop, debugger)
 	return nt
@@ -106,10 +108,10 @@ func (n *NodeUntainter) setup(stop <-chan struct{}, debugger *krt.DebugHandler) 
 			return nil
 		}
 		node := *pnode
-		if !hasTaint(node) {
+		if !n.hasTaint(node) {
 			return nil
 		}
-		return &node
+		return pnode
 	}, opts.WithName("ready-cni-nodes")...)
 
 	n.queue = controllers.NewQueue("untaint nodes",
@@ -146,15 +148,15 @@ func (n *NodeUntainter) reconcileNode(key types.NamespacedName) error {
 		return nil
 	}
 
-	err := removeReadinessTaint(n.nodesClient, node)
+	err := removeReadinessTaint(n.nodesClient, node, n.taintKey)
 	if err != nil {
 		log.Errorf("failed to remove readiness taint from node %v: %v", node.Name, err)
 	}
 	return err
 }
 
-func removeReadinessTaint(nodesClient kclient.Client[*v1.Node], node *v1.Node) error {
-	updatedTaint := deleteTaint(node.Spec.Taints)
+func removeReadinessTaint(nodesClient kclient.Client[*v1.Node], node *v1.Node, taintKey string) error {
+	updatedTaint := deleteTaint(node.Spec.Taints, taintKey)
 	if len(updatedTaint) == len(node.Spec.Taints) {
 		// nothing to remove..
 		return nil
@@ -189,10 +191,10 @@ func removeReadinessTaint(nodesClient kclient.Client[*v1.Node], node *v1.Node) e
 }
 
 // deleteTaint removes all the taints that have the same key and effect to given taintToDelete.
-func deleteTaint(taints []v1.Taint) []v1.Taint {
+func deleteTaint(taints []v1.Taint, taintKey string) []v1.Taint {
 	newTaints := []v1.Taint{}
 	for i := range taints {
-		if taints[i].Key == features.NodeUntaintTaintName {
+		if taints[i].Key == taintKey {
 			continue
 		}
 		newTaints = append(newTaints, taints[i])
@@ -200,9 +202,9 @@ func deleteTaint(taints []v1.Taint) []v1.Taint {
 	return newTaints
 }
 
-func hasTaint(n *v1.Node) bool {
-	for _, taint := range n.Spec.Taints {
-		if taint.Key == features.NodeUntaintTaintName {
+func (n *NodeUntainter) hasTaint(node *v1.Node) bool {
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == n.taintKey {
 			return true
 		}
 	}

--- a/pilot/pkg/controllers/untaint/nodeuntainter.go
+++ b/pilot/pkg/controllers/untaint/nodeuntainter.go
@@ -150,7 +150,7 @@ func (n *NodeUntainter) reconcileNode(key types.NamespacedName) error {
 
 	err := removeReadinessTaint(n.nodesClient, node, n.taintName)
 	if err != nil {
-		log.Errorf("failed to remove readiness taint from node %v: %v", node.Name, err)
+		log.Errorf("failed to remove readiness taint '%v' from node %v: %v", n.taintName, node.Name, err)
 	}
 	return err
 }

--- a/pilot/pkg/controllers/untaint/nodeuntainter_test.go
+++ b/pilot/pkg/controllers/untaint/nodeuntainter_test.go
@@ -100,9 +100,49 @@ func TestNodeUntainterOnlyUntaintsWhenIstiocniInourNs(t *testing.T) {
 	s.assertNodeTainted(t, "node2")
 }
 
+func TestNodeUntainterWithCustomTaintName(t *testing.T) {
+	setupLogging()
+	test.SetForTest(t, &features.EnableNodeUntaintControllers, true)
+	test.SetForTest(t, &features.NodeUntaintTaintName, "custom.io/not-ready")
+
+	s := newNodeUntainterTestServer(t)
+
+	s.addTaintedNodes(t, "node1")
+
+	node := generateNode("node2", nil)
+	node.Spec.Taints = append(node.Spec.Taints, corev1.Taint{
+		Key:    "cni.istio.io/not-ready",
+		Value:  "true",
+		Effect: corev1.TaintEffectNoSchedule,
+	})
+	s.nc.Create(node)
+
+	s.addCniPod(t, "node1", true)
+	s.addCniPod(t, "node2", true)
+
+	s.assertNodeUntainted(t, "node1")
+	s.assertNodeHasTaintKey(t, "node2", "cni.istio.io/not-ready")
+}
+
 func (s *nodeTainterTestServer) assertNodeTainted(t *testing.T, node string) {
 	t.Helper()
 	assert.Equal(t, s.isNodeUntainted(node), false)
+}
+
+func (s *nodeTainterTestServer) assertNodeHasTaintKey(t *testing.T, node, key string) {
+	t.Helper()
+	assert.EventuallyEqual(t, func() bool {
+		n := s.nc.Get(node, "")
+		if n == nil {
+			return false
+		}
+		for _, ta := range n.Spec.Taints {
+			if ta.Key == key {
+				return true
+			}
+		}
+		return false
+	}, true, retry.Timeout(time.Second*3))
 }
 
 func (s *nodeTainterTestServer) assertNodeUntainted(t *testing.T, node string) {
@@ -118,7 +158,7 @@ func (s *nodeTainterTestServer) isNodeUntainted(node string) bool {
 		return false
 	}
 	for _, t := range n.Spec.Taints {
-		if t.Key == TaintName {
+		if t.Key == features.NodeUntaintTaintName {
 			return false
 		}
 	}
@@ -131,7 +171,7 @@ func (s *nodeTainterTestServer) addTaintedNodes(t *testing.T, nodes ...string) {
 		node := generateNode(node, nil)
 		// add our special taint
 		node.Spec.Taints = append(node.Spec.Taints, corev1.Taint{
-			Key:    TaintName,
+			Key:    features.NodeUntaintTaintName,
 			Value:  "true",
 			Effect: corev1.TaintEffectNoSchedule,
 		})

--- a/pilot/pkg/controllers/untaint/nodeuntainter_test.go
+++ b/pilot/pkg/controllers/untaint/nodeuntainter_test.go
@@ -121,7 +121,8 @@ func TestNodeUntainterWithCustomTaintName(t *testing.T) {
 	s.addCniPod(t, "node2", true)
 
 	s.assertNodeUntainted(t, "node1")
-	// node2 still has the `cni.istio.io/not-ready` taint rather than the `custom.io/not-ready` one. The untaint controller should not remove it, as it only manages the `custom.io/not-ready` taint.
+	// node2 still has the `cni.istio.io/not-ready` taint rather than the `custom.io/not-ready` one.
+	// The untaint controller should not remove it, as it only manages the `custom.io/not-ready` taint.
 	s.assertNodeHasTaintKey(t, "node2", "cni.istio.io/not-ready")
 }
 

--- a/pilot/pkg/controllers/untaint/nodeuntainter_test.go
+++ b/pilot/pkg/controllers/untaint/nodeuntainter_test.go
@@ -121,7 +121,7 @@ func TestNodeUntainterWithCustomTaintName(t *testing.T) {
 	s.addCniPod(t, "node2", true)
 
 	s.assertNodeUntainted(t, "node1")
-	// node2 still has the default taint rather than the custom one. The untaint controller should not remove it, as it only manages the `custom.io/not-ready` taint.
+	// node2 still has the `cni.istio.io/not-ready` taint rather than the `custom.io/not-ready` one. The untaint controller should not remove it, as it only manages the `custom.io/not-ready` taint.
 	s.assertNodeHasTaintKey(t, "node2", "cni.istio.io/not-ready")
 }
 

--- a/pilot/pkg/controllers/untaint/nodeuntainter_test.go
+++ b/pilot/pkg/controllers/untaint/nodeuntainter_test.go
@@ -121,6 +121,7 @@ func TestNodeUntainterWithCustomTaintName(t *testing.T) {
 	s.addCniPod(t, "node2", true)
 
 	s.assertNodeUntainted(t, "node1")
+	// node2 still has the default taint rather than the custom one. The untaint controller should not remove it, as it only manages the `custom.io/not-ready` taint.
 	s.assertNodeHasTaintKey(t, "node2", "cni.istio.io/not-ready")
 }
 

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -170,6 +170,12 @@ var (
 		false,
 		"If enabled, controller that untaints nodes with cni pods ready will run. This should be enabled if you disabled ambient init containers.").Get()
 
+	NodeUntaintTaintName = env.Register(
+		"PILOT_NODE_UNTAINT_CONTROLLERS_TAINT_NAME",
+		"cni.istio.io/not-ready",
+		"The taint key used by the node-untaint controller to identify nodes that should be untainted.",
+	).Get()
+
 	EnableIPAutoallocate = env.Register(
 		"PILOT_ENABLE_IP_AUTOALLOCATE",
 		true,

--- a/releasenotes/notes/59499.yaml
+++ b/releasenotes/notes/59499.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 57844
+releaseNotes:
+  - |
+    Added PILOT_NODE_UNTAINT_CONTROLLERS_TAINT_NAME environment variable to allow users to specify 
+    a custom taint name for the pilot node untaint controller. Defaults to cni.istio.io/not-ready

--- a/releasenotes/notes/59499.yaml
+++ b/releasenotes/notes/59499.yaml
@@ -5,5 +5,5 @@ issue:
   - 57844
 releaseNotes:
   - |
-    Added PILOT_NODE_UNTAINT_CONTROLLERS_TAINT_NAME environment variable to allow users to specify 
-    a custom taint name for the pilot node untaint controller. Defaults to cni.istio.io/not-ready
+    **Added** support for a custom taint name for the pilot node untaint controller via 
+    PILOT_NODE_UNTAINT_CONTROLLERS_TAINT_NAME environment variable. Defaults to cni.istio.io/not-ready

--- a/releasenotes/notes/59499.yaml
+++ b/releasenotes/notes/59499.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: feature
-area: networking
+area: traffic-management
 issue:
   - 57844
 releaseNotes:

--- a/releasenotes/notes/59499.yaml
+++ b/releasenotes/notes/59499.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: feature
-area: traffic-management
+area: networking
 issue:
   - 57844
 releaseNotes:

--- a/tests/integration/ambient/untaint/main_test.go
+++ b/tests/integration/ambient/untaint/main_test.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/resource"
@@ -88,12 +89,12 @@ func taintNodes(t resource.Context) error {
 Outer:
 	for _, node := range nodes.Items {
 		for _, taint := range node.Spec.Taints {
-			if taint.Key == "cni.istio.io/not-ready" {
+			if taint.Key == features.NodeUntaintTaintName {
 				continue Outer
 			}
 		}
 		node.Spec.Taints = append(node.Spec.Taints, corev1.Taint{
-			Key:    "cni.istio.io/not-ready",
+			Key:    features.NodeUntaintTaintName,
 			Value:  "true",
 			Effect: corev1.TaintEffectNoSchedule,
 		})
@@ -119,7 +120,7 @@ func untaintNodes(t resource.Context) {
 	for _, node := range nodes.Items {
 		var taints []corev1.Taint
 		for _, taint := range node.Spec.Taints {
-			if taint.Key == "cni.istio.io/not-ready" {
+			if taint.Key == features.NodeUntaintTaintName {
 				continue
 			}
 			taints = append(taints, taint)

--- a/tests/integration/ambient/untaint/untaint_test.go
+++ b/tests/integration/ambient/untaint/untaint_test.go
@@ -23,6 +23,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/util/retry"
 )
@@ -44,7 +45,7 @@ func TestTaintsRemoved(t *testing.T) {
 
 				for _, node := range nodes.Items {
 					for _, taint := range node.Spec.Taints {
-						if taint.Key == "cni.istio.io/not-ready" {
+						if taint.Key == features.NodeUntaintTaintName {
 							return fmt.Errorf("node %v still has taint %v", node.Name, taint)
 						}
 					}


### PR DESCRIPTION
Description: This change makes the istiod node-untaint controller honor a configurable taint key instead of using a hard-coded value. Users can now configure the taint key via the environment variable PILOT_NODE_UNTAINT_CONTROLLERS_TAINT_NAME or via IstioOperator values (pilot.taint.name).

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions