### PR TITLE
Zt cidr integ testing

### DIFF
--- a/releasenotes/notes/59797.yaml
+++ b/releasenotes/notes/59797.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 59797
+releaseNotes:
+  - |
+    **Added** CIDR address support for ServiceEntry in ambient mode. ServiceEntries with CIDR
+    addresses (e.g., `10.0.0.0/24`) are now propagated to ztunnel, enabling longest-prefix-match
+    routing for traffic destined to IP ranges.

--- a/tests/integration/ambient/waypoint_test.go
+++ b/tests/integration/ambient/waypoint_test.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/netip"
 	"path"
 	"strings"
 	"testing"
@@ -587,8 +588,24 @@ spec:
 				t.Skip("not enough external service instances")
 			}
 
-			// Use the first subset service for testing consistency
-			subsetService := servicesForSubsets(t, external)[0]
+			subsetServices := servicesForSubsets(t, external)
+
+			hostHeader := http.Header{}
+			hostHeader.Set("Host", "fake-passthrough.example.com")
+
+			// Before applying the ServiceEntry, verify traffic to the ClusterIP
+			// is not routed through the waypoint.
+			runTest(t, fmt.Sprintf("before SE %s", subsetServices[0].ClusterIP), "",
+				"relies on unmeshed ClusterIPs as a simulated external service IP",
+				echo.CallOptions{
+					Address: subsetServices[0].ClusterIP,
+					HTTP:    echo.HTTP{Headers: hostHeader},
+					Port:    echo.Port{ServicePort: 8080},
+					Scheme:  scheme.HTTP,
+					Count:   1,
+					Check:   check.And(check.OK(), IsL4()),
+				})
+
 			resolutionNoneServiceEntry := `apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
@@ -611,32 +628,94 @@ spec:
 			t.ConfigIstio().
 				Eval(apps.Namespace.Name(), map[string]any{
 					"EgressNamespace": egressNamespace.Name(),
-					"IP":              subsetService.ClusterIP,
+					"IP":              subsetServices[0].ClusterIP,
 				}, resolutionNoneServiceEntry).
 				ApplyOrFail(t, apply.CleanupConditionally)
 
-			hostHeader := http.Header{}
-			hostHeader.Set("Host", "fake-passthrough.example.com")
-
-			// Test that we send traffic through the waypoint successfully
-			// The setup for this testing would be tricky in multi-network because the VIPs being used
-			// are not in the mesh, but they are in a cluster.
-			// This means each cluster's VIPs would need to be unique.
-			// That isn't useful for testing though because it's just turning the multi-cluster
-			// tests into multiple single-cluster tests.
-			// Arguably, egress gateways should never be accessed across a cluster-boundary,
-			// so perhaps the skips need not be removed as even in multi-cluster testing we expect egress
-			// to behave as though it is single-cluster.
-			testName := fmt.Sprintf("resolution none %s", subsetService.ClusterIP)
+			// After applying the ServiceEntry, traffic to the same ClusterIP
+			// should now be routed through the egress waypoint.
+			testName := fmt.Sprintf("resolution none %s", subsetServices[0].ClusterIP)
 			runTest(t, testName, "",
 				"relies on unmeshed ClusterIPs as a simulated external service IP",
 				echo.CallOptions{
-					Address: subsetService.ClusterIP,
+					Address: subsetServices[0].ClusterIP,
 					HTTP:    echo.HTTP{Headers: hostHeader},
 					Port:    echo.Port{ServicePort: 8080},
 					Scheme:  scheme.HTTP,
 					Count:   1,
-					Check:   check.And(check.OK(), IsL7(), check.Hostname(subsetService.Hostname)),
+					Check:   check.And(check.OK(), IsL7(), check.Hostname(subsetServices[0].Hostname)),
+				})
+
+			// Test CIDR-based ServiceEntry routing through the waypoint.
+			// Uses the second subset service so its ClusterIP is not claimed by
+			// the bare-IP ServiceEntry above — traffic can only match via CIDR.
+			if len(subsetServices) < 2 {
+				t.Fatal("expected at least 2 subset services for CIDR test")
+			}
+			cidrService := subsetServices[1]
+			ip, err := netip.ParseAddr(cidrService.ClusterIP)
+			if err != nil {
+				t.Fatalf("failed to parse ClusterIP %q: %v", cidrService.ClusterIP, err)
+			}
+			var cidr string
+			if ip.Is4() {
+				cidr = fmt.Sprintf("%s/24", cidrService.ClusterIP)
+			} else {
+				cidr = fmt.Sprintf("%s/112", cidrService.ClusterIP)
+			}
+
+			cidrHostHeader := http.Header{}
+			cidrHostHeader.Set("Host", "fake-cidr-passthrough.example.com")
+
+			// Before applying the CIDR ServiceEntry, verify traffic to the
+			// second subset's ClusterIP is NOT routed through the waypoint.
+			// This proves the CIDR SE is what causes waypoint routing below.
+			runTest(t, fmt.Sprintf("before CIDR SE %s", cidrService.ClusterIP), "",
+				"relies on unmeshed ClusterIPs as a simulated external service IP",
+				echo.CallOptions{
+					Address: cidrService.ClusterIP,
+					HTTP:    echo.HTTP{Headers: cidrHostHeader},
+					Port:    echo.Port{ServicePort: 8080},
+					Scheme:  scheme.HTTP,
+					Count:   1,
+					Check:   check.And(check.OK(), IsL4()),
+				})
+
+			resolutionNoneCIDRServiceEntry := `apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: external-resolution-none-cidr
+  labels:
+    istio.io/use-waypoint: egress-gateway
+    istio.io/use-waypoint-namespace: {{.EgressNamespace}}
+spec:
+  hosts:
+  - fake-cidr-passthrough.example.com
+  ports:
+  - name: http
+    number: 8080
+    protocol: HTTP
+  resolution: NONE
+  location: MESH_EXTERNAL
+  addresses:
+  - {{.CIDR}}
+`
+			t.ConfigIstio().
+				Eval(apps.Namespace.Name(), map[string]any{
+					"EgressNamespace": egressNamespace.Name(),
+					"CIDR":            cidr,
+				}, resolutionNoneCIDRServiceEntry).
+				ApplyOrFail(t, apply.CleanupConditionally)
+
+			runTest(t, fmt.Sprintf("resolution none CIDR %s", cidr), "",
+				"relies on unmeshed ClusterIPs as a simulated external service IP",
+				echo.CallOptions{
+					Address: cidrService.ClusterIP,
+					HTTP:    echo.HTTP{Headers: cidrHostHeader},
+					Port:    echo.Port{ServicePort: 8080},
+					Scheme:  scheme.HTTP,
+					Count:   1,
+					Check:   check.And(check.OK(), IsL7(), check.Hostname(cidrService.Hostname)),
 				})
 
 			service := `apiVersion: networking.istio.io/v1

