### PR TITLE
Make gateway and listenerset status reporting comply with Gateway API

### DIFF
--- a/pilot/pkg/config/kube/gateway/controller.go
+++ b/pilot/pkg/config/kube/gateway/controller.go
@@ -253,7 +253,6 @@ func NewController(
 		c.tagWatcher,
 		opts,
 	)
-	status.RegisterStatus(c.status, ListenerSetStatus, GetStatus, c.tagWatcher.AccessUnprotected())
 
 	// GatewaysStatus is not fully complete until its join with route attachments to report attachedRoutes.
 	// Do not register yet.
@@ -367,6 +366,9 @@ func NewController(
 
 	GatewayFinalStatus := FinalGatewayStatusCollection(GatewaysStatus, RouteAttachments, RouteAttachmentsIndex, opts)
 	status.RegisterStatus(c.status, GatewayFinalStatus, GetStatus, c.tagWatcher.AccessUnprotected())
+
+	ListenerSetFinalStatus := FinalListenerSetStatusCollection(ListenerSetStatus, RouteAttachments, RouteAttachmentsIndex, opts)
+	status.RegisterStatus(c.status, ListenerSetFinalStatus, GetStatus, c.tagWatcher.AccessUnprotected())
 
 	// Merge HTTP and gRPC base VirtualServices together so routes on the same
 	// gateway+hostname are combined into a single VirtualService, allowing

--- a/pilot/pkg/config/kube/gateway/gateway_collection.go
+++ b/pilot/pkg/config/kube/gateway/gateway_collection.go
@@ -349,7 +349,11 @@ func GatewayCollection(
 			result = append(result, res)
 		}
 		listenersFromSets := listenerIndex.Fetch(ctx, config.NamespacedName(obj))
+		// When reporting gateway status, we need to count the actual ListenerSets attached to the gateway
+		// and not the listeners.
+		listenerSets := make(map[parentKey]bool)
 		for _, ls := range listenersFromSets {
+			listenerSets[ls.Parent] = true
 			servers = append(servers, ls.Config.Spec.(*istio.Gateway).Servers...)
 			result = append(result, Gateway{
 				Config:     ls.Config,
@@ -359,7 +363,7 @@ func GatewayCollection(
 			})
 		}
 
-		reportGatewayStatus(context, obj, status, classInfo, gatewayServices, servers, len(listenersFromSets), err)
+		reportGatewayStatus(context, obj, status, classInfo, gatewayServices, servers, len(listenerSets), err)
 		return status, result
 	}, opts.WithName("KubernetesGateway")...)
 
@@ -395,6 +399,39 @@ func FinalGatewayStatusCollection(
 				Status: *status,
 			}
 		}, opts.WithName("GatewayFinalStatus")...)
+}
+
+// FinalListenerSetStatusCollection finalizes a ListenerSet status similarly to how FinalGatewayStatusCollection does it for gateways.
+// In a nutshell for conformance with Gateway API we need to report for each Listener in a ListenerSet to report how many
+// routes have been attached to that listener. That's what this function does, it takes a ListenerSet status collection
+// that container almost everything we need in the status already and just updates AttachedRoutes filed on each listener
+// after we actually constructed all the route collections.
+func FinalListenerSetStatusCollection(
+	listenerSetStatuses krt.StatusCollection[*gatewayv1.ListenerSet, gatewayv1.ListenerSetStatus],
+	routeAttachments krt.Collection[RouteAttachment],
+	routeAttachmentsIndex krt.Index[types.NamespacedName, RouteAttachment],
+	opts krt.OptionsBuilder,
+) krt.StatusCollection[*gatewayv1.ListenerSet, gatewayv1.ListenerSetStatus] {
+	return krt.NewCollection(
+		listenerSetStatuses,
+		func(
+			ctx krt.HandlerContext, i krt.ObjectWithStatus[*gatewayv1.ListenerSet, gatewayv1.ListenerSetStatus],
+		) *krt.ObjectWithStatus[*gatewayv1.ListenerSet, gatewayv1.ListenerSetStatus] {
+			routes := routeAttachmentsIndex.Fetch(ctx, config.NamespacedName(i.Obj))
+			counts := map[string]int32{}
+			for _, r := range routes {
+				counts[r.ListenerName]++
+			}
+			status := i.Status.DeepCopy()
+			for i, s := range status.Listeners {
+				s.AttachedRoutes = counts[string(s.Name)]
+				status.Listeners[i] = s
+			}
+			return &krt.ObjectWithStatus[*gatewayv1.ListenerSet, gatewayv1.ListenerSetStatus]{
+				Obj:    i.Obj,
+				Status: *status,
+			}
+		}, opts.WithName("ListenerSetFinalStatus")...)
 }
 
 // RouteParents holds information about things routes can reference as parents.

