### PR TITLE
Add configurable HBONE window sizing using feature flags (env vars)

### DIFF
--- a/pilot/pkg/features/ambient.go
+++ b/pilot/pkg/features/ambient.go
@@ -15,6 +15,8 @@
 package features
 
 import (
+	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
+
 	"istio.io/istio/pkg/env"
 	"istio.io/istio/pkg/log"
 )
@@ -88,6 +90,32 @@ var (
 		"If enabled, ztunnel will be configured with dry-run authorizationPolicies. "+
 			"Ensure ztunnel is 1.29 or above before enabling this feature. "+
 			"Older ztunnel will accept dry-run policies, but enforce them instead of only logging.")
+
+	HBONEInitialStreamWindowSize = func() *wrappers.UInt32Value {
+		v := env.Register(
+			"PILOT_HBONE_INITIAL_STREAM_WINDOW_SIZE",
+			uint32(0),
+			"Sets the HTTP/2 initial_stream_window_size on HBONE CONNECT upstream clusters generated for "+
+				"waypoints and east-west gateways. If 0 (the default), the field is left unset so Envoy's "+
+				"built-in default applies.").Get()
+		if v == 0 {
+			return nil
+		}
+		return &wrappers.UInt32Value{Value: v}
+	}()
+
+	HBONEInitialConnectionWindowSize = func() *wrappers.UInt32Value {
+		v := env.Register(
+			"PILOT_HBONE_INITIAL_CONNECTION_WINDOW_SIZE",
+			uint32(0),
+			"Sets the HTTP/2 initial_connection_window_size on HBONE CONNECT upstream clusters generated for "+
+				"waypoints and east-west gateways. If 0 (the default), the field is left unset so Envoy's "+
+				"built-in default applies.").Get()
+		if v == 0 {
+			return nil
+		}
+		return &wrappers.UInt32Value{Value: v}
+	}()
 )
 
 // registerAmbient registers a variable that is allowed only if EnableAmbient is set

--- a/pilot/pkg/features/ambient.go
+++ b/pilot/pkg/features/ambient.go
@@ -92,12 +92,12 @@ var (
 			"Older ztunnel will accept dry-run policies, but enforce them instead of only logging.")
 
 	HBONEInitialStreamWindowSize = func() *wrappers.UInt32Value {
-		v := env.Register(
+		v := registerAmbient(
 			"PILOT_HBONE_INITIAL_STREAM_WINDOW_SIZE",
-			uint32(0),
+			uint32(0), uint32(0),
 			"Sets the HTTP/2 initial_stream_window_size on HBONE CONNECT upstream clusters generated for "+
 				"waypoints and east-west gateways. If 0 (the default), the field is left unset so Envoy's "+
-				"built-in default applies.").Get()
+				"built-in default applies.")
 		if v == 0 {
 			return nil
 		}
@@ -105,12 +105,12 @@ var (
 	}()
 
 	HBONEInitialConnectionWindowSize = func() *wrappers.UInt32Value {
-		v := env.Register(
+		v := registerAmbient(
 			"PILOT_HBONE_INITIAL_CONNECTION_WINDOW_SIZE",
-			uint32(0),
+			uint32(0), uint32(0),
 			"Sets the HTTP/2 initial_connection_window_size on HBONE CONNECT upstream clusters generated for "+
 				"waypoints and east-west gateways. If 0 (the default), the field is left unset so Envoy's "+
-				"built-in default applies.").Get()
+				"built-in default applies.")
 		if v == 0 {
 			return nil
 		}

--- a/pilot/pkg/networking/core/cluster_waypoint.go
+++ b/pilot/pkg/networking/core/cluster_waypoint.go
@@ -556,7 +556,9 @@ func (cb *ClusterBuilder) h2connectUpgrade() map[string]*anypb.Any {
 			UpstreamProtocolOptions: &http.HttpProtocolOptions_ExplicitHttpConfig_{ExplicitHttpConfig: &http.HttpProtocolOptions_ExplicitHttpConfig{
 				ProtocolConfig: &http.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{
 					Http2ProtocolOptions: &core.Http2ProtocolOptions{
-						AllowConnect: true,
+						AllowConnect:                true,
+						InitialStreamWindowSize:     features.HBONEInitialStreamWindowSize,
+						InitialConnectionWindowSize: features.HBONEInitialConnectionWindowSize,
 					},
 				},
 			}},
@@ -583,7 +585,9 @@ func (cb *ClusterBuilder) h2connectUpgradeWithNoPooling() map[string]*anypb.Any 
 			UpstreamProtocolOptions: &http.HttpProtocolOptions_ExplicitHttpConfig_{ExplicitHttpConfig: &http.HttpProtocolOptions_ExplicitHttpConfig{
 				ProtocolConfig: &http.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{
 					Http2ProtocolOptions: &core.Http2ProtocolOptions{
-						AllowConnect: true,
+						AllowConnect:                true,
+						InitialStreamWindowSize:     features.HBONEInitialStreamWindowSize,
+						InitialConnectionWindowSize: features.HBONEInitialConnectionWindowSize,
 					},
 				},
 			}},

--- a/releasenotes/notes/59961.yaml
+++ b/releasenotes/notes/59961.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 59961
+releaseNotes:
+  - |
+    **Added** Initial HTTP/2 stream and connection window sizes for HBONE CONNECT upstream clusters (generated for
+    waypoints and east-west gateways) can be configured using feature flags 
+    PILOT_HBONE_INITIAL_STREAM_WINDOW_SIZE and PILOT_HBONE_INITIAL_CONNECTION_WINDOW_SIZE. These may be used to
+    reduce unwanted buffering.


### PR DESCRIPTION
**Please provide a description of this PR:**

This relates to https://github.com/istio/istio/issues/59887 which identifies excessive buffering within HBONE (and possible other areas).

This PR adds the ability to configure HBONE window sizing as one key improvement to the buffering problem.

The implementation should result in **no change to existing behaviour** (which leans on Envoy's defaults of 16MB and 24MB for initial stream and connection windows respectively).

This is a variant of https://github.com/istio/istio/pull/59943, using environment variables instead of API.

Note: I am very new to Istio and used Claude to help write these PRs. Please excuse any silliness, I have reviewed the code and think it makes sense.