### PR TITLE
flake: refactor virtual service sidecar scope creation test

### DIFF
--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -1531,9 +1531,11 @@ func TestCreateSidecarScope(t *testing.T) {
 		// list of services expected to be in the listener
 		expectedServices []*Service
 		expectedDr       *config.Config
+		setupFunc        func(t *testing.T)
 	}{
 		{
 			"no-sidecar-config",
+			nil,
 			nil,
 			nil,
 			nil,
@@ -1551,6 +1553,7 @@ func TestCreateSidecarScope(t *testing.T) {
 				},
 			},
 			nil,
+			nil,
 		},
 		{
 			"no-sidecar-config-not-merge-service-in-diff-namespaces",
@@ -1558,6 +1561,7 @@ func TestCreateSidecarScope(t *testing.T) {
 			services23,
 			nil,
 			[]*Service{services23[2]},
+			nil,
 			nil,
 		},
 		{
@@ -1577,6 +1581,7 @@ func TestCreateSidecarScope(t *testing.T) {
 				},
 			},
 			nil,
+			nil,
 		},
 		{
 			"no-sidecar-config-k8s-service-take-precedence",
@@ -1595,10 +1600,12 @@ func TestCreateSidecarScope(t *testing.T) {
 				},
 			},
 			nil,
+			nil,
 		},
 		{
 			"sidecar-with-multiple-egress",
 			configs1,
+			nil,
 			nil,
 			nil,
 			nil,
@@ -1616,6 +1623,7 @@ func TestCreateSidecarScope(t *testing.T) {
 				},
 			},
 			nil,
+			nil,
 		},
 		{
 			"sidecar-with-multiple-egress-with-service-on-same-port",
@@ -1623,6 +1631,7 @@ func TestCreateSidecarScope(t *testing.T) {
 			services3,
 			nil,
 			services3,
+			nil,
 			nil,
 		},
 		{
@@ -1639,10 +1648,12 @@ func TestCreateSidecarScope(t *testing.T) {
 				},
 			},
 			nil,
+			nil,
 		},
 		{
 			"sidecar-with-zero-egress",
 			configs2,
+			nil,
 			nil,
 			nil,
 			nil,
@@ -1662,10 +1673,12 @@ func TestCreateSidecarScope(t *testing.T) {
 				},
 			},
 			nil,
+			nil,
 		},
 		{
 			"sidecar-with-multiple-egress-noport",
 			configs3,
+			nil,
 			nil,
 			nil,
 			nil,
@@ -1677,6 +1690,7 @@ func TestCreateSidecarScope(t *testing.T) {
 			services2,
 			nil,
 			services2,
+			nil,
 			nil,
 		},
 		{
@@ -1693,6 +1707,7 @@ func TestCreateSidecarScope(t *testing.T) {
 				},
 			},
 			nil,
+			nil,
 		},
 		{
 			"sidecar-with-egress-port-match-with-services-with-and-without-port",
@@ -1700,6 +1715,7 @@ func TestCreateSidecarScope(t *testing.T) {
 			services5,
 			nil,
 			[]*Service{services5[0]},
+			nil,
 			nil,
 		},
 		{
@@ -1718,6 +1734,7 @@ func TestCreateSidecarScope(t *testing.T) {
 				},
 			},
 			nil,
+			nil,
 		},
 		{
 			"sidecar-with-egress-port-merges-service-ports",
@@ -1725,6 +1742,7 @@ func TestCreateSidecarScope(t *testing.T) {
 			services6,
 			nil,
 			services6,
+			nil,
 			nil,
 		},
 		{
@@ -1759,6 +1777,7 @@ func TestCreateSidecarScope(t *testing.T) {
 				},
 			},
 			nil,
+			nil,
 		},
 		{
 			"two-egresslisteners-one-with-port-and-without-port",
@@ -1766,6 +1785,7 @@ func TestCreateSidecarScope(t *testing.T) {
 			services8,
 			nil,
 			services8,
+			nil,
 			nil,
 		},
 		// Validates when service is scoped to Sidecar, it uses service port rather than listener port.
@@ -1775,6 +1795,7 @@ func TestCreateSidecarScope(t *testing.T) {
 			services9,
 			nil,
 			services9,
+			nil,
 			nil,
 		},
 		{
@@ -1808,6 +1829,7 @@ func TestCreateSidecarScope(t *testing.T) {
 					},
 				},
 			},
+			nil,
 			nil,
 		},
 		{
@@ -1858,6 +1880,7 @@ func TestCreateSidecarScope(t *testing.T) {
 				},
 			},
 			nil,
+			nil,
 		},
 		{
 			"wild-card-egress-listener-match-with-two-ports",
@@ -1890,6 +1913,7 @@ func TestCreateSidecarScope(t *testing.T) {
 					},
 				},
 			},
+			nil,
 			nil,
 		},
 		{
@@ -1924,6 +1948,7 @@ func TestCreateSidecarScope(t *testing.T) {
 				},
 			},
 			nil,
+			nil,
 		},
 		{
 			"virtual-service",
@@ -1950,6 +1975,7 @@ func TestCreateSidecarScope(t *testing.T) {
 				},
 			},
 			nil,
+			nil,
 		},
 		{
 			"virtual-service-destinations-matching-ports",
@@ -1966,6 +1992,7 @@ func TestCreateSidecarScope(t *testing.T) {
 					},
 				},
 			},
+			nil,
 			nil,
 		},
 		{
@@ -1992,6 +2019,7 @@ func TestCreateSidecarScope(t *testing.T) {
 				},
 			},
 			nil,
+			nil,
 		},
 		{
 			"virtual-service-destinations-matching-tcp-virtual-service-ports",
@@ -2009,6 +2037,7 @@ func TestCreateSidecarScope(t *testing.T) {
 				},
 			},
 			nil,