--- a/pilot/pkg/config/kube/gateway/route_collections.go
+++ b/pilot/pkg/config/kube/gateway/route_collections.go
@@ -786,7 +786,7 @@ func gatewayRouteAttachmentCountCollection[T controllers.Object](
 
 		parentRefs := extractParentReferenceInfo(ctx, inputs.RouteParents, obj)
 		return slices.MapFilter(filteredReferences(parentRefs), func(e routeParentReference) *RouteAttachment {
-			if e.ParentKey.Kind != gvk.KubernetesGateway {
+			if e.ParentKey.Kind != gvk.KubernetesGateway && e.ParentKey.Kind != gvk.ListenerSet {
 				return nil
 			}
 			return &RouteAttachment{

--- a/pilot/pkg/config/kube/gateway/testdata/listenerset-cross-namespace.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/listenerset-cross-namespace.status.yaml.golden
@@ -194,7 +194,7 @@ status:
   addresses:
   - type: IPAddress
     value: 1.2.3.4
-  attachedListenerSets: 4
+  attachedListenerSets: 3
   conditions:
   - lastTransitionTime: fake
     message: Resource accepted

--- a/pilot/pkg/config/kube/gateway/testdata/listenerset-same-name-different-ns.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/listenerset-same-name-different-ns.status.yaml.golden
@@ -17,7 +17,7 @@ status:
     status: "True"
     type: Programmed
   listeners:
-  - attachedRoutes: 0
+  - attachedRoutes: 1
     conditions:
     - lastTransitionTime: fake
       message: No errors found
@@ -65,7 +65,7 @@ status:
     status: "True"
     type: Programmed
   listeners:
-  - attachedRoutes: 0
+  - attachedRoutes: 1
     conditions:
     - lastTransitionTime: fake
       message: No errors found

--- a/pilot/pkg/config/kube/gateway/testdata/listenerset.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/listenerset.status.yaml.golden
@@ -94,7 +94,7 @@ status:
     status: "True"
     type: Programmed
   listeners:
-  - attachedRoutes: 0
+  - attachedRoutes: 2
     conditions:
     - lastTransitionTime: fake
       message: No errors found
@@ -194,7 +194,7 @@ status:
   addresses:
   - type: IPAddress
     value: 1.2.3.4
-  attachedListenerSets: 4
+  attachedListenerSets: 3
   conditions:
   - lastTransitionTime: fake
     message: Resource accepted

--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -282,11 +282,13 @@ func initGatewayConformanceTimeouts() {
 		"istio.test.gatewayConformance.tlsRouteMustHaveConditionTimeout", defaults.TLSRouteMustHaveCondition,
 		"Gateway conformance test timeout for waiting for an TLSRoute to have a certain condition.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.RouteMustHaveParents, "istio.test.gatewayConformance.routeMustHaveParentsTimeout",
-		defaults.RouteMustHaveParents, "Maximum time in the Gateway conformance test for an xRoute to have parents in status that match the expected parents before timing out.")
+		defaults.RouteMustHaveParents,
+		"Maximum time in the Gateway conformance test for an xRoute to have parents in status that match the expected parents before timing out.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.ManifestFetchTimeout, "istio.test.gatewayConformance.manifestFetchTimeout",
 		defaults.ManifestFetchTimeout, "Gateway conformance test timeout for the maximum time for getting content from a https:// URL.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.MaxTimeToConsistency, "istio.test.gatewayConformance.maxTimeToConsistency",
-		defaults.MaxTimeToConsistency, "Gateway conformance test setting for the maximum time for requiredConsecutiveSuccesses (default 3) requests to succeed in a row before failing the test.")
+		defaults.MaxTimeToConsistency,
+		"Gateway conformance test setting for the maximum time for requiredConsecutiveSuccesses (default 3) requests to succeed in a row before failing the test.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.NamespacesMustBeReady,
 		"istio.test.gatewayConformance.namespacesMustBeReadyTimeout", defaults.NamespacesMustBeReady,
 		"Gateway conformance test timeout for waiting for namespaces to be ready.")

--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"strings"
 
+	gwConformanceConfig "sigs.k8s.io/gateway-api/conformance/utils/config"
+
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework/config"
@@ -246,53 +248,56 @@ func init() {
 }
 
 func initGatewayConformanceTimeouts() {
+	defaults := gwConformanceConfig.DefaultTimeoutConfig()
+	settingsFromCommandLine.GatewayConformanceTimeoutConfig = defaults
+
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.CreateTimeout, "istio.test.gatewayConformance.createTimeout",
-		0, "Gateway conformance test timeout for waiting for creating a k8s resource.")
+		defaults.CreateTimeout, "Gateway conformance test timeout for waiting for creating a k8s resource.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.DeleteTimeout, "istio.test.gatewayConformance.deleteTimeout",
-		0, "Gateway conformance test timeout for getting a k8s resource.")
+		defaults.DeleteTimeout, "Gateway conformance test timeout for getting a k8s resource.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.GetTimeout, "istio.test.gatewayConformance.geTimeout",
-		0, "Gateway conformance test timeout for getting a k8s resource.")
+		defaults.GetTimeout, "Gateway conformance test timeout for getting a k8s resource.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.GatewayMustHaveAddress,
-		"istio.test.gatewayConformance.gatewayMustHaveAddressTimeout", 0,
+		"istio.test.gatewayConformance.gatewayMustHaveAddressTimeout", defaults.GatewayMustHaveAddress,
 		"Gateway conformance test timeout for waiting for a Gateway to have an address.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.GatewayMustHaveCondition,
-		"istio.test.gatewayConformance.gatewayMustHaveConditionTimeout", 0,
+		"istio.test.gatewayConformance.gatewayMustHaveConditionTimeout", defaults.GatewayMustHaveCondition,
 		"Gateway conformance test timeout for waiting for a Gateway to have a certain condition.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.GatewayStatusMustHaveListeners,
-		"istio.test.gatewayConformance.gatewayStatusMustHaveListenersTimeout", 0,
+		"istio.test.gatewayConformance.gatewayStatusMustHaveListenersTimeout", defaults.GatewayStatusMustHaveListeners,
 		"Gateway conformance test timeout for waiting for a Gateway's status to have listeners.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.GatewayListenersMustHaveConditions,
-		"istio.test.gatewayConformance.gatewayListenersMustHaveConditionTimeout", 0,
+		"istio.test.gatewayConformance.gatewayListenersMustHaveConditionTimeout", defaults.GatewayListenersMustHaveConditions,
 		"Gateway conformance test timeout for waiting for a Gateway's listeners to have certain conditions.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.GWCMustBeAccepted,
 		"istio.test.gatewayConformance.gatewayClassMustBeAcceptedTimeout",
-		0, "Gateway conformance test timeout for waiting for a GatewayClass to be accepted.")
+		defaults.GWCMustBeAccepted, "Gateway conformance test timeout for waiting for a GatewayClass to be accepted.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.HTTPRouteMustNotHaveParents,
-		"istio.test.gatewayConformance.httpRouteMustNotHaveParentsTimeout", 0,
+		"istio.test.gatewayConformance.httpRouteMustNotHaveParentsTimeout", defaults.HTTPRouteMustNotHaveParents,
 		"Gateway conformance test timeout for waiting for an HTTPRoute to either have no parents or a single parent that is not accepted.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.HTTPRouteMustHaveCondition,
 		"istio.test.gatewayConformance.httpRouteMustHaveConditionTimeout",
