### PR TITLE
allow port overrides for network gateway service

### DIFF
--- a/manifests/charts/gateway/templates/_helpers.tpl
+++ b/manifests/charts/gateway/templates/_helpers.tpl
@@ -40,6 +40,18 @@ istio.io/rev: {{ . | quote }}
 {{- end }}
 
 {{/*
+Render a single network gateway port entry with validation.
+Expects a dict with keys: ports (the networkGatewayPorts map), name (port name), defaultTargetPort (fallback).
+*/}}
+{{- define "gateway.networkGatewayPort" -}}
+{{- $cfg := index .ports .name | required (printf "networkGatewayPorts.%s is required when networkGateway is set" .name) -}}
+- name: {{ .name }}
+  port: {{ $cfg.port }}
+  targetPort: {{ $cfg.targetPort | default .defaultTargetPort }}
+  protocol: {{ $cfg.protocol | default "TCP" }}
+{{- end -}}
+
+{{/*
 Render resource requirements, omitting any nil values.
 */}}
 {{- define "gateway.resources" -}}

--- a/manifests/charts/gateway/templates/service.yaml
+++ b/manifests/charts/gateway/templates/service.yaml
@@ -50,19 +50,14 @@ spec:
 {{- end }}
   ports:
 {{- if .Values.networkGateway }}
-  - name: status-port
-    port: 15021
-    targetPort: 15021
-  - name: tls
-    port: 15443
-    targetPort: 15443
-  - name: tls-istiod
-    port: 15012
-    targetPort: 15012
-  - name: tls-webhook
-    port: 15017
-    targetPort: 15017
+  {{- include "gateway.networkGatewayPort" (dict "ports" .Values.networkGatewayPorts "name" "status-port" "defaultTargetPort" 15021) | nindent 2 }}
+  {{- include "gateway.networkGatewayPort" (dict "ports" .Values.networkGatewayPorts "name" "tls" "defaultTargetPort" 15443) | nindent 2 }}
+  {{- include "gateway.networkGatewayPort" (dict "ports" .Values.networkGatewayPorts "name" "tls-istiod" "defaultTargetPort" 15012) | nindent 2 }}
+  {{- include "gateway.networkGatewayPort" (dict "ports" .Values.networkGatewayPorts "name" "tls-webhook" "defaultTargetPort" 15017) | nindent 2 }}
 {{- else }}
+  {{- if not .Values.service.ports }}
+    {{- fail "service.ports must not be empty when networkGateway is not set" }}
+  {{- end }}
 {{ .Values.service.ports | toYaml | indent 4 }}
 {{- end }}
 {{- if .Values.service.externalIPs }}

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -271,6 +271,24 @@
         "networkGateway": {
           "type": "string"
         },
