### PR TITLE
fix TestZtunnelCRL: retry call to wait for CRL propagation

### DIFF
--- a/tests/integration/ambient/crl/crl_test.go
+++ b/tests/integration/ambient/crl/crl_test.go
@@ -29,7 +29,6 @@ import (
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
-	"istio.io/istio/pkg/test/framework/components/echo/check"
 	"istio.io/istio/pkg/test/framework/components/echo/deployment"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/namespace"
@@ -90,7 +89,9 @@ func TestZtunnelCRL(t *testing.T) {
 			// before enrollment, traffic bypasses ztunnel and CRL is never checked
 			waitForWorkloadEnrollment(t, revokedServerNS.Name())
 
-			// test should fail due to revoked cert
+			// test should fail due to revoked cert; retry because CRL is only
+			// checked during new TLS handshakes and the k8s secret volume update
+			// may not have propagated to this ztunnel's node yet
 			revokedOpts := echo.CallOptions{
 				To: revokedServer,
 				Port: echo.Port{
@@ -99,13 +100,15 @@ func TestZtunnelCRL(t *testing.T) {
 				Scheme:                  scheme.HTTP,
 				NewConnectionPerRequest: true,
 				Count:                   1,
-				Check:                   check.Error(),
 			}
 			t.Logf("testing call with revoked apps, expecting failure")
 			retry.UntilSuccessOrFail(t, func() error {
-				revokedClient.CallOrFail(t, revokedOpts)
+				_, err := revokedClient.Call(revokedOpts)
+				if err == nil {
+					return fmt.Errorf("expected error but call succeeded, CRL may not have propagated yet")
+				}
 				return nil
-			})
+			}, retry.Timeout(5*time.Minute), retry.Delay(5*time.Second))
 			t.Logf("call correctly failed with revoked apps")
 		})
 }


### PR DESCRIPTION
CRL is only checked during new TLS handshakes and k8s secret volume updates can take time to propagate. Use Call with retry instead of CallOrFail so the test waits for the updated CRL to reach the ztunnel. Fixes #59677