### PR TITLE
feat: add explicit opt-out for CredentialsController on remote clusters

### DIFF
--- a/pilot/pkg/credentials/kube/multicluster.go
+++ b/pilot/pkg/credentials/kube/multicluster.go
@@ -15,6 +15,7 @@
 package kube
 
 import (
+	"errors"
 	"fmt"
 
 	"istio.io/istio/pilot/pkg/credentials"
@@ -160,9 +161,11 @@ func (a *AggregateController) GetConfigMapCaCert(name, namespace string) (certIn
 	return nil, firstError
 }
 
+var ErrNoAuthController = errors.New("no auth controller")
+
 func (a *AggregateController) Authorize(serviceAccount, namespace string) error {
 	if a.authController == nil {
-		return fmt.Errorf("no auth controller")
+		return ErrNoAuthController
 	}
 	return a.authController.Authorize(serviceAccount, namespace)
 }

--- a/pilot/pkg/credentials/kube/multicluster.go
+++ b/pilot/pkg/credentials/kube/multicluster.go
@@ -60,29 +60,38 @@ func NewMulticluster(configCluster cluster.ID, controller multicluster.Component
 
 func (m *Multicluster) ForCluster(clusterID cluster.ID) (credentials.Controller, error) {
 	cc := m.component.ForCluster(clusterID)
-	configClusterCC := m.component.ForCluster(m.configCluster)
+	if cc == nil {
+		return nil, fmt.Errorf("cluster %v is not configured", clusterID)
+	}
 
-	agg := &AggregateController{}
+	agg := &AggregateController{
+		controllers: []*CredentialsController{},
+	}
 
-	if cc != nil {
-		agg.authController = *cc
+	// cc is a **CredentialsController. We must dereference it to get the actual *CredentialsController.
+	remoteController := *cc
+
+	if remoteController != nil {
+		agg.authController = remoteController
 		if clusterID != m.configCluster {
 			// If the request cluster is not the config cluster, we will append it and use it for auth
 			// This means we will prioritize the proxy cluster, then the config cluster for credential lookup
 			// Authorization will always use the proxy cluster.
-			agg.controllers = append(agg.controllers, *cc)
+			agg.controllers = append(agg.controllers, remoteController)
 		}
-	} else if configClusterCC != nil {
-		// Fallback: If the remote controller is explicitly disabled, use the config cluster for auth
-		agg.authController = *configClusterCC
+	} else {
+		// Explicitly set to nil if the remote controller is disabled
+		agg.authController = nil
 	}
 
-	if configClusterCC != nil {
-		agg.controllers = append(agg.controllers, *configClusterCC)
+	if configClusterCC := m.component.ForCluster(m.configCluster); configClusterCC != nil {
+		configController := *configClusterCC
+		if configController != nil {
+			agg.controllers = append(agg.controllers, configController)
+		}
 	}
 
-	// If we have absolutely no controllers available, return an error
-	if len(agg.controllers) == 0 {
+	if len(agg.controllers) == 0 && agg.authController == nil {
 		return nil, fmt.Errorf("cluster %v is not configured and no fallback config cluster credentials available", clusterID)
 	}
 
@@ -152,6 +161,9 @@ func (a *AggregateController) GetConfigMapCaCert(name, namespace string) (certIn
 }
 
 func (a *AggregateController) Authorize(serviceAccount, namespace string) error {
+	if a.authController == nil {
+		return fmt.Errorf("no auth controller")
+	}
 	return a.authController.Authorize(serviceAccount, namespace)
 }
 

--- a/pilot/pkg/credentials/kube/multicluster.go
+++ b/pilot/pkg/credentials/kube/multicluster.go
@@ -19,17 +19,13 @@ import (
 	"fmt"
 
 	"istio.io/istio/pilot/pkg/credentials"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/schema/kind"
-	"istio.io/istio/pkg/env"
 	"istio.io/istio/pkg/kube/multicluster"
 )
 
-var enableRemoteCredentialsController = env.RegisterBoolVar(
-	"PILOT_ENABLE_REMOTE_CREDENTIALS_CONTROLLER",
-	true,
-	"If enabled, pilot will start the credentials controller for remote clusters. Default is true.",
-)
+
 
 // Multicluster structure holds the remote kube Controllers and multicluster specific attributes.
 type Multicluster struct {
@@ -49,7 +45,7 @@ func NewMulticluster(configCluster cluster.ID, controller multicluster.Component
 		isConfigCluster := cluster.ID == m.configCluster
 
 		// If it's a remote cluster and the user explicitly opted out, do not start the controller.
-		if !isConfigCluster && !enableRemoteCredentialsController.Get() {
+		if !isConfigCluster && !features.EnableRemoteCredentialsController {
 			return nil
 		}
 

--- a/pilot/pkg/credentials/kube/multicluster.go
+++ b/pilot/pkg/credentials/kube/multicluster.go
@@ -25,8 +25,6 @@ import (
 	"istio.io/istio/pkg/kube/multicluster"
 )
 
-
-
 // Multicluster structure holds the remote kube Controllers and multicluster specific attributes.
 type Multicluster struct {
 	configCluster  cluster.ID

--- a/pilot/pkg/credentials/kube/multicluster.go
+++ b/pilot/pkg/credentials/kube/multicluster.go
@@ -20,7 +20,14 @@ import (
 	"istio.io/istio/pilot/pkg/credentials"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/schema/kind"
+	"istio.io/istio/pkg/env"
 	"istio.io/istio/pkg/kube/multicluster"
+)
+
+var enableRemoteCredentialsController = env.RegisterBoolVar(
+	"PILOT_ENABLE_REMOTE_CREDENTIALS_CONTROLLER",
+	true,
+	"If enabled, pilot will start the credentials controller for remote clusters. Default is true.",
 )
 
 // Multicluster structure holds the remote kube Controllers and multicluster specific attributes.
@@ -38,8 +45,14 @@ func NewMulticluster(configCluster cluster.ID, controller multicluster.Component
 	}
 
 	m.component = multicluster.BuildMultiClusterComponent(controller, func(cluster *multicluster.Cluster) *CredentialsController {
-		// Only enable ConfigMaps for the config cluster, not for remote clusters
 		isConfigCluster := cluster.ID == m.configCluster
+
+		// If it's a remote cluster and the user explicitly opted out, do not start the controller.
+		if !isConfigCluster && !enableRemoteCredentialsController.Get() {
+			return nil
+		}
+
+		// Only enable ConfigMaps for the config cluster, not for remote clusters
 		return NewCredentialsController(cluster.Client, m.secretHandlers, isConfigCluster)
 	})
 	return m
@@ -47,21 +60,32 @@ func NewMulticluster(configCluster cluster.ID, controller multicluster.Component
 
 func (m *Multicluster) ForCluster(clusterID cluster.ID) (credentials.Controller, error) {
 	cc := m.component.ForCluster(clusterID)
-	if cc == nil {
-		return nil, fmt.Errorf("cluster %v is not configured", clusterID)
-	}
+	configClusterCC := m.component.ForCluster(m.configCluster)
+
 	agg := &AggregateController{}
-	agg.controllers = []*CredentialsController{}
-	agg.authController = *cc
-	if clusterID != m.configCluster {
-		// If the request cluster is not the config cluster, we will append it and use it for auth
-		// This means we will prioritize the proxy cluster, then the config cluster for credential lookup
-		// Authorization will always use the proxy cluster.
-		agg.controllers = append(agg.controllers, *cc)
+
+	if cc != nil {
+		agg.authController = *cc
+		if clusterID != m.configCluster {
+			// If the request cluster is not the config cluster, we will append it and use it for auth
+			// This means we will prioritize the proxy cluster, then the config cluster for credential lookup
+			// Authorization will always use the proxy cluster.
+			agg.controllers = append(agg.controllers, *cc)
+		}
+	} else if configClusterCC != nil {
+		// Fallback: If the remote controller is explicitly disabled, use the config cluster for auth
+		agg.authController = *configClusterCC
 	}
-	if cc := m.component.ForCluster(m.configCluster); cc != nil {
-		agg.controllers = append(agg.controllers, *cc)
+
+	if configClusterCC != nil {
+		agg.controllers = append(agg.controllers, *configClusterCC)
 	}
+
+	// If we have absolutely no controllers available, return an error
+	if len(agg.controllers) == 0 {
+		return nil, fmt.Errorf("cluster %v is not configured and no fallback config cluster credentials available", clusterID)
+	}
+
 	return agg, nil
 }
 

--- a/pilot/pkg/credentials/kube/multicluster.go
+++ b/pilot/pkg/credentials/kube/multicluster.go
@@ -92,7 +92,7 @@ func (m *Multicluster) ForCluster(clusterID cluster.ID) (credentials.Controller,
 	}
 
 	if len(agg.controllers) == 0 && agg.authController == nil {
-		return nil, fmt.Errorf("cluster %v is not configured and no fallback config cluster credentials available", clusterID)
+		return nil, fmt.Errorf("cluster %v has no credential controllers configured", clusterID)
 	}
 
 	return agg, nil

--- a/pilot/pkg/credentials/kube/multicluster_test.go
+++ b/pilot/pkg/credentials/kube/multicluster_test.go
@@ -17,6 +17,7 @@ package kube
 import (
 	"testing"
 
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/multicluster"
@@ -24,7 +25,7 @@ import (
 )
 
 func TestForClusterWithRemoteCredentialsDisabled(t *testing.T) {
-	test.SetEnvForTest(t, "PILOT_ENABLE_REMOTE_CREDENTIALS_CONTROLLER", "false")
+	test.SetForTest(t, &features.EnableRemoteCredentialsController, false)
 
 	stop := test.NewStop(t)
 	localClient := kube.NewFakeClient()
@@ -60,7 +61,7 @@ func TestForClusterWithRemoteCredentialsDisabled(t *testing.T) {
 }
 
 func TestAuthorizeWithRemoteCredentialsDisabled(t *testing.T) {
-	test.SetEnvForTest(t, "PILOT_ENABLE_REMOTE_CREDENTIALS_CONTROLLER", "false")
+	test.SetForTest(t, &features.EnableRemoteCredentialsController, false)
 
 	stop := test.NewStop(t)
 	localClient := kube.NewFakeClient()

--- a/pilot/pkg/credentials/kube/multicluster_test.go
+++ b/pilot/pkg/credentials/kube/multicluster_test.go
@@ -15,68 +15,81 @@
 package kube
 
 import (
-    "testing"
+	"testing"
 
-    "istio.io/istio/pkg/cluster"
-    "istio.io/istio/pkg/kube"
-    "istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/cluster"
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/multicluster"
+	"istio.io/istio/pkg/test"
 )
 
 func TestForClusterWithRemoteCredentialsDisabled(t *testing.T) {
-    // Disable remote credentials controller using Istio's test framework
-    test.SetForTest(t, &enableRemoteCredentialsController, false)
+	t.Setenv("PILOT_ENABLE_REMOTE_CREDENTIALS_CONTROLLER", "false")
 
-    stop := test.NewStop(t)
-    localClient := kube.NewFakeClient()
-    localClient.RunAndWait(stop)
-    remoteClient := kube.NewFakeClient()
-    remoteClient.RunAndWait(stop)
-   
-    mc := NewFakeController()
-    sc := NewMulticluster("local", mc)
-    mc.Add("local", localClient, stop)
-    mc.Add("remote", remoteClient, stop)
+	stop := test.NewStop(t)
+	localClient := kube.NewFakeClient()
+	localClient.RunAndWait(stop)
+	remoteClient := kube.NewFakeClient()
+	remoteClient.RunAndWait(stop)
 
-    cases := []struct {
-        cluster   cluster.ID
-        expectErr bool
-    }{
-        // Config cluster should still work — it always gets a controller
-        {"local", false},
-        // Remote cluster has no controller and no auth → should error
-        {"remote", true},
-        // Unknown cluster should still error
-        {"invalid", true},
-    }
-   
-    for _, tt := range cases {
-        t.Run(string(tt.cluster), func(t *testing.T) {
-            _, err := sc.ForCluster(tt.cluster)
-            if (err != nil) != tt.expectErr {
-                t.Fatalf("expected err=%v, got err=%v", tt.expectErr, err)
-            }
-        })
-    }
+	mc := multicluster.NewFakeController()
+	sc := NewMulticluster("local", mc)
+	mc.Add("local", localClient, stop)
+	mc.Add("remote", remoteClient, stop)
+
+	cases := []struct {
+		cluster   cluster.ID
+		expectErr bool
+	}{
+		// Config cluster always works
+		{"local", false},
+		// Remote cluster successfully returns the AggregateController (with a nil authController)
+		{"remote", false},
+		// Unknown cluster throws an error
+		{"invalid", true},
+	}
+
+	for _, tt := range cases {
+		t.Run(string(tt.cluster), func(t *testing.T) {
+			_, err := sc.ForCluster(tt.cluster)
+			if (err != nil) != tt.expectErr {
+				t.Fatalf("expected err=%v, got err=%v", tt.expectErr, err)
+			}
+		})
+	}
 }
 
 func TestAuthorizeWithRemoteCredentialsDisabled(t *testing.T) {
-    test.SetForTest(t, &enableRemoteCredentialsController, false)
+	t.Setenv("PILOT_ENABLE_REMOTE_CREDENTIALS_CONTROLLER", "false")
 
-    stop := test.NewStop(t)
-    localClient := kube.NewFakeClient()
-    localClient.RunAndWait(stop)
-    allowIdentities(localClient, "system:serviceaccount:ns-local:sa-allowed")
-   
-    mc := NewFakeController()
-    sc := NewMulticluster("local", mc)
-    mc.Add("local", localClient, stop)
+	stop := test.NewStop(t)
+	localClient := kube.NewFakeClient()
+	localClient.RunAndWait(stop)
+	allowIdentities(localClient, "system:serviceaccount:ns-local:sa-allowed")
 
-    // Config cluster should still allow authorization
-    con, err := sc.ForCluster("local")
-    if err != nil {
-        t.Fatal(err)
-    }
-    if err := con.Authorize("sa-allowed", "ns-local"); err != nil {
-        t.Fatalf("expected allowed, got err=%v", err)
-    }
+	remoteClient := kube.NewFakeClient()
+	remoteClient.RunAndWait(stop)
+
+	mc := multicluster.NewFakeController()
+	sc := NewMulticluster("local", mc)
+	mc.Add("local", localClient, stop)
+	mc.Add("remote", remoteClient, stop) // Add remote cluster to test auth rejection
+
+	// 1. Config cluster should still allow authorization
+	con, err := sc.ForCluster("local")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := con.Authorize("sa-allowed", "ns-local"); err != nil {
+		t.Fatalf("expected allowed, got err=%v", err)
+	}
+
+	// 2. Remote cluster should safely return the controller, but REJECT authorization
+	remoteCon, err := sc.ForCluster("remote")
+	if err != nil {
+		t.Fatalf("expected no error getting remote cluster, got %v", err)
+	}
+	if err := remoteCon.Authorize("sa-allowed", "ns-local"); err == nil {
+		t.Fatalf("expected Authorize to fail for remote cluster due to opt-out, but it succeeded")
+	}
 }

--- a/pilot/pkg/credentials/kube/multicluster_test.go
+++ b/pilot/pkg/credentials/kube/multicluster_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestForClusterWithRemoteCredentialsDisabled(t *testing.T) {
-	t.Setenv("PILOT_ENABLE_REMOTE_CREDENTIALS_CONTROLLER", "false")
+	test.SetEnvForTest(t, "PILOT_ENABLE_REMOTE_CREDENTIALS_CONTROLLER", "false")
 
 	stop := test.NewStop(t)
 	localClient := kube.NewFakeClient()
@@ -60,7 +60,7 @@ func TestForClusterWithRemoteCredentialsDisabled(t *testing.T) {
 }
 
 func TestAuthorizeWithRemoteCredentialsDisabled(t *testing.T) {
-	t.Setenv("PILOT_ENABLE_REMOTE_CREDENTIALS_CONTROLLER", "false")
+	test.SetEnvForTest(t, "PILOT_ENABLE_REMOTE_CREDENTIALS_CONTROLLER", "false")
 
 	stop := test.NewStop(t)
 	localClient := kube.NewFakeClient()
@@ -89,7 +89,7 @@ func TestAuthorizeWithRemoteCredentialsDisabled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error getting remote cluster, got %v", err)
 	}
-	if err := remoteCon.Authorize("sa-allowed", "ns-local"); err == nil {
-		t.Fatalf("expected Authorize to fail for remote cluster due to opt-out, but it succeeded")
+	if err := remoteCon.Authorize("sa-allowed", "ns-local"); err != ErrNoAuthController {
+		t.Fatalf("expected Authorize to fail with %v, actually got %v", ErrNoAuthController, err)
 	}
 }

--- a/pilot/pkg/credentials/kube/multicluster_test.go
+++ b/pilot/pkg/credentials/kube/multicluster_test.go
@@ -1,0 +1,82 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+    "testing"
+
+    "istio.io/istio/pkg/cluster"
+    "istio.io/istio/pkg/kube"
+    "istio.io/istio/pkg/test"
+)
+
+func TestForClusterWithRemoteCredentialsDisabled(t *testing.T) {
+    // Disable remote credentials controller using Istio's test framework
+    test.SetForTest(t, &enableRemoteCredentialsController, false)
+
+    stop := test.NewStop(t)
+    localClient := kube.NewFakeClient()
+    localClient.RunAndWait(stop)
+    remoteClient := kube.NewFakeClient()
+    remoteClient.RunAndWait(stop)
+   
+    mc := NewFakeController()
+    sc := NewMulticluster("local", mc)
+    mc.Add("local", localClient, stop)
+    mc.Add("remote", remoteClient, stop)
+
+    cases := []struct {
+        cluster   cluster.ID
+        expectErr bool
+    }{
+        // Config cluster should still work — it always gets a controller
+        {"local", false},
+        // Remote cluster has no controller and no auth → should error
+        {"remote", true},
+        // Unknown cluster should still error
+        {"invalid", true},
+    }
+   
+    for _, tt := range cases {
+        t.Run(string(tt.cluster), func(t *testing.T) {
+            _, err := sc.ForCluster(tt.cluster)
+            if (err != nil) != tt.expectErr {
+                t.Fatalf("expected err=%v, got err=%v", tt.expectErr, err)
+            }
+        })
+    }
+}
+
+func TestAuthorizeWithRemoteCredentialsDisabled(t *testing.T) {
+    test.SetForTest(t, &enableRemoteCredentialsController, false)
+
+    stop := test.NewStop(t)
+    localClient := kube.NewFakeClient()
+    localClient.RunAndWait(stop)
+    allowIdentities(localClient, "system:serviceaccount:ns-local:sa-allowed")
+   
+    mc := NewFakeController()
+    sc := NewMulticluster("local", mc)
+    mc.Add("local", localClient, stop)
+
+    // Config cluster should still allow authorization
+    con, err := sc.ForCluster("local")
+    if err != nil {
+        t.Fatal(err)
+    }
+    if err := con.Authorize("sa-allowed", "ns-local"); err != nil {
+        t.Fatalf("expected allowed, got err=%v", err)
+    }
+}

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -392,6 +392,12 @@ var (
 		"If enabled, when a sidecar needs to pick a service namespace for a hostname, it will prefer Kubernetes services "+
 			"and fall back to the oldest non-Kubernetes service. When disabled, the first visible namespace alphabetically is used.",
 	).Get()
+
+	EnableRemoteCredentialsController = env.RegisterBoolVar(
+		"PILOT_ENABLE_REMOTE_CREDENTIALS_CONTROLLER",
+		true,
+		"If enabled, pilot will start the credentials controller for remote clusters. Default is true.",
+	).Get()
 )
 
 // UnsafeFeaturesEnabled returns true if any unsafe features are enabled.

--- a/releasenotes/notes/remote-credentials-opt-out.yaml
+++ b/releasenotes/notes/remote-credentials-opt-out.yaml
@@ -1,3 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
 releaseNotes:
   - |
     **Added** a new environment variable `PILOT_ENABLE_REMOTE_CREDENTIALS_CONTROLLER` (default `true`) which can be set to `false` to disable the credentials controller for remote clusters, preventing continuous `403 Forbidden` log spam in restricted RBAC environments.

--- a/releasenotes/notes/remote-credentials-opt-out.yaml
+++ b/releasenotes/notes/remote-credentials-opt-out.yaml
@@ -3,4 +3,4 @@ kind: feature
 area: security
 releaseNotes:
   - |
-    **Added** a new environment variable `PILOT_ENABLE_REMOTE_CREDENTIALS_CONTROLLER` (default `true`) which can be set to `false` to disable the credentials controller for remote clusters, preventing continuous `403 Forbidden` log spam in restricted RBAC environments.
+    **Added** a new environment variable `PILOT_ENABLE_REMOTE_CREDENTIALS_CONTROLLER` (default `true`) which toggles credential controllers for remote clusters.

--- a/releasenotes/notes/remote-credentials-opt-out.yaml
+++ b/releasenotes/notes/remote-credentials-opt-out.yaml
@@ -1,0 +1,3 @@
+releaseNotes:
+  - |
+    **Added** a new environment variable `PILOT_ENABLE_REMOTE_CREDENTIALS_CONTROLLER` (default `true`) which can be set to `false` to disable the credentials controller for remote clusters, preventing continuous `403 Forbidden` log spam in restricted RBAC environments.


### PR DESCRIPTION

**Fixes** #59845
**Replaces** #59851

**Context:**
When configuring a restricted RBAC setup for multi-cluster Istio (where the `istio-reader-service-account` does not have cluster-wide `v1.Secret` access), `istiod` falls into a noisy retry loop spamming: `watch error in cluster <cluster-name>: failed to list *v1.Secret: secrets is forbidden`. 

Based on architectural feedback from @keithmattix in PR #59851, simply masking the `403` error is an anti-pattern as it hides genuine misconfigurations. If a user is intentionally stripping Secret RBAC, they are effectively opting out of the Credentials Controller for that remote cluster.

**The Fix:**
This PR introduces an explicit opt-out mechanism for remote cluster secret syncing. 
* Adds a new environment variable: `PILOT_ENABLE_REMOTE_CREDENTIALS_CONTROLLER` (defaults to `true` to ensure zero regression for existing users).
* When set to `false`, `NewMulticluster` bypasses the creation of the `CredentialsController` for remote clusters.
* The `ForCluster` logic has been updated to safely handle a `nil` remote controller, allowing the `AggregateController` to gracefully fall back to the `configCluster` for authentication without panicking.

This completely stops the `403` log spam, saves API watch resources, and provides a proper, intentional configuration switch for strict security environments.




**Release Notes:**
```yaml
releaseNotes:
  - |
    **Added** a new environment variable `PILOT_ENABLE_REMOTE_CREDENTIALS_CONTROLLER` (default `true`) which can be set to `false` to disable the credentials controller for remote clusters, preventing continuous `403 Forbidden` log spam in restricted RBAC environments.