### PR TITLE
 Refactor DestinationRule sorting to use slices.SortFunc

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -2037,7 +2037,7 @@ func sortConfigBySelectorAndCreationTime(configs []config.Config) []config.Confi
 			return r // -1 means i is older than j, so it should be before than j, so return -1.
 		}
 		if r := strings.Compare(a.Name, b.Name); r != 0 {
-			return -r
+			return r
 		}
 		return strings.Compare(a.Namespace, b.Namespace)
 	})

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -2036,10 +2036,10 @@ func sortConfigBySelectorAndCreationTime(configs []config.Config) []config.Confi
 		if r := a.CreationTimestamp.Compare(b.CreationTimestamp); r != 0 {
 			return r // -1 means i is older than j, so it should be before than j, so return -1.
 		}
-		if r := cmp.Compare(a.Name, b.Name); r != 0 {
-			return r
+		if r := strings.Compare(a.Name, b.Name); r != 0 {
+			return -r
 		}
-		return cmp.Compare(a.Namespace, b.Namespace)
+		return strings.Compare(a.Namespace, b.Namespace)
 	})
 	return configs
 }

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -2032,12 +2032,14 @@ func sortConfigBySelectorAndCreationTime(configs []config.Config) []config.Confi
 			return +1
 		}
 
-		// ordered by creation time, name, namespace
-		return cmp.Or(
-            a.CreationTimestamp.Compare(b.CreationTimestamp),
-            cmp.Compare(a.Name, b.Name),
-            cmp.Compare(a.Namespace, b.Namespace),
-        )
+		// If priority is the same or neither has priority, fallback to creation time ordering
+		if r := a.CreationTimestamp.Compare(b.CreationTimestamp); r != 0 {
+			return r // -1 means i is older than j, so it should be before than j, so return -1.
+		}
+		if r := cmp.Compare(a.Name, b.Name); r != 0 {
+			return r
+		}
+		return cmp.Compare(a.Namespace, b.Namespace)
 	})
 	return configs
 }

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -2034,7 +2034,7 @@ func sortConfigBySelectorAndCreationTime(configs []config.Config) []config.Confi
 
 		// If priority is the same or neither has priority, fallback to creation time ordering
 		if r := a.CreationTimestamp.Compare(b.CreationTimestamp); r != 0 {
-			return r // -1 means i is older than j, so it should be before than j, so return -1.
+			return r // -1 means a is older than b, so it should be before than b, so return -1.
 		}
 		if r := strings.Compare(a.Name, b.Name); r != 0 {
 			return r

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -2034,7 +2034,7 @@ func sortConfigBySelectorAndCreationTime(configs []config.Config) []config.Confi
 
 		// If priority is the same or neither has priority, fallback to creation time ordering
 		if r := a.CreationTimestamp.Compare(b.CreationTimestamp); r != 0 {
-			return r // -1 means a is older than b, so it should be before than b, so return -1.
+			return r
 		}
 		if r := strings.Compare(a.Name, b.Name); r != 0 {
 			return r

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -2034,7 +2034,7 @@ func sortConfigBySelectorAndCreationTime(configs []config.Config) []config.Confi
 
 		// If priority is the same or neither has priority, fallback to creation time ordering
 		if r := configs[i].CreationTimestamp.Compare(configs[j].CreationTimestamp); r != 0 {
-			return r == -1 // -1 means i is less than j, so return true.
+			return r == -1 // -1 means i is older than j, so it should be before than j, so return true.
 		}
 		if r := cmp.Compare(configs[i].Name, configs[j].Name); r != 0 {
 			return r == -1

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -2021,25 +2021,23 @@ func (ps *PushContext) SetDestinationRulesForTesting(configs []config.Config) {
 
 // sortConfigBySelectorAndCreationTime sorts the list of config objects based on priority and creation time.
 func sortConfigBySelectorAndCreationTime(configs []config.Config) []config.Config {
-	sort.Slice(configs, func(i, j int) bool {
-		// check if one of the configs has priority
-		idr := configs[i].Spec.(*networking.DestinationRule)
-		jdr := configs[j].Spec.(*networking.DestinationRule)
+	slices.SortFunc(configs, func(a, b config.Config) int {
+		// check if one of the configs has workload selector
+		idr := a.Spec.(*networking.DestinationRule)
+		jdr := b.Spec.(*networking.DestinationRule)
 		if idr.GetWorkloadSelector() != nil && jdr.GetWorkloadSelector() == nil {
-			return true
+			return -1
 		}
 		if idr.GetWorkloadSelector() == nil && jdr.GetWorkloadSelector() != nil {
-			return false
+			return +1
 		}
 
-		// If priority is the same or neither has priority, fallback to creation time ordering
-		if r := configs[i].CreationTimestamp.Compare(configs[j].CreationTimestamp); r != 0 {
-			return r == -1 // -1 means i is older than j, so it should be before than j, so return true.
-		}
-		if r := cmp.Compare(configs[i].Name, configs[j].Name); r != 0 {
-			return r == -1
-		}
-		return cmp.Compare(configs[i].Namespace, configs[j].Namespace) == -1
+		// ordered by creation time, name, namespace
+		return cmp.Or(
+            a.CreationTimestamp.Compare(b.CreationTimestamp),
+            cmp.Compare(a.Name, b.Name),
+            cmp.Compare(a.Namespace, b.Namespace),
+        )
 	})
 	return configs
 }


### PR DESCRIPTION
What happens in this PR:
* Replace `sort.Slice` with `slices.SortFunc` in `sortConfigBySelectorAndCreationTime`, using an int-returning comparator instead of a bool-returning less function. `slices.SortFunc` is preferred over `sort.Slice` because it is type-safe (no interface{} or reflection), avoids per-element overheads and has performance improvements.
* Simplify the creation time / name / namespace fallback chain using `cmp.Or`, removing repetitive `if r != 0` checks.

This change is behavior-preserving: `slices.SortFunc` with `return -1` / `return +1` maps directly to the old `return true` / `return false` in `sort.Slice`, and `cmp.Or` short-circuits on the first non-zero value, which is exactly what the previous `if r != 0` chain did. The `cmp.Or` usage is a nice improvement -- it collapses five lines into three and makes the tiebreaker ordering immediately obvious at a glance.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**
- [x] Performance and Scalability