### PR TITLE
Add terminationMessagePolicy helm field for pilot container

### DIFF
--- a/manifests/charts/base/files/profile-platform-openshift.yaml
+++ b/manifests/charts/base/files/profile-platform-openshift.yaml
@@ -13,6 +13,7 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+  terminationMessagePolicy: FallbackToLogsOnError
 seLinuxOptions:
   type: spc_t
 # Openshift requires privileged pods to run in kube-system

--- a/manifests/charts/default/files/profile-platform-openshift.yaml
+++ b/manifests/charts/default/files/profile-platform-openshift.yaml
@@ -13,6 +13,7 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+  terminationMessagePolicy: FallbackToLogsOnError
 seLinuxOptions:
   type: spc_t
 # Openshift requires privileged pods to run in kube-system

--- a/manifests/charts/gateway/files/profile-platform-openshift.yaml
+++ b/manifests/charts/gateway/files/profile-platform-openshift.yaml
@@ -13,6 +13,7 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+  terminationMessagePolicy: FallbackToLogsOnError
 seLinuxOptions:
   type: spc_t
 # Openshift requires privileged pods to run in kube-system

--- a/manifests/charts/gateways/istio-egress/files/profile-platform-openshift.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-platform-openshift.yaml
@@ -13,6 +13,7 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+  terminationMessagePolicy: FallbackToLogsOnError
 seLinuxOptions:
   type: spc_t
 # Openshift requires privileged pods to run in kube-system

--- a/manifests/charts/gateways/istio-ingress/files/profile-platform-openshift.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-platform-openshift.yaml
@@ -13,6 +13,7 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+  terminationMessagePolicy: FallbackToLogsOnError
 seLinuxOptions:
   type: spc_t
 # Openshift requires privileged pods to run in kube-system

--- a/manifests/charts/istio-cni/files/profile-platform-openshift.yaml
+++ b/manifests/charts/istio-cni/files/profile-platform-openshift.yaml
@@ -13,6 +13,7 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+  terminationMessagePolicy: FallbackToLogsOnError
 seLinuxOptions:
   type: spc_t
 # Openshift requires privileged pods to run in kube-system

--- a/manifests/charts/istio-control/istio-discovery/files/profile-platform-openshift.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-platform-openshift.yaml
@@ -13,6 +13,7 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+  terminationMessagePolicy: FallbackToLogsOnError
 seLinuxOptions:
   type: spc_t
 # Openshift requires privileged pods to run in kube-system

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -103,6 +103,9 @@ spec:
 {{- if .Values.global.imagePullPolicy }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
 {{- end }}
+{{- if .Values.terminationMessagePolicy }}
+          terminationMessagePolicy: {{ .Values.terminationMessagePolicy }}
+{{- end }}
           args:
           - "discovery"
           - --monitoringAddr=:15014

--- a/manifests/charts/ztunnel/files/profile-platform-openshift.yaml
+++ b/manifests/charts/ztunnel/files/profile-platform-openshift.yaml
@@ -13,6 +13,7 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+  terminationMessagePolicy: FallbackToLogsOnError
 seLinuxOptions:
   type: spc_t
 # Openshift requires privileged pods to run in kube-system

--- a/manifests/helm-profiles/platform-openshift.yaml
+++ b/manifests/helm-profiles/platform-openshift.yaml
@@ -9,6 +9,7 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+  terminationMessagePolicy: FallbackToLogsOnError
 seLinuxOptions:
   type: spc_t
 # Openshift requires privileged pods to run in kube-system

--- a/releasenotes/notes/add-terminationmessagepolicy-field-to-istiod.yaml
+++ b/releasenotes/notes/add-terminationmessagepolicy-field-to-istiod.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+
+releaseNotes:
+  - |
+    **Added** `terminationMessagePolicy` helm field for the istiod (pilot) container, allowing configuration of how termination messages are populated.


### PR DESCRIPTION
**Please provide a description of this PR:**

By setting `terminationMessagePolicy: FallbackToLogsOnError`, the policy ensures that when a container crashes, the last chunk of log output is captured in the pod's status via the Kubernetes API, enabling easier debugging without needing to access log storage.

**Note**: OpenShift requires all platform pods to set `terminationMessagePolicy: FallbackToLogsOnError` on their containers.