### PR TITLE
fix: istioctl uninstall --revision now deletes per-revision leases

### DIFF
--- a/operator/cmd/mesh/uninstall.go
+++ b/operator/cmd/mesh/uninstall.go
@@ -15,12 +15,15 @@
 package mesh
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"istio.io/istio/istioctl/pkg/cli"
@@ -165,6 +168,8 @@ func runUninstall(cmd *cobra.Command, ctx cli.Context, rootArgs *RootArgs, uiArg
 	if err := uninstall.DeleteObjectsList(kubeClient, rootArgs.DryRun, l, objectsList); err != nil {
 		return fmt.Errorf("failed to delete control plane resources by revision: %v", err)
 	}
+	// Clean up per-revision leader election leases that aren't covered by label-based pruning
+	deleteRevisionLeases(kubeClient, uiArgs.revision, ctx.IstioNamespace(), rootArgs.DryRun, l)
 	pl.SetState(progress.StateUninstallComplete)
 	return nil
 }
@@ -250,4 +255,35 @@ func constructResourceListOutput(resourcesList []*unstructured.UnstructuredList)
 		}
 	}
 	return output, strings.Join(gwlist, ", ")
+}
+
+// deleteRevisionLeases deletes per-revision leader election leases that aren't covered by label-based pruning
+func deleteRevisionLeases(kubeClient kube.CLIClient, revision string, ns string, dryRun bool, l *clog.ConsoleLogger) {
+	if revision == "" {
+		return
+	}
+	// These are the per-revision lease prefixes from pilot/pkg/leaderelection
+	leasePrefixes := []string{
+		"istio-gateway-deployment",
+		"istio-gateway-status-leader",
+		"istio-gateway-inferencepool",
+		"istio-node-untaint",
+		"istio-ip-autoallocate",
+	}
+	for _, prefix := range leasePrefixes {
+		leaseName := prefix + "-" + revision
+		if dryRun {
+			l.LogAndPrintf("Not deleting lease %s/%s because of dry run.", ns, leaseName)
+			continue
+		}
+		err := kubeClient.Kube().CoordinationV1().Leases(ns).Delete(
+			context.Background(), leaseName, metav1.DeleteOptions{})
+		if err != nil {
+			if !kerrors.IsNotFound(err) {
+				l.LogAndPrintf("  Failed to delete lease %s/%s: %v", ns, leaseName, err)
+			}
+			continue
+		}
+		l.LogAndPrintf("  Removed coordination.k8s.io/v1, Kind=Lease/%s.%s.", leaseName, ns)
+	}
 }

--- a/operator/pkg/uninstall/prune.go
+++ b/operator/pkg/uninstall/prune.go
@@ -75,6 +75,7 @@ func NamespacedResources() []schema.GroupVersionKind {
 		{Group: "policy", Version: "v1", Kind: "PodDisruptionBudget"},
 		{Group: "autoscaling", Version: "v2", Kind: "HorizontalPodAutoscaler"},
 		gvk.EnvoyFilter.Kubernetes(),
+		{Group: "coordination.k8s.io", Version: "v1", Kind: "Lease"},
 	}
 	return res
 }

--- a/pilot/pkg/leaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/leaderelection.go
@@ -172,8 +172,15 @@ func (l *LeaderElection) create() (*k8sleaderelection.LeaderElector, error) {
 			leaseKey = ""
 		}
 		lock = &k8sresourcelock.LeaseLock{
-			LeaseMeta: metav1.ObjectMeta{Namespace: l.namespace, Name: l.electionID},
-			Client:    l.client.CoordinationV1(),
+			LeaseMeta: metav1.ObjectMeta{
+				Namespace: l.namespace,
+				Name:      l.electionID,
+				Labels: map[string]string{
+					"operator.istio.io/component": "Pilot",
+					"istio.io/rev":                l.revision,
+				},
+			},
+			Client: l.client.CoordinationV1(),
 			LockConfig: k8sresourcelock.ResourceLockConfig{
 				Identity: l.name,
 				Key:      leaseKey,


### PR DESCRIPTION
**Please provide a description of this PR:**

**Fixes:** #59968

Fixes an issue where `istioctl uninstall --revision <rev>` fails to clean up per-revision leader election Leases (e.g., `istio-gateway-deployment-<rev>`, `istio-gateway-status-leader-<rev>`), leaving them orphaned in the cluster.

This PR implements a robust two-part fix:
1. **Imperative Cleanup (Backward Compatibility):** Added `deleteRevisionLeases` to `uninstall.go` to explicitly delete known per-revision lease prefixes by name. This ensures leases left behind by older installations (which lack identifiable labels) are properly removed, bypassing the issue where the `istiod` heartbeat loop strips manually applied labels.
2. **Declarative Pruning (Architectural Fix):** Updated `leaderelection.go` to apply standard `istio.io/rev` and `operator.istio.io/component` labels to `LeaseMeta` upon creation, and added the `Lease` GVK to the `NamespacedResources` pruner list in `prune.go`.