### PR TITLE
fix: krt file mode waits for content before emitting events

### DIFF
--- a/pkg/kube/krt/files/files.go
+++ b/pkg/kube/krt/files/files.go
@@ -128,7 +128,7 @@ func (f *FolderWatch[T]) watch(stop <-chan struct{}) {
 	}()
 }
 
-const watchDebounceDelay = 50 * time.Millisecond
+const watchDebounceDelay = 250 * time.Millisecond
 
 // Trigger notifications when a file is mutated
 func (f *FolderWatch[T]) fileTrigger(events chan struct{}, stop <-chan struct{}) error {

--- a/pkg/kube/krt/files/files.go
+++ b/pkg/kube/krt/files/files.go
@@ -15,6 +15,7 @@
 package files
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -54,6 +55,8 @@ func NewFolderWatch[T any](fileDir string, parse func([]byte) ([]T, error), stop
 
 var supportedExtensions = sets.New(".yaml", ".yml")
 
+var errEmptyFile = errors.New("file empty, deferring reload")
+
 func (f *FolderWatch[T]) get() []T {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
@@ -75,10 +78,11 @@ func (f *FolderWatch[T]) readOnce() error {
 			return err
 		}
 		if len(data) == 0 {
-			// The file may be empty because the write is not atomic: the file can
-			// be created (firing a fsnotify event) before the writer has written
-			// its contents. Skip; another event will fire once content lands.
-			return nil
+			// the file may  be empty if:
+			// the file was just created and has not yet been written to, or
+			// the file was truncated and in the process of being re-written
+			// in either case, defer the reload until the file has data
+			return errEmptyFile
 		}
 		parsed, err := f.parse(data)
 		if err != nil {
@@ -88,11 +92,11 @@ func (f *FolderWatch[T]) readOnce() error {
 		result = append(result, parsed...)
 		return nil
 	})
+	if errors.Is(err, errEmptyFile) {
+		return nil
+	}
 	if err != nil {
 		log.Warnf("failure during filepath.Walk: %v", err)
-	}
-
-	if err != nil {
 		return err
 	}
 

--- a/pkg/kube/krt/files/files.go
+++ b/pkg/kube/krt/files/files.go
@@ -15,7 +15,6 @@
 package files
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -55,8 +54,6 @@ func NewFolderWatch[T any](fileDir string, parse func([]byte) ([]T, error), stop
 
 var supportedExtensions = sets.New(".yaml", ".yml")
 
-var errEmptyFile = errors.New("file empty, deferring reload")
-
 func (f *FolderWatch[T]) get() []T {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
@@ -78,11 +75,10 @@ func (f *FolderWatch[T]) readOnce() error {
 			return err
 		}
 		if len(data) == 0 {
-			// the file may  be empty if:
-			// the file was just created and has not yet been written to, or
-			// the file was truncated and in the process of being re-written
-			// in either case, defer the reload until the file has data
-			return errEmptyFile
+			// The file may be empty because the write is not atomic: the file can
+			// be created (firing a fsnotify event) before the writer has written
+			// its contents. Skip; another event will fire once content lands.
+			return nil
 		}
 		parsed, err := f.parse(data)
 		if err != nil {
@@ -92,11 +88,11 @@ func (f *FolderWatch[T]) readOnce() error {
 		result = append(result, parsed...)
 		return nil
 	})
-	if errors.Is(err, errEmptyFile) {
-		return nil
-	}
 	if err != nil {
 		log.Warnf("failure during filepath.Walk: %v", err)
+	}
+
+	if err != nil {
 		return err
 	}
 

--- a/pkg/kube/krt/files/files.go
+++ b/pkg/kube/krt/files/files.go
@@ -74,6 +74,12 @@ func (f *FolderWatch[T]) readOnce() error {
 			log.Warnf("Failed to readOnce %s: %v", path, err)
 			return err
 		}
+		if len(data) == 0 {
+			// The file may be empty because the write is not atomic: the file can
+			// be created (firing a fsnotify event) before the writer has written
+			// its contents. Skip; another event will fire once content lands.
+			return nil
+		}
 		parsed, err := f.parse(data)
 		if err != nil {
 			log.Warnf("Failed to parse %s: %v", path, err)


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes a very rare flake in `TestConformance/files`

```
 2793 runs so far, 1 failures (99.96% pass rate). 2.648647185s avg, 4.485780844s max, 1.139470596s 
  min                                                                                               
  /tmp/go-stress-20260428T093509-3604031499                                                         
  2026-04-28T16:35:32.037035Z   debug   krt     sync complete   name=tracker time=1.101µs           
  2026-04-28T16:35:32.087917Z   info    Triggering reload of file configuration                     
  2026-04-28T16:35:32.146892Z   info    Shutting down file watcher: /tmp/TestConformancefiles2988688
   {}                                                                                               
  --- FAIL: TestConformance (0.11s)                                                                 
      --- FAIL: TestConformance/files (0.11s)                                                       
          conformance_test.go:313: got events [add//], want add/a/b (0)
  FAIL                                                                                              
                                                            
  ERROR: exit status 1 
```