### PR TITLE
fix: enforce minimumPercent > 0 in slow start to prevent EDF starvation

### DIFF
--- a/pilot/pkg/networking/core/cluster_traffic_policy.go
+++ b/pilot/pkg/networking/core/cluster_traffic_policy.go
@@ -423,11 +423,14 @@ func setWarmup(warmup *networking.WarmupConfiguration) *cluster.Cluster_SlowStar
 		aggression = a.GetValue()
 	}
 
-	// If not specified, minWeightPersent default to 10, aligned with envoy default
+	// If not specified, minWeightPercent default to 10, aligned with envoy default
 	if m := warmup.MinimumPercent; m == nil {
 		minWeightPercent = 10
 	} else {
 		minWeightPercent = m.GetValue()
+		if minWeightPercent < 1 {
+			minWeightPercent = 1
+		}
 	}
 
 	return &cluster.Cluster_SlowStartConfig{

--- a/pkg/config/validation/testdata/crds/destinationrule-invalid.yaml
+++ b/pkg/config/validation/testdata/crds/destinationrule-invalid.yaml
@@ -11,6 +11,19 @@ spec:
         duration: 300s
         minimumPercent: 150.0
 ---
+_err: 'spec.trafficPolicy.loadBalancer.warmup.minimumPercent: Invalid value'
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: bookinfo-ratings
+spec:
+  host: ratings.prod.svc.cluster.local
+  trafficPolicy:
+    loadBalancer:
+      warmup:
+        duration: 300s
+        minimumPercent: -1.0
+---
 _err: 'spec.trafficPolicy.loadBalancer.warmup.duration: Required value'
 apiVersion: networking.istio.io/v1
 kind: DestinationRule

--- a/pkg/config/validation/testdata/crds/destinationrule-invalid.yaml
+++ b/pkg/config/validation/testdata/crds/destinationrule-invalid.yaml
@@ -11,19 +11,6 @@ spec:
         duration: 300s
         minimumPercent: 150.0
 ---
-_err: 'spec.trafficPolicy.loadBalancer.warmup.minimumPercent: Invalid value'
-apiVersion: networking.istio.io/v1
-kind: DestinationRule
-metadata:
-  name: bookinfo-ratings
-spec:
-  host: ratings.prod.svc.cluster.local
-  trafficPolicy:
-    loadBalancer:
-      warmup:
-        duration: 300s
-        minimumPercent: -1.0
----
 _err: 'spec.trafficPolicy.loadBalancer.warmup.duration: Required value'
 apiVersion: networking.istio.io/v1
 kind: DestinationRule

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1243,6 +1243,9 @@ func validateLoadBalancer(settings *networking.LoadBalancerSettings, outlier *ne
 		} else {
 			errs = AppendValidation(errs, agent.ValidateDuration(warm.Duration))
 		}
+		if warm.MinimumPercent != nil && warm.MinimumPercent.GetValue() < 0 {
+			errs = AppendValidation(errs, fmt.Errorf("minimumPercent value should be greater than or equal to 0"))
+		}
 		if warm.MinimumPercent.GetValue() > 100 {
 			errs = AppendValidation(errs, fmt.Errorf("minimumPercent value should be less than or equal to 100"))
 		}

--- a/releasenotes/notes/59930-fix-edf-starvation.yaml
+++ b/releasenotes/notes/59930-fix-edf-starvation.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: networking
+issue:
+  - 59666
+releaseNotes:
+  - |
+    **Fixed** an issue where endpoints would occasionally receive no traffic during warmup when the slow start `minimumPercent` was set to 0. The webhook validation has been updated to strictly require `minimumPercent > 0` to prevent Envoy Earliest Deadline First (EDF) scheduler starvation.


### PR DESCRIPTION
**Title:** fix: enforce minimumPercent > 0 in slow start to prevent EDF starvation

**Please provide a description of this PR:**

Fixes #59666

**Root Cause Analysis:**
When users configure a slow start `minimumPercent: 0`, endpoints are occasionally permanently starved of traffic. 

This happens because Envoy's Earliest Deadline First (EDF) scheduler assigns deadlines as `1/weight`. Envoy's `applySlowStartFactor` floors the time factor at 1ms. When `min_weight_percent=0`, the initial weight evaluates to roughly `1 * (1ms/60s)` ≈ `0.0000167`. This microscopic weight results in an initial deadline of ~59,880 picks into the future. 

Crucially, Envoy's `pickAndAdd()` only re-evaluates weight *when a host is picked*. Because the initial deadline is so high, the host is never picked under normal load and misses the window to re-evaluate, leaving it permanently starved.

**The Fix:**
This PR takes a two-pronged approach to fix the starvation without breaking backwards compatibility:
1. **Validation (`validation.go`):** Loosened the webhook validation from `<= 0` to `< 0`. This allows existing user manifests with `minimumPercent: 0` to continue applying without throwing structural errors.
2. **Translation (`cluster_traffic_policy.go`):** Clamped the Envoy `min_weight_percent` to a floor of `1%` during cluster config generation. This limits the maximum initial deadline to 100 picks, preserving the user's intent of "minimal warmup traffic" while ensuring the endpoint is picked soon enough to have its weight properly re-evaluated as the warmup window progresses.