### PR TITLE
ambient: add Mesh Settings support for ztunnel xDS

### DIFF
--- a/pilot/pkg/bootstrap/discovery.go
+++ b/pilot/pkg/bootstrap/discovery.go
@@ -53,6 +53,7 @@ func InitGenerators(
 	generators[v3.AddressType] = workloadGen
 	generators[v3.WorkloadType] = workloadGen
 	generators[v3.WorkloadAuthorizationType] = &xds.WorkloadRBACGenerator{Server: s}
+	generators[v3.WorkloadMeshSettingsType] = &xds.WorkloadMeshSettingsGenerator{Server: s}
 
 	generators["grpc"] = &grpcgen.GrpcConfigGenerator{}
 	generators["grpc/"+v3.EndpointType] = edsGen

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1320,9 +1320,10 @@ func (s *Server) initMeshHandlers(changeHandler func(_ *meshconfig.MeshConfig)) 
 	s.environment.AddMeshHandler(func() {
 		changeHandler(s.environment.Mesh())
 		s.XDSServer.ConfigUpdate(&model.PushRequest{
-			Full:   true,
-			Reason: model.NewReasonStats(model.GlobalUpdate),
-			Forced: true,
+			Full:           true,
+			Reason:         model.NewReasonStats(model.GlobalUpdate),
+			Forced:         true,
+			ConfigsUpdated: sets.New(model.ConfigKey{Kind: kind.MeshConfig}),
 		})
 	})
 }

