### PR TITLE
Bump golang to 1.25.8 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module istio.io/istio
 
-go 1.25.7
+go 1.25.8
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0


### PR DESCRIPTION
**Please provide a description of this PR:**

1.25.8 contains some [security fixes](https://github.com/golang/go/issues?q=milestone%3AGo1.25.8+label%3ACherryPickApproved) This is unfortunately [not covered by dependabot](https://github.com/dependabot/dependabot-core/issues/9057)