### PR TITLE
Fix retryBudget default percent value from 0.2 to 20

### DIFF
--- a/pilot/pkg/networking/core/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/cluster_builder_test.go
@@ -864,7 +864,7 @@ func TestApplyDestinationRule(t *testing.T) {
 									Value: 10,
 								},
 								RetryBudget: &cluster.CircuitBreakers_Thresholds_RetryBudget{
-									BudgetPercent:       &xdstype.Percent{Value: 0.2},
+									BudgetPercent:       &xdstype.Percent{Value: 20.0},
 									MinRetryConcurrency: &wrappers.UInt32Value{Value: 3},
 								},
 							},
@@ -3212,7 +3212,7 @@ func TestApplyConnectionPool(t *testing.T) {
 						MaxPendingRequests: &wrappers.UInt32Value{Value: math.MaxUint32},
 						TrackRemaining:     false,
 						RetryBudget: &cluster.CircuitBreakers_Thresholds_RetryBudget{
-							BudgetPercent:       &xdstype.Percent{Value: 0.2},
+							BudgetPercent:       &xdstype.Percent{Value: 20.0},
 							MinRetryConcurrency: &wrappers.UInt32Value{Value: 3},
 						},
 					},

--- a/pilot/pkg/networking/core/cluster_traffic_policy.go
+++ b/pilot/pkg/networking/core/cluster_traffic_policy.go
@@ -187,7 +187,7 @@ func applyRetryBudget(
 		return
 	}
 
-	percent := &xdstype.Percent{Value: 0.2} // default to 20%
+	percent := &xdstype.Percent{Value: 20.0} // default to 20%
 	if retryBudget.Percent != nil {
 		percent = &xdstype.Percent{Value: retryBudget.Percent.Value}
 	}

--- a/releasenotes/notes/retry-budget-percent.yaml
+++ b/releasenotes/notes/retry-budget-percent.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 59504
+releaseNotes:
+  - |
+    **Fixed** a bug where the default `percent` for `retryBudget` in `DestinationRule` was
+    incorrectly set to 0.2% instead of the intended 20%.


### PR DESCRIPTION
The applyRetryBudget function configures a default BudgetPercent of 0.2 when no explicit value is provided in the DestinationRule. However, the xdstype.Percent type uses a 0–100 scale, so this results in a 0.2% budget rather than the intended 20%.

This PR fixes the default to 20.0% to match the [documented behavior](https://istio.io/latest/docs/reference/config/networking/destination-rule/#TrafficPolicy-RetryBudget).

Fixes: https://github.com/istio/istio/issues/59504

- [x] Networking