### PR TITLE
docs: clarify that outlier detection implicitly activates locality LB failover

### DIFF
--- a/pilot/pkg/networking/core/cluster_traffic_policy.go
+++ b/pilot/pkg/networking/core/cluster_traffic_policy.go
@@ -320,6 +320,9 @@ func applyLocalityLoadBalancer(
 	failover bool,
 ) {
 	// Failover should only be applied with outlier detection, or traffic will never failover.
+	// Conversely, because the default mesh config enables LocalityLbSetting (Enabled:true),
+	// enabling outlier detection in a DestinationRule will automatically activate locality LB
+	// failover behavior even when no explicit localityLbSetting is configured in the DR.
 	enableFailover := failover || c.OutlierDetection != nil
 	// set locality weighted lb config when locality lb is enabled, otherwise it will influence the result of LBPolicy like `least request`
 	if features.EnableLocalityWeightedLbConfig ||

--- a/pilot/pkg/xds/endpoints/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder.go
@@ -411,6 +411,9 @@ func (b *EndpointBuilder) BuildClusterLoadAssignment(endpointIndex *model.Endpoi
 	// If locality aware routing is enabled, prioritize endpoints or set their lb weight.
 	// Failover should only be enabled when there is an outlier detection, otherwise Envoy
 	// will never detect the hosts are unhealthy and redirect traffic.
+	// Note: the default mesh config enables LocalityLbSetting (Enabled:true), so enabling
+	// outlier detection in a DestinationRule will automatically activate locality LB failover
+	// even when no explicit localityLbSetting is configured in the DR.
 	enableFailover, lb := getOutlierDetectionAndLoadBalancerSettings(b.DestinationRule(), b.port, b.subsetName)
 	lbSetting, forceFailover := loadbalancer.GetLocalityLbSetting(b.push.Mesh.GetLocalityLbSetting(), lb.GetLocalityLbSetting(), b.service)
 	enableFailover = enableFailover || forceFailover


### PR DESCRIPTION
Adds comments at the two callsites where `enableFailover` is derived from `OutlierDetection` (`endpoint_builder.go` and `cluster_traffic_policy.go`) to document a non-obvious coupling: Istio's default mesh config ships with `LocalityLbSetting` enabled (`Enabled:true`), so configuring `OutlierDetection` in a `DestinationRule` automatically activates locality-aware failover behavior even without an explicit `localityLbSetting` in the rule. The opt-out is to set `localityLbSetting.enabled: false` in the DR's load balancer settings.

**Areas affected:**
- [x] Networking
- [x] Docs

**Characteristics:**
- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.