### PR TITLE
fix kubelet probe failure with aws vpc cni security groups for pods

### DIFF
--- a/cni/pkg/nodeagent/brancheni_linux.go
+++ b/cni/pkg/nodeagent/brancheni_linux.go
@@ -34,11 +34,42 @@ type branchENIRoute struct {
 	iifPriority int // priority of aws-vpc-cni's "iif <veth> lookup <table>" rule
 }
 
-var earlyDemuxOnce sync.Once
+var (
+	earlyDemuxOnce     sync.Once
+	earlyDemuxDisabled bool // true if net.ipv4.tcp_early_demux=0 (prerequisite for SGP)
+)
+
+// tcpEarlyDemuxIsDisabled returns true if net.ipv4.tcp_early_demux=0, which AWS
+// requires operators to set on every node running Security Groups for Pods.
+// Since the kernel default is 1, this sysctl being 0 is an explicit operator
+// signal that the node is prepared for SGP - we use it as a gate so branch ENI
+// detection is fully inert on any other node.
+// See https://docs.aws.amazon.com/eks/latest/userguide/security-groups-pods-deployment.html
+func tcpEarlyDemuxIsDisabled() bool {
+	earlyDemuxOnce.Do(func() {
+		const path = "/proc/sys/net/ipv4/tcp_early_demux"
+		data, err := os.ReadFile(path)
+		if err != nil {
+			log.Debugf("could not read %s, assuming default (enabled): %v", path, err)
+			return
+		}
+		earlyDemuxDisabled = len(data) > 0 && data[0] == '0'
+		if earlyDemuxDisabled {
+			log.Infof("net.ipv4.tcp_early_demux=0; AWS branch ENI probe detection enabled")
+		} else {
+			log.Debugf("net.ipv4.tcp_early_demux=1 (default); AWS branch ENI probe detection skipped")
+		}
+	})
+	return earlyDemuxDisabled
+}
 
 // detectBranchENI checks if a pod IP is routed via a branch ENI (i.e., the route
 // exists only in a non-main routing table, indicating aws-vpc-cni SGP setup).
 // Returns nil if the pod uses standard veth routing (route in main table).
+//
+// Gated on net.ipv4.tcp_early_demux=0, which is required by AWS for SGP. On any
+// node without that sysctl set, we return nil immediately - there's no SGP
+// configuration to find and no rules we could meaningfully add.
 //
 // Detection: scan ip rules for iif-based entries whose routing table
 // contains a host route to the pod IP. If found, this is a branch ENI pod.