-		0, "Gateway conformance test timeout for waiting for an HTTPRoute to have a certain condition.")
+		defaults.HTTPRouteMustHaveCondition, "Gateway conformance test timeout for waiting for an HTTPRoute to have a certain condition.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.TLSRouteMustHaveCondition,
-		"istio.test.gatewayConformance.tlsRouteMustHaveConditionTimeout", 0,
+		"istio.test.gatewayConformance.tlsRouteMustHaveConditionTimeout", defaults.TLSRouteMustHaveCondition,
 		"Gateway conformance test timeout for waiting for an TLSRoute to have a certain condition.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.RouteMustHaveParents, "istio.test.gatewayConformance.routeMustHaveParentsTimeout",
-		0, "Maximum time in the Gateway conformance test for an xRoute to have parents in status that match the expected parents before timing out.")
+		defaults.RouteMustHaveParents, "Maximum time in the Gateway conformance test for an xRoute to have parents in status that match the expected parents before timing out.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.ManifestFetchTimeout, "istio.test.gatewayConformance.manifestFetchTimeout",
-		0, "Gateway conformance test timeout for the maximum time for getting content from a https:// URL.")
+		defaults.ManifestFetchTimeout, "Gateway conformance test timeout for the maximum time for getting content from a https:// URL.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.MaxTimeToConsistency, "istio.test.gatewayConformance.maxTimeToConsistency",
-		0, "Gateway conformance test setting for the maximum time for requiredConsecutiveSuccesses (default 3) requests to succeed in a row before failing the test.")
+		defaults.MaxTimeToConsistency, "Gateway conformance test setting for the maximum time for requiredConsecutiveSuccesses (default 3) requests to succeed in a row before failing the test.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.NamespacesMustBeReady,
-		"istio.test.gatewayConformance.namespacesMustBeReadyTimeout", 0,
+		"istio.test.gatewayConformance.namespacesMustBeReadyTimeout", defaults.NamespacesMustBeReady,
 		"Gateway conformance test timeout for waiting for namespaces to be ready.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.RequestTimeout, "istio.test.gatewayConformance.requestTimeout",
