### PR TITLE
test: accept remote connection failure in TLS origination CRL test

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,7 +4,7 @@
     "name": "PROXY_REPO_SHA",
     "repoName": "proxy",
     "file": "",
-    "lastStableSHA": "6c282620c04cd118ed13547d6d7d5250b37c67b0"
+    "lastStableSHA": "47b26b69d3fee7fd9e1bf0d0d2b9d00dc9234f4e"
   },
   {
     "_comment": "",

--- a/tests/integration/security/egress_sidecar_tls_origination_test.go
+++ b/tests/integration/security/egress_sidecar_tls_origination_test.go
@@ -126,7 +126,8 @@ func TestSidecarMutualTlsOrigination(t *testing.T) {
 					},
 				},
 				// Mutual TLS origination from an authorized sidecar to https endpoint with a CRL specifying the server certificate as revoked.
-				// This will result in `certificate verify failed`
+				// This will result in `certificate verify failed` or, after envoyproxy/envoy#44149,
+				// the upstream reset surfaces as `remote connection failure`.
 				{
 					name:             "valid crl",
 					credentialToUse:  credWithCRL,
@@ -136,6 +137,9 @@ func TestSidecarMutualTlsOrigination(t *testing.T) {
 					expectedResponse: ingressutil.ExpectedResponse{
 						StatusCode:   http.StatusServiceUnavailable,
 						ErrorMessage: "CERTIFICATE_VERIFY_FAILED",
+						AllowedErrorMessages: []string{
+							"remote connection failure",
+						},
 					},
 				},
 				// Mutual TLS origination from an authorized sidecar to https endpoint with a CRL with a dummy revoked certificate.
@@ -266,20 +270,41 @@ func newTLSSidecarCallOpts(to echo.Target, host string, exRsp ingressutil.Expect
 			Headers: headers.New().WithHost(host).Build(),
 		},
 		Check: func(result echo.CallResult, err error) error {
+			expected := append([]string{}, exRsp.AllowedErrorMessages...)
+			if exRsp.ErrorMessage != "" {
+				expected = append(expected, exRsp.ErrorMessage)
+			}
+			matches := func(s string) bool {
+				for _, e := range expected {
+					if strings.Contains(s, e) {
+						return true
+					}
+				}
+				return false
+			}
 			// Check that the error message is expected.
 			if err != nil {
-				// If expected error message is empty, but we got some error
-				// message then it should be treated as error.
-				if len(exRsp.ErrorMessage) == 0 {
+				if len(expected) == 0 {
 					return fmt.Errorf("unexpected error: %w", err)
 				}
-				if !strings.Contains(err.Error(), exRsp.ErrorMessage) {
-					return fmt.Errorf("expected response error message %s but got %w and the response code is %+v",
-						exRsp.ErrorMessage, err, result.Responses)
+				if !matches(err.Error()) {
+					return fmt.Errorf("expected one of %v but got error: %w and the response code is %+v",
+						expected, err, result.Responses)
 				}
 				return nil
 			}
-			return check.And(check.NoErrorAndStatus(exRsp.StatusCode), check.BodyContains(exRsp.ErrorMessage)).Check(result, nil)
+			if err := check.NoErrorAndStatus(exRsp.StatusCode).Check(result, nil); err != nil {
+				return err
+			}
+			if len(expected) == 0 {
+				return nil
+			}
+			for _, resp := range result.Responses {
+				if !matches(resp.RawContent) {
+					return fmt.Errorf("expected one of %v in body but got: %s", expected, resp.RawContent)
+				}
+			}
+			return nil
 		},
 	}
 }


### PR DESCRIPTION
After envoyproxy/envoy#44149, CRL revocation surfaces as 'remote connection failure' in the upstream connect error body instead of 'CERTIFICATE_VERIFY_FAILED'. Allow either string in TestSidecarMutualTlsOrigination/valid_crl so the proxy bump in #60034 can land.

envoy concern issue https://github.com/envoyproxy/envoy/issues/45011 - not sure if it's an intentional change.