### PR TITLE
fix: aggregate all ServiceEntry addresses in HTTP route domains

### DIFF
--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -964,10 +964,17 @@ func (sc *SidecarScope) appendSidecarServices(servicesAdded map[host.Name]sideca
 			return
 		}
 
-		// if both services have the same ports, no need to merge and we save a deepcopy
+		// if both services have the same ports, no need to merge ports and we save a deepcopy.
+		// However, if they have different addresses (e.g., ServiceEntry with multiple addresses),
+		// we still need to merge the addresses so that all IPs are exposed in route domains.
 		if existing.Ports.Equals(s.Ports) {
-			log.Debugf("Service %s/%s from registry %s ignored as it has the same ports as %s/%s/%s", s.Attributes.Namespace, s.Hostname,
-				s.Attributes.ServiceRegistry, existing.Attributes.Namespace, existing.Hostname, existing.Attributes.ServiceRegistry)
+			if s.DefaultAddress != existing.DefaultAddress &&
+				s.DefaultAddress != "" && s.DefaultAddress != constants.UnspecifiedIP {
+				mergeServiceAddresses(existing, s, foundSvc.index, sc, servicesAdded)
+			} else {
+				log.Debugf("Service %s/%s from registry %s ignored as it has the same ports as %s/%s/%s", s.Attributes.Namespace, s.Hostname,
+					s.Attributes.ServiceRegistry, existing.Attributes.Namespace, existing.Hostname, existing.Attributes.ServiceRegistry)
+			}
 			return
 		}
 
@@ -1008,6 +1015,40 @@ func (sc *SidecarScope) appendSidecarServices(servicesAdded map[host.Name]sideca
 		// update the existing service in the map to the merged one
 		sc.servicesByHostname[s.Hostname] = copied
 	}
