### PR TITLE
fix resource name logic for external sds provider at gateway

### DIFF
--- a/pilot/pkg/networking/core/gateway_simulation_test.go
+++ b/pilot/pkg/networking/core/gateway_simulation_test.go
@@ -2500,5 +2500,4 @@ spec:
 	if clusterName != expectedCluster {
 		t.Errorf("expected cluster %q, got %q", expectedCluster, clusterName)
 	}
-
 }

--- a/pilot/pkg/networking/core/gateway_simulation_test.go
+++ b/pilot/pkg/networking/core/gateway_simulation_test.go
@@ -17,6 +17,9 @@ package core_test
 import (
 	"testing"
 
+	auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+
+	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/simulation"
@@ -24,6 +27,7 @@ import (
 	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/env"
 	"istio.io/istio/pkg/test/util/tmpl"
@@ -2373,4 +2377,128 @@ spec:
 			},
 		})
 	})
+}
+
+func TestGatewayExternalSDSProviderSimulation(t *testing.T) {
+	mc := mesh.DefaultMeshConfig()
+	mc.ExtensionProviders = append(mc.ExtensionProviders, &meshconfig.MeshConfig_ExtensionProvider{
+		Name: "my-sds-provider",
+		Provider: &meshconfig.MeshConfig_ExtensionProvider_Sds{
+			Sds: &meshconfig.MeshConfig_ExtensionProvider_SDSProvider{
+				Name:    "my-sds-provider",
+				Service: "sds-provider.sds-system.svc.cluster.local",
+				Port:    8443,
+			},
+		},
+	})
+
+	configStr := `
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: external-sds-gateway
+  namespace: istio-system
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 443
+      name: https
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      credentialName: "sds://my-sds-provider"
+    hosts:
+    - "secure.example.com"
+---
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: secure-vs
+  namespace: istio-system
+spec:
+  hosts:
+  - "secure.example.com"
+  gateways:
+  - external-sds-gateway
+  http:
+  - route:
+    - destination:
+        host: backend.default.svc.cluster.local
+        port:
+          number: 80
+---
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: sds-provider
+  namespace: istio-system
+spec:
+  hosts:
+  - "sds-provider.sds-system.svc.cluster.local"
+  ports:
+  - number: 8443
+    name: grpc
+    protocol: GRPC
+  resolution: STATIC
+  location: MESH_INTERNAL
+  endpoints:
+  - address: 10.0.0.100
+`
+
+	proxy := &model.Proxy{
+		Labels: map[string]string{"istio": "ingressgateway"},
+		Metadata: &model.NodeMetadata{
+			Labels:    map[string]string{"istio": "ingressgateway"},
+			Namespace: "istio-system",
+		},
+		Type: model.Router,
+	}
+
+	o := xds.FakeOptions{
+		ConfigString: configStr,
+		MeshConfig:   mc,
+	}
+
+	s := xds.NewFakeDiscoveryServer(t, o)
+	sim := simulation.NewSimulation(t, s, s.SetupProxy(proxy))
+
+	// Verify the listener was created
+	l := xdstest.ExtractListener("0.0.0.0_443", sim.Listeners)
+	if l == nil {
+		t.Fatal("expected listener 0.0.0.0_443 to be created")
+	}
+
+	if len(l.FilterChains) == 0 {
+		t.Fatal("expected at least one filter chain")
+	}
+
+	fc := l.FilterChains[0]
+	if fc.GetTransportSocket() == nil {
+		t.Fatal("expected transport socket for TLS")
+	}
+
+	tlsContext := xdstest.UnmarshalAny[auth.DownstreamTlsContext](t, fc.GetTransportSocket().GetTypedConfig())
+	sdsConfigs := tlsContext.GetCommonTlsContext().GetTlsCertificateSdsSecretConfigs()
+	if len(sdsConfigs) == 0 {
+		t.Fatal("expected SDS secret configs")
+	}
+
+	sdsConfig := sdsConfigs[0]
+	if sdsConfig.GetName() != "sds://my-sds-provider" {
+		t.Errorf("expected SDS name %q, got %q", "sds://my-sds-provider", sdsConfig.GetName())
+	}
+
+	grpcServices := sdsConfig.GetSdsConfig().GetApiConfigSource().GetGrpcServices()
+	if len(grpcServices) == 0 {
+		t.Fatal("expected gRPC services in SDS config")
+	}
+
+	clusterName := grpcServices[0].GetEnvoyGrpc().GetClusterName()
+	expectedCluster := "outbound|8443||sds-provider.sds-system.svc.cluster.local"
+	if clusterName != expectedCluster {
+		t.Errorf("expected cluster %q, got %q", expectedCluster, clusterName)
+	}
+
 }

--- a/pilot/pkg/networking/core/gateway_simulation_test.go
+++ b/pilot/pkg/networking/core/gateway_simulation_test.go
@@ -2408,7 +2408,7 @@ spec:
       protocol: HTTPS
     tls:
       mode: SIMPLE
-      credentialName: "sds://my-sds-provider"
+      credentialName: "sds://my-credential"
     hosts:
     - "secure.example.com"
 ---
@@ -2486,8 +2486,8 @@ spec:
 	}
 
 	sdsConfig := sdsConfigs[0]
-	if sdsConfig.GetName() != "sds://my-sds-provider" {
-		t.Errorf("expected SDS name %q, got %q", "sds://my-sds-provider", sdsConfig.GetName())
+	if sdsConfig.GetName() != "my-credential" {
+		t.Errorf("expected SDS name %q, got %q", "my-credential", sdsConfig.GetName())
 	}
 
 	grpcServices := sdsConfig.GetSdsConfig().GetApiConfigSource().GetGrpcServices()

--- a/pilot/pkg/networking/core/gateway_test.go
+++ b/pilot/pkg/networking/core/gateway_test.go
@@ -5048,11 +5048,9 @@ func TestGatewayExternalSDSProvider(t *testing.T) {
 				if clusterName != tt.expectedClusterName {
 					t.Errorf("expected cluster name %q, got %q", tt.expectedClusterName, clusterName)
 				}
-			} else {
+			} else if len(sdsConfigs) > 0 && sdsConfigs[0].GetName() != "" {
 				// When no SDS provider is found and no UDS socket, the SDS config entry should have no name
-				if len(sdsConfigs) > 0 && sdsConfigs[0].GetName() != "" {
-					t.Errorf("expected empty SDS config name when no provider found, got %q", sdsConfigs[0].GetName())
-				}
+				t.Errorf("expected empty SDS config name when no provider found, got %q", sdsConfigs[0].GetName())
 			}
 
 			if tt.tlsMode == networking.ServerTLSSettings_MUTUAL {

--- a/pilot/pkg/networking/core/gateway_test.go
+++ b/pilot/pkg/networking/core/gateway_test.go
@@ -4891,3 +4891,175 @@ func TestListenerTransportSocketConnectTimeoutForGateway(t *testing.T) {
 		})
 	}
 }
