### PR TITLE
[agw] Increase rate limits for each gw conformance test

### DIFF
--- a/tests/integration/ambient/gateway_conformance_test.go
+++ b/tests/integration/ambient/gateway_conformance_test.go
@@ -171,11 +171,11 @@ func testConformance(gatewayClassName string, skippedTestKeys []string, t *testi
 			clientOptions := client.Options{
 				Scheme: kube.IstioScheme,
 			}
-			// Copy the REST config so each conformance run gets a fresh rate
-			// limiter. Without this, back-to-back runs share the same token
-			// bucket and the second run can starve on API calls.
+			// Copy the REST config so the conformance suite gets its own rate limiter
+			// with enough headroom for the suite's rapid polling (~10 req/sec)
 			restConfig := rest.CopyConfig(gatewayConformanceInputs.Client.RESTConfig())
-			restConfig.RateLimiter = nil
+			restConfig.QPS = 20
+			restConfig.Burst = 40
 			c, err := client.New(restConfig, clientOptions)
 			if err != nil {
 				t.Fatal(err)

--- a/tests/integration/ambient/gateway_conformance_test.go
+++ b/tests/integration/ambient/gateway_conformance_test.go
@@ -26,6 +26,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8ssets "k8s.io/apimachinery/pkg/util/sets" //nolint: depguard
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/conformance"
@@ -170,7 +171,12 @@ func testConformance(gatewayClassName string, skippedTestKeys []string, t *testi
 			clientOptions := client.Options{
 				Scheme: kube.IstioScheme,
 			}
-			c, err := client.New(gatewayConformanceInputs.Client.RESTConfig(), clientOptions)
+			// Copy the REST config so each conformance run gets a fresh rate
+			// limiter. Without this, back-to-back runs share the same token
+			// bucket and the second run can starve on API calls.
+			restConfig := rest.CopyConfig(gatewayConformanceInputs.Client.RESTConfig())
+			restConfig.RateLimiter = nil
+			c, err := client.New(restConfig, clientOptions)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -182,7 +188,7 @@ func testConformance(gatewayClassName string, skippedTestKeys []string, t *testi
 				Client:                   c,
 				ClientOptions:            clientOptions,
 				Clientset:                gatewayConformanceInputs.Client.Kube(),
-				RestConfig:               gatewayConformanceInputs.Client.RESTConfig(),
+				RestConfig:               restConfig,
 				GatewayClassName:         gatewayClassName,
 				Debug:                    scopes.Framework.DebugEnabled(),
 				CleanupBaseResources:     gatewayConformanceInputs.Cleanup,

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -172,11 +172,11 @@ func testConformance(gatewayClassName string, skippedTestKeys []string, t *testi
 			clientOptions := client.Options{
 				Scheme: kube.IstioScheme,
 			}
-			// Copy the REST config so each conformance run gets a fresh rate
-			// limiter. Without this, back-to-back runs share the same token
-			// bucket and the second run can starve on API calls.
+			// Copy the REST config so the conformance suite gets its own rate limiter
+			// with enough headroom for the suite's rapid polling (~10 req/sec)
 			restConfig := rest.CopyConfig(gatewayConformanceInputs.Client.RESTConfig())
-			restConfig.RateLimiter = nil
+			restConfig.QPS = 20
+			restConfig.Burst = 40
 			c, err := client.New(restConfig, clientOptions)
 			if err != nil {
 				t.Fatal(err)

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -26,6 +26,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8ssets "k8s.io/apimachinery/pkg/util/sets" //nolint: depguard
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/conformance"
@@ -171,7 +172,12 @@ func testConformance(gatewayClassName string, skippedTestKeys []string, t *testi
 			clientOptions := client.Options{
 				Scheme: kube.IstioScheme,
 			}
-			c, err := client.New(gatewayConformanceInputs.Client.RESTConfig(), clientOptions)
+			// Copy the REST config so each conformance run gets a fresh rate
+			// limiter. Without this, back-to-back runs share the same token
+			// bucket and the second run can starve on API calls.
+			restConfig := rest.CopyConfig(gatewayConformanceInputs.Client.RESTConfig())
+			restConfig.RateLimiter = nil
+			c, err := client.New(restConfig, clientOptions)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -192,7 +198,7 @@ func testConformance(gatewayClassName string, skippedTestKeys []string, t *testi
 				Client:                   c,
 				Clientset:                gatewayConformanceInputs.Client.Kube(),
 				ClientOptions:            clientOptions,
-				RestConfig:               gatewayConformanceInputs.Client.RESTConfig(),
+				RestConfig:               restConfig,
 				GatewayClassName:         gatewayClassName,
 				Debug:                    scopes.Framework.DebugEnabled(),
 				CleanupBaseResources:     gatewayConformanceInputs.Cleanup,


### PR DESCRIPTION
**Please provide a description of this PR:**

Avoid flakiness in gateway conformance tests caused by rate limiter blocking from frequent polling, mult sequential API calls, and 2 tests running back to back. Increases QPS and burst for rate limiter