### PR TITLE
Populate confromance test timeouts with defaults

### DIFF
--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -282,11 +282,13 @@ func initGatewayConformanceTimeouts() {
 		"istio.test.gatewayConformance.tlsRouteMustHaveConditionTimeout", defaults.TLSRouteMustHaveCondition,
 		"Gateway conformance test timeout for waiting for an TLSRoute to have a certain condition.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.RouteMustHaveParents, "istio.test.gatewayConformance.routeMustHaveParentsTimeout",
-		defaults.RouteMustHaveParents, "Maximum time in the Gateway conformance test for an xRoute to have parents in status that match the expected parents before timing out.")
+		defaults.RouteMustHaveParents,
+		"Maximum time in the Gateway conformance test for an xRoute to have parents in status that match the expected parents before timing out.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.ManifestFetchTimeout, "istio.test.gatewayConformance.manifestFetchTimeout",
 		defaults.ManifestFetchTimeout, "Gateway conformance test timeout for the maximum time for getting content from a https:// URL.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.MaxTimeToConsistency, "istio.test.gatewayConformance.maxTimeToConsistency",
-		defaults.MaxTimeToConsistency, "Gateway conformance test setting for the maximum time for requiredConsecutiveSuccesses (default 3) requests to succeed in a row before failing the test.")
+		defaults.MaxTimeToConsistency,
+		"Gateway conformance test setting for the maximum time for requiredConsecutiveSuccesses (default 3) requests to succeed in a row before failing the test.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.NamespacesMustBeReady,
 		"istio.test.gatewayConformance.namespacesMustBeReadyTimeout", defaults.NamespacesMustBeReady,
 		"Gateway conformance test timeout for waiting for namespaces to be ready.")

--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"strings"
 
+	gwConformanceConfig "sigs.k8s.io/gateway-api/conformance/utils/config"
+
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework/config"
@@ -246,53 +248,56 @@ func init() {
 }
 
 func initGatewayConformanceTimeouts() {
+	defaults := gwConformanceConfig.DefaultTimeoutConfig()
+	settingsFromCommandLine.GatewayConformanceTimeoutConfig = defaults
+
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.CreateTimeout, "istio.test.gatewayConformance.createTimeout",
-		0, "Gateway conformance test timeout for waiting for creating a k8s resource.")
+		defaults.CreateTimeout, "Gateway conformance test timeout for waiting for creating a k8s resource.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.DeleteTimeout, "istio.test.gatewayConformance.deleteTimeout",
-		0, "Gateway conformance test timeout for getting a k8s resource.")
+		defaults.DeleteTimeout, "Gateway conformance test timeout for getting a k8s resource.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.GetTimeout, "istio.test.gatewayConformance.geTimeout",
-		0, "Gateway conformance test timeout for getting a k8s resource.")
+		defaults.GetTimeout, "Gateway conformance test timeout for getting a k8s resource.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.GatewayMustHaveAddress,
-		"istio.test.gatewayConformance.gatewayMustHaveAddressTimeout", 0,
+		"istio.test.gatewayConformance.gatewayMustHaveAddressTimeout", defaults.GatewayMustHaveAddress,
 		"Gateway conformance test timeout for waiting for a Gateway to have an address.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.GatewayMustHaveCondition,
-		"istio.test.gatewayConformance.gatewayMustHaveConditionTimeout", 0,
+		"istio.test.gatewayConformance.gatewayMustHaveConditionTimeout", defaults.GatewayMustHaveCondition,
 		"Gateway conformance test timeout for waiting for a Gateway to have a certain condition.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.GatewayStatusMustHaveListeners,
-		"istio.test.gatewayConformance.gatewayStatusMustHaveListenersTimeout", 0,
+		"istio.test.gatewayConformance.gatewayStatusMustHaveListenersTimeout", defaults.GatewayStatusMustHaveListeners,
 		"Gateway conformance test timeout for waiting for a Gateway's status to have listeners.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.GatewayListenersMustHaveConditions,
