### PR TITLE
gatewayapi: fix SDS authorization for caCertificateRefs kind:Secret in frontend mTLS

### DIFF
--- a/pilot/pkg/model/gateway.go
+++ b/pilot/pkg/model/gateway.go
@@ -95,11 +95,11 @@ type MergedGateway struct {
 	// PortMap defines a mapping of targetPorts to the set of Service ports that reference them
 	PortMap GatewayPortMap
 
-	// VerifiedCertificateReferences contains a set of all credentialNames referenced by gateways *in the same namespace as the proxy*.
-	// These are considered "verified", since there is mutually agreement from the pod, Secret, and Gateway, as all
-	// reside in the same namespace and trust boundary.
-	// Note: Secrets that are not referenced by any Gateway, but are in the same namespace as the pod, are explicitly *not*
-	// included. This ensures we don't give permission to unexpected secrets, such as the citadel root key/cert.
+	// VerifiedCertificateReferences is the set of SDS certificate resources referenced by gateway config and
+	// authorized for this proxy. Authorization requires either same-namespace trust (the gateway config, Secret,
+	// and proxy workload are all in the same namespace) or an explicit cross-namespace reference policy (ReferenceGrant
+	// for Gateway API gateways). Secrets in the same namespace that are not referenced by any gateway config are
+	// explicitly excluded to prevent unintended access (e.g., the citadel root key/cert).
 	VerifiedCertificateReferences sets.String
 }
 
@@ -227,24 +227,30 @@ func mergeGateways(gateways []gatewayWithInstances, proxy *Proxy, ps *PushContex
 				cns = append(cns, s.GetTls().GetCredentialName())
 			}
 
+			gwKind := gvk.KubernetesGateway
+			if strings.HasPrefix(gatewayConfig.Annotations[constants.InternalParentNames], gvk.ListenerSet.Kind+"/") {
+				gwKind = gvk.ListenerSet
+			}
+			lookupNamespace := ""
+			configAndProxyAllowed := false
+			if identityVerified {
+				lookupNamespace = proxy.VerifiedIdentity.Namespace
+				if gwKind == gvk.ListenerSet {
+					lookupNamespace = gatewayConfig.Namespace
+				}
+				// For ListenerSet, we do not require the config to live in the same namespace. However, there is a trust handshake via AllowedListeners.
+				configAndProxyAllowed = gatewayConfig.Namespace == proxy.VerifiedIdentity.Namespace || gwKind == gvk.ListenerSet
+			}
+
 			for _, cn := range cns {
 				if !(cn != "" && identityVerified) {
 					continue
-				}
-
-				gwKind := gvk.KubernetesGateway
-				lookupNamespace := proxy.VerifiedIdentity.Namespace
-				if strings.HasPrefix(gatewayConfig.Annotations[constants.InternalParentNames], gvk.ListenerSet.Kind+"/") {
-					gwKind = gvk.ListenerSet
-					lookupNamespace = gatewayConfig.Namespace
 				}
 
 				// Ignore BuiltinGatewaySecretTypeURI, as it is not referencing a Secret at all
 				if !strings.HasPrefix(cn, credentials.BuiltinGatewaySecretTypeURI) {
 					rn := credentials.ToResourceName(cn)
 					parse, err := credentials.ParseResourceName(rn, proxy.VerifiedIdentity.Namespace, "", "")
-					// For ListenerSet, we do not require the config to live in the same namespace. However, there is a trust handshake via AllowedListeners.
-					configAndProxyAllowed := gatewayConfig.Namespace == proxy.VerifiedIdentity.Namespace || gwKind == gvk.ListenerSet
 					if err == nil && configAndProxyAllowed && parse.Namespace == lookupNamespace {
 						// Same namespace is always allowed
 						verifiedCertificateReferences.Insert(rn)
@@ -258,6 +264,21 @@ func mergeGateways(gateways []gatewayWithInstances, proxy *Proxy, ps *PushContex
 							verifiedCertificateReferences.Insert(rn + credentials.SdsCaSuffix)
 						}
 					}
+				}
+			}
+
+			// Explicit frontend mTLS CA credentials are SDS resources too; authorize them with the same
+			// Gateway API secret-reference rules as serving certs: same-namespace trust or ReferenceGrant.
+			// Only applies to KubernetesGatewaySecretType (kind:Secret); ConfigMap CA certs are
+			// unconditionally allowed in sds.go and do not need a VerifiedCertificateReferences entry.
+			if caCertCN := s.GetTls().GetCaCertCredentialName(); caCertCN != "" && identityVerified &&
+				strings.HasPrefix(caCertCN, credentials.KubernetesGatewaySecretType+"://") {
+				caCertRN := credentials.ToResourceName(caCertCN)
+				caParse, err := credentials.ParseResourceName(caCertRN, proxy.VerifiedIdentity.Namespace, "", "")
+				if err == nil && configAndProxyAllowed && caParse.Namespace == lookupNamespace {
+					verifiedCertificateReferences.Insert(caCertRN)
+				} else if err == nil && ps.SecretAllowed(gwKind, caCertRN, lookupNamespace) {
+					verifiedCertificateReferences.Insert(caCertRN)
 				}
 			}
 

