### PR TITLE
networking: support pathTemplate URI matching in VirtualService

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -237,3 +237,5 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
 )
+
+replace istio.io/api => ../api

--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -462,7 +462,7 @@ func parentMeta(obj controllers.Object, sectionName *k8s.SectionName) map[string
 	}
 }
 
-// getURIRank ranks a URI match type. Exact > Prefix > Regex
+// getURIRank ranks a URI match type. Exact > Prefix > Regex > PathTemplate
 func getURIRank(match *istio.HTTPMatchRequest) int {
 	if match.Uri == nil {
 		return -1
@@ -473,6 +473,8 @@ func getURIRank(match *istio.HTTPMatchRequest) int {
 	case *istio.StringMatch_Prefix:
 		return 2
 	case *istio.StringMatch_Regex:
+		return 1
+	case *istio.StringMatch_PathTemplate:
 		return 1
 	}
 	// should not happen
@@ -490,6 +492,8 @@ func getURILength(match *istio.HTTPMatchRequest) int {
 		return len(match.Uri.GetExact())
 	case *istio.StringMatch_Regex:
 		return len(match.Uri.GetRegex())
+	case *istio.StringMatch_PathTemplate:
+		return len(match.Uri.GetPathTemplate())
 	}
 	// should not happen
 	return -1

--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -475,7 +475,7 @@ func getURIRank(match *istio.HTTPMatchRequest) int {
 	case *istio.StringMatch_Regex:
 		return 1
 	case *istio.StringMatch_PathTemplate:
-		return 1
+		return 0
 	}
 	// should not happen
 	return -1

--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -410,6 +410,10 @@ func stringMatchConflict(root, leaf *networking.StringMatch) bool {
 	if root == nil || leaf == nil {
 		return false
 	}
+	// pathTemplate cannot be composed with delegate VirtualServices.
+	if root.GetPathTemplate() != "" || leaf.GetPathTemplate() != "" {
+		return true
+	}
 	// If root regex match is specified, delegate should not have other matches.
 	if root.GetRegex() != "" {
 		if leaf.GetRegex() != "" || leaf.GetPrefix() != "" || leaf.GetExact() != "" {

--- a/pilot/pkg/networking/core/route/route.go
+++ b/pilot/pkg/networking/core/route/route.go
@@ -44,6 +44,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/telemetry"
 	"istio.io/istio/pilot/pkg/networking/util"
 	authz "istio.io/istio/pilot/pkg/security/authz/model"
+	authmatcher "istio.io/istio/pilot/pkg/security/authz/matcher"
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
@@ -1107,6 +1108,13 @@ func TranslateRouteMatch(vs config.Config, in *networking.HTTPMatchRequest) *rou
 			out.PathSpecifier = &route.RouteMatch_SafeRegex{
 				SafeRegex: &matcher.RegexMatcher{
 					Regex: m.Regex,
+				},
+			}
+		case *networking.StringMatch_PathTemplate:
+			out.PathSpecifier = &route.RouteMatch_PathMatchPolicy{
+				PathMatchPolicy: &core.TypedExtensionConfig{
+					Name:        "envoy.path.match.uri_template.uri_template_matcher",
+					TypedConfig: protoconv.MessageToAny(authmatcher.PathTemplateMatcher(m.PathTemplate)),
 				},
 			}
 		}

--- a/pilot/pkg/networking/core/route/route_test.go
+++ b/pilot/pkg/networking/core/route/route_test.go
@@ -1210,6 +1210,26 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		}))
 	})
 
