### PR TITLE
test: bump envoy binary size on TestBinarySizes/envoy

### DIFF
--- a/tests/binary/binaries_test.go
+++ b/tests/binary/binaries_test.go
@@ -112,7 +112,7 @@ func TestBinarySizes(t *testing.T) {
 		"bug-report":      {60, 80},
 		"client":          {15, 30},
 		"server":          {15, 32},
-		"envoy":           {60, 160},
+		"envoy":           {60, 170},
 		"ztunnel":         {12, 17},
 	}
 

--- a/tests/binary/binaries_test.go
+++ b/tests/binary/binaries_test.go
@@ -112,7 +112,7 @@ func TestBinarySizes(t *testing.T) {
 		"bug-report":      {60, 80},
 		"client":          {15, 30},
 		"server":          {15, 32},
-		"envoy":           {60, 170},
+		"envoy":           {60, 165},
 		"ztunnel":         {12, 17},
 	}
 


### PR DESCRIPTION
**Please provide a description of this PR:**
Unblock https://github.com/istio/istio/pull/59965 by updating the binary size. From what I see, it's probably increased after this merge from 2 days ago: https://github.com/istio/proxy/pull/6955