### PR TITLE
bump chiron SignCSRK8s certWatchTimeout to 120s to fix arm64 flakes

### DIFF
--- a/releasenotes/notes/chiron-cert-watch-timeout.yaml
+++ b/releasenotes/notes/chiron-cert-watch-timeout.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+
+releaseNotes:
+  - |
+    **Fixed** flakes in K8s CA backed signing on slower control planes by raising the `SignCSRK8s` cert watch timeout from 60s to 120s. The previous value occasionally timed out before the signer returned the issued certificate.

--- a/security/pkg/k8s/chiron/utils.go
+++ b/security/pkg/k8s/chiron/utils.go
@@ -38,7 +38,11 @@ const (
 	keySize = 2048
 )
 
-var certWatchTimeout = 60 * time.Second
+// certWatchTimeout bounds how long SignCSRK8s waits for a signed CSR result.
+// Bumped from 60s to handle slower CI environments (notably arm64) and slow
+// real-world k8s control planes; the previous value flaked tests like
+// TestK8sSign and TestGenKeyCertK8sCA on arm64 prow workers.
+var certWatchTimeout = 120 * time.Second
 
 // GenKeyCertK8sCA : Generates a key pair and gets public certificate signed by K8s_CA
 // Options are meant to sign DNS certs


### PR DESCRIPTION
TestK8sSign and TestGenKeyCertK8sCA flake on arm64 prow workers because chiron's SignCSRK8s waits at most 60s for the signer to return a signed cert. On slower arm workers the fake informer occasionally takes >60s. Bumping the constant to 120s. Same shape as #60317 (timing assumptions tight enough to flake on slower hardware). Sample fail: https://prow.istio.io/view/s3/istio-prow/pr-logs/pull/istio_istio/60273/unit-tests-arm64_istio_release-1.30/2057669373597847552