-		"istio.test.gatewayConformance.gatewayListenersMustHaveConditionTimeout", 0,
+		"istio.test.gatewayConformance.gatewayListenersMustHaveConditionTimeout", defaults.GatewayListenersMustHaveConditions,
 		"Gateway conformance test timeout for waiting for a Gateway's listeners to have certain conditions.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.GWCMustBeAccepted,
 		"istio.test.gatewayConformance.gatewayClassMustBeAcceptedTimeout",
-		0, "Gateway conformance test timeout for waiting for a GatewayClass to be accepted.")
+		defaults.GWCMustBeAccepted, "Gateway conformance test timeout for waiting for a GatewayClass to be accepted.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.HTTPRouteMustNotHaveParents,
-		"istio.test.gatewayConformance.httpRouteMustNotHaveParentsTimeout", 0,
+		"istio.test.gatewayConformance.httpRouteMustNotHaveParentsTimeout", defaults.HTTPRouteMustNotHaveParents,
 		"Gateway conformance test timeout for waiting for an HTTPRoute to either have no parents or a single parent that is not accepted.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.HTTPRouteMustHaveCondition,
 		"istio.test.gatewayConformance.httpRouteMustHaveConditionTimeout",
-		0, "Gateway conformance test timeout for waiting for an HTTPRoute to have a certain condition.")
+		defaults.HTTPRouteMustHaveCondition, "Gateway conformance test timeout for waiting for an HTTPRoute to have a certain condition.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.TLSRouteMustHaveCondition,
-		"istio.test.gatewayConformance.tlsRouteMustHaveConditionTimeout", 0,
+		"istio.test.gatewayConformance.tlsRouteMustHaveConditionTimeout", defaults.TLSRouteMustHaveCondition,
 		"Gateway conformance test timeout for waiting for an TLSRoute to have a certain condition.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.RouteMustHaveParents, "istio.test.gatewayConformance.routeMustHaveParentsTimeout",
-		0, "Maximum time in the Gateway conformance test for an xRoute to have parents in status that match the expected parents before timing out.")
+		defaults.RouteMustHaveParents, "Maximum time in the Gateway conformance test for an xRoute to have parents in status that match the expected parents before timing out.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.ManifestFetchTimeout, "istio.test.gatewayConformance.manifestFetchTimeout",
-		0, "Gateway conformance test timeout for the maximum time for getting content from a https:// URL.")
+		defaults.ManifestFetchTimeout, "Gateway conformance test timeout for the maximum time for getting content from a https:// URL.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.MaxTimeToConsistency, "istio.test.gatewayConformance.maxTimeToConsistency",
-		0, "Gateway conformance test setting for the maximum time for requiredConsecutiveSuccesses (default 3) requests to succeed in a row before failing the test.")
+		defaults.MaxTimeToConsistency, "Gateway conformance test setting for the maximum time for requiredConsecutiveSuccesses (default 3) requests to succeed in a row before failing the test.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.NamespacesMustBeReady,
-		"istio.test.gatewayConformance.namespacesMustBeReadyTimeout", 0,
+		"istio.test.gatewayConformance.namespacesMustBeReadyTimeout", defaults.NamespacesMustBeReady,
 		"Gateway conformance test timeout for waiting for namespaces to be ready.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.RequestTimeout, "istio.test.gatewayConformance.requestTimeout",
-		0, "Gateway conformance test timeout for an HTTP request.")
+		defaults.RequestTimeout, "Gateway conformance test timeout for an HTTP request.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.LatestObservedGenerationSet,
-		"istio.test.gatewayConformance.latestObservedGenerationSetTimeout", 0,
+		"istio.test.gatewayConformance.latestObservedGenerationSetTimeout", defaults.LatestObservedGenerationSet,
 		"Gateway conformance test timeout for waiting for a latest observed generation to be set.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.DefaultTestTimeout, "istio.test.gatewayConformance.defaultTestTimeout",
