### PR TITLE
Add configurable DNS upstream timeout behavior

### DIFF
--- a/pilot/cmd/pilot-agent/options/agent.go
+++ b/pilot/cmd/pilot-agent/options/agent.go
@@ -62,6 +62,7 @@ func NewAgentOptions(proxy *ProxyArgs, cfg *meshconfig.ProxyConfig, sds istioage
 		DNSCapture:                  DNSCaptureByAgent.Get(),
 		DNSAtGateway:                EnableDNSAtGateway.Get(),
 		DNSForwardParallel:          DNSForwardParallel.Get(),
+		DNSForwardTimeout:           DNSForwardTimeout.Get(),
 		DNSAddr:                     DNSCaptureAddr.Get(),
 		ProxyNamespace:              PodNamespaceVar.Get(),
 		ProxyDomain:                 proxy.DNSDomain,

--- a/pilot/cmd/pilot-agent/options/options.go
+++ b/pilot/cmd/pilot-agent/options/options.go
@@ -21,6 +21,7 @@ import (
 
 	"istio.io/istio/pilot/cmd/pilot-agent/status"
 	"istio.io/istio/pkg/config/constants"
+	dnsClient "istio.io/istio/pkg/dns/client"
 	"istio.io/istio/pkg/env"
 	"istio.io/istio/pkg/jwt"
 	"istio.io/istio/pkg/security"
@@ -109,6 +110,9 @@ var (
 
 	DNSForwardParallel = env.Register("DNS_FORWARD_PARALLEL", false,
 		"If set to true, agent will send parallel DNS queries to all upstream nameservers")
+
+	DNSForwardTimeout = env.Register("DNS_FORWARD_TIMEOUT", dnsClient.DefaultUpstreamTimeout,
+		"Timeout for upstream DNS queries. Defaults to 5 seconds")
 
 	// Ability of istio-agent to retrieve proxyConfig via XDS for dynamic configuration updates
 	enableProxyConfigXdsEnv = env.Register("PROXY_CONFIG_XDS_AGENT", false,

--- a/pkg/dns/client/dns.go
+++ b/pkg/dns/client/dns.go
@@ -59,6 +59,7 @@ type LocalDNSServer struct {
 
 	respondBeforeSync         bool
 	forwardToUpstreamParallel bool
+	upstreamTimeout           time.Duration
 }
 
 // LookupTable is borrowed from https://github.com/coredns/coredns/blob/master/plugin/hosts/hostsfile.go
@@ -85,12 +86,38 @@ const (
 	// the latest IP for a host.
 	// TODO: make it configurable
 	defaultTTLInSeconds = 30
+
+	// DefaultUpstreamTimeout is the default timeout for DNS upstream queries
+	DefaultUpstreamTimeout = 5 * time.Second
 )
 
-func NewLocalDNSServer(proxyNamespace, proxyDomain string, addr string, forwardToUpstreamParallel bool) (*LocalDNSServer, error) {
+// LocalDNSServerOption is a functional option for configuring LocalDNSServer.
+type LocalDNSServerOption func(*LocalDNSServer)
+
+// WithParallelForwarding enables or disables parallel forwarding to upstream DNS servers.
+func WithParallelForwarding(parallel bool) LocalDNSServerOption {
+	return func(s *LocalDNSServer) {
+		s.forwardToUpstreamParallel = parallel
+	}
+}
+
+// WithUpstreamTimeout sets the timeout for upstream DNS queries.
+func WithUpstreamTimeout(timeout time.Duration) LocalDNSServerOption {
+	return func(s *LocalDNSServer) {
+		s.upstreamTimeout = timeout
+	}
+}
+
+func NewLocalDNSServer(proxyNamespace, proxyDomain string, addr string, opts ...LocalDNSServerOption) (*LocalDNSServer, error) {
 	h := &LocalDNSServer{
 		proxyNamespace:            proxyNamespace,
-		forwardToUpstreamParallel: forwardToUpstreamParallel,
+		forwardToUpstreamParallel: false,
+		upstreamTimeout:           DefaultUpstreamTimeout,
+	}
+
+	// Apply functional options
+	for _, opt := range opts {
+		opt(h)
 	}
 
 	// proxyDomain could contain the namespace making it redundant.
@@ -166,7 +193,7 @@ func NewLocalDNSServer(proxyNamespace, proxyDomain string, addr string, forwardT
 	}
 	for _, ipAddr := range addresses {
 		for _, proto := range []string{"udp", "tcp"} {
-			proxy, err := newDNSProxy(proto, ipAddr, h)
+			proxy, err := newDNSProxy(proto, ipAddr, h, h.upstreamTimeout)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/dns/client/dns_test.go
+++ b/pkg/dns/client/dns_test.go
@@ -43,7 +43,7 @@ func TestDNS(t *testing.T) {
 
 func TestBuildAlternateHosts(t *testing.T) {
 	// Create the server instance without starting it, as it's unnecessary for this test
-	d, err := NewLocalDNSServer("ns1", "ns1.svc.cluster.local", "localhost:0", false)
+	d, err := NewLocalDNSServer("ns1", "ns1.svc.cluster.local", "localhost:0")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -593,7 +593,7 @@ func makeUpstream(t test.Failer, responses map[string]string) string {
 
 func initDNS(t test.Failer, forwardToUpstreamParallel bool) *LocalDNSServer {
 	srv := makeUpstream(t, map[string]string{"www.bing.com.": "1.1.1.1"})
-	testAgentDNS, err := NewLocalDNSServer("ns1", "ns1.svc.cluster.local", "localhost:0", forwardToUpstreamParallel)
+	testAgentDNS, err := NewLocalDNSServer("ns1", "ns1.svc.cluster.local", "localhost:0", WithParallelForwarding(forwardToUpstreamParallel))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -679,4 +679,96 @@ func equalsDNSrecords(got []dns.RR, want []dns.RR) bool {
 		got[i].Header().Rdlength = 0
 	}
 	return reflect.DeepEqual(got, want)
+}
+
+func TestDNSTimeoutBehavior(t *testing.T) {
+	tests := []struct {
+		name        string
+		timeout     time.Duration
+		minDuration time.Duration // Should take at least this long
+		maxDuration time.Duration // But not more than this
+	}{
+		{
+			name:        "100ms timeout",
+			timeout:     100 * time.Millisecond,
+			minDuration: 90 * time.Millisecond,  // Allow 10ms tolerance
+			maxDuration: 200 * time.Millisecond, // Should timeout well before 200ms
+		},
+		{
+			name:        "200ms timeout",
+			timeout:     200 * time.Millisecond,
+			minDuration: 180 * time.Millisecond,
+			maxDuration: 400 * time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create an upstream DNS server that never responds (to trigger timeout)
+			unresponsiveHandler := func(w dns.ResponseWriter, req *dns.Msg) {
+				// Don't respond - just return without writing anything
+				// This will cause the client to timeout
+			}
+
+			up := make(chan struct{})
+			server := &dns.Server{
+				Addr:              "127.0.0.1:0",
+				Net:               "udp",
+				Handler:           dns.HandlerFunc(unresponsiveHandler),
+				NotifyStartedFunc: func() { close(up) },
+			}
+
+			go func() {
+				_ = server.ListenAndServe()
+			}()
+			defer func() {
+				_ = server.Shutdown()
+			}()
+
+			// Wait for server to be ready
+			select {
+			case <-time.After(time.Second * 10):
+				t.Fatal("server setup timeout")
+			case <-up:
+			}
+
+			dnsServer, err := NewLocalDNSServer("test-ns", "test-ns.svc.cluster.local", "localhost:0",
+				WithUpstreamTimeout(tt.timeout))
+			if err != nil {
+				t.Fatalf("Failed to create DNS server: %v", err)
+			}
+			defer dnsServer.Close()
+
+			// Override resolv.conf servers to point to our unresponsive test server
+			dnsServer.resolvConfServers = []string{server.PacketConn.LocalAddr().String()}
+
+			// Make a query and measure how long it takes
+			req := new(dns.Msg)
+			req.SetQuestion("test.example.com.", dns.TypeA)
+
+			start := time.Now()
+			response := dnsServer.queryUpstream(dnsServer.dnsProxies[0].upstreamClient, req, log)
+			duration := time.Since(start)
+
+			// Should get SERVFAIL due to timeout
+			if response.Rcode != dns.RcodeServerFailure {
+				t.Errorf("Expected SERVFAIL, got %v", response.Rcode)
+			}
+
+			// Verify the timeout happened in expected timeframe
+			if duration < tt.minDuration {
+				t.Errorf("Query completed too quickly: %v, expected >= %v (timeout was %v)",
+					duration, tt.minDuration, tt.timeout)
+			}
+			if duration > tt.maxDuration {
+				t.Errorf("Query took too long: %v, expected <= %v (timeout was %v)",
+					duration, tt.maxDuration, tt.timeout)
+			}
+
+			// Should have timed out (not gotten a response)
+			if len(response.Answer) > 0 {
+				t.Errorf("Expected timeout, but got answer")
+			}
+		})
+	}
 }

--- a/pkg/dns/client/proxy.go
+++ b/pkg/dns/client/proxy.go
@@ -32,15 +32,15 @@ type dnsProxy struct {
 	resolver       *LocalDNSServer
 }
 
-func newDNSProxy(protocol, addr string, resolver *LocalDNSServer) (*dnsProxy, error) {
+func newDNSProxy(protocol, addr string, resolver *LocalDNSServer, timeout time.Duration) (*dnsProxy, error) {
 	p := &dnsProxy{
 		serveMux: dns.NewServeMux(),
 		server:   &dns.Server{},
 		upstreamClient: &dns.Client{
 			Net:          protocol,
-			DialTimeout:  5 * time.Second,
-			ReadTimeout:  5 * time.Second,
-			WriteTimeout: 5 * time.Second,
+			DialTimeout:  timeout,
+			ReadTimeout:  timeout,
+			WriteTimeout: timeout,
 		},
 		protocol: protocol,
 		resolver: resolver,

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -161,6 +161,8 @@ type AgentOptions struct {
 	DNSAddr string
 	// DNSForwardParallel indicates whether the agent should send parallel DNS queries to all upstream nameservers.
 	DNSForwardParallel bool
+	// DNSForwardTimeout is the timeout for upstream DNS queries.
+	DNSForwardTimeout time.Duration
 	// ProxyType is the type of proxy we are configured to handle
 	ProxyType model.NodeType
 	// ProxyNamespace to use for local dns resolution
@@ -541,8 +543,13 @@ func (a *Agent) startFileWatcher(ctx context.Context, filePath string, handler f
 
 func (a *Agent) initLocalDNSServer() (err error) {
 	if a.isDNSServerEnabled() {
-		if a.localDNSServer, err = dnsClient.NewLocalDNSServer(a.cfg.ProxyNamespace, a.cfg.ProxyDomain, a.cfg.DNSAddr,
-			a.cfg.DNSForwardParallel); err != nil {
+		if a.localDNSServer, err = dnsClient.NewLocalDNSServer(
+			a.cfg.ProxyNamespace,
+			a.cfg.ProxyDomain,
+			a.cfg.DNSAddr,
+			dnsClient.WithParallelForwarding(a.cfg.DNSForwardParallel),
+			dnsClient.WithUpstreamTimeout(a.cfg.DNSForwardTimeout),
+		); err != nil {
 			return err
 		}
 		a.localDNSServer.StartDNS()

--- a/releasenotes/notes/dns-forward-timeout.yaml
+++ b/releasenotes/notes/dns-forward-timeout.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+- |
+  **Added** configurable DNS upstream timeout via `DNS_FORWARD_TIMEOUT` environment variable. The default timeout remains 5 seconds. Users can increase the timeout for high-latency DNS servers or decrease it to reduce user-impacting latency when DNS servers are unresponsive (fail faster to try next server sooner). Set via `DNS_FORWARD_TIMEOUT=10s` in istio-proxy container or mesh-wide via `proxyMetadata`.


### PR DESCRIPTION
## Description

  This PR adds the `DNS_FORWARD_TIMEOUT` environment variable to control DNS upstream query timeout behavior.

  ### DNS_FORWARD_TIMEOUT (default: 5s)
  - Configures the timeout for upstream DNS queries
  - Users can increase for high-latency DNS servers
  - Users can decrease to fail faster and reduce user-impacting latency
  - Applied to DialTimeout, ReadTimeout, and WriteTimeout

  ## Implementation Details

  - Refactored `NewLocalDNSServer` to use functional options pattern to handle growing configuration parameters more cleanly
  - Added comprehensive tests for timeout configuration
  - Tests verify that timeout is properly applied to all DNS proxies

  Can be configured per-pod via environment variables or mesh-wide via `proxyMetadata`.

  ## Testing

  - All existing DNS tests pass
  - New test added: `TestDNSTimeoutConfiguration` verifies timeout configuration for default (5s), custom 10s, and custom 2s timeouts

  ## Example Usage

  **Per-pod:**
  ```yaml
  spec:
    containers:
    - name: istio-proxy
      env:
      - name: DNS_FORWARD_TIMEOUT
        value: "10s"
```
  Mesh-wide:
```yaml
  meshConfig:
    defaultConfig:
      proxyMetadata:
        DNS_FORWARD_TIMEOUT: "10s"