### PR TITLE
[Fix postsubmit] require k8s 1.31+ for gateway-api CRD deployment

### DIFF
--- a/pkg/test/framework/components/crd/gateway.go
+++ b/pkg/test/framework/components/crd/gateway.go
@@ -35,7 +35,7 @@ import (
 // SupportsGatewayAPI checks if the gateway API is supported.
 func SupportsGatewayAPI(t resource.Context) bool {
 	for _, cluster := range t.Clusters() {
-		if !cluster.MinKubeVersion(23) { // API uses CEL which requires 1.23
+		if !cluster.MinKubeVersion(31) { // isIP() CEL function requires 1.31 (gateway-api v1.5.0)
 			return false
 		}
 	}


### PR DESCRIPTION
`gateway-api v1.5.0` added isIP() CEL validation to TLSRoute hostnames. That function requires k8s 1.31+, so applying the CRD fails on older clusters. This is why all the postsubmit jobs from those k8s versions we see this error message:

```
Invalid value: apiextensions.ValidationRule{Rule:"self.all(h, !isIP(h))", Message:"Hostnames cannot contain an IP"
```

Release Notes: https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.5.0 mentions `Additionally, note that TLSRoute's CEL validation requires Kubernetes 1.31 or higher.`