### PR TITLE
fix release note typos

### DIFF
--- a/releasenotes/notes/59117.yaml
+++ b/releasenotes/notes/59117.yaml
@@ -5,7 +5,7 @@ issue:
   - 59117 
 releaseNotes:
   - |
-    **Fixed** an issue where baggage-based peer metadata discovery interferred with TLS or
+    **Fixed** an issue where baggage-based peer metadata discovery interfered with TLS or
     PROXY traffic policies. As a short term fix we disable baggage-based metadata discovery
     for routes with TLS or PROXY traffic policies configured which may result in incomplete
     telemetry in multicluster deployments. We are working on addressing this limitation in

--- a/releasenotes/notes/59209.yaml
+++ b/releasenotes/notes/59209.yaml
@@ -5,6 +5,6 @@ issue:
   - 59209
 releaseNotes:
   - |
-    **Added** experimental support for agentgateway in istio. Agentgatewy
+    **Added** experimental support for agentgateway in istio. Agentgateway
     configuration can be enabled through the `EnableAgentGateway` feature flag.
     Istio supports agentgateway configuration via the gateway API resources.

--- a/releasenotes/notes/59700.yaml
+++ b/releasenotes/notes/59700.yaml
@@ -5,4 +5,4 @@ issue:
 - 59700
 releaseNotes:
 - |
-    **Fixed** serivceAccount matcher regex in AuthorizationPolicy to properly quote the service account name, allowing for correct matching of service accounts with special characters in their names.
+    **Fixed** serviceAccount matcher regex in AuthorizationPolicy to properly quote the service account name, allowing for correct matching of service accounts with special characters in their names.


### PR DESCRIPTION
Three typos in release notes that were tripping gen-release-notes lint: interferred, Agentgatewy, serivceAccount.