### PR TITLE
fix: prevent Content-Type duplication in ambient waypoint

### DIFF
--- a/pilot/pkg/networking/core/listener_waypoint.go
+++ b/pilot/pkg/networking/core/listener_waypoint.go
@@ -325,6 +325,7 @@ func (lb *ListenerBuilder) buildWaypointInboundConnectTerminate() *listener.List
 			}},
 			ClusterSpecifier: &route.RouteAction_Cluster{Cluster: MainInternalName},
 		}},
+		RequestHeadersToRemove: []string{"content-type"},
 	}}
 	return lb.buildConnectTerminateListener(routes)
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

**Fixes** #59781

**Context:**
In Ambient mode, when traffic passes through a waypoint proxy, the `Content-Type` header is duplicated (e.g., `application/json,application/json`). This breaks downstream services that rely on strict media type matching (like Express.js `type-is`).

**The Fix:**
This duplication occurs due to header bleeding during HBONE decapsulation. Both the outer CONNECT tunnel request and the inner HTTP payload carry the `Content-Type` header. When the `connect_terminate` listener hands the request off to the `main_internal` listener, Envoy merges the headers.

This PR adds `RequestHeadersToRemove: []string{"content-type"}` to the outer HBONE termination route config (`buildWaypointInboundConnectTerminate` in `listener_waypoint.go`). This safely strips the outer header, allowing the inner payload's original `Content-Type` to pass through cleanly without duplication.




**Release Notes:**
```yaml
releaseNotes:
  - |
    **Fixed** an issue in Ambient mode where waypoint proxies would duplicate the `Content-Type` header, breaking downstream strict media type parsers.