### PR TITLE
waypoint: include mesh-internal ServiceEntry backends in inbound-vip set

### DIFF
--- a/pilot/pkg/networking/core/waypoint.go
+++ b/pilot/pkg/networking/core/waypoint.go
@@ -84,10 +84,24 @@ func findWaypointResources(node *model.Proxy, push *model.PushContext) ([]model.
 		waypointServices.services[hostName] = svc
 	}
 
-	unorderedServices := maps.Values(waypointServices.services)
-	if len(serviceInfos) > 0 {
-		waypointServices.orderedServices = model.SortServicesByCreationTime(unorderedServices)
+	// Also include mesh-internal services referenced by waypoint-owned services' routes.
+	// These may have no local K8s Service, but need inbound-vip treatment so that
+	// traffic routes through main_internal rather than an outbound cluster.
+	referencedServices := push.ServicesAttachedToMesh()
+	for waypointSvcHost := range waypointServices.services {
+		for referencedHost := range referencedServices[string(waypointSvcHost)] {
+			refHostName := host.Name(referencedHost)
+			if _, ok := waypointServices.services[refHostName]; ok {
+				continue
+			}
+			svc := push.ServiceForHostname(node, refHostName)
+			if svc != nil && !svc.MeshExternal {
+				waypointServices.services[refHostName] = svc
+			}
+		}
 	}
+
+	waypointServices.orderedServices = model.SortServicesByCreationTime(maps.Values(waypointServices.services))
 	return workloads, waypointServices
 }
 

--- a/tests/integration/ambient/waypoint_test.go
+++ b/tests/integration/ambient/waypoint_test.go
@@ -1691,6 +1691,100 @@ spec:
 		})
 }
 
+// TestWaypointHTTPRouteToMeshInternalServiceEntry verifies that a waypoint generates an
+// inbound-vip cluster (not an outbound cluster) for a MESH_INTERNAL ServiceEntry backend
+// that has no local K8s Service.
+func TestWaypointHTTPRouteToMeshInternalServiceEntry(t *testing.T) {
+	framework.
+		NewTest(t).
+		Run(func(t framework.TestContext) {
+			ns := apps.Namespace.Name()
+			seHost := fmt.Sprintf("mesh-internal-only.%s.svc.cluster.local", ns)
+
+			// Create a MESH_INTERNAL ServiceEntry with a unique hostname (no K8s Service exists for
+			// this hostname). Its endpoint resolves to the Captured service so we have a real backend.
+			config := `
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: mesh-internal-only
+spec:
+  hosts:
+  - mesh-internal-only.{{.Namespace}}.svc.cluster.local
+  ports:
+  - name: http
+    number: 80
+    protocol: HTTP
+  resolution: DNS
+  location: MESH_INTERNAL
+  endpoints:
+  - address: {{.BackendHost}}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: waypoint-to-mesh-internal-se
+spec:
+  parentRefs:
+  - group: ""
+    kind: Service
+    name: {{.Service}}
+    sectionName: "80"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /se-backend
+    backendRefs:
+    - group: networking.istio.io
+      kind: Hostname
+      name: mesh-internal-only.{{.Namespace}}.svc.cluster.local
+      port: 80
+`
+			t.ConfigIstio().
+				Eval(ns, map[string]any{
+					"Namespace":   ns,
+					"Service":     ServiceAddressedWaypoint,
+					"BackendHost": fmt.Sprintf("%s.%s.svc.cluster.local", Captured, ns),
+				}, config).
+				ApplyOrFail(t, apply.CleanupConditionally)
+
+			waypointLabel := label.IoK8sNetworkingGatewayGatewayName.Name + "=waypoint-service"
+			fetchFn := kubetest.NewSinglePodFetch(t.Clusters().Default(), ns, waypointLabel)
+			pods, err := kubetest.WaitUntilPodsAreReady(fetchFn)
+			if err != nil {
+				t.Fatalf("failed to find waypoint pod: %v", err)
+			}
+			waypointPod := fmt.Sprintf("%s.%s", pods[0].Name, ns)
+
+			inboundVIPPrefix := string(model.TrafficDirectionInboundVIP) + "|"
+			retry.UntilSuccessOrFail(t, func() error {
+				output, _ := istioctl.NewOrFail(t, istioctl.Config{}).InvokeOrFail(t,
+					[]string{"proxy-config", "cluster", waypointPod, "-o", "json"})
+
+				var clusters []json.RawMessage
+				if err := json.Unmarshal([]byte(output), &clusters); err != nil {
+					return fmt.Errorf("failed to parse cluster dump: %v", err)
+				}
+				for _, raw := range clusters {
+					var c map[string]any
+					if err := json.Unmarshal(raw, &c); err != nil {
+						continue
+					}
+					name, _ := c["name"].(string)
+					if !strings.Contains(name, seHost) {
+						continue
+					}
+					if strings.HasPrefix(name, inboundVIPPrefix) {
+						return nil
+					}
+					return fmt.Errorf("expected %s cluster for %s, got %q", inboundVIPPrefix, seHost, name)
+				}
+				return fmt.Errorf("no cluster found for %s", seHost)
+			}, retry.Timeout(30*time.Second))
+		})
+}
+
 func GetCondition(conditions []metav1.Condition, condition string) *metav1.Condition {
 	for _, cond := range conditions {
 		if cond.Type == condition {


### PR DESCRIPTION
**Please provide a description of this PR:**

When an `HTTPRoute` attached to a waypoint-owned Service references a MESH_INTERNAL ServiceEntry that has no local K8s Service, the referenced host was missing from the waypoint's service set.
This caused the waypoint to generate an outbound cluster for that host instead of an inbound-vip cluster.

Fix by walking ServicesAttachedToMesh references for each waypoint-owned service and adding any mesh-internal, non-duplicate host to the waypoint service set before sorting.

## Testing

Added `TestWaypointHTTPRouteToMeshInternalServiceEntry` integration test (ambient suite) that:
- Creates a `MESH_INTERNAL` `ServiceEntry` with no backing K8s Service
- Attaches an `HTTPRoute` to a waypoint-owned Service routing `/se-backend` to that entry
- Asserts via `istioctl proxy-config cluster` that the waypoint generates an `inbound_vip|` cluster (not an outbound cluster) for the SE hostname