+	t.Run("for URI path template match", func(t *testing.T) {
+		g := NewWithT(t)
+		cg := core.NewConfigGenTest(t, core.TestOptions{})
+
+		routeOptsWithPush := routeOpts
+		routeOptsWithPush.Push = cg.PushContext()
+		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg),
+			virtualServiceWithPathTemplateMatch,
+			8080, gatewayNames, routeOptsWithPush)
+		xdstest.ValidateRoutes(t, routes)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
+
+		// Verify the route match uses PathMatchPolicy (URI template extension)
+		pathMatchPolicy, ok := routes[0].Match.PathSpecifier.(*envoyroute.RouteMatch_PathMatchPolicy)
+		g.Expect(ok).To(BeTrue(), "expected PathMatchPolicy specifier for path template match")
+		g.Expect(pathMatchPolicy.PathMatchPolicy.Name).To(Equal("envoy.path.match.uri_template.uri_template_matcher"))
+		g.Expect(pathMatchPolicy.PathMatchPolicy.TypedConfig).NotTo(BeNil())
+	})
+
 	t.Run("for host rewrite with XForwardedHost enabled", func(t *testing.T) {
 		g := NewWithT(t)
 		cg := core.NewConfigGenTest(t, core.TestOptions{})
@@ -2380,6 +2400,39 @@ var virtualServiceWithPathRegexMatchRegexRewrite = config.Config{
 					UriRegexRewrite: &networking.RegexRewrite{
 						Match:   "^/service/([^/]+)(/.*)$",
 						Rewrite: "\\2/instance/\\1",
+					},
+				},
+				Route: []*networking.HTTPRouteDestination{
+					{
+						Destination: &networking.Destination{
+							Host: "foo.example.org",
+						},
+						Weight: 100,
+					},
+				},
+			},
+		},
+	},
+}
+
+var virtualServiceWithPathTemplateMatch = config.Config{
+	Meta: config.Meta{
+		GroupVersionKind: gvk.VirtualService,
+		Name:             "acme",
+	},
+	Spec: &networking.VirtualService{
+		Hosts:    []string{},
+		Gateways: []string{"some-gateway"},
+		Http: []*networking.HTTPRoute{
+			{
+				Match: []*networking.HTTPMatchRequest{
+					{
+						Name: "path-template",
+						Uri: &networking.StringMatch{
+							MatchType: &networking.StringMatch_PathTemplate{
+								PathTemplate: "/users/{*}/orders/{**}",
+							},
+						},
 					},
 				},
 				Route: []*networking.HTTPRouteDestination{

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -2310,6 +2310,16 @@ func validateStringMatch(sm *networking.StringMatch, where string) error {
 		}
 	case *networking.StringMatch_Regex:
 		return validateStringMatchRegexp(sm, where)
+	case *networking.StringMatch_PathTemplate:
+		return fmt.Errorf("%q: pathTemplate is only supported for uri matches", where)
+	}
+	return nil
+}
+
+func validatePathTemplateMatch(sm *networking.StringMatch, where string) error {
+	switch sm.GetMatchType().(type) {
+	case *networking.StringMatch_PathTemplate:
+		return security.CheckValidPathTemplate(where, []string{sm.GetPathTemplate()})
 	}
 	return nil
 }

--- a/pkg/config/validation/virtualservice.go
+++ b/pkg/config/validation/virtualservice.go
@@ -159,6 +159,7 @@ func validateHTTPRouteMatchRequest(http *networking.HTTPRoute) (errs error) {
 			// whereas scheme/method/authority does not:
 			// https://github.com/envoyproxy/envoy/blob/v1.29.2/api/envoy/type/matcher/string.proto#L38
 			errs = appendErrors(errs, validateStringMatchRegexp(match.GetUri(), "uri"))
+			errs = appendErrors(errs, validatePathTemplateMatch(match.GetUri(), "uri"))
 			errs = appendErrors(errs, validateStringMatch(match.GetScheme(), "scheme"))
 			errs = appendErrors(errs, validateStringMatch(match.GetMethod(), "method"))
 			errs = appendErrors(errs, validateStringMatch(match.GetAuthority(), "authority"))

--- a/pkg/config/validation/virtualservice_test.go
+++ b/pkg/config/validation/virtualservice_test.go
@@ -348,6 +348,39 @@ func TestValidateRootHTTPRoute(t *testing.T) {
 				},
 			}},
 		}, valid: true},
