### PR TITLE
added quote function to namespace so numeric namespace values can be used

### DIFF
--- a/manifests/charts/base/templates/defaultrevision-validatingwebhookconfiguration.yaml
+++ b/manifests/charts/base/templates/defaultrevision-validatingwebhookconfiguration.yaml
@@ -23,7 +23,7 @@ webhooks:
         {{- else }}
         name: istiod-{{ .Values.defaultRevision }}
         {{- end }}
-        namespace: {{ .Values.global.istioNamespace }}
+        namespace: {{ .Values.global.istioNamespace | quote }}
         path: "/validate"
       {{- end }}
       {{- if .Values.base.validationCABundle }}

--- a/manifests/charts/base/templates/reader-serviceaccount.yaml
+++ b/manifests/charts/base/templates/reader-serviceaccount.yaml
@@ -13,7 +13,7 @@ imagePullSecrets:
     {{- end }}
 metadata:
   name: istio-reader-service-account
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace | quote }}
   labels:
     app: istio-reader
     release: {{ .Release.Name }}

--- a/manifests/charts/default/templates/mutatingwebhook.yaml
+++ b/manifests/charts/default/templates/mutatingwebhook.yaml
@@ -14,7 +14,7 @@
     {{- else }}
     service:
       name: istiod{{- if not (eq .revision "") }}-{{ .revision }}{{- end }}
-      namespace: {{ .namespace }}
+      namespace: {{ .namespace | quote }}
       path: "/inject"
     {{- end }}
   sideEffects: None

--- a/manifests/charts/default/templates/validatingwebhook.yaml
+++ b/manifests/charts/default/templates/validatingwebhook.yaml
@@ -20,7 +20,7 @@ webhooks:
       {{- else }}
       service:
         name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-        namespace: {{ .Values.global.istioNamespace }}
+        namespace: {{ .Values.global.istioNamespace | quote }}
         path: "/validate"
       {{- end }}
     rules:

--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: {{ .Values.kind | default "Deployment" }}
 metadata:
   name: {{ include "gateway.name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: {{ include "gateway.name" . }}
     {{- include "istio.labels" . | nindent 4}}

--- a/manifests/charts/gateway/templates/hpa.yaml
+++ b/manifests/charts/gateway/templates/hpa.yaml
@@ -3,7 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "gateway.name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: {{ include "gateway.name" . }}
     {{- include "istio.labels" . | nindent 4}}

--- a/manifests/charts/gateway/templates/networkpolicy.yaml
+++ b/manifests/charts/gateway/templates/networkpolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "gateway.name" . }}{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ include "gateway.name" . }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}

--- a/manifests/charts/gateway/templates/poddisruptionbudget.yaml
+++ b/manifests/charts/gateway/templates/poddisruptionbudget.yaml
@@ -5,7 +5,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "gateway.name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: {{ include "gateway.name" . }}
     {{- include "istio.labels" . | nindent 4}}

--- a/manifests/charts/gateway/templates/role.yaml
+++ b/manifests/charts/gateway/templates/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "gateway.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: {{ include "gateway.name" . }}
     {{- include "istio.labels" . | nindent 4}}
@@ -20,7 +20,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "gateway.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: {{ include "gateway.name" . }}
     {{- include "istio.labels" . | nindent 4}}

--- a/manifests/charts/gateway/templates/service.yaml
+++ b/manifests/charts/gateway/templates/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "gateway.name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: {{ include "gateway.name" . }}
     {{- include "istio.labels" . | nindent 4}}

--- a/manifests/charts/gateway/templates/serviceaccount.yaml
+++ b/manifests/charts/gateway/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "gateway.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: {{ include "gateway.name" . }}
     {{- include "istio.labels" . | nindent 4}}

--- a/manifests/charts/gateways/istio-egress/templates/autoscale.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/autoscale.yaml
@@ -4,7 +4,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ $gateway.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ $gateway.labels | toYaml | indent 4 }}
     release: {{ .Release.Name }}

--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $gateway.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ $gateway.labels | toYaml | indent 4 }}
     release: {{ .Release.Name }}

