### PR TITLE
pilot: skip empty IPRangeMatcher for headless services on IPv6 waypoint

### DIFF
--- a/pilot/pkg/networking/core/listener_builder_test.go
+++ b/pilot/pkg/networking/core/listener_builder_test.go
@@ -1399,6 +1399,64 @@ func extractIPMatcherFromListener(t *testing.T, l *listener.Listener) *matcher.I
 	return ipMatcher
 }
 
+// TestWaypointInternalHeadlessServiceNoEmptyRanges verifies that a service
+// with no addresses (the shape headless services take on IPv6 clusters,
+// where constants.UnspecifiedIP gets filtered out by FilterAddressesByIPFamily)
+// does not produce an IPMatcher_IPRangeMatcher with an empty Ranges slice.
+// An empty Ranges violates the proto's repeated.min_items=1 rule and is
+// rejected by envoy. See https://github.com/istio/istio/issues/60310.
+func TestWaypointInternalHeadlessServiceNoEmptyRanges(t *testing.T) {
+	test.SetForTest(t, &features.EnableAmbient, true)
+
+	cg := NewConfigGenTest(t, TestOptions{})
+
+	// Headless service: no ClusterVIPs, no AutoAllocated address, no
+	// DefaultAddress. svcAddresses in buildWaypointInternal will be empty.
+	svc := &model.Service{
+		Hostname: host.Name("headless.default.svc.cluster.local"),
+		Attributes: model.ServiceAttributes{
+			Namespace: "default",
+		},
+		Ports: model.PortList{
+			&model.Port{
+				Name:     "http",
+				Port:     80,
+				Protocol: protocol.HTTP,
+			},
+		},
+	}
+
+	proxy := &model.Proxy{
+		Type:            model.Waypoint,
+		ConfigNamespace: "default",
+		Metadata: &model.NodeMetadata{
+			ClusterID: "cluster-1",
+			Network:   "network-a",
+		},
+	}
+	proxy = cg.SetupProxy(proxy)
+
+	lb := &ListenerBuilder{
+		push: cg.PushContext(),
+		node: proxy,
+	}
+
+	l := lb.buildWaypointInternal(nil, []*model.Service{svc})
+	if l == nil {
+		t.Fatal("expected listener from buildWaypointInternal")
+	}
+
+	// If an IPMatcher exists, none of its RangeMatchers may have empty Ranges.
+	if ipMatcher := extractIPMatcherFromListener(t, l); ipMatcher != nil {
+		for i, rm := range ipMatcher.RangeMatchers {
+			if len(rm.Ranges) == 0 {
+				t.Fatalf("IPMatcher.RangeMatchers[%d].Ranges is empty; envoy rejects this (proto min_items=1). "+
+					"Headless services must elide the IPRangeMatcher entry entirely.", i)
+			}
+		}
+	}
+}
+
 func TestPreserveHeader(t *testing.T) {
 	cg := NewConfigGenTest(t, TestOptions{
 		MeshConfig: &meshconfig.MeshConfig{

--- a/pilot/pkg/networking/core/listener_waypoint.go
+++ b/pilot/pkg/networking/core/listener_waypoint.go
@@ -578,7 +578,10 @@ func (lb *ListenerBuilder) buildWaypointInternal(wls []model.WorkloadInfo, svcs 
 				delete(svcHostnameMap.Map, authorityKey)
 			}
 		}
-		if len(portMapper.Map) > 0 {
+		// Skip the IP-range matcher when there are no addresses; envoy
+		// rejects an empty Ranges (proto min_items=1). Mirrors the
+		// svcHostnameMap guard above. See https://github.com/istio/istio/issues/60310.
+		if len(portMapper.Map) > 0 && len(svcAddresses) > 0 {
 			ranges := slices.Map(svcAddresses, func(vip string) *xds.CidrRange {
 				cidr := util.ConvertAddressToCidr(vip)
 				return &xds.CidrRange{

--- a/releasenotes/notes/60310.yaml
+++ b/releasenotes/notes/60310.yaml
@@ -1,0 +1,21 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 60310
+releaseNotes:
+  - |
+    **Fixed** an issue where the waypoint listener config on IPv6 clusters
+    contained an `IPMatcher.RangeMatcher` with an empty `ranges` field when a
+    headless Service (`spec.clusterIP: None`) was present in the waypoint's
+    scope. This was produced because the IPv4-encoded `constants.UnspecifiedIP`
+    placeholder used for headless services' `DefaultAddress` is filtered out
+    for IPv6-only proxies by `FilterAddressesByIPFamily`. Envoy 1.38
+    strict-validates the proto's `repeated.min_items=1` rule on
+    `IPMatcher.RangeMatcher.ranges` and rejects the LDS push. The waypoint
+    listener builder now elides the `IPRangeMatcher` entry when there are no
+    addresses to put into it, matching the existing behaviour of the
+    surrounding code that already removes the hostname half from
+    `svcHostnameMap` for the same case. IPv4 clusters are unaffected
+    behaviourally — the placeholder matcher that was previously emitted
+    matched nothing.


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes #60310.

`buildWaypointInternal` in `pilot/pkg/networking/core/listener_waypoint.go` emits an `IPMatcher.RangeMatcher` with empty `Ranges` whenever `svcAddresses` is empty. On IPv4 clusters this doesn't bite — headless services' `DefaultAddress` falls back to `constants.UnspecifiedIP` (`"0.0.0.0"`) and that placeholder survives `FilterAddressesByIPFamily`, so the matcher ends up with a single no-op `{0.0.0.0/32}` range and envoy accepts it. On IPv6-only clusters the `"0.0.0.0"` placeholder is filtered out for IPv6 proxies, leaving `svcAddresses` empty; the resulting matcher has `Ranges: []` which violates the proto's `repeated.min_items=1` rule on `IPMatcher.RangeMatcher.ranges`. Envoy 1.38 strict-validates this and rejects the LDS push.

The fix is a one-line guard `&& len(svcAddresses) > 0` on the existing `len(portMapper.Map) > 0` check, mirroring the line ~577 guard a few lines above that already removes the hostname half from `svcHostnameMap` for the same case:

```diff
+ // Skip the IP-range matcher when there are no addresses; envoy NACKs
+ // an empty Ranges (proto min_items=1). Mirrors the svcHostnameMap
+ // guard above. See https://github.com/istio/istio/issues/60310.
- if len(portMapper.Map) > 0 {
+ if len(portMapper.Map) > 0 && len(svcAddresses) > 0 {
```

**IPv4 behaviour is unchanged** — the placeholder matcher this removes matched nothing.
**IPv6 behaviour:** the waypoint listener no longer contains a degenerate matcher, the LDS push succeeds, the waypoint pod becomes Ready.

Reproduced reliably by @sberz on a kind cluster with `networking.ipFamily: ipv6` plus a headless Service in a namespace labeled `istio.io/dataplane-mode: ambient` + `istio.io/use-waypoint`, and observed on EKS IPv6 production clusters. Full repro recipe and IPv4-vs-IPv6 config-dump comparison in [#60310](https://github.com/istio/istio/issues/60310).

A release note is included at `releasenotes/notes/60310.yaml`.

**Out of scope (could be follow-ups):**

- Making headless services actually routable through the waypoint via per-pod (EndpointSlice) IPs in `svcAddresses` — that's an enhancement, not a bug fix. This PR keeps the existing semantics: headless services don't get an IP-range matcher entry, just like `svcHostnameMap` already removes the hostname half.
- Introducing an `UnspecifiedIPv6 = "::"` constant in `pkg/config/constants/constants.go` and teaching every `UnspecifiedIP` check to handle both families — same end state as this guard with much more code surface, and a candidate for the deeper IP-family-aware refactor mentioned in the issue.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [x] Dual Stack
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
