### PR TITLE
fix cross-namespace access in statusgen xds debug endpoints

### DIFF
--- a/pilot/pkg/xds/debug_test.go
+++ b/pilot/pkg/xds/debug_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
@@ -430,6 +431,100 @@ func TestStatusGenRequiresAuth(t *testing.T) {
 		_, _, err := gen.Generate(proxy, &model.WatchedResource{TypeUrl: xds.TypeDebugSyncronization}, nil)
 		if err != nil {
 			t.Fatalf("expected no error when auth disabled, got %v", err)
+		}
+	})
+}
+
+// TestStatusGenNamespaceRestriction verifies that StatusGen (XDS istio.io/debug/syncz
+// and istio.io/debug/config_dump) enforces same-namespace restriction for non-system
+// callers. Without this, an authenticated workload in any namespace can enumerate and
+// dump config for proxies in other namespaces.
+func TestStatusGenNamespaceRestriction(t *testing.T) {
+	t.Run("syncz filters to caller namespace", func(t *testing.T) {
+		test.SetForTest(t, &features.EnableDebugEndpointAuth, true)
+		s := xdsfake.NewFakeDiscoveryServer(t, xdsfake.FakeOptions{})
+
+		victim := s.ConnectADS().
+			WithID("sidecar~10.0.0.1~victim.production~production.svc.cluster.local").
+			WithMetadata(model.NodeMetadata{
+				Namespace:   "production",
+				ProxyConfig: &model.NodeMetaProxyConfig{},
+			})
+		victim.RequestResponseAck(t, &discovery.DiscoveryRequest{TypeUrl: v3.ClusterType})
+
+		gen := xds.NewStatusGen(s.Discovery)
+
+		cases := []struct {
+			name         string
+			callerNS     string
+			wantVictimID bool
+		}{
+			{"system namespace sees all", "istio-system", true},
+			{"same namespace sees victim", "production", true},
+			{"cross namespace denied", "attacker", false},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				caller := &model.Proxy{
+					ID:               "caller." + tc.callerNS,
+					VerifiedIdentity: &spiffe.Identity{Namespace: tc.callerNS},
+				}
+				res, _, err := gen.Generate(caller, &model.WatchedResource{TypeUrl: xds.TypeDebugSyncronization}, nil)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				saw := false
+				for _, r := range res {
+					if strings.Contains(r.Name, "victim.production") {
+						saw = true
+					}
+				}
+				assert.Equal(t, saw, tc.wantVictimID,
+					fmt.Sprintf("caller ns=%s should see victim=%v", tc.callerNS, tc.wantVictimID))
+			})
+		}
+	})
+
+	t.Run("config_dump denies cross-namespace", func(t *testing.T) {
+		test.SetForTest(t, &features.EnableDebugEndpointAuth, true)
+		s := xdsfake.NewFakeDiscoveryServer(t, xdsfake.FakeOptions{})
+
+		victim := s.ConnectADS().WithID("sidecar~10.0.0.1~victim.production~production.svc.cluster.local")
+		victim.RequestResponseAck(t, &discovery.DiscoveryRequest{TypeUrl: v3.ClusterType})
+
+		gen := xds.NewStatusGen(s.Discovery)
+
+		cases := []struct {
+			name     string
+			callerNS string
+			wantData bool
+		}{
+			{"system namespace allowed", "istio-system", true},
+			{"same namespace allowed", "production", true},
+			{"cross namespace denied", "attacker", false},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				caller := &model.Proxy{
+					ID:               "caller." + tc.callerNS,
+					VerifiedIdentity: &spiffe.Identity{Namespace: tc.callerNS},
+				}
+				wr := &model.WatchedResource{
+					TypeUrl:       xds.TypeDebugConfigDump,
+					ResourceNames: sets.New("victim.production"),
+				}
+				res, _, err := gen.Generate(caller, wr, nil)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if tc.wantData {
+					assert.Equal(t, len(res) > 0, true,
+						fmt.Sprintf("caller ns=%s should get config_dump but got empty", tc.callerNS))
+				} else {
+					assert.Equal(t, len(res), 0,
+						fmt.Sprintf("caller ns=%s must not receive config_dump for cross-namespace proxy", tc.callerNS))
+				}
+			})
 		}
 	})
 }

--- a/pilot/pkg/xds/statusgen.go
+++ b/pilot/pkg/xds/statusgen.go
@@ -29,6 +29,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/slices"
 )
 
@@ -85,11 +86,15 @@ func (sg *StatusGen) handleInternalRequest(proxy *model.Proxy, w *model.WatchedR
 		return nil, model.DefaultXdsLogDetails, grpcstatus.Error(codes.Unauthenticated, "authentication required")
 	}
 