+        "networkGatewayPorts": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "port": {
+                "type": "integer"
+              },
+              "targetPort": {
+                "type": "integer"
+              },
+              "protocol": {
+                "type": "string"
+              }
+            },
+            "required": ["port"]
+          }
+        },
         "imagePullPolicy": {
           "type": "string",
           "enum": [

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -132,6 +132,21 @@ _internal_defaults_do_not_set:
   # If specified, the gateway will act as a network gateway for the given network.
   networkGateway: ""
 
+  # Ports for the network gateway service. Only used when networkGateway is set.
+  networkGatewayPorts:
+    status-port:
+      port: 15021
+      targetPort: 15021
+    tls:
+      port: 15443
+      targetPort: 15443
+    tls-istiod:
+      port: 15012
+      targetPort: 15012
+    tls-webhook:
+      port: 15017
+      targetPort: 15017
+
   # Specify image pull policy if default behavior isn't desired.
   # Default behavior: latest images will be Always else IfNotPresent
   imagePullPolicy: ""

--- a/operator/pkg/helm/helm_test.go
+++ b/operator/pkg/helm/helm_test.go
@@ -200,6 +200,27 @@ func TestRender(t *testing.T) {
 			diffSelect:  "PodDisruptionBudget:*:istio-ingress",
 		},
 		{
+			desc:        "gateway-service-default",
+			releaseName: "istio-ingress",
+			namespace:   "istio-ingress",
+			chartName:   "gateway",
+			diffSelect:  "Service:*:istio-ingress",
+		},
+		{
+			desc:        "gateway-network-gateway-default",
+			releaseName: "istio-eastwest",
+			namespace:   "istio-system",
+			chartName:   "gateway",
+			diffSelect:  "Service:*:istio-eastwest",
+		},
+		{
+			desc:        "gateway-network-gateway-port-override",
+			releaseName: "istio-eastwest",
+			namespace:   "istio-system",
+			chartName:   "gateway",
+			diffSelect:  "Service:*:istio-eastwest",
+		},
+		{
 			desc:        "ztunnel-dns-config",
 			releaseName: "ztunnel",
 			namespace:   "istio-system",

--- a/operator/pkg/helm/testdata/input/gateway-network-gateway-default.yaml
+++ b/operator/pkg/helm/testdata/input/gateway-network-gateway-default.yaml
@@ -1,0 +1,3 @@
+spec:
+  values:
+    networkGateway: network-1

--- a/operator/pkg/helm/testdata/input/gateway-network-gateway-port-override.yaml
+++ b/operator/pkg/helm/testdata/input/gateway-network-gateway-port-override.yaml
@@ -1,0 +1,16 @@
+spec:
+  values:
+    networkGateway: network-1
+    networkGatewayPorts:
+      status-port:
+        port: 15021
+        targetPort: 15021
+      tls:
+        port: 443
+        targetPort: 15443
+      tls-istiod:
+        port: 15012
+        targetPort: 15012
+      tls-webhook:
+        port: 15017
+        targetPort: 15017

--- a/operator/pkg/helm/testdata/input/gateway-service-default.yaml
+++ b/operator/pkg/helm/testdata/input/gateway-service-default.yaml
@@ -1,0 +1,2 @@
+spec:
+  values: {}

--- a/operator/pkg/helm/testdata/output/gateway-network-gateway-default.golden.yaml
+++ b/operator/pkg/helm/testdata/output/gateway-network-gateway-default.golden.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-eastwest
+  namespace: istio-system
+  labels:
+    app.kubernetes.io/name: istio-eastwest
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "istio-eastwest"
+    app.kubernetes.io/part-of: "istio"
+    app.kubernetes.io/version: "1.0.0"
+    helm.sh/chart: gateway-1.0.0
+    app: istio-eastwest
+    istio: eastwest
+    "istio.io/dataplane-mode": "none"
+    topology.istio.io/network: "network-1"
+  annotations:
+    {}
+spec:
+  type: LoadBalancer
+  ports:
+  - name: status-port
+    port: 15021
+    targetPort: 15021
+    protocol: TCP
+  - name: tls
+    port: 15443
+    targetPort: 15443
+    protocol: TCP
+  - name: tls-istiod
+    port: 15012
+    targetPort: 15012
+    protocol: TCP
+  - name: tls-webhook
+    port: 15017
+    targetPort: 15017
+    protocol: TCP
+  selector:
+    app: istio-eastwest
+    istio: eastwest

--- a/operator/pkg/helm/testdata/output/gateway-network-gateway-port-override.golden.yaml
+++ b/operator/pkg/helm/testdata/output/gateway-network-gateway-port-override.golden.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-eastwest
+  namespace: istio-system
+  labels:
+    app.kubernetes.io/name: istio-eastwest
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "istio-eastwest"
+    app.kubernetes.io/part-of: "istio"
+    app.kubernetes.io/version: "1.0.0"
+    helm.sh/chart: gateway-1.0.0
+    app: istio-eastwest
+    istio: eastwest
+    "istio.io/dataplane-mode": "none"
+    topology.istio.io/network: "network-1"
+  annotations:
+    {}
+spec:
+  type: LoadBalancer
+  ports:
+  - name: status-port
+    port: 15021
+    targetPort: 15021
+    protocol: TCP
+  - name: tls
+    port: 443
+    targetPort: 15443
+    protocol: TCP
+  - name: tls-istiod
+    port: 15012
+    targetPort: 15012
+    protocol: TCP
+  - name: tls-webhook
+    port: 15017
+    targetPort: 15017
+    protocol: TCP
+  selector:
+    app: istio-eastwest
+    istio: eastwest

--- a/operator/pkg/helm/testdata/output/gateway-service-default.golden.yaml
+++ b/operator/pkg/helm/testdata/output/gateway-service-default.golden.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-ingress
+  namespace: istio-ingress
+  labels:
+    app.kubernetes.io/name: istio-ingress
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "istio-ingress"
+    app.kubernetes.io/part-of: "istio"
+    app.kubernetes.io/version: "1.0.0"
+    helm.sh/chart: gateway-1.0.0
+    app: istio-ingress
+    istio: ingress
+    "istio.io/dataplane-mode": "none"
+  annotations:
+    {}
+spec:
+  type: LoadBalancer
+  ports:
+    - name: status-port
+      port: 15021
+      protocol: TCP
+      targetPort: 15021
+    - name: http2
+      port: 80
+      protocol: TCP
+      targetPort: 80
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 443
+  selector:
+    app: istio-ingress
+    istio: ingress

--- a/releasenotes/notes/59072.yaml
+++ b/releasenotes/notes/59072.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue: [59072]
+releaseNotes:
+  - |
+    **Added** configurable port overrides for the network gateway service via `networkGatewayPorts` values.
+  - |
+    **Added** template validation to fail early when `service.ports` is empty and `networkGateway` is not set.


### PR DESCRIPTION
**Allow port overrides for Istio Gateway Service with `networkGateway` set**

Fixes #59072

## Summary

- Moves the hardcoded `networkGateway` service ports from the template into `values.yaml` as a `networkGatewayPorts` map
- Helm's native deep merge lets users override individual ports without redeclaring all four (e.g. `--set networkGatewayPorts.tls.port=443`)
- Port names are hardcoded in the template to ensure all four ports are always present — only `port`/`targetPort` values are configurable
- Adds a `fail` guard for empty `service.ports` when `networkGateway` is not set
- Adds schema validation for the new field

## Behavior

| Scenario | Result |
|---|---|
| `networkGateway` set, no port overrides | Identical to current behavior (ports 15021, 15443, 15012, 15017) |
| `--set networkGatewayPorts.tls.port=443` | External port changes to 443, targetPort stays at 15443 (values.yaml default) |
| `--set networkGatewayPorts.tls.port=443 --set networkGatewayPorts.tls.targetPort=15443` | External port 443, targetPort 15443 |
| `networkGateway` not set | Uses `service.ports` as before, completely unaffected |

## Use case

When using a network gateway for multi-cluster traffic, the LoadBalancer port is hardcoded to 15443. Some environments only allow standard outbound ports (e.g. 443). This change lets users customize the external port while keeping the target port unchanged:

```bash
helm install istio-eastwestgateway istio/gateway \
  --set networkGateway=network-1 \
  --set networkGatewayPorts.tls.port=443 \
  --set networkGatewayPorts.tls.targetPort=15443
```

## Test plan

- [x] `helm template` with `networkGateway` set — default ports render identically to before
- [x] `helm template` with single port override — `targetPort` stays at default
- [x] `helm template` with explicit `port` + `targetPort` — both values respected
- [x] `helm template` without `networkGateway` — uses `service.ports`, no change