### PR TITLE
Initialize the KubeOptions for the ConfigController

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1177,6 +1177,8 @@ func (s *Server) initControllers(args *PilotArgs) error {
 		s.initIPAutoallocateController(args)
 	}
 
+	s.initKubeOptions(args)
+
 	if err := s.initConfigController(args); err != nil {
 		return fmt.Errorf("error initializing config controller: %v", err)
 	}

--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -100,8 +100,7 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 	return nil
 }
 
-// initKubeRegistry creates all the k8s service controllers under this pilot
-func (s *Server) initKubeRegistry(args *PilotArgs) (err error) {
+func (s *Server) initKubeOptions(args *PilotArgs) {
 	args.RegistryOptions.KubeOptions.ClusterID = s.clusterID
 	args.RegistryOptions.KubeOptions.Revision = args.Revision
 	args.RegistryOptions.KubeOptions.KrtDebugger = args.KrtDebugger
@@ -111,6 +110,10 @@ func (s *Server) initKubeRegistry(args *PilotArgs) (err error) {
 	args.RegistryOptions.KubeOptions.MeshWatcher = s.environment.Watcher
 	args.RegistryOptions.KubeOptions.SystemNamespace = args.Namespace
 	args.RegistryOptions.KubeOptions.MeshServiceController = s.ServiceController()
+}
+
+// initKubeRegistry creates all the k8s service controllers under this pilot
+func (s *Server) initKubeRegistry(args *PilotArgs) (err error) {
 	// pass namespace to k8s service registry
 	kubecontroller.NewMulticluster(args.PodName,
 		args.RegistryOptions.KubeOptions,


### PR DESCRIPTION


**Please provide a description of this PR:**

The ConfigController uses parts of the KubeOptions before its initialized. Move most of what is done prior to initializing the controllers.




closes https://github.com/istio/istio/issues/60065