### PR TITLE
Add WaypointBound status condition for WorkloadEntries

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1383,7 +1383,7 @@ type WorkloadInfo struct {
 	// Labels for the workload. Note these are only used internally, not sent over XDS
 	Labels map[string]string
 	// Source is the type that introduced this workload.
-	Source kind.Kind
+	Source TypedObject
 	// CreationTime is the time when the workload was created. Note this is used internally only.
 	CreationTime time.Time
 	// MarshaledAddress contains the pre-marshaled representation.
@@ -1392,13 +1392,15 @@ type WorkloadInfo struct {
 	// AsAddress contains a pre-created AddressInfo representation. This ensures we do not need repeated conversions on
 	// the hotpath
 	AsAddress AddressInfo
+	Waypoint  WaypointBindingStatus
 }
 
 func (i WorkloadInfo) Equals(other WorkloadInfo) bool {
 	return equalUsingPremarshaled(i.Workload, i.MarshaledAddress, other.Workload, other.MarshaledAddress) &&
 		maps.Equal(i.Labels, other.Labels) &&
 		i.Source == other.Source &&
-		i.CreationTime == other.CreationTime
+		i.CreationTime.Equal(other.CreationTime) &&
+		i.Waypoint.Equals(other.Waypoint)
 }
 
 func workloadResourceName(w *workloadapi.Workload) string {
@@ -1411,7 +1413,32 @@ func (i *WorkloadInfo) Clone() *WorkloadInfo {
 		Labels:       maps.Clone(i.Labels),
 		Source:       i.Source,
 		CreationTime: i.CreationTime,
+		Waypoint:     i.Waypoint,
 	}
+}
+
+func (i WorkloadInfo) GetStatusTarget() TypedObject {
+	return i.Source
+}
+
+func (i WorkloadInfo) GetConditions(currentConditions map[string]Condition) ConditionSet {
+	set := ConditionSet{
+		WaypointBound: nil,
+	}
+	if i.Waypoint.ResourceName != "" {
+		set[WaypointBound] = &Condition{
+			Status:  true,
+			Reason:  string(WaypointAccepted),
+			Message: "Successfully attached to waypoint " + i.Waypoint.ResourceName,
+		}
+	} else if i.Waypoint.Error != nil {
+		set[WaypointBound] = &Condition{
+			Status:  false,
+			Reason:  i.Waypoint.Error.Reason,
+			Message: i.Waypoint.Error.Message,
+		}
+	}
+	return set
 }
 
 func (i WorkloadInfo) ResourceName() string {

--- a/pilot/pkg/serviceregistry/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex.go
@@ -227,6 +227,7 @@ func New(options Options) Index {
 			serviceEntries,
 			servicesClient,
 			authzPolicies,
+			workloadEntries,
 			options,
 			opts,
 		)
@@ -373,6 +374,16 @@ func New(options Options) Index {
 		Namespaces,
 		opts,
 	)
+	if features.EnableAmbientStatus {
+		workloadEntriesWriter := kclient.NewWriteClient[*networkingclient.WorkloadEntry](client)
+		statusqueue.Register(a.statusQueue, "istio-ambient-workloadentry", Workloads,
+			func(info model.WorkloadInfo) (kclient.Patcher, map[string]model.Condition) {
+				if info.Source.Kind != kind.WorkloadEntry {
+					return nil, nil
+				}
+				return kclient.ToPatcher(workloadEntriesWriter), getConditions(info.Source.NamespacedName, workloadEntries)
+			})
+	}
 
 	WorkloadAddressIndex := krt.NewIndex[networkAddress, model.WorkloadInfo](Workloads, "networkAddress", networkAddressFromWorkload)
 	WorkloadServiceIndex := krt.NewIndex[string, model.WorkloadInfo](Workloads, "service", func(o model.WorkloadInfo) []string {
@@ -499,6 +510,8 @@ func getConditions[T controllers.ComparableObject](name types.NamespacedName, i 
 	case *networkingclient.ServiceEntry:
 		return translateIstioCondition(t.Status.Conditions)
 	case *securityclient.AuthorizationPolicy:
+		return translateIstioCondition(t.Status.Conditions)
+	case *networkingclient.WorkloadEntry:
 		return translateIstioCondition(t.Status.Conditions)
 	default:
 		log.Fatalf("unknown type %T; cannot write status", o)

--- a/pilot/pkg/serviceregistry/ambient/multicluster.go
+++ b/pilot/pkg/serviceregistry/ambient/multicluster.go
@@ -58,6 +58,7 @@ func (a *index) buildGlobalCollections(
 	localServiceEntryInformers kclient.Informer[*networkingclient.ServiceEntry],
 	localServiceInformers kclient.Informer[*v1.Service],
 	localAuthzInformers kclient.Informer[*securityclient.AuthorizationPolicy],
+	localWorkloadEntryInformers kclient.Informer[*networkingclient.WorkloadEntry],
 	options Options,
 	opts krt.OptionsBuilder,
 ) {
@@ -307,6 +308,16 @@ func (a *index) buildGlobalCollections(
 		options.DomainSuffix,
 		opts,
 	)
+	if features.EnableAmbientStatus {
+		workloadEntriesWriter := kclient.NewWriteClient[*networkingclient.WorkloadEntry](localCluster.Client)
+		statusqueue.Register(a.statusQueue, "istio-ambient-workloadentry", GlobalWorkloads,
+			func(info model.WorkloadInfo) (kclient.Patcher, map[string]model.Condition) {
+				if info.Source.Kind != kind.WorkloadEntry {
+					return nil, nil
+				}
+				return kclient.ToPatcher(workloadEntriesWriter), getConditions(info.Source.NamespacedName, localWorkloadEntryInformers)
+			})
+	}
 
 	GlobalWorkloadServiceIndex := krt.NewIndex[string, model.WorkloadInfo](GlobalWorkloads, "service", func(o model.WorkloadInfo) []string {
 		return maps.Keys(o.Workload.Services)
@@ -803,7 +814,7 @@ func (a *index) createSplitHorizonWorkload(
 
 	wi := model.WorkloadInfo{
 		Workload: &wl,
-		Source:   kind.KubernetesGateway,
+		Source:   model.TypedObject{Kind: kind.KubernetesGateway},
 		Labels:   labelutil.AugmentLabels(nil, networkGateway.Cluster, "", "", networkGateway.Network),
 	}
 	return precomputeWorkload(wi)

--- a/pilot/pkg/serviceregistry/ambient/waypoints.go
+++ b/pilot/pkg/serviceregistry/ambient/waypoints.go
@@ -185,6 +185,11 @@ func fetchWaypointForWorkload(ctx krt.HandlerContext, Waypoints krt.Collection[W
 	// Waypoint does not support Workload traffic
 	log.Debugf("Unable to add workload waypoint %s/%s; traffic type %s not supported for %s/%s",
 		w.Namespace, w.Name, w.TrafficType, o.Namespace, o.Name)
+	// If the binding was inherited from the namespace (workload has no direct label),
+	// this is not an error — the waypoint is for services, not workloads.
+	if _, hasLabel := o.Labels[label.IoIstioUseWaypoint.Name]; !hasLabel {
+		return nil, nil
+	}
 	return nil, ReportWaypointUnsupportedTrafficType(w.ResourceName(), constants.WorkloadTraffic)
 }
 

--- a/pilot/pkg/serviceregistry/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/ambient/workloads.go
@@ -545,7 +545,7 @@ func workloadEntryWorkloadBuilder(
 		meshCfg := krt.FetchOne(ctx, meshConfig.AsCollection())
 		policies := buildWorkloadPolicies(ctx, authorizationPolicies, peerAuths, meshCfg, wle.Labels, wle.Namespace)
 
-		appTunnel, targetWaypoint := computeWaypoint(ctx, waypoints, namespaces, wle.ObjectMeta)
+		appTunnel, targetWaypoint, waypointErr := computeWaypoint(ctx, waypoints, namespaces, wle.ObjectMeta)
 
 		fo := []krt.FetchOption{krt.FilterIndex(workloadServicesNamespaceIndex, wle.Namespace), krt.FilterSelectsNonEmpty(wle.GetLabels())}
 		if !flags.EnableK8SServiceSelectWorkloadEntries {
@@ -593,11 +593,18 @@ func workloadEntryWorkloadBuilder(
 		w.CanonicalName, w.CanonicalRevision = kubelabels.CanonicalService(wle.Labels, w.WorkloadName)
 
 		setTunnelProtocol(wle.Labels, wle.Annotations, w, flags)
+		var waypointStatus model.WaypointBindingStatus
+		if targetWaypoint != nil {
+			waypointStatus.ResourceName = targetWaypoint.ResourceName()
+		} else if waypointErr != nil {
+			waypointStatus.Error = waypointErr
+		}
 		wi := &model.WorkloadInfo{
 			Workload:     w,
 			Labels:       wle.Labels,
-			Source:       kind.WorkloadEntry,
+			Source:       model.TypedObject{NamespacedName: types.NamespacedName{Name: wle.Name, Namespace: wle.Namespace}, Kind: kind.WorkloadEntry},
 			CreationTime: wle.CreationTimestamp.Time,
+			Waypoint:     waypointStatus,
 		}
 		if canSkipPrecompute && network != localNetworkGetter(ctx).String() {
 			// Remote network workload that will be coalesced into a split-horizon workload; skip precompute
@@ -638,9 +645,10 @@ func computeWaypoint(
 	waypoints krt.Collection[Waypoint],
 	namespaces krt.Collection[*v1.Namespace],
 	workloadMeta metav1.ObjectMeta,
-) (*workloadapi.ApplicationTunnel, *Waypoint) {
+) (*workloadapi.ApplicationTunnel, *Waypoint, *model.StatusMessage) {
 	var appTunnel *workloadapi.ApplicationTunnel
 	var targetWaypoint *Waypoint
+	var waypointErr *model.StatusMessage
 	if instancedWaypoint := fetchWaypointForInstance(ctx, waypoints, workloadMeta); instancedWaypoint != nil {
 		// we're an instance of a waypoint, set inbound tunnel info if needed
 		if db := instancedWaypoint.DefaultBinding; db != nil {
@@ -651,10 +659,11 @@ func computeWaypoint(
 		}
 	} else if waypoint, err := fetchWaypointForWorkload(ctx, waypoints, namespaces, workloadMeta); err == nil {
 		// there is a workload-attached waypoint, point there with a GatewayAddress
-		// TODO: report status for workload-attached waypoints
 		targetWaypoint = waypoint
+	} else {
+		waypointErr = err
 	}
-	return appTunnel, targetWaypoint
+	return appTunnel, targetWaypoint, waypointErr
 }
 
 func podWorkloadBuilder(
@@ -716,7 +725,7 @@ func podWorkloadBuilder(
 		// We only check the network of the first IP. This should be fine; it is not supported for a single pod to span multiple networks
 		network := networkGetter(ctx).String()
 
-		appTunnel, targetWaypoint := computeWaypoint(ctx, waypoints, namespaces, p.ObjectMeta)
+		appTunnel, targetWaypoint, _ := computeWaypoint(ctx, waypoints, namespaces, p.ObjectMeta)
 
 		// enforce traversing waypoints
 		policies = append(policies, implicitWaypointPolicies(flags, ctx, waypoints, targetWaypoint, services)...)
@@ -752,7 +761,7 @@ func podWorkloadBuilder(
 		wi := &model.WorkloadInfo{
 			Workload:     w,
 			Labels:       p.Labels,
-			Source:       kind.Pod,
+			Source:       model.TypedObject{NamespacedName: types.NamespacedName{Name: p.Name, Namespace: p.Namespace}, Kind: kind.Pod},
 			CreationTime: p.CreationTimestamp.Time,
 		}
 		if canSkipPrecompute && network != localNetworkGetter(ctx).String() {
@@ -964,7 +973,7 @@ func serviceEntryWorkloadBuilder(
 					Namespace: se.Namespace,
 					Labels:    wle.Labels,
 				}
-				appTunnel, targetWaypoint = computeWaypoint(ctx, waypoints, namespaces, objMeta)
+				appTunnel, targetWaypoint, _ = computeWaypoint(ctx, waypoints, namespaces, objMeta)
 			}
 
 			// enforce traversing waypoints
@@ -1006,7 +1015,7 @@ func serviceEntryWorkloadBuilder(
 			res = append(res, precomputeWorkload(model.WorkloadInfo{
 				Workload:     w,
 				Labels:       se.Labels,
-				Source:       kind.WorkloadEntry,
+				Source:       model.TypedObject{Kind: kind.WorkloadEntry},
 				CreationTime: se.CreationTimestamp.Time,
 			}))
 		}
@@ -1165,7 +1174,7 @@ func endpointSlicesBuilder(
 			res = append(res, precomputeWorkload(model.WorkloadInfo{
 				Workload:     w,
 				Labels:       nil,
-				Source:       kind.EndpointSlice,
+				Source:       model.TypedObject{Kind: kind.EndpointSlice},
 				CreationTime: es.CreationTimestamp.Time,
 			}))
 		}

--- a/pilot/pkg/serviceregistry/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/ambient/workloads_test.go
@@ -1515,6 +1515,120 @@ func TestWorkloadEntryConditions(t *testing.T) {
 				model.WaypointBound: nil,
 			},
 		},
+		{
+			name: "workload entry with namespace-inherited service-only waypoint produces no condition",
+			inputs: []any{
+				Waypoint{
+					Named: krt.Named{
+						Name:      "service-waypoint",
+						Namespace: "ns",
+					},
+					TrafficType: constants.ServiceTraffic,
+					Address:     waypointAddr,
+					AllowedRoutes: WaypointSelector{
+						FromNamespaces: gatewayv1.NamespacesFromSame,
+					},
+				},
+				&v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ns",
+						Labels: map[string]string{
+							v1.LabelMetadataName:          "ns",
+							label.IoIstioUseWaypoint.Name: "service-waypoint",
+						},
+					},
+				},
+			},
+			we: &networkingclient.WorkloadEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "ns",
+				},
+				Spec: networking.WorkloadEntry{
+					Address: "1.2.3.4",
+				},
+			},
+			conditions: model.ConditionSet{
+				model.WaypointBound: nil,
+			},
+		},
+		{
+			name: "workload entry with direct service-only waypoint label produces error",
+			inputs: []any{
+				Waypoint{
+					Named: krt.Named{
+						Name:      "service-waypoint",
+						Namespace: "ns",
+					},
+					TrafficType: constants.ServiceTraffic,
+					Address:     waypointAddr,
+					AllowedRoutes: WaypointSelector{
+						FromNamespaces: gatewayv1.NamespacesFromSame,
+					},
+				},
+				ns,
+			},
+			we: &networkingclient.WorkloadEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "ns",
+					Labels: map[string]string{
+						label.IoIstioUseWaypoint.Name: "service-waypoint",
+					},
+				},
+				Spec: networking.WorkloadEntry{
+					Address: "1.2.3.4",
+				},
+			},
+			conditions: model.ConditionSet{
+				model.WaypointBound: {
+					Status:  false,
+					Reason:  "UnsupportedTrafficType",
+					Message: `attempting to bind to traffic type "workload" which the waypoint "ns/service-waypoint" does not support`,
+				},
+			},
+		},
+		{
+			name: "workload entry with namespace-inherited all-traffic waypoint binds successfully",
+			inputs: []any{
+				Waypoint{
+					Named: krt.Named{
+						Name:      "all-waypoint",
+						Namespace: "ns",
+					},
+					TrafficType: constants.AllTraffic,
+					Address:     waypointAddr,
+					AllowedRoutes: WaypointSelector{
+						FromNamespaces: gatewayv1.NamespacesFromSame,
+					},
+				},
+				&v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ns",
+						Labels: map[string]string{
+							v1.LabelMetadataName:          "ns",
+							label.IoIstioUseWaypoint.Name: "all-waypoint",
+						},
+					},
+				},
+			},
+			we: &networkingclient.WorkloadEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "ns",
+				},
+				Spec: networking.WorkloadEntry{
+					Address: "1.2.3.4",
+				},
+			},
+			conditions: model.ConditionSet{
+				model.WaypointBound: {
+					Status:  true,
+					Reason:  string(model.WaypointAccepted),
+					Message: "Successfully attached to waypoint ns/all-waypoint",
+				},
+			},
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pilot/pkg/serviceregistry/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/ambient/workloads_test.go
@@ -22,6 +22,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -1403,6 +1404,135 @@ func TestWorkloadEntryWorkloads(t *testing.T) {
 				res = wrapper.Workload
 			}
 			assert.Equal(t, res, tt.result)
+		})
+	}
+}
+
+func TestWorkloadEntryConditions(t *testing.T) {
+	waypointAddr := &workloadapi.GatewayAddress{
+		Destination: &workloadapi.GatewayAddress_Hostname{
+			Hostname: &workloadapi.NamespacedHostname{
+				Namespace: "ns",
+				Hostname:  "hostname.example",
+			},
+		},
+		HboneMtlsPort: 15008,
+	}
+
+	waypoint := Waypoint{
+		Named: krt.Named{
+			Name:      "waypoint",
+			Namespace: "waypoint-ns",
+		},
+		TrafficType: constants.AllTraffic,
+		Address:     waypointAddr,
+		AllowedRoutes: WaypointSelector{
+			FromNamespaces: gatewayv1.NamespacesFromSelector,
+			Selector:       labels.ValidatedSetSelector(map[string]string{v1.LabelMetadataName: "ns"}),
+		},
+	}
+
+	ns := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ns",
+			Labels: map[string]string{
+				v1.LabelMetadataName: "ns",
+			},
+		},
+	}
+
+	cases := []struct {
+		name       string
+		inputs     []any
+		we         *networkingclient.WorkloadEntry
+		conditions model.ConditionSet
+	}{
+		{
+			name: "workload entry bound to waypoint",
+			inputs: []any{
+				waypoint,
+				ns,
+			},
+			we: &networkingclient.WorkloadEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "ns",
+					Labels: map[string]string{
+						label.IoIstioUseWaypoint.Name:          "waypoint",
+						label.IoIstioUseWaypointNamespace.Name: "waypoint-ns",
+					},
+				},
+				Spec: networking.WorkloadEntry{
+					Address: "1.2.3.4",
+				},
+			},
+			conditions: model.ConditionSet{
+				model.WaypointBound: {
+					Status:  true,
+					Reason:  string(model.WaypointAccepted),
+					Message: "Successfully attached to waypoint waypoint-ns/waypoint",
+				},
+			},
+		},
+		{
+			name: "workload entry with waypoint not ready",
+			inputs: []any{
+				ns,
+			},
+			we: &networkingclient.WorkloadEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "ns",
+					Labels: map[string]string{
+						label.IoIstioUseWaypoint.Name: "missing-waypoint",
+					},
+				},
+				Spec: networking.WorkloadEntry{
+					Address: "1.2.3.4",
+				},
+			},
+			conditions: model.ConditionSet{
+				model.WaypointBound: {
+					Status:  false,
+					Reason:  "WaypointIsNotReady",
+					Message: `waypoint "ns/missing-waypoint" is not ready`,
+				},
+			},
+		},
+		{
+			name:   "workload entry without waypoint",
+			inputs: []any{},
+			we: &networkingclient.WorkloadEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "ns",
+				},
+				Spec: networking.WorkloadEntry{
+					Address: "1.2.3.4",
+				},
+			},
+			conditions: model.ConditionSet{
+				model.WaypointBound: nil,
+			},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := krttest.NewMock(t, tt.inputs)
+			a := newAmbientUnitTest(t)
+			WorkloadServices := krttest.GetMockCollection[model.ServiceInfo](mock)
+			WorkloadServicesNamespaceIndex := krt.NewNamespaceIndex(WorkloadServices)
+			builder := a.workloadEntryWorkloadBuilder(
+				GetMeshConfig(mock),
+				krttest.GetMockCollection[model.WorkloadAuthorization](mock),
+				krttest.GetMockCollection[*securityclient.PeerAuthentication](mock),
+				krttest.GetMockCollection[Waypoint](mock),
+				WorkloadServices,
+				WorkloadServicesNamespaceIndex,
+				krttest.GetMockCollection[*v1.Namespace](mock),
+			)
+			wrapper := builder(krt.TestingDummyContext{}, tt.we)
+			assert.Equal(t, wrapper.GetConditions(nil), tt.conditions)
 		})
 	}
 }

