### PR TITLE
[release-1.28] Add configurable HBONE window sizing using feature flags (env vars)

### DIFF
--- a/pilot/pkg/features/ambient.go
+++ b/pilot/pkg/features/ambient.go
@@ -15,6 +15,8 @@
 package features
 
 import (
+	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
+
 	"istio.io/istio/pkg/env"
 	"istio.io/istio/pkg/log"
 )
@@ -76,6 +78,32 @@ var (
 		"ENABLE_LAYERED_WAYPOINT_AUTHORIZATION_POLICIES",
 		false,
 		"If enabled, selector based authorization policies will be enforced as L4 policies in front of the waypoint.").Get()
+
+	HBONEInitialStreamWindowSize = func() *wrappers.UInt32Value {
+		v := registerAmbient(
+			"PILOT_HBONE_INITIAL_STREAM_WINDOW_SIZE",
+			uint32(0), uint32(0),
+			"Sets the HTTP/2 initial_stream_window_size on HBONE CONNECT upstream clusters generated for "+
+				"waypoints and east-west gateways. If 0 (the default), the field is left unset so Envoy's "+
+				"built-in default applies.")
+		if v == 0 {
+			return nil
+		}
+		return &wrappers.UInt32Value{Value: v}
+	}()
+
+	HBONEInitialConnectionWindowSize = func() *wrappers.UInt32Value {
+		v := registerAmbient(
+			"PILOT_HBONE_INITIAL_CONNECTION_WINDOW_SIZE",
+			uint32(0), uint32(0),
+			"Sets the HTTP/2 initial_connection_window_size on HBONE CONNECT upstream clusters generated for "+
+				"waypoints and east-west gateways. If 0 (the default), the field is left unset so Envoy's "+
+				"built-in default applies.")
+		if v == 0 {
+			return nil
+		}
+		return &wrappers.UInt32Value{Value: v}
+	}()
 )
 
 // registerAmbient registers a variable that is allowed only if EnableAmbient is set

--- a/pilot/pkg/networking/core/cluster_waypoint.go
+++ b/pilot/pkg/networking/core/cluster_waypoint.go
@@ -523,7 +523,9 @@ func h2connectUpgrade() map[string]*anypb.Any {
 			UpstreamProtocolOptions: &http.HttpProtocolOptions_ExplicitHttpConfig_{ExplicitHttpConfig: &http.HttpProtocolOptions_ExplicitHttpConfig{
 				ProtocolConfig: &http.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{
 					Http2ProtocolOptions: &core.Http2ProtocolOptions{
-						AllowConnect: true,
+						AllowConnect:                true,
+						InitialStreamWindowSize:     features.HBONEInitialStreamWindowSize,
+						InitialConnectionWindowSize: features.HBONEInitialConnectionWindowSize,
 					},
 				},
 			}},
@@ -549,7 +551,9 @@ func h2connectUpgradeWithNoPooling() map[string]*anypb.Any {
 			UpstreamProtocolOptions: &http.HttpProtocolOptions_ExplicitHttpConfig_{ExplicitHttpConfig: &http.HttpProtocolOptions_ExplicitHttpConfig{
 				ProtocolConfig: &http.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{
 					Http2ProtocolOptions: &core.Http2ProtocolOptions{
-						AllowConnect: true,
+						AllowConnect:                true,
+						InitialStreamWindowSize:     features.HBONEInitialStreamWindowSize,
+						InitialConnectionWindowSize: features.HBONEInitialConnectionWindowSize,
 					},
 				},
 			}},

--- a/releasenotes/notes/59961.yaml
+++ b/releasenotes/notes/59961.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 59961
+releaseNotes:
+  - |
+    **Added** Initial HTTP/2 stream and connection window sizes for HBONE CONNECT upstream clusters (generated for
+    waypoints and east-west gateways) can be configured using feature flags 
+    PILOT_HBONE_INITIAL_STREAM_WINDOW_SIZE and PILOT_HBONE_INITIAL_CONNECTION_WINDOW_SIZE. These may be used to
+    reduce unwanted buffering.


### PR DESCRIPTION
**Please provide a description of this PR:**

Cherry-pick of https://github.com/istio/istio/pull/59961 to resolve https://github.com/istio/istio/issues/59978

FYI the merge conflicts were on these vars:
- `ENABLE_AMBIENT_MULTINETWORK_BAGGAGE` - https://github.com/istio/istio/pull/58901
- `AMBIENT_ENABLE_MULTI_NETWORK_INGRESS` - https://github.com/istio/istio/pull/58777
- `AMBIENT_ENABLE_DRY_RUN_AUTHORIZATION_POLICY` - https://github.com/istio/istio/pull/58657

I have excluded them from `release-1.28` as inspecting the respective PRs I don't see any intention for them to have existed in `1.28`.