### PR TITLE
fix empty issue field in use-registry-istio-io release note

### DIFF
--- a/releasenotes/notes/use-registry-istio-io.yaml
+++ b/releasenotes/notes/use-registry-istio-io.yaml
@@ -25,7 +25,7 @@ area: installation
 
 # issue is a list of GitHub issues resolved in this note.
 # If issue is not in the current repo, specify its full URL instead.
-issue:
+issue: []
 
 # releaseNotes is a markdown listing of any user facing changes. This will appear in the
 # release notes.


### PR DESCRIPTION
Schema requires `issue:` to be an array. Was tripping gen-release-notes lint.
