### PR TITLE
[Release-1.28] fix: resources improperly being set when trying to remove resource values (#58824)

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -330,8 +330,8 @@ copy-templates:
 
 	# gateway charts
 	cp -r manifests/charts/gateways/istio-ingress/templates/* manifests/charts/gateways/istio-egress/templates
-	find ./manifests/charts/gateways/istio-egress/templates -type f -name "*.yaml" ! -name "networkpolicy.yaml" -exec sed -i -e 's/ingress/egress/g' {} \;
-	find ./manifests/charts/gateways/istio-egress/templates -type f -name "*.yaml" ! -name "networkpolicy.yaml" -exec sed -i -e 's/Ingress/Egress/g' {} \;
+	find ./manifests/charts/gateways/istio-egress/templates -type f \( -name "*.yaml" -o -name "*.tpl" \) ! -name "networkpolicy.yaml" -exec sed -i -e 's/ingress/egress/g' {} \;
+	find ./manifests/charts/gateways/istio-egress/templates -type f \( -name "*.yaml" -o -name "*.tpl" \) ! -name "networkpolicy.yaml" -exec sed -i -e 's/Ingress/Egress/g' {} \;
 	if [ -f ./manifests/charts/gateways/istio-egress/templates/networkpolicy.yaml ]; then \
 		sed -i -e 's/"IngressGateways"/"EgressGateways"/g' ./manifests/charts/gateways/istio-egress/templates/networkpolicy.yaml; \
 		sed -i -e 's/istio-ingress/istio-egress/g' ./manifests/charts/gateways/istio-egress/templates/networkpolicy.yaml; \

--- a/manifests/charts/gateway/templates/_helpers.tpl
+++ b/manifests/charts/gateway/templates/_helpers.tpl
@@ -38,3 +38,28 @@ istio.io/rev: {{ . | quote }}
 {{- .Values.serviceAccount.name | default "default" }}
 {{- end }}
 {{- end }}
+
+{{/*
+Render resource requirements, omitting any nil values.
+*/}}
+{{- define "gateway.resources" -}}
+{{- range $key := list "limits" "requests" }}
+  {{- $resources := index $ $key }}
+  {{- if $resources }}
+    {{- $hasValues := false }}
+    {{- range $name, $value := $resources }}
+      {{- if $value }}
+        {{- $hasValues = true }}
+      {{- end }}
+    {{- end }}
+    {{- if $hasValues }}
+{{ $key }}:
+      {{- range $name, $value := $resources }}
+        {{- if $value }}
+  {{ $name }}: {{ $value }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -107,7 +107,7 @@ spec:
             protocol: TCP
             name: http-envoy-prom
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- include "gateway.resources" .Values.resources | trim | nindent 12 }}
           {{- with .Values.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}

--- a/manifests/charts/gateways/istio-egress/templates/_helpers.tpl
+++ b/manifests/charts/gateways/istio-egress/templates/_helpers.tpl
@@ -1,16 +1,7 @@
-{{- define "name" -}}
-    istio-cni
-{{- end }}
-
-
-{{- define "istio-tag" -}}
-    {{ .Values.tag | default .Values.global.tag }}{{with (.Values.variant | default .Values.global.variant)}}-{{.}}{{end}}
-{{- end }}
-
 {{/*
 Render resource requirements, omitting any nil values.
 */}}
-{{- define "istio-cni.resources" -}}
+{{- define "istio-egress.resources" -}}
 {{- range $key := list "limits" "requests" }}
   {{- $resources := index $ $key }}
   {{- if $resources }}

--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -134,9 +134,9 @@ spec:
             timeoutSeconds: 1
           resources:
 {{- if $gateway.resources }}
-{{ toYaml $gateway.resources | indent 12 }}
+{{ include "istio-egress.resources" $gateway.resources | trim | indent 12 }}
 {{- else }}
-{{ toYaml .Values.global.defaultResources | indent 12 }}
+{{ include "istio-egress.resources" .Values.global.defaultResources | trim | indent 12 }}
 {{- end }}
           env:
           - name: PILOT_CERT_PROVIDER

--- a/manifests/charts/gateways/istio-egress/templates/injected-deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/injected-deployment.yaml
@@ -98,9 +98,9 @@ spec:
         {{- end }}
           resources:
 {{- if $gateway.resources }}
-{{ toYaml $gateway.resources | indent 12 }}
+{{ include "istio-egress.resources" $gateway.resources | trim | indent 12 }}
 {{- else }}
-{{ toYaml .Values.global.defaultResources | indent 12 }}
+{{ include "istio-egress.resources" .Values.global.defaultResources | trim | indent 12 }}
 {{- end }}
           env:
           {{- if not $gateway.runAsRoot }}

--- a/manifests/charts/gateways/istio-ingress/templates/_helpers.tpl
+++ b/manifests/charts/gateways/istio-ingress/templates/_helpers.tpl
@@ -1,16 +1,7 @@
-{{- define "name" -}}
-    istio-cni
-{{- end }}
-
-
-{{- define "istio-tag" -}}
-    {{ .Values.tag | default .Values.global.tag }}{{with (.Values.variant | default .Values.global.variant)}}-{{.}}{{end}}
-{{- end }}
-
 {{/*
 Render resource requirements, omitting any nil values.
 */}}
-{{- define "istio-cni.resources" -}}
+{{- define "istio-ingress.resources" -}}
 {{- range $key := list "limits" "requests" }}
   {{- $resources := index $ $key }}
   {{- if $resources }}

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -134,9 +134,9 @@ spec:
             timeoutSeconds: 1
           resources:
 {{- if $gateway.resources }}
-{{ toYaml $gateway.resources | indent 12 }}
+{{ include "istio-ingress.resources" $gateway.resources | trim | indent 12 }}
 {{- else }}
-{{ toYaml .Values.global.defaultResources | indent 12 }}
+{{ include "istio-ingress.resources" .Values.global.defaultResources | trim | indent 12 }}
 {{- end }}
           env:
           - name: PILOT_CERT_PROVIDER

--- a/manifests/charts/gateways/istio-ingress/templates/injected-deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/injected-deployment.yaml
@@ -98,9 +98,9 @@ spec:
         {{- end }}
           resources:
 {{- if $gateway.resources }}
-{{ toYaml $gateway.resources | indent 12 }}
+{{ include "istio-ingress.resources" $gateway.resources | trim | indent 12 }}
 {{- else }}
-{{ toYaml .Values.global.defaultResources | indent 12 }}
+{{ include "istio-ingress.resources" .Values.global.defaultResources | trim | indent 12 }}
 {{- end }}
           env:
           {{- if not $gateway.runAsRoot }}

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -216,9 +216,9 @@ spec:
             {{ end }}
           resources:
 {{- if .Values.resources }}
-{{ toYaml .Values.resources | trim | indent 12 }}
+{{ include "istio-cni.resources" .Values.resources | trim | indent 12 }}
 {{- else }}
-{{ toYaml .Values.global.defaultResources | trim | indent 12 }}
+{{ include "istio-cni.resources" .Values.global.defaultResources | trim | indent 12 }}
 {{- end }}
       volumes:
         # Used to install CNI.

--- a/manifests/charts/istio-control/istio-discovery/files/agentgateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/agentgateway.yaml
@@ -12,14 +12,11 @@ metadata:
         "gateway.networking.k8s.io/gateway-name" .Name
         "gateway.networking.k8s.io/gateway-class-name" .GatewayClass
       ) | nindent 4 }}