+}
+
+// mergeServiceAddresses merges the DefaultAddress from s into the existing service's ClusterVIPs.
+// This is needed for ServiceEntry with multiple addresses, where the conversion layer creates
+// one Service per address with the same hostname and ports. Without merging, only one address
+// would be visible in HTTP route domains.
+func mergeServiceAddresses(existing, s *Service, idx int, sc *SidecarScope, servicesAdded map[host.Name]sidecarServiceIndex) {
+	copied := existing.ShallowCopy()
+	// Collect all unique addresses into ClusterVIPs under empty cluster ID,
+	// which is the convention for ServiceEntry-originated services.
+	var addresses []string
+	existingAddrs := copied.ClusterVIPs.GetAddressesFor("")
+	if len(existingAddrs) > 0 {
+		addresses = append(addresses, existingAddrs...)
+	} else if copied.DefaultAddress != "" && copied.DefaultAddress != constants.UnspecifiedIP {
+		addresses = []string{copied.DefaultAddress}
+	}
+	// Add the new address if not already present.
+	addr := s.DefaultAddress
+	found := false
+	for _, a := range addresses {
+		if a == addr {
+			found = true
+			break
+		}
+	}
+	if !found {
+		addresses = append(addresses, addr)
+	}
+	copied.ClusterVIPs.SetAddressesFor("", addresses)
+
+	sc.services[idx] = copied
+	servicesAdded[copied.Hostname] = sidecarServiceIndex{copied, idx}
+	sc.servicesByHostname[copied.Hostname] = copied
 }
 
 func canMergeServices(s1, s2 *Service) bool {

--- a/pilot/pkg/networking/core/httproute.go
+++ b/pilot/pkg/networking/core/httproute.go
@@ -325,23 +325,34 @@ func BuildSidecarOutboundVirtualHosts(node *model.Proxy, push *model.PushContext
 		if listenerPort == 0 {
 			// Take all ports when listen port is 0 (http_proxy or uds)
 			// Expect virtualServices to resolve to right port
-			servicesByName[svc.Hostname] = svc
+			if existing, ok := servicesByName[svc.Hostname]; ok {
+				// ServiceEntry with multiple addresses creates multiple services with the same hostname.
+				// Merge additional addresses so that all IPs appear in VirtualHost domains.
+				addServiceAddress(existing, svc.GetAddressForProxy(node))
+			} else {
+				servicesByName[svc.Hostname] = svc
+			}
 		} else if svcPort, exists := svc.Ports.GetByPort(listenerPort); exists {
 			h := host.Name(strings.ToLower(string(svc.Hostname)))
-			servicesByName[h] = &model.Service{
-				Hostname:       h,
-				DefaultAddress: svc.GetAddressForProxy(node),
-				ClusterVIPs:    model.AddressMap{Addresses: svc.ClusterVIPs.Addresses},
-				MeshExternal:   svc.MeshExternal,
-				Resolution:     svc.Resolution,
-				Ports:          []*model.Port{svcPort},
-				Attributes: model.ServiceAttributes{
-					Namespace:       svc.Attributes.Namespace,
-					ServiceRegistry: svc.Attributes.ServiceRegistry,
-					Labels:          svc.Attributes.Labels,
-					Aliases:         svc.Attributes.Aliases,
-					K8sAttributes:   svc.Attributes.K8sAttributes,
-				},
+			addr := svc.GetAddressForProxy(node)
+			if existing, ok := servicesByName[h]; ok {
+				addServiceAddress(existing, addr)
+			} else {
+				servicesByName[h] = &model.Service{
+					Hostname:       h,
+					DefaultAddress: addr,
+					ClusterVIPs:    model.AddressMap{Addresses: svc.ClusterVIPs.Addresses},
+					MeshExternal:   svc.MeshExternal,
+					Resolution:     svc.Resolution,
+					Ports:          []*model.Port{svcPort},
+					Attributes: model.ServiceAttributes{
+						Namespace:       svc.Attributes.Namespace,
+						ServiceRegistry: svc.Attributes.ServiceRegistry,
+						Labels:          svc.Attributes.Labels,
+						Aliases:         svc.Attributes.Aliases,
+						K8sAttributes:   svc.Attributes.K8sAttributes,
+					},
+				}
 			}
 		}
 	}
@@ -544,6 +555,31 @@ func SidecarIgnorePort(node *model.Proxy) bool {
 	return !node.IsProxylessGrpc()
 }
 
+// addServiceAddress adds addr to dst's ClusterVIPs under the empty cluster ID so that
+// generateVirtualHostDomains includes it in the VirtualHost domains list.
+// This handles ServiceEntry with multiple addresses where each address creates a separate
+// Service object with the same hostname. Without merging, only one address would be visible.
+func addServiceAddress(dst *model.Service, addr string) {
+	if len(addr) == 0 || addr == constants.UnspecifiedIP {
+		return
+	}
+	// Check if addr is already the DefaultAddress or already in ClusterVIPs.
+	if dst.DefaultAddress == addr {
+		return
+	}
+	existing := dst.ClusterVIPs.GetAddressesFor("")
+	for _, a := range existing {
+		if a == addr {
+			return
+		}
+	}
+	// First merge: include dst's own DefaultAddress in the list.
+	if len(existing) == 0 && dst.DefaultAddress != "" && dst.DefaultAddress != constants.UnspecifiedIP {
+		existing = []string{dst.DefaultAddress}
+	}
+	dst.ClusterVIPs.SetAddressesFor("", append(existing, addr))
+}
+
 // generateVirtualHostDomains generates the set of domain matches for a service being accessed from
 // a proxy node
 func generateVirtualHostDomains(service *model.Service, listenerPort int, port int, node *model.Proxy) ([]string, []string) {
@@ -572,7 +608,18 @@ func generateVirtualHostDomains(service *model.Service, listenerPort int, port i
 		}
 	}
 
-	for _, svcAddr := range service.GetAllAddressesForProxy(node) {
+	// Collect all addresses for this service. GetAllAddressesForProxy handles the common case,
+	// but when multiple addresses are merged from a ServiceEntry (issue #58692), we also need
+	// to check ClusterVIPs directly in case the proxy has no ClusterID set.
+	svcAddresses := service.GetAllAddressesForProxy(node)
+	if node.Metadata == nil || node.Metadata.ClusterID == "" {
+		// When ClusterID is empty, GetAllAddressesForProxy only returns DefaultAddress.
+		// Check ClusterVIPs for additional merged addresses.
+		if vips := service.ClusterVIPs.GetAddressesFor(""); len(vips) > len(svcAddresses) {
+			svcAddresses = vips
+		}
+	}
+	for _, svcAddr := range svcAddresses {
 		if len(svcAddr) > 0 && svcAddr != constants.UnspecifiedIP {
 			domains = appendDomainPort(domains, svcAddr, port)
 		}

--- a/pilot/pkg/networking/core/httproute_test.go
+++ b/pilot/pkg/networking/core/httproute_test.go
@@ -1999,6 +1999,76 @@ func testSidecarRDSVHosts(t *testing.T, services []*model.Service,
 	}
 }
 
+// TestServiceEntryMultipleAddresses verifies that a ServiceEntry with multiple addresses
+// exposes all addresses in the HTTP VirtualHost domains (issue #58692).
+// When a ServiceEntry has multiple addresses, the conversion layer creates multiple
+// model.Service objects with the same hostname but different DefaultAddress values.
+// All of these addresses must appear in the VirtualHost domains.
+func TestServiceEntryMultipleAddresses(t *testing.T) {
+	cg := NewConfigGenTest(t, TestOptions{
+		ConfigString: `
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: multi-address-http
+  namespace: default
+spec:
+  hosts:
+  - example.com
+  addresses:
+  - 10.2.2.118
+  - 10.4.2.206
+  ports:
+  - name: http-port-80
+    number: 80
+    protocol: HTTP
+  endpoints:
+  - address: 10.0.0.1
+  location: MESH_EXTERNAL
+  resolution: STATIC`,
+	})
+
+	proxy := cg.SetupProxy(nil)
+
+	vHostCache := make(map[int][]*route.VirtualHost)
+	resource, _ := cg.ConfigGen.buildSidecarOutboundHTTPRouteConfig(
+		proxy, &model.PushRequest{Push: cg.PushContext()}, "80", vHostCache, nil, nil)
+	if resource == nil {
+		t.Fatal("Expected route configuration, got nil")
+	}
+
+	routeCfg := &route.RouteConfiguration{}
+	if err := resource.Resource.UnmarshalTo(routeCfg); err != nil {
+		t.Fatalf("Failed to unmarshal route configuration: %v", err)
+	}
+	xdstest.ValidateRouteConfiguration(t, routeCfg)
+
+	// Find the VirtualHost for example.com:80.
+	var found *route.VirtualHost
+	for _, vh := range routeCfg.VirtualHosts {
+		if vh.Name == "example.com:80" {
+			found = vh
+			break
+		}
+	}
+	if found == nil {
+		var names []string
+		for _, vh := range routeCfg.VirtualHosts {
+			names = append(names, vh.Name)
+		}
+		t.Fatalf("VirtualHost 'example.com:80' not found; got: %v", names)
+	}
+
+	domains := sets.New(found.Domains...)
+
+	// Both addresses from the ServiceEntry must appear in the domains.
+	for _, addr := range []string{"10.2.2.118", "10.4.2.206"} {
+		if !domains.Contains(addr) {
+			t.Errorf("Address %s missing from VirtualHost domains: %v", addr, found.Domains)
+		}
+	}
+}
+
 func buildHTTPServiceWithLabels(hostname string, v visibility.Instance, ip, namespace string, labels map[string]string, ports ...int) *model.Service {
 	svc := buildHTTPService(hostname, v, ip, namespace, ports...)
 	svc.Attributes.Labels = labels


### PR DESCRIPTION
**What this PR does:**
Fixes ServiceEntry with multiple `addresses` only exposing one address for HTTP traffic in RDS route generation.

**Root cause:**
When multiple `model.Service` objects exist for the same hostname (one per address in a ServiceEntry), they were collapsed into a single entry in three places:

1. `SidecarScope.appendSidecarServices` dropped services with the same hostname and ports without merging addresses
2. `BuildSidecarOutboundVirtualHosts` overwrote the `servicesByName` map entry for duplicate hostnames
3. `generateVirtualHostDomains` only returned `DefaultAddress` when the proxy had no ClusterID set, missing merged addresses stored in ClusterVIPs

**Fix:**
- In `appendSidecarServices`: detect when services have the same ports but different addresses (e.g., from a multi-address ServiceEntry) and merge the addresses into ClusterVIPs
- In `BuildSidecarOutboundVirtualHosts`: when a service with the same hostname is already in the map, merge the new address instead of overwriting
- In `generateVirtualHostDomains`: also check ClusterVIPs for merged addresses when the proxy has no ClusterID

**Testing:**
- Added `TestServiceEntryMultipleAddresses` which creates a ServiceEntry with two addresses and verifies both appear in VirtualHost domains
- All existing `httproute` and sidecar tests pass

Fixes #58692