### PR TITLE
Use credentials secret for publish

### DIFF
--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -18,7 +18,8 @@ WD=$(dirname "$0")
 WD=$(cd "$WD"; pwd)
 ROOT=$(dirname "$WD")
 
-set -eux
+set -eu
+set +x
 
 # shellcheck source=prow/lib.sh
 source "${ROOT}/prow/lib.sh"
@@ -107,7 +108,6 @@ release-builder validate --release "${WORK_DIR}/out"
 
 if [[ -z "${DRY_RUN:-}" ]]; then
   ENDPOINT="$(echo "${CF_CREDENTIALS}" | jq -r '.endpoint' | tr -d '\n')"
-
   AWS_ACCESS_KEY_ID="$(echo "${CF_CREDENTIALS}" | jq -r '.access_key' | tr -d '\n')" \
     AWS_SECRET_ACCESS_KEY="$(echo "${CF_CREDENTIALS}" | jq -r '.secret_key' | tr -d '\n')" \
     AWS_REGION="$(echo "${CF_CREDENTIALS}" | jq -r '.region' | tr -d '\n')" \

--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -106,14 +106,14 @@ release-builder build --manifest <(echo "${MANIFEST}")
 release-builder validate --release "${WORK_DIR}/out"
 
 if [[ -z "${DRY_RUN:-}" ]]; then
-  ENDPOINT="$(echo "${CF_CREDENTIALS}" | jq -r '.endpoint'| tr -d '\n')"
+  ENDPOINT="$(echo "${CF_CREDENTIALS}" | jq -r '.endpoint' | tr -d '\n')"
 
-  AWS_ACCESS_KEY_ID="$(echo "${CF_CREDENTIALS}" | jq -r '.access_key'| tr -d '\n')" \
-    AWS_SECRET_ACCESS_KEY="$(echo "${CF_CREDENTIALS}" | jq -r '.secret_key'| tr -d '\n')" \
-    AWS_REGION="$(echo "${CF_CREDENTIALS}" | jq -r '.region'| tr -d '\n')" \
-    AWS_SESSION_TOKEN="$(echo "${CF_CREDENTIALS}" | jq -r '.session_token'| tr -d '\n')" \
+  AWS_ACCESS_KEY_ID="$(echo "${CF_CREDENTIALS}" | jq -r '.access_key' | tr -d '\n')" \
+    AWS_SECRET_ACCESS_KEY="$(echo "${CF_CREDENTIALS}" | jq -r '.secret_key' | tr -d '\n')" \
+    AWS_REGION="$(echo "${CF_CREDENTIALS}" | jq -r '.region' | tr -d '\n')" \
+    AWS_SESSION_TOKEN="$(echo "${CF_CREDENTIALS}" | jq -r '.session_token' | tr -d '\n')" \
     release-builder publish --release "${WORK_DIR}/out" \
       --gcsbucket "${GCS_BUCKET}" --gcsaliases "${TAG},${NEXT_VERSION}-dev,latest" \
-      --s3bucket "${R2_BUCKET}" --s3aliases "${TAG},${NEXT_VERSION}-dev,latest" --s3-base-endpoint "${ENDPOINT}" 
+      --s3bucket "${R2_BUCKET}" --s3aliases "${TAG},${NEXT_VERSION}-dev,latest" --s3-base-endpoint "${ENDPOINT}" \
       --dockerhub "gcr.io/istio-testing" --helmhub "${HELM_HUB}" --dockertags "${TAG},${VERSION},${NEXT_VERSION}-dev,latest"
 fi

--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -38,7 +38,7 @@ docker run --rm --privileged "${DOCKER_HUB}/qemu-user-static" --reset -p yes
 export ISTIO_DOCKER_QEMU=true
 
 # Use a pinned version in case breaking changes are needed
-BUILDER_SHA=762cf9b80f28efad2cd3d418a34d90ec64b925a4
+BUILDER_SHA=664c072ac90f6c1918f450eaae8550ee15b768b0
 
 # Reference to the next minor version of Istio
 # This will create a version like 1.30.0-alpha.<sha>
@@ -106,8 +106,14 @@ release-builder build --manifest <(echo "${MANIFEST}")
 release-builder validate --release "${WORK_DIR}/out"
 
 if [[ -z "${DRY_RUN:-}" ]]; then
-  release-builder publish --release "${WORK_DIR}/out" \
-    --gcsbucket "${GCS_BUCKET}" --gcsaliases "${TAG},${NEXT_VERSION}-dev,latest" \
-    --r2bucket "${R2_BUCKET}" --r2aliases "${TAG},${NEXT_VERSION}-dev,latest" \
-    --dockerhub "gcr.io/istio-testing" --helmhub "${HELM_HUB}" --dockertags "${TAG},${VERSION},${NEXT_VERSION}-dev,latest"
+  ENDPOINT="$(echo "${CF_CREDENTIALS}" | jq -r '.endpoint'| tr -d '\n')"
+
+  AWS_ACCESS_KEY_ID="$(echo "${CF_CREDENTIALS}" | jq -r '.access_key'| tr -d '\n')" \
+    AWS_SECRET_ACCESS_KEY="$(echo "${CF_CREDENTIALS}" | jq -r '.secret_key'| tr -d '\n')" \
+    AWS_REGION="$(echo "${CF_CREDENTIALS}" | jq -r '.region'| tr -d '\n')" \
+    AWS_SESSION_TOKEN="$(echo "${CF_CREDENTIALS}" | jq -r '.session_token'| tr -d '\n')" \
+    release-builder publish --release "${WORK_DIR}/out" \
+      --gcsbucket "${GCS_BUCKET}" --gcsaliases "${TAG},${NEXT_VERSION}-dev,latest" \
+      --s3bucket "${R2_BUCKET}" --s3aliases "${TAG},${NEXT_VERSION}-dev,latest" --s3-base-endpoint "${ENDPOINT}" 
+      --dockerhub "gcr.io/istio-testing" --helmhub "${HELM_HUB}" --dockertags "${TAG},${VERSION},${NEXT_VERSION}-dev,latest"
 fi


### PR DESCRIPTION
**Please provide a description of this PR:**

Some context: prow expects our s3/r2 credentials to be in a single secret in json format, so I figure we store all our r2/cloudflare/s3 credentials in the prow format:

```json
{
    "access_key": "xxx",
    "secret_key": "xxx",
    "endpoint": "xxx",
    "region": "xxx"
    "session_token": "xxx"
}
```

We also need to change up the environment variable/release-builder arguments because of this PR (https://github.com/istio/release-builder/pull/2311).