### PR TITLE
[release-1.29] Gateways render once the push context is loaded (#59711)

### DIFF
--- a/pilot/pkg/config/kube/gateway/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller.go
@@ -17,6 +17,7 @@ package gateway
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -480,6 +481,8 @@ func (d *DeploymentController) Reconcile(req types.NamespacedName) error {
 	return d.configureIstioGateway(log, *gw, ci)
 }
 
+var errPushContext = errors.New("PushContext not initialized")
+
 func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gateway.Gateway, gi classInfo) error {
 	// If user explicitly sets addresses, we are assuming they are pointing to an existing deployment.
 	// We will not manage it in this case
@@ -490,6 +493,10 @@ func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gat
 	if !IsManaged(&gw.Spec) {
 		log.Debug("skip disabled gateway")
 		return nil
+	}
+	if !d.env.PushContext().InitDone.Load() {
+		log.Debug("skip PushContext not initialized")
+		return errPushContext
 	}
 	existingControllerVersion, overwriteControllerVersion, shouldHandle := ManagedGatewayControllerVersion(gw)
 	if !shouldHandle {

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
@@ -671,6 +671,7 @@ metadata:
 			stop := test.NewStop(t)
 			env := newTestEnv()
 			env.PushContext().ProxyConfigs = tt.pcs
+			env.PushContext().InitDone.Store(true)
 			tw := revisions.NewTagWatcher(client, "", "istio-system")
 			go tw.Run(stop)
 			d := NewDeploymentController(client, cluster.ID(features.ClusterName), env, testInjectionConfig(t, tt.values), func(fn func()) {
@@ -749,6 +750,7 @@ func TestMeshGatewayReconciliation(t *testing.T) {
 
 	stop := test.NewStop(t)
 	gws := clienttest.Wrap(t, d.gateways)
+	env.PushContext().InitDone.Store(true)
 	go tw.Run(stop)
 	go d.Run(stop)
 	c.RunAndWait(stop)
@@ -831,6 +833,7 @@ func TestVersionManagement(t *testing.T) {
 	}
 	stop := test.NewStop(t)
 	gws := clienttest.Wrap(t, d.gateways)
+	env.PushContext().InitDone.Store(true)
 	go tw.Run(stop)
 	go d.Run(stop)
 	c.RunAndWait(stop)

--- a/releasenotes/notes/59709.yaml
+++ b/releasenotes/notes/59709.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 59709
+releaseNotes:
+- |
+  **Fixed** an issue where all Gateways were restarted after istiod was restarted.


### PR DESCRIPTION
**Manual cherry-pick**
Do not attempt to render when the proxy configs have not be initialized. The ProxyConfig will bounce between {} and some content. This will cause any existing Gateway to have its deployment re-configured twice.

**Please provide a description of this PR:**






closes https://github.com/istio/istio/issues/59721