### PR TITLE
krt: mark finished collections as synced

### DIFF
--- a/pkg/kube/krt/processor.go
+++ b/pkg/kube/krt/processor.go
@@ -318,6 +318,7 @@ func (t *countingTracker) Finished(count int) {
 	}
 	if !t.hasSynced && t.upstreamHasSyncedButEventsPending && result == 0 && count != 0 {
 		close(t.synced)
+		t.hasSynced = true
 	}
 }
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Events coming in after finished may cause a panic when we try to close the already closed synced channel. 

https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/59715/unit-tests_istio/2039844084385845248 has a failure related to this

this is easy to reproduce:

<details>

<pre>
landow@fractal ~/go/src/istio.io/istio$ stress ./memory.test           master 
1 runs so far, 0 failures (100.00% pass rate). 51.512217ms avg, 51.512217ms max, 51.512217ms min
process still running after 515.693557ms
61 runs so far, 1 failures (98.39% pass rate). 503.894363ms avg, 581.292159ms max, 48.240068ms min
/tmp/go-stress-20260402T231758-3985087008
2026-04-03T06:17:59.571664Z	info	Created mock descriptor
2026-04-03T06:17:59.571731Z	info	Make mock objects
2026-04-03T06:17:59.571804Z	info	Created mock objects
2026-04-03T06:17:59.571823Z	info	Got stored elements
2026-04-03T06:17:59.571876Z	info	Delete elements
2026-04-03T06:17:59.571878Z	info	Test done, deleting namespace
2026-04-03T06:17:59.572113Z	info	Created mock descriptor
2026-04-03T06:17:59.572129Z	info	Make mock objects
2026-04-03T06:17:59.572219Z	info	Added 1, deleted 0
panic: close of closed channel

goroutine 58 [running]:
istio.io/istio/pkg/kube/krt.(*countingTracker).ParentSynced(...)
	/home/landow/go/src/istio.io/istio/pkg/kube/krt/processor.go:301
istio.io/istio/pkg/kube/krt.(*processorListener[...]).run(0x3149500)
	/home/landow/go/src/istio.io/istio/pkg/kube/krt/processor.go:259 +0x18a
k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
	/home/landow/go/pkg/mod/k8s.io/apimachinery@v0.35.3/pkg/util/wait/wait.go:72 +0x4c
created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 57
	/home/landow/go/pkg/mod/k8s.io/apimachinery@v0.35.3/pkg/util/wait/wait.go:70 +0x73

ERROR: exit status 2
62 runs so far, 2 failures (96.88% pass rate). 488.950898ms avg, 581.292159ms max, 48.240068ms min
/tmp/go-stress-20260402T231758-1890496712
2026-04-03T06:17:59.582664Z	info	Created mock descriptor
2026-04-03T06:17:59.582711Z	info	Make mock objects
2026-04-03T06:17:59.582783Z	info	Created mock objects
2026-04-03T06:17:59.582809Z	info	Got stored elements
2026-04-03T06:17:59.582871Z	info	Delete elements
2026-04-03T06:17:59.582873Z	info	Test done, deleting namespace
2026-04-03T06:17:59.583124Z	info	Created mock descriptor
2026-04-03T06:17:59.583162Z	info	Make mock objects
2026-04-03T06:17:59.583561Z	info	Added 1, deleted 0
panic: close of closed channel

goroutine 74 [running]:
istio.io/istio/pkg/kube/krt.(*countingTracker).ParentSynced(...)
	/home/landow/go/src/istio.io/istio/pkg/kube/krt/processor.go:301
istio.io/istio/pkg/kube/krt.(*processorListener[...]).run(0x3149500)
	/home/landow/go/src/istio.io/istio/pkg/kube/krt/processor.go:259 +0x18a
k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
	/home/landow/go/pkg/mod/k8s.io/apimachinery@v0.35.3/pkg/util/wait/wait.go:72 +0x4c
created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 73
	/home/landow/go/pkg/mod/k8s.io/apimachinery@v0.35.3/pkg/util/wait/wait.go:70 +0x73

ERROR: exit status 2
94 runs so far, 2 failures (97.92% pass rate). 490.405577ms avg, 581.292159ms max, 48.240068ms min
218 runs so far, 2 failures (99.09% pass rate). 494.993057ms avg, 584.2672ms max, 27.938659ms min
</pre>

</details>

If we mark ourselves closed 