### PR TITLE
Fix the pqc test skips

### DIFF
--- a/tests/integration/ambient/pqc/main_test.go
+++ b/tests/integration/ambient/pqc/main_test.go
@@ -136,7 +136,7 @@ spec:
 			return ctx.ConfigIstio().YAML(i.Settings().SystemNamespace, peerAuthYaml).Apply(apply.Wait)
 		}).
 		SkipIf("K8s < 1.34 doesn't support PQC", func(ctx resource.Context) bool {
-			return ctx.Clusters().Default().MinKubeVersion(34)
+			return !ctx.Clusters().Default().MinKubeVersion(34)
 		}).
 		Run()
 }

--- a/tests/integration/security/pqc/main_test.go
+++ b/tests/integration/security/pqc/main_test.go
@@ -99,7 +99,7 @@ spec:
 			return ctx.ConfigIstio().YAML(i.Settings().SystemNamespace, peerAuthYaml).Apply(apply.Wait)
 		}).
 		SkipIf("K8s < 1.34 doesn't support PQC", func(ctx resource.Context) bool {
-			return ctx.Clusters().Default().MinKubeVersion(34)
+			return !ctx.Clusters().Default().MinKubeVersion(34)
 		}).
 		Run()
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
Misread the function signatures; right now we're skipping tests on k8s versions > 1.34