### PR TITLE
detect metadata-only secret rotation events

### DIFF
--- a/releasenotes/notes/59912.yaml
+++ b/releasenotes/notes/59912.yaml
@@ -5,4 +5,4 @@ issue:
   - 59912
 releaseNotes:
   - |
-    - **Fixed** pilot-agent handling of file-mounted certificate rotations when Kubernetes emits metadata-only secret update events (`..data`, `..data_tmp`, timestamped staging directories), which could otherwise miss updates on second and subsequent rotations.
+    - **Fixed** pilot-agent missing certificate reloads on second and subsequent Kubernetes secret rotations for file-mounted certs.

--- a/releasenotes/notes/59912.yaml
+++ b/releasenotes/notes/59912.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+issue:
+  - 59912
+releaseNotes:
+  - |
+    - **Fixed** pilot-agent handling of file-mounted certificate rotations when Kubernetes emits metadata-only secret update events (`..data`, `..data_tmp`, timestamped staging directories), which could otherwise miss updates on second and subsequent rotations.

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -957,7 +957,7 @@ func (sc *SecretManagerClient) handleFileEvent(event fsnotify.Event, resources m
 		symlinkDir := filepath.Dir(fc.Filename)
 		kubeDataPublish := isKubeDataPublish(event, symlinkDir)
 		if fc.Filename == event.Name || fc.TargetPath == event.Name || symlinkDir == event.Name || kubeDataPublish {
-			cacheLog.Infof("file event matched for %s: event=%s op=%v", fc.ResourceName, event.Name, event.Op)
+			cacheLog.Debugf("file event matched for %s: event=%s op=%v", fc.ResourceName, event.Name, event.Op)
 			// If the symlink itself changed (removed/recreated), we need to re-resolve it
 			if fc.Filename == event.Name && (isRemove(event) || isCreate(event)) {
 				sc.handleSymlinkChange(fc)
@@ -984,7 +984,6 @@ func (sc *SecretManagerClient) handleFileEvent(event fsnotify.Event, resources m
 			if kubeDataPublish {
 				// Kubelet atomically publishes new secret files via MOVED_TO on ..data.
 				// Re-resolve the symlink so the watcher picks up the new target.
-				cacheLog.Infof("kubernetes secret rotation detected: ..data publish event for %s, re-resolving symlink", fc.ResourceName)
 				sc.handleSymlinkChange(fc)
 				shouldTriggerUpdate = true
 			}
@@ -992,8 +991,6 @@ func (sc *SecretManagerClient) handleFileEvent(event fsnotify.Event, resources m
 			if shouldTriggerUpdate {
 				updatedResources[fc.ResourceName] = struct{}{}
 			}
-		} else {
-			cacheLog.Infof("FASEELA:file event ignored for %s: event=%s op=%v (not ..data publish, not cert file)", fc.ResourceName, event.Name, event.Op)
 		}
 	}
 

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -23,7 +23,6 @@ import (
 	"math/rand/v2"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -47,9 +46,6 @@ var (
 	cacheLog = istiolog.RegisterScope("cache", "cache debugging")
 	// The total timeout for any credential retrieval process, default value of 10s is used.
 	totalTimeout = time.Second * 10
-	// kubeTimestampedDir matches kubelet timestamped staging directories used during secret
-	// rotation, e.g. ..2026_04_17_07_17_21.2769404793.
-	kubeTimestampedDir = regexp.MustCompile(`^\.\.[0-9]`)
 )
 
 const (
@@ -959,8 +955,9 @@ func (sc *SecretManagerClient) handleFileEvent(event fsnotify.Event, resources m
 		// Process symlinks (those with TargetPath set)
 		// Check if the event is for the symlink itself, its target file, or its directory
 		symlinkDir := filepath.Dir(fc.Filename)
-		kubeSecretMetadataEvent := isKubernetesSecretMetadataPath(event.Name, symlinkDir)
-		if fc.Filename == event.Name || fc.TargetPath == event.Name || symlinkDir == event.Name || kubeSecretMetadataEvent {
+		kubeDataPublish := isKubeDataPublish(event, symlinkDir)
+		if fc.Filename == event.Name || fc.TargetPath == event.Name || symlinkDir == event.Name || kubeDataPublish {
+			cacheLog.Infof("file event matched for %s: event=%s op=%v", fc.ResourceName, event.Name, event.Op)
 			// If the symlink itself changed (removed/recreated), we need to re-resolve it
 			if fc.Filename == event.Name && (isRemove(event) || isCreate(event)) {
 				sc.handleSymlinkChange(fc)
@@ -984,22 +981,19 @@ func (sc *SecretManagerClient) handleFileEvent(event fsnotify.Event, resources m
 				shouldTriggerUpdate = true
 			}
 
-			if kubeSecretMetadataEvent {
-				// Kubernetes secret volume rotation works by atomically swapping the ..data symlink
-				// to a new timestamped directory (e.g. ..2026_04_17_07_17_21.x). On second and
-				// subsequent rotations, only these metadata paths fire, not the cert files directly.
-				// Treat them as cert changes and trigger proxy updates.
+			if kubeDataPublish {
+				// Kubelet atomically publishes new secret files via MOVED_TO on ..data.
+				// Re-resolve the symlink so the watcher picks up the new target.
+				cacheLog.Infof("kubernetes secret rotation detected: ..data publish event for %s, re-resolving symlink", fc.ResourceName)
+				sc.handleSymlinkChange(fc)
 				shouldTriggerUpdate = true
-
-				// Keep target watcher path in sync when ..data link itself changes.
-				if filepath.Base(event.Name) == "..data" {
-					sc.handleSymlinkChange(fc)
-				}
 			}
 
 			if shouldTriggerUpdate {
 				updatedResources[fc.ResourceName] = struct{}{}
 			}
+		} else {
+			cacheLog.Infof("FASEELA:file event ignored for %s: event=%s op=%v (not ..data publish, not cert file)", fc.ResourceName, event.Name, event.Op)
 		}
 	}
 
@@ -1097,15 +1091,13 @@ func isWrite(event fsnotify.Event) bool {
 	return event.Has(fsnotify.Write)
 }
 
-// isKubernetesSecretMetadataPath reports whether eventPath is a kubelet secret
-// rotation metadata path inside symlinkDir (..data, ..data_tmp, or a timestamped
-// staging directory like ..2026_04_17_07_17_21.2769404793).
-func isKubernetesSecretMetadataPath(eventPath, symlinkDir string) bool {
-	if filepath.Dir(eventPath) != symlinkDir {
-		return false
-	}
-	base := filepath.Base(eventPath)
-	return base == "..data" || base == "..data_tmp" || kubeTimestampedDir.MatchString(base)
+// isKubeDataPublish reports whether event is a kubelet secret volume publish:
+// MOVED_TO on the "..data" symlink (fsnotify.Create), which is the final atomic
+// step kubelet performs after staging new files in a private timestamped directory.
+func isKubeDataPublish(event fsnotify.Event, symlinkDir string) bool {
+	return isCreate(event) &&
+		filepath.Dir(event.Name) == symlinkDir &&
+		filepath.Base(event.Name) == "..data"
 }
 
 func isCreate(event fsnotify.Event) bool {

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"regexp"
 
 	"github.com/fsnotify/fsnotify"
 
@@ -46,6 +47,9 @@ var (
 	cacheLog = istiolog.RegisterScope("cache", "cache debugging")
 	// The total timeout for any credential retrieval process, default value of 10s is used.
 	totalTimeout = time.Second * 10
+	// kubeTimestampedDir matches kubelet timestamped staging directories used during secret
+	// rotation, e.g. ..2026_04_17_07_17_21.2769404793.
+	kubeTimestampedDir = regexp.MustCompile(`^\.\.[0-9]`)
 )
 
 const (
@@ -955,7 +959,8 @@ func (sc *SecretManagerClient) handleFileEvent(event fsnotify.Event, resources m
 		// Process symlinks (those with TargetPath set)
 		// Check if the event is for the symlink itself, its target file, or its directory
 		symlinkDir := filepath.Dir(fc.Filename)
-		if fc.Filename == event.Name || fc.TargetPath == event.Name || symlinkDir == event.Name {
+		kubeSecretMetadataEvent := isKubernetesSecretMetadataPath(event.Name, symlinkDir)
+		if fc.Filename == event.Name || fc.TargetPath == event.Name || symlinkDir == event.Name || kubeSecretMetadataEvent {
 			// If the symlink itself changed (removed/recreated), we need to re-resolve it
 			if fc.Filename == event.Name && (isRemove(event) || isCreate(event)) {
 				sc.handleSymlinkChange(fc)
@@ -977,6 +982,19 @@ func (sc *SecretManagerClient) handleFileEvent(event fsnotify.Event, resources m
 			if symlinkDir == event.Name {
 				// Always trigger for directory changes (including removal)
 				shouldTriggerUpdate = true
+			}
+
+			if kubeSecretMetadataEvent {
+				// Kubernetes secret volume rotation works by atomically swapping the ..data symlink
+				// to a new timestamped directory (e.g. ..2026_04_17_07_17_21.x). On second and
+				// subsequent rotations, only these metadata paths fire, not the cert files directly.
+				// Treat them as cert changes and trigger proxy updates.
+				shouldTriggerUpdate = true
+
+				// Keep target watcher path in sync when ..data link itself changes.
+				if filepath.Base(event.Name) == "..data" {
+					sc.handleSymlinkChange(fc)
+				}
 			}
 
 			if shouldTriggerUpdate {
@@ -1077,6 +1095,17 @@ func (sc *SecretManagerClient) handleSymlinkChange(fc FileCert) {
 
 func isWrite(event fsnotify.Event) bool {
 	return event.Has(fsnotify.Write)
+}
+
+// isKubernetesSecretMetadataPath reports whether eventPath is a kubelet secret
+// rotation metadata path inside symlinkDir (..data, ..data_tmp, or a timestamped
+// staging directory like ..2026_04_17_07_17_21.2769404793).
+func isKubernetesSecretMetadataPath(eventPath, symlinkDir string) bool {
+	if filepath.Dir(eventPath) != symlinkDir {
+		return false
+	}
+	base := filepath.Base(eventPath)
+	return base == "..data" || base == "..data_tmp" || kubeTimestampedDir.MatchString(base)
 }
 
 func isCreate(event fsnotify.Event) bool {

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -23,10 +23,10 @@ import (
 	"math/rand/v2"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
-	"regexp"
 
 	"github.com/fsnotify/fsnotify"
 

--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/stretchr/testify/require"
 
 	"istio.io/istio/pkg/file"
@@ -1253,6 +1254,45 @@ func TestSymlinkDirectoryCleanup(t *testing.T) {
 		t.Logf("Test completed - reviewer example validated")
 		t.Logf("Watching symlink path: %s", symlinkCertPath)
 		t.Logf("Watching resolved path: %s", realCertFile)
+	})
+}
+
+func TestHandleFileEventKubernetesSecretRotationEventsTriggerUpdate(t *testing.T) {
+	resourceName := "file-cert:/etc/sleep/client_certs/client.example.com/tls.crt~/etc/sleep/client_certs/client.example.com/tls.key"
+	symlinkFile := "/etc/sleep/client_certs/client.example.com/tls.crt"
+	targetFile := "/etc/sleep/client_certs/client.example.com/..data/tls.crt"
+
+	sc := &SecretManagerClient{
+		fileCerts: map[FileCert]struct{}{
+			{
+				ResourceName: resourceName,
+				Filename:     symlinkFile,
+				TargetPath:   targetFile,
+			}: {},
+		},
+	}
+
+	resources := map[FileCert]struct{}{}
+	for fc := range sc.fileCerts {
+		resources[fc] = struct{}{}
+	}
+
+	t.Run("first rotation direct cert chmod", func(t *testing.T) {
+		event := fsnotify.Event{
+			Name: symlinkFile,
+			Op:   fsnotify.Chmod,
+		}
+		updated := sc.handleFileEvent(event, resources)
+		require.Contains(t, updated, resourceName)
+	})
+
+	t.Run("second rotation metadata data symlink create", func(t *testing.T) {
+		event := fsnotify.Event{
+			Name: "/etc/sleep/client_certs/client.example.com/..data",
+			Op:   fsnotify.Create,
+		}
+		updated := sc.handleFileEvent(event, resources)
+		require.Contains(t, updated, resourceName)
 	})
 }
 

--- a/tests/integration/security/filebased_tls_origination/destination_rule_tls_test.go
+++ b/tests/integration/security/filebased_tls_origination/destination_rule_tls_test.go
@@ -116,8 +116,8 @@ spec:
 			call := func(expected int) func() error {
 				return func() error {
 					_, err := secretClient[0].Call(echo.CallOptions{
-						To:    server,
-						Count: 1,
+						To:                      server,
+						Count:                   1,
 						NewConnectionPerRequest: true,
 						Port: echo.Port{
 							Name: "http",

--- a/tests/integration/security/filebased_tls_origination/destination_rule_tls_test.go
+++ b/tests/integration/security/filebased_tls_origination/destination_rule_tls_test.go
@@ -17,12 +17,17 @@
 package filebasedtlsorigination
 
 import (
+	"net/http"
 	"testing"
+	"time"
 
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/check"
+	"istio.io/istio/pkg/test/framework/resource/config/apply"
+	"istio.io/istio/pkg/test/util/retry"
+	sdsutil "istio.io/istio/tests/integration/security/sds_ingress/util"
 )
 
 // TestDestinationRuleTls tests that MUTUAL tls mode is respected in DestinationRule.
@@ -67,5 +72,87 @@ spec:
 					client[0].CallOrFail(t, opts)
 				})
 			}
+		})
+}
+
+// TestDestinationRuleTlsSecretRotation verifies that pilot-agent correctly reloads
+// file-mounted certificates referenced in a DestinationRule when the underlying
+// Kubernetes secret is rotated. Two rotations are tested:
+//   - rotate to incompatible cert set: traffic must fail (503)
+//   - rotate back to original cert set: traffic must recover (200)
+func TestDestinationRuleTlsSecretRotation(t *testing.T) {
+	framework.
+		NewTest(t).
+		Run(func(t framework.TestContext) {
+			ns := appNS
+
+			t.ConfigIstio().YAML(ns.Name(), `
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: db-mtls-secret-client
+spec:
+  exportTo: ["."]
+  host: server
+  trafficPolicy:
+    connectionPool:
+      http:
+        maxRequestsPerConnection: 1
+    tls:
+      mode: MUTUAL
+      clientCertificate: /etc/secret-client/client_certs/client.example.com/tls.crt
+      privateKey: /etc/secret-client/client_certs/client.example.com/tls.key
+      caCertificates: /etc/secret-client/ca_certs/example.com/cacert
+      sni: server
+`).ApplyOrFail(t, apply.CleanupConditionally)
+
+			t.CleanupConditionally(func() {
+				_ = updateSecretClientCertsFromInline(t, ns,
+					mustReadCert("cert-chain.pem"),
+					mustReadCert("key.pem"),
+					mustReadCert("root-cert.pem"))
+			})
+
+			call := func(expected int) func() error {
+				return func() error {
+					_, err := secretClient[0].Call(echo.CallOptions{
+						To:    server,
+						Count: 1,
+						NewConnectionPerRequest: true,
+						Port: echo.Port{
+							Name: "http",
+						},
+						Check: check.And(check.NoError(), check.Status(expected)),
+					})
+					return err
+				}
+			}
+
+			// Verify baseline connectivity with original certs.
+			retry.UntilSuccessOrFail(t, call(http.StatusOK), retry.Delay(time.Second), retry.Timeout(2*time.Minute))
+
+			// Rotate to an incompatible cert set (different CA). pilot-agent should detect the
+			// change via inotify and push updated certs to Envoy, causing TLS verification to fail (503).
+			t.NewSubTest("rotate to wrong cert: traffic fails").Run(func(t framework.TestContext) {
+				if err := updateSecretClientCertsFromInline(t, ns,
+					sdsutil.TLSClientCertB,
+					sdsutil.TLSClientKeyB,
+					sdsutil.CaCertB); err != nil {
+					t.Fatalf("failed rotating secret-client to set B: %v", err)
+				}
+				retry.UntilSuccessOrFail(t, call(http.StatusServiceUnavailable), retry.Delay(5*time.Second), retry.Timeout(2*time.Minute))
+			})
+
+			// Rotate back to the original certs. pilot-agent must detect the symlink swap and
+			// push reloaded certs to Envoy so traffic recovers (200).
+			t.NewSubTest("rotate back to original cert: traffic recovers").Run(func(t framework.TestContext) {
+				if err := updateSecretClientCertsFromInline(t, ns,
+					mustReadCert("cert-chain.pem"),
+					mustReadCert("key.pem"),
+					mustReadCert("root-cert.pem")); err != nil {
+					t.Fatalf("failed rotating secret-client back to original: %v", err)
+				}
+				retry.UntilSuccessOrFail(t, call(http.StatusOK), retry.Delay(5*time.Second), retry.Timeout(2*time.Minute))
+			})
 		})
 }

--- a/tests/integration/security/filebased_tls_origination/main_test.go
+++ b/tests/integration/security/filebased_tls_origination/main_test.go
@@ -23,10 +23,11 @@ import (
 	"path"
 	"testing"
 
-	"istio.io/api/annotation"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"istio.io/api/annotation"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/echo/common"
 	"istio.io/istio/pkg/test/env"
@@ -155,8 +156,11 @@ func setupApps(ctx resource.Context, appNs namespace.Getter,
 		Subsets: []echo.SubsetConfig{{
 			Version: "v1",
 			Annotations: map[string]string{
-				annotation.SidecarUserVolume.Name:      `{"client-secret":{"secret":{"secretName":"` + secretClientCredentialName + `"}},"ca-secret":{"secret":{"secretName":"` + secretClientCACertName + `"}}}`,
-				annotation.SidecarUserVolumeMount.Name: `{"client-secret":{"mountPath":"/etc/secret-client/client_certs/client.example.com","readOnly":true},"ca-secret":{"mountPath":"/etc/secret-client/ca_certs/example.com","readOnly":true}}`,
+				annotation.SidecarUserVolume.Name: `{"client-secret":{"secret":{"secretName":"` +
+					secretClientCredentialName + `"}},"ca-secret":{"secret":{"secretName":"` + secretClientCACertName + `"}}}`,
+				annotation.SidecarUserVolumeMount.Name: `{"client-secret":{"mountPath":` +
+					`"/etc/secret-client/client_certs/client.example.com","readOnly":true},` +
+					`"ca-secret":{"mountPath":"/etc/secret-client/ca_certs/example.com","readOnly":true}}`,
 			},
 		}},
 		Cluster: ctx.Clusters().Default(),
@@ -303,7 +307,6 @@ func updateSecretClientCertsFromInline(ctx resource.Context, ns namespace.Instan
 }
 
 func applySecretClientCerts(ctx resource.Context, ns namespace.Instance, clientCert, clientKey, rootCert []byte) error {
-
 	for _, c := range ctx.AllClusters() {
 		credential := &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{

--- a/tests/integration/security/filebased_tls_origination/main_test.go
+++ b/tests/integration/security/filebased_tls_origination/main_test.go
@@ -17,12 +17,16 @@
 package filebasedtlsorigination
 
 import (
+	"context"
 	"log"
 	"os"
 	"path"
 	"testing"
 
 	"istio.io/api/annotation"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/echo/common"
 	"istio.io/istio/pkg/test/env"
@@ -41,12 +45,18 @@ var (
 	inst            istio.Instance
 	apps            deployment.TwoNamespaceView
 	client          echo.Instances
+	secretClient    echo.Instances
 	server          echo.Instances
 	internalClient  echo.Instances
 	externalService echo.Instances
 	appNS           namespace.Instance
 	serviceNS       namespace.Instance
 	customConfig    []echo.Config
+)
+
+const (
+	secretClientCredentialName = "secret-client-credential"
+	secretClientCACertName     = "secret-client-cacert"
 )
 
 func TestMain(m *testing.M) {
@@ -117,6 +127,9 @@ func setupApps(ctx resource.Context, appNs namespace.Getter,
 ) error {
 	appNamespace := appNs.Get()
 	serviceNamespace := serviceNs.Get()
+	if err := createSecretClientCerts(ctx, appNamespace); err != nil {
+		return err
+	}
 	var customConfig []echo.Config
 	client := echo.Config{
 		Service:   "client",
@@ -130,6 +143,20 @@ func setupApps(ctx resource.Context, appNs namespace.Getter,
 			Annotations: map[string]string{
 				annotation.SidecarUserVolume.Name:      `{"custom-certs":{"configMap":{"name":"server-certs"}}}`,
 				annotation.SidecarUserVolumeMount.Name: `{"custom-certs":{"mountPath":"/etc/certs/custom"}}`,
+			},
+		}},
+		Cluster: ctx.Clusters().Default(),
+	}
+
+	secretClient := echo.Config{
+		Service:   "secret-client",
+		Namespace: appNamespace,
+		Ports:     []echo.Port{},
+		Subsets: []echo.SubsetConfig{{
+			Version: "v1",
+			Annotations: map[string]string{
+				annotation.SidecarUserVolume.Name:      `{"client-secret":{"secret":{"secretName":"` + secretClientCredentialName + `"}},"ca-secret":{"secret":{"secretName":"` + secretClientCACertName + `"}}}`,
+				annotation.SidecarUserVolumeMount.Name: `{"client-secret":{"mountPath":"/etc/secret-client/client_certs/client.example.com","readOnly":true},"ca-secret":{"mountPath":"/etc/secret-client/ca_certs/example.com","readOnly":true}}`,
 			},
 		}},
 		Cluster: ctx.Clusters().Default(),
@@ -219,7 +246,7 @@ func setupApps(ctx resource.Context, appNs namespace.Getter,
 		}},
 		Cluster: ctx.Clusters().Default(),
 	}
-	customConfig = append(customConfig, client, server, internalClient, externalService)
+	customConfig = append(customConfig, client, secretClient, server, internalClient, externalService)
 	*customCfg = customConfig
 	return nil
 }
@@ -229,6 +256,8 @@ func createCustomInstances(apps *deployment.TwoNamespaceView) error {
 		switch {
 		case namespacedName.Name == "client":
 			client = apps.Ns1.All[index]
+		case namespacedName.Name == "secret-client":
+			secretClient = apps.Ns1.All[index]
 		case namespacedName.Name == "server":
 			server = apps.Ns1.All[index]
 		case namespacedName.Name == "internal-client":
@@ -250,4 +279,71 @@ func mustReadCert(f string) string {
 		log.Fatalf("failed to read %v: %v", f, err)
 	}
 	return string(b)
+}
+
+func createSecretClientCerts(ctx resource.Context, ns namespace.Instance) error {
+	clientCert, err := cert.ReadCustomCertFromFile("cert-chain.pem")
+	if err != nil {
+		return err
+	}
+	clientKey, err := cert.ReadCustomCertFromFile("key.pem")
+	if err != nil {
+		return err
+	}
+	rootCert, err := cert.ReadCustomCertFromFile("root-cert.pem")
+	if err != nil {
+		return err
+	}
+
+	return applySecretClientCerts(ctx, ns, clientCert, clientKey, rootCert)
+}
+
+func updateSecretClientCertsFromInline(ctx resource.Context, ns namespace.Instance, clientCert, clientKey, rootCert string) error {
+	return applySecretClientCerts(ctx, ns, []byte(clientCert), []byte(clientKey), []byte(rootCert))
+}
+
+func applySecretClientCerts(ctx resource.Context, ns namespace.Instance, clientCert, clientKey, rootCert []byte) error {
+
+	for _, c := range ctx.AllClusters() {
+		credential := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretClientCredentialName,
+				Namespace: ns.Name(),
+			},
+			Data: map[string][]byte{
+				"tls.crt": clientCert,
+				"tls.key": clientKey,
+			},
+		}
+		if _, err := c.Kube().CoreV1().Secrets(ns.Name()).Create(context.TODO(), credential, metav1.CreateOptions{}); err != nil {
+			if errors.IsAlreadyExists(err) {
+				if _, err := c.Kube().CoreV1().Secrets(ns.Name()).Update(context.TODO(), credential, metav1.UpdateOptions{}); err != nil {
+					return err
+				}
+			} else {
+				return err
+			}
+		}
+
+		caCert := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretClientCACertName,
+				Namespace: ns.Name(),
+			},
+			Data: map[string][]byte{
+				"cacert": rootCert,
+			},
+		}
+		if _, err := c.Kube().CoreV1().Secrets(ns.Name()).Create(context.TODO(), caCert, metav1.CreateOptions{}); err != nil {
+			if errors.IsAlreadyExists(err) {
+				if _, err := c.Kube().CoreV1().Secrets(ns.Name()).Update(context.TODO(), caCert, metav1.UpdateOptions{}); err != nil {
+					return err
+				}
+			} else {
+				return err
+			}
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
File-mounted cert updates are missed after initial Kubernetes secret rotation, so pilot-agent stops pushing refreshed certs to workloads. This bug affects second+ secret rotations only: first rotation typically has a direct cert event, while later rotations may be metadata-only and were skipped by old matching logic.

Fixes: https://github.com/istio/istio/issues/59912

The fix updates file-event matching to treat Kubernetes secret rotation metadata path ..data as valid cert-change signal, and refreshes symlink target watchers when ..data flips, so second-and-later rotations reliably trigger `OnSecretUpdate`.

And an interesting read on the notification sequence here: https://github.com/envoyproxy/envoy/issues/9359#issuecomment-579314094