### PR TITLE
Add PQC label to be able to skip PQC tests (e.g. on FIPS env)

### DIFF
--- a/pkg/test/framework/label/labels.go
+++ b/pkg/test/framework/label/labels.go
@@ -24,12 +24,16 @@ const (
 	// IPv4 indicates a test is only compatible with IPv4 clusters.
 	// Any usage of this should have an associated GitHub issue to make it compatible with IPv6
 	IPv4 Instance = "ipv4"
+
+	// PQC indicates PQC tests
+	PQC Instance = "pqc"
 )
 
 var all = NewSet(
 	Postsubmit,
 	CustomSetup,
-	IPv4)
+	IPv4,
+	PQC)
 
 // Find the label with the given name
 func Find(name string) (Instance, bool) {

--- a/tests/integration/ambient/pqc/main_test.go
+++ b/tests/integration/ambient/pqc/main_test.go
@@ -62,6 +62,7 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
 		Label(testlabel.CustomSetup).
+		Label(testlabel.PQC).
 		Setup(istio.Setup(&i, func(ctx resource.Context, cfg *istio.Config) {
 			ctx.Settings().Ambient = true
 			ctx.Settings().SkipVMs()

--- a/tests/integration/security/pqc/main_test.go
+++ b/tests/integration/security/pqc/main_test.go
@@ -56,6 +56,7 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
 		Label(label.CustomSetup).
+		Label(label.PQC).
 		Setup(istio.Setup(&i, func(ctx resource.Context, cfg *istio.Config) {
 			cfg.ControlPlaneValues = `
 values:


### PR DESCRIPTION
**Please provide a description of this PR:**
Add PQC test label to be able to skip PQC tests on FIPS cluster since X25519MLKEM is not FIPS-compliant
e.g.
```
--istio.test.select=-pqc
```
^the pqc tests will be skipped 