### PR TITLE
feat(inference): Support AppProtocol in InferencePool

### DIFF
--- a/pilot/pkg/config/kube/gateway/inferencepool_collection.go
+++ b/pilot/pkg/config/kube/gateway/inferencepool_collection.go
@@ -604,7 +604,6 @@ func (c *Controller) applyShadowService(kubeClient kube.Client, service *corev1.
 	if err != nil {
 		return fmt.Errorf("failed to marshal service for SSA: %v", err)
 	}
-	log.Infof("Applying shadow service: %s", string(data))
 
 	ctx := context.Background()
 	_, err = kubeClient.Kube().CoreV1().Services(service.Namespace).Patch(

--- a/pilot/pkg/config/kube/gateway/inferencepool_collection.go
+++ b/pilot/pkg/config/kube/gateway/inferencepool_collection.go
@@ -65,10 +65,11 @@ func getSupportedControllers() sets.Set[gatewayv1.GatewayController] {
 }
 
 type shadowServiceInfo struct {
-	key      types.NamespacedName
-	selector map[string]string
-	poolName string
-	poolUID  types.UID
+	key         types.NamespacedName
+	selector    map[string]string
+	poolName    string
+	poolUID     types.UID
+	appProtocol string
 	// targetPorts is the port number on the pods selected by the selector.
 	// Currently, inference extension only supports a single target port.
 	targetPorts []targetPort
@@ -164,6 +165,7 @@ func createInferencePoolObject(pool *inferencev1.InferencePool, gatewayParents s
 		poolName:    pool.GetName(),
 		targetPorts: make([]targetPort, 0, len(pool.Spec.TargetPorts)),
 		poolUID:     pool.GetUID(),
+		appProtocol: string(pool.Spec.AppProtocol),
 	}
 
 	for k, v := range pool.Spec.Selector.MatchLabels {
@@ -514,11 +516,16 @@ func translateShadowServiceToService(shadow shadowServiceInfo, extRef extRefInfo
 
 	for i, tp := range shadow.targetPorts {
 		portName := fmt.Sprintf("http-%d", i)
+		appProtocolStr := shadow.appProtocol
+		if appProtocolStr == "" {
+			appProtocolStr = string(inferencev1.AppProtocolHTTP)
+		}
 		ports = append(ports, corev1.ServicePort{
-			Name:       portName,
-			Protocol:   corev1.ProtocolTCP,
-			Port:       baseDummyPort + int32(i),
-			TargetPort: intstr.FromInt(int(tp.port)),
+			Name:        portName,
+			Protocol:    corev1.ProtocolTCP,
+			Port:        baseDummyPort + int32(i),
+			TargetPort:  intstr.FromInt(int(tp.port)),
+			AppProtocol: ptr.Of(appProtocolStr),
 		})
 	}
 
@@ -597,6 +604,7 @@ func (c *Controller) applyShadowService(kubeClient kube.Client, service *corev1.
 	if err != nil {
 		return fmt.Errorf("failed to marshal service for SSA: %v", err)
 	}
+	log.Infof("Applying shadow service: %s", string(data))
 
 	ctx := context.Background()
 	_, err = kubeClient.Kube().CoreV1().Services(service.Namespace).Patch(

--- a/pilot/pkg/config/kube/gateway/inferencepool_test.go
+++ b/pilot/pkg/config/kube/gateway/inferencepool_test.go
@@ -41,6 +41,7 @@ func TestReconcileInferencePool(t *testing.T) {
 		expectedLabels      map[string]string
 		expectedServiceName string
 		expectedTargetPorts []int32
+		expectedAppProtocol string
 	}{
 		{
 			name: "basic shadow service creation",
@@ -209,6 +210,40 @@ func TestReconcileInferencePool(t *testing.T) {
 			},
 			expectedTargetPorts: []int32{8000, 8001, 8002},
 		},
+		{
+			name: "shadow service with h2c appProtocol",
+			inferencePool: &inferencev1.InferencePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "h2c-pool",
+					Namespace: "default",
+				},
+				Spec: inferencev1.InferencePoolSpec{
+					AppProtocol: "kubernetes.io/h2c",
+					TargetPorts: []inferencev1.Port{
+						{
+							Number: inferencev1.PortNumber(8080),
+						},
+					},
+					Selector: inferencev1.LabelSelector{
+						MatchLabels: map[inferencev1.LabelKey]inferencev1.LabelValue{
+							"app": "test",
+						},
+					},
+					EndpointPickerRef: inferencev1.EndpointPickerRef{
+						Name: "dummy",
+						Port: &inferencev1.Port{
+							Number: inferencev1.PortNumber(5421),
+						},
+					},
+				},
+			},
+			expectedLabels: map[string]string{
+				constants.InternalServiceSemantics: constants.ServiceSemanticsInferencePool,
+				InferencePoolRefLabel:              "h2c-pool",
+			},
+			expectedTargetPorts: []int32{8080},
+			expectedAppProtocol: "kubernetes.io/h2c",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -258,10 +293,16 @@ func TestReconcileInferencePool(t *testing.T) {
 			expectedPortCount := len(tc.inferencePool.Spec.TargetPorts)
 			assert.Equal(t, len(service.Spec.Ports), expectedPortCount, fmt.Sprintf("Shadow service should have %d ports", expectedPortCount))
 
-			for i := 1; i < len(service.Spec.Ports); i++ {
+			for i := 0; i < len(service.Spec.Ports); i++ {
 				assert.Equal(t, service.Spec.Ports[i].Port, int32(54321+i))
 				assert.Equal(t, service.Spec.Ports[i].TargetPort.IntVal, tc.expectedTargetPorts[i])
 				assert.Equal(t, service.Spec.Ports[i].Name, fmt.Sprintf("http-%d", i))
+				
+				expectedAppProto := tc.expectedAppProtocol
+				if expectedAppProto == "" {
+					expectedAppProto = "http"
+				}
+				assert.Equal(t, *service.Spec.Ports[i].AppProtocol, expectedAppProto)
 			}
 
 			assert.Equal(t, service.OwnerReferences[0].Name, tc.inferencePool.Name)

--- a/pilot/pkg/config/kube/gateway/inferencepool_test.go
+++ b/pilot/pkg/config/kube/gateway/inferencepool_test.go
@@ -297,7 +297,7 @@ func TestReconcileInferencePool(t *testing.T) {
 				assert.Equal(t, service.Spec.Ports[i].Port, int32(54321+i))
 				assert.Equal(t, service.Spec.Ports[i].TargetPort.IntVal, tc.expectedTargetPorts[i])
 				assert.Equal(t, service.Spec.Ports[i].Name, fmt.Sprintf("http-%d", i))
-				
+
 				expectedAppProto := tc.expectedAppProtocol
 				if expectedAppProto == "" {
 					expectedAppProto = "http"

--- a/releasenotes/notes/inference-appprotocol.yaml
+++ b/releasenotes/notes/inference-appprotocol.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+- |
+  **Added** support for specifying `AppProtocol` in `InferencePool` to configure the application protocol of the generated shadow service.

--- a/tests/integration/pilot/gie/inferencepool_test.go
+++ b/tests/integration/pilot/gie/inferencepool_test.go
@@ -476,7 +476,7 @@ spec:
 
 				ctx.Logf("Shadow service AppProtocol verified successfully: %s", *appProto)
 				return nil
-			})
+			}, retry.Timeout(60*time.Second))
 
 			// Wait for Gateway resource to be ready
 			retry.UntilSuccessOrFail(ctx, func() error {

--- a/tests/integration/pilot/gie/inferencepool_test.go
+++ b/tests/integration/pilot/gie/inferencepool_test.go
@@ -372,10 +372,26 @@ func TestInferencePoolAppProtocol(t *testing.T) {
 			crd.DeployGatewayAPIOrSkip(ctx)
 			crd.DeployGatewayAPIInferenceExtensionOrSkip(ctx)
 
+			cfg := istio.DefaultConfigOrFail(t, ctx)
+
 			ns := namespace.NewOrFail(ctx, namespace.Config{
 				Prefix: "inferencepool-appproto",
 				Inject: true,
 			})
+
+			// Create a dummy service for EPP to satisfy ResolvedRefs
+			dummySvc := fmt.Sprintf(`
+apiVersion: v1
+kind: Service
+metadata:
+  name: dummy-epp
+  namespace: %s
+spec:
+  ports:
+  - port: 9002
+    name: grpc
+`, ns.Name())
+			ctx.ConfigIstio().YAML(ns.Name(), dummySvc).ApplyOrFail(ctx)
 
 			inferencePoolManifest := fmt.Sprintf(`
 apiVersion: inference.networking.k8s.io/v1
@@ -396,6 +412,42 @@ spec:
       number: 9002
 `, ns.Name())
 			ctx.ConfigIstio().YAML(ns.Name(), inferencePoolManifest).ApplyOrFail(ctx)
+
+			// Deploy Gateway and HTTPRoute
+			gatewayManifest := fmt.Sprintf(`
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: appproto-gateway
+  namespace: %s
+spec:
+  gatewayClassName: %s
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: appproto-route
+  namespace: %s
+spec:
+  parentRefs:
+  - name: appproto-gateway
+  hostnames:
+  - "appproto.example.com"
+  rules:
+  - backendRefs:
+    - group: inference.networking.k8s.io
+      kind: InferencePool
+      name: appproto-pool
+      port: 80
+`, ns.Name(), cfg.GatewayClassName, ns.Name())
+			ctx.ConfigIstio().YAML(ns.Name(), gatewayManifest).ApplyOrFail(ctx)
 
 			// Verify shadow service was created with correct AppProtocol
 			retry.UntilSuccessOrFail(ctx, func() error {
@@ -425,5 +477,49 @@ spec:
 				ctx.Logf("Shadow service AppProtocol verified successfully: %s", *appProto)
 				return nil
 			})
+
+			// Wait for Gateway resource to be ready
+			retry.UntilSuccessOrFail(ctx, func() error {
+				// Get the Gateway resource and check its status
+				gw, err := ctx.Clusters().Default().Dynamic().Resource(schema.GroupVersionResource{
+					Group:    "gateway.networking.k8s.io",
+					Version:  "v1",
+					Resource: "gateways",
+				}).Namespace(ns.Name()).Get(context.TODO(), "appproto-gateway", metav1.GetOptions{})
+				if err != nil {
+					return fmt.Errorf("gateway resource not found: %v", err)
+				}
+
+				// Check Gateway status conditions for Accepted and Programmed
+				status, found, err := unstructured.NestedSlice(gw.Object, "status", "conditions")
+				if err != nil || !found {
+					return fmt.Errorf("gateway status conditions not found")
+				}
+
+				accepted := false
+				programmed := false
+				for _, cond := range status {
+					condition := cond.(map[string]interface{})
+					condType := condition["type"].(string)
+					condStatus := condition["status"].(string)
+
+					if condType == "Accepted" && condStatus == "True" {
+						accepted = true
+					}
+					if condType == "Programmed" && condStatus == "True" {
+						programmed = true
+					}
+				}
+
+				if !accepted {
+					return fmt.Errorf("gateway not accepted yet")
+				}
+				if !programmed {
+					return fmt.Errorf("gateway not programmed yet")
+				}
+
+				ctx.Logf("Gateway is ready (Accepted and Programmed)")
+				return nil
+			}, retry.Timeout(60*time.Second))
 		})
 }

--- a/tests/integration/pilot/gie/inferencepool_test.go
+++ b/tests/integration/pilot/gie/inferencepool_test.go
@@ -362,3 +362,68 @@ spec:
 			}
 		})
 }
+
+// TestInferencePoolAppProtocol verifies that InferencePool with appProtocol set
+// creates a shadow service with the correct AppProtocol.
+func TestInferencePoolAppProtocol(t *testing.T) {
+	framework.
+		NewTest(t).
+		Run(func(ctx framework.TestContext) {
+			crd.DeployGatewayAPIOrSkip(ctx)
+			crd.DeployGatewayAPIInferenceExtensionOrSkip(ctx)
+
+			ns := namespace.NewOrFail(ctx, namespace.Config{
+				Prefix: "inferencepool-appproto",
+				Inject: true,
+			})
+
+			inferencePoolManifest := fmt.Sprintf(`
+apiVersion: inference.networking.k8s.io/v1
+kind: InferencePool
+metadata:
+  name: appproto-pool
+  namespace: %s
+spec:
+  appProtocol: kubernetes.io/h2c
+  targetPorts:
+  - number: 8080
+  selector:
+    matchLabels:
+      app: inference-workload
+  endpointPickerRef:
+    name: dummy-epp
+    port:
+      number: 9002
+`, ns.Name())
+			ctx.ConfigIstio().YAML(ns.Name(), inferencePoolManifest).ApplyOrFail(ctx)
+
+			// Verify shadow service was created with correct AppProtocol
+			retry.UntilSuccessOrFail(ctx, func() error {
+				client := ctx.Clusters().Default().Kube()
+				services, err := client.CoreV1().Services(ns.Name()).List(context.TODO(), metav1.ListOptions{
+					LabelSelector: "istio.io/inferencepool-name=appproto-pool",
+				})
+				if err != nil || len(services.Items) == 0 {
+					return fmt.Errorf("failed to list services: %v", err)
+				}
+
+				svc := services.Items[0]
+
+				if len(svc.Spec.Ports) == 0 {
+					return fmt.Errorf("shadow service has no ports")
+				}
+
+				appProto := svc.Spec.Ports[0].AppProtocol
+				if appProto == nil {
+					return fmt.Errorf("shadow service port AppProtocol is nil")
+				}
+
+				if *appProto != "kubernetes.io/h2c" {
+					return fmt.Errorf("expected AppProtocol kubernetes.io/h2c, got %s", *appProto)
+				}
+
+				ctx.Logf("Shadow service AppProtocol verified successfully: %s", *appProto)
+				return nil
+			})
+		})
+}


### PR DESCRIPTION
**Please provide a description of this PR:**

Convert the InferencePool AppProtocol to ShadowService Protocol.
Inference.[AppProtocol](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/bd8b1c3c3913a33f49ad25bbcead2601a788dbeb/api/v1/inferencepool_types.go#L83-L94) is introduced in GAIE v1.4.0

Fixes #59858