### PR TITLE
Fix --set parsing for values containing equals signs

### DIFF
--- a/operator/pkg/values/map.go
+++ b/operator/pkg/values/map.go
@@ -510,7 +510,7 @@ func extractKV(seg string) (string, string, bool) {
 
 // getPV returns the path and value components for the given set flag string, which must be in path=value format.
 func getPV(setFlag string) (path string, value string) {
-	pv := strings.Split(setFlag, "=")
+	pv := strings.SplitN(setFlag, "=", 2)
 	if len(pv) != 2 {
 		return setFlag, ""
 	}

--- a/operator/pkg/values/map_test.go
+++ b/operator/pkg/values/map_test.go
@@ -271,6 +271,23 @@ func TestParseValue(t *testing.T) {
 	}
 }
 
+func TestSetPathsAllowsEqualsInValue(t *testing.T) {
+	m := Map{}
+
+	err := m.SetPaths("spec.values.global.proxy.privileged=true", "spec.values.global.proxy.env=FOO=bar=baz")
+
+	assert.NoError(t, err)
+	assert.Equal(t, `{"spec":{"values":{"global":{"proxy":{"env":"FOO=bar=baz","privileged":true}}}}}`, m.JSON())
+}
+
+func TestGetValueForSetFlagAllowsEqualsInValue(t *testing.T) {
+	got := GetValueForSetFlag([]string{
+		"spec.values.global.proxy.env=FOO=bar=baz",
+	}, "spec.values.global.proxy.env")
+
+	assert.Equal(t, "FOO=bar=baz", got)
+}
+
 func TestMergeFrom(t *testing.T) {
 	fromJSON := func(s string) Map {
 		m, err := fromJSON[Map]([]byte(s))

--- a/releasenotes/notes/set-value-equals.yaml
+++ b/releasenotes/notes/set-value-equals.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+issue: []
+releaseNotes:
+- |
+  **Fixed** an issue where `istioctl` manifest `--set` values containing `=` were parsed as malformed input.


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes a tiny parser papercut in operator values. `--set foo=bar=baz` now splits on the first `=` only, so the value stays `bar=baz`. Before this, it got parsed as a key named `foo=bar=baz` with an empty value. not great.

Repro:

```bash
go test ./operator/pkg/values -run 'Test(SetPathsAllowsEqualsInValue|GetValueForSetFlagAllowsEqualsInValue)'
go run ./istioctl/cmd/istioctl manifest generate --set profile=minimal --set meshConfig.defaultConfig.proxyMetadata.TEST_VALUE=foo=bar | rg 'TEST_VALUE|foo=bar'
```

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [X] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [X] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [X] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