+			nil,
 		},
 		{
 			"virtual-service-destinations-matching-tls-virtual-service-ports",
@@ -2025,6 +2054,7 @@ func TestCreateSidecarScope(t *testing.T) {
 					},
 				},
 			},
+			nil,
 			nil,
 		},
 		{
@@ -2053,6 +2083,7 @@ func TestCreateSidecarScope(t *testing.T) {
 				},
 			},
 			nil,
+			nil,
 		},
 		{
 			"virtual-service-prefer-config-namespace",
@@ -2078,6 +2109,7 @@ func TestCreateSidecarScope(t *testing.T) {
 					},
 				},
 			},
+			nil,
 			nil,
 		},
 		{
@@ -2107,6 +2139,39 @@ func TestCreateSidecarScope(t *testing.T) {
 				},
 			},
 			nil,
+			nil,
+		},
+		{
+			"virtual-service-pick-alphabetical",
+			configs11,
+			// Ambiguous; same hostname in ns1 and ns2, neither is config namespace
+			// with SidecarPickBestServiceNamespace disabled, ns1 wins alphabetically
+			services12,
+			virtualServices1,
+			[]*Service{
+				{
+					Hostname: "baz.svc.cluster.local",
+					Ports:    port7443,
+					Attributes: ServiceAttributes{
+						Name:      "baz",
+						Namespace: "ns3",
+					},
+				},
+				{
+					Hostname: "foo.svc.cluster.local",
+					Ports:    port7443,
+					Attributes: ServiceAttributes{
+						Name:      "foo",
+						Namespace: "ns1",
+					},
+				},
+			},
+			nil,
+			// disable SidecarPickBestServiceNamespace
+			// to use alphabetical order of ns for deconfliction method
+			func(t *testing.T) {
+				test.SetForTest(t, &features.SidecarPickBestServiceNamespace, false)
+			},
 		},
 		{
 			"virtual-service-pick-public",
@@ -2134,6 +2199,7 @@ func TestCreateSidecarScope(t *testing.T) {
 				},
 			},
 			nil,
+			nil,
 		},
 		{
 			"virtual-service-bad-host",
@@ -2142,6 +2208,7 @@ func TestCreateSidecarScope(t *testing.T) {
 			virtualServices1,
 			services9,
 			nil,
+			nil,
 		},
 		{
 			"virtual-service-destination-port-missing-from-service",
@@ -2149,6 +2216,7 @@ func TestCreateSidecarScope(t *testing.T) {
 			services22,
 			virtualServices3,
 			[]*Service{},
+			nil,
 			nil,
 		},
 		{
@@ -2175,6 +2243,7 @@ func TestCreateSidecarScope(t *testing.T) {
 				},
 			},
 			nil,
+			nil,
 		},
 		{
 			"virtual-service-2-match-service-and-domain",
@@ -2199,6 +2268,7 @@ func TestCreateSidecarScope(t *testing.T) {
 					},
 				},
 			},
+			nil,
 			nil,
 		},
 		{
@@ -2225,6 +2295,7 @@ func TestCreateSidecarScope(t *testing.T) {
 				},
 			},
 			nil,
+			nil,
 		},
 		{
 			"virtual-service-6-match-source-namespace",
@@ -2250,6 +2321,7 @@ func TestCreateSidecarScope(t *testing.T) {
 				},
 			},
 			nil,
+			nil,
 		},
 		{
 			"sidecar-scope-with-illegal-host",
@@ -2257,6 +2329,7 @@ func TestCreateSidecarScope(t *testing.T) {
 			services14,
 			nil,
 			services14,
+			nil,
 			nil,
 		},
 		{
@@ -2273,6 +2346,7 @@ func TestCreateSidecarScope(t *testing.T) {
 					},
 				},
 			},
+			nil,
 			nil,
 		},
 		{
@@ -2297,6 +2371,7 @@ func TestCreateSidecarScope(t *testing.T) {
 				},
 			},
 			nil,
+			nil,
 		},
 		{
 			"sidecar-scope-with-matching-workloadselector-dr",
@@ -2312,6 +2387,7 @@ func TestCreateSidecarScope(t *testing.T) {
 				},
 			},
 			&destinationRule2,
+			nil,
 		},
 		{
 			"sidecar-scope-with-non-matching-workloadselector-dr",
@@ -2327,6 +2403,7 @@ func TestCreateSidecarScope(t *testing.T) {
 				},
 			},
 			&nonWorkloadSelectorDr,
+			nil,
 		},
 		{
 			"sidecar-scope-same-workloadselector-labels-drs-should-be-merged",
@@ -2342,6 +2419,7 @@ func TestCreateSidecarScope(t *testing.T) {
 				},
 			},
 			&mergedDr1and3,
+			nil,
 		},
 		{
 			name: "multi-service-merge",
@@ -2763,6 +2841,10 @@ func TestCreateSidecarScope(t *testing.T) {
 			env := NewEnvironment()
 			env.Watcher = meshwatcher.NewTestWatcher(meshConfig)
 			ps.Mesh = env.Mesh()
+
+			if tt.setupFunc != nil {
+				tt.setupFunc(t)
+			}
 
 			env.ServiceDiscovery = &localServiceDiscovery{services: tt.services}
 			ps.initDefaultExportMaps()


### PR DESCRIPTION
**Please provide a description of this PR:**
With https://github.com/istio/istio/pull/59486 we changed the default deconfliction methodology for choosing a service namespace on hostname conflicts from alphabetical to creation time.  Currently, there is still a test case enforcing the old deconfliction strategy which will now be flaky. This PR updates the test expectations to conform with the new default behavior.