-  {{- if ge .KubeVersion 128 }}
-  # Safe since 1.28: https://github.com/kubernetes/kubernetes/pull/117412
   ownerReferences:
-  - apiVersion: gateway.networking.k8s.io/v1beta1
+  - apiVersion: gateway.networking.k8s.io/v1
     kind: Gateway
     name: "{{.Name}}"
     uid: "{{.UID}}"
-  {{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -34,10 +31,10 @@ metadata:
       (strdict
         "gateway.networking.k8s.io/gateway-name" .Name
         "gateway.networking.k8s.io/gateway-class-name" .GatewayClass
-        "gateway.istio.io/managed" "istio.io-gateway-controller"
+        "gateway.istio.io/managed" "istio.io-agentgateway-controller"
       ) | nindent 4 }}
   ownerReferences:
-  - apiVersion: gateway.networking.k8s.io/v1beta1
+  - apiVersion: gateway.networking.k8s.io/v1
     kind: Gateway
     name: {{.Name}}
     uid: "{{.UID}}"
@@ -67,7 +64,7 @@ spec:
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name
             "gateway.networking.k8s.io/gateway-class-name" .GatewayClass
-            "gateway.istio.io/managed" "istio.io-gateway-controller"
+            "gateway.istio.io/managed" "istio.io-agentgateway-controller"
           ) | nindent 8 }}
     spec:
       securityContext:
@@ -75,7 +72,7 @@ spec:
         {{- toYaml .Values.gateways.securityContext | nindent 8 }}
       {{- else }}
         sysctls:
-        - name: net.ipv4.ip_unprivileged_port_start
+        - name: net.ipv4.ip_unprivileged_port_start # allows binding to 80 and 443 without root
           value: "0"
       {{- if .Values.gateways.seccompProfile }}
         seccompProfile:
@@ -84,11 +81,11 @@ spec:
       {{- end }}
       serviceAccountName: {{.ServiceAccount | quote}}
       containers:
-      - name: istio-proxy
-      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
-        image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+      - name: agentgateway
+      {{- if contains "/" (annotation .ObjectMeta `gateway.istio.io/agentgatewayImage` .Values.global.agentgateway.image) }}
+        image: "{{ annotation .ObjectMeta `gateway.istio.io/agentgatewayImage` .Values.global.agentgateway.image }}"
       {{- else }}
-        image: "{{ .ProxyImage }}"
+        image: "{{ .AgentgatewayImage }}"
       {{- end }}
         {{- if .Values.global.proxy.resources }}
         resources:
@@ -102,8 +99,8 @@ spec:
           allowPrivilegeEscalation: false
           privileged: false
           readOnlyRootFilesystem: true
-          runAsUser: {{ .ProxyUID | default "1337" }}
-          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "10101" }}
+          runAsGroup: {{ .ProxyGID | default "10101" }}
           runAsNonRoot: true
         ports:
         - containerPort: 15020
@@ -112,44 +109,23 @@ spec:
         - containerPort: 15021
           name: status-port
           protocol: TCP
-        - containerPort: 15090
-          protocol: TCP
-          name: http-envoy-prom
         args:
-        - proxy
-        - router
-        - --domain
-        - $(POD_NAMESPACE).svc.{{ .Values.global.proxy.clusterDomain }}
-        - --proxyLogLevel
-        - {{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel | quote}}
-        - --proxyComponentLogLevel
-        - {{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel | quote}}
-        - --log_output_level
-        - {{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level | quote}}
-      {{- if .Values.global.sts.servicePort }}
-        - --stsPort={{ .Values.global.sts.servicePort }}
-      {{- end }}
-      {{- if .Values.global.logAsJson }}
-        - --log_as_json
-      {{- end }}
+        - --config
+        - '{}'
       {{- if .Values.global.proxy.lifecycle }}
         lifecycle:
           {{- toYaml .Values.global.proxy.lifecycle | nindent 10 }}
       {{- end }}
         env:
-        - name: PILOT_CERT_PROVIDER
-          value: {{ .Values.global.pilotCertProvider }}
-        - name: CA_ADDR
-        {{- if .Values.global.caAddress }}
-          value: {{ .Values.global.caAddress }}
-        {{- else }}
-          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
-        {{- end }}
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
         - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -161,51 +137,20 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: HOST_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: ISTIO_CPU_LIMIT
+        - name: CPU_LIMIT
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
-        - name: PROXY_CONFIG
-          value: |
-                 {{ protoToJSON .ProxyConfig }}
-        - name: ISTIO_META_POD_PORTS
-          value: "[]"
-        - name: ISTIO_META_APP_CONTAINERS
-          value: ""
-        - name: GOMEMLIMIT
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
+              divisor: "1"
+        - name: GATEWAY
+          value: {{.Name|quote}}
+        - name: RUST_BACKTRACE
+          value: "1"
+        - name: CLUSTER_ID
           value: "{{ valueOrDefault .Values.global.multiCluster.clusterName .ClusterID }}"
-        - name: ISTIO_META_NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: ISTIO_META_INTERCEPTION_MODE
-          value: "{{ .ProxyConfig.InterceptionMode.String }}"
         {{- with (valueOrDefault  (index .InfrastructureLabels "topology.istio.io/network") .Values.global.network) }}
-        - name: ISTIO_META_NETWORK
+        - name: NETWORK
           value: {{.|quote}}
