### PR TITLE
fix: use multiport match for iptables port exclusion rules

### DIFF
--- a/tools/istio-iptables/pkg/capture/run.go
+++ b/tools/istio-iptables/pkg/capture/run.go
@@ -120,10 +120,8 @@ func (cfg *IptablesConfigurator) handleInboundPortsInclude() {
 		if cfg.cfg.InboundPortsInclude == "*" {
 			// Apply any user-specified port exclusions.
 			if cfg.cfg.InboundPortsExclude != "" {
-				for _, port := range config.Split(cfg.cfg.InboundPortsExclude) {
-					cfg.ruleBuilder.AppendRule(constants.ISTIOINBOUND, table, "-p", "tcp",
-						"--dport", port, "-j", "RETURN")
-				}
+				ports := config.Split(cfg.cfg.InboundPortsExclude)
+				appendMultiportRules(cfg.ruleBuilder.AppendRule, constants.ISTIOINBOUND, table, "tcp", ports, "RETURN")
 			}
 			// Redirect remaining inbound traffic to Envoy.
 			if cfg.cfg.InboundInterceptionMode == "TPROXY" {
@@ -151,6 +149,37 @@ func (cfg *IptablesConfigurator) handleInboundPortsInclude() {
 						constants.ISTIOINBOUND, "nat", "-p", "tcp", "--dport", port, "-j", constants.ISTIOINREDIRECT)
 				}
 			}
+		}
+	}
+}
+
+// appendMultiportRules consolidates individual per-port iptables rules into multiport rules.
+// The iptables multiport extension supports up to 15 ports per rule, so ports are chunked
+// into groups of 15 if necessary. For a single port, a simple --dport rule is used instead
+// of the multiport extension for clarity and compatibility.
+func appendMultiportRules(
+	appendFn func(chain string, table string, params ...string) *builder.IptablesRuleBuilder,
+	chain, table, protocol string, ports []string, target string,
+) {
+	if len(ports) == 0 {
+		return
+	}
+	if len(ports) == 1 {
+		appendFn(chain, table, "-p", protocol, "--dport", ports[0], "-j", target)
+		return
+	}
+	// multiport supports up to 15 ports per rule
+	const maxMultiport = 15
+	for i := 0; i < len(ports); i += maxMultiport {
+		end := i + maxMultiport
+		if end > len(ports) {
+			end = len(ports)
+		}
+		chunk := ports[i:end]
+		if len(chunk) == 1 {
+			appendFn(chain, table, "-p", protocol, "--dport", chunk[0], "-j", target)
+		} else {
+			appendFn(chain, table, "-p", protocol, "-m", "multiport", "--dports", strings.Join(chunk, ","), "-j", target)
 		}
 	}
 }
