### PR TITLE
fix: gateway: report InvalidFilter status for HTTPRoute headers with invalid characters

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -139,7 +139,10 @@ func convertHTTPRoute(ctx RouteContext, r k8s.HTTPRouteRule,
 	for _, filter := range r.Filters {
 		switch filter.Type {
 		case k8s.HTTPRouteFilterRequestHeaderModifier:
-			h := createHeadersFilter(filter.RequestHeaderModifier)
+			h, err := createHeadersFilter(filter.RequestHeaderModifier)
+			if err != nil {
+				return nil, nil, err
+			}
 			if h == nil {
 				continue
 			}
@@ -148,7 +151,10 @@ func convertHTTPRoute(ctx RouteContext, r k8s.HTTPRouteRule,
 			}
 			vs.Headers.Request = h
 		case k8s.HTTPRouteFilterResponseHeaderModifier:
-			h := createHeadersFilter(filter.ResponseHeaderModifier)
+			h, err := createHeadersFilter(filter.ResponseHeaderModifier)
+			if err != nil {
+				return nil, nil, err
+			}
 			if h == nil {
 				continue
 			}
@@ -285,7 +291,10 @@ func convertGRPCRoute(ctx RouteContext, r k8s.GRPCRouteRule,
 	for _, filter := range r.Filters {
 		switch filter.Type {
 		case k8s.GRPCRouteFilterRequestHeaderModifier:
-			h := createHeadersFilter(filter.RequestHeaderModifier)
+			h, err := createHeadersFilter(filter.RequestHeaderModifier)
+			if err != nil {
+				return nil, err
+			}
 			if h == nil {
 				continue
 			}
@@ -294,7 +303,10 @@ func convertGRPCRoute(ctx RouteContext, r k8s.GRPCRouteRule,
 			}
 			vs.Headers.Request = h
 		case k8s.GRPCRouteFilterResponseHeaderModifier:
-			h := createHeadersFilter(filter.ResponseHeaderModifier)
+			h, err := createHeadersFilter(filter.ResponseHeaderModifier)
+			if err != nil {
+				return nil, err
+			}
 			if h == nil {
 				continue
 			}
@@ -958,7 +970,10 @@ func buildHTTPDestination(
 		for _, filter := range fwd.Filters {
 			switch filter.Type {
 			case k8s.HTTPRouteFilterRequestHeaderModifier:
-				h := createHeadersFilter(filter.RequestHeaderModifier)
+				h, err := createHeadersFilter(filter.RequestHeaderModifier)
+				if err != nil {
+					return nil, ipCfg, nil, err
+				}
 				if h == nil {
 					continue
 				}
@@ -967,7 +982,10 @@ func buildHTTPDestination(
 				}
 				rd.Headers.Request = h
 			case k8s.HTTPRouteFilterResponseHeaderModifier:
-				h := createHeadersFilter(filter.ResponseHeaderModifier)
+				h, err := createHeadersFilter(filter.ResponseHeaderModifier)
+				if err != nil {
+					return nil, ipCfg, nil, err
+				}
 				if h == nil {
 					continue
 				}
@@ -1026,7 +1044,10 @@ func buildGRPCDestination(
 		for _, filter := range fwd.Filters {
 			switch filter.Type {
 			case k8s.GRPCRouteFilterRequestHeaderModifier:
-				h := createHeadersFilter(filter.RequestHeaderModifier)
+				h, err := createHeadersFilter(filter.RequestHeaderModifier)
+				if err != nil {
+					return nil, nil, err
+				}
 				if h == nil {
 					continue
 				}
@@ -1035,7 +1056,10 @@ func buildGRPCDestination(
 				}
 				rd.Headers.Request = h
 			case k8s.GRPCRouteFilterResponseHeaderModifier:
-				h := createHeadersFilter(filter.ResponseHeaderModifier)
+				h, err := createHeadersFilter(filter.ResponseHeaderModifier)
+				if err != nil {
+					return nil, nil, err
+				}
 				if h == nil {
 					continue
 				}
@@ -1388,15 +1412,23 @@ func createRedirectFilter(filter *k8s.HTTPRequestRedirectFilter) *istio.HTTPRedi
 	return resp
 }
 
-func createHeadersFilter(filter *k8s.HTTPHeaderFilter) *istio.Headers_HeaderOperations {
+func createHeadersFilter(filter *k8s.HTTPHeaderFilter) (*istio.Headers_HeaderOperations, *ConfigError) {
 	if filter == nil {
-		return nil
+		return nil, nil
+	}
+	for _, h := range append(filter.Set, filter.Add...) {
+		if strings.ContainsAny(h.Value, "\r\n") {
+			return nil, &ConfigError{
+				Reason:  InvalidFilter,
+				Message: fmt.Sprintf("header %q value contains invalid characters (\\r or \\n)", h.Name),
+			}
+		}
 	}
 	return &istio.Headers_HeaderOperations{
 		Add:    headerListToMap(filter.Add),
 		Remove: filter.Remove,
 		Set:    headerListToMap(filter.Set),
-	}
+	}, nil
 }
 
 // nolint: unparam

--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -1412,15 +1412,25 @@ func createRedirectFilter(filter *k8s.HTTPRequestRedirectFilter) *istio.HTTPRedi
 	return resp
 }
 
+func isValidHeaderValue(v string) bool {
+	for _, c := range []byte(v) {
+		if c == 0x09 || c >= 0x20 {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
 func createHeadersFilter(filter *k8s.HTTPHeaderFilter) (*istio.Headers_HeaderOperations, *ConfigError) {
 	if filter == nil {
 		return nil, nil
 	}
 	for _, h := range append(filter.Set, filter.Add...) {
-		if strings.ContainsAny(h.Value, "\r\n") {
+		if !isValidHeaderValue(h.Value) {
 			return nil, &ConfigError{
 				Reason:  InvalidFilter,
-				Message: fmt.Sprintf("header %q value contains invalid characters (\\r or \\n)", h.Name),
+				Message: fmt.Sprintf("header %q value contains invalid characters", h.Name),
 			}
 		}
 	}

--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -1414,7 +1414,7 @@ func createRedirectFilter(filter *k8s.HTTPRequestRedirectFilter) *istio.HTTPRedi
 
 func isValidHeaderValue(v string) bool {
 	for _, c := range []byte(v) {
-		if c == 0x09 || c >= 0x20 {
+		if c == 0x09 || c >= 0x20 && c != 0x7F {
 			continue
 		}
 		return false

--- a/pilot/pkg/config/kube/gateway/conversion_test.go
+++ b/pilot/pkg/config/kube/gateway/conversion_test.go
@@ -1693,6 +1693,73 @@ func marshalYaml(t test.Failer, cl []config.Config) []byte {
 	return result
 }
 
+func TestCreateHeadersFilter(t *testing.T) {
+	tests := []struct {
+		name      string
+		filter    *k8s.HTTPHeaderFilter
+		wantErr   bool
+		errReason ConfigErrorReason
+	}{
+		{
+			name:    "nil filter",
+			filter:  nil,
+			wantErr: false,
+		},
+		{
+			name: "valid headers",
+			filter: &k8s.HTTPHeaderFilter{
+				Set: []k8s.HTTPHeader{{Name: "x-foo", Value: "bar"}},
+				Add: []k8s.HTTPHeader{{Name: "x-baz", Value: "qux"}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "newline in set header value",
+			filter: &k8s.HTTPHeaderFilter{
+				Set: []k8s.HTTPHeader{{Name: "content-security-policy", Value: "default-src 'self';\nscript-src 'self';"}},
+			},
+			wantErr:   true,
+			errReason: InvalidFilter,
+		},
+		{
+			name: "carriage return in set header value",
+			filter: &k8s.HTTPHeaderFilter{
+				Set: []k8s.HTTPHeader{{Name: "x-foo", Value: "bar\rbaz"}},
+			},
+			wantErr:   true,
+			errReason: InvalidFilter,
+		},
+		{
+			name: "newline in add header value",
+			filter: &k8s.HTTPHeaderFilter{
+				Add: []k8s.HTTPHeader{{Name: "x-foo", Value: "bar\nbaz"}},
+			},
+			wantErr:   true,
+			errReason: InvalidFilter,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := createHeadersFilter(tt.filter)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error but got none")
+				}
+				if err.Reason != tt.errReason {
+					t.Errorf("got reason %q, want %q", err.Reason, tt.errReason)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if tt.filter != nil && got == nil {
+					t.Errorf("expected non-nil result for non-nil filter")
+				}
+			}
+		})
+	}
+}
+
 func TestHumanReadableJoin(t *testing.T) {
 	tests := []struct {
 		input []string

--- a/pilot/pkg/config/kube/gateway/conversion_test.go
+++ b/pilot/pkg/config/kube/gateway/conversion_test.go
@@ -1754,6 +1754,14 @@ func TestCreateHeadersFilter(t *testing.T) {
 			errReason: InvalidFilter,
 		},
 		{
+			name: "DEL character in header value",
+			filter: &k8s.HTTPHeaderFilter{
+				Set: []k8s.HTTPHeader{{Name: "x-foo", Value: "bar\x7Fbaz"}},
+			},
+			wantErr:   true,
+			errReason: InvalidFilter,
+		},
+		{
 			name: "tab in header value is valid",
 			filter: &k8s.HTTPHeaderFilter{
 				Set: []k8s.HTTPHeader{{Name: "x-foo", Value: "bar\tbaz"}},

--- a/pilot/pkg/config/kube/gateway/conversion_test.go
+++ b/pilot/pkg/config/kube/gateway/conversion_test.go
@@ -1737,6 +1737,29 @@ func TestCreateHeadersFilter(t *testing.T) {
 			wantErr:   true,
 			errReason: InvalidFilter,
 		},
+		{
+			name: "null byte in header value",
+			filter: &k8s.HTTPHeaderFilter{
+				Set: []k8s.HTTPHeader{{Name: "x-foo", Value: "bar\x00baz"}},
+			},
+			wantErr:   true,
+			errReason: InvalidFilter,
+		},
+		{
+			name: "control character in header value",
+			filter: &k8s.HTTPHeaderFilter{
+				Set: []k8s.HTTPHeader{{Name: "x-foo", Value: "bar\x01baz"}},
+			},
+			wantErr:   true,
+			errReason: InvalidFilter,
+		},
+		{
+			name: "tab in header value is valid",
+			filter: &k8s.HTTPHeaderFilter{
+				Set: []k8s.HTTPHeader{{Name: "x-foo", Value: "bar\tbaz"}},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/releasenotes/notes/59933.yaml
+++ b/releasenotes/notes/59933.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+issue:
+  - 59933
+
+releaseNotes:
+  - |
+    **Fixed** an issue where HTTPRoute and GRPCRoute filters with invalid header values were silently dropped from the Envoy config instead of reporting an InvalidFilter status.


### PR DESCRIPTION
…haracters

**Please provide a description of this PR:**

When an HTTPRoute or GRPCRoute filter sets a header value containing newline (\n) or return (\r) characters, Istio previously reported the route as valid while silently dropping it from the Envoy config with a constraint validation error. This change validates header values in createHeadersFilter and returns an InvalidFilter ConfigError.

Fixes #59933