### PR TITLE
perf: remove unused serviceTargets in clusters, optimize sort

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -51,6 +50,7 @@ import (
 	pm "istio.io/istio/pkg/model"
 	"istio.io/istio/pkg/monitoring"
 	"istio.io/istio/pkg/network"
+	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/util/identifier"
 	netutil "istio.io/istio/pkg/util/net"
@@ -597,15 +597,15 @@ func (node *Proxy) SetServiceTargets(serviceDiscovery ServiceDiscovery) {
 	instances := serviceDiscovery.GetProxyServiceTargets(node)
 
 	// Keep service instances in order of creation/hostname.
-	sort.SliceStable(instances, func(i, j int) bool {
-		if instances[i].Service != nil && instances[j].Service != nil {
-			if !instances[i].Service.CreationTime.Equal(instances[j].Service.CreationTime) {
-				return instances[i].Service.CreationTime.Before(instances[j].Service.CreationTime)
+	slices.SortStableFunc(instances, func(a, b ServiceTarget) int {
+		if a.Service != nil && b.Service != nil {
+			if c := a.Service.CreationTime.Compare(b.Service.CreationTime); c != 0 {
+				return c
 			}
 			// Additionally, sort by hostname just in case services created automatically at the same second.
-			return instances[i].Service.Hostname < instances[j].Service.Hostname
+			return strings.Compare(string(a.Service.Hostname), string(b.Service.Hostname))
 		}
-		return true
+		return -1
 	})
 
 	node.ServiceTargets = instances

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -2428,7 +2428,7 @@ func (ps *PushContext) mergeGateways(proxy *Proxy) *MergedGateway {
 		gw := cfg.Spec.(*networking.Gateway)
 		if gwsvcstr, f := cfg.Annotations[InternalGatewayServiceAnnotation]; f {
 			gwsvcs := strings.Split(gwsvcstr, ",")
-			known := sets.New[string](gwsvcs...)
+			known := sets.New(gwsvcs...)
 			cfgNamespace := ptr.NonEmptyOrDefault(cfg.Annotations[constants.InternalParentNamespace], cfg.Namespace)
 			matchingInstances := make([]ServiceTarget, 0, len(proxy.ServiceTargets))
 			for _, si := range proxy.ServiceTargets {

--- a/pilot/pkg/networking/core/cluster.go
+++ b/pilot/pkg/networking/core/cluster.go
@@ -945,7 +945,6 @@ type buildClusterOpts struct {
 	policy          *networking.TrafficPolicy
 	port            *model.Port
 	serviceAccounts []string
-	serviceTargets  []model.ServiceTarget
 	// Used for traffic across multiple network clusters
 	// the east-west gateway in a remote cluster will use this value to route
 	// traffic to the appropriate service

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -128,23 +128,22 @@ type ClusterBuilder struct {
 	// Proxy related information used to build clusters.
 	// The fields below that influence cluster configuration must be reflected in clusterCache
 	// to ensure accurate differentiation and caching of clusters.
-	serviceTargets     []model.ServiceTarget // Service targets of Proxy.
-	metadataCerts      *metadataCerts        // Client certificates specified in metadata.
-	clusterID          string                // Cluster in which proxy is running.
-	proxyID            string                // Identifier that uniquely identifies a proxy.
-	proxyMetadata      *model.NodeMetadata   // Metadata of the proxy.
-	proxyVersion       *model.IstioVersion   // Version of Proxy.
-	proxyType          model.NodeType        // Indicates whether the proxy is sidecar or gateway.
-	sidecarScope       *model.SidecarScope   // Computed sidecar for the proxy.
-	passThroughBindIPs []string              // Passthrough IPs to be used while building clusters.
-	supportsIPv4       bool                  // Whether Proxy IPs has IPv4 address.
-	supportsIPv6       bool                  // Whether Proxy IPs has IPv6 address.
-	sendHbone          bool                  // Does the proxy support HBONE
-	locality           *core.Locality        // Locality information of proxy.
-	proxyLabels        map[string]string     // Proxy labels.
-	proxyView          model.ProxyView       // Proxy view of endpoints.
-	proxyIPAddresses   []string              // IP addresses on which proxy is listening on.
-	configNamespace    string                // Proxy config namespace.
+	metadataCerts      *metadataCerts      // Client certificates specified in metadata.
+	clusterID          string              // Cluster in which proxy is running.
+	proxyID            string              // Identifier that uniquely identifies a proxy.
+	proxyMetadata      *model.NodeMetadata // Metadata of the proxy.
+	proxyVersion       *model.IstioVersion // Version of Proxy.
+	proxyType          model.NodeType      // Indicates whether the proxy is sidecar or gateway.
+	sidecarScope       *model.SidecarScope // Computed sidecar for the proxy.
+	passThroughBindIPs []string            // Passthrough IPs to be used while building clusters.
+	supportsIPv4       bool                // Whether Proxy IPs has IPv4 address.
+	supportsIPv6       bool                // Whether Proxy IPs has IPv6 address.
+	sendHbone          bool                // Does the proxy support HBONE
+	locality           *core.Locality      // Locality information of proxy.
+	proxyLabels        map[string]string   // Proxy labels.
+	proxyView          model.ProxyView     // Proxy view of endpoints.
+	proxyIPAddresses   []string            // IP addresses on which proxy is listening on.
+	configNamespace    string              // Proxy config namespace.
 	// PushRequest to look for updates.
 	req                       *model.PushRequest
 	cache                     model.XdsCache
@@ -155,7 +154,6 @@ type ClusterBuilder struct {
 // NewClusterBuilder builds an instance of ClusterBuilder.
 func NewClusterBuilder(proxy *model.Proxy, req *model.PushRequest, cache model.XdsCache) *ClusterBuilder {
 	cb := &ClusterBuilder{
-		serviceTargets:     proxy.ServiceTargets,
 		proxyID:            proxy.ID,
 		proxyMetadata:      proxy.Metadata,
 		proxyType:          proxy.Type,
@@ -357,7 +355,6 @@ func (cb *ClusterBuilder) applyDestinationRule(mc *clusterWrapper, clusterMode C
 	trafficPolicy, _ := util.GetPortLevelTrafficPolicy(destinationRule.GetTrafficPolicy(), port)
 	opts := buildClusterOpts{
 		mesh:                      cb.req.Push.Mesh,
-		serviceTargets:            cb.serviceTargets,
 		mutable:                   mc,
 		policy:                    trafficPolicy,
 		port:                      port,
@@ -634,7 +631,6 @@ func (cb *ClusterBuilder) buildInboundCluster(clusterPort int, bind string,
 		policy:          nil,
 		port:            instance.Port.ServicePort,
 		serviceAccounts: nil,
-		serviceTargets:  cb.serviceTargets,
 		istioMtlsSni:    "",
 		clusterMode:     DefaultClusterMode,
 		direction:       model.TrafficDirectionInbound,

--- a/pilot/pkg/networking/core/cluster_waypoint.go
+++ b/pilot/pkg/networking/core/cluster_waypoint.go
@@ -235,13 +235,12 @@ func (cb *ClusterBuilder) buildWaypointInboundVIPCluster(
 
 	// TLS and PROXY are more involved, since these impact the transport socket which is customized for HBONE.
 	opts := &buildClusterOpts{
-		mesh:           cb.req.Push.Mesh,
-		mutable:        localCluster,
-		policy:         policy,
-		port:           &port,
-		serviceTargets: cb.serviceTargets,
-		clusterMode:    DefaultClusterMode,
-		direction:      model.TrafficDirectionInboundVIP,
+		mesh:        cb.req.Push.Mesh,
+		mutable:     localCluster,
+		policy:      policy,
+		port:        &port,
+		clusterMode: DefaultClusterMode,
+		direction:   model.TrafficDirectionInboundVIP,
 	}
 	transportSocket := util.RawBufferTransport()
 	disableBaggageDiscovery := false


### PR DESCRIPTION
**Please provide a description of this PR:**
Found this while making another refactor,`serviceTargets` in `ClusterBuilders` where unused.
Also optimized the service target sorting.