### PR TITLE
fix(conformance): Enable GatewayClassObservedGenerationBump conformance test

### DIFF
--- a/tests/integration/ambient/gateway_conformance_test.go
+++ b/tests/integration/ambient/gateway_conformance_test.go
@@ -107,7 +107,6 @@ var skippedTests = map[string]string{
 	// The following tests were modified between v1.4.0 && v1.5.0
 	"BackendTLSPolicy": "TODO",
 
-	"GatewayClassObservedGenerationBump":    "TODO",
 	"GatewayWithAttachedRoutes":             "TODO",
 	"GatewayWithAttachedRoutesWithPort8080": "TODO",
 

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -105,7 +105,6 @@ var skippedTests = map[string]string{
 	// The following tests were modified between v1.4.0 && v1.5.0
 	"BackendTLSPolicy": "TODO",
 
-	"GatewayClassObservedGenerationBump":    "TODO",
 	"GatewayWithAttachedRoutes":             "TODO",
 	"GatewayWithAttachedRoutesWithPort8080": "TODO",
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Enable the core `GatewayClassObservedGenerationBump` test for Gateway API v1.5.1 conformance. This was being explicitly skipped.