### PR TITLE
[agw] Stop guarding ListenerSet feature behind alpha flag and fix status reporting

### DIFF
--- a/pilot/pkg/config/kube/agentgateway/agentgateway_controller.go
+++ b/pilot/pkg/config/kube/agentgateway/agentgateway_controller.go
@@ -216,6 +216,7 @@ func (c *Controller) initializeInputs(kc kube.Client, opts krt.OptionsBuilder) {
 		GRPCRoutes:         buildClient[*gatewayv1.GRPCRoute](c, kc, gvr.GRPCRoute, opts, "informer/GRPCRoutes"),
 		TLSRoutes:          buildClient[*gatewayv1.TLSRoute](c, kc, gvr.TLSRoute, opts, "informer/TLSRoutes"),
 		BackendTLSPolicies: buildClient[*gatewayv1.BackendTLSPolicy](c, kc, gvr.BackendTLSPolicy, opts, "informer/BackendTLSPolicies"),
+		ListenerSets:       buildClient[*gatewayv1.ListenerSet](c, kc, gvr.ListenerSet, opts, "informer/ListenerSets"),
 
 		ReferenceGrants: buildClient[*gateway.ReferenceGrant](c, kc, gvr.ReferenceGrant, opts, "informer/ReferenceGrants"),
 		ServiceEntries:  buildClient[*networkingclient.ServiceEntry](c, kc, gvr.ServiceEntry, opts, "informer/ServiceEntries"),
@@ -228,12 +229,10 @@ func (c *Controller) initializeInputs(kc kube.Client, opts krt.OptionsBuilder) {
 	if features.EnableAlphaGatewayAPI {
 		inputs.TCPRoutes = buildClient[*gatewayalpha.TCPRoute](c, kc, gvr.TCPRoute, opts, "informer/TCPRoutes")
 		inputs.BackendTrafficPolicy = buildClient[*gatewayx.XBackendTrafficPolicy](c, kc, gvr.XBackendTrafficPolicy, opts, "informer/XBackendTrafficPolicy")
-		inputs.ListenerSets = buildClient[*gatewayv1.ListenerSet](c, kc, gvr.ListenerSet, opts, "informer/ListenerSets")
 	} else {
 		// If disabled, still build a collection but make it always empty
 		inputs.TCPRoutes = krt.NewStaticCollection[*gatewayalpha.TCPRoute](nil, nil, opts.WithName("disable/TCPRoutes")...)
 		inputs.BackendTrafficPolicy = krt.NewStaticCollection[*gatewayx.XBackendTrafficPolicy](nil, nil, opts.WithName("disable/XBackendTrafficPolicy")...)
-		inputs.ListenerSets = krt.NewStaticCollection[*gatewayv1.ListenerSet](nil, nil, opts.WithName("disable/ListenerSets")...)
 	}
 
 	if features.EnableGatewayAPIInferenceExtension {

--- a/pilot/pkg/config/kube/agentgateway/gateway_status.go
+++ b/pilot/pkg/config/kube/agentgateway/gateway_status.go
@@ -246,7 +246,6 @@ func reportUnsupportedListenerSet(class string, status *gatewayv1.ListenerSetSta
 func reportNotAllowedListenerSet(status *gatewayv1.ListenerSetStatus, obj *gatewayv1.ListenerSet) {
 	gatewayConditions := map[string]*Condition{
 		string(gatewayv1.GatewayConditionAccepted): {
-			status: metav1.ConditionFalse,
 			reason: string(gatewayv1.GatewayReasonAccepted),
 			error: &ConfigError{
 				Reason:  string(gatewayv1.ListenerSetReasonNotAllowed),
@@ -254,7 +253,6 @@ func reportNotAllowedListenerSet(status *gatewayv1.ListenerSetStatus, obj *gatew
 			},
 		},
 		string(gatewayv1.GatewayConditionProgrammed): {
-			status: metav1.ConditionFalse,
 			reason: string(gatewayv1.GatewayReasonProgrammed),
 			error: &ConfigError{
 				Reason:  string(gatewayv1.ListenerSetReasonNotAllowed),

--- a/releasenotes/notes/agw-fix-listenerset-not-allowed-reporting.yaml
+++ b/releasenotes/notes/agw-fix-listenerset-not-allowed-reporting.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed**: ListenerSet status reporting when ListenerSet is not allowed by the parent
+    Gateway resource for agentgateway. When ListnerSet is not allowed by the parent Gateway
+    we must report `Accepted` condition status as `False`, but it wasn't the case.
+    Additionally, given that ListenerSet feature is not experimental as of Gateway API v1.5.0,
+    it's no longer guarded by the `PILOT_ENABLE_ALPHA_GATEWAY_API` feature flag.

--- a/tests/integration/pilot/agentgateway/gateway_conformance_test.go
+++ b/tests/integration/pilot/agentgateway/gateway_conformance_test.go
@@ -83,7 +83,6 @@ var skippedTests = map[string]string{
 	"HTTPRouteCORS":                                   "TODO",
 	"HTTPRouteHTTPSListenerDetectMisdirectedRequests": "TODO",
 
-	"ListenerSetAllowedNamespaceNone":        "TODO",
 	"ListenerSetAllowedNamespaceSame":        "TODO",
 	"ListenerSetAllowedNamespaceSelector":    "TODO",
 	"ListenerSetAllowedRoutesNamespaces":     "TODO",


### PR DESCRIPTION
**Please provide a description of this PR:**

ListenerSet is not an exeperimental feature anymore (it's part of the extended feature set, so it shouldn't really be hidden behind the EnableAlphaGatewayAPI feature flag anymore.

It's not guarded by this flag for regular sidecar or ambient modes - I think we just overlooked agentgateway when we changed it and that's why it still behind a feature flag for agentgateway.

While testing this change I also spotted an issue with status reporting for ListenerSets. Basically, for agentgateway, when ListenerSet is not allowed by the parent gateway we call
[reportNotAllowedListenerSet](https://github.com/istio/istio/blob/master/pilot/pkg/config/kube/agentgateway/gateway_status.go#L245-L267) function.

This function is almost exact copy of
[reportNotAllowedListenerSet](https://github.com/istio/istio/blob/cc0e2585a811f7b43e9812912bd2b7db3fa7e81e/pilot/pkg/config/kube/gateway/conversion.go#L1945-L1965) with one difference - it explicitly sets status for `Accepted` and `Programmed` conditions to be false.

That sounds reasonable, but unfortunately that's not correct in somewhat weird way. The `reportNotAllowedListenerSet` function (both of them actually) call `setConditions` to actually update conditions in the status.

`setConditions` does something somewhat surprising - it checks if the condition has an error and if it does it inverts the status (see https://github.com/istio/istio/blob/master/pilot/pkg/config/kube/agentgateway/conditions.go#L55). So when you explicitly set status to false and provide an error it will convert the status to true.

Removing explicit status fixes at least one of the Gateway API conformance tests for ListenerSet: `ListenerSetAllowedNamespaceNone`.

Related to #60018


**Please check any characteristics that apply to this pull request.**

+cc @jaellio 

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.