### PR TITLE
Simplify some code with slices.Contains/ContainsFunc.

### DIFF
--- a/pilot/pkg/config/kube/ingress/ingress.go
+++ b/pilot/pkg/config/kube/ingress/ingress.go
@@ -27,6 +27,7 @@ import (
 	"istio.io/istio/pkg/config/mesh/meshwatcher"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/slices"
 	netutil "istio.io/istio/pkg/util/net"
 )
 
@@ -122,7 +123,7 @@ func runningAddresses(
 		addrs := make([]string, 0)
 		for _, address := range node.Status.Addresses {
 			if address.Type == corev1.NodeExternalIP {
-				if address.Address != "" && !addressInSlice(address.Address, addrs) {
+				if address.Address != "" && !slices.Contains(addrs, address.Address) {
 					addrs = append(addrs, address.Address)
 				}
 			}
@@ -242,14 +243,4 @@ func lessLoadBalancerIngress(addrs []knetworking.IngressLoadBalancerIngress) fun
 		}
 		return addrs[a].IP < addrs[b].IP
 	}
-}
-
-func addressInSlice(addr string, list []string) bool {
-	for _, v := range list {
-		if v == addr {
-			return true
-		}
-	}
-
-	return false
 }

--- a/pilot/pkg/leaderelection/leaderelection_test.go
+++ b/pilot/pkg/leaderelection/leaderelection_test.go
@@ -28,6 +28,7 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 
 	"istio.io/istio/pkg/revisions"
+	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test/util/retry"
 )
 
@@ -250,17 +251,8 @@ func TestPrioritizationCycles(t *testing.T) {
 	}
 }
 
