### PR TITLE
Skip pqc on old k8s versions

### DIFF
--- a/tests/integration/ambient/pqc/main_test.go
+++ b/tests/integration/ambient/pqc/main_test.go
@@ -135,6 +135,9 @@ spec:
     mode: STRICT`
 			return ctx.ConfigIstio().YAML(i.Settings().SystemNamespace, peerAuthYaml).Apply(apply.Wait)
 		}).
+		SkipIf("K8s < 1.34 doesn't support PQC", func(ctx resource.Context) bool {
+			return ctx.Clusters().Default().MinKubeVersion(34)
+		}).
 		Run()
 }
 

--- a/tests/integration/security/pqc/main_test.go
+++ b/tests/integration/security/pqc/main_test.go
@@ -98,6 +98,9 @@ spec:
     mode: STRICT`
 			return ctx.ConfigIstio().YAML(i.Settings().SystemNamespace, peerAuthYaml).Apply(apply.Wait)
 		}).
+		SkipIf("K8s < 1.34 doesn't support PQC", func(ctx resource.Context) bool {
+			return ctx.Clusters().Default().MinKubeVersion(34)
+		}).
 		Run()
 }
 


### PR DESCRIPTION
**Please provide a description of this PR:**
Older k8s versions were build with older versions of Go which didn't support (or k8s didn't enable) PQC by default. We should adjust for this in our e2es and also probably document the k8s version requirement /cc @jewertow 