--- a/manifests/charts/gateways/istio-egress/templates/injected-deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/injected-deployment.yaml
@@ -8,7 +8,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $gateway.name | default "istio-egressgateway" }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ $gateway.labels | toYaml | indent 4 }}
     release: {{ .Release.Name }}

--- a/manifests/charts/gateways/istio-egress/templates/networkpolicy.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/networkpolicy.yaml
@@ -4,7 +4,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ $gateway.name }}{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ $gateway.name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}

--- a/manifests/charts/gateways/istio-egress/templates/poddisruptionbudget.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/poddisruptionbudget.yaml
@@ -6,7 +6,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ $gateway.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ $gateway.labels | toYaml | trim | indent 4 }}
     release: {{ .Release.Name }}

--- a/manifests/charts/gateways/istio-egress/templates/role.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ $gateway.name }}-sds
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}

--- a/manifests/charts/gateways/istio-egress/templates/rolebindings.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/rolebindings.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ $gateway.name }}-sds
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}

--- a/manifests/charts/gateways/istio-egress/templates/service.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $gateway.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   annotations:
     {{- range $key, $val := $gateway.serviceAnnotations }}
     {{ $key }}: {{ $val | quote }}

--- a/manifests/charts/gateways/istio-egress/templates/serviceaccount.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/serviceaccount.yaml
@@ -9,7 +9,7 @@ imagePullSecrets:
 {{- end }}
 metadata:
   name: {{ $gateway.name }}-service-account
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ $gateway.labels | toYaml | trim | indent 4 }}
     release: {{ .Release.Name }}

--- a/manifests/charts/gateways/istio-ingress/templates/autoscale.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/autoscale.yaml
@@ -4,7 +4,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ $gateway.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ $gateway.labels | toYaml | indent 4 }}
     release: {{ .Release.Name }}

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $gateway.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ $gateway.labels | toYaml | indent 4 }}
     release: {{ .Release.Name }}

--- a/manifests/charts/gateways/istio-ingress/templates/injected-deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/injected-deployment.yaml
@@ -8,7 +8,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $gateway.name | default "istio-ingressgateway" }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ $gateway.labels | toYaml | indent 4 }}
     release: {{ .Release.Name }}

--- a/manifests/charts/gateways/istio-ingress/templates/networkpolicy.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/networkpolicy.yaml
@@ -4,7 +4,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ $gateway.name }}{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ $gateway.name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}

--- a/manifests/charts/gateways/istio-ingress/templates/poddisruptionbudget.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/poddisruptionbudget.yaml
@@ -6,7 +6,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ $gateway.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ $gateway.labels | toYaml | trim | indent 4 }}
     release: {{ .Release.Name }}

--- a/manifests/charts/gateways/istio-ingress/templates/role.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ $gateway.name }}-sds
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}

--- a/manifests/charts/gateways/istio-ingress/templates/rolebindings.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/rolebindings.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ $gateway.name }}-sds
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}

--- a/manifests/charts/gateways/istio-ingress/templates/service.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $gateway.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   annotations:
     {{- range $key, $val := $gateway.serviceAnnotations }}
     {{ $key }}: {{ $val | quote }}

--- a/manifests/charts/gateways/istio-ingress/templates/serviceaccount.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/serviceaccount.yaml
@@ -9,7 +9,7 @@ imagePullSecrets:
 {{- end }}
 metadata:
   name: {{ $gateway.name }}-service-account
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ $gateway.labels | toYaml | trim | indent 4 }}
     release: {{ .Release.Name }}

--- a/manifests/charts/istio-cni/templates/clusterrolebinding.yaml
+++ b/manifests/charts/istio-cni/templates/clusterrolebinding.yaml
@@ -19,7 +19,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
 ---
 {{- if .Values.repair.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -37,7 +37,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ template "name" . }}
