### PR TITLE
remove redundant application-level CIDR check from BuildLocalJwks

### DIFF
--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -295,45 +295,11 @@ func (r *JwksResolver) GetPublicKey(issuer string, jwksURI string, timeout time.
 func (r *JwksResolver) BuildLocalJwks(jwksURI, jwtIssuer, jwtPubKey string, timeout time.Duration) *envoy_jwt.JwtProvider_LocalJwks {
 	var err error
 	if jwtPubKey == "" {
-		// Check if the jwksURI resolves to any blocked CIDRs before fetching the key
-		// If it does, we skip fetching and use the fake jwks instead
-		blocked := false
-		if len(features.BlockedCIDRsInJWKURIs) > 0 {
-			// Parse the URL to get the hostname
-			u, parseErr := url.Parse(jwksURI)
-			if parseErr != nil {
-				log.Errorf("Failed to parse jwksURI %q: %v", jwksURI, parseErr)
-			} else {
-				host := u.Hostname()
-				// Resolve the hostname to get IP addresses
-				ips, resolveErr := net.DefaultResolver.LookupIP(context.Background(), "ip", host)
-				if resolveErr != nil {
-					log.Warnf("Failed to resolve hostname %q from jwksURI %q: %v", host, jwksURI, resolveErr)
-				}
-
-				// Check if any resolved IP is in the blocked list
-				for _, ip := range ips {
-					ipStr := ip.String()
-					// Check CIDR ranges
-					for _, cidr := range features.BlockedCIDRsInJWKURIs {
-						if cidr.Contains(ip) {
-							log.Errorf("jwksURI %q resolved to IP %q which is in blocked CIDR range %s", jwksURI, ipStr, cidr.String())
-							blocked = true
-							break
-						}
-					}
-					if blocked {
-						break
-					}
-				}
-			}
-		}
-		if !blocked {
-			// jwtKeyResolver should never be nil since the function is only called in Discovery Server request processing
-			// workflow, where the JWT key resolver should have already been initialized on server creation.
-			jwtPubKey, err = r.GetPublicKey(jwtIssuer, jwksURI, timeout)
-		}
-		if err != nil || blocked {
+		// jwtKeyResolver should never be nil since the function is only called in Discovery Server request processing
+		// workflow, where the JWT key resolver should have already been initialized on server creation.
+		// CIDR blocking is handled at the transport level by blockedCIDRDialContext on both HTTP clients.
+		jwtPubKey, err = r.GetPublicKey(jwtIssuer, jwksURI, timeout)
+		if err != nil {
 			log.Warnf("JWKS fetch failed for issuer %s (%s), using public-only JWKS with discarded private key - JWT requests will be rejected", jwtIssuer, jwksURI)
 			// fail closed: use a public key where the private key has been permanently discarded
 			// nobody can sign valid JWTs because the private key doesn't exist anywhere


### PR DESCRIPTION
security fixes in #59370 re-introduced the old application-level CIDR check in BuildLocalJwks that #59236 replaced with transport-level blockedCIDRDialContext. removes the redundant check — CIDR blocking is handled at the transport level on both HTTP clients.