### PR TITLE
wip: gateway controller watches proxy config via krt

### DIFF
--- a/pilot/pkg/config/kube/gatewaycommon/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gatewaycommon/deploymentcontroller.go
@@ -36,6 +36,8 @@ import (
 	gateway "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/yaml"
 
+	"google.golang.org/protobuf/proto"
+
 	"istio.io/api/annotation"
 	"istio.io/api/label"
 	meshapi "istio.io/api/mesh/v1alpha1"
@@ -47,6 +49,7 @@ import (
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/gvr"
@@ -101,20 +104,21 @@ type DeploymentController struct {
 	listenerSets        kclient.Informer[*gateway.ListenerSet]
 	listenerSetByParent kclient.Index[types.NamespacedName, *gateway.ListenerSet]
 
-	clients          map[schema.GroupVersionResource]getter
-	injectConfig     func() inject.WebhookConfig
-	deployments      kclient.Client[*appsv1.Deployment]
-	services         kclient.Client[*corev1.Service]
-	hpas             kclient.Client[*autoscalingv2.HorizontalPodAutoscaler]
-	pdbs             kclient.Client[*policyv1.PodDisruptionBudget]
-	configMaps       kclient.Client[*corev1.ConfigMap]
-	serviceAccounts  kclient.Client[*corev1.ServiceAccount]
-	namespaces       kclient.Client[*corev1.Namespace]
-	proxyConfigs     kclient.Client[*istioclient.ProxyConfig]
-	proxyConfigsByNs krt.Index[string, *istioclient.ProxyConfig]
-	tagWatcher       revisions.TagWatcher
-	revision         string
-	systemNamespace  string
+	clients              map[schema.GroupVersionResource]getter
+	injectConfig         func() inject.WebhookConfig
+	deployments          kclient.Client[*appsv1.Deployment]
+	services             kclient.Client[*corev1.Service]
+	hpas                 kclient.Client[*autoscalingv2.HorizontalPodAutoscaler]
+	pdbs                 kclient.Client[*policyv1.PodDisruptionBudget]
+	configMaps           kclient.Client[*corev1.ConfigMap]
+	serviceAccounts      kclient.Client[*corev1.ServiceAccount]
+	namespaces           kclient.Client[*corev1.Namespace]
+	proxyConfigs         kclient.Client[*istioclient.ProxyConfig]
+	proxyConfigsByNs     krt.Index[string, *istioclient.ProxyConfig]
+	effectiveProxyConfig krt.Collection[gwProxyConfig]
+	tagWatcher           revisions.TagWatcher
+	revision             string
+	systemNamespace      string
 }
 
 // Patcher is a function that abstracts patching logic. This is largely because client-go fakes do not handle patching
@@ -229,32 +233,25 @@ func NewDeploymentController(
 
 	dc.proxyConfigs = kclient.New[*istioclient.ProxyConfig](client)
 	proxyConfigCol := krt.WrapClient(dc.proxyConfigs, krt.WithName("ProxyConfigs"))
-	dc.proxyConfigsByNs = krt.NewIndex(proxyConfigCol, "namespace", func(pc *istioclient.ProxyConfig) []string {
-		return []string{pc.Namespace}
-	})
-	// ProxyConfig matching is indirect (it matches labels on the generated pod template,
-	// not on the Gateway itself), so we requeue all gateways in the affected namespace.
-	// If the ProxyConfig is in the root namespace, it could affect any gateway.
-	proxyConfigCol.Register(func(o krt.Event[*istioclient.ProxyConfig]) {
-		var ns string
-		pc := o.Latest()
-		if pc != nil {
-			ns = pc.Namespace
+	dc.proxyConfigsByNs = krt.NewNamespaceIndex(proxyConfigCol)
+	gwCol := krt.WrapClient(gateways, krt.WithName("Gateways"))
+	dc.effectiveProxyConfig = buildEffectiveProxyConfigs(gwCol, proxyConfigCol, dc.proxyConfigsByNs, dc.env.Watcher)
+	// When the effective proxy config for a gateway changes (due to ProxyConfig CRD or MeshConfig changes),
+	// requeue just that gateway. Skip Add events since the gateway event handler already queues new gateways.
+	dc.effectiveProxyConfig.Register(func(o krt.Event[gwProxyConfig]) {
+		if o.Event == controllers.EventAdd {
+			return
 		}
-		// Use the current mesh config's root namespace to decide if this ProxyConfig
-		// is global. If rootNamespace itself changes, the mesh Watcher's handler
-		// already requeues all gateways, so we don't need to react to that here.
-		if ns == dc.env.Watcher.Mesh().GetRootNamespace() {
-			ns = metav1.NamespaceAll
-		}
-		for _, gw := range dc.gateways.List(ns, klabels.Everything()) {
+		epc := o.Latest()
+		gw := dc.gateways.Get(epc.Name, epc.Namespace)
+		if gw != nil {
 			dc.queue.AddObject(gw)
 		}
 	})
 
 	dc.env.Watcher.AddMeshHandler(func() {
-		// if there is a change to the meshconfig we need to reprocess all gateways
-		// to reconcile things like the deployment image
+		// Mesh config affects rendering beyond just proxy config (e.g. image hub/tag, injection templates).
+		// Requeue all gateways on any mesh config change.
 		for _, gw := range dc.gateways.List(corev1.NamespaceAll, klabels.Everything()) {
 			dc.queue.AddObject(gw)
 		}
@@ -332,6 +329,7 @@ func (d *DeploymentController) Run(stop <-chan struct{}) {
 		d.gateways.HasSynced,
 		d.gatewayClasses.HasSynced,
 		d.proxyConfigs.HasSynced,
+		d.effectiveProxyConfig.HasSynced,
 		d.tagWatcher.HasSynced,
 		d.env.Watcher.AsCollection().HasSynced,
 	)
@@ -652,8 +650,7 @@ func (d *DeploymentController) render(templateName string, mi TemplateInput) ([]
 		templateOverlays = append(templateOverlays, cm.Data)
 	}
 
-	labelToMatch := map[string]string{label.IoK8sNetworkingGatewayGatewayName.Name: mi.Name}
-	proxyConfig := d.effectiveProxyConfig(mi.Namespace, labelToMatch, cfg.MeshConfig)
+	proxyConfig := d.computeEffectiveProxyConfig(mi.Namespace, mi.Name, cfg.MeshConfig)
 	input := derivedInput{
 		TemplateInput: mi,
 		ProxyImage: inject.ProxyImage(
@@ -689,23 +686,43 @@ func (d *DeploymentController) render(templateName string, mi TemplateInput) ([]
 	return transformedOutput, nil
 }
 
-// effectiveProxyConfig computes the merged ProxyConfig for a gateway directly from ProxyConfig CRDs
-// and mesh config, without going through PushContext. This ensures the deployment controller has
-// a direct, reactive data path for proxy configuration.
-func (d *DeploymentController) effectiveProxyConfig(namespace string, gwLabels map[string]string, mc *meshapi.MeshConfig) *meshapi.ProxyConfig {
-	rootNamespace := mc.GetRootNamespace()
+// gwProxyConfig holds the effective merged ProxyConfig for a specific gateway.
+// It is produced by a krt collection derived from Gateway × ProxyConfig × MeshConfig.
+type gwProxyConfig struct {
+	krt.Named
+	config *meshapi.ProxyConfig
+}
 
-	// Build the namespace→specs map from krt index lookups, sorted by creation time
+func (g gwProxyConfig) Equals(other gwProxyConfig) bool {
+	return proto.Equal(g.config, other.config)
+}
+
+// mergeProxyConfigs computes the effective ProxyConfig for a gateway by looking up
+// ProxyConfig CRDs from the given namespace index and merging them with mesh config.
+func mergeProxyConfigs(
+	namespace, gwName string,
+	proxyConfigsByNs krt.Index[string, *istioclient.ProxyConfig],
+	mc *meshapi.MeshConfig,
+) *meshapi.ProxyConfig {
+	rootNamespace := mc.GetRootNamespace()
+	gwLabels := map[string]string{label.IoK8sNetworkingGatewayGatewayName.Name: gwName}
+
+	nsConfigs := proxyConfigsByNs.Lookup(namespace)
+	var rootConfigs []*istioclient.ProxyConfig
+	if rootNamespace != "" && rootNamespace != namespace {
+		rootConfigs = proxyConfigsByNs.Lookup(rootNamespace)
+	}
+
+	// Build the namespace→specs map, sorted by creation time for deterministic precedence.
 	nsToPCs := map[string][]*networkingv1beta1.ProxyConfig{}
-	for _, ns := range []string{rootNamespace, namespace} {
-		if ns == "" {
+	for ns, configs := range map[string][]*istioclient.ProxyConfig{
+		namespace:     nsConfigs,
+		rootNamespace: rootConfigs,
+	} {
+		if ns == "" || len(configs) == 0 {
 			continue
 		}
-		if _, done := nsToPCs[ns]; done {
-			continue
-		}
-		crdList := d.proxyConfigsByNs.Lookup(ns)
-		sorted := slices.Clone(crdList)
+		sorted := slices.Clone(configs)
 		slices.SortFunc(sorted, func(a, b *istioclient.ProxyConfig) int {
 			return a.CreationTimestamp.Time.Compare(b.CreationTimestamp.Time)
 		})
@@ -721,6 +738,42 @@ func (d *DeploymentController) effectiveProxyConfig(namespace string, gwLabels m
 		Namespace: namespace,
 		Labels:    gwLabels,
 	}, mc)
+}
+
+// computeEffectiveProxyConfig computes the merged ProxyConfig for a gateway during rendering.
+func (d *DeploymentController) computeEffectiveProxyConfig(namespace, gwName string, mc *meshapi.MeshConfig) *meshapi.ProxyConfig {
+	return mergeProxyConfigs(namespace, gwName, d.proxyConfigsByNs, mc)
+}
+
+// buildEffectiveProxyConfigs creates a krt collection that tracks the effective ProxyConfig
+// for each gateway. When a ProxyConfig CRD changes, only the affected gateways are recomputed.
+// This is used for change detection via Register to precisely requeue only gateways whose
+// effective proxy config has actually changed.
+// Note: mesh config changes are handled separately by the mesh handler, not through this collection.
+func buildEffectiveProxyConfigs(
+	gateways krt.Collection[*gateway.Gateway],
+	proxyConfigs krt.Collection[*istioclient.ProxyConfig],
+	proxyConfigsByNs krt.Index[string, *istioclient.ProxyConfig],
+	meshCfgGetter mesh.Holder,
+) krt.Collection[gwProxyConfig] {
+	return krt.NewCollection(gateways, func(ctx krt.HandlerContext, gw *gateway.Gateway) *gwProxyConfig {
+		mc := meshCfgGetter.Mesh()
+		if mc == nil {
+			mc = mesh.DefaultMeshConfig()
+		}
+
+		// Fetch ProxyConfigs from the gateway's namespace and root namespace to establish krt dependencies.
+		rootNamespace := mc.GetRootNamespace()
+		krt.Fetch(ctx, proxyConfigs, krt.FilterIndex(proxyConfigsByNs, gw.Namespace))
+		if rootNamespace != "" && rootNamespace != gw.Namespace {
+			krt.Fetch(ctx, proxyConfigs, krt.FilterIndex(proxyConfigsByNs, rootNamespace))
+		}
+
+		return &gwProxyConfig{
+			Named:  krt.NewNamed(gw),
+			config: mergeProxyConfigs(gw.Namespace, gw.Name, proxyConfigsByNs, mc),
+		}
+	}, krt.WithName("GatewayEffectiveProxyConfig"))
 }
 
 var supportedOverlays = sets.New(

--- a/pilot/pkg/config/kube/gatewaycommon/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gatewaycommon/deploymentcontroller.go
@@ -39,6 +39,8 @@ import (
 	"istio.io/api/annotation"
 	"istio.io/api/label"
 	meshapi "istio.io/api/mesh/v1alpha1"
+	networkingv1beta1 "istio.io/api/networking/v1beta1"
+	istioclient "istio.io/client-go/pkg/apis/networking/v1beta1"
 	"istio.io/istio/pilot/pkg/config/kube/crd"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
@@ -53,6 +55,7 @@ import (
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/inject"
 	"istio.io/istio/pkg/kube/kclient"
+	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/kube/kubetypes"
 	istiolog "istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/maps"
@@ -98,18 +101,20 @@ type DeploymentController struct {
 	listenerSets        kclient.Informer[*gateway.ListenerSet]
 	listenerSetByParent kclient.Index[types.NamespacedName, *gateway.ListenerSet]
 
-	clients         map[schema.GroupVersionResource]getter
-	injectConfig    func() inject.WebhookConfig
-	deployments     kclient.Client[*appsv1.Deployment]
-	services        kclient.Client[*corev1.Service]
-	hpas            kclient.Client[*autoscalingv2.HorizontalPodAutoscaler]
-	pdbs            kclient.Client[*policyv1.PodDisruptionBudget]
-	configMaps      kclient.Client[*corev1.ConfigMap]
-	serviceAccounts kclient.Client[*corev1.ServiceAccount]
-	namespaces      kclient.Client[*corev1.Namespace]
-	tagWatcher      revisions.TagWatcher
-	revision        string
-	systemNamespace string
+	clients          map[schema.GroupVersionResource]getter
+	injectConfig     func() inject.WebhookConfig
+	deployments      kclient.Client[*appsv1.Deployment]
+	services         kclient.Client[*corev1.Service]
+	hpas             kclient.Client[*autoscalingv2.HorizontalPodAutoscaler]
+	pdbs             kclient.Client[*policyv1.PodDisruptionBudget]
+	configMaps       kclient.Client[*corev1.ConfigMap]
+	serviceAccounts  kclient.Client[*corev1.ServiceAccount]
+	namespaces       kclient.Client[*corev1.Namespace]
+	proxyConfigs     kclient.Client[*istioclient.ProxyConfig]
+	proxyConfigsByNs krt.Index[string, *istioclient.ProxyConfig]
+	tagWatcher       revisions.TagWatcher
+	revision         string
+	systemNamespace  string
 }
 
 // Patcher is a function that abstracts patching logic. This is largely because client-go fakes do not handle patching
@@ -222,6 +227,31 @@ func NewDeploymentController(
 		}
 	}))
 
+	dc.proxyConfigs = kclient.New[*istioclient.ProxyConfig](client)
+	proxyConfigCol := krt.WrapClient(dc.proxyConfigs, krt.WithName("ProxyConfigs"))
+	dc.proxyConfigsByNs = krt.NewIndex(proxyConfigCol, "namespace", func(pc *istioclient.ProxyConfig) []string {
+		return []string{pc.Namespace}
+	})
+	// ProxyConfig matching is indirect (it matches labels on the generated pod template,
+	// not on the Gateway itself), so we requeue all gateways in the affected namespace.
+	// If the ProxyConfig is in the root namespace, it could affect any gateway.
+	proxyConfigCol.Register(func(o krt.Event[*istioclient.ProxyConfig]) {
+		var ns string
+		pc := o.Latest()
+		if pc != nil {
+			ns = pc.Namespace
+		}
+		// Use the current mesh config's root namespace to decide if this ProxyConfig
+		// is global. If rootNamespace itself changes, the mesh Watcher's handler
+		// already requeues all gateways, so we don't need to react to that here.
+		if ns == dc.env.Watcher.Mesh().GetRootNamespace() {
+			ns = metav1.NamespaceAll
+		}
+		for _, gw := range dc.gateways.List(ns, klabels.Everything()) {
+			dc.queue.AddObject(gw)
+		}
+	})
+
 	dc.env.Watcher.AddMeshHandler(func() {
 		// if there is a change to the meshconfig we need to reprocess all gateways
 		// to reconcile things like the deployment image
@@ -301,6 +331,7 @@ func (d *DeploymentController) Run(stop <-chan struct{}) {
 		d.pdbs.HasSynced,
 		d.gateways.HasSynced,
 		d.gatewayClasses.HasSynced,
+		d.proxyConfigs.HasSynced,
 		d.tagWatcher.HasSynced,
 		d.env.Watcher.AsCollection().HasSynced,
 	)
@@ -315,6 +346,7 @@ func (d *DeploymentController) Run(stop <-chan struct{}) {
 		d.pdbs,
 		d.gateways,
 		d.gatewayClasses,
+		d.proxyConfigs,
 	)
 }
 
@@ -621,7 +653,7 @@ func (d *DeploymentController) render(templateName string, mi TemplateInput) ([]
 	}
 
 	labelToMatch := map[string]string{label.IoK8sNetworkingGatewayGatewayName.Name: mi.Name}
-	proxyConfig := d.env.GetProxyConfigOrDefault(mi.Namespace, labelToMatch, nil, cfg.MeshConfig)
+	proxyConfig := d.effectiveProxyConfig(mi.Namespace, labelToMatch, cfg.MeshConfig)
 	input := derivedInput{
 		TemplateInput: mi,
 		ProxyImage: inject.ProxyImage(
@@ -655,6 +687,40 @@ func (d *DeploymentController) render(templateName string, mi TemplateInput) ([]
 		}
 	}
 	return transformedOutput, nil
+}
+
+// effectiveProxyConfig computes the merged ProxyConfig for a gateway directly from ProxyConfig CRDs
+// and mesh config, without going through PushContext. This ensures the deployment controller has
+// a direct, reactive data path for proxy configuration.
+func (d *DeploymentController) effectiveProxyConfig(namespace string, gwLabels map[string]string, mc *meshapi.MeshConfig) *meshapi.ProxyConfig {
+	rootNamespace := mc.GetRootNamespace()
+
+	// Build the namespace→specs map from krt index lookups, sorted by creation time
+	nsToPCs := map[string][]*networkingv1beta1.ProxyConfig{}
+	for _, ns := range []string{rootNamespace, namespace} {
+		if ns == "" {
+			continue
+		}
+		if _, done := nsToPCs[ns]; done {
+			continue
+		}
+		crdList := d.proxyConfigsByNs.Lookup(ns)
+		sorted := slices.Clone(crdList)
+		slices.SortFunc(sorted, func(a, b *istioclient.ProxyConfig) int {
+			return a.CreationTimestamp.Time.Compare(b.CreationTimestamp.Time)
+		})
+		specs := make([]*networkingv1beta1.ProxyConfig, 0, len(sorted))
+		for _, pc := range sorted {
+			specs = append(specs, &pc.Spec)
+		}
+		nsToPCs[ns] = specs
+	}
+
+	pcs := model.NewProxyConfigs(nsToPCs, rootNamespace)
+	return pcs.EffectiveProxyConfig(&model.NodeMetadata{
+		Namespace: namespace,
+		Labels:    gwLabels,
+	}, mc)
 }
 
 var supportedOverlays = sets.New(

--- a/pilot/pkg/config/kube/gatewaycommon/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gatewaycommon/deploymentcontroller.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 
+	"google.golang.org/protobuf/proto"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
@@ -35,8 +36,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	gateway "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/yaml"
-
-	"google.golang.org/protobuf/proto"
 
 	"istio.io/api/annotation"
 	"istio.io/api/label"

--- a/pilot/pkg/config/kube/gatewaycommon/deploymentcontroller_test.go
+++ b/pilot/pkg/config/kube/gatewaycommon/deploymentcontroller_test.go
@@ -38,17 +38,17 @@ import (
 
 	"istio.io/api/annotation"
 	"istio.io/api/label"
+	meshapi "istio.io/api/mesh/v1alpha1"
 	istioio_networking_v1beta1 "istio.io/api/networking/v1beta1"
 	istio_type_v1beta1 "istio.io/api/type/v1beta1"
+	istioclientv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/test/util"
 	"istio.io/istio/pkg/cluster"
-	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/mesh/meshwatcher"
-	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/gvr"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
@@ -119,14 +119,12 @@ func TestConfigureIstioGateway(t *testing.T) {
 	}
 
 	defaultObjects := []runtime.Object{defaultNamespace}
-	store := model.NewFakeStore()
-	if _, err := store.Create(config.Config{
-		Meta: config.Meta{
-			GroupVersionKind: gvk.ProxyConfig,
-			Name:             "test",
-			Namespace:        "default",
+	proxyConfigCRD := &istioclientv1beta1.ProxyConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
 		},
-		Spec: &istioio_networking_v1beta1.ProxyConfig{
+		Spec: istioio_networking_v1beta1.ProxyConfig{
 			Selector: &istio_type_v1beta1.WorkloadSelector{
 				MatchLabels: map[string]string{
 					label.IoK8sNetworkingGatewayGatewayName.Name: "default",
@@ -136,15 +134,12 @@ func TestConfigureIstioGateway(t *testing.T) {
 				ImageType: "distroless",
 			},
 		},
-	}); err != nil {
-		t.Fatalf("failed to create ProxyConfigs: %s", err)
 	}
-	proxyConfig := model.GetProxyConfigs(store, mesh.DefaultMeshConfig())
 	tests := []struct {
 		name                     string
 		gw                       k8s.Gateway
 		objects                  []runtime.Object
-		pcs                      *model.ProxyConfigs
+		proxyConfigCRDs          []*istioclientv1beta1.ProxyConfig
 		values                   string
 		discoveryNamespaceFilter kubetypes.DynamicObjectFilter
 		ignore                   bool
@@ -439,8 +434,8 @@ func TestConfigureIstioGateway(t *testing.T) {
 					GatewayClassName: k8s.ObjectName(features.GatewayAPIDefaultGatewayClass),
 				},
 			},
-			objects: defaultObjects,
-			pcs:     proxyConfig,
+			objects:         defaultObjects,
+			proxyConfigCRDs: []*istioclientv1beta1.ProxyConfig{proxyConfigCRD},
 		},
 		{
 			name: "custom-class",
@@ -673,11 +668,13 @@ metadata:
 			kclient.NewWriteClient[*appsv1.Deployment](client).Create(upgradeDeployment)
 			stop := test.NewStop(t)
 			env := newTestEnv()
-			env.PushContext().ProxyConfigs = tt.pcs
 			tw := revisions.NewTagWatcher(client, "", "istio-system")
 			go tw.Run(stop)
 			d := NewDeploymentController(client, cluster.ID(features.ClusterName), env, testInjectionConfig(t, tt.values), func(fn func()) {
 			}, tw, "", "")
+			for _, pc := range tt.proxyConfigCRDs {
+				kclient.NewWriteClient[*istioclientv1beta1.ProxyConfig](client).Create(pc)
+			}
 			d.patcher = func(gvr schema.GroupVersionResource, name string, namespace string, data []byte, subresources ...string) error {
 				b, err := yaml.JSONToYAML(data)
 				if err != nil {
@@ -782,6 +779,166 @@ func TestMeshGatewayReconciliation(t *testing.T) {
 	assert.ChannelHasItem(t, writes)
 	expectReconciled()
 	assert.ChannelIsEmpty(t, writes)
+}
+
+// TestProxyConfigReconciliation verifies that the deployment controller correctly
+// picks up ProxyConfig CRDs and mesh config for gateway reconciliation, and that
+// all pre-existing resources are synced before the first reconcile (no partial state).
+func TestProxyConfigReconciliation(t *testing.T) {
+	defaultNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+	defaultGateway := &k8s.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gw",
+			Namespace: "default",
+		},
+		Spec: k8s.GatewaySpec{
+			GatewayClassName: k8s.ObjectName(features.GatewayAPIDefaultGatewayClass),
+		},
+	}
+
+	makeProxyConfigCRD := func() *istioclientv1beta1.ProxyConfig {
+		return &istioclientv1beta1.ProxyConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gw-pc",
+				Namespace: "default",
+			},
+			Spec: istioio_networking_v1beta1.ProxyConfig{
+				Selector: &istio_type_v1beta1.WorkloadSelector{
+					MatchLabels: map[string]string{
+						label.IoK8sNetworkingGatewayGatewayName.Name: "gw",
+					},
+				},
+				Image: &istioio_networking_v1beta1.ProxyImage{
+					ImageType: "distroless",
+				},
+			},
+		}
+	}
+
+	// helper: start the controller, create the gateway, and return channels + controls
+	type testHarness struct {
+		deploymentImages chan string // receives the image string from each Deployment patch
+		reconciles       *atomic.Int32
+		gws              clienttest.TestClient[*k8s.Gateway]
+		watch            meshwatcher.TestWatcher
+		client           kube.Client
+		stop             chan struct{}
+	}
+
+	setup := func(t *testing.T, meshCfg *meshapi.MeshConfig, proxyConfigCRDs []*istioclientv1beta1.ProxyConfig) *testHarness {
+		t.Helper()
+		c := kube.NewFakeClient(defaultNs)
+
+		watch := meshwatcher.NewTestWatcher(meshCfg)
+		env := model.NewEnvironment()
+		env.Watcher = watch
+		tw := revisions.NewTagWatcher(c, "default", "istio-system")
+		// Build injection config that dynamically reads the mesh watcher's current config,
+		// mirroring the production setup where webhookInfo.getWebhookConfig does the same.
+		injCfg := testInjectionConfig(t, "")
+		dynamicInjCfg := func() inject.WebhookConfig {
+			cfg := injCfg()
+			cfg.MeshConfig = watch.Mesh()
+			return cfg
+		}
+		d := NewDeploymentController(c, "", env, dynamicInjCfg, func(fn func()) {}, tw, "", "")
+
+		// create ProxyConfig CRDs before starting informers so they are visible on initial list
+		pcWriter := kclient.NewWriteClient[*istioclientv1beta1.ProxyConfig](c)
+		for _, pc := range proxyConfigCRDs {
+			pcWriter.Create(pc)
+		}
+
+		deploymentImages := make(chan string, 10)
+		reconciles := atomic.NewInt32(0)
+		d.patcher = func(g schema.GroupVersionResource, name string, namespace string, data []byte, subresources ...string) error {
+			if g == gvr.Service {
+				reconciles.Inc()
+			}
+			if g == gvr.Deployment {
+				b, err := yaml.JSONToYAML(data)
+				if err != nil {
+					return err
+				}
+				// extract image line
+				for _, line := range strings.Split(string(b), "\n") {
+					trimmed := strings.TrimSpace(line)
+					if strings.HasPrefix(trimmed, "image:") && strings.Contains(trimmed, "proxyv2") {
+						deploymentImages <- strings.TrimSpace(strings.TrimPrefix(trimmed, "image:"))
+						break
+					}
+				}
+			}
+			return nil
+		}
+
+		stop := test.NewStop(t)
+		gws := clienttest.Wrap(t, d.gateways)
+		go tw.Run(stop)
+		c.RunAndWait(stop)
+		go d.Run(stop)
+		kube.WaitForCacheSync("test", stop, d.queue.HasSynced)
+
+		return &testHarness{
+			deploymentImages: deploymentImages,
+			reconciles:       reconciles,
+			gws:              gws,
+			watch:            watch,
+			client:           c,
+			stop:             stop,
+		}
+	}
+
+	expectImage := func(t *testing.T, h *testHarness, wantSuffix string) {
+		t.Helper()
+		img := assert.ChannelHasItem(t, h.deploymentImages)
+		if !strings.HasSuffix(img, wantSuffix) {
+			t.Fatalf("expected image ending with %q, got %q", wantSuffix, img)
+		}
+	}
+
+	t.Run("nothing at start, add proxyconfig then meshconfig later", func(t *testing.T) {
+		h := setup(t, mesh.DefaultMeshConfig(), nil)
+
+		// create gateway — first reconcile should use default image (no distroless)
+		h.gws.Create(defaultGateway.DeepCopy())
+		expectImage(t, h, "test/proxyv2:test")
+
+		// add a ProxyConfig CRD — should re-reconcile with distroless
+		kclient.NewWriteClient[*istioclientv1beta1.ProxyConfig](h.client).Create(makeProxyConfigCRD())
+		expectImage(t, h, "test/proxyv2:test-distroless")
+
+		// now update mesh config with a different image type — the workload-scoped
+		// ProxyConfig CRD has higher precedence so distroless should stick
+		m := mesh.DefaultMeshConfig()
+		m.DefaultConfig.Image = &istioio_networking_v1beta1.ProxyImage{ImageType: "debug"}
+		h.watch.Set(m)
+		expectImage(t, h, "test/proxyv2:test-distroless")
+	})
+
+	t.Run("meshconfig with custom image at start", func(t *testing.T) {
+		m := mesh.DefaultMeshConfig()
+		m.DefaultConfig.Image = &istioio_networking_v1beta1.ProxyImage{ImageType: "distroless"}
+		h := setup(t, m, nil)
+
+		// create gateway — first reconcile should already have distroless from mesh config
+		h.gws.Create(defaultGateway.DeepCopy())
+		expectImage(t, h, "test/proxyv2:test-distroless")
+	})
+
+	t.Run("everything at start", func(t *testing.T) {
+		m := mesh.DefaultMeshConfig()
+		m.DefaultConfig.Image = &istioio_networking_v1beta1.ProxyImage{ImageType: "debug"}
+		h := setup(t, m, []*istioclientv1beta1.ProxyConfig{makeProxyConfigCRD()})
+
+		// create gateway — first reconcile should see both mesh config and ProxyConfig CRD.
+		// The workload-scoped ProxyConfig (distroless) takes precedence over mesh default (debug).
+		h.gws.Create(defaultGateway.DeepCopy())
+		expectImage(t, h, "test/proxyv2:test-distroless")
+
+		// verify no spurious re-reconcile with wrong image
+		assert.ChannelIsEmpty(t, h.deploymentImages)
+	})
 }
 
 func buildFilter(allowedNamespace string) kubetypes.DynamicObjectFilter {

--- a/pilot/pkg/model/proxy_config.go
+++ b/pilot/pkg/model/proxy_config.go
@@ -81,6 +81,16 @@ func GetProxyConfigs(store ConfigStore, mc *meshconfig.MeshConfig) *ProxyConfigs
 	return proxyconfigs
 }
 
+// NewProxyConfigs constructs a ProxyConfigs directly from a pre-sorted (by creation time)
+// map of namespace → ProxyConfig specs. This allows callers that already have the CRDs
+// (e.g. from krt collections) to build a ProxyConfigs without going through ConfigStore.
+func NewProxyConfigs(namespaceToConfigs map[string][]*v1beta1.ProxyConfig, rootNamespace string) *ProxyConfigs {
+	return &ProxyConfigs{
+		namespaceToProxyConfigs: namespaceToConfigs,
+		rootNamespace:           rootNamespace,
+	}
+}
+
 func (p *ProxyConfigs) mergedGlobalConfig() *meshconfig.ProxyConfig {
 	return p.mergedNamespaceConfig(p.rootNamespace)
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

Reading from env/push context isn't reliable, and i think we don't actually know if we're ready before we reconcile

we may reconcile once with the wrong information, and then again later once we know the actual proxyconfig/meshconfig

this could make istiod restarts result in waypoints being redeployed twice, once with the wrong config and then again with correct config