--- a/pilot/pkg/model/gateway_test.go
+++ b/pilot/pkg/model/gateway_test.go
@@ -90,6 +90,18 @@ func TestMergeGateways(t *testing.T) {
 	gwListenerSetCredCrossNSAllowed := makeListenerSetConfig(fmt.Sprintf("kubernetes-gateway://%s/foo", AllowedNamespace))
 	gwListenerSetCredCrossNSNotAllowed := makeListenerSetConfig(fmt.Sprintf("kubernetes-gateway://%s/foo", NotAllowedNamespace))
 
+	// Configs with an explicit frontend mTLS CA credential (CaCertCredentialName already includes -cacert suffix).
+	gwMutualWithCaCertCredSameNS := makeConfigWithCaCert("foo1", "ns", "foo.bar.com", "name1", "http", 7, "ingressgateway",
+		networking.ServerTLSSettings_MUTUAL, "kubernetes-gateway://ns/server-cert", "kubernetes-gateway://ns/client-ca-cacert", "sa")
+	gwMutualWithCaCertCredAllowedNS := makeConfigWithCaCert("foo1", "ns", "foo.bar.com", "name1", "http", 7, "ingressgateway",
+		networking.ServerTLSSettings_MUTUAL,
+		fmt.Sprintf("kubernetes-gateway://%s/server-cert", AllowedNamespace),
+		fmt.Sprintf("kubernetes-gateway://%s/client-ca-cacert", AllowedNamespace), "sa")
+	gwMutualWithCaCertCredNotAllowedNS := makeConfigWithCaCert("foo1", "ns", "foo.bar.com", "name1", "http", 7, "ingressgateway",
+		networking.ServerTLSSettings_MUTUAL,
+		fmt.Sprintf("kubernetes-gateway://%s/server-cert", NotAllowedNamespace),
+		fmt.Sprintf("kubernetes-gateway://%s/client-ca-cacert", NotAllowedNamespace), "sa")
+
 	// TODO(ramaraochavali): Add more test cases here.
 	tests := []struct {
 		name               string
@@ -332,6 +344,51 @@ func TestMergeGateways(t *testing.T) {
 			1,
 			0,
 		},
+		{
+			"mutual-with-explicit-ca-cert-cred-same-ns",
+			[]config.Config{gwMutualWithCaCertCredSameNS},
+			proxyIdentity,
+			1,
+			1,
+			map[string]int{"http.7": 1},
+			1,
+			3,
+		},
+		{
+			"mutual-with-explicit-ca-cert-cred-allowed-ns",
+			[]config.Config{gwMutualWithCaCertCredAllowedNS},
+			proxyIdentity,
+			1,
+			1,
+			map[string]int{"http.7": 1},
+			1,
+			3,
+		},
+		{
+			"mutual-with-explicit-ca-cert-cred-not-allowed-ns",
+			[]config.Config{gwMutualWithCaCertCredNotAllowedNS},
+			proxyIdentity,
+			1,
+			1,
+			map[string]int{"http.7": 1},
+			1,
+			0,
+		},
+	}
+
+	// Exact-set assertions for the CaCertCredentialName test cases only.
+	caCertExpected := map[string]sets.Set[string]{
+		"mutual-with-explicit-ca-cert-cred-same-ns": sets.New(
+			"kubernetes-gateway://ns/server-cert",
+			"kubernetes-gateway://ns/server-cert-cacert",
+			"kubernetes-gateway://ns/client-ca-cacert",
+		),
+		"mutual-with-explicit-ca-cert-cred-allowed-ns": sets.New(
+			"kubernetes-gateway://"+AllowedNamespace+"/server-cert",
+			"kubernetes-gateway://"+AllowedNamespace+"/server-cert-cacert",
+			"kubernetes-gateway://"+AllowedNamespace+"/client-ca-cacert",
+		),
+		"mutual-with-explicit-ca-cert-cred-not-allowed-ns": sets.New[string](),
 	}
 
 	for idx, tt := range tests {
@@ -364,6 +421,10 @@ func TestMergeGateways(t *testing.T) {
 			}
 			if mgw.VerifiedCertificateReferences.Len() != tt.verifiedCertNum {
 				t.Errorf("Incorrect number of verified certs. Expected: %v Got: %d", tt.verifiedCertNum, mgw.VerifiedCertificateReferences.Len())
+			}
+			if expected, ok := caCertExpected[tt.name]; ok && !expected.Equals(mgw.VerifiedCertificateReferences) {
+				t.Errorf("VerifiedCertificateReferences mismatch for %q: want %v, got %v",
+					tt.name, expected, mgw.VerifiedCertificateReferences)
 			}
 		})
 	}
@@ -555,6 +616,36 @@ func makeTLSSettings(mode networking.ServerTLSSettings_TLSmode, credNames []stri
 	}
 
 	return &networking.ServerTLSSettings{Mode: mode, CredentialNames: credNames}
