### PR TITLE
test: scale framework timeouts 3x on arm64

### DIFF
--- a/pkg/test/framework/components/echo/flags.go
+++ b/pkg/test/framework/components/echo/flags.go
@@ -16,16 +16,26 @@ package echo
 
 import (
 	"flag"
+	"runtime"
 	"time"
 
 	"istio.io/istio/pkg/test/util/retry"
 )
 
+// scaleForArch returns d, scaled up on slower architectures (arm64) to account
+// for slower CPU-per-core on the prow arm64 worker pool. amd64 unchanged.
+func scaleForArch(d time.Duration) time.Duration {
+	if runtime.GOARCH == "arm64" {
+		return 3 * d
+	}
+	return d
+}
+
 var (
-	callTimeout      = 30 * time.Second
+	callTimeout      = scaleForArch(30 * time.Second)
 	callDelay        = 20 * time.Millisecond
 	callConverge     = 3
-	readinessTimeout = 10 * time.Minute
+	readinessTimeout = scaleForArch(10 * time.Minute)
 	callsPerWorkload = 3
 )
 

--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -18,6 +18,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 
 	gwConformanceConfig "sigs.k8s.io/gateway-api/conformance/utils/config"
@@ -27,6 +28,31 @@ import (
 	"istio.io/istio/pkg/test/framework/config"
 	"istio.io/istio/pkg/test/framework/label"
 )
+
+// scaleGwConformanceTimeoutsForArch bumps the gateway-conformance suite
+// timeouts on arm64 since the prow arm64 worker pool is markedly slower than
+// amd64. Per-RPC timeouts (Get/Delete/Request) are left alone since they don't
+// suffer from CPU speed, only from controller reconcile lag.
+func scaleGwConformanceTimeoutsForArch(c *gwConformanceConfig.TimeoutConfig) {
+	if runtime.GOARCH != "arm64" {
+		return
+	}
+	const mult = 3
+	c.CreateTimeout *= mult
+	c.GatewayMustHaveAddress *= mult
+	c.GatewayMustHaveCondition *= mult
+	c.GatewayStatusMustHaveListeners *= mult
+	c.GatewayListenersMustHaveConditions *= mult
+	c.GWCMustBeAccepted *= mult
+	c.HTTPRouteMustNotHaveParents *= mult
+	c.HTTPRouteMustHaveCondition *= mult
+	c.TLSRouteMustHaveCondition *= mult
+	c.RouteMustHaveParents *= mult
+	c.MaxTimeToConsistency *= mult
+	c.NamespacesMustBeReady *= mult
+	c.LatestObservedGenerationSet *= mult
+	c.DefaultTestTimeout *= mult
+}
 
 var settingsFromCommandLine = DefaultSettings()
 
@@ -251,6 +277,7 @@ func init() {
 
 func initGatewayConformanceTimeouts() {
 	defaults := gwConformanceConfig.DefaultTimeoutConfig()
+	scaleGwConformanceTimeoutsForArch(&defaults)
 	settingsFromCommandLine.GatewayConformanceTimeoutConfig = defaults
 
 	flag.DurationVar(&settingsFromCommandLine.GatewayConformanceTimeoutConfig.CreateTimeout, "istio.test.gatewayConformance.createTimeout",


### PR DESCRIPTION
Bumps echo callTimeout and gateway-conformance suite defaults 3x on arm64 to address flakes. The prow arm64 worker pool is markedly slower per-core than amd64, and tests like TestTraffic/jwt-claim-route hit the 30s default before envoy finishes config propagation.