--- a/tests/integration/ambient/waypoint_test.go
+++ b/tests/integration/ambient/waypoint_test.go
@@ -584,11 +584,12 @@ spec:
 
 			external := apps.MockExternal.Instances()[0]
 
-			if len(external.WorkloadsOrFail(t)) < 1 {
-				t.Skip("not enough external service instances")
-			}
-
 			subsetServices := servicesForSubsets(t, external)
+
+			if len(subsetServices) < 2 {
+				// don't quietly skip if cluster doesn't have enough mock external services available
+				t.Fatal("expected at least 2 subset services for waypoint egress testing")
+			}
 
 			hostHeader := http.Header{}
 			hostHeader.Set("Host", "fake-passthrough.example.com")
@@ -649,9 +650,6 @@ spec:
 			// Test CIDR-based ServiceEntry routing through the waypoint.
 			// Uses the second subset service so its ClusterIP is not claimed by
 			// the bare-IP ServiceEntry above — traffic can only match via CIDR.
-			if len(subsetServices) < 2 {
-				t.Fatal("expected at least 2 subset services for CIDR test")
-			}
 			cidrService := subsetServices[1]
 			ip, err := netip.ParseAddr(cidrService.ClusterIP)
 			if err != nil {


### PR DESCRIPTION
**Please provide a description of this PR:**

Following up on the work in #59797 this adds:
- release note
- integration test coverage

The test follows a similar pattern to the previous egress waypoint with a resolution none SE using the ClusterIP of an uncaptured "external" subset.

It also strengthens the testing a bit to make assertions that before the SE is created we just L4 direct to the ClusterIP to try to account for edges where more and more external testing is co-opting these services. We could back them out if folks think it's unnecessary, but I was starting to worry about it so I added them in.

Also, this bumps istio.deps ztunnel to use the latest SHA because I didn't feel like waiting for automation to handle that