### PR TITLE
[Release-1.28] istio-cni: improve binary detection lock contention (cherry pick from #58582)

### DIFF
--- a/releasenotes/notes/58507.yaml
+++ b/releasenotes/notes/58507.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+- 58507
+releaseNotes:
+- |
+  **Fixed** an issue where `iptables` command was not waiting to acquire a lock on
+  `/run/xtables.lock`, causing some misleading errors in the logs.


### PR DESCRIPTION
**Please provide a description of this PR:**

This fix is already in version `1.29` of Istio, still happening in version `1.28` though. Fix was performed by me in the PR:
- https://github.com/istio/istio/pull/58582
This is a manual cherry-pick as seems I can't trigger the automation for automatic cherry-picking. As stated in the original pull request:

When checking if the iptables binary should be used, check if the binary supports the --wait flag. If yes, use the flag to reduce the errors around the binary not being available because is locked by another application.

The flag is passed with 30 seconds, because is what is already used in the code - in the executeXTables function.