### PR TITLE
Draft: Merge port level settings from different destination rules

### DIFF
--- a/pilot/pkg/model/destination_rule.go
+++ b/pilot/pkg/model/destination_rule.go
@@ -111,10 +111,22 @@ func (ps *PushContext) mergeDestinationRule(p *consolidatedDestRules, destRuleCo
 				}
 			}
 
-			// If there is no top level policy and the incoming rule has top level
-			// traffic policy, use the one from the incoming rule.
-			if mergedRule.TrafficPolicy == nil && rule.TrafficPolicy != nil {
-				mergedRule.TrafficPolicy = rule.TrafficPolicy
+			if rule.TrafficPolicy != nil {
+				// If there is no top level policy and the incoming rule has top level
+				// traffic policy, use the one from the incoming rule.
+				if mergedRule.TrafficPolicy == nil {
+					mergedRule.TrafficPolicy = rule.TrafficPolicy
+				} else {
+					// If there is already a top level traffic policy, we merge
+					//the port level traffic policies if there are any in the incoming rule.
+					if len(rule.TrafficPolicy.PortLevelSettings) > 0 {
+						for _, portLevelSetting := range rule.TrafficPolicy.PortLevelSettings {
+							// TODO: check if there are any duplicate port level settings and log if there are any.
+							mergedRule.TrafficPolicy.PortLevelSettings = append(
+								mergedRule.TrafficPolicy.PortLevelSettings, portLevelSetting)
+						}
+					}
+				}
 			}
 		}
 		if appendSeparately {


### PR DESCRIPTION
Currently, if two destination rules with same hosts defined two port-level settings for different ports, only the first one works. In this MR, since `PortTrafficPolicy` in `TrafficPolicy` is an slice, we merge port-level policies and ignore duplicated port-level settings for same port (with giving priority to the original rule).
This feature can come with a feature flag to enable or disable the merge functionality (similar to `features.EnableEnhancedDestinationRuleMerge`). 

Fixes #60169