-func alreadyHit(cur instance, chain []instance) bool {
-	for _, cc := range chain {
-		if cur == cc {
-			return true
-		}
-	}
-	return false
-}
-
 func checkCycles(t *testing.T, start instance, cases []instance, chain []instance) {
-	if alreadyHit(start, chain) {
+	if slices.Contains(chain, start) {
 		t.Fatalf("cycle on leader election: cur %v, chain %v", start, chain)
 	}
 	for _, nextHop := range cases {

--- a/pilot/pkg/networking/core/envoyfilter/cluster_patch.go
+++ b/pilot/pkg/networking/core/envoyfilter/cluster_patch.go
@@ -28,6 +28,7 @@ import (
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/proto/merge"
+	"istio.io/istio/pkg/slices"
 )
 
 // ApplyClusterMerge processes the MERGE operation and merges the supplied configuration to the matched clusters.
@@ -170,7 +171,7 @@ func clusterMatch(cluster *cluster.Cluster, cp *model.EnvoyFilterConfigPatchWrap
 		return false
 	}
 
-	if cMatch.Service != "" && !hostContains(hostMatches, host.Name(cMatch.Service)) {
+	if cMatch.Service != "" && !slices.Contains(hostMatches, host.Name(cMatch.Service)) {
 		return false
 	}
 
@@ -180,13 +181,4 @@ func clusterMatch(cluster *cluster.Cluster, cp *model.EnvoyFilterConfigPatchWrap
 		return false
 	}
 	return true
-}
-
-func hostContains(hosts []host.Name, service host.Name) bool {
-	for _, h := range hosts {
-		if h == service {
-			return true
-		}
-	}
-	return false
 }

--- a/pilot/pkg/networking/core/envoyfilter/listener_patch.go
+++ b/pilot/pkg/networking/core/envoyfilter/listener_patch.go
@@ -664,14 +664,7 @@ func filterChainMatch(listener *listener.Listener, fc *listener.FilterChain, lp 
 		if fc.FilterChainMatch == nil || len(fc.FilterChainMatch.ServerNames) == 0 {
 			return false
 		}
-		sniMatched := false
-		for _, sni := range fc.FilterChainMatch.ServerNames {
-			if sni == match.Sni {
-				sniMatched = true
-				break
-			}
-		}
-		if !sniMatched {
+		if !slices.Contains(fc.FilterChainMatch.ServerNames, match.Sni) {
 			return false
 		}
 	}

--- a/pilot/pkg/networking/core/httproute.go
+++ b/pilot/pkg/networking/core/httproute.go
@@ -265,18 +265,10 @@ func selectVirtualServices(virtualServices []*config.Config, servicesByName map[
 						break
 					}
 				}
-			} else {
+			} else if slices.ContainsFunc(wcSvcHosts, lch.Matches) {
 				// If non wildcard vs host isn't be found in service map, only loop through
 				// wildcard service hosts to avoid repeated matching.
-				for _, svcHost := range wcSvcHosts {
-					if lch.Matches(svcHost) {
-						match = true
-						break
-					}
-				}
-			}
-
-			if match {
+				match = true
 				break
 			}
 		}

--- a/pilot/pkg/networking/core/listener.go
+++ b/pilot/pkg/networking/core/listener.go
@@ -1279,15 +1279,7 @@ func (chain *filterChainOpts) toFilterChainMatch() *listener.FilterChainMatch {
 		TransportProtocol:    chain.transportProtocol,
 	}
 	if len(chain.sniHosts) > 0 {
-		fullWildcardFound := false
-		for _, h := range chain.sniHosts {
-			if h == "*" {
-				fullWildcardFound = true
-				// If we have a host with *, it effectively means match anything, i.e.
-				// no SNI based matching for this host.
-				break
-			}
-		}
+		fullWildcardFound := slices.Contains(chain.sniHosts, "*")
 		if !fullWildcardFound {
 			chain.sniHosts = append([]string{}, chain.sniHosts...)
 			sort.Stable(sort.StringSlice(chain.sniHosts))

--- a/pilot/pkg/networking/core/listener_test.go
+++ b/pilot/pkg/networking/core/listener_test.go
@@ -1443,14 +1443,7 @@ func TestOutboundTLSDynamicDNSWildcardServerNames(t *testing.T) {
 	if len(fc.FilterChainMatch.ServerNames) == 0 {
 		t.Fatalf("expected filter_chain_match.server_names (e.g. [%q]), got %v", hostname, fc.FilterChainMatch.ServerNames)
 	}
-	found := false
-	for _, sn := range fc.FilterChainMatch.ServerNames {
-		if sn == hostname {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if !slices.Contains(fc.FilterChainMatch.ServerNames, hostname) {
 		t.Fatalf("expected server_names to contain %q, got %v", hostname, fc.FilterChainMatch.ServerNames)
 	}
 }
@@ -2992,12 +2985,7 @@ func buildOutboundListeners(t *testing.T, proxy *model.Proxy, sidecarConfig *con
 }
 
 func isHTTPListener(listener *listener.Listener) bool {
-	for _, fc := range listener.GetFilterChains() {
-		if isHTTPFilterChain(fc) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(listener.GetFilterChains(), isHTTPFilterChain)
 }
 
 func isMysqlListener(listener *listener.Listener) bool {

--- a/pilot/pkg/security/trustdomain/bundle.go
+++ b/pilot/pkg/security/trustdomain/bundle.go
@@ -112,7 +112,7 @@ func (t Bundle) replaceTrustDomains(principal, trustDomainFromPrincipal string) 
 		// Check to make sure we don't generate duplicated principals. This happens when trust domain
 		// has a * prefix. For example, "*-td" can match with "old-td" and "new-td", but we only want
 		// to keep the principal as-is in the generated config, .i.e. *-td.
-		if !isKeyInList(newPrincipal, principalsForAliases) {
+		if !slices.Contains(principalsForAliases, newPrincipal) {
 			principalsForAliases = append(principalsForAliases, newPrincipal)
 		}
 	}

--- a/pilot/pkg/security/trustdomain/util.go
+++ b/pilot/pkg/security/trustdomain/util.go
@@ -48,13 +48,3 @@ func suffixMatch(a string, pattern string) bool {
 	pattern = strings.TrimPrefix(pattern, "*")
 	return strings.HasSuffix(a, pattern)
 }
-
-// isKeyInList it's fine to use this naive implementation for searching in a very short list.
-func isKeyInList(key string, list []string) bool {
-	for _, l := range list {
-		if key == l {
-			return true
-		}
-	}
-	return false
-}

--- a/pilot/pkg/simulation/traffic.go
+++ b/pilot/pkg/simulation/traffic.go
@@ -457,10 +457,8 @@ func (sim *Simulation) matchVirtualHost(rc *route.RouteConfiguration, host strin
 	}
 	// Exact match
 	for _, vh := range rc.VirtualHosts {
-		for _, d := range vh.Domains {
-			if d == host {
-				return vh
-			}
+		if slices.Contains(vh.Domains, host) {
+			return vh
 		}
 	}
 	// prefix match
@@ -498,10 +496,8 @@ func (sim *Simulation) matchVirtualHost(rc *route.RouteConfiguration, host strin
 	}
 	// wildcard match
 	for _, vh := range rc.VirtualHosts {
-		for _, d := range vh.Domains {
-			if d == "*" {
-				return vh
-			}
+		if slices.Contains(vh.Domains, "*") {
+			return vh
 		}
 	}
 	return nil

--- a/pkg/config/schema/collection/schemas.go
+++ b/pkg/config/schema/collection/schemas.go
@@ -141,10 +141,8 @@ func (s Schemas) FindByGroupVersionKind(gvk config.GroupVersionKind) (resource.S
 // if not found, it will search for version aliases for the schema to see if there is a match.
 func (s Schemas) FindByGroupVersionAliasesKind(gvk config.GroupVersionKind) (resource.Schema, bool) {
 	for _, rs := range s.byAddOrder {
-		for _, va := range rs.GroupVersionAliasKinds() {
-			if va == gvk {
-				return rs, true
-			}
+		if slices.Contains(rs.GroupVersionAliasKinds(), gvk) {
+			return rs, true
 		}
 	}
 	return nil, false

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1867,12 +1867,7 @@ func isSniHost(context *networking.VirtualService) bool {
 }
 
 func isGateway(context *networking.VirtualService) bool {
-	for _, gatewayName := range context.Gateways {
-		if gatewayName == constants.IstioMeshGateway {
-			return false
-		}
-	}
-	return true
+	return !slices.Contains(context.Gateways, constants.IstioMeshGateway)
 }
 
 // genMatchHTTPRoutes build the match rules into struct OverlappingMatchValidationForHTTPRoute

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -51,6 +51,7 @@ import (
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/slices"
 	"istio.io/istio/tools/istio-iptables/pkg/constants"
 )
 
@@ -209,10 +210,8 @@ func injectRequired(ignored []string, config *Config, podSpec *corev1.PodSpec, m
 	}
 
 	// skip special kubernetes system namespaces
-	for _, namespace := range ignored {
-		if metadata.Namespace == namespace {
-			return false
-		}
+	if slices.Contains(ignored, metadata.Namespace) {
+		return false
 	}
 
 	annos := metadata.GetAnnotations()

--- a/pkg/kube/krt/index.go
+++ b/pkg/kube/krt/index.go
@@ -132,12 +132,7 @@ func (i index[K, O]) Fetch(ctx HandlerContext, key K, opts ...FetchOption) []O {
 
 // nolint: unused // (not true)
 func (i index[K, O]) objectHasKey(obj O, k K) bool {
-	for _, got := range i.extract(obj) {
-		if got == k {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(i.extract(obj), k)
 }
 
 // nolint: unused // (not true)

--- a/pkg/test/kube/dump.go
+++ b/pkg/test/kube/dump.go
@@ -37,6 +37,7 @@ import (
 
 	"istio.io/api/annotation"
 	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/components/istioctl"
 	"istio.io/istio/pkg/test/framework/resource"
@@ -557,14 +558,7 @@ func hasEnvoy(pod corev1.Pod) bool {
 		// assume VMs run Envoy
 		return true
 	}
-	f := false
-	for _, c := range pod.Spec.Containers {
-		if proxyContainer.IsContainer(c) {
-			f = true
-			break
-		}
-	}
-	if !f {
+	if !slices.ContainsFunc(pod.Spec.Containers, proxyContainer.IsContainer) {
 		// no proxy container
 		return false
 	}

--- a/tests/binary/dependencies_test.go
+++ b/tests/binary/dependencies_test.go
@@ -171,14 +171,7 @@ func TestDependencies(t *testing.T) {
 		all, err := getDependencies(env.IstioSrc+"/...", "integ", true)
 		assert.NoError(t, err)
 		for _, d := range allDenials {
-			found := false
-			for _, dep := range all {
-				if d.MatchString(dep) {
-					found = true
-					break
-				}
-			}
-			if !found {
+			if !slices.ContainsFunc(all, d.MatchString) {
 				t.Errorf("Had a deny rule %q, but it doesn't match *any* dependency in the repo. This is likely a bug.", d)
 			}
 		}


### PR DESCRIPTION
**Please provide a description of this PR:**

`slices` can be used to delete utility functions that basically do the same. There is more, but smaller chunks may help with the review process.

I don't understand why the slices package needs to have all the code duplicated inside the repository. `depguard` is configured to prohibit direct imports of `slices`.

[modernize](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize#hdr-Analyzer_slicescontains) can find the code that can be simplified, while also doing the work.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [x] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
