### PR TITLE
Fix istioctl zc cidrvips

### DIFF
--- a/istioctl/pkg/writer/ztunnel/configdump/api.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/api.go
@@ -14,6 +14,12 @@
 
 package configdump
 
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
 type Locality struct {
 	Region  string `json:"region,omitempty"`
 	Zone    string `json:"zone,omitempty"`
@@ -67,11 +73,42 @@ type ZtunnelEndpoint struct {
 	Port        map[uint16]uint16 `json:"port"`
 }
 
+type CIDRVIP struct {
+	CIDR    string `json:"cidr"`
+	Network string `json:"network,omitempty"`
+}
+
+func (c *CIDRVIP) UnmarshalJSON(data []byte) error {
+	type alias CIDRVIP
+	var raw alias
+	if err := json.Unmarshal(data, &raw); err == nil {
+		*c = CIDRVIP(raw)
+		return nil
+	}
+
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	network, cidr, found := strings.Cut(s, "/")
+	if !found {
+		return fmt.Errorf("invalid cidrVip %q", s)
+	}
+	c.Network = network
+	c.CIDR = cidr
+	return nil
+}
+
+func (c CIDRVIP) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c.Network + "/" + c.CIDR)
+}
+
 type ZtunnelService struct {
 	Name            string                      `json:"name"`
 	Namespace       string                      `json:"namespace"`
 	Hostname        string                      `json:"hostname"`
 	Addresses       []string                    `json:"vips"`
+	CIDRVIPs        []CIDRVIP                   `json:"cidrVips,omitempty"`
 	Ports           map[string]int              `json:"ports"`
 	LoadBalancer    *LoadBalancer               `json:"loadBalancer,omitempty"`
 	Waypoint        *GatewayAddress             `json:"waypoint,omitempty"`

--- a/istioctl/pkg/writer/ztunnel/configdump/configdump_test.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/configdump_test.go
@@ -169,7 +169,7 @@ func TestConfigWriter_PrintSummary(t *testing.T) {
 	}
 }
 
-func TestConfigWriter_PrintServiceDumpPreservesCanonical(t *testing.T) {
+func TestConfigWriter_PrintServiceDumpPreservesServiceFields(t *testing.T) {
 	configDump := []byte(`{
 		"services": {
 			"/10.0.0.1": {
@@ -178,6 +178,15 @@ func TestConfigWriter_PrintServiceDumpPreservesCanonical(t *testing.T) {
 				"hostname": "svc.ns.svc.cluster.local",
 				"vips": [
 					"/10.0.0.1"
+				],
+				"cidrVips": [
+					{
+						"cidr": "240.240.0.0/16"
+					},
+					{
+						"cidr": "2001:db8::/64",
+						"network": "network1"
+					}
 				],
 				"ports": {
 					"80": 8080
@@ -198,6 +207,7 @@ func TestConfigWriter_PrintServiceDumpPreservesCanonical(t *testing.T) {
 			Namespace:       "ns",
 			Hostname:        "svc.ns.svc.cluster.local",
 			Addresses:       []string{"/10.0.0.1"},
+			CIDRVIPs:        []CIDRVIP{{CIDR: "240.240.0.0/16"}, {CIDR: "2001:db8::/64", Network: "network1"}},
 			Ports:           map[string]int{"80": 8080},
 			Endpoints:       map[string]*ZtunnelEndpoint{},
 			SubjectAltNames: []string{},
@@ -212,7 +222,21 @@ func TestConfigWriter_PrintServiceDumpPreservesCanonical(t *testing.T) {
 	assert.Equal(t, want, cw.ztunnelDump.Services)
 	assert.NoError(t, cw.PrintServiceDump(ServiceFilter{}, "json"))
 
-	var got []*ZtunnelService
+	var got []struct {
+		Name      string   `json:"name"`
+		CIDRVIPs  []string `json:"cidrVips"`
+		Canonical bool     `json:"canonical"`
+	}
 	assert.NoError(t, json.Unmarshal(gotOut.Bytes(), &got))
-	assert.Equal(t, want, got)
+	assert.Equal(t, []struct {
+		Name      string   `json:"name"`
+		CIDRVIPs  []string `json:"cidrVips"`
+		Canonical bool     `json:"canonical"`
+	}{
+		{
+			Name:      "svc",
+			CIDRVIPs:  []string{"/240.240.0.0/16", "network1/2001:db8::/64"},
+			Canonical: true,
+		},
+	}, got)
 }

--- a/releasenotes/notes/fix-istioctl-zc-cidrvips.yaml
+++ b/releasenotes/notes/fix-istioctl-zc-cidrvips.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+
+issue:
+  - https://github.com/istio/istio/issues/59962
+
+releaseNotes:
+  - |
+    **Fixed** an issue where `istioctl ztunnel-config service` JSON and YAML output did not include `cidrVips` from the ztunnel config dump.


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix istioctl zc services missing cidrvips

this builds on top of #59963 which is separated because it needs to cherry-pick to 1.29 as well