--- a/pkg/config/analysis/analyzers/conditions/conditions.go
+++ b/pkg/config/analysis/analyzers/conditions/conditions.go
@@ -41,6 +41,7 @@ func (c *ConditionAnalyzer) Metadata() analysis.Metadata {
 		Inputs: []config.GroupVersionKind{
 			groupVersionKind.Service,
 			groupVersionKind.ServiceEntry,
+			groupVersionKind.WorkloadEntry,
 			groupVersionKind.AuthorizationPolicy,
 			groupVersionKind.KubernetesGateway,
 			groupVersionKind.HTTPRoute,
@@ -55,6 +56,7 @@ func (c *ConditionAnalyzer) Analyze(ctx analysis.Context) {
 	for _, gvk := range []config.GroupVersionKind{
 		groupVersionKind.Service,
 		groupVersionKind.ServiceEntry,
+		groupVersionKind.WorkloadEntry,
 		groupVersionKind.AuthorizationPolicy,
 		groupVersionKind.KubernetesGateway,
 		groupVersionKind.HTTPRoute, groupVersionKind.GRPCRoute,
@@ -93,6 +95,9 @@ var negativeConditionsToReport = map[config.GroupVersionKind]map[string]metav1.C
 		"istio.io/WaypointBound": metav1.ConditionFalse,
 	},
 	groupVersionKind.ServiceEntry: {
+		"istio.io/WaypointBound": metav1.ConditionFalse,
+	},
+	groupVersionKind.WorkloadEntry: {
 		"istio.io/WaypointBound": metav1.ConditionFalse,
 	},
 	groupVersionKind.AuthorizationPolicy: {

--- a/releasenotes/notes/59993.yaml
+++ b/releasenotes/notes/59993.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: ambient
+releaseNotes:
+  - |
+    **Added** `WaypointBound` status condition to `WorkloadEntry` resources, reporting whether the workload is
+    successfully attached to its waypoint proxy or if there was an error binding.

--- a/releasenotes/notes/59993.yaml
+++ b/releasenotes/notes/59993.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: feature
-area: ambient
+area: installation
 releaseNotes:
   - |
     **Added** `WaypointBound` status condition to `WorkloadEntry` resources, reporting whether the workload is


### PR DESCRIPTION
This change implements `istio.io/WaypointBound` status conditions on WorkloadEntry resources in ambient mode. This resolves a TODO where waypoint errors were being disregarded and now matches the behavior for ServiceEntries.

The new condition reports one of four outcomes:

| Reason | Status | Description |
|---|---|---|
| `WaypointAccepted` | True | Successfully bound to the referenced waypoint |
| `WaypointIsNotReady` | False | The referenced waypoint does not exist or is not ready |
| `AttachmentDenied` | False | The waypoint's `allowedRoutes` does not permit attachment from this namespace |
| `UnsupportedTrafficType` | False | The waypoint does not support workload traffic |

No condition is set when a WorkloadEntry does not reference a waypoint and if the label is on the namespace but the waypoint doesn't support workloads.

## Validation

You can validate behavior with a simple ambient install and by applying the following manifests and verify conditions with:

```bash
kubectl get workloadentries -n default \
  -o jsonpath='{range .items[*]}{"NAME: "}{.metadata.name}{"\n"}{"CONDITIONS: "}{.status.conditions}{"\n\n"}{end}'
```

Validation manifests:

```yaml
# Waypoint Gateway for workload traffic (prerequisite for success case)
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: test-waypoint
  namespace: default
  labels:
    istio.io/waypoint-for: workload
spec:
  gatewayClassName: istio-waypoint
  listeners:
  - name: mesh
    port: 15008
    protocol: HBONE
---
# WorkloadEntry successfully bound to waypoint
# Expected: WaypointBound=True, reason=WaypointAccepted
apiVersion: networking.istio.io/v1
kind: WorkloadEntry
metadata:
  name: wle-bound
  namespace: default
  labels:
    app: external-app
    istio.io/use-waypoint: test-waypoint
spec:
  address: 192.168.1.10
  labels:
    app: external-app
---
# WorkloadEntry referencing a waypoint that doesn't exist
# Expected: WaypointBound=False, reason=WaypointIsNotReady
apiVersion: networking.istio.io/v1
kind: WorkloadEntry
metadata:
  name: wle-missing-waypoint
  namespace: default
  labels:
    app: external-app
    istio.io/use-waypoint: nonexistent-waypoint
spec:
  address: 192.168.1.11
  labels:
    app: external-app
---
# Namespace for the restricted waypoint
apiVersion: v1
kind: Namespace
metadata:
  name: other-namespace
---
# Waypoint in other-namespace with default allowedRoutes (Same namespace only)
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: restricted-waypoint
  namespace: other-namespace
  labels:
    istio.io/waypoint-for: workload
spec:
  gatewayClassName: istio-waypoint
  listeners:
  - name: mesh
    port: 15008
    protocol: HBONE
---
# WorkloadEntry in default namespace referencing the other-namespace waypoint
# Expected: WaypointBound=False, reason=AttachmentDenied
apiVersion: networking.istio.io/v1
kind: WorkloadEntry
metadata:
  name: wle-denied-waypoint
  namespace: default
  labels:
    app: external-app
    istio.io/use-waypoint: restricted-waypoint
    istio.io/use-waypoint-namespace: other-namespace
spec:
  address: 192.168.1.12
  labels:
    app: external-app
---
# WorkloadEntry with no waypoint label
# Expected: no WaypointBound condition
apiVersion: networking.istio.io/v1
kind: WorkloadEntry
metadata:
  name: wle-no-waypoint
  namespace: default
  labels:
    app: external-app
spec:
  address: 192.168.1.13
  labels:
    app: external-app
---
# Service-only waypoint (for wrong traffic type test)
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: service-only-waypoint
  namespace: default
  labels:
    istio.io/waypoint-for: service
spec:
  gatewayClassName: istio-waypoint
  listeners:
  - name: mesh
    port: 15008
    protocol: HBONE
---
# WorkloadEntry targeting a service-only waypoint
# Expected: WaypointBound=False, reason=UnsupportedTrafficType
apiVersion: networking.istio.io/v1
kind: WorkloadEntry
metadata:
  name: wle-wrong-traffic-type
  namespace: default
  labels:
    app: external-app
    istio.io/use-waypoint: service-only-waypoint
spec:
  address: 192.168.1.14
  labels:
    app: external-app
```