### PR TITLE
fix(operator): translate k8s.hpaSpec.minReplicas to Helm values for P…

### DIFF
--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -316,18 +316,29 @@ func TestManifestGenerateGateways(t *testing.T) {
 	})
 }
 
-// TestManifestGenerateGatewayHPAPDB verifies that setting k8s.hpaSpec.minReplicas
-// on a gateway causes a PodDisruptionBudget to be generated, without requiring
-// the user to also set values.gateways.istio-ingressgateway.autoscaleMin.
-func TestManifestGenerateGatewayHPAPDB(t *testing.T) {
-	g := NewWithT(t)
-	objss := runManifestCommands(t, "gateway_hpa_pdb", "", liveCharts, nil)
-	for _, objs := range objss {
-		g.Expect(objs.kind(manifest.PodDisruptionBudget).size()).Should(Equal(1))
-		g.Expect(objs.kind(manifest.HorizontalPodAutoscaler).size()).Should(Equal(1))
-		for _, o := range objs.kind(manifest.HorizontalPodAutoscaler).objSlice {
-			g.Expect(o.Unstructured.Object).Should(HavePathValueEqual(PathValue{"spec.minReplicas", int64(2)}))
-		}
+// TestManifestGenerateHPAPDB verifies that setting k8s.hpaSpec.minReplicas causes
+// a PodDisruptionBudget to be generated without requiring the user to also set the
+// component's autoscaleMin Helm value directly.
+func TestManifestGenerateHPAPDB(t *testing.T) {
+	cases := []struct {
+		name     string
+		testCase string
+	}{
+		{"gateway", "gateway_hpa_pdb"},
+		{"pilot", "pilot_hpa_pdb"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			objss := runManifestCommands(t, tc.testCase, "", liveCharts, nil)
+			for _, objs := range objss {
+				g.Expect(objs.kind(manifest.PodDisruptionBudget).size()).Should(Equal(1))
+				g.Expect(objs.kind(manifest.HorizontalPodAutoscaler).size()).Should(Equal(1))
+				for _, o := range objs.kind(manifest.HorizontalPodAutoscaler).objSlice {
+					g.Expect(o.Unstructured.Object).Should(HavePathValueEqual(PathValue{"spec.minReplicas", int64(2)}))
+				}
+			}
+		})
 	}
 }
 

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -316,6 +316,21 @@ func TestManifestGenerateGateways(t *testing.T) {
 	})
 }
 
