### PR TITLE
Add view and edit user-facing clusterroles

### DIFF
--- a/manifests/charts/base/templates/edit-clusterrole.yaml
+++ b/manifests/charts/base/templates/edit-clusterrole.yaml
@@ -1,0 +1,29 @@
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "cluster") }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: istio-edit
+  labels:
+    app: istio
+    release: {{ .Release.Name }}
+    app.kubernetes.io/name: "istio"
+    {{- include "istio.labels" . | nindent 4 }}
+    {{- if .Values.base.aggregateClusterRoles }}
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    {{- end }}
+rules:
+  - apiGroups:
+      - networking.istio.io
+      - security.istio.io
+      - telemetry.istio.io
+      - extensions.istio.io
+    resources:
+      - "*"
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection
+{{- end }}

--- a/manifests/charts/base/templates/view-clusterrole.yaml
+++ b/manifests/charts/base/templates/view-clusterrole.yaml
@@ -1,0 +1,28 @@
+{{- if or (eq .Values.global.resourceScope "all") (eq .Values.global.resourceScope "cluster") }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: istio-view
+  labels:
+    app: istio
+    release: {{ .Release.Name }}
+    app.kubernetes.io/name: "istio"
+    {{- include "istio.labels" . | nindent 4 }}
+    {{- if .Values.base.aggregateClusterRoles }}
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    {{- end }}
+rules:
+  - apiGroups:
+      - networking.istio.io
+      - security.istio.io
+      - telemetry.istio.io
+      - extensions.istio.io
+    resources:
+      - "*"
+    verbs:
+      - get
+      - list
+      - watch
+{{- end }}

--- a/manifests/charts/base/values.yaml
+++ b/manifests/charts/base/values.yaml
@@ -44,6 +44,9 @@ _internal_defaults_do_not_set:
     # For istioctl usage to disable istio config crds in base
     enableIstioConfigCRDs: true
 
+    # Aggregate ClusterRoles to Kubernetes default user-facing roles. For more information, see [User-facing roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles)
+    aggregateClusterRoles: false
+
   defaultRevision: "default"
   experimental:
     stableValidationPolicy: false

--- a/operator/pkg/apis/values_types.pb.go
+++ b/operator/pkg/apis/values_types.pb.go
@@ -4946,8 +4946,10 @@ type BaseConfig struct {
 	ValidateGateway       *wrapperspb.BoolValue `protobuf:"bytes,4,opt,name=validateGateway,proto3" json:"validateGateway,omitempty"`
 	// validation webhook CA bundle
 	ValidationCABundle string `protobuf:"bytes,5,opt,name=validationCABundle,proto3" json:"validationCABundle,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// Aggregate ClusterRoles to Kubernetes default user-facing roles.
+	AggregateClusterRoles *wrapperspb.BoolValue `protobuf:"bytes,7,opt,name=aggregateClusterRoles,proto3" json:"aggregateClusterRoles,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *BaseConfig) Reset() {
@@ -5020,6 +5022,13 @@ func (x *BaseConfig) GetValidationCABundle() string {
 		return x.ValidationCABundle
 	}
 	return ""
+}
+
+func (x *BaseConfig) GetAggregateClusterRoles() *wrapperspb.BoolValue {
+	if x != nil {
+		return x.AggregateClusterRoles
+	}
+	return nil
 }
 
 type IstiodRemoteConfig struct {
@@ -5981,7 +5990,7 @@ const file_pkg_apis_values_types_proto_rawDesc = "" +
 	"\x05debug\x18\x01 \x01(\v2\x1a.google.protobuf.BoolValueR\x05debug\x124\n" +
 	"\x15maxNumberOfAttributes\x18\x02 \x01(\rR\x15maxNumberOfAttributes\x126\n" +
 	"\x16maxNumberOfAnnotations\x18\x03 \x01(\rR\x16maxNumberOfAnnotations\x12:\n" +
-	"\x18maxNumberOfMessageEvents\x18\x04 \x01(\rR\x18maxNumberOfMessageEvents\"\xea\x02\n" +
+	"\x18maxNumberOfMessageEvents\x18\x04 \x01(\rR\x18maxNumberOfMessageEvents\"\xbc\x03\n" +
 	"\n" +
 	"BaseConfig\x12J\n" +
 	"\x12enableCRDTemplates\x18\x01 \x01(\v2\x1a.google.protobuf.BoolValueR\x12enableCRDTemplates\x12\"\n" +
@@ -5989,7 +5998,8 @@ const file_pkg_apis_values_types_proto_rawDesc = "" +
 	"\rvalidationURL\x18\x02 \x01(\tR\rvalidationURL\x12P\n" +
 	"\x15enableIstioConfigCRDs\x18\x03 \x01(\v2\x1a.google.protobuf.BoolValueR\x15enableIstioConfigCRDs\x12D\n" +
 	"\x0fvalidateGateway\x18\x04 \x01(\v2\x1a.google.protobuf.BoolValueR\x0fvalidateGateway\x12.\n" +
-	"\x12validationCABundle\x18\x05 \x01(\tR\x12validationCABundle\"\x9e\x02\n" +
+	"\x12validationCABundle\x18\x05 \x01(\tR\x12validationCABundle\x12P\n" +
+	"\x15aggregateClusterRoles\x18\a \x01(\v2\x1a.google.protobuf.BoolValueR\x15aggregateClusterRoles\"\x9e\x02\n" +
 	"\x12IstiodRemoteConfig\x12\"\n" +
 	"\finjectionURL\x18\x01 \x01(\tR\finjectionURL\x12$\n" +
 	"\rinjectionPath\x18\x02 \x01(\tR\rinjectionPath\x12,\n" +
@@ -6312,35 +6322,36 @@ var file_pkg_apis_values_types_proto_depIdxs = []int32{
 	57,  // 174: istio.operator.v1alpha1.BaseConfig.enableCRDTemplates:type_name -> google.protobuf.BoolValue
 	57,  // 175: istio.operator.v1alpha1.BaseConfig.enableIstioConfigCRDs:type_name -> google.protobuf.BoolValue
 	57,  // 176: istio.operator.v1alpha1.BaseConfig.validateGateway:type_name -> google.protobuf.BoolValue
-	57,  // 177: istio.operator.v1alpha1.IstiodRemoteConfig.enabled:type_name -> google.protobuf.BoolValue
-	57,  // 178: istio.operator.v1alpha1.IstiodRemoteConfig.enabledLocalInjectorIstiod:type_name -> google.protobuf.BoolValue
-	5,   // 179: istio.operator.v1alpha1.Values.cni:type_name -> istio.operator.v1alpha1.CNIConfig
-	16,  // 180: istio.operator.v1alpha1.Values.gateways:type_name -> istio.operator.v1alpha1.GatewaysConfig
-	17,  // 181: istio.operator.v1alpha1.Values.global:type_name -> istio.operator.v1alpha1.GlobalConfig
-	25,  // 182: istio.operator.v1alpha1.Values.pilot:type_name -> istio.operator.v1alpha1.PilotConfig
-	58,  // 183: istio.operator.v1alpha1.Values.ztunnel:type_name -> google.protobuf.Value
-	29,  // 184: istio.operator.v1alpha1.Values.telemetry:type_name -> istio.operator.v1alpha1.TelemetryConfig
-	40,  // 185: istio.operator.v1alpha1.Values.sidecarInjectorWebhook:type_name -> istio.operator.v1alpha1.SidecarInjectorConfig
-	6,   // 186: istio.operator.v1alpha1.Values.istio_cni:type_name -> istio.operator.v1alpha1.CNIUsageConfig
-	58,  // 187: istio.operator.v1alpha1.Values.meshConfig:type_name -> google.protobuf.Value
-	46,  // 188: istio.operator.v1alpha1.Values.base:type_name -> istio.operator.v1alpha1.BaseConfig
-	47,  // 189: istio.operator.v1alpha1.Values.istiodRemote:type_name -> istio.operator.v1alpha1.IstiodRemoteConfig
-	49,  // 190: istio.operator.v1alpha1.Values.experimental:type_name -> istio.operator.v1alpha1.ExperimentalConfig
-	58,  // 191: istio.operator.v1alpha1.Values.gatewayClasses:type_name -> google.protobuf.Value
-	57,  // 192: istio.operator.v1alpha1.ExperimentalConfig.stableValidationPolicy:type_name -> google.protobuf.BoolValue
-	61,  // 193: istio.operator.v1alpha1.IntOrString.intVal:type_name -> google.protobuf.Int32Value
-	62,  // 194: istio.operator.v1alpha1.IntOrString.strVal:type_name -> google.protobuf.StringValue
-	11,  // 195: istio.operator.v1alpha1.WaypointConfig.resources:type_name -> istio.operator.v1alpha1.Resources
-	59,  // 196: istio.operator.v1alpha1.WaypointConfig.affinity:type_name -> google.protobuf.Struct
-	59,  // 197: istio.operator.v1alpha1.WaypointConfig.topologySpreadConstraints:type_name -> google.protobuf.Struct
-	59,  // 198: istio.operator.v1alpha1.WaypointConfig.nodeSelector:type_name -> google.protobuf.Struct
-	59,  // 199: istio.operator.v1alpha1.WaypointConfig.toleration:type_name -> google.protobuf.Struct
-	57,  // 200: istio.operator.v1alpha1.NetworkPolicyConfig.enabled:type_name -> google.protobuf.BoolValue
-	201, // [201:201] is the sub-list for method output_type
-	201, // [201:201] is the sub-list for method input_type
-	201, // [201:201] is the sub-list for extension type_name
-	201, // [201:201] is the sub-list for extension extendee
-	0,   // [0:201] is the sub-list for field type_name
+	57,  // 177: istio.operator.v1alpha1.BaseConfig.aggregateClusterRoles:type_name -> google.protobuf.BoolValue
+	57,  // 178: istio.operator.v1alpha1.IstiodRemoteConfig.enabled:type_name -> google.protobuf.BoolValue
+	57,  // 179: istio.operator.v1alpha1.IstiodRemoteConfig.enabledLocalInjectorIstiod:type_name -> google.protobuf.BoolValue
+	5,   // 180: istio.operator.v1alpha1.Values.cni:type_name -> istio.operator.v1alpha1.CNIConfig
+	16,  // 181: istio.operator.v1alpha1.Values.gateways:type_name -> istio.operator.v1alpha1.GatewaysConfig
+	17,  // 182: istio.operator.v1alpha1.Values.global:type_name -> istio.operator.v1alpha1.GlobalConfig
+	25,  // 183: istio.operator.v1alpha1.Values.pilot:type_name -> istio.operator.v1alpha1.PilotConfig
+	58,  // 184: istio.operator.v1alpha1.Values.ztunnel:type_name -> google.protobuf.Value
+	29,  // 185: istio.operator.v1alpha1.Values.telemetry:type_name -> istio.operator.v1alpha1.TelemetryConfig
+	40,  // 186: istio.operator.v1alpha1.Values.sidecarInjectorWebhook:type_name -> istio.operator.v1alpha1.SidecarInjectorConfig
+	6,   // 187: istio.operator.v1alpha1.Values.istio_cni:type_name -> istio.operator.v1alpha1.CNIUsageConfig
+	58,  // 188: istio.operator.v1alpha1.Values.meshConfig:type_name -> google.protobuf.Value
+	46,  // 189: istio.operator.v1alpha1.Values.base:type_name -> istio.operator.v1alpha1.BaseConfig
+	47,  // 190: istio.operator.v1alpha1.Values.istiodRemote:type_name -> istio.operator.v1alpha1.IstiodRemoteConfig
+	49,  // 191: istio.operator.v1alpha1.Values.experimental:type_name -> istio.operator.v1alpha1.ExperimentalConfig
+	58,  // 192: istio.operator.v1alpha1.Values.gatewayClasses:type_name -> google.protobuf.Value
+	57,  // 193: istio.operator.v1alpha1.ExperimentalConfig.stableValidationPolicy:type_name -> google.protobuf.BoolValue
+	61,  // 194: istio.operator.v1alpha1.IntOrString.intVal:type_name -> google.protobuf.Int32Value
+	62,  // 195: istio.operator.v1alpha1.IntOrString.strVal:type_name -> google.protobuf.StringValue
+	11,  // 196: istio.operator.v1alpha1.WaypointConfig.resources:type_name -> istio.operator.v1alpha1.Resources
+	59,  // 197: istio.operator.v1alpha1.WaypointConfig.affinity:type_name -> google.protobuf.Struct
+	59,  // 198: istio.operator.v1alpha1.WaypointConfig.topologySpreadConstraints:type_name -> google.protobuf.Struct
+	59,  // 199: istio.operator.v1alpha1.WaypointConfig.nodeSelector:type_name -> google.protobuf.Struct
+	59,  // 200: istio.operator.v1alpha1.WaypointConfig.toleration:type_name -> google.protobuf.Struct
+	57,  // 201: istio.operator.v1alpha1.NetworkPolicyConfig.enabled:type_name -> google.protobuf.BoolValue
+	202, // [202:202] is the sub-list for method output_type
+	202, // [202:202] is the sub-list for method input_type
+	202, // [202:202] is the sub-list for extension type_name
+	202, // [202:202] is the sub-list for extension extendee
+	0,   // [0:202] is the sub-list for field type_name
 }
 
 func init() { file_pkg_apis_values_types_proto_init() }

--- a/operator/pkg/apis/values_types.proto
+++ b/operator/pkg/apis/values_types.proto
@@ -1390,6 +1390,9 @@ message BaseConfig {
 
   // validation webhook CA bundle
   string validationCABundle = 5;
+
+  // Aggregate ClusterRoles to Kubernetes default user-facing roles.
+  google.protobuf.BoolValue aggregateClusterRoles = 7;
 }
 
 message IstiodRemoteConfig {

--- a/operator/pkg/helm/helm_test.go
+++ b/operator/pkg/helm/helm_test.go
@@ -325,6 +325,20 @@ func TestRender(t *testing.T) {
 			chartName:   "istio-control/istio-discovery",
 			diffSelect:  "ConfigMap:*:istio-sidecar-injector",
 		},
+		{
+			desc:        "base-clusterroles",
+			releaseName: "istio-base",
+			namespace:   "istio-system",
+			chartName:   "base",
+			diffSelect:  "ClusterRole::istio-view,ClusterRole::istio-edit",
+		},
+		{
+			desc:        "base-clusterroles-aggregation",
+			releaseName: "istio-base",
+			namespace:   "istio-system",
+			chartName:   "base",
+			diffSelect:  "ClusterRole::istio-view,ClusterRole::istio-edit",
+		},
 	}
 
 	for _, tc := range cases {

--- a/operator/pkg/helm/testdata/input/base-clusterroles-aggregation.yaml
+++ b/operator/pkg/helm/testdata/input/base-clusterroles-aggregation.yaml
@@ -1,0 +1,4 @@
+spec:
+  values:
+    base:
+      aggregateClusterRoles: true

--- a/operator/pkg/helm/testdata/output/base-clusterroles-aggregation.golden.yaml
+++ b/operator/pkg/helm/testdata/output/base-clusterroles-aggregation.golden.yaml
@@ -1,0 +1,58 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: istio-edit
+  labels:
+    app: istio
+    release: istio-base
+    app.kubernetes.io/name: "istio"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "istio-base"
+    app.kubernetes.io/part-of: "istio"
+    app.kubernetes.io/version: "1.0.0"
+    helm.sh/chart: base-1.0.0
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+  - apiGroups:
+      - networking.istio.io
+      - security.istio.io
+      - telemetry.istio.io
+      - extensions.istio.io
+    resources:
+      - "*"
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: istio-view
+  labels:
+    app: istio
+    release: istio-base
+    app.kubernetes.io/name: "istio"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "istio-base"
+    app.kubernetes.io/part-of: "istio"
+    app.kubernetes.io/version: "1.0.0"
+    helm.sh/chart: base-1.0.0
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - apiGroups:
+      - networking.istio.io
+      - security.istio.io
+      - telemetry.istio.io
+      - extensions.istio.io
+    resources:
+      - "*"
+    verbs:
+      - get
+      - list
+      - watch

--- a/operator/pkg/helm/testdata/output/base-clusterroles.golden.yaml
+++ b/operator/pkg/helm/testdata/output/base-clusterroles.golden.yaml
@@ -1,0 +1,53 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: istio-edit
+  labels:
+    app: istio
+    release: istio-base
+    app.kubernetes.io/name: "istio"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "istio-base"
+    app.kubernetes.io/part-of: "istio"
+    app.kubernetes.io/version: "1.0.0"
+    helm.sh/chart: base-1.0.0
+rules:
+  - apiGroups:
+      - networking.istio.io
+      - security.istio.io
+      - telemetry.istio.io
+      - extensions.istio.io
+    resources:
+      - "*"
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: istio-view
+  labels:
+    app: istio
+    release: istio-base
+    app.kubernetes.io/name: "istio"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "istio-base"
+    app.kubernetes.io/part-of: "istio"
+    app.kubernetes.io/version: "1.0.0"
+    helm.sh/chart: base-1.0.0
+rules:
+  - apiGroups:
+      - networking.istio.io
+      - security.istio.io
+      - telemetry.istio.io
+      - extensions.istio.io
+    resources:
+      - "*"
+    verbs:
+      - get
+      - list
+      - watch

--- a/operator/pkg/test/util.go
+++ b/operator/pkg/test/util.go
@@ -51,10 +51,14 @@ func FilterManifest(t test.Failer, ms string, selectResources string) string {
 
 // buildResourceRegexp translates the resource indicator to regexp.
 func buildResourceRegexp(s string) (*regexp.Regexp, error) {
-	hash := strings.Split(s, ":")
-	for i, v := range hash {
-		if v == "" || v == "*" {
-			hash[i] = ".*"
+	var hash []string
+	for _, v := range strings.Split(s, ":") {
+		switch v {
+		case "":
+		case "*":
+			hash = append(hash, ".*")
+		default:
+			hash = append(hash, v)
 		}
 	}
 	return regexp.Compile(strings.Join(hash, ":"))

--- a/releasenotes/notes/add-clusterroles.yaml
+++ b/releasenotes/notes/add-clusterroles.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+releaseNotes:
+  - |
+    **Added** two new user-facing cluster roles, `istio-edit` and `istio-view`, allowing respectively creation, modification, destruction and listing, reading of Istio custom resources. These cluster roles can optionaly aggregate to Kubernetes default [user-facing cluster roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles) when `base.aggregateClusterRoles` Helm value is set to `true`.
+upgradeNotes:
+  - title: New user-facing cluster roles
+    content: |
+      If you’ve previously created user-facing cluster roles for Istio custom resources management, you must ensure these do not conflict with the new user-facing cluster roles and you could consider moving to using the latter.


### PR DESCRIPTION
This is a follow-up of https://github.com/istio/istio/pull/58547.

**Please provide a description of this PR:**

Currently, users granted view, edit or admin clusterroles cannot view/edit Istio CRDs. Adding istio-view and istio-edit clusterroles which aggregate to the view, edit and admin clusterroles greatly improves the out of the box user experience with Istio.