--- a/pilot/pkg/xds/v3/model.go
+++ b/pilot/pkg/xds/v3/model.go
@@ -33,6 +33,7 @@ const (
 	AddressType                = model.AddressType
 	WorkloadType               = model.WorkloadType
 	WorkloadAuthorizationType  = model.WorkloadAuthorizationType
+	WorkloadMeshSettingsType   = model.WorkloadMeshSettingsType
 
 	// nolint
 	HttpProtocolOptionsType = "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"

--- a/pilot/pkg/xds/workload.go
+++ b/pilot/pkg/xds/workload.go
@@ -17,11 +17,13 @@ package xds
 import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
+	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/util/sets"
+	"istio.io/istio/pkg/workloadapi"
 )
 
 type WorkloadGenerator struct {
@@ -225,4 +227,84 @@ func (e WorkloadRBACGenerator) Generate(proxy *model.Proxy, w *model.WatchedReso
 var (
 	_ model.XdsResourceGenerator      = &WorkloadRBACGenerator{}
 	_ model.XdsDeltaResourceGenerator = &WorkloadRBACGenerator{}
+)
+
+// WorkloadMeshSettingsGenerator generates MeshSettings resources for ztunnel.
+// This sends mesh-wide configuration (trust domain, TLS settings, etc.) to ztunnel.
+type WorkloadMeshSettingsGenerator struct {
+	Server *DiscoveryServer
+}
+
+func (e WorkloadMeshSettingsGenerator) GenerateDeltas(
+	proxy *model.Proxy,
+	req *model.PushRequest,
+	w *model.WatchedResource,
+) (model.Resources, model.DeletedResources, model.XdsLogDetails, bool, error) {
+	// Only respond if:
+	// 1. This is an explicit subscription request for MeshSettings, OR
+	// 2. MeshConfig changed (which contains meshMTLS, trustDomain, etc.)
+	if !req.IsRequest() && !req.ConfigsUpdated.Contains(model.ConfigKey{Kind: kind.MeshConfig}) {
+		return nil, nil, model.DefaultXdsLogDetails, false, nil
+	}
+
+	mesh := e.Server.Env.Mesh()
+	if mesh == nil {
+		return nil, nil, model.DefaultXdsLogDetails, false, nil
+	}
+
+	meshSettings := e.buildMeshSettings(mesh)
+
+	resources := model.Resources{
+		&discovery.Resource{
+			Name:     "mesh", // Single global resource
+			Resource: protoconv.MessageToAny(meshSettings),
+		},
+	}
+
+	return resources, nil, model.XdsLogDetails{}, true, nil
+}
+
+func (e WorkloadMeshSettingsGenerator) Generate(
+	proxy *model.Proxy,
+	w *model.WatchedResource,
+	req *model.PushRequest,
+) (model.Resources, model.XdsLogDetails, error) {
+	resources, _, details, _, err := e.GenerateDeltas(proxy, req, w)
+	return resources, details, err
+}
+
+func (e WorkloadMeshSettingsGenerator) buildMeshSettings(mesh *meshconfig.MeshConfig) *workloadapi.MeshSettings {
+	settings := &workloadapi.MeshSettings{
+		TrustDomain:        mesh.GetTrustDomain(),
+		TrustDomainAliases: mesh.GetTrustDomainAliases(),
+	}
+
+	// Add TLS config if meshMTLS is configured
+	meshMTLS := mesh.GetMeshMTLS()
+	if meshMTLS != nil {
+		// Map MeshConfig TLS version to workloadapi TLS version
+		var minVersion workloadapi.TlsVersion
+		switch meshMTLS.GetMinProtocolVersion() {
+		case meshconfig.MeshConfig_TLSConfig_TLSV1_2:
+			minVersion = workloadapi.TlsVersion_TLS_1_2
+		case meshconfig.MeshConfig_TLSConfig_TLSV1_3:
+			minVersion = workloadapi.TlsVersion_TLS_1_3
+		default:
+			// TLS_AUTO defaults to TLS 1.2
+			minVersion = workloadapi.TlsVersion_TLS_1_2
+		}
+
+		settings.Tls = &workloadapi.TlsConfig{
+			MinProtocolVersion: minVersion,
+			CipherSuites:       meshMTLS.GetCipherSuites(),
+			EcdhCurves:         meshMTLS.GetEcdhCurves(),
+		}
+	}
+
+	return settings
+}
+
+var (
+	_ model.XdsResourceGenerator      = &WorkloadMeshSettingsGenerator{}
+	_ model.XdsDeltaResourceGenerator = &WorkloadMeshSettingsGenerator{}
 )

--- a/pilot/pkg/xds/workload_test.go
+++ b/pilot/pkg/xds/workload_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"istio.io/api/annotation"
+	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/api/security/v1beta1"
 	metav1beta1 "istio.io/api/type/v1beta1"
 	securityclient "istio.io/client-go/pkg/apis/security/v1"
@@ -36,14 +37,19 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pilot/test/xds"
+	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/config/mesh"
+	"istio.io/istio/pkg/config/mesh/meshwatcher"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/kube/kclient/clienttest"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/util/sets"
+	"istio.io/istio/pkg/workloadapi"
 )
 
 func init() {
@@ -549,4 +555,92 @@ func TestPeerAuthenticationUpdate(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	ads.ExpectNoResponse()
+}
+
+func TestWorkloadMeshSettings(t *testing.T) {
+	meshCfg := mesh.DefaultMeshConfig()
+	meshCfg.TrustDomain = "test.example.com"
+	meshCfg.TrustDomainAliases = []string{"alias1.example.com"}
+	meshCfg.MeshMTLS = &meshconfig.MeshConfig_TLSConfig{
+		MinProtocolVersion: meshconfig.MeshConfig_TLSConfig_TLSV1_3,
+		CipherSuites:       []string{"TLS_AES_256_GCM_SHA384"},
+	}
+
+	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
+		MeshConfig: meshCfg,
+	})
+	ads := s.ConnectDeltaADS().WithType(v3.WorkloadMeshSettingsType).WithTimeout(time.Second * 10).WithNodeType(model.Ztunnel)
+
+	// Initial subscription should return MeshSettings
+	resp := ads.RequestResponseAck(&discovery.DeltaDiscoveryRequest{
+		ResourceNamesSubscribe: []string{"*"},
+	})
+	if len(resp.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(resp.Resources))
+	}
+	if resp.Resources[0].Name != "mesh" {
+		t.Fatalf("expected resource name 'mesh', got %q", resp.Resources[0].Name)
+	}
+	settings := xdstest.UnmarshalAny[workloadapi.MeshSettings](t, resp.Resources[0].Resource)
+	assert.Equal(t, settings.TrustDomain, "test.example.com")
+	assert.Equal(t, settings.TrustDomainAliases, []string{"alias1.example.com"})
+	assert.Equal(t, settings.Tls.MinProtocolVersion, workloadapi.TlsVersion_TLS_1_3)
+	assert.Equal(t, settings.Tls.CipherSuites, []string{"TLS_AES_256_GCM_SHA384"})
+
+	// Irrelevant push (pod creation) should not trigger MeshSettings update
+	createPod(s, "pod", "sa", "127.0.0.1", "node")
+	ads.ExpectNoResponse()
+
+	// Generic forced push (e.g. startup) should NOT trigger duplicate MeshSettings
+	s.Discovery.ConfigUpdate(&model.PushRequest{
+		Full:   true,
+		Forced: true,
+	})
+	ads.ExpectNoResponse()
+
+	// MeshConfig change should trigger update
+	newMeshCfg := mesh.DefaultMeshConfig()
+	newMeshCfg.TrustDomain = "updated.example.com"
+	newMeshCfg.TrustDomainAliases = []string{"old.example.com", "other.example.com"}
+	newMeshCfg.MeshMTLS = &meshconfig.MeshConfig_TLSConfig{
+		MinProtocolVersion: meshconfig.MeshConfig_TLSConfig_TLSV1_2,
+		CipherSuites:       []string{"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"},
+	}
+	s.Env().Watcher.(meshwatcher.TestWatcher).Set(newMeshCfg)
+	s.Discovery.ConfigUpdate(&model.PushRequest{
+		Full:           true,
+		Reason:         model.NewReasonStats(model.GlobalUpdate),
+		ConfigsUpdated: sets.New(model.ConfigKey{Kind: kind.MeshConfig}),
+	})
+	resp = ads.ExpectResponse()
+	if len(resp.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(resp.Resources))
+	}
+	settings = xdstest.UnmarshalAny[workloadapi.MeshSettings](t, resp.Resources[0].Resource)
+	assert.Equal(t, settings.TrustDomain, "updated.example.com")
+	assert.Equal(t, settings.TrustDomainAliases, []string{"old.example.com", "other.example.com"})
+	assert.Equal(t, settings.Tls.MinProtocolVersion, workloadapi.TlsVersion_TLS_1_2)
+	assert.Equal(t, settings.Tls.CipherSuites, []string{"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"})
+}
+
+func TestWorkloadMeshSettingsNoTLS(t *testing.T) {
+	meshCfg := mesh.DefaultMeshConfig()
+	meshCfg.TrustDomain = "notls.example.com"
+
+	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
+		MeshConfig: meshCfg,
+	})
+	ads := s.ConnectDeltaADS().WithType(v3.WorkloadMeshSettingsType).WithTimeout(time.Second * 10).WithNodeType(model.Ztunnel)
+
+	resp := ads.RequestResponseAck(&discovery.DeltaDiscoveryRequest{
+		ResourceNamesSubscribe: []string{"*"},
+	})
+	if len(resp.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(resp.Resources))
+	}
+	settings := xdstest.UnmarshalAny[workloadapi.MeshSettings](t, resp.Resources[0].Resource)
+	assert.Equal(t, settings.TrustDomain, "notls.example.com")
+	if settings.Tls != nil {
+		t.Fatalf("expected nil TLS config when meshMTLS is not set, got %v", settings.Tls)
+	}
 }

