### PR TITLE
Add `--tls-curves` flag to istiod

### DIFF
--- a/pilot/cmd/pilot-discovery/app/cmd.go
+++ b/pilot/cmd/pilot-discovery/app/cmd.go
@@ -184,6 +184,10 @@ func addFlags(c *cobra.Command) {
 	c.PersistentFlags().StringVar(&serverArgs.ServerOptions.TLSOptions.TLSMinVersion, "tls-min-version", bootstrap.TLSMinVersion1_2,
 		"Minimum TLS version for the istiod TLS server. "+
 			fmt.Sprintf("Only %s and %s are supported.", bootstrap.TLSMinVersion1_2, bootstrap.TLSMinVersion1_3))
+	c.PersistentFlags().StringSliceVar(&serverArgs.ServerOptions.TLSOptions.TLSCurves, "tls-curves", nil,
+		"Comma-separated list of ECDH curves for istiod TLS server. "+
+			"If omitted, the default Go curves will be used. \n"+
+			"Supported values: "+strings.Join(bootstrap.TLSCurveNames(), ", ")+".")
 
 	c.PersistentFlags().Float32Var(&serverArgs.RegistryOptions.KubeOptions.KubernetesAPIQPS, "kubernetesApiQPS", 80.0,
 		"Maximum QPS when communicating with the kubernetes API")

--- a/pilot/cmd/pilot-discovery/app/options.go
+++ b/pilot/cmd/pilot-discovery/app/options.go
@@ -72,8 +72,14 @@ func validateFlags(serverArgs *bootstrap.PilotArgs) error {
 		return err
 	}
 
-	_, err := bootstrap.TLSCipherSuites(serverArgs.ServerOptions.TLSOptions.TLSCipherSuites)
+	if _, err := bootstrap.TLSCipherSuites(serverArgs.ServerOptions.TLSOptions.TLSCipherSuites); err != nil {
+		return err
+	}
+
+	if _, err := bootstrap.TLSCurvePreferences(serverArgs.ServerOptions.TLSOptions.TLSCurves); err != nil {
+		return err
+	}
 
 	// TODO: add validation for other flags
-	return err
+	return nil
 }

