### PR TITLE
chore: fix duplicated words in cluster_test.go and samples/curl/README

### DIFF
--- a/pilot/pkg/networking/core/cluster_test.go
+++ b/pilot/pkg/networking/core/cluster_test.go
@@ -4995,7 +4995,7 @@ func TestBuildStaticClusterWithCredentialSocket(t *testing.T) {
 		"BlackHoleCluster", "InboundPassthroughCluster", "PassthroughCluster", security.SDSExternalClusterName,
 	}))
 
-	// Expect no sds_external cluster be added if if credentialSocket does NOT exists
+	// Expect no sds_external cluster be added if credentialSocket does NOT exists
 	proxy = cg.SetupProxy(nil)
 	clusters = cg.Clusters(proxy)
 	xdstest.ValidateClusters(t, clusters)

--- a/samples/curl/README.md
+++ b/samples/curl/README.md
@@ -1,6 +1,6 @@
 # Simple curl service
 
-This sample is a a request source for invoking other services, to experiment with Istio networking.
+This sample is a request source for invoking other services, to experiment with Istio networking.
 It consists of a pod that does nothing but sleep. You can get a shell on the pod (an Alpine container) and use `curl`.
 
 To use it:


### PR DESCRIPTION
Two small typo fixes: doubled `if if` in a cluster_test.go comment, and doubled `a a` in samples/curl/README.md. No functional change.