### PR TITLE
bug-report: capture ztunnel coverage when --include is scoped

### DIFF
--- a/releasenotes/notes/bug-report-istio-namespace-include.yaml
+++ b/releasenotes/notes/bug-report-istio-namespace-include.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+- |
+  **Fixed** `istioctl bug-report` dropping pods in the Istio control plane namespace (ztunnel, istiod, CNI, gateways) when `--include` was scoped to workload namespaces. Control plane pods are now always captured; explicit `--exclude` still applies.

--- a/releasenotes/notes/bug-report-ztunnel-coverage.yaml
+++ b/releasenotes/notes/bug-report-ztunnel-coverage.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+releaseNotes:
+- |
+  **Fixed** `istioctl bug-report` to always capture pods in the Istio control plane namespace (ztunnel, istiod, CNI, gateways) even when `--include` is scoped to workload namespaces. Explicit `--exclude` still applies.
+- |
+  **Added** ztunnel Prometheus metrics collection to `istioctl bug-report`. Ztunnel serves stats on a separate port from its admin endpoint, so a new `--ztunnel-stats-port` flag (default 15020) controls where `stats/prometheus` is fetched. Metrics are written to the existing per-pod `proxies/<ns>/<pod>/` directory.

--- a/releasenotes/notes/bug-report-ztunnel-stats.yaml
+++ b/releasenotes/notes/bug-report-ztunnel-stats.yaml
@@ -3,6 +3,4 @@ kind: feature
 area: istioctl
 releaseNotes:
 - |
-  **Fixed** `istioctl bug-report` to always capture pods in the Istio control plane namespace (ztunnel, istiod, CNI, gateways) even when `--include` is scoped to workload namespaces. Explicit `--exclude` still applies.
-- |
   **Added** ztunnel Prometheus metrics collection to `istioctl bug-report`. Ztunnel serves stats on a separate port from its admin endpoint, so a new `--ztunnel-stats-port` flag (default 15020) controls where `stats/prometheus` is fetched. Metrics are written to the existing per-pod `proxies/<ns>/<pod>/` directory.

--- a/tools/bug-report/pkg/bugreport/bugreport.go
+++ b/tools/bug-report/pkg/bugreport/bugreport.go
@@ -355,7 +355,11 @@ func gatherInfo(runner *kubectlcmd.Runner, config *config.BugReportConfig, resou
 					getFromCluster(content.GetNetstat, cp, proxyDir, &mandatoryWg)
 				}
 				if !config.SkipProxyDebug {
-					getFromCluster(content.GetZtunnelInfo, cp.SetProxyAdminPort(config.ProxyAdminPort), archive.ProxyOutputPath(tempDir, namespace, pod), &optionalWg)
+					ztunnelParams := cp.SetProxyAdminPort(config.ProxyAdminPort).SetZtunnelStatsPort(config.ZtunnelStatsPort)
+					getFromCluster(content.GetZtunnelInfo, ztunnelParams, archive.ProxyOutputPath(tempDir, namespace, pod), &optionalWg)
+					if config.ZtunnelStatsPort != 0 {
+						getFromCluster(content.GetZtunnelStats, ztunnelParams, archive.ProxyOutputPath(tempDir, namespace, pod), &optionalWg)
+					}
 				}
 				getProxyLogs(runner, config, resources, p, namespace, pod, container, &optionalWg)
 			}

--- a/tools/bug-report/pkg/bugreport/flags.go
+++ b/tools/bug-report/pkg/bugreport/flags.go
@@ -56,6 +56,10 @@ func addFlags(cmd *cobra.Command, args *config2.BugReportConfig) {
 	cmd.PersistentFlags().IntVar(&args.ProxyAdminPort, "proxy-admin-port", util.DefaultProxyAdminPort,
 		"Envoy proxy admin port")
 
+	cmd.PersistentFlags().IntVar(&args.ZtunnelStatsPort, "ztunnel-stats-port", 15020,
+		"Ztunnel stats (Prometheus metrics) port. Ztunnel serves metrics on this port separately "+
+			"from the admin port used for config_dump.")
+
 	// full secrets
 	cmd.PersistentFlags().BoolVarP(&args.FullSecrets, "full-secrets", "", false,
 		"If set, secret contents are included in output.")

--- a/tools/bug-report/pkg/cluster/cluster.go
+++ b/tools/bug-report/pkg/cluster/cluster.go
@@ -84,6 +84,13 @@ func shouldSkipPod(pod *corev1.Pod, config *config2.BugReportConfig) bool {
 		}
 	}
 