--- a/pilot/pkg/bootstrap/options.go
+++ b/pilot/pkg/bootstrap/options.go
@@ -17,8 +17,6 @@ package bootstrap
 import (
 	"crypto/tls"
 	"fmt"
-	"maps"
-	"slices"
 	"time"
 
 	kubecontroller "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
@@ -27,6 +25,7 @@ import (
 	"istio.io/istio/pkg/env"
 	"istio.io/istio/pkg/keepalive"
 	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/util/sets"
 )
 
@@ -232,7 +231,7 @@ var curveNamesToIDs = map[string]tls.CurveID{
 
 // TLSCurveNames returns the list of supported TLS curve names.
 func TLSCurveNames() []string {
-	return slices.Collect(maps.Keys(curveNamesToIDs))
+	return maps.Keys(curveNamesToIDs)
 }
 
 // TLSCurvePreferences returns a list of curve IDs from the curve names passed.

--- a/pilot/pkg/bootstrap/options.go
+++ b/pilot/pkg/bootstrap/options.go
@@ -17,6 +17,8 @@ package bootstrap
 import (
 	"crypto/tls"
 	"fmt"
+	"maps"
+	"slices"
 	"time"
 
 	kubecontroller "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
@@ -25,6 +27,7 @@ import (
 	"istio.io/istio/pkg/env"
 	"istio.io/istio/pkg/keepalive"
 	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/util/sets"
 )
 
 // RegistryOptions provide configuration options for the configuration controller. If FileDir is set, that directory will
@@ -104,14 +107,15 @@ const (
 
 // TLSOptions is optional TLS parameters for Istiod server.
 type TLSOptions struct {
-	// CaCertFile and related are set using CLI flags.
-	CaCertFile      string
-	CertFile        string
-	KeyFile         string
-	TLSCipherSuites []string
-	CipherSuites    []uint16 // This is the parsed cipher suites
-	TLSMinVersion   string   // Minimum TLS version for the server (e.g., "1.2", "1.3")
-	MinVersion      uint16   // This is the parsed minimum TLS version
+	CaCertFile       string
+	CertFile         string
+	KeyFile          string
+	TLSCipherSuites  []string
+	CipherSuites     []uint16 // This is the parsed cipher suites
+	TLSCurves        []string
+	CurvePreferences []tls.CurveID // This is the parsed curve preferences
+	TLSMinVersion    string        // Minimum TLS version for the server (e.g., "1.2", "1.3")
+	MinVersion       uint16        // This is the parsed minimum TLS version
 }
 
 var (
@@ -159,11 +163,19 @@ func (p *PilotArgs) Complete() error {
 		return err
 	}
 	p.ServerOptions.TLSOptions.CipherSuites = cipherSuites
+
 	minVersion, err := TLSMinVersion(p.ServerOptions.TLSOptions.TLSMinVersion)
 	if err != nil {
 		return err
 	}
 	p.ServerOptions.TLSOptions.MinVersion = minVersion
+
+	curvePreferences, err := TLSCurvePreferences(p.ServerOptions.TLSOptions.TLSCurves)
+	if err != nil {
+		return err
+	}
+	p.ServerOptions.TLSOptions.CurvePreferences = curvePreferences
+
 	return nil
 }
 
@@ -205,4 +217,36 @@ func TLSMinVersion(version string) (uint16, error) {
 	default:
 		return tls.VersionTLS12, fmt.Errorf("minimum TLS version: %s is not supported. Only %s and %s are supported", version, TLSMinVersion1_2, TLSMinVersion1_3)
 	}
+}
+
+// Map of curve names to curve IDs.
+// This may be a different list than security.ValidECDHCurves because what go
+// supports and what envoy supports are not always the same.
+var curveNamesToIDs = map[string]tls.CurveID{
+	"P-256":          tls.CurveP256,
+	"P-521":          tls.CurveP521,
+	"P-384":          tls.CurveP384,
+	"X25519":         tls.X25519,
+	"X25519MLKEM768": tls.X25519MLKEM768,
+}
+
+// TLSCurveNames returns the list of supported TLS curve names.
+func TLSCurveNames() []string {
+	return slices.Collect(maps.Keys(curveNamesToIDs))
+}
+
+// TLSCurvePreferences returns a list of curve IDs from the curve names passed.
+func TLSCurvePreferences(curveNames []string) ([]tls.CurveID, error) {
+	if len(curveNames) == 0 {
+		return nil, nil
+	}
+	curves := sets.New[tls.CurveID]()
+	for _, curve := range curveNames {
+		curveID, ok := curveNamesToIDs[curve]
+		if !ok {
+			return nil, fmt.Errorf("curve %s not supported or doesn't exist. Supported curves: %v", curve, TLSCurveNames())
+		}
+		curves.Insert(curveID)
+	}
+	return curves.UnsortedList(), nil
 }

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -804,8 +804,9 @@ func (s *Server) initSecureDiscoveryService(args *PilotArgs, trustDomain string)
 			}
 			return err
 		},
-		MinVersion:   tls.VersionTLS12,
-		CipherSuites: args.ServerOptions.TLSOptions.CipherSuites,
+		MinVersion:       tls.VersionTLS12,
+		CipherSuites:     args.ServerOptions.TLSOptions.CipherSuites,
+		CurvePreferences: args.ServerOptions.TLSOptions.CurvePreferences,
 	}
 	if args.ServerOptions.TLSOptions.MinVersion != 0 {
 		cfg.MinVersion = args.ServerOptions.TLSOptions.MinVersion

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -832,7 +832,7 @@ func TestIstiodCurvePreferences(t *testing.T) {
 				Timeout: time.Second,
 				Transport: &http.Transport{
 					TLSClientConfig: &tls.Config{
-						InsecureSkipVerify: true,
+						InsecureSkipVerify: true, //nolint:gosec
 						CurvePreferences:   c.clientCurvePreferences,
 						MinVersion:         tls.VersionTLS12,
 						MaxVersion:         tls.VersionTLS12,

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -760,6 +760,103 @@ func TestIstiodMinTLSVersion(t *testing.T) {
 	}
 }
 
+func TestIstiodCurvePreferences(t *testing.T) {
+	cases := []struct {
+		name                   string
+		serverCurvePreferences []tls.CurveID
+		clientCurvePreferences []tls.CurveID
+		expectSuccess          bool
+	}{
+		{
+			name:          "default curve preferences",
+			expectSuccess: true,
+		},
+		{
+			name:                   "client and istiod curve preferences match",
+			serverCurvePreferences: []tls.CurveID{tls.CurveP256, tls.CurveP384},
+			clientCurvePreferences: []tls.CurveID{tls.CurveP256, tls.CurveP384},
+			expectSuccess:          true,
+		},
+		{
+			name:                   "server restricted to P256, client supports P256",
+			serverCurvePreferences: []tls.CurveID{tls.CurveP256},
+			clientCurvePreferences: []tls.CurveID{tls.CurveP256, tls.CurveP384, tls.X25519},
+			expectSuccess:          true,
+		},
+		{
+			name:                   "server restricted to P384, client only supports P256",
+			serverCurvePreferences: []tls.CurveID{tls.CurveP384},
+			clientCurvePreferences: []tls.CurveID{tls.CurveP256},
+			expectSuccess:          false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			configDir := t.TempDir()
+			args := NewPilotArgs(func(p *PilotArgs) {
+				p.Namespace = "istio-system"
+				p.ServerOptions = DiscoveryServerOptions{
+					// Dynamically assign all ports.
+					HTTPAddr:       ":0",
+					MonitoringAddr: ":0",
+					GRPCAddr:       ":0",
+					HTTPSAddr:      ":0",
+					TLSOptions: TLSOptions{
+						CurvePreferences: c.serverCurvePreferences,
+					},
+				}
+				p.RegistryOptions = RegistryOptions{
+					KubeConfig: "config",
+					FileDir:    configDir,
+				}
+
+				// Include all of the default plugins
+				p.ShutdownDuration = 1 * time.Millisecond
+			})
+
+			g := NewWithT(t)
+			s, err := NewServer(args, func(s *Server) {
+				s.kubeClient = kube.NewFakeClient()
+			})
+			g.Expect(err).To(Succeed())
+
+			stop := make(chan struct{})
+			g.Expect(s.Start(stop)).To(Succeed())
+			defer func() {
+				close(stop)
+				s.WaitUntilCompletion()
+			}()
+
+			httpsReadyClient := &http.Client{
+				Timeout: time.Second,
+				Transport: &http.Transport{
+					TLSClientConfig: &tls.Config{
+						InsecureSkipVerify: true,
+						CurvePreferences:   c.clientCurvePreferences,
+						MinVersion:         tls.VersionTLS12,
+						MaxVersion:         tls.VersionTLS12,
+					},
+				},
+			}
+
+			retry.UntilSuccessOrFail(t, func() error {
+				response, err := httpsReadyClient.Get("https://" + s.httpsAddr + "/ready")
+				if response != nil {
+					defer response.Body.Close()
+				}
+				if c.expectSuccess && err != nil {
+					return fmt.Errorf("expect success but got err %v", err)
+				}
+				if !c.expectSuccess && err == nil {
+					return fmt.Errorf("expect failure but succeeded")
+				}
+				return nil
+			})
+		})
+	}
+}
+
 func TestIstiodReadinessHandler(t *testing.T) {
 	configDir := t.TempDir()
 

--- a/pilot/pkg/bootstrap/webhook.go
+++ b/pilot/pkg/bootstrap/webhook.go
@@ -53,9 +53,10 @@ func (s *Server) initSecureWebhookServer(args *PilotArgs) {
 	}
 
 	tlsConfig := &tls.Config{
-		GetCertificate: s.getIstiodCertificate,
-		MinVersion:     tls.VersionTLS12,
-		CipherSuites:   args.ServerOptions.TLSOptions.CipherSuites,
+		GetCertificate:   s.getIstiodCertificate,
+		MinVersion:       tls.VersionTLS12,
+		CipherSuites:     args.ServerOptions.TLSOptions.CipherSuites,
+		CurvePreferences: args.ServerOptions.TLSOptions.CurvePreferences,
 	}
 	if args.ServerOptions.TLSOptions.MinVersion != 0 {
 		tlsConfig.MinVersion = args.ServerOptions.TLSOptions.MinVersion

--- a/releasenotes/notes/tls-curves-flag.yaml
+++ b/releasenotes/notes/tls-curves-flag.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue: []
+releaseNotes:
+  - |
+    **Added** `--tls-curves` flag to `pilot-discovery` to configure the ECDH curve preferences
+    for the istiod server and webhook.


### PR DESCRIPTION
**Please provide a description of this PR:**

Adds a command line flag to limit the TLS curves that istiod accepts.