### PR TITLE
fix: handle multiple ServiceEntries with same host but different ports/resolutions

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -120,12 +120,30 @@ type Service struct {
 	// by the caller)
 	Resolution Resolution
 
+	// PortResolutionOverrides stores per-port resolution overrides. When multiple ServiceEntries
+	// share the same hostname but have different resolution modes, ports merged from a ServiceEntry
+	// with a different resolution will have their resolution recorded here. The key is the port number.
+	// If a port is not in this map, the service-level Resolution field applies.
+	PortResolutionOverrides map[int]Resolution `json:"portResolutionOverrides,omitempty"`
+
 	// MeshExternal (if true) indicates that the service is external to the mesh.
 	// These services are defined using Istio's ServiceEntry spec.
 	MeshExternal bool
 
 	// ResourceVersion represents the internal version of this object.
 	ResourceVersion string
+}
+
+// GetPortResolution returns the resolution mode for a specific port. If a per-port override
+// exists (from merging ServiceEntries with different resolutions), it is returned. Otherwise,
+// the service-level Resolution is returned.
+func (s *Service) GetPortResolution(portNumber int) Resolution {
+	if s.PortResolutionOverrides != nil {
+		if r, ok := s.PortResolutionOverrides[portNumber]; ok {
+			return r
+		}
+	}
+	return s.Resolution
 }
 
 // UseInferenceSemantics determines which logic we should use for Service
@@ -1847,6 +1865,12 @@ func (s *Service) DeepCopy() *Service {
 
 	out.ServiceAccounts = slices.Clone(s.ServiceAccounts)
 	out.ClusterVIPs = *s.ClusterVIPs.DeepCopy()
+	if s.PortResolutionOverrides != nil {
+		out.PortResolutionOverrides = make(map[int]Resolution, len(s.PortResolutionOverrides))
+		for k, v := range s.PortResolutionOverrides {
+			out.PortResolutionOverrides[k] = v
+		}
+	}
 	return &out
 }
 
@@ -1877,6 +1901,10 @@ func (s *Service) Equals(other *Service) bool {
 		if v2, ok := other.ClusterVIPs.Addresses[k]; !ok || !slices.Equal(v1, v2) {
 			return false
 		}
+	}
+
+	if !maps.Equal(s.PortResolutionOverrides, other.PortResolutionOverrides) {
+		return false
 	}
 
 	return true

--- a/pilot/pkg/model/service_test.go
+++ b/pilot/pkg/model/service_test.go
@@ -1055,3 +1055,59 @@ func TestGetTrafficDistribution(t *testing.T) {
 		})
 	}
 }