-  namespace: {{ .Release.Namespace}}
+  namespace: {{ .Release.Namespace | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -60,7 +60,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "name" . }}
-    namespace: {{ .Release.Namespace}}
+    namespace: {{ .Release.Namespace | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/charts/istio-cni/templates/configmap-cni.yaml
+++ b/manifests/charts/istio-cni/templates/configmap-cni.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: {{ template "name" . }}-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -20,7 +20,7 @@ metadata:
   # if this name is changed, CNI plugin logic that checks for this name
   # format should also be updated.
   name: {{ template "name" . }}-node
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     k8s-app: {{ template "name" . }}-node
     release: {{ .Release.Name }}

--- a/manifests/charts/istio-cni/templates/networkpolicy.yaml
+++ b/manifests/charts/istio-cni/templates/networkpolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ template "name" . }}{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     k8s-app: {{ template "name" . }}-node
     release: {{ .Release.Name }}

--- a/manifests/charts/istio-cni/templates/resourcequota.yaml
+++ b/manifests/charts/istio-cni/templates/resourcequota.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ResourceQuota
 metadata:
   name: {{ template "name" . }}-resource-quota
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: {{ template "name" . }}
     {{- include "istio.labels" . | nindent 4 }}

--- a/manifests/charts/istio-cni/templates/serviceaccount.yaml
+++ b/manifests/charts/istio-cni/templates/serviceaccount.yaml
@@ -9,7 +9,7 @@ imagePullSecrets:
 {{- end }}
 metadata:
   name: {{ template "name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}

--- a/manifests/charts/istio-control/istio-discovery/templates/autoscale.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/autoscale.yaml
@@ -6,7 +6,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: istiod
     release: {{ .Release.Name }}

--- a/manifests/charts/istio-control/istio-discovery/templates/clusterrolebinding.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/clusterrolebinding.yaml
@@ -18,7 +18,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: istiod{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}
-    namespace: {{ .Values.global.istioNamespace }}
+    namespace: {{ .Values.global.istioNamespace | quote }}
 ---
 {{- if not (eq (toString .Values.env.PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER) "false") }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -37,7 +37,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: istiod{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace | quote }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/configmap-jwks.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap-jwks.yaml
@@ -6,7 +6,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: pilot-jwks-extra-cacerts{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     release: {{ .Release.Name }}
     istio.io/rev: {{ .Values.revision | default "default" | quote }}

--- a/manifests/charts/istio-control/istio-discovery/templates/configmap-values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap-values.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: values{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   annotations:
     kubernetes.io/description: This ConfigMap contains the Helm values used during chart rendering. This ConfigMap is rendered for debugging purposes and external tooling; modifying these values has no effect.
   labels:

--- a/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
@@ -7,7 +7,7 @@
     # When processing a leaf namespace Istio will search for declarations in that namespace first
     # and if none are found it will search in the root namespace. Any matching declaration found in the root namespace
     # is processed as if it were declared in the leaf namespace.
-    rootNamespace: {{ .Values.meshConfig.rootNamespace | default .Values.global.istioNamespace }}
+    rootNamespace: {{ (.Values.meshConfig.rootNamespace | default .Values.global.istioNamespace) | quote }}
 
   {{ $prom := include "default-prometheus" . | eq "true" }}
   {{ $sdMetrics := include "default-sd-metrics" . | eq "true" }}
@@ -84,7 +84,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: istio{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -5,7 +5,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}

--- a/manifests/charts/istio-control/istio-discovery/templates/gateway-class-configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/gateway-class-configmap.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: istio-{{ $.Values.revision | default "default"  }}-gatewayclass-{{$key}}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ $.Release.Namespace | quote }}
   labels:
     istio.io/rev: {{ $.Values.revision | default "default" | quote }}
     install.operator.istio.io/owning-resource: {{ $.Values.ownerName | default "unknown" }}

--- a/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: istio-sidecar-injector{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}

--- a/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -18,7 +18,7 @@ a unique prefix to each. */}}
     {{- else }}
     service:
       name: istiod{{- if not (eq .revision "") }}-{{ .revision }}{{- end }}
-      namespace: {{ .namespace }}
+      namespace: {{ .namespace | quote }}
       path: "{{ .injectionPath }}"
       port: 443
     {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/networkpolicy.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/networkpolicy.yaml
@@ -4,7 +4,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}

--- a/manifests/charts/istio-control/istio-discovery/templates/poddisruptionbudget.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/poddisruptionbudget.yaml
@@ -8,7 +8,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: istiod
     istio.io/rev: {{ .Values.revision | default "default" | quote }}

--- a/manifests/charts/istio-control/istio-discovery/templates/reader-clusterrolebinding.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/reader-clusterrolebinding.yaml
@@ -20,6 +20,6 @@ subjects:
     namespace: {{ dig "global" "readerServiceAccount" "namespace" "" .Values }}
 {{- else }}
     name: istio-reader-service-account
-    namespace: {{ .Values.global.istioNamespace }}
+    namespace: {{ .Values.global.istioNamespace | quote }}
 {{- end }}
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/remote-istiod-endpointslices.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/remote-istiod-endpointslices.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- else }}
   name: istiod{{- if .Values.revision }}-{{ .Values.revision}}{{- end }}
   {{- end }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- if .Values.istiodRemote.enabledLocalInjectorIstiod }}
     # only primary `istiod` to xds and local `istiod` injection installs.

