### PR TITLE
Add prometheus.istio.io/scrape-targets annotation for multi-port metrics merging

### DIFF
--- a/architecture/networking/multi-port-metrics-merging.md
+++ b/architecture/networking/multi-port-metrics-merging.md
@@ -93,7 +93,7 @@ Replace the single-endpoint block with a concurrent fan-out (see Merge Strategy 
 After reading the existing three `prometheus.io/*` annotations, also check `prometheus.istio.io/scrape-targets`:
 
 ```go
-const prometheusIstioTargetsAnnotation = "prometheus_istio_io_scrape-targets"
+const prometheusIstioTargetsAnnotation = "prometheus_istio_io_scrape_targets"
 
 // in switch:
 case prometheusIstioTargetsAnnotation:

--- a/architecture/networking/multi-port-metrics-merging.md
+++ b/architecture/networking/multi-port-metrics-merging.md
@@ -1,6 +1,6 @@
 # Design Proposal: Multi-Port Metrics Merging
 
-**Issue:** https://github.com/istio/istio/issues/59567
+**Issue:** <https://github.com/istio/istio/issues/59567>
 
 ---
 
@@ -38,7 +38,7 @@ It's an Istio-owned namespace, already used for other Istio-specific hints, and 
 
 ### 1. `pilot/cmd/pilot-agent/status/server.go`
 
-**`PrometheusScrapeConfiguration` (line ~507)**
+#### `PrometheusScrapeConfiguration` (line ~507)
 
 Add a `Targets` slice alongside the existing fields:
 
@@ -58,7 +58,7 @@ type PrometheusScrapeConfiguration struct {
 
 Old JSON (`{"scrape":"true","port":"8080","path":"/metrics"}`) unmarshals cleanly with `Targets == nil`. No breaking change.
 
-**`NewServer()` (line ~245)**
+#### `NewServer()` (line ~245)
 
 After unmarshaling `ISTIO_PROMETHEUS_ANNOTATIONS`, normalize to the `Targets` representation:
 
@@ -80,7 +80,7 @@ for i, t := range prom.Targets {
 
 `Server.prometheus` type stays as `*PrometheusScrapeConfiguration`; no field type change needed.
 
-**`handleStats()` (line ~513)**
+#### `handleStats()` (line ~513)
 
 Replace the single-endpoint block with a concurrent fan-out (see Merge Strategy below). The existing serial `io.Copy` for Envoy stats and agent metrics is unchanged.
 
@@ -88,7 +88,7 @@ Replace the single-endpoint block with a concurrent fan-out (see Merge Strategy 
 
 ### 2. `pkg/kube/inject/webhook.go`
 
-**`getPrometheusScrapeConfiguration()` (line ~959)**
+#### `getPrometheusScrapeConfiguration()` (line ~959)
 
 After reading the existing three `prometheus.io/*` annotations, also check `prometheus.istio.io/scrape-targets`:
 
@@ -102,7 +102,7 @@ case prometheusIstioTargetsAnnotation:
 
 Parse `RawTargets` into `[]ScrapeTarget` here or in `applyPrometheusMerge`.
 
-**`applyPrometheusMerge()` (line ~884)**
+#### `applyPrometheusMerge()` (line ~884)
 
 Build the `Targets` slice:
 1. If `RawTargets` is set, parse it; each entry overrides/augments the single `Port`/`Path` fields.
@@ -118,7 +118,7 @@ No change to the annotation rewrite block — `prometheus.io/port` is still set 
 
 ### Current behavior (N=1)
 
-```
+```text
 agent metrics  →  io.Copy
 Envoy stats    →  io.Copy
 app endpoint   →  scrape() → io.Copy

--- a/architecture/networking/multi-port-metrics-merging.md
+++ b/architecture/networking/multi-port-metrics-merging.md
@@ -1,0 +1,237 @@
+# Design Proposal: Multi-Port Metrics Merging
+
+**Issue:** https://github.com/istio/istio/issues/59567
+
+---
+
+## Problem Statement
+
+`handleStats` (`pilot/cmd/pilot-agent/status/server.go`) merges application metrics by scraping a single endpoint encoded in `ISTIO_PROMETHEUS_ANNOTATIONS` — a JSON blob carrying one `port` and one `path`. This works for pods with a single metrics-emitting container, but breaks for common multi-container patterns: a primary app on `:8080/metrics` paired with a sidecar exporter (e.g., node-exporter, JMX exporter, custom business metrics) on `:9100/metrics`. Under `STRICT` mTLS, Prometheus cannot reach application ports directly; all scraping must flow through the agent at `:15020/stats/prometheus`. Since the agent only fans out to one app endpoint, the second container's metrics are silently dropped with no error surfaced. The annotation rewrite in `applyPrometheusMerge` also overwrites `prometheus.io/port` to `15020`, so there is no way for the second container to be scraped at all once a sidecar is injected.
+
+---
+
+## Proposed Annotation Format
+
+### New annotation: `prometheus.istio.io/scrape-targets`
+
+```yaml
+annotations:
+  prometheus.istio.io/scrape-targets: "8080:/metrics,9100:/metrics"
+```
+
+Value is a comma-separated list of `port:path` pairs. Each entry is trimmed; order is preserved (determines merge order). An empty path component defaults to `/metrics`.
+
+**Why not extend `prometheus.io/port`?**
+`prometheus.io/port` is consumed by external tooling (kube-state-metrics, Prometheus operator CRDs, annotation-based scrape configs). Changing its semantics (e.g., comma-separated) would silently break any cluster that scrapes it without the Istio agent in the path. Non-starter.
+
+**Why not `prometheus.io/port2`, `prometheus.io/port3`, …?**
+No standard exists; it would require n independent annotations with no defined upper bound. Parsing is fragile and ordering is undefined if the annotation set is unsorted. The Kubernetes annotation key space doesn't guarantee iteration order.
+
+**Why `prometheus.istio.io/` namespace?**
+It's an Istio-owned namespace, already used for other Istio-specific hints, and makes the Istio-specific semantics unambiguous to operators.
+
+**Backward compatibility:** The existing `prometheus.io/port` + `prometheus.io/path` single-endpoint flow is unchanged. If `prometheus.istio.io/scrape-targets` is absent, the webhook and agent behave exactly as today. Pods that were injected before this feature is available continue to work because old-format `ISTIO_PROMETHEUS_ANNOTATIONS` JSON remains valid.
+
+---
+
+## Required Changes
+
+### 1. `pilot/cmd/pilot-agent/status/server.go`
+
+**`PrometheusScrapeConfiguration` (line ~507)**
+
+Add a `Targets` slice alongside the existing fields:
+
+```go
+type ScrapeTarget struct {
+    Port string `json:"port"`
+    Path string `json:"path"`
+}
+
+type PrometheusScrapeConfiguration struct {
+    Scrape  string         `json:"scrape"`
+    Path    string         `json:"path"`   // kept for backward compat
+    Port    string         `json:"port"`   // kept for backward compat
+    Targets []ScrapeTarget `json:"targets,omitempty"`
+}
+```
+
+Old JSON (`{"scrape":"true","port":"8080","path":"/metrics"}`) unmarshals cleanly with `Targets == nil`. No breaking change.
+
+**`NewServer()` (line ~245)**
+
+After unmarshaling `ISTIO_PROMETHEUS_ANNOTATIONS`, normalize to the `Targets` representation:
+
+```go
+if len(prom.Targets) == 0 && prom.Port != "" {
+    // legacy single-port: synthesize a one-element list
+    prom.Targets = []ScrapeTarget{{Port: prom.Port, Path: prom.Path}}
+}
+// default path
+for i, t := range prom.Targets {
+    if t.Path == "" {
+        prom.Targets[i].Path = "/metrics"
+    }
+    if t.Port == strconv.Itoa(int(config.StatusPort)) {
+        return nil, fmt.Errorf("invalid prometheus scrape configuration: target port %s points at agent status port", t.Port)
+    }
+}
+```
+
+`Server.prometheus` type stays as `*PrometheusScrapeConfiguration`; no field type change needed.
+
+**`handleStats()` (line ~513)**
+
+Replace the single-endpoint block with a concurrent fan-out (see Merge Strategy below). The existing serial `io.Copy` for Envoy stats and agent metrics is unchanged.
+
+---
+
+### 2. `pkg/kube/inject/webhook.go`
+
+**`getPrometheusScrapeConfiguration()` (line ~959)**
+
+After reading the existing three `prometheus.io/*` annotations, also check `prometheus.istio.io/scrape-targets`:
+
+```go
+const prometheusIstioTargetsAnnotation = "prometheus_istio_io_scrape-targets"
+
+// in switch:
+case prometheusIstioTargetsAnnotation:
+    cfg.RawTargets = val  // "8080:/metrics,9100:/metrics"
+```
+
+Parse `RawTargets` into `[]ScrapeTarget` here or in `applyPrometheusMerge`.
+
+**`applyPrometheusMerge()` (line ~884)**
+
+Build the `Targets` slice:
+1. If `RawTargets` is set, parse it; each entry overrides/augments the single `Port`/`Path` fields.
+2. If only the single-port annotation is present, produce the existing single-entry flow (no behavior change).
+3. Validate every target port ≠ `targetPort` (15020).
+4. JSON-encode the full struct (including `Targets`) into `ISTIO_PROMETHEUS_ANNOTATIONS`.
+
+No change to the annotation rewrite block — `prometheus.io/port` is still set to `15020`.
+
+---
+
+## Merge Strategy
+
+### Current behavior (N=1)
+
+```
+agent metrics  →  io.Copy
+Envoy stats    →  io.Copy
+app endpoint   →  scrape() → io.Copy
+```
+
+All sequential. The response writer is the only synchronization point. `handleStats` never returns an HTTP error; any scrape failure is logged and skipped.
+
+### Proposed behavior (N≥1)
+
+Fan out app endpoint scrapes concurrently, then stream results into the response writer in deterministic order:
+
+```go
+type scraped struct {
+    body        io.ReadCloser
+    contentType string
+    err         error
+}
+
+results := make([]scraped, len(targets))
+var wg sync.WaitGroup
+for i, target := range targets {
+    wg.Add(1)
+    go func(i int, t ScrapeTarget) {
+        defer wg.Done()
+        url := fmt.Sprintf("http://localhost:%s%s", t.Port, t.Path)
+        body, cancel, ct, err := s.scrape(url, r.Header)
+        results[i] = scraped{body, ct, err}
+        if cancel != nil { defer cancel() }  // lifetime tied to handleStats return
+    }(i, target)
+}
+wg.Wait()
+```
+
+Then stream in order after Envoy stats:
+
+```go
+for i, res := range results {
+    if res.err != nil {
+        appScrapeErrors.Increment()
+        log.Warnf("failed to scrape app target %d: %v", i, res.err)
+        continue
+    }
+    if i < len(results)-1 || format == FmtText {
+        // strip # EOF so it only appears on the final write
+        io.Copy(w, newEOFStrippingReader(res.body))
+    } else {
+        io.Copy(w, res.body)
+    }
+    res.body.Close()
+}
+```
+
+**`newEOFStrippingReader`** is a thin `io.Reader` wrapper that drops lines equal to `# EOF\n` during streaming — no buffering of the full body required.
+
+**Per-endpoint timeout:** The incoming `X-Prometheus-Scrape-Timeout-Seconds` value is already forwarded in `scrape()`. With N concurrent goroutines all sharing the same context derived from the header, each endpoint gets the same wall-clock deadline. This matches how Prometheus handles parallel scrapes across targets — total timeout, not per-target.
+
+**Best-effort semantics:** A failed endpoint increments `metrics.AppScrapeErrors` and is skipped. Other endpoints are unaffected. This is consistent with the existing philosophy ("we do not return any errors here; if we do, we will drop metrics").
+
+**Format negotiation:** If any endpoint returns `application/openmetrics-text`, the response `Content-Type` is set to openmetrics. The `# EOF` stripping only applies to non-terminal endpoints; the last successfully scraped app endpoint writes its body as-is (preserving EOF if present). If all app endpoints fail, falls back to the existing behavior (text/plain, Envoy + agent only).
+
+**Metric family name conflicts:** Two app containers advertising the same metric family name will still produce a Prometheus parse error — same behavior as today with Envoy vs. app conflicts. Deduplication is out of scope for this change; the existing `TestStats` conflict test cases document this.
+
+---
+
+## Testing Plan
+
+### Unit tests (`pilot/cmd/pilot-agent/status/server_test.go`)
+
+Extend `TestStats` with new table cases:
+- Two healthy endpoints, distinct metric families → merged output contains both families
+- Two healthy endpoints, one produces openmetrics → EOF stripped from first, present in second
+- First endpoint down, second healthy → second metrics present, `AppScrapeErrors` incremented
+- Both endpoints down → only agent + Envoy metrics returned (best-effort)
+- Multi-endpoint with one family conflict → Prometheus parse error (expected)
+
+Extend `TestStatsError` to exercise the per-endpoint error path.
+
+Add `TestParseScrapetargets` for the `prometheus.istio.io/scrape-targets` parsing logic (covers malformed inputs, empty path defaulting, whitespace trimming).
+
+### Webhook unit tests (`pkg/kube/inject/webhook.go` → `inject_test.go`)
+
+Add a new golden file (e.g., `testdata/hello-multi-port-metrics.yaml.injected`) verifying:
+- `ISTIO_PROMETHEUS_ANNOTATIONS` encodes both targets
+- `prometheus.io/port` is rewritten to `15020`
+- `prometheus.io/path` is rewritten to `/stats/prometheus`
+
+Extend `TestEnablePrometheusAggregation` (or add `TestMultiPortPrometheusAggregation`) for the two-target case.
+
+### Integration tests (`tests/integration/telemetry/api/`)
+
+Add a test case (following the `TestStatsFilter` pattern) that deploys a pod with two containers each exposing distinct metric families, then scrapes `:15020/stats/prometheus` and asserts both families appear. This exercises the full annotation → webhook → env var → handleStats → merged response path.
+
+---
+
+## PR Breakdown
+
+**PR 1 — Data model and annotation parsing (no scrape behavior change)**
+- `PrometheusScrapeConfiguration`: add `ScrapeTarget` and `Targets` field
+- `NewServer()`: normalize legacy single-port into `Targets`; validate all target ports
+- `getPrometheusScrapeConfiguration()` + `applyPrometheusMerge()`: parse and encode `prometheus.istio.io/scrape-targets`
+- Unit tests for parsing and backward compat
+- Golden file update for multi-port injection
+
+This PR is purely additive; with `Targets` populated but `handleStats` still only reading `s.prometheus.Port`/`Path`, existing behavior is identical.
+
+**PR 2 — Concurrent fan-out in `handleStats`**
+- Replace single-endpoint block with goroutine fan-out
+- `newEOFStrippingReader` for OpenMetrics interop
+- Update `handleStats` to read from `s.prometheus.Targets`
+- Unit tests: multi-endpoint happy path, partial failure, format negotiation
+- This PR requires PR 1 to be merged first (depends on `Targets` field)
+
+**PR 3 — Integration test**
+- New multi-container echo deployment in `tests/integration/telemetry/api/`
+- Assert merged scrape contains metrics from both containers
+- Can be developed against PR 2's branch but reviewed/merged after PR 2 lands

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -261,6 +261,25 @@ func NewServer(config Options) (*Server, error) {
 					"application port is the same as agent port, which may lead to a recursive loop. "+
 					"Ensure pod does not have prometheus.io/port=%d label, or that injection is not happening multiple times", config.StatusPort)
 			}
+			// Synthesize Targets from legacy Port/Path when not already populated.
+			if len(s.prometheus.Targets) == 0 && s.prometheus.Port != "" {
+				s.prometheus.Targets = []ScrapeTarget{{Port: s.prometheus.Port, Path: s.prometheus.Path}}
+			}
+			// Default path and validate every target port.
+			statusPortStr := strconv.Itoa(int(config.StatusPort))
+			for i, t := range s.prometheus.Targets {
+				if t.Path == "" {
+					s.prometheus.Targets[i].Path = "/metrics"
+				}
+				if t.Port == statusPortStr {
+					return nil, fmt.Errorf("invalid prometheus scrape configuration: "+
+						"target port %s is the same as agent port, which may lead to a recursive loop", t.Port)
+				}
+				if reason, reserved := IstioReservedPortReason(t.Port); reserved {
+					return nil, fmt.Errorf("invalid prometheus scrape configuration: "+
+						"target port %s is reserved for Istio (%s) and cannot be scraped", t.Port, reason)
+				}
+			}
 		}
 	}
 
@@ -504,10 +523,71 @@ func (s *Server) isReady() error {
 	return nil
 }
 
+// ScrapeTarget represents a single application metrics endpoint to scrape.
+type ScrapeTarget struct {
+	Port string `json:"port"`
+	Path string `json:"path"`
+}
+
 type PrometheusScrapeConfiguration struct {
-	Scrape string `json:"scrape"`
-	Path   string `json:"path"`
-	Port   string `json:"port"`
+	Scrape  string         `json:"scrape"`
+	Path    string         `json:"path"`
+	Port    string         `json:"port"`
+	Targets []ScrapeTarget `json:"targets,omitempty"`
+}
+
+// IsEmpty reports whether no scrape configuration is set.
+func (p PrometheusScrapeConfiguration) IsEmpty() bool {
+	return p.Scrape == "" && p.Path == "" && p.Port == "" && len(p.Targets) == 0
+}
+
+// istioReservedPorts are data-plane ports the Istio sidecar/agent owns. Users must
+// not point metrics-merging scrape targets at any of these: they either hit a
+// non-application surface (admin, tunnel, traffic capture, DNS) or would create a
+// recursive / double-counted scrape (15020 is the merged endpoint itself; 15090 is
+// Envoy's raw Prom output, already merged).
+var istioReservedPorts = map[string]string{
+	"15000": "Envoy admin",
+	"15001": "outbound traffic capture",
+	"15004": "pilot debug",
+	"15006": "inbound traffic capture",
+	"15008": "HBONE tunnel",
+	"15020": "pilot-agent status / merged Prometheus",
+	"15021": "Envoy health",
+	"15053": "DNS proxy",
+	"15090": "Envoy Prometheus (already merged)",
+}
+
+// IstioReservedPortReason returns the human-readable reason port is reserved by the
+// Istio data plane, along with whether it is reserved. Callers should surface the
+// reason to users; the error message is more actionable when users see *why*.
+func IstioReservedPortReason(port string) (string, bool) {
+	reason, ok := istioReservedPorts[port]
+	return reason, ok
+}
+
+// ParseScrapeTargets parses a comma-separated list of "port:path" pairs into ScrapeTargets.
+// Whitespace is trimmed from each entry. An empty path defaults to "/metrics".
+// Returns an error if any entry has an empty port.
+func ParseScrapeTargets(raw string) ([]ScrapeTarget, error) {
+	var targets []ScrapeTarget
+	for _, entry := range strings.Split(raw, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		parts := strings.SplitN(entry, ":", 2)
+		port := strings.TrimSpace(parts[0])
+		if port == "" {
+			return nil, fmt.Errorf("empty port in scrape target %q", entry)
+		}
+		path := "/metrics"
+		if len(parts) == 2 && strings.TrimSpace(parts[1]) != "" {
+			path = strings.TrimSpace(parts[1])
+		}
+		targets = append(targets, ScrapeTarget{Port: port, Path: path})
+	}
+	return targets, nil
 }
 
 // handleStats handles prometheus stats scraping. This will scrape envoy metrics, and, if configured,

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -250,20 +250,29 @@ func NewServer(config Options) (*Server, error) {
 		log.Infof("Prometheus scraping configuration: %v", prom)
 		if prom.Scrape != "false" {
 			s.prometheus = &prom
-			if s.prometheus.Path == "" {
-				s.prometheus.Path = "/metrics"
-			}
-			if s.prometheus.Port == "" {
-				s.prometheus.Port = "80"
-			}
-			if s.prometheus.Port == strconv.Itoa(int(config.StatusPort)) {
-				return nil, fmt.Errorf("invalid prometheus scrape configuration: "+
-					"application port is the same as agent port, which may lead to a recursive loop. "+
-					"Ensure pod does not have prometheus.io/port=%d label, or that injection is not happening multiple times", config.StatusPort)
-			}
-			// Synthesize Targets from legacy Port/Path when not already populated.
-			if len(s.prometheus.Targets) == 0 && s.prometheus.Port != "" {
+			if len(s.prometheus.Targets) == 0 {
+				// Legacy path: apply defaults and synthesize a single Targets entry.
+				if s.prometheus.Path == "" {
+					s.prometheus.Path = "/metrics"
+				}
+				if s.prometheus.Port == "" {
+					s.prometheus.Port = "80"
+				}
+				if s.prometheus.Port == strconv.Itoa(int(config.StatusPort)) {
+					return nil, fmt.Errorf("invalid prometheus scrape configuration: "+
+						"application port is the same as agent port, which may lead to a recursive loop. "+
+						"Ensure pod does not have prometheus.io/port=%d label, or that injection is not happening multiple times", config.StatusPort)
+				}
 				s.prometheus.Targets = []ScrapeTarget{{Port: s.prometheus.Port, Path: s.prometheus.Path}}
+			} else {
+				// New-format path: populate legacy Port/Path from Targets[0] if absent so that
+				// handleStats (which reads Port/Path directly) scrapes the primary endpoint correctly.
+				if s.prometheus.Port == "" {
+					s.prometheus.Port = s.prometheus.Targets[0].Port
+				}
+				if s.prometheus.Path == "" {
+					s.prometheus.Path = s.prometheus.Targets[0].Path
+				}
 			}
 			// Default path and validate every target port.
 			statusPortStr := strconv.Itoa(int(config.StatusPort))

--- a/pilot/cmd/pilot-agent/status/server_test.go
+++ b/pilot/cmd/pilot-agent/status/server_test.go
@@ -1835,6 +1835,12 @@ func TestNewServerPrometheusNormalization(t *testing.T) {
 			wantPort:    "8080",
 			wantTargets: []ScrapeTarget{{Port: "9100", Path: "/custom"}},
 		},
+		{
+			name:        "new-format JSON with targets but no top-level port syncs Port from Targets[0]",
+			envJSON:     `{"scrape":"true","targets":[{"port":"8080","path":"/metrics"}]}`,
+			wantPort:    "8080",
+			wantTargets: []ScrapeTarget{{Port: "8080", Path: "/metrics"}},
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pilot/cmd/pilot-agent/status/server_test.go
+++ b/pilot/cmd/pilot-agent/status/server_test.go
@@ -1664,3 +1664,201 @@ func TestingRegistry(t test.Failer) prometheus.Gatherer {
 	}
 	return r
 }
+
+func TestParseScrapeTargets(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		want    []ScrapeTarget
+		wantErr bool
+	}{
+		{
+			name:  "single target",
+			input: "8080:/metrics",
+			want:  []ScrapeTarget{{Port: "8080", Path: "/metrics"}},
+		},
+		{
+			name:  "two targets",
+			input: "8080:/metrics,9100:/custom",
+			want:  []ScrapeTarget{{Port: "8080", Path: "/metrics"}, {Port: "9100", Path: "/custom"}},
+		},
+		{
+			name:  "no path defaults to /metrics",
+			input: "8080",
+			want:  []ScrapeTarget{{Port: "8080", Path: "/metrics"}},
+		},
+		{
+			name:  "empty path component defaults to /metrics",
+			input: "8080:,9100:/custom",
+			want:  []ScrapeTarget{{Port: "8080", Path: "/metrics"}, {Port: "9100", Path: "/custom"}},
+		},
+		{
+			name:  "whitespace trimmed",
+			input: " 8080:/metrics , 9100:/custom ",
+			want:  []ScrapeTarget{{Port: "8080", Path: "/metrics"}, {Port: "9100", Path: "/custom"}},
+		},
+		{
+			name:  "empty string returns nil",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "only commas returns nil",
+			input: ",,,",
+			want:  nil,
+		},
+		{
+			name:    "empty port is an error",
+			input:   ":/metrics",
+			wantErr: true,
+		},
+		{
+			name:    "mixed valid and invalid stops at first empty port",
+			input:   "8080:/metrics,:/bad,9100:/custom",
+			wantErr: true,
+		},
+		{
+			name:  "duplicate ports accepted (dedup is not this layer's job)",
+			input: "8080:/metrics,8080:/other",
+			want:  []ScrapeTarget{{Port: "8080", Path: "/metrics"}, {Port: "8080", Path: "/other"}},
+		},
+		{
+			name:  "path with query string preserved verbatim",
+			input: "8080:/metrics?foo=bar",
+			want:  []ScrapeTarget{{Port: "8080", Path: "/metrics?foo=bar"}},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseScrapeTargets(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseScrapeTargets(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseScrapeTargets(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIstioReservedPortReason(t *testing.T) {
+	reserved := []string{"15000", "15001", "15004", "15006", "15008", "15020", "15021", "15053", "15090"}
+	for _, p := range reserved {
+		t.Run("reserved/"+p, func(t *testing.T) {
+			reason, ok := IstioReservedPortReason(p)
+			if !ok {
+				t.Errorf("IstioReservedPortReason(%q) = _, false; want reserved", p)
+			}
+			if reason == "" {
+				t.Errorf("IstioReservedPortReason(%q) returned empty reason", p)
+			}
+		})
+	}
+	nonReserved := []string{"80", "8080", "9090", "15002", "15007", "15091", "15099", ""}
+	for _, p := range nonReserved {
+		t.Run("non-reserved/"+p, func(t *testing.T) {
+			if _, ok := IstioReservedPortReason(p); ok {
+				t.Errorf("IstioReservedPortReason(%q) returned reserved=true; want false", p)
+			}
+		})
+	}
+	// Ports are compared as opaque strings so annotation-layer values round-trip
+	// verbatim; canonical integer equality (15020 == 015020) is intentionally NOT
+	// applied here.
+	t.Run("boundary/leading-zero not matched", func(t *testing.T) {
+		if _, ok := IstioReservedPortReason("015020"); ok {
+			t.Errorf("IstioReservedPortReason(%q) matched; want string-equality only", "015020")
+		}
+	})
+}
+
+func TestNewServerPrometheusNormalization(t *testing.T) {
+	const statusPort = 15020
+	cases := []struct {
+		name        string
+		envJSON     string
+		wantTargets []ScrapeTarget
+		wantPort    string
+		wantErr     bool
+	}{
+		{
+			name:        "legacy single-port JSON synthesizes one target",
+			envJSON:     `{"scrape":"true","port":"8080","path":"/metrics"}`,
+			wantPort:    "8080",
+			wantTargets: []ScrapeTarget{{Port: "8080", Path: "/metrics"}},
+		},
+		{
+			name:        "new-format JSON with targets field is preserved",
+			envJSON:     `{"scrape":"true","port":"8080","path":"/metrics","targets":[{"port":"8080","path":"/metrics"},{"port":"9100","path":"/custom"}]}`,
+			wantPort:    "8080",
+			wantTargets: []ScrapeTarget{{Port: "8080", Path: "/metrics"}, {Port: "9100", Path: "/custom"}},
+		},
+		{
+			name:    "target port equal to status port is an error",
+			envJSON: `{"scrape":"true","targets":[{"port":"15020","path":"/metrics"}]}`,
+			wantErr: true,
+		},
+		{
+			name:        "empty port defaults to 80 and synthesizes one target",
+			envJSON:     `{"scrape":"true"}`,
+			wantPort:    "80",
+			wantTargets: []ScrapeTarget{{Port: "80", Path: "/metrics"}},
+		},
+		{
+			name:        "empty path in target defaults to /metrics",
+			envJSON:     `{"scrape":"true","targets":[{"port":"8080","path":""}]}`,
+			wantTargets: []ScrapeTarget{{Port: "8080", Path: "/metrics"}},
+		},
+		{
+			name:    "target on reserved Envoy admin port is rejected",
+			envJSON: `{"scrape":"true","targets":[{"port":"15000","path":"/metrics"}]}`,
+			wantErr: true,
+		},
+		{
+			name:    "target on reserved Envoy Prometheus port is rejected",
+			envJSON: `{"scrape":"true","targets":[{"port":"15090","path":"/metrics"}]}`,
+			wantErr: true,
+		},
+		{
+			name:    "target on reserved inbound redirect port is rejected",
+			envJSON: `{"scrape":"true","targets":[{"port":"15006","path":"/metrics"}]}`,
+			wantErr: true,
+		},
+		{
+			name:    "one good target plus one reserved target is rejected",
+			envJSON: `{"scrape":"true","targets":[{"port":"8080","path":"/metrics"},{"port":"15000","path":"/metrics"}]}`,
+			wantErr: true,
+		},
+		{
+			name:        "both legacy Port and Targets present — Targets are preserved verbatim, legacy Port is not overwritten",
+			envJSON:     `{"scrape":"true","port":"8080","path":"/metrics","targets":[{"port":"9100","path":"/custom"}]}`,
+			wantPort:    "8080",
+			wantTargets: []ScrapeTarget{{Port: "9100", Path: "/custom"}},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(PrometheusScrapingConfig.Name, tt.envJSON)
+			s, err := NewServer(Options{
+				NodeType:           "sidecar",
+				StatusPort:         statusPort,
+				PrometheusRegistry: TestingRegistry(t),
+			})
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("NewServer() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if s.prometheus == nil {
+				t.Fatal("expected s.prometheus to be set")
+			}
+			if tt.wantPort != "" && s.prometheus.Port != tt.wantPort {
+				t.Errorf("Port = %q, want %q", s.prometheus.Port, tt.wantPort)
+			}
+			if !reflect.DeepEqual(s.prometheus.Targets, tt.wantTargets) {
+				t.Errorf("Targets = %v, want %v", s.prometheus.Targets, tt.wantTargets)
+			}
+		})
+	}
+}

--- a/pkg/kube/inject/testdata/inject/hello-multiport-metrics.yaml
+++ b/pkg/kube/inject/testdata/inject/hello-multiport-metrics.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.istio.io/scrape-targets: "8080:/metrics,9100:/custom-metrics"
+  name: hellopod
+spec:
+  containers:
+    - name: hello
+      image: "fake.docker.io/google-samples/hello-go-gke:1.0"
+      ports:
+        - name: http
+          containerPort: 80

--- a/pkg/kube/inject/testdata/inject/hello-multiport-metrics.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multiport-metrics.yaml.injected
@@ -1,0 +1,242 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    istio.io/rev: default
+    kubectl.kubernetes.io/default-container: hello
+    kubectl.kubernetes.io/default-logs-container: hello
+    prometheus.io/path: /stats/prometheus
+    prometheus.io/port: "15020"
+    prometheus.io/scrape: "true"
+    sidecar.istio.io/status: '{"initContainers":["istio-init","istio-proxy"],"containers":null,"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert","istio-ca-crl"],"imagePullSecrets":null,"revision":"default"}'
+  labels:
+    security.istio.io/tlsMode: istio
+    service.istio.io/canonical-name: hellopod
+    service.istio.io/canonical-revision: latest
+  name: hellopod
+spec:
+  containers:
+  - image: fake.docker.io/google-samples/hello-go-gke:1.0
+    name: hello
+    ports:
+    - containerPort: 80
+      name: http
+    resources: {}
+  initContainers:
+  - args:
+    - istio-iptables
+    - -p
+    - "15001"
+    - -z
+    - "15006"
+    - -u
+    - "1337"
+    - -m
+    - REDIRECT
+    - -i
+    - '*'
+    - -x
+    - ""
+    - -b
+    - '*'
+    - -d
+    - 15090,15021,15020
+    - --log_output_level=default:info
+    image: gcr.io/istio-testing/proxyv2:latest
+    name: istio-init
+    resources:
+      limits:
+        cpu: "2"
+        memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_ADMIN
+        - NET_RAW
+        drop:
+        - ALL
+      privileged: false
+      readOnlyRootFilesystem: false
+      runAsGroup: 0
+      runAsNonRoot: false
+      runAsUser: 0
+  - args:
+    - proxy
+    - sidecar
+    - --domain
+    - $(POD_NAMESPACE).svc.cluster.local
+    - --proxyLogLevel=warning
+    - --proxyComponentLogLevel=misc:error
+    - --log_output_level=default:info
+    env:
+    - name: PILOT_CERT_PROVIDER
+      value: istiod
+    - name: CA_ADDR
+      value: istiod.istio-system.svc:15012
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: INSTANCE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    - name: SERVICE_ACCOUNT
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.serviceAccountName
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
+    - name: ISTIO_CPU_LIMIT
+      valueFrom:
+        resourceFieldRef:
+          divisor: "1"
+          resource: limits.cpu
+    - name: PROXY_CONFIG
+      value: |
+        {}
+    - name: ISTIO_META_POD_PORTS
+      value: |-
+        [
+            {"name":"http","containerPort":80}
+        ]
+    - name: ISTIO_META_APP_CONTAINERS
+      value: hello
+    - name: GOMEMLIMIT
+      valueFrom:
+        resourceFieldRef:
+          divisor: "1"
+          resource: limits.memory
+    - name: GOMAXPROCS
+      valueFrom:
+        resourceFieldRef:
+          divisor: "1"
+          resource: limits.cpu
+    - name: ISTIO_META_CLUSTER_ID
+      value: Kubernetes
+    - name: ISTIO_META_NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: ISTIO_META_INTERCEPTION_MODE
+      value: REDIRECT
+    - name: ISTIO_META_WORKLOAD_NAME
+      value: hellopod
+    - name: ISTIO_META_OWNER
+      value: kubernetes://apis/v1/namespaces/default/pods/hellopod
+    - name: ISTIO_META_MESH_ID
+      value: cluster.local
+    - name: TRUST_DOMAIN
+      value: cluster.local
+    - name: ISTIO_PROMETHEUS_ANNOTATIONS
+      value: '{"scrape":"true","path":"/metrics","port":"8080","targets":[{"port":"8080","path":"/metrics"},{"port":"9100","path":"/custom-metrics"}]}'
+    image: gcr.io/istio-testing/proxyv2:latest
+    lifecycle:
+      preStop:
+        exec:
+          command:
+          - pilot-agent
+          - request
+          - --debug-port=15020
+          - POST
+          - drain
+    name: istio-proxy
+    ports:
+    - containerPort: 15090
+      name: http-envoy-prom
+      protocol: TCP
+    readinessProbe:
+      failureThreshold: 4
+      httpGet:
+        path: /healthz/ready
+        port: 15021
+      periodSeconds: 15
+      timeoutSeconds: 3
+    resources:
+      limits:
+        cpu: "2"
+        memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+    restartPolicy: Always
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      readOnlyRootFilesystem: true
+      runAsGroup: 1337
+      runAsNonRoot: true
+      runAsUser: 1337
+    startupProbe:
+      failureThreshold: 600
+      httpGet:
+        path: /healthz/ready
+        port: 15021
+      periodSeconds: 1
+      timeoutSeconds: 3
+    volumeMounts:
+    - mountPath: /var/run/secrets/workload-spiffe-uds
+      name: workload-socket
+    - mountPath: /var/run/secrets/credential-uds
+      name: credential-socket
+    - mountPath: /var/run/secrets/workload-spiffe-credentials
+      name: workload-certs
+    - mountPath: /var/run/secrets/istio
+      name: istiod-ca-cert
+    - mountPath: /var/run/secrets/istio/crl
+      name: istio-ca-crl
+    - mountPath: /var/lib/istio/data
+      name: istio-data
+    - mountPath: /etc/istio/proxy
+      name: istio-envoy
+    - mountPath: /var/run/secrets/tokens
+      name: istio-token
+    - mountPath: /etc/istio/pod
+      name: istio-podinfo
+  volumes:
+  - name: workload-socket
+  - name: credential-socket
+  - name: workload-certs
+  - emptyDir:
+      medium: Memory
+    name: istio-envoy
+  - emptyDir: {}
+    name: istio-data
+  - downwardAPI:
+      items:
+      - fieldRef:
+          fieldPath: metadata.labels
+        path: labels
+      - fieldRef:
+          fieldPath: metadata.annotations
+        path: annotations
+    name: istio-podinfo
+  - name: istio-token
+    projected:
+      sources:
+      - serviceAccountToken:
+          audience: istio-ca
+          expirationSeconds: 43200
+          path: istio-token
+  - configMap:
+      name: istio-ca-root-cert
+    name: istiod-ca-cert
+  - configMap:
+      name: istio-ca-crl
+      optional: true
+    name: istio-ca-crl
+status: {}
+---

--- a/pkg/kube/inject/testdata/inject/hello-multiport-metrics.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multiport-metrics.yaml.injected
@@ -42,7 +42,7 @@ spec:
     - -d
     - 15090,15021,15020
     - --log_output_level=default:info
-    image: gcr.io/istio-testing/proxyv2:latest
+    image: registry.istio.io/testing/proxyv2:latest
     name: istio-init
     resources:
       limits:
@@ -140,7 +140,7 @@ spec:
       value: cluster.local
     - name: ISTIO_PROMETHEUS_ANNOTATIONS
       value: '{"scrape":"true","path":"/metrics","port":"8080","targets":[{"port":"8080","path":"/metrics"},{"port":"9100","path":"/custom-metrics"}]}'
-    image: gcr.io/istio-testing/proxyv2:latest
+    image: registry.istio.io/testing/proxyv2:latest
     lifecycle:
       preStop:
         exec:

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -85,9 +85,10 @@ const (
 	// prometheus will convert annotation to this format
 	// `prometheus.io/scrape` `prometheus.io.scrape` `prometheus-io/scrape` have the same meaning in Prometheus
 	// for more details, please checkout [here](https://github.com/prometheus/prometheus/blob/71a0f42331566a8849863d77078083edbb0b3bc4/util/strutil/strconv.go#L40)
-	prometheusScrapeAnnotation = "prometheus_io_scrape"
-	prometheusPortAnnotation   = "prometheus_io_port"
-	prometheusPathAnnotation   = "prometheus_io_path"
+	prometheusScrapeAnnotation             = "prometheus_io_scrape"
+	prometheusPortAnnotation               = "prometheus_io_port"
+	prometheusPathAnnotation               = "prometheus_io_path"
+	prometheusIstioScrapeTargetsAnnotation = "prometheus_istio_io_scrape_targets"
 
 	watchDebounceDelay = 100 * time.Millisecond
 )
@@ -879,8 +880,6 @@ func mergeOrAppendProbers(previouslyInjected bool, envVars []corev1.EnvVar, newP
 	return append(envVars, corev1.EnvVar{Name: status.KubeAppProberEnvName, Value: newProbers})
 }
 
-var emptyScrape = status.PrometheusScrapeConfiguration{}
-
 // applyPrometheusMerge configures prometheus scraping annotations for the "metrics merge" feature.
 // This moves the current prometheus.io annotations into an environment variable and replaces them
 // pointing to the agent.
@@ -896,8 +895,22 @@ func applyPrometheusMerge(pod *corev1.Pod, mesh *meshconfig.MeshConfig) error {
 			}
 		}
 		scrape := getPrometheusScrapeConfiguration(pod)
+		// When scrape-targets are present, set legacy Port/Path from the first target so that
+		// old agents (which don't know about Targets) can still scrape the primary endpoint.
+		if len(scrape.Targets) > 0 {
+			scrape.Port = scrape.Targets[0].Port
+			scrape.Path = scrape.Targets[0].Path
+			for _, t := range scrape.Targets {
+				if t.Port == targetPort {
+					return fmt.Errorf("invalid prometheus scrape targets: target port %s conflicts with agent port", t.Port)
+				}
+				if reason, reserved := status.IstioReservedPortReason(t.Port); reserved {
+					return fmt.Errorf("invalid prometheus scrape targets: target port %s is reserved for Istio (%s) and cannot be scraped", t.Port, reason)
+				}
+			}
+		}
 		sidecar := FindSidecar(pod)
-		if sidecar != nil && scrape != emptyScrape {
+		if sidecar != nil && !scrape.IsEmpty() {
 			by, err := json.Marshal(scrape)
 			if err != nil {
 				return err
@@ -940,6 +953,7 @@ var prometheusAnnotations = sets.New(
 	prometheusPathAnnotation,
 	prometheusPortAnnotation,
 	prometheusScrapeAnnotation,
+	prometheusIstioScrapeTargetsAnnotation,
 )
 
 func clearPrometheusAnnotations(pod *corev1.Pod) {
@@ -968,6 +982,13 @@ func getPrometheusScrapeConfiguration(pod *corev1.Pod) status.PrometheusScrapeCo
 			cfg.Scrape = val
 		case prometheusPathAnnotation:
 			cfg.Path = val
+		case prometheusIstioScrapeTargetsAnnotation:
+			targets, err := status.ParseScrapeTargets(val)
+			if err != nil {
+				log.Warnf("failed to parse %s annotation: %v", k, err)
+			} else {
+				cfg.Targets = targets
+			}
 		}
 	}
 

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -908,6 +908,14 @@ func applyPrometheusMerge(pod *corev1.Pod, mesh *meshconfig.MeshConfig) error {
 					return fmt.Errorf("invalid prometheus scrape targets: target port %s is reserved for Istio (%s) and cannot be scraped", t.Port, reason)
 				}
 			}
+		} else if scrape.Port != "" {
+			// Validate legacy prometheus.io/port annotation when the new scrape-targets annotation is not used.
+			if scrape.Port == targetPort {
+				return fmt.Errorf("invalid prometheus scrape configuration: port %s conflicts with agent port", scrape.Port)
+			}
+			if reason, reserved := status.IstioReservedPortReason(scrape.Port); reserved {
+				return fmt.Errorf("invalid prometheus scrape configuration: port %s is reserved for Istio (%s) and cannot be scraped", scrape.Port, reason)
+			}
 		}
 		sidecar := FindSidecar(pod)
 		if sidecar != nil && !scrape.IsEmpty() {

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -1717,6 +1717,39 @@ func TestApplyPrometheusMergeScrapeTargets(t *testing.T) {
 		}
 	})
 
+	t.Run("legacy port equal to agent port triggers no-op via early-return guard", func(t *testing.T) {
+		// When prometheus.io/port already points at the agent (15020), applyPrometheusMerge treats
+		// the pod as already-injected and returns nil without rewriting annotations. This is the
+		// existing re-injection guard; no error is expected or desired.
+		agentPort := strconv.Itoa(int(meshCfg.GetDefaultConfig().GetStatusPort()))
+		pod := newPod(map[string]string{
+			"prometheus.io/scrape": "true",
+			"prometheus.io/port":   agentPort,
+		})
+		err := applyPrometheusMerge(pod, meshCfg)
+		if err != nil {
+			t.Fatalf("expected nil (no-op early return), got %v", err)
+		}
+		// Pod annotations must NOT be rewritten by the merge.
+		if got := pod.Annotations["prometheus.io/port"]; got != agentPort {
+			t.Errorf("prometheus.io/port = %q, want %q (unchanged)", got, agentPort)
+		}
+	})
+
+	t.Run("legacy reserved port rejected at injection time", func(t *testing.T) {
+		pod := newPod(map[string]string{
+			"prometheus.io/scrape": "true",
+			"prometheus.io/port":   "15000",
+		})
+		err := applyPrometheusMerge(pod, meshCfg)
+		if err == nil {
+			t.Fatal("expected error for reserved port 15000 in legacy annotation, got nil")
+		}
+		if !strings.Contains(err.Error(), "15000") || !strings.Contains(err.Error(), "reserved for Istio") {
+			t.Errorf("error = %v, want one mentioning port 15000 and Istio-reserved", err)
+		}
+	})
+
 	t.Run("happy path strips prometheus.istio.io/scrape-targets annotation", func(t *testing.T) {
 		pod := newPod(map[string]string{
 			"prometheus.io/scrape":               "true",

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -1589,4 +1590,150 @@ func TestDetectNativeSidecar(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetPrometheusScrapeConfigurationMultiTarget(t *testing.T) {
+	cases := []struct {
+		name        string
+		annotations map[string]string
+		wantPort    string
+		wantPath    string
+		wantTargets []status.ScrapeTarget
+	}{
+		{
+			name: "scrape-targets only",
+			annotations: map[string]string{
+				"prometheus.istio.io/scrape-targets": "8080:/metrics,9100:/custom",
+			},
+			wantTargets: []status.ScrapeTarget{
+				{Port: "8080", Path: "/metrics"},
+				{Port: "9100", Path: "/custom"},
+			},
+		},
+		{
+			name: "scrape-targets with legacy port annotation",
+			annotations: map[string]string{
+				"prometheus.io/port":                 "8080",
+				"prometheus.io/path":                 "/metrics",
+				"prometheus.istio.io/scrape-targets": "8080:/metrics,9100:/custom",
+			},
+			wantPort: "8080",
+			wantPath: "/metrics",
+			wantTargets: []status.ScrapeTarget{
+				{Port: "8080", Path: "/metrics"},
+				{Port: "9100", Path: "/custom"},
+			},
+		},
+		{
+			name: "legacy only, no targets",
+			annotations: map[string]string{
+				"prometheus.io/port": "8080",
+				"prometheus.io/path": "/health",
+			},
+			wantPort:    "8080",
+			wantPath:    "/health",
+			wantTargets: nil,
+		},
+		{
+			name: "whitespace trimmed in scrape-targets",
+			annotations: map[string]string{
+				"prometheus.istio.io/scrape-targets": " 8080:/metrics , 9100:/custom ",
+			},
+			wantTargets: []status.ScrapeTarget{
+				{Port: "8080", Path: "/metrics"},
+				{Port: "9100", Path: "/custom"},
+			},
+		},
+		{
+			name: "malformed scrape-targets is logged and Targets left nil",
+			annotations: map[string]string{
+				"prometheus.istio.io/scrape-targets": ":/metrics",
+			},
+			wantTargets: nil,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tt.annotations,
+				},
+			}
+			got := getPrometheusScrapeConfiguration(pod)
+			if got.Port != tt.wantPort {
+				t.Errorf("Port = %q, want %q", got.Port, tt.wantPort)
+			}
+			if got.Path != tt.wantPath {
+				t.Errorf("Path = %q, want %q", got.Path, tt.wantPath)
+			}
+			if !reflect.DeepEqual(got.Targets, tt.wantTargets) {
+				t.Errorf("Targets = %v, want %v", got.Targets, tt.wantTargets)
+			}
+		})
+	}
+}
+
+// TestApplyPrometheusMergeScrapeTargets covers the two webhook-side changes for
+// multi-port metrics merging: rejecting reserved Istio ports and stripping the
+// new prometheus.istio.io/scrape-targets annotation from the injected pod.
+func TestApplyPrometheusMergeScrapeTargets(t *testing.T) {
+	meshCfg := mesh.DefaultMeshConfig()
+	meshCfg.EnablePrometheusMerge = &wrapperspb.BoolValue{Value: true}
+
+	newPod := func(ann map[string]string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Annotations: ann},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "app"},
+					{Name: "istio-proxy"},
+				},
+			},
+		}
+	}
+
+	t.Run("reserved port rejected at injection time", func(t *testing.T) {
+		pod := newPod(map[string]string{
+			"prometheus.io/scrape":               "true",
+			"prometheus.istio.io/scrape-targets": "8080:/metrics,15000:/metrics",
+		})
+		err := applyPrometheusMerge(pod, meshCfg)
+		if err == nil {
+			t.Fatal("expected error for reserved port 15000, got nil")
+		}
+		if !strings.Contains(err.Error(), "15000") || !strings.Contains(err.Error(), "reserved for Istio") {
+			t.Errorf("error = %v, want one mentioning port 15000 and Istio-reserved", err)
+		}
+	})
+
+	t.Run("agent port rejected independently of reserved check", func(t *testing.T) {
+		pod := newPod(map[string]string{
+			"prometheus.io/scrape":               "true",
+			"prometheus.istio.io/scrape-targets": "15020:/metrics",
+		})
+		err := applyPrometheusMerge(pod, meshCfg)
+		if err == nil {
+			t.Fatal("expected error for target == agent port, got nil")
+		}
+	})
+
+	t.Run("happy path strips prometheus.istio.io/scrape-targets annotation", func(t *testing.T) {
+		pod := newPod(map[string]string{
+			"prometheus.io/scrape":               "true",
+			"prometheus.istio.io/scrape-targets": "8080:/metrics,9100:/custom",
+		})
+		if err := applyPrometheusMerge(pod, meshCfg); err != nil {
+			t.Fatalf("applyPrometheusMerge returned %v, want nil", err)
+		}
+		if _, ok := pod.Annotations["prometheus.istio.io/scrape-targets"]; ok {
+			t.Error("prometheus.istio.io/scrape-targets must be stripped after injection, but is still present")
+		}
+		// Legacy annotations must be rewritten to point at the agent.
+		if got := pod.Annotations["prometheus.io/port"]; got != strconv.Itoa(int(meshCfg.GetDefaultConfig().GetStatusPort())) {
+			t.Errorf("prometheus.io/port = %q, want agent status port", got)
+		}
+		if got := pod.Annotations["prometheus.io/path"]; got != "/stats/prometheus" {
+			t.Errorf("prometheus.io/path = %q, want /stats/prometheus", got)
+		}
+	})
 }

--- a/releasenotes/notes/multi-port-scrape-targets.yaml
+++ b/releasenotes/notes/multi-port-scrape-targets.yaml
@@ -1,0 +1,12 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+issue:
+  - 59567
+
+releaseNotes:
+  - |
+    **Added** a new pod annotation `prometheus.istio.io/scrape-targets` that lets users
+    declare multiple application-metrics endpoints per pod as a comma-separated
+    `port:path` list. Targets colliding with the agent status port or any Istio-reserved
+    data-plane port are rejected at injection time with a human-readable error.


### PR DESCRIPTION
**Please provide a description of this PR:**

Part 1 of 3 for #59567. Adds a new annotation, `prometheus.istio.io/scrape-targets`, that lets users declare multiple application metrics endpoints per pod as a comma-separated `port:path` list, addressing the silent data loss reported in the issue.

- Parses the annotation in the injection webhook, stores the list in `PrometheusScrapeConfiguration.Targets` (`omitempty`, backward-compatible across old and new webhooks and agents), and normalizes legacy single-port input into a one-element `Targets` slice inside the agent.
- Rejects targets that collide with the agent status port or any Istio-reserved data-plane port (15000, 15001, 15004, 15006, 15008, 15020, 15021, 15053, 15090) with a human-readable reason, per the maintainer requirement on the issue.

`handleStats` still scrapes only the first target in this PR; the concurrent fan-out (#59925) and multi-container integration test (#59926) are the next two PRs in the plan agreed on the issue thread.

### Test plan

- [x] `go test ./pilot/cmd/pilot-agent/status/... ./pkg/kube/inject/...` green
- [x] `TestParseScrapeTargets`: positive, negative, boundary (empty, whitespace, empty port, mixed valid/invalid, duplicate ports, path with query string)
- [x] `TestIstioReservedPortReason`: all 9 reserved ports, 8 non-reserved ports, leading-zero string-equality boundary
- [x] `TestNewServerPrometheusNormalization`: legacy single-port synthesis, new-format preservation, agent-port self-loop rejection, reserved-port rejection, mixed good/reserved rejection, legacy Port + new Targets both present
- [x] `TestGetPrometheusScrapeConfigurationMultiTarget`: scrape-targets only, scrape-targets alongside legacy annotations, legacy-only, whitespace, malformed-annotation warn path
- [x] `TestApplyPrometheusMergeScrapeTargets`: reserved-port rejection, agent-port rejection, happy-path stripping of `prometheus.istio.io/scrape-targets` from the injected pod
- [x] Golden `hello-multiport-metrics.yaml.injected` regenerated via `REFRESH_GOLDEN=true`; diff confirms the annotation is stripped after injection
- [x] `go vet ./...` and `go build ./...` clean
- [x] Kind-cluster end-to-end smoke (covered by #59926; `TestMultiPortMetricsMerge` + `TestMultiPortMetricsMergePartialFailure` PASS against a local kind cluster built from this stack, full `tests/integration/telemetry/api` suite green: 19/19)

### Related

- Design proposal: `architecture/networking/multi-port-metrics-merging.md`
- Maintainer green light: [#59567 (comment)](https://github.com/istio/istio/issues/59567#issuecomment-4247129072)

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [x] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.

