### PR TITLE
chore: fix conflicting message

### DIFF
--- a/pilot/pkg/model/gateway.go
+++ b/pilot/pkg/model/gateway.go
@@ -296,7 +296,7 @@ func mergeGateways(gateways []gatewayWithInstances, proxy *Proxy, ps *PushContex
 					if current, exists := plainTextServers[resolvedPort]; exists {
 						if !canMergeProtocols(serverProtocol, protocol.Parse(current.Protocol)) && current.Bind == serverPort.Bind {
 							log.Infof("skipping server on gateway %s port %s.%d.%s: conflict with existing server %d.%s",
-								gatewayConfig.Name, s.Port.Name, resolvedPort, s.Port.Protocol, serverPort.Number, serverPort.Protocol)
+								gatewayConfig.Name, s.Port.Name, resolvedPort, s.Port.Protocol, current.Number, current.Protocol)
 							RecordRejectedConfig(gatewayName)
 							continue
 						}


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix the wrong protocol in conflicting gateway server message.

The current message is quite confusing while debugging since multiple servers on the same HTTPS ports are actually allowed.

Before:  skipping server on gateway gateway-b port https.8443.HTTPS: conflict with existing server 8443.HTTPS
After:     skipping server on gateway gateway-b port https.8443.HTTPS: conflict with existing server **_8443.HTTP_**

```yaml
- apiVersion: networking.istio.io/v1
  kind: Gateway
  metadata:
    name: gateway-a
    resourceVersion: "9459"
  spec:
    selector:
      istio: ingressgateway
    servers:
    - hosts:
      - app-a.example.com
      port:
        name: http
        number: 443
        protocol: HTTP
- apiVersion: networking.istio.io/v1
  kind: Gateway
  metadata:
    name: gateway-b
  spec:
    selector:
      istio: ingressgateway
    servers:
    - hosts:
      - app-b.example.com
      port:
        name: https
        number: 443
        protocol: HTTPS
      tls:
        credentialName: gw-credential
        mode: SIMPLE
```