### PR TITLE
Use CF_CREDENTIALS to authenticate to s3 when pulling envoy/ztunnel

### DIFF
--- a/bin/build_ztunnel.sh
+++ b/bin/build_ztunnel.sh
@@ -49,6 +49,9 @@ function set_download_command () {
   exit 1
 }
 
+# shellcheck source=bin/setup_cf_credentials.sh
+source "$(dirname "${BASH_SOURCE[0]}")/setup_cf_credentials.sh"
+
 # Params:
 #   $1: The URL of the ztunnel binary to be downloaded.
 #   $2: The full path of the output binary.
@@ -57,16 +60,17 @@ function download_ztunnel_if_necessary () {
   if [[ -f "$2" ]]; then
     return
   fi
+  local URL="$1"
   # If $1 is an s3:// URL, get a presigned URL
   if [[ "$1" == s3://* ]]; then
+    setup_cf_credentials
     echo "Getting presigned URL for $1"
     # Use AWS CLI to get a presigned URL that is valid for 1 minute
-    if ! URL=$(aws s3 presign "$1" --expires-in 60 --endpoint-url "${AWS_ENDPOINT_URL:-}"); then
+    if ! URL=$(aws s3 presign "$1" --expires-in 60 ${AWS_ENDPOINT_URL:+--endpoint-url "$AWS_ENDPOINT_URL"}); then
       echo "Error: Failed to get presigned URL for $1"
-      exit 1
+      return 1
     fi
   fi
-
 
   # Enter the output directory.
   mkdir -p "$(dirname "$2")"
@@ -75,10 +79,11 @@ function download_ztunnel_if_necessary () {
   # Download and make the binary executable
   echo "Downloading ztunnel: $1 to $2"
 
-  # Don't leak the presigned url
-  set +x
+  # Don't leak the presigned URL via xtrace.
+  case $- in *x*) local _xtrace=1;; *) local _xtrace=0;; esac
+  { set +x; } 2>/dev/null
   time ${DOWNLOAD_COMMAND} "${URL}" > "$2"
-  set -x
+  [[ $_xtrace == 1 ]] && set -x
   chmod +x "$2"
 
   # Make a copy named just "ztunnel" in the same directory (overwrite if necessary).

--- a/bin/build_ztunnel.sh
+++ b/bin/build_ztunnel.sh
@@ -57,13 +57,28 @@ function download_ztunnel_if_necessary () {
   if [[ -f "$2" ]]; then
     return
   fi
+  # If $1 is an s3:// URL, get a presigned URL
+  if [[ "$1" == s3://* ]]; then
+    echo "Getting presigned URL for $1"
+    # Use AWS CLI to get a presigned URL that is valid for 1 minute
+    if ! URL=$(aws s3 presign "$1" --expires-in 60 --endpoint-url "${AWS_ENDPOINT_URL:-}"); then
+      echo "Error: Failed to get presigned URL for $1"
+      exit 1
+    fi
+  fi
+
+
   # Enter the output directory.
   mkdir -p "$(dirname "$2")"
   pushd "$(dirname "$2")"
 
   # Download and make the binary executable
   echo "Downloading ztunnel: $1 to $2"
-  time ${DOWNLOAD_COMMAND} --header "${AUTH_HEADER:-}" "$1" > "$2"
+
+  # Don't leak the presigned url
+  set +x
+  time ${DOWNLOAD_COMMAND} "${URL}" > "$2"
+  set -x
   chmod +x "$2"
 
   # Make a copy named just "ztunnel" in the same directory (overwrite if necessary).

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -97,21 +97,25 @@ function set_download_command () {
   exit 1
 }
 
+# shellcheck source=bin/setup_cf_credentials.sh
+source "$(dirname "${BASH_SOURCE[0]}")/setup_cf_credentials.sh"
+
 # Downloads and extract an Envoy binary if the artifact doesn't already exist.
 # Params:
 #   $1: The URL of the Envoy tar.gz to be downloaded.
 #   $2: The full path of the output binary.
 #   $3: Non-versioned name to use
 function download_envoy_if_necessary () {
+  local URL="$1"
   # If $1 is an s3:// URL, get a presigned URL
   if [[ "$1" == s3://* ]]; then
+    setup_cf_credentials
     echo "Getting presigned URL for $1"
     # Use AWS CLI to get a presigned URL that is valid for 60 secs
-    if ! URL=$(aws s3 presign "$1" --expires-in 60 --endpoint-url "${AWS_ENDPOINT_URL:-}"); then
+    if ! URL=$(aws s3 presign "$1" --expires-in 60 ${AWS_ENDPOINT_URL:+--endpoint-url "$AWS_ENDPOINT_URL"}); then
       echo "Error: Failed to get presigned URL for $1"
-      exit 1
+      return 1
     fi
-    # Update $1 to use the presigned URL for downloading
   fi
   if [[ ! -f "$2" ]] ; then
     # Enter the output directory.
@@ -121,11 +125,12 @@ function download_envoy_if_necessary () {
     # Download and extract the binary to the output directory.
     echo "Downloading ${SIDECAR}: $1 to $2"
 
-    # Don't leak the presigned url
-    set +x
-    time ${DOWNLOAD_COMMAND} "${URL}" |\
+    # Don't leak the presigned URL via xtrace.
+    case $- in *x*) local _xtrace=1;; *) local _xtrace=0;; esac
+    { set +x; } 2>/dev/null
+    time ${DOWNLOAD_COMMAND} "${DOWNLOAD_ARGS[@]}" "${URL}" |\
       tar --extract --gzip --strip-components=3 --to-stdout > "$2"
-    set -x
+    [[ $_xtrace == 1 ]] && set -x
     chmod +x "$2"
 
     # Make a copy named just "envoy" in the same directory (overwrite if necessary).
@@ -141,8 +146,6 @@ mkdir -p "${TARGET_OUT}"
 set_download_command
 
 if [[ -n "${DEBUG_IMAGE:-}" ]]; then
-
-
   # Download and extract the Envoy linux debug binary.
   download_envoy_if_necessary "${ISTIO_ENVOY_LINUX_DEBUG_URL}" "$ISTIO_ENVOY_LINUX_DEBUG_PATH" "${SIDECAR}"
 else
@@ -150,8 +153,6 @@ else
 fi
 
 # Download and extract the Envoy linux release binary.
-
-# If ISTIO_ENVOY_LINUX_RELEASE_URL starts with s3://, get a presigned URL
 download_envoy_if_necessary "${ISTIO_ENVOY_LINUX_RELEASE_URL}" "$ISTIO_ENVOY_LINUX_RELEASE_PATH" "${SIDECAR}"
 ISTIO_ENVOY_NATIVE_PATH=${ISTIO_ENVOY_LINUX_RELEASE_PATH}
 

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -103,6 +103,16 @@ function set_download_command () {
 #   $2: The full path of the output binary.
 #   $3: Non-versioned name to use
 function download_envoy_if_necessary () {
+  # If $1 is an s3:// URL, get a presigned URL
+  if [[ "$1" == s3://* ]]; then
+    echo "Getting presigned URL for $1"
+    # Use AWS CLI to get a presigned URL that is valid for 60 secs
+    if ! URL=$(aws s3 presign "$1" --expires-in 60 --endpoint-url "${AWS_ENDPOINT_URL:-}"); then
+      echo "Error: Failed to get presigned URL for $1"
+      exit 1
+    fi
+    # Update $1 to use the presigned URL for downloading
+  fi
   if [[ ! -f "$2" ]] ; then
     # Enter the output directory.
     mkdir -p "$(dirname "$2")"
@@ -110,8 +120,12 @@ function download_envoy_if_necessary () {
 
     # Download and extract the binary to the output directory.
     echo "Downloading ${SIDECAR}: $1 to $2"
-    time ${DOWNLOAD_COMMAND} --header "${AUTH_HEADER:-}" "$1" |\
+
+    # Don't leak the presigned url
+    set +x
+    time ${DOWNLOAD_COMMAND} "${URL}" |\
       tar --extract --gzip --strip-components=3 --to-stdout > "$2"
+    set -x
     chmod +x "$2"
 
     # Make a copy named just "envoy" in the same directory (overwrite if necessary).
@@ -127,6 +141,8 @@ mkdir -p "${TARGET_OUT}"
 set_download_command
 
 if [[ -n "${DEBUG_IMAGE:-}" ]]; then
+
+
   # Download and extract the Envoy linux debug binary.
   download_envoy_if_necessary "${ISTIO_ENVOY_LINUX_DEBUG_URL}" "$ISTIO_ENVOY_LINUX_DEBUG_PATH" "${SIDECAR}"
 else
@@ -134,6 +150,8 @@ else
 fi
 
 # Download and extract the Envoy linux release binary.
+
+# If ISTIO_ENVOY_LINUX_RELEASE_URL starts with s3://, get a presigned URL
 download_envoy_if_necessary "${ISTIO_ENVOY_LINUX_RELEASE_URL}" "$ISTIO_ENVOY_LINUX_RELEASE_PATH" "${SIDECAR}"
 ISTIO_ENVOY_NATIVE_PATH=${ISTIO_ENVOY_LINUX_RELEASE_PATH}
 

--- a/bin/setup_cf_credentials.sh
+++ b/bin/setup_cf_credentials.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# If CF_CREDENTIALS (a JSON blob with R2 credentials, set by Prow) is present,
+# translate it into the standard AWS_* env vars that `aws s3` expects. No-op if
+# AWS_ACCESS_KEY_ID is already set or CF_CREDENTIALS is empty, so local dev
+# flows that export AWS_* directly are unaffected.
+# Example CF_CREDENTIALS value:
+# {
+#   "access_key": "AKIAIOSFODNN7EXAMPLE",
+#   "secret_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+#   "session_token": "AQoDYXdzEJr...<remainder of security token>",
+#   "region": "auto",
+#   "endpoint": "https://12345.r2.cloudflarestorage.com"
+# }
+function setup_cf_credentials () {
+  if [[ -z "${CF_CREDENTIALS:-}" || -n "${AWS_ACCESS_KEY_ID:-}" ]]; then
+    return 0
+  fi
+  local _xtrace=0
+  case $- in *x*) _xtrace=1;; esac
+  { set +x; } 2>/dev/null
+  AWS_ACCESS_KEY_ID="$(echo "${CF_CREDENTIALS}" | jq -r '.access_key' | tr -d '\n')"
+  AWS_SECRET_ACCESS_KEY="$(echo "${CF_CREDENTIALS}" | jq -r '.secret_key' | tr -d '\n')"
+  AWS_SESSION_TOKEN="$(echo "${CF_CREDENTIALS}" | jq -r '.session_token' | tr -d '\n')"
+  AWS_REGION="$(echo "${CF_CREDENTIALS}" | jq -r '.region' | tr -d '\n')"
+  AWS_ENDPOINT_URL="$(echo "${CF_CREDENTIALS}" | jq -r '.endpoint' | tr -d '\n')"
+  export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_REGION AWS_ENDPOINT_URL
+  [[ $_xtrace == 1 ]] && set -x
+}


### PR DESCRIPTION
We can't just throw and Bearer token for stuff in r2/s3. With this PR, we check if the URI has a scheme of `s3://` and if so, attempt to get a signed url using the s3 CLI.