### PR TITLE
chore: disable supported features of gateway api that we don't fully test

### DIFF
--- a/pilot/pkg/config/kube/gateway/supported_features.go
+++ b/pilot/pkg/config/kube/gateway/supported_features.go
@@ -18,18 +18,13 @@ import (
 	"sigs.k8s.io/gateway-api/pkg/features"
 )
 
-var SupportedFeatures = features.AllFeatures.Clone().
-	// TODO: Fix skipped tests and reenable these features.
-	// skipped: GatewayBackendClientCertificateFeature, GatewayInvalidTLSBackendConfiguration.
-	Delete(features.GatewayBackendClientCertificateFeature).
-	// skipped: GatewayFrontendInvalidDefaultClientCertificateValidation,
-	// GatewayInvalidFrontendClientCertificateValidation,
-	// GatewayFrontendClientCertificateValidationInsecureFallback.
-	Delete(features.GatewayFrontendClientCertificateValidationFeature).
-	// skipped: GatewayFrontendClientCertificateValidationInsecureFallback.
-	Delete(features.GatewayFrontendClientCertificateValidationInsecureFallbackFeature).
-	// skipped: HTTPRouteHTTPSListenerDetectMisdirectedRequests.
-	Delete(features.GatewayHTTPSListenerDetectMisdirectedRequestsFeature).
-	// skipped: ListenerSetHostnameConflict, ListenerSetProtocolConflict,
-	// ListenerSetReferenceGrant.
-	Delete(features.ListenerSetFeature)
+// TODO: Fix skipped tests and reenable these features.
+var skippedExtendedFeatures = []features.Feature{
+	features.GatewayBackendClientCertificateFeature,                            // GatewayBackendClientCertificateFeature, GatewayInvalidTLSBackendConfiguration
+	features.GatewayFrontendClientCertificateValidationFeature,                 // GatewayFrontendInvalidDefaultClientCertificateValidation, GatewayInvalidFrontendClientCertificateValidation, GatewayFrontendClientCertificateValidationInsecureFallback
+	features.GatewayFrontendClientCertificateValidationInsecureFallbackFeature, // GatewayFrontendClientCertificateValidationInsecureFallback
+	features.GatewayHTTPSListenerDetectMisdirectedRequestsFeature,              // HTTPRouteHTTPSListenerDetectMisdirectedRequests
+	features.ListenerSetFeature,                                                // ListenerSetHostnameConflict, ListenerSetProtocolConflict, ListenerSetReferenceGrant
+}
+
+var SupportedFeatures = features.AllFeatures.Clone().Delete(skippedExtendedFeatures...)

--- a/pilot/pkg/config/kube/gateway/supported_features.go
+++ b/pilot/pkg/config/kube/gateway/supported_features.go
@@ -18,4 +18,18 @@ import (
 	"sigs.k8s.io/gateway-api/pkg/features"
 )
 
-var SupportedFeatures = features.AllFeatures
+var SupportedFeatures = features.AllFeatures.Clone().
+	// TODO: Fix skipped tests and reenable these features.
+	// skipped: GatewayBackendClientCertificateFeature, GatewayInvalidTLSBackendConfiguration.
+	Delete(features.GatewayBackendClientCertificateFeature).
+	// skipped: GatewayFrontendInvalidDefaultClientCertificateValidation,
+	// GatewayInvalidFrontendClientCertificateValidation,
+	// GatewayFrontendClientCertificateValidationInsecureFallback.
+	Delete(features.GatewayFrontendClientCertificateValidationFeature).
+	// skipped: GatewayFrontendClientCertificateValidationInsecureFallback.
+	Delete(features.GatewayFrontendClientCertificateValidationInsecureFallbackFeature).
+	// skipped: HTTPRouteHTTPSListenerDetectMisdirectedRequests.
+	Delete(features.GatewayHTTPSListenerDetectMisdirectedRequestsFeature).
+	// skipped: ListenerSetHostnameConflict, ListenerSetProtocolConflict,
+	// ListenerSetReferenceGrant.
+	Delete(features.ListenerSetFeature)

--- a/pilot/pkg/config/kube/gateway/supported_features.go
+++ b/pilot/pkg/config/kube/gateway/supported_features.go
@@ -20,11 +20,17 @@ import (
 
 // TODO: Fix skipped tests and reenable these features.
 var skippedExtendedFeatures = []features.Feature{
-	features.GatewayBackendClientCertificateFeature,                            // GatewayBackendClientCertificateFeature, GatewayInvalidTLSBackendConfiguration
-	features.GatewayFrontendClientCertificateValidationFeature,                 // GatewayFrontendInvalidDefaultClientCertificateValidation, GatewayInvalidFrontendClientCertificateValidation, GatewayFrontendClientCertificateValidationInsecureFallback
-	features.GatewayFrontendClientCertificateValidationInsecureFallbackFeature, // GatewayFrontendClientCertificateValidationInsecureFallback
-	features.GatewayHTTPSListenerDetectMisdirectedRequestsFeature,              // HTTPRouteHTTPSListenerDetectMisdirectedRequests
-	features.ListenerSetFeature,                                                // ListenerSetHostnameConflict, ListenerSetProtocolConflict, ListenerSetReferenceGrant
+	// GatewayBackendClientCertificateFeature, GatewayInvalidTLSBackendConfiguration
+	features.GatewayBackendClientCertificateFeature,
+	// GatewayFrontendInvalidDefaultClientCertificateValidation, GatewayInvalidFrontendClientCertificateValidation,
+	// GatewayFrontendClientCertificateValidationInsecureFallback
+	features.GatewayFrontendClientCertificateValidationFeature,
+	// GatewayFrontendClientCertificateValidationInsecureFallback
+	features.GatewayFrontendClientCertificateValidationInsecureFallbackFeature,
+	// HTTPRouteHTTPSListenerDetectMisdirectedRequests
+	features.GatewayHTTPSListenerDetectMisdirectedRequestsFeature,
+	// ListenerSetHostnameConflict, ListenerSetProtocolConflict, ListenerSetReferenceGrant
+	features.ListenerSetFeature,
 }
 
 var SupportedFeatures = features.AllFeatures.Clone().Delete(skippedExtendedFeatures...)


### PR DESCRIPTION
**Please provide a description of this PR:**

In order for us to submit Istio's conformance report for Gateway API v1.5.1, with an accurate representation of supported features for users, we need to temporarily disable certain extended features.

Skipped tests will be addressed and disabled features will be subsequently reenabled, but this will be done after Istio 1.30 is released.

This was the consensus, and best option for us to submit a new conformance report for Gateway API v1.5.1.

See: https://github.com/kubernetes-sigs/gateway-api/pull/4797, https://github.com/istio/istio/issues/60018