### PR TITLE
gateway: don't drop config when istio.io/rev label changes

### DIFF
--- a/pilot/pkg/config/kube/agentgateway/gateway_collection.go
+++ b/pilot/pkg/config/kube/agentgateway/gateway_collection.go
@@ -143,14 +143,17 @@ func ListenerSetCollection(
 	krt.StatusCollection[*gatewayv1.ListenerSet, gatewayv1.ListenerSetStatus],
 	krt.Collection[ListenerSet],
 ) {
+	// Note: tagWatcher.IsMine() is intentionally not filtered at this config-emission layer. Filtering
+	// here caused a temporary outage when a Gateway's or ListenerSet's istio.io/rev label was changed:
+	// the prior owning control plane immediately dropped the resource and pushed empty xDS config to
+	// pods still running on the old revision (see https://github.com/istio/istio/issues/59959). Status
+	// writes are filtered to the owning revision via RegisterStatus in pilot/pkg/status/collections.go,
+	// and Deployment management is filtered in pilot/pkg/config/kube/gatewaycommon/deploymentcontroller.go.
 	statusCol, gw := krt.NewStatusManyCollection(listenerSets,
 		func(ctx krt.HandlerContext, obj *gatewayv1.ListenerSet) (*gatewayv1.ListenerSetStatus, []ListenerSet) {
 			// We currently depend on service discovery information not known to krt; mark we depend on it.
 			context := gatewayContext.Get(ctx).Load()
 			if context == nil {
-				return nil, nil
-			}
-			if !tagWatcher.Get(ctx).IsMine(obj.ObjectMeta) {
 				return nil, nil
 			}
 			result := []ListenerSet{}
@@ -311,12 +314,11 @@ func GatewayCollection(
 	listenerIndex := krt.NewIndex(listenerSets, "gatewayParent", func(o ListenerSet) []types.NamespacedName {
 		return []types.NamespacedName{o.GatewayParent}
 	})
+	// Note: tagWatcher.IsMine() is intentionally not filtered at this config-emission layer. See the
+	// comment in ListenerSetCollection above for the rationale.
 	gwstatus, gw := krt.NewStatusManyCollection(gateways, func(ctx krt.HandlerContext, obj *gatewayv1.Gateway) (*gatewayv1.GatewayStatus, []*GatewayListener) {
 		context := gatewayContext.Get(ctx).Load()
 		if context == nil {
-			return nil, nil
-		}
-		if !tagWatcher.Get(ctx).IsMine(obj.ObjectMeta) {
 			return nil, nil
 		}
 		result := []*GatewayListener{}

--- a/pilot/pkg/config/kube/gateway/controller_test.go
+++ b/pilot/pkg/config/kube/gateway/controller_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8s "sigs.k8s.io/gateway-api/apis/v1"
 
+	"istio.io/api/label"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/networking/core"
@@ -76,13 +77,17 @@ var AlwaysReady = func(class schema.GroupVersionResource, stop <-chan struct{}) 
 }
 
 func setupController(t *testing.T, objs ...runtime.Object) *Controller {
+	return setupControllerWithRevision(t, "", objs...)
+}
+
+func setupControllerWithRevision(t *testing.T, revision string, objs ...runtime.Object) *Controller {
 	kc := kube.NewFakeClient(objs...)
 	setupClientCRDs(t, kc)
 	stop := test.NewStop(t)
 	controller := NewController(
 		kc,
 		AlwaysReady,
-		controller.Options{KrtDebugger: krt.GlobalDebugHandler},
+		controller.Options{KrtDebugger: krt.GlobalDebugHandler, Revision: revision},
 		nil)
 	kc.RunAndWait(stop)
 	go controller.Run(stop)
@@ -133,4 +138,47 @@ func TestListGatewayResourceType(t *testing.T) {
 		assert.Equal(t, c.Namespace, "ns1")
 		assert.Equal(t, c.Spec, any(expectedgw))
 	}
+}
+
+// TestListGatewayResourceAcrossRevisions verifies that a Gateway whose istio.io/rev label
+// points to a different revision is still emitted as config by this control plane. Without
+// this behavior, changing the istio.io/rev label on a live Gateway causes the previously
+// owning control plane to push empty xDS config to pods still running on the old revision,
+// breaking traffic for ~30s during a canary upgrade. See issue #59959.
+//
+// Status writes for non-owning revisions are filtered separately in
+// pilot/pkg/status/collections.go (RegisterStatus), and Deployment management is filtered in
+// pilot/pkg/config/kube/gatewaycommon/deploymentcontroller.go, so cross-revision config
+// emission does not cause status flapping or duplicate Deployment management.
+func TestListGatewayResourceAcrossRevisions(t *testing.T) {
+	controller := setupControllerWithRevision(t, "stable",
+		&k8s.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "gwclass",
+			},
+			Spec: *gatewayClassSpec,
+		},
+		// Gateway labeled for a *different* revision than the one we're running.
+		// Pre-fix, this Gateway would be filtered out by tagWatcher.IsMine in
+		// gateway_collection.go and produce no config, leading to an empty xDS push.
+		&k8s.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "canary-gw",
+				Namespace: "ns1",
+				Labels: map[string]string{
+					label.IoIstioRev.Name: "canary",
+				},
+			},
+			Spec: *gatewaySpec,
+		},
+	)
+
+	dumpOnFailure(t, krt.GlobalDebugHandler)
+	cfg := controller.List(gvk.Gateway, "ns1")
+	assert.Equal(t, len(cfg), 1)
+	got := cfg[0]
+	assert.Equal(t, got.GroupVersionKind, gvk.Gateway)
+	assert.Equal(t, got.Name, "canary-gw"+"~"+constants.KubernetesGatewayName+"~default")
+	assert.Equal(t, got.Namespace, "ns1")
+	assert.Equal(t, got.Spec, any(expectedgw))
 }

--- a/pilot/pkg/config/kube/gateway/gateway_collection.go
+++ b/pilot/pkg/config/kube/gateway/gateway_collection.go
@@ -87,14 +87,18 @@ func ListenerSetCollection(
 	krt.StatusCollection[*gatewayv1.ListenerSet, gatewayv1.ListenerSetStatus],
 	krt.Collection[ListenerSet],
 ) {
+	// Note: tagWatcher.IsMine() is intentionally not filtered at this config-emission layer. Filtering
+	// here caused a temporary outage when a Gateway's or ListenerSet's istio.io/rev label was changed:
+	// the prior owning control plane immediately dropped the resource and pushed empty xDS config to
+	// pods still running on the old revision (see https://github.com/istio/istio/issues/59959).
+	// Status writes are filtered to the owning revision via RegisterStatus in
+	// pilot/pkg/status/collections.go, and Deployment management is filtered in deploymentcontroller.go,
+	// so emitting config from non-owning revisions is safe and matches how core Istio CRDs behave.
 	statusCol, gw := krt.NewStatusManyCollection(listenerSets,
 		func(ctx krt.HandlerContext, obj *gatewayv1.ListenerSet) (*gatewayv1.ListenerSetStatus, []ListenerSet) {
 			// We currently depend on service discovery information not know to krt; mark we depend on it.
 			context := gatewayContext.Get(ctx).Load()
 			if context == nil {
-				return nil, nil
-			}
-			if !tagWatcher.Get(ctx).IsMine(obj.ObjectMeta) {
 				return nil, nil
 			}
 			result := []ListenerSet{}
@@ -249,13 +253,12 @@ func GatewayCollection(
 	listenerIndex := krt.NewIndex(listenerSets, "gatewayParent", func(o ListenerSet) []types.NamespacedName {
 		return []types.NamespacedName{o.GatewayParent}
 	})
+	// Note: tagWatcher.IsMine() is intentionally not filtered at this config-emission layer. See the
+	// comment in ListenerSetCollection above for the rationale.
 	statusCol, gw := krt.NewStatusManyCollection(gateways, func(ctx krt.HandlerContext, obj *gatewayv1.Gateway) (*gatewayv1.GatewayStatus, []Gateway) {
 		// We currently depend on service discovery information not known to krt; mark we depend on it.
 		context := gatewayContext.Get(ctx).Load()
 		if context == nil {
-			return nil, nil
-		}
-		if !tagWatcher.Get(ctx).IsMine(obj.ObjectMeta) {
 			return nil, nil
 		}
 		result := []Gateway{}

--- a/releasenotes/notes/59959.yaml
+++ b/releasenotes/notes/59959.yaml
@@ -1,0 +1,14 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+issue:
+  - https://github.com/istio/istio/issues/59959
+
+releaseNotes:
+  - |
+    **Fixed** a brief traffic outage when changing the `istio.io/rev` label on a Kubernetes
+    Gateway (or `ListenerSet`). The previously-owning control plane no longer drops the
+    resource and pushes empty xDS config to gateway pods that are still running on the old
+    revision. Status writes for non-owning revisions are still suppressed, so revisions do
+    not flap on each other's status.


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes #59959
Fixes #60388

When a Kubernetes Gateway (or `ListenerSet`)'s `istio.io/rev` label is changed — e.g. flipping `default` from `1-28-6` to `1-29-2` during a canary control-plane upgrade — the previously-owning istiod was immediately dropping the resource from its config-emission collections in `pilot/pkg/config/kube/gateway/gateway_collection.go` (and the agentgateway equivalent). Existing gateway pods that were still on the old revision and still connected to that istiod received an empty xDS push, blackholing all traffic for ~30s until the gateway Deployment finished rolling onto the new revision.

The `tagWatcher.IsMine()` check at the config-emission layer was the only thing causing this. It is redundant for status (PR #58292 / issue #57734 added an `IsMine` filter at the status writer in `pilot/pkg/status/collections.go`) and it is redundant for Deployment management (`pilot/pkg/config/kube/gatewaycommon/deploymentcontroller.go` has its own `IsMine` filter). It is actively harmful for config emission because it makes the K8s `Gateway` resource invisible to the old control plane the moment ownership flips.

This change removes the redundant filter from the config-emission layer in both `pilot/pkg/config/kube/gateway/gateway_collection.go` and `pilot/pkg/config/kube/agentgateway/gateway_collection.go`. After this:

* Both control planes process the K8s `Gateway` for config purposes during a revision flip — proxies on the old revision keep getting valid xDS until they roll.
* Only the owning revision writes status (writer-level filter, unchanged).
* Only the owning revision manages the `Deployment` (deployment-controller filter, unchanged).
* Behavior now matches how Istio CRDs (VirtualService, DestinationRule) already work across revisions.

This also addresses both concerns @howardjohn raised on the alternative `DiscardResult` approach in #59583:
1. It does not depend on KRT's "last-known output" — a freshly-started istiod replica sees and processes the Gateway.
2. It removes (rather than patches) the divergent codepath, so there is no risk of other revision-aware codepaths going stale.

A regression test (`TestListGatewayResourceAcrossRevisions`) is added in `pilot/pkg/config/kube/gateway/controller_test.go`. It verifies that a `Gateway` labeled `istio.io/rev=canary` is still emitted as config by a control plane running revision `stable`. With the existing IsMine filter on master, this test fails (`len(cfg) == 0`); with the fix, it passes.


**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes.

Release note added at `releasenotes/notes/59959.yaml`.