### PR TITLE
Allow DaemonSet kind in gateway deployment controller

### DIFF
--- a/pilot/pkg/config/kube/gatewaycommon/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gatewaycommon/deploymentcontroller.go
@@ -790,7 +790,7 @@ func (d *DeploymentController) apply(controller string, yml string, input Templa
 	// safeguard: validate object type matches default template
 	// only allow the 5 kinds defined in kube-gateway.yaml
 	kind := us.GetKind()
-	allowedKinds := sets.New("Deployment", "Service", "ServiceAccount", "HorizontalPodAutoscaler", "PodDisruptionBudget")
+	allowedKinds := sets.New("Deployment", "DaemonSet", "Service", "ServiceAccount", "HorizontalPodAutoscaler", "PodDisruptionBudget")
 	if !allowedKinds.Contains(kind) {
 		return fmt.Errorf("unexpected object kind %q, only %v are allowed", kind, allowedKinds.UnsortedList())
 	}

--- a/releasenotes/notes/59662.yaml
+++ b/releasenotes/notes/59662.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 59498
+releaseNotes:
+  - |
+    **Fixed** gateway deployment controller rejecting DaemonSet kind during reconciliation.


### PR DESCRIPTION
Add `DaemonSet` to the allowed object kinds in the gateway deployment controller's safeguard validation. The security hardening in #58940 added validation but omitted DaemonSet, preventing reconciliation of gateways configured with `kind: DaemonSet` via `gatewayClasses`.

Fixes #59498