### PR TITLE
feat(#59567): fan out handleStats to all scrape-targets concurrently (PR 2/3)

### DIFF
--- a/architecture/networking/multi-port-metrics-merging.md
+++ b/architecture/networking/multi-port-metrics-merging.md
@@ -147,33 +147,36 @@ func (s *Server) scrapeMultipleApps(r *http.Request) (expfmt.Format, [][]byte) {
                 return
             }
             defer body.Close()
-            // Cap per-target body at 10 MiB to bound agent memory across N concurrent
-            // targets; treat saturation as a target failure rather than returning a
-            // truncated half-line that downstream parsers would error on.
-            buf, readErr := io.ReadAll(io.LimitReader(body, int64(maxAppMetricsBodyBytes)+1))
-            if readErr != nil || len(buf) > maxAppMetricsBodyBytes {
+            // Cap per-target body at s.maxAppBodyBytes (10 MiB default) to bound agent
+            // memory across N concurrent targets. Read errors are logged at Errorf;
+            // exceeding the cap is logged at Warnf (avoids log-flood under attack).
+            // Both increment AppScrapeErrors and drop the target.
+            buf := bytes.NewBuffer(make([]byte, 0, 64*1024))
+            if _, readErr := buf.ReadFrom(io.LimitReader(body, int64(s.maxAppBodyBytes)+1)); readErr != nil {
                 metrics.AppScrapeErrors.Increment()
                 return
             }
-            bodies[idx] = buf
+            if buf.Len() > s.maxAppBodyBytes {
+                metrics.AppScrapeErrors.Increment()
+                return
+            }
+            bodies[idx] = buf.Bytes()
             contentTypes[idx] = ct
         }(i, t)
     }
     wg.Wait()
 
-    // First successful target's format wins, EXCEPT when successful targets disagree:
+    // First successful target's format wins, unless any later successful target disagrees:
     // mixed-format bodies in a single response are invalid, so we downgrade to text.
-    format := FmtText
-    firstFmt := ""
-    allMatch := true
+    var format expfmt.Format
     for i, ct := range contentTypes {
         if bodies[i] == nil { continue }
-        f := string(negotiateMetricsFormat(ct))
-        if firstFmt == "" { firstFmt = f; continue }
-        if f != firstFmt { allMatch = false; break }
+        f := negotiateMetricsFormat(ct)
+        if format == "" { format = f; continue }
+        if f != format { format = FmtText; break }
     }
-    if allMatch && firstFmt != "" {
-        format = expfmt.Format(firstFmt)
+    if format == "" {
+        format = FmtText
     }
     return format, bodies
 }

--- a/architecture/networking/multi-port-metrics-merging.md
+++ b/architecture/networking/multi-port-metrics-merging.md
@@ -249,7 +249,7 @@ This PR is purely additive; with `Targets` populated but `handleStats` still onl
 
 **PR 2 — Concurrent fan-out in `handleStats`**
 - Replace single-endpoint block with goroutine fan-out
-- `newEOFStrippingReader` for OpenMetrics interop
+- `stripOpenMetricsEOF` helper for OpenMetrics interop
 - Update `handleStats` to read from `s.prometheus.Targets`
 - Unit tests: multi-endpoint happy path, partial failure, format negotiation
 - This PR requires PR 1 to be merged first (depends on `Targets` field)

--- a/architecture/networking/multi-port-metrics-merging.md
+++ b/architecture/networking/multi-port-metrics-merging.md
@@ -126,60 +126,83 @@ app endpoint   →  scrape() → io.Copy
 
 All sequential. The response writer is the only synchronization point. `handleStats` never returns an HTTP error; any scrape failure is logged and skipped.
 
-### Proposed behavior (N≥1)
+### Proposed behavior (N > 1)
 
-Fan out app endpoint scrapes concurrently, then stream results into the response writer in deterministic order:
-
-```go
-type scraped struct {
-    body        io.ReadCloser
-    contentType string
-    err         error
-}
-
-results := make([]scraped, len(targets))
-var wg sync.WaitGroup
-for i, target := range targets {
-    wg.Add(1)
-    go func(i int, t ScrapeTarget) {
-        defer wg.Done()
-        url := fmt.Sprintf("http://localhost:%s%s", t.Port, t.Path)
-        body, cancel, ct, err := s.scrape(url, r.Header)
-        results[i] = scraped{body, ct, err}
-        if cancel != nil { defer cancel() }  // lifetime tied to handleStats return
-    }(i, target)
-}
-wg.Wait()
-```
-
-Then stream in order after Envoy stats:
+When `len(s.prometheus.Targets) > 1`, `handleStats` dispatches to a fan-out helper that scrapes every target concurrently, buffers each response, and writes them into the response in `Targets` order. The single-target case (`len(Targets) <= 1`) keeps the existing streaming `io.Copy` hot path byte-for-byte unchanged, so legacy pods pay no concurrency or buffering overhead.
 
 ```go
-for i, res := range results {
-    if res.err != nil {
-        appScrapeErrors.Increment()
-        log.Warnf("failed to scrape app target %d: %v", i, res.err)
-        continue
+func (s *Server) scrapeMultipleApps(r *http.Request) (expfmt.Format, [][]byte) {
+    bodies := make([][]byte, len(s.prometheus.Targets))
+    contentTypes := make([]string, len(s.prometheus.Targets))
+    var wg sync.WaitGroup
+    for i, t := range s.prometheus.Targets {
+        wg.Add(1)
+        go func(idx int, tgt ScrapeTarget) {
+            defer wg.Done()
+            url := fmt.Sprintf("http://localhost:%s%s", tgt.Port, tgt.Path)
+            body, cancel, ct, err := s.scrape(url, r.Header)
+            if cancel != nil { defer cancel() }
+            if err != nil {
+                metrics.AppScrapeErrors.Increment()
+                return
+            }
+            defer body.Close()
+            buf, readErr := io.ReadAll(body)
+            if readErr != nil {
+                metrics.AppScrapeErrors.Increment()
+                return
+            }
+            bodies[idx] = buf
+            contentTypes[idx] = ct
+        }(i, t)
     }
-    if i < len(results)-1 || format == FmtText {
-        // strip # EOF so it only appears on the final write
-        io.Copy(w, newEOFStrippingReader(res.body))
-    } else {
-        io.Copy(w, res.body)
+    wg.Wait()
+    // Pick the first successful target's format. With Targets[0] typically succeeding, this
+    // reduces to Targets[0]'s format and preserves single-target semantics.
+    format := FmtText
+    for i := range bodies {
+        if bodies[i] != nil {
+            format = negotiateMetricsFormat(contentTypes[i])
+            break
+        }
     }
-    res.body.Close()
+    return format, bodies
 }
 ```
 
-**`newEOFStrippingReader`** is a thin `io.Reader` wrapper that drops lines equal to `# EOF\n` during streaming — no buffering of the full body required.
+After agent-internal and Envoy metrics are written, the buffered app bodies are written in `Targets` order:
 
-**Per-endpoint timeout:** The incoming `X-Prometheus-Scrape-Timeout-Seconds` value is already forwarded in `scrape()`. With N concurrent goroutines all sharing the same context derived from the header, each endpoint gets the same wall-clock deadline. This matches how Prometheus handles parallel scrapes across targets — total timeout, not per-target.
+```go
+openMetrics := strings.HasPrefix(string(format), expfmt.OpenMetricsType)
+lastSuccess := -1
+for i, b := range appBodies {
+    if b != nil { lastSuccess = i }
+}
+for i, body := range appBodies {
+    if body == nil { continue }
+    out := body
+    if !openMetrics || i != lastSuccess {
+        out = stripOpenMetricsEOF(body)
+    }
+    w.Write(out)
+}
+```
 
-**Best-effort semantics:** A failed endpoint increments `metrics.AppScrapeErrors` and is skipped. Other endpoints are unaffected. This is consistent with the existing philosophy ("we do not return any errors here; if we do, we will drop metrics").
+**Ordering:** Results are written by `Targets` position (indexed slice, not completion order), so the response is deterministic regardless of which goroutine finishes first.
 
-**Format negotiation:** If any endpoint returns `application/openmetrics-text`, the response `Content-Type` is set to openmetrics. The `# EOF` stripping only applies to non-terminal endpoints; the last successfully scraped app endpoint writes its body as-is (preserving EOF if present). If all app endpoints fail, falls back to the existing behavior (text/plain, Envoy + agent only).
+**Buffering vs. streaming:** Each body is read into memory because (a) the `# EOF` stripping rule below needs to inspect the trailer, and (b) writing in `Targets` order requires waiting for all goroutines anyway. `N` is expected to be small (≤10 in practice); memory cost is bounded by `N × response size`.
 
-**Metric family name conflicts:** Two app containers advertising the same metric family name will still produce a Prometheus parse error — same behavior as today with Envoy vs. app conflicts. Deduplication is out of scope for this change; the existing `TestStats` conflict test cases document this.
+**Per-endpoint timeout:** The incoming `X-Prometheus-Scrape-Timeout-Seconds` value is forwarded per-goroutine via `scrape()`. Each target gets its own context and cancel function.
+
+**Best-effort semantics:** A failed target (scrape error or read error) leaves `bodies[i] == nil`, increments `metrics.AppScrapeErrors` once, and does not abort the response. The merged output still returns 200 with partial data, consistent with the existing "we do not return any errors here" philosophy.
+
+**Format negotiation:** The response `Content-Type` is the negotiated format of the first successful target. Because `Targets[0]` is treated as the primary endpoint (matching the legacy single-port contract), this equals `Targets[0]`'s format when `Targets[0]` succeeds, and falls back to the first successful target otherwise, or `FmtText` if every target fails.
+
+**OpenMetrics `# EOF` handling:**
+- When the negotiated response format is OpenMetrics, keep exactly one `# EOF` at the end: `stripOpenMetricsEOF` removes it from every body except the final successful one.
+- When the response is text, strip `# EOF` from every body unconditionally; a text exposition must not carry OpenMetrics-specific terminators.
+
+**Metric family name conflicts:** Two targets advertising the same metric family name will still produce a Prometheus parse error at the consumer, same as today's Envoy vs. app conflict behavior. Deduplication is out of scope; users are responsible for keeping target metric namespaces disjoint. The existing `TestStats` conflict test cases document this contract.
 
 ---
 

--- a/architecture/networking/multi-port-metrics-merging.md
+++ b/architecture/networking/multi-port-metrics-merging.md
@@ -147,8 +147,11 @@ func (s *Server) scrapeMultipleApps(r *http.Request) (expfmt.Format, [][]byte) {
                 return
             }
             defer body.Close()
-            buf, readErr := io.ReadAll(body)
-            if readErr != nil {
+            // Cap per-target body at 10 MiB to bound agent memory across N concurrent
+            // targets; treat saturation as a target failure rather than returning a
+            // truncated half-line that downstream parsers would error on.
+            buf, readErr := io.ReadAll(io.LimitReader(body, int64(maxAppMetricsBodyBytes)+1))
+            if readErr != nil || len(buf) > maxAppMetricsBodyBytes {
                 metrics.AppScrapeErrors.Increment()
                 return
             }
@@ -157,14 +160,20 @@ func (s *Server) scrapeMultipleApps(r *http.Request) (expfmt.Format, [][]byte) {
         }(i, t)
     }
     wg.Wait()
-    // Pick the first successful target's format. With Targets[0] typically succeeding, this
-    // reduces to Targets[0]'s format and preserves single-target semantics.
+
+    // First successful target's format wins, EXCEPT when successful targets disagree:
+    // mixed-format bodies in a single response are invalid, so we downgrade to text.
     format := FmtText
-    for i := range bodies {
-        if bodies[i] != nil {
-            format = negotiateMetricsFormat(contentTypes[i])
-            break
-        }
+    firstFmt := ""
+    allMatch := true
+    for i, ct := range contentTypes {
+        if bodies[i] == nil { continue }
+        f := string(negotiateMetricsFormat(ct))
+        if firstFmt == "" { firstFmt = f; continue }
+        if f != firstFmt { allMatch = false; break }
+    }
+    if allMatch && firstFmt != "" {
+        format = expfmt.Format(firstFmt)
     }
     return format, bodies
 }
