### PR TITLE
dependabot: add 1.28 transitive bump triggers and drop EOL 1.27 stanza

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -104,6 +104,10 @@ updates:
       - dependency-name: "sigs.k8s.io/*"
       - dependency-name: "github.com/envoyproxy/go-control-plane/*"
       - dependency-name: "github.com/prometheus/prometheus"
+      - dependency-name: "helm.sh/helm/v3"
+      - dependency-name: "google.golang.org/grpc"
+      - dependency-name: "github.com/quic-go/quic-go"
+      - dependency-name: "github.com/containernetworking/plugins"
     groups:
       all-dependencies:
         patterns:
@@ -114,33 +118,10 @@ updates:
           - "sigs.k8s.io/*"
           - "github.com/envoyproxy/go-control-plane/*"
           - "github.com/prometheus/prometheus"
-
-  - package-ecosystem: "gomod"
-    directories:
-      - "/"
-      - "!/samples/**"
-    schedule:
-      interval: "daily"
-    labels:
-      - "release-notes-none"
-    target-branch: "release-1.27"
-    # See master stanza above for why both ignore and exclude-patterns are required.
-    ignore:
-      - dependency-name: "istio.io/*"
-      - dependency-name: "k8s.io/*"
-      - dependency-name: "sigs.k8s.io/*"
-      - dependency-name: "github.com/envoyproxy/go-control-plane/*"
-      - dependency-name: "github.com/prometheus/prometheus"
-    groups:
-      all-dependencies:
-        patterns:
-          - "*"
-        exclude-patterns:
-          - "istio.io/*"
-          - "k8s.io/*"
-          - "sigs.k8s.io/*"
-          - "github.com/envoyproxy/go-control-plane/*"
-          - "github.com/prometheus/prometheus"
+          - "helm.sh/helm/v3"
+          - "google.golang.org/grpc"
+          - "github.com/quic-go/quic-go"
+          - "github.com/containernetworking/plugins"
 
   # Ignore all dependency updates in samples/
   # We do not care about the dependencies in the samples/ directory as they are not meant

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -77,6 +77,8 @@ updates:
       - dependency-name: "sigs.k8s.io/*"
       - dependency-name: "github.com/envoyproxy/go-control-plane/*"
       - dependency-name: "github.com/prometheus/prometheus"
+      - dependency-name: "helm.sh/helm/v3"
+      - dependency-name: "google.golang.org/grpc"
     groups:
       all-dependencies:
         patterns:
@@ -87,6 +89,8 @@ updates:
           - "sigs.k8s.io/*"
           - "github.com/envoyproxy/go-control-plane/*"
           - "github.com/prometheus/prometheus"
+          - "helm.sh/helm/v3"
+          - "google.golang.org/grpc"
 
   - package-ecosystem: "gomod"
     directories:


### PR DESCRIPTION
Adds helm.sh/helm/v3, google.golang.org/grpc, github.com/quic-go/quic-go, github.com/containernetworking/plugins to the release-1.28 ignore list (each transitively pulled k8s.io, envoy, license-lint NONE, or cyphar past safe versions in #60137). Drops the release-1.27 stanza since 1.27 is EOL.