### PR TITLE
fix EnvoyFilter patches were applied multiple times 

### DIFF
--- a/pilot/pkg/networking/core/envoyfilter/rc_patch.go
+++ b/pilot/pkg/networking/core/envoyfilter/rc_patch.go
@@ -52,6 +52,30 @@ func ApplyRouteConfigurationPatches(
 		portMap = proxy.MergedGateway.PortMap
 	}
 
+	routeConfiguration = ApplyMergeRouteConfiguration(patchContext, proxy, efw, routeConfiguration)
+	patchVirtualHosts(patchContext, efw.Patches, out, portMap)
+
+	return routeConfiguration
+}
+
+func ApplyMergeRouteConfiguration(patchContext networking.EnvoyFilter_PatchContext,
+	proxy *model.Proxy,
+	efw *model.MergedEnvoyFilterWrapper,
+	routeConfiguration *route.RouteConfiguration) (out *route.RouteConfiguration) {
+	defer runtime.HandleCrash(runtime.LogPanic, func(any) {
+		IncrementEnvoyFilterErrorMetric(Route)
+		log.Errorf("route patch caused panic, so the patches did not take effect")
+	})
+	// In case the patches cause panic, use the route generated before to reduce the influence.
+	out = routeConfiguration
+	if efw == nil {
+		return out
+	}
+
+	var portMap model.GatewayPortMap
+	if proxy.MergedGateway != nil {
+		portMap = proxy.MergedGateway.PortMap
+	}
 	// only merge is applicable for route configuration.
 	for _, rp := range efw.Patches[networking.EnvoyFilter_ROUTE_CONFIGURATION] {
 		if rp.Operation != networking.EnvoyFilter_Patch_MERGE {
@@ -65,8 +89,6 @@ func ApplyRouteConfigurationPatches(
 			IncrementEnvoyFilterMetric(rp.Key(), Route, false)
 		}
 	}
-	patchVirtualHosts(patchContext, efw.Patches, routeConfiguration, portMap)
-
 	return routeConfiguration
 }
 

--- a/pilot/pkg/networking/core/envoyfilter/rc_patch.go
+++ b/pilot/pkg/networking/core/envoyfilter/rc_patch.go
@@ -61,7 +61,8 @@ func ApplyRouteConfigurationPatches(
 func ApplyMergeRouteConfiguration(patchContext networking.EnvoyFilter_PatchContext,
 	proxy *model.Proxy,
 	efw *model.MergedEnvoyFilterWrapper,
-	routeConfiguration *route.RouteConfiguration) (out *route.RouteConfiguration) {
+	routeConfiguration *route.RouteConfiguration,
+) (out *route.RouteConfiguration) {
 	defer runtime.HandleCrash(runtime.LogPanic, func(any) {
 		IncrementEnvoyFilterErrorMetric(Route)
 		log.Errorf("route patch caused panic, so the patches did not take effect")

--- a/pilot/pkg/networking/core/httproute.go
+++ b/pilot/pkg/networking/core/httproute.go
@@ -24,6 +24,7 @@ import (
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	statefulsession "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/stateful_session/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	pb "google.golang.org/protobuf/proto"
 	anypb "google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 
@@ -41,6 +42,7 @@ import (
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/proto"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/sets"
@@ -70,12 +72,14 @@ func (configgen *ConfigGeneratorImpl) BuildHTTPRoutes(
 			networking.EnvoyFilter_VIRTUAL_HOST,
 			networking.EnvoyFilter_HTTP_ROUTE,
 		)
+		sort.Strings(routeNames)
 		for _, routeName := range routeNames {
 			rc, cached := configgen.buildSidecarOutboundHTTPRouteConfig(node, req, routeName, vHostCache, efw, envoyfilterKeys)
 			if cached && !features.EnableUnsafeAssertions {
 				hit++
 			} else {
 				miss++
+				log.Debugf("Building route configuration for %s with routeName %s", node.ID, routeName)
 			}
 			if rc == nil {
 				emptyRoute := &route.RouteConfiguration{
@@ -198,7 +202,12 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(
 	}
 
 	// apply envoy filter patches
-	out = envoyfilter.ApplyRouteConfigurationPatches(networking.EnvoyFilter_SIDECAR_OUTBOUND, node, efw, out)
+	if useSniffing && cacheHit {
+		// do nothing if useSniffing and cache hit, as the virtual hosts have already been patched with EnvoyFilter
+		log.Debugf("Skipping to apply EnvoyFilter for route %s because of cache hit", routeName)
+	} else {
+		out = envoyfilter.ApplyRouteConfigurationPatches(networking.EnvoyFilter_SIDECAR_OUTBOUND, node, efw, out)
+	}
 
 	resource = &discovery.Resource{
 		Name:     out.Name,
@@ -531,6 +540,8 @@ func getVirtualHostsForSniffedServicePort(vhosts []*route.VirtualHost, routeName
 		return virtualHosts
 	}
 	if len(virtualHosts) == 1 {
+		// Clone before mutating to avoid affecting cached objects
+		virtualHosts[0] = pb.Clone(virtualHosts[0]).(*route.VirtualHost)
 		virtualHosts[0].Domains = []string{"*"}
 		return virtualHosts
 	}

--- a/pilot/pkg/networking/core/httproute.go
+++ b/pilot/pkg/networking/core/httproute.go
@@ -72,7 +72,6 @@ func (configgen *ConfigGeneratorImpl) BuildHTTPRoutes(
 			networking.EnvoyFilter_VIRTUAL_HOST,
 			networking.EnvoyFilter_HTTP_ROUTE,
 		)
-		sort.Strings(routeNames)
 		for _, routeName := range routeNames {
 			rc, cached := configgen.buildSidecarOutboundHTTPRouteConfig(node, req, routeName, vHostCache, efw, envoyfilterKeys)
 			if cached && !features.EnableUnsafeAssertions {

--- a/pilot/pkg/networking/core/httproute.go
+++ b/pilot/pkg/networking/core/httproute.go
@@ -202,6 +202,9 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(
 	// This is to prevent double applying envoy filter patches which may cause unexpected behavior.
 	if !cacheHit {
 		out = envoyfilter.ApplyRouteConfigurationPatches(networking.EnvoyFilter_SIDECAR_OUTBOUND, node, efw, out)
+	} else {
+		// This's a little tricky, we need to always apply envoyfilters for ROUTE_CONFIGURATION.
+		out = envoyfilter.ApplyMergeRouteConfiguration(networking.EnvoyFilter_SIDECAR_OUTBOUND, node, efw, out)
 	}
 
 	resource = &discovery.Resource{

--- a/pilot/pkg/networking/core/httproute.go
+++ b/pilot/pkg/networking/core/httproute.go
@@ -42,7 +42,6 @@ import (
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
-	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/proto"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/sets"
@@ -78,7 +77,6 @@ func (configgen *ConfigGeneratorImpl) BuildHTTPRoutes(
 				hit++
 			} else {
 				miss++
-				log.Debugf("Building route configuration for %s with routeName %s", node.ID, routeName)
 			}
 			if rc == nil {
 				emptyRoute := &route.RouteConfiguration{
@@ -200,11 +198,9 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(
 		IgnorePortInHostMatching:       true,
 	}
 
-	// apply envoy filter patches
-	if useSniffing && cacheHit {
-		// do nothing if useSniffing and cache hit, as the virtual hosts have already been patched with EnvoyFilter
-		log.Debugf("Skipping to apply EnvoyFilter for route %s because of cache hit", routeName)
-	} else {
+	// apply envoy filter patches only when cache is not hit, as the cache result is already applied with envoy filter patches.
+	// This is to prevent double applying envoy filter patches which may cause unexpected behavior.
+	if !cacheHit {
 		out = envoyfilter.ApplyRouteConfigurationPatches(networking.EnvoyFilter_SIDECAR_OUTBOUND, node, efw, out)
 	}
 

--- a/pilot/pkg/networking/core/httproute_test.go
+++ b/pilot/pkg/networking/core/httproute_test.go
@@ -2034,3 +2034,111 @@ func buildHTTPService(hostname string, v visibility.Instance, ip, namespace stri
 	service.Ports = Ports
 	return service
 }
+
+// TestEnvoyFilterCacheDoublePatch verifies that EnvoyFilter patches are not applied multiple times
+// when vHostCache is reused for different route names on the same port.
+// This tests the bug where cached virtual hosts are modified in-place by EnvoyFilter patches,
+// causing patches to be applied again when the cache is reused for sniffed routes.
+func TestEnvoyFilterCacheDoublePatch(t *testing.T) {
+	// Create two services on the same port 8080
+	service1 := buildHTTPService("service1.default.svc.cluster.local", visibility.Public, "10.0.0.1", "default", 8080)
+	service2 := buildHTTPService("service2.default.svc.cluster.local", visibility.Public, "10.0.0.2", "default", 8080)
+
+	// Create an EnvoyFilter that merges request_headers_to_add to all virtual hosts
+	envoyFilter := config.Config{
+		Meta: config.Meta{
+			GroupVersionKind: gvk.EnvoyFilter,
+			Name:             "test-filter",
+			Namespace:        "default",
+		},
+		Spec: &networking.EnvoyFilter{
+			ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
+				{
+					ApplyTo: networking.EnvoyFilter_VIRTUAL_HOST,
+					Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
+						Context: networking.EnvoyFilter_SIDECAR_OUTBOUND,
+					},
+					Patch: &networking.EnvoyFilter_Patch{
+						Operation: networking.EnvoyFilter_Patch_MERGE,
+						Value: buildPatchStruct(`{
+							"request_headers_to_add": [
+								{
+									"header": {
+										"key": "x-test-header",
+										"value": "test-value"
+									}
+								}
+							]
+						}`),
+					},
+				},
+			},
+		},
+	}
+
+	// Setup config generator with services and EnvoyFilter
+	cg := NewConfigGenTest(t, TestOptions{
+		Services: []*model.Service{service1, service2},
+		Configs:  []config.Config{envoyFilter},
+	})
+
+	setupProxy := cg.SetupProxy(&model.Proxy{ConfigNamespace: "default", DNSDomain: "default.example.org"})
+	push := &model.PushRequest{Push: cg.PushContext()}
+	vHostCache := make(map[int][]*route.VirtualHost)
+
+	// Get the EnvoyFilter wrapper from push context
+	efw := push.Push.EnvoyFilters(setupProxy)
+	efKeys := efw.KeysApplyingTo(networking.EnvoyFilter_ROUTE_CONFIGURATION, networking.EnvoyFilter_VIRTUAL_HOST)
+
+	// First call: routeName "8080" - builds and caches all virtual hosts for the port
+	resource1, _ := cg.ConfigGen.buildSidecarOutboundHTTPRouteConfig(
+		setupProxy, push, "8080", vHostCache, efw, efKeys)
+	routeCfg1 := &route.RouteConfiguration{}
+	resource1.Resource.UnmarshalTo(routeCfg1)
+
+	// Get per-vhost header count from first call (should be 1 header per vhost after EnvoyFilter)
+	var firstVhostHeaderCount int
+	if len(routeCfg1.VirtualHosts) > 0 {
+		firstVhostHeaderCount = len(routeCfg1.VirtualHosts[0].RequestHeadersToAdd)
+	}
+	t.Logf("First call (route=8080): %d vhosts, first vhost has %d headers",
+		len(routeCfg1.VirtualHosts), firstVhostHeaderCount)
+
+	// Second call: sniffed route "service1.default.svc.cluster.local:8080"
+	// This should reuse cached vhosts and filter to service1
+	resource2, _ := cg.ConfigGen.buildSidecarOutboundHTTPRouteConfig(
+		setupProxy, push, "service1.default.svc.cluster.local:8080", vHostCache, efw, efKeys)
+	routeCfg2 := &route.RouteConfiguration{}
+	resource2.Resource.UnmarshalTo(routeCfg2)
+
+	var secondVhostHeaderCount int
+	if len(routeCfg2.VirtualHosts) > 0 {
+		secondVhostHeaderCount = len(routeCfg2.VirtualHosts[0].RequestHeadersToAdd)
+	}
+	t.Logf("Second call (route=service1...): %d vhosts, first vhost has %d headers",
+		len(routeCfg2.VirtualHosts), secondVhostHeaderCount)
+
+	// Third call: Same sniffed route again - should get same result as second call
+	resource3, _ := cg.ConfigGen.buildSidecarOutboundHTTPRouteConfig(
+		setupProxy, push, "service1.default.svc.cluster.local:8080", vHostCache, efw, efKeys)
+	routeCfg3 := &route.RouteConfiguration{}
+	resource3.Resource.UnmarshalTo(routeCfg3)
+
+	var thirdVhostHeaderCount int
+	if len(routeCfg3.VirtualHosts) > 0 {
+		thirdVhostHeaderCount = len(routeCfg3.VirtualHosts[0].RequestHeadersToAdd)
+	}
+	t.Logf("Third call (route=service1...): %d vhosts, first vhost has %d headers",
+		len(routeCfg3.VirtualHosts), thirdVhostHeaderCount)
+
+	// All calls should have the same header count per vhost (no double patching)
+	// The bug would cause header counts to increase on subsequent calls
+	if secondVhostHeaderCount != firstVhostHeaderCount || thirdVhostHeaderCount != firstVhostHeaderCount {
+		t.Errorf("BUG: EnvoyFilter patches applied multiple times! "+
+			"First: %d headers, Second: %d headers, Third: %d headers. "+
+			"Cached virtual hosts are being mutated.",
+			firstVhostHeaderCount, secondVhostHeaderCount, thirdVhostHeaderCount)
+	} else if firstVhostHeaderCount > 0 {
+		t.Logf("SUCCESS: All calls have same header count (%d per vhost), cache not mutated", firstVhostHeaderCount)
+	}
+}

--- a/releasenotes/notes/fix-envoyfilter-double-patch.yaml
+++ b/releasenotes/notes/fix-envoyfilter-double-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 58914
+releaseNotes:
+  - |
+    **Fixed** an issue where EnvoyFilter patches were applied multiple times when the virtual host cache was reused for different route names on the same port.


### PR DESCRIPTION
**Please provide a description of this PR:**

fixes: #58914


https://github.com/istio/istio/issues/58914#issuecomment-4279073437 showed a steps to reproduce this, and it recover after restarting istiod or cache missed once.

There's two routes(e.g.`8080` and `helloworld.sample.svc.cluster.local:8080`) in XDS.
if `8080` cooked before `helloworld.sample.svc.cluster.local:8080`, `buildSidecarOutboundHTTPRouteConfig` reuse the virtualHosts from cache which applied EnvoyFilters in previous loop.