-		0, "Gateway conformance test timeout for an HTTP request.")
+		defaults.RequestTimeout, "Gateway conformance test timeout for an HTTP request.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.LatestObservedGenerationSet,
-		"istio.test.gatewayConformance.latestObservedGenerationSetTimeout", 0,
+		"istio.test.gatewayConformance.latestObservedGenerationSetTimeout", defaults.LatestObservedGenerationSet,
 		"Gateway conformance test timeout for waiting for a latest observed generation to be set.")
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.DefaultTestTimeout, "istio.test.gatewayConformance.defaultTestTimeout",
-		0, "Default gateway conformance test case timeout.")
+		defaults.DefaultTestTimeout, "Default gateway conformance test case timeout.")
 	flag.IntVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.RequiredConsecutiveSuccesses,
-		"istio.test.gatewayConformance.requiredConsecutiveSuccesses", 0,
+		"istio.test.gatewayConformance.requiredConsecutiveSuccesses", defaults.RequiredConsecutiveSuccesses,
 		"Gateway conformance test setting for the required number of consecutive successes before failing the test.")
 }

--- a/releasenotes/notes/report-attached-listenersets-and-routes-on-gateway.yaml
+++ b/releasenotes/notes/report-attached-listenersets-and-routes-on-gateway.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed**: status reporting for Gateway and ListenerSet resources to comply with the Gateway API specification v1.5.0.
+    It changes Gateway status reporting to report the number of ListenerSets to be reported in AttachedListenerSets field
+    of the Gateway resource, instead of the number of Listeners. It also changes status reporting for ListenerSets to
+    report the number of routes attached to each listener in the ListenerSet.

