### PR TITLE
tests: fix flaky PQC tests by handling TCP RST on TLS handshake failure

### DIFF
--- a/pkg/test/framework/components/echo/check/checkers.go
+++ b/pkg/test/framework/components/echo/check/checkers.go
@@ -116,6 +116,10 @@ func TLSHandshakeFailure() echo.Checker {
 	return ErrorContains("tls: handshake failure")
 }
 
+func ConnectionResetByPeer() echo.Checker {
+	return ErrorContains("read: connection reset by peer")
+}
+
 func ErrorOrStatus(expected int) echo.Checker {
 	return Or(Error(), Status(expected))
 }

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -2797,7 +2797,7 @@ spec:
 var CheckDeny = check.Or(
 	check.ErrorContains("rpc error: code = PermissionDenied"), // gRPC
 	check.ErrorContains("EOF"),                                // TCP envoy
-	check.ErrorContains("read: connection reset by peer"),     // TCP ztunnel
+	check.ConnectionResetByPeer(),                             // TCP ztunnel
 	check.NoErrorAndStatus(http.StatusForbidden),              // HTTP
 	check.NoErrorAndStatus(http.StatusServiceUnavailable),     // HTTP client, TCP server
 )

--- a/tests/integration/ambient/pqc/main_test.go
+++ b/tests/integration/ambient/pqc/main_test.go
@@ -170,7 +170,6 @@ func setupAppsConfig(_ resource.Context) error {
 func TestIngress(t *testing.T) {
 	framework.NewTest(t).
 		Run(func(t framework.TestContext) {
-			t.Skip("https://github.com/istio/istio/issues/59520")
 			credName := "ingress-pqc-credential"
 			host := "ingress-pqc.example.com"
 			gatewayName := "ingress-pqc-credential"
@@ -249,7 +248,7 @@ spec:
 						MinVersion:       "1.3",
 						CurvePreferences: []string{"P-256"},
 					},
-					Check: check.TLSHandshakeFailure(),
+					Check: check.Or(check.TLSHandshakeFailure(), check.ConnectionResetByPeer()),
 				})
 			})
 		})
@@ -258,7 +257,6 @@ spec:
 func TestWaypoint(t *testing.T) {
 	framework.NewTest(t).
 		Run(func(t framework.TestContext) {
-			t.Skip("https://github.com/istio/istio/issues/59520")
 			serviceEntryYaml := `
 apiVersion: networking.istio.io/v1
 kind: ServiceEntry
@@ -310,7 +308,7 @@ spec:
 						CurvePreferences: []string{"P-256"},
 					},
 					Timeout: 1 * time.Second,
-					Check:   check.TLSHandshakeFailure(),
+					Check:   check.Or(check.TLSHandshakeFailure(), check.ConnectionResetByPeer()),
 				})
 			})
 

--- a/tests/integration/security/pqc/main_test.go
+++ b/tests/integration/security/pqc/main_test.go
@@ -213,7 +213,7 @@ spec:
 						CurvePreferences: []string{"P-256"},
 					},
 					Timeout: 1 * time.Second,
-					Check:   check.TLSHandshakeFailure(),
+					Check:   check.Or(check.TLSHandshakeFailure(), check.ConnectionResetByPeer()),
 				})
 			})
 		})
@@ -341,7 +341,7 @@ spec:
 						CurvePreferences: []string{"P-256"},
 					},
 					Timeout: 1 * time.Second,
-					Check:   check.TLSHandshakeFailure(),
+					Check:   check.Or(check.TLSHandshakeFailure(), check.ConnectionResetByPeer()),
 				})
 			})
 


### PR DESCRIPTION
**Please provide a description of this PR:**

The test cases for TLS handshake failure sometimes fail, because the client receives TCP RST and logs "read: connection reset by peer", while the server logs "TLS handshake error from 10.244.1.120:41724: tls: no key exchanges supported by both client and server", so that means the handshake fails as expected, but the server reset the connection before the client received TLS alert. I tried to fix it by setting SO_LINGER (#59598), but it still fails, so we can keep it simple and check both TLS alert and TCP RST.

Fixes #59520 