### PR TITLE
Fix deadlock in secret controller during remote cluster update (Fixes #59875)

### DIFF
--- a/pkg/kube/multicluster/component.go
+++ b/pkg/kube/multicluster/component.go
@@ -84,6 +84,15 @@ func (m *Component[T]) clusterDeleted(cluster cluster.ID) {
 	delete(m.clusters, cluster)
 }
 
+func (m *Component[T]) clusterClosing(cluster cluster.ID) {
+	m.mu.RLock()
+	old, f := m.clusters[cluster]
+	m.mu.RUnlock()
+	if f {
+		old.Close()
+	}
+}
+
 func (m *Component[T]) HasSynced() bool {
 	for _, c := range m.All() {
 		if !c.HasSynced() {

--- a/pkg/kube/multicluster/secretcontroller.go
+++ b/pkg/kube/multicluster/secretcontroller.go
@@ -79,6 +79,7 @@ type handler interface {
 	clusterAdded(cluster *Cluster) ComponentConstraint
 	clusterUpdated(cluster *Cluster) ComponentConstraint
 	clusterDeleted(clusterID cluster.ID)
+	clusterClosing(clusterID cluster.ID)
 	HasSynced() bool
 }
 
@@ -361,6 +362,9 @@ func (c *Controller) addSecret(name types.NamespacedName, s *corev1.Secret) erro
 			}
 			// stop previous remote cluster
 			prev.Stop()
+			for _, h := range c.handlers {
+				h.clusterClosing(prev.ID)
+			}
 			prev.Client.Shutdown() // Shutdown all of the informers so that the goroutines won't leak
 		} else if c.cs.Contains(cluster.ID(clusterID)) {
 			// if the cluster has been registered before by another secret, ignore the new one.

--- a/releasenotes/notes/59876.yaml
+++ b/releasenotes/notes/59876.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue: [59875]
+releaseNotes:
+- |
+  **Fixed** a deadlock in the multicluster secret controller that could occur during remote cluster updates.


### PR DESCRIPTION
This PR fixes a critical deadlock in the secret controller during remote cluster updates in a multiversion setup (specifically observed with a 1.29 control plane and a 1.27 remote cluster).

The root cause was that the per-cluster `MeshWatcher` introduced in 1.29 was not properly stopped before `prev.Client.Shutdown()` was called. This caused `Shutdown()` to hang indefinitely waiting for the informer to terminate.

To fix this, we extended the `handler` interface to include a `clusterClosing` method. This allows components to gracefully close their informers without removing the cluster from the internal map, thus preserving the "seamless migration" design and avoiding deadlocks.

Fixes #59875
