### PR TITLE
[#59843 followup] Update test imageregistry image version

### DIFF
--- a/pkg/test/fakes/imageregistry/Makefile
+++ b/pkg/test/fakes/imageregistry/Makefile
@@ -22,7 +22,7 @@ BIN_NAME := main
 
 # NOTE: TAG should be updated whenever changes are made in this directory
 # This should also be updated in dependent components
-TAG := 1.4
+TAG := 1.5
 
 all: build_and_push clean
 


### PR DESCRIPTION
**Please provide a description of this PR:**
After made a change to the test fake imageregistry server code in the following PR - https://github.com/istio/istio/pull/59843, I forgot to update the image version to trigger the creation of the new image.
Modifying the image version from 1.4 to 1.5.