+}
+
+// makeConfigWithCaCert creates a gateway config with an explicit CaCertCredentialName, used to test
+// GEP-91 implementation-specific support for caCertificateRefs kind:Secret.
+func makeConfigWithCaCert(name, namespace, host, portName, portProtocol string, portNumber uint32, gw string,
+	mode networking.ServerTLSSettings_TLSmode, serverCredName, caCertCredName, sa string,
+) config.Config {
+	return config.Config{
+		Meta: config.Meta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				"internal.istio.io/service-account-name": sa,
+			},
+		},
+		Spec: &networking.Gateway{
+			Selector: map[string]string{"istio": gw},
+			Servers: []*networking.Server{
+				{
+					Hosts: []string{host},
+					Port:  &networking.Port{Name: portName, Number: portNumber, Protocol: portProtocol},
+					Tls: &networking.ServerTLSSettings{
+						Mode:                 mode,
+						CredentialName:       serverCredName,
+						CaCertCredentialName: caCertCredName,
+					},
+				},
+			},
+		},
+	}
 }
 
 func makeProxy(fn func() *spiffe.Identity) *Proxy {

--- a/releasenotes/notes/cacert-secret-sds-auth.yaml
+++ b/releasenotes/notes/cacert-secret-sds-auth.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+issue:
+  - 60277
+releaseNotes:
+  - |
+    **Fixed** an issue where `caCertificateRefs[].kind: Secret` in Gateway API frontend mTLS (`spec.tls.frontend.default.validation.caCertificateRefs`) was rejected by SDS at runtime despite valid Gateway configuration, including same-namespace references and cross-namespace references allowed by `ReferenceGrant`


### PR DESCRIPTION
**Please provide a description of this PR:**

Since Istio 1.28, `caCertificateRefs[].kind: Secret` in Gateway API frontend mTLS has been unconditionally rejected by SDS at runtime. The [official secure-ingress documentation](https://istio.io/latest/docs/tasks/traffic-management/ingress/secure-ingress/#configure-a-mutual-tls-ingress-gateway) (step 2, "Gateway API" tab) has shown `kind: Secret` as a valid configuration since that release — anyone following the tutorial hits this bug. `kind: ConfigMap` is unaffected.

**Root cause:** `mergeGateways()` populates `MergedGateway.VerifiedCertificateReferences` only from serving certificate credentials (`CredentialName`/`CredentialNames`). `CaCertCredentialName` is never added. SDS unconditionally denies any `KubernetesGatewaySecretType` resource not present in that set, so a valid `caCertificateRefs[].kind: Secret` config converts without error but fails at runtime:

```
proxy <pod>.istio-system attempted to access unauthorized certificates
<name>-cacert: cross namespace secret reference requires ReferenceGrant
```

This error appears even for same-namespace Secrets and even when a valid `ReferenceGrant` is present, because the denial is in the SDS authorization path, not in namespace policy.

**If `kind: Secret` is intentionally unsupported, the conversion layer should reject it with a status condition rather than silently producing an SDS resource that is then unconditionally denied at runtime — and the official documentation should be corrected accordingly.**

**History:**
- [#56549](https://github.com/istio/istio/pull/56549) — added `CaCertCredentialName`; `kind: ConfigMap` path works
- [#57183](https://github.com/istio/istio/pull/57183) — added Gateway API frontend validation; conversion accepts `kind: Secret` but SDS authorization was not completed; shipped in 1.28
- istio.io [#16739](https://github.com/istio/istio.io/pull/16739) — official docs added `kind: Secret` example; present in releases 1.28, 1.29, 1.30
- `kind: Secret` has been silently broken since 1.28 through current 1.30

**Fix:** adds `CaCertCredentialName` to `VerifiedCertificateReferences` in `mergeGateways()` using the same authorization rules as serving cert credentials: same-namespace trust is always allowed, cross-namespace requires a `ReferenceGrant`. Per [GEP-91](https://gateway-api.sigs.k8s.io/geps/gep-91/), `kind: Secret` for CA bundles is implementation-specific (optional); only `kubernetes-gateway://` URIs are processed here — `ConfigMap`-backed CA certs are unconditionally allowed in `sds.go` and need no entry in `VerifiedCertificateReferences`.

`TestMergeGateways` is extended with three new cases covering same-namespace, cross-namespace-allowed, and cross-namespace-denied scenarios. Each asserts the exact set of authorized SDS resource names.

**Refactor note:** the per-server authorization context (`gwKind`, `lookupNamespace`, `configAndProxyAllowed`) is hoisted out of the credential loop so the new `CaCertCredentialName` authorization path — which lives outside the loop, as a sibling to it — can share the same computed values. These inputs are loop-invariant (they depend on `gatewayConfig` and `proxy.VerifiedIdentity`, not on `cn`), so behavior of the existing serving-cert path is unchanged. The `if identityVerified` guard on `lookupNamespace`/`configAndProxyAllowed` preserves the prior safety property that `proxy.VerifiedIdentity` is only dereferenced when verified.

Fixes #60277