@@ -173,18 +182,21 @@ func (s *Server) scrapeMultipleApps(r *http.Request) (expfmt.Format, [][]byte) {
 After agent-internal and Envoy metrics are written, the buffered app bodies are written in `Targets` order:
 
 ```go
+// Strip "# EOF" from every body unconditionally; append a single "# EOF\n" once at
+// the very end only if the negotiated format is OpenMetrics. This keeps exactly one
+// "# EOF" terminator in every OpenMetrics response and zero in every text response,
+// regardless of how many targets succeeded or what their bodies looked like.
 openMetrics := strings.HasPrefix(string(format), expfmt.OpenMetricsType)
-lastSuccess := -1
-for i, b := range appBodies {
-    if b != nil { lastSuccess = i }
-}
-for i, body := range appBodies {
+for _, body := range appBodies {
     if body == nil { continue }
-    out := body
-    if !openMetrics || i != lastSuccess {
-        out = stripOpenMetricsEOF(body)
+    out := stripOpenMetricsEOF(body)
+    if len(out) > 0 && out[len(out)-1] != '\n' {
+        out = append(out, '\n')
     }
     w.Write(out)
+}
+if openMetrics {
+    w.Write([]byte("# EOF\n"))
 }
 ```
 
@@ -196,11 +208,9 @@ for i, body := range appBodies {
 
 **Best-effort semantics:** A failed target (scrape error or read error) leaves `bodies[i] == nil`, increments `metrics.AppScrapeErrors` once, and does not abort the response. The merged output still returns 200 with partial data, consistent with the existing "we do not return any errors here" philosophy.
 
-**Format negotiation:** The response `Content-Type` is the negotiated format of the first successful target. Because `Targets[0]` is treated as the primary endpoint (matching the legacy single-port contract), this equals `Targets[0]`'s format when `Targets[0]` succeeds, and falls back to the first successful target otherwise, or `FmtText` if every target fails.
+**Format negotiation:** The response `Content-Type` is the negotiated format of the first successful target, **downgraded to `text/plain` if any other successful target disagrees on format**. A single response body must commit to one structural format — wedging an OpenMetrics body and a text body under one Content-Type produces invalid output for the consumer's parser. In the common case `Targets[0]` is the primary endpoint and the rest agree, so the negotiated format matches `Targets[0]`'s and operators see no behavioral change. `FmtText` is also the fall-back when every target fails.
 
-**OpenMetrics `# EOF` handling:**
-- When the negotiated response format is OpenMetrics, keep exactly one `# EOF` at the end: `stripOpenMetricsEOF` removes it from every body except the final successful one.
-- When the response is text, strip `# EOF` from every body unconditionally; a text exposition must not carry OpenMetrics-specific terminators.
+**OpenMetrics `# EOF` handling:** `stripOpenMetricsEOF` runs on every body unconditionally. The merged response then receives a single `# EOF\n` appended at the very end only when the negotiated format is OpenMetrics. Text responses (including the mixed-format downgrade case above) carry no terminator. This keeps exactly one `# EOF` at the end of every OpenMetrics response and zero in every text response.
 
 **Metric family name conflicts:** Two targets advertising the same metric family name will still produce a Prometheus parse error at the consumer, same as today's Envoy vs. app conflict behavior. Deduplication is out of scope; users are responsible for keeping target metric namespaces disjoint. The existing `TestStats` conflict test cases document this contract.
 

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -15,6 +15,7 @@
 package status
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -648,16 +649,24 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Scrape app metrics if defined and capture their format
+	// Scrape app metrics if defined and capture their format.
+	// Single-target case keeps the streaming io.Copy hot path. Multi-target case fans out
+	// one scrape per entry in s.prometheus.Targets concurrently, buffers each response so
+	// we can strip redundant OpenMetrics # EOF trailers, and writes them in Targets order.
 	var format expfmt.Format
+	var appBodies [][]byte
 	if s.prometheus != nil {
-		var contentType string
-		url := fmt.Sprintf("http://localhost:%s%s", s.prometheus.Port, s.prometheus.Path)
-		if application, appCancel, contentType, err = s.scrape(url, r.Header); err != nil {
-			log.Errorf("failed scraping application metrics: %v", err)
-			metrics.AppScrapeErrors.Increment()
+		if len(s.prometheus.Targets) > 1 {
+			format, appBodies = s.scrapeMultipleApps(r)
+		} else {
+			var contentType string
+			url := fmt.Sprintf("http://localhost:%s%s", s.prometheus.Port, s.prometheus.Path)
+			if application, appCancel, contentType, err = s.scrape(url, r.Header); err != nil {
+				log.Errorf("failed scraping application metrics: %v", err)
+				metrics.AppScrapeErrors.Increment()
+			}
+			format = negotiateMetricsFormat(contentType)
 		}
-		format = negotiateMetricsFormat(contentType)
 	} else {
 		// Without app metrics format use a default
 		format = FmtText
@@ -688,6 +697,90 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 			metrics.AppScrapeErrors.Increment()
 		}
 	}
+	if appBodies != nil {
+		// Multi-target path: write each target's buffered body in Targets order.
+		// EOF-handling rule:
+		//   - When the negotiated response format is OpenMetrics, keep exactly one "# EOF" at
+		//     the very end: strip it from every body except the final successful one.
+		//   - When the response is text, strip "# EOF" from every body unconditionally because
+		//     a text exposition does not carry OpenMetrics-specific terminators.
+		openMetrics := strings.HasPrefix(string(format), expfmt.OpenMetricsType)
+		lastSuccess := -1
+		for i, body := range appBodies {
+			if body != nil {
+				lastSuccess = i
+			}
+		}
+		for i, body := range appBodies {
+			if body == nil {
+				continue
+			}
+			out := body
+			if !openMetrics || i != lastSuccess {
+				out = stripOpenMetricsEOF(body)
+			}
+			if _, werr := w.Write(out); werr != nil {
+				log.Errorf("failed writing application metrics from target %d: %v", i, werr)
+				metrics.AppScrapeErrors.Increment()
+			}
+		}
+	}
+}
+
+// scrapeMultipleApps fans out one scrape per entry in s.prometheus.Targets concurrently and
+// returns the bodies indexed by Targets position. Failed targets are represented by nil entries;
+// each failure increments metrics.AppScrapeErrors once. The returned format is the first successful
+// target's negotiated format (which matches Targets[0] when Targets[0] succeeds), falling back to
+// FmtText when no target succeeds.
+func (s *Server) scrapeMultipleApps(r *http.Request) (expfmt.Format, [][]byte) {
+	bodies := make([][]byte, len(s.prometheus.Targets))
+	contentTypes := make([]string, len(s.prometheus.Targets))
+	var wg sync.WaitGroup
+	for i, t := range s.prometheus.Targets {
+		wg.Add(1)
+		go func(idx int, tgt ScrapeTarget) {
+			defer wg.Done()
+			url := fmt.Sprintf("http://localhost:%s%s", tgt.Port, tgt.Path)
+			body, cancel, contentType, err := s.scrape(url, r.Header)
+			if cancel != nil {
+				defer cancel()
+			}
+			if err != nil {
+				log.Errorf("failed scraping application metrics from %s: %v", url, err)
+				metrics.AppScrapeErrors.Increment()
+				return
+			}
+			defer body.Close()
+			buf, readErr := io.ReadAll(body)
+			if readErr != nil {
+				log.Errorf("failed reading application metrics from %s: %v", url, readErr)
+				metrics.AppScrapeErrors.Increment()
+				return
+			}
+			bodies[idx] = buf
+			contentTypes[idx] = contentType
+		}(i, t)
+	}
+	wg.Wait()
+
+	var format expfmt.Format = FmtText
+	for i := range bodies {
+		if bodies[i] != nil {
+			format = negotiateMetricsFormat(contentTypes[i])
+			break
+		}
+	}
+	return format, bodies
+}
+
+// stripOpenMetricsEOF removes the trailing "# EOF" line from an OpenMetrics exposition,
+// leaving the rest of the body intact. Tolerant of trailing whitespace and \r\n line endings.
+func stripOpenMetricsEOF(body []byte) []byte {
+	trimmed := bytes.TrimRight(body, " \t\r\n")
+	if bytes.HasSuffix(trimmed, []byte("# EOF")) {
+		return trimmed[:len(trimmed)-len("# EOF")]
+	}
+	return body
 }
 
 const (

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -755,9 +755,15 @@ func (s *Server) scrapeMultipleApps(r *http.Request) (expfmt.Format, [][]byte) {
 				return
 			}
 			defer body.Close()
-			buf, readErr := io.ReadAll(body)
+			buf, readErr := io.ReadAll(io.LimitReader(body, int64(maxAppMetricsBodyBytes)+1))
 			if readErr != nil {
 				log.Errorf("failed reading application metrics from %s:%s: %v", tgt.Port, tgt.Path, readErr)
+				metrics.AppScrapeErrors.Increment()
+				return
+			}
+			if len(buf) > maxAppMetricsBodyBytes {
+				log.Warnf("application metrics response from %s:%s exceeds %d bytes; dropping target",
+					tgt.Port, tgt.Path, maxAppMetricsBodyBytes)
 				metrics.AppScrapeErrors.Increment()
 				return
 			}
@@ -767,12 +773,29 @@ func (s *Server) scrapeMultipleApps(r *http.Request) (expfmt.Format, [][]byte) {
 	}
 	wg.Wait()
 
+	// Coerce to text when successful targets disagree on Content-Type format: an OpenMetrics
+	// response containing a text body (or vice versa) is invalid, so when the targets do
+	// not agree we fall back to the lowest-common-denominator format. Single-format
+	// scrapes (all-text or all-OM) keep their format and EOF semantics.
 	var format expfmt.Format = FmtText
-	for i := range bodies {
-		if bodies[i] != nil {
-			format = negotiateMetricsFormat(contentTypes[i])
+	firstFmt := ""
+	allMatch := true
+	for i, ct := range contentTypes {
+		if bodies[i] == nil {
+			continue
+		}
+		f := string(negotiateMetricsFormat(ct))
+		if firstFmt == "" {
+			firstFmt = f
+			continue
+		}
+		if f != firstFmt {
+			allMatch = false
 			break
 		}
+	}
+	if allMatch && firstFmt != "" {
+		format = expfmt.Format(firstFmt)
 	}
 	return format, bodies
 }
@@ -780,6 +803,12 @@ func (s *Server) scrapeMultipleApps(r *http.Request) (expfmt.Format, [][]byte) {
 func appMetricsURL(port, path string) string {
 	return fmt.Sprintf("http://localhost:%s%s", port, path)
 }
+
+// maxAppMetricsBodyBytes caps the per-target app metrics body to bound agent memory
+// across N concurrent scrape targets. Reads above the cap are dropped as failures and
+// incremented on AppScrapeErrors. Declared as a var (not a const) only so tests can
+// shrink it to a tractable size; do not mutate at runtime.
+var maxAppMetricsBodyBytes = 10 * 1024 * 1024 // 10 MiB
 
 // stripOpenMetricsEOF removes the trailing "# EOF" line from an OpenMetrics exposition,
 // leaving the rest of the body intact. Tolerant of trailing whitespace and \r\n line endings.

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -665,8 +665,7 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 			format, appBodies = s.scrapeMultipleApps(r)
 		} else {
 			var contentType string
-			url := fmt.Sprintf("http://localhost:%s%s", s.prometheus.Port, s.prometheus.Path)
-			if application, appCancel, contentType, err = s.scrape(url, r.Header); err != nil {
+			if application, appCancel, contentType, err = s.scrape(appMetricsURL(s.prometheus.Port, s.prometheus.Path), r.Header); err != nil {
 				log.Errorf("failed scraping application metrics: %v", err)
 				metrics.AppScrapeErrors.Increment()
 			}
@@ -746,20 +745,19 @@ func (s *Server) scrapeMultipleApps(r *http.Request) (expfmt.Format, [][]byte) {
 		wg.Add(1)
 		go func(idx int, tgt ScrapeTarget) {
 			defer wg.Done()
-			url := fmt.Sprintf("http://localhost:%s%s", tgt.Port, tgt.Path)
-			body, cancel, contentType, err := s.scrape(url, r.Header)
+			body, cancel, contentType, err := s.scrape(appMetricsURL(tgt.Port, tgt.Path), r.Header)
 			if cancel != nil {
 				defer cancel()
 			}
 			if err != nil {
-				log.Errorf("failed scraping application metrics from %s: %v", url, err)
+				log.Errorf("failed scraping application metrics from %s:%s: %v", tgt.Port, tgt.Path, err)
 				metrics.AppScrapeErrors.Increment()
 				return
 			}
 			defer body.Close()
 			buf, readErr := io.ReadAll(body)
 			if readErr != nil {
-				log.Errorf("failed reading application metrics from %s: %v", url, readErr)
+				log.Errorf("failed reading application metrics from %s:%s: %v", tgt.Port, tgt.Path, readErr)
 				metrics.AppScrapeErrors.Increment()
 				return
 			}
@@ -777,6 +775,10 @@ func (s *Server) scrapeMultipleApps(r *http.Request) (expfmt.Format, [][]byte) {
 		}
 	}
 	return format, bodies
+}
+
+func appMetricsURL(port, path string) string {
+	return fmt.Sprintf("http://localhost:%s%s", port, path)
 }
 
 // stripOpenMetricsEOF removes the trailing "# EOF" line from an OpenMetrics exposition,

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -275,17 +275,22 @@ func NewServer(config Options) (*Server, error) {
 					s.prometheus.Path = s.prometheus.Targets[0].Path
 				}
 			}
-			// Default path and validate every target port.
-			statusPortStr := strconv.Itoa(int(config.StatusPort))
+			// Default path and validate every target port numerically to catch leading-zero
+			// representations (e.g. "015020" dials 15020 at runtime but != "15020" as a string).
 			for i, t := range s.prometheus.Targets {
 				if t.Path == "" {
 					s.prometheus.Targets[i].Path = "/metrics"
 				}
-				if t.Port == statusPortStr {
+				portNum, atoiErr := strconv.Atoi(t.Port)
+				if atoiErr != nil || portNum < 1 || portNum > 65535 {
+					return nil, fmt.Errorf("invalid prometheus scrape configuration: "+
+						"invalid target port %q", t.Port)
+				}
+				if portNum == int(config.StatusPort) {
 					return nil, fmt.Errorf("invalid prometheus scrape configuration: "+
 						"target port %s is the same as agent port, which may lead to a recursive loop", t.Port)
 				}
-				if reason, reserved := IstioReservedPortReason(t.Port); reserved {
+				if reason, reserved := IstioReservedPortReason(strconv.Itoa(portNum)); reserved {
 					return nil, fmt.Errorf("invalid prometheus scrape configuration: "+
 						"target port %s is reserved for Istio (%s) and cannot be scraped", t.Port, reason)
 				}
@@ -700,27 +705,28 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 	if appBodies != nil {
 		// Multi-target path: write each target's buffered body in Targets order.
 		// EOF-handling rule:
-		//   - When the negotiated response format is OpenMetrics, keep exactly one "# EOF" at
-		//     the very end: strip it from every body except the final successful one.
-		//   - When the response is text, strip "# EOF" from every body unconditionally because
-		//     a text exposition does not carry OpenMetrics-specific terminators.
+		//   - Strip "# EOF" from every body unconditionally.
+		//   - When the negotiated format is OpenMetrics, append a single "# EOF\n" after
+		//     all bodies. When the format is text, no terminator is appended.
+		// Newline rule: ensure a "\n" separates concatenated bodies in case a target
+		// response does not end with one.
 		openMetrics := strings.HasPrefix(string(format), expfmt.OpenMetricsType)
-		lastSuccess := -1
-		for i, body := range appBodies {
-			if body != nil {
-				lastSuccess = i
-			}
-		}
 		for i, body := range appBodies {
 			if body == nil {
 				continue
 			}
-			out := body
-			if !openMetrics || i != lastSuccess {
-				out = stripOpenMetricsEOF(body)
+			out := stripOpenMetricsEOF(body)
+			if len(out) > 0 && out[len(out)-1] != '\n' {
+				out = append(out, '\n')
 			}
 			if _, werr := w.Write(out); werr != nil {
 				log.Errorf("failed writing application metrics from target %d: %v", i, werr)
+				metrics.AppScrapeErrors.Increment()
+			}
+		}
+		if openMetrics {
+			if _, werr := w.Write([]byte("# EOF\n")); werr != nil {
+				log.Errorf("failed writing application metrics EOF marker: %v", werr)
 				metrics.AppScrapeErrors.Increment()
 			}
 		}

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -663,10 +663,8 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Scrape app metrics if defined and capture their format.
-	// Single-target case keeps the streaming io.Copy hot path. Multi-target case fans out
-	// one scrape per entry in s.prometheus.Targets concurrently, buffers each response so
-	// we can strip redundant OpenMetrics # EOF trailers, and writes them in Targets order.
+	// Scrape app metrics. Multi-target buffers each response so we can rewrite the
+	// OpenMetrics "# EOF" trailer; single-target streams via io.Copy.
 	var format expfmt.Format
 	var appBodies [][]byte
 	if s.prometheus != nil {
@@ -681,7 +679,6 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 			format = negotiateMetricsFormat(contentType)
 		}
 	} else {
-		// Without app metrics format use a default
 		format = FmtText
 	}
 
@@ -831,8 +828,10 @@ func appMetricsURL(port, path string) string {
 // openMetricsEOF is the OpenMetrics exposition terminator without trailing newline.
 var openMetricsEOF = []byte("# EOF")
 
-// stripOpenMetricsEOF removes the trailing "# EOF" line from an OpenMetrics exposition,
-// leaving the rest of the body intact. Tolerant of trailing whitespace and \r\n line endings.
+// stripOpenMetricsEOF returns body without its trailing "# EOF" line if present,
+// or the body unchanged if not. Trailing whitespace and "\r\n" line endings around
+// the terminator are tolerated. This is the "strip" half of the OpenMetrics merge
+// rule; the matching reappend uses expfmt.FinalizeOpenMetrics.
 func stripOpenMetricsEOF(body []byte) []byte {
 	trimmed := bytes.TrimRight(body, " \t\r\n")
 	if bytes.HasSuffix(trimmed, openMetricsEOF) {

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -710,25 +710,32 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 		// EOF-handling rule:
 		//   - Strip "# EOF" from every body unconditionally.
 		//   - When the negotiated format is OpenMetrics, append a single "# EOF\n" after
-		//     all bodies. When the format is text, no terminator is appended.
+		//     all bodies via expfmt.FinalizeOpenMetrics. When the format is text, no
+		//     terminator is appended.
 		// Newline rule: ensure a "\n" separates concatenated bodies in case a target
-		// response does not end with one.
-		openMetrics := strings.HasPrefix(string(format), expfmt.OpenMetricsType)
+		// response does not end with one. Split into a second w.Write so the stripped
+		// sub-slice does not trigger a body-sized append+realloc.
+		openMetrics := format.FormatType() == expfmt.TypeOpenMetrics
 		for i, body := range appBodies {
 			if body == nil {
 				continue
 			}
 			out := stripOpenMetricsEOF(body)
-			if len(out) > 0 && out[len(out)-1] != '\n' {
-				out = append(out, '\n')
-			}
 			if _, werr := w.Write(out); werr != nil {
 				log.Errorf("failed writing application metrics from target %d: %v", i, werr)
 				metrics.AppScrapeErrors.Increment()
+			} else if len(out) > 0 && out[len(out)-1] != '\n' {
+				if _, werr := w.Write([]byte{'\n'}); werr != nil {
+					log.Errorf("failed writing newline separator for target %d: %v", i, werr)
+					metrics.AppScrapeErrors.Increment()
+				}
 			}
+			// Release the body for GC before the next iteration; the merged response is
+			// already on the wire (or in the buffered ResponseWriter) at this point.
+			appBodies[i] = nil
 		}
 		if openMetrics {
-			if _, werr := w.Write([]byte("# EOF\n")); werr != nil {
+			if _, werr := expfmt.FinalizeOpenMetrics(w); werr != nil {
 				log.Errorf("failed writing application metrics EOF marker: %v", werr)
 				metrics.AppScrapeErrors.Increment()
 			}
@@ -754,57 +761,65 @@ func (s *Server) scrapeMultipleApps(r *http.Request) (expfmt.Format, [][]byte) {
 		wg.Add(1)
 		go func(idx int, tgt ScrapeTarget) {
 			defer wg.Done()
+			// fail* dedup the log+counter+return shape across the three failure paths.
+			// Path is %q-quoted to neutralize CWE-117 log injection via newline-containing
+			// annotation values (the path comes from prometheus.istio.io/scrape-targets).
+			failErr := func(format string, args ...any) {
+				log.Errorf("scrape target %q:%q: "+format, append([]any{tgt.Port, tgt.Path}, args...)...)
+				metrics.AppScrapeErrors.Increment()
+			}
+			failWarn := func(format string, args ...any) {
+				log.Warnf("scrape target %q:%q: "+format, append([]any{tgt.Port, tgt.Path}, args...)...)
+				metrics.AppScrapeErrors.Increment()
+			}
 			body, cancel, contentType, err := s.scrape(appMetricsURL(tgt.Port, tgt.Path), r.Header)
 			if cancel != nil {
 				defer cancel()
 			}
 			if err != nil {
-				log.Errorf("failed scraping application metrics from %s:%s: %v", tgt.Port, tgt.Path, err)
-				metrics.AppScrapeErrors.Increment()
+				failErr("scrape failed: %v", err)
 				return
 			}
 			defer body.Close()
-			buf, readErr := io.ReadAll(io.LimitReader(body, int64(s.maxAppBodyBytes)+1))
-			if readErr != nil {
-				log.Errorf("failed reading application metrics from %s:%s: %v", tgt.Port, tgt.Path, readErr)
-				metrics.AppScrapeErrors.Increment()
+			// Pre-size the read buffer to 64 KiB so io.ReadAll's power-of-two growth does
+			// not allocate ~14 times for a 10 MiB body. cap+1 lets us distinguish at-cap
+			// (legitimate boundary) from saturation (cap+1 or more bytes consumed).
+			buf := bytes.NewBuffer(make([]byte, 0, 64*1024))
+			if _, readErr := buf.ReadFrom(io.LimitReader(body, int64(s.maxAppBodyBytes)+1)); readErr != nil {
+				failErr("read failed: %v", readErr)
 				return
 			}
-			if len(buf) > s.maxAppBodyBytes {
-				log.Warnf("application metrics response from %s:%s exceeds %d bytes; dropping target",
-					tgt.Port, tgt.Path, s.maxAppBodyBytes)
-				metrics.AppScrapeErrors.Increment()
+			if buf.Len() > s.maxAppBodyBytes {
+				failWarn("response exceeds %d bytes; dropping target", s.maxAppBodyBytes)
 				return
 			}
-			bodies[idx] = buf
+			bodies[idx] = buf.Bytes()
 			contentTypes[idx] = contentType
 		}(i, t)
 	}
 	wg.Wait()
 
-	// Coerce to text when successful targets disagree on Content-Type format: an OpenMetrics
-	// response containing a text body (or vice versa) is invalid, so when the targets do
-	// not agree we fall back to the lowest-common-denominator format. Single-format
-	// scrapes (all-text or all-OM) keep their format and EOF semantics.
-	var format expfmt.Format = FmtText
-	firstFmt := ""
-	allMatch := true
+	// Format selection: first successful target's format wins, unless any later successful
+	// target disagrees — in which case we downgrade to text. An OpenMetrics-claimed
+	// response containing a text body (or vice versa) is invalid. Single-format scrapes
+	// (all-text or all-OM) keep their format and EOF semantics.
+	var format expfmt.Format
 	for i, ct := range contentTypes {
 		if bodies[i] == nil {
 			continue
 		}
-		f := string(negotiateMetricsFormat(ct))
-		if firstFmt == "" {
-			firstFmt = f
+		f := negotiateMetricsFormat(ct)
+		if format == "" {
+			format = f
 			continue
 		}
-		if f != firstFmt {
-			allMatch = false
+		if f != format {
+			format = FmtText
 			break
 		}
 	}
-	if allMatch && firstFmt != "" {
-		format = expfmt.Format(firstFmt)
+	if format == "" {
+		format = FmtText
 	}
 	return format, bodies
 }
@@ -813,12 +828,15 @@ func appMetricsURL(port, path string) string {
 	return fmt.Sprintf("http://localhost:%s%s", port, path)
 }
 
+// openMetricsEOF is the OpenMetrics exposition terminator without trailing newline.
+var openMetricsEOF = []byte("# EOF")
+
 // stripOpenMetricsEOF removes the trailing "# EOF" line from an OpenMetrics exposition,
 // leaving the rest of the body intact. Tolerant of trailing whitespace and \r\n line endings.
 func stripOpenMetricsEOF(body []byte) []byte {
 	trimmed := bytes.TrimRight(body, " \t\r\n")
-	if bytes.HasSuffix(trimmed, []byte("# EOF")) {
-		return trimmed[:len(trimmed)-len("# EOF")]
+	if bytes.HasSuffix(trimmed, openMetricsEOF) {
+		return trimmed[:len(trimmed)-len(openMetricsEOF)]
 	}
 	return body
 }

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -165,7 +165,15 @@ type Server struct {
 	shutdown              context.CancelCauseFunc
 	drain                 func()
 	disableDrain          func()
+
+	// maxAppBodyBytes caps the per-target app metrics body to bound agent memory
+	// across N concurrent scrape targets. Reads above the cap are dropped as failures
+	// and incremented on AppScrapeErrors. Defaults to defaultMaxAppMetricsBodyBytes;
+	// tests may override via the struct literal.
+	maxAppBodyBytes int
 }
+
+const defaultMaxAppMetricsBodyBytes = 10 * 1024 * 1024 // 10 MiB
 
 func initializeMonitoring() (prometheus.Gatherer, error) {
 	registry := prometheus.NewRegistry()
@@ -233,6 +241,7 @@ func NewServer(config Options) (*Server, error) {
 		shutdown:              config.Shutdown,
 		drain:                 config.TriggerDrain,
 		disableDrain:          config.DisableDrain,
+		maxAppBodyBytes:       defaultMaxAppMetricsBodyBytes,
 	}
 	if LegacyLocalhostProbeDestination.Get() {
 		s.appProbersDestination = "localhost"
@@ -693,14 +702,9 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// App metrics must go last because if they are FmtOpenMetrics,
-	// they will have a trailing "# EOF" which terminates the full exposition
-	if application != nil {
-		_, err = io.Copy(w, application)
-		if err != nil {
-			log.Errorf("failed to scraping and writing application metrics: %v", err)
-			metrics.AppScrapeErrors.Increment()
-		}
-	}
+	// they will have a trailing "# EOF" which terminates the full exposition.
+	// The two branches are mutually exclusive: the dispatcher above sets exactly
+	// one of `application` (single-target streaming) or `appBodies` (multi-target buffered).
 	if appBodies != nil {
 		// Multi-target path: write each target's buffered body in Targets order.
 		// EOF-handling rule:
@@ -729,6 +733,11 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 				metrics.AppScrapeErrors.Increment()
 			}
 		}
+	} else if application != nil {
+		if _, err = io.Copy(w, application); err != nil {
+			log.Errorf("failed to scraping and writing application metrics: %v", err)
+			metrics.AppScrapeErrors.Increment()
+		}
 	}
 }
 
@@ -755,15 +764,15 @@ func (s *Server) scrapeMultipleApps(r *http.Request) (expfmt.Format, [][]byte) {
 				return
 			}
 			defer body.Close()
-			buf, readErr := io.ReadAll(io.LimitReader(body, int64(maxAppMetricsBodyBytes)+1))
+			buf, readErr := io.ReadAll(io.LimitReader(body, int64(s.maxAppBodyBytes)+1))
 			if readErr != nil {
 				log.Errorf("failed reading application metrics from %s:%s: %v", tgt.Port, tgt.Path, readErr)
 				metrics.AppScrapeErrors.Increment()
 				return
 			}
-			if len(buf) > maxAppMetricsBodyBytes {
+			if len(buf) > s.maxAppBodyBytes {
 				log.Warnf("application metrics response from %s:%s exceeds %d bytes; dropping target",
-					tgt.Port, tgt.Path, maxAppMetricsBodyBytes)
+					tgt.Port, tgt.Path, s.maxAppBodyBytes)
 				metrics.AppScrapeErrors.Increment()
 				return
 			}
@@ -803,12 +812,6 @@ func (s *Server) scrapeMultipleApps(r *http.Request) (expfmt.Format, [][]byte) {
 func appMetricsURL(port, path string) string {
 	return fmt.Sprintf("http://localhost:%s%s", port, path)
 }
-
-// maxAppMetricsBodyBytes caps the per-target app metrics body to bound agent memory
-// across N concurrent scrape targets. Reads above the cap are dropped as failures and
-// incremented on AppScrapeErrors. Declared as a var (not a const) only so tests can
-// shrink it to a tractable size; do not mutate at runtime.
-var maxAppMetricsBodyBytes = 10 * 1024 * 1024 // 10 MiB
 
 // stripOpenMetricsEOF removes the trailing "# EOF" line from an OpenMetrics exposition,
 // leaving the rest of the body intact. Tolerant of trailing whitespace and \r\n line endings.

--- a/pilot/cmd/pilot-agent/status/server_test.go
+++ b/pilot/cmd/pilot-agent/status/server_test.go
@@ -686,28 +686,103 @@ func TestStatsError(t *testing.T) {
 	}
 }
 
+// targetSpec parameterizes a single httptest.Server backing one ScrapeTarget in the
+// multi-target Server tests. Defined at file scope so the helper newMultiTargetTestServer
+// can take a []targetSpec.
+type targetSpec struct {
+	body        string
+	contentType string // empty → default text/plain from httptest
+	fail        bool   // when true, handler returns 500
+}
+
+// wantStats groups the expected outcomes for a TestStatsMultiTarget case, separating
+// "what the request looked like" (envoy, targets) from "what the response should be."
+type wantStats struct {
+	ordered, contains, notContains []string
+	eofCount                       *int // nil = don't check
+	parseOM, parseText, parseError bool
+	appScrapeErrorsDelta           float64
+}
+
+// intPtr is a one-line helper for building *int literals inside wantStats.
+func intPtr(i int) *int { return &i }
+
+// newMultiTargetTestServer spins up an envoy httptest.Server backed by envoyBody and one
+// httptest.Server per targetSpec, then wires a *Server to scrape them. All servers are
+// closed via t.Cleanup. The returned Server has maxAppBodyBytes defaulted; tests needing
+// a tractable cap should set the field after the call.
+//
+// Note: this helper deliberately uses the process-global Prometheus registry via
+// TestingRegistry(t). Tests calling handleStats from this Server therefore MUST NOT run
+// under t.Parallel() — the registry is shared and AppScrapeErrors deltas would race.
+func newMultiTargetTestServer(t *testing.T, envoyBody string, specs []targetSpec) (*Server, *httptest.ResponseRecorder, *http.Request) {
+	t.Helper()
+	envoyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, err := w.Write([]byte(envoyBody)); err != nil {
+			t.Fatalf("envoy write failed: %v", err)
+		}
+	}))
+	t.Cleanup(envoyServer.Close)
+
+	targets := make([]ScrapeTarget, 0, len(specs))
+	for _, spec := range specs {
+		spec := spec
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			if spec.fail {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			if spec.contentType != "" {
+				w.Header().Set("Content-Type", spec.contentType)
+			}
+			if _, err := w.Write([]byte(spec.body)); err != nil {
+				t.Fatalf("target write failed: %v", err)
+			}
+		}))
+		t.Cleanup(srv.Close)
+		_, port, err := net.SplitHostPort(strings.TrimPrefix(srv.URL, "http://"))
+		if err != nil {
+			t.Fatalf("split host port: %v", err)
+		}
+		targets = append(targets, ScrapeTarget{Port: port, Path: "/metrics"})
+	}
+
+	_, envoyPortStr, err := net.SplitHostPort(strings.TrimPrefix(envoyServer.URL, "http://"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	envoyPort, err := strconv.Atoi(envoyPortStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := &Server{
+		prometheus: &PrometheusScrapeConfiguration{
+			Port:    targets[0].Port,
+			Path:    targets[0].Path,
+			Targets: targets,
+		},
+		envoyStatsPort:  envoyPort,
+		http:            &http.Client{},
+		registry:        TestingRegistry(t),
+		maxAppBodyBytes: defaultMaxAppMetricsBodyBytes,
+	}
+	return server, httptest.NewRecorder(), &http.Request{}
+}
+
 // TestStatsMultiTarget exercises the concurrent fan-out path in handleStats when
 // s.prometheus.Targets contains more than one entry. The single-target path is covered
 // by TestStats above and must remain byte-for-byte unchanged.
+//
+// This test reads and asserts on a process-global Prometheus counter via the want.appScrapeErrorsDelta
+// field; do not add t.Parallel() to any subtest without first moving the counter off the
+// package-level global (see appScrapeErrorCount).
 func TestStatsMultiTarget(t *testing.T) {
-	// Each target's response is defined by body + optional content-type + fail flag.
-	type targetSpec struct {
-		body        string
-		contentType string // empty → default text/plain
-		fail        bool   // when true, handler returns 500
-	}
 	cases := []struct {
-		name                       string
-		envoy                      string
-		targets                    []targetSpec
-		containsOrdered            []string // substrings that must appear in output in this exact order
-		mustNotContain             []string
-		mustContain                []string
-		expectEOFCount             int     // expected count of "# EOF" lines in the merged output; -1 = don't check
-		expectParseOM              bool    // if true, parse merged output as OpenMetrics
-		expectParseText            bool    // if true, parse merged output as text
-		expectParseError           bool    // if true, an expected parse failure must occur; absence is itself a failure
-		expectAppScrapeErrorsDelta float64 // expected delta of istio_agent_scrape_failures_total{type="application"}
+		name    string
+		envoy   string
+		targets []targetSpec
+		want    wantStats
 	}{
 		{
 			name: "two text targets with disjoint metrics merge in target order",
@@ -715,9 +790,11 @@ func TestStatsMultiTarget(t *testing.T) {
 				{body: "# TYPE metric_a counter\nmetric_a{} 1\n"},
 				{body: "# TYPE metric_b counter\nmetric_b{} 2\n"},
 			},
-			containsOrdered: []string{"metric_a{} 1", "metric_b{} 2"},
-			expectEOFCount:  0,
-			expectParseText: true,
+			want: wantStats{
+				ordered:   []string{"metric_a{} 1", "metric_b{} 2"},
+				eofCount:  intPtr(0),
+				parseText: true,
+			},
 		},
 		{
 			name: "three text targets preserve Targets-slice order even when goroutines race",
@@ -726,9 +803,11 @@ func TestStatsMultiTarget(t *testing.T) {
 				{body: "# TYPE metric_one counter\nmetric_one{} 1\n"},
 				{body: "# TYPE metric_two counter\nmetric_two{} 2\n"},
 			},
-			containsOrdered: []string{"metric_zero", "metric_one", "metric_two"},
-			expectEOFCount:  0,
-			expectParseText: true,
+			want: wantStats{
+				ordered:   []string{"metric_zero", "metric_one", "metric_two"},
+				eofCount:  intPtr(0),
+				parseText: true,
+			},
 		},
 		{
 			name: "two OpenMetrics targets emit exactly one # EOF at the end",
@@ -742,10 +821,12 @@ func TestStatsMultiTarget(t *testing.T) {
 					contentType: string(FmtOpenMetrics_1_0_0),
 				},
 			},
-			containsOrdered: []string{"metric_a", "metric_b"},
-			mustContain:     []string{"# EOF"},
-			expectEOFCount:  1,
-			expectParseOM:   true,
+			want: wantStats{
+				ordered:  []string{"metric_a", "metric_b"},
+				contains: []string{"# EOF"},
+				eofCount: intPtr(1),
+				parseOM:  true,
+			},
 		},
 		{
 			name: "one failing target does not prevent successful targets from appearing",
@@ -753,10 +834,12 @@ func TestStatsMultiTarget(t *testing.T) {
 				{body: "# TYPE metric_ok counter\nmetric_ok{} 7\n"},
 				{fail: true},
 			},
-			mustContain:                []string{"metric_ok{} 7"},
-			expectEOFCount:             0,
-			expectParseText:            true,
-			expectAppScrapeErrorsDelta: 1,
+			want: wantStats{
+				contains:             []string{"metric_ok{} 7"},
+				eofCount:             intPtr(0),
+				parseText:            true,
+				appScrapeErrorsDelta: 1,
+			},
 		},
 		{
 			name: "all failing targets still return 200 with envoy + agent metrics",
@@ -767,11 +850,12 @@ envoy_metric{} 9
 				{fail: true},
 				{fail: true},
 			},
-			mustContain: []string{"envoy_metric{} 9"},
-			// agent metric baked into the agent registry
-			expectEOFCount:             0,
-			expectParseText:            true,
-			expectAppScrapeErrorsDelta: 2,
+			want: wantStats{
+				contains:             []string{"envoy_metric{} 9"},
+				eofCount:             intPtr(0),
+				parseText:            true,
+				appScrapeErrorsDelta: 2,
+			},
 		},
 		{
 			name: "Targets[0] failure falls back to first successful target's format",
@@ -782,10 +866,12 @@ envoy_metric{} 9
 					contentType: string(FmtOpenMetrics_1_0_0),
 				},
 			},
-			mustContain:                []string{"metric_fallback_total 3", "# EOF"},
-			expectEOFCount:             1,
-			expectParseOM:              true,
-			expectAppScrapeErrorsDelta: 1,
+			want: wantStats{
+				contains:             []string{"metric_fallback_total 3", "# EOF"},
+				eofCount:             intPtr(1),
+				parseOM:              true,
+				appScrapeErrorsDelta: 1,
+			},
 		},
 		{
 			name: "mixed formats — Targets[0] is text so response is text and OM target's EOF is stripped",
@@ -796,10 +882,12 @@ envoy_metric{} 9
 					contentType: string(FmtOpenMetrics_1_0_0),
 				},
 			},
-			mustContain:     []string{"metric_text{} 4", "metric_om_total 5"},
-			mustNotContain:  []string{"# EOF"},
-			expectEOFCount:  0,
-			expectParseText: true,
+			want: wantStats{
+				contains:    []string{"metric_text{} 4", "metric_om_total 5"},
+				notContains: []string{"# EOF"},
+				eofCount:    intPtr(0),
+				parseText:   true,
+			},
 		},
 		{
 			// D3 — the OM-first counterpart of the case above. Without the format-mismatch
@@ -816,10 +904,12 @@ envoy_metric{} 9
 					contentType: string(FmtText),
 				},
 			},
-			mustContain:     []string{"metric_om_total 1", "metric_text{} 2"},
-			mustNotContain:  []string{"# EOF"},
-			expectEOFCount:  0,
-			expectParseText: true,
+			want: wantStats{
+				contains:    []string{"metric_om_total 1", "metric_text{} 2"},
+				notContains: []string{"# EOF"},
+				eofCount:    intPtr(0),
+				parseText:   true,
+			},
 		},
 		{
 			// D1 — two targets advertising the same metric family. The agent does not
@@ -830,91 +920,43 @@ envoy_metric{} 9
 				{body: "# TYPE metric_x counter\nmetric_x 1\n"},
 				{body: "# TYPE metric_x counter\nmetric_x 2\n"},
 			},
-			mustContain:      []string{"metric_x 1", "metric_x 2"},
-			expectEOFCount:   0,
-			expectParseText:  true,
-			expectParseError: true,
+			want: wantStats{
+				contains:   []string{"metric_x 1", "metric_x 2"},
+				eofCount:   intPtr(0),
+				parseText:  true,
+				parseError: true,
+			},
 		},
 	}
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			envoyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if _, err := w.Write([]byte(tt.envoy)); err != nil {
-					t.Fatalf("envoy write failed: %v", err)
-				}
-			}))
-			defer envoyServer.Close()
+			server, rec, req := newMultiTargetTestServer(t, tt.envoy, tt.targets)
 
-			targets := make([]ScrapeTarget, 0, len(tt.targets))
-			for _, spec := range tt.targets {
-				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					if spec.fail {
-						w.WriteHeader(http.StatusInternalServerError)
-						return
-					}
-					if spec.contentType != "" {
-						w.Header().Set("Content-Type", spec.contentType)
-					}
-					if _, err := w.Write([]byte(spec.body)); err != nil {
-						t.Fatalf("target write failed: %v", err)
-					}
-				}))
-				defer srv.Close()
-				_, port, err := net.SplitHostPort(strings.TrimPrefix(srv.URL, "http://"))
-				if err != nil {
-					t.Fatalf("split host port: %v", err)
-				}
-				targets = append(targets, ScrapeTarget{Port: port, Path: "/metrics"})
-			}
-
-			_, envoyPortStr, err := net.SplitHostPort(strings.TrimPrefix(envoyServer.URL, "http://"))
-			if err != nil {
-				t.Fatal(err)
-			}
-			envoyPort, err := strconv.Atoi(envoyPortStr)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			// Mirror the first target into legacy Port/Path so the hot path would also work,
-			// matching what NewServer() produces after PR 1 normalization.
-			server := &Server{
-				prometheus: &PrometheusScrapeConfiguration{
-					Port:    targets[0].Port,
-					Path:    targets[0].Path,
-					Targets: targets,
-				},
-				envoyStatsPort: envoyPort,
-				http:           &http.Client{},
-				registry:       TestingRegistry(t),
-			}
-
-			rec := httptest.NewRecorder()
 			beforeErrors := appScrapeErrorCount(t, server.registry)
-			server.handleStats(rec, &http.Request{})
+			server.handleStats(rec, req)
 			if rec.Code != 200 {
 				t.Fatalf("handleStats() => %v; want 200", rec.Code)
 			}
-			if got := appScrapeErrorCount(t, server.registry) - beforeErrors; got != tt.expectAppScrapeErrorsDelta {
-				t.Errorf("AppScrapeErrors delta = %v, want %v", got, tt.expectAppScrapeErrorsDelta)
+			if got := appScrapeErrorCount(t, server.registry) - beforeErrors; got != tt.want.appScrapeErrorsDelta {
+				t.Errorf("AppScrapeErrors delta = %v, want %v", got, tt.want.appScrapeErrorsDelta)
 			}
 
 			body := rec.Body.String()
 
-			for _, s := range tt.mustContain {
+			for _, s := range tt.want.contains {
 				if !strings.Contains(body, s) {
 					t.Errorf("body missing %q; body:\n%s", s, body)
 				}
 			}
-			for _, s := range tt.mustNotContain {
+			for _, s := range tt.want.notContains {
 				if strings.Contains(body, s) {
 					t.Errorf("body must not contain %q; body:\n%s", s, body)
 				}
 			}
 			// Assert Targets-order preservation via ascending substring indices.
 			lastIdx := -1
-			for _, s := range tt.containsOrdered {
+			for _, s := range tt.want.ordered {
 				idx := strings.Index(body, s)
 				if idx < 0 {
 					t.Errorf("body missing ordered substring %q; body:\n%s", s, body)
@@ -925,22 +967,22 @@ envoy_metric{} 9
 				}
 				lastIdx = idx
 			}
-			if tt.expectEOFCount >= 0 {
-				if got := strings.Count(body, "# EOF"); got != tt.expectEOFCount {
-					t.Errorf("# EOF count = %d, want %d; body:\n%s", got, tt.expectEOFCount, body)
+			if tt.want.eofCount != nil {
+				if got := strings.Count(body, "# EOF"); got != *tt.want.eofCount {
+					t.Errorf("# EOF count = %d, want %d; body:\n%s", got, *tt.want.eofCount, body)
 				}
 			}
-			if tt.expectParseText {
+			if tt.want.parseText {
 				parser := expfmt.NewTextParser(model.LegacyValidation)
 				_, err := parser.TextToMetricFamilies(strings.NewReader(body))
 				switch {
-				case err != nil && !tt.expectParseError:
+				case err != nil && !tt.want.parseError:
 					t.Fatalf("text parse failed: %v; body:\n%s", err, body)
-				case err == nil && tt.expectParseError:
+				case err == nil && tt.want.parseError:
 					t.Fatalf("expected text parse error, got none; body:\n%s", body)
 				}
 			}
-			if tt.expectParseOM {
+			if tt.want.parseOM {
 				omp := textparse.NewOpenMetricsParser(rec.Body.Bytes(), labels.NewSymbolTable())
 				var parseErr error
 				for {
@@ -954,9 +996,9 @@ envoy_metric{} 9
 					}
 				}
 				switch {
-				case parseErr != nil && !tt.expectParseError:
+				case parseErr != nil && !tt.want.parseError:
 					t.Fatalf("openmetrics parse failed: %v; body:\n%s", parseErr, body)
-				case parseErr == nil && tt.expectParseError:
+				case parseErr == nil && tt.want.parseError:
 					t.Fatalf("expected openmetrics parse error, got none; body:\n%s", body)
 				}
 			}
@@ -965,69 +1007,31 @@ envoy_metric{} 9
 }
 
 // TestScrapeMultipleAppsBodyCap verifies that scrapeMultipleApps drops target responses
-// that exceed maxAppMetricsBodyBytes (Fix A regression). The cap is shrunk to a tractable
-// size for the test; one target returns exactly cap bytes (accepted, present in the
-// merged response) and another returns cap+1 bytes (dropped, absent from the response,
-// AppScrapeErrors incremented).
+// that exceed Server.maxAppBodyBytes. The cap is shrunk to a tractable size via the Server
+// struct literal (no global mutation); one target returns exactly cap bytes (accepted,
+// present in the merged response) and another returns cap+1 bytes (dropped, absent from
+// the response, AppScrapeErrors incremented).
 func TestScrapeMultipleAppsBodyCap(t *testing.T) {
-	prev := maxAppMetricsBodyBytes
-	maxAppMetricsBodyBytes = 100
-	t.Cleanup(func() { maxAppMetricsBodyBytes = prev })
+	const cap = 100
+	atCap := strings.Repeat("a", cap)
+	overCap := strings.Repeat("b", cap+1)
 
-	atCap := strings.Repeat("a", 100)
-	overCap := strings.Repeat("b", 101)
+	server, rec, req := newMultiTargetTestServer(t, "", []targetSpec{
+		{body: atCap},
+		{body: overCap},
+	})
+	server.maxAppBodyBytes = cap
 
-	targets := make([]ScrapeTarget, 0, 2)
-	for _, body := range []string{atCap, overCap} {
-		body := body
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if _, err := w.Write([]byte(body)); err != nil {
-				t.Fatalf("target write failed: %v", err)
-			}
-		}))
-		defer srv.Close()
-		_, port, err := net.SplitHostPort(strings.TrimPrefix(srv.URL, "http://"))
-		if err != nil {
-			t.Fatalf("split host port: %v", err)
-		}
-		targets = append(targets, ScrapeTarget{Port: port, Path: "/metrics"})
-	}
-
-	envoyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Empty envoy body — we only care about app target behavior here.
-	}))
-	defer envoyServer.Close()
-	_, envoyPortStr, err := net.SplitHostPort(strings.TrimPrefix(envoyServer.URL, "http://"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	envoyPort, err := strconv.Atoi(envoyPortStr)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	server := &Server{
-		prometheus: &PrometheusScrapeConfiguration{
-			Port:    targets[0].Port,
-			Path:    targets[0].Path,
-			Targets: targets,
-		},
-		envoyStatsPort: envoyPort,
-		http:           &http.Client{},
-		registry:       TestingRegistry(t),
-	}
-
-	rec := httptest.NewRecorder()
 	before := appScrapeErrorCount(t, server.registry)
-	server.handleStats(rec, &http.Request{})
+	server.handleStats(rec, req)
 	after := appScrapeErrorCount(t, server.registry)
 
 	body := rec.Body.String()
 	if !strings.Contains(body, atCap) {
-		t.Errorf("at-cap body (100 bytes of 'a') should be present in merged response; len(body)=%d", len(body))
+		t.Errorf("at-cap body (%d bytes of 'a') should be present in merged response; len(body)=%d", cap, len(body))
 	}
 	if strings.Contains(body, overCap) {
-		t.Errorf("over-cap body (101 bytes of 'b') should NOT be present; len(body)=%d", len(body))
+		t.Errorf("over-cap body (%d bytes of 'b') should NOT be present; len(body)=%d", cap+1, len(body))
 	}
 	if got := after - before; got != 1 {
 		t.Errorf("AppScrapeErrors delta = %v, want 1 (only the over-cap target should fail)", got)

--- a/pilot/cmd/pilot-agent/status/server_test.go
+++ b/pilot/cmd/pilot-agent/status/server_test.go
@@ -686,6 +686,224 @@ func TestStatsError(t *testing.T) {
 	}
 }
 
+// TestStatsMultiTarget exercises the concurrent fan-out path in handleStats when
+// s.prometheus.Targets contains more than one entry. The single-target path is covered
+// by TestStats above and must remain byte-for-byte unchanged.
+func TestStatsMultiTarget(t *testing.T) {
+	// Each target's response is defined by body + optional content-type + fail flag.
+	type targetSpec struct {
+		body        string
+		contentType string // empty → default text/plain
+		fail        bool   // when true, handler returns 500
+	}
+	cases := []struct {
+		name             string
+		envoy            string
+		targets          []targetSpec
+		containsOrdered  []string // substrings that must appear in output in this exact order
+		mustNotContain   []string
+		mustContain      []string
+		expectEOFCount   int  // expected count of "# EOF" lines in the merged output; -1 = don't check
+		expectParseOM    bool // if true, parse merged output as OpenMetrics
+		expectParseText  bool // if true, parse merged output as text
+		expectParseError bool
+	}{
+		{
+			name: "two text targets with disjoint metrics merge in target order",
+			targets: []targetSpec{
+				{body: "# TYPE metric_a counter\nmetric_a{} 1\n"},
+				{body: "# TYPE metric_b counter\nmetric_b{} 2\n"},
+			},
+			containsOrdered: []string{"metric_a{} 1", "metric_b{} 2"},
+			expectEOFCount:  0,
+			expectParseText: true,
+		},
+		{
+			name: "three text targets preserve Targets-slice order even when goroutines race",
+			targets: []targetSpec{
+				{body: "# TYPE metric_zero counter\nmetric_zero{} 0\n"},
+				{body: "# TYPE metric_one counter\nmetric_one{} 1\n"},
+				{body: "# TYPE metric_two counter\nmetric_two{} 2\n"},
+			},
+			containsOrdered: []string{"metric_zero", "metric_one", "metric_two"},
+			expectEOFCount:  0,
+			expectParseText: true,
+		},
+		{
+			name: "two OpenMetrics targets emit exactly one # EOF at the end",
+			targets: []targetSpec{
+				{
+					body:        "# TYPE metric_a counter\n# HELP metric_a desc\nmetric_a_total 1\n# EOF\n",
+					contentType: string(FmtOpenMetrics_1_0_0),
+				},
+				{
+					body:        "# TYPE metric_b counter\n# HELP metric_b desc\nmetric_b_total 2\n# EOF\n",
+					contentType: string(FmtOpenMetrics_1_0_0),
+				},
+			},
+			containsOrdered: []string{"metric_a", "metric_b"},
+			mustContain:     []string{"# EOF"},
+			expectEOFCount:  1,
+			expectParseOM:   true,
+		},
+		{
+			name: "one failing target does not prevent successful targets from appearing",
+			targets: []targetSpec{
+				{body: "# TYPE metric_ok counter\nmetric_ok{} 7\n"},
+				{fail: true},
+			},
+			mustContain:     []string{"metric_ok{} 7"},
+			expectEOFCount:  0,
+			expectParseText: true,
+		},
+		{
+			name: "all failing targets still return 200 with envoy + agent metrics",
+			envoy: `# TYPE envoy_metric counter
+envoy_metric{} 9
+`,
+			targets: []targetSpec{
+				{fail: true},
+				{fail: true},
+			},
+			mustContain: []string{"envoy_metric{} 9"},
+			// agent metric baked into the agent registry
+			expectEOFCount:  0,
+			expectParseText: true,
+		},
+		{
+			name: "Targets[0] failure falls back to first successful target's format",
+			targets: []targetSpec{
+				{fail: true},
+				{
+					body:        "# TYPE metric_fallback counter\nmetric_fallback_total 3\n# EOF\n",
+					contentType: string(FmtOpenMetrics_1_0_0),
+				},
+			},
+			mustContain:    []string{"metric_fallback_total 3", "# EOF"},
+			expectEOFCount: 1,
+			expectParseOM:  true,
+		},
+		{
+			name: "mixed formats — Targets[0] is text so response is text and OM target's EOF is stripped",
+			targets: []targetSpec{
+				{body: "# TYPE metric_text counter\nmetric_text{} 4\n"},
+				{
+					body:        "# TYPE metric_om counter\n# HELP metric_om desc\nmetric_om_total 5\n# EOF\n",
+					contentType: string(FmtOpenMetrics_1_0_0),
+				},
+			},
+			mustContain:     []string{"metric_text{} 4", "metric_om_total 5"},
+			mustNotContain:  []string{"# EOF"},
+			expectEOFCount:  0,
+			expectParseText: true,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			envoyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if _, err := w.Write([]byte(tt.envoy)); err != nil {
+					t.Fatalf("envoy write failed: %v", err)
+				}
+			}))
+			defer envoyServer.Close()
+
+			targets := make([]ScrapeTarget, 0, len(tt.targets))
+			for _, spec := range tt.targets {
+				spec := spec
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if spec.fail {
+						w.WriteHeader(http.StatusInternalServerError)
+						return
+					}
+					if spec.contentType != "" {
+						w.Header().Set("Content-Type", spec.contentType)
+					}
+					if _, err := w.Write([]byte(spec.body)); err != nil {
+						t.Fatalf("target write failed: %v", err)
+					}
+				}))
+				defer srv.Close()
+				port := strings.Split(srv.URL, ":")[2]
+				targets = append(targets, ScrapeTarget{Port: port, Path: "/metrics"})
+			}
+
+			envoyPort, err := strconv.Atoi(strings.Split(envoyServer.URL, ":")[2])
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Mirror the first target into legacy Port/Path so the hot path would also work,
+			// matching what NewServer() produces after PR 1 normalization.
+			server := &Server{
+				prometheus: &PrometheusScrapeConfiguration{
+					Port:    targets[0].Port,
+					Path:    targets[0].Path,
+					Targets: targets,
+				},
+				envoyStatsPort: envoyPort,
+				http:           &http.Client{},
+				registry:       TestingRegistry(t),
+			}
+
+			rec := httptest.NewRecorder()
+			server.handleStats(rec, &http.Request{})
+			if rec.Code != 200 {
+				t.Fatalf("handleStats() => %v; want 200", rec.Code)
+			}
+
+			body := rec.Body.String()
+
+			for _, s := range tt.mustContain {
+				if !strings.Contains(body, s) {
+					t.Errorf("body missing %q; body:\n%s", s, body)
+				}
+			}
+			for _, s := range tt.mustNotContain {
+				if strings.Contains(body, s) {
+					t.Errorf("body must not contain %q; body:\n%s", s, body)
+				}
+			}
+			// Assert Targets-order preservation via ascending substring indices.
+			lastIdx := -1
+			for _, s := range tt.containsOrdered {
+				idx := strings.Index(body, s)
+				if idx < 0 {
+					t.Errorf("body missing ordered substring %q; body:\n%s", s, body)
+					continue
+				}
+				if idx < lastIdx {
+					t.Errorf("substring %q at index %d appeared before earlier target (last index %d); body:\n%s", s, idx, lastIdx, body)
+				}
+				lastIdx = idx
+			}
+			if tt.expectEOFCount >= 0 {
+				if got := strings.Count(body, "# EOF"); got != tt.expectEOFCount {
+					t.Errorf("# EOF count = %d, want %d; body:\n%s", got, tt.expectEOFCount, body)
+				}
+			}
+			if tt.expectParseText {
+				parser := expfmt.NewTextParser(model.LegacyValidation)
+				if _, err := parser.TextToMetricFamilies(strings.NewReader(body)); err != nil && !tt.expectParseError {
+					t.Fatalf("text parse failed: %v; body:\n%s", err, body)
+				}
+			}
+			if tt.expectParseOM {
+				omp := textparse.NewOpenMetricsParser(rec.Body.Bytes(), labels.NewSymbolTable())
+				for {
+					_, perr := omp.Next()
+					if perr == io.EOF {
+						break
+					}
+					if perr != nil {
+						t.Fatalf("openmetrics parse failed: %v; body:\n%s", perr, body)
+					}
+				}
+			}
+		})
+	}
+}
+
 // initServerWithSize size is kB
 func initServerWithSize(t *testing.B, size int) *Server {
 	appText := `# TYPE jvm info

--- a/pilot/cmd/pilot-agent/status/server_test.go
+++ b/pilot/cmd/pilot-agent/status/server_test.go
@@ -727,7 +727,6 @@ func newMultiTargetTestServer(t *testing.T, envoyBody string, specs []targetSpec
 
 	targets := make([]ScrapeTarget, 0, len(specs))
 	for _, spec := range specs {
-		spec := spec
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			if spec.fail {
 				w.WriteHeader(http.StatusInternalServerError)
@@ -1061,15 +1060,15 @@ envoy_metric{} 9
 // present in the merged response) and another returns cap+1 bytes (dropped, absent from
 // the response, AppScrapeErrors incremented).
 func TestScrapeMultipleAppsBodyCap(t *testing.T) {
-	const cap = 100
-	atCap := strings.Repeat("a", cap)
-	overCap := strings.Repeat("b", cap+1)
+	const bodyCap = 100
+	atCap := strings.Repeat("a", bodyCap)
+	overCap := strings.Repeat("b", bodyCap+1)
 
 	server, rec, req := newMultiTargetTestServer(t, "", []targetSpec{
 		{body: atCap},
 		{body: overCap},
 	})
-	server.maxAppBodyBytes = cap
+	server.maxAppBodyBytes = bodyCap
 
 	before := appScrapeErrorCount(t, server.registry)
 	server.handleStats(rec, req)
@@ -1077,10 +1076,10 @@ func TestScrapeMultipleAppsBodyCap(t *testing.T) {
 
 	body := rec.Body.String()
 	if !strings.Contains(body, atCap) {
-		t.Errorf("at-cap body (%d bytes of 'a') should be present in merged response; len(body)=%d", cap, len(body))
+		t.Errorf("at-cap body (%d bytes of 'a') should be present in merged response; len(body)=%d", bodyCap, len(body))
 	}
 	if strings.Contains(body, overCap) {
-		t.Errorf("over-cap body (%d bytes of 'b') should NOT be present; len(body)=%d", cap+1, len(body))
+		t.Errorf("over-cap body (%d bytes of 'b') should NOT be present; len(body)=%d", bodyCap+1, len(body))
 	}
 	if got := after - before; got != 1 {
 		t.Errorf("AppScrapeErrors delta = %v, want 1 (only the over-cap target should fail)", got)

--- a/pilot/cmd/pilot-agent/status/server_test.go
+++ b/pilot/cmd/pilot-agent/status/server_test.go
@@ -697,16 +697,17 @@ func TestStatsMultiTarget(t *testing.T) {
 		fail        bool   // when true, handler returns 500
 	}
 	cases := []struct {
-		name             string
-		envoy            string
-		targets          []targetSpec
-		containsOrdered  []string // substrings that must appear in output in this exact order
-		mustNotContain   []string
-		mustContain      []string
-		expectEOFCount   int  // expected count of "# EOF" lines in the merged output; -1 = don't check
-		expectParseOM    bool // if true, parse merged output as OpenMetrics
-		expectParseText  bool // if true, parse merged output as text
-		expectParseError bool
+		name                       string
+		envoy                      string
+		targets                    []targetSpec
+		containsOrdered            []string // substrings that must appear in output in this exact order
+		mustNotContain             []string
+		mustContain                []string
+		expectEOFCount             int     // expected count of "# EOF" lines in the merged output; -1 = don't check
+		expectParseOM              bool    // if true, parse merged output as OpenMetrics
+		expectParseText            bool    // if true, parse merged output as text
+		expectParseError           bool    // if true, an expected parse failure must occur; absence is itself a failure
+		expectAppScrapeErrorsDelta float64 // expected delta of istio_agent_scrape_failures_total{type="application"}
 	}{
 		{
 			name: "two text targets with disjoint metrics merge in target order",
@@ -752,9 +753,10 @@ func TestStatsMultiTarget(t *testing.T) {
 				{body: "# TYPE metric_ok counter\nmetric_ok{} 7\n"},
 				{fail: true},
 			},
-			mustContain:     []string{"metric_ok{} 7"},
-			expectEOFCount:  0,
-			expectParseText: true,
+			mustContain:                []string{"metric_ok{} 7"},
+			expectEOFCount:             0,
+			expectParseText:            true,
+			expectAppScrapeErrorsDelta: 1,
 		},
 		{
 			name: "all failing targets still return 200 with envoy + agent metrics",
@@ -767,8 +769,9 @@ envoy_metric{} 9
 			},
 			mustContain: []string{"envoy_metric{} 9"},
 			// agent metric baked into the agent registry
-			expectEOFCount:  0,
-			expectParseText: true,
+			expectEOFCount:             0,
+			expectParseText:            true,
+			expectAppScrapeErrorsDelta: 2,
 		},
 		{
 			name: "Targets[0] failure falls back to first successful target's format",
@@ -779,9 +782,10 @@ envoy_metric{} 9
 					contentType: string(FmtOpenMetrics_1_0_0),
 				},
 			},
-			mustContain:    []string{"metric_fallback_total 3", "# EOF"},
-			expectEOFCount: 1,
-			expectParseOM:  true,
+			mustContain:                []string{"metric_fallback_total 3", "# EOF"},
+			expectEOFCount:             1,
+			expectParseOM:              true,
+			expectAppScrapeErrorsDelta: 1,
 		},
 		{
 			name: "mixed formats — Targets[0] is text so response is text and OM target's EOF is stripped",
@@ -796,6 +800,40 @@ envoy_metric{} 9
 			mustNotContain:  []string{"# EOF"},
 			expectEOFCount:  0,
 			expectParseText: true,
+		},
+		{
+			// D3 — the OM-first counterpart of the case above. Without the format-mismatch
+			// downgrade, this response would claim OpenMetrics but contain a text body
+			// without "# EOF", producing invalid OpenMetrics. Fix B coerces to text.
+			name: "mixed formats — Targets[0] is OpenMetrics and Targets[1] is text; response downgrades to text and emits no # EOF",
+			targets: []targetSpec{
+				{
+					body:        "# TYPE metric_om counter\n# HELP metric_om desc\nmetric_om_total 1\n# EOF\n",
+					contentType: string(FmtOpenMetrics_1_0_0),
+				},
+				{
+					body:        "# TYPE metric_text counter\nmetric_text{} 2\n",
+					contentType: string(FmtText),
+				},
+			},
+			mustContain:     []string{"metric_om_total 1", "metric_text{} 2"},
+			mustNotContain:  []string{"# EOF"},
+			expectEOFCount:  0,
+			expectParseText: true,
+		},
+		{
+			// D1 — two targets advertising the same metric family. The agent does not
+			// dedupe across targets (out of scope per design); both blocks appear in the
+			// merged body, and the consumer's parser fails on the duplicate # TYPE.
+			name: "two targets emit the same metric family name; merged body contains both blocks (consumer parses-errors per design contract)",
+			targets: []targetSpec{
+				{body: "# TYPE metric_x counter\nmetric_x 1\n"},
+				{body: "# TYPE metric_x counter\nmetric_x 2\n"},
+			},
+			mustContain:      []string{"metric_x 1", "metric_x 2"},
+			expectEOFCount:   0,
+			expectParseText:  true,
+			expectParseError: true,
 		},
 	}
 
@@ -853,9 +891,13 @@ envoy_metric{} 9
 			}
 
 			rec := httptest.NewRecorder()
+			beforeErrors := appScrapeErrorCount(t, server.registry)
 			server.handleStats(rec, &http.Request{})
 			if rec.Code != 200 {
 				t.Fatalf("handleStats() => %v; want 200", rec.Code)
+			}
+			if got := appScrapeErrorCount(t, server.registry) - beforeErrors; got != tt.expectAppScrapeErrorsDelta {
+				t.Errorf("AppScrapeErrors delta = %v, want %v", got, tt.expectAppScrapeErrorsDelta)
 			}
 
 			body := rec.Body.String()
@@ -890,23 +932,105 @@ envoy_metric{} 9
 			}
 			if tt.expectParseText {
 				parser := expfmt.NewTextParser(model.LegacyValidation)
-				if _, err := parser.TextToMetricFamilies(strings.NewReader(body)); err != nil && !tt.expectParseError {
+				_, err := parser.TextToMetricFamilies(strings.NewReader(body))
+				switch {
+				case err != nil && !tt.expectParseError:
 					t.Fatalf("text parse failed: %v; body:\n%s", err, body)
+				case err == nil && tt.expectParseError:
+					t.Fatalf("expected text parse error, got none; body:\n%s", body)
 				}
 			}
 			if tt.expectParseOM {
 				omp := textparse.NewOpenMetricsParser(rec.Body.Bytes(), labels.NewSymbolTable())
+				var parseErr error
 				for {
 					_, perr := omp.Next()
 					if perr == io.EOF {
 						break
 					}
 					if perr != nil {
-						t.Fatalf("openmetrics parse failed: %v; body:\n%s", perr, body)
+						parseErr = perr
+						break
 					}
+				}
+				switch {
+				case parseErr != nil && !tt.expectParseError:
+					t.Fatalf("openmetrics parse failed: %v; body:\n%s", parseErr, body)
+				case parseErr == nil && tt.expectParseError:
+					t.Fatalf("expected openmetrics parse error, got none; body:\n%s", body)
 				}
 			}
 		})
+	}
+}
+
+// TestScrapeMultipleAppsBodyCap verifies that scrapeMultipleApps drops target responses
+// that exceed maxAppMetricsBodyBytes (Fix A regression). The cap is shrunk to a tractable
+// size for the test; one target returns exactly cap bytes (accepted, present in the
+// merged response) and another returns cap+1 bytes (dropped, absent from the response,
+// AppScrapeErrors incremented).
+func TestScrapeMultipleAppsBodyCap(t *testing.T) {
+	prev := maxAppMetricsBodyBytes
+	maxAppMetricsBodyBytes = 100
+	t.Cleanup(func() { maxAppMetricsBodyBytes = prev })
+
+	atCap := strings.Repeat("a", 100)
+	overCap := strings.Repeat("b", 101)
+
+	targets := make([]ScrapeTarget, 0, 2)
+	for _, body := range []string{atCap, overCap} {
+		body := body
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if _, err := w.Write([]byte(body)); err != nil {
+				t.Fatalf("target write failed: %v", err)
+			}
+		}))
+		defer srv.Close()
+		_, port, err := net.SplitHostPort(strings.TrimPrefix(srv.URL, "http://"))
+		if err != nil {
+			t.Fatalf("split host port: %v", err)
+		}
+		targets = append(targets, ScrapeTarget{Port: port, Path: "/metrics"})
+	}
+
+	envoyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Empty envoy body — we only care about app target behavior here.
+	}))
+	defer envoyServer.Close()
+	_, envoyPortStr, err := net.SplitHostPort(strings.TrimPrefix(envoyServer.URL, "http://"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	envoyPort, err := strconv.Atoi(envoyPortStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := &Server{
+		prometheus: &PrometheusScrapeConfiguration{
+			Port:    targets[0].Port,
+			Path:    targets[0].Path,
+			Targets: targets,
+		},
+		envoyStatsPort: envoyPort,
+		http:           &http.Client{},
+		registry:       TestingRegistry(t),
+	}
+
+	rec := httptest.NewRecorder()
+	before := appScrapeErrorCount(t, server.registry)
+	server.handleStats(rec, &http.Request{})
+	after := appScrapeErrorCount(t, server.registry)
+
+	body := rec.Body.String()
+	if !strings.Contains(body, atCap) {
+		t.Errorf("at-cap body (100 bytes of 'a') should be present in merged response; len(body)=%d", len(body))
+	}
+	if strings.Contains(body, overCap) {
+		t.Errorf("over-cap body (101 bytes of 'b') should NOT be present; len(body)=%d", len(body))
+	}
+	if got := after - before; got != 1 {
+		t.Errorf("AppScrapeErrors delta = %v, want 1 (only the over-cap target should fail)", got)
 	}
 }
 
@@ -1887,6 +2011,31 @@ func TestingRegistry(t test.Failer) prometheus.Gatherer {
 		t.Fatal(err)
 	}
 	return r
+}
+
+// appScrapeErrorCount reads istio_agent_scrape_failures_total{type="application"} from the
+// test registry. The agent wraps the registry with the "istio_agent_" prefix at startup
+// (server.go: WrapRegistererWithPrefix), so the bare "scrape_failures_total" name will not
+// match. Tests should capture this value before and after handleStats, then assert on the
+// delta — the registry is process-global and accumulates across tests in the package.
+func appScrapeErrorCount(t test.Failer, g prometheus.Gatherer) float64 {
+	families, err := g.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, mf := range families {
+		if mf.GetName() != "istio_agent_scrape_failures_total" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			for _, lp := range m.GetLabel() {
+				if lp.GetName() == "type" && lp.GetValue() == "application" {
+					return m.GetCounter().GetValue()
+				}
+			}
+		}
+	}
+	return 0
 }
 
 func TestParseScrapeTargets(t *testing.T) {

--- a/pilot/cmd/pilot-agent/status/server_test.go
+++ b/pilot/cmd/pilot-agent/status/server_test.go
@@ -699,9 +699,10 @@ type targetSpec struct {
 // "what the request looked like" (envoy, targets) from "what the response should be."
 type wantStats struct {
 	ordered, contains, notContains []string
-	eofCount                       *int // nil = don't check
+	eofCount                       *int // nil = don't check count
 	parseOM, parseText, parseError bool
 	appScrapeErrorsDelta           float64
+	contentType                    expfmt.Format // empty = don't check
 }
 
 // intPtr is a one-line helper for building *int literals inside wantStats.
@@ -791,9 +792,10 @@ func TestStatsMultiTarget(t *testing.T) {
 				{body: "# TYPE metric_b counter\nmetric_b{} 2\n"},
 			},
 			want: wantStats{
-				ordered:   []string{"metric_a{} 1", "metric_b{} 2"},
-				eofCount:  intPtr(0),
-				parseText: true,
+				ordered:     []string{"metric_a{} 1", "metric_b{} 2"},
+				eofCount:    intPtr(0),
+				parseText:   true,
+				contentType: FmtText,
 			},
 		},
 		{
@@ -804,9 +806,10 @@ func TestStatsMultiTarget(t *testing.T) {
 				{body: "# TYPE metric_two counter\nmetric_two{} 2\n"},
 			},
 			want: wantStats{
-				ordered:   []string{"metric_zero", "metric_one", "metric_two"},
-				eofCount:  intPtr(0),
-				parseText: true,
+				ordered:     []string{"metric_zero", "metric_one", "metric_two"},
+				eofCount:    intPtr(0),
+				parseText:   true,
+				contentType: FmtText,
 			},
 		},
 		{
@@ -822,10 +825,11 @@ func TestStatsMultiTarget(t *testing.T) {
 				},
 			},
 			want: wantStats{
-				ordered:  []string{"metric_a", "metric_b"},
-				contains: []string{"# EOF"},
-				eofCount: intPtr(1),
-				parseOM:  true,
+				ordered:     []string{"metric_a", "metric_b"},
+				contains:    []string{"# EOF"},
+				eofCount:    intPtr(1),
+				parseOM:     true,
+				contentType: FmtOpenMetrics_1_0_0,
 			},
 		},
 		{
@@ -839,6 +843,7 @@ func TestStatsMultiTarget(t *testing.T) {
 				eofCount:             intPtr(0),
 				parseText:            true,
 				appScrapeErrorsDelta: 1,
+				contentType:          FmtText,
 			},
 		},
 		{
@@ -855,6 +860,7 @@ envoy_metric{} 9
 				eofCount:             intPtr(0),
 				parseText:            true,
 				appScrapeErrorsDelta: 2,
+				contentType:          FmtText,
 			},
 		},
 		{
@@ -871,6 +877,7 @@ envoy_metric{} 9
 				eofCount:             intPtr(1),
 				parseOM:              true,
 				appScrapeErrorsDelta: 1,
+				contentType:          FmtOpenMetrics_1_0_0,
 			},
 		},
 		{
@@ -887,6 +894,7 @@ envoy_metric{} 9
 				notContains: []string{"# EOF"},
 				eofCount:    intPtr(0),
 				parseText:   true,
+				contentType: FmtText,
 			},
 		},
 		{
@@ -909,6 +917,7 @@ envoy_metric{} 9
 				notContains: []string{"# EOF"},
 				eofCount:    intPtr(0),
 				parseText:   true,
+				contentType: FmtText,
 			},
 		},
 		{
@@ -921,10 +930,34 @@ envoy_metric{} 9
 				{body: "# TYPE metric_x counter\nmetric_x 2\n"},
 			},
 			want: wantStats{
-				contains:   []string{"metric_x 1", "metric_x 2"},
-				eofCount:   intPtr(0),
-				parseText:  true,
-				parseError: true,
+				contains:    []string{"metric_x 1", "metric_x 2"},
+				eofCount:    intPtr(0),
+				parseText:   true,
+				parseError:  true,
+				contentType: FmtText,
+			},
+		},
+		{
+			// D-CRLF — verifies stripOpenMetricsEOF tolerates "\r\n# EOF\r\n" trailers as
+			// documented. The merged OpenMetrics response should contain one terminator
+			// at the very end (FinalizeOpenMetrics writes "# EOF\n", no CR in output).
+			name: "OpenMetrics targets with CRLF EOF trailers — strip + reappend exactly once",
+			targets: []targetSpec{
+				{
+					body:        "# TYPE metric_crlf_a counter\nmetric_crlf_a_total 1\n# EOF\r\n",
+					contentType: string(FmtOpenMetrics_1_0_0),
+				},
+				{
+					body:        "# TYPE metric_crlf_b counter\nmetric_crlf_b_total 2\n# EOF\r\n",
+					contentType: string(FmtOpenMetrics_1_0_0),
+				},
+			},
+			want: wantStats{
+				ordered:     []string{"metric_crlf_a", "metric_crlf_b"},
+				contains:    []string{"# EOF"},
+				eofCount:    intPtr(1),
+				parseOM:     true,
+				contentType: FmtOpenMetrics_1_0_0,
 			},
 		},
 	}
@@ -970,6 +1003,22 @@ envoy_metric{} 9
 			if tt.want.eofCount != nil {
 				if got := strings.Count(body, "# EOF"); got != *tt.want.eofCount {
 					t.Errorf("# EOF count = %d, want %d; body:\n%s", got, *tt.want.eofCount, body)
+				}
+				// When an OpenMetrics response carries exactly one EOF, the terminator
+				// must land at the very end of the response (design contract). This
+				// catches regressions that emit "# EOF" mid-response while still
+				// satisfying the count.
+				if *tt.want.eofCount == 1 && tt.want.parseOM && !strings.HasSuffix(body, "# EOF\n") {
+					tail := body
+					if len(body) > 32 {
+						tail = body[len(body)-32:]
+					}
+					t.Errorf("OpenMetrics response must end with %q; body tail: %q", "# EOF\n", tail)
+				}
+			}
+			if tt.want.contentType != "" {
+				if got := rec.Header().Get("Content-Type"); got != string(tt.want.contentType) {
+					t.Errorf("Content-Type = %q, want %q", got, string(tt.want.contentType))
 				}
 			}
 			if tt.want.parseText {

--- a/pilot/cmd/pilot-agent/status/server_test.go
+++ b/pilot/cmd/pilot-agent/status/server_test.go
@@ -810,7 +810,6 @@ envoy_metric{} 9
 
 			targets := make([]ScrapeTarget, 0, len(tt.targets))
 			for _, spec := range tt.targets {
-				spec := spec
 				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					if spec.fail {
 						w.WriteHeader(http.StatusInternalServerError)
@@ -824,11 +823,18 @@ envoy_metric{} 9
 					}
 				}))
 				defer srv.Close()
-				port := strings.Split(srv.URL, ":")[2]
+				_, port, err := net.SplitHostPort(strings.TrimPrefix(srv.URL, "http://"))
+				if err != nil {
+					t.Fatalf("split host port: %v", err)
+				}
 				targets = append(targets, ScrapeTarget{Port: port, Path: "/metrics"})
 			}
 
-			envoyPort, err := strconv.Atoi(strings.Split(envoyServer.URL, ":")[2])
+			_, envoyPortStr, err := net.SplitHostPort(strings.TrimPrefix(envoyServer.URL, "http://"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			envoyPort, err := strconv.Atoi(envoyPortStr)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -2058,6 +2064,21 @@ func TestNewServerPrometheusNormalization(t *testing.T) {
 			envJSON:     `{"scrape":"true","targets":[{"port":"8080","path":"/metrics"}]}`,
 			wantPort:    "8080",
 			wantTargets: []ScrapeTarget{{Port: "8080", Path: "/metrics"}},
+		},
+		{
+			name:    "leading-zero port equal to status port is rejected by numeric comparison",
+			envJSON: `{"scrape":"true","targets":[{"port":"015020","path":"/metrics"}]}`,
+			wantErr: true,
+		},
+		{
+			name:    "leading-zero reserved port is rejected by numeric comparison",
+			envJSON: `{"scrape":"true","targets":[{"port":"015000","path":"/metrics"}]}`,
+			wantErr: true,
+		},
+		{
+			name:    "non-numeric port is rejected",
+			envJSON: `{"scrape":"true","targets":[{"port":"abc","path":"/metrics"}]}`,
+			wantErr: true,
 		},
 	}
 	for _, tt := range cases {

--- a/releasenotes/notes/multi-port-metrics-fanout.yaml
+++ b/releasenotes/notes/multi-port-metrics-fanout.yaml
@@ -7,8 +7,11 @@ issue:
 releaseNotes:
   - |
     **Improved** the pilot-agent's `/stats/prometheus` endpoint to concurrently scrape
-    every target declared by the `prometheus.istio.io/scrape-targets` annotation and
+    multiple targets declared by the `prometheus.istio.io/scrape-targets` annotation and
     merge the output in the declared order. Single-target pods keep the existing
-    streaming code path byte-for-byte. OpenMetrics responses are rewritten so the
-    merged output contains exactly one `# EOF` terminator. Per-target scrape failures
-    are non-blocking and increment `istio_agent_scrape_failures_total{type="application"}`.
+    streaming code path byte-for-byte. For multi-target pods, OpenMetrics responses are
+    rewritten so the merged output contains exactly one `# EOF` terminator. Individual
+    target metrics responses are capped at 10 MiB to bound agent memory; responses
+    exceeding this limit are dropped and counted as scrape failures. Per-target scrape
+    failures are non-blocking and increment
+    `istio_agent_scrape_failures_total{type="application"}`.

--- a/releasenotes/notes/multi-port-metrics-fanout.yaml
+++ b/releasenotes/notes/multi-port-metrics-fanout.yaml
@@ -1,0 +1,14 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+issue:
+  - 59567
+
+releaseNotes:
+  - |
+    **Improved** the pilot-agent's `/stats/prometheus` endpoint to concurrently scrape
+    every target declared by the `prometheus.istio.io/scrape-targets` annotation and
+    merge the output in the declared order. Single-target pods keep the existing
+    streaming code path byte-for-byte. OpenMetrics responses are rewritten so the
+    merged output contains exactly one `# EOF` terminator. Per-target scrape failures
+    are non-blocking and increment `istio_agent_scrape_failures_total{type="application"}`.


### PR DESCRIPTION
**Please provide a description of this PR:**

Part 2 of 3 for [#59567](https://github.com/istio/istio/issues/59567). Stacked on #59924 (PR 1 — data model and annotation parsing). Merge order: PR 1 first, then this PR against master.

- Replaces the single-endpoint `io.Copy` block in `handleStats` with a concurrent fan-out when `len(s.prometheus.Targets) > 1`; each target is scraped in its own goroutine via `sync.WaitGroup`, results buffered in a pre-allocated indexed slice so output is written in `Targets` order regardless of goroutine completion order.
- Single-target path (`len(Targets) <= 1`) is untouched: existing streaming `io.Copy` runs byte-for-byte as before; no buffering or goroutine overhead for the common case.
- Adds `stripOpenMetricsEOF` to strip the `# EOF` trailer from each buffered body; exactly one `# EOF` is appended at the very end when the negotiated format is OpenMetrics.
- Numeric port validation closes a leading-zero bypass in the reserved-port check.
- Inserts a newline separator between concatenated bodies so a body that doesn't end with `\n` cannot corrupt the next body's first line.

### Test plan

- [x] `go test -count=1 -race ./pilot/cmd/pilot-agent/status/...` — all existing tests pass, `TestStatsMultiTarget` (7 subtests) covers: two-target happy path, three-target order preservation, one-of-two fails (partial data + `AppScrapeErrors` incremented), both-targets-fail (Envoy + agent metrics still returned), OpenMetrics EOF stripped from non-final bodies, mixed format (Targets[0] text / Targets[1] OpenMetrics), single-target regression (hot path chosen, not fan-out).
- [x] `go test -count=1 ./pkg/kube/inject/...` — webhook tests unchanged, still green.
- [x] No data race on `results[i]` writes under `-race` (each goroutine writes only its own index).
- [x] Leading-zero port validation regression (`TestNewServerPrometheusNormalization` extended cases).
- [x] Kind-cluster end-to-end smoke (covered by #59926; `TestMultiPortMetricsMerge` + `TestMultiPortMetricsMergePartialFailure` PASS against a local kind cluster built from this stack, full `tests/integration/telemetry/api` suite green: 19/19)

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [x] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.

