### PR TITLE
Do not filter gateway-api routes by revision at the informer level

### DIFF
--- a/pilot/pkg/config/kube/gateway/controller.go
+++ b/pilot/pkg/config/kube/gateway/controller.go
@@ -473,8 +473,14 @@ func buildClient[I controllers.ComparableObject](
 		ObjectFilter: kubetypes.ComposeFilters(kc.ObjectFilter(), c.inRevision),
 	}
 
-	// all other types are filtered by revision, but for gateways we need to select tags as well
-	if res == gvr.KubernetesGateway {
+	// Gateways are not filtered by revision because they use tag-based selection instead.
+	// Routes (HTTPRoute, GRPCRoute, TCPRoute, TLSRoute) are also not filtered by revision
+	// so that they remain globally visible to all revisions. This is critical for multi-revision
+	// canary upgrade scenarios where a route labeled with revision A must still be programmed
+	// by a Gateway owned by revision B. Status writing is already independently gated by
+	// tagWatcher.IsMine() in RegisterStatus, so revision-scoped ownership is preserved there.
+	switch res {
+	case gvr.KubernetesGateway, gvr.HTTPRoute, gvr.GRPCRoute, gvr.TCPRoute, gvr.TLSRoute:
 		filter.ObjectFilter = kc.ObjectFilter()
 	}
 

--- a/pilot/pkg/config/kube/gateway/controller_test.go
+++ b/pilot/pkg/config/kube/gateway/controller_test.go
@@ -93,6 +93,90 @@ func setupController(t *testing.T, objs ...runtime.Object) *Controller {
 	return controller
 }
 
+func setupControllerWithRevision(t *testing.T, revision string, objs ...runtime.Object) *Controller {
+	kc := kube.NewFakeClient(objs...)
+	setupClientCRDs(t, kc)
+	stop := test.NewStop(t)
+	ctrl := NewController(
+		kc,
+		AlwaysReady,
+		controller.Options{
+			Revision:    revision,
+			KrtDebugger: krt.GlobalDebugHandler,
+		},
+		nil)
+	kc.RunAndWait(stop)
+	go ctrl.Run(stop)
+	cg := core.NewConfigGenTest(t, core.TestOptions{})
+	ctrl.Reconcile(cg.PushContext())
+	kube.WaitForCacheSync("test", stop, ctrl.HasSynced)
+	return ctrl
+}
+
+// TestHTTPRouteVisibleAcrossRevisions verifies that an HTTPRoute labeled with
+// one revision is still programmed into a VirtualService by a controller
+// running under a different revision. This is the fix for
+// https://github.com/istio/istio/issues/58840 where revision-scoped informer
+// filtering caused routes to be invisible during multi-revision canary upgrades.
+func TestHTTPRouteVisibleAcrossRevisions(t *testing.T) {
+	// The controller runs as revision "rev-B".  The Gateway is labeled with
+	// "rev-B" so tagWatcher.IsMine claims it.  The HTTPRoute is labeled with
+	// "rev-A" (a different revision).  Without the fix, the inRevision
+	// informer filter would drop the route entirely, producing zero
+	// VirtualServices.
+	ctrl := setupControllerWithRevision(t, "rev-B",
+		&k8s.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "gwclass",
+			},
+			Spec: *gatewayClassSpec,
+		},
+		&k8s.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gwspec",
+				Namespace: "ns1",
+				Labels: map[string]string{
+					"istio.io/rev": "rev-B",
+				},
+			},
+			Spec: *gatewaySpec,
+		},
+		&k8s.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cross-rev-route",
+				Namespace: "ns1",
+				Labels: map[string]string{
+					"istio.io/rev": "rev-A",
+				},
+			},
+			Spec: k8s.HTTPRouteSpec{
+				CommonRouteSpec: k8s.CommonRouteSpec{ParentRefs: []k8s.ParentReference{{
+					Name: "gwspec",
+				}}},
+				Hostnames: []k8s.Hostname{"test.cluster.local"},
+				Rules: []k8s.HTTPRouteRule{{
+					BackendRefs: []k8s.HTTPBackendRef{{
+						BackendRef: k8s.BackendRef{
+							BackendObjectReference: k8s.BackendObjectReference{
+								Name: "test-service",
+								Port: func() *k8s.PortNumber { p := k8s.PortNumber(80); return &p }(),
+							},
+						},
+					}},
+				}},
+			},
+		})
+
+	dumpOnFailure(t, krt.GlobalDebugHandler)
+
+	// The route should produce a VirtualService even though the route carries
+	// a different revision label than the controller.
+	vs := ctrl.List(gvk.VirtualService, "ns1")
+	if len(vs) == 0 {
+		t.Fatalf("expected VirtualService to be generated for cross-revision HTTPRoute, got none")
+	}
+}
+
 func TestListInvalidGroupVersionKind(t *testing.T) {
 	controller := setupController(t)
 


### PR DESCRIPTION
## Summary

After the change in PR #57734, HTTPRoutes (and other route types) labeled with a specific `istio.io/rev` revision were only visible to that revision's controller informer due to the `inRevision` filter in `buildClient()`. This caused routes to be invisible to controllers running under a different revision, breaking multi-revision canary upgrade scenarios where a route labeled with revision A must still be programmed by a Gateway owned by revision B.

**Root cause:** The `buildClient` function in `controller.go` applied a revision-based informer filter to all resource types except Gateways. This meant that if an HTTPRoute had `istio.io/rev: 1-27-0`, only the `1-27-0` controller would even see it in its informer cache.

**Fix:** Exempt route types (HTTPRoute, GRPCRoute, TCPRoute, TLSRoute) from revision-based informer filtering, the same way Gateways are already exempted. Routes must remain globally visible so that any revision's Gateway can program them. Status writing remains correctly revision-scoped through the existing `tagWatcher.IsMine()` check in `RegisterStatus`.

- Adds HTTPRoute, GRPCRoute, TCPRoute, and TLSRoute to the list of resource types that skip the `inRevision` informer filter in `buildClient()`
- Adds `TestHTTPRouteVisibleAcrossRevisions` to verify that an HTTPRoute labeled with one revision still produces a VirtualService when processed by a controller running under a different revision

Fixes #58840

## Test plan

- [x] New unit test `TestHTTPRouteVisibleAcrossRevisions` covers the cross-revision scenario
- [x] All existing gateway package tests pass (`go test ./pilot/pkg/config/kube/gateway/...`)
- [ ] Manual validation in a multi-revision cluster: deploy two Istio control planes, label a Gateway with revision A, label an HTTPRoute with revision B, verify the route is programmed by both controllers