### PR TITLE
bump min k8s version to 1.32

### DIFF
--- a/istioctl/pkg/install/k8sversion/version.go
+++ b/istioctl/pkg/install/k8sversion/version.go
@@ -28,7 +28,7 @@ import (
 const (
 	// MinK8SVersion is the minimum k8s version required to run this version of Istio
 	// https://istio.io/docs/setup/platform-setup/
-	MinK8SVersion               = 30
+	MinK8SVersion               = 32
 	UnSupportedK8SVersionLogMsg = "\nThe Kubernetes version %s is not supported by Istio %s. The minimum supported Kubernetes version is 1.%d.\n" +
 		"Proceeding with the installation, but you might experience problems. " +
 		"See https://istio.io/latest/docs/releases/supported-releases/ for a list of supported versions.\n"

--- a/istioctl/pkg/install/k8sversion/version_test.go
+++ b/istioctl/pkg/install/k8sversion/version_test.go
@@ -94,6 +94,16 @@ var (
 		Minor:      "30",
 		GitVersion: "v1.30",
 	}
+	version1_31 = &version.Info{
+		Major:      "1",
+		Minor:      "31",
+		GitVersion: "v1.31",
+	}
+	version1_32 = &version.Info{
+		Major:      "1",
+		Minor:      "32",
+		GitVersion: "v1.32",
+	}
 	version1_19RC = &version.Info{
 		Major:      "1",
 		Minor:      "19",
@@ -274,6 +284,16 @@ func TestIsK8VersionSupported(t *testing.T) {
 		},
 		{
 			version: version1_30,
+			logMsg:  fmt.Sprintf(UnSupportedK8SVersionLogMsg, version1_30.GitVersion, pkgVersion.Info.Version, MinK8SVersion),
+			isValid: false,
+		},
+		{
+			version: version1_31,
+			logMsg:  fmt.Sprintf(UnSupportedK8SVersionLogMsg, version1_31.GitVersion, pkgVersion.Info.Version, MinK8SVersion),
+			isValid: false,
+		},
+		{
+			version: version1_32,
 			isValid: true,
 		},
 	}

--- a/releasenotes/notes/updateMinK8sto1.32.yaml
+++ b/releasenotes/notes/updateMinK8sto1.32.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+- |
+  **Updated** minimum supported Kubernetes version to 1.32.x.


### PR DESCRIPTION
Bumps MinK8SVersion to 1.32 to align with the supported k8s matrix in istio.io supportStatus.yml.