-        {{- end }}
-        - name: ISTIO_META_WORKLOAD_NAME
-          value: {{.DeploymentName|quote}}
-        - name: ISTIO_META_OWNER
-          value: "kubernetes://apis/apps/v1/namespaces/{{.Namespace}}/deployments/{{.DeploymentName}}"
-        {{- if .Values.global.meshID }}
-        - name: ISTIO_META_MESH_ID
-          value: "{{ .Values.global.meshID }}"
-        {{- else if (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}
-        - name: ISTIO_META_MESH_ID
-          value: "{{ (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}"
         {{- end }}
         {{- with (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain)  }}
         - name: TRUST_DOMAIN
@@ -215,10 +160,8 @@ spec:
         - name: {{ $key }}
           value: "{{ $value }}"
         {{- end }}
-        {{- with (index .InfrastructureLabels "topology.istio.io/network") }}
-        - name: ISTIO_META_REQUESTED_NETWORK_VIEW
-          value: {{.|quote}}
-        {{- end }}
+        - name: XDS_ADDRESS
+          value: {{ .ProxyConfig.DiscoveryAddress | quote }}
         startupProbe:
           failureThreshold: 30
           httpGet:
@@ -240,64 +183,20 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         volumeMounts:
-        - name: workload-socket
-          mountPath: /var/run/secrets/workload-spiffe-uds
-        - name: credential-socket
-          mountPath: /var/run/secrets/credential-uds
-        {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
-        - name: gke-workload-certificate
-          mountPath: /var/run/secrets/workload-spiffe-credentials
-          readOnly: true
-        {{- else }}
-        - name: workload-certs
-          mountPath: /var/run/secrets/workload-spiffe-credentials
-        {{- end }}
-        {{- if eq .Values.global.pilotCertProvider "istiod" }}
-        - mountPath: /var/run/secrets/istio
+        - mountPath: /var/run/secrets/xds
           name: istiod-ca-cert
-        {{- end }}
-        - mountPath: /var/lib/istio/data
-          name: istio-data
-        # SDS channel between istioagent and Envoy
-        - mountPath: /etc/istio/proxy
-          name: istio-envoy
-        - mountPath: /var/run/secrets/tokens
+        - mountPath: /var/run/secrets/xds-tokens
           name: istio-token
-        - name: istio-podinfo
-          mountPath: /etc/istio/pod
+        - mountPath: /tmp
+          name: tmp
       volumes:
       - emptyDir: {}
-        name: workload-socket
-      - emptyDir: {}
-        name: credential-socket
-      {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
-      - name: gke-workload-certificate
-        csi:
-          driver: workloadcertificates.security.cloud.google.com
-      {{- else}}
-      - emptyDir: {}
-        name: workload-certs
-      {{- end }}
-      # SDS channel between istioagent and Envoy
-      - emptyDir:
-          medium: Memory
-        name: istio-envoy
-      - name: istio-data
-        emptyDir: {}
-      - name: istio-podinfo
-        downwardAPI:
-          items:
-            - path: "labels"
-              fieldRef:
-                fieldPath: metadata.labels
-            - path: "annotations"
-              fieldRef:
-                fieldPath: metadata.annotations
+        name: tmp
       - name: istio-token
         projected:
           sources:
           - serviceAccountToken:
-              path: istio-token
+              path: xds-token
               expirationSeconds: 43200
               audience: {{ .Values.global.sds.token.aud }}
       {{- if eq .Values.global.pilotCertProvider "istiod" }}
@@ -335,7 +234,7 @@ metadata:
   name: {{.DeploymentName | quote}}
   namespace: {{.Namespace | quote}}
   ownerReferences:
-  - apiVersion: gateway.networking.k8s.io/v1beta1
+  - apiVersion: gateway.networking.k8s.io/v1
     kind: Gateway
     name: {{.Name}}
     uid: {{.UID}}
@@ -370,7 +269,7 @@ metadata:
           "gateway.networking.k8s.io/gateway-class-name" .GatewayClass
           ) | nindent 4 }}
   ownerReferences:
-    - apiVersion: gateway.networking.k8s.io/v1beta1
+    - apiVersion: gateway.networking.k8s.io/v1
       kind: Gateway
       name: {{.Name}}
       uid: "{{.UID}}"
@@ -396,7 +295,7 @@ metadata:
           "gateway.networking.k8s.io/gateway-class-name" .GatewayClass
           ) | nindent 4 }}
   ownerReferences:
-    - apiVersion: gateway.networking.k8s.io/v1beta1
+    - apiVersion: gateway.networking.k8s.io/v1
       kind: Gateway
       name: {{.Name}}
       uid: "{{.UID}}"

--- a/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
@@ -20,7 +20,7 @@
     {{- end }}
   {{- else }}
     {{- if .Values.global.proxy.resources }}
-      {{ toYaml .Values.global.proxy.resources | indent 6 }}
+      {{ toYaml (omitNil .Values.global.proxy.resources) | indent 6 }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -20,7 +20,7 @@
     {{- end }}
   {{- else }}
     {{- if .Values.global.proxy.resources }}
-      {{ toYaml .Values.global.proxy.resources | indent 6 }}
+      {{ toYaml (omitNil .Values.global.proxy.resources) | indent 6 }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
@@ -213,7 +213,7 @@ spec:
         {{- end }}
         {{- if .Values.global.waypoint.resources }}
         resources:
-        {{- toYaml .Values.global.waypoint.resources | nindent 10 }}
+        {{- toYaml (omitNil .Values.global.waypoint.resources) | nindent 10 }}
         {{- end }}
         startupProbe:
           failureThreshold: 30

--- a/manifests/charts/istio-control/istio-discovery/templates/_helpers.tpl
+++ b/manifests/charts/istio-control/istio-discovery/templates/_helpers.tpl
@@ -21,3 +21,28 @@
   .Values.telemetry.enabled .Values.telemetry.v2.enabled .Values.telemetry.v2.stackdriver.enabled
 }}
 {{- end }}