+
+func TestGatewayExternalSDSProvider(t *testing.T) {
+	cases := []struct {
+		name                string
+		credentialName      string
+		tlsMode             networking.ServerTLSSettings_TLSmode
+		providerName        string
+		providerService     string
+		providerPort        uint32
+		expectedClusterName string
+		expectSDS           bool
+	}{
+		{
+			name:                "external SDS provider with SIMPLE TLS",
+			credentialName:      "sds://my-sds-provider",
+			tlsMode:             networking.ServerTLSSettings_SIMPLE,
+			providerName:        "my-sds-provider",
+			providerService:     "sds-service.sds-ns.svc.cluster.local",
+			providerPort:        8443,
+			expectedClusterName: "outbound|8443||sds-service.sds-ns.svc.cluster.local",
+			expectSDS:           true,
+		},
+		{
+			name:                "external SDS provider with MUTUAL TLS",
+			credentialName:      "sds://mutual-sds-provider",
+			tlsMode:             networking.ServerTLSSettings_MUTUAL,
+			providerName:        "mutual-sds-provider",
+			providerService:     "sds-mutual.sds-ns.svc.cluster.local",
+			providerPort:        9443,
+			expectedClusterName: "outbound|9443||sds-mutual.sds-ns.svc.cluster.local",
+			expectSDS:           true,
+		},
+		{
+			name:                "sds:// prefix without matching provider falls back to ADS",
+			credentialName:      "sds://unknown-provider",
+			tlsMode:             networking.ServerTLSSettings_SIMPLE,
+			providerName:        "different-provider",
+			providerService:     "sds-service.sds-ns.svc.cluster.local",
+			providerPort:        8443,
+			expectedClusterName: "",
+			expectSDS:           false,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := mesh.DefaultMeshConfig()
+			mc.ExtensionProviders = append(mc.ExtensionProviders, &meshconfig.MeshConfig_ExtensionProvider{
+				Name: tt.providerName,
+				Provider: &meshconfig.MeshConfig_ExtensionProvider_Sds{
+					Sds: &meshconfig.MeshConfig_ExtensionProvider_SDSProvider{
+						Name:    tt.providerName,
+						Service: tt.providerService,
+						Port:    tt.providerPort,
+					},
+				},
+			})
+
+			gatewayConfig := config.Config{
+				Meta: config.Meta{Name: "tls-gateway", Namespace: "testns", GroupVersionKind: gvk.Gateway},
+				Spec: &networking.Gateway{
+					Servers: []*networking.Server{
+						{
+							Port:  &networking.Port{Name: "https", Number: 443, Protocol: "HTTPS"},
+							Hosts: []string{"secure.example.com"},
+							Tls: &networking.ServerTLSSettings{
+								Mode:           tt.tlsMode,
+								CredentialName: tt.credentialName,
+							},
+						},
+					},
+				},
+			}
+			vsConfig := config.Config{
+				Meta: config.Meta{Name: "vs", Namespace: "testns", GroupVersionKind: gvk.VirtualService},
+				Spec: &networking.VirtualService{
+					Gateways: []string{"testns/tls-gateway"},
+					Hosts:    []string{"secure.example.com"},
+					Http: []*networking.HTTPRoute{
+						{
+							Route: []*networking.HTTPRouteDestination{
+								{
+									Destination: &networking.Destination{
+										Host: "backend.testns.svc.cluster.local",
+										Port: &networking.PortSelector{Number: 80},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			cg := NewConfigGenTest(t, TestOptions{
+				Configs:    []config.Config{gatewayConfig, vsConfig},
+				MeshConfig: mc,
+			})
+			cg.PushContext().ServiceIndex.HostnameAndNamespace = map[host.Name]map[string]*pilot_model.Service{
+				host.Name(tt.providerService): {
+					"sds-ns": {
+						Hostname: host.Name(tt.providerService),
+						Ports: []*pilot_model.Port{
+							{
+								Name:     "grpc",
+								Port:     int(tt.providerPort),
+								Protocol: protocol.GRPC,
+							},
+						},
+					},
+				},
+			}
+
+			proxy := cg.SetupProxy(&proxyGateway)
+			proxy.Metadata = &proxyGatewayMetadata
+
+			lb := NewListenerBuilder(proxy, cg.PushContext())
+			builder := cg.ConfigGen.buildGatewayListeners(lb)
+
+			if len(builder.gatewayListeners) == 0 {
+				t.Fatal("expected at least one gateway listener")
+			}
+
+			listener := builder.gatewayListeners[0]
+			if len(listener.FilterChains) == 0 {
+				t.Fatal("expected at least one filter chain")
+			}
+
+			fc := listener.FilterChains[0]
+			if fc.GetTransportSocket() == nil {
+				t.Fatal("expected transport socket to be set for TLS")
+			}
+
+			tlsContext := xdstest.UnmarshalAny[auth.DownstreamTlsContext](t, fc.GetTransportSocket().GetTypedConfig())
+			sdsConfigs := tlsContext.GetCommonTlsContext().GetTlsCertificateSdsSecretConfigs()
+			if len(sdsConfigs) == 0 {
+				t.Fatal("expected SDS secret configs to be set")
+			}
+
+			sdsConfig := sdsConfigs[0]
+
+			if tt.expectSDS {
+				if sdsConfig.GetName() != tt.credentialName {
+					t.Errorf("expected SDS secret name %q, got %q", tt.credentialName, sdsConfig.GetName())
+				}
+				grpcServices := sdsConfig.GetSdsConfig().GetApiConfigSource().GetGrpcServices()
+				if len(grpcServices) == 0 {
+					t.Fatal("expected gRPC services in SDS config")
+				}
+				clusterName := grpcServices[0].GetEnvoyGrpc().GetClusterName()
+				if clusterName != tt.expectedClusterName {
+					t.Errorf("expected cluster name %q, got %q", tt.expectedClusterName, clusterName)
+				}
+			} else {
+				// When provider is not found, falls back to ADS with kubernetes:// prefix
+				expectedName := "kubernetes://" + tt.credentialName
+				if sdsConfig.GetName() != expectedName {
+					t.Errorf("expected fallback SDS secret name %q, got %q", expectedName, sdsConfig.GetName())
+				}
+				if sdsConfig.GetSdsConfig().GetAds() == nil {
+					t.Error("expected ADS config source for fallback case")
+				}
+			}
+
+			if tt.tlsMode == networking.ServerTLSSettings_MUTUAL {
+				validationCtx := tlsContext.GetCommonTlsContext().GetCombinedValidationContext()
+				if validationCtx == nil {
+					t.Error("expected combined validation context for MUTUAL TLS")
+				}
+			}
+		})
+	}
+}

--- a/pilot/pkg/networking/core/gateway_test.go
+++ b/pilot/pkg/networking/core/gateway_test.go
@@ -17,6 +17,7 @@ package core
 import (
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -4902,10 +4903,11 @@ func TestGatewayExternalSDSProvider(t *testing.T) {
 		providerPort        uint32
 		expectedClusterName string
 		expectSDS           bool
+		noSDSProvider       bool
 	}{
 		{
 			name:                "external SDS provider with SIMPLE TLS",
-			credentialName:      "sds://my-sds-provider",
+			credentialName:      "sds://my-credential",
 			tlsMode:             networking.ServerTLSSettings_SIMPLE,
 			providerName:        "my-sds-provider",
 			providerService:     "sds-service.sds-ns.svc.cluster.local",
@@ -4915,39 +4917,42 @@ func TestGatewayExternalSDSProvider(t *testing.T) {
 		},
 		{
 			name:                "external SDS provider with MUTUAL TLS",
-			credentialName:      "sds://mutual-sds-provider",
+			credentialName:      "sds://mutual-credential",
 			tlsMode:             networking.ServerTLSSettings_MUTUAL,
-			providerName:        "mutual-sds-provider",
+			providerName:        "my-sds-provider",
 			providerService:     "sds-mutual.sds-ns.svc.cluster.local",
 			providerPort:        9443,
 			expectedClusterName: "outbound|9443||sds-mutual.sds-ns.svc.cluster.local",
 			expectSDS:           true,
 		},
 		{
-			name:                "sds:// prefix without matching provider falls back to ADS",
-			credentialName:      "sds://unknown-provider",
+			name:                "sds:// prefix without any SDS provider returns nil",
+			credentialName:      "sds://some-credential",
 			tlsMode:             networking.ServerTLSSettings_SIMPLE,
-			providerName:        "different-provider",
-			providerService:     "sds-service.sds-ns.svc.cluster.local",
-			providerPort:        8443,
+			providerName:        "",
+			providerService:     "",
+			providerPort:        0,
 			expectedClusterName: "",
 			expectSDS:           false,
+			noSDSProvider:       true,
 		},
 	}
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			mc := mesh.DefaultMeshConfig()
-			mc.ExtensionProviders = append(mc.ExtensionProviders, &meshconfig.MeshConfig_ExtensionProvider{
-				Name: tt.providerName,
-				Provider: &meshconfig.MeshConfig_ExtensionProvider_Sds{
-					Sds: &meshconfig.MeshConfig_ExtensionProvider_SDSProvider{
-						Name:    tt.providerName,
-						Service: tt.providerService,
-						Port:    tt.providerPort,
+			if !tt.noSDSProvider {
+				mc.ExtensionProviders = append(mc.ExtensionProviders, &meshconfig.MeshConfig_ExtensionProvider{
+					Name: tt.providerName,
+					Provider: &meshconfig.MeshConfig_ExtensionProvider_Sds{
+						Sds: &meshconfig.MeshConfig_ExtensionProvider_SDSProvider{
+							Name:    tt.providerName,
+							Service: tt.providerService,
+							Port:    tt.providerPort,
+						},
 					},
-				},
-			})
+				})
+			}
 
 			gatewayConfig := config.Config{
 				Meta: config.Meta{Name: "tls-gateway", Namespace: "testns", GroupVersionKind: gvk.Gateway},
@@ -5025,15 +5030,15 @@ func TestGatewayExternalSDSProvider(t *testing.T) {
 
 			tlsContext := xdstest.UnmarshalAny[auth.DownstreamTlsContext](t, fc.GetTransportSocket().GetTypedConfig())
 			sdsConfigs := tlsContext.GetCommonTlsContext().GetTlsCertificateSdsSecretConfigs()
-			if len(sdsConfigs) == 0 {
-				t.Fatal("expected SDS secret configs to be set")
-			}
-
-			sdsConfig := sdsConfigs[0]
 
 			if tt.expectSDS {
-				if sdsConfig.GetName() != tt.credentialName {
-					t.Errorf("expected SDS secret name %q, got %q", tt.credentialName, sdsConfig.GetName())
+				if len(sdsConfigs) == 0 {
+					t.Fatal("expected SDS secret configs to be set")
+				}
+				sdsConfig := sdsConfigs[0]
+				expectedResourceName := strings.TrimPrefix(tt.credentialName, "sds://")
+				if sdsConfig.GetName() != expectedResourceName {
+					t.Errorf("expected SDS secret name %q, got %q", expectedResourceName, sdsConfig.GetName())
 				}
 				grpcServices := sdsConfig.GetSdsConfig().GetApiConfigSource().GetGrpcServices()
 				if len(grpcServices) == 0 {
@@ -5044,13 +5049,9 @@ func TestGatewayExternalSDSProvider(t *testing.T) {
 					t.Errorf("expected cluster name %q, got %q", tt.expectedClusterName, clusterName)
 				}
 			} else {
-				// When provider is not found, falls back to ADS with kubernetes:// prefix
-				expectedName := "kubernetes://" + tt.credentialName
-				if sdsConfig.GetName() != expectedName {
-					t.Errorf("expected fallback SDS secret name %q, got %q", expectedName, sdsConfig.GetName())
-				}
-				if sdsConfig.GetSdsConfig().GetAds() == nil {
-					t.Error("expected ADS config source for fallback case")
+				// When no SDS provider is found and no UDS socket, the SDS config entry should have no name
+				if len(sdsConfigs) > 0 && sdsConfigs[0].GetName() != "" {
+					t.Errorf("expected empty SDS config name when no provider found, got %q", sdsConfigs[0].GetName())
 				}
 			}
 

--- a/pilot/pkg/networking/core/gateway_test.go
+++ b/pilot/pkg/networking/core/gateway_test.go
@@ -4903,6 +4903,7 @@ func TestGatewayExternalSDSProvider(t *testing.T) {
 		providerPort        uint32
 		expectedClusterName string
 		expectSDS           bool
+		expectADSFallback   bool
 		noSDSProvider       bool
 	}{
 		{
@@ -4926,7 +4927,7 @@ func TestGatewayExternalSDSProvider(t *testing.T) {
 			expectSDS:           true,
 		},
 		{
-			name:                "sds:// prefix without any SDS provider returns nil",
+			name:                "sds:// prefix without any SDS provider falls back to ADS",
 			credentialName:      "sds://some-credential",
 			tlsMode:             networking.ServerTLSSettings_SIMPLE,
 			providerName:        "",
@@ -4934,6 +4935,7 @@ func TestGatewayExternalSDSProvider(t *testing.T) {
 			providerPort:        0,
 			expectedClusterName: "",
 			expectSDS:           false,
+			expectADSFallback:   true,
 			noSDSProvider:       true,
 		},
 	}
@@ -5048,9 +5050,14 @@ func TestGatewayExternalSDSProvider(t *testing.T) {
 				if clusterName != tt.expectedClusterName {
 					t.Errorf("expected cluster name %q, got %q", tt.expectedClusterName, clusterName)
 				}
-			} else if len(sdsConfigs) > 0 && sdsConfigs[0].GetName() != "" {
-				// When no SDS provider is found and no UDS socket, the SDS config entry should have no name
-				t.Errorf("expected empty SDS config name when no provider found, got %q", sdsConfigs[0].GetName())
+			} else if tt.expectADSFallback {
+				if len(sdsConfigs) == 0 {
+					t.Fatal("expected SDS secret configs for ADS fallback")
+				}
+				expectedName := "kubernetes://" + strings.TrimPrefix(tt.credentialName, "sds://")
+				if sdsConfigs[0].GetName() != expectedName {
+					t.Errorf("expected ADS fallback SDS name %q, got %q", expectedName, sdsConfigs[0].GetName())
+				}
 			}
 
 			if tt.tlsMode == networking.ServerTLSSettings_MUTUAL {

--- a/pilot/pkg/networking/core/listener_test.go
+++ b/pilot/pkg/networking/core/listener_test.go
@@ -3402,7 +3402,7 @@ func TestBuildListenerTLSContext(t *testing.T) {
 			name: "external SDS provider with credential name",
 			serverTLSSettings: &networking.ServerTLSSettings{
 				Mode:           networking.ServerTLSSettings_SIMPLE,
-				CredentialName: "sds://provider-cert",
+				CredentialName: "sds://my-credential",
 			},
 			proxy: &model.Proxy{
 				Metadata: &model.NodeMetadata{},
@@ -3412,10 +3412,10 @@ func TestBuildListenerTLSContext(t *testing.T) {
 					Mesh: &meshconfig.MeshConfig{
 						ExtensionProviders: []*meshconfig.MeshConfig_ExtensionProvider{
 							{
-								Name: "provider-cert",
+								Name: "my-sds-provider",
 								Provider: &meshconfig.MeshConfig_ExtensionProvider_Sds{
 									Sds: &meshconfig.MeshConfig_ExtensionProvider_SDSProvider{
-										Name:    "provider-cert",
+										Name:    "my-sds-provider",
 										Service: "sds-provider-service",
 										Port:    8080,
 									},
@@ -3449,7 +3449,7 @@ func TestBuildListenerTLSContext(t *testing.T) {
 			name: "external SDS provider with mutual TLS",
 			serverTLSSettings: &networking.ServerTLSSettings{
 				Mode:            networking.ServerTLSSettings_MUTUAL,
-				CredentialName:  "sds://provider-cert",
+				CredentialName:  "sds://my-credential",
 				SubjectAltNames: []string{"test.com"},
 			},
 			proxy: &model.Proxy{
@@ -3460,10 +3460,10 @@ func TestBuildListenerTLSContext(t *testing.T) {
 					Mesh: &meshconfig.MeshConfig{
 						ExtensionProviders: []*meshconfig.MeshConfig_ExtensionProvider{
 							{
-								Name: "provider-cert",
+								Name: "my-sds-provider",
 								Provider: &meshconfig.MeshConfig_ExtensionProvider_Sds{
 									Sds: &meshconfig.MeshConfig_ExtensionProvider_SDSProvider{
-										Name:    "provider-cert",
+										Name:    "my-sds-provider",
 										Service: "sds-provider-service",
 										Port:    8080,
 									},

--- a/pilot/pkg/security/model/authentication.go
+++ b/pilot/pkg/security/model/authentication.go
@@ -89,7 +89,9 @@ func ConstructSdsSecretConfigForCredential(name string, credentialSocketExist bo
 	if strings.HasPrefix(name, security.SDSExternalCredentialPrefix) {
 		resourceName, _ := strings.CutPrefix(name, security.SDSExternalCredentialPrefix)
 		if credentialSocketExist {
-			return ConstructSdsSecretConfigForCredentialSocket(resourceName, security.SDSExternalClusterName)
+			// Preserve full name (including sds:// prefix) for backward compatibility —
+			// existing UDS-based SDS agents expect the complete credentialName as the resource name.
+			return ConstructSdsSecretConfigForCredentialSocket(name, security.SDSExternalClusterName)
 		}
 		if push != nil {
 			for _, provider := range push.Mesh.ExtensionProviders {

--- a/pilot/pkg/security/model/authentication.go
+++ b/pilot/pkg/security/model/authentication.go
@@ -81,7 +81,7 @@ func ConstructSdsSecretConfigForCredential(name string, credentialSocketExist bo
 	// Priority order:
 	//   1. UDS socket (credential metadata on the proxy) — local SDS agent on the gateway pod
 	//   2. SDS extension provider in meshConfig — remote SDS server referenced by service/port
-	//   3. nil — no SDS configuration available
+	//   3. ADS fallback — treat resource name as a Kubernetes Secret reference via istiod
 	//
 	// Currently only a single SDS extension provider is supported; the first one found is used.
 	// To support multiple providers in the future, the format could be extended to
@@ -104,7 +104,8 @@ func ConstructSdsSecretConfigForCredential(name string, credentialSocketExist bo
 				}
 			}
 		}
-		return nil
+		// No UDS socket or extension provider — fall back to ADS (Kubernetes Secret via istiod)
+		name = resourceName
 	}
 
 	return &tls.SdsSecretConfig{

--- a/pilot/pkg/security/model/authentication.go
+++ b/pilot/pkg/security/model/authentication.go
@@ -74,26 +74,37 @@ func ConstructSdsSecretConfigForCredential(name string, credentialSocketExist bo
 	if name == credentials.BuiltinGatewaySecretTypeURI+SdsCaSuffix {
 		return ConstructSdsSecretConfig(SDSRootResourceName)
 	}
+	// External SDS: credentialName format is "sds://<resource-name>".
+	// The resource name (after stripping the sds:// prefix) is sent as-is to the SDS server,
+	// allowing the server to differentiate between different certificates.
+	//
+	// Priority order:
+	//   1. UDS socket (credential metadata on the proxy) — local SDS agent on the gateway pod
+	//   2. SDS extension provider in meshConfig — remote SDS server referenced by service/port
+	//   3. nil — no SDS configuration available
+	//
+	// Currently only a single SDS extension provider is supported; the first one found is used.
+	// To support multiple providers in the future, the format could be extended to
+	// "sds://<resource-name>@<provider-name>" to allow explicit provider selection.
 	if strings.HasPrefix(name, security.SDSExternalCredentialPrefix) {
-		// Check if External SDS is a provider and use its cluster name
-		if sdsName, ok := strings.CutPrefix(name, security.SDSExternalCredentialPrefix); ok {
+		resourceName, _ := strings.CutPrefix(name, security.SDSExternalCredentialPrefix)
+		if credentialSocketExist {
+			return ConstructSdsSecretConfigForCredentialSocket(resourceName, security.SDSExternalClusterName)
+		}
+		if push != nil {
 			for _, provider := range push.Mesh.ExtensionProviders {
-				if provider.GetSds() != nil && provider.GetSds().Name == sdsName {
+				if provider.GetSds() != nil {
 					_, cluster, err := model.LookupCluster(push, provider.GetSds().Service, int(provider.GetSds().Port))
 					if err != nil {
 						model.IncLookupClusterFailures("externalSds")
 						log.Errorf("could not find cluster for external sds provider %q: %v", provider.GetSds(), err)
 						return nil
 					}
-					return ConstructSdsSecretConfigForCredentialSocket(name, cluster)
+					return ConstructSdsSecretConfigForCredentialSocket(resourceName, cluster)
 				}
 			}
 		}
-	}
-	// if credentialSocketExist exists and credentialName is using SDSExternalCredentialPrefix
-	// SDS will be served via SDSExternalClusterName
-	if credentialSocketExist && strings.HasPrefix(name, security.SDSExternalCredentialPrefix) {
-		return ConstructSdsSecretConfigForCredentialSocket(name, security.SDSExternalClusterName)
+		return nil
 	}
 
 	return &tls.SdsSecretConfig{

--- a/pilot/pkg/security/model/authentication_test.go
+++ b/pilot/pkg/security/model/authentication_test.go
@@ -713,11 +713,11 @@ func TestConstructSdsSecretConfigForCredential(t *testing.T) {
 			},
 		},
 		{
-			name:                   "sds://external-cert",
+			name:                   "sds://my-credential",
 			credentialSocketExists: true,
 			push:                   &model.PushContext{Mesh: &meshconfig.MeshConfig{}},
 			expected: &auth.SdsSecretConfig{
-				Name: "sds://external-cert",
+				Name: "my-credential",
 				SdsConfig: &core.ConfigSource{
 					ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
 						ApiConfigSource: &core.ApiConfigSource{
@@ -747,17 +747,17 @@ func TestConstructSdsSecretConfigForCredential(t *testing.T) {
 			},
 		},
 		{
-			name:                   "sds://provider-cert",
+			name:                   "sds://my-credential",
 			credentialSocketExists: false,
 			push: func() *model.PushContext {
 				pc := &model.PushContext{
 					Mesh: &meshconfig.MeshConfig{
 						ExtensionProviders: []*meshconfig.MeshConfig_ExtensionProvider{
 							{
-								Name: "provider-cert",
+								Name: "my-sds-provider",
 								Provider: &meshconfig.MeshConfig_ExtensionProvider_Sds{
 									Sds: &meshconfig.MeshConfig_ExtensionProvider_SDSProvider{
-										Name:    "provider-cert",
+										Name:    "my-sds-provider",
 										Service: "sds-provider-service",
 										Port:    8080,
 									},
@@ -783,7 +783,7 @@ func TestConstructSdsSecretConfigForCredential(t *testing.T) {
 				return pc
 			}(),
 			expected: &auth.SdsSecretConfig{
-				Name: "sds://provider-cert",
+				Name: "my-credential",
 				SdsConfig: &core.ConfigSource{
 					ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
 						ApiConfigSource: &core.ApiConfigSource{
@@ -804,17 +804,17 @@ func TestConstructSdsSecretConfigForCredential(t *testing.T) {
 			},
 		},
 		{
-			name:                   "sds://provider-cert",
+			name:                   "sds://my-credential-missing-service",
 			credentialSocketExists: false,
 			push: func() *model.PushContext {
 				pc := &model.PushContext{
 					Mesh: &meshconfig.MeshConfig{
 						ExtensionProviders: []*meshconfig.MeshConfig_ExtensionProvider{
 							{
-								Name: "provider-cert",
+								Name: "my-sds-provider",
 								Provider: &meshconfig.MeshConfig_ExtensionProvider_Sds{
 									Sds: &meshconfig.MeshConfig_ExtensionProvider_SDSProvider{
-										Name:    "provider-cert",
+										Name:    "my-sds-provider",
 										Service: "missing-service",
 										Port:    8080,
 									},
@@ -828,6 +828,12 @@ func TestConstructSdsSecretConfigForCredential(t *testing.T) {
 				return pc
 			}(),
 			expected: nil,
+		},
+		{
+			name:                   "sds://no-provider-no-socket",
+			credentialSocketExists: false,
+			push:                   &model.PushContext{Mesh: &meshconfig.MeshConfig{}},
+			expected:               nil,
 		},
 	}
 
@@ -931,7 +937,7 @@ func TestApplyCredentialSDSToServerCommonTLSContext(t *testing.T) {
 			name: "credential name with socket",
 			tlsOpts: &networking.ServerTLSSettings{
 				Mode:           networking.ServerTLSSettings_SIMPLE,
-				CredentialName: "sds://external-cert",
+				CredentialName: "sds://my-credential",
 			},
 			credentialSocketExist:  true,
 			expectedCertCount:      1,

--- a/pilot/pkg/security/model/authentication_test.go
+++ b/pilot/pkg/security/model/authentication_test.go
@@ -833,7 +833,10 @@ func TestConstructSdsSecretConfigForCredential(t *testing.T) {
 			name:                   "sds://no-provider-no-socket",
 			credentialSocketExists: false,
 			push:                   &model.PushContext{Mesh: &meshconfig.MeshConfig{}},
-			expected:               nil,
+			expected: &auth.SdsSecretConfig{
+				Name:      "kubernetes://no-provider-no-socket",
+				SdsConfig: SDSAdsConfig,
+			},
 		},
 	}
 

--- a/pilot/pkg/security/model/authentication_test.go
+++ b/pilot/pkg/security/model/authentication_test.go
@@ -717,7 +717,7 @@ func TestConstructSdsSecretConfigForCredential(t *testing.T) {
 			credentialSocketExists: true,
 			push:                   &model.PushContext{Mesh: &meshconfig.MeshConfig{}},
 			expected: &auth.SdsSecretConfig{
-				Name: "my-credential",
+				Name: "sds://my-credential",
 				SdsConfig: &core.ConfigSource{
 					ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
 						ApiConfigSource: &core.ApiConfigSource{

--- a/releasenotes/notes/external-sds-gateway-fix.yaml
+++ b/releasenotes/notes/external-sds-gateway-fix.yaml
@@ -1,0 +1,14 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+issue:
+  - 57080
+
+releaseNotes:
+- |
+  **Fixed** external SDS provider for gateways to use the credential name (after stripping the `sds://`
+  prefix) as the SDS resource name instead of the provider name. This allows multiple gateways using the
+  same SDS provider to request different certificates. For MUTUAL TLS, the CA certificate resource name
+  is correctly derived as `<credential-name>-cacert`. When neither a UDS socket nor an SDS extension
+  provider is configured, the gateway now falls back to fetching certificates via ADS (Kubernetes Secrets)
+  instead of failing silently.

--- a/tests/integration/security/external_sds_provider/external_sds_test.go
+++ b/tests/integration/security/external_sds_provider/external_sds_test.go
@@ -365,10 +365,10 @@ spec:
 								if !strings.Contains(lStr, `"my-credential"`) {
 									return fmt.Errorf("SDS secret config name not found in listener")
 								}
-								if !strings.Contains(lStr, `"clusterName":"outbound|8443||sds-grpc-server.istio-system.svc.cluster.local"`) {
+								if !strings.Contains(lStr, "outbound|8443||sds-grpc-server.istio-system.svc.cluster.local") {
 									return fmt.Errorf("expected cluster name not found in SDS config")
 								}
-								if !strings.Contains(lStr, `"apiType":"GRPC"`) {
+								if !strings.Contains(lStr, "GRPC") {
 									return fmt.Errorf("expected GRPC apiType in SDS config")
 								}
 								break

--- a/tests/integration/security/external_sds_provider/external_sds_test.go
+++ b/tests/integration/security/external_sds_provider/external_sds_test.go
@@ -33,6 +33,14 @@ import (
 	ingressutil "istio.io/istio/tests/integration/security/sds_ingress/util"
 )
 
+func gatewayLabel() string {
+	label := gatewayLabel()
+	if label == "" {
+		return "ingressgateway"
+	}
+	return label
+}
+
 // TestExternalSDSProvider verifies that configuring a Gateway with credentialName
 // using the sds:// prefix correctly generates Envoy listener config pointing to the
 // external SDS provider's cluster (as defined in meshConfig.extensionProviders).
@@ -80,7 +88,7 @@ spec:
       protocol: HTTPS
     tls:
       mode: SIMPLE
-      credentialName: "sds://my-sds-provider"
+      credentialName: "sds://my-credential"
     hosts:
     - "external-sds.example.com"
 ---
@@ -99,7 +107,7 @@ spec:
         host: a
         port:
           number: 80
-`, inst.Settings().IngressGatewayIstioLabel)
+`, gatewayLabel())
 					t.ConfigIstio().YAML(echoNS.Name(), gatewayConfig).ApplyOrFail(t)
 					return nil
 				}).
@@ -127,8 +135,8 @@ spec:
 							return fmt.Errorf("istioctl error output: %s", errOutput)
 						}
 
-						if !strings.Contains(output, "sds://my-sds-provider") {
-							return fmt.Errorf("listener config does not contain SDS credential name 'sds://my-sds-provider'")
+						if !strings.Contains(output, `"my-credential"`) {
+							return fmt.Errorf("listener config does not contain SDS resource name 'my-credential'")
 						}
 
 						if !strings.Contains(output, "outbound|8443||sds-grpc-server.istio-system.svc.cluster.local") {
@@ -187,7 +195,7 @@ spec:
       protocol: HTTPS
     tls:
       mode: MUTUAL
-      credentialName: "sds://my-sds-provider"
+      credentialName: "sds://my-credential"
     hosts:
     - "external-sds-mtls.example.com"
 ---
@@ -206,7 +214,7 @@ spec:
         host: a
         port:
           number: 80
-`, inst.Settings().IngressGatewayIstioLabel)
+`, gatewayLabel())
 					t.ConfigIstio().YAML(echoNS.Name(), gatewayConfig).ApplyOrFail(t)
 					return nil
 				}).
@@ -233,8 +241,8 @@ spec:
 							return fmt.Errorf("istioctl error output: %s", errOutput)
 						}
 
-						if !strings.Contains(output, "sds://my-sds-provider") {
-							return fmt.Errorf("listener config does not contain SDS credential name 'sds://my-sds-provider'")
+						if !strings.Contains(output, `"my-credential"`) {
+							return fmt.Errorf("listener config does not contain SDS resource name 'my-credential'")
 						}
 
 						if !strings.Contains(output, "outbound|8443||sds-grpc-server.istio-system.svc.cluster.local") {
@@ -242,8 +250,8 @@ spec:
 						}
 
 						// For MUTUAL TLS, verify that the validation context references the CA cert SDS config.
-						if !strings.Contains(output, "sds://my-sds-provider-cacert") {
-							return fmt.Errorf("listener config does not contain CA cert SDS name 'sds://my-sds-provider-cacert'")
+						if !strings.Contains(output, `"my-credential-cacert"`) {
+							return fmt.Errorf("listener config does not contain CA cert SDS name 'my-credential-cacert'")
 						}
 
 						return nil
@@ -297,7 +305,7 @@ spec:
       protocol: HTTPS
     tls:
       mode: SIMPLE
-      credentialName: "sds://my-sds-provider"
+      credentialName: "sds://my-credential"
     hosts:
     - "external-sds-details.example.com"
 ---
@@ -316,7 +324,7 @@ spec:
         host: a
         port:
           number: 80
-`, inst.Settings().IngressGatewayIstioLabel)
+`, gatewayLabel())
 					t.ConfigIstio().YAML(echoNS.Name(), gatewayConfig).ApplyOrFail(t)
 					return nil
 				}).
@@ -354,7 +362,7 @@ spec:
 							if strings.Contains(lStr, "external-sds-details.example.com") {
 								found = true
 								// Verify SDS config structure
-								if !strings.Contains(lStr, `"name":"sds://my-sds-provider"`) {
+								if !strings.Contains(lStr, `"my-credential"`) {
 									return fmt.Errorf("SDS secret config name not found in listener")
 								}
 								if !strings.Contains(lStr, `"clusterName":"outbound|8443||sds-grpc-server.istio-system.svc.cluster.local"`) {

--- a/tests/integration/security/external_sds_provider/external_sds_test.go
+++ b/tests/integration/security/external_sds_provider/external_sds_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func gatewayLabel() string {
-	label := gatewayLabel()
+	label := inst.Settings().IngressGatewayIstioLabel
 	if label == "" {
 		return "ingressgateway"
 	}

--- a/tests/integration/security/external_sds_provider/external_sds_test.go
+++ b/tests/integration/security/external_sds_provider/external_sds_test.go
@@ -1,0 +1,377 @@
+//go:build integ
+
+//  Copyright Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package externalsdsprovider
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/cluster"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echotest"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/istioctl"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/util/retry"
+	ingressutil "istio.io/istio/tests/integration/security/sds_ingress/util"
+)
+
+// TestExternalSDSProvider verifies that configuring a Gateway with credentialName
+// using the sds:// prefix correctly generates Envoy listener config pointing to the
+// external SDS provider's cluster (as defined in meshConfig.extensionProviders).
+func TestExternalSDSProvider(t *testing.T) {
+	framework.
+		NewTest(t).
+		Run(func(t framework.TestContext) {
+			istioCfg := istio.DefaultConfigOrFail(t, t)
+			systemNS := namespace.ClaimOrFail(t, istioCfg.SystemNamespace)
+
+			// Deploy a ServiceEntry for the SDS provider service so Istio can resolve its cluster.
+			sdsServiceEntry := `
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: sds-grpc-server
+spec:
+  hosts:
+  - "sds-grpc-server.istio-system.svc.cluster.local"
+  ports:
+  - number: 8443
+    name: grpc
+    protocol: GRPC
+  resolution: STATIC
+  location: MESH_INTERNAL
+  endpoints:
+  - address: 127.0.0.1
+`
+			t.ConfigIstio().YAML(systemNS.Name(), sdsServiceEntry).ApplyOrFail(t)
+
+			echotest.New(t, ingressutil.A).
+				SetupForDestination(func(t framework.TestContext, _ echo.Target) error {
+					gatewayConfig := fmt.Sprintf(`
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: external-sds-gateway
+spec:
+  selector:
+    istio: %s
+  servers:
+  - port:
+      number: 443
+      name: https
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      credentialName: "sds://my-sds-provider"
+    hosts:
+    - "external-sds.example.com"
+---
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: external-sds-vs
+spec:
+  hosts:
+  - "external-sds.example.com"
+  gateways:
+  - external-sds-gateway
+  http:
+  - route:
+    - destination:
+        host: a
+        port:
+          number: 80
+`, inst.Settings().IngressGatewayIstioLabel)
+					t.ConfigIstio().YAML(echoNS.Name(), gatewayConfig).ApplyOrFail(t)
+					return nil
+				}).
+				To(echotest.SingleSimplePodServiceAndAllSpecial()).
+				RunFromClusters(func(t framework.TestContext, _ cluster.Cluster, _ echo.Target) {
+					ing := inst.IngressFor(t.Clusters().Default())
+					if ing == nil {
+						t.Skip("no ingress gateway found")
+					}
+
+					istioCtl := istioctl.NewOrFail(t, istioctl.Config{Cluster: t.Clusters().Default()})
+
+					podID, err := ing.PodID(0)
+					if err != nil {
+						t.Fatalf("failed to get ingress gateway pod ID: %v", err)
+					}
+					podName := fmt.Sprintf("%s.%s", podID, ing.Namespace())
+
+					// Verify the listener config contains the external SDS provider cluster reference.
+					retry.UntilSuccessOrFail(t, func() error {
+						output, errOutput := istioCtl.InvokeOrFail(t, []string{
+							"pc", "listener", podName, "-o", "json",
+						})
+						if errOutput != "" {
+							return fmt.Errorf("istioctl error output: %s", errOutput)
+						}
+
+						if !strings.Contains(output, "sds://my-sds-provider") {
+							return fmt.Errorf("listener config does not contain SDS credential name 'sds://my-sds-provider'")
+						}
+
+						if !strings.Contains(output, "outbound|8443||sds-grpc-server.istio-system.svc.cluster.local") {
+							return fmt.Errorf("listener config does not reference external SDS provider cluster " +
+								"'outbound|8443||sds-grpc-server.istio-system.svc.cluster.local'")
+						}
+
+						return nil
+					}, retry.Timeout(retry.DefaultTimeout))
+				})
+		})
+}
+
+// TestExternalSDSProviderMutualTLS verifies that configuring a Gateway with MUTUAL TLS
+// and sds:// credentialName generates correct validation context in addition to the SDS cert config.
+func TestExternalSDSProviderMutualTLS(t *testing.T) {
+	framework.
+		NewTest(t).
+		Run(func(t framework.TestContext) {
+			istioCfg := istio.DefaultConfigOrFail(t, t)
+			systemNS := namespace.ClaimOrFail(t, istioCfg.SystemNamespace)
+
+			sdsServiceEntry := `
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: sds-grpc-server-mtls
+spec:
+  hosts:
+  - "sds-grpc-server.istio-system.svc.cluster.local"
+  ports:
+  - number: 8443
+    name: grpc
+    protocol: GRPC
+  resolution: STATIC
+  location: MESH_INTERNAL
+  endpoints:
+  - address: 127.0.0.1
+`
+			t.ConfigIstio().YAML(systemNS.Name(), sdsServiceEntry).ApplyOrFail(t)
+
+			echotest.New(t, ingressutil.A).
+				SetupForDestination(func(t framework.TestContext, _ echo.Target) error {
+					gatewayConfig := fmt.Sprintf(`
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: external-sds-mtls-gateway
+spec:
+  selector:
+    istio: %s
+  servers:
+  - port:
+      number: 443
+      name: https
+      protocol: HTTPS
+    tls:
+      mode: MUTUAL
+      credentialName: "sds://my-sds-provider"
+    hosts:
+    - "external-sds-mtls.example.com"
+---
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: external-sds-mtls-vs
+spec:
+  hosts:
+  - "external-sds-mtls.example.com"
+  gateways:
+  - external-sds-mtls-gateway
+  http:
+  - route:
+    - destination:
+        host: a
+        port:
+          number: 80
+`, inst.Settings().IngressGatewayIstioLabel)
+					t.ConfigIstio().YAML(echoNS.Name(), gatewayConfig).ApplyOrFail(t)
+					return nil
+				}).
+				To(echotest.SingleSimplePodServiceAndAllSpecial()).
+				RunFromClusters(func(t framework.TestContext, _ cluster.Cluster, _ echo.Target) {
+					ing := inst.IngressFor(t.Clusters().Default())
+					if ing == nil {
+						t.Skip("no ingress gateway found")
+					}
+
+					istioCtl := istioctl.NewOrFail(t, istioctl.Config{Cluster: t.Clusters().Default()})
+
+					podID, err := ing.PodID(0)
+					if err != nil {
+						t.Fatalf("failed to get ingress gateway pod ID: %v", err)
+					}
+					podName := fmt.Sprintf("%s.%s", podID, ing.Namespace())
+
+					retry.UntilSuccessOrFail(t, func() error {
+						output, errOutput := istioCtl.InvokeOrFail(t, []string{
+							"pc", "listener", podName, "-o", "json",
+						})
+						if errOutput != "" {
+							return fmt.Errorf("istioctl error output: %s", errOutput)
+						}
+
+						if !strings.Contains(output, "sds://my-sds-provider") {
+							return fmt.Errorf("listener config does not contain SDS credential name 'sds://my-sds-provider'")
+						}
+
+						if !strings.Contains(output, "outbound|8443||sds-grpc-server.istio-system.svc.cluster.local") {
+							return fmt.Errorf("listener config does not reference external SDS provider cluster")
+						}
+
+						// For MUTUAL TLS, verify that the validation context references the CA cert SDS config.
+						if !strings.Contains(output, "sds://my-sds-provider-cacert") {
+							return fmt.Errorf("listener config does not contain CA cert SDS name 'sds://my-sds-provider-cacert'")
+						}
+
+						return nil
+					}, retry.Timeout(retry.DefaultTimeout))
+				})
+		})
+}
+
+// TestExternalSDSProviderListenerDetails verifies the detailed structure of the
+// generated SDS config (cluster name, API type, transport version) using JSON config dump.
+func TestExternalSDSProviderListenerDetails(t *testing.T) {
+	framework.
+		NewTest(t).
+		Run(func(t framework.TestContext) {
+			istioCfg := istio.DefaultConfigOrFail(t, t)
+			systemNS := namespace.ClaimOrFail(t, istioCfg.SystemNamespace)
+
+			sdsServiceEntry := `
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: sds-grpc-server-details
+spec:
+  hosts:
+  - "sds-grpc-server.istio-system.svc.cluster.local"
+  ports:
+  - number: 8443
+    name: grpc
+    protocol: GRPC
+  resolution: STATIC
+  location: MESH_INTERNAL
+  endpoints:
+  - address: 127.0.0.1
+`
+			t.ConfigIstio().YAML(systemNS.Name(), sdsServiceEntry).ApplyOrFail(t)
+
+			echotest.New(t, ingressutil.A).
+				SetupForDestination(func(t framework.TestContext, _ echo.Target) error {
+					gatewayConfig := fmt.Sprintf(`
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: external-sds-details-gateway
+spec:
+  selector:
+    istio: %s
+  servers:
+  - port:
+      number: 443
+      name: https
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      credentialName: "sds://my-sds-provider"
+    hosts:
+    - "external-sds-details.example.com"
+---
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: external-sds-details-vs
+spec:
+  hosts:
+  - "external-sds-details.example.com"
+  gateways:
+  - external-sds-details-gateway
+  http:
+  - route:
+    - destination:
+        host: a
+        port:
+          number: 80
+`, inst.Settings().IngressGatewayIstioLabel)
+					t.ConfigIstio().YAML(echoNS.Name(), gatewayConfig).ApplyOrFail(t)
+					return nil
+				}).
+				To(echotest.SingleSimplePodServiceAndAllSpecial()).
+				RunFromClusters(func(t framework.TestContext, _ cluster.Cluster, _ echo.Target) {
+					ing := inst.IngressFor(t.Clusters().Default())
+					if ing == nil {
+						t.Skip("no ingress gateway found")
+					}
+
+					istioCtl := istioctl.NewOrFail(t, istioctl.Config{Cluster: t.Clusters().Default()})
+
+					podID, err := ing.PodID(0)
+					if err != nil {
+						t.Fatalf("failed to get ingress gateway pod ID: %v", err)
+					}
+					podName := fmt.Sprintf("%s.%s", podID, ing.Namespace())
+
+					retry.UntilSuccessOrFail(t, func() error {
+						output, errOutput := istioCtl.InvokeOrFail(t, []string{
+							"pc", "listener", podName, "-o", "json",
+						})
+						if errOutput != "" {
+							return fmt.Errorf("istioctl error output: %s", errOutput)
+						}
+
+						var listeners []json.RawMessage
+						if err := json.Unmarshal([]byte(output), &listeners); err != nil {
+							return fmt.Errorf("failed to parse listener JSON: %v", err)
+						}
+
+						found := false
+						for _, l := range listeners {
+							lStr := string(l)
+							if strings.Contains(lStr, "external-sds-details.example.com") {
+								found = true
+								// Verify SDS config structure
+								if !strings.Contains(lStr, `"name":"sds://my-sds-provider"`) {
+									return fmt.Errorf("SDS secret config name not found in listener")
+								}
+								if !strings.Contains(lStr, `"clusterName":"outbound|8443||sds-grpc-server.istio-system.svc.cluster.local"`) {
+									return fmt.Errorf("expected cluster name not found in SDS config")
+								}
+								if !strings.Contains(lStr, `"apiType":"GRPC"`) {
+									return fmt.Errorf("expected GRPC apiType in SDS config")
+								}
+								break
+							}
+						}
+						if !found {
+							return fmt.Errorf("listener for external-sds-details.example.com not found")
+						}
+
+						return nil
+					}, retry.Timeout(retry.DefaultTimeout))
+				})
+		})
+}

--- a/tests/integration/security/external_sds_provider/main_test.go
+++ b/tests/integration/security/external_sds_provider/main_test.go
@@ -1,0 +1,73 @@
+//go:build integ
+
+//  Copyright Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package externalsdsprovider
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/common/deployment"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
+	ingressutil "istio.io/istio/tests/integration/security/sds_ingress/util"
+)
+
+var (
+	inst         istio.Instance
+	apps         deployment.SingleNamespaceView
+	echoNS       namespace.Instance
+	customConfig []echo.Config
+)
+
+func TestMain(m *testing.M) {
+	framework.
+		NewSuite(m).
+		Label(label.CustomSetup).
+		Setup(istio.Setup(&inst, setupConfig)).
+		Setup(namespace.Setup(&echoNS, namespace.Config{Prefix: "echo", Inject: true})).
+		Setup(func(ctx resource.Context) error {
+			return ingressutil.SetupTest(ctx, &customConfig, namespace.Future(&echoNS))
+		}).
+		Setup(deployment.SetupSingleNamespace(&apps, deployment.Config{
+			Namespaces: []namespace.Getter{
+				namespace.Future(&echoNS),
+			},
+			Configs: echo.ConfigFuture(&customConfig),
+		})).
+		Setup(func(ctx resource.Context) error {
+			return ingressutil.SetInstances(apps.All)
+		}).
+		Run()
+}
+
+func setupConfig(_ resource.Context, cfg *istio.Config) {
+	if cfg == nil {
+		return
+	}
+	cfg.ControlPlaneValues = `
+meshConfig:
+  extensionProviders:
+  - name: my-sds-provider
+    sds:
+      name: my-sds-provider
+      service: sds-grpc-server.istio-system.svc.cluster.local
+      port: 8443
+`
+}


### PR DESCRIPTION
 https://github.com/istio/istio/pull/57080 added support for external SDS server support at Gateway. But it passed the same that user passes like "sds://<provider-name>" as resource name. What this means is if multiple gateways use the same "sds://<provider-name>",  the SDS server has no way to identify which certs to send, This was a miss in he original implementation.

Now the new logic is changed to behave exactly same as UDS based SDS i.e. if user specifies, `sds://<credential-name>` the same credential name is passed to SDS server. The logic to pick UDS vs external SDS is dictated by presence of the domain socket. If sds:// is used for Gateway and UDS is present, it is used. If not external SDS is used. Also only currently the assumption is only one SDS provider is configured. In future, if more than one SDS provider support is needed, it can be easily extended with sds://cred-name@provider-name syntax.

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions