### PR TITLE
fix data race in krt conformance test

### DIFF
--- a/pkg/kube/krt/conformance_test.go
+++ b/pkg/kube/krt/conformance_test.go
@@ -364,7 +364,9 @@ func runConformance[T any](t *testing.T, factory func(t *testing.T) Rig[T]) {
 		keys = append(keys, fmt.Sprintf("a/%v", n))
 	}
 	raceHandler := assert.NewTracker[string](t)
+	done := make(chan struct{})
 	go func() {
+		defer close(done)
 		for _, k := range keys {
 			collection.CreateObject(k)
 		}
@@ -381,6 +383,10 @@ func runConformance[T any](t *testing.T, factory func(t *testing.T) Rig[T]) {
 	// We should get every event exactly one time
 	raceHandler.WaitUnordered(want...)
 	raceHandler.Empty()
+
+	// Wait for the goroutine to finish before the test returns,
+	// to avoid calling assert.NoError on a completed *testing.T.
+	<-done
 
 	removeHandler.Empty()
 


### PR DESCRIPTION
**Fix data race in krt conformance test**

Fixes #59884

### Root Cause

The goroutine spawned in `runConformance` to test race conditions can outlive the parent test. For the `fileRig` implementation, `CreateObject` calls `assert.NoError(r.t, err)`, which accesses the `*testing.T` after it has been cleaned up by the test runner — causing a data race and panic: `"Fail in goroutine after TestConformance has completed"`.

`WaitUnordered` waits for the *events* to arrive, but doesn't guarantee the goroutine has *returned* — the file watcher emits events asynchronously after the file is written, so `WaitUnordered` can complete while `CreateObject` is still on the stack.

This only affects the `files` subtest because `fileRig` is the only rig whose `CreateObject` calls `assert` on the test's `*testing.T`.

### Fix

Add a `sync.WaitGroup` around the goroutine to ensure it completes before `runConformance` returns.