### PR TITLE
Simplify code with modernize/stringscut+stringscutprefix

### DIFF
--- a/istioctl/pkg/workload/workload.go
+++ b/istioctl/pkg/workload/workload.go
@@ -648,7 +648,7 @@ func unstructureIstioType(spec any) (map[string]any, error) {
 func convertToUnsignedInt32Map(s []string) map[string]uint32 {
 	out := make(map[string]uint32, len(s))
 	for _, l := range s {
-		k, v := splitEqual(l)
+		k, v, _ := strings.Cut(l, "=")
 		u64, err := strconv.ParseUint(v, 10, 32)
 		if err != nil {
 			log.Errorf("failed to convert to uint32: %v", err)
@@ -661,20 +661,10 @@ func convertToUnsignedInt32Map(s []string) map[string]uint32 {
 func convertToStringMap(s []string) map[string]string {
 	out := make(map[string]string, len(s))
 	for _, l := range s {
-		k, v := splitEqual(l)
+		k, v, _ := strings.Cut(l, "=")
 		out[k] = v
 	}
 	return out
-}
-
-// splitEqual splits key=value string into key,value. if no = is found
-// the whole string is the key and value is empty.
-func splitEqual(str string) (string, string) {
-	if k, v, ok := strings.Cut(str, "="); ok {
-		return k, v
-	}
-
-	return str, ""
 }
 
 // validateFlagIsSetManuallyOrNot can validate that a persistent flag is set manually or not by user for given command

--- a/istioctl/pkg/workload/workload.go
+++ b/istioctl/pkg/workload/workload.go
@@ -670,16 +670,11 @@ func convertToStringMap(s []string) map[string]string {
 // splitEqual splits key=value string into key,value. if no = is found
 // the whole string is the key and value is empty.
 func splitEqual(str string) (string, string) {
-	idx := strings.Index(str, "=")
-	var k string
-	var v string
-	if idx >= 0 {
-		k = str[:idx]
-		v = str[idx+1:]
-	} else {
-		k = str
+	if k, v, ok := strings.Cut(str, "="); ok {
+		return k, v
 	}
-	return k, v
+
+	return str, ""
 }
 
 // validateFlagIsSetManuallyOrNot can validate that a persistent flag is set manually or not by user for given command

--- a/istioctl/pkg/workload/workload_test.go
+++ b/istioctl/pkg/workload/workload_test.go
@@ -459,28 +459,3 @@ func TestConvertToMap(t *testing.T) {
 		})
 	}
 }
-
-func TestSplitEqual(t *testing.T) {
-	tests := []struct {
-		arg       string
-		wantKey   string
-		wantValue string
-	}{
-		{arg: "key=value", wantKey: "key", wantValue: "value"},
-		{arg: "key==value", wantKey: "key", wantValue: "=value"},
-		{arg: "key=", wantKey: "key", wantValue: ""},
-		{arg: "key", wantKey: "key", wantValue: ""},
-		{arg: "", wantKey: "", wantValue: ""},
-	}
-	for _, tt := range tests {
-		t.Run(tt.arg, func(t *testing.T) {
-			gotKey, gotValue := splitEqual(tt.arg)
-			if gotKey != tt.wantKey {
-				t.Errorf("splitEqual(%v) got = %v, want %v", tt.arg, gotKey, tt.wantKey)
-			}
-			if gotValue != tt.wantValue {
-				t.Errorf("splitEqual(%v) got1 = %v, want %v", tt.arg, gotValue, tt.wantValue)
-			}
-		})
-	}
-}

--- a/operator/pkg/helm/helm.go
+++ b/operator/pkg/helm/helm.go
@@ -137,8 +137,8 @@ func renderChart(releaseName string, namespace string, vals values.Map, chrt *ch
 func extractWarnings(v string) Warnings {
 	var w Warnings
 	for _, l := range strings.Split(v, "\n") {
-		if strings.HasPrefix(l, "WARNING: ") {
-			w = util.AppendErr(w, errors.New(strings.TrimPrefix(l, "WARNING: ")))
+		if after, ok := strings.CutPrefix(l, "WARNING: "); ok {
+			w = util.AppendErr(w, errors.New(after))
 		}
 	}
 	return w

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1080,8 +1080,8 @@ func (s *Server) createPeerCertVerifier(tlsOptions TLSOptions, trustDomain strin
 		}
 	} else {
 		if s.RA != nil {
-			if strings.HasPrefix(features.PilotCertProvider, constants.CertProviderKubernetesSignerPrefix) {
-				signerName := strings.TrimPrefix(features.PilotCertProvider, constants.CertProviderKubernetesSignerPrefix)
+			if after, ok := strings.CutPrefix(features.PilotCertProvider, constants.CertProviderKubernetesSignerPrefix); ok {
+				signerName := after
 				caBundle, _ := s.RA.GetRootCertFromMeshConfig(signerName)
 				rootCertBytes = append(rootCertBytes, caBundle...)
 			} else {

--- a/pilot/pkg/config/kube/ingress/virtualservices.go
+++ b/pilot/pkg/config/kube/ingress/virtualservices.go
@@ -289,14 +289,14 @@ func createFallbackStringMatch(s string) *networking.StringMatch {
 	// Note that this implementation only converts prefix and exact matches, not regexps.
 
 	// Replace e.g. "foo.*" with prefix match
-	if strings.HasSuffix(s, ".*") {
+	if before, ok := strings.CutSuffix(s, ".*"); ok {
 		return &networking.StringMatch{
-			MatchType: &networking.StringMatch_Prefix{Prefix: strings.TrimSuffix(s, ".*")},
+			MatchType: &networking.StringMatch_Prefix{Prefix: before},
 		}
 	}
-	if strings.HasSuffix(s, "/*") {
+	if before, ok := strings.CutSuffix(s, "/*"); ok {
 		return &networking.StringMatch{
-			MatchType: &networking.StringMatch_Prefix{Prefix: strings.TrimSuffix(s, "/*")},
+			MatchType: &networking.StringMatch_Prefix{Prefix: before},
 		}
 	}
 

--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -265,9 +265,8 @@ func resolveGatewayName(gwname string, meta config.Meta) string {
 		}
 	} else {
 		// remove the . from ./gateway and substitute it with the namespace name
-		i := strings.Index(gwname, "/")
-		if gwname[:i] == "." {
-			out = meta.Namespace + "/" + gwname[i+1:]
+		if before, after, _ := strings.Cut(gwname, "/"); before == "." {
+			out = meta.Namespace + "/" + after
 		}
 	}
 	return out

--- a/pilot/pkg/model/credentials/resource.go
+++ b/pilot/pkg/model/credentials/resource.go
@@ -96,13 +96,13 @@ func ToResourceName(name string) string {
 // ParseResourceName parses a raw resourceName string.
 func ParseResourceName(resourceName string, proxyNamespace string, proxyCluster cluster.ID, configCluster cluster.ID) (SecretResource, error) {
 	sep := "/"
-	if strings.HasPrefix(resourceName, KubernetesSecretTypeURI) {
+	if after, ok := strings.CutPrefix(resourceName, KubernetesSecretTypeURI); ok {
 		// Valid formats:
 		// * kubernetes://secret-name
 		// * kubernetes://secret-namespace/secret-name
 		// If namespace is not set, we will fetch from the namespace of the proxy. The secret will be read from
 		// the cluster the proxy resides in. This mirrors the legacy behavior mounting a secret as a file
-		res := strings.TrimPrefix(resourceName, KubernetesSecretTypeURI)
+		res := after
 		split := strings.Split(res, sep)
 		namespace := proxyNamespace
 		name := split[0]
@@ -118,11 +118,11 @@ func ParseResourceName(resourceName string, proxyNamespace string, proxyCluster 
 			ResourceName: resourceName,
 			Cluster:      proxyCluster,
 		}, nil
-	} else if strings.HasPrefix(resourceName, KubernetesConfigMapTypeURI) {
+	} else if after, ok := strings.CutPrefix(resourceName, KubernetesConfigMapTypeURI); ok {
 		// Valid formats:
 		// * configmap://secret-namespace/secret-name
 		// Namespace is required. The secret is read from the config cluster; this is the primary difference from KubernetesSecretType.
-		res := strings.TrimPrefix(resourceName, KubernetesConfigMapTypeURI)
+		res := after
 		split := strings.Split(res, sep)
 		if len(split) <= 1 {
 			return SecretResource{}, fmt.Errorf("invalid resource name %q. Expected namespace and name", resourceName)
@@ -143,11 +143,11 @@ func ParseResourceName(resourceName string, proxyNamespace string, proxyCluster 
 			ResourceName: resourceName,
 			Cluster:      configCluster,
 		}, nil
-	} else if strings.HasPrefix(resourceName, kubernetesGatewaySecretTypeURI) {
+	} else if after, ok := strings.CutPrefix(resourceName, kubernetesGatewaySecretTypeURI); ok {
 		// Valid formats:
 		// * kubernetes-gateway://secret-namespace/secret-name
 		// Namespace is required. The secret is read from the config cluster; this is the primary difference from KubernetesSecretType.
-		res := strings.TrimPrefix(resourceName, kubernetesGatewaySecretTypeURI)
+		res := after
 		split := strings.Split(res, sep)
 		if len(split) <= 1 {
 			return SecretResource{}, fmt.Errorf("invalid resource name %q. Expected namespace and name", resourceName)

--- a/pilot/pkg/networking/core/httproute.go
+++ b/pilot/pkg/networking/core/httproute.go
@@ -655,7 +655,7 @@ func GenerateAltVirtualHosts(hostname string, port int, proxyDomain string) []st
 const portNoAppendPortSuffix = 0
 
 func generateAltVirtualHostsForKubernetesService(hostname string, port int, proxyDomain string) []string {
-	id := strings.Index(proxyDomain, ".svc.")
+	before, _, _ := strings.Cut(proxyDomain, ".svc.")
 	ih := strings.Index(hostname, ".svc.")
 	if ih > 0 { // Proxy and service hostname are in kube
 		ns := strings.Index(hostname, ".")
@@ -663,7 +663,7 @@ func generateAltVirtualHostsForKubernetesService(hostname string, port int, prox
 			// Invalid domain
 			return nil
 		}
-		if hostname[ns+1:ih] == proxyDomain[:id] {
+		if hostname[ns+1:ih] == before {
 			// Same namespace
 			if port == portNoAppendPortSuffix {
 				return []string{

--- a/pilot/pkg/security/authz/builder/extauthz.go
+++ b/pilot/pkg/security/authz/builder/extauthz.go
@@ -354,13 +354,13 @@ func generateHeaders(headers []string) *envoy_type_matcher_v3.ListStringMatcher 
 		pattern := &envoy_type_matcher_v3.StringMatcher{
 			IgnoreCase: true,
 		}
-		if strings.HasPrefix(header, "*") {
+		if after, ok := strings.CutPrefix(header, "*"); ok {
 			pattern.MatchPattern = &envoy_type_matcher_v3.StringMatcher_Suffix{
-				Suffix: strings.TrimPrefix(header, "*"),
+				Suffix: after,
 			}
-		} else if strings.HasSuffix(header, "*") {
+		} else if before, ok := strings.CutSuffix(header, "*"); ok {
 			pattern.MatchPattern = &envoy_type_matcher_v3.StringMatcher_Prefix{
-				Prefix: strings.TrimSuffix(header, "*"),
+				Prefix: before,
 			}
 		} else {
 			pattern.MatchPattern = &envoy_type_matcher_v3.StringMatcher_Exact{

--- a/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
@@ -580,9 +580,8 @@ func createWorkloadEntry(name, namespace string, spec *networking.WorkloadEntry)
 
 func convertPortNameToProtocol(name string) protocol.Instance {
 	prefix := name
-	i := strings.Index(name, "-")
-	if i >= 0 {
-		prefix = name[:i]
+	if before, _, ok := strings.Cut(name, "-"); ok {
+		prefix = before
 	}
 	return protocol.Parse(prefix)
 }

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -669,8 +669,8 @@ func GetNodeMetaData(options MetadataOptions) (*model.Node, error) {
 	untypedMeta := map[string]any{}
 
 	for k, v := range options.ProxyConfig.GetProxyMetadata() {
-		if strings.HasPrefix(k, IstioMetaPrefix) {
-			untypedMeta[strings.TrimPrefix(k, IstioMetaPrefix)] = v
+		if after, ok := strings.CutPrefix(k, IstioMetaPrefix); ok {
+			untypedMeta[after] = v
 		}
 	}
 

--- a/pkg/config/analysis/analyzers/authz/authorizationpolicies.go
+++ b/pkg/config/analysis/analyzers/authz/authorizationpolicies.go
@@ -177,11 +177,11 @@ func namespaceMatch(ns, exp string) bool {
 	if strings.EqualFold(exp, "*") {
 		return true
 	}
-	if strings.HasPrefix(exp, "*") {
-		return strings.HasSuffix(ns, strings.TrimPrefix(exp, "*"))
+	if after, ok := strings.CutPrefix(exp, "*"); ok {
+		return strings.HasSuffix(ns, after)
 	}
-	if strings.HasSuffix(exp, "*") {
-		return strings.HasPrefix(ns, strings.TrimSuffix(exp, "*"))
+	if before, ok := strings.CutSuffix(exp, "*"); ok {
+		return strings.HasPrefix(ns, before)
 	}
 
 	return strings.EqualFold(ns, exp)

--- a/pkg/config/analysis/analyzers/util/find_errorline_utils.go
+++ b/pkg/config/analysis/analyzers/util/find_errorline_utils.go
@@ -127,11 +127,10 @@ func ErrorLine(r *resource.Instance, path string) (line int, found bool) {
 
 // ExtractLabelFromSelectorString returns the label of the match in the k8s labels.Selector
 func ExtractLabelFromSelectorString(s string) string {
-	equalIndex := strings.Index(s, "=")
-	if equalIndex < 0 {
-		return ""
+	if k, _, ok := strings.Cut(s, "="); ok {
+		return k
 	}
-	return s[:equalIndex]
+	return ""
 }
 
 func AddLineNumber(r *resource.Instance, ann string, m diag.Message) bool {

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -513,8 +513,8 @@ func validateServerPort(port *networking.Port, bind string) (errs Validation) {
 }
 
 func validateServerBind(port *networking.Port, bind string) (errs error) {
-	if strings.HasPrefix(bind, UnixAddressPrefix) {
-		errs = appendErrors(errs, ValidateUnixAddress(strings.TrimPrefix(bind, UnixAddressPrefix)))
+	if after, ok := strings.CutPrefix(bind, UnixAddressPrefix); ok {
+		errs = appendErrors(errs, ValidateUnixAddress(after))
 		if port != nil && port.Number != 0 {
 			errs = appendErrors(errs, fmt.Errorf("port number must be 0 for unix domain socket: %v", port))
 		}
@@ -823,8 +823,8 @@ var ValidateSidecar = RegisterValidateFunc("ValidateSidecar",
 			portMap.Insert(i.Port.Number)
 
 			if len(i.DefaultEndpoint) != 0 {
-				if strings.HasPrefix(i.DefaultEndpoint, UnixAddressPrefix) {
-					errs = AppendValidation(errs, ValidateUnixAddress(strings.TrimPrefix(i.DefaultEndpoint, UnixAddressPrefix)))
+				if after, ok0 := strings.CutPrefix(i.DefaultEndpoint, UnixAddressPrefix); ok0 {
+					errs = AppendValidation(errs, ValidateUnixAddress(after))
 				} else {
 					// format should be 127.0.0.1:port, [::1]:port or :port
 					sHost, sPort, sErr := net.SplitHostPort(i.DefaultEndpoint)

--- a/pkg/ctrlz/topics/env.go
+++ b/pkg/ctrlz/topics/env.go
@@ -50,9 +50,7 @@ func getVars() []envVar {
 
 	result := []envVar{}
 	for _, v := range env {
-		eq := strings.Index(v, "=")
-		name := v[:eq] //nolint
-		value := v[eq+1:]
+		name, value, _ := strings.Cut(v, "=")
 		result = append(result, envVar{Name: name, Value: value})
 	}
 

--- a/pkg/istio-agent/agent_test.go
+++ b/pkg/istio-agent/agent_test.go
@@ -825,8 +825,8 @@ func proxyConfigToMetadata(t *testing.T, proxyConfig *meshconfig.ProxyConfig) mo
 	t.Helper()
 	m := map[string]any{}
 	for k, v := range proxyConfig.ProxyMetadata {
-		if strings.HasPrefix(k, bootstrap.IstioMetaPrefix) {
-			m[strings.TrimPrefix(k, bootstrap.IstioMetaPrefix)] = v
+		if after, ok := strings.CutPrefix(k, bootstrap.IstioMetaPrefix); ok {
+			m[after] = v
 		}
 	}
 	b, err := json.Marshal(m)

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -437,8 +437,8 @@ func ExtractBearerToken(ctx context.Context) (string, error) {
 	}
 
 	for _, value := range authHeader {
-		if strings.HasPrefix(value, BearerTokenPrefix) {
-			return strings.TrimPrefix(value, BearerTokenPrefix), nil
+		if after, ok0 := strings.CutPrefix(value, BearerTokenPrefix); ok0 {
+			return after, nil
 		}
 	}
 
@@ -451,11 +451,11 @@ func ExtractRequestToken(req *http.Request) (string, error) {
 		return "", fmt.Errorf("no HTTP authorization header exists")
 	}
 
-	if strings.HasPrefix(value, BearerTokenPrefix) {
-		return strings.TrimPrefix(value, BearerTokenPrefix), nil
+	if after, ok := strings.CutPrefix(value, BearerTokenPrefix); ok {
+		return after, nil
 	}
-	if strings.HasPrefix(value, K8sTokenPrefix) {
-		return strings.TrimPrefix(value, K8sTokenPrefix), nil
+	if after, ok := strings.CutPrefix(value, K8sTokenPrefix); ok {
+		return after, nil
 	}
 
 	return "", fmt.Errorf("no bearer token exists in HTTP authorization header")
@@ -556,15 +556,15 @@ func (s SdsCertificateConfig) IsKeyCertificate() bool {
 // SdsCertificateConfigFromResourceName converts the provided resource name into a SdsCertificateConfig
 // If the resource name is not valid, false is returned.
 func SdsCertificateConfigFromResourceName(resource string) (SdsCertificateConfig, bool) {
-	if strings.HasPrefix(resource, "file-cert:") {
-		filesString := strings.TrimPrefix(resource, "file-cert:")
+	if after, ok := strings.CutPrefix(resource, "file-cert:"); ok {
+		filesString := after
 		split := strings.Split(filesString, ResourceSeparator)
 		if len(split) != 2 {
 			return SdsCertificateConfig{}, false
 		}
 		return SdsCertificateConfig{split[0], split[1], ""}, true
-	} else if strings.HasPrefix(resource, "file-root:") {
-		filesString := strings.TrimPrefix(resource, "file-root:")
+	} else if after, ok := strings.CutPrefix(resource, "file-root:"); ok {
+		filesString := after
 		split := strings.Split(filesString, ResourceSeparator)
 
 		if len(split) != 1 {

--- a/security/pkg/nodeagent/caclient/providers/citadel/client_test.go
+++ b/security/pkg/nodeagent/caclient/providers/citadel/client_test.go
@@ -314,8 +314,8 @@ func extractBearerToken(ctx context.Context) (string, error) {
 	}
 
 	for _, value := range authHeader {
-		if strings.HasPrefix(value, bearerTokenPrefix) {
-			return strings.TrimPrefix(value, bearerTokenPrefix), nil
+		if after, ok0 := strings.CutPrefix(value, bearerTokenPrefix); ok0 {
+			return after, nil
 		}
 	}
 

--- a/tools/docker-builder/dockerfile/parse.go
+++ b/tools/docker-builder/dockerfile/parse.go
@@ -79,13 +79,6 @@ type state struct {
 	shlex *shell.Lex
 }
 
-func cut(s, sep string) (string, string) {
-	if before, after, ok := strings.Cut(s, sep); ok {
-		return before, after
-	}
-	return s, ""
-}
-
 // Parse parses the provided Dockerfile with the given args
 func Parse(f string, opts ...Option) (builder.Args, error) {
 	empty := builder.Args{}
@@ -118,7 +111,7 @@ func Parse(f string, opts ...Option) (builder.Args, error) {
 	for _, c := range cmds {
 		switch c.Cmd {
 		case "ARG":
-			k, v := cut(c.Value[0], "=")
+			k, v, _ := strings.Cut(c.Value[0], "=")
 			_, f := s.args[k]
 			if !f {
 				s.args[k] = v

--- a/tools/docker-builder/dockerfile/parse.go
+++ b/tools/docker-builder/dockerfile/parse.go
@@ -79,9 +79,9 @@ type state struct {
 	shlex *shell.Lex
 }
 
-func cut(s, sep string) (before, after string) {
-	if i := strings.Index(s, sep); i >= 0 {
-		return s[:i], s[i+len(sep):]
+func cut(s, sep string) (string, string) {
+	if before, after, ok := strings.Cut(s, sep); ok {
+		return before, after
 	}
 	return s, ""
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

These rules make simpler and more intuitive code to understand.
The code has been edited using and quickly looked over to see that everything was fine.

```sh
go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -stringscut -stringscutprefix -fix -test ./...
```

There is some documentation about the rules:
* https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize#hdr-Analyzer_stringscutprefix
* https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize#hdr-Analyzer_stringscut

I did find some issues related to this rule. This relates to *empty* prefixes.
* https://github.com/golang/go/issues/77563