### PR TITLE
Set correct protocol on Service ports for UDP Gateway listeners

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -348,7 +348,7 @@ spec:
   {{- range $key, $val := .Ports }}
   - name: {{ $val.Name | quote }}
     port: {{ $val.Port }}
-    protocol: TCP
+    protocol: {{ $val.Protocol }}
     appProtocol: {{ $val.AppProtocol }}
   {{- end }}
   selector:

--- a/pilot/pkg/config/kube/gatewaycommon/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gatewaycommon/deploymentcontroller.go
@@ -914,6 +914,7 @@ func extractServicePorts(gw gateway.Gateway, listenerSets []gateway.Listener) []
 	svcPorts = append(svcPorts, corev1.ServicePort{
 		Name:        "status-port",
 		Port:        int32(15021),
+		Protocol:    corev1.ProtocolTCP,
 		AppProtocol: &tcp,
 	})
 	portNums := sets.New[int32]()
@@ -929,9 +930,14 @@ func extractServicePorts(gw gateway.Gateway, listenerSets []gateway.Listener) []
 			name = fmt.Sprintf("%s-%d", strings.ToLower(string(l.Protocol)), i)
 		}
 		appProtocol := strings.ToLower(string(l.Protocol))
+		svcPortProtocol := corev1.ProtocolTCP
+		if l.Protocol == gateway.UDPProtocolType {
+			svcPortProtocol = corev1.ProtocolUDP
+		}
 		svcPorts = append(svcPorts, corev1.ServicePort{
 			Name:        name,
 			Port:        l.Port,
+			Protocol:    svcPortProtocol,
 			AppProtocol: &appProtocol,
 		})
 	}

--- a/pilot/pkg/config/kube/gatewaycommon/deploymentcontroller_test.go
+++ b/pilot/pkg/config/kube/gatewaycommon/deploymentcontroller_test.go
@@ -658,6 +658,25 @@ metadata:
 			objects:               defaultObjects,
 			copyLabelsAnnotations: &copyLabelsAnnotationsEnabled,
 		},
+		{
+			name: "udp-listener",
+			gw: k8s.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "default",
+					Namespace: "default",
+				},
+				Spec: k8s.GatewaySpec{
+					GatewayClassName: k8s.ObjectName(features.GatewayAPIDefaultGatewayClass),
+					Listeners: []k8s.Listener{{
+						Name:     "dns",
+						Port:     53,
+						Protocol: k8s.UDPProtocolType,
+					}},
+				},
+			},
+			objects:                  defaultObjects,
+			discoveryNamespaceFilter: discoveryNamespacesFilter,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/udp-listener.yaml
+++ b/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/udp-listener.yaml
@@ -1,0 +1,252 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.istio.io/controller-version: "5"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-class-name: istio
+    gateway.networking.k8s.io/gateway-name: default
+  name: default-istio
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    name: default
+    uid: ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-class-name: istio
+    gateway.networking.k8s.io/gateway-name: default
+  name: default-istio
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    name: default
+    uid: ""
+spec:
+  selector:
+    matchLabels:
+      gateway.networking.k8s.io/gateway-name: default
+  template:
+    metadata:
+      annotations:
+        istio.io/rev: default
+        prometheus.io/path: /stats/prometheus
+        prometheus.io/port: "15020"
+        prometheus.io/scrape: "true"
+      labels:
+        gateway.istio.io/managed: istio.io-gateway-controller
+        gateway.networking.k8s.io/gateway-class-name: istio
+        gateway.networking.k8s.io/gateway-name: default
+        service.istio.io/canonical-name: default-istio
+        service.istio.io/canonical-revision: latest
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - args:
+        - proxy
+        - router
+        - --domain
+        - $(POD_NAMESPACE).svc.<no value>
+        - --proxyLogLevel
+        - <nil>
+        - --proxyComponentLogLevel
+        - <nil>
+        - --log_output_level
+        - <nil>
+        env:
+        - name: PILOT_CERT_PROVIDER
+          value: <no value>
+        - name: CA_ADDR
+          value: istiod-<no value>.<no value>.svc:15012
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_CPU_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              divisor: "1"
+              resource: limits.cpu
+        - name: PROXY_CONFIG
+          value: |
+            {}
+        - name: ISTIO_META_POD_PORTS
+          value: '[]'
+        - name: ISTIO_META_APP_CONTAINERS
+          value: ""
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              divisor: "1"
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              divisor: "1"
+              resource: limits.cpu
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
+        - name: ISTIO_META_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: default-istio
+        - name: ISTIO_META_OWNER
+          value: kubernetes://apis/apps/v1/namespaces/default/deployments/default-istio
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        - name: TRUST_DOMAIN
+          value: cluster.local
+        image: test/proxyv2:test
+        name: istio-proxy
+        ports:
+        - containerPort: 15020
+          name: metrics
+          protocol: TCP
+        - containerPort: 15021
+          name: status-port
+          protocol: TCP
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 4
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          initialDelaySeconds: 0
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
+        startupProbe:
+          failureThreshold: 30
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          initialDelaySeconds: 1
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 1
+        volumeMounts:
+        - mountPath: /var/run/secrets/workload-spiffe-uds
+          name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
+        - mountPath: /var/run/secrets/workload-spiffe-credentials
+          name: workload-certs
+        - mountPath: /var/lib/istio/data
+          name: istio-data
+        - mountPath: /etc/istio/proxy
+          name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
+        - mountPath: /etc/istio/pod
+          name: istio-podinfo
+      securityContext:
+        sysctls:
+        - name: net.ipv4.ip_unprivileged_port_start
+          value: "0"
+      serviceAccountName: default-istio
+      volumes:
+      - emptyDir: {}
+        name: workload-socket
+      - emptyDir: {}
+        name: credential-socket
+      - emptyDir: {}
+        name: workload-certs
+      - emptyDir:
+          medium: Memory
+        name: istio-envoy
+      - emptyDir: {}
+        name: istio-data
+      - downwardAPI:
+          items:
+          - fieldRef:
+              fieldPath: metadata.labels
+            path: labels
+          - fieldRef:
+              fieldPath: metadata.annotations
+            path: annotations
+        name: istio-podinfo
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: <no value>
+              expirationSeconds: 43200
+              path: istio-token
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-class-name: istio
+    gateway.networking.k8s.io/gateway-name: default
+  name: default-istio
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    name: default
+    uid: null
+spec:
+  ipFamilyPolicy: PreferDualStack
+  ports:
+  - appProtocol: tcp
+    name: status-port
+    port: 15021
+    protocol: TCP
+  - appProtocol: udp
+    name: dns
+    port: 53
+    protocol: UDP
+  selector:
+    gateway.networking.k8s.io/gateway-name: default
+  type: LoadBalancer
+---

--- a/releasenotes/notes/59663.yaml
+++ b/releasenotes/notes/59663.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 59663
+releaseNotes:
+  - |
+    **Fixed** auto-provisioned Gateway Service ports using TCP protocol for UDP listeners.


### PR DESCRIPTION
Gateway listeners with protocol UDP produce Service ports with hardcoded `protocol: TCP` instead of `protocol: UDP`. This breaks UDP load balancing on cloud providers.

- Set `corev1.ProtocolUDP` on ServicePort when listener protocol is UDP
- Update kube-gateway template to use the port's Protocol field instead of hardcoding TCP
- Add test case for UDP listener gateway deployment