### PR TITLE
Update test registryredirector deployment image

### DIFF
--- a/pkg/test/framework/components/registryredirector/registry_redirector_server.yaml
+++ b/pkg/test/framework/components/registryredirector/registry_redirector_server.yaml
@@ -40,7 +40,7 @@ spec:
         app: registry-redirector
     spec:
       containers:
-      - image: {{ or .Image "registry.istio.io/testing/fake-registry:1.4"}}
+      - image: {{ or .Image "registry.istio.io/testing/fake-registry:1.5"}}
         name: registry-redirector
         {{- if .TargetRegistry }}
         args: ["--registry", {{ .TargetRegistry }}, "--scheme", {{ or .Scheme "https" }}]


### PR DESCRIPTION
**Please provide a description of this PR:**
After the change of the test imageregistry server code #59843 and creation of the new version #59844, the new image was built and pushed to the registry with the new tag - fake-registry:1.5.

Update the registryredirector deployment to use the new image.