### PR TITLE
Fix test fake imageregistry default registry flag

### DIFF
--- a/pkg/test/fakes/imageregistry/main.go
+++ b/pkg/test/fakes/imageregistry/main.go
@@ -33,7 +33,7 @@ import (
 
 var (
 	port             = flag.Int("port", 1338, "port to run registry on")
-	registry         = flag.String("registry", "gcr.io", "name of registry to redirect registry request to")
+	registry         = flag.String("registry", "registry.istio.io", "name of registry to redirect registry request to")
 	scheme           = flag.String("scheme", "https", "scheme of the URL to the image registry")
 	regexForManifest = regexp.MustCompile(`(?P<Prefix>/v\d+)?/(?P<ImageName>.+)/manifests/(?P<Tag>[^:]*)$`)
 	regexForLayer    = regexp.MustCompile(`/layer/v1/(?P<ImageName>[^:]+):(?P<Tag>[^:]+)`)


### PR DESCRIPTION
**Please provide a description of this PR:**
When the registry has been changed from gcr.io to registry.istio.io, in PR #59364, it changed the namespace of the image from "istio-release" to "release" in telemetry tests, for example.

But the default value of the registry in "imageregistry" server was not changed, so if "--registry" argument is not used and "TargetRegistry" is not set (like in Kind env) as a result, it fails to the default value (like in Openshift env).
And it results to an image not found error.

The default value should be modified to "registry.istio.io" to reflect the new path of the image - "testing/wasm/header-injector", instead of "istio-testing/wasm/header-injector".