### PR TITLE
TTL clamping for leaf certificates

### DIFF
--- a/releasenotes/notes/59768.yaml
+++ b/releasenotes/notes/59768.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: pilot
+
+issue:
+  - https://github.com/istio/istio/issues/59768
+
+releaseNotes:
+  - |
+    **Fixed** an issue where Istiod could issue leaf certificates with a `NotAfter` time beyond
+    the signing certificate's expiration.

--- a/releasenotes/notes/59768.yaml
+++ b/releasenotes/notes/59768.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: bug-fix
-area: pilot
+area: security
 
 issue:
   - https://github.com/istio/istio/issues/59768

--- a/security/pkg/pki/ca/ca_test.go
+++ b/security/pkg/pki/ca/ca_test.go
@@ -669,8 +669,7 @@ func TestSignCSR(t *testing.T) {
 
 // TestSignCSRWithTTLClamping verifies that the full IstioCA.Sign() path correctly clamps
 // leaf certificate TTL to the signing certificate's remaining validity when using a
-// short-lived CA. This is an integration test that exercises the complete signing flow,
-// not just the generate_cert utility functions.
+// short-lived CA.
 func TestSignCSRWithTTLClamping(t *testing.T) {
 	// Create a root CA with long TTL
 	rootCAOpts := util.CertOptions{
@@ -762,11 +761,6 @@ func TestSignCSRWithTTLClamping(t *testing.T) {
 	intermediateCACert, err := util.ParsePemEncodedCertificate(intermediateCert)
 	if err != nil {
 		t.Fatalf("failed to parse intermediate CA certificate: %v", err)
-	}
-
-	// Verify that the leaf cert NotAfter does not exceed the intermediate CA cert NotAfter
-	if leafCert.NotAfter.After(intermediateCACert.NotAfter) {
-		t.Errorf("leaf cert NotAfter (%v) exceeds intermediate CA cert NotAfter (%v)", leafCert.NotAfter, intermediateCACert.NotAfter)
 	}
 
 	// Verify that the leaf cert NotAfter was actually clamped (equals intermediate CA NotAfter)

--- a/security/pkg/pki/ca/ca_test.go
+++ b/security/pkg/pki/ca/ca_test.go
@@ -1003,12 +1003,12 @@ func TestBuildSecret(t *testing.T) {
 }
 
 func createCA(maxTTL time.Duration, ecSigAlg util.SupportedECSignatureAlgorithms) (*IstioCA, error) {
-	// Generate root CA key and cert. Use a 2-year TTL so the signing cert's validity does not
-	// artificially cap leaf certificate TTLs during testing.
+	// Generate root CA key and cert. Use a TTL longer than the max leaf cert TTL
+	// requested in tests (30 days) so that TTL clamping does not interfere.
 	rootCAOpts := util.CertOptions{
 		IsCA:         true,
 		IsSelfSigned: true,
-		TTL:          2 * 365 * 24 * time.Hour,
+		TTL:          60 * 24 * time.Hour,
 		Org:          "Root CA",
 		RSAKeySize:   2048,
 		ECSigAlg:     ecSigAlg,
@@ -1032,7 +1032,7 @@ func createCA(maxTTL time.Duration, ecSigAlg util.SupportedECSignatureAlgorithms
 	intermediateCAOpts := util.CertOptions{
 		IsCA:         true,
 		IsSelfSigned: false,
-		TTL:          2 * 365 * 24 * time.Hour,
+		TTL:          60 * 24 * time.Hour,
 		Org:          "Intermediate CA",
 		RSAKeySize:   2048,
 		SignerCert:   rootCert,

--- a/security/pkg/pki/ca/ca_test.go
+++ b/security/pkg/pki/ca/ca_test.go
@@ -667,6 +667,126 @@ func TestSignCSR(t *testing.T) {
 	}
 }
 
+// TestSignCSRWithTTLClamping verifies that the full IstioCA.Sign() path correctly clamps
+// leaf certificate TTL to the signing certificate's remaining validity when using a
+// short-lived CA. This is an integration test that exercises the complete signing flow,
+// not just the generate_cert utility functions.
+func TestSignCSRWithTTLClamping(t *testing.T) {
+	// Create a root CA with long TTL
+	rootCAOpts := util.CertOptions{
+		IsCA:         true,
+		IsSelfSigned: true,
+		TTL:          365 * 24 * time.Hour,
+		Org:          "Root CA",
+		RSAKeySize:   2048,
+	}
+	rootCertBytes, rootKeyBytes, err := util.GenCertKeyFromOptions(rootCAOpts)
+	if err != nil {
+		t.Fatalf("failed to generate root CA: %v", err)
+	}
+	rootCert, err := util.ParsePemEncodedCertificate(rootCertBytes)
+	if err != nil {
+		t.Fatalf("failed to parse root cert: %v", err)
+	}
+	rootKey, err := util.ParsePemEncodedKey(rootKeyBytes)
+	if err != nil {
+		t.Fatalf("failed to parse root key: %v", err)
+	}
+
+	// Create a short-lived intermediate CA with 1 hour validity
+	intermediateCAOpts := util.CertOptions{
+		IsCA:         true,
+		IsSelfSigned: false,
+		TTL:          1 * time.Hour,
+		Org:          "Intermediate CA",
+		RSAKeySize:   2048,
+		SignerCert:   rootCert,
+		SignerPriv:   rootKey,
+	}
+	intermediateCert, intermediateKey, err := util.GenCertKeyFromOptions(intermediateCAOpts)
+	if err != nil {
+		t.Fatalf("failed to generate intermediate CA: %v", err)
+	}
+
+	bundle, err := util.NewVerifiedKeyCertBundleFromPem(
+		intermediateCert, intermediateKey, intermediateCert, rootCertBytes, nil)
+	if err != nil {
+		t.Fatalf("failed to create key cert bundle: %v", err)
+	}
+
+	rootCertCheckInverval := time.Duration(0)
+	caOpts := &IstioCAOptions{
+		DefaultCertTTL: 1 * time.Hour,
+		MaxCertTTL:     2 * time.Hour, // Allow requesting longer TTLs to test clamping
+		KeyCertBundle:  bundle,
+		RotatorConfig: &SelfSignedCARootCertRotatorConfig{
+			CheckInterval: rootCertCheckInverval,
+		},
+	}
+
+	ca, err := NewIstioCA(caOpts)
+	if err != nil {
+		t.Fatalf("failed to create IstioCA: %v", err)
+	}
+
+	// Generate a CSR for a leaf certificate
+	leafCertOpts := util.CertOptions{
+		Host:       "spiffe://example.com/ns/test/sa/test",
+		RSAKeySize: 2048,
+		IsCA:       false,
+	}
+	csrPEM, keyPEM, err := util.GenCSR(leafCertOpts)
+	if err != nil {
+		t.Fatalf("failed to generate CSR: %v", err)
+	}
+
+	// Request a 2-hour TTL (longer than the 1-hour CA validity)
+	// The issued cert should be clamped to the CA's NotAfter
+	caCertOpts := CertOpts{
+		SubjectIDs: []string{"spiffe://example.com/ns/test/sa/test"},
+		TTL:        2 * time.Hour,
+		ForCA:      false,
+	}
+	certPEM, err := ca.Sign(csrPEM, caCertOpts)
+	if err != nil {
+		t.Fatalf("Sign() failed: %v", err)
+	}
+
+	// Parse the issued certificate
+	leafCert, err := util.ParsePemEncodedCertificate(certPEM)
+	if err != nil {
+		t.Fatalf("failed to parse issued certificate: %v", err)
+	}
+
+	// Parse the intermediate CA certificate to get its NotAfter
+	intermediateCACert, err := util.ParsePemEncodedCertificate(intermediateCert)
+	if err != nil {
+		t.Fatalf("failed to parse intermediate CA certificate: %v", err)
+	}
+
+	// Verify that the leaf cert NotAfter does not exceed the intermediate CA cert NotAfter
+	if leafCert.NotAfter.After(intermediateCACert.NotAfter) {
+		t.Errorf("leaf cert NotAfter (%v) exceeds intermediate CA cert NotAfter (%v)", leafCert.NotAfter, intermediateCACert.NotAfter)
+	}
+
+	// Verify that the leaf cert NotAfter was actually clamped (equals intermediate CA NotAfter)
+	if !leafCert.NotAfter.Equal(intermediateCACert.NotAfter) {
+		t.Errorf("expected leaf cert NotAfter to be clamped to intermediate CA NotAfter (%v), got %v", intermediateCACert.NotAfter, leafCert.NotAfter)
+	}
+
+	// Verify the certificate is otherwise valid
+	_, _, certChainBytes, rootCertBytes := ca.GetCAKeyCertBundle().GetAll()
+	verifyFields := util.VerifyFields{
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		IsCA:        false,
+		Host:        "spiffe://example.com/ns/test/sa/test",
+	}
+	if err := util.VerifyCertificate(keyPEM, append(certPEM, certChainBytes...), rootCertBytes, &verifyFields); err != nil {
+		t.Errorf("certificate verification failed: %v", err)
+	}
+}
+
 func TestAppendRootCerts(t *testing.T) {
 	root1 := "root-cert-1"
 	expRootCerts := `root-cert-1
@@ -889,11 +1009,12 @@ func TestBuildSecret(t *testing.T) {
 }
 
 func createCA(maxTTL time.Duration, ecSigAlg util.SupportedECSignatureAlgorithms) (*IstioCA, error) {
-	// Generate root CA key and cert.
+	// Generate root CA key and cert. Use a 2-year TTL so the signing cert's validity does not
+	// artificially cap leaf certificate TTLs during testing.
 	rootCAOpts := util.CertOptions{
 		IsCA:         true,
 		IsSelfSigned: true,
-		TTL:          time.Hour,
+		TTL:          2 * 365 * 24 * time.Hour,
 		Org:          "Root CA",
 		RSAKeySize:   2048,
 		ECSigAlg:     ecSigAlg,
@@ -917,7 +1038,7 @@ func createCA(maxTTL time.Duration, ecSigAlg util.SupportedECSignatureAlgorithms
 	intermediateCAOpts := util.CertOptions{
 		IsCA:         true,
 		IsSelfSigned: false,
-		TTL:          time.Hour,
+		TTL:          2 * 365 * 24 * time.Hour,
 		Org:          "Intermediate CA",
 		RSAKeySize:   2048,
 		SignerCert:   rootCert,

--- a/security/pkg/pki/util/generate_cert.go
+++ b/security/pkg/pki/util/generate_cert.go
@@ -245,7 +245,7 @@ func MergeCertOptions(defaultOpts, deltaOpts CertOptions) CertOptions {
 func GenCertFromCSR(csr *x509.CertificateRequest, signingCert *x509.Certificate, publicKey any,
 	signingKey crypto.PrivateKey, subjectIDs []string, ttl time.Duration, isCA bool,
 ) (cert []byte, err error) {
-	tmpl, err := genCertTemplateFromCSR(csr, subjectIDs, ttl, isCA)
+	tmpl, err := genCertTemplateFromCSR(csr, subjectIDs, ttl, isCA, signingCert)
 	if err != nil {
 		return nil, err
 	}
@@ -286,7 +286,9 @@ const ClockSkewGracePeriod = time.Minute * 2
 
 // genCertTemplateFromCSR generates a certificate template with the given CSR.
 // The NotBefore value of the cert is set to current time.
-func genCertTemplateFromCSR(csr *x509.CertificateRequest, subjectIDs []string, ttl time.Duration, isCA bool) (
+// If signingCert is provided, the template's NotAfter is clamped to the signing cert's NotAfter
+// to prevent leaf certificates from outliving their signing certificate.
+func genCertTemplateFromCSR(csr *x509.CertificateRequest, subjectIDs []string, ttl time.Duration, isCA bool, signingCert *x509.Certificate) (
 	*x509.Certificate, error,
 ) {
 	subjectIDsInString := strings.Join(subjectIDs, ",")
@@ -327,13 +329,24 @@ func genCertTemplateFromCSR(csr *x509.CertificateRequest, subjectIDs []string, t
 	if err != nil {
 		return nil, err
 	}
+
+	// Reject expired signing certificates to prevent issuing already-expired leaf certificates
+	if signingCert != nil && !now.Before(signingCert.NotAfter) {
+		return nil, fmt.Errorf("signing certificate has expired at %v", signingCert.NotAfter)
+	}
+
+	notAfter := now.Add(ttl)
+	if signingCert != nil && !notAfter.Before(signingCert.NotAfter) {
+		notAfter = signingCert.NotAfter
+	}
+
 	// SignatureAlgorithm will use the default algorithm.
 	// See https://golang.org/src/crypto/x509/x509.go?s=5131:5158#L1965 .
 	return &x509.Certificate{
 		SerialNumber:          serialNum,
 		Subject:               subject,
 		NotBefore:             now.Add(-ClockSkewGracePeriod),
-		NotAfter:              now.Add(ttl),
+		NotAfter:              notAfter,
 		KeyUsage:              keyUsage,
 		ExtKeyUsage:           extKeyUsages,
 		IsCA:                  isCA,

--- a/security/pkg/pki/util/generate_cert.go
+++ b/security/pkg/pki/util/generate_cert.go
@@ -335,8 +335,10 @@ func genCertTemplateFromCSR(csr *x509.CertificateRequest, subjectIDs []string, t
 		return nil, fmt.Errorf("signing certificate has expired at %v", signingCert.NotAfter)
 	}
 
+	// notAfter and notBefore are both derived from the same 'now' captured above.
 	notAfter := now.Add(ttl)
 	if signingCert != nil && !notAfter.Before(signingCert.NotAfter) {
+		log.Debugf("clamping leaf cert TTL from %v to signing cert NotAfter %v", ttl, signingCert.NotAfter)
 		notAfter = signingCert.NotAfter
 	}
 

--- a/security/pkg/pki/util/generate_cert_test.go
+++ b/security/pkg/pki/util/generate_cert_test.go
@@ -1016,9 +1016,9 @@ func TestGenCertFromCSRWithTTLClamping(t *testing.T) {
 	subjectIDs := []string{"spiffe://cluster.local/leaf"}
 
 	cases := []struct {
-		name           string
-		ttl            time.Duration
-		expectClamped  bool
+		name          string
+		ttl           time.Duration
+		expectClamped bool
 	}{
 		{
 			name:          "TTL shorter than signing cert - no clamping",

--- a/security/pkg/pki/util/generate_cert_test.go
+++ b/security/pkg/pki/util/generate_cert_test.go
@@ -969,3 +969,141 @@ func TestMergeCertOptions(t *testing.T) {
 			mergedCertOptions.IsDualUse, deltaCertOptions.IsDualUse)
 	}
 }
+
+// TestGenCertFromCSRWithTTLClamping verifies that leaf certificates are clamped to the signing
+// certificate's NotAfter when the requested TTL would extend beyond that boundary.
+func TestGenCertFromCSRWithTTLClamping(t *testing.T) {
+	// Generate a CA cert with 1-hour validity; use ECSigAlg so GenCertKeyFromOptions returns the EC private key.
+	caCertOptions := CertOptions{
+		Host:         "test-ca.example.com",
+		TTL:          time.Hour,
+		Org:          "TestOrg",
+		IsCA:         true,
+		IsSelfSigned: true,
+		ECSigAlg:     EcdsaSigAlg,
+	}
+	caCertPemBytes, caKeyPemBytes, err := GenCertKeyFromOptions(caCertOptions)
+	if err != nil {
+		t.Fatalf("failed to generate CA cert: %v", err)
+	}
+	signingCert, err := ParsePemEncodedCertificate(caCertPemBytes)
+	if err != nil {
+		t.Fatalf("failed to parse CA cert: %v", err)
+	}
+	caKey, err := ParsePemEncodedKey(caKeyPemBytes)
+	if err != nil {
+		t.Fatalf("failed to parse CA key: %v", err)
+	}
+
+	// Generate a leaf key and CSR.
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate leaf key: %v", err)
+	}
+	csrTemplate := &x509.CertificateRequest{
+		Subject:            pkix.Name{CommonName: "leaf.example.com"},
+		SignatureAlgorithm: x509.ECDSAWithSHA256,
+	}
+	csrDer, err := x509.CreateCertificateRequest(rand.Reader, csrTemplate, leafKey)
+	if err != nil {
+		t.Fatalf("failed to create CSR: %v", err)
+	}
+	csr, err := x509.ParseCertificateRequest(csrDer)
+	if err != nil {
+		t.Fatalf("failed to parse CSR: %v", err)
+	}
+
+	subjectIDs := []string{"spiffe://cluster.local/leaf"}
+
+	cases := []struct {
+		name           string
+		ttl            time.Duration
+		expectClamped  bool
+	}{
+		{
+			name:          "TTL shorter than signing cert - no clamping",
+			ttl:           30 * time.Minute,
+			expectClamped: false,
+		},
+		{
+			name:          "TTL longer than signing cert - clamped",
+			ttl:           2 * time.Hour,
+			expectClamped: true,
+		},
+		{
+			name:          "TTL exactly equals signing cert remaining lifetime - clamped (boundary)",
+			ttl:           time.Hour,
+			expectClamped: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			certDer, err := GenCertFromCSR(csr, signingCert, leafKey.Public(), caKey, subjectIDs, c.ttl, false)
+			if err != nil {
+				t.Fatalf("GenCertFromCSR failed: %v", err)
+			}
+			leafCert, err := x509.ParseCertificate(certDer)
+			if err != nil {
+				t.Fatalf("failed to parse leaf cert: %v", err)
+			}
+
+			if c.expectClamped {
+				// Leaf NotAfter must not exceed signing cert NotAfter.
+				if leafCert.NotAfter.After(signingCert.NotAfter) {
+					t.Errorf("leaf cert NotAfter (%v) exceeds signing cert NotAfter (%v)", leafCert.NotAfter, signingCert.NotAfter)
+				}
+				if !leafCert.NotAfter.Equal(signingCert.NotAfter) {
+					t.Errorf("expected leaf cert NotAfter to be clamped to %v, got %v", signingCert.NotAfter, leafCert.NotAfter)
+				}
+			} else {
+				// Leaf NotAfter should be approximately now+ttl (within a few seconds).
+				expectedNotAfter := time.Now().Add(c.ttl)
+				delta := leafCert.NotAfter.Sub(expectedNotAfter)
+				if delta < -5*time.Second || delta > 5*time.Second {
+					t.Errorf("leaf cert NotAfter (%v) not close to expected (%v), delta %v", leafCert.NotAfter, expectedNotAfter, delta)
+				}
+			}
+
+			// In all cases, leaf cert must not outlive signing cert.
+			if leafCert.NotAfter.After(signingCert.NotAfter) {
+				t.Errorf("leaf cert NotAfter (%v) must not exceed signing cert NotAfter (%v)", leafCert.NotAfter, signingCert.NotAfter)
+			}
+		})
+	}
+
+	// Test expired signing certificate
+	t.Run("Expired signing certificate - error", func(t *testing.T) {
+		// Create an expired signing cert (NotAfter is in the past)
+		expiredSigningCertOpts := CertOptions{
+			Host:         "CA",
+			NotBefore:    time.Now().Add(-2 * time.Hour),
+			TTL:          1 * time.Hour, // Expired 1 hour ago
+			RSAKeySize:   2048,
+			IsSelfSigned: true,
+			IsCA:         true,
+			Org:          "Expired CA",
+		}
+		expiredCertPEM, expiredKeyPEM, err := GenCertKeyFromOptions(expiredSigningCertOpts)
+		if err != nil {
+			t.Fatalf("failed to generate expired signing cert: %v", err)
+		}
+		expiredCert, err := ParsePemEncodedCertificate(expiredCertPEM)
+		if err != nil {
+			t.Fatalf("failed to parse expired signing cert: %v", err)
+		}
+		expiredKey, err := ParsePemEncodedKey(expiredKeyPEM)
+		if err != nil {
+			t.Fatalf("failed to parse expired signing key: %v", err)
+		}
+
+		// Attempt to issue a leaf cert using the expired signing cert
+		_, err = GenCertFromCSR(csr, expiredCert, leafKey.Public(), expiredKey, subjectIDs, 30*time.Minute, false)
+		if err == nil {
+			t.Fatalf("expected error when using expired signing cert, got nil")
+		}
+		if !strings.Contains(err.Error(), "signing certificate has expired") {
+			t.Errorf("expected error message to contain 'signing certificate has expired', got: %v", err)
+		}
+	})
+}

--- a/security/pkg/pki/util/generate_cert_test.go
+++ b/security/pkg/pki/util/generate_cert_test.go
@@ -1030,15 +1030,11 @@ func TestGenCertFromCSRWithTTLClamping(t *testing.T) {
 			ttl:           2 * time.Hour,
 			expectClamped: true,
 		},
-		{
-			name:          "TTL exactly equals signing cert remaining lifetime - clamped (boundary)",
-			ttl:           time.Hour,
-			expectClamped: true,
-		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			beforeSign := time.Now()
 			certDer, err := GenCertFromCSR(csr, signingCert, leafKey.Public(), caKey, subjectIDs, c.ttl, false)
 			if err != nil {
 				t.Fatalf("GenCertFromCSR failed: %v", err)
@@ -1049,18 +1045,15 @@ func TestGenCertFromCSRWithTTLClamping(t *testing.T) {
 			}
 
 			if c.expectClamped {
-				// Leaf NotAfter must not exceed signing cert NotAfter.
-				if leafCert.NotAfter.After(signingCert.NotAfter) {
-					t.Errorf("leaf cert NotAfter (%v) exceeds signing cert NotAfter (%v)", leafCert.NotAfter, signingCert.NotAfter)
-				}
+				// Leaf NotAfter must equal the signing cert NotAfter.
 				if !leafCert.NotAfter.Equal(signingCert.NotAfter) {
 					t.Errorf("expected leaf cert NotAfter to be clamped to %v, got %v", signingCert.NotAfter, leafCert.NotAfter)
 				}
 			} else {
-				// Leaf NotAfter should be approximately now+ttl (within a few seconds).
-				expectedNotAfter := time.Now().Add(c.ttl)
-				delta := leafCert.NotAfter.Sub(expectedNotAfter)
-				if delta < -5*time.Second || delta > 5*time.Second {
+				// Leaf NotAfter should be approximately beforeSign+ttl.
+				expectedNotAfter := beforeSign.Add(c.ttl)
+				delta := leafCert.NotAfter.Sub(expectedNotAfter).Abs()
+				if delta > 5*time.Second {
 					t.Errorf("leaf cert NotAfter (%v) not close to expected (%v), delta %v", leafCert.NotAfter, expectedNotAfter, delta)
 				}
 			}


### PR DESCRIPTION
Closes: https://github.com/istio/istio/issues/59768

**Summary**
Prevents leaf certificates from outliving their signing certificate by adding TTL clamping logic in certificate generation. This fixes TLS handshake failures where the intermediate CA has shorter validity than requested leaf certificate TTL.

**Changes**
- Added expired signing certificate guard in `genCertTemplateFromCSR` 
- Added TTL clamping when leaf cert would extend beyond signing cert NotAfter
- Added unit tests `TestGenCertFromCSRWithTTLClamping` and `TestSignCSRWithTTLClamping` validating IstioCA.Sign() path