--- a/manifests/charts/istio-control/istio-discovery/templates/remote-istiod-service.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/remote-istiod-service.yaml
@@ -10,7 +10,7 @@ metadata:
   {{- else }}
   name: istiod{{- if .Values.revision }}-{{ .Values.revision}}{{- end }}
   {{- end }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" | quote }}
     app.kubernetes.io/name: "istiod"

--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags-mwc.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags-mwc.yaml
@@ -19,7 +19,7 @@ a unique prefix to each. */}}
     {{- else }}
     service:
       name: istiod{{- if not (eq .revision "") }}-{{ .revision }}{{- end }}
-      namespace: {{ .namespace }}
+      namespace: {{ .namespace | quote }}
       path: "{{ .injectionPath }}"
       port: 443
     {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags-svc.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags-svc.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: istiod-revision-tag-{{ $tagName }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ $.Release.Namespace | quote }}
   {{- if $.Values.serviceAnnotations }}
   annotations:
 {{ toYaml $.Values.serviceAnnotations | indent 4 }}

--- a/manifests/charts/istio-control/istio-discovery/templates/role.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/role.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: istiod{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace | quote }}
   labels:
     app: istiod
     release: {{ .Release.Name }}

--- a/manifests/charts/istio-control/istio-discovery/templates/rolebinding.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/rolebinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: istiod{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace | quote }}
   labels:
     app: istiod
     release: {{ .Release.Name }}
@@ -18,6 +18,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-    namespace: {{ .Values.global.istioNamespace }}
+    namespace: {{ .Values.global.istioNamespace | quote }}
 {{- end }}
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/service.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/service.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   {{- if .Values.serviceAnnotations }}
   annotations:
 {{ toYaml .Values.serviceAnnotations | indent 4 }}

--- a/manifests/charts/istio-control/istio-discovery/templates/serviceaccount.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/serviceaccount.yaml
@@ -11,7 +11,7 @@ imagePullSecrets:
   {{- end }}
 metadata:
   name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace | quote }}
   labels:
     app: istiod
     release: {{ .Release.Name }}

--- a/manifests/charts/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
@@ -24,7 +24,7 @@ webhooks:
       {{- else }}
       service:
         name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-        namespace: {{ .Values.global.istioNamespace }}
+        namespace: {{ .Values.global.istioNamespace | quote }}
         path: "/validate"
       {{- end }}
       {{- if .Values.base.validationCABundle }}

--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "ztunnel.release-name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: ztunnel
     {{- include "istio.labels" . | nindent 4}}