--- a/pkg/config/validation/agent/validation.go
+++ b/pkg/config/validation/agent/validation.go
@@ -767,13 +767,15 @@ func validateTrustDomainConfig(config *meshconfig.MeshConfig) (errs error) {
 	return errs
 }
 
-func ValidateMeshTLSConfig(mesh *meshconfig.MeshConfig) (errs error) {
+func ValidateMeshTLSConfig(mesh *meshconfig.MeshConfig) Validation {
+	v := Validation{}
 	if meshMTLS := mesh.MeshMTLS; meshMTLS != nil {
 		if meshMTLS.EcdhCurves != nil {
-			errs = multierror.Append(errs, errors.New("mesh TLS does not support ECDH curves configuration"))
+			v = AppendWarningf(v, "meshMTLS.ecdhCurves is set but not yet supported for Envoy sidecars; "+
+				"the values will be forwarded to ztunnel but ignored by Envoy")
 		}
 	}
-	return errs
+	return v
 }
 
 func ValidateMeshTLSDefaults(mesh *meshconfig.MeshConfig) (v Validation) {

--- a/pkg/config/validation/agent/validation_test.go
+++ b/pkg/config/validation/agent/validation_test.go
@@ -1102,7 +1102,6 @@ func TestValidateMeshConfig(t *testing.T) {
 			"trustDomainAliases[0]",
 			"trustDomainAliases[1]",
 			"trustDomainAliases[2]",
-			"mesh TLS does not support ECDH curves configuration",
 		}
 		switch err := err.(type) {
 		case *multierror.Error:
@@ -1124,6 +1123,7 @@ func TestValidateMeshConfig(t *testing.T) {
 		t.Errorf("expected a warning on invalid proxy mesh config: %v", invalid)
 	} else {
 		wantWarnings := []string{
+			"meshMTLS.ecdhCurves is set but not yet supported",
 			"detected unrecognized ECDH curves",
 			"detected duplicate ECDH curves",
 		}

--- a/pkg/model/xds.go
+++ b/pkg/model/xds.go
@@ -38,6 +38,7 @@ const (
 	AddressType               = APITypePrefix + "istio.workload.Address"
 	WorkloadType              = APITypePrefix + "istio.workload.Workload"
 	WorkloadAuthorizationType = APITypePrefix + "istio.security.Authorization"
+	WorkloadMeshSettingsType  = APITypePrefix + "istio.workload.MeshSettings"
 
 	// AgentGateway
 	AgwResourceType = APITypePrefix + "agentgateway.dev.resource.Resource"
@@ -66,6 +67,8 @@ func GetShortType(typeURL string) string {
 		return "WDS"
 	case WorkloadAuthorizationType:
 		return "WADS"
+	case WorkloadMeshSettingsType:
+		return "WMDS"
 	default:
 		return typeURL
 	}
@@ -96,6 +99,8 @@ func GetMetricType(typeURL string) string {
 		return "wds"
 	case WorkloadAuthorizationType:
 		return "wads"
+	case WorkloadMeshSettingsType:
+		return "wmds"
 	default:
 		return typeURL
 	}
@@ -125,6 +130,8 @@ func GetResourceType(shortType string) string {
 		return AddressType
 	case "WADS":
 		return WorkloadAuthorizationType
+	case "WMDS":
+		return WorkloadMeshSettingsType
 	default:
 		return shortType
 	}

--- a/pkg/workloadapi/workload.pb.go
+++ b/pkg/workloadapi/workload.pb.go
@@ -356,6 +356,55 @@ func (TunnelProtocol) EnumDescriptor() ([]byte, []int) {
 	return file_workloadapi_workload_proto_rawDescGZIP(), []int{5}
 }
 
+// TlsVersion represents the TLS protocol versions that can be configured.
+type TlsVersion int32
+
+const (
+	// TLS 1.2 - minimum version when TLS 1.2 is enabled
+	TlsVersion_TLS_1_2 TlsVersion = 0
+	// TLS 1.3 - minimum version for TLS 1.3 only mode
+	TlsVersion_TLS_1_3 TlsVersion = 1
+)
+
+// Enum value maps for TlsVersion.
+var (
+	TlsVersion_name = map[int32]string{
+		0: "TLS_1_2",
+		1: "TLS_1_3",
+	}
+	TlsVersion_value = map[string]int32{
+		"TLS_1_2": 0,
+		"TLS_1_3": 1,
+	}
+)
+
+func (x TlsVersion) Enum() *TlsVersion {
+	p := new(TlsVersion)
+	*p = x
+	return p
+}
+
+func (x TlsVersion) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (TlsVersion) Descriptor() protoreflect.EnumDescriptor {
+	return file_workloadapi_workload_proto_enumTypes[6].Descriptor()
+}
+
+func (TlsVersion) Type() protoreflect.EnumType {
+	return &file_workloadapi_workload_proto_enumTypes[6]
+}
+
+func (x TlsVersion) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use TlsVersion.Descriptor instead.
+func (TlsVersion) EnumDescriptor() ([]byte, []int) {
+	return file_workloadapi_workload_proto_rawDescGZIP(), []int{6}
+}
+
 type LoadBalancing_Scope int32
 
 const (
@@ -407,11 +456,11 @@ func (x LoadBalancing_Scope) String() string {
 }
 
 func (LoadBalancing_Scope) Descriptor() protoreflect.EnumDescriptor {
-	return file_workloadapi_workload_proto_enumTypes[6].Descriptor()
+	return file_workloadapi_workload_proto_enumTypes[7].Descriptor()
 }
 
 func (LoadBalancing_Scope) Type() protoreflect.EnumType {
-	return &file_workloadapi_workload_proto_enumTypes[6]
+	return &file_workloadapi_workload_proto_enumTypes[7]
 }
 
 func (x LoadBalancing_Scope) Number() protoreflect.EnumNumber {
@@ -472,11 +521,11 @@ func (x LoadBalancing_Mode) String() string {
 }
 
 func (LoadBalancing_Mode) Descriptor() protoreflect.EnumDescriptor {
-	return file_workloadapi_workload_proto_enumTypes[7].Descriptor()
+	return file_workloadapi_workload_proto_enumTypes[8].Descriptor()
 }
 
 func (LoadBalancing_Mode) Type() protoreflect.EnumType {
-	return &file_workloadapi_workload_proto_enumTypes[7]
+	return &file_workloadapi_workload_proto_enumTypes[8]
 }
 
 func (x LoadBalancing_Mode) Number() protoreflect.EnumNumber {
@@ -520,11 +569,11 @@ func (x LoadBalancing_HealthPolicy) String() string {
 }
 
 func (LoadBalancing_HealthPolicy) Descriptor() protoreflect.EnumDescriptor {
-	return file_workloadapi_workload_proto_enumTypes[8].Descriptor()
+	return file_workloadapi_workload_proto_enumTypes[9].Descriptor()
 }
 
 func (LoadBalancing_HealthPolicy) Type() protoreflect.EnumType {
-	return &file_workloadapi_workload_proto_enumTypes[8]
+	return &file_workloadapi_workload_proto_enumTypes[9]
 }
 
 func (x LoadBalancing_HealthPolicy) Number() protoreflect.EnumNumber {
@@ -572,11 +621,11 @@ func (x ApplicationTunnel_Protocol) String() string {
 }
 
 func (ApplicationTunnel_Protocol) Descriptor() protoreflect.EnumDescriptor {
-	return file_workloadapi_workload_proto_enumTypes[9].Descriptor()
+	return file_workloadapi_workload_proto_enumTypes[10].Descriptor()
 }
 
 func (ApplicationTunnel_Protocol) Type() protoreflect.EnumType {
-	return &file_workloadapi_workload_proto_enumTypes[9]
+	return &file_workloadapi_workload_proto_enumTypes[10]
 }
 
 func (x ApplicationTunnel_Protocol) Number() protoreflect.EnumNumber {
@@ -1724,6 +1773,147 @@ func (x *Extension) GetConfig() *anypb.Any {
 	return nil
 }
 
+// TlsConfig defines the TLS configuration for mTLS connections.
+// This matches Istio's MeshConfig.meshMTLS (TLSConfig) structure.
+type TlsConfig struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Minimum TLS protocol version (required).
+	// Determines which TLS versions are enabled for connections.
+	MinProtocolVersion TlsVersion `protobuf:"varint,1,opt,name=min_protocol_version,json=minProtocolVersion,proto3,enum=istio.workload.TlsVersion" json:"min_protocol_version,omitempty"`
+	// Cipher suites to enable, specified as standard TLS cipher suite names.
+	// Examples: "TLS_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+	// If empty, defaults to provider's default cipher suites based on enabled TLS versions.
+	CipherSuites []string `protobuf:"bytes,2,rep,name=cipher_suites,json=cipherSuites,proto3" json:"cipher_suites,omitempty"`
+	// Key exchange groups (ECDH curves) for TLS handshake.
+	// Examples: "P-256", "P-384", "X25519", "X25519MLKEM768"
+	// If empty, defaults based on crypto provider capabilities.
+	// Note: "X25519MLKEM768" enables post-quantum cryptography if supported by the provider.
+	EcdhCurves    []string `protobuf:"bytes,3,rep,name=ecdh_curves,json=ecdhCurves,proto3" json:"ecdh_curves,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TlsConfig) Reset() {
+	*x = TlsConfig{}
+	mi := &file_workloadapi_workload_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TlsConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TlsConfig) ProtoMessage() {}
+
+func (x *TlsConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_workloadapi_workload_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TlsConfig.ProtoReflect.Descriptor instead.
+func (*TlsConfig) Descriptor() ([]byte, []int) {
+	return file_workloadapi_workload_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *TlsConfig) GetMinProtocolVersion() TlsVersion {
+	if x != nil {
+		return x.MinProtocolVersion
+	}
+	return TlsVersion_TLS_1_2
+}
+
+func (x *TlsConfig) GetCipherSuites() []string {
+	if x != nil {
+		return x.CipherSuites
+	}
+	return nil
+}
+
+func (x *TlsConfig) GetEcdhCurves() []string {
+	if x != nil {
+		return x.EcdhCurves
+	}
+	return nil
+}
+
+// MeshSettings provides mesh-wide configuration pushed from istiod to ztunnel.
+// This consolidates settings that were previously scattered across environment variables,
+// enabling dynamic updates without requiring ztunnel restarts.
+type MeshSettings struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Trust domain for SPIFFE identities (e.g., "cluster.local").
+	// Used for constructing and validating workload identities.
+	// If empty, falls back to TRUST_DOMAIN environment variable.
+	TrustDomain string `protobuf:"bytes,1,opt,name=trust_domain,json=trustDomain,proto3" json:"trust_domain,omitempty"`
+	// Alternate trust domains that should be treated as equivalent.
+	// Used for multi-cluster trust domain migration and federation.
+	TrustDomainAliases []string `protobuf:"bytes,2,rep,name=trust_domain_aliases,json=trustDomainAliases,proto3" json:"trust_domain_aliases,omitempty"`
+	// TLS configuration for mTLS connections between workloads.
+	// If not set, falls back to environment variable defaults (TLS12_ENABLED, COMPLIANCE_POLICY).
+	Tls           *TlsConfig `protobuf:"bytes,3,opt,name=tls,proto3" json:"tls,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MeshSettings) Reset() {
+	*x = MeshSettings{}
+	mi := &file_workloadapi_workload_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MeshSettings) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MeshSettings) ProtoMessage() {}
+
+func (x *MeshSettings) ProtoReflect() protoreflect.Message {
+	mi := &file_workloadapi_workload_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MeshSettings.ProtoReflect.Descriptor instead.
+func (*MeshSettings) Descriptor() ([]byte, []int) {
+	return file_workloadapi_workload_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *MeshSettings) GetTrustDomain() string {
+	if x != nil {
+		return x.TrustDomain
+	}
+	return ""
+}
+
+func (x *MeshSettings) GetTrustDomainAliases() []string {
+	if x != nil {
+		return x.TrustDomainAliases
+	}
+	return nil
+}
+
+func (x *MeshSettings) GetTls() *TlsConfig {
+	if x != nil {
+		return x.Tls
+	}
+	return nil
+}
+
 var File_workloadapi_workload_proto protoreflect.FileDescriptor
 
 const file_workloadapi_workload_proto_rawDesc = "" +
@@ -1839,7 +2029,16 @@ const file_workloadapi_workload_proto_rawDesc = "" +
 	"\bhostname\x18\x02 \x01(\tR\bhostname\"M\n" +
 	"\tExtension\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12,\n" +
-	"\x06config\x18\x02 \x01(\v2\x14.google.protobuf.AnyR\x06config*C\n" +
+	"\x06config\x18\x02 \x01(\v2\x14.google.protobuf.AnyR\x06config\"\x9f\x01\n" +
+	"\tTlsConfig\x12L\n" +
+	"\x14min_protocol_version\x18\x01 \x01(\x0e2\x1a.istio.workload.TlsVersionR\x12minProtocolVersion\x12#\n" +
+	"\rcipher_suites\x18\x02 \x03(\tR\fcipherSuites\x12\x1f\n" +
+	"\vecdh_curves\x18\x03 \x03(\tR\n" +
+	"ecdhCurves\"\x90\x01\n" +
+	"\fMeshSettings\x12!\n" +
+	"\ftrust_domain\x18\x01 \x01(\tR\vtrustDomain\x120\n" +
+	"\x14trust_domain_aliases\x18\x02 \x03(\tR\x12trustDomainAliases\x12+\n" +
+	"\x03tls\x18\x03 \x01(\v2\x19.istio.workload.TlsConfigR\x03tls*C\n" +
 	"\n" +
 	"IPFamilies\x12\r\n" +
 	"\tAUTOMATIC\x10\x00\x12\r\n" +
@@ -1869,7 +2068,11 @@ const file_workloadapi_workload_proto_rawDesc = "" +
 	"\x0eTunnelProtocol\x12\b\n" +
 	"\x04NONE\x10\x00\x12\t\n" +
 	"\x05HBONE\x10\x01\x12\x15\n" +
-	"\x11LEGACY_ISTIO_MTLS\x10\x02B Z\x1eistio.io/istio/pkg/workloadapib\x06proto3"
+	"\x11LEGACY_ISTIO_MTLS\x10\x02*&\n" +
+	"\n" +
+	"TlsVersion\x12\v\n" +
+	"\aTLS_1_2\x10\x00\x12\v\n" +
+	"\aTLS_1_3\x10\x01B Z\x1eistio.io/istio/pkg/workloadapib\x06proto3"
 
 var (
 	file_workloadapi_workload_proto_rawDescOnce sync.Once
@@ -1883,8 +2086,8 @@ func file_workloadapi_workload_proto_rawDescGZIP() []byte {
 	return file_workloadapi_workload_proto_rawDescData
 }
 
-var file_workloadapi_workload_proto_enumTypes = make([]protoimpl.EnumInfo, 10)
-var file_workloadapi_workload_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
+var file_workloadapi_workload_proto_enumTypes = make([]protoimpl.EnumInfo, 11)
+var file_workloadapi_workload_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_workloadapi_workload_proto_goTypes = []any{
 	(IPFamilies)(0),                 // 0: istio.workload.IPFamilies
 	(NetworkMode)(0),                // 1: istio.workload.NetworkMode
@@ -1892,61 +2095,66 @@ var file_workloadapi_workload_proto_goTypes = []any{
 	(WorkloadType)(0),               // 3: istio.workload.WorkloadType
 	(AppProtocol)(0),                // 4: istio.workload.AppProtocol
 	(TunnelProtocol)(0),             // 5: istio.workload.TunnelProtocol
-	(LoadBalancing_Scope)(0),        // 6: istio.workload.LoadBalancing.Scope
-	(LoadBalancing_Mode)(0),         // 7: istio.workload.LoadBalancing.Mode
-	(LoadBalancing_HealthPolicy)(0), // 8: istio.workload.LoadBalancing.HealthPolicy
-	(ApplicationTunnel_Protocol)(0), // 9: istio.workload.ApplicationTunnel.Protocol
-	(*Address)(nil),                 // 10: istio.workload.Address
-	(*Service)(nil),                 // 11: istio.workload.Service
-	(*LoadBalancing)(nil),           // 12: istio.workload.LoadBalancing
-	(*Workload)(nil),                // 13: istio.workload.Workload
-	(*Locality)(nil),                // 14: istio.workload.Locality
-	(*PortList)(nil),                // 15: istio.workload.PortList
-	(*Port)(nil),                    // 16: istio.workload.Port
-	(*ApplicationTunnel)(nil),       // 17: istio.workload.ApplicationTunnel
-	(*GatewayAddress)(nil),          // 18: istio.workload.GatewayAddress
-	(*NetworkAddress)(nil),          // 19: istio.workload.NetworkAddress
-	(*NamespacedHostname)(nil),      // 20: istio.workload.NamespacedHostname
-	(*Extension)(nil),               // 21: istio.workload.Extension
-	nil,                             // 22: istio.workload.Workload.ServicesEntry
-	(*wrapperspb.UInt32Value)(nil),  // 23: google.protobuf.UInt32Value
-	(*anypb.Any)(nil),               // 24: google.protobuf.Any
+	(TlsVersion)(0),                 // 6: istio.workload.TlsVersion
+	(LoadBalancing_Scope)(0),        // 7: istio.workload.LoadBalancing.Scope
+	(LoadBalancing_Mode)(0),         // 8: istio.workload.LoadBalancing.Mode
+	(LoadBalancing_HealthPolicy)(0), // 9: istio.workload.LoadBalancing.HealthPolicy
+	(ApplicationTunnel_Protocol)(0), // 10: istio.workload.ApplicationTunnel.Protocol
+	(*Address)(nil),                 // 11: istio.workload.Address
+	(*Service)(nil),                 // 12: istio.workload.Service
+	(*LoadBalancing)(nil),           // 13: istio.workload.LoadBalancing
+	(*Workload)(nil),                // 14: istio.workload.Workload
+	(*Locality)(nil),                // 15: istio.workload.Locality
+	(*PortList)(nil),                // 16: istio.workload.PortList
+	(*Port)(nil),                    // 17: istio.workload.Port
+	(*ApplicationTunnel)(nil),       // 18: istio.workload.ApplicationTunnel
+	(*GatewayAddress)(nil),          // 19: istio.workload.GatewayAddress
+	(*NetworkAddress)(nil),          // 20: istio.workload.NetworkAddress
+	(*NamespacedHostname)(nil),      // 21: istio.workload.NamespacedHostname
+	(*Extension)(nil),               // 22: istio.workload.Extension
+	(*TlsConfig)(nil),               // 23: istio.workload.TlsConfig
+	(*MeshSettings)(nil),            // 24: istio.workload.MeshSettings
+	nil,                             // 25: istio.workload.Workload.ServicesEntry
+	(*wrapperspb.UInt32Value)(nil),  // 26: google.protobuf.UInt32Value
+	(*anypb.Any)(nil),               // 27: google.protobuf.Any
 }
 var file_workloadapi_workload_proto_depIdxs = []int32{
-	13, // 0: istio.workload.Address.workload:type_name -> istio.workload.Workload
-	11, // 1: istio.workload.Address.service:type_name -> istio.workload.Service
-	19, // 2: istio.workload.Service.addresses:type_name -> istio.workload.NetworkAddress
-	16, // 3: istio.workload.Service.ports:type_name -> istio.workload.Port
-	18, // 4: istio.workload.Service.waypoint:type_name -> istio.workload.GatewayAddress
-	12, // 5: istio.workload.Service.load_balancing:type_name -> istio.workload.LoadBalancing
+	14, // 0: istio.workload.Address.workload:type_name -> istio.workload.Workload
+	12, // 1: istio.workload.Address.service:type_name -> istio.workload.Service
+	20, // 2: istio.workload.Service.addresses:type_name -> istio.workload.NetworkAddress
+	17, // 3: istio.workload.Service.ports:type_name -> istio.workload.Port
+	19, // 4: istio.workload.Service.waypoint:type_name -> istio.workload.GatewayAddress
+	13, // 5: istio.workload.Service.load_balancing:type_name -> istio.workload.LoadBalancing
 	0,  // 6: istio.workload.Service.ip_families:type_name -> istio.workload.IPFamilies
-	21, // 7: istio.workload.Service.extensions:type_name -> istio.workload.Extension
-	6,  // 8: istio.workload.LoadBalancing.routing_preference:type_name -> istio.workload.LoadBalancing.Scope
-	7,  // 9: istio.workload.LoadBalancing.mode:type_name -> istio.workload.LoadBalancing.Mode
-	8,  // 10: istio.workload.LoadBalancing.health_policy:type_name -> istio.workload.LoadBalancing.HealthPolicy
+	22, // 7: istio.workload.Service.extensions:type_name -> istio.workload.Extension
+	7,  // 8: istio.workload.LoadBalancing.routing_preference:type_name -> istio.workload.LoadBalancing.Scope
+	8,  // 9: istio.workload.LoadBalancing.mode:type_name -> istio.workload.LoadBalancing.Mode
+	9,  // 10: istio.workload.LoadBalancing.health_policy:type_name -> istio.workload.LoadBalancing.HealthPolicy
 	5,  // 11: istio.workload.Workload.tunnel_protocol:type_name -> istio.workload.TunnelProtocol
-	18, // 12: istio.workload.Workload.waypoint:type_name -> istio.workload.GatewayAddress
-	18, // 13: istio.workload.Workload.network_gateway:type_name -> istio.workload.GatewayAddress
+	19, // 12: istio.workload.Workload.waypoint:type_name -> istio.workload.GatewayAddress
+	19, // 13: istio.workload.Workload.network_gateway:type_name -> istio.workload.GatewayAddress
 	3,  // 14: istio.workload.Workload.workload_type:type_name -> istio.workload.WorkloadType
-	17, // 15: istio.workload.Workload.application_tunnel:type_name -> istio.workload.ApplicationTunnel
-	22, // 16: istio.workload.Workload.services:type_name -> istio.workload.Workload.ServicesEntry
+	18, // 15: istio.workload.Workload.application_tunnel:type_name -> istio.workload.ApplicationTunnel
+	25, // 16: istio.workload.Workload.services:type_name -> istio.workload.Workload.ServicesEntry
 	2,  // 17: istio.workload.Workload.status:type_name -> istio.workload.WorkloadStatus
-	14, // 18: istio.workload.Workload.locality:type_name -> istio.workload.Locality
+	15, // 18: istio.workload.Workload.locality:type_name -> istio.workload.Locality
 	1,  // 19: istio.workload.Workload.network_mode:type_name -> istio.workload.NetworkMode
-	21, // 20: istio.workload.Workload.extensions:type_name -> istio.workload.Extension
-	23, // 21: istio.workload.Workload.capacity:type_name -> google.protobuf.UInt32Value
-	16, // 22: istio.workload.PortList.ports:type_name -> istio.workload.Port
+	22, // 20: istio.workload.Workload.extensions:type_name -> istio.workload.Extension
+	26, // 21: istio.workload.Workload.capacity:type_name -> google.protobuf.UInt32Value
+	17, // 22: istio.workload.PortList.ports:type_name -> istio.workload.Port
 	4,  // 23: istio.workload.Port.app_protocol:type_name -> istio.workload.AppProtocol
-	9,  // 24: istio.workload.ApplicationTunnel.protocol:type_name -> istio.workload.ApplicationTunnel.Protocol
-	20, // 25: istio.workload.GatewayAddress.hostname:type_name -> istio.workload.NamespacedHostname
-	19, // 26: istio.workload.GatewayAddress.address:type_name -> istio.workload.NetworkAddress
-	24, // 27: istio.workload.Extension.config:type_name -> google.protobuf.Any
-	15, // 28: istio.workload.Workload.ServicesEntry.value:type_name -> istio.workload.PortList
-	29, // [29:29] is the sub-list for method output_type
-	29, // [29:29] is the sub-list for method input_type
-	29, // [29:29] is the sub-list for extension type_name
-	29, // [29:29] is the sub-list for extension extendee
-	0,  // [0:29] is the sub-list for field type_name
+	10, // 24: istio.workload.ApplicationTunnel.protocol:type_name -> istio.workload.ApplicationTunnel.Protocol
+	21, // 25: istio.workload.GatewayAddress.hostname:type_name -> istio.workload.NamespacedHostname
+	20, // 26: istio.workload.GatewayAddress.address:type_name -> istio.workload.NetworkAddress
+	27, // 27: istio.workload.Extension.config:type_name -> google.protobuf.Any
+	6,  // 28: istio.workload.TlsConfig.min_protocol_version:type_name -> istio.workload.TlsVersion
+	23, // 29: istio.workload.MeshSettings.tls:type_name -> istio.workload.TlsConfig
+	16, // 30: istio.workload.Workload.ServicesEntry.value:type_name -> istio.workload.PortList
+	31, // [31:31] is the sub-list for method output_type
+	31, // [31:31] is the sub-list for method input_type
+	31, // [31:31] is the sub-list for extension type_name
+	31, // [31:31] is the sub-list for extension extendee
+	0,  // [0:31] is the sub-list for field type_name
 }
 
 func init() { file_workloadapi_workload_proto_init() }
@@ -1968,8 +2176,8 @@ func file_workloadapi_workload_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_workloadapi_workload_proto_rawDesc), len(file_workloadapi_workload_proto_rawDesc)),
-			NumEnums:      10,
-			NumMessages:   13,
+			NumEnums:      11,
+			NumMessages:   15,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/workloadapi/workload.proto
+++ b/pkg/workloadapi/workload.proto
@@ -409,3 +409,48 @@ message Extension {
   // config provides some opaque configuration.
   google.protobuf.Any config = 2;
 }
+
+// TlsVersion represents the TLS protocol versions that can be configured.
+enum TlsVersion {
+  // TLS 1.2 - minimum version when TLS 1.2 is enabled
+  TLS_1_2 = 0;
+  // TLS 1.3 - minimum version for TLS 1.3 only mode
+  TLS_1_3 = 1;
+}
+
+// TlsConfig defines the TLS configuration for mTLS connections.
+// This matches Istio's MeshConfig.meshMTLS (TLSConfig) structure.
+message TlsConfig {
+  // Minimum TLS protocol version (required).
+  // Determines which TLS versions are enabled for connections.
+  TlsVersion min_protocol_version = 1;
+
+  // Cipher suites to enable, specified as standard TLS cipher suite names.
+  // Examples: "TLS_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+  // If empty, defaults to provider's default cipher suites based on enabled TLS versions.
+  repeated string cipher_suites = 2;
+
+  // Key exchange groups (ECDH curves) for TLS handshake.
+  // Examples: "P-256", "P-384", "X25519", "X25519MLKEM768"
+  // If empty, defaults based on crypto provider capabilities.
+  // Note: "X25519MLKEM768" enables post-quantum cryptography if supported by the provider.
+  repeated string ecdh_curves = 3;
+}
+
+// MeshSettings provides mesh-wide configuration pushed from istiod to ztunnel.
+// This consolidates settings that were previously scattered across environment variables,
+// enabling dynamic updates without requiring ztunnel restarts.
+message MeshSettings {
+  // Trust domain for SPIFFE identities (e.g., "cluster.local").
+  // Used for constructing and validating workload identities.
+  // If empty, falls back to TRUST_DOMAIN environment variable.
+  string trust_domain = 1;
+
+  // Alternate trust domains that should be treated as equivalent.
+  // Used for multi-cluster trust domain migration and federation.
+  repeated string trust_domain_aliases = 2;
+
+  // TLS configuration for mTLS connections between workloads.
+  // If not set, falls back to environment variable defaults (TLS12_ENABLED, COMPLIANCE_POLICY).
+  TlsConfig tls = 3;
+}

--- a/pkg/workloadapi/workload_json.gen.go
+++ b/pkg/workloadapi/workload_json.gen.go
@@ -138,6 +138,28 @@ func (this *Extension) UnmarshalJSON(b []byte) error {
 	return WorkloadUnmarshaler.Unmarshal(bytes.NewReader(b), this)
 }
 
+// MarshalJSON is a custom marshaler for TlsConfig
+func (this *TlsConfig) MarshalJSON() ([]byte, error) {
+	str, err := WorkloadMarshaler.MarshalToString(this)
+	return []byte(str), err
+}
+
+// UnmarshalJSON is a custom unmarshaler for TlsConfig
+func (this *TlsConfig) UnmarshalJSON(b []byte) error {
+	return WorkloadUnmarshaler.Unmarshal(bytes.NewReader(b), this)
+}
+
+// MarshalJSON is a custom marshaler for MeshSettings
+func (this *MeshSettings) MarshalJSON() ([]byte, error) {
+	str, err := WorkloadMarshaler.MarshalToString(this)
+	return []byte(str), err
+}
+
+// UnmarshalJSON is a custom unmarshaler for MeshSettings
+func (this *MeshSettings) UnmarshalJSON(b []byte) error {
+	return WorkloadUnmarshaler.Unmarshal(bytes.NewReader(b), this)
+}
+
 var (
 	WorkloadMarshaler   = &jsonpb.Marshaler{}
 	WorkloadUnmarshaler = &jsonpb.Unmarshaler{AllowUnknownFields: true}

--- a/pkg/workloadapi/workload_vtproto.pb.go
+++ b/pkg/workloadapi/workload_vtproto.pb.go
@@ -621,6 +621,74 @@ func (this *Extension) EqualMessageVT(thatMsg proto.Message) bool {
 	}
 	return this.EqualVT(that)
 }
+func (this *TlsConfig) EqualVT(that *TlsConfig) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.MinProtocolVersion != that.MinProtocolVersion {
+		return false
+	}
+	if len(this.CipherSuites) != len(that.CipherSuites) {
+		return false
+	}
+	for i, vx := range this.CipherSuites {
+		vy := that.CipherSuites[i]
+		if vx != vy {
+			return false
+		}
+	}
+	if len(this.EcdhCurves) != len(that.EcdhCurves) {
+		return false
+	}
+	for i, vx := range this.EcdhCurves {
+		vy := that.EcdhCurves[i]
+		if vx != vy {
+			return false
+		}
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *TlsConfig) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*TlsConfig)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *MeshSettings) EqualVT(that *MeshSettings) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.TrustDomain != that.TrustDomain {
+		return false
+	}
+	if len(this.TrustDomainAliases) != len(that.TrustDomainAliases) {
+		return false
+	}
+	for i, vx := range this.TrustDomainAliases {
+		vy := that.TrustDomainAliases[i]
+		if vx != vy {
+			return false
+		}
+	}
+	if !this.Tls.EqualVT(that.Tls) {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *MeshSettings) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*MeshSettings)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (m *Address) MarshalVTStrict() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -1632,6 +1700,121 @@ func (m *Extension) MarshalToSizedBufferVTStrict(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *TlsConfig) MarshalVTStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TlsConfig) MarshalToVTStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStrict(dAtA[:size])
+}
+
+func (m *TlsConfig) MarshalToSizedBufferVTStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.EcdhCurves) > 0 {
+		for iNdEx := len(m.EcdhCurves) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.EcdhCurves[iNdEx])
+			copy(dAtA[i:], m.EcdhCurves[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.EcdhCurves[iNdEx])))
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
+	if len(m.CipherSuites) > 0 {
+		for iNdEx := len(m.CipherSuites) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.CipherSuites[iNdEx])
+			copy(dAtA[i:], m.CipherSuites[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.CipherSuites[iNdEx])))
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if m.MinProtocolVersion != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.MinProtocolVersion))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MeshSettings) MarshalVTStrict() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVTStrict(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MeshSettings) MarshalToVTStrict(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVTStrict(dAtA[:size])
+}
+
+func (m *MeshSettings) MarshalToSizedBufferVTStrict(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Tls != nil {
+		size, err := m.Tls.MarshalToSizedBufferVTStrict(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.TrustDomainAliases) > 0 {
+		for iNdEx := len(m.TrustDomainAliases) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.TrustDomainAliases[iNdEx])
+			copy(dAtA[i:], m.TrustDomainAliases[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.TrustDomainAliases[iNdEx])))
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if len(m.TrustDomain) > 0 {
+		i -= len(m.TrustDomain)
+		copy(dAtA[i:], m.TrustDomain)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.TrustDomain)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *Address) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -2051,6 +2234,55 @@ func (m *Extension) SizeVT() (n int) {
 	}
 	if m.Config != nil {
 		l = (*anypb.Any)(m.Config).SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *TlsConfig) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.MinProtocolVersion != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.MinProtocolVersion))
