### PR TITLE
Remove a single "+build integ" annotation.

### DIFF
--- a/tests/integration/security/authz_multiple_providers_test.go
+++ b/tests/integration/security/authz_multiple_providers_test.go
@@ -1,5 +1,4 @@
 //go:build integ
-// +build integ
 
 // Copyright Istio Authors
 //

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -94,7 +94,7 @@ endef
 # Ensure that all test files are tagged properly. This ensures that we don't accidentally skip tests
 # and that integration tests are not run as part of the unit test suite.
 check-go-tag:
-	@go list ./tests/integration/... 2>/dev/null | xargs -r -I{} sh -c 'echo "Detected a file in tests/integration/ without a build tag set. Add // +build integ to the files: {}"; exit 2'
+	@go list ./tests/integration/... 2>/dev/null | xargs -r -I{} sh -c 'echo "Detected a file in tests/integration/ without a build tag set. Add //go:build integ to the files: {}"; exit 2'
 
 # Generate integration test targets for kubernetes environment.
 test.integration.%.kube: | $(JUNIT_REPORT) check-go-tag


### PR DESCRIPTION
**Please provide a description of this PR:**

There were two instances of the legacy `// +build` tag. The `forvar` rule is already covered by the `copyloopvar` linter.