### PR TITLE
Apply meshMTLS.ecdhCurves to mTLS traffic and warn on invalid curves

### DIFF
--- a/pilot/pkg/networking/core/cluster_tls.go
+++ b/pilot/pkg/networking/core/cluster_tls.go
@@ -170,6 +170,10 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 				tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNInMesh
 			}
 		}
+		// Apply ECDH curves from meshMTLS config for mesh mTLS traffic.
+		if meshMTLS := opts.mesh.GetMeshMTLS(); meshMTLS != nil && len(meshMTLS.EcdhCurves) > 0 {
+			tlsContext.CommonTlsContext.TlsParams.EcdhCurves = meshMTLS.EcdhCurves
+		}
 		// Set auto_sni, auto_san_validation and allow_insecure_cluster_options for sidecar DFP clusters.
 		if c.isDFPCluster && opts.direction == model.TrafficDirectionOutbound {
 			setAutoSniAndAutoSanValidation(c, tls)

--- a/pilot/pkg/networking/core/cluster_tls_test.go
+++ b/pilot/pkg/networking/core/cluster_tls_test.go
@@ -1611,9 +1611,9 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 				err: nil,
 			},
 		},
-		// ecdh curves from MeshConfig should be ignored for ISTIO_MUTUAL mode
+		// tlsDefaults.EcdhCurves should be ignored for ISTIO_MUTUAL mode (meshMTLS is used instead)
 		{
-			name: "tls mode ISTIO_MUTUAL with EcdhCurves specified in Mesh Config",
+			name: "tls mode ISTIO_MUTUAL with EcdhCurves specified in TlsDefaults",
 			opts: &buildClusterOpts{
 				mutable: newTestCluster(),
 				mesh: &meshconfig.MeshConfig{
@@ -1634,6 +1634,85 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 							// if not specified, envoy use TLSv1_2 as default for client.
 							TlsMaximumProtocolVersion: tls.TlsParameters_TLSv1_3,
 							TlsMinimumProtocolVersion: tls.TlsParameters_TLSv1_2,
+						},
+						TlsCertificateSdsSecretConfigs: []*tls.SdsSecretConfig{
+							{
+								Name: "default",
+								SdsConfig: &core.ConfigSource{
+									ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+										ApiConfigSource: &core.ApiConfigSource{
+											ApiType:                   core.ApiConfigSource_GRPC,
+											SetNodeOnFirstMessageOnly: true,
+											TransportApiVersion:       core.ApiVersion_V3,
+											GrpcServices: []*core.GrpcService{
+												{
+													TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
+														EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: "sds-grpc"},
+													},
+												},
+											},
+										},
+									},
+									InitialFetchTimeout: durationpb.New(time.Second * 0),
+									ResourceApiVersion:  core.ApiVersion_V3,
+								},
+							},
+						},
+						ValidationContextType: &tls.CommonTlsContext_CombinedValidationContext{
+							CombinedValidationContext: &tls.CommonTlsContext_CombinedCertificateValidationContext{
+								DefaultValidationContext: &tls.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch([]string{"SAN"})},
+								ValidationContextSdsSecretConfig: &tls.SdsSecretConfig{
+									Name: "ROOTCA",
+									SdsConfig: &core.ConfigSource{
+										ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+											ApiConfigSource: &core.ApiConfigSource{
+												ApiType:                   core.ApiConfigSource_GRPC,
+												SetNodeOnFirstMessageOnly: true,
+												TransportApiVersion:       core.ApiVersion_V3,
+												GrpcServices: []*core.GrpcService{
+													{
+														TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
+															EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: "sds-grpc"},
+														},
+													},
+												},
+											},
+										},
+										InitialFetchTimeout: durationpb.New(time.Second * 0),
+										ResourceApiVersion:  core.ApiVersion_V3,
+									},
+								},
+							},
+						},
+						AlpnProtocols: util.ALPNInMeshWithMxc,
+					},
+					Sni: "some-sni.com",
+				},
+				err: nil,
+			},
+		},
+		{
+			name: "tls mode ISTIO_MUTUAL with EcdhCurves specified in MeshMTLS",
+			opts: &buildClusterOpts{
+				mutable: newTestCluster(),
+				mesh: &meshconfig.MeshConfig{
+					MeshMTLS: &meshconfig.MeshConfig_TLSConfig{
+						EcdhCurves: []string{"P-256", "P-384"},
+					},
+				},
+			},
+			tls: &networking.ClientTLSSettings{
+				Mode:            networking.ClientTLSSettings_ISTIO_MUTUAL,
+				SubjectAltNames: []string{"SAN"},
+				Sni:             "some-sni.com",
+			},
+			result: expectedResult{
+				tlsContext: &tls.UpstreamTlsContext{
+					CommonTlsContext: &tls.CommonTlsContext{
+						TlsParams: &tls.TlsParameters{
+							TlsMaximumProtocolVersion: tls.TlsParameters_TLSv1_3,
+							TlsMinimumProtocolVersion: tls.TlsParameters_TLSv1_2,
+							EcdhCurves:                []string{"P-256", "P-384"},
 						},
 						TlsCertificateSdsSecretConfigs: []*tls.SdsSecretConfig{
 							{

--- a/pilot/pkg/security/authn/utils/utils.go
+++ b/pilot/pkg/security/authn/utils/utils.go
@@ -73,9 +73,14 @@ func BuildInboundTLS(mTLSMode model.MutualTLSMode, node *model.Proxy,
 	if mc != nil && mc.MeshMTLS != nil && mc.MeshMTLS.CipherSuites != nil {
 		ciphers = mc.MeshMTLS.CipherSuites
 	}
-	// Set Minimum TLS version to match the default client version and allowed strong cipher suites for sidecars.
+	var ecdhCurves []string
+	if mc != nil && mc.MeshMTLS != nil && len(mc.MeshMTLS.EcdhCurves) > 0 {
+		ecdhCurves = mc.MeshMTLS.EcdhCurves
+	}
+	// Set TLS parameters: minimum version, cipher suites, and ECDH curves for sidecars.
 	ctx.CommonTlsContext.TlsParams = &tls.TlsParameters{
 		CipherSuites:              ciphers,
+		EcdhCurves:                ecdhCurves,
 		TlsMinimumProtocolVersion: minTLSVersion,
 		TlsMaximumProtocolVersion: tls.TlsParameters_TLSv1_3,
 	}

--- a/pilot/pkg/security/authn/utils/utils_test.go
+++ b/pilot/pkg/security/authn/utils/utils_test.go
@@ -100,3 +100,41 @@ func TestGetMTLSCipherSuites(t *testing.T) {
 		})
 	}
 }
+
+func TestGetMTLSECDHCurves(t *testing.T) {
+	tests := []struct {
+		name               string
+		mesh               meshconfig.MeshConfig
+		expectedECDHCurves []string
+	}{
+		{
+			name:               "Default MTLS ECDH curves",
+			expectedECDHCurves: nil,
+		},
+		{
+			name: "Configure MTLS ECDH curves",
+			mesh: meshconfig.MeshConfig{
+				MeshMTLS: &meshconfig.MeshConfig_TLSConfig{
+					EcdhCurves: []string{"P-256", "P-384"},
+				},
+			},
+			expectedECDHCurves: []string{"P-256", "P-384"},
+		},
+	}
+	for i := range tests {
+		tt := &tests[i]
+		t.Run(tt.name, func(t *testing.T) {
+			testNode := &model.Proxy{
+				Labels: map[string]string{
+					"app": "foo",
+				},
+				Metadata: &model.NodeMetadata{},
+			}
+
+			got := BuildInboundTLS(model.MTLSStrict, testNode, networking.ListenerProtocolTCP, []string{}, tls.TlsParameters_TLSv1_2, &tt.mesh)
+			if diff := cmp.Diff(tt.expectedECDHCurves, got.CommonTlsContext.TlsParams.EcdhCurves, protocmp.Transform()); diff != "" {
+				t.Errorf("unexpected ECDH curves: %v", diff)
+			}
+		})
+	}
+}

--- a/pkg/config/validation/agent/validation.go
+++ b/pkg/config/validation/agent/validation.go
@@ -767,13 +767,31 @@ func validateTrustDomainConfig(config *meshconfig.MeshConfig) (errs error) {
 	return errs
 }
 
-func ValidateMeshTLSConfig(mesh *meshconfig.MeshConfig) (errs error) {
+func ValidateMeshTLSConfig(mesh *meshconfig.MeshConfig) (v Validation) {
 	if meshMTLS := mesh.MeshMTLS; meshMTLS != nil {
-		if meshMTLS.EcdhCurves != nil {
-			errs = multierror.Append(errs, errors.New("mesh TLS does not support ECDH curves configuration"))
+		unrecognizedECDHCurves := sets.New[string]()
+		validECDHCurves := sets.New[string]()
+		duplicateECDHCurves := sets.New[string]()
+		for _, cs := range meshMTLS.EcdhCurves {
+			if cs == "" {
+				continue
+			}
+			if !security.IsValidECDHCurve(cs) {
+				unrecognizedECDHCurves.Insert(cs)
+			} else if validECDHCurves.InsertContains(cs) {
+				duplicateECDHCurves.Insert(cs)
+			}
+		}
+
+		if len(unrecognizedECDHCurves) > 0 {
+			v = AppendWarningf(v, "detected unrecognized ECDH curves in mesh mTLS: %v", sets.SortedList(unrecognizedECDHCurves))
+		}
+
+		if len(duplicateECDHCurves) > 0 {
+			v = AppendWarningf(v, "detected duplicate ECDH curves in mesh mTLS: %v", sets.SortedList(duplicateECDHCurves))
 		}
 	}
-	return errs
+	return v
 }
 
 func ValidateMeshTLSDefaults(mesh *meshconfig.MeshConfig) (v Validation) {

--- a/pkg/config/validation/agent/validation_test.go
+++ b/pkg/config/validation/agent/validation_test.go
@@ -1077,7 +1077,7 @@ func TestValidateMeshConfig(t *testing.T) {
 			},
 		},
 		MeshMTLS: &meshconfig.MeshConfig_TLSConfig{
-			EcdhCurves: []string{"P-256"},
+			EcdhCurves: []string{"P-256", "P-256", "invalid-curve"},
 		},
 		TlsDefaults: &meshconfig.MeshConfig_TLSConfig{
 			EcdhCurves: []string{"P-256", "P-256", "invalid"},
@@ -1102,7 +1102,6 @@ func TestValidateMeshConfig(t *testing.T) {
 			"trustDomainAliases[0]",
 			"trustDomainAliases[1]",
 			"trustDomainAliases[2]",
-			"mesh TLS does not support ECDH curves configuration",
 		}
 		switch err := err.(type) {
 		case *multierror.Error:
@@ -1124,6 +1123,8 @@ func TestValidateMeshConfig(t *testing.T) {
 		t.Errorf("expected a warning on invalid proxy mesh config: %v", invalid)
 	} else {
 		wantWarnings := []string{
+			"detected unrecognized ECDH curves in mesh mTLS",
+			"detected duplicate ECDH curves in mesh mTLS",
 			"detected unrecognized ECDH curves",
 			"detected duplicate ECDH curves",
 		}

--- a/releasenotes/notes/mesh-mtls-ecdh-curves.yaml
+++ b/releasenotes/notes/mesh-mtls-ecdh-curves.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+issue:
+  - https://github.com/istio/istio/issues/52290
+releaseNotes:
+  - |
+    **Added** support for `meshMTLS.ecdhCurves` in the mesh config allowing users to configure
+    ECDH curves for sidecar mesh mTLS on both inbound and outbound connections. Previously this field
+    was rejected.


### PR DESCRIPTION
**Please provide a description of this PR:**
Allows setting `meshMTLS.ecdhCurves` and, when set, applies this setting to mTLS traffic.

Fixes https://github.com/istio/istio/issues/52290