### PR TITLE
[release-1.30] fix: use PEM-parsed cert set comparison for CA bundle rotation

### DIFF
--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"os"
 	"path"
@@ -36,6 +37,7 @@ import (
 	"istio.io/istio/pkg/env"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/security"
+	"istio.io/istio/pkg/util/sets"
 	"istio.io/istio/security/pkg/cmd"
 	"istio.io/istio/security/pkg/pki/ca"
 	"istio.io/istio/security/pkg/pki/ra"
@@ -355,10 +357,9 @@ func handleEvent(s *Server) {
 			return
 		}
 
-		// in order to support root ca rotation, or we are removing the old ca,
-		// we need to make the new CA bundle contain both old and new CA certs
-		if bytes.Contains(currentCABundle, newCABundle) ||
-			bytes.Contains(newCABundle, currentCABundle) {
+		// allow the update when one CA bundle is a subset of the other,
+		// which covers both adding CA certs (rotation) and removing old CA certs
+		if pemBundleHasSubsetRelation(currentCABundle, newCABundle) {
 			log.Info("Updating new ROOT-CA")
 		} else {
 			log.Warn("Updating new ROOT-CA not supported")
@@ -726,4 +727,35 @@ func hasValidChainFiles(files []string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// pemBundleHasSubsetRelation checks whether one PEM bundle is a subset of the other,
+// by comparing DER-encoded certificate bytes. Returns true if a ⊆ b or b ⊆ a.
+func pemBundleHasSubsetRelation(a []byte, b []byte) bool {
+	certsA := pemToRawCertSet(a)
+	certsB := pemToRawCertSet(b)
+	if certsA.IsEmpty() || certsB.IsEmpty() {
+		return false
+	}
+	return certsA.SupersetOf(certsB) || certsB.SupersetOf(certsA)
+}
+
+// pemToRawCertSet decodes PEM data and returns a set of DER-encoded certificate bytes.
+// Only standard "CERTIFICATE" PEM blocks are considered; other block types (e.g.,
+// "TRUSTED CERTIFICATE", "X509 CERTIFICATE") are ignored. This is consistent with
+// existing CA bundle handling in Istio (see VerifyCABundle in pkg/webhooks/util and
+// readCACert in security/pkg/k8s/chiron), which reject non-"CERTIFICATE" blocks.
+func pemToRawCertSet(pemData []byte) sets.String {
+	certs := sets.New[string]()
+	for {
+		var block *pem.Block
+		block, pemData = pem.Decode(pemData)
+		if block == nil {
+			break
+		}
+		if block.Type == "CERTIFICATE" {
+			certs.Insert(string(block.Bytes))
+		}
+	}
+	return certs
 }

--- a/pilot/pkg/bootstrap/istio_ca_test.go
+++ b/pilot/pkg/bootstrap/istio_ca_test.go
@@ -221,3 +221,119 @@ func createCASecret(t test.Failer, client kube.Client) {
 func readSampleCertFromFile(f string) ([]byte, error) {
 	return os.ReadFile(path.Join(env.IstioSrc, "samples/certs", f))
 }
+
+func TestPemBundleHasSubsetRelation(t *testing.T) {
+	certA, err := readSampleCertFromFile("root-cert.pem")
+	if err != nil {
+		t.Fatal(err)
+	}
+	certB, err := readSampleCertFromFile("ca-cert.pem")
+	if err != nil {
+		t.Fatal(err)
+	}
+	certC, err := readSampleCertFromFile("ca-cert-alt.pem")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bundleAB := append(append([]byte{}, certA...), certB...)
+	bundleBA := append(append([]byte{}, certB...), certA...)
+	bundleABC := append(append(append([]byte{}, certA...), certB...), certC...)
+	bundleCBA := append(append(append([]byte{}, certC...), certB...), certA...)
+	bundleAC := append(append([]byte{}, certA...), certC...)
+
+	cases := []struct {
+		name     string
+		a        []byte
+		b        []byte
+		expected bool
+	}{
+		{
+			name:     "identical single cert",
+			a:        certA,
+			b:        certA,
+			expected: true,
+		},
+		{
+			name:     "identical bundle",
+			a:        bundleAB,
+			b:        bundleAB,
+			expected: true,
+		},
+		{
+			name:     "superset and subset",
+			a:        bundleAB,
+			b:        certA,
+			expected: true,
+		},
+		{
+			name:     "subset and superset",
+			a:        certA,
+			b:        bundleAB,
+			expected: true,
+		},
+		{
+			name:     "reordered bundle",
+			a:        bundleBA,
+			b:        bundleAB,
+			expected: true,
+		},
+		{
+			name:     "disjoint certs",
+			a:        certA,
+			b:        certB,
+			expected: false,
+		},
+		{
+			name:     "empty a",
+			a:        []byte{},
+			b:        certA,
+			expected: false,
+		},
+		{
+			name:     "empty b",
+			a:        certA,
+			b:        []byte{},
+			expected: false,
+		},
+		{
+			name:     "invalid pem",
+			a:        []byte("not a pem"),
+			b:        certA,
+			expected: false,
+		},
+		{
+			name:     "three certs rotation adds one",
+			a:        bundleABC,
+			b:        bundleAB,
+			expected: true,
+		},
+		{
+			name:     "three certs rotation removes one",
+			a:        bundleAB,
+			b:        bundleABC,
+			expected: true,
+		},
+		{
+			name:     "three certs reordered",
+			a:        bundleCBA,
+			b:        bundleABC,
+			expected: true,
+		},
+		{
+			name:     "three certs partial overlap not subset",
+			a:        bundleAC,
+			b:        bundleAB,
+			expected: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := pemBundleHasSubsetRelation(tc.a, tc.b)
+			if result != tc.expected {
+				t.Errorf("pemBundleHasSubsetRelation() = %v, want %v", result, tc.expected)
+			}
+		})
+	}
+}

--- a/releasenotes/notes/ca-bundle-order-independent-comparison.yaml
+++ b/releasenotes/notes/ca-bundle-order-independent-comparison.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+issue:
+  - 59909
+
+releaseNotes:
+- |
+  **Fixed** a bug where CA bundle rotation would not occur when certificates appeared in different orders.
+  Only standard `CERTIFICATE` PEM blocks are considered during comparison; other block types
+  (e.g., `TRUSTED CERTIFICATE`) are ignored, consistent with existing CA bundle handling in Istio.


### PR DESCRIPTION
Manual cherry-pick of #59909, auto cherry-pick didn't trigger.