### PR TITLE
synthesize xfcc from filter state at ambient waypoint

### DIFF
--- a/pilot/pkg/networking/core/listener_waypoint.go
+++ b/pilot/pkg/networking/core/listener_waypoint.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net/netip"
 	"strconv"
+	"strings"
 	"time"
 
 	xds "github.com/cncf/xds/go/xds/core/v3"
@@ -74,7 +75,25 @@ const (
 	// applied already.
 	downstreamSourceHeader        = "x-istio-source"
 	downstreamOriginNetworkHeader = "x-forwarded-network"
+
+	// xfccClientIdentityAnnotation opts a waypoint in to synthesizing an
+	// x-forwarded-client-cert entry from the ztunnel-provided source workload
+	// identity. When set to "true" on the Gateway (propagated to the waypoint
+	// pod via infrastructureAnnotations), the waypoint overwrites XFCC on the
+	// main_internal HCM so upstream apps see the originating client identity.
+	// TODO(https://github.com/istio/istio/issues/54995): promote to istio.io/api
+	// once the feature stabilizes.
+	xfccClientIdentityAnnotation = "ambient.istio.io/xfcc-include-client-identity"
 )
+
+// xfccIncludeClientIdentityEnabled reports whether the waypoint has opted in to
+// synthesizing XFCC from filter state via xfccClientIdentityAnnotation.
+func xfccIncludeClientIdentityEnabled(node *model.Proxy) bool {
+	if node == nil || node.Metadata == nil {
+		return false
+	}
+	return strings.EqualFold(node.Metadata.Annotations[xfccClientIdentityAnnotation], "true")
+}
 
 func (lb *ListenerBuilder) serviceForHostname(name host.Name) *model.Service {
 	return lb.push.ServiceForHostname(lb.node, name)
@@ -831,6 +850,12 @@ func (lb *ListenerBuilder) buildWaypointHTTPFilters(svc *model.Service) (pre []*
 	)
 	// TODO: how to deal with ext-authz? It will be in the ordering twice
 	// TODO policies here will need to be different per-chain (service attached)
+	// If the waypoint has opted in via annotation, synthesize XFCC from the
+	// ztunnel-provided source workload identity kept in filter state. Runs before
+	// authn/authz so any XFCC-consuming policies see the synthesized value.
+	if xfccIncludeClientIdentityEnabled(lb.node) {
+		pre = append(pre, xdsfilters.WaypointXFCCClientIdentityFilter)
+	}
 	pre = append(pre, authzCustomBuilder.BuildHTTP(cls)...)
 	pre = extension.PopAppendHTTPTrafficExtension(pre, trafficExtensions, extensions.TrafficExtension_AUTHN)
 	pre = append(pre, authnBuilder.BuildHTTP(cls)...)
@@ -876,6 +901,14 @@ func (lb *ListenerBuilder) buildWaypointInboundHTTPFilters(svc *model.Service, c
 		httpOpts.connectionManager.HttpProtocolOptions = &core.Http1ProtocolOptions{
 			AcceptHttp_10: true,
 		}
+	}
+	// When XFCC is synthesized from filter state via header_mutation, default
+	// ForwardClientCertDetails on the main_internal HCM is SANITIZE, which would
+	// strip the synthesized header before forwarding. ALWAYS_FORWARD_ONLY passes
+	// it through; the ALWAYS_ variant is required because main_internal has no
+	// peer mTLS cert.
+	if xfccIncludeClientIdentityEnabled(lb.node) {
+		httpOpts.connectionManager.ForwardClientCertDetails = hcm.HttpConnectionManager_ALWAYS_FORWARD_ONLY
 	}
 	h := lb.buildHTTPConnectionManager(httpOpts)
 

--- a/pilot/pkg/networking/core/listener_waypoint_test.go
+++ b/pilot/pkg/networking/core/listener_waypoint_test.go
@@ -1,0 +1,114 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"testing"
+
+	"istio.io/istio/pilot/pkg/model"
+	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
+)
+
+func TestXFCCIncludeClientIdentityEnabled(t *testing.T) {
+	cases := []struct {
+		name     string
+		node     *model.Proxy
+		expected bool
+	}{
+		{
+			name:     "nil proxy",
+			node:     nil,
+			expected: false,
+		},
+		{
+			name:     "no metadata",
+			node:     &model.Proxy{},
+			expected: false,
+		},
+		{
+			name: "no annotations",
+			node: &model.Proxy{
+				Metadata: &model.NodeMetadata{},
+			},
+			expected: false,
+		},
+		{
+			name: "annotation unset",
+			node: &model.Proxy{
+				Metadata: &model.NodeMetadata{
+					Annotations: map[string]string{"other": "value"},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "annotation false",
+			node: &model.Proxy{
+				Metadata: &model.NodeMetadata{
+					Annotations: map[string]string{xfccClientIdentityAnnotation: "false"},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "annotation true",
+			node: &model.Proxy{
+				Metadata: &model.NodeMetadata{
+					Annotations: map[string]string{xfccClientIdentityAnnotation: "true"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "annotation TRUE (case-insensitive)",
+			node: &model.Proxy{
+				Metadata: &model.NodeMetadata{
+					Annotations: map[string]string{xfccClientIdentityAnnotation: "TRUE"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "annotation 1 is not accepted as true",
+			node: &model.Proxy{
+				Metadata: &model.NodeMetadata{
+					Annotations: map[string]string{xfccClientIdentityAnnotation: "1"},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := xfccIncludeClientIdentityEnabled(tc.node); got != tc.expected {
+				t.Fatalf("xfccIncludeClientIdentityEnabled(%v) = %v, want %v", tc.node, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestWaypointXFCCClientIdentityFilterConfig(t *testing.T) {
+	f := xdsfilters.WaypointXFCCClientIdentityFilter
+	if f == nil {
+		t.Fatal("WaypointXFCCClientIdentityFilter is nil")
+	}
+	if f.Name != "istio.waypoint.xfcc_client_identity" {
+		t.Fatalf("unexpected filter name: %q", f.Name)
+	}
+	if f.GetTypedConfig() == nil {
+		t.Fatal("filter missing typed config")
+	}
+}

--- a/pilot/pkg/xds/filters/filters.go
+++ b/pilot/pkg/xds/filters/filters.go
@@ -16,6 +16,7 @@ package filters
 
 import (
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	mutation_rulesv3 "github.com/envoyproxy/go-control-plane/envoy/config/common/mutation_rules/v3"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
@@ -27,6 +28,7 @@ import (
 	fault "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/fault/v3"
 	grpcstats "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/grpc_stats/v3"
 	grpcweb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/grpc_web/v3"
+	header_mutationv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/header_mutation/v3"
 	router "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
 	sfs "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/set_filter_state/v3"
 	statefulsession "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/stateful_session/v3"
@@ -369,6 +371,33 @@ var (
 					},
 					SharedWithUpstream: sfsvalue.FilterStateValue_ONCE,
 				}},
+			}),
+		},
+	}
+
+	// WaypointXFCCClientIdentityFilter synthesizes an x-forwarded-client-cert header
+	// on the waypoint main_internal HCM, populated from the ztunnel-provided source
+	// workload identity kept in filter state. mTLS is terminated on the outer
+	// CONNECT listener, so Envoy's native XFCC handling on main_internal has no peer
+	// cert and cannot populate the header. Any existing XFCC on the request is
+	// replaced to avoid forwarding values the waypoint has not verified.
+	WaypointXFCCClientIdentityFilter = &hcm.HttpFilter{
+		Name: "istio.waypoint.xfcc_client_identity",
+		ConfigType: &hcm.HttpFilter_TypedConfig{
+			TypedConfig: protoconv.MessageToAny(&header_mutationv3.HeaderMutation{
+				Mutations: &header_mutationv3.Mutations{
+					RequestMutations: []*mutation_rulesv3.HeaderMutation{{
+						Action: &mutation_rulesv3.HeaderMutation_Append{
+							Append: &core.HeaderValueOption{
+								Header: &core.HeaderValue{
+									Key:   "x-forwarded-client-cert",
+									Value: `By=%FILTER_STATE(io.istio.local_principal:PLAIN)%;URI=%FILTER_STATE(io.istio.peer_principal:PLAIN)%`,
+								},
+								AppendAction: core.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
+							},
+						},
+					}},
+				},
 			}),
 		},
 	}

--- a/releasenotes/notes/54995.yaml
+++ b/releasenotes/notes/54995.yaml
@@ -1,0 +1,13 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 54995
+releaseNotes:
+  - |
+    **Added** opt-in synthesis of `x-forwarded-client-cert` at ambient waypoints. Setting the
+    annotation `ambient.istio.io/xfcc-include-client-identity: "true"` on a waypoint `Gateway`
+    (or its `GatewayClass`) causes the waypoint to overwrite XFCC on forwarded requests with an
+    entry populated from the ztunnel-provided source workload SPIFFE identity, so upstream apps
+    can see the originating client. Any inbound XFCC value is replaced. Waypoints without the
+    annotation are unaffected.

--- a/tests/integration/ambient/xfcc_client_identity_test.go
+++ b/tests/integration/ambient/xfcc_client_identity_test.go
@@ -1,0 +1,124 @@
+//go:build integ
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ambient
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	echot "istio.io/istio/pkg/test/echo"
+	"istio.io/istio/pkg/test/echo/common/scheme"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/check"
+	"istio.io/istio/pkg/test/util/retry"
+)
+
+const xfccClientIdentityAnnotation = "ambient.istio.io/xfcc-include-client-identity"
+
+// TestWaypointXFCCClientIdentity verifies that when a waypoint Gateway is annotated with
+// ambient.istio.io/xfcc-include-client-identity=true, the waypoint synthesizes an
+// x-forwarded-client-cert header populated from the ztunnel-provided source workload
+// SPIFFE identity. Without the annotation XFCC does not contain the client URI.
+func TestWaypointXFCCClientIdentity(t *testing.T) {
+	framework.NewTest(t).Run(func(t framework.TestContext) {
+		runTestToServiceWaypoint(t, func(t framework.TestContext, src echo.Instance, dst echo.Target, opt echo.CallOptions) {
+			if opt.Scheme != scheme.HTTP {
+				return
+			}
+			waypointName := dst.Config().ServiceWaypointProxy
+			if waypointName == "" {
+				return
+			}
+			ns := apps.Namespace.Name()
+
+			addAnnotation := []byte(fmt.Sprintf(
+				`{"metadata":{"annotations":{%q:"true"}}}`, xfccClientIdentityAnnotation))
+			removeAnnotation := []byte(fmt.Sprintf(
+				`{"metadata":{"annotations":{%q:null}}}`, xfccClientIdentityAnnotation))
+
+			for _, c := range t.AllClusters() {
+				if _, err := c.GatewayAPI().GatewayV1().Gateways(ns).Patch(
+					context.TODO(), waypointName, types.MergePatchType, addAnnotation, metav1.PatchOptions{}); err != nil {
+					t.Fatalf("failed annotating waypoint %s: %v", waypointName, err)
+				}
+				t.Cleanup(func() {
+					_, err := c.GatewayAPI().GatewayV1().Gateways(ns).Patch(
+						context.TODO(), waypointName, types.MergePatchType, removeAnnotation, metav1.PatchOptions{})
+					if err != nil {
+						t.Logf("failed removing xfcc annotation from waypoint %s: %v", waypointName, err)
+					}
+				})
+			}
+
+			expectedURI := "spiffe://" + src.Config().SpiffeIdentity()
+			// Retry with larger timeout so the waypoint pod has time to roll out with
+			// the new annotation and reconnect to istiod.
+			opt.Count = 5
+			opt.Retry.Options = []retry.Option{
+				retry.Timeout(90 * time.Second),
+				retry.Delay(2 * time.Second),
+			}
+			opt.Check = check.And(
+				check.OK(),
+				check.Each(func(r echot.Response) error {
+					xfcc := firstXFCC(r)
+					if xfcc == "" {
+						return fmt.Errorf("no X-Forwarded-Client-Cert header in response: %v", r.RequestHeaders)
+					}
+					if !containsXFCCField(xfcc, "URI", expectedURI) {
+						return fmt.Errorf("XFCC missing URI=%s; got %q", expectedURI, xfcc)
+					}
+					return nil
+				}),
+			)
+			src.CallOrFail(t, opt)
+		})
+	})
+}
+
+func firstXFCC(r echot.Response) string {
+	if v := r.RequestHeaders.Get("X-Forwarded-Client-Cert"); v != "" {
+		return v
+	}
+	// gRPC lowercases header names; the echo server records request headers verbatim.
+	return r.RequestHeaders.Get("x-forwarded-client-cert")
+}
+
+// containsXFCCField returns true when the XFCC header contains a field with the
+// given key and exact value. XFCC entries are comma-separated, fields within an
+// entry are semicolon-separated, and values may be quoted.
+func containsXFCCField(xfcc, key, want string) bool {
+	for _, entry := range strings.Split(xfcc, ",") {
+		for _, field := range strings.Split(entry, ";") {
+			k, v, ok := strings.Cut(strings.TrimSpace(field), "=")
+			if !ok {
+				continue
+			}
+			if strings.EqualFold(k, key) && strings.Trim(v, `"`) == want {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Opt-in via `ambient.istio.io/xfcc-include-client-identity` annotation on the waypoint Gateway. Fixes #54995.