### PR TITLE
fix conflicting node informer objecttransform in agentgateway controller

### DIFF
--- a/pilot/pkg/config/kube/agentgateway/agentgateway_controller.go
+++ b/pilot/pkg/config/kube/agentgateway/agentgateway_controller.go
@@ -188,7 +188,8 @@ func (c *Controller) initializeInputs(kc kube.Client, opts krt.OptionsBuilder) {
 	inputs := &AgwInputs{
 		Namespaces: krt.NewInformer[*corev1.Namespace](kc, opts.WithName("informer/Namespaces")...),
 		Nodes: krt.NewFilteredInformer[*corev1.Node](kc, kclient.Filter{
-			ObjectFilter: kc.ObjectFilter(),
+			ObjectTransform: kube.StripNodeUnusedFields,
+			ObjectFilter:    kc.ObjectFilter(),
 		}, opts.WithName("informer/Nodes")...),
 		Pods: krt.NewFilteredInformer[*corev1.Pod](kc, kclient.Filter{
 			ObjectTransform: kube.StripPodUnusedFields,


### PR DESCRIPTION
**Please provide a description of this PR:**
cc @jaellio @keithmattix 
#59798 added `PILOT_ENABLE_AGENTGATEWAY=true` to pilot + ambient integ main_test.go, which activates the agentgateway controller during tests. The controller's `initializeInputs` registers a Nodes informer with no ObjectTransform at `pilot/pkg/config/kube/agentgateway/agentgateway_controller.go:190`, conflicting with istiod's existing Nodes registrations in `pkg/kube/inject/webhook.go` and `pkg/kube/multicluster/cluster.go` which use `kube.StripNodeUnusedFields`.

Warn normally, fatal under `UNSAFE_PILOT_ENABLE_RUNTIME_ASSERTIONS`. Has been breaking master postsubmit since #59798 merged on Apr 22, but only postsubmit runs it so it went unnoticed.

From istiod discovery log on the #59798 merge commit (d49f490836):

    2026-04-22T19:13:54.713820Z  fatal  for type /v1, Resource=nodes, registered conflicting ObjectTransform. 0x2522080 != 0x0, Stack: goroutine 1 [running]:
    ...
    istio.io/istio/pilot/pkg/config/kube/agentgateway.(*Controller).initializeInputs
        pilot/pkg/config/kube/agentgateway/agentgateway_controller.go:190
    istio.io/istio/pilot/pkg/config/kube/agentgateway.NewAgwController
        pilot/pkg/config/kube/agentgateway/agentgateway_controller.go:178
    istio.io/istio/pilot/pkg/bootstrap.(*Server).initK8SConfigStore
        pilot/pkg/bootstrap/configcontroller.go:205

prow: https://prow.istio.io/view/gs/istio-prow/logs/integ-assertion_istio_postsubmit/2047029005479055360
raw istiod log: https://storage.googleapis.com/istio-prow/logs/integ-assertion_istio_postsubmit/2047029005479055360/artifacts/ambient-479e6b29004e4085a43dd43/_suite_context/istio-state-3599783616/primary-0/istiod-59d9cf887c-cvz74_discovery.log

Fix: mirror the Pods informer right below (line 194) which already sets `kube.StripPodUnusedFields`.