### PR TITLE
Fix "release_istio_postsubmit" job failure - unknown flag

### DIFF
--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -38,7 +38,7 @@ docker run --rm --privileged "${DOCKER_HUB}/qemu-user-static" --reset -p yes
 export ISTIO_DOCKER_QEMU=true
 
 # Use a pinned version in case breaking changes are needed
-BUILDER_SHA=2a166a509fc3651fe08fb06975501765e4b2d865
+BUILDER_SHA=9307d20423a0a20cb20297c3c8953eb8113278e5
 
 # Reference to the next minor version of Istio
 # This will create a version like 1.4-alpha.sha


### PR DESCRIPTION
**Please provide a description of this PR:**
The "release_istio_postsubmit" job fails with the following error: Error: unknown flag: --r2bucket
https://prow.istio.io/view/gs/istio-prow/logs/release_istio_postsubmit/2044520396853612544

This happens because "--r2bucket" flag has been recently added to the "release-builder" flow -
istio/release-builder#2291.

But BUILDER_SHA within "prow/release-commit.sh" was not updated and points for an older sha which is missing the required functionality.

Update the BUILDER_SHA with the sha contains the required flag.