### PR TITLE
TestDelayQueueRetry data race

### DIFF
--- a/pkg/queue/delay_test.go
+++ b/pkg/queue/delay_test.go
@@ -20,6 +20,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"go.uber.org/atomic"
 )
 
 func TestPriorityQueue(t *testing.T) {
@@ -177,14 +179,14 @@ func TestDelayQueueRetry(t *testing.T) {
 	defer close(stop)
 	go dq.Run(stop)
 
-	count := 0
+	count := atomic.NewInt32(0)
 	done := make(chan struct{})
 	dq.PushDelayed(func() error {
-		count++
-		if count == maxTaskRetry+1 {
+		cnt := count.Inc()
+		if cnt == maxTaskRetry+1 {
 			close(done)
 		}
-		return fmt.Errorf("error count %d", count)
+		return fmt.Errorf("error count %d", cnt)
 	}, 200*time.Millisecond)
 
 	select {
@@ -193,7 +195,7 @@ func TestDelayQueueRetry(t *testing.T) {
 	case <-done:
 	}
 
-	if count != maxTaskRetry+1 {
-		t.Errorf("running count %d != %d", count, maxTaskRetry+1)
+	if cnt := count.Load(); cnt != maxTaskRetry+1 {
+		t.Errorf("running count %d != %d", cnt, maxTaskRetry+1)
 	}
 }


### PR DESCRIPTION
Prevent the race between updating the count
and reading it after the channel closes.

**Please provide a description of this PR:**
```
{Failed      delay_test.go:192: timeout waiting for the task done
==================
WARNING: DATA RACE
Read at 0x00c0001b6168 by goroutine 26:
  istio.io/istio/pkg/queue.TestDelayQueueRetry()
      /home/prow/go/src/istio.io/istio/pkg/queue/delay_test.go:196 +0x35e
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:2036 +0x21c
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:2101 +0x38

Previous write at 0x00c0001b6168 by goroutine 28:
  istio.io/istio/pkg/queue.TestDelayQueueRetry.func1()
      /home/prow/go/src/istio.io/istio/pkg/queue/delay_test.go:183 +0x49
  istio.io/istio/pkg/queue.(*delayQueue).work.func1()
      /home/prow/go/src/istio.io/istio/pkg/queue/delay.go:269 +0x1b4
```
**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
