### PR TITLE
fix:  istiod_remote_cluster_sync_status always reporting timeout

### DIFF
--- a/pkg/kube/multicluster/cluster.go
+++ b/pkg/kube/multicluster/cluster.go
@@ -206,9 +206,9 @@ func (c *Cluster) Run(mesh meshwatcher.WatcherCollection, handlers []handler, ac
 				timeouts.With(clusterLabel.Value(string(c.ID))).Increment()
 				// Signal that sync is complete (timed out)
 				c.closeSyncedCh()
+				c.initialSyncTimeout.Store(true)
+				c.reportStatus(SyncStatusTimeout)
 			}
-			c.initialSyncTimeout.Store(true)
-			c.reportStatus(SyncStatusTimeout)
 		})
 	}
 


### PR DESCRIPTION
Fixes #60082

## summary

### Trigger Scenario                                                                                                                                                        
  In a multi-cluster Istio deployment, when a remote cluster is registered via kubeconfig secret, it starts a sync process and simultaneously arms a timeout timer. The callback fires after the configured timeout duration, regardless of whether the cluster already synced successfully.  
                                                                                
  Fault Manifestation
  - The Prometheus metric istiod_remote_cluster_sync_status{status="timeout"} permanently returns 1, indicating all remote clusters are in a timeout state.               
  - Meanwhile, istioctl remote-clusters correctly shows all clusters as synced.                                                                                         
  - The two data sources contradict each other, rendering the monitoring metric completely unreliable.                                                                    

  After a cluster syncs successfully, the metric should report synced. The timeout status should only be reported when the sync genuinely fails to complete within the    
  configured timeout.                                                                                                                                                   
                                                                                                                                                                          
  ### Root Cause                                                                                                                                                    
  the timeout callback unconditionally executes:                                                                                                                                                                             
  c.initialSyncTimeout.Store(true)                                                                                                                                        
  c.reportStatus(SyncStatusTimeout)                                                                                                                                       
                                                                                                                                                                          
  These two lines are placed outside the if !c.initialSync.Load() block, so they execute regardless of whether the cluster already succeeded. 



- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [x] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions


