### PR TITLE
fix release note formatting and missing issue references

### DIFF
--- a/releasenotes/notes/58584.yaml
+++ b/releasenotes/notes/58584.yaml
@@ -1,6 +1,8 @@
 apiVersion: release-notes/v2
 kind: feature
 area: istioctl
+issue:
+  - 58584
 releaseNotes:
 - |
   **Added** port validation to `istioctl` commands to prevent invalid values outside the 1-65535 range.

--- a/releasenotes/notes/58912.yaml
+++ b/releasenotes/notes/58912.yaml
@@ -1,6 +1,8 @@
 apiVersion: release-notes/v2
 kind: bug-fix
 area: security
+issue:
+  - 58912
 releaseNotes:
   - |
     **Fixed** incorrect mapping of `meshConfig.tlsDefaults.minProtocolVersion` to `tls_minimum_protocol_version` in downstream TLS context.

--- a/releasenotes/notes/58912.yaml
+++ b/releasenotes/notes/58912.yaml
@@ -3,4 +3,4 @@ kind: bug-fix
 area: security
 releaseNotes:
   - |
-    - **Fixed** incorrect mapping of `meshConfig.tlsDefaults.minProtocolVersion` to `tls_minimum_protocol_version` in downstream TLS context.
+    **Fixed** incorrect mapping of `meshConfig.tlsDefaults.minProtocolVersion` to `tls_minimum_protocol_version` in downstream TLS context.

--- a/releasenotes/notes/58927.yaml
+++ b/releasenotes/notes/58927.yaml
@@ -1,6 +1,8 @@
 apiVersion: release-notes/v2
 kind: feature
 area: traffic-management
+issue:
+  - 58927
 releaseNotes:
 - |
   **Added** support for loading multicluster remote secrets from a local filesystem path specified by

--- a/releasenotes/notes/59018.yaml
+++ b/releasenotes/notes/59018.yaml
@@ -1,6 +1,8 @@
 apiVersion: release-notes/v2
 kind: bug-fix
 area: traffic-management
+issue:
+  - 59018
 releaseNotes:
   - |
     **Fixed** Gateway API CORS origin parsing to properly handle wildcard origins and ignore unmatched preflights.

--- a/releasenotes/notes/59018.yaml
+++ b/releasenotes/notes/59018.yaml
@@ -3,5 +3,4 @@ kind: bug-fix
 area: traffic-management
 releaseNotes:
   - |
-    - **Fixed** properly parse Gateway API Cors origin when wildcard is used, and 
-    ignore unmatched preflights.
+    **Fixed** Gateway API CORS origin parsing to properly handle wildcard origins and ignore unmatched preflights.

--- a/releasenotes/notes/59026.yaml
+++ b/releasenotes/notes/59026.yaml
@@ -3,4 +3,4 @@ kind: bug-fix
 area: traffic-management
 releaseNotes:
   - |
-    - **Fixed** On Gateway API, make Origin parsing stricter
+    **Fixed** Gateway API to apply stricter Origin header parsing.

--- a/releasenotes/notes/59026.yaml
+++ b/releasenotes/notes/59026.yaml
@@ -1,6 +1,8 @@
 apiVersion: release-notes/v2
 kind: bug-fix
 area: traffic-management
+issue:
+  - 59026
 releaseNotes:
   - |
     **Fixed** Gateway API to apply stricter Origin header parsing.

--- a/releasenotes/notes/59098.yaml
+++ b/releasenotes/notes/59098.yaml
@@ -1,6 +1,8 @@
 apiVersion: release-notes/v2
 kind: bug-fix
 area: traffic-management
+issue:
+  - 59098
 releaseNotes:
   - |
     **Fixed** Gateway API `tls.Options[gateway.istio.io/tls-terminate-mode]` to properly override TLS mode after CACertificateRefs processing.

--- a/releasenotes/notes/59117.yaml
+++ b/releasenotes/notes/59117.yaml
@@ -5,7 +5,7 @@ issue:
   - 59117 
 releaseNotes:
   - |
-    **Fixed** an issue where baggage-based peer metadata discovery interferred with TLS or
+    **Fixed** an issue where baggage-based peer metadata discovery interfered with TLS or
     PROXY traffic policies. As a short term fix we disable baggage-based metadata discovery
     for routes with TLS or PROXY traffic policies configured which may result in incomplete
     telemetry in multicluster deployments. We are working on addressing this limitation in

--- a/releasenotes/notes/59209.yaml
+++ b/releasenotes/notes/59209.yaml
@@ -5,6 +5,6 @@ issue:
   - 59209
 releaseNotes:
   - |
-    **Added** experimental support for agentgateway in istio. Agentgatewy
+    **Added** experimental support for agentgateway in istio. Agentgateway
     configuration can be enabled through the `EnableAgentGateway` feature flag.
     Istio supports agentgateway configuration via the gateway API resources.

--- a/releasenotes/notes/59321.yaml
+++ b/releasenotes/notes/59321.yaml
@@ -3,6 +3,8 @@ apiVersion: release-notes/v2
 kind: bug-fix
 
 area: traffic-management
+issue:
+  - 59321
 
 releaseNotes:
 - |

--- a/releasenotes/notes/59484.yaml
+++ b/releasenotes/notes/59484.yaml
@@ -5,4 +5,4 @@ issue:
   - 59483
 releaseNotes:
   - |
-    - **Fixed** applying multiple VirtualService for the same hostname to waypoints.
+    **Fixed** applying multiple VirtualService for the same hostname to waypoints.

--- a/releasenotes/notes/59700.yaml
+++ b/releasenotes/notes/59700.yaml
@@ -5,4 +5,4 @@ issue:
 - 59700
 releaseNotes:
 - |
-    **Fixed** serivceAccount matcher regex in AuthorizationPolicy to properly quote the service account name, allowing for correct matching of service accounts with special characters in their names.
+    **Fixed** serviceAccount matcher regex in AuthorizationPolicy to properly quote the service account name, allowing for correct matching of service accounts with special characters in their names.

--- a/releasenotes/notes/59993.yaml
+++ b/releasenotes/notes/59993.yaml
@@ -1,6 +1,8 @@
 apiVersion: release-notes/v2
 kind: feature
 area: installation
+issue:
+  - 59993
 releaseNotes:
   - |
     **Added** `WaypointBound` status condition to `WorkloadEntry` resources, reporting whether the workload is

--- a/releasenotes/notes/ambient-dns-connection-strategy.yaml
+++ b/releasenotes/notes/ambient-dns-connection-strategy.yaml
@@ -1,6 +1,8 @@
 apiVersion: release-notes/v2
 kind: feature
 area: traffic-management
+issue:
+  - 59083
 
 releaseNotes:
   - |

--- a/releasenotes/notes/dns-failover-priority.yaml
+++ b/releasenotes/notes/dns-failover-priority.yaml
@@ -1,6 +1,8 @@
 apiVersion: release-notes/v2
 kind: feature
 area: traffic-management
+issue:
+  - 58674
 releaseNotes:
 - |
   **Added** failover priority support for DNS clusters.

--- a/releasenotes/notes/dns-forward-timeout.yaml
+++ b/releasenotes/notes/dns-forward-timeout.yaml
@@ -1,6 +1,8 @@
 apiVersion: release-notes/v2
 kind: feature
 area: traffic-management
+issue:
+  - 59813
 releaseNotes:
 - |
   **Added** configurable DNS upstream timeout via `DNS_FORWARD_TIMEOUT` environment variable. The default timeout remains 5 seconds. Users can increase the timeout for high-latency DNS servers or decrease it to reduce user-impacting latency when DNS servers are unresponsive (fail faster to try next server sooner). Set via `DNS_FORWARD_TIMEOUT=10s` in istio-proxy container or mesh-wide via `proxyMetadata`.

--- a/releasenotes/notes/ewgw-tls-passthrough.yaml
+++ b/releasenotes/notes/ewgw-tls-passthrough.yaml
@@ -1,6 +1,8 @@
 apiVersion: release-notes/v2
 kind: feature
 area: traffic-management
+issue:
+  - 59223
 
 releaseNotes:
 - |

--- a/releasenotes/notes/namespace-traffic-distribution.yaml
+++ b/releasenotes/notes/namespace-traffic-distribution.yaml
@@ -1,6 +1,8 @@
 apiVersion: release-notes/v2
 kind: feature
 area: traffic-management
+issue:
+  - 58701
 
 releaseNotes:
 - |

--- a/releasenotes/notes/use-registry-istio-io.yaml
+++ b/releasenotes/notes/use-registry-istio-io.yaml
@@ -25,7 +25,7 @@ area: installation
 
 # issue is a list of GitHub issues resolved in this note.
 # If issue is not in the current repo, specify its full URL instead.
-issue:
+issue: []
 
 # releaseNotes is a markdown listing of any user facing changes. This will appear in the
 # release notes.


### PR DESCRIPTION
cleanup pass on 1.30 release notes:

- several release-note YAMLs had a leading `- ` inside the `releaseNotes` list value, causing double-dash output (`- - **Fixed**...`) when rendered through gen-release-notes (58912, 59018, 59026, 59484)
- typo fixes: Agentgatewy, interferred, serivceAccount (59117, 59209, 59700)
- added missing `issue:` field to release notes whose filename matched the PR number but didn't reference it (58584, 58927, 59098, 59321, 59993), so the rendered output now links back to the PR
- added missing `issue:` field to five theme-named release notes for prominent features (ambient-dns-connection-strategy, dns-failover-priority, dns-forward-timeout, ewgw-tls-passthrough, namespace-traffic-distribution)
- normalized empty `issue:` to `issue: []` on use-registry-istio-io.yaml to match the schema (was tripping gen-release-notes validation)

Fixes #59425
