### PR TITLE
crd validation: allow opting in to skipping CRD validation

### DIFF
--- a/pkg/config/crd/validator.go
+++ b/pkg/config/crd/validator.go
@@ -49,6 +49,22 @@ import (
 	"istio.io/istio/pkg/util/sets"
 )
 
+type validatorConfig struct {
+	skipCRDValidation bool
+}
+
+// ValidatorOption configures how validators are built.
+type ValidatorOption func(*validatorConfig)
+
+// WithoutCRDValidation skips validating each CRD definition before building validators.
+// This avoids Kubernetes' full CRD validator, which is expensive; use this when
+// the CRDs are already trusted and only resource validation is needed.
+func WithoutCRDValidation() ValidatorOption {
+	return func(o *validatorConfig) {
+		o.skipCRDValidation = true
+	}
+}
+
 // Validator returns a new validator for custom resources
 // Warning: this is meant for usage in tests only
 type Validator struct {
@@ -166,6 +182,11 @@ func (v *Validator) ValidateCustomResource(o runtime.Object) error {
 }
 
 func NewValidatorFromFiles(files ...string) (*Validator, error) {
+	return NewValidatorFromFilesWithOptions(files)
+}
+
+// NewValidatorFromFilesWithOptions builds a Validator from CRD YAML files.
+func NewValidatorFromFilesWithOptions(files []string, opts ...ValidatorOption) (*Validator, error) {
 	crds := []apiextensions.CustomResourceDefinition{}
 	closers := make([]io.Closer, 0, len(files))
 	defer func() {
@@ -239,10 +260,20 @@ func NewValidatorFromFiles(files ...string) (*Validator, error) {
 			crds = append(crds, crd)
 		}
 	}
-	return NewValidatorFromCRDs(crds...)
+	return NewValidatorFromCRDsWithOptions(crds, opts...)
 }
 
 func NewValidatorFromCRDs(crds ...apiextensions.CustomResourceDefinition) (*Validator, error) {
+	return NewValidatorFromCRDsWithOptions(crds)
+}
+
+// NewValidatorFromCRDsWithOptions builds a Validator from CRD definitions.
+func NewValidatorFromCRDsWithOptions(crds []apiextensions.CustomResourceDefinition, opts ...ValidatorOption) (*Validator, error) {
+	cfg := validatorConfig{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
 	v := &Validator{
 		byGvk:      map[schema.GroupVersionKind]validation.SchemaCreateValidator{},
 		structural: map[schema.GroupVersionKind]*structuralschema.Structural{},
@@ -256,9 +287,11 @@ func NewValidatorFromCRDs(crds ...apiextensions.CustomResourceDefinition) (*Vali
 		crd.Status.StoredVersions = slices.Map(versions, func(e apiextensions.CustomResourceDefinitionVersion) string {
 			return e.Name
 		})
-		errs := apiextval.ValidateCustomResourceDefinition(context.Background(), &crd)
-		if len(errs) > 0 {
-			return nil, fmt.Errorf("CRD %v is not valid: %v", crd.Name, errs.ToAggregate())
+		if !cfg.skipCRDValidation {
+			errs := apiextval.ValidateCustomResourceDefinition(context.Background(), &crd)
+			if len(errs) > 0 {
+				return nil, fmt.Errorf("CRD %v is not valid: %v", crd.Name, errs.ToAggregate())
+			}
 		}
 		for _, ver := range versions {
 			gvk := schema.GroupVersionKind{


### PR DESCRIPTION
This is super expensive: can easily take 1s on a top end CPU. When used
in repeated tests it adds up a lot. Ability to turn off means we can
cheaply load the CRD once and validate CRs, while other tests can
validate the CRD itself.