+
+{{/*
+Render resource requirements, omitting any nil values.
+*/}}
+{{- define "istiod.resources" -}}
+{{- range $key := list "limits" "requests" }}
+  {{- $resources := index $ $key }}
+  {{- if $resources }}
+    {{- $hasValues := false }}
+    {{- range $name, $value := $resources }}
+      {{- if $value }}
+        {{- $hasValues = true }}
+      {{- end }}
+    {{- end }}
+    {{- if $hasValues }}
+{{ $key }}:
+      {{- range $name, $value := $resources }}
+        {{- if $value }}
+  {{ $name }}: {{ $value }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -221,9 +221,9 @@ spec:
             value: "{{ coalesce .Values.global.platform .Values.platform }}"
           resources:
 {{- if .Values.resources }}
-{{ toYaml .Values.resources | trim | indent 12 }}
+{{ include "istiod.resources" .Values.resources | trim | indent 12 }}
 {{- else }}
-{{ toYaml .Values.global.defaultResources | trim | indent 12 }}
+{{ include "istiod.resources" .Values.global.defaultResources | trim | indent 12 }}
 {{- end }}
           securityContext:
             allowPrivilegeEscalation: false

--- a/manifests/charts/ztunnel/templates/_helpers.tpl
+++ b/manifests/charts/ztunnel/templates/_helpers.tpl
@@ -1,1 +1,26 @@
 {{ define "ztunnel.release-name" }}{{ .Values.resourceName| default "ztunnel" }}{{ end }}
+
+{{/*
+Render resource requirements, omitting any nil values.
+*/}}
+{{- define "ztunnel.resources" -}}
+{{- range $key := list "limits" "requests" }}
+  {{- $resources := index $ $key }}
+  {{- if $resources }}
+    {{- $hasValues := false }}
+    {{- range $name, $value := $resources }}
+      {{- if $value }}
+        {{- $hasValues = true }}
+      {{- end }}
+    {{- end }}
+    {{- if $hasValues }}
+{{ $key }}:
+      {{- range $name, $value := $resources }}
+        {{- if $value }}
+  {{ $name }}: {{ $value }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -66,7 +66,7 @@ spec:
           protocol: TCP
         resources:
 {{- if .Values.resources }}
-{{ toYaml .Values.resources | trim | indent 10 }}
+{{ include "ztunnel.resources" .Values.resources | trim | indent 10 }}
 {{- end }}
 {{- with .Values.imagePullPolicy }}
         imagePullPolicy: {{ . }}

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
@@ -283,6 +283,55 @@ func TestConfigureIstioGateway(t *testing.T) {
   network: network-2`,
 		},
 		{
+			name: "waypoint-resources-null",
+			gw: k8sbeta.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "namespace",
+					Namespace: "default",
+				},
+				Spec: k8s.GatewaySpec{
+					GatewayClassName: constants.WaypointGatewayClassName,
+					Listeners: []k8s.Listener{{
+						Name:     "mesh",
+						Port:     k8s.PortNumber(15008),
+						Protocol: "ALL",
+					}},
+				},
+			},
+			objects: defaultObjects,
+			values: `global:
+  waypoint:
+    resources:
+      limits:
+        cpu: null
+        memory: 500Mi
+      requests:
+        cpu: null
+        memory: 150Mi`,
+		},
+		{
+			name: "kube-gateway-resources-null",
+			gw: k8sbeta.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "default",
+					Namespace: "default",
+				},
+				Spec: k8s.GatewaySpec{
+					GatewayClassName: k8s.ObjectName(features.GatewayAPIDefaultGatewayClass),
+				},
+			},
+			objects: defaultObjects,
+			values: `global:
+  proxy:
+    resources:
+      limits:
+        cpu: null
+        memory: 500Mi
+      requests:
+        cpu: null
+        memory: 150Mi`,
+		},
+		{
 			name: "waypoint-no-network-label",
 			gw: k8sbeta.Gateway{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/agentgateway-resources-null.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/agentgateway-resources-null.yaml
@@ -1,0 +1,197 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.istio.io/controller-version: "5"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-agentgateway-controller
+    gateway.networking.k8s.io/gateway-class-name: istio-agentgateway
+    gateway.networking.k8s.io/gateway-name: namespace
+    istio.io/dataplane-mode: none
+  name: namespace-istio-agentgateway
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    name: namespace
+    uid: ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-agentgateway-controller
+    gateway.networking.k8s.io/gateway-class-name: istio-agentgateway
+    gateway.networking.k8s.io/gateway-name: namespace
+    istio.io/dataplane-mode: none
+  name: namespace-istio-agentgateway
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    name: namespace
+    uid: ""
+spec:
+  selector:
+    matchLabels:
+      gateway.networking.k8s.io/gateway-name: namespace
+  template:
+    metadata:
+      annotations:
+        istio.io/rev: default
+        prometheus.io/path: /stats/prometheus
+        prometheus.io/port: "15020"
+        prometheus.io/scrape: "true"
+      labels:
+        gateway.istio.io/managed: istio.io-agentgateway-controller
+        gateway.networking.k8s.io/gateway-class-name: istio-agentgateway
+        gateway.networking.k8s.io/gateway-name: namespace
+        istio.io/dataplane-mode: none
+        service.istio.io/canonical-name: namespace-istio-agentgateway
+        service.istio.io/canonical-revision: latest
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - args:
+        - --config
+        - '{}'
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: CPU_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              divisor: "1"
+              resource: limits.cpu
+        - name: GATEWAY
+          value: namespace
+        - name: RUST_BACKTRACE
+          value: "1"
+        - name: CLUSTER_ID
+          value: Kubernetes
+        - name: TRUST_DOMAIN
+          value: cluster.local
+        - name: XDS_ADDRESS
+          value: istiod.istio-system.svc:15012
+        image: '/agentgateway:'
+        name: agentgateway
+        ports:
+        - containerPort: 15020
+          name: metrics
+          protocol: TCP
+        - containerPort: 15021
+          name: status-port
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 4
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          initialDelaySeconds: 0
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 500Mi
+          requests:
+            memory: 150Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
+        startupProbe:
+          failureThreshold: 30
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          initialDelaySeconds: 1
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 1
+        volumeMounts:
+        - mountPath: /var/run/secrets/xds
+          name: istiod-ca-cert
+        - mountPath: /var/run/secrets/xds-tokens
+          name: istio-token
+        - mountPath: /tmp
+          name: tmp
+      securityContext:
+        sysctls:
+        - name: net.ipv4.ip_unprivileged_port_start
+          value: "0"
+      serviceAccountName: namespace-istio-agentgateway
+      volumes:
+      - emptyDir: {}
+        name: tmp
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: <no value>
+              expirationSeconds: 43200
+              path: xds-token
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-agentgateway-controller
+    gateway.networking.k8s.io/gateway-class-name: istio-agentgateway
+    gateway.networking.k8s.io/gateway-name: namespace
+    istio.io/dataplane-mode: none
+  name: namespace-istio-agentgateway
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    name: namespace
+    uid: null
+spec:
+  ipFamilyPolicy: PreferDualStack
+  ports:
+  - appProtocol: tcp
+    name: status-port
+    port: 15021
+    protocol: TCP
+  - appProtocol: http
+    name: http
+    port: 80
+    protocol: TCP
+  selector:
+    gateway.networking.k8s.io/gateway-name: namespace
+  type: LoadBalancer
+---

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/kube-gateway-resources-null.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/kube-gateway-resources-null.yaml
@@ -1,0 +1,254 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.istio.io/controller-version: "5"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-class-name: istio
+    gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
+  name: default-istio
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    name: default
+    uid: ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-class-name: istio
+    gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
+  name: default-istio
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    name: default
+    uid: ""
+spec:
+  selector:
+    matchLabels:
+      gateway.networking.k8s.io/gateway-name: default
+  template:
+    metadata:
+      annotations:
+        istio.io/rev: default
+        prometheus.io/path: /stats/prometheus
+        prometheus.io/port: "15020"
+        prometheus.io/scrape: "true"
+      labels:
+        gateway.istio.io/managed: istio.io-gateway-controller
+        gateway.networking.k8s.io/gateway-class-name: istio
+        gateway.networking.k8s.io/gateway-name: default
+        istio.io/dataplane-mode: none
+        service.istio.io/canonical-name: default-istio
+        service.istio.io/canonical-revision: latest
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - args:
+        - proxy
+        - router
+        - --domain
+        - $(POD_NAMESPACE).svc.<no value>
+        - --proxyLogLevel
+        - <nil>
+        - --proxyComponentLogLevel
+        - <nil>
+        - --log_output_level
+        - <nil>
+        env:
+        - name: PILOT_CERT_PROVIDER
+          value: <no value>
+        - name: CA_ADDR
+          value: istiod-<no value>.<no value>.svc:15012
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_CPU_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: PROXY_CONFIG
+          value: |
+            {}
+        - name: ISTIO_META_POD_PORTS
+          value: '[]'
+        - name: ISTIO_META_APP_CONTAINERS
+          value: ""
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
+        - name: ISTIO_META_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: default-istio
+        - name: ISTIO_META_OWNER
+          value: kubernetes://apis/apps/v1/namespaces/default/deployments/default-istio
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        - name: TRUST_DOMAIN
+          value: cluster.local
+        image: '/proxyv2:'
+        name: istio-proxy
+        ports:
+        - containerPort: 15020
+          name: metrics
+          protocol: TCP
+        - containerPort: 15021
+          name: status-port
+          protocol: TCP
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 4
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          initialDelaySeconds: 0
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 500Mi
+          requests:
+            memory: 150Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
+        startupProbe:
+          failureThreshold: 30
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          initialDelaySeconds: 1
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 1
+        volumeMounts:
+        - mountPath: /var/run/secrets/workload-spiffe-uds
+          name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
+        - mountPath: /var/run/secrets/workload-spiffe-credentials
+          name: workload-certs
+        - mountPath: /var/lib/istio/data
+          name: istio-data
+        - mountPath: /etc/istio/proxy
+          name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
+        - mountPath: /etc/istio/pod
+          name: istio-podinfo
+      securityContext:
+        sysctls:
+        - name: net.ipv4.ip_unprivileged_port_start
+          value: "0"
+      serviceAccountName: default-istio
+      volumes:
+      - emptyDir: {}
+        name: workload-socket
+      - emptyDir: {}
+        name: credential-socket
+      - emptyDir: {}
+        name: workload-certs
+      - emptyDir:
+          medium: Memory
+        name: istio-envoy
+      - emptyDir: {}
+        name: istio-data
+      - downwardAPI:
+          items:
+          - fieldRef:
+              fieldPath: metadata.labels
+            path: labels
+          - fieldRef:
+              fieldPath: metadata.annotations
+            path: annotations
+        name: istio-podinfo
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: <no value>
+              expirationSeconds: 43200
+              path: istio-token
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-class-name: istio
+    gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
+  name: default-istio
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    name: default
+    uid: null
+spec:
+  ipFamilyPolicy: PreferDualStack
+  ports:
+  - appProtocol: tcp
+    name: status-port
+    port: 15021
+    protocol: TCP
+  selector:
+    gateway.networking.k8s.io/gateway-name: default
+  type: LoadBalancer
+---

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint-resources-null.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint-resources-null.yaml
@@ -1,0 +1,256 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.istio.io/controller-version: "5"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-mesh-controller
+    gateway.networking.k8s.io/gateway-class-name: istio-waypoint
+    gateway.networking.k8s.io/gateway-name: namespace
+  name: namespace
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    name: namespace
+    uid: ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-mesh-controller
+    gateway.networking.k8s.io/gateway-class-name: istio-waypoint
+    gateway.networking.k8s.io/gateway-name: namespace
+  name: namespace
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    name: namespace
+    uid: ""
+spec:
+  selector:
+    matchLabels:
+      gateway.networking.k8s.io/gateway-name: namespace
+  template:
+    metadata:
+      annotations:
+        istio.io/rev: default
+        prometheus.io/path: /stats/prometheus
+        prometheus.io/port: "15020"
+        prometheus.io/scrape: "true"
+      labels:
+        gateway.istio.io/managed: istio.io-mesh-controller
+        gateway.networking.k8s.io/gateway-class-name: istio-waypoint
+        gateway.networking.k8s.io/gateway-name: namespace
+        istio.io/dataplane-mode: none
+        service.istio.io/canonical-name: namespace
+        service.istio.io/canonical-revision: latest
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - args:
+        - proxy
+        - waypoint
+        - --domain
+        - $(POD_NAMESPACE).svc.<no value>
+        - --serviceCluster
+        - namespace.$(POD_NAMESPACE)
+        - --proxyLogLevel
+        - <nil>
+        - --proxyComponentLogLevel
+        - <nil>
+        - --log_output_level
+        - <nil>
+        env:
+        - name: ISTIO_META_SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: ISTIO_META_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: PILOT_CERT_PROVIDER
+          value: <no value>
+        - name: CA_ADDR
+          value: istiod-<no value>.<no value>.svc:15012
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_CPU_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: PROXY_CONFIG
+          value: |
+            {}
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: namespace
+        - name: ISTIO_META_OWNER
+          value: kubernetes://apis/apps/v1/namespaces/default/deployments/namespace
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        - name: TRUST_DOMAIN
+          value: cluster.local
+        image: '/proxyv2:'
+        name: istio-proxy
+        ports:
+        - containerPort: 15020
+          name: metrics
+          protocol: TCP
+        - containerPort: 15021
+          name: status-port
+          protocol: TCP
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 4
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          initialDelaySeconds: 0
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 500Mi
+          requests:
+            memory: 150Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
+        startupProbe:
+          failureThreshold: 30
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          initialDelaySeconds: 1
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 1
+        volumeMounts:
+        - mountPath: /var/run/secrets/workload-spiffe-uds
+          name: workload-socket
+        - mountPath: /var/run/secrets/istio
+          name: istiod-ca-cert
+        - mountPath: /var/lib/istio/data
+          name: istio-data
+        - mountPath: /etc/istio/proxy
+          name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
+        - mountPath: /etc/istio/pod
+          name: istio-podinfo
+      serviceAccountName: namespace
+      volumes:
+      - emptyDir: {}
+        name: workload-socket
+      - emptyDir:
+          medium: Memory
+        name: istio-envoy
+      - emptyDir:
+          medium: Memory
+        name: go-proxy-envoy
+      - emptyDir: {}
+        name: istio-data
+      - emptyDir: {}
+        name: go-proxy-data
+      - downwardAPI:
+          items:
+          - fieldRef:
+              fieldPath: metadata.labels
+            path: labels
+          - fieldRef:
+              fieldPath: metadata.annotations
+            path: annotations
+        name: istio-podinfo
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: istiod-ca-cert
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    networking.istio.io/traffic-distribution: PreferClose
+  labels:
+    gateway.istio.io/managed: istio.io-mesh-controller
+    gateway.networking.k8s.io/gateway-class-name: istio-waypoint
+    gateway.networking.k8s.io/gateway-name: namespace
+  name: namespace
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    name: namespace
+    uid: ""
+spec:
+  ipFamilyPolicy: PreferDualStack
+  ports:
+  - appProtocol: tcp
+    name: status-port
+    port: 15021
+    protocol: TCP
+  - appProtocol: all
+    name: mesh
+    port: 15008
+    protocol: TCP
+  selector:
+    gateway.networking.k8s.io/gateway-name: namespace
+  type: ClusterIP
+---

--- a/pkg/kube/inject/inject_test.go
+++ b/pkg/kube/inject/inject_test.go
@@ -549,6 +549,21 @@ func TestInjection(t *testing.T) {
 			},
 		},
 		{
+			in:         "proxy-resources-null.yaml",
+			want:       "proxy-resources-null.yaml.injected",
+			inFilePath: "proxy-resources-null.iop.yaml",
+		},
+		{
+			in:         "proxy-resources-null-no-init.yaml",
+			want:       "proxy-resources-null-no-init.yaml.injected",
+			inFilePath: "proxy-resources-null.iop.yaml",
+		},
+		{
+			in:         "proxy-resources-zero.yaml",
+			want:       "proxy-resources-zero.yaml.injected",
+			inFilePath: "proxy-resources-zero.iop.yaml",
+		},
+		{
 			in:         "sidecar-spire.yaml",
 			want:       "sidecar-spire.yaml.injected",
 			inFilePath: "spire-template.iop.yaml",

--- a/pkg/kube/inject/template_test.go
+++ b/pkg/kube/inject/template_test.go
@@ -1,0 +1,94 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inject
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestOmitNil(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want any
+	}{
+		{
+			name: "no nils",
+			in:   map[string]any{"a": 1, "b": "c"},
+			want: map[string]any{"a": 1, "b": "c"},
+		},
+		{
+			name: "top level nil",
+			in:   map[string]any{"a": nil, "b": "c"},
+			want: map[string]any{"b": "c"},
+		},
+		{
+			name: "nested nil",
+			in:   map[string]any{"a": map[string]any{"x": nil, "y": 2}, "b": "c"},
+			want: map[string]any{"a": map[string]any{"y": 2}, "b": "c"},
+		},
+		{
+			name: "slice with nil",
+			in:   []any{1, nil, 3},
+			want: []any{1, 3},
+		},
+		{
+			name: "nested slice nil",
+			in:   map[string]any{"a": []any{nil, map[string]any{"x": nil}}},
+			want: nil,
+		},
+		{
+			name: "all nils map",
+			in:   map[string]any{"a": nil, "b": map[string]any{"x": nil}},
+			want: nil,
+		},
+		{
+			name: "complex mixed",
+			in: map[string]any{
+				"global": map[string]any{
+					"proxy": map[string]any{
+						"resources": map[string]any{
+							"limits": map[string]any{
+								"cpu":    nil,
+								"memory": "500Mi",
+							},
+						},
+					},
+				},
+			},
+			want: map[string]any{
+				"global": map[string]any{
+					"proxy": map[string]any{
+						"resources": map[string]any{
+							"limits": map[string]any{
+								"memory": "500Mi",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := omitNil(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/kube/inject/testdata/inject/proxy-resources-null-no-init.yaml
+++ b/pkg/kube/inject/testdata/inject/proxy-resources-null-no-init.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: proxy-resources-null-no-init
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: proxy-resources-null-no-init
+  template:
+    metadata:
+      labels:
+        app: proxy-resources-null-no-init
+    spec:
+      containers:
+      - name: hello
+        image: "fake.docker.io/google-samples/hello-go-gke:1.0"

--- a/pkg/kube/inject/testdata/inject/proxy-resources-null-no-init.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-resources-null-no-init.yaml.injected
@@ -1,0 +1,241 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: proxy-resources-null-no-init
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: proxy-resources-null-no-init
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        istio.io/rev: default
+        kubectl.kubernetes.io/default-container: hello
+        kubectl.kubernetes.io/default-logs-container: hello
+        prometheus.io/path: /stats/prometheus
+        prometheus.io/port: "15020"
+        prometheus.io/scrape: "true"
+        sidecar.istio.io/status: '{"initContainers":["istio-init","istio-proxy"],"containers":null,"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert","istio-ca-crl"],"imagePullSecrets":null,"revision":"default"}'
+      labels:
+        app: proxy-resources-null-no-init
+        security.istio.io/tlsMode: istio
+        service.istio.io/canonical-name: proxy-resources-null-no-init
+        service.istio.io/canonical-revision: latest
+    spec:
+      containers:
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        resources: {}
+      initContainers:
+      - args:
+        - istio-iptables
+        - -p
+        - "15001"
+        - -z
+        - "15006"
+        - -u
+        - "1337"
+        - -m
+        - REDIRECT
+        - -i
+        - '*'
+        - -x
+        - ""
+        - -b
+        - '*'
+        - -d
+        - 15090,15021,15020
+        - --log_output_level=default:info
+        image: gcr.io/istio-testing/proxyv2:latest
+        name: istio-init
+        resources:
+          limits:
+            memory: 500Mi
+          requests:
+            memory: 150Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_ADMIN
+            - NET_RAW
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: false
+          runAsGroup: 0
+          runAsNonRoot: false
+          runAsUser: 0
+      - args:
+        - proxy
+        - sidecar
+        - --domain
+        - $(POD_NAMESPACE).svc.cluster.local
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
+        - --log_output_level=default:info
+        env:
+        - name: PILOT_CERT_PROVIDER
+          value: istiod
+        - name: CA_ADDR
+          value: istiod.istio-system.svc:15012
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_CPU_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              divisor: "0"
+              resource: limits.cpu
+        - name: PROXY_CONFIG
+          value: |
+            {}
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+            ]
+        - name: ISTIO_META_APP_CONTAINERS
+          value: hello
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              divisor: "0"
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              divisor: "0"
+              resource: limits.cpu
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
+        - name: ISTIO_META_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: proxy-resources-null-no-init
+        - name: ISTIO_META_OWNER
+          value: kubernetes://apis/apps/v1/namespaces/default/deployments/proxy-resources-null-no-init
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        - name: TRUST_DOMAIN
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - pilot-agent
+              - request
+              - --debug-port=15020
+              - POST
+              - drain
+        name: istio-proxy
+        ports:
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 4
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+          periodSeconds: 15
+          timeoutSeconds: 3
+        resources:
+          limits:
+            memory: 500Mi
+          requests:
+            memory: 150Mi
+        restartPolicy: Always
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
+        startupProbe:
+          failureThreshold: 600
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+          periodSeconds: 1
+          timeoutSeconds: 3
+        volumeMounts:
+        - mountPath: /var/run/secrets/workload-spiffe-uds
+          name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
+        - mountPath: /var/run/secrets/workload-spiffe-credentials
+          name: workload-certs
+        - mountPath: /var/run/secrets/istio
+          name: istiod-ca-cert
+        - mountPath: /var/run/secrets/istio/crl
+          name: istio-ca-crl
+        - mountPath: /var/lib/istio/data
+          name: istio-data
+        - mountPath: /etc/istio/proxy
+          name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
+        - mountPath: /etc/istio/pod
+          name: istio-podinfo
+      volumes:
+      - name: workload-socket
+      - name: credential-socket
+      - name: workload-certs
+      - emptyDir:
+          medium: Memory
+        name: istio-envoy
+      - emptyDir: {}
+        name: istio-data
+      - downwardAPI:
+          items:
+          - fieldRef:
+              fieldPath: metadata.labels
+            path: labels
+          - fieldRef:
+              fieldPath: metadata.annotations
+            path: annotations
+        name: istio-podinfo
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: istiod-ca-cert
+      - configMap:
+          name: istio-ca-crl
+          optional: true
+        name: istio-ca-crl
+status: {}
+---

--- a/pkg/kube/inject/testdata/inject/proxy-resources-null.iop.yaml
+++ b/pkg/kube/inject/testdata/inject/proxy-resources-null.iop.yaml
@@ -1,0 +1,13 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  values:
+    global:
+      proxy:
+        resources:
+          limits:
+            cpu: null
+            memory: 500Mi
+          requests:
+            cpu: null
+            memory: 150Mi

--- a/pkg/kube/inject/testdata/inject/proxy-resources-null.yaml
+++ b/pkg/kube/inject/testdata/inject/proxy-resources-null.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: proxy-resources-null
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: proxy-resources-null
+  template:
+    metadata:
+      labels:
+        app: proxy-resources-null
+    spec:
+      initContainers:
+      - name: existing-init
+        image: busybox
+        command: ["sh", "-c", "true"]
+      containers:
+      - name: hello
+        image: "fake.docker.io/google-samples/hello-go-gke:1.0"

--- a/pkg/kube/inject/testdata/inject/proxy-resources-null.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-resources-null.yaml.injected
@@ -1,0 +1,248 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: proxy-resources-null
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: proxy-resources-null
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        istio.io/rev: default
+        kubectl.kubernetes.io/default-container: hello
+        kubectl.kubernetes.io/default-logs-container: hello
+        prometheus.io/path: /stats/prometheus
+        prometheus.io/port: "15020"
+        prometheus.io/scrape: "true"
+        sidecar.istio.io/status: '{"initContainers":["istio-init","istio-proxy"],"containers":null,"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert","istio-ca-crl"],"imagePullSecrets":null,"revision":"default"}'
+      labels:
+        app: proxy-resources-null
+        security.istio.io/tlsMode: istio
+        service.istio.io/canonical-name: proxy-resources-null
+        service.istio.io/canonical-revision: latest
+    spec:
+      containers:
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        resources: {}
+      initContainers:
+      - args:
+        - istio-iptables
+        - -p
+        - "15001"
+        - -z
+        - "15006"
+        - -u
+        - "1337"
+        - -m
+        - REDIRECT
+        - -i
+        - '*'
+        - -x
+        - ""
+        - -b
+        - '*'
+        - -d
+        - 15090,15021,15020
+        - --log_output_level=default:info
+        image: gcr.io/istio-testing/proxyv2:latest
+        name: istio-init
+        resources:
+          limits:
+            memory: 500Mi
+          requests:
+            memory: 150Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_ADMIN
+            - NET_RAW
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: false
+          runAsGroup: 0
+          runAsNonRoot: false
+          runAsUser: 0
+      - args:
+        - proxy
+        - sidecar
+        - --domain
+        - $(POD_NAMESPACE).svc.cluster.local
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
+        - --log_output_level=default:info
+        env:
+        - name: PILOT_CERT_PROVIDER
+          value: istiod
+        - name: CA_ADDR
+          value: istiod.istio-system.svc:15012
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_CPU_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              divisor: "0"
+              resource: limits.cpu
+        - name: PROXY_CONFIG
+          value: |
+            {}
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+            ]
+        - name: ISTIO_META_APP_CONTAINERS
+          value: hello
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              divisor: "0"
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              divisor: "0"
+              resource: limits.cpu
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
+        - name: ISTIO_META_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: proxy-resources-null
+        - name: ISTIO_META_OWNER
+          value: kubernetes://apis/apps/v1/namespaces/default/deployments/proxy-resources-null
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        - name: TRUST_DOMAIN
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - pilot-agent
+              - request
+              - --debug-port=15020
+              - POST
+              - drain
+        name: istio-proxy
+        ports:
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 4
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+          periodSeconds: 15
+          timeoutSeconds: 3
+        resources:
+          limits:
+            memory: 500Mi
+          requests:
+            memory: 150Mi
+        restartPolicy: Always
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
+        startupProbe:
+          failureThreshold: 600
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+          periodSeconds: 1
+          timeoutSeconds: 3
+        volumeMounts:
+        - mountPath: /var/run/secrets/workload-spiffe-uds
+          name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
+        - mountPath: /var/run/secrets/workload-spiffe-credentials
+          name: workload-certs
+        - mountPath: /var/run/secrets/istio
+          name: istiod-ca-cert
+        - mountPath: /var/run/secrets/istio/crl
+          name: istio-ca-crl
+        - mountPath: /var/lib/istio/data
+          name: istio-data
+        - mountPath: /etc/istio/proxy
+          name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
+        - mountPath: /etc/istio/pod
+          name: istio-podinfo
+      - command:
+        - sh
+        - -c
+        - "true"
+        image: busybox
+        name: existing-init
+        resources: {}
+      volumes:
+      - name: workload-socket
+      - name: credential-socket
+      - name: workload-certs
+      - emptyDir:
+          medium: Memory
+        name: istio-envoy
+      - emptyDir: {}
+        name: istio-data
+      - downwardAPI:
+          items:
+          - fieldRef:
+              fieldPath: metadata.labels
+            path: labels
+          - fieldRef:
+              fieldPath: metadata.annotations
+            path: annotations
+        name: istio-podinfo
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: istiod-ca-cert
+      - configMap:
+          name: istio-ca-crl
+          optional: true
+        name: istio-ca-crl
+status: {}
+---

--- a/pkg/kube/inject/testdata/inject/proxy-resources-zero.iop.yaml
+++ b/pkg/kube/inject/testdata/inject/proxy-resources-zero.iop.yaml
@@ -1,0 +1,13 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  values:
+    global:
+      proxy:
+        resources:
+          limits:
+            cpu: "0"
+            memory: 500Mi
+          requests:
+            cpu: "0"
+            memory: 150Mi

--- a/pkg/kube/inject/testdata/inject/proxy-resources-zero.yaml
+++ b/pkg/kube/inject/testdata/inject/proxy-resources-zero.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: proxy-resources-zero
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: proxy-resources-zero
+  template:
+    metadata:
+      labels:
+        app: proxy-resources-zero
+    spec:
+      initContainers:
+      - name: existing-init
+        image: busybox
+        command: ["sh", "-c", "true"]
+      containers:
+      - name: hello
+        image: "fake.docker.io/google-samples/hello-go-gke:1.0"

--- a/pkg/kube/inject/testdata/inject/proxy-resources-zero.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-resources-zero.yaml.injected
@@ -1,0 +1,252 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: proxy-resources-zero
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: proxy-resources-zero
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        istio.io/rev: default
+        kubectl.kubernetes.io/default-container: hello
+        kubectl.kubernetes.io/default-logs-container: hello
+        prometheus.io/path: /stats/prometheus
+        prometheus.io/port: "15020"
+        prometheus.io/scrape: "true"
+        sidecar.istio.io/status: '{"initContainers":["istio-init","istio-proxy"],"containers":null,"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert","istio-ca-crl"],"imagePullSecrets":null,"revision":"default"}'
+      labels:
+        app: proxy-resources-zero
+        security.istio.io/tlsMode: istio
+        service.istio.io/canonical-name: proxy-resources-zero
+        service.istio.io/canonical-revision: latest
+    spec:
+      containers:
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        resources: {}
+      initContainers:
+      - args:
+        - istio-iptables
+        - -p
+        - "15001"
+        - -z
+        - "15006"
+        - -u
+        - "1337"
+        - -m
+        - REDIRECT
+        - -i
+        - '*'
+        - -x
+        - ""
+        - -b
+        - '*'
+        - -d
+        - 15090,15021,15020
+        - --log_output_level=default:info
+        image: gcr.io/istio-testing/proxyv2:latest
+        name: istio-init
+        resources:
+          limits:
+            cpu: "0"
+            memory: 500Mi
+          requests:
+            cpu: "0"
+            memory: 150Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_ADMIN
+            - NET_RAW
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: false
+          runAsGroup: 0
+          runAsNonRoot: false
+          runAsUser: 0
+      - args:
+        - proxy
+        - sidecar
+        - --domain
+        - $(POD_NAMESPACE).svc.cluster.local
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
+        - --log_output_level=default:info
+        env:
+        - name: PILOT_CERT_PROVIDER
+          value: istiod
+        - name: CA_ADDR
+          value: istiod.istio-system.svc:15012
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_CPU_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              divisor: "0"
+              resource: limits.cpu
+        - name: PROXY_CONFIG
+          value: |
+            {}
+        - name: ISTIO_META_POD_PORTS
+          value: |-
+            [
+            ]
+        - name: ISTIO_META_APP_CONTAINERS
+          value: hello
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              divisor: "0"
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              divisor: "0"
+              resource: limits.cpu
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
+        - name: ISTIO_META_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: proxy-resources-zero
+        - name: ISTIO_META_OWNER
+          value: kubernetes://apis/apps/v1/namespaces/default/deployments/proxy-resources-zero
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        - name: TRUST_DOMAIN
+          value: cluster.local
+        image: gcr.io/istio-testing/proxyv2:latest
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - pilot-agent
+              - request
+              - --debug-port=15020
+              - POST
+              - drain
+        name: istio-proxy
+        ports:
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 4
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+          periodSeconds: 15
+          timeoutSeconds: 3
+        resources:
+          limits:
+            cpu: "0"
+            memory: 500Mi
+          requests:
+            cpu: "0"
+            memory: 150Mi
+        restartPolicy: Always
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
+        startupProbe:
+          failureThreshold: 600
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+          periodSeconds: 1
+          timeoutSeconds: 3
+        volumeMounts:
+        - mountPath: /var/run/secrets/workload-spiffe-uds
+          name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
+        - mountPath: /var/run/secrets/workload-spiffe-credentials
+          name: workload-certs
+        - mountPath: /var/run/secrets/istio
+          name: istiod-ca-cert
+        - mountPath: /var/run/secrets/istio/crl
+          name: istio-ca-crl
+        - mountPath: /var/lib/istio/data
+          name: istio-data
+        - mountPath: /etc/istio/proxy
+          name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
+        - mountPath: /etc/istio/pod
+          name: istio-podinfo
+      - command:
+        - sh
+        - -c
+        - "true"
+        image: busybox
+        name: existing-init
+        resources: {}
+      volumes:
+      - name: workload-socket
+      - name: credential-socket
+      - name: workload-certs
+      - emptyDir:
+          medium: Memory
+        name: istio-envoy
+      - emptyDir: {}
+        name: istio-data
+      - downwardAPI:
+          items:
+          - fieldRef:
+              fieldPath: metadata.labels
+            path: labels
+          - fieldRef:
+              fieldPath: metadata.annotations
+            path: annotations
+        name: istio-podinfo
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: istiod-ca-cert
+      - configMap:
+          name: istio-ca-crl
+          optional: true
+        name: istio-ca-crl
+status: {}
+---

--- a/releasenotes/notes/fix-null-resource-limits.yaml
+++ b/releasenotes/notes/fix-null-resource-limits.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+  - 58805
+releaseNotes:
+- |
+  **Fixed** an issue where setting resource limits or requests to `null` would cause validation errors (`cpu request must be less than or equal to cpu limit of 0`). This affected proxy injection, gateway generation, and Helm chart deployments.


### PR DESCRIPTION
**Please provide a description of this PR:**
**Manual cherry-pick**
Manual cherry-pick of https://github.com/istio/istio/pull/58824

This PR resolves issue https://github.com/istio/istio/issues/58805 where Istio sidecar injection fails with a Kubernetes validation error (`cpu request must be less than or equal to cpu limit of 0`) when `proxy.resources.limits.cpu` is explicitly set to null in the Istio configuration. This instead allows for the explicit removal of a resource value without locally customizing the injector.