### PR TITLE
Reopening: fix(manifests): fix cniBinDir path for k3d (Blocked by k3d-io/k3d#1604)

### DIFF
--- a/manifests/charts/base/files/profile-platform-k3d.yaml
+++ b/manifests/charts/base/files/profile-platform-k3d.yaml
@@ -4,4 +4,4 @@
 
 cni:
   cniConfDir: /var/lib/rancher/k3s/agent/etc/cni/net.d
-  cniBinDir: /bin
+  cniBinDir: /var/lib/rancher/k3s/data/cni

--- a/manifests/charts/default/files/profile-platform-k3d.yaml
+++ b/manifests/charts/default/files/profile-platform-k3d.yaml
@@ -4,4 +4,4 @@
 
 cni:
   cniConfDir: /var/lib/rancher/k3s/agent/etc/cni/net.d
-  cniBinDir: /bin
+  cniBinDir: /var/lib/rancher/k3s/data/cni

--- a/manifests/charts/gateway/files/profile-platform-k3d.yaml
+++ b/manifests/charts/gateway/files/profile-platform-k3d.yaml
@@ -4,4 +4,4 @@
 
 cni:
   cniConfDir: /var/lib/rancher/k3s/agent/etc/cni/net.d
-  cniBinDir: /bin
+  cniBinDir: /var/lib/rancher/k3s/data/cni

--- a/manifests/charts/gateways/istio-egress/files/profile-platform-k3d.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-platform-k3d.yaml
@@ -4,4 +4,4 @@
 
 cni:
   cniConfDir: /var/lib/rancher/k3s/agent/etc/cni/net.d
-  cniBinDir: /bin
+  cniBinDir: /var/lib/rancher/k3s/data/cni

--- a/manifests/charts/gateways/istio-ingress/files/profile-platform-k3d.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-platform-k3d.yaml
@@ -4,4 +4,4 @@
 
 cni:
   cniConfDir: /var/lib/rancher/k3s/agent/etc/cni/net.d
-  cniBinDir: /bin
+  cniBinDir: /var/lib/rancher/k3s/data/cni

--- a/manifests/charts/istio-cni/files/profile-platform-k3d.yaml
+++ b/manifests/charts/istio-cni/files/profile-platform-k3d.yaml
@@ -4,4 +4,4 @@
 
 cni:
   cniConfDir: /var/lib/rancher/k3s/agent/etc/cni/net.d
-  cniBinDir: /bin
+  cniBinDir: /var/lib/rancher/k3s/data/cni

--- a/manifests/charts/istio-control/istio-discovery/files/profile-platform-k3d.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-platform-k3d.yaml
@@ -4,4 +4,4 @@
 
 cni:
   cniConfDir: /var/lib/rancher/k3s/agent/etc/cni/net.d
-  cniBinDir: /bin
+  cniBinDir: /var/lib/rancher/k3s/data/cni

--- a/manifests/charts/ztunnel/files/profile-platform-k3d.yaml
+++ b/manifests/charts/ztunnel/files/profile-platform-k3d.yaml
@@ -4,4 +4,4 @@
 
 cni:
   cniConfDir: /var/lib/rancher/k3s/agent/etc/cni/net.d
-  cniBinDir: /bin
+  cniBinDir: /var/lib/rancher/k3s/data/cni

--- a/manifests/helm-profiles/platform-k3d.yaml
+++ b/manifests/helm-profiles/platform-k3d.yaml
@@ -1,3 +1,3 @@
 cni:
   cniConfDir: /var/lib/rancher/k3s/agent/etc/cni/net.d
-  cniBinDir: /bin
+  cniBinDir: /var/lib/rancher/k3s/data/cni


### PR DESCRIPTION
**Description**
I am reopening the discussion regarding the fix for cniBinDir path for k3d (previously tracked in PR #57110). The original PR was closed due to inactivity while waiting for a dependency update in the k3d project.

**Context**
The issue was that k3d used an older version of k3s as default, which didn't use the new CNI path. This created a compatibility risk for users on default settings.

The blocker is now resolved: k3d has merged the update to bump the default k3s version (see [k3d-io/k3d#1604](https://github.com/k3d-io/k3d/issues/1604)).

With k3d now aligned with the latest k3s patch versions, we can safely update the Istio manifests to use the correct path without breaking the default user experience.

**Link to previous work**
Original PR: https://github.com/istio/istio/pull/57110

Related k3d Issue: https://github.com/k3d-io/k3d/issues/1604

**Affected area**
[x] Ambient
[x] Environments