### PR TITLE
Fix missing RetryBudget in merged subset trafficPolicy

### DIFF
--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -876,6 +876,9 @@ func mergeTrafficPolicy(mergedPolicy, subsetPolicy *networking.TrafficPolicy, ha
 	if subsetPolicy.ProxyProtocol != nil {
 		mergedPolicy.ProxyProtocol = subsetPolicy.ProxyProtocol
 	}
+	if subsetPolicy.RetryBudget != nil {
+		mergedPolicy.RetryBudget = subsetPolicy.RetryBudget
+	}
 	return mergedPolicy
 }
 
@@ -903,6 +906,7 @@ func ShallowCopyTrafficPolicy(original *networking.TrafficPolicy) *networking.Tr
 	ret.Tls = original.Tls
 	ret.Tunnel = original.Tunnel
 	ret.ProxyProtocol = original.ProxyProtocol
+	ret.RetryBudget = original.RetryBudget
 	return ret
 }
 

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -1699,6 +1699,56 @@ func TestMergeSubsetTrafficPolicy(t *testing.T) {
 			},
 		},
 		{
+			name: "top-level retryBudget is preserved when subset has a traffic policy",
+			original: &networking.TrafficPolicy{
+				ConnectionPool: &networking.ConnectionPoolSettings{
+					Http: &networking.ConnectionPoolSettings_HTTPSettings{
+						MaxRetries: 10,
+					},
+				},
+				RetryBudget: &networking.TrafficPolicy_RetryBudget{
+					MinRetryConcurrency: 5,
+				},
+			},
+			subset: &networking.TrafficPolicy{
+				ConnectionPool: &networking.ConnectionPoolSettings{
+					Http: &networking.ConnectionPoolSettings_HTTPSettings{
+						Http2MaxRequests: 1000,
+					},
+				},
+			},
+			port: nil,
+			expected: &networking.TrafficPolicy{
+				ConnectionPool: &networking.ConnectionPoolSettings{
+					Http: &networking.ConnectionPoolSettings_HTTPSettings{
+						Http2MaxRequests: 1000,
+					},
+				},
+				RetryBudget: &networking.TrafficPolicy_RetryBudget{
+					MinRetryConcurrency: 5,
+				},
+			},
+		},
+		{
+			name: "subset-level retryBudget overrides top-level retryBudget",
+			original: &networking.TrafficPolicy{
+				RetryBudget: &networking.TrafficPolicy_RetryBudget{
+					MinRetryConcurrency: 3,
+				},
+			},
+			subset: &networking.TrafficPolicy{
+				RetryBudget: &networking.TrafficPolicy_RetryBudget{
+					MinRetryConcurrency: 10,
+				},
+			},
+			port: nil,
+			expected: &networking.TrafficPolicy{
+				RetryBudget: &networking.TrafficPolicy_RetryBudget{
+					MinRetryConcurrency: 10,
+				},
+			},
+		},
+		{
 			name: "default cluster, non-matching port selector",
 			original: &networking.TrafficPolicy{
 				LoadBalancer: &networking.LoadBalancerSettings{

--- a/releasenotes/notes/retry-budget-subset-merge.yaml
+++ b/releasenotes/notes/retry-budget-subset-merge.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+Issue:
+  - 59667
+releaseNotes:
+  - |
+    **Fixed** a bug where `retryBudget` set in a DestinationRule's top-level `trafficPolicy`
+    was silently dropped when the destination also had a subset with its own `trafficPolicy`.
+    Additionally, the `retryBudget` defined at the subset level was also ignored.


### PR DESCRIPTION
The current implementation of ShallowCopyTrafficPolicy and mergeTrafficPolicy does not include RetryBudget when copying or merging TrafficPolicy objects.

Because of this
1. a RetryBudget defined at the DestinationRule level is unintentionally dropped whenever a subset defines its own trafficPolicy.
2. a RetryBudget specified at the subset level is never applied.

Fixes: https://github.com/istio/istio/issues/59667
- [x] Networking