### PR TITLE
krt: introduce new "Partial fetch" concept

### DIFF
--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -174,6 +174,9 @@ func objectChanged(dependencies []*dependency, sourceCollection collectionUID, e
 		if id != sourceCollection {
 			continue
 		}
+		if dep.filter.SuppressChange(ev) {
+			continue
+		}
 		// For each input, we will check if it depends on this event.
 		// We use Items() to check both the old and new object; we will recompute if either matched
 		for _, item := range ev.Items() {

--- a/pkg/kube/krt/collection_test.go
+++ b/pkg/kube/krt/collection_test.go
@@ -15,6 +15,7 @@
 package krt_test
 
 import (
+	"cmp"
 	"fmt"
 	"strconv"
 	"strings"
@@ -642,6 +643,59 @@ func TestCollectionMultipleFetchAllAndKey(t *testing.T) {
 	assert.EventuallyEqual(t, func() string {
 		return ptr.OrEmpty(Collection.Get()).Size
 	}, "2")
+}
+
+func TestCollectionFetchWithSuppressChange(t *testing.T) {
+	stop := test.NewStop(t)
+	opts := testOptions(t)
+	source := krt.NewStaticCollection[SimplePod](nil, nil, opts.WithName("SimplePod")...)
+	tt := assert.NewTracker[string](t)
+	counts := atomic.NewUint64(0)
+
+	Collection := krt.NewSingleton(func(ctx krt.HandlerContext) *Static {
+		counts.Inc()
+		pods := krt.PartialFetchComparable(ctx, source,
+			func(a SimplePod) Named {
+				return a.Named
+			},
+		)
+		if len(pods) == 0 {
+			return nil
+		}
+		best := slices.MaxFunc(pods, func(a, b Named) int {
+			return cmp.Compare(a.ResourceName(), b.ResourceName())
+		})
+		return &Static{Value: best.ResourceName()}
+	}, opts.WithName("Collection")...)
+	Collection.AsCollection().Register(TrackerHandler[Static](tt))
+
+	assert.Equal(t, Collection.AsCollection().WaitUntilSynced(stop), true)
+	assert.Equal(t, counts.Load(), uint64(1))
+
+	source.UpdateObject(SimplePod{
+		Named: Named{Namespace: "namespace", Name: "n1"},
+		IP:    "v1",
+	})
+	assert.EventuallyEqual(t, Collection.Get, &Static{Value: "namespace/n1"})
+	assert.Equal(t, counts.Load(), uint64(2))
+
+	source.UpdateObject(SimplePod{
+		Named: Named{Namespace: "namespace", Name: "n1"},
+		IP:    "v2",
+	})
+	// No change, and no recomputation
+	assert.Equal(t, Collection.Get(), &Static{Value: "namespace/n1"})
+	assert.Equal(t, counts.Load(), uint64(2))
+
+	source.Reset([]SimplePod{{
+		Named: Named{Namespace: "namespace", Name: "n2"},
+		IP:    "v3",
+	}})
+	assert.EventuallyEqual(t, Collection.Get, &Static{Value: "namespace/n2"})
+	// Recomputed now
+	assert.Equal(t, counts.Load(), uint64(3))
+
+	tt.WaitOrdered("add/static", "update/static")
 }
 
 func TestCollectionMultipleFetchKeys(t *testing.T) {

--- a/pkg/kube/krt/fetch.go
+++ b/pkg/kube/krt/fetch.go
@@ -36,6 +36,21 @@ func FetchOrList[T any](ctx HandlerContext, cc Collection[T], opts ...FetchOptio
 	return fetch[T](ctx, cc, true, opts...)
 }
 
+// PartialFetch is a wrapper around Fetch + withUnsafeSuppressChange to safely fetch a subset of an object, without trigger
+// recomputation when the unused part of the object changes
+func PartialFetch[T any, S any](ctx HandlerContext, cc Collection[T], xfm func(T) S, equality func(S, S) bool, opts ...FetchOption) []S {
+	t := fetch[T](ctx, cc, false, append(opts, withUnsafeSuppressChange(func(a T, b T) bool {
+		return equality(xfm(a), xfm(b))
+	}))...)
+	return slices.Map(t, xfm)
+}
+
+func PartialFetchComparable[T any, S comparable](ctx HandlerContext, cc Collection[T], xfm func(T) S, opts ...FetchOption) []S {
+	return PartialFetch(ctx, cc, xfm, func(s S, s2 S) bool {
+		return s == s2
+	}, opts...)
+}
+
 // Fetch runs a query against the provided collection and subscribes to updates.
 func Fetch[T any](ctx HandlerContext, cc Collection[T], opts ...FetchOption) []T {
 	return fetch[T](ctx, cc, false, opts...)

--- a/pkg/kube/krt/filter.go
+++ b/pkg/kube/krt/filter.go
@@ -33,6 +33,7 @@ type filter struct {
 	selects         map[string]string
 	labels          map[string]string
 	generic         func(any) bool
+	suppressChange  func(o, n any) bool
 
 	index *indexFilter
 }
@@ -81,6 +82,9 @@ func (f *filter) String() string {
 	}
 	if f.generic != nil {
 		attrs = append(attrs, "generic")
+	}
+	if f.suppressChange != nil {
+		attrs = append(attrs, "suppressChange")
 	}
 	res := strings.Join(attrs, ",")
 	return fmt.Sprintf("{%s}", res)
@@ -157,6 +161,25 @@ func FilterGeneric(f func(any) bool) FetchOption {
 	return func(h *dependency) {
 		h.filter.generic = f
 	}
+}
+
+// withUnsafeSuppressChange skips incoming update events when fn returns true.
+// This only applies to dependency change handling for Fetch calls; it does not affect the initial list result.
+// This is dangerous to use; if you use any parts of the object *outside* the comparison function, you will get stale data.
+// Recommended to use with PartialFetch
+func withUnsafeSuppressChange[T any](fn func(T, T) bool) FetchOption {
+	return func(h *dependency) {
+		h.filter.suppressChange = func(o, n any) bool {
+			return fn(o.(T), n.(T))
+		}
+	}
+}
+
+func (f *filter) SuppressChange(ev Event[any]) bool {
+	if f.suppressChange == nil || ev.Old == nil || ev.New == nil {
+		return false
+	}
+	return f.suppressChange(*ev.Old, *ev.New)
 }
 
 func (f *filter) Matches(object any, forList bool) bool {


### PR DESCRIPTION
This is intended to introduce an optimization for a common pattern of fetching an object but not wanting to be notified about irrelevant changes.

For example, I may depend on "does this object exist" for status purposes; if the object is one changing rapidly, we will recompute many times.

The existing workaround is to make a new collection with the subset. However, this has a cost; we need to duplicate all of the storage. In the case where building the subset is cheap, its much more efficient to just do this.

Because this can be unsafe if done wrong, I made the primitive discouraged and built a safe wrapper around it