### PR TITLE
fix arm64 timing flakes: ChannelHasItem, serviceentry test

### DIFF
--- a/pilot/pkg/serviceregistry/serviceentry/controller_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller_test.go
@@ -1435,16 +1435,22 @@ func TestServiceDiscoveryWorkloadInstance(t *testing.T) {
 		expectServiceInstances(t, sd, selector, 0, instances)
 		expectEvents(t, events, Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 2})
 
-		// Validate we have exactly 1 instance for selector host in outputs
-		countForSelector := 0
-		for _, si := range sd.outputs.ServiceInstances.List() {
-			if si.Service.Attributes.Namespace == selector.Namespace && string(si.Service.Hostname) == "selector.com" {
-				countForSelector++
+		// Validate we have exactly 2 instances for selector host in outputs.
+		// expectEvents above waits for the eds event; the ServiceInstances output
+		// collection is updated by a separate handler chain that may not have
+		// drained yet, so retry until it has.
+		retry.UntilSuccessOrFail(t, func() error {
+			countForSelector := 0
+			for _, si := range sd.outputs.ServiceInstances.List() {
+				if si.Service.Attributes.Namespace == selector.Namespace && string(si.Service.Hostname) == "selector.com" {
+					countForSelector++
+				}
 			}
-		}
-		if countForSelector != 2 {
-			t.Fatalf("service instances count mismatch for selector.com, expect 2, got %d", countForSelector)
-		}
+			if countForSelector != 2 {
+				return fmt.Errorf("service instances count mismatch for selector.com, expect 2, got %d", countForSelector)
+			}
+			return nil
+		}, retry.Timeout(time.Second*5))
 
 		// The following sections mimic this scenario:
 		// f1 starts terminating, f3 picks up the IP, f3 delete event (pod
@@ -1462,16 +1468,20 @@ func TestServiceDiscoveryWorkloadInstance(t *testing.T) {
 		expectServiceInstances(t, sd, selector, 0, instances)
 		expectEvents(t, events, Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 0})
 
-		// After deletions, ensure we have zero instances for selector host
-		countForSelector = 0
-		for _, si := range sd.outputs.ServiceInstances.List() {
-			if si.Service.Attributes.Namespace == selector.Namespace && string(si.Service.Hostname) == "selector.com" {
-				countForSelector++
+		// After deletions, ensure we have zero instances for selector host.
+		// Retry to let the ServiceInstances output collection drain after the eds event.
+		retry.UntilSuccessOrFail(t, func() error {
+			countForSelector := 0
+			for _, si := range sd.outputs.ServiceInstances.List() {
+				if si.Service.Attributes.Namespace == selector.Namespace && string(si.Service.Hostname) == "selector.com" {
+					countForSelector++
+				}
 			}
-		}
-		if countForSelector != 0 {
-			t.Fatalf("service instances count mismatch for selector.com, expect 0, got %d", countForSelector)
-		}
+			if countForSelector != 0 {
+				return fmt.Errorf("service instances count mismatch for selector.com, expect 0, got %d", countForSelector)
+			}
+			return nil
+		}, retry.Timeout(time.Second*5))
 
 		// Add f3 event
 		callInstanceHandlers([]*model.WorkloadInstance{fi3}, sd, model.EventAdd, t)

--- a/pkg/test/util/assert/assert.go
+++ b/pkg/test/util/assert/assert.go
@@ -150,14 +150,15 @@ func NoError(t test.Failer, err error) {
 	}
 }
 
-// ChannelHasItem asserts a channel has an element within 5s and returns the element
+// ChannelHasItem asserts a channel has an element within 30s and returns the element.
+// The timeout is generous so the helper does not flake on slower CI workers (notably arm64).
 func ChannelHasItem[T any](t test.Failer, c <-chan T) T {
 	t.Helper()
 	select {
 	case r := <-c:
 		return r
-	case <-time.After(time.Second * 5):
-		t.Fatal("failed to receive event after 5s")
+	case <-time.After(time.Second * 30):
+		t.Fatal("failed to receive event after 30s")
 	}
 	// Not reachable
 	return ptr.Empty[T]()


### PR DESCRIPTION
Three arm64 unit-test flakes seen across recent master and release-1.30 PRs, all variations of "hardcoded timeout tight enough to flake on slower arm workers".

- assert.ChannelHasItem had a hardcoded 5s timeout. On slower arm64 prow workers this fired during TestNetworkUpdateTriggers/add_meshnetworks (network_test.go:77) and TestHandlerEnqueueFunction/update_event_change_label. Bumped to 30s. Only 6 call sites in 2 test files (both the ones that flake).

- TestServiceDiscoveryWorkloadInstance/delete_workload_instance asserted ServiceInstances counts inline right after expectEvents returns. expectEvents waits for the eds event but the ServiceInstances output collection is updated by a separate handler chain that can lag, so the count check raced. Wrapped both inline counts in retry.UntilSuccessOrFail like the rest of the file.

Sample failure logs:
- https://prow.istio.io/view/s3/istio-prow/pr-logs/pull/istio_istio/60102/unit-tests-arm64_istio/2055251091955650560 (TestNetworkUpdateTriggers)
- https://prow.istio.io/view/s3/istio-prow/pr-logs/pull/istio_istio/60183/unit-tests-arm64_istio/2054610355891474432 (TestHandlerEnqueueFunction)
- https://prow.istio.io/view/s3/istio-prow/pr-logs/pull/istio_istio/60185/unit-tests-arm64_istio/2053915955838324736 (TestServiceDiscoveryWorkloadInstance)
- https://prow.istio.io/view/s3/istio-prow/pr-logs/pull/istio_istio/60273/unit-tests-arm64_istio_release-1.30/2057669373597847552 (TestK8sSign)
