### PR TITLE
update release-builder SHA for 1.30 RC0

### DIFF
--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -37,7 +37,7 @@ docker run --rm --privileged "${DOCKER_HUB}/qemu-user-static" --reset -p yes
 export ISTIO_DOCKER_QEMU=true
 
 # Use a pinned version in case breaking changes are needed
-BUILDER_SHA=bfe2e49ea314d34b567b088674acc481249354a1
+BUILDER_SHA=018a8cb7223c8f23a824b2cde2de7838f5bc0ab3
 
 # Reference to the next minor version of Istio
 # This will create a version like 1.4-alpha.sha


### PR DESCRIPTION
Picks up the latest release-builder SHA on release-1.30 in preparation for 1.30.0-rc.0 build.