### PR TITLE
[Release-1.30.0] Add release-1.30 dependabot tracking

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,31 @@ updates:
       interval: "daily"
     labels:
       - "release-notes-none"
+    target-branch: "release-1.30"
+    # See master stanza above for why both ignore and exclude-patterns are required.
+    ignore:
+      - dependency-name: "istio.io/*"
+      - dependency-name: "k8s.io/*"
+      - dependency-name: "sigs.k8s.io/*"
+      - dependency-name: "github.com/envoyproxy/go-control-plane/*"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "istio.io/*"
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+          - "github.com/envoyproxy/go-control-plane/*"
+
+  - package-ecosystem: "gomod"
+    directories:
+      - "/"
+      - "!/samples/**"
+    schedule:
+      interval: "daily"
+    labels:
+      - "release-notes-none"
     target-branch: "release-1.29"
     # See master stanza above for why both ignore and exclude-patterns are required.
     ignore:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,7 @@ updates:
       - dependency-name: "k8s.io/*"
       - dependency-name: "sigs.k8s.io/*"
       - dependency-name: "github.com/envoyproxy/go-control-plane/*"
+      - dependency-name: "github.com/prometheus/prometheus"
     groups:
       all-dependencies:
         patterns:
@@ -31,6 +32,7 @@ updates:
           - "k8s.io/*"
           - "sigs.k8s.io/*"
           - "github.com/envoyproxy/go-control-plane/*"
+          - "github.com/prometheus/prometheus"
 
   - package-ecosystem: "gomod"
     directories:
@@ -47,6 +49,7 @@ updates:
       - dependency-name: "k8s.io/*"
       - dependency-name: "sigs.k8s.io/*"
       - dependency-name: "github.com/envoyproxy/go-control-plane/*"
+      - dependency-name: "github.com/prometheus/prometheus"
     groups:
       all-dependencies:
         patterns:
@@ -56,6 +59,7 @@ updates:
           - "k8s.io/*"
           - "sigs.k8s.io/*"
           - "github.com/envoyproxy/go-control-plane/*"
+          - "github.com/prometheus/prometheus"
 
   - package-ecosystem: "gomod"
     directories:
@@ -72,6 +76,7 @@ updates:
       - dependency-name: "k8s.io/*"
       - dependency-name: "sigs.k8s.io/*"
       - dependency-name: "github.com/envoyproxy/go-control-plane/*"
+      - dependency-name: "github.com/prometheus/prometheus"
     groups:
       all-dependencies:
         patterns:
@@ -81,6 +86,7 @@ updates:
           - "k8s.io/*"
           - "sigs.k8s.io/*"
           - "github.com/envoyproxy/go-control-plane/*"
+          - "github.com/prometheus/prometheus"
 
   - package-ecosystem: "gomod"
     directories:
@@ -97,6 +103,7 @@ updates:
       - dependency-name: "k8s.io/*"
       - dependency-name: "sigs.k8s.io/*"
       - dependency-name: "github.com/envoyproxy/go-control-plane/*"
+      - dependency-name: "github.com/prometheus/prometheus"
     groups:
       all-dependencies:
         patterns:
@@ -106,6 +113,7 @@ updates:
           - "k8s.io/*"
           - "sigs.k8s.io/*"
           - "github.com/envoyproxy/go-control-plane/*"
+          - "github.com/prometheus/prometheus"
 
   - package-ecosystem: "gomod"
     directories:
@@ -122,6 +130,7 @@ updates:
       - dependency-name: "k8s.io/*"
       - dependency-name: "sigs.k8s.io/*"
       - dependency-name: "github.com/envoyproxy/go-control-plane/*"
+      - dependency-name: "github.com/prometheus/prometheus"
     groups:
       all-dependencies:
         patterns:
@@ -131,6 +140,7 @@ updates:
           - "k8s.io/*"
           - "sigs.k8s.io/*"
           - "github.com/envoyproxy/go-control-plane/*"
+          - "github.com/prometheus/prometheus"
 
   # Ignore all dependency updates in samples/
   # We do not care about the dependencies in the samples/ directory as they are not meant


### PR DESCRIPTION
Adds release-1.30 entry to .github/dependabot.yml mirroring the existing release-1.29 stanza. Refs #59425