### PR TITLE
Trigger gateway status change by endpoints events

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -184,7 +184,7 @@ func (s *Server) initK8SConfigStore(args *PilotArgs) error {
 			s.initStatusManager(args)
 		}
 		args.RegistryOptions.KubeOptions.KrtDebugger = args.KrtDebugger
-		gwc := gateway.NewController(s.kubeClient, s.kubeClient.CrdWatcher().WaitForCRD, args.RegistryOptions.KubeOptions, s.XDSServer)
+		gwc := gateway.NewController(s.kubeClient, s.environment.EndpointIndex.AsCollection(), s.kubeClient.CrdWatcher().WaitForCRD, args.RegistryOptions.KubeOptions, s.XDSServer)
 		s.environment.GatewayAPIController = gwc
 		s.ConfigStores = append(s.ConfigStores, s.environment.GatewayAPIController)
 

--- a/pilot/pkg/config/kube/agentgateway/gateway_collection.go
+++ b/pilot/pkg/config/kube/agentgateway/gateway_collection.go
@@ -26,6 +26,7 @@ import (
 
 	istio "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/config/kube/gatewaycommon"
+	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
@@ -135,6 +136,7 @@ func ListenerSetCollection(
 	grants gatewaycommon.ReferenceGrants,
 	configMaps krt.Collection[*corev1.ConfigMap],
 	secrets krt.Collection[*corev1.Secret],
+	endpoints krt.Collection[*model.IstioEndpoints],
 	domainSuffix string,
 	gatewayContext krt.RecomputeProtected[*atomic.Pointer[gatewaycommon.GatewayContext]],
 	tagWatcher krt.RecomputeProtected[revisions.TagWatcher],
@@ -198,7 +200,7 @@ func ListenerSetCollection(
 			gatewayServices, err := extractGatewayServices(domainSuffix, parentGwObj, classInfo)
 			if len(gatewayServices) == 0 && err != nil {
 				// Short circuit if it's a hard failure
-				reportListenerSetStatus(context, parentGwObj, obj, status, gatewayServices, nil, err)
+				reportListenerSetStatus(ctx, context, parentGwObj, obj, status, gatewayServices, endpoints, nil, err)
 				return status, nil
 			}
 
@@ -245,7 +247,7 @@ func ListenerSetCollection(
 				result = append(result, res)
 			}
 
-			reportListenerSetStatus(context, parentGwObj, obj, status, gatewayServices, servers, err)
+			reportListenerSetStatus(ctx, context, parentGwObj, obj, status, gatewayServices, endpoints, servers, err)
 			return status, result
 		}, opts.WithName("ListenerSets")...)
 
@@ -253,15 +255,17 @@ func ListenerSetCollection(
 }
 
 func reportListenerSetStatus(
+	ctx krt.HandlerContext,
 	r *gatewaycommon.GatewayContext,
 	parentGwObj *gatewayv1.Gateway,
 	obj *gatewayv1.ListenerSet,
 	gs *gatewayv1.ListenerSetStatus,
 	gatewayServices []string,
+	endpoints krt.Collection[*model.IstioEndpoints],
 	servers []*istio.Server,
 	cond *Condition,
 ) {
-	internal, _, _, _, warnings, allUsable := r.ResolveGatewayInstances(parentGwObj.Namespace, gatewayServices, servers)
+	internal, _, _, _, warnings, allUsable := r.ResolveGatewayInstances(ctx, parentGwObj.Namespace, gatewayServices, endpoints, servers)
 
 	// Setup initial conditions to the success state. If we encounter errors, we will update this.
 	// We have two status
@@ -300,6 +304,7 @@ func GatewayCollection(
 	grants gatewaycommon.ReferenceGrants,
 	configMaps krt.Collection[*corev1.ConfigMap],
 	secrets krt.Collection[*corev1.Secret],
+	endpoints krt.Collection[*model.IstioEndpoints],
 	domainSuffix string,
 	gatewayContext krt.RecomputeProtected[*atomic.Pointer[gatewaycommon.GatewayContext]],
 	tagWatcher krt.RecomputeProtected[revisions.TagWatcher],
@@ -347,7 +352,7 @@ func GatewayCollection(
 		if len(gatewayServices) == 0 && err != nil {
 			// Short circuit if its a hard failure
 			log.Errorf("failed to translate gwv1", "name", obj.GetName(), "namespace", obj.GetNamespace(), "err", err.message)
-			reportGatewayStatus(context, obj, status, classInfo, gatewayServices, servers, 0, err.error)
+			reportGatewayStatus(ctx, context, obj, status, classInfo, gatewayServices, endpoints, servers, 0, err.error)
 			return status, nil
 		}
 		var gatewayErr *ConfigError
@@ -411,7 +416,7 @@ func GatewayCollection(
 			})
 		}
 
-		reportGatewayStatus(context, obj, status, classInfo, gatewayServices, servers, len(listenersFromSets), gatewayErr)
+		reportGatewayStatus(ctx, context, obj, status, classInfo, gatewayServices, endpoints, servers, len(listenersFromSets), gatewayErr)
 		return status, result
 	}, opts.WithName("KubernetesGateway")...)
 