@@ -281,9 +310,9 @@ func (cfg *IptablesConfigurator) Run() error {
 
 	// Apply port based exclusions. Must be applied before connections back to self are redirected.
 	if cfg.cfg.OutboundPortsExclude != "" {
-		for _, port := range config.Split(cfg.cfg.OutboundPortsExclude) {
-			cfg.ruleBuilder.AppendRule(constants.ISTIOOUTPUT, "nat", "-p", "tcp", "--dport", port, "-j", "RETURN")
-			cfg.ruleBuilder.AppendRule(constants.ISTIOOUTPUT, "nat", "-p", "udp", "--dport", port, "-j", "RETURN")
+		ports := config.Split(cfg.cfg.OutboundPortsExclude)
+		for _, proto := range []string{"tcp", "udp"} {
+			appendMultiportRules(cfg.ruleBuilder.AppendRule, constants.ISTIOOUTPUT, "nat", proto, ports, "RETURN")
 		}
 	}
 

--- a/tools/istio-iptables/pkg/capture/run_test.go
+++ b/tools/istio-iptables/pkg/capture/run_test.go
@@ -21,6 +21,7 @@ import (
 
 	testutil "istio.io/istio/pilot/test/util"
 	"istio.io/istio/tools/common/config"
+	"istio.io/istio/tools/istio-iptables/pkg/builder"
 	"istio.io/istio/tools/istio-iptables/pkg/constants"
 	dep "istio.io/istio/tools/istio-iptables/pkg/dependencies"
 )
@@ -250,6 +251,101 @@ func getCommonTestCases() []struct {
 				cfg.HostIPv4LoopbackCidr = "127.0.0.1/8"
 			},
 		},
+		{
+			"outbound-ports-exclude",
+			func(cfg *config.Config) {
+				cfg.OutboundPortsExclude = "22,80,443"
+			},
+		},
+		{
+			"outbound-ports-exclude-single",
+			func(cfg *config.Config) {
+				cfg.OutboundPortsExclude = "22"
+			},
+		},
+		{
+			"inbound-wildcard-exclude",
+			func(cfg *config.Config) {
+				cfg.InboundPortsInclude = "*"
+				cfg.InboundPortsExclude = "22,80,443"
+			},
+		},
+	}
+}
+
+func TestAppendMultiportRules(t *testing.T) {
+	tests := []struct {
+		name     string
+		ports    []string
+		protocol string
+		want     []string // expected rule snippets
+	}{
+		{
+			name:     "empty ports",
+			ports:    []string{},
+			protocol: "tcp",
+			want:     nil,
+		},
+		{
+			name:     "single port uses dport",
+			ports:    []string{"22"},
+			protocol: "tcp",
+			want:     []string{"-p tcp --dport 22 -j RETURN"},
+		},
+		{
+			name:     "two ports uses multiport",
+			ports:    []string{"22", "80"},
+			protocol: "tcp",
+			want:     []string{"-p tcp -m multiport --dports 22,80 -j RETURN"},
+		},
+		{
+			name:     "15 ports in single multiport rule",
+			ports:    []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15"},
+			protocol: "tcp",
+			want:     []string{"-p tcp -m multiport --dports 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15 -j RETURN"},
+		},
+		{
+			name:     "16 ports splits into two rules",
+			ports:    []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16"},
+			protocol: "udp",
+			want: []string{
+				"-p udp -m multiport --dports 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15 -j RETURN",
+				"-p udp --dport 16 -j RETURN",
+			},
+		},
+		{
+			name: "31 ports splits into three rules",
+			ports: []string{
+				"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15",
+				"16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30",
+				"31",
+			},
+			protocol: "tcp",
+			want: []string{
+				"-p tcp -m multiport --dports 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15 -j RETURN",
+				"-p tcp -m multiport --dports 16,17,18,19,20,21,22,23,24,25,26,27,28,29,30 -j RETURN",
+				"-p tcp --dport 31 -j RETURN",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got []string
+			mockAppend := func(chain string, table string, params ...string) *builder.IptablesRuleBuilder {
+				got = append(got, strings.Join(params, " "))
+				return nil
+			}
+			appendMultiportRules(mockAppend, "TEST_CHAIN", "nat", tt.protocol, tt.ports, "RETURN")
+			if len(tt.want) != len(got) {
+				t.Fatalf("expected %d rules, got %d: %v", len(tt.want), len(got), got)
+			}
+			for i, want := range tt.want {
+				if got[i] != want {
+					t.Errorf("rule[%d] = %q, want %q", i, got[i], want)
+				}
+			}
+		})
 	}
 }
 

--- a/tools/istio-iptables/pkg/capture/testdata/inbound-wildcard-exclude.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/inbound-wildcard-exclude.golden
@@ -1,0 +1,24 @@
+iptables-save
+ip6tables-save
+* nat
+-N ISTIO_INBOUND
+-N ISTIO_REDIRECT
+-N ISTIO_IN_REDIRECT
+-N ISTIO_OUTPUT
+-A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
+-A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
+-A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+-A PREROUTING -p tcp -j ISTIO_INBOUND
+-A ISTIO_INBOUND -p tcp -m multiport --dports 22,80,443 -j RETURN
+-A ISTIO_INBOUND -p tcp -j ISTIO_IN_REDIRECT
+-A OUTPUT -j ISTIO_OUTPUT
+-A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
+-A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 15008 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
+-A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN
+-A ISTIO_OUTPUT -m owner --uid-owner 1337 -j RETURN
+-A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 15008 -m owner --gid-owner 1337 -j ISTIO_IN_REDIRECT
+-A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1337 -j RETURN
+-A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN
+-A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN
+COMMIT
+iptables-save

