### PR TITLE
Fix istio-ca-root-cert ConfigMap not created in multi-revision CPs with different discoverySelectors

### DIFF
--- a/pilot/pkg/leaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/leaderelection.go
@@ -247,6 +247,13 @@ func NewLeaderElectionMulticluster(namespace, name, electionID, revision string,
 	return newLeaderElection(namespace, name, electionID, revision, false, remote, false, client)
 }
 
+// NewPerRevisionLeaderElectionMulticluster creates a *per revision* leader election for multicluster.
+// This means there will be one leader for each revision, allowing each revisioned control plane
+// to independently manage resources for its own set of namespaces (e.g., via discoverySelectors).
+func NewPerRevisionLeaderElectionMulticluster(namespace, name, electionID, revision string, remote bool, client kube.Client) *LeaderElection {
+	return newLeaderElection(namespace, name, electionID, revision, true, remote, true, client)
+}
+
 func newLeaderElection(namespace, name, electionID, revision string, perRevision bool, remote bool, leaseLock bool, client kube.Client) *LeaderElection {
 	var watcher revisions.DefaultWatcher
 	if features.EnableLeaderElection {

--- a/pilot/pkg/leaderelection/leaderelection_test.go
+++ b/pilot/pkg/leaderelection/leaderelection_test.go
@@ -179,6 +179,19 @@ func TestMulticlusterLeaderElection(t *testing.T) {
 	close(stop)
 }
 
+func TestPerRevisionMulticlusterLeaderElection(t *testing.T) {
+	client := fake.NewClientset()
+	watcher := &fakeDefaultWatcher{}
+	// Two different revisions can both be leaders simultaneously because they use separate locks
+	_, stop := createElectionMulticluster(t, "pod1", "1-22", true, true, watcher, true, client)
+	_, stop2 := createElectionMulticluster(t, "pod2", "1-23", true, true, watcher, true, client)
+	// A second pod for the same revision cannot become leader
+	_, stop3 := createElectionMulticluster(t, "pod3", "1-22", true, true, watcher, false, client)
+	close(stop3)
+	close(stop2)
+	close(stop)
+}
+
 func TestPrioritizedMulticlusterLeaderElection(t *testing.T) {
 	client := fake.NewClientset()
 	watcher := &fakeDefaultWatcher{defaultRevision: "red"}

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -247,8 +247,13 @@ func (m *Multicluster) initializeCluster(cluster *multicluster.Cluster, kubeCont
 				m.s.RunComponentAsyncAndWait("clustertrustbundle controller", func(_ <-chan struct{}) error {
 					log.Infof("joining leader-election for %s in %s on cluster %s",
 						leaderelection.ClusterTrustBundleController, options.SystemNamespace, options.ClusterID)
+					// Use per-revision leader election so each revisioned control plane independently
+					// manages its own namespaces based on its discoverySelectors. Without this, only
+					// one revision wins the shared lock and creates resources only for namespaces
+					// matching its own selectors, leaving other revisions' namespaces without the
+					// istio-ca-root-cert ConfigMap (istio/istio#56594).
 					election := leaderelection.
-						NewLeaderElectionMulticluster(options.SystemNamespace, m.serverID, leaderelection.NamespaceController, m.revision, !configCluster, client).
+						NewPerRevisionLeaderElectionMulticluster(options.SystemNamespace, m.serverID, leaderelection.ClusterTrustBundleController, m.revision, !configCluster, client).
 						AddRunFunction(func(leaderStop <-chan struct{}) {
 							log.Infof("starting clustertrustbundle controller for cluster %s", cluster.ID)
 							c := clustertrustbundle.NewController(client, m.caBundleWatcher)
@@ -263,8 +268,13 @@ func (m *Multicluster) initializeCluster(cluster *multicluster.Cluster, kubeCont
 				m.s.RunComponentAsyncAndWait("namespace controller", func(_ <-chan struct{}) error {
 					log.Infof("joining leader-election for %s in %s on cluster %s",
 						leaderelection.NamespaceController, options.SystemNamespace, options.ClusterID)
+					// Use per-revision leader election so each revisioned control plane independently
+					// manages its own namespaces based on its discoverySelectors. Without this, only
+					// one revision wins the shared lock and creates ConfigMaps only for namespaces
+					// matching its own selectors, leaving other revisions' namespaces without the
+					// istio-ca-root-cert ConfigMap (istio/istio#56594).
 					election := leaderelection.
-						NewLeaderElectionMulticluster(options.SystemNamespace, m.serverID, leaderelection.NamespaceController, m.revision, !configCluster, client).
+						NewPerRevisionLeaderElectionMulticluster(options.SystemNamespace, m.serverID, leaderelection.NamespaceController, m.revision, !configCluster, client).
 						AddRunFunction(func(leaderStop <-chan struct{}) {
 							log.Infof("starting namespace controller for cluster %s", cluster.ID)
 							nc := NewNamespaceController(client, m.caBundleWatcher)

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
@@ -259,6 +259,103 @@ func TestNamespaceControllerDiscovery(t *testing.T) {
 	expectConfigMapNotExist(t, nc.configmaps, "selected")
 }
 
+// TestMultiRevisionNamespaceController verifies that two revisioned control planes with
+// different discoverySelectors can independently create istio-ca-root-cert ConfigMaps
+// for their respective namespaces. This is the scenario described in istio/istio#56594.
+func TestMultiRevisionNamespaceController(t *testing.T) {
+	// Use two separate kube clients (simulating two istiod processes) but sharing
+	// the same underlying fake API server for namespaces.
+	client1 := kube.NewFakeClient()
+	t.Cleanup(client1.Shutdown)
+	client2 := kube.NewFakeClient()
+	t.Cleanup(client2.Shutdown)
+
+	// Revision 1-22 selects namespaces with istio-discovery=istio-1-22
+	watcher1 := keycertbundle.NewWatcher()
+	caBundle1 := []byte("caBundle-rev122")
+	watcher1.SetAndNotify(nil, nil, caBundle1)
+	meshWatcher1 := meshwatcher.NewTestWatcher(&meshconfig.MeshConfig{
+		DiscoverySelectors: []*meshconfig.LabelSelector{{
+			MatchLabels: map[string]string{"istio-discovery": "istio-1-22"},
+		}},
+	})
+
+	// Revision 1-23 selects namespaces with istio-discovery=istio-1-23
+	watcher2 := keycertbundle.NewWatcher()
+	caBundle2 := []byte("caBundle-rev123")
+	watcher2.SetAndNotify(nil, nil, caBundle2)
+	meshWatcher2 := meshwatcher.NewTestWatcher(&meshconfig.MeshConfig{
+		DiscoverySelectors: []*meshconfig.LabelSelector{{
+			MatchLabels: map[string]string{"istio-discovery": "istio-1-23"},
+		}},
+	})
+
+	stop := test.NewStop(t)
+
+	// Set up discovery filters per revision
+	filter1 := filter.NewDiscoveryNamespacesFilter(
+		kclient.New[*v1.Namespace](client1),
+		meshWatcher1,
+		stop,
+	)
+	kube.SetObjectFilter(client1, filter1)
+
+	filter2 := filter.NewDiscoveryNamespacesFilter(
+		kclient.New[*v1.Namespace](client2),
+		meshWatcher2,
+		stop,
+	)
+	kube.SetObjectFilter(client2, filter2)
+
+	// Create namespace controllers per revision
+	nc1 := NewNamespaceController(client1, watcher1)
+	nc2 := NewNamespaceController(client2, watcher2)
+
+	client1.RunAndWait(stop)
+	client2.RunAndWait(stop)
+	go nc1.Run(stop)
+	go nc2.Run(stop)
+	retry.UntilOrFail(t, nc1.queue.HasSynced)
+	retry.UntilOrFail(t, nc2.queue.HasSynced)
+
+	expectedData1 := map[string]string{
+		constants.CACertNamespaceConfigMapDataName: string(caBundle1),
+	}
+	expectedData2 := map[string]string{
+		constants.CACertNamespaceConfigMapDataName: string(caBundle2),
+	}
+
+	// Create namespaces for revision 1-22
+	createNamespace(t, client1.Kube(), "httpbin122", map[string]string{
+		"istio-discovery": "istio-1-22",
+		"istio.io/rev":    "1-22",
+	})
+	createNamespace(t, client1.Kube(), "httpbin122-v2", map[string]string{
+		"istio-discovery": "istio-1-22",
+		"istio.io/rev":    "1-22",
+	})
+
+	// Create namespaces for revision 1-23
+	createNamespace(t, client2.Kube(), "httpbin123", map[string]string{
+		"istio-discovery": "istio-1-23",
+		"istio.io/rev":    "1-23",
+	})
+
+	// Revision 1-22 should create ConfigMaps for its namespaces
+	expectConfigMap(t, nc1.configmaps, CACertNamespaceConfigMap, "httpbin122", expectedData1)
+	expectConfigMap(t, nc1.configmaps, CACertNamespaceConfigMap, "httpbin122-v2", expectedData1)
+
+	// Revision 1-23 should create ConfigMaps for its namespaces
+	expectConfigMap(t, nc2.configmaps, CACertNamespaceConfigMap, "httpbin123", expectedData2)
+
+	// Revision 1-22 should NOT see namespaces for revision 1-23 (filtered out)
+	expectConfigMapNotExist(t, nc1.configmaps, "httpbin123")
+
+	// Revision 1-23 should NOT see namespaces for revision 1-22 (filtered out)
+	expectConfigMapNotExist(t, nc2.configmaps, "httpbin122")
+	expectConfigMapNotExist(t, nc2.configmaps, "httpbin122-v2")
+}
+
 func deleteConfigMap(t *testing.T, client kubernetes.Interface, ns string) {
 	t.Helper()
 	_, err := client.CoreV1().ConfigMaps(ns).Get(context.TODO(), CACertNamespaceConfigMap, metav1.GetOptions{})


### PR DESCRIPTION
## Summary

Fixes #56594

When multiple revisioned control planes (e.g., 1-22 and 1-23) are deployed with different `discoverySelectors`, the `istio-ca-root-cert` ConfigMap is only created for namespaces matching one revision's selectors, leaving pods in other revisions' namespaces stuck in `Init:0/1`.

**Root cause:** The namespace controller (and clustertrustbundle controller) used a shared (non-per-revision) leader election lock (`istio-namespace-controller-election`). Only one revision wins the lock at a time, and that revision's controller only creates ConfigMaps for namespaces matching its own `discoverySelectors`.

**Fix:** Switch both controllers to use per-revision leader election. Each revision now gets its own independent leader lock (e.g., `istio-namespace-controller-election-1-22` and `istio-namespace-controller-election-1-23`), allowing each revisioned control plane to independently manage `istio-ca-root-cert` ConfigMaps for its own namespaces.

Also fixes a pre-existing bug where the clustertrustbundle controller's leader election was incorrectly using the `NamespaceController` election ID instead of its own `ClusterTrustBundleController` ID.

### Changes
- Added `NewPerRevisionLeaderElectionMulticluster` to `leaderelection` package
- Changed namespace controller and clustertrustbundle controller in `multicluster.go` to use per-revision leader election
- Added `TestPerRevisionMulticlusterLeaderElection` test for leader election
- Added `TestMultiRevisionNamespaceController` test simulating two revisions with different discoverySelectors

## Test plan

- [x] New unit test `TestPerRevisionMulticlusterLeaderElection` verifies two revisions can independently acquire leader locks
- [x] New unit test `TestMultiRevisionNamespaceController` verifies two namespace controllers with different discoverySelectors independently create ConfigMaps for their respective namespaces
- [x] All existing leader election tests pass
- [ ] Manual verification with two revisioned istiod deployments and different discoverySelectors (reproducing the scenario from the issue)