### PR TITLE
[release-1.30] test: accept remote connection failure in TLS origination CRL test

### DIFF
--- a/tests/integration/security/egress_sidecar_tls_origination_test.go
+++ b/tests/integration/security/egress_sidecar_tls_origination_test.go
@@ -126,7 +126,8 @@ func TestSidecarMutualTlsOrigination(t *testing.T) {
 					},
 				},
 				// Mutual TLS origination from an authorized sidecar to https endpoint with a CRL specifying the server certificate as revoked.
-				// This will result in `certificate verify failed`
+				// This will result in `certificate verify failed` or, after envoyproxy/envoy#44149,
+				// the upstream reset surfaces as `remote connection failure`.
 				{
 					name:             "valid crl",
 					credentialToUse:  credWithCRL,
@@ -136,6 +137,9 @@ func TestSidecarMutualTlsOrigination(t *testing.T) {
 					expectedResponse: ingressutil.ExpectedResponse{
 						StatusCode:   http.StatusServiceUnavailable,
 						ErrorMessage: "CERTIFICATE_VERIFY_FAILED",
+						AllowedErrorMessages: []string{
+							"remote connection failure",
+						},
 					},
 				},
 				// Mutual TLS origination from an authorized sidecar to https endpoint with a CRL with a dummy revoked certificate.
@@ -266,20 +270,41 @@ func newTLSSidecarCallOpts(to echo.Target, host string, exRsp ingressutil.Expect
 			Headers: headers.New().WithHost(host).Build(),
 		},
 		Check: func(result echo.CallResult, err error) error {
+			expected := append([]string{}, exRsp.AllowedErrorMessages...)
+			if exRsp.ErrorMessage != "" {
+				expected = append(expected, exRsp.ErrorMessage)
+			}
+			matches := func(s string) bool {
+				for _, e := range expected {
+					if strings.Contains(s, e) {
+						return true
+					}
+				}
+				return false
+			}
 			// Check that the error message is expected.
 			if err != nil {
-				// If expected error message is empty, but we got some error
-				// message then it should be treated as error.
-				if len(exRsp.ErrorMessage) == 0 {
+				if len(expected) == 0 {
 					return fmt.Errorf("unexpected error: %w", err)
 				}
-				if !strings.Contains(err.Error(), exRsp.ErrorMessage) {
-					return fmt.Errorf("expected response error message %s but got %w and the response code is %+v",
-						exRsp.ErrorMessage, err, result.Responses)
+				if !matches(err.Error()) {
+					return fmt.Errorf("expected one of %v but got error: %w and the response code is %+v",
+						expected, err, result.Responses)
 				}
 				return nil
 			}
-			return check.And(check.NoErrorAndStatus(exRsp.StatusCode), check.BodyContains(exRsp.ErrorMessage)).Check(result, nil)
+			if err := check.NoErrorAndStatus(exRsp.StatusCode).Check(result, nil); err != nil {
+				return err
+			}
+			if len(expected) == 0 {
+				return nil
+			}
+			for _, resp := range result.Responses {
+				if !matches(resp.RawContent) {
+					return fmt.Errorf("expected one of %v in body but got: %s", expected, resp.RawContent)
+				}
+			}
+			return nil
 		},
 	}
 }


### PR DESCRIPTION
Cherry-pick of #60185 to unblock proxy bump #60220. Fixes #60223