+	// Pods in the Istio control plane namespace are always captured once they pass the
+	// --exclude checks above, so users scoping --include to workload namespaces still get
+	// ztunnel, istiod, CNI, and gateway logs/debug.
+	if config.IstioNamespace != "" && pod.Namespace == config.IstioNamespace {
+		return false
+	}
+
 	for _, ild := range config.Include {
 		if len(ild.Namespaces) > 0 {
 			if !isIncludeOrExcludeEntriesMatched(ild.Namespaces, pod.Namespace) {
@@ -145,12 +152,8 @@ func shouldSkipPod(pod *corev1.Pod, config *config2.BugReportConfig) bool {
 }
 
 func shouldSkipDeployment(deployment string, config *config2.BugReportConfig) bool {
-	for _, eld := range config.Exclude {
-		if len(eld.Deployments) > 0 {
-			if isIncludeOrExcludeEntriesMatched(eld.Deployments, deployment) {
-				return true
-			}
-		}
+	if shouldExcludeDeployment(deployment, config) {
+		return true
 	}
 
 	for _, ild := range config.Include {
@@ -164,18 +167,41 @@ func shouldSkipDeployment(deployment string, config *config2.BugReportConfig) bo
 	return false
 }
 
-func shouldSkipDaemonSet(daemonSet string, config *config2.BugReportConfig) bool {
+// shouldExcludeDeployment evaluates only the --exclude side of the deployment filter.
+// Used when a pod is unconditionally captured (e.g. control plane pods) but the user
+// has explicitly excluded its owning deployment.
+func shouldExcludeDeployment(deployment string, config *config2.BugReportConfig) bool {
 	for _, eld := range config.Exclude {
-		if len(eld.Daemonsets) > 0 {
-			if isIncludeOrExcludeEntriesMatched(eld.Daemonsets, daemonSet) {
+		if len(eld.Deployments) > 0 {
+			if isIncludeOrExcludeEntriesMatched(eld.Deployments, deployment) {
 				return true
 			}
 		}
+	}
+	return false
+}
+
+func shouldSkipDaemonSet(daemonSet string, config *config2.BugReportConfig) bool {
+	if shouldExcludeDaemonSet(daemonSet, config) {
+		return true
 	}
 
 	for _, ild := range config.Include {
 		if len(ild.Daemonsets) > 0 {
 			if !isIncludeOrExcludeEntriesMatched(ild.Daemonsets, daemonSet) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// shouldExcludeDaemonSet evaluates only the --exclude side of the daemonset filter.
+// See shouldExcludeDeployment.
+func shouldExcludeDaemonSet(daemonSet string, config *config2.BugReportConfig) bool {
+	for _, eld := range config.Exclude {
+		if len(eld.Daemonsets) > 0 {
+			if isIncludeOrExcludeEntriesMatched(eld.Daemonsets, daemonSet) {
 				return true
 			}
 		}
@@ -265,14 +291,27 @@ func GetClusterResources(ctx context.Context, clientset kubernetes.Interface, co
 			continue
 		}
 
+		// Pods in the Istio control plane namespace bypass the deployment/daemonset include
+		// filters so a user scoping --include to a workload deployment still gets ztunnel,
+		// istiod, and gateways. Exclude filters still apply.
+		isControlPlanePod := config.IstioNamespace != "" && p.Namespace == config.IstioNamespace
+
 		// Resolve the pod's owning deployment or daemonset via the pre-built lookup maps,
 		// and apply deployment/daemonset-level include/exclude filters.
 		deployment := getOwnerDeployment(&p, rsOwnerMap)
-		if skip := shouldSkipDeployment(deployment, config); skip {
+		if !isControlPlanePod {
+			if skip := shouldSkipDeployment(deployment, config); skip {
+				continue
+			}
+		} else if shouldExcludeDeployment(deployment, config) {
 			continue
 		}
 		daemonset := getOwnerDaemonSet(&p, dsNameMap)
-		if skip := shouldSkipDaemonSet(daemonset, config); skip {
+		if !isControlPlanePod {
+			if skip := shouldSkipDaemonSet(daemonset, config); skip {
+				continue
+			}
+		} else if shouldExcludeDaemonSet(daemonset, config) {
 			continue
 		}
 

--- a/tools/bug-report/pkg/cluster/cluster_test.go
+++ b/tools/bug-report/pkg/cluster/cluster_test.go
@@ -503,6 +503,188 @@ func TestShouldSkipPod(t *testing.T) {
 	}
 }
 
+// TestShouldSkipPod_IstioNamespaceAlwaysIncluded covers the implicit-include behavior for
+// pods in the configured Istio control plane namespace. Users scoping --include to workload
+// namespaces should still capture ztunnel / istiod / gateway pods.
+func TestShouldSkipPod_IstioNamespaceAlwaysIncluded(t *testing.T) {
+	istioNS := "istio-system"
+	cases := []struct {
+		name     string
+		pod      *v1.Pod
+		config   *config2.BugReportConfig
+		expected bool
+	}{
+		{
+			"ztunnel pod survives include scoped to workload namespace",
+			&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: istioNS,
+					Name:      "ztunnel-abcde",
+					Labels:    map[string]string{"app": "ztunnel"},
+				},
+			},
+			&config2.BugReportConfig{
+				IstioNamespace: istioNS,
+				Include: []*config2.SelectionSpec{
+					{Namespaces: []string{"workload-ns"}},
+				},
+			},
+			false,
+		},
+		{
+			"istiod pod survives include scoped to workload namespace",
+			&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: istioNS,
+					Name:      "istiod-1",
+					Labels:    map[string]string{"app": "istiod"},
+				},
+			},
+			&config2.BugReportConfig{
+				IstioNamespace: istioNS,
+				Include: []*config2.SelectionSpec{
+					{Namespaces: []string{"workload-ns"}},
+				},
+			},
+			false,
+		},
+		{
+			"explicit exclude of istio namespace still applies",
+			&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: istioNS,
+					Name:      "ztunnel-abcde",
+				},
+			},
+			&config2.BugReportConfig{
+				IstioNamespace: istioNS,
+				Include: []*config2.SelectionSpec{
+					{Namespaces: []string{"workload-ns"}},
+				},
+				Exclude: []*config2.SelectionSpec{
+					{Namespaces: []string{istioNS}},
+				},
+			},
+			true,
+		},
+		{
+			"explicit exclude of ztunnel pod still applies",
+			&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: istioNS,
+					Name:      "ztunnel-abcde",
+				},
+			},
+			&config2.BugReportConfig{
+				IstioNamespace: istioNS,
+				Exclude: []*config2.SelectionSpec{
+					{Pods: []string{"ztunnel-*"}},
+				},
+			},
+			true,
+		},
+		{
+			"unset IstioNamespace falls back to existing include behavior",
+			&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: istioNS,
+					Name:      "ztunnel-abcde",
+				},
+			},
+			&config2.BugReportConfig{
+				IstioNamespace: "",
+				Include: []*config2.SelectionSpec{
+					{Namespaces: []string{"workload-ns"}},
+				},
+			},
+			true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			skip := shouldSkipPod(c.pod, c.config)
+			if skip != c.expected {
+				t.Errorf("shouldSkipPod() for %q return= %v, want %v", c.name, skip, c.expected)
+			}
+		})
+	}
+}
+
+func TestShouldExcludeDeployment(t *testing.T) {
+	cases := []struct {
+		name       string
+		deployment string
+		config     *config2.BugReportConfig
+		expected   bool
+	}{
+		{
+			"deployment excluded",
+			"istiod",
+			&config2.BugReportConfig{
+				Exclude: []*config2.SelectionSpec{
+					{Deployments: []string{"istiod"}},
+				},
+			},
+			true,
+		},
+		{
+			"include filter is ignored",
+			"",
+			&config2.BugReportConfig{
+				Include: []*config2.SelectionSpec{
+					{Deployments: []string{"some-deploy"}},
+				},
+			},
+			false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := shouldExcludeDeployment(c.deployment, c.config); got != c.expected {
+				t.Errorf("shouldExcludeDeployment() = %v, want %v", got, c.expected)
+			}
+		})
+	}
+}
+
+func TestShouldExcludeDaemonSet(t *testing.T) {
+	cases := []struct {
+		name      string
+		daemonSet string
+		config    *config2.BugReportConfig
+		expected  bool
+	}{
+		{
+			"daemonset excluded",
+			"ztunnel",
+			&config2.BugReportConfig{
+				Exclude: []*config2.SelectionSpec{
+					{Daemonsets: []string{"ztunnel"}},
+				},
+			},
+			true,
+		},
+		{
+			"include filter is ignored",
+			"ztunnel",
+			&config2.BugReportConfig{
+				Include: []*config2.SelectionSpec{
+					{Daemonsets: []string{"some-ds"}},
+				},
+			},
+			false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := shouldExcludeDaemonSet(c.daemonSet, c.config); got != c.expected {
+				t.Errorf("shouldExcludeDaemonSet() = %v, want %v", got, c.expected)
+			}
+		})
+	}
+}
+
 func TestShouldSkipDeployment(t *testing.T) {
 	cases := []struct {
 		name       string

--- a/tools/bug-report/pkg/common/common.go
+++ b/tools/bug-report/pkg/common/common.go
@@ -46,6 +46,7 @@ type resourceNames struct {
 	istioDebugURLs   []string
 	proxyDebugURLs   []string
 	ztunnelDebugURLs []string
+	ztunnelStatsURLs []string
 }
 
 var versionMap = map[string]*resourceNames{
@@ -88,6 +89,11 @@ var versionMap = map[string]*resourceNames{
 		ztunnelDebugURLs: []string{
 			"config_dump",
 		},
+		// Ztunnel serves Prometheus metrics on a separate stats port (default 15020) rather
+		// than the admin port used for config_dump. See ztunnel src/config.rs DEFAULT_STATS_PORT.
+		ztunnelStatsURLs: []string{
+			"stats/prometheus",
+		},
 	},
 }
 
@@ -101,9 +107,16 @@ func ProxyDebugURLs(clusterVersion string) []string {
 	return versionMap[getVersionKey(clusterVersion)].proxyDebugURLs
 }
 
-// ZtunnelDebugURLs returns a list of ztunnel debug URLs for the given version.
+// ZtunnelDebugURLs returns a list of ztunnel debug URLs for the given version. These are
+// served on the ztunnel admin port.
 func ZtunnelDebugURLs(clusterVersion string) []string {
 	return versionMap[getVersionKey(clusterVersion)].ztunnelDebugURLs
+}
+
+// ZtunnelStatsURLs returns a list of ztunnel stats URLs for the given version. These are
+// served on the ztunnel stats port, which is distinct from the admin port.
+func ZtunnelStatsURLs(clusterVersion string) []string {
+	return versionMap[getVersionKey(clusterVersion)].ztunnelStatsURLs
 }
 
 // IsDiscoveryContainer reports whether the given container is an Istio discovery container for the given version.

--- a/tools/bug-report/pkg/common/common_test.go
+++ b/tools/bug-report/pkg/common/common_test.go
@@ -15,8 +15,9 @@
 package common
 
 import (
-	"slices"
 	"testing"
+
+	"istio.io/istio/pkg/slices"
 )
 
 func TestZtunnelStatsURLs(t *testing.T) {

--- a/tools/bug-report/pkg/common/common_test.go
+++ b/tools/bug-report/pkg/common/common_test.go
@@ -1,0 +1,43 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestZtunnelStatsURLs(t *testing.T) {
+	got := ZtunnelStatsURLs("")
+	if !slices.Contains(got, "stats/prometheus") {
+		t.Errorf("expected stats/prometheus in ZtunnelStatsURLs, got %v", got)
+	}
+}
+
+func TestZtunnelStatsURLs_UnknownVersionFallsBackToLatest(t *testing.T) {
+	got := ZtunnelStatsURLs("0.0.0-not-a-real-version")
+	if !slices.Contains(got, "stats/prometheus") {
+		t.Errorf("expected fallback to latest, got %v", got)
+	}
+}
+
+func TestZtunnelDebugURLsExcludesStats(t *testing.T) {
+	// Stats live on a different port and must not be fetched via the admin port URL list.
+	for _, u := range ZtunnelDebugURLs("") {
+		if u == "stats/prometheus" || u == "stats" {
+			t.Errorf("stats URLs must not appear in ZtunnelDebugURLs (admin-port list): %q", u)
+		}
+	}
+}

--- a/tools/bug-report/pkg/config/config.go
+++ b/tools/bug-report/pkg/config/config.go
@@ -144,6 +144,10 @@ type BugReportConfig struct {
 	// ProxyAdminPort is envoy proxy admin port
 	ProxyAdminPort int `json:"proxyAdminPort,omitempty"`
 
+	// ZtunnelStatsPort is the ztunnel stats (metrics) port. Distinct from ProxyAdminPort
+	// because ztunnel serves Prometheus metrics on a separate listener.
+	ZtunnelStatsPort int `json:"ztunnelStatsPort,omitempty"`
+
 	// CommandTimeout is the maximum amount of time running the command
 	// before giving up, even if not all logs are captured. Upon timeout,
 	// the command creates an archive with only the logs captured so far.

--- a/tools/bug-report/pkg/content/content.go
+++ b/tools/bug-report/pkg/content/content.go
@@ -50,6 +50,7 @@ type Params struct {
 	KubeConfig         string
 	KubeContext        string
 	ProxyAdminPort     int
+	ZtunnelStatsPort   int
 	IncludedNamespaces []string
 }
 
@@ -68,6 +69,12 @@ func (p *Params) SetVerbose(verbose bool) *Params {
 func (p *Params) SetProxyAdminPort(proxyAdminPort int) *Params {
 	out := *p
 	out.ProxyAdminPort = proxyAdminPort
+	return &out
+}
+
+func (p *Params) SetZtunnelStatsPort(ztunnelStatsPort int) *Params {
+	out := *p
+	out.ZtunnelStatsPort = ztunnelStatsPort
 	return &out
 }
 
@@ -265,6 +272,31 @@ func GetZtunnelInfo(p *Params) (map[string]string, error) {
 	ret := make(map[string]string)
 	for _, url := range common.ZtunnelDebugURLs(p.ClusterVersion) {
 		out, err := p.Runner.EnvoyGet(p.Namespace, p.Pod, url, p.DryRun, p.ProxyAdminPort)
+		if err != nil {
+			errs = multierror.Append(errs, err)
+			continue
+		}
+		ret[url] = out
+	}
+	if errs.ErrorOrNil() != nil {
+		return nil, errs
+	}
+	return ret, nil
+}
+
+// GetZtunnelStats returns ztunnel Prometheus metrics. Ztunnel serves these on a stats
+// port that is distinct from its admin port, so we cannot reuse ProxyAdminPort here.
+func GetZtunnelStats(p *Params) (map[string]string, error) {
+	if p.Namespace == "" || p.Pod == "" {
+		return nil, fmt.Errorf("getZtunnelStats requires namespace and pod")
+	}
+	if p.ZtunnelStatsPort == 0 {
+		return nil, fmt.Errorf("getZtunnelStats requires a ztunnel stats port")
+	}
+	errs := istiomultierror.New()
+	ret := make(map[string]string)
+	for _, url := range common.ZtunnelStatsURLs(p.ClusterVersion) {
+		out, err := p.Runner.EnvoyGet(p.Namespace, p.Pod, url, p.DryRun, p.ZtunnelStatsPort)
 		if err != nil {
 			errs = multierror.Append(errs, err)
 			continue

--- a/tools/bug-report/pkg/content/content_test.go
+++ b/tools/bug-report/pkg/content/content_test.go
@@ -1,0 +1,46 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package content
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParamsSetZtunnelStatsPort(t *testing.T) {
+	p := &Params{}
+	out := p.SetZtunnelStatsPort(15020)
+	if out.ZtunnelStatsPort != 15020 {
+		t.Errorf("SetZtunnelStatsPort did not set port, got %d", out.ZtunnelStatsPort)
+	}
+	if p.ZtunnelStatsPort != 0 {
+		t.Errorf("SetZtunnelStatsPort mutated receiver, got %d", p.ZtunnelStatsPort)
+	}
+}
+
+func TestGetZtunnelStatsRequiresStatsPort(t *testing.T) {
+	p := &Params{Namespace: "istio-system", Pod: "ztunnel-abc"}
+	_, err := GetZtunnelStats(p)
+	if err == nil || !strings.Contains(err.Error(), "ztunnel stats port") {
+		t.Errorf("expected error about missing stats port, got %v", err)
+	}
+}
+
+func TestGetZtunnelStatsRequiresNamespaceAndPod(t *testing.T) {
+	_, err := GetZtunnelStats(&Params{ZtunnelStatsPort: 15020})
+	if err == nil {
+		t.Errorf("expected error for missing namespace/pod")
+	}
+}


### PR DESCRIPTION
**Please provide a description of this PR:**

Two changes that close gaps people hit when collecting **ambient** bug reports with --include scoped to workload namespaces.

1. Pods in the Istio control plane namespace are now always captured (subject to --exclude) regardless of --include. Previously, ztunnel, istiod, CNI, and gateway pods were silently filtered out when users passed --include workload-ns. shouldSkipPod, shouldSkipDeployment, and shouldSkipDaemonSet now short-circuit for control-plane-namespace pods while still honoring --exclude.

2. Add ztunnel Prometheus metrics collection. Ztunnel serves stats on a separate port (default 15020) from its admin port (15000) where config_dump lives. Added a --ztunnel-stats-port flag, a ztunnelStatsURLs list, and a GetZtunnelStats fetch that runs alongside GetZtunnelInfo in the ztunnel branch of gatherInfo. Output lands in the existing proxies/<ns>/<pod>/ directory.