--- a/tests/integration/ambient/gateway_conformance_test.go
+++ b/tests/integration/ambient/gateway_conformance_test.go
@@ -89,13 +89,9 @@ var skippedTests = map[string]string{
 	"HTTPRouteCORS":                                   "TODO",
 	"HTTPRouteHTTPSListenerDetectMisdirectedRequests": "TODO",
 
-	"ListenerSetAllowedRoutesNamespaces":     "TODO",
-	"ListenerSetAllowedRoutesSupportedKinds": "TODO",
-	"ListenerSetDefaultNotAllowed":           "TODO",
-	"ListenerSetHostnameConflict":            "TODO",
-	"ListenerSetHTTPRouting":                 "TODO",
-	"ListenerSetProtocolConflict":            "TODO",
-	"ListenerSetReferenceGrant":              "TODO",
+	"ListenerSetHostnameConflict": "TODO",
+	"ListenerSetProtocolConflict": "TODO",
+	"ListenerSetReferenceGrant":   "TODO",
 
 	"MeshHTTPRoute303Redirect": "TODO",
 	"MeshHTTPRoute307Redirect": "TODO",
@@ -113,9 +109,13 @@ var agentgatewaySkippedTests = map[string]string{
 	"TLSRouteTerminateSimpleSameNamespace":  "TODO",
 	"TLSRouteMixedTerminationSameNamespace": "TODO",
 
-	"ListenerSetAllowedNamespaceNone":     "TODO",
-	"ListenerSetAllowedNamespaceSame":     "TODO",
-	"ListenerSetAllowedNamespaceSelector": "TODO",
+	"ListenerSetAllowedNamespaceNone":        "TODO",
+	"ListenerSetAllowedNamespaceSame":        "TODO",
+	"ListenerSetAllowedNamespaceSelector":    "TODO",
+	"ListenerSetAllowedRoutesNamespaces":     "TODO",
+	"ListenerSetAllowedRoutesSupportedKinds": "TODO",
+	"ListenerSetDefaultNotAllowed":           "TODO",
+	"ListenerSetHTTPRouting":                 "TODO",
 }
 
 func TestGatewayConformance(t *testing.T) {

--- a/tests/integration/ambient/gateway_conformance_test.go
+++ b/tests/integration/ambient/gateway_conformance_test.go
@@ -115,6 +115,7 @@ var agentgatewaySkippedTests = map[string]string{
 
 	"ListenerSetAllowedNamespaceNone": "TODO",
 	"ListenerSetAllowedNamespaceSame": "TODO",
+	"ListenerSetAllowedNamespaceSelector": "TODO",
 }
 
 func TestGatewayConformance(t *testing.T) {

--- a/tests/integration/ambient/gateway_conformance_test.go
+++ b/tests/integration/ambient/gateway_conformance_test.go
@@ -89,8 +89,6 @@ var skippedTests = map[string]string{
 	"HTTPRouteCORS":                                   "TODO",
 	"HTTPRouteHTTPSListenerDetectMisdirectedRequests": "TODO",
 
-	"ListenerSetAllowedNamespaceNone":        "TODO",
-	"ListenerSetAllowedNamespaceSame":        "TODO",
 	"ListenerSetAllowedNamespaceSelector":    "TODO",
 	"ListenerSetAllowedRoutesNamespaces":     "TODO",
 	"ListenerSetAllowedRoutesSupportedKinds": "TODO",

--- a/tests/integration/ambient/gateway_conformance_test.go
+++ b/tests/integration/ambient/gateway_conformance_test.go
@@ -113,8 +113,8 @@ var agentgatewaySkippedTests = map[string]string{
 	"TLSRouteTerminateSimpleSameNamespace":  "TODO",
 	"TLSRouteMixedTerminationSameNamespace": "TODO",
 
-	"ListenerSetAllowedNamespaceNone": "TODO",
-	"ListenerSetAllowedNamespaceSame": "TODO",
+	"ListenerSetAllowedNamespaceNone":     "TODO",
+	"ListenerSetAllowedNamespaceSame":     "TODO",
 	"ListenerSetAllowedNamespaceSelector": "TODO",
 }
 

--- a/tests/integration/ambient/gateway_conformance_test.go
+++ b/tests/integration/ambient/gateway_conformance_test.go
@@ -89,7 +89,6 @@ var skippedTests = map[string]string{
 	"HTTPRouteCORS":                                   "TODO",
 	"HTTPRouteHTTPSListenerDetectMisdirectedRequests": "TODO",
 
-	"ListenerSetAllowedNamespaceSelector":    "TODO",
 	"ListenerSetAllowedRoutesNamespaces":     "TODO",
 	"ListenerSetAllowedRoutesSupportedKinds": "TODO",
 	"ListenerSetDefaultNotAllowed":           "TODO",

--- a/tests/integration/ambient/gateway_conformance_test.go
+++ b/tests/integration/ambient/gateway_conformance_test.go
@@ -113,6 +113,9 @@ var skippedTests = map[string]string{
 var agentgatewaySkippedTests = map[string]string{
 	"TLSRouteTerminateSimpleSameNamespace":  "TODO",
 	"TLSRouteMixedTerminationSameNamespace": "TODO",
+
+	"ListenerSetAllowedNamespaceNone": "TODO",
+	"ListenerSetAllowedNamespaceSame": "TODO",
 }
 
 func TestGatewayConformance(t *testing.T) {

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -112,8 +112,8 @@ var agentgatewaySkippedTests = map[string]string{
 	"TLSRouteTerminateSimpleSameNamespace":  "TODO",
 	"TLSRouteMixedTerminationSameNamespace": "TODO",
 
-	"ListenerSetAllowedNamespaceNone": "TODO",
-	"ListenerSetAllowedNamespaceSame": "TODO",
+	"ListenerSetAllowedNamespaceNone":     "TODO",
+	"ListenerSetAllowedNamespaceSame":     "TODO",
 	"ListenerSetAllowedNamespaceSelector": "TODO",
 }
 

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -87,7 +87,6 @@ var skippedTests = map[string]string{
 	"HTTPRouteCORS":                                   "TODO",
 	"HTTPRouteHTTPSListenerDetectMisdirectedRequests": "TODO",
 
-	"ListenerSetAllowedNamespaceSelector":    "TODO",
 	"ListenerSetAllowedRoutesNamespaces":     "TODO",
 	"ListenerSetAllowedRoutesSupportedKinds": "TODO",
 	"ListenerSetDefaultNotAllowed":           "TODO",

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -87,14 +87,6 @@ var skippedTests = map[string]string{
 	"HTTPRouteCORS":                                   "TODO",
 	"HTTPRouteHTTPSListenerDetectMisdirectedRequests": "TODO",
 
-	"ListenerSetAllowedRoutesNamespaces":     "TODO",
-	"ListenerSetAllowedRoutesSupportedKinds": "TODO",
-	"ListenerSetDefaultNotAllowed":           "TODO",
-	"ListenerSetHostnameConflict":            "TODO",
-	"ListenerSetHTTPRouting":                 "TODO",
-	"ListenerSetProtocolConflict":            "TODO",
-	"ListenerSetReferenceGrant":              "TODO",
-
 	"MeshHTTPRoute303Redirect": "TODO",
 	"MeshHTTPRoute307Redirect": "TODO",
 	"MeshHTTPRoute308Redirect": "TODO",
@@ -115,6 +107,9 @@ var agentgatewaySkippedTests = map[string]string{
 	"ListenerSetAllowedNamespaceNone":     "TODO",
 	"ListenerSetAllowedNamespaceSame":     "TODO",
 	"ListenerSetAllowedNamespaceSelector": "TODO",
+	"ListenerSetHostnameConflict":         "TODO",
+	"ListenerSetProtocolConflict":         "TODO",
+	"ListenerSetReferenceGrant":           "TODO",
 }
 
 func TestGatewayConformance(t *testing.T) {

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -114,6 +114,7 @@ var agentgatewaySkippedTests = map[string]string{
 
 	"ListenerSetAllowedNamespaceNone": "TODO",
 	"ListenerSetAllowedNamespaceSame": "TODO",
+	"ListenerSetAllowedNamespaceSelector": "TODO",
 }
 
 func TestGatewayConformance(t *testing.T) {

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -112,6 +112,9 @@ var agentgatewaySkippedTests = map[string]string{
 	// The following tests were added in v1.5.0
 	"TLSRouteTerminateSimpleSameNamespace":  "TODO",
 	"TLSRouteMixedTerminationSameNamespace": "TODO",
+
+	"ListenerSetAllowedNamespaceNone": "TODO",
+	"ListenerSetAllowedNamespaceSame": "TODO",
 }
 
 func TestGatewayConformance(t *testing.T) {

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -87,8 +87,6 @@ var skippedTests = map[string]string{
 	"HTTPRouteCORS":                                   "TODO",
 	"HTTPRouteHTTPSListenerDetectMisdirectedRequests": "TODO",
 
-	"ListenerSetAllowedNamespaceNone":        "TODO",
-	"ListenerSetAllowedNamespaceSame":        "TODO",
 	"ListenerSetAllowedNamespaceSelector":    "TODO",
 	"ListenerSetAllowedRoutesNamespaces":     "TODO",
 	"ListenerSetAllowedRoutesSupportedKinds": "TODO",


### PR DESCRIPTION
**Please provide a description of this PR:**

There are a couple of issues in the status reporting currently that this PR fixes:
- Istio reports the number of listeners instead of listenersets for gateway in AttachedListenerSets field
- Istio does not report the number of attached routes for listeners in listenersets.

This PR changes the status reporting to fix those issues and with that it makes the following conformance tests pass:
- ListenerSetAllowedRoutesNamespaces
- ListenerSetAllowedRoutesSupportedKinds
- ListenerSetDefaultNotAllowed
- ListenerSetHTTPRouting

There are still a few ListenerSet conformance tests in gateway API 1.5.0 that are failing for Istio, but those fail for different reasons and will be addressed separately.

Related to #60018






+cc @jaellio @jgreeer @ericdbishop @keithmattix 