+		{name: "path template uri match", route: &networking.HTTPRoute{
+			Delegate: &networking.Delegate{
+				Name:      "test",
+				Namespace: "test",
+			},
+			Match: []*networking.HTTPMatchRequest{{
+				Uri: &networking.StringMatch{
+					MatchType: &networking.StringMatch_PathTemplate{PathTemplate: "/users/{*}/orders/{**}"},
+				},
+			}},
+		}, valid: true},
+		{name: "invalid path template uri match with multiple {**}", route: &networking.HTTPRoute{
+			Delegate: &networking.Delegate{
+				Name:      "test",
+				Namespace: "test",
+			},
+			Match: []*networking.HTTPMatchRequest{{
+				Uri: &networking.StringMatch{
+					MatchType: &networking.StringMatch_PathTemplate{PathTemplate: "/users/{**}/{**}"},
+				},
+			}},
+		}, valid: false},
+		{name: "path template on non-uri field is invalid", route: &networking.HTTPRoute{
+			Delegate: &networking.Delegate{
+				Name:      "test",
+				Namespace: "test",
+			},
+			Match: []*networking.HTTPMatchRequest{{
+				Method: &networking.StringMatch{
+					MatchType: &networking.StringMatch_PathTemplate{PathTemplate: "/users/{*}"},
+				},
+			}},
+		}, valid: false},
 		{
 			name: "prefix queryParams match", route: &networking.HTTPRoute{
 				Delegate: &networking.Delegate{

--- a/releasenotes/notes/59533.yaml
+++ b/releasenotes/notes/59533.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 59533
+
+releaseNotes:
+- |
+  **Added** support for `pathTemplate` URI matching in VirtualService `HTTPMatchRequest`, using `{*}` (matches one path segment) and `{**}` (matches one or more path segments) operators. This is backed by Envoy's URI template path matching extension and is consistent with the existing `pathTemplate` support in `AuthorizationPolicy`. See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/path/match/uri_template/v3/uri_template_match.proto


### PR DESCRIPTION
## Description

Add support for `pathTemplate` URI matching in VirtualService `HTTPMatchRequest`, using `{*}` (matches one path segment) and `{**}` (matches one or more path segments) operators.

```yaml
apiVersion: networking.istio.io/v1
kind: VirtualService
metadata:
  name: example
spec:
  hosts:
  - example.com
  http:
  - match:
    - uri:
        pathTemplate: "/users/{*}/orders"
    route:
    - destination:
        host: orders-service
```

## Changes

- **`pilot/pkg/networking/core/route/route.go`**: `StringMatch_PathTemplate` maps to `RouteMatch_PathMatchPolicy` with the `envoy.path.match.uri_template.uri_template_matcher` extension. Reuses `authmatcher.PathTemplateMatcher()` for `{*}`→`*` / `{**}`→`**` sanitization, consistent with how `AuthorizationPolicy` handles path templates.
- **`pkg/config/validation/validation.go`**: `validateStringMatch` rejects `pathTemplate` on non-uri fields; `validatePathTemplateMatch` validates templates via `security.CheckValidPathTemplate()` (same function used by `AuthorizationPolicy`).
- **`pkg/config/validation/virtualservice.go`**: wires `validatePathTemplateMatch` into uri match validation.
- **`pilot/pkg/model/virtualservice.go`**: `stringMatchConflict` explicitly marks `pathTemplate` as incompatible with delegate VirtualService composition.
- **`pilot/pkg/config/kube/gateway/conversion.go`**: `getURIRank` and `getURILength` handle `pathTemplate` (ranked same as regex).

## Related

- Fixes #59533
- Depends on istio/api#3675 (adds `pathTemplate` field to `StringMatch` proto)
- #47306 — existing `{*}`/`{**}` support in `AuthorizationPolicy`

> **Note**: `go.mod` currently has `replace istio.io/api => ../api` pointing to the local fork during development. This will be updated to the released version of istio/api#3675 once that PR merges before this can be merged.