--- a/pilot/pkg/config/kube/agentgateway/gateway_status.go
+++ b/pilot/pkg/config/kube/agentgateway/gateway_status.go
@@ -29,6 +29,7 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/sets"
@@ -82,17 +83,19 @@ func extractGatewayServices(domainSuffix string, kgw *gatewayv1.Gateway, info ga
 }
 
 func reportGatewayStatus(
+	ctx krt.HandlerContext,
 	r *gatewaycommon.GatewayContext,
 	obj *gatewayv1.Gateway,
 	gs *gatewayv1.GatewayStatus,
 	classInfo gatewaycommon.ClassInfo,
 	gatewayServices []string,
+	endpoints krt.Collection[*model.IstioEndpoints],
 	servers []*istio.Server,
 	listenerSetCount int,
 	gatewayErr *ConfigError,
 ) {
 	// TODO: we lose address if servers is empty due to an error
-	internal, internalIP, external, pending, warnings, allUsable := r.ResolveGatewayInstances(obj.Namespace, gatewayServices, servers)
+	internal, internalIP, external, pending, warnings, allUsable := r.ResolveGatewayInstances(ctx, obj.Namespace, gatewayServices, endpoints, servers)
 
 	// Setup initial conditions to the success state. If we encounter errors, we will update this.
 	// We have two status

--- a/pilot/pkg/config/kube/gateway/controller.go
+++ b/pilot/pkg/config/kube/gateway/controller.go
@@ -158,6 +158,7 @@ var _ model.GatewayController = &Controller{}
 
 func NewController(
 	kc kube.Client,
+	endpoints krt.Collection[*model.IstioEndpoints],
 	waitForCRD func(class schema.GroupVersionResource, stop <-chan struct{}) bool,
 	options controller.Options,
 	xdsUpdater model.XDSUpdater,
@@ -248,6 +249,7 @@ func NewController(
 		ReferenceGrants,
 		inputs.ConfigMaps,
 		inputs.Secrets,
+		endpoints,
 		options.DomainSuffix,
 		c.gatewayContext,
 		c.tagWatcher,
@@ -265,6 +267,7 @@ func NewController(
 		ReferenceGrants,
 		inputs.ConfigMaps,
 		inputs.Secrets,
+		endpoints,
 		c.domainSuffix,
 		c.gatewayContext,
 		c.tagWatcher,

--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -1695,17 +1695,19 @@ func getListenerNames(spec *k8s.GatewaySpec) sets.Set[k8s.SectionName] {
 }
 
 func reportGatewayStatus(
+	ctx krt.HandlerContext,
 	r *gatewaycommon.GatewayContext,
 	obj *k8s.Gateway,
 	gs *k8s.GatewayStatus,
 	classInfo gatewaycommon.ClassInfo,
 	gatewayServices []string,
+	endpoints krt.Collection[*model.IstioEndpoints],
 	servers []*istio.Server,
 	listenerSetCount int,
 	gatewayErr *ConfigError,
 ) {
 	// TODO: we lose address if servers is empty due to an error
-	internal, internalIP, external, pending, warnings, allUsable := r.ResolveGatewayInstances(obj.Namespace, gatewayServices, servers)
+	internal, internalIP, external, pending, warnings, allUsable := r.ResolveGatewayInstances(ctx, obj.Namespace, gatewayServices, endpoints, servers)
 
 	// Setup initial conditions to the success state. If we encounter errors, we will update this.
 	// We have two status
@@ -1782,15 +1784,17 @@ func reportGatewayStatus(
 }
 
 func reportListenerSetStatus(
+	ctx krt.HandlerContext,
 	r *gatewaycommon.GatewayContext,
 	parentGwObj *k8s.Gateway,
 	obj *k8s.ListenerSet,
 	gs *k8s.ListenerSetStatus,
 	gatewayServices []string,
+	endpoints krt.Collection[*model.IstioEndpoints],
 	servers []*istio.Server,
 	gatewayErr *ConfigError,
 ) {
-	internal, _, _, _, warnings, allUsable := r.ResolveGatewayInstances(parentGwObj.Namespace, gatewayServices, servers)
+	internal, _, _, _, warnings, allUsable := r.ResolveGatewayInstances(ctx, parentGwObj.Namespace, gatewayServices, endpoints, servers)
 
 	// Setup initial conditions to the success state. If we encounter errors, we will update this.
 	// We have two status

--- a/pilot/pkg/config/kube/gateway/gateway_collection.go
+++ b/pilot/pkg/config/kube/gateway/gateway_collection.go
@@ -79,6 +79,7 @@ func ListenerSetCollection(
 	grants gatewaycommon.ReferenceGrants,
 	configMaps krt.Collection[*corev1.ConfigMap],
 	secrets krt.Collection[*corev1.Secret],
+	endpoints krt.Collection[*model.IstioEndpoints],
 	domainSuffix string,
 	gatewayContext krt.RecomputeProtected[*atomic.Pointer[gatewaycommon.GatewayContext]],
 	tagWatcher krt.RecomputeProtected[revisions.TagWatcher],
@@ -141,7 +142,7 @@ func ListenerSetCollection(
 			gatewayServices, err := extractGatewayServices(domainSuffix, parentGwObj, classInfo)
 			if len(gatewayServices) == 0 && err != nil {
 				// Short circuit if it's a hard failure
-				reportListenerSetStatus(context, parentGwObj, obj, status, gatewayServices, nil, err)
+				reportListenerSetStatus(ctx, context, parentGwObj, obj, status, gatewayServices, endpoints, nil, err)
 				return status, nil
 			}
 
@@ -216,7 +217,7 @@ func ListenerSetCollection(
 				result = append(result, res)
 			}
 
-			reportListenerSetStatus(context, parentGwObj, obj, status, gatewayServices, servers, err)
+			reportListenerSetStatus(ctx, context, parentGwObj, obj, status, gatewayServices, endpoints, servers, err)
 			return status, result
 		}, opts.WithName("ListenerSets")...)
 
@@ -231,6 +232,7 @@ func GatewayCollection(
 	grants gatewaycommon.ReferenceGrants,
 	configMaps krt.Collection[*corev1.ConfigMap],
 	secrets krt.Collection[*corev1.Secret],
+	endpoints krt.Collection[*model.IstioEndpoints],
 	domainSuffix string,
 	gatewayContext krt.RecomputeProtected[*atomic.Pointer[gatewaycommon.GatewayContext]],
 	tagWatcher krt.RecomputeProtected[revisions.TagWatcher],
@@ -274,7 +276,7 @@ func GatewayCollection(
 		gatewayServices, err := extractGatewayServices(domainSuffix, obj, classInfo)
 		if len(gatewayServices) == 0 && err != nil {
 			// Short circuit if its a hard failure
-			reportGatewayStatus(context, obj, status, classInfo, gatewayServices, servers, 0, err)
+			reportGatewayStatus(ctx, context, obj, status, classInfo, gatewayServices, endpoints, servers, 0, err)
 			return status, nil
 		}
 
@@ -359,7 +361,7 @@ func GatewayCollection(
 			})
 		}
 
-		reportGatewayStatus(context, obj, status, classInfo, gatewayServices, servers, len(listenersFromSets), err)
+		reportGatewayStatus(ctx, context, obj, status, classInfo, gatewayServices, endpoints, servers, len(listenersFromSets), err)
 		return status, result
 	}, opts.WithName("KubernetesGateway")...)
 

--- a/pilot/pkg/config/kube/gatewaycommon/context.go
+++ b/pilot/pkg/config/kube/gatewaycommon/context.go
@@ -27,6 +27,8 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/host"
+	"istio.io/istio/pkg/kube/krt"
+
 	istiolog "istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/util/sets"
 )
@@ -64,8 +66,10 @@ func (gc GatewayContext) Cluster() cluster.ID {
 // * Pending addresses (eg istio-ingressgateway.istio-system.svc), are LoadBalancer-type services with pending external addresses.
 // * Warnings for references that could not be resolved. These are intended to be user facing.
 func (gc GatewayContext) ResolveGatewayInstances(
+	ctx krt.HandlerContext,
 	namespace string,
 	gwsvcs []string,
+	endpoints krt.Collection[*model.IstioEndpoints],
 	servers []*networking.Server,
 ) (internal, internalIP, external, pending, warns []string, allUsable bool) {
 	ports := map[int]struct{}{}
@@ -96,9 +100,23 @@ func (gc GatewayContext) ResolveGatewayInstances(
 			foundUnusable = true
 			continue
 		}
-		svcKey := svc.Key()
+
+		istioEndpoints := krt.Fetch(ctx, endpoints, krt.FilterLabel(map[string]string{
+			"service":   svc.Hostname.String(),
+			"namespace": namespace,
+		}))
+		instancesByPort := map[int][]*model.IstioEndpoint{}
+		for _, shard := range istioEndpoints {
+			for _, endpoint := range shard.Endpoints {
+				if endpoint.HealthStatus != model.Healthy {
+					continue
+				}
+				instancesByPort[int(endpoint.EndpointPort)] = append(instancesByPort[int(endpoint.EndpointPort)], endpoint)
+			}
+		}
+
 		for port := range ports {
-			instances := gc.ps.ServiceEndpointsByPort(svc, port, nil)
+			instances := instancesByPort[port]
 			if len(instances) > 0 {
 				foundInternal.Insert(g + ":" + strconv.Itoa(port))
 				dummyProxy := &model.Proxy{Metadata: &model.NodeMetadata{ClusterID: gc.cluster}}
@@ -116,7 +134,6 @@ func (gc GatewayContext) ResolveGatewayInstances(
 					}
 				}
 			} else {
-				instancesByPort := gc.ps.ServiceEndpoints(svcKey)
 				if InstancesEmpty(instancesByPort) {
 					warnings = append(warnings, fmt.Sprintf("no instances found for hostname %q", g))
 				} else {

--- a/pilot/pkg/model/endpointshards.go
+++ b/pilot/pkg/model/endpointshards.go
@@ -15,12 +15,14 @@
 package model
 
 import (
+	"fmt"
 	"sort"
 	"sync"
 
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/schema/kind"
+	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/util/sets"
 )
 
@@ -135,6 +137,34 @@ func (es *EndpointShards) DeepCopy() *EndpointShards {
 	return res
 }
 
+type IstioEndpoints struct {
+	Endpoints []*IstioEndpoint
+	Service   string
+	Namespace string
+	ShardKey  ShardKey
+}
+
+func (e *IstioEndpoints) ResourceName() string {
+	return fmt.Sprintf("%s/%s/%s", e.ShardKey, e.Namespace, e.Service)
+}
+
+func (e *IstioEndpoints) Equals(other *IstioEndpoints) bool {
+	if e.ShardKey != other.ShardKey || e.Service != other.Service ||
+		e.Namespace != other.Namespace || len(e.Endpoints) != len(other.Endpoints) {
+		return false
+	}
+	_, equals := endpointUpdateRequiresPush(e.Endpoints, other.Endpoints)
+	return equals
+}
+
+func (e *IstioEndpoints) GetLabels() map[string]string {
+	return map[string]string{
+		"service":   e.Service,
+		"namespace": e.Namespace,
+		"shardKey":  e.ShardKey.String(),
+	}
+}
+
 // EndpointIndex is a mutex protected index of endpoint shards
 type EndpointIndex struct {
 	mu sync.RWMutex
@@ -142,7 +172,24 @@ type EndpointIndex struct {
 	shardsBySvc map[string]map[string]*EndpointShards
 	// We'll need to clear the cache in-sync with endpoint shards modifications.
 	cache XdsCache
+
+	col     *krt.StaticCollection[*IstioEndpoints]
+	initCol sync.Once
 }
+
+type syncedSyncer struct{}
+
+// HasSynced implements [krt.Syncer].
+func (s *syncedSyncer) HasSynced() bool {
+	return true
+}
+
+// WaitUntilSynced implements [krt.Syncer].
+func (s *syncedSyncer) WaitUntilSynced(stop <-chan struct{}) bool {
+	return true
+}
+
+var _ krt.Syncer = &syncedSyncer{}
 
 func NewEndpointIndex(cache XdsCache) *EndpointIndex {
 	return &EndpointIndex{
@@ -249,7 +296,41 @@ func (e *EndpointIndex) deleteServiceInner(shard ShardKey, serviceName, namespac
 			delete(e.shardsBySvc, serviceName)
 		}
 	}
+
+	if e.col != nil {
+		e.col.DeleteObject(fmt.Sprintf("%s/%s/%s", shard, namespace, serviceName))
+	}
+
 	epShards.Unlock()
+}
+
+func (e *EndpointIndex) AsCollection() krt.Collection[*IstioEndpoints] {
+	e.initCol.Do(func() {
+		col := krt.NewStaticCollection[*IstioEndpoints](&syncedSyncer{}, e.buildIstioEndpoints())
+		e.col = &col
+	})
+	return e.col
+}
+
+func (e *EndpointIndex) buildIstioEndpoints() []*IstioEndpoints {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	endpoints := []*IstioEndpoints{}
+	for svc, shardsByNamespace := range e.shardsBySvc {
+		for ns, shards := range shardsByNamespace {
+			shards.RLock()
+			for shardKey, istioEndpoints := range shards.Shards {
+				endpoints = append(endpoints, &IstioEndpoints{
+					Service:   svc,
+					Namespace: ns,
+					ShardKey:  shardKey,
+					Endpoints: istioEndpoints,
+				})
+			}
+			shards.RUnlock()
+		}
+	}
+	return endpoints
 }
 
 // PushType is an enumeration that decides what type push we should do when we get EDS update.
@@ -335,6 +416,15 @@ func (e *EndpointIndex) UpdateServiceEndpoints(
 	// immediately. However, clearing the cache here has almost no impact on cache performance as we
 	// would clear it shortly after anyways.
 	e.clearCacheForService(hostname, namespace)
+
+	if e.col != nil {
+		e.col.UpdateObject(&IstioEndpoints{
+			Endpoints: istioEndpoints,
+			Service:   hostname,
+			Namespace: namespace,
+			ShardKey:  shard,
+		})
+	}
 
 	return pushType
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
Here's a polished version of your PR description:

---

To address the inconsistency issue in #59501, I’ve implemented a mechanism where endpoint changes trigger gateway status updates via a new IstioEndpoints collection in EndpointIndex.

I'm presenting this as a potential fix, but I’d like to confirm if this change is considered necessary, or is there a better architectural way to handle this dependency?

The functionally of this change is tested in my environment. Tests will be updated once the implementation strategy is finalized.