### PR TITLE
fix: istiod panic processing VS without any routes

### DIFF
--- a/pilot/pkg/networking/core/gateway.go
+++ b/pilot/pkg/networking/core/gateway.go
@@ -880,6 +880,9 @@ func (lb *ListenerBuilder) buildGatewayNetworkFiltersFromTCPRoutes(server *netwo
 		// based on the match port/server port and the gateway name
 		for _, tcp := range vsvc.Tcp {
 			if l4MultiMatch(tcp.Match, server, gatewayName) {
+				if len(tcp.Route) == 0 {
+					continue
+				}
 				includeMx := server.GetTls().GetMode() == networking.ServerTLSSettings_ISTIO_MUTUAL
 				return lb.buildOutboundNetworkFilters(tcp.Route, port, v.Meta, includeMx)
 			}
@@ -945,6 +948,9 @@ func (lb *ListenerBuilder) buildGatewayNetworkFiltersFromTLSRoutes(server *netwo
 			// matches, one for 1.foo.com, another for 2.foo.com, this code will produce duplicate filter
 			// chain matches
 			for _, tls := range vsvc.Tls {
+				if len(tls.Route) == 0 {
+					continue
+				}
 				for i, match := range tls.Match {
 					if l4SingleMatch(convertTLSMatchToL4Match(match), server, gatewayName) {
 						// Envoy will reject config that has multiple filter chain matches with the same matching rules

--- a/pilot/pkg/networking/core/gateway_test.go
+++ b/pilot/pkg/networking/core/gateway_test.go
@@ -3649,6 +3649,73 @@ func TestBuildGatewayListeners(t *testing.T) {
 			// With QUIC enabled: []string{"10.0.0.1_443", "10.0.0.2_443", "udp_10.0.0.1_443", "udp_10.0.0.2_443"}
 			[]string{"10.0.0.1_443", "10.0.0.2_443"},
 		},
+		{
+			"gateway TCP server with VS TCP empty route",
+			&pilot_model.Proxy{},
+			[]config.Config{
+				{
+					Meta: config.Meta{Name: "gateway1", Namespace: "testns", GroupVersionKind: gvk.Gateway},
+					Spec: &networking.Gateway{
+						Servers: []*networking.Server{
+							{
+								Port:  &networking.Port{Name: "tcp", Number: 9000, Protocol: "TCP"},
+								Hosts: []string{"tcp.example.com"},
+							},
+						},
+					},
+				},
+			},
+			[]config.Config{
+				{
+					Meta: config.Meta{Name: uuid.NewString(), Namespace: "testns", GroupVersionKind: gvk.VirtualService},
+					Spec: &networking.VirtualService{
+						Gateways: []string{"testns/gateway1"},
+						Hosts:    []string{"tcp.example.com"},
+						Tcp: []*networking.TCPRoute{
+							{
+								Match: []*networking.L4MatchAttributes{{Port: 9000}},
+								// Route intentionally left empty
+							},
+						},
+					},
+				},
+			},
+			[]string{},
+		},
+		{
+			"gateway TLS terminate server with VS TCP empty route",
+			&pilot_model.Proxy{},
+			[]config.Config{
+				{
+					Meta: config.Meta{Name: "gateway1", Namespace: "testns", GroupVersionKind: gvk.Gateway},
+					Spec: &networking.Gateway{
+						Servers: []*networking.Server{
+							{
+								Port:  &networking.Port{Name: "tls", Number: 9443, Protocol: "TLS"},
+								Hosts: []string{"tcp.example.com"},
+								Tls:   &networking.ServerTLSSettings{CredentialName: "test", Mode: networking.ServerTLSSettings_SIMPLE},
+							},
+						},
+					},
+				},
+			},
+			[]config.Config{
+				{
+					Meta: config.Meta{Name: uuid.NewString(), Namespace: "testns", GroupVersionKind: gvk.VirtualService},
+					Spec: &networking.VirtualService{
+						Gateways: []string{"testns/gateway1"},
+						Hosts:    []string{"tcp.example.com"},
+						Tcp: []*networking.TCPRoute{
+							{
+								Match: []*networking.L4MatchAttributes{{Port: 9443}},
+								// Route intentionally left empty
+							},
+						},
+					},
+				},
+			},
+			[]string{},
+		},
 	}
 
 	for _, tt := range cases {

--- a/pilot/pkg/networking/core/listener_test.go
+++ b/pilot/pkg/networking/core/listener_test.go
@@ -783,6 +783,151 @@ func TestOutboundListenerTCPWithVSExactBalance(t *testing.T) {
 	}
 }
 
+func TestOutboundListenerTCPWithVSEmptyRoute(t *testing.T) {
+	// Regression test: a VirtualService with a TCP match but no routes should not
+	// cause a panic in buildOutboundNetworkFilters. The VS should be skipped and
+	// the default service route should be used instead.
+	tests := []struct {
+		name string
+		vs   *networking.VirtualService
+	}{
+		{
+			name: "tcp match with port but no routes",
+			vs: &networking.VirtualService{
+				Hosts:    []string{"test.com"},
+				Gateways: []string{"mesh"},
+				Tcp: []*networking.TCPRoute{
+					{
+						Match: []*networking.L4MatchAttributes{
+							{
+								Port: 8080,
+							},
+						},
+						// Route intentionally left empty
+					},
+				},
+			},
+		},
+		{
+			name: "tcp implicit match with no routes",
+			vs: &networking.VirtualService{
+				Hosts:    []string{"test.com"},
+				Gateways: []string{"mesh"},
+				Tcp: []*networking.TCPRoute{
+					{
+						// No match and no route
+					},
+				},
+			},
+		},
+		{
+			name: "tcp match with destination subnets but no routes",
+			vs: &networking.VirtualService{
+				Hosts:    []string{"test.com"},
+				Gateways: []string{"mesh"},
+				Tcp: []*networking.TCPRoute{
+					{
+						Match: []*networking.L4MatchAttributes{
+							{
+								DestinationSubnets: []string{"10.10.0.0/24"},
+								Port:               8080,
+							},
+						},
+						// Route intentionally left empty
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			services := []*model.Service{
+				buildService("test.com", "10.10.0.0/24", protocol.TCP, tnow),
+			}
+
+			virtualService := config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.VirtualService,
+					Name:             "test_vs",
+					Namespace:        "default",
+				},
+				Spec: tt.vs,
+			}
+			listeners := buildOutboundListeners(t, getProxy(), nil, &virtualService, services...)
+
+			if len(listeners) != 1 {
+				t.Fatalf("expected %d listeners, found %d", 1, len(listeners))
+			}
+
+			// The VS with empty routes should be skipped, so the default service
+			// route should be used. Verify we have a valid TCP filter chain.
+			for _, l := range listeners {
+				for _, fc := range l.GetFilterChains() {
+					listenertest.VerifyFilterChain(t, fc, listenertest.FilterChainTest{
+						NetworkFilters: []string{wellknown.TCPProxy},
+						TotalMatch:     true,
+					})
+					tcpProxy := xdstest.ExtractTCPProxy(t, fc)
+					if tcpProxy == nil {
+						t.Fatal("expected tcp proxy filter, found none")
+					}
+					// Should route to the default service cluster
+					if tcpProxy.GetCluster() == "" && tcpProxy.GetWeightedClusters() == nil {
+						t.Fatal("expected a cluster or weighted clusters in TCP proxy, found none")
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestOutboundListenerTLSWithVSEmptyRoute(t *testing.T) {
+	// Regression test: a VirtualService with a TLS match but no routes should not
+	// cause a panic in buildSidecarOutboundTLSFilterChainOpts. The VS should be skipped.
+	services := []*model.Service{
+		{
+			CreationTime:   tnow,
+			Hostname:       host.Name("test.com"),
+			DefaultAddress: wildcardIPv4,
+			Ports: model.PortList{
+				&model.Port{
+					Name:     "https",
+					Port:     8080,
+					Protocol: protocol.HTTPS,
+				},
+			},
+			Resolution: model.Passthrough,
+			Attributes: model.ServiceAttributes{Namespace: "default"},
+		},
+	}
+	virtualService := config.Config{
+		Meta: config.Meta{
+			GroupVersionKind: gvk.VirtualService,
+			Name:             "test_vs",
+			Namespace:        "default",
+		},
+		Spec: &networking.VirtualService{
+			Hosts:    []string{"test.com"},
+			Gateways: []string{"mesh"},
+			Tls: []*networking.TLSRoute{
+				{
+					Match: []*networking.TLSMatchAttributes{
+						{
+							Port:     8080,
+							SniHosts: []string{"test.com"},
+						},
+					},
+					// Route intentionally left empty
+				},
+			},
+		},
+	}
+	// Should not panic.
+	for _, p := range []*model.Proxy{getProxy(), &dualStackProxy} {
+		buildOutboundListeners(t, p, nil, &virtualService, services...)
+	}
+}
+
 func TestOutboundListenerForHeadlessServices(t *testing.T) {
 	svc := buildServiceWithPort("test.com", 9999, protocol.TCP, tnow)
 	svc.Resolution = model.Passthrough

--- a/pilot/pkg/networking/core/tls.go
+++ b/pilot/pkg/networking/core/tls.go
@@ -137,6 +137,9 @@ func buildSidecarOutboundTLSFilterChainOpts(node *model.Proxy, push *model.PushC
 	for _, cfg := range configs {
 		virtualService := cfg.Spec.(*v1alpha3.VirtualService)
 		for _, tls := range virtualService.Tls {
+			if len(tls.Route) == 0 {
+				continue
+			}
 			for _, match := range tls.Match {
 				if matchTLS(match, node.Labels, gateways, listenPort.Port, node.Metadata.Namespace) {
 					// Use the service's CIDRs.
@@ -248,6 +251,10 @@ TcpLoop:
 	for _, cfg := range configs {
 		virtualService := cfg.Spec.(*v1alpha3.VirtualService)
 		for _, tcp := range virtualService.Tcp {
+			if len(tcp.Route) == 0 {
+				// no routes, skip (validated at admission but config may still arrive without routes)
+				continue
+			}
 			if len(tcp.Match) == 0 {
 				// implicit match
 				out = append(out, &filterChainOpts{

--- a/releasenotes/notes/istiod-panic-vs-empty-routes.yaml
+++ b/releasenotes/notes/istiod-panic-vs-empty-routes.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 60110
+releaseNotes:
+  - |
+    **Fixed** an istiod panic when processing a `VirtualService` with TCP or TLS routes that have no destinations, which could occur when the validating webhook is not installed (e.g. deployments without a default revision).


### PR DESCRIPTION
**Please provide a description of this PR:**

Prevents `istiod` crash loop when a VS without any routes is processed for reconciliation to a proxy.

Admission controller would typically block this, however if Istio is deployed without a defaultRevision configured, the default validating webhook is not created.  While not a typical configuration, it is valid as possibly present in a number of clusters if the IstioOperator or some other deployment method was used for deployment of previous revisions that have since been upgraded from and cleaned up.