### PR TITLE
fix multicluster ClusterStore recursive RLock deadlock

### DIFF
--- a/pkg/kube/multicluster/clusterstore.go
+++ b/pkg/kube/multicluster/clusterstore.go
@@ -163,7 +163,7 @@ func (c *ClusterStore) AllReady() map[string]map[cluster.ID]*Cluster {
 			}
 			if !cl.HasSynced() {
 				log.Debugf("remote cluster %s registered informers have not been synced up yet. Skipping and will recompute on sync", cl.ID)
-				c.triggerRecomputeOnSync(cl.ID)
+				c.triggerRecomputeOnSync(cl)
 				continue
 			}
 			outCluster := *cl
@@ -232,15 +232,14 @@ func (c *ClusterStore) HasSynced() bool {
 }
 
 // triggerRecomputeOnSync sets up a goroutine to wait for the cluster to be synced,
-// and then triggers a recompute when it is.
-func (c *ClusterStore) triggerRecomputeOnSync(id cluster.ID) {
+// and then triggers a recompute when it is. Callers must pass the cluster directly
+// rather than its ID: AllReady holds the store RLock when calling this, and looking
+// the cluster up here would attempt a recursive RLock that can deadlock against a
+// concurrent writer waiting on the same RWMutex.
+func (c *ClusterStore) triggerRecomputeOnSync(cl *Cluster) {
 	c.casMu.Lock()
 	defer c.casMu.Unlock()
-	cluster := c.GetByID(id)
-	if cluster == nil {
-		log.Debugf("cluster %s not found in store to trigger recompute", id)
-		return
-	}
+	id := cl.ID
 	exists := c.clustersAwaitingSync.InsertContains(id)
 	if exists {
 		// Already waiting for sync
@@ -252,8 +251,10 @@ func (c *ClusterStore) triggerRecomputeOnSync(id cluster.ID) {
 		// Wait until the cluster is synced. If it's deleted from the store before
 		// it's fully synced, this will return because of the stop.
 		// Double check to make sure this cluster is still in the store
-		// and that it wasn't closed/timed out (we don't want to send an event for bad clusters)
-		if cluster.WaitUntilSynced(cluster.stop) && !cluster.Closed() && !cluster.SyncDidTimeout() && c.GetByID(id) != nil {
+		// and that it wasn't closed/timed out (we don't want to send an event for bad clusters).
+		// The GetByID call below runs without holding the caller's RLock, so it does not
+		// reintroduce the recursive-lock hazard.
+		if cl.WaitUntilSynced(cl.stop) && !cl.Closed() && !cl.SyncDidTimeout() && c.GetByID(id) != nil {
 			// Let dependent krt collections know that this cluster is ready to use
 			c.TriggerRecomputation()
 			// And clean up our tracking set

--- a/releasenotes/notes/multicluster-clusterstore-rlock-deadlock.yaml
+++ b/releasenotes/notes/multicluster-clusterstore-rlock-deadlock.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+releaseNotes:
+  - |
+    **Fixed** a deadlock in the multicluster `ClusterStore` where `AllReady` could recursively acquire the store `RWMutex` for read via `triggerRecomputeOnSync` -> `GetByID` while a writer was waiting, blocking further reads and writes against the store.


### PR DESCRIPTION
ClusterStore.AllReady holds the store RWMutex for read and calls triggerRecomputeOnSync, which acquires casMu and then GetByID. GetByID tries to take the RWMutex for read again. Go's RWMutex blocks recursive RLock if a writer is waiting, so a concurrent Store/Swap/Delete deadlocks against AllReady.

Caught on a 9m57s arm64 test hang (panic: test timed out after 10m0s) in TestControllerFileSourceClusterIDChange with goroutine 491 stuck on sync.RWMutex.RLock at clusterstore.go:139.

link to the test that caught the issue: https://gcsweb.istio.io/s3/istio-prow/pr-logs/pull/istio_istio/60156/unit-tests-arm64_istio/2054213577350320128/build-log.txt
Details:
```
panic: test timed out after 10m0s
    running tests:
        TestControllerFileSourceClusterIDChange (9m57s)
...
goroutine 491 [sync.RWMutex.RLock, 9 minutes]:
istio.io/istio/pkg/kube/multicluster.(*ClusterStore).GetByID(0xc00085e980, {0x467a499, 0x8})
    /home/prow/go/src/istio.io/istio/pkg/kube/multicluster/clusterstore.go:139 +0x44
istio.io/istio/pkg/kube/multicluster.TestControllerFileSourceClusterIDChange.func2()
    /home/prow/go/src/istio.io/istio/pkg/kube/multicluster/secretcontroller_test.go:151 +0x54

```


Fix: pass *Cluster directly into triggerRecomputeOnSync. The caller already has it.