### PR TITLE
Fix DefaultWatcher to scope webhook lookup by Istio namespace

### DIFF
--- a/istioctl/pkg/cli/context.go
+++ b/istioctl/pkg/cli/context.go
@@ -222,7 +222,7 @@ func (i *instance) RevisionOrDefault(rev string) string {
 	if i.defaultWatcher == nil {
 		// Try to initialize the default watcher using a basic client
 		if basicClient := i.getBasicClientForDefaultWatcher(); basicClient != nil {
-			i.defaultWatcher = revisions.NewDefaultWatcher(basicClient, "")
+			i.defaultWatcher = revisions.NewDefaultWatcher(basicClient, "", i.IstioNamespace())
 			basicClient.RunAndWait(stop)
 			go i.defaultWatcher.Run(stop)
 			kube.WaitForCacheSync("default revision watcher", stop, i.defaultWatcher.HasSynced)

--- a/pilot/pkg/leaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/leaderelection.go
@@ -250,7 +250,7 @@ func NewLeaderElectionMulticluster(namespace, name, electionID, revision string,
 func newLeaderElection(namespace, name, electionID, revision string, perRevision bool, remote bool, leaseLock bool, client kube.Client) *LeaderElection {
 	var watcher revisions.DefaultWatcher
 	if features.EnableLeaderElection {
-		watcher = revisions.NewDefaultWatcher(client, revision)
+		watcher = revisions.NewDefaultWatcher(client, revision, "")
 	}
 	// Default revision for consistency. Note that on Kubernetes, there is ~always a revision set.
 	if revision == "" {

--- a/pkg/revisions/default_watcher.go
+++ b/pkg/revisions/default_watcher.go
@@ -52,14 +52,27 @@ type defaultWatcher struct {
 	mu       sync.RWMutex
 }
 
-func NewDefaultWatcher(client kube.Client, revision string) DefaultWatcher {
+// NewDefaultWatcher creates a watcher that tracks the default revision by watching
+// MutatingWebhookConfigurations. The istioNamespace parameter scopes the lookup to
+// the webhook for a specific Istio namespace. When Istio is installed outside of
+// istio-system, the webhook is named "istio-revision-tag-default-<namespace>" instead
+// of "istio-revision-tag-default". If istioNamespace is empty, the watcher falls back
+// to matching by the canonical name "istio-revision-tag-default".
+func NewDefaultWatcher(client kube.Client, revision string, istioNamespace string) DefaultWatcher {
 	p := &defaultWatcher{
 		revision: revision,
 		mu:       sync.RWMutex{},
 	}
 	p.queue = controllers.NewQueue("default revision", controllers.WithReconciler(p.setDefault))
 	p.webhooks = kclient.New[*admitv1.MutatingWebhookConfiguration](client)
-	p.webhooks.AddEventHandler(controllers.FilteredObjectHandler(p.queue.AddObject, isDefaultTagWebhook))
+
+	expectedName := defaultTagWebhookName
+	if istioNamespace != "" && istioNamespace != "istio-system" {
+		expectedName = defaultTagWebhookName + "-" + istioNamespace
+	}
+	p.webhooks.AddEventHandler(controllers.FilteredObjectHandler(p.queue.AddObject, func(obj controllers.Object) bool {
+		return obj.GetName() == expectedName
+	}))
 
 	return p
 }
@@ -106,8 +119,4 @@ func (p *defaultWatcher) setDefault(key types.NamespacedName) error {
 	p.defaultRevision = revision
 	p.notifyHandlers()
 	return nil
-}
-
-func isDefaultTagWebhook(obj controllers.Object) bool {
-	return obj.GetName() == defaultTagWebhookName
 }

--- a/pkg/revisions/default_watcher_test.go
+++ b/pkg/revisions/default_watcher_test.go
@@ -30,10 +30,14 @@ import (
 )
 
 func webhook(revision string) *v1.MutatingWebhookConfiguration {
+	return webhookWithName(defaultTagWebhookName, revision)
+}
+
+func webhookWithName(name, revision string) *v1.MutatingWebhookConfiguration {
 	return &v1.MutatingWebhookConfiguration{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: defaultTagWebhookName,
+			Name: name,
 			Labels: map[string]string{
 				label.IoIstioRev.Name: revision,
 			},
@@ -66,7 +70,7 @@ func expectRevisionChan(t test.Failer, revisionChan chan string, expected string
 func TestNoDefaultRevision(t *testing.T) {
 	stop := make(chan struct{})
 	client := kube.NewFakeClient()
-	w := NewDefaultWatcher(client, "default")
+	w := NewDefaultWatcher(client, "default", "")
 	client.RunAndWait(stop)
 	go w.Run(stop)
 	// if have no default tag for some reason, should return ""
@@ -77,7 +81,7 @@ func TestNoDefaultRevision(t *testing.T) {
 func TestDefaultRevisionChanges(t *testing.T) {
 	stop := test.NewStop(t)
 	client := kube.NewFakeClient()
-	w := NewDefaultWatcher(client, "default").(*defaultWatcher)
+	w := NewDefaultWatcher(client, "default", "").(*defaultWatcher)
 	client.RunAndWait(stop)
 	go w.Run(stop)
 	whc := clienttest.Wrap(t, w.webhooks)
@@ -98,7 +102,7 @@ func TestDefaultRevisionChanges(t *testing.T) {
 func TestHandlers(t *testing.T) {
 	stop := test.NewStop(t)
 	client := kube.NewFakeClient()
-	w := NewDefaultWatcher(client, "default").(*defaultWatcher)
+	w := NewDefaultWatcher(client, "default", "").(*defaultWatcher)
 	client.RunAndWait(stop)
 	go w.Run(stop)
 	whc := clienttest.Wrap(t, w.webhooks)
@@ -112,4 +116,49 @@ func TestHandlers(t *testing.T) {
 	w.AddHandler(handler)
 	whc.CreateOrUpdate(webhook("green"))
 	expectRevisionChan(t, newDefaultChan, "green")
+}
+
+func TestDefaultRevisionWithCustomNamespace(t *testing.T) {
+	stop := test.NewStop(t)
+	client := kube.NewFakeClient()
+	// Pass a custom namespace so the watcher looks for "istio-revision-tag-default-custom-istio-ns"
+	w := NewDefaultWatcher(client, "default", "custom-istio-ns").(*defaultWatcher)
+	client.RunAndWait(stop)
+	go w.Run(stop)
+	whc := clienttest.Wrap(t, w.webhooks)
+	expectRevision(t, w, "")
+
+	// The canonical name webhook should NOT be matched when a custom namespace is specified
+	whc.CreateOrUpdate(webhookWithName(defaultTagWebhookName, "wrong-revision"))
+	expectRevision(t, w, "")
+
+	// The namespace-suffixed webhook should be matched
+	customName := defaultTagWebhookName + "-custom-istio-ns"
+	whc.CreateOrUpdate(webhookWithName(customName, "rev-1"))
+	expectRevision(t, w, "rev-1")
+
+	// change revision
+	whc.CreateOrUpdate(webhookWithName(customName, "rev-2"))
+	expectRevision(t, w, "rev-2")
+
+	// remove webhook
+	whc.Delete(customName, "")
+	expectRevision(t, w, "")
+}
+
+func TestDefaultRevisionWithIstioSystemNamespace(t *testing.T) {
+	stop := test.NewStop(t)
+	client := kube.NewFakeClient()
+	// Passing "istio-system" should use the canonical name, not a suffixed one
+	w := NewDefaultWatcher(client, "default", "istio-system").(*defaultWatcher)
+	client.RunAndWait(stop)
+	go w.Run(stop)
+	whc := clienttest.Wrap(t, w.webhooks)
+	expectRevision(t, w, "")
+
+	whc.CreateOrUpdate(webhook("rev-1"))
+	expectRevision(t, w, "rev-1")
+
+	whc.Delete(defaultTagWebhookName, "")
+	expectRevision(t, w, "")
 }

--- a/releasenotes/notes/60232.yaml
+++ b/releasenotes/notes/60232.yaml
@@ -1,0 +1,12 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+
+issue:
+  - 60232
+
+releaseNotes:
+- |
+  **Fixed** `istioctl` failing to discover istiod when Istio is installed in a non-default namespace
+  (other than `istio-system`) with a revision tag. The `DefaultWatcher` now constructs the expected
+  webhook name based on the Istio namespace passed via the `-i` flag.


### PR DESCRIPTION
**Please provide a description of this PR:**

The `DefaultWatcher` in `pkg/revisions/default_watcher.go` uses a hardcoded name `istio-revision-tag-default` to find the default revision webhook. However, when Istio is installed in a namespace other than `istio-system` (via Helm with `--set global.istioNamespace=<custom-ns>` or `istioctl install --set values.global.istioNamespace=<custom-ns>`), the webhook is named `istio-revision-tag-default-<namespace>`. This causes the watcher to miss it entirely, and `RevisionOrDefault()` falls back to the literal string `"default"`, which then filters pods by `istio.io/rev=default` — matching nothing.

This affects **all** istioctl commands that omit `--revision`, including `version`, `proxy-status`, `admin log`, `describe`, `dashboard controlz`, `kube-inject`, `precheck`, and `proxy-config clusters`.

**The fix:** Change `NewDefaultWatcher` to accept an `istioNamespace` parameter and construct the expected webhook name deterministically based on the namespace. For `istio-system` (or empty), it uses the canonical name `istio-revision-tag-default`. For any other namespace, it uses `istio-revision-tag-default-<namespace>`. The `istioctl` CLI context passes its `-i` / `--istioNamespace` value through to the watcher.

**Changes:**
- `NewDefaultWatcher` now takes a `string` parameter `istioNamespace` instead of matching by label
- `istioctl/pkg/cli/context.go` passes `IstioNamespace()` to the watcher
- `pilot/pkg/leaderelection/leaderelection.go` passes `""` (canonical name behavior, no change in semantics)
- Added `TestDefaultRevisionWithCustomNamespace` and `TestDefaultRevisionWithIstioSystemNamespace` tests

**Testing:** Verified with `go run` against a live cluster with Istio installed in `custom-istio-system` — `istioctl version` correctly discovers istiod. All existing and new unit tests pass.

Fixes https://github.com/istio/istio/issues/60232