### PR TITLE
Remove a few hidden go-routines.

### DIFF
--- a/istioctl/pkg/dashboard/dashboard.go
+++ b/istioctl/pkg/dashboard/dashboard.go
@@ -544,7 +544,7 @@ func portForward(podName, namespace, flavor, urlFormat, localAddress string, rem
 		}
 
 		// Close the port forwarder when the command is terminated.
-		ClosePortForwarderOnInterrupt(fw)
+		go ClosePortForwarderOnInterrupt(fw)
 
 		log.Debugf(fmt.Sprintf("port-forward to %s pod ready", flavor))
 		openBrowser(fmt.Sprintf(urlFormat, fw.Address()), writer, browser)
@@ -559,13 +559,11 @@ func portForward(podName, namespace, flavor, urlFormat, localAddress string, rem
 }
 
 func ClosePortForwarderOnInterrupt(fw kube.PortForwarder) {
-	go func() {
-		signals := make(chan os.Signal, 1)
-		signal.Notify(signals, os.Interrupt)
-		defer signal.Stop(signals)
-		<-signals
-		fw.Close()
-	}()
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt)
+	defer signal.Stop(signals)
+	<-signals
+	fw.Close()
 }
 
 func openBrowser(url string, writer io.Writer, browser bool) {

--- a/istioctl/pkg/metrics/metrics.go
+++ b/istioctl/pkg/metrics/metrics.go
@@ -131,7 +131,7 @@ func run(c *cobra.Command, ctx cli.Context, args []string) error {
 
 	// Close the forwarder either when we exit or when this process is interrupted.
 	defer fw.Close()
-	dashboard.ClosePortForwarderOnInterrupt(fw)
+	go dashboard.ClosePortForwarderOnInterrupt(fw)
 
 	log.Debugf("port-forward to prometheus pod ready")
 

--- a/tools/bug-report/pkg/bugreport/bugreport.go
+++ b/tools/bug-report/pkg/bugreport/bugreport.go
@@ -101,7 +101,7 @@ var (
 
 func runBugReportCommand(ctx cli.Context, _ *cobra.Command, logOpts *log.Options) error {
 	runner := kubectlcmd.NewRunner(gConfig.RequestConcurrency)
-	runner.ReportRunningTasks()
+	go runner.ReportRunningTasks()
 	if err := configLogs(logOpts); err != nil {
 		return err
 	}

--- a/tools/bug-report/pkg/kubectlcmd/kubectlcmd.go
+++ b/tools/bug-report/pkg/kubectlcmd/kubectlcmd.go
@@ -72,12 +72,10 @@ func (r *Runner) SetClient(client kube.CLIClient) {
 }
 
 func (r *Runner) ReportRunningTasks() {
-	go func() {
-		time.Sleep(reportInterval)
-		for range r.runningTasksTicker.C {
-			r.printRunningTasks()
-		}
-	}()
+	time.Sleep(reportInterval)
+	for range r.runningTasksTicker.C {
+		r.printRunningTasks()
+	}
 }
 
 // Options contains the Run options.


### PR DESCRIPTION
**Please provide a description of this PR:**

This is bad practice. Instead, the caller should call the function with a go. There are many blog posts that discuss the anti-pattern.

The matches were found with a [semgrep rule](https://github.com/semgrep/semgrep-rules/blob/develop/go/lang/best-practice/hidden-goroutine.go) There is a single hidden go routine but this is more complicated to refactor.

Amazon has a [page](https://docs.aws.amazon.com/amazonq/detector-library/go/hidden-goroutine/) outlining why it's a bad idea.