-		0, "Default gateway conformance test case timeout.")
+		defaults.DefaultTestTimeout, "Default gateway conformance test case timeout.")
 	flag.IntVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.RequiredConsecutiveSuccesses,
-		"istio.test.gatewayConformance.requiredConsecutiveSuccesses", 0,
+		"istio.test.gatewayConformance.requiredConsecutiveSuccesses", defaults.RequiredConsecutiveSuccesses,
 		"Gateway conformance test setting for the required number of consecutive successes before failing the test.")
 }

--- a/tests/integration/ambient/gateway_conformance_test.go
+++ b/tests/integration/ambient/gateway_conformance_test.go
@@ -115,6 +115,7 @@ var agentgatewaySkippedTests = map[string]string{
 
 	"ListenerSetAllowedNamespaceNone": "TODO",
 	"ListenerSetAllowedNamespaceSame": "TODO",
+	"ListenerSetAllowedNamespaceSelector": "TODO",
 }
 
 func TestGatewayConformance(t *testing.T) {

--- a/tests/integration/ambient/gateway_conformance_test.go
+++ b/tests/integration/ambient/gateway_conformance_test.go
@@ -89,8 +89,6 @@ var skippedTests = map[string]string{
 	"HTTPRouteCORS":                                   "TODO",
 	"HTTPRouteHTTPSListenerDetectMisdirectedRequests": "TODO",
 
-	"ListenerSetAllowedNamespaceNone":        "TODO",
-	"ListenerSetAllowedNamespaceSame":        "TODO",
 	"ListenerSetAllowedNamespaceSelector":    "TODO",
 	"ListenerSetAllowedRoutesNamespaces":     "TODO",
 	"ListenerSetAllowedRoutesSupportedKinds": "TODO",

--- a/tests/integration/ambient/gateway_conformance_test.go
+++ b/tests/integration/ambient/gateway_conformance_test.go
@@ -113,8 +113,8 @@ var agentgatewaySkippedTests = map[string]string{
 	"TLSRouteTerminateSimpleSameNamespace":  "TODO",
 	"TLSRouteMixedTerminationSameNamespace": "TODO",
 
-	"ListenerSetAllowedNamespaceNone": "TODO",
-	"ListenerSetAllowedNamespaceSame": "TODO",
+	"ListenerSetAllowedNamespaceNone":     "TODO",
+	"ListenerSetAllowedNamespaceSame":     "TODO",
 	"ListenerSetAllowedNamespaceSelector": "TODO",
 }
 

--- a/tests/integration/ambient/gateway_conformance_test.go
+++ b/tests/integration/ambient/gateway_conformance_test.go
@@ -89,7 +89,6 @@ var skippedTests = map[string]string{
 	"HTTPRouteCORS":                                   "TODO",
 	"HTTPRouteHTTPSListenerDetectMisdirectedRequests": "TODO",
 
-	"ListenerSetAllowedNamespaceSelector":    "TODO",
 	"ListenerSetAllowedRoutesNamespaces":     "TODO",
 	"ListenerSetAllowedRoutesSupportedKinds": "TODO",
 	"ListenerSetDefaultNotAllowed":           "TODO",

--- a/tests/integration/ambient/gateway_conformance_test.go
+++ b/tests/integration/ambient/gateway_conformance_test.go
@@ -113,6 +113,9 @@ var skippedTests = map[string]string{
 var agentgatewaySkippedTests = map[string]string{
 	"TLSRouteTerminateSimpleSameNamespace":  "TODO",
 	"TLSRouteMixedTerminationSameNamespace": "TODO",
+
+	"ListenerSetAllowedNamespaceNone": "TODO",
+	"ListenerSetAllowedNamespaceSame": "TODO",
 }
 
 func TestGatewayConformance(t *testing.T) {

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -112,8 +112,8 @@ var agentgatewaySkippedTests = map[string]string{
 	"TLSRouteTerminateSimpleSameNamespace":  "TODO",
 	"TLSRouteMixedTerminationSameNamespace": "TODO",
 
-	"ListenerSetAllowedNamespaceNone": "TODO",
-	"ListenerSetAllowedNamespaceSame": "TODO",
+	"ListenerSetAllowedNamespaceNone":     "TODO",
+	"ListenerSetAllowedNamespaceSame":     "TODO",
 	"ListenerSetAllowedNamespaceSelector": "TODO",
 }
 

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -87,7 +87,6 @@ var skippedTests = map[string]string{
 	"HTTPRouteCORS":                                   "TODO",
 	"HTTPRouteHTTPSListenerDetectMisdirectedRequests": "TODO",
 
-	"ListenerSetAllowedNamespaceSelector":    "TODO",
 	"ListenerSetAllowedRoutesNamespaces":     "TODO",
 	"ListenerSetAllowedRoutesSupportedKinds": "TODO",
 	"ListenerSetDefaultNotAllowed":           "TODO",

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -114,6 +114,7 @@ var agentgatewaySkippedTests = map[string]string{
 
 	"ListenerSetAllowedNamespaceNone": "TODO",
 	"ListenerSetAllowedNamespaceSame": "TODO",
+	"ListenerSetAllowedNamespaceSelector": "TODO",
 }
 
 func TestGatewayConformance(t *testing.T) {

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -112,6 +112,9 @@ var agentgatewaySkippedTests = map[string]string{
 	// The following tests were added in v1.5.0
 	"TLSRouteTerminateSimpleSameNamespace":  "TODO",
 	"TLSRouteMixedTerminationSameNamespace": "TODO",
+
+	"ListenerSetAllowedNamespaceNone": "TODO",
+	"ListenerSetAllowedNamespaceSame": "TODO",
 }
 
 func TestGatewayConformance(t *testing.T) {

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -87,8 +87,6 @@ var skippedTests = map[string]string{
 	"HTTPRouteCORS":                                   "TODO",
 	"HTTPRouteHTTPSListenerDetectMisdirectedRequests": "TODO",
 
-	"ListenerSetAllowedNamespaceNone":        "TODO",
-	"ListenerSetAllowedNamespaceSame":        "TODO",
 	"ListenerSetAllowedNamespaceSelector":    "TODO",
 	"ListenerSetAllowedRoutesNamespaces":     "TODO",
 	"ListenerSetAllowedRoutesSupportedKinds": "TODO",


### PR DESCRIPTION
**Please provide a description of this PR:**

Until now we basically relied on the assumption that when timeout is set to 0, Gateway API conformance tests will populate it with some sensible default.

NOTE: In gateway API conformance test suite this happens inside [SetupTimeoutConfig](https://github.com/kubernetes-sigs/gateway-api/blob/efb744260101b06ffa3cce7cbe41d48bc614de34/conformance/utils/config/timeout.go#L221C6-L280), which in turn is called inside [NewConformanceTestSuite](https://github.com/kubernetes-sigs/gateway-api/blob/efb744260101b06ffa3cce7cbe41d48bc614de34/conformance/utils/suite/suite.go#L262).

That's a reasonable assumption, but for some of the timeouts it does not hold, specifically for `ListenerSetMustHaveCondition` it's not true and that's why `ListenerSetAllowedNamespaceNone` and
`ListenerSetAllowedNamespaceSame` seem to be failing, even though the functionality is there.

I belive it's a bug in the gateway API conformance test harness, but it's faster to fix it in Istio repo, plus looking at the code, I can see how this type of bug could happen, so I wouldn't be surprised if it happens again at some point in the future.

With that in mind, this PR populates the timeouts with the default values explicitly instead of relying on Gateway API to replace zero values with defaults, thus making things slightly more robust.

Related to #60018

+cc @jaellio @ericdbishop @jgreeer @keithmattix 