### PR TITLE
optimize: serviceregistry building

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -64,12 +64,12 @@ var _ Metrics = &PushContext{}
 
 // serviceIndex is an index of all services by various fields for easy access during push.
 type serviceIndex struct {
-	// privateByNamespace are services that can reachable within the same namespace, with exportTo "."
-	privateByNamespace map[string]*[]*Service
+	// private are services that are reachable within the same namespace, with exportTo "."
+	private []*Service
 	// public are services reachable within the mesh with exportTo "*"
 	public []*Service
 	// exportedToNamespace are services that were made visible to this namespace
-	// by an exportTo explicitly specifying this namespace.
+	// by an exportTo explicitly specifying this namespace or because they are private to the namespace.
 	exportedToNamespace map[string]*[]*Service
 
 	// HostnameAndNamespace has all services, indexed by hostname then namespace.
@@ -84,7 +84,7 @@ type serviceIndex struct {
 func newServiceIndex() serviceIndex {
 	return serviceIndex{
 		public:               []*Service{},
-		privateByNamespace:   map[string]*[]*Service{},
+		private:              []*Service{},
 		exportedToNamespace:  map[string]*[]*Service{},
 		HostnameAndNamespace: map[host.Name]map[string]*Service{},
 		instancesByPort:      map[string]map[int][]*IstioEndpoint{},
@@ -1038,15 +1038,11 @@ func (ps *PushContext) servicesExportedToNamespace(ns string) []*Service {
 
 	// First add private services and explicitly exportedTo services
 	if ns == NamespaceAll {
-		out = make([]*Service, 0, len(ps.ServiceIndex.privateByNamespace)+len(ps.ServiceIndex.public))
-		for _, privateServices := range ps.ServiceIndex.privateByNamespace {
-			out = append(out, *privateServices...)
-		}
+		out = make([]*Service, 0, len(ps.ServiceIndex.private)+len(ps.ServiceIndex.public))
+		out = append(out, ps.ServiceIndex.private...)
 	} else {
-		privateServices := ptr.OrEmpty(ps.ServiceIndex.privateByNamespace[ns])
 		exportedServices := ptr.OrEmpty(ps.ServiceIndex.exportedToNamespace[ns])
-		out = make([]*Service, 0, len(privateServices)+len(exportedServices)+len(ps.ServiceIndex.public))
-		out = append(out, privateServices...)
+		out = make([]*Service, 0, len(exportedServices)+len(ps.ServiceIndex.public))
 		out = append(out, exportedServices...)
 	}
 
@@ -1578,12 +1574,13 @@ func (ps *PushContext) initServiceRegistry(env *Environment, configsUpdate sets.
 		ns := s.Attributes.Namespace
 		if s.Attributes.ExportTo.IsEmpty() {
 			if ps.exportToDefaults.service.Contains(visibility.Private) {
-				privateServices, ok := ps.ServiceIndex.privateByNamespace[ns]
+				ps.ServiceIndex.private = append(ps.ServiceIndex.private, s)
+				exportedServices, ok := ps.ServiceIndex.exportedToNamespace[ns]
 				if !ok {
-					privateServices = &[]*Service{}
-					ps.ServiceIndex.privateByNamespace[ns] = privateServices
+					exportedServices = &[]*Service{}
+					ps.ServiceIndex.exportedToNamespace[ns] = exportedServices
 				}
-				*privateServices = append(*privateServices, s)
+				*exportedServices = append(*exportedServices, s)
 			} else if ps.exportToDefaults.service.Contains(visibility.Public) {
 				ps.ServiceIndex.public = append(ps.ServiceIndex.public, s)
 			}
@@ -1599,23 +1596,20 @@ func (ps *PushContext) initServiceRegistry(env *Environment, configsUpdate sets.
 			}
 			// . or other namespaces
 			for exportTo := range s.Attributes.ExportTo {
-				if exportTo == visibility.Private || string(exportTo) == ns {
+				key := string(exportTo)
+				if exportTo == visibility.Private || key == ns {
 					// exportTo with same namespace is effectively private
-					privateServices, ok := ps.ServiceIndex.privateByNamespace[ns]
-					if !ok {
-						privateServices = &[]*Service{}
-						ps.ServiceIndex.privateByNamespace[ns] = privateServices
-					}
-					*privateServices = append(*privateServices, s)
-				} else {
-					// exportTo is a specific target namespace
-					exportedServices, ok := ps.ServiceIndex.exportedToNamespace[string(exportTo)]
-					if !ok {
-						exportedServices = &[]*Service{}
-						ps.ServiceIndex.exportedToNamespace[string(exportTo)] = exportedServices
-					}
-					*exportedServices = append(*exportedServices, s)
+					key = ns
+					ps.ServiceIndex.private = append(ps.ServiceIndex.private, s)
 				}
+
+				// exportTo is a specific target namespace
+				exportedServices, ok := ps.ServiceIndex.exportedToNamespace[key]
+				if !ok {
+					exportedServices = &[]*Service{}
+					ps.ServiceIndex.exportedToNamespace[key] = exportedServices
+				}
+				*exportedServices = append(*exportedServices, s)
 			}
 		}
 	}

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -70,7 +70,7 @@ type serviceIndex struct {
 	public []*Service
 	// exportedToNamespace are services that were made visible to this namespace
 	// by an exportTo explicitly specifying this namespace or because they are private to the namespace.
-	exportedToNamespace map[string]*[]*Service
+	exportedToNamespace map[string][]*Service
 
 	// HostnameAndNamespace has all services, indexed by hostname then namespace.
 	HostnameAndNamespace map[host.Name]map[string]*Service `json:"-"`
@@ -85,7 +85,7 @@ func newServiceIndex() serviceIndex {
 	return serviceIndex{
 		public:               []*Service{},
 		private:              []*Service{},
-		exportedToNamespace:  map[string]*[]*Service{},
+		exportedToNamespace:  map[string][]*Service{},
 		HostnameAndNamespace: map[host.Name]map[string]*Service{},
 		instancesByPort:      map[string]map[int][]*IstioEndpoint{},
 	}
@@ -1041,7 +1041,7 @@ func (ps *PushContext) servicesExportedToNamespace(ns string) []*Service {
 		out = make([]*Service, 0, len(ps.ServiceIndex.private)+len(ps.ServiceIndex.public))
 		out = append(out, ps.ServiceIndex.private...)
 	} else {
-		exportedServices := ptr.OrEmpty(ps.ServiceIndex.exportedToNamespace[ns])
+		exportedServices := ps.ServiceIndex.exportedToNamespace[ns]
 		out = make([]*Service, 0, len(exportedServices)+len(ps.ServiceIndex.public))
 		out = append(out, exportedServices...)
 	}
@@ -1577,10 +1577,9 @@ func (ps *PushContext) initServiceRegistry(env *Environment, configsUpdate sets.
 				ps.ServiceIndex.private = append(ps.ServiceIndex.private, s)
 				exportedServices, ok := ps.ServiceIndex.exportedToNamespace[ns]
 				if !ok {
-					exportedServices = &[]*Service{}
-					ps.ServiceIndex.exportedToNamespace[ns] = exportedServices
+					exportedServices = make([]*Service, 0)
 				}
-				*exportedServices = append(*exportedServices, s)
+				ps.ServiceIndex.exportedToNamespace[ns] = append(exportedServices, s)
 			} else if ps.exportToDefaults.service.Contains(visibility.Public) {
 				ps.ServiceIndex.public = append(ps.ServiceIndex.public, s)
 			}
@@ -1606,10 +1605,9 @@ func (ps *PushContext) initServiceRegistry(env *Environment, configsUpdate sets.
 				// exportTo is a specific target namespace
 				exportedServices, ok := ps.ServiceIndex.exportedToNamespace[key]
 				if !ok {
-					exportedServices = &[]*Service{}
-					ps.ServiceIndex.exportedToNamespace[key] = exportedServices
+					exportedServices = make([]*Service, 0)
 				}
-				*exportedServices = append(*exportedServices, s)
+				ps.ServiceIndex.exportedToNamespace[key] = append(exportedServices, s)
 			}
 		}
 	}

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -65,12 +65,12 @@ var _ Metrics = &PushContext{}
 // serviceIndex is an index of all services by various fields for easy access during push.
 type serviceIndex struct {
 	// privateByNamespace are services that can reachable within the same namespace, with exportTo "."
-	privateByNamespace map[string][]*Service
+	privateByNamespace map[string]*[]*Service
 	// public are services reachable within the mesh with exportTo "*"
 	public []*Service
 	// exportedToNamespace are services that were made visible to this namespace
 	// by an exportTo explicitly specifying this namespace.
-	exportedToNamespace map[string][]*Service
+	exportedToNamespace map[string]*[]*Service
 
 	// HostnameAndNamespace has all services, indexed by hostname then namespace.
 	HostnameAndNamespace map[host.Name]map[string]*Service `json:"-"`
@@ -84,8 +84,8 @@ type serviceIndex struct {
 func newServiceIndex() serviceIndex {
 	return serviceIndex{
 		public:               []*Service{},
-		privateByNamespace:   map[string][]*Service{},
-		exportedToNamespace:  map[string][]*Service{},
+		privateByNamespace:   map[string]*[]*Service{},
+		exportedToNamespace:  map[string]*[]*Service{},
 		HostnameAndNamespace: map[host.Name]map[string]*Service{},
 		instancesByPort:      map[string]map[int][]*IstioEndpoint{},
 	}
@@ -1040,13 +1040,14 @@ func (ps *PushContext) servicesExportedToNamespace(ns string) []*Service {
 	if ns == NamespaceAll {
 		out = make([]*Service, 0, len(ps.ServiceIndex.privateByNamespace)+len(ps.ServiceIndex.public))
 		for _, privateServices := range ps.ServiceIndex.privateByNamespace {
-			out = append(out, privateServices...)
+			out = append(out, *privateServices...)
 		}
 	} else {
-		out = make([]*Service, 0, len(ps.ServiceIndex.privateByNamespace[ns])+
-			len(ps.ServiceIndex.exportedToNamespace[ns])+len(ps.ServiceIndex.public))
-		out = append(out, ps.ServiceIndex.privateByNamespace[ns]...)
-		out = append(out, ps.ServiceIndex.exportedToNamespace[ns]...)
+		privateServices := ptr.OrEmpty(ps.ServiceIndex.privateByNamespace[ns])
+		exportedServices := ptr.OrEmpty(ps.ServiceIndex.exportedToNamespace[ns])
+		out = make([]*Service, 0, len(privateServices)+len(exportedServices)+len(ps.ServiceIndex.public))
+		out = append(out, privateServices...)
+		out = append(out, exportedServices...)
 	}
 
 	// Second add public services
@@ -1525,46 +1526,64 @@ func (ps *PushContext) initServiceRegistry(env *Environment, configsUpdate sets.
 	allServices := SortServicesByCreationTime(env.Services())
 	resolveServiceAliases(allServices, configsUpdate)
 
+	ps.ServiceIndex.instancesByPort = make(map[string]map[int][]*IstioEndpoint, len(allServices))
+	ps.serviceAccounts = make(map[serviceAccountKey][]string, len(allServices))
 	for _, s := range allServices {
-		portMap := map[string]int{}
-		ports := sets.New[int]()
+		portMap := make(map[string]int, len(s.Ports))
+		ports := sets.NewWithLength[int](len(s.Ports))
 		for _, port := range s.Ports {
 			portMap[port.Name] = port.Port
 			ports.Insert(port.Port)
 		}
 
 		svcKey := s.Key()
-		if _, ok := ps.ServiceIndex.instancesByPort[svcKey]; !ok {
-			ps.ServiceIndex.instancesByPort[svcKey] = make(map[int][]*IstioEndpoint)
+		instancesByPort, ok := ps.ServiceIndex.instancesByPort[svcKey]
+		if !ok {
+			instancesByPort = make(map[int][]*IstioEndpoint, len(s.Ports))
+			ps.ServiceIndex.instancesByPort[svcKey] = instancesByPort
 		}
+		var accounts sets.String
 		shards, ok := env.EndpointIndex.ShardsForService(string(s.Hostname), s.Attributes.Namespace)
 		if ok {
-			instancesByPort := shards.CopyEndpoints(portMap, ports)
+			endpoints := shards.CopyEndpoints(portMap, ports)
 			// Iterate over the instances and add them to the service index to avoid overriding the existing port instances.
-			for port, instances := range instancesByPort {
-				ps.ServiceIndex.instancesByPort[svcKey][port] = instances
+			for port, instances := range endpoints {
+				instancesByPort[port] = instances
 			}
+			// Extract service accounts while we have the shards.
+			shards.RLock()
+			accounts = shards.ServiceAccounts.Copy()
+			shards.RUnlock()
 		}
-		if _, f := ps.ServiceIndex.HostnameAndNamespace[s.Hostname]; !f {
-			ps.ServiceIndex.HostnameAndNamespace[s.Hostname] = map[string]*Service{}
+		ps.addServiceAccounts(s, accounts)
+
+		hostMap, f := ps.ServiceIndex.HostnameAndNamespace[s.Hostname]
+		if !f {
+			hostMap = map[string]*Service{}
+			ps.ServiceIndex.HostnameAndNamespace[s.Hostname] = hostMap
 		}
 		// In some scenarios, there may be multiple Services defined for the same hostname due to ServiceEntry allowing
 		// arbitrary hostnames. In these cases, we want to pick the first Service, which is the oldest. This ensures
 		// newly created Services cannot take ownership unexpectedly.
 		// However, the Service is from Kubernetes it should take precedence over ones not. This prevents someone from
 		// "domain squatting" on the hostname before a Kubernetes Service is created.
-		if existing := ps.ServiceIndex.HostnameAndNamespace[s.Hostname][s.Attributes.Namespace]; existing != nil &&
+		if existing := hostMap[s.Attributes.Namespace]; existing != nil &&
 			!(existing.Attributes.ServiceRegistry != provider.Kubernetes && s.Attributes.ServiceRegistry == provider.Kubernetes) {
 			log.Debugf("Service %s/%s from registry %s ignored by %s/%s/%s", s.Attributes.Namespace, s.Hostname, s.Attributes.ServiceRegistry,
 				existing.Attributes.ServiceRegistry, existing.Attributes.Namespace, existing.Hostname)
 		} else {
-			ps.ServiceIndex.HostnameAndNamespace[s.Hostname][s.Attributes.Namespace] = s
+			hostMap[s.Attributes.Namespace] = s
 		}
 
 		ns := s.Attributes.Namespace
 		if s.Attributes.ExportTo.IsEmpty() {
 			if ps.exportToDefaults.service.Contains(visibility.Private) {
-				ps.ServiceIndex.privateByNamespace[ns] = append(ps.ServiceIndex.privateByNamespace[ns], s)
+				privateServices, ok := ps.ServiceIndex.privateByNamespace[ns]
+				if !ok {
+					privateServices = &[]*Service{}
+					ps.ServiceIndex.privateByNamespace[ns] = privateServices
+				}
+				*privateServices = append(*privateServices, s)
 			} else if ps.exportToDefaults.service.Contains(visibility.Public) {
 				ps.ServiceIndex.public = append(ps.ServiceIndex.public, s)
 			}
@@ -1582,16 +1601,38 @@ func (ps *PushContext) initServiceRegistry(env *Environment, configsUpdate sets.
 			for exportTo := range s.Attributes.ExportTo {
 				if exportTo == visibility.Private || string(exportTo) == ns {
 					// exportTo with same namespace is effectively private
-					ps.ServiceIndex.privateByNamespace[ns] = append(ps.ServiceIndex.privateByNamespace[ns], s)
+					privateServices, ok := ps.ServiceIndex.privateByNamespace[ns]
+					if !ok {
+						privateServices = &[]*Service{}
+						ps.ServiceIndex.privateByNamespace[ns] = privateServices
+					}
+					*privateServices = append(*privateServices, s)
 				} else {
 					// exportTo is a specific target namespace
-					ps.ServiceIndex.exportedToNamespace[string(exportTo)] = append(ps.ServiceIndex.exportedToNamespace[string(exportTo)], s)
+					exportedServices, ok := ps.ServiceIndex.exportedToNamespace[string(exportTo)]
+					if !ok {
+						exportedServices = &[]*Service{}
+						ps.ServiceIndex.exportedToNamespace[string(exportTo)] = exportedServices
+					}
+					*exportedServices = append(*exportedServices, s)
 				}
 			}
 		}
 	}
+}
 
-	ps.initServiceAccounts(env, allServices)
+func (ps *PushContext) addServiceAccounts(s *Service, accounts sets.String) {
+	if len(s.ServiceAccounts) > 0 {
+		if accounts == nil {
+			accounts = sets.New(s.ServiceAccounts...)
+		} else {
+			accounts = accounts.InsertAll(s.ServiceAccounts...)
+		}
+	}
+	ps.serviceAccounts[serviceAccountKey{
+		hostname:  s.Hostname,
+		namespace: s.Attributes.Namespace,
+	}] = sets.SortedList(spiffe.ExpandWithTrustDomains(accounts, ps.Mesh.TrustDomainAliases))
 }
 
 // resolveServiceAliases sets the Aliases attributes on all services. The incoming Service's will just have AliasFor set,
@@ -1610,6 +1651,10 @@ func resolveServiceAliases(allServices []*Service, configsUpdated sets.Set[Confi
 			Namespace: s.Attributes.Namespace,
 		}
 		rawAlias[nh] = host.Name(s.Attributes.K8sAttributes.ExternalName)
+	}
+
+	if len(rawAlias) == 0 {
+		return
 	}
 
 	// unnamespacedRawAlias is like rawAlias but without namespaces.
@@ -1678,7 +1723,7 @@ func resolveServiceAliases(allServices []*Service, configsUpdated sets.Set[Confi
 	// Sort aliases so order is deterministic.
 	for _, v := range aliasesForService {
 		slices.SortFunc(v, func(a, b NamespacedHostname) int {
-			if r := cmp.Compare(a.Namespace, b.Namespace); r != 0 {
+			if r := strings.Compare(a.Namespace, b.Namespace); r != 0 {
 				return r
 			}
 			return cmp.Compare(a.Hostname, b.Hostname)
@@ -1705,41 +1750,12 @@ func SortServicesByCreationTime(services []*Service) []*Service {
 		// If creation time is the same, then behavior is nondeterministic. In this case, we can
 		// pick an arbitrary but consistent ordering based on name and namespace, which is unique.
 		// CreationTimestamp is stored in seconds, so this is not uncommon.
-		if r := cmp.Compare(i.Attributes.Name, j.Attributes.Name); r != 0 {
+		if r := strings.Compare(i.Attributes.Name, j.Attributes.Name); r != 0 {
 			return r
 		}
-		return cmp.Compare(i.Attributes.Namespace, j.Attributes.Namespace)
+		return strings.Compare(i.Attributes.Namespace, j.Attributes.Namespace)
 	})
 	return services
-}
-
-// Caches list of service accounts in the registry
-func (ps *PushContext) initServiceAccounts(env *Environment, services []*Service) {
-	for _, svc := range services {
-		var accounts sets.String
-		// First get endpoint level service accounts
-		shard, f := env.EndpointIndex.ShardsForService(string(svc.Hostname), svc.Attributes.Namespace)
-		if f {
-			shard.RLock()
-			// copy here to reduce the lock time
-			// endpoints could update frequently, so the longer it locks, the more likely it will block other threads.
-			accounts = shard.ServiceAccounts.Copy()
-			shard.RUnlock()
-		}
-		if len(svc.ServiceAccounts) > 0 {
-			if accounts == nil {
-				accounts = sets.New(svc.ServiceAccounts...)
-			} else {
-				accounts = accounts.InsertAll(svc.ServiceAccounts...)
-			}
-		}
-		sa := sets.SortedList(spiffe.ExpandWithTrustDomains(accounts, ps.Mesh.TrustDomainAliases))
-		key := serviceAccountKey{
-			hostname:  svc.Hostname,
-			namespace: svc.Attributes.Namespace,
-		}
-		ps.serviceAccounts[key] = sa
-	}
 }
 
 // Caches list of authentication policies
@@ -2036,10 +2052,10 @@ func sortConfigBySelectorAndCreationTime(configs []config.Config) []config.Confi
 		if r := configs[i].CreationTimestamp.Compare(configs[j].CreationTimestamp); r != 0 {
 			return r == -1 // -1 means i is less than j, so return true.
 		}
-		if r := cmp.Compare(configs[i].Name, configs[j].Name); r != 0 {
+		if r := strings.Compare(configs[i].Name, configs[j].Name); r != 0 {
 			return r == -1
 		}
-		return cmp.Compare(configs[i].Namespace, configs[j].Namespace) == -1
+		return strings.Compare(configs[i].Namespace, configs[j].Namespace) == -1
 	})
 	return configs
 }

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -1549,8 +1549,8 @@ func TestServiceIndex(t *testing.T) {
 
 	// Should have exported and private services in the right namespaces
 	g.Expect(si.exportedToNamespace).To(HaveLen(2))
-	g.Expect(serviceNames(*si.exportedToNamespace["namespace"])).To(Equal([]string{"svc-namespace"}))
-	g.Expect(serviceNames(*si.exportedToNamespace["test1"])).To(Equal([]string{"svc-private"}))
+	g.Expect(serviceNames(si.exportedToNamespace["namespace"])).To(Equal([]string{"svc-namespace"}))
+	g.Expect(serviceNames(si.exportedToNamespace["test1"])).To(Equal([]string{"svc-private"}))
 
 	g.Expect(serviceNames(si.public)).To(Equal([]string{"svc-public", "svc-unset"}))
 

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -1547,15 +1547,16 @@ func TestServiceIndex(t *testing.T) {
 	g.Expect(si.instancesByPort).To(HaveLen(5))
 	g.Expect(si.HostnameAndNamespace).To(HaveLen(5))
 
-	// Should just have "namespace"
-	g.Expect(si.exportedToNamespace).To(HaveLen(1))
+	// Should have exported and private services in the right namespaces
+	g.Expect(si.exportedToNamespace).To(HaveLen(2))
 	g.Expect(serviceNames(*si.exportedToNamespace["namespace"])).To(Equal([]string{"svc-namespace"}))
+	g.Expect(serviceNames(*si.exportedToNamespace["test1"])).To(Equal([]string{"svc-private"}))
 
 	g.Expect(serviceNames(si.public)).To(Equal([]string{"svc-public", "svc-unset"}))
 
 	// Should just have "test1"
-	g.Expect(si.privateByNamespace).To(HaveLen(1))
-	g.Expect(serviceNames(*si.privateByNamespace["test1"])).To(Equal([]string{"svc-private"}))
+	g.Expect(si.private).To(HaveLen(1))
+	g.Expect(serviceNames(si.private)).To(Equal([]string{"svc-private"}))
 }
 
 func TestIsServiceVisible(t *testing.T) {

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -3777,4 +3777,3 @@ func TestResolveServiceAliases(t *testing.T) {
 		})
 	}
 }
-

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -1549,13 +1549,13 @@ func TestServiceIndex(t *testing.T) {
 
 	// Should just have "namespace"
 	g.Expect(si.exportedToNamespace).To(HaveLen(1))
-	g.Expect(serviceNames(si.exportedToNamespace["namespace"])).To(Equal([]string{"svc-namespace"}))
+	g.Expect(serviceNames(*si.exportedToNamespace["namespace"])).To(Equal([]string{"svc-namespace"}))
 
 	g.Expect(serviceNames(si.public)).To(Equal([]string{"svc-public", "svc-unset"}))
 
 	// Should just have "test1"
 	g.Expect(si.privateByNamespace).To(HaveLen(1))
-	g.Expect(serviceNames(si.privateByNamespace["test1"])).To(Equal([]string{"svc-private"}))
+	g.Expect(serviceNames(*si.privateByNamespace["test1"])).To(Equal([]string{"svc-private"}))
 }
 
 func TestIsServiceVisible(t *testing.T) {
@@ -3778,64 +3778,3 @@ func TestResolveServiceAliases(t *testing.T) {
 	}
 }
 
-func BenchmarkInitServiceAccounts(b *testing.B) {
-	ps := NewPushContext()
-	index := NewEndpointIndex(DisabledCache{})
-	env := &Environment{EndpointIndex: index}
-	ps.Mesh = &meshconfig.MeshConfig{TrustDomainAliases: []string{"td1", "td2"}}
-
-	services := []*Service{
-		{
-			Hostname: "svc-unset",
-			Ports:    allPorts,
-			Attributes: ServiceAttributes{
-				Namespace: "test1",
-			},
-		},
-		{
-			Hostname: "svc-public",
-			Ports:    allPorts,
-			Attributes: ServiceAttributes{
-				Namespace: "test1",
-				ExportTo:  sets.New(visibility.Public),
-			},
-		},
-		{
-			Hostname: "svc-private",
-			Ports:    allPorts,
-			Attributes: ServiceAttributes{
-				Namespace: "test1",
-				ExportTo:  sets.New(visibility.Private),
-			},
-		},
-		{
-			Hostname: "svc-none",
-			Ports:    allPorts,
-			Attributes: ServiceAttributes{
-				Namespace: "test1",
-				ExportTo:  sets.New(visibility.None),
-			},
-		},
-		{
-			Hostname: "svc-namespace",
-			Ports:    allPorts,
-			Attributes: ServiceAttributes{
-				Namespace: "test1",
-				ExportTo:  sets.New(visibility.Instance("namespace")),
-			},
-		},
-	}
-
-	for _, svc := range services {
-		if index.shardsBySvc[string(svc.Hostname)] == nil {
-			index.shardsBySvc[string(svc.Hostname)] = map[string]*EndpointShards{}
-		}
-		index.shardsBySvc[string(svc.Hostname)][svc.Attributes.Namespace] = &EndpointShards{
-			ServiceAccounts: sets.New("spiffe://cluster.local/ns/def/sa/sa1", "spiffe://cluster.local/ns/def/sa/sa2"),
-		}
-	}
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		ps.initServiceAccounts(env, services)
-	}
-}

--- a/pilot/pkg/serviceregistry/serviceentry/auto_allocation.go
+++ b/pilot/pkg/serviceregistry/serviceentry/auto_allocation.go
@@ -66,7 +66,7 @@ func autoAllocateIPs(services []*model.Service) []*model.Service {
 	//   where PRIME is the max prime number below MAXIPS.
 	// - Calculate new hash iteratively till we find an empty slot with (h1(k) + i*h2(k)) % MAXIPS
 	j := 0
-	for _, svc := range services {
+	for i, svc := range services {
 		// we can allocate IPs only if
 		// 1. the service has resolution set to static/dns. We cannot allocate
 		//   for NONE because we will not know the original DST IP that the application requested.
@@ -84,7 +84,10 @@ func autoAllocateIPs(services []*model.Service) []*model.Service {
 			// Check if there is a service with this hash first. If there is no service
 			// at this location - then we can safely assign this position for this service.
 			if hashedServices[firstHash] == nil {
-				hashedServices[firstHash] = svc
+				// make a shallow copy because the service will be modified
+				svcCopy := svc.ShallowCopy()
+				hashedServices[firstHash] = svcCopy
+				services[i] = svcCopy
 			} else {
 				// This means we have a collision. Resolve collision by "DoubleHashing".
 				i := uint32(1)
@@ -92,7 +95,10 @@ func autoAllocateIPs(services []*model.Service) []*model.Service {
 				for {
 					nh := (s + i*secondHash) % uint32(maxIPs-1)
 					if hashedServices[nh] == nil {
-						hashedServices[nh] = svc
+						// make a shallow copy because the service will be modified
+						svcCopy := svc.ShallowCopy()
+						hashedServices[nh] = svcCopy
+						services[i] = svcCopy
 						break
 					}
 					i++

--- a/pilot/pkg/serviceregistry/serviceentry/auto_allocation.go
+++ b/pilot/pkg/serviceregistry/serviceentry/auto_allocation.go
@@ -66,7 +66,7 @@ func autoAllocateIPs(services []*model.Service) []*model.Service {
 	//   where PRIME is the max prime number below MAXIPS.
 	// - Calculate new hash iteratively till we find an empty slot with (h1(k) + i*h2(k)) % MAXIPS
 	j := 0
-	for i, svc := range services {
+	for idx, svc := range services {
 		// we can allocate IPs only if
 		// 1. the service has resolution set to static/dns. We cannot allocate
 		//   for NONE because we will not know the original DST IP that the application requested.
@@ -87,7 +87,7 @@ func autoAllocateIPs(services []*model.Service) []*model.Service {
 				// make a shallow copy because the service will be modified
 				svcCopy := svc.ShallowCopy()
 				hashedServices[firstHash] = svcCopy
-				services[i] = svcCopy
+				services[idx] = svcCopy
 			} else {
 				// This means we have a collision. Resolve collision by "DoubleHashing".
 				i := uint32(1)
@@ -98,7 +98,7 @@ func autoAllocateIPs(services []*model.Service) []*model.Service {
 						// make a shallow copy because the service will be modified
 						svcCopy := svc.ShallowCopy()
 						hashedServices[nh] = svcCopy
-						services[i] = svcCopy
+						services[idx] = svcCopy
 						break
 					}
 					i++

--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -15,7 +15,7 @@
 package serviceentry
 
 import (
-	"cmp"
+	"strings"
 
 	v1 "k8s.io/api/core/v1"
 
@@ -391,13 +391,9 @@ func (s *Controller) Services() []*model.Service {
 	}
 
 	allServices := s.outputs.Services.List()
-	copySvcs := make([]*model.Service, len(allServices))
-	for i, svc := range allServices {
-		// shallow copy, copy `AutoAllocatedIPv4Address` and `AutoAllocatedIPv6Address`
-		// if return the pointer directly, there will be a race with `BuildNameTable`
-		copySvcs[i] = svc.Service.ShallowCopy()
-	}
-	return autoAllocateIPs(copySvcs)
+	return autoAllocateIPs(slices.Map(allServices, func(s ServiceWithInstances) *model.Service {
+		return s.Service
+	}))
 }
 
 // GetService retrieves a service by host name if it exists.
@@ -527,16 +523,16 @@ func sortServicesByCreationTime(services []ServiceWithInstances) {
 		// If creation time is the same, then behavior is nondeterministic. In this case, we can
 		// pick an arbitrary but consistent ordering based on name and namespace, which is unique.
 		// CreationTimestamp is stored in seconds, so this is not uncommon.
-		if r := cmp.Compare(i.Service.Attributes.Name, j.Service.Attributes.Name); r != 0 {
+		if r := strings.Compare(i.Service.Attributes.Name, j.Service.Attributes.Name); r != 0 {
 			return r
 		}
 
-		if r := cmp.Compare(i.Service.Attributes.Namespace, j.Service.Attributes.Namespace); r != 0 {
+		if r := strings.Compare(i.Service.Attributes.Namespace, j.Service.Attributes.Namespace); r != 0 {
 			return r
 		}
 
 		// Fallback on Attributes.K8sAttributes.ObjectName because Attributes.Name is actually the hostname
 		// and we can have multiple services with the same hostname in the same namespace.
-		return cmp.Compare(i.Service.Attributes.K8sAttributes.ObjectName, j.Service.Attributes.K8sAttributes.ObjectName)
+		return strings.Compare(i.Service.Attributes.K8sAttributes.ObjectName, j.Service.Attributes.K8sAttributes.ObjectName)
 	})
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
this is showing as a significant part of our production profiles:

- refactor `privateByNamespace map[ns][]*Service` into a single `private []*Service` to avoid maintaining an unnecessary map. When a service is private we now also store it in `exportedToNamespace`, same as exported services, and we store a slices containing all private Services to be used when Listing all services.
- store pointer to slices in `exportedToNamespace` map, to avoid constantly re-assigning the map.
- `initServiceAccounts` now happens inline with serviceRegistry initialization, to avoid re-scanning all services and calling `ShardsForService` all over again.
- early return `resolveServiceAliases` if there are no alias services, these saves a bunch of unnecessary work.
- initialize maps with length were possible.
- avoid double map lookups in cases where keys already exist
- prefer `strings.Compare` vs `cmp.Compare`