### PR TITLE
Unskip TestTraffic gateway integration test

### DIFF
--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -1977,7 +1977,6 @@ spec:
 		// See https://github.com/istio/istio/issues/27315
 		// See https://github.com/istio/istio/issues/34609
 		name:             "http return 400 with with x-forwarded-proto https when vs port specify https",
-		skip:             skip{skip: true, reason: "https://github.com/istio/istio/issues/59833"},
 		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,


### PR DESCRIPTION
This PR removes the skip added for the `TestTraffic/gateway` suite.