+// TestManifestGenerateGatewayHPAPDB verifies that setting k8s.hpaSpec.minReplicas
+// on a gateway causes a PodDisruptionBudget to be generated, without requiring
+// the user to also set values.gateways.istio-ingressgateway.autoscaleMin.
+func TestManifestGenerateGatewayHPAPDB(t *testing.T) {
+	g := NewWithT(t)
+	objss := runManifestCommands(t, "gateway_hpa_pdb", "", liveCharts, nil)
+	for _, objs := range objss {
+		g.Expect(objs.kind(manifest.PodDisruptionBudget).size()).Should(Equal(1))
+		g.Expect(objs.kind(manifest.HorizontalPodAutoscaler).size()).Should(Equal(1))
+		for _, o := range objs.kind(manifest.HorizontalPodAutoscaler).objSlice {
+			g.Expect(o.Unstructured.Object).Should(HavePathValueEqual(PathValue{"spec.minReplicas", int64(2)}))
+		}
+	}
+}
+
 func TestManifestGenerateWithDuplicateMutatingWebhookConfig(t *testing.T) {
 	testResourceFile := "duplicate_mwc"
 

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -320,26 +320,20 @@ func TestManifestGenerateGateways(t *testing.T) {
 // a PodDisruptionBudget to be generated without requiring the user to also set the
 // component's autoscaleMin Helm value directly.
 func TestManifestGenerateHPAPDB(t *testing.T) {
-	cases := []struct {
-		name     string
-		testCase string
-	}{
-		{"gateway", "gateway_hpa_pdb"},
-		{"pilot", "pilot_hpa_pdb"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			g := NewWithT(t)
-			objss := runManifestCommands(t, tc.testCase, "", liveCharts, nil)
-			for _, objs := range objss {
-				g.Expect(objs.kind(manifest.PodDisruptionBudget).size()).Should(Equal(1))
-				g.Expect(objs.kind(manifest.HorizontalPodAutoscaler).size()).Should(Equal(1))
-				for _, o := range objs.kind(manifest.HorizontalPodAutoscaler).objSlice {
-					g.Expect(o.Unstructured.Object).Should(HavePathValueEqual(PathValue{"spec.minReplicas", int64(2)}))
-				}
-			}
-		})
-	}
+	runTestGroup(t, testGroup{
+		{
+			desc:        "gateway_hpa_pdb",
+			diffSelect:  "HorizontalPodAutoscaler:*:istio-ingressgateway,PodDisruptionBudget:*:istio-ingressgateway",
+			fileSelect:  []string{"templates/autoscale.yaml", "templates/poddisruptionbudget.yaml"},
+			chartSource: liveCharts,
+		},
+		{
+			desc:        "pilot_hpa_pdb",
+			diffSelect:  "HorizontalPodAutoscaler:*:istiod,PodDisruptionBudget:*:istiod",
+			fileSelect:  []string{"templates/autoscale.yaml", "templates/poddisruptionbudget.yaml"},
+			chartSource: liveCharts,
+		},
+	})
 }
 
 func TestManifestGenerateWithDuplicateMutatingWebhookConfig(t *testing.T) {

--- a/operator/cmd/mesh/testdata/manifest-generate/input/gateway_hpa_pdb.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/input/gateway_hpa_pdb.yaml
@@ -1,0 +1,13 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  profile: empty
+  components:
+    ingressGateways:
+      - name: istio-ingressgateway
+        enabled: true
+        k8s:
+          hpaSpec:
+            minReplicas: 2
+          podDisruptionBudget:
+            maxUnavailable: 1

--- a/operator/cmd/mesh/testdata/manifest-generate/input/pilot_hpa_pdb.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/input/pilot_hpa_pdb.yaml
@@ -1,0 +1,12 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  profile: empty
+  components:
+    pilot:
+      enabled: true
+      k8s:
+        hpaSpec:
+          minReplicas: 2
+        podDisruptionBudget:
+          maxUnavailable: 1

--- a/operator/cmd/mesh/testdata/manifest-generate/output/gateway_hpa_pdb.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/gateway_hpa_pdb.golden.yaml
@@ -1,0 +1,58 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app: istio-ingressgateway
+    app.kubernetes.io/instance: istio
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: istio-ingressgateway
+    app.kubernetes.io/part-of: istio
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: istio-ingress-1.0.0
+    install.operator.istio.io/owning-resource: unknown
+    istio: ingressgateway
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
+    release: istio
+  name: istio-ingressgateway
+  namespace: istio-system
+spec:
+  maxUnavailable: 1
+  minAvailable: null
+  selector:
+    matchLabels:
+      app: istio-ingressgateway
+      istio: ingressgateway
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    app: istio-ingressgateway
+    app.kubernetes.io/instance: istio
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: istio-ingressgateway
+    app.kubernetes.io/part-of: istio
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: istio-ingress-1.0.0
+    install.operator.istio.io/owning-resource: unknown
+    istio: ingressgateway
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
+    release: istio
+  name: istio-ingressgateway
+  namespace: istio-system
+spec:
+  maxReplicas: 5
+  metrics:
+  - resource:
+      name: cpu
+      target:
+        averageUtilization: 80
+        type: Utilization
+    type: Resource
+  minReplicas: 2
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: istio-ingressgateway

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_hpa_pdb.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_hpa_pdb.golden.yaml
@@ -1,0 +1,57 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app: istiod
+    app.kubernetes.io/instance: istio
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: istiod
+    app.kubernetes.io/part-of: istio
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: istiod-1.0.0
+    install.operator.istio.io/owning-resource: unknown
+    istio: pilot
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
+    release: istio
+  name: istiod
+  namespace: istio-system
+spec:
+  maxUnavailable: 1
+  minAvailable: null
+  selector:
+    matchLabels:
+      app: istiod
+      istio: pilot
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    app: istiod
+    app.kubernetes.io/instance: istio
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: istiod
+    app.kubernetes.io/part-of: istio
+    app.kubernetes.io/version: 1.0.0
+    helm.sh/chart: istiod-1.0.0
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
+    release: istio
+  name: istiod
+  namespace: istio-system
+spec:
+  maxReplicas: 5
+  metrics:
+  - resource:
+      name: cpu
+      target:
+        averageUtilization: 80
+        type: Utilization
+    type: Resource
+  minReplicas: 2
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: istiod

--- a/operator/pkg/render/manifest.go
+++ b/operator/pkg/render/manifest.go
@@ -195,6 +195,21 @@ func applyComponentValuesToHelmValues(comp component.Component, spec apis.Gatewa
 			_ = merged.SetPath(fmt.Sprintf("spec.values.%s.ports", root), ports)
 		}
 	}
+	// Translate k8s HPA/replica settings to Helm values so that template guard
+	// conditions (e.g. PDB creation requiring autoscaleMin > 1) see them.
+	// Without this, k8s.hpaSpec.minReplicas only patches the HPA post-render
+	// and the PDB is never generated.
+	if spec.Kubernetes != nil {
+		if !comp.IsGateway() {
+			merged = merged.DeepClone()
+		}
+		if spec.Kubernetes.HpaSpec != nil && spec.Kubernetes.HpaSpec.MinReplicas != nil {
+			_ = merged.SetPath(fmt.Sprintf("spec.values.%s.autoscaleMin", root), int64(*spec.Kubernetes.HpaSpec.MinReplicas))
+		}
+		if spec.Kubernetes.ReplicaCount > 0 {
+			_ = merged.SetPath(fmt.Sprintf("spec.values.%s.replicaCount", root), int64(spec.Kubernetes.ReplicaCount))
+		}
+	}
 	// No changes needed, skip early to avoid copy
 	if !comp.FlattenValues && spec.Hub == "" && spec.Tag == nil && spec.Label == nil {
 		return merged

--- a/operator/pkg/render/manifest.go
+++ b/operator/pkg/render/manifest.go
@@ -195,16 +195,22 @@ func applyComponentValuesToHelmValues(comp component.Component, spec apis.Gatewa
 			_ = merged.SetPath(fmt.Sprintf("spec.values.%s.ports", root), ports)
 		}
 	}
-	// Translate k8s HPA/replica settings to Helm values so that template guard
-	// conditions (e.g. PDB creation requiring autoscaleMin > 1) see them.
-	// Without this, k8s.hpaSpec.minReplicas only patches the HPA post-render
-	// and the PDB is never generated.
-	if spec.Kubernetes != nil {
+	// For Deployment-based components, translate k8s HPA/replica settings to Helm
+	// values so that template guard conditions (e.g. PDB requiring autoscaleMin > 1)
+	// see them. Without this, k8s.hpaSpec.minReplicas only patches the HPA
+	// post-render and the PDB is never generated. DaemonSet components (CNI,
+	// ztunnel) have no autoscaling, so we skip them.
+	if comp.ResourceType == "Deployment" && spec.Kubernetes != nil {
 		if !comp.IsGateway() {
 			merged = merged.DeepClone()
 		}
-		if spec.Kubernetes.HpaSpec != nil && spec.Kubernetes.HpaSpec.MinReplicas != nil {
-			_ = merged.SetPath(fmt.Sprintf("spec.values.%s.autoscaleMin", root), int64(*spec.Kubernetes.HpaSpec.MinReplicas))
+		if spec.Kubernetes.HpaSpec != nil {
+			if spec.Kubernetes.HpaSpec.MinReplicas != nil {
+				_ = merged.SetPath(fmt.Sprintf("spec.values.%s.autoscaleMin", root), int64(*spec.Kubernetes.HpaSpec.MinReplicas))
+			}
+			if spec.Kubernetes.HpaSpec.MaxReplicas > 0 {
+				_ = merged.SetPath(fmt.Sprintf("spec.values.%s.autoscaleMax", root), int64(spec.Kubernetes.HpaSpec.MaxReplicas))
+			}
 		}
 		if spec.Kubernetes.ReplicaCount > 0 {
 			_ = merged.SetPath(fmt.Sprintf("spec.values.%s.replicaCount", root), int64(spec.Kubernetes.ReplicaCount))


### PR DESCRIPTION
…DB generation

When using IstioOperator with ``k8s.hpaSpec.minReplicas`, the value was only applied as a post-render overlay to the HPA resource. The PDB template's guard condition (`autoscaleMin` > 1) checks Helm values, which still had the default of 1, causing the PDB to never be rendered.

This translates `k8s.hpaSpec.minReplicas` and `k8s.replicaCount` to their corresponding Helm values (autoscaleMin, replicaCount) before template rendering, so that PDB generation works correctly.

Fixes https://github.com/istio/istio/issues/12602

On this configuration istioctl 1.27.9 generates PDB, but version 1.28.6 doesn't.
```
apiVersion: install.istio.io/v1beta1
kind: IstioOperator
# RUN `make generate` to update the generated manifests.
spec:
  values:
    global:
      hub: gcr.io/istio-release
  profile: empty
  components:
    ingressGateways:
      - name: grpc-gateway-gateway-external-alb
        enabled: true
        label:
          app: grpc-gateway-gateway-external-alb
          istio: grpc-gateway-gateway-external-alb
        k8s:
          podDisruptionBudget:
            maxUnavailable: 1
          hpaSpec:
            minReplicas: 2
```

Attached fix fixes it.

Existing workaround is to add under `spec.values`:

```
    gateways:
      istio-ingressgateway:
        autoscaleMin: 2
```

**Please provide a description of this PR:**

Fixes issue when one uses `IstioOperator` to generate ingressgateways only. Without this fix, istioctl on version 1.28.6 generates manifests without PDB, most probably caused by #12602  