@@ -50,6 +81,10 @@ var earlyDemuxOnce sync.Once
 // This approach avoids hardcoding table ranges or priorities and works for
 // both IPv4 and IPv6.
 func detectBranchENI(podIP netip.Addr) *branchENIRoute {
+	if !tcpEarlyDemuxIsDisabled() {
+		return nil
+	}
+
 	ip := net.IP(podIP.AsSlice())
 
 	family := unix.AF_INET
@@ -133,10 +168,6 @@ func detectBranchENI(podIP netip.Addr) *branchENIRoute {
 //     instead of being hijacked by aws-vpc-cni's iif rule that routes it back to VPC.
 //     Priority is set to one less than aws-vpc-cni's iif rule priority.
 func addBranchENIRules(podIP netip.Addr, info *branchENIRoute) error {
-	// Warn once per process if tcp_early_demux is enabled, since we are about
-	// to add rules that only work correctly when it is disabled.
-	checkTCPEarlyDemux()
-
 	ip := net.IP(podIP.AsSlice())
 	family := unix.AF_INET
 	bits := 32
@@ -228,19 +259,3 @@ func delBranchENIRules(podIP netip.Addr, info *branchENIRoute) {
 	log.Debugf("removed branch ENI rules for pod %s veth %s", podIP, info.vethName)
 }
 
-// checkTCPEarlyDemux warns if net.ipv4.tcp_early_demux is enabled, which
-// breaks kubelet connectivity to pods on branch ENIs.
-// See https://docs.aws.amazon.com/eks/latest/userguide/security-groups-pods-deployment.html
-func checkTCPEarlyDemux() {
-	earlyDemuxOnce.Do(func() {
-		const path = "/proc/sys/net/ipv4/tcp_early_demux"
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return
-		}
-		if len(data) > 0 && data[0] == '1' {
-			log.Warnf("net.ipv4.tcp_early_demux is enabled; this must be disabled for health probes " +
-				"to work with AWS Security Groups for Pods. Set DISABLE_TCP_EARLY_DEMUX=true on the aws-node daemonset.")
-		}
-	})
-}

--- a/cni/pkg/nodeagent/brancheni_linux.go
+++ b/cni/pkg/nodeagent/brancheni_linux.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
+
+	pconstants "istio.io/istio/cni/pkg/constants"
 )
 
 // branchENIRoute holds the routing table, veth name, and the priority of aws-vpc-cni's
@@ -47,7 +49,7 @@ var (
 // See https://docs.aws.amazon.com/eks/latest/userguide/security-groups-pods-deployment.html
 func tcpEarlyDemuxIsDisabled() bool {
 	earlyDemuxOnce.Do(func() {
-		const path = "/proc/sys/net/ipv4/tcp_early_demux"
+		path := pconstants.HostMountsPath + "/proc/sys/net/ipv4/tcp_early_demux"
 		data, err := os.ReadFile(path)
 		if err != nil {
 			log.Debugf("could not read %s, assuming default (enabled): %v", path, err)

--- a/cni/pkg/nodeagent/brancheni_linux.go
+++ b/cni/pkg/nodeagent/brancheni_linux.go
@@ -1,0 +1,234 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodeagent
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+	"os"
+	"sync"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+// branchENIRoute holds the routing table, veth info, and the priority of aws-vpc-cni's
+// iif rule for a branch ENI pod.
+type branchENIRoute struct {
+	table       int
+	vethIndex   int
+	vethName    string
+	iifPriority int // priority of aws-vpc-cni's "iif <veth> lookup <table>" rule
+}
+
+var earlyDemuxOnce sync.Once
+
+// detectBranchENI checks if a pod IP is routed via a branch ENI (i.e., the route
+// exists only in a non-main routing table, indicating aws-vpc-cni SGP setup).
+// Returns nil if the pod uses standard veth routing (route in main table).
+//
+// Detection: scan ip rules for iif-based entries whose routing table
+// contains a host route to the pod IP. If found, this is a branch ENI pod.
+// If not found, it's a regular veth pod (no action needed).
+//
+// Regular veth pods have destination-based rules ("512: to <podIP> lookup main")
+// and never have iif rules. Only branch ENI pods get iif rules from aws-vpc-cni.
+//
+// This approach avoids hardcoding table ranges or priorities and works for
+// both IPv4 and IPv6.
+func detectBranchENI(podIP netip.Addr) *branchENIRoute {
+	ip := net.IP(podIP.AsSlice())
+
+	family := unix.AF_INET
+	if podIP.Is6() {
+		family = unix.AF_INET6
+	}
+
+	rules, err := netlink.RuleList(family)
+	if err != nil {
+		log.Debugf("failed to list ip rules: %v", err)
+		return nil
+	}
+
+	// Build a map of table -> iif rules for quick lookup.
+	type iifRule struct {
+		iifName  string
+		priority int
+	}
+	tableIIFRules := make(map[int][]iifRule)
+	for _, rule := range rules {
+		if rule.IifName == "" || rule.Table <= 0 || rule.Table == 254 || rule.Table == 255 {
+			continue
+		}
+		tableIIFRules[rule.Table] = append(tableIIFRules[rule.Table], iifRule{
+			iifName:  rule.IifName,
+			priority: rule.Priority,
+		})
+	}
+
+	// For each table that has iif rules, check if it contains a host route to our pod.
+	for table, iifRules := range tableIIFRules {
+		tableRoutes, err := netlink.RouteListFiltered(unix.AF_UNSPEC, &netlink.Route{
+			Table: table,
+		}, netlink.RT_FILTER_TABLE)
+		if err != nil {
+			continue
+		}
+
+		for _, r := range tableRoutes {
+			if r.Dst == nil || !r.Dst.IP.Equal(ip) {
+				continue
+			}
+			ones, _ := r.Dst.Mask.Size()
+			if ones != 32 && ones != 128 {
+				continue
+			}
+			// Found a host route to the pod in this table.
+			// Now find the iif rule whose device matches the route's link index.
+			routeLink, err := netlink.LinkByIndex(r.LinkIndex)
+			if err != nil {
+				continue
+			}
+			routeDevName := routeLink.Attrs().Name
+
+			for _, ir := range iifRules {
+				if ir.iifName == routeDevName {
+					log.Infof("detected branch ENI pod %s: veth=%s table=%d iifPriority=%d",
+						podIP, routeDevName, table, ir.priority)
+					return &branchENIRoute{
+						table:       table,
+						vethIndex:   r.LinkIndex,
+						vethName:    routeDevName,
+						iifPriority: ir.priority,
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// addBranchENIRules adds ip rules to route probe traffic via the veth for a branch ENI pod.
+// This is needed because aws-vpc-cni routes branch ENI pod traffic through VPC fabric,
+// which cannot handle the link-local SNAT address (169.254.7.127) used by istio-cni.
+//
+// Two rules are added:
+//   - Forward path: "ip rule add to <podIP> lookup <table> priority 512"
+//     Routes host-originated traffic to the pod via the veth instead of VPC gateway.
+//     Priority 512 matches what aws-vpc-cni uses for regular veth pods.
+//   - Return path: "ip rule add iif <veth> lookup local priority <N>"
+//     Ensures reply traffic from the pod is delivered locally (to conntrack/kubelet)
+//     instead of being hijacked by aws-vpc-cni's iif rule that routes it back to VPC.
+//     Priority is set to one less than aws-vpc-cni's iif rule priority.
+func addBranchENIRules(podIP netip.Addr, info *branchENIRoute) error {
+	ip := net.IP(podIP.AsSlice())
+	family := unix.AF_INET
+	bits := 32
+	if podIP.Is6() {
+		family = unix.AF_INET6
+		bits = 128
+	}
+
+	// Forward path: route to pod via veth
+	fwdRule := netlink.NewRule()
+	fwdRule.Family = family
+	fwdRule.Dst = &net.IPNet{IP: ip, Mask: net.CIDRMask(bits, bits)}
+	fwdRule.Table = info.table
+	fwdRule.Priority = 512
+
+	if err := netlink.RuleAdd(fwdRule); err != nil {
+		if !os.IsExist(err) {
+			return fmt.Errorf("failed to add forward ip rule for branch ENI pod %s: %w", podIP, err)
+		}
+	}
+	log.Infof("added branch ENI forward rule: to %s lookup %d priority 512", podIP, info.table)
+
+	// Return path: deliver locally before aws-vpc-cni's iif rule.
+	// Insert at priority one less than the existing iif rule so we run first.
+	retPriority := info.iifPriority - 1
+	if retPriority < 0 {
+		retPriority = 0
+	}
+
+	retRule := netlink.NewRule()
+	retRule.Family = family
+	retRule.IifName = info.vethName
+	retRule.Table = 255 // 255 = local table
+	retRule.Priority = retPriority
+
+	if err := netlink.RuleAdd(retRule); err != nil {
+		if !os.IsExist(err) {
+			return fmt.Errorf("failed to add return ip rule for branch ENI veth %s: %w", info.vethName, err)
+		}
+	}
+	log.Infof("added branch ENI return rule: iif %s lookup local priority %d", info.vethName, retPriority)
+
+	return nil
+}
+
+// delBranchENIRules removes the ip rules added by addBranchENIRules.
+// Errors are logged but not returned since removal is best-effort
+// (the pod may already be gone, rules may have been cleaned up, etc).
+func delBranchENIRules(podIP netip.Addr, info *branchENIRoute) {
+	ip := net.IP(podIP.AsSlice())
+	family := unix.AF_INET
+	bits := 32
+	if podIP.Is6() {
+		family = unix.AF_INET6
+		bits = 128
+	}
+
+	fwdRule := netlink.NewRule()
+	fwdRule.Family = family
+	fwdRule.Dst = &net.IPNet{IP: ip, Mask: net.CIDRMask(bits, bits)}
+	fwdRule.Table = info.table
+	fwdRule.Priority = 512
+	if err := netlink.RuleDel(fwdRule); err != nil {
+		log.Debugf("failed to remove branch ENI forward rule for %s: %v", podIP, err)
+	}
+
+	retPriority := info.iifPriority - 1
+	if retPriority < 0 {
+		retPriority = 0
+	}
+	retRule := netlink.NewRule()
+	retRule.Family = family
+	retRule.IifName = info.vethName
+	retRule.Table = 255
+	retRule.Priority = retPriority
+	if err := netlink.RuleDel(retRule); err != nil {
+		log.Debugf("failed to remove branch ENI return rule for %s: %v", info.vethName, err)
+	}
+
+	log.Infof("removed branch ENI rules for pod %s veth %s", podIP, info.vethName)
+}
+
+// checkTCPEarlyDemux warns if net.ipv4.tcp_early_demux is enabled, which
+// breaks kubelet connectivity to pods on branch ENIs.
+// See https://docs.aws.amazon.com/eks/latest/userguide/security-groups-pods-deployment.html
+func checkTCPEarlyDemux() {
+	earlyDemuxOnce.Do(func() {
+		const path = "/proc/sys/net/ipv4/tcp_early_demux"
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return
+		}
+		if len(data) > 0 && data[0] == '1' {
+			log.Warnf("net.ipv4.tcp_early_demux is enabled; this must be disabled for health probes " +
+				"to work with AWS Security Groups for Pods. Set DISABLE_TCP_EARLY_DEMUX=true on the aws-node daemonset.")
+		}
+	})
+}

--- a/cni/pkg/nodeagent/brancheni_linux.go
+++ b/cni/pkg/nodeagent/brancheni_linux.go
@@ -258,4 +258,3 @@ func delBranchENIRules(podIP netip.Addr, info *branchENIRoute) {
 
 	log.Debugf("removed branch ENI rules for pod %s veth %s", podIP, info.vethName)
 }
-

--- a/cni/pkg/nodeagent/brancheni_linux.go
+++ b/cni/pkg/nodeagent/brancheni_linux.go
@@ -15,6 +15,7 @@
 package nodeagent
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
@@ -25,11 +26,10 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// branchENIRoute holds the routing table, veth info, and the priority of aws-vpc-cni's
+// branchENIRoute holds the routing table, veth name, and the priority of aws-vpc-cni's
 // iif rule for a branch ENI pod.
 type branchENIRoute struct {
 	table       int
-	vethIndex   int
 	vethName    string
 	iifPriority int // priority of aws-vpc-cni's "iif <veth> lookup <table>" rule
 }
@@ -106,11 +106,10 @@ func detectBranchENI(podIP netip.Addr) *branchENIRoute {
 
 			for _, ir := range iifRules {
 				if ir.iifName == routeDevName {
-					log.Infof("detected branch ENI pod %s: veth=%s table=%d iifPriority=%d",
+					log.Debugf("detected branch ENI pod %s: veth=%s table=%d iifPriority=%d",
 						podIP, routeDevName, table, ir.priority)
 					return &branchENIRoute{
 						table:       table,
-						vethIndex:   r.LinkIndex,
 						vethName:    routeDevName,
 						iifPriority: ir.priority,
 					}
@@ -134,6 +133,10 @@ func detectBranchENI(podIP netip.Addr) *branchENIRoute {
 //     instead of being hijacked by aws-vpc-cni's iif rule that routes it back to VPC.
 //     Priority is set to one less than aws-vpc-cni's iif rule priority.
 func addBranchENIRules(podIP netip.Addr, info *branchENIRoute) error {
+	// Warn once per process if tcp_early_demux is enabled, since we are about
+	// to add rules that only work correctly when it is disabled.
+	checkTCPEarlyDemux()
+
 	ip := net.IP(podIP.AsSlice())
 	family := unix.AF_INET
 	bits := 32
@@ -149,12 +152,15 @@ func addBranchENIRules(podIP netip.Addr, info *branchENIRoute) error {
 	fwdRule.Table = info.table
 	fwdRule.Priority = 512
 
+	fwdAdded := false
 	if err := netlink.RuleAdd(fwdRule); err != nil {
-		if !os.IsExist(err) {
+		if !errors.Is(err, unix.EEXIST) {
 			return fmt.Errorf("failed to add forward ip rule for branch ENI pod %s: %w", podIP, err)
 		}
+	} else {
+		fwdAdded = true
 	}
-	log.Infof("added branch ENI forward rule: to %s lookup %d priority 512", podIP, info.table)
+	log.Debugf("added branch ENI forward rule: to %s lookup %d priority 512", podIP, info.table)
 
 	// Return path: deliver locally before aws-vpc-cni's iif rule.
 	// Insert at priority one less than the existing iif rule so we run first.
@@ -170,11 +176,17 @@ func addBranchENIRules(podIP netip.Addr, info *branchENIRoute) error {
 	retRule.Priority = retPriority
 
 	if err := netlink.RuleAdd(retRule); err != nil {
-		if !os.IsExist(err) {
+		if !errors.Is(err, unix.EEXIST) {
+			// Rollback the forward rule so we don't leave a stale entry on the host.
+			if fwdAdded {
+				if delErr := netlink.RuleDel(fwdRule); delErr != nil {
+					log.Warnf("failed to rollback forward ip rule for branch ENI pod %s: %v", podIP, delErr)
+				}
+			}
 			return fmt.Errorf("failed to add return ip rule for branch ENI veth %s: %w", info.vethName, err)
 		}
 	}
-	log.Infof("added branch ENI return rule: iif %s lookup local priority %d", info.vethName, retPriority)
+	log.Debugf("added branch ENI return rule: iif %s lookup local priority %d", info.vethName, retPriority)
 
 	return nil
 }
@@ -213,7 +225,7 @@ func delBranchENIRules(podIP netip.Addr, info *branchENIRoute) {
 		log.Debugf("failed to remove branch ENI return rule for %s: %v", info.vethName, err)
 	}
 
-	log.Infof("removed branch ENI rules for pod %s veth %s", podIP, info.vethName)
+	log.Debugf("removed branch ENI rules for pod %s veth %s", podIP, info.vethName)
 }
 
 // checkTCPEarlyDemux warns if net.ipv4.tcp_early_demux is enabled, which

--- a/cni/pkg/nodeagent/brancheni_linux_test.go
+++ b/cni/pkg/nodeagent/brancheni_linux_test.go
@@ -24,11 +24,20 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// forceEarlyDemuxDisabled sets the one-shot sysctl gate to "disabled"
+// so tests can exercise detection without depending on the host sysctl.
+func forceEarlyDemuxDisabled(t *testing.T) {
+	t.Helper()
+	earlyDemuxOnce = sync.Once{}
+	earlyDemuxOnce.Do(func() {})
+	earlyDemuxDisabled = true
+}
+
 func TestDetectBranchENI_NoBranchENI(t *testing.T) {
 	// When there are no iif rules, detectBranchENI should return nil.
 	// This test verifies that on a system without branch ENI pods,
 	// the detection is a no-op.
-	// Note: this test runs on the test host which won't have branch ENI rules.
+	forceEarlyDemuxDisabled(t)
 	podIP := netip.MustParseAddr("10.0.0.1")
 	result := detectBranchENI(podIP)
 	if result != nil {
@@ -37,6 +46,7 @@ func TestDetectBranchENI_NoBranchENI(t *testing.T) {
 }
 
 func TestDetectBranchENI_IPv6NoBranchENI(t *testing.T) {
+	forceEarlyDemuxDisabled(t)
 	podIP := netip.MustParseAddr("fd00::1")
 	result := detectBranchENI(podIP)
 	if result != nil {
@@ -174,17 +184,20 @@ func TestAddDelBranchENIRules_IPv6(t *testing.T) {
 	}
 }
 
-func TestCheckTCPEarlyDemux(t *testing.T) {
-	// Just verify it doesn't panic. The actual sysctl check is best tested
-	// in integration since it depends on /proc.
-	earlyDemuxOnce = sync.Once{} // reset for test
-	checkTCPEarlyDemux()
+func TestTCPEarlyDemuxIsDisabled(t *testing.T) {
+	// On a stock host, tcp_early_demux defaults to 1, so detection should skip.
+	// This mainly verifies the gate returns without panicking; the actual sysctl
+	// value is host-dependent, so we don't assert a specific result.
+	earlyDemuxOnce = sync.Once{}
+	earlyDemuxDisabled = false
+	_ = tcpEarlyDemuxIsDisabled()
 }
 
 func TestDetectBranchENI_WithIIFRule(t *testing.T) {
 	if unix.Getuid() != 0 {
 		t.Skip("requires root for netlink operations")
 	}
+	forceEarlyDemuxDisabled(t)
 
 	// Set up a fake branch ENI environment:
 	// 1. Create a route in table 197 for a test IP via loopback

--- a/cni/pkg/nodeagent/brancheni_linux_test.go
+++ b/cni/pkg/nodeagent/brancheni_linux_test.go
@@ -1,0 +1,247 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodeagent
+
+import (
+	"net"
+	"net/netip"
+	"sync"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+func TestDetectBranchENI_NoBranchENI(t *testing.T) {
+	// When there are no iif rules, detectBranchENI should return nil.
+	// This test verifies that on a system without branch ENI pods,
+	// the detection is a no-op.
+	// Note: this test runs on the test host which won't have branch ENI rules.
+	podIP := netip.MustParseAddr("10.0.0.1")
+	result := detectBranchENI(podIP)
+	if result != nil {
+		t.Errorf("expected nil for non-branch-ENI pod, got %+v", result)
+	}
+}
+
+func TestDetectBranchENI_IPv6NoBranchENI(t *testing.T) {
+	podIP := netip.MustParseAddr("fd00::1")
+	result := detectBranchENI(podIP)
+	if result != nil {
+		t.Errorf("expected nil for non-branch-ENI IPv6 pod, got %+v", result)
+	}
+}
+
+func TestAddDelBranchENIRules_IPv4(t *testing.T) {
+	// Skip if not root - netlink rule operations require CAP_NET_ADMIN
+	if unix.Getuid() != 0 {
+		t.Skip("requires root for netlink operations")
+	}
+
+	podIP := netip.MustParseAddr("10.99.99.99")
+	info := &branchENIRoute{
+		table:       199,
+		vethIndex:   1,
+		vethName:    "lo", // use loopback as a stand-in
+		iifPriority: 10,
+	}
+
+	// Create the routing table with a host route (needed for cleanup detection)
+	lo, err := netlink.LinkByName("lo")
+	if err != nil {
+		t.Fatalf("failed to get lo: %v", err)
+	}
+	route := &netlink.Route{
+		Dst:       &net.IPNet{IP: net.ParseIP("10.99.99.99"), Mask: net.CIDRMask(32, 32)},
+		Table:     199,
+		LinkIndex: lo.Attrs().Index,
+		Scope:     netlink.SCOPE_LINK,
+	}
+	if err := netlink.RouteAdd(route); err != nil {
+		t.Fatalf("failed to add test route: %v", err)
+	}
+	defer netlink.RouteDel(route)
+
+	// Add rules
+	if err := addBranchENIRules(podIP, info); err != nil {
+		t.Fatalf("addBranchENIRules failed: %v", err)
+	}
+
+	// Verify forward rule exists
+	rules, _ := netlink.RuleList(unix.AF_INET)
+	foundFwd := false
+	foundRet := false
+	for _, r := range rules {
+		if r.Priority == 512 && r.Table == 199 && r.Dst != nil && r.Dst.IP.Equal(net.ParseIP("10.99.99.99")) {
+			foundFwd = true
+		}
+		if r.Priority == 9 && r.Table == 255 && r.IifName == "lo" {
+			foundRet = true
+		}
+	}
+	if !foundFwd {
+		t.Error("forward rule not found after addBranchENIRules")
+	}
+	if !foundRet {
+		t.Error("return rule not found after addBranchENIRules")
+	}
+
+	// Delete rules
+	delBranchENIRules(podIP, info)
+
+	// Verify rules are gone
+	rules, _ = netlink.RuleList(unix.AF_INET)
+	for _, r := range rules {
+		if r.Priority == 512 && r.Table == 199 && r.Dst != nil && r.Dst.IP.Equal(net.ParseIP("10.99.99.99")) {
+			t.Error("forward rule still exists after delBranchENIRules")
+		}
+		if r.Priority == 9 && r.Table == 255 && r.IifName == "lo" {
+			t.Error("return rule still exists after delBranchENIRules")
+		}
+	}
+}
+
+func TestAddDelBranchENIRules_IPv6(t *testing.T) {
+	if unix.Getuid() != 0 {
+		t.Skip("requires root for netlink operations")
+	}
+
+	podIP := netip.MustParseAddr("fd99::1")
+	info := &branchENIRoute{
+		table:       198,
+		vethIndex:   1,
+		vethName:    "lo",
+		iifPriority: 10,
+	}
+
+	lo, err := netlink.LinkByName("lo")
+	if err != nil {
+		t.Fatalf("failed to get lo: %v", err)
+	}
+	route := &netlink.Route{
+		Dst:       &net.IPNet{IP: net.ParseIP("fd99::1"), Mask: net.CIDRMask(128, 128)},
+		Table:     198,
+		LinkIndex: lo.Attrs().Index,
+		Scope:     netlink.SCOPE_LINK,
+	}
+	if err := netlink.RouteAdd(route); err != nil {
+		t.Fatalf("failed to add test route: %v", err)
+	}
+	defer netlink.RouteDel(route)
+
+	if err := addBranchENIRules(podIP, info); err != nil {
+		t.Fatalf("addBranchENIRules IPv6 failed: %v", err)
+	}
+
+	rules, _ := netlink.RuleList(unix.AF_INET6)
+	foundFwd := false
+	foundRet := false
+	for _, r := range rules {
+		if r.Priority == 512 && r.Table == 198 && r.Dst != nil && r.Dst.IP.Equal(net.ParseIP("fd99::1")) {
+			foundFwd = true
+		}
+		if r.Priority == 9 && r.Table == 255 && r.IifName == "lo" {
+			foundRet = true
+		}
+	}
+	if !foundFwd {
+		t.Error("IPv6 forward rule not found")
+	}
+	if !foundRet {
+		t.Error("IPv6 return rule not found")
+	}
+
+	delBranchENIRules(podIP, info)
+
+	rules, _ = netlink.RuleList(unix.AF_INET6)
+	for _, r := range rules {
+		if r.Priority == 512 && r.Table == 198 && r.Dst != nil && r.Dst.IP.Equal(net.ParseIP("fd99::1")) {
+			t.Error("IPv6 forward rule still exists after delete")
+		}
+		if r.Priority == 9 && r.Table == 255 && r.IifName == "lo" {
+			t.Error("IPv6 return rule still exists after delete")
+		}
+	}
+}
+
+func TestCheckTCPEarlyDemux(t *testing.T) {
+	// Just verify it doesn't panic. The actual sysctl check is best tested
+	// in integration since it depends on /proc.
+	earlyDemuxOnce = sync.Once{} // reset for test
+	checkTCPEarlyDemux()
+}
+
+func TestDetectBranchENI_WithIIFRule(t *testing.T) {
+	if unix.Getuid() != 0 {
+		t.Skip("requires root for netlink operations")
+	}
+
+	// Set up a fake branch ENI environment:
+	// 1. Create a route in table 197 for a test IP via loopback
+	// 2. Create an iif rule for loopback pointing to table 197
+	// 3. detectBranchENI should find it
+
+	podIP := netip.MustParseAddr("10.88.88.88")
+
+	lo, err := netlink.LinkByName("lo")
+	if err != nil {
+		t.Fatalf("failed to get lo: %v", err)
+	}
+
+	// Add host route in table 197
+	route := &netlink.Route{
+		Dst:       &net.IPNet{IP: net.ParseIP("10.88.88.88"), Mask: net.CIDRMask(32, 32)},
+		Table:     197,
+		LinkIndex: lo.Attrs().Index,
+		Scope:     netlink.SCOPE_LINK,
+	}
+	if err := netlink.RouteAdd(route); err != nil {
+		t.Fatalf("failed to add test route: %v", err)
+	}
+	defer netlink.RouteDel(route)
+
+	// Add iif rule
+	rule := netlink.NewRule()
+	rule.Family = unix.AF_INET
+	rule.IifName = "lo"
+	rule.Table = 197
+	rule.Priority = 10
+	if err := netlink.RuleAdd(rule); err != nil {
+		t.Fatalf("failed to add test rule: %v", err)
+	}
+	defer netlink.RuleDel(rule)
+
+	// Detect
+	result := detectBranchENI(podIP)
+	if result == nil {
+		t.Fatal("expected to detect branch ENI, got nil")
+	}
+	if result.table != 197 {
+		t.Errorf("expected table 197, got %d", result.table)
+	}
+	if result.vethName != "lo" {
+		t.Errorf("expected veth 'lo', got %s", result.vethName)
+	}
+	if result.iifPriority != 10 {
+		t.Errorf("expected iifPriority 10, got %d", result.iifPriority)
+	}
+}
+
+func TestFeatureFlag(t *testing.T) {
+	// Verify the feature flag variable exists and defaults to true
+	if !EnableAWSBranchENIProbe {
+		t.Error("EnableAWSBranchENIProbe should default to true")
+	}
+}

--- a/cni/pkg/nodeagent/brancheni_linux_test.go
+++ b/cni/pkg/nodeagent/brancheni_linux_test.go
@@ -53,7 +53,6 @@ func TestAddDelBranchENIRules_IPv4(t *testing.T) {
 	podIP := netip.MustParseAddr("10.99.99.99")
 	info := &branchENIRoute{
 		table:       199,
-		vethIndex:   1,
 		vethName:    "lo", // use loopback as a stand-in
 		iifPriority: 10,
 	}
@@ -121,7 +120,6 @@ func TestAddDelBranchENIRules_IPv6(t *testing.T) {
 	podIP := netip.MustParseAddr("fd99::1")
 	info := &branchENIRoute{
 		table:       198,
-		vethIndex:   1,
 		vethName:    "lo",
 		iifPriority: 10,
 	}

--- a/cni/pkg/nodeagent/meshdataplane_linux.go
+++ b/cni/pkg/nodeagent/meshdataplane_linux.go
@@ -260,6 +260,19 @@ func (s *meshDataplane) addPodToHostAddrSet(pod *corev1.Pod, podIPs []netip.Addr
 			} else {
 				addedIps = append(addedIps, pip)
 			}
+
+			// Detect branch ENI pods (AWS VPC CNI with Security Groups for Pods).
+			// These pods route through VPC fabric by default, which cannot handle
+			// the link-local SNAT address used for probe identification.
+			// Fix: add ip rules to route probe traffic via the existing veth pair.
+			if EnableAWSBranchENIProbe {
+				if info := detectBranchENI(pip); info != nil {
+					checkTCPEarlyDemux()
+					if err := addBranchENIRules(pip, info); err != nil {
+						log.Errorf("failed to add branch ENI rules for pod %s: %v", pip, err)
+					}
+				}
+			}
 		}
 		return nil
 	})
@@ -286,6 +299,13 @@ func removePodFromHostAddrSet(pod *corev1.Pod, hostsideProbeSet set.AddressSetMa
 				log.Warnf("pod ip %s could not be removed from addressSet, found entry with pod UID %s instead", pip, uidMismatch)
 			}
 			log.Debugf("removed pod from host addressSet by ip %s", pip)
+
+			// Clean up branch ENI rules if they were added
+			if EnableAWSBranchENIProbe {
+				if info := detectBranchENI(pip); info != nil {
+					delBranchENIRules(pip, info)
+				}
+			}
 		}
 		return nil
 	})

--- a/cni/pkg/nodeagent/meshdataplane_linux.go
+++ b/cni/pkg/nodeagent/meshdataplane_linux.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"net/netip"
+	"sync"
 
 	"golang.org/x/sys/unix"
 	corev1 "k8s.io/api/core/v1"
@@ -33,6 +34,12 @@ type meshDataplane struct {
 	netServer          MeshDataplane
 	hostTrafficManager trafficmanager.TrafficRuleManager
 	hostAddrSet        set.AddressSetManager
+
+	// branchENIRules tracks the branch ENI routing info we added rules for,
+	// keyed by pod IP. We cache it at add time so teardown can delete the rules
+	// even if aws-vpc-cni has already removed its iif rule (making re-detection fail).
+	branchENIMu    sync.Mutex
+	branchENIRules map[netip.Addr]*branchENIRoute
 }
 
 // ConstructInitialSnapshot is always called first, before Start.
@@ -69,11 +76,49 @@ func (s *meshDataplane) Stop(skipCleanup bool) {
 			if err := s.hostAddrSet.DestroySet(); err != nil {
 				log.Warnf("could not destroy host addressSet on shutdown")
 			}
+			// Clean up any branch ENI ip rules we added. We use the cached info
+			// instead of re-detecting, since aws-vpc-cni may have already torn
+			// down its iif rules by the time we run.
+			s.flushBranchENIRules()
 			return nil
 		})
 	}
 
 	s.netServer.Stop(skipCleanup)
+}
+
+// rememberBranchENIRoute caches the branch ENI info for a pod IP so we can
+// clean up its rules later without re-scanning.
+func (s *meshDataplane) rememberBranchENIRoute(podIP netip.Addr, info *branchENIRoute) {
+	s.branchENIMu.Lock()
+	defer s.branchENIMu.Unlock()
+	if s.branchENIRules == nil {
+		s.branchENIRules = map[netip.Addr]*branchENIRoute{}
+	}
+	s.branchENIRules[podIP] = info
+}
+
+// forgetBranchENIRoute removes a cached branch ENI entry and returns it.
+func (s *meshDataplane) forgetBranchENIRoute(podIP netip.Addr) *branchENIRoute {
+	s.branchENIMu.Lock()
+	defer s.branchENIMu.Unlock()
+	info, ok := s.branchENIRules[podIP]
+	if !ok {
+		return nil
+	}
+	delete(s.branchENIRules, podIP)
+	return info
+}
+
+// flushBranchENIRules removes ip rules for every branch ENI entry we remembered.
+func (s *meshDataplane) flushBranchENIRules() {
+	s.branchENIMu.Lock()
+	cached := s.branchENIRules
+	s.branchENIRules = nil
+	s.branchENIMu.Unlock()
+	for podIP, info := range cached {
+		delBranchENIRules(podIP, info)
+	}
 }
 
 // AddPodToMesh attempts to inject iptables rules into the pod, and sends the pod to ztunnel.
@@ -157,7 +202,7 @@ func (s *meshDataplane) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod, 
 
 	// Remove the hostside ipset entry first, and unconditionally - if later failures happen, we never
 	// want to leave stale entries (and the pod healthchecks will start to fail, which is a good signal)
-	if err := removePodFromHostAddrSet(pod, s.hostAddrSet); err != nil {
+	if err := s.removePodFromHostAddrSet(pod); err != nil {
 		log.Errorf("failed to remove pod %s from host addressSet, error was: %v", pod.Name, err)
 		// Removing pod from ipset should never fail, even if the IP is no longer there
 		// (unless we have a kernel incompatibility).
@@ -267,9 +312,10 @@ func (s *meshDataplane) addPodToHostAddrSet(pod *corev1.Pod, podIPs []netip.Addr
 			// Fix: add ip rules to route probe traffic via the existing veth pair.
 			if EnableAWSBranchENIProbe {
 				if info := detectBranchENI(pip); info != nil {
-					checkTCPEarlyDemux()
 					if err := addBranchENIRules(pip, info); err != nil {
 						log.Errorf("failed to add branch ENI rules for pod %s: %v", pip, err)
+					} else {
+						s.rememberBranchENIRoute(pip, info)
 					}
 				}
 			}
@@ -286,23 +332,25 @@ func (s *meshDataplane) addPodToHostAddrSet(pod *corev1.Pod, podIPs []netip.Addr
 // removePodFromHostAddrSet will remove (v4, v6) pod IPs from the host IP set(s).
 // Note that unlike when we add the IP to the set, on removal we will simply
 // skip removing the IP if the IP matches, but the UID comment does not match our pod.
-func removePodFromHostAddrSet(pod *corev1.Pod, hostsideProbeSet set.AddressSetManager) error {
+func (s *meshDataplane) removePodFromHostAddrSet(pod *corev1.Pod) error {
 	podUID := string(pod.ObjectMeta.UID)
-	log := log.WithLabels("ns", pod.Namespace, "name", pod.Name, "podUID", podUID, "ipset", hostsideProbeSet.GetPrefix())
+	log := log.WithLabels("ns", pod.Namespace, "name", pod.Name, "podUID", podUID, "ipset", s.hostAddrSet.GetPrefix())
 
 	podIPs := util.GetPodIPsIfPresent(pod)
 	return util.RunAsHost(func() error {
 		for _, pip := range podIPs {
-			if uidMismatch, err := hostsideProbeSet.ClearEntriesWithIPAndComment(pip, podUID); err != nil {
+			if uidMismatch, err := s.hostAddrSet.ClearEntriesWithIPAndComment(pip, podUID); err != nil {
 				return err
 			} else if uidMismatch != "" {
 				log.Warnf("pod ip %s could not be removed from addressSet, found entry with pod UID %s instead", pip, uidMismatch)
 			}
 			log.Debugf("removed pod from host addressSet by ip %s", pip)
 
-			// Clean up branch ENI rules if they were added
+			// Clean up branch ENI rules if we added any. Use the cached info from
+			// the add path instead of re-detecting, since aws-vpc-cni may have
+			// already torn down its iif rules.
 			if EnableAWSBranchENIProbe {
-				if info := detectBranchENI(pip); info != nil {
+				if info := s.forgetBranchENIRoute(pip); info != nil {
 					delBranchENIRules(pip, info)
 				}
 			}

--- a/cni/pkg/nodeagent/options.go
+++ b/cni/pkg/nodeagent/options.go
@@ -31,6 +31,8 @@ var (
 	HostProbeSNATIP                = netip.MustParseAddr(env.RegisterStringVar("HOST_PROBE_SNAT_IP", DefaultHostProbeSNATIP, "").Get())
 	HostProbeSNATIPV6              = netip.MustParseAddr(env.RegisterStringVar("HOST_PROBE_SNAT_IPV6", DefaultHostProbeSNATIPV6, "").Get())
 	UseScopedIptablesLegacyLocking = env.RegisterBoolVar("AMBIENT_USE_SCOPED_XTABLES_LOCKING", true, "").Get()
+	EnableAWSBranchENIProbe        = env.RegisterBoolVar("AMBIENT_ENABLE_AWS_BRANCH_ENI_PROBE", true,
+		"If true, detect AWS VPC CNI branch ENI pods and add ip rules to route probe traffic via veth").Get()
 )
 
 const (

--- a/cni/pkg/nodeagent/server_linux_test.go
+++ b/cni/pkg/nodeagent/server_linux_test.go
@@ -460,7 +460,8 @@ func TestMeshDataplaneRemovePodIPFromHostNSIPSets(t *testing.T) {
 		string(pod.ObjectMeta.UID),
 	).Return("", nil)
 
-	err := removePodFromHostAddrSet(pod, setWrapper)
+	dp := &meshDataplane{hostAddrSet: setWrapper}
+	err := dp.removePodFromHostAddrSet(pod)
 	assert.NoError(t, err)
 	fakeIPSetDeps.AssertExpectations(t)
 }
@@ -484,7 +485,8 @@ func TestMeshDataplaneRemovePodIPFromHostNSIPSetsIgnoresEntriesWithMismatchedUID
 		string(pod.ObjectMeta.UID),
 	).Return("mismatched-uid", nil)
 
-	err := removePodFromHostAddrSet(pod, setWrapper)
+	dp := &meshDataplane{hostAddrSet: setWrapper}
+	err := dp.removePodFromHostAddrSet(pod)
 	assert.NoError(t, err)
 	fakeIPSetDeps.AssertExpectations(t)
 }

--- a/releasenotes/notes/aws-brancheni-probe-fix.yaml
+++ b/releasenotes/notes/aws-brancheni-probe-fix.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+releaseNotes:
+  - |
+    **Fixed** kubelet health probe failures for ambient mesh pods on AWS EKS when using
+    Security Groups for Pods (branch ENI). istio-cni now detects branch ENI pods and
+    adds ip rules to route probe traffic via the veth pair instead of VPC fabric.
+    Gated behind `AMBIENT_ENABLE_AWS_BRANCH_ENI_PROBE` (enabled by default).


### PR DESCRIPTION
**Please provide a description of this PR:**

## problem

kubelet health probes (liveness/readiness/startup) fail for ambient mesh pods when AWS VPC CNI is configured with Security Groups for Pods (SGP). pods go into CrashLoopBackOff.

SGP places pods on branch ENIs (VLAN-tagged interfaces on a trunk ENI). host-to-pod traffic for branch ENI pods routes through AWS VPC fabric instead of kernel veth pairs. istio-cni SNATs probe traffic to a link-local address (169.254.7.127 / fd16:9254:7127:1337:ffff:ffff:ffff:ffff) which is unroutable in VPC, so the probe reply is dropped.

regular (non-SGP) pods use veth pairs where the packet stays in-kernel and conntrack handles the de-SNAT. branch ENI pods have a veth too, but aws-vpc-cni's routing policy sends all traffic through VPC for security group enforcement.

## fix

istio-cni detects branch ENI pods during pod setup and adds two ip rules on the host to route probe traffic via the existing veth pair:

- **forward**: `ip rule add to <podIP> lookup <table> priority 512` - routes host-originated traffic to the pod via veth instead of VPC gateway
- **return**: `ip rule add iif <veth> lookup local priority <N>` - delivers reply traffic locally instead of being hijacked by aws-vpc-cni's iif rule back to VPC

this makes the probe flow identical to regular veth pods: SNAT in host POSTROUTING, packet via veth, pod accepts src=169.254.7.127, reply via veth, conntrack de-SNATs, kubelet gets reply.

no changes to SNAT address, ztunnel logic, or pod-side iptables rules. the fix is gated behind a feature flag `AMBIENT_ENABLE_AWS_BRANCH_ENI_PROBE` (enabled by default). disable with `AMBIENT_ENABLE_AWS_BRANCH_ENI_PROBE=false` on the istio-cni daemonset if the detection causes issues.

prerequisite: `net.ipv4.tcp_early_demux=0` on the node (already required by AWS for SGP, see https://docs.aws.amazon.com/eks/latest/userguide/security-groups-pods-deployment.html).

## detection

istio-cni reads existing ip rules (netlink.RuleList) to find `iif <veth> lookup <table>` entries where `<table>` contains a host route (/32 or /128) to the pod IP via the iif device.

- no hardcoded table ranges or priorities - adapts to whatever aws-vpc-cni configures
- works for both IPv4 and IPv6
- regular veth pods never have iif rules, so detection returns nil (no action taken)
- rules are cleaned up when the pod is removed from the mesh

## security considerations

**does this bypass security group enforcement?**

the forward ip rule routes ALL host-originated traffic to the pod via veth, not just probes. in practice, the only host-originated traffic going directly to a pod IP is kubelet probes. pod-to-pod traffic enters via an interface, hits the iif rules at priority 10 (before our priority 512), and goes to VPC as normal.

this is consistent with AWS's approach.

**no change to probe discrimination**: the SNAT address 169.254.7.127 is preserved. only traffic from local sockets (--socket-exists) matching probe port ipset gets SNATed. kube-proxy forwarded traffic is unaffected.

## false positive risk

detection requires all three: (1) iif rule (2) per-pod routing table (3) host route to pod IP via the iif device. this pattern is specific to aws-vpc-cni SGP. other CNIs (Calico, Cilium, regular aws-vpc-cni without SGP) don't create iif rules with per-pod routing tables. no known false positives. additionally `net.ipv4.tcp_early_demux=0` is being checked and it's 1 by default, it means it was the environment operator's conscious decision. 

## dependency on iptables vs nftables

the fix uses `ip rule` and `ip route` via netlink (kernel routing policy). these are independent of iptables/nftables. if aws-vpc-cni or the kernel migrates to nftables, the ip rule mechanism continues to work unchanged.

## testing

manually tested on:
- EKS 1.31 / istio (master when 1.29+ is the latest) / aws-vpc-cni latest
- IPv4 with custom networking + SGP (branch ENI) - clean cluster, fresh install
- IPv6 with SGP (branch ENI) - clean cluster, fresh install
- both liveness and readiness probes, 0 restarts

unit tests coverage:
- detection logic (branch ENI present, not present, IPv4, IPv6)
- rule addition and cleanup
- tcp_early_demux warning
