### PR TITLE
fix: Avoid wrong control-plane ownership when default revision tags use custom Istio namespaces

### DIFF
--- a/pkg/revisions/tag_watcher.go
+++ b/pkg/revisions/tag_watcher.go
@@ -53,19 +53,24 @@ type tagWatcher struct {
 	revision string
 	handlers []TagHandler
 
-	namespaces    kclient.Client[*corev1.Namespace]
-	queue         controllers.Queue
-	webhooks      kclient.Client[*admissionregistrationv1.MutatingWebhookConfiguration]
-	vWebhooks     kclient.Client[*admissionregistrationv1.ValidatingWebhookConfiguration]
-	services      kclient.Client[*corev1.Service]
-	webhooksIndex kclient.Index[string, *admissionregistrationv1.MutatingWebhookConfiguration]
-	servicesIndex kclient.Index[string, *corev1.Service]
+	namespaces                    kclient.Client[*corev1.Namespace]
+	queue                         controllers.Queue
+	webhooks                      kclient.Client[*admissionregistrationv1.MutatingWebhookConfiguration]
+	vWebhooks                     kclient.Client[*admissionregistrationv1.ValidatingWebhookConfiguration]
+	services                      kclient.Client[*corev1.Service]
+	webhooksIndex                 kclient.Index[string, *admissionregistrationv1.MutatingWebhookConfiguration]
+	servicesIndex                 kclient.Index[string, *corev1.Service]
+	defaultTagMutatingWebhookName string
 }
 
 func NewTagWatcher(client kube.Client, revision string, systemNamespace string) TagWatcher {
 	log.Debugf("Creating tag watcher for revision %s in namespace %s", revision, systemNamespace)
 	p := &tagWatcher{
-		revision: revision,
+		revision:                      revision,
+		defaultTagMutatingWebhookName: defaultTagMutatingWebhookName,
+	}
+	if systemNamespace != "" && systemNamespace != "istio-system" {
+		p.defaultTagMutatingWebhookName += "-" + systemNamespace
 	}
 	p.queue = controllers.NewQueue("tag", controllers.WithReconciler(func(key types.NamespacedName) error {
 		p.notifyHandlers()
@@ -143,7 +148,7 @@ func (p *tagWatcher) IsMine(obj metav1.ObjectMeta) bool {
 	// Figure out if there is a default tag that doesn't point to us
 	var otherDefaultTagExists bool
 	if !myTags.Contains("default") {
-		defaultTag := p.webhooks.Get(defaultTagMutatingWebhookName, "")
+		defaultTag := p.webhooks.Get(p.defaultTagMutatingWebhookName, "")
 		otherDefaultTagExists = defaultTag != nil
 	}
 	var weAreDefaultRevision bool
@@ -187,7 +192,7 @@ func (p *tagWatcher) notifyHandlers() {
 		if !myTags.Contains("default") && currentDefaultRevision.Labels[label.IoIstioRev.Name] == p.revision {
 			// Check and see if there is a tag named "default" that doesn't point to us
 			// This isn't valid (except maybe for a short time during a transition), so log a warning
-			defaultTag := p.webhooks.Get(defaultTagMutatingWebhookName, "")
+			defaultTag := p.webhooks.Get(p.defaultTagMutatingWebhookName, "")
 			if defaultTag != nil {
 				log.Warnf("Default revision is %s, but there is a tag named 'default' pointing to revision %s. " +
 					"If using a default tag, do not set the default revision to a different value")

--- a/pkg/revisions/tag_watcher_test.go
+++ b/pkg/revisions/tag_watcher_test.go
@@ -89,14 +89,54 @@ func TestTagWatcher(t *testing.T) {
 	assert.Equal(t, tw.GetMyTags(), sets.New("revision", "tag-mwc-foo", "tag-svc-foo", "shared-tag"))
 }
 
+func TestTagWatcherDefaultTagInCustomNamespaceTakesPrecedence(t *testing.T) {
+	c := kube.NewFakeClient()
+	tw := NewTagWatcher(c, "default-revision", "custom-istio-ns").(*tagWatcher)
+	namespaces := clienttest.Wrap(t, tw.namespaces)
+	whs := clienttest.Wrap(t, tw.webhooks)
+	vwhs := clienttest.Wrap(t, tw.vWebhooks)
+	stop := test.NewStop(t)
+	c.RunAndWait(stop)
+	go tw.Run(stop)
+	kube.WaitForCacheSync("test", stop, tw.HasSynced)
+
+	namespaces.Create(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "app",
+		},
+	})
+	vwhs.Create(makeDefaultRevision("default-revision"))
+	whs.Create(makeTagWithName("other-revision", "default", "istio-revision-tag-default-custom-istio-ns"))
+
+	assert.EventuallyEqual(t, func() bool {
+		return tw.IsMine(metav1.ObjectMeta{Namespace: "app"})
+	}, false)
+}
+
 func makeTag(revision string, tg string) *admissionregistrationv1.MutatingWebhookConfiguration {
+	return makeTagWithName(revision, tg, tg)
+}
+
+func makeTagWithName(revision, tg, name string) *admissionregistrationv1.MutatingWebhookConfiguration {
 	return &admissionregistrationv1.MutatingWebhookConfiguration{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: tg,
+			Name: name,
 			Labels: map[string]string{
 				label.IoIstioRev.Name: revision,
 				label.IoIstioTag.Name: tg,
+			},
+		},
+	}
+}
+
+func makeDefaultRevision(revision string) *admissionregistrationv1.ValidatingWebhookConfiguration {
+	return &admissionregistrationv1.ValidatingWebhookConfiguration{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: defaultRevisionValidatingWebhookName,
+			Labels: map[string]string{
+				label.IoIstioRev.Name: revision,
 			},
 		},
 	}


### PR DESCRIPTION
fix: Avoid wrong control-plane ownership when default revision tags use custom Istio namespaces

**Please provide a description of this PR:**

Issue Trigger Scenario
Istio is installed in a custom control-plane namespace, for example custom-istio-ns, with a default revision tag. In this setup, the default tag webhook is named:  istio-revision-tag-default-custom-istio-ns
  But TagWatcher still looked for the hardcoded canonical name:  istio-revision-tag-default

  Failure Symptom
  TagWatcher.IsMine() can incorrectly decide that unlabelled resources belong to the default revision, even when the default tag in the custom namespace  points to another revision.
  This can cause the wrong control plane to process Gateway, ListenerSet, Ingress, or status-related resources.



  Root Cause
  The webhook naming rule depends on the Istio namespace, but TagWatcher used a hardcoded webhook name when checking whether another default tag exists.
  When a default revision tag exists, it must take precedence over the default revision. In a custom Istio namespace, TagWatcher should look for:  istio-revision-tag-default-<namespace>