+	}
+	if len(m.CipherSuites) > 0 {
+		for _, s := range m.CipherSuites {
+			l = len(s)
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	if len(m.EcdhCurves) > 0 {
+		for _, s := range m.EcdhCurves {
+			l = len(s)
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *MeshSettings) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.TrustDomain)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.TrustDomainAliases) > 0 {
+		for _, s := range m.TrustDomainAliases {
+			l = len(s)
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	if m.Tls != nil {
+		l = m.Tls.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)

--- a/releasenotes/notes/ztunnel-mesh-settings-xds.yaml
+++ b/releasenotes/notes/ztunnel-mesh-settings-xds.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+
+kind: feature
+
+area: security
+
+releaseNotes:
+- |
+  **Added** xDS-based delivery of mesh-wide TLS and trust domain configuration to ztunnel. MeshConfig settings (`meshMTLS`, `trustDomain`, `trustDomainAliases`) are now pushed to ztunnel at runtime, enabling dynamic updates without pod restarts.


### PR DESCRIPTION
**Please provide a description of this PR:**
Implement xDS generator that pushes MeshSettings (trust domain, TLS config) from istiod to ztunnel. Responds to initial subscription, forced pushes (MeshConfig changes), and ConfigsUpdated with MeshConfig.

Related: https://github.com/istio/ztunnel/pull/1861
Resolves: https://github.com/istio/ztunnel/issues/1817