### PR TITLE
test(#59567): integration test for multi-port metrics merging

### DIFF
--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -591,7 +591,9 @@ func IstioReservedPortReason(port string) (string, bool) {
 }
 
 // ParseScrapeTargets parses a comma-separated list of "port:path" pairs into ScrapeTargets.
-// Whitespace is trimmed from each entry. An empty path defaults to "/metrics".
+// Whitespace is trimmed from each entry. An empty path defaults to "/metrics"; a non-empty
+// path without a leading slash has one prepended, so "8080:metrics" yields path "/metrics"
+// rather than building a malformed scrape URL like "http://localhost:8080metrics".
 // Returns an error if any entry has an empty port.
 func ParseScrapeTargets(raw string) ([]ScrapeTarget, error) {
 	var targets []ScrapeTarget
@@ -608,6 +610,9 @@ func ParseScrapeTargets(raw string) ([]ScrapeTarget, error) {
 		path := "/metrics"
 		if len(parts) == 2 && strings.TrimSpace(parts[1]) != "" {
 			path = strings.TrimSpace(parts[1])
+		}
+		if !strings.HasPrefix(path, "/") {
+			path = "/" + path
 		}
 		targets = append(targets, ScrapeTarget{Port: port, Path: path})
 	}

--- a/pilot/cmd/pilot-agent/status/server_test.go
+++ b/pilot/cmd/pilot-agent/status/server_test.go
@@ -2152,6 +2152,16 @@ func TestParseScrapeTargets(t *testing.T) {
 			input: "8080:/metrics?foo=bar",
 			want:  []ScrapeTarget{{Port: "8080", Path: "/metrics?foo=bar"}},
 		},
+		{
+			name:  "path missing leading slash is normalized",
+			input: "8080:metrics",
+			want:  []ScrapeTarget{{Port: "8080", Path: "/metrics"}},
+		},
+		{
+			name:  "mixed valid paths with and without leading slash are normalized",
+			input: "8080:custom,9100:/other",
+			want:  []ScrapeTarget{{Port: "8080", Path: "/custom"}, {Port: "9100", Path: "/other"}},
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -901,19 +901,29 @@ func applyPrometheusMerge(pod *corev1.Pod, mesh *meshconfig.MeshConfig) error {
 			scrape.Port = scrape.Targets[0].Port
 			scrape.Path = scrape.Targets[0].Path
 			for _, t := range scrape.Targets {
-				if t.Port == targetPort {
+				portNum, err := strconv.Atoi(t.Port)
+				if err != nil || portNum < 1 || portNum > 65535 {
+					return fmt.Errorf("invalid prometheus scrape targets: invalid target port %q", t.Port)
+				}
+				canon := strconv.Itoa(portNum)
+				if canon == targetPort {
 					return fmt.Errorf("invalid prometheus scrape targets: target port %s conflicts with agent port", t.Port)
 				}
-				if reason, reserved := status.IstioReservedPortReason(t.Port); reserved {
+				if reason, reserved := status.IstioReservedPortReason(canon); reserved {
 					return fmt.Errorf("invalid prometheus scrape targets: target port %s is reserved for Istio (%s) and cannot be scraped", t.Port, reason)
 				}
 			}
 		} else if scrape.Port != "" {
 			// Validate legacy prometheus.io/port annotation when the new scrape-targets annotation is not used.
-			if scrape.Port == targetPort {
+			portNum, err := strconv.Atoi(scrape.Port)
+			if err != nil || portNum < 1 || portNum > 65535 {
+				return fmt.Errorf("invalid prometheus scrape configuration: invalid port %q", scrape.Port)
+			}
+			canon := strconv.Itoa(portNum)
+			if canon == targetPort {
 				return fmt.Errorf("invalid prometheus scrape configuration: port %s conflicts with agent port", scrape.Port)
 			}
-			if reason, reserved := status.IstioReservedPortReason(scrape.Port); reserved {
+			if reason, reserved := status.IstioReservedPortReason(canon); reserved {
 				return fmt.Errorf("invalid prometheus scrape configuration: port %s is reserved for Istio (%s) and cannot be scraped", scrape.Port, reason)
 			}
 		}

--- a/tests/integration/telemetry/api/multiport_metrics_test.go
+++ b/tests/integration/telemetry/api/multiport_metrics_test.go
@@ -17,9 +17,10 @@
 package api
 
 import (
+	"context"
 	"fmt"
+	"strings"
 	"testing"
-	"time"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/prometheus"
@@ -154,6 +155,36 @@ func TestMultiPortMetricsMerge(t *testing.T) {
 
 			cluster := t.Clusters().Default()
 
+			// Phase 1: direct pod-exec assertion against :15020/stats/prometheus. Hitting the
+			// agent endpoint directly distinguishes "the agent didn't merge" (a fast failure,
+			// observable here) from "Prometheus hasn't scraped yet" (a slow path observed in
+			// phase 2). The merged-metrics endpoint is reachable from any container in the pod
+			// because they share the network namespace; the primary busybox container has wget
+			// natively, so we exec there.
+			retry.UntilSuccessOrFail(t, func() error {
+				pods, err := cluster.PodsForSelector(context.TODO(), ns, "app=multiport-metrics-app")
+				if err != nil {
+					return fmt.Errorf("listing multiport-metrics-app pods: %w", err)
+				}
+				if len(pods.Items) == 0 {
+					return fmt.Errorf("no multiport-metrics-app pods yet")
+				}
+				stdout, _, err := cluster.PodExec(pods.Items[0].Name, ns, "primary",
+					"wget -qO- http://localhost:15020/stats/prometheus")
+				if err != nil {
+					return fmt.Errorf("PodExec wget against :15020/stats/prometheus failed: %w", err)
+				}
+				if !strings.Contains(stdout, "primary_metric_total") {
+					return fmt.Errorf("merged response missing primary_metric_total; got:\n%s", stdout)
+				}
+				if !strings.Contains(stdout, "secondary_metric_total") {
+					return fmt.Errorf("merged response missing secondary_metric_total; got:\n%s", stdout)
+				}
+				return nil
+			}, retry.Delay(framework.TelemetryRetryDelay), retry.Timeout(framework.TelemetryRetryTimeout))
+
+			// Phase 2: full pipeline via Prometheus. Validates the scrape-to-Prometheus path
+			// once the agent-side behavior is confirmed.
 			retry.UntilSuccessOrFail(t, func() error {
 				v, err := promInst.RawQuery(cluster, fmt.Sprintf(`primary_metric_total{namespace=%q}`, ns))
 				if err != nil {
@@ -172,7 +203,7 @@ func TestMultiPortMetricsMerge(t *testing.T) {
 				}
 
 				return nil
-			}, retry.Delay(5*time.Second), retry.Timeout(5*time.Minute))
+			}, retry.Delay(framework.TelemetryRetryDelay), retry.Timeout(framework.TelemetryRetryTimeout))
 		})
 }
 
@@ -192,6 +223,28 @@ func TestMultiPortMetricsMergePartialFailure(t *testing.T) {
 
 			cluster := t.Clusters().Default()
 
+			// Phase 1: direct pod-exec assertion. Confirms the agent serves primary metrics
+			// even when the secondary target is unreachable, without waiting on Prometheus.
+			retry.UntilSuccessOrFail(t, func() error {
+				pods, err := cluster.PodsForSelector(context.TODO(), ns, "app=multiport-failing-app")
+				if err != nil {
+					return fmt.Errorf("listing multiport-failing-app pods: %w", err)
+				}
+				if len(pods.Items) == 0 {
+					return fmt.Errorf("no multiport-failing-app pods yet")
+				}
+				stdout, _, err := cluster.PodExec(pods.Items[0].Name, ns, "primary",
+					"wget -qO- http://localhost:15020/stats/prometheus")
+				if err != nil {
+					return fmt.Errorf("PodExec wget against :15020/stats/prometheus failed: %w", err)
+				}
+				if !strings.Contains(stdout, "primary_metric_total") {
+					return fmt.Errorf("primary_metric_total missing from merged response despite healthy port 8080; got:\n%s", stdout)
+				}
+				return nil
+			}, retry.Delay(framework.TelemetryRetryDelay), retry.Timeout(framework.TelemetryRetryTimeout))
+
+			// Phase 2: full pipeline via Prometheus.
 			retry.UntilSuccessOrFail(t, func() error {
 				// Primary metrics from port 8080 must still be present.
 				v, err := promInst.RawQuery(cluster, fmt.Sprintf(`primary_metric_total{namespace=%q}`, ns))
@@ -202,9 +255,13 @@ func TestMultiPortMetricsMergePartialFailure(t *testing.T) {
 					return fmt.Errorf("primary_metric_total absent despite port 8080 being healthy: %w", err)
 				}
 
-				// At least one app scrape error must be recorded.
-				// Metric name: monitoring.NewSum("scrape_failures_total", ...) → istio_agent_scrape_failures_total
-				v, err = promInst.RawQuery(cluster, `istio_agent_scrape_failures_total{type="application"}`)
+				// At least one app scrape error must be recorded against THIS deployment.
+				// The pod-label filter `pod=~"multiport-failing-app-.*"` scopes the cumulative
+				// counter so a stray failure from any other sidecar in the namespace cannot
+				// satisfy the >= 1 assertion. AppScrapeErrors counter is exported by
+				// pilot-agent as istio_agent_scrape_failures_total{type="application"}.
+				v, err = promInst.RawQuery(cluster, fmt.Sprintf(
+					`sum(istio_agent_scrape_failures_total{type="application",namespace=%q,pod=~"multiport-failing-app-.*"})`, ns))
 				if err != nil {
 					return fmt.Errorf("querying istio_agent_scrape_failures_total: %w", err)
 				}
@@ -213,10 +270,10 @@ func TestMultiPortMetricsMergePartialFailure(t *testing.T) {
 					return fmt.Errorf("istio_agent_scrape_failures_total absent: %w", err)
 				}
 				if total < 1 {
-					return fmt.Errorf("expected >= 1 app scrape error, got %v", total)
+					return fmt.Errorf("expected >= 1 app scrape error from multiport-failing-app, got %v", total)
 				}
 
 				return nil
-			}, retry.Delay(5*time.Second), retry.Timeout(5*time.Minute))
+			}, retry.Delay(framework.TelemetryRetryDelay), retry.Timeout(framework.TelemetryRetryTimeout))
 		})
 }

--- a/tests/integration/telemetry/api/multiport_metrics_test.go
+++ b/tests/integration/telemetry/api/multiport_metrics_test.go
@@ -75,7 +75,7 @@ spec:
     spec:
       containers:
       - name: primary
-        image: busybox
+        image: busybox:1.28
         command: ["httpd", "-f", "-p", "8080", "-h", "/www"]
         ports:
         - containerPort: 8080
@@ -83,7 +83,7 @@ spec:
         - name: primary-metrics
           mountPath: /www
       - name: secondary
-        image: busybox
+        image: busybox:1.28
         command: ["httpd", "-f", "-p", "9100", "-h", "/www"]
         ports:
         - containerPort: 9100
@@ -120,7 +120,7 @@ spec:
     spec:
       containers:
       - name: primary
-        image: busybox
+        image: busybox:1.28
         command: ["httpd", "-f", "-p", "8080", "-h", "/www"]
         ports:
         - containerPort: 8080
@@ -128,7 +128,7 @@ spec:
         - name: primary-metrics
           mountPath: /www
       - name: noop
-        image: busybox
+        image: busybox:1.28
         command: ["sleep", "infinity"]
       volumes:
       - name: primary-metrics
@@ -178,7 +178,7 @@ func TestMultiPortMetricsMerge(t *testing.T) {
 
 // TestMultiPortMetricsMergePartialFailure verifies that when one of the scrape
 // targets is unreachable the pilot-agent still serves metrics from the healthy
-// target and increments the AppScrapeErrors counter exactly once per scrape.
+// target and increments the AppScrapeErrors counter at least once.
 func TestMultiPortMetricsMergePartialFailure(t *testing.T) {
 	framework.NewTest(t).
 		Run(func(t framework.TestContext) {

--- a/tests/integration/telemetry/api/multiport_metrics_test.go
+++ b/tests/integration/telemetry/api/multiport_metrics_test.go
@@ -1,0 +1,222 @@
+//go:build integ
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/prometheus"
+	"istio.io/istio/pkg/test/util/retry"
+)
+
+// multiPortPrimaryConfigMap serves "primary_metric_total" on port 8080 at /metrics.
+// busybox httpd maps /www/<filename> → GET /<filename>, so key "metrics" is deliberate.
+const multiPortPrimaryConfigMap = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: multiport-primary-metrics
+data:
+  metrics: |
+    # HELP primary_metric_total Test metric from container 1 (port 8080).
+    # TYPE primary_metric_total counter
+    primary_metric_total{container="primary"} 1
+`
+
+// multiPortSecondaryConfigMap serves "secondary_metric_total" on port 9100 at /metrics.
+const multiPortSecondaryConfigMap = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: multiport-secondary-metrics
+data:
+  metrics: |
+    # HELP secondary_metric_total Test metric from container 2 (port 9100).
+    # TYPE secondary_metric_total counter
+    secondary_metric_total{container="secondary"} 42
+`
+
+// multiPortDeployment runs two busybox httpd containers on distinct ports.
+// The prometheus.istio.io/scrape-targets annotation triggers multi-port fan-out
+// in the pilot-agent; the webhook rewrites prometheus.io/* to point to :15020.
+const multiPortDeployment = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: multiport-metrics-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: multiport-metrics-app
+  template:
+    metadata:
+      labels:
+        app: multiport-metrics-app
+      annotations:
+        prometheus.istio.io/scrape-targets: "8080:/metrics,9100:/metrics"
+    spec:
+      containers:
+      - name: primary
+        image: busybox
+        command: ["httpd", "-f", "-p", "8080", "-h", "/www"]
+        ports:
+        - containerPort: 8080
+        volumeMounts:
+        - name: primary-metrics
+          mountPath: /www
+      - name: secondary
+        image: busybox
+        command: ["httpd", "-f", "-p", "9100", "-h", "/www"]
+        ports:
+        - containerPort: 9100
+        volumeMounts:
+        - name: secondary-metrics
+          mountPath: /www
+      volumes:
+      - name: primary-metrics
+        configMap:
+          name: multiport-primary-metrics
+      - name: secondary-metrics
+        configMap:
+          name: multiport-secondary-metrics
+`
+
+// multiPortFailingDeployment has the same annotation but port 9100 is never
+// bound, so the pilot-agent gets connection-refused and increments AppScrapeErrors.
+const multiPortFailingDeployment = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: multiport-failing-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: multiport-failing-app
+  template:
+    metadata:
+      labels:
+        app: multiport-failing-app
+      annotations:
+        prometheus.istio.io/scrape-targets: "8080:/metrics,9100:/metrics"
+    spec:
+      containers:
+      - name: primary
+        image: busybox
+        command: ["httpd", "-f", "-p", "8080", "-h", "/www"]
+        ports:
+        - containerPort: 8080
+        volumeMounts:
+        - name: primary-metrics
+          mountPath: /www
+      - name: noop
+        image: busybox
+        command: ["sleep", "infinity"]
+      volumes:
+      - name: primary-metrics
+        configMap:
+          name: multiport-primary-metrics
+`
+
+// TestMultiPortMetricsMerge verifies that when a pod carries the
+// prometheus.istio.io/scrape-targets annotation with two ports, Prometheus
+// receives metrics from both containers via the pilot-agent's merged :15020
+// endpoint, even under STRICT mTLS where direct pod scraping is blocked.
+func TestMultiPortMetricsMerge(t *testing.T) {
+	framework.NewTest(t).
+		Run(func(t framework.TestContext) {
+			ns := apps.Namespace.Name()
+
+			t.ConfigIstio().YAML(ist.Settings().SystemNamespace, strictMtlsPeerAuthenticationConfig).ApplyOrFail(t)
+			t.ConfigIstio().YAML(ns,
+				multiPortPrimaryConfigMap+"\n---"+
+					multiPortSecondaryConfigMap+"\n---"+
+					multiPortDeployment,
+			).ApplyOrFail(t)
+
+			cluster := t.Clusters().Default()
+
+			retry.UntilSuccessOrFail(t, func() error {
+				v, err := promInst.RawQuery(cluster, fmt.Sprintf(`primary_metric_total{namespace=%q}`, ns))
+				if err != nil {
+					return fmt.Errorf("querying primary_metric_total: %w", err)
+				}
+				if _, err := prometheus.Sum(v); err != nil {
+					return fmt.Errorf("primary_metric_total absent in namespace %s: %w", ns, err)
+				}
+
+				v, err = promInst.RawQuery(cluster, fmt.Sprintf(`secondary_metric_total{namespace=%q}`, ns))
+				if err != nil {
+					return fmt.Errorf("querying secondary_metric_total: %w", err)
+				}
+				if _, err := prometheus.Sum(v); err != nil {
+					return fmt.Errorf("secondary_metric_total absent in namespace %s: %w", ns, err)
+				}
+
+				return nil
+			}, retry.Delay(5*time.Second), retry.Timeout(5*time.Minute))
+		})
+}
+
+// TestMultiPortMetricsMergePartialFailure verifies that when one of the scrape
+// targets is unreachable the pilot-agent still serves metrics from the healthy
+// target and increments the AppScrapeErrors counter exactly once per scrape.
+func TestMultiPortMetricsMergePartialFailure(t *testing.T) {
+	framework.NewTest(t).
+		Run(func(t framework.TestContext) {
+			ns := apps.Namespace.Name()
+
+			t.ConfigIstio().YAML(ist.Settings().SystemNamespace, strictMtlsPeerAuthenticationConfig).ApplyOrFail(t)
+			t.ConfigIstio().YAML(ns,
+				multiPortPrimaryConfigMap+"\n---"+
+					multiPortFailingDeployment,
+			).ApplyOrFail(t)
+
+			cluster := t.Clusters().Default()
+
+			retry.UntilSuccessOrFail(t, func() error {
+				// Primary metrics from port 8080 must still be present.
+				v, err := promInst.RawQuery(cluster, fmt.Sprintf(`primary_metric_total{namespace=%q}`, ns))
+				if err != nil {
+					return fmt.Errorf("querying primary_metric_total: %w", err)
+				}
+				if _, err := prometheus.Sum(v); err != nil {
+					return fmt.Errorf("primary_metric_total absent despite port 8080 being healthy: %w", err)
+				}
+
+				// At least one app scrape error must be recorded.
+				// Metric name: monitoring.NewSum("scrape_failures_total", ...) → istio_agent_scrape_failures_total
+				v, err = promInst.RawQuery(cluster, `istio_agent_scrape_failures_total{type="application"}`)
+				if err != nil {
+					return fmt.Errorf("querying istio_agent_scrape_failures_total: %w", err)
+				}
+				total, err := prometheus.Sum(v)
+				if err != nil {
+					return fmt.Errorf("istio_agent_scrape_failures_total absent: %w", err)
+				}
+				if total < 1 {
+					return fmt.Errorf("expected >= 1 app scrape error, got %v", total)
+				}
+
+				return nil
+			}, retry.Delay(5*time.Second), retry.Timeout(5*time.Minute))
+		})
+}


### PR DESCRIPTION
**Please provide a description of this PR:**

Integration test for the multi-port metrics merging feature (#59567), stacked on #59924 (annotation parsing) and #59925 (concurrent fan-out in `handleStats`). Merge order: PR 1, then PR 2, then this PR against master.

The new file `tests/integration/telemetry/api/multiport_metrics_test.go` exercises the full pipeline under STRICT mTLS — pod annotation → webhook env var → pilot-agent fan-out → merged `:15020/stats/prometheus` → Prometheus — on a two-container pod that no prior test covered.

- **`TestMultiPortMetricsMerge`**: two `busybox httpd` containers serve distinct Prometheus metric families on ports 8080 and 9100. Asserts both `primary_metric_total` and `secondary_metric_total` appear in Prometheus via the merged endpoint.
- **`TestMultiPortMetricsMergePartialFailure`**: the secondary container sleeps (port 9100 never bound). Asserts `primary_metric_total` is still scraped and `istio_agent_scrape_failures_total{type="application"} >= 1`, verifying the non-blocking partial-failure semantics.

### Test plan

- [x] `go build -tags integ ./tests/integration/telemetry/api/...` — compiles locally.
- [x] `go vet -tags integ ./tests/integration/telemetry/api/...` — no diagnostics.
- [x] `TestMultiPortMetricsMerge` — **PASS** in 15.05s on a local kind cluster (Istio built from this stack, `HUB=localhost:5000 TAG=istio-testing`, STRICT mTLS applied via `PeerAuthentication`).
- [x] `TestMultiPortMetricsMergePartialFailure` — **PASS** in 15.07s on the same cluster; secondary container's port 9100 was never bound, `primary_metric_total` was still scraped, and `istio_agent_scrape_failures_total{type="application"}` incremented as expected.
- [x] Full API telemetry suite green: `ok istio.io/istio/tests/integration/telemetry/api 221.100s` — **19 PASS / 0 FAIL**, covering `TestAccessLogs`, `TestAccessLogsFilter`, `TestAccessLogsMode`, `TestAccessLogsDefaultProvider`, `TestAccessLogWithFilterState`, `TestCustomizeMetrics`, `TestDashboard`, `TestIstioctlMetrics`, `TestMultiPortMetricsMerge`, `TestMultiPortMetricsMergePartialFailure`, `TestStatsFilter`, `TestStatsTCPFilter`, `TestStatsGatewayServerTCPFilter`, `TestGRPCCountMetrics`, `TestImagePullPolicy`, `TestGatewaySelection`, `TestImagePullPolicyWithHTTP`, `TestBadWasmRemoteLoad`, `TestBadWasmWithFailOpen`. Run invocation: `INTEGRATION_TEST_FLAGS="--istio.test.skipWorkloads=tproxy --istio.test.skipVM" ISTIO_DOCKER_BUILDER=docker prow/integ-suite-kind.sh test.integration.telemetry.api.kube` (tproxy/VM workload classes skipped — unrelated to the change under test).

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [x] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.