--- a/tools/istio-iptables/pkg/capture/testdata/outbound-ports-exclude-single.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/outbound-ports-exclude-single.golden
@@ -1,0 +1,23 @@
+iptables-save
+ip6tables-save
+* nat
+-N ISTIO_INBOUND
+-N ISTIO_REDIRECT
+-N ISTIO_IN_REDIRECT
+-N ISTIO_OUTPUT
+-A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
+-A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
+-A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+-A OUTPUT -j ISTIO_OUTPUT
+-A ISTIO_OUTPUT -p tcp --dport 22 -j RETURN
+-A ISTIO_OUTPUT -p udp --dport 22 -j RETURN
+-A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
+-A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 15008 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
+-A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN
+-A ISTIO_OUTPUT -m owner --uid-owner 1337 -j RETURN
+-A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 15008 -m owner --gid-owner 1337 -j ISTIO_IN_REDIRECT
+-A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1337 -j RETURN
+-A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN
+-A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN
+COMMIT
+iptables-save

--- a/tools/istio-iptables/pkg/capture/testdata/outbound-ports-exclude.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/outbound-ports-exclude.golden
@@ -1,0 +1,23 @@
+iptables-save
+ip6tables-save
+* nat
+-N ISTIO_INBOUND
+-N ISTIO_REDIRECT
+-N ISTIO_IN_REDIRECT
+-N ISTIO_OUTPUT
+-A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
+-A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
+-A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+-A OUTPUT -j ISTIO_OUTPUT
+-A ISTIO_OUTPUT -p tcp -m multiport --dports 22,80,443 -j RETURN
+-A ISTIO_OUTPUT -p udp -m multiport --dports 22,80,443 -j RETURN
+-A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
+-A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 15008 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
+-A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN
+-A ISTIO_OUTPUT -m owner --uid-owner 1337 -j RETURN
+-A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -p tcp ! --dport 15008 -m owner --gid-owner 1337 -j ISTIO_IN_REDIRECT
+-A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1337 -j RETURN
+-A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN
+-A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN
+COMMIT
+iptables-save


### PR DESCRIPTION
**What this PR does:**
Consolidates individual per-port iptables RETURN rules into multiport rules, significantly reducing the total number of NAT table rules.

**Problem:**
Istio generates individual `-p tcp --dport X -j RETURN` and `-p udp --dport X -j RETURN` rules for each excluded port. With many excluded ports, the total rule count can exceed iptables buffer limits, particularly in gVisor environments which have an 8KB `maxOptLen` limit for `iptables-restore`.

For example, with 16 excluded outbound ports, the current code generates 32 individual rules (16 ports x 2 protocols). This contributes to `iptables-restore --noflush` failures in constrained environments.

**Fix:**
Use the iptables `-m multiport --dports port1,port2,...` match extension to consolidate up to 15 ports per rule, reducing rule count from `2*N` to `ceil(N/15)*2` for outbound exclusions, and from `N` to `ceil(N/15)` for inbound exclusions.

A single port still uses the simpler `--dport` syntax for clarity and compatibility.

**Testing:**
- Added `TestAppendMultiportRules` unit test covering: empty ports, single port (uses `--dport`), multiple ports (uses multiport), exactly 15 ports (single multiport rule), 16 ports (chunks into 15+1), and 31 ports (chunks into 15+15+1)
- Added golden file tests for `outbound-ports-exclude`, `outbound-ports-exclude-single`, and `inbound-wildcard-exclude`
- All 30 existing + new tests pass, no regressions

Fixes #59353