### PR TITLE
gatewayapi: fix backendtlspolicy conflict detection

### DIFF
--- a/pilot/pkg/config/kube/gateway/backend_policies.go
+++ b/pilot/pkg/config/kube/gateway/backend_policies.go
@@ -287,6 +287,11 @@ func BackendTLSPolicyCollection(
 	domainSuffix string,
 	opts krt.OptionsBuilder,
 ) (krt.StatusCollection[*gw.BackendTLSPolicy, gw.PolicyStatus], krt.Collection[BackendPolicy]) {
+	btlsTargetIdx := krt.NewIndex(tlsPolicies, "btls-targets", func(o *gw.BackendTLSPolicy) []string {
+		return slices.Map(o.Spec.TargetRefs, func(e gw.LocalPolicyTargetReferenceWithSectionName) string {
+			return fmt.Sprintf("%s/%s/%s", o.Namespace, e.Kind, e.Name)
+		})
+	})
 	return krt.NewStatusManyCollection(tlsPolicies, func(ctx krt.HandlerContext, i *gw.BackendTLSPolicy) (
 		*gw.PolicyStatus,
 		[]BackendPolicy,
@@ -388,24 +393,36 @@ func BackendTLSPolicyCollection(
 					}
 				}
 
-				for _, host := range hosts {
-					res = append(res, BackendPolicy{
-						Source: TypedNamespacedName{
-							NamespacedName: config.NamespacedName(i),
-							Kind:           kind.BackendTLSPolicy,
-						},
-						TargetIndex:  idx,
-						Target:       target,
-						Host:         host,
-						SectionName:  sectionName,
-						TLS:          tls,
-						CreationTime: i.CreationTimestamp.Time,
-					})
-					ancestorBackends := krt.Fetch(ctx, ancestors, krt.FilterKey(target.String()))
-					for _, gwl := range ancestorBackends {
-						for _, i := range gwl.Objects {
-							uniqueGateways.Insert(i.Gateway)
-						}
+				tgtKey := fmt.Sprintf("%s/%s/%s", i.Namespace, t.Kind, t.Name)
+				allPoliciesForTarget := btlsTargetIdx.Fetch(ctx, tgtKey)
+				conflicted := btlsIsConflicted(i, t, allPoliciesForTarget)
+
+				if conflicted {
+					conds[string(gw.PolicyConditionAccepted)].error = &ConfigError{
+						Reason:  string(gw.PolicyReasonConflicted),
+						Message: "Conflicts with an older BackendTLSPolicy targeting the same backend",
+					}
+				} else {
+					for _, host := range hosts {
+						res = append(res, BackendPolicy{
+							Source: TypedNamespacedName{
+								NamespacedName: config.NamespacedName(i),
+								Kind:           kind.BackendTLSPolicy,
+							},
+							TargetIndex:  idx,
+							Target:       target,
+							Host:         host,
+							SectionName:  sectionName,
+							TLS:          tls,
+							CreationTime: i.CreationTimestamp.Time,
+						})
+					}
+				}
+
+				ancestorBackends := krt.Fetch(ctx, ancestors, krt.FilterKey(target.String()))
+				for _, gwl := range ancestorBackends {
+					for _, ab := range gwl.Objects {
+						uniqueGateways.Insert(ab.Gateway)
 					}
 				}
 			}
@@ -665,6 +682,51 @@ func mergeAncestors(existing []gw.PolicyAncestorStatus, incoming []gw.PolicyAnce
 	existing = append(existing, incoming...)
 	// There is a max of 16
 	return existing[:min(len(existing), 16)]
+}
+
+func btlsIsConflicted(
+	btls *gw.BackendTLSPolicy,
+	target gw.LocalPolicyTargetReferenceWithSectionName,
+	allPolicies []*gw.BackendTLSPolicy,
+) bool {
+	for _, other := range allPolicies {
+		if other.UID == btls.UID {
+			continue
+		}
+		hasMatchingTarget := false
+		for _, t := range other.Spec.TargetRefs {
+			if btlsTargetRefEqual(target, t) {
+				hasMatchingTarget = true
+				break
+			}
+		}
+		if !hasMatchingTarget {
+			continue
+		}
+		if btlsHasHigherPriority(other, btls) {
+			return true
+		}
+	}
+	return false
+}
+
+func btlsHasHigherPriority(a, b metav1.Object) bool {
+	ts := a.GetCreationTimestamp().Compare(b.GetCreationTimestamp().Time)
+	if ts != 0 {
+		return ts < 0
+	}
+	ns := cmp.Compare(a.GetNamespace(), b.GetNamespace())
+	if ns != 0 {
+		return ns < 0
+	}
+	return a.GetName() < b.GetName()
+}
+
+func btlsTargetRefEqual(a, b gw.LocalPolicyTargetReferenceWithSectionName) bool {
+	return a.Group == b.Group &&
+		a.Kind == b.Kind &&
+		a.Name == b.Name &&
+		ptr.Equal(a.SectionName, b.SectionName)
 }
 
 func generateDRName(target TypedNamespacedName, host string) string {

--- a/pilot/pkg/config/kube/gateway/backend_policies.go
+++ b/pilot/pkg/config/kube/gateway/backend_policies.go
@@ -684,6 +684,7 @@ func mergeAncestors(existing []gw.PolicyAncestorStatus, incoming []gw.PolicyAnce
 	return existing[:min(len(existing), 16)]
 }
 
+// btlsIsConflicted checks if this BackendTLSPolicy is conflicted by a higher-priority policy targeting the same backend.
 func btlsIsConflicted(
 	btls *gw.BackendTLSPolicy,
 	target gw.LocalPolicyTargetReferenceWithSectionName,
@@ -710,15 +711,16 @@ func btlsIsConflicted(
 	return false
 }
 
+// btlsHasHigherPriority returns true if a has higher priority than b.
+// a higher priority means:
+// - policy 'a' is older than policy 'b'
+// - in case they have the same age, policy 'a' is alphabetically lower than policy 'b'
 func btlsHasHigherPriority(a, b metav1.Object) bool {
 	ts := a.GetCreationTimestamp().Compare(b.GetCreationTimestamp().Time)
 	if ts != 0 {
 		return ts < 0
 	}
-	ns := cmp.Compare(a.GetNamespace(), b.GetNamespace())
-	if ns != 0 {
-		return ns < 0
-	}
+
 	return a.GetName() < b.GetName()
 }
 

--- a/pilot/pkg/config/kube/gateway/backend_policies.go
+++ b/pilot/pkg/config/kube/gateway/backend_policies.go
@@ -395,12 +395,12 @@ func BackendTLSPolicyCollection(
 
 				tgtKey := fmt.Sprintf("%s/%s/%s", i.Namespace, t.Kind, t.Name)
 				allPoliciesForTarget := btlsTargetIdx.Fetch(ctx, tgtKey)
-				conflicted := btlsIsConflicted(i, t, allPoliciesForTarget)
+				conflicted, highPriorityPolicy := btlsIsConflicted(i, t, allPoliciesForTarget)
 
 				if conflicted {
 					conds[string(gw.PolicyConditionAccepted)].error = &ConfigError{
 						Reason:  string(gw.PolicyReasonConflicted),
-						Message: "Conflicts with an older BackendTLSPolicy targeting the same backend",
+						Message: fmt.Sprintf("Conflicts with BackendTLSPolicy %q targeting the same backend", highPriorityPolicy),
 					}
 				} else {
 					for _, host := range hosts {
@@ -685,11 +685,12 @@ func mergeAncestors(existing []gw.PolicyAncestorStatus, incoming []gw.PolicyAnce
 }
 
 // btlsIsConflicted checks if this BackendTLSPolicy is conflicted by a higher-priority policy targeting the same backend.
+// In case it is conflicted, it also returns the policy name with higher priority
 func btlsIsConflicted(
 	btls *gw.BackendTLSPolicy,
 	target gw.LocalPolicyTargetReferenceWithSectionName,
 	allPolicies []*gw.BackendTLSPolicy,
-) bool {
+) (bool, string) {
 	for _, other := range allPolicies {
 		if other.UID == btls.UID {
 			continue
@@ -705,10 +706,10 @@ func btlsIsConflicted(
 			continue
 		}
 		if btlsHasHigherPriority(other, btls) {
-			return true
+			return true, other.GetName()
 		}
 	}
-	return false
+	return false, ""
 }
 
 // btlsHasHigherPriority returns true if a has higher priority than b.

--- a/pilot/pkg/config/kube/gateway/testdata/backend-tls-policy.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/backend-tls-policy.status.yaml.golden
@@ -350,7 +350,8 @@ status:
       name: echo
     conditions:
     - lastTransitionTime: fake
-      message: Conflicts with an older BackendTLSPolicy targeting the same backend
+      message: Conflicts with BackendTLSPolicy "tls-upstream-echo" targeting the same
+        backend
       reason: Conflicted
       status: "False"
       type: Accepted

--- a/pilot/pkg/config/kube/gateway/testdata/backend-tls-policy.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/backend-tls-policy.status.yaml.golden
@@ -337,6 +337,31 @@ status:
     controllerName: istio.io/mesh-controller
 ---
 apiVersion: gateway.networking.k8s.io/v1
+kind: BackendTLSPolicy
+metadata:
+  name: xxx-tls-upstream-echo
+  namespace: default
+spec: null
+status:
+  ancestors:
+  - ancestorRef:
+      group: ""
+      kind: Service
+      name: echo
+    conditions:
+    - lastTransitionTime: fake
+      message: Conflicts with an older BackendTLSPolicy targeting the same backend
+      reason: Conflicted
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: Configuration is valid
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: istio.io/mesh-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
   name: istio

--- a/pilot/pkg/config/kube/gateway/testdata/backend-tls-policy.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/backend-tls-policy.status.yaml.golden
@@ -339,7 +339,7 @@ status:
 apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
-  name: xxx-tls-upstream-echo
+  name: xtls-upstream-echo
   namespace: default
 spec: null
 status:

--- a/pilot/pkg/config/kube/gateway/testdata/backend-tls-policy.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/backend-tls-policy.yaml
@@ -72,7 +72,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
-  name: xxx-tls-upstream-echo
+  name: xtls-upstream-echo # The xprefix here makes this policy has lower priority and be conflicting
   namespace: default
   uid: "12345" # We MUST set a different uid to be sure conflict management will consider it different
 spec:

--- a/pilot/pkg/config/kube/gateway/testdata/backend-tls-policy.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/backend-tls-policy.yaml
@@ -72,6 +72,24 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
+  name: xxx-tls-upstream-echo
+  namespace: default
+  uid: "12345" # We MUST set a different uid to be sure conflict management will consider it different
+spec:
+  targetRefs:
+    - kind: Service
+      name: echo
+      group: ""
+  validation:
+    caCertificateRefs:
+      - kind: ConfigMap
+        name: auth-cert
+        group: ""
+    hostname: auth.example.com
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: BackendTLSPolicy
+metadata:
   name: tls-upstream-echo-https-merged-rules
   namespace: default
 spec:

--- a/releasenotes/notes/57817.yaml
+++ b/releasenotes/notes/57817.yaml
@@ -1,6 +1,8 @@
 apiVersion: release-notes/v2
 kind: bug-fix
 area: traffic-management
+issue:
+  - 57817
 releaseNotes:
   - |
     - **Fixed** On Gateway API, implement BackendTLSPolicyConflictResolution

--- a/releasenotes/notes/57817.yaml
+++ b/releasenotes/notes/57817.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    - **Fixed** On Gateway API, implement BackendTLSPolicyConflictResolution

--- a/tests/integration/ambient/gateway_conformance_test.go
+++ b/tests/integration/ambient/gateway_conformance_test.go
@@ -67,8 +67,6 @@ var conformanceNamespaces = []string{
 }
 
 var skippedTests = map[string]string{
-	"BackendTLSPolicyConflictResolution": "https://github.com/istio/istio/issues/57817",
-
 	// The following tests were added in v1.5.0
 
 	"GatewayBackendClientCertificateFeature":                     "TODO",

--- a/tests/integration/pilot/agentgateway/gateway_conformance_test.go
+++ b/tests/integration/pilot/agentgateway/gateway_conformance_test.go
@@ -64,8 +64,6 @@ var conformanceNamespaces = []string{
 }
 
 var skippedTests = map[string]string{
-	"BackendTLSPolicyConflictResolution": "https://github.com/istio/istio/issues/57817",
-
 	// The following tests were added in v1.5.0
 	"BackendTLSPolicyObservedGenerationBump": "TODO",
 

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -64,8 +64,6 @@ var conformanceNamespaces = []string{
 }
 
 var skippedTests = map[string]string{
-	"BackendTLSPolicyConflictResolution": "https://github.com/istio/istio/issues/57817",
-
 	// The following tests were added in v1.5.0
 	"GatewayBackendClientCertificateFeature":                     "TODO",
 	"GatewayFrontendClientCertificateValidationInsecureFallback": "TODO",


### PR DESCRIPTION
**Please provide a description of this PR:**

This is a (claude based) attempt to fix the BackendTLSPolicy collection to pass the conformance test `BackendTLSPolicyConflictResolution`.

The approach copies the already existing fix from AgentGateway into Istio main controller. Claude suggested to reuse the same function from AGW instead of copying, but this was left as a followup (or eventually a result of this PR review), but for now my goal was to make the changes clear.

The approach suggests the creation of a new krt index that will contain the targetRef as the index to be queried later during BackendTLSPolicy reconciliation.

Fixes: #57817 