### PR TITLE
feat(helm): add ztunnel xDS unhealthy threshold value

### DIFF
--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -119,6 +119,10 @@ spec:
         {{- else }}
           value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.istioNamespace }}.svc:15012
         {{- end }}
+        {{- if and .Values.xdsUnhealthyThreshold (not (hasKey (.Values.env | default dict) "XDS_UNHEALTHY_THRESHOLD")) }}
+        - name: XDS_UNHEALTHY_THRESHOLD
+          value: {{ .Values.xdsUnhealthyThreshold | quote }}
+        {{- end }}
         {{- if .Values.logAsJson }}
         - name: LOG_FORMAT
           value: json

--- a/manifests/charts/ztunnel/values.yaml
+++ b/manifests/charts/ztunnel/values.yaml
@@ -113,6 +113,12 @@ _internal_defaults_do_not_set:
   # By default, it is istiod.istio-system.svc:15012 if revision is not set, or istiod-<revision>.<istioNamespace>.svc:15012
   xdsAddress: ""
 
+  # Duration after xDS disconnect before ztunnel readiness reports unhealthy.
+  # Leave empty to preserve the existing behavior where readiness is not re-armed after initial sync.
+  # Valid examples: "5m", "300s", "1h".
+  # This renders XDS_UNHEALTHY_THRESHOLD; env.XDS_UNHEALTHY_THRESHOLD takes precedence if set.
+  xdsUnhealthyThreshold: ""
+
   # Used to locate the XDS and CA, if caAddress or xdsAddress are not set.
   istioNamespace: istio-system
 

--- a/operator/pkg/helm/helm_test.go
+++ b/operator/pkg/helm/helm_test.go
@@ -366,3 +366,52 @@ func TestRender(t *testing.T) {
 		})
 	}
 }
+
+func renderManifestString(t *testing.T, releaseName, namespace, chartName string, vals values.Map, diffSelect string) string {
+	t.Helper()
+	m, _, err := renderWithOptions(releaseName, namespace, chartName, vals, false)
+	require.NoError(t, err)
+
+	b := strings.Builder{}
+	for _, mf := range m {
+		b.WriteString(mf.Content)
+		b.WriteString("\n---\n")
+	}
+	got := b.String()
+	if diffSelect != "" {
+		got = operatortest.FilterManifest(t, got, diffSelect)
+	}
+	return got
+}
+
+func TestZtunnelXdsUnhealthyThreshold(t *testing.T) {
+	data := []byte(`
+spec:
+  values:
+    xdsUnhealthyThreshold: 5m
+`)
+	var vals values.Map
+	require.NoError(t, yaml.Unmarshal(data, &vals))
+
+	got := renderManifestString(t, "ztunnel", "istio-system", "ztunnel", vals, "DaemonSet:*:ztunnel")
+
+	require.Contains(t, got, "- name: XDS_UNHEALTHY_THRESHOLD\n          value: \"5m\"")
+}
+
+func TestZtunnelXdsUnhealthyThresholdEnvOverride(t *testing.T) {
+	data := []byte(`
+spec:
+  values:
+    xdsUnhealthyThreshold: 5m
+    env:
+      XDS_UNHEALTHY_THRESHOLD: 10m
+`)
+	var vals values.Map
+	require.NoError(t, yaml.Unmarshal(data, &vals))
+
+	got := renderManifestString(t, "ztunnel", "istio-system", "ztunnel", vals, "DaemonSet:*:ztunnel")
+
+	require.Contains(t, got, "- name: XDS_UNHEALTHY_THRESHOLD\n          value: \"10m\"")
+	require.NotContains(t, got, "- name: XDS_UNHEALTHY_THRESHOLD\n          value: \"5m\"")
+	require.Equal(t, 1, strings.Count(got, "name: XDS_UNHEALTHY_THRESHOLD"))
+}

--- a/releasenotes/notes/ztunnel-xds-unhealthy-threshold-helm.yaml
+++ b/releasenotes/notes/ztunnel-xds-unhealthy-threshold-helm.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+
+releaseNotes:
+  - |
+    **Added** `xdsUnhealthyThreshold` to the ztunnel Helm chart to configure the `XDS_UNHEALTHY_THRESHOLD` readiness re-arm setting.


### PR DESCRIPTION
## Description

Adds `xdsUnhealthyThreshold` to the ztunnel Helm chart so operators can configure the `XDS_UNHEALTHY_THRESHOLD` readiness re-arm setting through Helm values.

When `values.xdsUnhealthyThreshold` is set, the ztunnel DaemonSet renders `XDS_UNHEALTHY_THRESHOLD` with that duration. If `values.env.XDS_UNHEALTHY_THRESHOLD` is already set, the explicit environment override takes precedence and the chart does not render a duplicate value.

Related ztunnel implementation: [istio/ztunnel#1910](https://github.com/istio/ztunnel/pull/1910)

## Changes

- Added `xdsUnhealthyThreshold` to the ztunnel chart values with examples and precedence notes.
- Rendered `XDS_UNHEALTHY_THRESHOLD` in the ztunnel DaemonSet when the new Helm value is configured.
- Added Helm rendering coverage for the new value and for `env.XDS_UNHEALTHY_THRESHOLD` override behavior.
- Added a release note for the new installation option.

---