### PR TITLE
fix ingress+waypoint semantics in multi-network

### DIFF
--- a/pilot/pkg/networking/core/listener.go
+++ b/pilot/pkg/networking/core/listener.go
@@ -1518,7 +1518,6 @@ func buildInnerConnectOriginateListener(push *model.PushContext, proxy *model.Pr
 // tunnel, but unlike the inner_connect_originate it does not need to capture any metadata - it uses what
 // inner_connect_originate already captured and put in the filter state.
 func buildOuterConnectOriginateListener(push *model.PushContext, proxy *model.Proxy) *listener.Listener {
-
 	// the e/w gateway uses the x-istio-source header to determine whether we require L7 processing on that side
 	var source string
 	switch proxy.Type {

--- a/pilot/pkg/networking/core/listener.go
+++ b/pilot/pkg/networking/core/listener.go
@@ -1518,18 +1518,30 @@ func buildInnerConnectOriginateListener(push *model.PushContext, proxy *model.Pr
 // tunnel, but unlike the inner_connect_originate it does not need to capture any metadata - it uses what
 // inner_connect_originate already captured and put in the filter state.
 func buildOuterConnectOriginateListener(push *model.PushContext, proxy *model.Proxy) *listener.Listener {
+
+	// the e/w gateway uses the x-istio-source header to determine whether we require L7 processing on that side
+	var source string
+	switch proxy.Type {
+	case model.Router:
+		source = downstreamSourceGateway
+	case model.Waypoint:
+		source = downstreamSourceWaypoint
+	case model.SidecarProxy:
+		source = downstreamSourceSidecar
+	}
+	var headers []*core.HeaderValueOption
+	if source != "" {
+		headers = []*core.HeaderValueOption{{
+			AppendAction: core.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
+			Header:       &core.HeaderValue{Key: downstreamSourceHeader, Value: source},
+		}}
+	}
 	tcpProxy := &tcp.TcpProxy{
 		StatPrefix:       DoubleHBONEOuterConnectOriginate,
 		ClusterSpecifier: &tcp.TcpProxy_Cluster{Cluster: DoubleHBONEOuterConnectOriginate},
 		TunnelingConfig: &tcp.TcpProxy_TunnelingConfig{
-			Hostname: "%FILTER_STATE(istio.double_hbone.hbone_target_address:PLAIN)%",
-			HeadersToAdd: []*core.HeaderValueOption{{
-				AppendAction: core.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
-				Header: &core.HeaderValue{
-					Key:   downstreamSourceHeader,
-					Value: "waypoint",
-				},
-			}},
+			Hostname:     "%FILTER_STATE(istio.double_hbone.hbone_target_address:PLAIN)%",
+			HeadersToAdd: headers,
 		},
 	}
 	accessLogBuilder.setHboneOriginationAccessLog(push, proxy, tcpProxy, istionetworking.ListenerClassSidecarInbound)

--- a/pilot/pkg/networking/core/listener_waypoint.go
+++ b/pilot/pkg/networking/core/listener_waypoint.go
@@ -76,6 +76,18 @@ const (
 	downstreamSourceHeader        = "x-istio-source"
 	downstreamOriginNetworkHeader = "x-forwarded-network"
 
+	// downstreamSourceWaypoint indicates the request was emitted by a waypoint, so L7 policies
+	// have already been applied. The receiving E/W gateway can skip the waypoint hop.
+	downstreamSourceWaypoint = "waypoint"
+	// downstreamSourceGateway indicates the request was emitted by an ingress gateway. The
+	// receiving E/W gateway honors the per-service IngressUseWaypoint setting to decide whether
+	// to insert the waypoint or route directly to the service.
+	downstreamSourceGateway = "gateway"
+	// downstreamSourceSidecar indicates the request was emitted by a sidecar proxy. The
+	// receiving E/W gateway treats this as L7-not-yet-applied (matcher OnNoMatch) and inserts
+	// the waypoint as it would for a ztunnel-originated request.
+	downstreamSourceSidecar = "sidecar"
+
 	// xfccClientIdentityAnnotation opts a waypoint in to synthesizing an
 	// x-forwarded-client-cert entry from the ztunnel-provided source workload
 	// identity. When set to "true" on the Gateway (propagated to the waypoint
@@ -348,16 +360,18 @@ func (lb *ListenerBuilder) buildWaypointInboundConnectTerminate() *listener.List
 	return lb.buildConnectTerminateListener(routes)
 }
 
-func (lb *ListenerBuilder) findServiceWaypoint(svc *model.Service) host.Name {
+// findServiceWaypoint returns the waypoint for the given service, and whether it should
+// be used for from-ingress traffic.
+func (lb *ListenerBuilder) findServiceWaypoint(svc *model.Service) (host.Name, bool) {
 	ws := lb.push.ServicesWithWaypoint(svc.Attributes.Namespace + "/" + string(svc.Hostname))
 	if len(ws) == 0 {
-		return ""
+		return "", false
 	}
 	if len(ws) > 1 {
 		log.Warnf("unexpected multiple waypoint services for %s", svc.Hostname)
 	}
 	waypoint := ws[0]
-	return host.Name(waypoint.WaypointHostname)
+	return host.Name(waypoint.WaypointHostname), waypoint.IngressUseWaypoint
 }
 
 // This is the regular waypoint flow, where we terminate the tunnel, and then re-encap.
@@ -416,8 +430,9 @@ func (lb *ListenerBuilder) buildWaypointInternal(wls []model.WorkloadInfo, svcs 
 
 	for _, svc := range svcs {
 		var waypoint host.Name
+		var ingressUseWaypoint bool
 		if isAmbientEastWestGateway && features.EnableAmbientMultiNetwork {
-			waypoint = lb.findServiceWaypoint(svc)
+			waypoint, ingressUseWaypoint = lb.findServiceWaypoint(svc)
 		}
 
 		svcAddresses := sets.SortedList(sets.New(append(
@@ -491,8 +506,17 @@ func (lb *ListenerBuilder) buildWaypointInternal(wls []model.WorkloadInfo, svcs 
 					// this loop would generate a cluster and corresponding filter chain for the waypoint service.
 					waypointClusterName := model.BuildSubsetKey(model.TrafficDirectionInboundVIP, "tcp", waypoint, hbonePort)
 
+					// x-istio-source dispatch:
+					//   "waypoint" - L7 policies already applied upstream; skip the waypoint.
+					//   "gateway"  - request came from an ingress gateway; honor the ingress-use-waypoint
+					//   no match   - assume L7 has not been processed and send to the waypoint
 					m := match.NewRequestSource()
-					m.Map["waypoint"] = match.ToChain(tcpChain.Name)
+					m.Map[downstreamSourceWaypoint] = match.ToChain(tcpChain.Name)
+					if ingressUseWaypoint {
+						m.Map[downstreamSourceGateway] = match.ToChain(waypointClusterName)
+					} else {
+						m.Map[downstreamSourceGateway] = match.ToChain(tcpChain.Name)
+					}
 					m.OnNoMatch = match.ToChain(waypointClusterName)
 
 					requestSourceMatcher := match.ToMatcher(m.BuildMatcher())

--- a/releasenotes/notes/60162.yaml
+++ b/releasenotes/notes/60162.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed** multi-network ambient now routes to the waypoint when the ingress
+    on one network calls a service on a different network, and only if the
+    Service is configured with `istio.io/ingress-use-waypoint`.

--- a/tests/integration/ambient/multinetwork_test.go
+++ b/tests/integration/ambient/multinetwork_test.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/api/label"
+	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/ambient"
@@ -240,6 +241,79 @@ func TestMultinetworkFailover(t *testing.T) {
 			deployWaypointsOrFail(t, local, waypointName, ns1)
 			deployWaypointsOrFail(t, local, waypointName, ns2)
 			runTest(t, local, remote, ns1, ns2)
+
+			t.NewSubTest("ingress-use-waypoint").Run(func(t framework.TestContext) {
+				SetNsIngressUseWaypoint(t, ns1.Name())
+
+				t.ConfigIstio().Eval(ns1.Name(), map[string]string{
+					"Service": brokenService1,
+					"Port":    fmt.Sprintf("%d", ports.HTTP.ServicePort),
+				}, `apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: tag-via-waypoint
+spec:
+  parentRefs:
+  - group: ""
+    kind: Service
+    name: {{.Service}}
+  rules:
+  - filters:
+    - type: ResponseHeaderModifier
+      responseHeaderModifier:
+        add:
+        - name: x-traversed-waypoint
+          value: "true"
+    backendRefs:
+    - group: ""
+      kind: Service
+      name: {{.Service}}
+      port: {{.Port}}
+`).ApplyOrFail(t)
+
+				t.ConfigIstio().Eval(ns1.Name(), map[string]string{
+					"Destination": fmt.Sprintf("%s.%s.svc.cluster.local", brokenService1, ns1.Name()),
+				}, `apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: gateway
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts: ["*"]
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: route
+spec:
+  gateways:
+  - gateway
+  hosts:
+  - "*"
+  http:
+  - route:
+    - destination:
+        host: "{{.Destination}}"
+`).ApplyOrFail(t)
+
+				i.IngressFor(local).CallOrFail(t, echo.CallOptions{
+					Port: echo.Port{
+						Protocol:    protocol.HTTP,
+						ServicePort: 80,
+					},
+					Scheme: scheme.HTTP,
+					Check: check.And(
+						check.OK(),
+						check.ResponseHeader("x-traversed-waypoint", "true"),
+					),
+				})
+			})
 		})
 	})
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

Before this PR, we were always sending `x-istio-source: waypoint` from the ingress, so we'd always skip l7 at the gateway. In the case that we have "ingress on n1, service and waypoint only on n2" we'd never actually use the waypoint. 

  | x-istio-source | meaning | E/W gateway action |
  | --- | --- | --- |
  | waypoint | L7 already applied | skip waypoint (existing behavior) |
  | gateway (new) | from an ingress gateway, L7 not applied | consult IngressUseWaypoint — skip if false, otherwise insert waypoint |
  | missing/other | from ztunnel/sidecar | always insert waypoint (existing behavior) |