--- a/manifests/charts/ztunnel/templates/networkpolicy.yaml
+++ b/manifests/charts/ztunnel/templates/networkpolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "ztunnel.release-name" . }}{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: ztunnel
     app.kubernetes.io/name: ztunnel

--- a/manifests/charts/ztunnel/templates/rbac.yaml
+++ b/manifests/charts/ztunnel/templates/rbac.yaml
@@ -47,7 +47,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "ztunnel.release-name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
 {{- end }}
 ---
 {{- end }}

--- a/manifests/charts/ztunnel/templates/resourcequota.yaml
+++ b/manifests/charts/ztunnel/templates/resourcequota.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ResourceQuota
 metadata:
   name: {{ include "ztunnel.release-name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: ztunnel
     {{- include "istio.labels" . | nindent 4}}

--- a/manifests/charts/ztunnel/templates/serviceaccount.yaml
+++ b/manifests/charts/ztunnel/templates/serviceaccount.yaml
@@ -9,7 +9,7 @@ imagePullSecrets:
   {{- end }}
 metadata:
   name: {{ include "ztunnel.release-name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: ztunnel
     {{- include "istio.labels" . | nindent 4}}

--- a/operator/pkg/helm/testdata/output/base-webhook-cabundle-policy.golden.yaml
+++ b/operator/pkg/helm/testdata/output/base-webhook-cabundle-policy.golden.yaml
@@ -18,7 +18,7 @@ webhooks:
     clientConfig:
       service:
         name: istiod
-        namespace: istio-system
+        namespace: "istio-system"
         path: "/validate"
       caBundle: "dGVzdC1jYQ=="
     rules:

--- a/operator/pkg/helm/testdata/output/base-webhook-failure-policy.golden.yaml
+++ b/operator/pkg/helm/testdata/output/base-webhook-failure-policy.golden.yaml
@@ -18,7 +18,7 @@ webhooks:
     clientConfig:
       service:
         name: istiod
-        namespace: istio-system
+        namespace: "istio-system"
         path: "/validate"
     rules:
       - operations:

--- a/operator/pkg/helm/testdata/output/base-webhook-install.golden.yaml
+++ b/operator/pkg/helm/testdata/output/base-webhook-install.golden.yaml
@@ -18,7 +18,7 @@ webhooks:
     clientConfig:
       service:
         name: istiod
-        namespace: istio-system
+        namespace: "istio-system"
         path: "/validate"
     rules:
       - operations:

--- a/operator/pkg/helm/testdata/output/base-webhook-upgrade-failure-policy.golden.yaml
+++ b/operator/pkg/helm/testdata/output/base-webhook-upgrade-failure-policy.golden.yaml
@@ -18,7 +18,7 @@ webhooks:
     clientConfig:
       service:
         name: istiod
-        namespace: istio-system
+        namespace: "istio-system"
         path: "/validate"
     rules:
       - operations:

--- a/operator/pkg/helm/testdata/output/base-webhook-upgrade-ignore.golden.yaml
+++ b/operator/pkg/helm/testdata/output/base-webhook-upgrade-ignore.golden.yaml
@@ -18,7 +18,7 @@ webhooks:
     clientConfig:
       service:
         name: istiod
-        namespace: istio-system
+        namespace: "istio-system"
         path: "/validate"
     rules:
       - operations:

--- a/operator/pkg/helm/testdata/output/base-webhook-upgrade.golden.yaml
+++ b/operator/pkg/helm/testdata/output/base-webhook-upgrade.golden.yaml
@@ -18,7 +18,7 @@ webhooks:
     clientConfig:
       service:
         name: istiod
-        namespace: istio-system
+        namespace: "istio-system"
         path: "/validate"
     rules:
       - operations:

--- a/operator/pkg/helm/testdata/output/gateway-additional-containers.golden.yaml
+++ b/operator/pkg/helm/testdata/output/gateway-additional-containers.golden.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: istio-ingress
-  namespace: istio-ingress
+  namespace: "istio-ingress"
   labels:
     app.kubernetes.io/name: istio-ingress
     app.kubernetes.io/managed-by: "Helm"

--- a/operator/pkg/helm/testdata/output/gateway-deployment.golden.yaml
+++ b/operator/pkg/helm/testdata/output/gateway-deployment.golden.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: istio-ingress
-  namespace: istio-ingress
+  namespace: "istio-ingress"
   labels:
     app.kubernetes.io/name: istio-ingress
     app.kubernetes.io/managed-by: "Helm"

--- a/operator/pkg/helm/testdata/output/gateway-dns-config.golden.yaml
+++ b/operator/pkg/helm/testdata/output/gateway-dns-config.golden.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: istio-ingress
-  namespace: istio-ingress
+  namespace: "istio-ingress"
   labels:
     app.kubernetes.io/name: istio-ingress
     app.kubernetes.io/managed-by: "Helm"

--- a/operator/pkg/helm/testdata/output/gateway-env-var-from.golden.yaml
+++ b/operator/pkg/helm/testdata/output/gateway-env-var-from.golden.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: istio-ingress
-  namespace: istio-ingress
+  namespace: "istio-ingress"
   labels:
     app.kubernetes.io/name: istio-ingress
     app.kubernetes.io/managed-by: "Helm"

--- a/operator/pkg/helm/testdata/output/gateway-init-containers.golden.yaml
+++ b/operator/pkg/helm/testdata/output/gateway-init-containers.golden.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: istio-ingress
-  namespace: istio-ingress
+  namespace: "istio-ingress"
   labels:
     app.kubernetes.io/name: istio-ingress
     app.kubernetes.io/managed-by: "Helm"

--- a/operator/pkg/helm/testdata/output/gateway-network-gateway-default.golden.yaml
+++ b/operator/pkg/helm/testdata/output/gateway-network-gateway-default.golden.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: istio-eastwest
-  namespace: istio-system
+  namespace: "istio-system"
   labels:
     app.kubernetes.io/name: istio-eastwest
     app.kubernetes.io/managed-by: "Helm"

--- a/operator/pkg/helm/testdata/output/gateway-network-gateway-port-override.golden.yaml
+++ b/operator/pkg/helm/testdata/output/gateway-network-gateway-port-override.golden.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: istio-eastwest
-  namespace: istio-system
+  namespace: "istio-system"
   labels:
     app.kubernetes.io/name: istio-eastwest
     app.kubernetes.io/managed-by: "Helm"

--- a/operator/pkg/helm/testdata/output/gateway-pdb-2replicas.golden.yaml
+++ b/operator/pkg/helm/testdata/output/gateway-pdb-2replicas.golden.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: istio-ingress
-  namespace: istio-ingress
+  namespace: "istio-ingress"
   labels:
     app.kubernetes.io/name: istio-ingress
     app.kubernetes.io/managed-by: "Helm"

--- a/operator/pkg/helm/testdata/output/gateway-pdb-autoscaleMin2.golden.yaml
+++ b/operator/pkg/helm/testdata/output/gateway-pdb-autoscaleMin2.golden.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: istio-ingress
-  namespace: istio-ingress
+  namespace: "istio-ingress"
   labels:
     app.kubernetes.io/name: istio-ingress
     app.kubernetes.io/managed-by: "Helm"

--- a/operator/pkg/helm/testdata/output/gateway-service-default.golden.yaml
+++ b/operator/pkg/helm/testdata/output/gateway-service-default.golden.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: istio-ingress
-  namespace: istio-ingress
+  namespace: "istio-ingress"
   labels:
     app.kubernetes.io/name: istio-ingress
     app.kubernetes.io/managed-by: "Helm"

--- a/operator/pkg/helm/testdata/output/gateway-service-selector-labels.golden.yaml
+++ b/operator/pkg/helm/testdata/output/gateway-service-selector-labels.golden.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: istio-ingress
-  namespace: istio-ingress
+  namespace: "istio-ingress"
   labels:
     app.kubernetes.io/name: istio-ingress
     app.kubernetes.io/managed-by: "Helm"

--- a/operator/pkg/helm/testdata/output/istiod-pdb-2replicas.golden.yaml
+++ b/operator/pkg/helm/testdata/output/istiod-pdb-2replicas.golden.yaml
@@ -4,7 +4,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: istiod
-  namespace: istio-system
+  namespace: "istio-system"
   labels:
     app: istiod
     istio.io/rev: "default"

--- a/operator/pkg/helm/testdata/output/istiod-pdb-autoscaleMin2.golden.yaml
+++ b/operator/pkg/helm/testdata/output/istiod-pdb-autoscaleMin2.golden.yaml
@@ -4,7 +4,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: istiod
-  namespace: istio-system
+  namespace: "istio-system"
   labels:
     app: istiod
     istio.io/rev: "default"

--- a/operator/pkg/helm/testdata/output/istiod-pdb-max-unavailable.golden.yaml
+++ b/operator/pkg/helm/testdata/output/istiod-pdb-max-unavailable.golden.yaml
@@ -4,7 +4,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: istiod
-  namespace: istio-system
+  namespace: "istio-system"
   labels:
     app: istiod
     istio.io/rev: "default"

--- a/operator/pkg/helm/testdata/output/istiod-pdb-unhealthy-pod-eviction-policy.golden.yaml
+++ b/operator/pkg/helm/testdata/output/istiod-pdb-unhealthy-pod-eviction-policy.golden.yaml
@@ -4,7 +4,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: istiod
-  namespace: istio-system
+  namespace: "istio-system"
   labels:
     app: istiod
     istio.io/rev: "default"

--- a/operator/pkg/helm/testdata/output/istiod-traffic-distribution.golden.yaml
+++ b/operator/pkg/helm/testdata/output/istiod-traffic-distribution.golden.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: istiod
-  namespace: istio-system
+  namespace: "istio-system"
   labels:
     istio.io/rev: "default"
     install.operator.istio.io/owning-resource: unknown

--- a/operator/pkg/helm/testdata/output/istiod-waypoint-workload-socket.golden.yaml
+++ b/operator/pkg/helm/testdata/output/istiod-waypoint-workload-socket.golden.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: istio-sidecar-injector
-  namespace: istio-system
+  namespace: "istio-system"
   labels:
     istio.io/rev: "default"
     install.operator.istio.io/owning-resource: unknown

--- a/operator/pkg/helm/testdata/output/istiod-webhook-cabundle-policy.golden.yaml
+++ b/operator/pkg/helm/testdata/output/istiod-webhook-cabundle-policy.golden.yaml
@@ -22,7 +22,7 @@ webhooks:
       # Should change from base but cannot for API compat
       service:
         name: istiod
-        namespace: istio-system
+        namespace: "istio-system"
         path: "/validate"
       caBundle: "dGVzdC1jYQ=="
     rules:

--- a/operator/pkg/helm/testdata/output/istiod-webhook-failure-policy.golden.yaml
+++ b/operator/pkg/helm/testdata/output/istiod-webhook-failure-policy.golden.yaml
@@ -22,7 +22,7 @@ webhooks:
       # Should change from base but cannot for API compat
       service:
         name: istiod
-        namespace: istio-system
+        namespace: "istio-system"
         path: "/validate"
     rules:
       - operations:

--- a/operator/pkg/helm/testdata/output/istiod-webhook-install.golden.yaml
+++ b/operator/pkg/helm/testdata/output/istiod-webhook-install.golden.yaml
@@ -22,7 +22,7 @@ webhooks:
       # Should change from base but cannot for API compat
       service:
         name: istiod
-        namespace: istio-system
+        namespace: "istio-system"
         path: "/validate"
     rules:
       - operations:

--- a/operator/pkg/helm/testdata/output/istiod-webhook-upgrade-failure-policy.golden.yaml
+++ b/operator/pkg/helm/testdata/output/istiod-webhook-upgrade-failure-policy.golden.yaml
@@ -22,7 +22,7 @@ webhooks:
       # Should change from base but cannot for API compat
       service:
         name: istiod
-        namespace: istio-system
+        namespace: "istio-system"
         path: "/validate"
     rules:
       - operations:

--- a/operator/pkg/helm/testdata/output/istiod-webhook-upgrade-ignore.golden.yaml
+++ b/operator/pkg/helm/testdata/output/istiod-webhook-upgrade-ignore.golden.yaml
@@ -22,7 +22,7 @@ webhooks:
       # Should change from base but cannot for API compat
       service:
         name: istiod
-        namespace: istio-system
+        namespace: "istio-system"
         path: "/validate"
     rules:
       - operations:

--- a/operator/pkg/helm/testdata/output/istiod-webhook-upgrade.golden.yaml
+++ b/operator/pkg/helm/testdata/output/istiod-webhook-upgrade.golden.yaml
@@ -22,7 +22,7 @@ webhooks:
       # Should change from base but cannot for API compat
       service:
         name: istiod
-        namespace: istio-system
+        namespace: "istio-system"
         path: "/validate"
     rules:
       - operations:

--- a/operator/pkg/helm/testdata/output/ztunnel-dns-config.golden.yaml
+++ b/operator/pkg/helm/testdata/output/ztunnel-dns-config.golden.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: ztunnel
-  namespace: istio-system
+  namespace: "istio-system"
   labels:
     app.kubernetes.io/name: ztunnel
     app.kubernetes.io/managed-by: "Helm"

--- a/releasenotes/notes/60239.yaml
+++ b/releasenotes/notes/60239.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+  - 60239
+releaseNotes:
+- |
+  **Fixed** Helm chart rendering when `global.istioNamespace` or the release namespace is numeric-only (for example, `1234`). Namespace fields in rendered manifests are now quoted so YAML parsers treat them as strings instead of numbers.

--- a/tests/integration/helm/install_test.go
+++ b/tests/integration/helm/install_test.go
@@ -37,6 +37,8 @@ import (
 	"istio.io/istio/tests/util/sanitycheck"
 )
 
+const numericNamespaceInstallEnvVar = "ISTIO_TEST_HELM_NUMERIC_NAMESPACE"
+
 // TestDefaultInstall tests Istio installation using Helm with default options
 func TestDefaultInstall(t *testing.T) {
 	values := map[string]interface{}{
@@ -209,6 +211,37 @@ func TestNativeNftablesInstall(t *testing.T) {
 	framework.
 		NewTest(t).
 		Run(setupInstallation(values, false, DefaultNamespaceConfig, ""))
+}
+
+// TestNumericNamespaceInstall verifies Helm install when the control-plane namespace is numeric-only.
+// Such names must remain strings in rendered manifests (e.g. YAML fields that would otherwise parse as numbers).
+//
+// This test is opt-in only. Set ISTIO_TEST_HELM_NUMERIC_NAMESPACE=1 to run it, as conflicts with other tests due to CRD/CR owner references.
+func TestNumericNamespaceInstall(t *testing.T) {
+	if os.Getenv(numericNamespaceInstallEnvVar) != "1" {
+		t.Skipf("Skipping TestNumericNamespaceInstall; set %s=1 to run", numericNamespaceInstallEnvVar)
+	}
+
+	numericNS := "123456"
+	nsConfig := NewNamespaceConfig(
+		types.NamespacedName{Name: BaseReleaseName, Namespace: numericNS},
+		types.NamespacedName{Name: IstiodReleaseName, Namespace: numericNS},
+		types.NamespacedName{Name: IngressReleaseName, Namespace: numericNS},
+	)
+	values := map[string]interface{}{
+		"global": map[string]interface{}{
+			"istioNamespace": numericNS,
+		},
+		// Gateway injection sets CA_ADDR from global.istioNamespace, but xDS uses
+		// proxyConfig.DiscoveryAddress which defaults to istiod.istio-system.svc when
+		// PROXY_CONFIG is empty. Set discoveryAddress explicitly for non-istio-system installs.
+		"podAnnotations": map[string]interface{}{
+			"proxy.istio.io/config": fmt.Sprintf(`{"discoveryAddress":"istiod.%s.svc:15012"}`, numericNS),
+		},
+	}
+	framework.
+		NewTest(t).
+		Run(setupInstallation(values, false, nsConfig, ""))
 }
 
 // nolint: unparam


### PR DESCRIPTION
Fixes #60239

Istio operator fails to install charts that have a number as a namespace, quoting should fix this
- https://github.com/istio-ecosystem/sail-operator/issues/1957