+
+func TestGetPortResolution(t *testing.T) {
+	tests := []struct {
+		name       string
+		svc        *Service
+		portNumber int
+		want       Resolution
+	}{
+		{
+			name: "no overrides returns service resolution",
+			svc: &Service{
+				Resolution: Passthrough,
+			},
+			portNumber: 443,
+			want:       Passthrough,
+		},
+		{
+			name: "port with override returns override resolution",
+			svc: &Service{
+				Resolution: Passthrough,
+				PortResolutionOverrides: map[int]Resolution{
+					443: DNSLB,
+				},
+			},
+			portNumber: 443,
+			want:       DNSLB,
+		},
+		{
+			name: "port without override returns service resolution",
+			svc: &Service{
+				Resolution: Passthrough,
+				PortResolutionOverrides: map[int]Resolution{
+					443: DNSLB,
+				},
+			},
+			portNumber: 9093,
+			want:       Passthrough,
+		},
+		{
+			name: "empty overrides map returns service resolution",
+			svc: &Service{
+				Resolution:              DNSLB,
+				PortResolutionOverrides: map[int]Resolution{},
+			},
+			portNumber: 443,
+			want:       DNSLB,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.svc.GetPortResolution(tt.portNumber)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -977,6 +977,8 @@ func (sc *SidecarScope) appendSidecarServices(servicesAdded map[host.Name]sideca
 			return
 		}
 
+		resolutionDiffers := existing.Resolution != s.Resolution
+
 		// If it comes here, it means we can merge the services.
 		// Merge the ports to service when each listener generates partial service.
 		// We only merge if the found service is in the same namespace as the one we're trying to add
@@ -987,6 +989,15 @@ func (sc *SidecarScope) appendSidecarServices(servicesAdded map[host.Name]sideca
 			p := *port
 			copied.Ports = append(copied.Ports, &p)
 		}
+
+		// Deep copy any existing port resolution overrides
+		if foundSvc.svc.PortResolutionOverrides != nil {
+			copied.PortResolutionOverrides = make(map[int]Resolution, len(foundSvc.svc.PortResolutionOverrides)+len(s.Ports))
+			for k, v := range foundSvc.svc.PortResolutionOverrides {
+				copied.PortResolutionOverrides[k] = v
+			}
+		}
+
 		// Add new ports from s, avoiding duplicates
 		for _, p := range s.Ports {
 			found := false
@@ -998,6 +1009,13 @@ func (sc *SidecarScope) appendSidecarServices(servicesAdded map[host.Name]sideca
 			}
 			if !found {
 				copied.Ports = append(copied.Ports, p)
+				// When resolution differs, record the incoming service's resolution for this port
+				if resolutionDiffers {
+					if copied.PortResolutionOverrides == nil {
+						copied.PortResolutionOverrides = make(map[int]Resolution, len(s.Ports))
+					}
+					copied.PortResolutionOverrides[p.Port] = s.Resolution
+				}
 			}
 		}
 		// replace service in slice
@@ -1013,9 +1031,6 @@ func (sc *SidecarScope) appendSidecarServices(servicesAdded map[host.Name]sideca
 func canMergeServices(s1, s2 *Service) bool {
 	// Hostname has been compared in the caller `appendSidecarServices`, so we do not need to compare again.
 	if s1.Attributes.Namespace != s2.Attributes.Namespace {
-		return false
-	}
-	if s1.Resolution != s2.Resolution {
 		return false
 	}
 	// kuberneres service registry has been checked before

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -2615,7 +2615,7 @@ func TestCreateSidecarScope(t *testing.T) {
 			},
 		},
 		{
-			name:          "serviceentry not merge when resolution is different",
+			name:          "serviceentry merge when resolution is different with per-port overrides",
 			sidecarConfig: configs22,
 			services: []*Service{
 				{
@@ -2639,10 +2639,57 @@ func TestCreateSidecarScope(t *testing.T) {
 			expectedServices: []*Service{
 				{
 					Hostname: "foobar.svc.cluster.local",
-					Ports:    port803x[:3],
+					Ports:    port803x,
 					Attributes: ServiceAttributes{
 						Name:      "foo",
 						Namespace: "ns1",
+					},
+					PortResolutionOverrides: map[int]Resolution{
+						8034: DNSLB,
+						8035: DNSLB,
+					},
+				},
+			},
+		},
+		{
+			// Regression test for https://github.com/istio/istio/issues/54988
+			// Two ServiceEntries: same host, different ports, different resolutions (NONE vs DNS)
+			name:          "serviceentry merge same host different port and resolution",
+			sidecarConfig: nil,
+			services: []*Service{
+				{
+					Hostname:   "example.com",
+					Ports:      []*Port{{Name: "https-passthrough", Port: 9093, Protocol: "HTTPS"}},
+					Resolution: Passthrough,
+					Attributes: ServiceAttributes{
+						Name:      "service-entry-1",
+						Namespace: "mynamespace",
+					},
+				},
+				{
+					Hostname:   "example.com",
+					Ports:      []*Port{{Name: "https-dns", Port: 443, Protocol: "HTTPS"}},
+					Resolution: DNSLB,
+					Attributes: ServiceAttributes{
+						Name:      "service-entry-2",
+						Namespace: "mynamespace",
+					},
+				},
+			},
+			expectedServices: []*Service{
+				{
+					Hostname: "example.com",
+					Ports: []*Port{
+						{Name: "https-passthrough", Port: 9093, Protocol: "HTTPS"},
+						{Name: "https-dns", Port: 443, Protocol: "HTTPS"},
+					},
+					Resolution: Passthrough,
+					Attributes: ServiceAttributes{
+						Name:      "service-entry-1",
+						Namespace: "mynamespace",
+					},
+					PortResolutionOverrides: map[int]Resolution{
+						443: DNSLB,
 					},
 				},
 			},

--- a/pilot/pkg/networking/core/cluster.go
+++ b/pilot/pkg/networking/core/cluster.go
@@ -439,7 +439,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(cb *ClusterBuilder, 
 			}
 
 			// create default cluster
-			discoveryType := convertResolution(cb.proxyType, service)
+			discoveryType := convertResolution(cb.proxyType, service, port.Port)
 			defaultCluster := cb.buildCluster(clusterKey.clusterName, discoveryType, lbEndpoints, model.TrafficDirectionOutbound, port, service, nil, "")
 			if defaultCluster == nil {
 				continue
@@ -549,13 +549,14 @@ func (configgen *ConfigGeneratorImpl) buildOutboundSniDnatClusters(proxy *model.
 			}
 
 			// create default cluster
-			discoveryType := convertResolution(cb.proxyType, service)
+			portResolution := service.GetPortResolution(port.Port)
+			discoveryType := convertResolution(cb.proxyType, service, port.Port)
 			clusterName := model.BuildDNSSrvSubsetKey(model.TrafficDirectionOutbound, "",
 				service.Hostname, port.Port)
 
 			var lbEndpoints []*endpoint.LocalityLbEndpoints
 			var endpointBuilder *endpoints.EndpointBuilder
-			if service.Resolution == model.DNSLB || service.Resolution == model.DNSRoundRobinLB {
+			if portResolution == model.DNSLB || portResolution == model.DNSRoundRobinLB {
 				endpointBuilder = endpoints.NewCDSEndpointBuilder(proxy, cb.req.Push,
 					clusterName, model.TrafficDirectionOutbound, "", service.Hostname, port.Port,
 					service, destRule,
@@ -801,8 +802,12 @@ func findOrCreateService(instances []model.ServiceTarget,
 	}
 }
 
-func convertResolution(proxyType model.NodeType, service *model.Service) cluster.Cluster_DiscoveryType {
-	switch service.Resolution {
+func convertResolution(proxyType model.NodeType, service *model.Service, portNumber ...int) cluster.Cluster_DiscoveryType {
+	resolution := service.Resolution
+	if len(portNumber) > 0 {
+		resolution = service.GetPortResolution(portNumber[0])
+	}
+	switch resolution {
 	case model.ClientSideLB:
 		return cluster.Cluster_EDS
 	case model.DNSLB:

--- a/pilot/pkg/networking/core/cluster_cache.go
+++ b/pilot/pkg/networking/core/cluster_cache.go
@@ -182,7 +182,8 @@ func buildClusterKey(service *model.Service, port *model.Port, cb *ClusterBuilde
 	clusterName := model.BuildSubsetKey(model.TrafficDirectionOutbound, "", service.Hostname, port.Port)
 	dr := proxy.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, proxy, service.Hostname)
 	var eb *endpoints.EndpointBuilder
-	if service.Resolution == model.DNSLB || service.Resolution == model.DNSRoundRobinLB {
+	portResolution := service.GetPortResolution(port.Port)
+	if portResolution == model.DNSLB || portResolution == model.DNSRoundRobinLB {
 		eb = endpoints.NewCDSEndpointBuilder(
 			proxy,
 			cb.req.Push,

--- a/pilot/pkg/networking/core/cluster_waypoint.go
+++ b/pilot/pkg/networking/core/cluster_waypoint.go
@@ -153,8 +153,8 @@ func (cb *ClusterBuilder) buildWaypointInboundVIPCluster(
 	var endpointBuilder *endpoints.EndpointBuilder
 	// All non custom DiscoveryTypes use the same cluster creation logic
 	// DynamicDNS uses a custom DiscoveryType
-	if svc.Resolution != model.DynamicDNS {
-		discoveryType := convertResolution(cb.proxyType, svc)
+	if svc.GetPortResolution(port.Port) != model.DynamicDNS {
+		discoveryType := convertResolution(cb.proxyType, svc, port.Port)
 		var lbEndpoints []*endpoint.LocalityLbEndpoints
 		if discoveryType == cluster.Cluster_STRICT_DNS || discoveryType == cluster.Cluster_LOGICAL_DNS {
 			endpointBuilder = endpoints.NewCDSEndpointBuilder(
@@ -223,7 +223,7 @@ func (cb *ClusterBuilder) buildWaypointInboundVIPCluster(
 	applyOutlierDetection(nil, localCluster.cluster, outlierDetection)
 
 	// Unless the svc resolution type is DynamicDNS, we apply the LB settings
-	if svc.Resolution != model.DynamicDNS {
+	if svc.GetPortResolution(port.Port) != model.DynamicDNS {
 		applyLoadBalancer(svc, localCluster.cluster, loadBalancer, &port, cb.locality, cb.proxyLabels, mesh, nil)
 	}
 
@@ -322,11 +322,11 @@ func (cb *ClusterBuilder) buildWaypointInboundVIP(proxy *model.Proxy, svcs map[h
 				continue
 			}
 			// For dynamic DNS (dynamic forward proxy) resolution protocol other than HTTP and TLS are not supported
-			if svc.Resolution == model.DynamicDNS && port.Protocol != protocol.HTTP && port.Protocol != protocol.TLS {
+			if svc.GetPortResolution(port.Port) == model.DynamicDNS && port.Protocol != protocol.HTTP && port.Protocol != protocol.TLS {
 				log.Debugf("skipping waypoint VIP cluster for unsupported protocol %s for service %s with DynamicDNS resolution", port.Protocol, svc.Hostname)
 				continue
 			}
-			if svc.Resolution == model.DynamicDNS && port.Protocol == protocol.TLS && !features.EnableWildcardHostServiceEntriesForTLS {
+			if svc.GetPortResolution(port.Port) == model.DynamicDNS && port.Protocol == protocol.TLS && !features.EnableWildcardHostServiceEntriesForTLS {
 				log.Warnf("skipping waypoint VIP cluster for TLS protocol for service %s with DynamicDNS resolution since the feature is disabled", svc.Hostname)
 				continue
 			}

--- a/pilot/pkg/networking/core/listener.go
+++ b/pilot/pkg/networking/core/listener.go
@@ -500,7 +500,7 @@ func (lb *ListenerBuilder) buildSidecarOutboundListeners(node *model.Proxy,
 					// Instead of generating a single 0.0.0.0:Port listener, generate a listener
 					// for each instance. HTTP services can happily reside on 0.0.0.0:PORT and use the
 					// wildcard route match to get to the appropriate IP through original dst clusters.
-					if bind.Primary() == "" && service.Resolution == model.Passthrough &&
+					if bind.Primary() == "" && service.GetPortResolution(servicePort.Port) == model.Passthrough &&
 						saddress == constants.UnspecifiedIP && (servicePort.Protocol.IsTCP() || servicePort.Protocol.IsUnsupported()) {
 						instances := push.ServiceEndpointsByPort(service, servicePort.Port, nil)
 						if service.Attributes.ServiceRegistry != provider.Kubernetes && len(instances) == 0 && service.Attributes.LabelSelectors == nil {


### PR DESCRIPTION
## Summary

Fixes #54988

When multiple `ServiceEntry` resources share the same hostname but have different ports and resolution modes (e.g., `NONE` on port 9093 and `DNS` on port 443), the second ServiceEntry's cluster was not generated, resulting in `NoClusterFound` errors.

**Root cause:** `canMergeServices` rejected merging when the `Resolution` field differed, causing the second ServiceEntry's ports to be silently dropped from `servicesByHostname`. Since each port gets its own Envoy cluster, the correct behavior is to merge the ports and track per-port resolution.

**Changes:**
- Add `PortResolutionOverrides` map to `Service` struct to store per-port resolution when merged services have different resolutions
- Add `GetPortResolution(portNumber)` helper that checks overrides before falling back to the service-level resolution
- Remove the resolution equality check from `canMergeServices` to allow merging services with different resolutions
- Store per-port resolution overrides during merge in `appendSidecarServices`
- Update cluster builder (`cluster.go`, `cluster_cache.go`), waypoint (`cluster_waypoint.go`), and listener (`listener.go`) to use `GetPortResolution` for per-port cluster discovery type
- Update `DeepCopy` and `Equals` on `Service` to handle the new field
- Add regression test matching the exact scenario from the bug report
- Update existing test expectations to reflect the new merge behavior

## Test plan

- [x] Updated existing test "serviceentry not merge when resolution is different" to expect merge with per-port overrides
- [x] Added new test "serviceentry merge same host different port and resolution" matching the exact issue scenario (NONE/9093 + DNS/443)
- [x] Added unit tests for `GetPortResolution` covering all edge cases (no overrides, with override, missing port, empty map)
- [x] All existing `TestCreateSidecarScope` tests pass (58 subtests)
- [x] All `pilot/pkg/model` tests pass
- [x] Fuzz tests for `DeepCopy` pass