### PR TITLE
feat: implement allow_any_dynamic_dns mode in outbound traffic policy

### DIFF
--- a/pilot/cmd/pilot-agent/options/options.go
+++ b/pilot/cmd/pilot-agent/options/options.go
@@ -104,8 +104,8 @@ var (
 		"If set to true, starts the DNS server on :15053. This won't automatically capture the DNS traffic and can be used "+
 			"when we want Gateways to resolve DNS using this as Resolver for use cases like Dynamic Forward Proxy")
 
-	// DNSCaptureAddr is the address to listen.
-	DNSCaptureAddr = env.Register("DNS_PROXY_ADDR", "localhost:15053",
+	// DNSCaptureAddr is the address istio-agent listens on for the DNS proxy.
+	DNSCaptureAddr = env.Register("DNS_PROXY_ADDR", constants.DefaultDNSProxyAddr,
 		"Custom address for the DNS proxy. If it ends with :53 and running as root allows running without iptable DNS capture")
 
 	DNSForwardParallel = env.Register("DNS_FORWARD_PARALLEL", false,

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -274,6 +274,12 @@ var (
 	EnableAdditionalIpv4OutboundListenerForIpv6Only = env.RegisterBoolVar("ISTIO_ENABLE_IPV4_OUTBOUND_LISTENER_FOR_IPV6_CLUSTERS", false,
 		"If true, pilot will configure an additional IPv4 listener for outbound traffic in IPv6 only clusters, e.g. AWS EKS IPv6 only clusters.").Get()
 
+	// AllowAnyDynamicDNSMaxHosts caps the number of resolved hosts held in the shared DFP DNS cache
+	// for ALLOW_ANY_DYNAMIC_DNS mode. This matches Envoy's own default (1024) and bounds the memory
+	// used by the cache; raise it for proxies that fan out to a very large number of external hosts.
+	AllowAnyDynamicDNSMaxHosts = env.RegisterIntVar("PILOT_ALLOW_ANY_DYNAMIC_DNS_MAX_HOSTS", 1024,
+		"Maximum number of hosts kept in the dynamic forward proxy DNS cache for ALLOW_ANY_DYNAMIC_DNS outbound traffic mode.").Get()
+
 	EnableVtprotobuf = env.Register("ENABLE_VTPROTOBUF", true,
 		"If true, will use optimized vtprotobuf based marshaling. Requires a build with -tags=vtprotobuf.").Get()
 

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -22,7 +22,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 
-	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
@@ -183,10 +182,6 @@ type SidecarScope struct {
 	// If OutboundTrafficPolicy is ALLOW_ANY traffic to unknown destinations will
 	// be forwarded.
 	OutboundTrafficPolicy *networking.OutboundTrafficPolicy
-
-	// OutboundTrafficPolicyTLS holds the client TLS settings from MeshConfig's
-	// OutboundTrafficPolicy. Applicable only when mode is ALLOW_ANY_DYNAMIC_DNS (mesh-level only).
-	OutboundTrafficPolicyTLS *networking.ClientTLSSettings
 
 	// Set of known configs this sidecar depends on.
 	// This field will be used to determine the config/resource scope
@@ -352,10 +347,6 @@ func initSidecarScopeInternalIndexes(ps *PushContext, sidecarScope *SidecarScope
 		if ps.Mesh.OutboundTrafficPolicy != nil {
 			mode := networking.OutboundTrafficPolicy_Mode(ps.Mesh.OutboundTrafficPolicy.Mode)
 			sidecarScope.OutboundTrafficPolicy = &networking.OutboundTrafficPolicy{Mode: mode}
-			if ps.Mesh.OutboundTrafficPolicy.Mode ==
-				meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY_DYNAMIC_DNS {
-				sidecarScope.OutboundTrafficPolicyTLS = ps.Mesh.OutboundTrafficPolicy.GetTls()
-			}
 		}
 	} else {
 		sidecarScope.OutboundTrafficPolicy = sidecarScope.Sidecar.GetOutboundTrafficPolicy()

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 
+	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
@@ -182,6 +183,10 @@ type SidecarScope struct {
 	// If OutboundTrafficPolicy is ALLOW_ANY traffic to unknown destinations will
 	// be forwarded.
 	OutboundTrafficPolicy *networking.OutboundTrafficPolicy
+
+	// OutboundTrafficPolicyTLS holds the client TLS settings from MeshConfig's
+	// OutboundTrafficPolicy. Applicable only when mode is ALLOW_ANY_DYNAMIC_DNS (mesh-level only).
+	OutboundTrafficPolicyTLS *networking.ClientTLSSettings
 
 	// Set of known configs this sidecar depends on.
 	// This field will be used to determine the config/resource scope
@@ -345,8 +350,11 @@ func initSidecarScopeInternalIndexes(ps *PushContext, sidecarScope *SidecarScope
 
 	if sidecarScope.Sidecar.GetOutboundTrafficPolicy() == nil {
 		if ps.Mesh.OutboundTrafficPolicy != nil {
-			sidecarScope.OutboundTrafficPolicy = &networking.OutboundTrafficPolicy{
-				Mode: networking.OutboundTrafficPolicy_Mode(ps.Mesh.OutboundTrafficPolicy.Mode),
+			mode := networking.OutboundTrafficPolicy_Mode(ps.Mesh.OutboundTrafficPolicy.Mode)
+			sidecarScope.OutboundTrafficPolicy = &networking.OutboundTrafficPolicy{Mode: mode}
+			if ps.Mesh.OutboundTrafficPolicy.Mode ==
+				meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY_DYNAMIC_DNS {
+				sidecarScope.OutboundTrafficPolicyTLS = ps.Mesh.OutboundTrafficPolicy.GetTls()
 			}
 		}
 	} else {

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -3534,6 +3534,70 @@ outboundTrafficPolicy:
 	}
 }
 
+func TestSidecarOutboundTrafficPolicyAllowAnyDynamicDNS(t *testing.T) {
+	tlsSettings := &networking.ClientTLSSettings{
+		Mode: networking.ClientTLSSettings_SIMPLE,
+	}
+	meshWithDynamicDNS := &v1alpha1.MeshConfig{
+		OutboundTrafficPolicy: &v1alpha1.MeshConfig_OutboundTrafficPolicy{
+			Mode: v1alpha1.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY_DYNAMIC_DNS,
+			Tls:  tlsSettings,
+		},
+	}
+	meshWithDynamicDNSNoTLS := &v1alpha1.MeshConfig{
+		OutboundTrafficPolicy: &v1alpha1.MeshConfig_OutboundTrafficPolicy{
+			Mode: v1alpha1.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY_DYNAMIC_DNS,
+		},
+	}
+
+	tests := []struct {
+		name         string
+		meshConfig   *v1alpha1.MeshConfig
+		expectedMode networking.OutboundTrafficPolicy_Mode
+		expectedTLS  *networking.ClientTLSSettings
+	}{
+		{
+			name:         "ALLOW_ANY_DYNAMIC_DNS with TLS propagates TLS settings",
+			meshConfig:   meshWithDynamicDNS,
+			expectedMode: networking.OutboundTrafficPolicy_Mode(v1alpha1.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY_DYNAMIC_DNS),
+			expectedTLS:  tlsSettings,
+		},
+		{
+			name:         "ALLOW_ANY_DYNAMIC_DNS without TLS has nil TLS",
+			meshConfig:   meshWithDynamicDNSNoTLS,
+			expectedMode: networking.OutboundTrafficPolicy_Mode(v1alpha1.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY_DYNAMIC_DNS),
+			expectedTLS:  nil,
+		},
+		{
+			name:         "ALLOW_ANY does not propagate TLS",
+			meshConfig:   mesh.DefaultMeshConfig(),
+			expectedMode: networking.OutboundTrafficPolicy_ALLOW_ANY,
+			expectedTLS:  nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ps := NewPushContext()
+			ps.Mesh = tc.meshConfig
+
+			sidecarScope := convertToSidecarScope(ps, nil, "not-default")
+			if features.EnableLazySidecarEvaluation {
+				sidecarScope.initFunc()
+			}
+
+			gotMode := sidecarScope.OutboundTrafficPolicy.Mode
+			if gotMode != tc.expectedMode {
+				t.Errorf("OutboundTrafficPolicy mode: want %v, got %v", tc.expectedMode, gotMode)
+			}
+
+			if !reflect.DeepEqual(tc.expectedTLS, sidecarScope.OutboundTrafficPolicyTLS) {
+				t.Errorf("OutboundTrafficPolicyTLS: want %v, got %v", tc.expectedTLS, sidecarScope.OutboundTrafficPolicyTLS)
+			}
+		})
+	}
+}
+
 func TestInboundConnectionPoolForPort(t *testing.T) {
 	connectionPoolSettings := &networking.ConnectionPoolSettings{
 		Http: &networking.ConnectionPoolSettings_HTTPSettings{

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -3535,16 +3535,7 @@ outboundTrafficPolicy:
 }
 
 func TestSidecarOutboundTrafficPolicyAllowAnyDynamicDNS(t *testing.T) {
-	tlsSettings := &networking.ClientTLSSettings{
-		Mode: networking.ClientTLSSettings_SIMPLE,
-	}
 	meshWithDynamicDNS := &v1alpha1.MeshConfig{
-		OutboundTrafficPolicy: &v1alpha1.MeshConfig_OutboundTrafficPolicy{
-			Mode: v1alpha1.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY_DYNAMIC_DNS,
-			Tls:  tlsSettings,
-		},
-	}
-	meshWithDynamicDNSNoTLS := &v1alpha1.MeshConfig{
 		OutboundTrafficPolicy: &v1alpha1.MeshConfig_OutboundTrafficPolicy{
 			Mode: v1alpha1.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY_DYNAMIC_DNS,
 		},
@@ -3554,25 +3545,16 @@ func TestSidecarOutboundTrafficPolicyAllowAnyDynamicDNS(t *testing.T) {
 		name         string
 		meshConfig   *v1alpha1.MeshConfig
 		expectedMode networking.OutboundTrafficPolicy_Mode
-		expectedTLS  *networking.ClientTLSSettings
 	}{
 		{
-			name:         "ALLOW_ANY_DYNAMIC_DNS with TLS propagates TLS settings",
+			name:         "ALLOW_ANY_DYNAMIC_DNS mode propagates to sidecar scope",
 			meshConfig:   meshWithDynamicDNS,
 			expectedMode: networking.OutboundTrafficPolicy_Mode(v1alpha1.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY_DYNAMIC_DNS),
-			expectedTLS:  tlsSettings,
 		},
 		{
-			name:         "ALLOW_ANY_DYNAMIC_DNS without TLS has nil TLS",
-			meshConfig:   meshWithDynamicDNSNoTLS,
-			expectedMode: networking.OutboundTrafficPolicy_Mode(v1alpha1.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY_DYNAMIC_DNS),
-			expectedTLS:  nil,
-		},
-		{
-			name:         "ALLOW_ANY does not propagate TLS",
+			name:         "ALLOW_ANY does not enable dynamic DNS",
 			meshConfig:   mesh.DefaultMeshConfig(),
 			expectedMode: networking.OutboundTrafficPolicy_ALLOW_ANY,
-			expectedTLS:  nil,
 		},
 	}
 
@@ -3589,10 +3571,6 @@ func TestSidecarOutboundTrafficPolicyAllowAnyDynamicDNS(t *testing.T) {
 			gotMode := sidecarScope.OutboundTrafficPolicy.Mode
 			if gotMode != tc.expectedMode {
 				t.Errorf("OutboundTrafficPolicy mode: want %v, got %v", tc.expectedMode, gotMode)
-			}
-
-			if !reflect.DeepEqual(tc.expectedTLS, sidecarScope.OutboundTrafficPolicyTLS) {
-				t.Errorf("OutboundTrafficPolicyTLS: want %v, got %v", tc.expectedTLS, sidecarScope.OutboundTrafficPolicyTLS)
 			}
 		})
 	}

--- a/pilot/pkg/networking/core/cluster.go
+++ b/pilot/pkg/networking/core/cluster.go
@@ -333,6 +333,10 @@ func (configgen *ConfigGeneratorImpl) buildClusters(proxy *model.Proxy, req *mod
 		resources = append(resources, ob...)
 		// Add a blackhole and passthrough cluster for catching traffic to unresolved routes
 		clusters = outboundPatcher.conditionallyAppend(clusters, nil, cb.buildBlackHoleCluster(), cb.buildDefaultPassthroughCluster())
+		if util.IsAllowAnyDynamicDNSOutbound(proxy) {
+			dfpCluster := cb.buildAllowAnyDFPCluster(proxy.SidecarScope.OutboundTrafficPolicyTLS)
+			clusters = outboundPatcher.conditionallyAppend(clusters, nil, dfpCluster.build())
+		}
 		clusters = append(clusters, outboundPatcher.insertedClusters()...)
 		// Setup inbound clusters
 		inboundPatcher := clusterPatcher{efw: envoyFilterPatches, pctx: networking.EnvoyFilter_SIDECAR_INBOUND}

--- a/pilot/pkg/networking/core/cluster.go
+++ b/pilot/pkg/networking/core/cluster.go
@@ -334,7 +334,7 @@ func (configgen *ConfigGeneratorImpl) buildClusters(proxy *model.Proxy, req *mod
 		// Add a blackhole and passthrough cluster for catching traffic to unresolved routes
 		clusters = outboundPatcher.conditionallyAppend(clusters, nil, cb.buildBlackHoleCluster(), cb.buildDefaultPassthroughCluster())
 		if util.IsAllowAnyDynamicDNSOutbound(proxy) {
-			dfpCluster := cb.buildAllowAnyDFPCluster(proxy.SidecarScope.OutboundTrafficPolicyTLS)
+			dfpCluster := cb.buildAllowAnyDFPCluster(req.Push.Mesh.GetOutboundTrafficPolicy().GetTls())
 			clusters = outboundPatcher.conditionallyAppend(clusters, nil, dfpCluster.build())
 		}
 		clusters = append(clusters, outboundPatcher.insertedClusters()...)

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -564,6 +564,56 @@ func (cb *ClusterBuilder) buildCluster(name string, discoveryType cluster.Cluste
 	return ec
 }
 
+// buildAllowAnyDFPCluster builds the DFP cluster for ALLOW_ANY_DYNAMIC_DNS mode.
+// Plaintext HTTP traffic is routed here via the HTTP DFP filter which resolves hostnames
+// from the Host/:authority header. Optional TLS origination is applied when OutboundTrafficPolicyTLS
+// is configured.
+func (cb *ClusterBuilder) buildAllowAnyDFPCluster(tls *networking.ClientTLSSettings) *clusterWrapper {
+	c := &cluster.Cluster{
+		Name:     util.AllowAnyDynamicDNSCluster,
+		LbPolicy: cluster.Cluster_CLUSTER_PROVIDED,
+		ClusterDiscoveryType: &cluster.Cluster_ClusterType{ClusterType: &cluster.Cluster_CustomClusterType{
+			Name: "envoy.clusters.dynamic_forward_proxy",
+			TypedConfig: protoconv.MessageToAny(&dfpcluster.ClusterConfig{
+				ClusterImplementationSpecifier: &dfpcluster.ClusterConfig_DnsCacheConfig{
+					DnsCacheConfig: buildAllowAnyDynamicDNSDNSCacheConfig(cb.proxyMetadata),
+				},
+				// Required to bypass Envoy's auto_sni/auto_san_validation guard when no upstream TLS is set.
+				AllowInsecureClusterOptions: tls == nil || tls.Mode == networking.ClientTLSSettings_DISABLE,
+			}),
+		}},
+		ConnectTimeout: cb.req.Push.Mesh.ConnectTimeout,
+	}
+	c.AltStatName = util.DelimitedStatsPrefix(util.AllowAnyDynamicDNSCluster)
+	// Use same protocol options as passthrough cluster
+	httpProtocolOptions := passthroughHttpProtocolOptions
+	if shouldPreserveHeaderCase(cb.proxyMetadata, cb.req.Push) {
+		httpProtocolOptions = passthroughHttpProtocolOptionsWithPreserveHeaderCase
+	}
+	c.TypedExtensionProtocolOptions = map[string]*anypb.Any{
+		v3.HttpProtocolOptionsType: httpProtocolOptions,
+	}
+	ec := newDFPClusterWrapper(c)
+	if tls != nil && tls.Mode != networking.ClientTLSSettings_DISABLE {
+		opts := &buildClusterOpts{
+			mesh:      cb.req.Push.Mesh,
+			mutable:   ec,
+			direction: model.TrafficDirectionOutbound,
+		}
+		tlsContext, err := cb.buildUpstreamClusterTLSContext(opts, tls)
+		if err != nil {
+			log.Errorf("failed to build TLS context for %s cluster: %v", util.AllowAnyDynamicDNSCluster, err)
+		} else if tlsContext != nil {
+			c.TransportSocket = &core.TransportSocket{
+				Name:       wellknown.TransportSocketTLS,
+				ConfigType: &core.TransportSocket_TypedConfig{TypedConfig: protoconv.MessageToAny(tlsContext)},
+			}
+		}
+	}
+	cb.applyMetadataExchange(c)
+	return ec
+}
+
 // Builds a dynamic forward proxy cluster with DNS cache config, stats configuration
 // and upstream protocol settings.
 func (cb *ClusterBuilder) buildDFPCluster(name string, service *model.Service, port *model.Port) *clusterWrapper {

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -41,7 +41,6 @@ import (
 	"istio.io/istio/pilot/pkg/networking/core/loadbalancer"
 	"istio.io/istio/pilot/pkg/networking/telemetry"
 	"istio.io/istio/pilot/pkg/networking/util"
-	networkutil "istio.io/istio/pilot/pkg/util/network"
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pilot/pkg/xds/endpoints"
 	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
@@ -486,28 +485,7 @@ func (cb *ClusterBuilder) buildCluster(name string, discoveryType cluster.Cluste
 
 	switch discoveryType {
 	case cluster.Cluster_STRICT_DNS, cluster.Cluster_LOGICAL_DNS:
-		if networkutil.AllIPv4(cb.proxyIPAddresses) {
-			// IPv4 only
-			c.DnsLookupFamily = cluster.Cluster_V4_ONLY
-		} else if networkutil.AllIPv6(cb.proxyIPAddresses) {
-			// IPv6 only
-			c.DnsLookupFamily = cluster.Cluster_V6_ONLY
-			// If we are in this mode, Istio sees ourselves as only have IPv6 addresses, but there is actually a link-local
-			// interface that serves the IPv4. Allow both families.
-			// This ensures we do not break DNS resolution to destinations that are IPv4 only.
-			if features.EnableAdditionalIpv4OutboundListenerForIpv6Only {
-				c.DnsLookupFamily = cluster.Cluster_ALL
-			}
-		} else {
-			// Dual Stack
-			if features.EnableDualStack {
-				// using Cluster_ALL to enable Happy Eyeballsfor upstream connections
-				c.DnsLookupFamily = cluster.Cluster_ALL
-			} else {
-				// keep the original logic if Dual Stack is disable
-				c.DnsLookupFamily = cluster.Cluster_V4_ONLY
-			}
-		}
+		c.DnsLookupFamily = util.SelectDNSLookupFamily(cb.proxyIPAddresses)
 		dnsResolverConfig, err := anypb.New(&cares.CaresDnsResolverConfig{
 			UdpMaxQueries: wrappers.UInt32(features.PilotDNSCaresUDPMaxQueries),
 		})
@@ -593,6 +571,9 @@ func (cb *ClusterBuilder) buildAllowAnyDFPCluster(tls *networking.ClientTLSSetti
 		v3.HttpProtocolOptionsType: httpProtocolOptions,
 	}
 	ec := newDFPClusterWrapper(c)
+	// Apply the default connection pool so this cluster gets Istio's high circuit-breaker
+	// thresholds instead of Envoy's low defaults (max 1024), matching the PassthroughCluster.
+	cb.applyConnectionPool(cb.req.Push.Mesh, ec, &networking.ConnectionPoolSettings{}, nil)
 	if tls != nil && tls.Mode != networking.ClientTLSSettings_DISABLE {
 		opts := &buildClusterOpts{
 			mesh:      cb.req.Push.Mesh,
@@ -625,7 +606,7 @@ func (cb *ClusterBuilder) buildDFPCluster(name string, service *model.Service, p
 				ClusterImplementationSpecifier: &dfpcluster.ClusterConfig_DnsCacheConfig{
 					DnsCacheConfig: &dfpcommon.DnsCacheConfig{
 						Name:            model.BuildDNSCacheName(service.Hostname),
-						DnsLookupFamily: cluster.Cluster_V4_ONLY,
+						DnsLookupFamily: util.SelectDNSLookupFamily(cb.proxyIPAddresses),
 					},
 				},
 			}),

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -566,8 +566,7 @@ func (cb *ClusterBuilder) buildCluster(name string, discoveryType cluster.Cluste
 
 // buildAllowAnyDFPCluster builds the DFP cluster for ALLOW_ANY_DYNAMIC_DNS mode.
 // Plaintext HTTP traffic is routed here via the HTTP DFP filter which resolves hostnames
-// from the Host/:authority header. Optional TLS origination is applied when OutboundTrafficPolicyTLS
-// is configured.
+// from the Host/:authority header. Optional TLS origination is applied when OutboundTrafficPolicy tls is configured.
 func (cb *ClusterBuilder) buildAllowAnyDFPCluster(tls *networking.ClientTLSSettings) *clusterWrapper {
 	c := &cluster.Cluster{
 		Name:     util.AllowAnyDynamicDNSCluster,

--- a/pilot/pkg/networking/core/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/cluster_builder_test.go
@@ -3943,3 +3943,72 @@ func TestInsecureSkipVerify(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildAllowAnyDFPClusterTLSSettings(t *testing.T) {
+	cg := NewConfigGenTest(t, TestOptions{})
+	proxy := cg.SetupProxy(nil)
+	cb := NewClusterBuilder(proxy, &model.PushRequest{Push: cg.PushContext()}, nil)
+
+	tests := []struct {
+		name      string
+		tls       *networking.ClientTLSSettings
+		expectTLS bool
+	}{
+		{
+			name: "no TLS settings",
+			tls:  nil,
+		},
+		{
+			name: "TLS DISABLE — no transport socket",
+			tls:  &networking.ClientTLSSettings{Mode: networking.ClientTLSSettings_DISABLE},
+		},
+		{
+			name:      "TLS SIMPLE — transport socket applied",
+			tls:       &networking.ClientTLSSettings{Mode: networking.ClientTLSSettings_SIMPLE},
+			expectTLS: true,
+		},
+		{
+			name:      "TLS ISTIO_MUTUAL — transport socket applied",
+			tls:       &networking.ClientTLSSettings{Mode: networking.ClientTLSSettings_ISTIO_MUTUAL},
+			expectTLS: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := cb.buildAllowAnyDFPCluster(tc.tls).cluster
+
+			if tc.expectTLS {
+				if c.TransportSocket == nil {
+					t.Fatal("expected TransportSocket to be set for TLS mode")
+				}
+				assert.Equal(t, c.TransportSocket.Name, "envoy.transport_sockets.tls")
+			} else if c.TransportSocket != nil {
+				t.Errorf("expected no TransportSocket, got %v", c.TransportSocket.Name)
+			}
+
+			// Verify UseDownstreamProtocolConfig is set for HTTP/2 (gRPC) support
+			anyOpts := c.TypedExtensionProtocolOptions[v3.HttpProtocolOptionsType]
+			if anyOpts == nil {
+				t.Fatal("expected TypedExtensionProtocolOptions to be set")
+			}
+			gotOpts := &http.HttpProtocolOptions{}
+			if err := anyOpts.UnmarshalTo(gotOpts); err != nil {
+				t.Fatalf("failed to unmarshal HttpProtocolOptions: %v", err)
+			}
+			wantOpts := &http.HttpProtocolOptions{
+				CommonHttpProtocolOptions: &core.HttpProtocolOptions{
+					IdleTimeout: durationpb.New(5 * time.Minute),
+				},
+				UpstreamProtocolOptions: &http.HttpProtocolOptions_UseDownstreamProtocolConfig{
+					UseDownstreamProtocolConfig: &http.HttpProtocolOptions_UseDownstreamHttpConfig{
+						HttpProtocolOptions:  &core.Http1ProtocolOptions{},
+						Http2ProtocolOptions: &core.Http2ProtocolOptions{},
+					},
+				},
+			}
+			if diff := cmp.Diff(wantOpts, gotOpts, protocmp.Transform()); diff != "" {
+				t.Errorf("HttpProtocolOptions mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pilot/pkg/networking/core/httproute.go
+++ b/pilot/pkg/networking/core/httproute.go
@@ -355,7 +355,7 @@ func BuildSidecarOutboundVirtualHosts(node *model.Proxy, push *model.PushContext
 			DNSDomain:       node.DNSDomain,
 			DNSCapture:      bool(node.Metadata.DNSCapture),
 			DNSAutoAllocate: bool(node.Metadata.DNSAutoAllocate),
-			AllowAny:        util.IsAllowAnyOutbound(node),
+			AllowAny:        util.IsAllowAnyOutbound(node) || util.IsAllowAnyDynamicDNSOutbound(node),
 			ListenerPort:    listenerPort,
 			Services:        services,
 			VirtualServices: virtualServices,
@@ -761,6 +761,31 @@ func getUniqueAndSharedDNSDomain(fqdnHostname, proxyDomain string) (partsUnique 
 }
 
 func buildCatchAllVirtualHost(node *model.Proxy, includeRequestAttemptCount bool, appendXForwardedHost bool) *route.VirtualHost {
+	if util.IsAllowAnyDynamicDNSOutbound(node) {
+		notimeout := durationpb.New(0)
+		return &route.VirtualHost{
+			Name:    util.AllowAnyDynamicDNS,
+			Domains: []string{"*"},
+			Routes: []*route.Route{
+				{
+					Name: util.AllowAnyDynamicDNS,
+					Match: &route.RouteMatch{
+						PathSpecifier: &route.RouteMatch_Prefix{Prefix: "/"},
+					},
+					Action: &route.Route_Route{
+						Route: &route.RouteAction{
+							ClusterSpecifier:     &route.RouteAction_Cluster{Cluster: util.AllowAnyDynamicDNSCluster},
+							Timeout:              notimeout,
+							MaxGrpcTimeout:       notimeout,
+							AppendXForwardedHost: appendXForwardedHost,
+						},
+					},
+				},
+			},
+			IncludeRequestAttemptCount: includeRequestAttemptCount,
+		}
+	}
+
 	if util.IsAllowAnyOutbound(node) {
 		egressCluster := util.PassthroughCluster
 		notimeout := durationpb.New(0)

--- a/pilot/pkg/networking/core/listener_builder.go
+++ b/pilot/pkg/networking/core/listener_builder.go
@@ -20,6 +20,7 @@ import (
 	accesslog "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	tcp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -131,7 +132,7 @@ func (lb *ListenerBuilder) buildVirtualOutboundListener() *ListenerBuilder {
 		isTransparentProxy = proto.BoolTrue
 	}
 
-	filterChains := buildOutboundCatchAllNetworkFilterChains(lb.node, lb.push)
+	filterChains := lb.buildOutboundCatchAllNetworkFilterChains()
 
 	actualWildcards, _ := getWildcardsAndLocalHost(lb.node.GetIPMode())
 	// add an extra listener that binds to the port that is the recipient of the iptables redirect
@@ -151,6 +152,11 @@ func (lb *ListenerBuilder) buildVirtualOutboundListener() *ListenerBuilder {
 		// add an additional IPv4 outbound listener for IPv6 only clusters
 		ipv4Wildcards, _ := getWildcardsAndLocalHost(model.IPv4) // get the IPv4 based wildcards
 		ipTablesListener.AdditionalAddresses = util.BuildAdditionalAddresses(ipv4Wildcards[0:], uint32(lb.push.Mesh.ProxyListenPort))
+	}
+
+	if util.IsAllowAnyDynamicDNSOutbound(lb.node) {
+		// HTTP inspector detects plaintext HTTP ALPNs for routing to the DFP chain.
+		ipTablesListener.ListenerFilters = append(ipTablesListener.ListenerFilters, xdsfilters.HTTPInspector)
 	}
 
 	class := model.OutboundListenerClass(lb.node.Type)
@@ -227,10 +233,13 @@ func (lb *ListenerBuilder) getListeners() []*listener.Listener {
 	return listeners
 }
 
+// buildOutboundCatchAllNetworkFiltersOnly builds the fallthrough (DefaultFilterChain) filter stack
+// for per-port outbound listeners. Both ALLOW_ANY and ALLOW_ANY_DYNAMIC_DNS use PassthroughCluster
+// as the fallthrough target; non-HTTP traffic is not eligible for DFP resolution.
 func buildOutboundCatchAllNetworkFiltersOnly(push *model.PushContext, node *model.Proxy) []*listener.Filter {
 	var egressCluster string
 
-	if util.IsAllowAnyOutbound(node) {
+	if util.IsAllowAnyDynamicDNSOutbound(node) || util.IsAllowAnyOutbound(node) {
 		// We need a passthrough filter to fill in the filter stack for orig_dst listener
 		egressCluster = util.PassthroughCluster
 
@@ -276,14 +285,69 @@ func parseDuration(s string) *durationpb.Duration {
 // with TLS blocks and build the appropriate filter chain matches and routes here. And then finally
 // evaluate the left over unmatched TLS traffic using allow_any or registry_only.
 // See https://github.com/istio/istio/issues/21170
-func buildOutboundCatchAllNetworkFilterChains(node *model.Proxy, push *model.PushContext) []*listener.FilterChain {
-	filterStack := buildOutboundCatchAllNetworkFiltersOnly(push, node)
-	chains := make([]*listener.FilterChain, 0, 2)
-	chains = append(chains, blackholeFilterChain(push, node), &listener.FilterChain{
+func (lb *ListenerBuilder) buildOutboundCatchAllNetworkFilterChains() []*listener.FilterChain {
+	node := lb.node
+	push := lb.push
+	chains := []*listener.FilterChain{blackholeFilterChain(push, node)}
+
+	if util.IsAllowAnyDynamicDNSOutbound(node) {
+		// Plaintext HTTP: HTTP inspector detects HTTP traffic → HCM with DFP filter → AllowAnyDynamicDNSCluster.
+		chains = append(chains, lb.buildAllowAnyDynamicDNSHTTPFilterChain())
+	}
+	// Everything else (TLS, plain TCP): PassthroughCluster (or EgressProxy) for ALLOW_ANY/ALLOW_ANY_DYNAMIC_DNS,
+	// BlackHoleCluster for REGISTRY_ONLY.
+	chains = append(chains, &listener.FilterChain{
 		Name:    model.VirtualOutboundCatchAllTCPFilterChainName,
-		Filters: filterStack,
+		Filters: buildOutboundCatchAllNetworkFiltersOnly(push, node),
 	})
+
 	return chains
+}
+
+// buildAllowAnyDynamicDNSHTTPFilterChain builds an HTTP filter chain for the virtual outbound
+// listener that handles plaintext HTTP traffic (detected by the HTTP inspector). The HCM
+// includes the DFP HTTP filter and an inline route config with the allow_any_dynamic_dns
+// catch-all route, so unknown HTTP requests are forwarded via the DFP cluster.
+func (lb *ListenerBuilder) buildAllowAnyDynamicDNSHTTPFilterChain() *listener.FilterChain {
+	ph := util.GetProxyHeaders(lb.node, lb.push, istionetworking.ListenerClassSidecarOutbound)
+	routeConfig := &route.RouteConfiguration{
+		Name:                           util.AllowAnyDynamicDNS,
+		VirtualHosts:                   []*route.VirtualHost{buildCatchAllVirtualHost(lb.node, ph.IncludeRequestAttemptCount, ph.XForwardedHost)},
+		ValidateClusters:               proto.BoolFalse,
+		MaxDirectResponseBodySizeBytes: istio_route.DefaultMaxDirectResponseBodySizeBytes,
+		IgnorePortInHostMatching:       true,
+	}
+	httpOpts := &httpListenerOpts{
+		useRemoteAddress: features.UseRemoteAddress,
+		connectionManager: &hcm.HttpConnectionManager{
+			ServerName:                 ph.ServerName,
+			ServerHeaderTransformation: ph.ServerHeaderTransformation,
+			GenerateRequestId:          ph.GenerateRequestID,
+		},
+		suppressEnvoyDebugHeaders: ph.SuppressDebugHeaders,
+		skipIstioMXHeaders:        ph.SkipIstioMXHeaders,
+		class:                     istionetworking.ListenerClassSidecarOutbound,
+		protocol:                  protocol.HTTP,
+		routeConfig:               routeConfig,
+		statPrefix:                util.DelimitedStatsPrefix("outbound_" + model.VirtualOutboundListenerName + "_allow_any_dynamic_dns"),
+	}
+	if features.HTTP10 || enableHTTP10(lb.node.Metadata.HTTP10) {
+		httpOpts.connectionManager.HttpProtocolOptions = &core.Http1ProtocolOptions{
+			AcceptHttp_10: true,
+		}
+	}
+	connMgr := lb.buildHTTPConnectionManager(httpOpts)
+	hcmFilter := &listener.Filter{
+		Name:       wellknown.HTTPConnectionManager,
+		ConfigType: &listener.Filter_TypedConfig{TypedConfig: protoconv.MessageToAny(connMgr)},
+	}
+	return &listener.FilterChain{
+		Name: model.VirtualOutboundCatchAllTCPFilterChainName + "-http",
+		FilterChainMatch: &listener.FilterChainMatch{
+			ApplicationProtocols: plaintextHTTPALPNs,
+		},
+		Filters: []*listener.Filter{hcmFilter},
+	}
 }
 
 func blackholeFilterChain(push *model.PushContext, node *model.Proxy) *listener.FilterChain {
@@ -457,6 +521,13 @@ func (lb *ListenerBuilder) buildHTTPConnectionManager(httpOpts *httpListenerOpts
 		httpOpts.class == istionetworking.ListenerClassSidecarOutbound {
 		dfpCacheName := model.BuildDNSCacheName(httpOpts.policySvc.Hostname)
 		filters = append(filters, xdsfilters.BuildSidecarOutboundDynamicForwardProxyFilter(dfpCacheName))
+	}
+
+	// Global DFP HTTP filter for ALLOW_ANY_DYNAMIC_DNS mode: enables the DFP cluster
+	// to resolve hostnames from the Host/:authority header for catch-all routes.
+	if httpOpts.class == istionetworking.ListenerClassSidecarOutbound &&
+		util.IsAllowAnyDynamicDNSOutbound(lb.node) {
+		filters = append(filters, buildAllowAnyDynamicDNSHTTPForwardProxyFilter(lb.node.Metadata))
 	}
 
 	// Router filter must be last

--- a/pilot/pkg/networking/core/listener_builder.go
+++ b/pilot/pkg/networking/core/listener_builder.go
@@ -511,7 +511,7 @@ func (lb *ListenerBuilder) buildHTTPConnectionManager(httpOpts *httpListenerOpts
 	// Create DFP filter for wildcard hosts in waypoint inbound for ambient mode
 	if httpOpts.policySvc != nil && httpOpts.policySvc.Hostname.IsWildCarded() && httpOpts.class == istionetworking.ListenerClassSidecarInbound {
 		dfpCacheName := model.BuildDNSCacheName(httpOpts.policySvc.Hostname)
-		filters = append(filters, xdsfilters.BuildWaypointInboundDFPFilter(dfpCacheName))
+		filters = append(filters, xdsfilters.BuildWaypointInboundDFPFilter(dfpCacheName, util.SelectDNSLookupFamily(lb.node.IPAddresses)))
 	}
 
 	// Create DFP filter for wildcard hosts in sidecar outbound for DYNAMIC_DNS ServiceEntries
@@ -520,11 +520,14 @@ func (lb *ListenerBuilder) buildHTTPConnectionManager(httpOpts *httpListenerOpts
 		httpOpts.policySvc.Resolution == model.DynamicDNS &&
 		httpOpts.class == istionetworking.ListenerClassSidecarOutbound {
 		dfpCacheName := model.BuildDNSCacheName(httpOpts.policySvc.Hostname)
-		filters = append(filters, xdsfilters.BuildSidecarOutboundDynamicForwardProxyFilter(dfpCacheName))
+		filters = append(filters, xdsfilters.BuildSidecarOutboundDynamicForwardProxyFilter(dfpCacheName, util.SelectDNSLookupFamily(lb.node.IPAddresses)))
 	}
 
-	// Global DFP HTTP filter for ALLOW_ANY_DYNAMIC_DNS mode: enables the DFP cluster
-	// to resolve hostnames from the Host/:authority header for catch-all routes.
+	// DFP HTTP filter for ALLOW_ANY_DYNAMIC_DNS mode: enables the DFP cluster to resolve
+	// hostnames from the Host/:authority header. This is required on every sidecar outbound
+	// HCM (not just the virtual outbound catch-all chain) because buildCatchAllVirtualHost
+	// appends the allow_any_dynamic_dns catch-all virtual host -- which routes unknown hosts
+	// to the DFP cluster -- to every per-service outbound HTTP route config as well.
 	if httpOpts.class == istionetworking.ListenerClassSidecarOutbound &&
 		util.IsAllowAnyDynamicDNSOutbound(lb.node) {
 		filters = append(filters, buildAllowAnyDynamicDNSHTTPForwardProxyFilter(lb.node.Metadata))

--- a/pilot/pkg/networking/core/listener_builder_test.go
+++ b/pilot/pkg/networking/core/listener_builder_test.go
@@ -35,12 +35,14 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core/listenertest"
 	"istio.io/istio/pilot/pkg/networking/plugin/authz"
+	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/memory"
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
 	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/host"
+	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/network"
@@ -1445,5 +1447,84 @@ func TestPreserveHeader(t *testing.T) {
 			}
 			assert.NoError(t, tt.isExpected(lb.buildHTTPConnectionManager(tt.opts)))
 		})
+	}
+}
+
+func TestVirtualOutboundListenerAllowAnyDynamicDNS(t *testing.T) {
+	meshCfg := mesh.DefaultMeshConfig()
+	meshCfg.OutboundTrafficPolicy = &meshconfig.MeshConfig_OutboundTrafficPolicy{
+		Mode: meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY_DYNAMIC_DNS,
+	}
+	listeners := buildListeners(t, TestOptions{
+		Services:   testServices,
+		MeshConfig: meshCfg,
+	}, nil)
+
+	vo := xdstest.ExtractListener(model.VirtualOutboundListenerName, listeners)
+	if vo == nil {
+		t.Fatal("didn't find virtual outbound listener")
+	}
+
+	listenertest.VerifyListener(t, vo, listenertest.ListenerTest{
+		Filters: []string{wellknown.HTTPInspector},
+		FilterChains: []listenertest.FilterChainTest{
+			{Name: model.VirtualOutboundBlackholeFilterChainName},
+			{
+				Name:           model.VirtualOutboundCatchAllTCPFilterChainName + "-http",
+				NetworkFilters: []string{wellknown.HTTPConnectionManager},
+				HTTPFilters:    []string{"envoy.filters.http.dynamic_forward_proxy"},
+				ValidateHCM: func(t test.Failer, h *hcm.HttpConnectionManager) {
+					rc := h.GetRouteConfig()
+					if rc == nil || len(rc.VirtualHosts) == 0 || len(rc.VirtualHosts[0].Routes) == 0 {
+						t.Fatalf("expected catch-all route in HCM route config")
+					}
+					cluster := rc.VirtualHosts[0].Routes[0].GetRoute().GetCluster()
+					assert.Equal(t, cluster, util.AllowAnyDynamicDNSCluster)
+				},
+			},
+			{
+				Name:           model.VirtualOutboundCatchAllTCPFilterChainName,
+				NetworkFilters: []string{wellknown.TCPProxy},
+			},
+		},
+		TotalMatch: true,
+	})
+}
+
+func TestDFPHTTPFilterInjectedInOutboundHCM(t *testing.T) {
+	meshCfg := mesh.DefaultMeshConfig()
+	meshCfg.OutboundTrafficPolicy = &meshconfig.MeshConfig_OutboundTrafficPolicy{
+		Mode: meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY_DYNAMIC_DNS,
+	}
+	listeners := buildListeners(t, TestOptions{
+		Services:   testServices,
+		MeshConfig: meshCfg,
+	}, nil)
+
+	for _, l := range listeners {
+		if l.Name == model.VirtualOutboundListenerName || l.Name == model.VirtualInboundListenerName {
+			continue
+		}
+		for _, fc := range l.FilterChains {
+			for _, f := range fc.Filters {
+				if f.Name != wellknown.HTTPConnectionManager {
+					continue
+				}
+				hcmCfg := &hcm.HttpConnectionManager{}
+				if err := f.GetTypedConfig().UnmarshalTo(hcmCfg); err != nil {
+					t.Fatalf("failed to unmarshal HCM: %v", err)
+				}
+				foundDFP := false
+				for _, hf := range hcmCfg.HttpFilters {
+					if hf.Name == "envoy.filters.http.dynamic_forward_proxy" {
+						foundDFP = true
+						break
+					}
+				}
+				if !foundDFP {
+					t.Errorf("listener %s chain %s: expected DFP HTTP filter in outbound HCM", l.Name, fc.Name)
+				}
+			}
+		}
 	}
 }

--- a/pilot/pkg/networking/core/listener_waypoint.go
+++ b/pilot/pkg/networking/core/listener_waypoint.go
@@ -1005,7 +1005,7 @@ func (lb *ListenerBuilder) buildWaypointNetworkFilters(svc *model.Service, fcc i
 
 		// Conditionally build SNI DFP for wildcard hosts with Dynamic DNS resolution
 		if svcHostname.IsWildCarded() && svc.Resolution == model.DynamicDNS {
-			sniDFPFilter = buildSNIDFPFilter(fcc.port.Port, svc)
+			sniDFPFilter = buildSNIDFPFilter(fcc.port.Port, svc, util.SelectDNSLookupFamily(lb.node.IPAddresses))
 		}
 	}
 

--- a/pilot/pkg/networking/core/networkfilter.go
+++ b/pilot/pkg/networking/core/networkfilter.go
@@ -34,6 +34,7 @@ import (
 	hashpolicy "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	anypb "google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
+	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
 	extensions "istio.io/api/extensions/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
@@ -86,11 +87,11 @@ func setAccessLogAndBuildTCPFilter(push *model.PushContext, node *model.Proxy,
 	return tcpFilter
 }
 
-func buildSNIDFPFilter(port int, svc *model.Service) *listener.Filter {
+func buildSNIDFPFilter(port int, svc *model.Service, lookupFamily cluster.Cluster_DnsLookupFamily) *listener.Filter {
 	sniDfp := &snidfp.FilterConfig{
 		DnsCacheConfig: &dfp.DnsCacheConfig{
 			Name:            model.BuildDNSCacheName(svc.Hostname),
-			DnsLookupFamily: cluster.Cluster_V4_ONLY,
+			DnsLookupFamily: lookupFamily,
 		},
 		PortSpecifier: &snidfp.FilterConfig_PortValue{
 			PortValue: uint32(port),
@@ -108,8 +109,15 @@ func buildSNIDFPFilter(port int, svc *model.Service) *listener.Filter {
 // Otherwise no explicit resolver is set and Envoy uses its default DNS resolution.
 func buildAllowAnyDynamicDNSDNSCacheConfig(meta *model.NodeMetadata) *dfp.DnsCacheConfig {
 	cfg := &dfp.DnsCacheConfig{
-		Name:            util.AllowAnyDFPDNSCacheName,
-		DnsLookupFamily: cluster.Cluster_V4_ONLY,
+		Name: util.AllowAnyDFPDNSCacheName,
+		// Envoy defaults MaxHosts to 1024 when unset. Set it explicitly so the cap is
+		// visible in the generated config and tunable via PILOT_ALLOW_ANY_DYNAMIC_DNS_MAX_HOSTS.
+		MaxHosts: wrappers.UInt32(uint32(features.AllowAnyDynamicDNSMaxHosts)),
+	}
+	if meta != nil {
+		cfg.DnsLookupFamily = util.SelectDNSLookupFamily(meta.InstanceIPs)
+	} else {
+		cfg.DnsLookupFamily = cluster.Cluster_V4_ONLY
 	}
 	if meta == nil || !bool(meta.DNSCapture) {
 		return cfg
@@ -237,7 +245,7 @@ func (lb *ListenerBuilder) buildCompleteNetworkFilters(
 		policySvc != nil &&
 		policySvc.Hostname.IsWildCarded() &&
 		policySvc.Resolution == model.DynamicDNS {
-		sniDFPFilter := buildSNIDFPFilter(port, policySvc)
+		sniDFPFilter := buildSNIDFPFilter(port, policySvc, util.SelectDNSLookupFamily(lb.node.IPAddresses))
 		filters = append(filters, sniDFPFilter)
 	}
 

--- a/pilot/pkg/networking/core/networkfilter.go
+++ b/pilot/pkg/networking/core/networkfilter.go
@@ -15,17 +15,24 @@
 package core
 
 import (
+	"net"
+	"strconv"
 	"time"
 
 	mysql "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/mysql_proxy/v3"
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	dfp "github.com/envoyproxy/go-control-plane/envoy/extensions/common/dynamic_forward_proxy/v3"
+	httpdfp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/dynamic_forward_proxy/v3"
+	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	mongo "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/mongo_proxy/v3"
 	redis "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/redis_proxy/v3"
 	snidfp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/sni_dynamic_forward_proxy/v3"
 	tcp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
+	cares "github.com/envoyproxy/go-control-plane/envoy/extensions/network/dns_resolver/cares/v3"
 	hashpolicy "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	extensions "istio.io/api/extensions/v1alpha1"
@@ -38,6 +45,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/core/tunnelingconfig"
 	"istio.io/istio/pilot/pkg/networking/plugin/authz"
 	"istio.io/istio/pilot/pkg/networking/telemetry"
+	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
 	"istio.io/istio/pkg/config"
@@ -91,6 +99,64 @@ func buildSNIDFPFilter(port int, svc *model.Service) *listener.Filter {
 	return &listener.Filter{
 		Name:       wellknown.SNIDynamicForwardProxy,
 		ConfigType: &listener.Filter_TypedConfig{TypedConfig: protoconv.MessageToAny(sniDfp)},
+	}
+}
+
+// buildAllowAnyDynamicDNSDNSCacheConfig builds the shared DnsCacheConfig for ALLOW_ANY_DYNAMIC_DNS mode.
+// When DNS_CAPTURE is enabled, the resolver is pointed at the Istio DNS proxy (DNS_PROXY_ADDR).
+// Otherwise no explicit resolver is set and Envoy uses its default DNS resolution.
+func buildAllowAnyDynamicDNSDNSCacheConfig(meta *model.NodeMetadata) *dfp.DnsCacheConfig {
+	cfg := &dfp.DnsCacheConfig{
+		Name:            util.AllowAnyDFPDNSCacheName,
+		DnsLookupFamily: cluster.Cluster_V4_ONLY,
+	}
+	if meta == nil || !bool(meta.DNSCapture) {
+		return cfg
+	}
+	addr := meta.DNSProxyAddr
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		host, portStr = "127.0.0.1", "15053"
+	}
+	if host == "localhost" {
+		host = "127.0.0.1"
+	}
+	port, err := strconv.ParseUint(portStr, 10, 32)
+	if err != nil {
+		port = 15053
+	}
+	caresConfig, err := anypb.New(&cares.CaresDnsResolverConfig{
+		Resolvers: []*core.Address{{
+			Address: &core.Address_SocketAddress{
+				SocketAddress: &core.SocketAddress{
+					Address:       host,
+					PortSpecifier: &core.SocketAddress_PortValue{PortValue: uint32(port)},
+				},
+			},
+		}},
+	})
+	if err == nil {
+		cfg.TypedDnsResolverConfig = &core.TypedExtensionConfig{
+			Name:        "envoy.network.dns_resolver.cares",
+			TypedConfig: caresConfig,
+		}
+	}
+	return cfg
+}
+
+// buildAllowAnyDynamicDNSHTTPForwardProxyFilter builds an HTTP dynamic forward proxy filter for
+// ALLOW_ANY_DYNAMIC_DNS mode. It resolves hostnames from the Host/:authority header using the
+// shared DNS cache (Istio DNS proxy).
+func buildAllowAnyDynamicDNSHTTPForwardProxyFilter(meta *model.NodeMetadata) *hcm.HttpFilter {
+	return &hcm.HttpFilter{
+		Name: "envoy.filters.http.dynamic_forward_proxy",
+		ConfigType: &hcm.HttpFilter_TypedConfig{
+			TypedConfig: protoconv.MessageToAny(&httpdfp.FilterConfig{
+				ImplementationSpecifier: &httpdfp.FilterConfig_DnsCacheConfig{
+					DnsCacheConfig: buildAllowAnyDynamicDNSDNSCacheConfig(meta),
+				},
+			}),
+		},
 	}
 }
 

--- a/pilot/pkg/networking/core/networkfilter.go
+++ b/pilot/pkg/networking/core/networkfilter.go
@@ -51,6 +51,7 @@ import (
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/wellknown"
 )
 
@@ -116,6 +117,7 @@ func buildAllowAnyDynamicDNSDNSCacheConfig(meta *model.NodeMetadata) *dfp.DnsCac
 	addr := meta.DNSProxyAddr
 	host, portStr, err := net.SplitHostPort(addr)
 	if err != nil {
+		log.Warnf("failed to parse DNSProxyAddr %q, falling back to 127.0.0.1:15053: %v", addr, err)
 		host, portStr = "127.0.0.1", "15053"
 	}
 	if host == "localhost" {

--- a/pilot/pkg/networking/core/networkfilter_test.go
+++ b/pilot/pkg/networking/core/networkfilter_test.go
@@ -31,6 +31,7 @@ import (
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/api/security/v1beta1"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core/listenertest"
 	"istio.io/istio/pilot/pkg/networking/telemetry"
@@ -957,6 +958,9 @@ func TestBuildAllowAnyDynamicDNSDNSCacheConfig(t *testing.T) {
 			}
 			if cfg.DnsLookupFamily != cluster.Cluster_V4_ONLY {
 				t.Errorf("expected dns lookup family V4_ONLY, got %v", cfg.DnsLookupFamily)
+			}
+			if cfg.GetMaxHosts().GetValue() != uint32(features.AllowAnyDynamicDNSMaxHosts) {
+				t.Errorf("expected max hosts %d, got %d", features.AllowAnyDynamicDNSMaxHosts, cfg.GetMaxHosts().GetValue())
 			}
 			if !tc.expectResolver {
 				if cfg.TypedDnsResolverConfig != nil {

--- a/pilot/pkg/networking/core/networkfilter_test.go
+++ b/pilot/pkg/networking/core/networkfilter_test.go
@@ -19,9 +19,14 @@ import (
 	"testing"
 	"time"
 
+	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	httpdfp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/dynamic_forward_proxy/v3"
+	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	redis "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/redis_proxy/v3"
 	tcp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
+	cares "github.com/envoyproxy/go-control-plane/envoy/extensions/network/dns_resolver/cares/v3"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	networking "istio.io/api/networking/v1alpha3"
@@ -29,6 +34,8 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core/listenertest"
 	"istio.io/istio/pilot/pkg/networking/telemetry"
+	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/istio/pilot/pkg/util/protoconv"
 	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
 	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/pkg/config"
@@ -885,5 +892,117 @@ func node(version *model.IstioVersion) *model.Proxy {
 			Namespace: "foo",
 		},
 		IstioVersion: version,
+	}
+}
+
+func TestBuildAllowAnyDynamicDNSDNSCacheConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		meta           *model.NodeMetadata
+		expectResolver bool
+		expectHost     string
+		expectPort     uint32
+	}{
+		{
+			name:           "nil metadata — no resolver set",
+			meta:           nil,
+			expectResolver: false,
+		},
+		{
+			name:           "DNS_CAPTURE disabled — no resolver set",
+			meta:           &model.NodeMetadata{DNSCapture: false},
+			expectResolver: false,
+		},
+		{
+			name:           "DNS_CAPTURE enabled with explicit addr",
+			meta:           &model.NodeMetadata{DNSCapture: true, DNSProxyAddr: "10.0.0.1:15053"},
+			expectResolver: true,
+			expectHost:     "10.0.0.1",
+			expectPort:     15053,
+		},
+		{
+			name:           "DNS_CAPTURE enabled, empty addr falls back to defaults",
+			meta:           &model.NodeMetadata{DNSCapture: true},
+			expectResolver: true,
+			expectHost:     "127.0.0.1",
+			expectPort:     15053,
+		},
+		{
+			name:           "DNS_CAPTURE enabled, localhost resolved to 127.0.0.1",
+			meta:           &model.NodeMetadata{DNSCapture: true, DNSProxyAddr: "localhost:15053"},
+			expectResolver: true,
+			expectHost:     "127.0.0.1",
+			expectPort:     15053,
+		},
+		{
+			name:           "DNS_CAPTURE enabled, custom port",
+			meta:           &model.NodeMetadata{DNSCapture: true, DNSProxyAddr: "127.0.0.1:53"},
+			expectResolver: true,
+			expectHost:     "127.0.0.1",
+			expectPort:     53,
+		},
+		{
+			name:           "DNS_CAPTURE enabled, invalid addr falls back to defaults",
+			meta:           &model.NodeMetadata{DNSCapture: true, DNSProxyAddr: "not-a-valid-addr"},
+			expectResolver: true,
+			expectHost:     "127.0.0.1",
+			expectPort:     15053,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := buildAllowAnyDynamicDNSDNSCacheConfig(tc.meta)
+			if cfg.Name != util.AllowAnyDFPDNSCacheName {
+				t.Errorf("expected cache name %q, got %q", util.AllowAnyDFPDNSCacheName, cfg.Name)
+			}
+			if cfg.DnsLookupFamily != cluster.Cluster_V4_ONLY {
+				t.Errorf("expected dns lookup family V4_ONLY, got %v", cfg.DnsLookupFamily)
+			}
+			if !tc.expectResolver {
+				if cfg.TypedDnsResolverConfig != nil {
+					t.Error("expected no TypedDnsResolverConfig when DNS_CAPTURE is not set")
+				}
+				return
+			}
+			if cfg.TypedDnsResolverConfig == nil {
+				t.Fatal("expected TypedDnsResolverConfig to be set")
+			}
+			caresResolver := &cares.CaresDnsResolverConfig{}
+			if err := cfg.TypedDnsResolverConfig.TypedConfig.UnmarshalTo(caresResolver); err != nil {
+				t.Fatalf("failed to unmarshal c-ares config: %v", err)
+			}
+			if len(caresResolver.Resolvers) != 1 {
+				t.Fatalf("expected 1 resolver, got %d", len(caresResolver.Resolvers))
+			}
+			sa := caresResolver.Resolvers[0].GetSocketAddress()
+			if sa == nil {
+				t.Fatal("expected resolver to have SocketAddress")
+			}
+			if sa.Address != tc.expectHost {
+				t.Errorf("expected resolver host %q, got %q", tc.expectHost, sa.Address)
+			}
+			if sa.GetPortValue() != tc.expectPort {
+				t.Errorf("expected resolver port %d, got %d", tc.expectPort, sa.GetPortValue())
+			}
+		})
+	}
+}
+
+func TestBuildAllowAnyDynamicDNSHTTPForwardProxyFilter(t *testing.T) {
+	meta := &model.NodeMetadata{DNSCapture: true, DNSProxyAddr: "10.0.0.5:15053"}
+	got := buildAllowAnyDynamicDNSHTTPForwardProxyFilter(meta)
+
+	want := &hcm.HttpFilter{
+		Name: "envoy.filters.http.dynamic_forward_proxy",
+		ConfigType: &hcm.HttpFilter_TypedConfig{
+			TypedConfig: protoconv.MessageToAny(&httpdfp.FilterConfig{
+				ImplementationSpecifier: &httpdfp.FilterConfig_DnsCacheConfig{
+					DnsCacheConfig: buildAllowAnyDynamicDNSDNSCacheConfig(meta),
+				},
+			}),
+		},
+	}
+	if !proto.Equal(got, want) {
+		t.Errorf("filter mismatch:\ngot:  %v\nwant: %v", got, want)
 	}
 }

--- a/pilot/pkg/networking/core/sidecar_simulation_test.go
+++ b/pilot/pkg/networking/core/sidecar_simulation_test.go
@@ -1355,6 +1355,7 @@ func TestPassthroughTraffic(t *testing.T) {
 	for _, tp := range []meshconfig.MeshConfig_OutboundTrafficPolicy_Mode{
 		meshconfig.MeshConfig_OutboundTrafficPolicy_REGISTRY_ONLY,
 		meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY,
+		meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY_DYNAMIC_DNS,
 	} {
 		t.Run(tp.String(), func(t *testing.T) {
 			o := xds.FakeOptions{
@@ -1365,8 +1366,9 @@ func TestPassthroughTraffic(t *testing.T) {
 				}(),
 			}
 			expectedCluster := map[meshconfig.MeshConfig_OutboundTrafficPolicy_Mode]string{
-				meshconfig.MeshConfig_OutboundTrafficPolicy_REGISTRY_ONLY: util.BlackHoleCluster,
-				meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY:     util.PassthroughCluster,
+				meshconfig.MeshConfig_OutboundTrafficPolicy_REGISTRY_ONLY:         util.BlackHoleCluster,
+				meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY:             util.PassthroughCluster,
+				meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY_DYNAMIC_DNS: util.AllowAnyDynamicDNSCluster,
 			}[tp]
 			t.Run("with VIP", func(t *testing.T) {
 				testCalls := []simulation.Expect{}
@@ -1378,11 +1380,25 @@ func TestPassthroughTraffic(t *testing.T) {
 							ClusterMatched: expectedCluster,
 						},
 					}
-					// For blackhole, we will 502 where possible instead of blackhole cluster
-					// This only works for HTTP on HTTP
-					if expectedCluster == util.BlackHoleCluster && call.IsHTTP() && isHTTPPort(call.Port) {
-						e.Result.ClusterMatched = ""
-						e.Result.VirtualHostMatched = util.BlackHole
+					// With VIP, call address doesn't match VIP so traffic goes through
+					// virtualOutbound. Mode-specific overrides:
+					switch tp {
+					case meshconfig.MeshConfig_OutboundTrafficPolicy_REGISTRY_ONLY:
+						// 502 via blackhole VH where possible (HTTP on HTTP ports)
+						if call.IsHTTP() && isHTTPPort(call.Port) {
+							e.Result.ClusterMatched = ""
+							e.Result.VirtualHostMatched = util.BlackHole
+						}
+					case meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY:
+						if call.Protocol == simulation.TCP && call.TLS == simulation.Plaintext &&
+							!isHTTPPort(call.Port) {
+							e.Result.ClusterMatched = util.PassthroughCluster
+						}
+					case meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY_DYNAMIC_DNS:
+						// Only plaintext HTTP goes via DFP; everything else PassthroughCluster.
+						if call.TLS != simulation.Plaintext || !call.IsHTTP() {
+							e.Result.ClusterMatched = util.PassthroughCluster
+						}
 					}
 					testCalls = append(testCalls, e)
 				}
@@ -1415,11 +1431,21 @@ spec:
 							ClusterMatched: expectedCluster,
 						},
 					}
-					// For blackhole, we will 502 where possible instead of blackhole cluster
-					// This only works for HTTP on HTTP
-					if expectedCluster == util.BlackHoleCluster && call.IsHTTP() && (isHTTPPort(call.Port) || isAutoPort(call.Port)) {
-						e.Result.ClusterMatched = ""
-						e.Result.VirtualHostMatched = util.BlackHole
+					// Without VIP, traffic goes to per-port listeners. Mode-specific overrides:
+					switch tp {
+					case meshconfig.MeshConfig_OutboundTrafficPolicy_REGISTRY_ONLY:
+						// 502 via blackhole VH where possible (HTTP on HTTP/auto ports)
+						if call.IsHTTP() && (isHTTPPort(call.Port) || isAutoPort(call.Port)) {
+							e.Result.ClusterMatched = ""
+							e.Result.VirtualHostMatched = util.BlackHole
+						}
+					case meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY_DYNAMIC_DNS:
+						// Only plaintext HTTP on HCM ports (HTTP/GRPC/H2/auto) uses DFP
+						// (already the default); everything else PassthroughCluster.
+						if call.TLS != simulation.Plaintext || !call.IsHTTP() ||
+							!(isHTTPPort(call.Port) || isAutoPort(call.Port)) {
+							e.Result.ClusterMatched = util.PassthroughCluster
+						}
 					}
 					// TCP without a VIP will capture everything.
 					// Auto without a VIP is similar, but HTTP happens to work because routing is done on header

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -66,6 +66,13 @@ const (
 	// PassthroughCluster
 	Passthrough = "allow_any"
 
+	// AllowAnyDynamicDNSCluster is the DFP cluster used for ALLOW_ANY_DYNAMIC_DNS outbound traffic policy mode.
+	AllowAnyDynamicDNSCluster = "AllowAnyDynamicDNSCluster"
+	// AllowAnyDynamicDNS is the name of the virtual host and route name for ALLOW_ANY_DYNAMIC_DNS mode.
+	AllowAnyDynamicDNS = "allow_any_dynamic_dns"
+	// AllowAnyDFPDNSCacheName is the shared DNS cache name used by the DFP cluster and filters for ALLOW_ANY_DYNAMIC_DNS.
+	AllowAnyDFPDNSCacheName = "allow_any_dfp_dns_cache"
+
 	// PassthroughFilterChain to catch traffic that doesn't match other filter chains.
 	PassthroughFilterChain = "PassthroughFilterChain"
 
@@ -514,7 +521,16 @@ func addIstioEndpointLabel(metadata *core.Metadata, key string, val *structpb.Va
 	metadata.FilterMetadata[IstioMetadataKey].Fields[key] = val
 }
 
-// IsAllowAnyOutbound checks if allow_any is enabled for outbound traffic
+// IsAllowAnyDynamicDNSOutbound checks if ALLOW_ANY_DYNAMIC_DNS mode is enabled for outbound traffic.
+func IsAllowAnyDynamicDNSOutbound(node *model.Proxy) bool {
+	return node.SidecarScope != nil &&
+		node.SidecarScope.OutboundTrafficPolicy != nil &&
+		meshconfig.MeshConfig_OutboundTrafficPolicy_Mode(node.SidecarScope.OutboundTrafficPolicy.Mode) ==
+			meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY_DYNAMIC_DNS
+}
+
+// IsAllowAnyOutbound checks if outbound traffic to unknown destinations should be allowed
+// (either via ALLOW_ANY passthrough or ALLOW_ANY_DYNAMIC_DNS via DFP).
 func IsAllowAnyOutbound(node *model.Proxy) bool {
 	return node.SidecarScope != nil &&
 		node.SidecarScope.OutboundTrafficPolicy != nil &&

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -522,8 +522,10 @@ func addIstioEndpointLabel(metadata *core.Metadata, key string, val *structpb.Va
 }
 
 // IsAllowAnyDynamicDNSOutbound checks if ALLOW_ANY_DYNAMIC_DNS mode is enabled for outbound traffic.
+// This mode is scoped to sidecar proxies only — gateways are not eligible.
 func IsAllowAnyDynamicDNSOutbound(node *model.Proxy) bool {
-	return node.SidecarScope != nil &&
+	return node.Type == model.SidecarProxy &&
+		node.SidecarScope != nil &&
 		node.SidecarScope.OutboundTrafficPolicy != nil &&
 		meshconfig.MeshConfig_OutboundTrafficPolicy_Mode(node.SidecarScope.OutboundTrafficPolicy.Mode) ==
 			meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY_DYNAMIC_DNS

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 
+	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
@@ -43,6 +44,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	istionetworking "istio.io/istio/pilot/pkg/networking"
 	"istio.io/istio/pilot/pkg/serviceregistry/util/label"
+	networkutil "istio.io/istio/pilot/pkg/util/network"
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
@@ -102,6 +104,34 @@ const (
 	// to indicate whether Istio rewrite the ALPN headers
 	AlpnOverrideMetadataKey = "alpn_override"
 )
+
+// SelectDNSLookupFamily derives the DNS lookup family for DNS-resolving constructs (STRICT_DNS /
+// LOGICAL_DNS clusters and dynamic forward proxy DNS caches) from the proxy's own IP addresses.
+// Centralizing this keeps the behavior consistent across the default cluster builder and all the
+// DFP builders. When the proxy IPs are unknown the historical V4_ONLY default is used.
+func SelectDNSLookupFamily(proxyIPAddresses []string) cluster.Cluster_DnsLookupFamily {
+	switch {
+	case len(proxyIPAddresses) == 0:
+		return cluster.Cluster_V4_ONLY
+	case networkutil.AllIPv4(proxyIPAddresses):
+		// IPv4 only.
+		return cluster.Cluster_V4_ONLY
+	case networkutil.AllIPv6(proxyIPAddresses):
+		// IPv6 only. Istio sees only IPv6 addresses, but there may be a link-local interface
+		// serving IPv4. Allow both families so we do not break resolution to IPv4-only destinations.
+		if features.EnableAdditionalIpv4OutboundListenerForIpv6Only {
+			return cluster.Cluster_ALL
+		}
+		return cluster.Cluster_V6_ONLY
+	default:
+		// Dual stack: use Cluster_ALL to enable Happy Eyeballs when dual stack is enabled,
+		// otherwise keep the original V4_ONLY behavior.
+		if features.EnableDualStack {
+			return cluster.Cluster_ALL
+		}
+		return cluster.Cluster_V4_ONLY
+	}
+}
 
 // ALPNH2Only advertises that Proxy is going to use HTTP/2 when talking to the cluster.
 var ALPNH2Only = pm.ALPNH2Only

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -834,10 +834,76 @@ func TestIsAllowAnyOutbound(t *testing.T) {
 			},
 			result: true,
 		},
+		{
+			name: "OutboundTrafficPolicyAllowAnyDynamicDNS",
+			node: &model.Proxy{
+				SidecarScope: &model.SidecarScope{
+					OutboundTrafficPolicy: &networking.OutboundTrafficPolicy{
+						Mode: networking.OutboundTrafficPolicy_Mode(meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY_DYNAMIC_DNS),
+					},
+				},
+			},
+			result: false,
+		},
 	}
 	for i := range tests {
 		t.Run(tests[i].name, func(t *testing.T) {
 			out := IsAllowAnyOutbound(tests[i].node)
+			if out != tests[i].result {
+				t.Errorf("Expected %t but got %t for test case: %v\n", tests[i].result, out, tests[i].node)
+			}
+		})
+	}
+}
+
+func TestIsAllowAnyDynamicDNSOutbound(t *testing.T) {
+	tests := []struct {
+		name   string
+		node   *model.Proxy
+		result bool
+	}{
+		{
+			name:   "NilSidecarScope",
+			node:   &model.Proxy{},
+			result: false,
+		},
+		{
+			name: "AllowAny",
+			node: &model.Proxy{
+				SidecarScope: &model.SidecarScope{
+					OutboundTrafficPolicy: &networking.OutboundTrafficPolicy{
+						Mode: networking.OutboundTrafficPolicy_ALLOW_ANY,
+					},
+				},
+			},
+			result: false,
+		},
+		{
+			name: "RegistryOnly",
+			node: &model.Proxy{
+				SidecarScope: &model.SidecarScope{
+					OutboundTrafficPolicy: &networking.OutboundTrafficPolicy{
+						Mode: networking.OutboundTrafficPolicy_REGISTRY_ONLY,
+					},
+				},
+			},
+			result: false,
+		},
+		{
+			name: "AllowAnyDynamicDNS",
+			node: &model.Proxy{
+				SidecarScope: &model.SidecarScope{
+					OutboundTrafficPolicy: &networking.OutboundTrafficPolicy{
+						Mode: networking.OutboundTrafficPolicy_Mode(meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY_DYNAMIC_DNS),
+					},
+				},
+			},
+			result: true,
+		},
+	}
+	for i := range tests {
+		t.Run(tests[i].name, func(t *testing.T) {
+			out := IsAllowAnyDynamicDNSOutbound(tests[i].node)
 			if out != tests[i].result {
 				t.Errorf("Expected %t but got %t for test case: %v\n", tests[i].result, out, tests[i].node)
 			}

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"testing"
 
+	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
@@ -2045,4 +2046,24 @@ func BenchmarkAddConfigInfoMetadata(b *testing.B) {
 			}
 		}
 	})
+}
+
+func TestSelectDNSLookupFamily(t *testing.T) {
+	tests := []struct {
+		name string
+		ips  []string
+		want cluster.Cluster_DnsLookupFamily
+	}{
+		{"no ips defaults to v4", nil, cluster.Cluster_V4_ONLY},
+		{"ipv4 only", []string{"10.0.0.1"}, cluster.Cluster_V4_ONLY},
+		{"ipv6 only", []string{"2001:db8::1"}, cluster.Cluster_V6_ONLY},
+		{"dual stack defaults to v4", []string{"10.0.0.1", "2001:db8::1"}, cluster.Cluster_V4_ONLY},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SelectDNSLookupFamily(tc.ips); got != tc.want {
+				t.Errorf("SelectDNSLookupFamily(%v) = %v, want %v", tc.ips, got, tc.want)
+			}
+		})
+	}
 }

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -864,12 +864,13 @@ func TestIsAllowAnyDynamicDNSOutbound(t *testing.T) {
 	}{
 		{
 			name:   "NilSidecarScope",
-			node:   &model.Proxy{},
+			node:   &model.Proxy{Type: model.SidecarProxy},
 			result: false,
 		},
 		{
 			name: "AllowAny",
 			node: &model.Proxy{
+				Type: model.SidecarProxy,
 				SidecarScope: &model.SidecarScope{
 					OutboundTrafficPolicy: &networking.OutboundTrafficPolicy{
 						Mode: networking.OutboundTrafficPolicy_ALLOW_ANY,
@@ -881,6 +882,7 @@ func TestIsAllowAnyDynamicDNSOutbound(t *testing.T) {
 		{
 			name: "RegistryOnly",
 			node: &model.Proxy{
+				Type: model.SidecarProxy,
 				SidecarScope: &model.SidecarScope{
 					OutboundTrafficPolicy: &networking.OutboundTrafficPolicy{
 						Mode: networking.OutboundTrafficPolicy_REGISTRY_ONLY,
@@ -890,8 +892,9 @@ func TestIsAllowAnyDynamicDNSOutbound(t *testing.T) {
 			result: false,
 		},
 		{
-			name: "AllowAnyDynamicDNS",
+			name: "AllowAnyDynamicDNS_Sidecar",
 			node: &model.Proxy{
+				Type: model.SidecarProxy,
 				SidecarScope: &model.SidecarScope{
 					OutboundTrafficPolicy: &networking.OutboundTrafficPolicy{
 						Mode: networking.OutboundTrafficPolicy_Mode(meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY_DYNAMIC_DNS),
@@ -899,6 +902,18 @@ func TestIsAllowAnyDynamicDNSOutbound(t *testing.T) {
 				},
 			},
 			result: true,
+		},
+		{
+			name: "AllowAnyDynamicDNS_Gateway_NotEligible",
+			node: &model.Proxy{
+				Type: model.Router,
+				SidecarScope: &model.SidecarScope{
+					OutboundTrafficPolicy: &networking.OutboundTrafficPolicy{
+						Mode: networking.OutboundTrafficPolicy_Mode(meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY_DYNAMIC_DNS),
+					},
+				},
+			},
+			result: false,
 		},
 	}
 	for i := range tests {

--- a/pilot/pkg/xds/filters/filters.go
+++ b/pilot/pkg/xds/filters/filters.go
@@ -674,21 +674,21 @@ func additionalLabels(cfg map[string]any) {
 }
 
 // BuildWaypointInboundDFPFilter builds a dynamic forward proxy filter for waypoint inbound listeners
-// using the specified DNS cache config name. This name must match the name used in the corresponding
-// dynamic forward proxy cluster.
-func BuildWaypointInboundDFPFilter(dnsCacheConfigName string) *hcm.HttpFilter {
-	return buildDynamicForwardProxyFilter(dnsCacheConfigName)
+// using the specified DNS cache config name and lookup family. The name and lookup family must match
+// those used in the corresponding dynamic forward proxy cluster, since Envoy dedupes DNS caches by name.
+func BuildWaypointInboundDFPFilter(dnsCacheConfigName string, lookupFamily cluster.Cluster_DnsLookupFamily) *hcm.HttpFilter {
+	return buildDynamicForwardProxyFilter(dnsCacheConfigName, lookupFamily)
 }
 
 // BuildSidecarOutboundDynamicForwardProxyFilter builds a dynamic forward proxy filter for sidecar outbound listeners
-// using the specified DNS cache config name. This name must match the name used in the corresponding
-// dynamic forward proxy cluster.
-func BuildSidecarOutboundDynamicForwardProxyFilter(dnsCacheConfigName string) *hcm.HttpFilter {
-	return buildDynamicForwardProxyFilter(dnsCacheConfigName)
+// using the specified DNS cache config name and lookup family. The name and lookup family must match those used in
+// the corresponding dynamic forward proxy cluster, since Envoy dedupes DNS caches by name.
+func BuildSidecarOutboundDynamicForwardProxyFilter(dnsCacheConfigName string, lookupFamily cluster.Cluster_DnsLookupFamily) *hcm.HttpFilter {
+	return buildDynamicForwardProxyFilter(dnsCacheConfigName, lookupFamily)
 }
 
-// buildDynamicForwardProxyFilter builds a DFP HTTP filter using the specified DNS cache config name.
-func buildDynamicForwardProxyFilter(dnsCacheConfigName string) *hcm.HttpFilter {
+// buildDynamicForwardProxyFilter builds a DFP HTTP filter using the specified DNS cache config name and lookup family.
+func buildDynamicForwardProxyFilter(dnsCacheConfigName string, lookupFamily cluster.Cluster_DnsLookupFamily) *hcm.HttpFilter {
 	return &hcm.HttpFilter{
 		Name: "envoy.filters.http.dynamic_forward_proxy",
 		ConfigType: &hcm.HttpFilter_TypedConfig{
@@ -696,7 +696,7 @@ func buildDynamicForwardProxyFilter(dnsCacheConfigName string) *hcm.HttpFilter {
 				ImplementationSpecifier: &dfp.FilterConfig_DnsCacheConfig{
 					DnsCacheConfig: &dfpcommon.DnsCacheConfig{
 						Name:            dnsCacheConfigName,
-						DnsLookupFamily: cluster.Cluster_V4_ONLY,
+						DnsLookupFamily: lookupFamily,
 					},
 				},
 			}),

--- a/pilot/test/xdstest/validate.go
+++ b/pilot/test/xdstest/validate.go
@@ -165,10 +165,18 @@ func validateListenerTLS(t testing.TB, l *listener.Listener) {
 // matches logic in https://github.com/envoyproxy/envoy/blob/22683a0a24ffbb0cdeb4111eec5ec90246bec9cb/source/server/listener_impl.cc#L41
 func validateInspector(t testing.TB, l *listener.Listener) {
 	t.Helper()
+	hasTLSInspector := false
+	hasHTTPInspector := false
 	for _, lf := range l.ListenerFilters {
 		if lf.Name == xdsfilters.TLSInspector.Name {
-			return
+			hasTLSInspector = true
 		}
+		if lf.Name == xdsfilters.HTTPInspector.Name {
+			hasHTTPInspector = true
+		}
+	}
+	if hasTLSInspector {
+		return
 	}
 	for _, fc := range l.FilterChains {
 		m := fc.FilterChainMatch
@@ -181,10 +189,8 @@ func validateInspector(t testing.TB, l *listener.Listener) {
 		if m.TransportProtocol == "" && len(m.ServerNames) > 0 {
 			t.Errorf("server names set, but missing tls inspector: %v", Dump(t, l))
 		}
-		// This is a bit suspect; I suspect this could be done with just http inspector without tls inspector,
-		// but this mirrors Envoy validation logic
-		if m.TransportProtocol == "" && len(m.ApplicationProtocols) > 0 {
-			t.Errorf("application protocol set, but missing tls inspector: %v", Dump(t, l))
+		if m.TransportProtocol == "" && len(m.ApplicationProtocols) > 0 && !hasHTTPInspector {
+			t.Errorf("application protocol set, but missing tls inspector or http inspector: %v", Dump(t, l))
 		}
 	}
 }

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -685,6 +685,11 @@ func GetNodeMetaData(options MetadataOptions) (*model.Node, error) {
 		}
 	}, untypedMeta)
 
+	// DNS_PROXY_ADDR is not ISTIO_META_*-prefixed. Read the process env directly (pilot-agent uses os.Environ() for options.Envs).
+	if v, ok := os.LookupEnv("DNS_PROXY_ADDR"); ok && v != "" {
+		untypedMeta["DNS_PROXY_ADDR"] = v
+	}
+
 	j, err := json.Marshal(untypedMeta)
 	if err != nil {
 		return nil, err

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -20,6 +20,9 @@ const (
 	// UnspecifiedIPv6 constant for empty IPv6 address
 	UnspecifiedIPv6 = "::"
 
+	// DefaultDNSProxyAddr is the default host:port for the Istio DNS proxy (istio-agent DNS_PROXY_ADDR).
+	DefaultDNSProxyAddr = "localhost:15053"
+
 	// StatPrefixDelimiter constant for the stat delimiter
 	StatPrefixDelimiter = ";"
 

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -34,6 +34,7 @@ import (
 	"istio.io/api/annotation"
 	extensions "istio.io/api/extensions/v1alpha1"
 	"istio.io/api/label"
+	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	networkingv1beta1 "istio.io/api/networking/v1beta1"
 	security_beta "istio.io/api/security/v1beta1"
@@ -978,6 +979,14 @@ func validateSidecarOutboundTrafficPolicy(tp *networking.OutboundTrafficPolicy) 
 		return errs
 	}
 	mode := tp.GetMode()
+
+	// ALLOW_ANY_DYNAMIC_DNS is only supported at the mesh level (MeshConfig),
+	// not in the Sidecar CRD.
+	if meshconfig.MeshConfig_OutboundTrafficPolicy_Mode(mode) == meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY_DYNAMIC_DNS {
+		errs = appendErrors(errs, fmt.Errorf("sidecar: ALLOW_ANY_DYNAMIC_DNS mode is only supported in MeshConfig, not in Sidecar resource"))
+		return errs
+	}
+
 	if tp.EgressProxy != nil {
 		if mode != networking.OutboundTrafficPolicy_ALLOW_ANY {
 			errs = appendErrors(errs, fmt.Errorf("sidecar: egress_proxy must be set only with ALLOW_ANY outbound_traffic_policy mode"))

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -6455,6 +6455,16 @@ func TestValidateSidecar(t *testing.T) {
 				},
 			},
 		}, false, false},
+		{"ALLOW_ANY_DYNAMIC_DNS rejected in sidecar", &networking.Sidecar{
+			OutboundTrafficPolicy: &networking.OutboundTrafficPolicy{
+				Mode: networking.OutboundTrafficPolicy_Mode(3),
+			},
+			Egress: []*networking.IstioEgressListener{
+				{
+					Hosts: []string{"*/*"},
+				},
+			},
+		}, false, false},
 		{"sidecar egress only one wildcarded", &networking.Sidecar{
 			Egress: []*networking.IstioEgressListener{
 				{

--- a/pkg/dns/client/dns.go
+++ b/pkg/dns/client/dns.go
@@ -28,6 +28,7 @@ import (
 	"github.com/miekg/dns"
 
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	dnsProto "istio.io/istio/pkg/dns/proto"
 	istiolog "istio.io/istio/pkg/log"
@@ -144,7 +145,7 @@ func NewLocalDNSServer(proxyNamespace, proxyDomain string, addr string, opts ...
 			}
 		} else {
 			log.Error("DNS address :53 and not running as root, use default")
-			addr = "localhost:15053"
+			addr = constants.DefaultDNSProxyAddr
 		}
 	}
 
@@ -172,7 +173,7 @@ func NewLocalDNSServer(proxyNamespace, proxyDomain string, addr string, opts ...
 	log.WithLabels("search", h.searchNamespaces, "servers", h.resolvConfServers).Debugf("initialized DNS")
 
 	if addr == "" {
-		addr = "localhost:15053"
+		addr = constants.DefaultDNSProxyAddr
 	}
 	v4, v6 := netutil.ParseIPsSplitToV4V6(dnsConfig.Servers)
 	host, port, err := net.SplitHostPort(addr)

--- a/pkg/model/proxy.go
+++ b/pkg/model/proxy.go
@@ -292,6 +292,10 @@ type NodeMetadata struct {
 	// This depends on DNSCapture.
 	DNSAutoAllocate StringBool `json:"DNS_AUTO_ALLOCATE,omitempty"`
 
+	// DNSProxyAddr is the host:port where istio-agent listens for DNS (DNS_PROXY_ADDR). Populated from bootstrap
+	// so Pilot can point Envoy dynamic forward proxy at the same address.
+	DNSProxyAddr string `json:"DNS_PROXY_ADDR,omitempty"`
+
 	// EnableHBONE, if set, will enable generation of HBONE listener config.
 	// Note: this only impacts sidecars and gateways; ztunnel and waypoint proxy unconditionally use HBONE.
 	EnableHBONE StringBool `json:"ENABLE_HBONE,omitempty"`

--- a/releasenotes/notes/allow-any-dynamic-dns.yaml
+++ b/releasenotes/notes/allow-any-dynamic-dns.yaml
@@ -1,0 +1,12 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+releaseNotes:
+- |
+  **Added** `ALLOW_ANY_DYNAMIC_DNS` outbound traffic policy mode. When set in
+  `meshConfig.outboundTrafficPolicy.mode`, plaintext HTTP requests to unknown destinations are
+  forwarded via Envoy's Dynamic Forward Proxy, resolving hostnames from the Host header at
+  request time. Non-HTTP traffic (TLS, raw TCP) continues to use PassthroughCluster.
+  Scoped to sidecar proxies only. Not supported in the Sidecar CRD. Optional upstream TLS
+  origination can be configured via `meshConfig.outboundTrafficPolicy.tls`.

--- a/tests/integration/telemetry/policy/dynamicdns/main_test.go
+++ b/tests/integration/telemetry/policy/dynamicdns/main_test.go
@@ -1,0 +1,52 @@
+//go:build integ
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dynamics
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+var ist istio.Instance
+
+// setupConfig configures the mesh with ALLOW_ANY_DYNAMIC_DNS outbound traffic policy.
+// This mode is only valid at the MeshConfig level (rejected by validation in Sidecar CRD),
+// so it must be applied via the istio install rather than per-namespace.
+func setupConfig(_ resource.Context, cfg *istio.Config) {
+	if cfg == nil {
+		return
+	}
+	cfg.ControlPlaneValues = `
+meshConfig:
+  outboundTrafficPolicy:
+    mode: ALLOW_ANY_DYNAMIC_DNS
+`
+	cfg.RemoteClusterValues = cfg.ControlPlaneValues
+}
+
+func TestMain(m *testing.M) {
+	// nolint: staticcheck
+	framework.
+		NewSuite(m).
+		Label(label.CustomSetup).
+		Setup(istio.Setup(&ist, setupConfig)).
+		Run()
+}

--- a/tests/integration/telemetry/policy/dynamicdns/traffic_allow_any_dynamic_dns_test.go
+++ b/tests/integration/telemetry/policy/dynamicdns/traffic_allow_any_dynamic_dns_test.go
@@ -1,0 +1,201 @@
+//go:build integ
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dynamics
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+	"testing"
+	"time"
+
+	"istio.io/api/annotation"
+	"istio.io/istio/istioctl/pkg/util"
+	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/test/echo/common"
+	"istio.io/istio/pkg/test/env"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/check"
+	"istio.io/istio/pkg/test/framework/components/echo/deployment"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/util/retry"
+)
+
+const sidecarScope = `
+apiVersion: networking.istio.io/v1
+kind: Sidecar
+metadata:
+  name: restrict-egress
+spec:
+  egress:
+  - hosts:
+    - "{{.ImportNamespace}}/*"
+    - "istio-system/*"
+`
+
+// TestAllowAnyDynamicDNSPolicy verifies traffic routing under mesh mode ALLOW_ANY_DYNAMIC_DNS:
+//   - HTTP to an unknown destination is forwarded via AllowAnyDynamicDNSCluster.
+//   - HTTPS (non-HTTP / unknown protocol) still falls through to PassthroughCluster.
+//
+// Asserts on Envoy admin stats from the client proxy to avoid coupling to the istio-proxy
+// stats filter labeling.
+func TestAllowAnyDynamicDNSPolicy(t *testing.T) {
+	framework.NewTest(t).Run(func(t framework.TestContext) {
+		appsNS := namespace.NewOrFail(t, namespace.Config{Prefix: "app", Inject: true})
+		serviceNS := namespace.NewOrFail(t, namespace.Config{Prefix: "service", Inject: true})
+
+		args := map[string]string{"ImportNamespace": serviceNS.Name()}
+		t.ConfigIstio().Eval(appsNS.Name(), args, sidecarScope).ApplyOrFail(t)
+
+		var client, dest echo.Instance
+		deployment.New(t).
+			With(&client, echo.Config{
+				Service:   "client",
+				Namespace: appsNS,
+				// Istio-proxy strips most cluster.* counters by default; opt these in so /stats
+				// exposes upstream_rq_total for the clusters we assert on.
+				Subsets: []echo.SubsetConfig{{
+					Annotations: map[string]string{
+						annotation.SidecarStatsInclusionPrefixes.Name: "cluster.AllowAnyDynamicDNSCluster,cluster.PassthroughCluster,cluster.BlackHoleCluster",
+					},
+				}},
+			}).
+			With(&dest, echo.Config{
+				Service:   "destination",
+				Namespace: appsNS,
+				Subsets:   []echo.SubsetConfig{{}},
+				Ports: []echo.Port{
+					{
+						Name:         "http",
+						Protocol:     protocol.HTTP,
+						ServicePort:  80,
+						WorkloadPort: 8080,
+					},
+					{
+						Name:         "https",
+						Protocol:     protocol.HTTPS,
+						ServicePort:  443,
+						WorkloadPort: 8443,
+						TLS:          true,
+					},
+				},
+				TLSSettings: &common.TLSSettings{
+					ClientCert: mustReadCert(t, "cert.crt"),
+					Key:        mustReadCert(t, "cert.key"),
+				},
+			}).BuildOrFail(t)
+
+		t.NewSubTest("http-via-dfp").Run(func(t framework.TestContext) {
+			baseline := clusterUpstreamRqTotal(t, client, "AllowAnyDynamicDNSCluster")
+			passthroughBaseline := clusterUpstreamRqTotal(t, client, "PassthroughCluster")
+
+			client.CallOrFail(t, echo.CallOptions{
+				To:    dest,
+				Count: 1,
+				Port:  echo.Port{Name: "http"},
+				Check: check.OK(),
+			})
+
+			retry.UntilSuccessOrFail(t, func() error {
+				got := clusterUpstreamRqTotal(t, client, "AllowAnyDynamicDNSCluster")
+				if got <= baseline {
+					return fmt.Errorf("AllowAnyDynamicDNSCluster.upstream_rq_total did not increase: baseline=%d got=%d", baseline, got)
+				}
+				return nil
+			}, retry.Delay(time.Second), retry.Timeout(20*time.Second))
+
+			if got := clusterUpstreamRqTotal(t, client, "PassthroughCluster"); got != passthroughBaseline {
+				t.Fatalf("HTTP request unexpectedly hit PassthroughCluster: baseline=%d got=%d", passthroughBaseline, got)
+			}
+		})
+
+		t.NewSubTest("https-via-passthrough").Run(func(t framework.TestContext) {
+			baseline := clusterUpstreamRqTotal(t, client, "PassthroughCluster")
+			dfpBaseline := clusterUpstreamRqTotal(t, client, "AllowAnyDynamicDNSCluster")
+
+			client.CallOrFail(t, echo.CallOptions{
+				To:    dest,
+				Count: 1,
+				Port:  echo.Port{Name: "https"},
+				Check: check.OK(),
+			})
+
+			retry.UntilSuccessOrFail(t, func() error {
+				got := clusterUpstreamRqTotal(t, client, "PassthroughCluster")
+				if got <= baseline {
+					return fmt.Errorf("PassthroughCluster.upstream_rq_total did not increase: baseline=%d got=%d", baseline, got)
+				}
+				return nil
+			}, retry.Delay(time.Second), retry.Timeout(20*time.Second))
+
+			if got := clusterUpstreamRqTotal(t, client, "AllowAnyDynamicDNSCluster"); got != dfpBaseline {
+				t.Fatalf("HTTPS request unexpectedly hit AllowAnyDynamicDNSCluster: baseline=%d got=%d", dfpBaseline, got)
+			}
+		})
+	})
+}
+
+func mustReadCert(t framework.TestContext, f string) string {
+	t.Helper()
+	b, err := os.ReadFile(path.Join(env.IstioSrc, "tests/testdata/certs", f))
+	if err != nil {
+		t.Fatalf("failed to read %v: %v", f, err)
+	}
+	return string(b)
+}
+
+func clusterUpstreamRqTotal(t framework.TestContext, c echo.Instance, clusterName string) int {
+	t.Helper()
+	wl := c.WorkloadsOrFail(t)[0]
+	body, err := wl.Cluster().EnvoyDoWithPort(
+		context.TODO(),
+		wl.PodName(),
+		c.Config().Namespace.Name(),
+		"GET",
+		"stats?filter=^cluster\\."+clusterName,
+		util.DefaultProxyAdminPort,
+	)
+	if err != nil {
+		t.Fatalf("failed to query envoy stats: %v", err)
+	}
+	// Envoy may emit "cluster.<name>;.upstream_rq_total" (stat-tag form) or the bare form.
+	clusterTok := "cluster." + clusterName
+	const suffix = ".upstream_rq_total"
+	for _, line := range strings.Split(string(body), "\n") {
+		line = strings.TrimSpace(line)
+		idx := strings.LastIndex(line, ":")
+		if idx < 0 {
+			continue
+		}
+		key := strings.TrimSpace(line[:idx])
+		if !strings.HasPrefix(key, clusterTok) || !strings.HasSuffix(key, suffix) {
+			continue
+		}
+		mid := key[len(clusterTok) : len(key)-len(suffix)]
+		if mid != "" && mid != ";" {
+			continue
+		}
+		var n int
+		if _, err := fmt.Sscanf(strings.TrimSpace(line[idx+1:]), "%d", &n); err == nil {
+			return n
+		}
+	}
+	return 0
+}

--- a/tests/integration/telemetry/policy/dynamicdns/traffic_allow_any_dynamic_dns_test.go
+++ b/tests/integration/telemetry/policy/dynamicdns/traffic_allow_any_dynamic_dns_test.go
@@ -28,7 +28,9 @@ import (
 	"istio.io/api/annotation"
 	"istio.io/istio/istioctl/pkg/util"
 	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/http/headers"
 	"istio.io/istio/pkg/test/echo/common"
+	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
@@ -154,7 +156,8 @@ func TestAllowAnyDynamicDNSPolicy(t *testing.T) {
 
 // TestAllowAnyDynamicDNSWithTLS verifies that when outboundTrafficPolicy.tls is configured with
 // mode SIMPLE, the proxy originates TLS to unknown external destinations via the DFP cluster.
-// A plain HTTP request to www.google.com is resolved by DFP and forwarded over TLS to :443.
+// An external echo instance (no sidecar) serves TLS. The client sends plaintext HTTP; the
+// proxy's DFP cluster resolves the host and originates TLS to the external destination.
 func TestAllowAnyDynamicDNSWithTLS(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
 		ist.PatchMeshConfigOrFail(t, `
@@ -162,10 +165,16 @@ outboundTrafficPolicy:
   mode: ALLOW_ANY_DYNAMIC_DNS
   tls:
     mode: SIMPLE
+    insecureSkipVerify: true
 `)
 		appsNS := namespace.NewOrFail(t, namespace.Config{Prefix: "app-tls", Inject: true})
+		serviceNS := namespace.NewOrFail(t, namespace.Config{Prefix: "service-tls", Inject: true})
+		externalNS := namespace.NewOrFail(t, namespace.Config{Prefix: "external-tls", Inject: false})
 
-		var client echo.Instance
+		args := map[string]string{"ImportNamespace": serviceNS.Name()}
+		t.ConfigIstio().Eval(appsNS.Name(), args, sidecarScope).ApplyOrFail(t)
+
+		var client, external echo.Instance
 		deployment.New(t).
 			With(&client, echo.Config{
 				Service:   "client",
@@ -175,17 +184,40 @@ outboundTrafficPolicy:
 						annotation.SidecarStatsInclusionPrefixes.Name: "cluster.AllowAnyDynamicDNSCluster,cluster.PassthroughCluster,cluster.BlackHoleCluster",
 					},
 				}},
+			}).
+			With(&external, echo.Config{
+				Service:   "external-tls",
+				Namespace: externalNS,
+				Subsets: []echo.SubsetConfig{{
+					Annotations: map[string]string{annotation.SidecarInject.Name: "false"},
+				}},
+				Ports: []echo.Port{
+					{
+						Name:         "https",
+						Protocol:     protocol.HTTPS,
+						ServicePort:  443,
+						WorkloadPort: 8443,
+						TLS:          true,
+					},
+				},
+				TLSSettings: &common.TLSSettings{
+					ClientCert: mustReadCert(t, "cert.crt"),
+					Key:        mustReadCert(t, "cert.key"),
+				},
 			}).BuildOrFail(t)
 
 		t.NewSubTest("http-to-external-with-tls-origination").Run(func(t framework.TestContext) {
 			baseline := clusterUpstreamRqTotal(t, client, "AllowAnyDynamicDNSCluster")
 
 			client.CallOrFail(t, echo.CallOptions{
-				Address: "www.google.com",
+				Address: "external-tls." + externalNS.Name() + ".svc.cluster.local",
 				Port: echo.Port{
-					Name:        "http",
-					ServicePort: 80,
+					ServicePort: 443,
 					Protocol:    protocol.HTTP,
+				},
+				Scheme: scheme.HTTP,
+				HTTP: echo.HTTP{
+					Headers: headers.New().WithHost("external-tls." + externalNS.Name() + ".svc.cluster.local").Build(),
 				},
 				Count: 1,
 				Check: check.OK(),

--- a/tests/integration/telemetry/policy/dynamicdns/traffic_allow_any_dynamic_dns_test.go
+++ b/tests/integration/telemetry/policy/dynamicdns/traffic_allow_any_dynamic_dns_test.go
@@ -152,6 +152,56 @@ func TestAllowAnyDynamicDNSPolicy(t *testing.T) {
 	})
 }
 
+// TestAllowAnyDynamicDNSWithTLS verifies that when outboundTrafficPolicy.tls is configured with
+// mode SIMPLE, the proxy originates TLS to unknown external destinations via the DFP cluster.
+// A plain HTTP request to www.google.com is resolved by DFP and forwarded over TLS to :443.
+func TestAllowAnyDynamicDNSWithTLS(t *testing.T) {
+	framework.NewTest(t).Run(func(t framework.TestContext) {
+		ist.PatchMeshConfigOrFail(t, `
+outboundTrafficPolicy:
+  mode: ALLOW_ANY_DYNAMIC_DNS
+  tls:
+    mode: SIMPLE
+`)
+		appsNS := namespace.NewOrFail(t, namespace.Config{Prefix: "app-tls", Inject: true})
+
+		var client echo.Instance
+		deployment.New(t).
+			With(&client, echo.Config{
+				Service:   "client",
+				Namespace: appsNS,
+				Subsets: []echo.SubsetConfig{{
+					Annotations: map[string]string{
+						annotation.SidecarStatsInclusionPrefixes.Name: "cluster.AllowAnyDynamicDNSCluster,cluster.PassthroughCluster,cluster.BlackHoleCluster",
+					},
+				}},
+			}).BuildOrFail(t)
+
+		t.NewSubTest("http-to-external-with-tls-origination").Run(func(t framework.TestContext) {
+			baseline := clusterUpstreamRqTotal(t, client, "AllowAnyDynamicDNSCluster")
+
+			client.CallOrFail(t, echo.CallOptions{
+				Address: "www.google.com",
+				Port: echo.Port{
+					Name:        "http",
+					ServicePort: 80,
+					Protocol:    protocol.HTTP,
+				},
+				Count: 1,
+				Check: check.OK(),
+			})
+
+			retry.UntilSuccessOrFail(t, func() error {
+				got := clusterUpstreamRqTotal(t, client, "AllowAnyDynamicDNSCluster")
+				if got <= baseline {
+					return fmt.Errorf("AllowAnyDynamicDNSCluster.upstream_rq_total did not increase: baseline=%d got=%d", baseline, got)
+				}
+				return nil
+			}, retry.Delay(time.Second), retry.Timeout(20*time.Second))
+		})
+	})
+}
+
 func mustReadCert(t framework.TestContext, f string) string {
 	t.Helper()
 	b, err := os.ReadFile(path.Join(env.IstioSrc, "tests/testdata/certs", f))


### PR DESCRIPTION
**Please provide a description of this PR:**
Implements a new `ALLOW_ANY_DYNAMIC_DNS` outbound traffic policy mode (introduced in istio/api#3667) that uses Dynamic Forward Proxy (DFP) to resolve unknown outbound HTTP traffic via DNS. 
* Plaintext HTTP traffic is detected by the HTTP inspector on the `virtualOutbound` listener and routed through an HCM with a DFP HTTP filter. The filter resolves the hostname from the `host/:authority` header using a shared DNS cache, then forwards to the `AllowAnyDynamicDNSCluster`. Optional TLS origination can be configured via `OutboundTrafficPolicy.tls`.
* All other traffic (TLS, plain TCP) falls through to `PassthroughCluster`, identical to `ALLOW_ANY` behavior since DFP cannot resolve hostnames without an HTTP Host header.
* Per-port outbound listeners also get the DFP HTTP filter injected into their HCMs. The catch-all virtual host in the HTTP route config points to the `AllowAnyDynamicDNSCluster` in this mode, so unmatched HTTP requests are forwarded via DFP. The default filter chain fallthrough uses `PassthroughCluster` (same as `ALLOW_ANY`).
* When `DNS_CAPTURE` is enabled, the DFP DNS cache resolves via the Istio DNS proxy `DNS_PROXY_ADDR`. Otherwise, no explicit resolver is set in the DFP config and Envoy uses its default DNS resolution.
* EgressProxy is supported: if configured, it replaces PassthroughCluster as the fallthrough destination for non-HTTP traffic.

**Testing:**
* Setup Istio with changes with OTP config set:
```
./out/darwin_arm64/istioctl install -y --set hub=docker.io/rudrakhpanigrahi056 --set tag=allow_any_dynamic_dns --set meshConfig.defaultConfig.proxyMetadata.ISTIO_META_DNS_CAPTURE=true --set meshConfig.outboundTrafficPolicy.mode=ALLOW_ANY_DYNAMIC_DNS --set meshConfig.outboundTrafficPolicy.tls.mode=ISTIO_MUTUAL --set meshConfig.outboundTrafficPolicy.tls.insecureSkipVerify=true
```
Note that `insecureSkipVerify` has to be set because `ISTIO_MUTUAL` certs don't have SANs for auto_san_validation. Can be unset for `MUTUAL_TLS` with custom certs with DNS SANs.
* To test the DFP path with TLS config, a Sidecar was applied to the ratings pods to details pods are not visible to it and all calls to details go via catch all route:
```
apiVersion: networking.istio.io/v1
kind: Sidecar
metadata:
  name: restrict-default
  namespace: default
spec:
  egress:
  - hosts:
    - istio-system/*
  workloadSelector:
    labels:
      app: ratings
```
* Make the HTTP call and check stats:
```
❯ POD_NAME=$(kubectl get pod -n default -l app=ratings -o jsonpath='{.items[0].metadata.name}') && echo "Making test request..." && kubectl exec $POD_NAME -n default -c ratings -- curl -sS -o /dev/null -w "HTTP %{http_code}\n" details.default.svc.cluster.local:9080/details/0 && echo "Checking stats after request..." && kubectl exec $POD_NAME -c istio-proxy -- curl -s localhost:15000/clusters | grep "AllowAnyDynamicDNSCluster" | grep -E "rq_total|rq_success"
Making test request...
HTTP 200
Checking stats after request...
AllowAnyDynamicDNSCluster::10.96.35.238:9080::rq_success::1
AllowAnyDynamicDNSCluster::10.96.35.238:9080::rq_total::1
```
* Test Passthrough path for non-HTTP calls:
```
❯ POD_NAME=$(kubectl get pod -n default -l app=ratings -o jsonpath='{.items[0].metadata.name}') && echo "Making test request..." && kubectl exec $POD_NAME -n default -c ratings -- curl -sS -o /dev/null -w "HTTP %{http_code}\n" https://www.google.com && echo "Checking stats after request..." && kubectl exec $POD_NAME -c istio-proxy -- curl -s localhost:15000/clusters | grep "PassthroughCluster" | grep -E "rq|cx"
Making test request...
HTTP 200
Checking stats after request...
PassthroughCluster::142.251.157.119:443::cx_active::0
PassthroughCluster::142.251.157.119:443::cx_connect_fail::0
PassthroughCluster::142.251.157.119:443::cx_total::1
PassthroughCluster::142.251.157.119:443::rq_active::0
PassthroughCluster::142.251.157.119:443::rq_error::0
PassthroughCluster::142.251.157.119:443::rq_success::0
PassthroughCluster::142.251.157.119:443::rq_timeout::0
PassthroughCluster::142.251.157.119:443::rq_total::1
```
* Set OTP tls config to `SIMPLE`:
```
❯ ./out/darwin_arm64/istioctl install -y --set hub=docker.io/rudrakhpanigrahi056 --set tag=allow_any_dynamic_dns --set meshConfig.defaultConfig.proxyMetadata.ISTIO_META_DNS_CAPTURE=true --set meshConfig.outboundTrafficPolicy.mode=ALLOW_ANY_DYNAMIC_DNS --set meshConfig.outboundTrafficPolicy.tls.mode=SIMPLE                                                                        ─╯
```
* Test out simple TLS path now goes via DFP cluster:
```
❯ POD_NAME=$(kubectl get pod -n default -l app=ratings -o jsonpath='{.items[0].metadata.name}') && echo "Making test request..." && kubectl exec $POD_NAME -n default -c ratings -- curl -sS -o /dev/null -w "HTTP %{http_code}\n" http://www.google.com && echo "Checking stats after request..." && kubectl exec $POD_NAME -c istio-proxy -- curl -s localhost:15000/clusters | grep "AllowAnyDynamicDNSCluster" | grep -E "rq|cx"
Making test request...
HTTP 200
Checking stats after request...
AllowAnyDynamicDNSCluster::142.251.150.119:443::cx_active::1
AllowAnyDynamicDNSCluster::142.251.150.119:443::cx_connect_fail::0
AllowAnyDynamicDNSCluster::142.251.150.119:443::cx_total::1
AllowAnyDynamicDNSCluster::142.251.150.119:443::rq_active::0
AllowAnyDynamicDNSCluster::142.251.150.119:443::rq_error::0
AllowAnyDynamicDNSCluster::142.251.150.119:443::rq_success::1
AllowAnyDynamicDNSCluster::142.251.150.119:443::rq_timeout::0
AllowAnyDynamicDNSCluster::142.251.150.119:443::rq_total::1
```


 Implements a new API that shouldn't affect existing ones.