### PR TITLE
fix: use semantic versions for charts in commit releases

### DIFF
--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -40,10 +40,10 @@ export ISTIO_DOCKER_QEMU=true
 BUILDER_SHA=0d2d6c63fa55fd0a059d873f84ffc82d7cb799d9
 
 # Reference to the next minor version of Istio
-# This will create a version like 1.4-alpha.sha
+# This will create a version like 1.30.0-alpha.<sha>
 NEXT_VERSION=$(cat "${ROOT}/VERSION")
 TAG=$(git rev-parse HEAD)
-VERSION="${NEXT_VERSION}-alpha.${TAG}"
+VERSION="${NEXT_VERSION}.0-alpha.${TAG}"
 
 # In CI we want to store the outputs to artifacts, which will preserve the build
 # If not specified, we can just create a temporary directory


### PR DESCRIPTION
**Please provide a description of this PR:**
Currently, our commit releases produce charts with non-semantic version numbers. This trips up helm4 linting:

```
 ==> Linting v1.30-alpha.f44b4795/charts/istiod
[WARNING] Chart.yaml: version '1.30-alpha.f44b47959894b1f460d9e0cc301578ce77619bfc' is not a valid SemVerV2
[...snip...]
Error: 5 chart(s) linted, 1 chart(s) failed
```

We don't run into it in our CI because we never commit these version numbers but only push them as part of the helm chart artifacts, but IMO we should fix it especially as we're using helm4 with ``--strict` linting ourselves.