### PR TITLE
R2 for bins and benches

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -50,7 +50,7 @@ export VERSION
 
 # Base version of Istio image to use
 BASE_VERSION ?= master-2026-04-09T19-02-13
-ISTIO_BASE_REGISTRY ?= gcr.io/istio-release
+ISTIO_BASE_REGISTRY ?= registry.istio.io/release
 
 export GO111MODULE ?= on
 export GOPROXY ?= https://proxy.golang.org

--- a/bin/build_ztunnel.sh
+++ b/bin/build_ztunnel.sh
@@ -63,7 +63,7 @@ function download_ztunnel_if_necessary () {
 
   # Download and make the binary executable
   echo "Downloading ztunnel: $1 to $2"
-  time ${DOWNLOAD_COMMAND} --header "${AUTH_HEADER:-}" "$1" > "$2"
+  time ${DOWNLOAD_COMMAND} "$1" > "$2"
   chmod +x "$2"
 
   # Make a copy named just "ztunnel" in the same directory (overwrite if necessary).
@@ -117,12 +117,6 @@ function maybe_build_ztunnel() {
 
 # ztunnel binary vars (TODO handle debug builds, arm, darwin etc.)
 ISTIO_ZTUNNEL_BASE_URL="${ISTIO_ZTUNNEL_BASE_URL:-https://blob.istio.io/istio-build/ztunnel}"
-
-# If we are not using the default, assume its private and we need to authenticate
-if [[ "${ISTIO_ZTUNNEL_BASE_URL}" != "https://blob.istio.io/istio-build/ztunnel" ]]; then
-  AUTH_HEADER="Authorization: Bearer $(gcloud auth print-access-token)"
-  export AUTH_HEADER
-fi
 
 ZTUNNEL_REPO_SHA="${ZTUNNEL_REPO_SHA:-$(grep ZTUNNEL_REPO_SHA istio.deps  -A 4 | grep lastStableSHA | cut -f 4 -d '"')}"
 ISTIO_ZTUNNEL_VERSION="${ISTIO_ZTUNNEL_VERSION:-${ZTUNNEL_REPO_SHA}}"

--- a/bin/build_ztunnel.sh
+++ b/bin/build_ztunnel.sh
@@ -116,10 +116,10 @@ function maybe_build_ztunnel() {
 }
 
 # ztunnel binary vars (TODO handle debug builds, arm, darwin etc.)
-ISTIO_ZTUNNEL_BASE_URL="${ISTIO_ZTUNNEL_BASE_URL:-https://storage.googleapis.com/istio-build/ztunnel}"
+ISTIO_ZTUNNEL_BASE_URL="${ISTIO_ZTUNNEL_BASE_URL:-https://blob.istio.io/istio-build/ztunnel}"
 
 # If we are not using the default, assume its private and we need to authenticate
-if [[ "${ISTIO_ZTUNNEL_BASE_URL}" != "https://storage.googleapis.com/istio-build/ztunnel" ]]; then
+if [[ "${ISTIO_ZTUNNEL_BASE_URL}" != "https://blob.istio.io/istio-build/ztunnel" ]]; then
   AUTH_HEADER="Authorization: Bearer $(gcloud auth print-access-token)"
   export AUTH_HEADER
 fi

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -39,12 +39,6 @@ PROXY_REPO_SHA="${PROXY_REPO_SHA:-$(grep PROXY_REPO_SHA istio.deps  -A 4 | grep 
 # Envoy binary variables
 ISTIO_ENVOY_BASE_URL="${ISTIO_ENVOY_BASE_URL:-https://blob.istio.io/istio-build/proxy}"
 
-# If we are not using the default, assume its private and we need to authenticate
-if [[ "${ISTIO_ENVOY_BASE_URL}" != "https://blob.istio.io/istio-build/proxy" ]]; then
-  AUTH_HEADER="Authorization: Bearer $(gcloud auth print-access-token)"
-  export AUTH_HEADER
-fi
-
 SIDECAR="${SIDECAR:-envoy}"
 
 # OS-neutral vars. These currently only work for linux.
@@ -110,7 +104,7 @@ function download_envoy_if_necessary () {
 
     # Download and extract the binary to the output directory.
     echo "Downloading ${SIDECAR}: $1 to $2"
-    time ${DOWNLOAD_COMMAND} --header "${AUTH_HEADER:-}" "$1" |\
+    time ${DOWNLOAD_COMMAND} "$1" |\
       tar --extract --gzip --strip-components=3 --to-stdout > "$2"
     chmod +x "$2"
 

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -37,10 +37,10 @@ fi
 PROXY_REPO_SHA="${PROXY_REPO_SHA:-$(grep PROXY_REPO_SHA istio.deps  -A 4 | grep lastStableSHA | cut -f 4 -d '"')}"
 
 # Envoy binary variables
-ISTIO_ENVOY_BASE_URL="${ISTIO_ENVOY_BASE_URL:-https://storage.googleapis.com/istio-build/proxy}"
+ISTIO_ENVOY_BASE_URL="${ISTIO_ENVOY_BASE_URL:-https://blob.istio.io/istio-build/proxy}"
 
 # If we are not using the default, assume its private and we need to authenticate
-if [[ "${ISTIO_ENVOY_BASE_URL}" != "https://storage.googleapis.com/istio-build/proxy" ]]; then
+if [[ "${ISTIO_ENVOY_BASE_URL}" != "https://blob.istio.io/istio-build/proxy" ]]; then
   AUTH_HEADER="Authorization: Bearer $(gcloud auth print-access-token)"
   export AUTH_HEADER
 fi

--- a/bin/update_proxy.sh
+++ b/bin/update_proxy.sh
@@ -29,20 +29,20 @@ cd "${ROOTDIR}"
 # Wait for the proxy to become available
 ISTIO_ENVOY_VERSION=${ISTIO_ENVOY_VERSION:-$1}
 ISTIO_ENVOY_LINUX_VERSION=${ISTIO_ENVOY_LINUX_VERSION:-${ISTIO_ENVOY_VERSION}}
-ISTIO_ENVOY_BASE_URL=${ISTIO_ENVOY_BASE_URL:-https://storage.googleapis.com/istio-build/proxy}
+ISTIO_ENVOY_BASE_URL=${ISTIO_ENVOY_BASE_URL:-https://blob.istio.io/istio-build/proxy}
 ISTIO_ENVOY_RELEASE_URL=${ISTIO_ENVOY_RELEASE_URL:-${ISTIO_ENVOY_BASE_URL}/envoy-alpha-${ISTIO_ENVOY_LINUX_VERSION}.tar.gz}
 ISTIO_ENVOY_ARM_RELEASE_URL=${ISTIO_ENVOY_ARM_RELEASE_URL:-${ISTIO_ENVOY_BASE_URL}/envoy-alpha-${ISTIO_ENVOY_LINUX_VERSION}-arm64.tar.gz}
 SLEEP_TIME=60
 
 printf "Verifying %s is available\n" "$ISTIO_ENVOY_RELEASE_URL"
-until curl --output /dev/null --silent --head --fail "$ISTIO_ENVOY_RELEASE_URL"; do
+until curl -L --output /dev/null --silent --head --fail "$ISTIO_ENVOY_RELEASE_URL"; do
     printf '.'
     sleep $SLEEP_TIME
 done
 printf '\n'
 
 printf "Verifying %s is available\n" "$ISTIO_ENVOY_ARM_RELEASE_URL"
-until curl --output /dev/null --silent --head --fail "$ISTIO_ENVOY_ARM_RELEASE_URL"; do
+until curl -L --output /dev/null --silent --head --fail "$ISTIO_ENVOY_ARM_RELEASE_URL"; do
     printf '.'
     sleep $SLEEP_TIME
 done

--- a/pkg/config/analysis/analyzers/testdata/blocked-cidrs-configured.yaml
+++ b/pkg/config/analysis/analyzers/testdata/blocked-cidrs-configured.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: discovery
-          image: gcr.io/istio-testing/pilot:latest
+          image: registry.istio.io/testing/pilot:latest
           env:
             - name: BLOCKED_CIDRS_IN_JWKS_URIS
               value: "10.0.0.0/8,192.168.0.0/16,172.16.0.0/12"

--- a/pkg/config/analysis/analyzers/testdata/blocked-cidrs-missing.yaml
+++ b/pkg/config/analysis/analyzers/testdata/blocked-cidrs-missing.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
         - name: discovery
-          image: gcr.io/istio-testing/pilot:latest
+          image: registry.istio.io/testing/pilot:latest
           env:
             - name: PILOT_ENABLE_ANALYSIS
               value: "true"

--- a/pkg/config/analysis/analyzers/testdata/blocked-cidrs-no-ra.yaml
+++ b/pkg/config/analysis/analyzers/testdata/blocked-cidrs-no-ra.yaml
@@ -16,4 +16,4 @@ spec:
     spec:
       containers:
         - name: discovery
-          image: gcr.io/istio-testing/pilot:latest
+          image: registry.istio.io/testing/pilot:latest

--- a/prow/benchtest.sh
+++ b/prow/benchtest.sh
@@ -22,9 +22,10 @@ ROOT=$(dirname "$WD")
 source "${ROOT}/prow/lib.sh"
 setup_and_export_git_sha
 
-set -eux
+set -eu
+set +x
 
-GCS_BENCHMARK_DIR="${GCS_BENCHMARK_DIR:-istio-prow/benchmarks}"
+S3_BENCHMARK_DIR="${S3_BENCHMARK_DIR:-istio-prow/benchmarks}"
 
 BENCHMARK_COUNT="${BENCHMARK_COUNT:-5}"
 BENCHMARK_CPUS="${BENCHMARK_CPUS:-8}"
@@ -49,13 +50,17 @@ case "${1}" in
     cat "${REPORT_PLAINTEXT}"
     ;;
   report)
-    # Upload the reports to a well known path based on git SHA
-    gsutil cp "${REPORT_JUNIT}" "gs://${GCS_BENCHMARK_DIR}/${GIT_SHA}.xml"
-    gsutil cp "${REPORT_PLAINTEXT}" "gs://${GCS_BENCHMARK_DIR}/${GIT_SHA}.txt"
+    ENDPOINT=$(echo "${CF_CREDENTIALS}" | jq -r '.endpoint')
+    AWS_ACCESS_KEY_ID=$(echo "${CF_CREDENTIALS}" | jq -r '.access_key')
+    AWS_SECRET_ACCESS_KEY=$(echo "${CF_CREDENTIALS}" | jq -r '.secret_key')
+    AWS_SESSION_TOKEN=$(echo "${CF_CREDENTIALS}" | jq -r '.session_token')
+    export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+    aws --endpoint-url="${ENDPOINT}" s3 cp "${REPORT_JUNIT}" "s3://${S3_BENCHMARK_DIR}/${GIT_SHA}.xml"
+    aws --endpoint-url="${ENDPOINT}" s3 cp "${REPORT_PLAINTEXT}" "s3://${S3_BENCHMARK_DIR}/${GIT_SHA}.txt"
     ;;
   compare)
     # Fetch previous results, and compare them.
-    curl "https://storage.googleapis.com/${GCS_BENCHMARK_DIR}/${COMPARE_GIT_SHA}.txt" > "${ARTIFACTS}/baseline-benchmark-log.txt"
+    curl -L "https://blob.istio.io/${S3_BENCHMARK_DIR}/${COMPARE_GIT_SHA}.txt" > "${ARTIFACTS}/baseline-benchmark-log.txt"
     benchstat "${ARTIFACTS}/baseline-benchmark-log.txt" "${REPORT_PLAINTEXT}"
     ;;
   *)


### PR DESCRIPTION
**Please provide a description of this PR:**

Fetch ztunnel and proxy binaries by default from R2. I've copied the last 60 days' worth of data form gs://istio-build to r2://istio-build.

This also changes the benchest uploads to r2://istio-prow.