+	// Non-system callers are restricted to proxies in their own namespace.
+	// Empty callerNamespace means unrestricted (auth disabled, caller from system namespace, or in allow-list).
+	callerNamespace := sg.callerNamespaceFilter(proxy)
+
 	res := model.Resources{}
 
 	switch w.TypeUrl {
 	case TypeDebugSyncronization:
-		res = sg.debugSyncz()
+		res = sg.debugSyncz(callerNamespace)
 	case TypeDebugConfigDump:
 		if len(w.ResourceNames) == 0 || len(w.ResourceNames) > 1 {
 			// Malformed request from client
@@ -97,7 +102,7 @@ func (sg *StatusGen) handleInternalRequest(proxy *model.Proxy, w *model.WatchedR
 			break
 		}
 		var err error
-		dumpRes, err := sg.debugConfigDump(w.ResourceNames.UnsortedList()[0])
+		dumpRes, err := sg.debugConfigDump(w.ResourceNames.UnsortedList()[0], callerNamespace)
 		if err != nil {
 			log.Infof("%s failed: %v", TypeDebugConfigDump, err)
 			break
@@ -105,6 +110,22 @@ func (sg *StatusGen) handleInternalRequest(proxy *model.Proxy, w *model.WatchedR
 		res = dumpRes
 	}
 	return res, model.DefaultXdsLogDetails, nil
+}
+
+// callerNamespaceFilter returns the namespace the caller is restricted to, or "" if unrestricted.
+func (sg *StatusGen) callerNamespaceFilter(proxy *model.Proxy) string {
+	if !features.EnableDebugEndpointAuth || proxy.VerifiedIdentity == nil {
+		return ""
+	}
+	systemNamespace := constants.IstioSystemNamespace
+	if env := sg.Server.Env; env != nil && env.Mesh() != nil && env.Mesh().GetRootNamespace() != "" {
+		systemNamespace = env.Mesh().GetRootNamespace()
+	}
+	ns := proxy.VerifiedIdentity.Namespace
+	if ns == systemNamespace || features.DebugEndpointAuthAllowedNamespaces.Contains(ns) {
+		return ""
+	}
+	return ns
 }
 
 // isSidecar ad-hoc method to see if connection represents a sidecar
@@ -122,13 +143,13 @@ func isZtunnel(con *Connection) bool {
 		con.proxy.Type == model.Ztunnel
 }
 
-func (sg *StatusGen) debugSyncz() model.Resources {
+func (sg *StatusGen) debugSyncz(callerNamespace string) model.Resources {
 	res := model.Resources{}
 
 	for _, con := range sg.Server.Clients() {
 		con.proxy.RLock()
 		// Skip "nodes" without metadata (they are probably istioctl queries!)
-		if isProxy(con) || isZtunnel(con) {
+		if (isProxy(con) || isZtunnel(con)) && (callerNamespace == "" || con.proxy.ConfigNamespace == callerNamespace) {
 			xdsConfigs := make([]*status.ClientConfig_GenericXdsConfig, 0)
 			wrs := con.proxy.DeepCloneWatchedResources()
 			for _, wr := range wrs {
@@ -183,11 +204,15 @@ func debugSyncStatus(wr model.WatchedResource) status.ConfigStatus {
 	return status.ConfigStatus_STALE
 }
 
-func (sg *StatusGen) debugConfigDump(proxyID string) (model.Resources, error) {
+func (sg *StatusGen) debugConfigDump(proxyID string, callerNamespace string) (model.Resources, error) {
 	conn := sg.Server.getProxyConnection(proxyID)
 	if conn == nil {
 		// This is "like" a 404.  The error is the client's.  However, this endpoint
 		// only tracks a single "shard" of connections.  The client may try another instance.
+		return nil, fmt.Errorf("config dump could not find connection for proxyID %q", proxyID)
+	}
+	// Non-system callers can only dump proxies in their own namespace.
+	if callerNamespace != "" && conn.proxy.ConfigNamespace != callerNamespace {
 		return nil, fmt.Errorf("config dump could not find connection for proxyID %q", proxyID)
 	}
 

--- a/releasenotes/notes/statusgen-xds-namespace.yaml
+++ b/releasenotes/notes/statusgen-xds-namespace.yaml
@@ -1,0 +1,14 @@
+apiVersion: release-notes/v2
+
+kind: security-fix
+
+area: security
+
+# no public issue for security vulnerability
+issue: []
+
+releaseNotes:
+- |
+  **Fixed** XDS debug endpoints (`istio.io/debug/syncz`, `istio.io/debug/config_dump`) served by StatusGen to enforce
+  same-namespace authorization for non-system callers. Previously an authenticated workload from any namespace could
+  enumerate proxies and retrieve config dumps for workloads in other namespaces.

--- a/releasenotes/notes/statusgen-xds-namespace.yaml
+++ b/releasenotes/notes/statusgen-xds-namespace.yaml
@@ -12,3 +12,5 @@ releaseNotes:
   **Fixed** XDS debug endpoints (`istio.io/debug/syncz`, `istio.io/debug/config_dump`) served by StatusGen to enforce
   same-namespace authorization for non-system callers. Previously an authenticated workload from any namespace could
   enumerate proxies and retrieve config dumps for workloads in other namespaces.
+
+  **Credit**: This vulnerability was discovered and reported by 1seal (https://github.com/1seal).


### PR DESCRIPTION
statusgen serving istio.io/debug/syncz and istio.io/debug/config_dump did not enforce same-namespace restriction for non-system callers, leaving a gap that the debuggen fix in #58958 closed for the other paths. this adds the equivalent check.