### PR TITLE
fix: Enable Missing External SDS Support for DestinationRules to Prevent TLS Failures

### DIFF
--- a/pilot/pkg/networking/core/cluster.go
+++ b/pilot/pkg/networking/core/cluster.go
@@ -941,6 +941,7 @@ const (
 
 type buildClusterOpts struct {
 	mesh            *meshconfig.MeshConfig
+	push            *model.PushContext
 	mutable         *clusterWrapper
 	policy          *networking.TrafficPolicy
 	port            *model.Port

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -355,6 +355,7 @@ func (cb *ClusterBuilder) applyDestinationRule(mc *clusterWrapper, clusterMode C
 	trafficPolicy, _ := util.GetPortLevelTrafficPolicy(destinationRule.GetTrafficPolicy(), port)
 	opts := buildClusterOpts{
 		mesh:                      cb.req.Push.Mesh,
+		push:                      cb.req.Push,
 		mutable:                   mc,
 		policy:                    trafficPolicy,
 		port:                      port,
@@ -627,6 +628,7 @@ func (cb *ClusterBuilder) buildInboundCluster(clusterPort int, bind string,
 
 	opts := buildClusterOpts{
 		mesh:            cb.req.Push.Mesh,
+		push:            cb.req.Push,
 		mutable:         localCluster,
 		policy:          nil,
 		port:            instance.Port.ServicePort,

--- a/pilot/pkg/networking/core/cluster_tls.go
+++ b/pilot/pkg/networking/core/cluster_tls.go
@@ -203,9 +203,9 @@ func constructUpstreamTLS(opts *buildClusterOpts, tls *networking.ClientTLSSetti
 		tls.SubjectAltNames = opts.serviceAccounts
 	}
 	if tls.CredentialName != "" {
-		// If credential name is specified at Destination Rule config and originating node is egress gateway, create
-		// SDS config for egress gateway to fetch key/cert at gateway agent.
-		sec_model.ApplyCustomSDSToClientCommonTLSContext(tlsContext.CommonTlsContext, tls, opts.credentialSocketExist)
+		// If credential name is specified at Destination Rule config, create
+		// SDS config to fetch key/cert.
+		sec_model.ApplyCustomSDSToClientCommonTLSContext(tlsContext.CommonTlsContext, tls, opts.credentialSocketExist, opts.push)
 	} else {
 		// These are certs being mounted from within the pod and specified in Destination Rules.
 		// Rather than reading directly in Envoy, which does not support rotation, we will

--- a/pilot/pkg/networking/core/cluster_waypoint.go
+++ b/pilot/pkg/networking/core/cluster_waypoint.go
@@ -236,6 +236,7 @@ func (cb *ClusterBuilder) buildWaypointInboundVIPCluster(
 	// TLS and PROXY are more involved, since these impact the transport socket which is customized for HBONE.
 	opts := &buildClusterOpts{
 		mesh:        cb.req.Push.Mesh,
+		push:        cb.req.Push,
 		mutable:     localCluster,
 		policy:      policy,
 		port:        &port,

--- a/pilot/pkg/networking/core/external_sds_test.go
+++ b/pilot/pkg/networking/core/external_sds_test.go
@@ -1,0 +1,123 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"testing"
+
+	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config/host"
+)
+
+func TestBuildUpstreamClusterTLSContext_ExternalSDS(t *testing.T) {
+	proxy := &model.Proxy{
+		Type:         model.Router,
+		Metadata:     &model.NodeMetadata{},
+		IstioVersion: &model.IstioVersion{Major: 1, Minor: 24},
+	}
+	push := model.NewPushContext()
+	push.Mesh = &meshconfig.MeshConfig{
+		ExtensionProviders: []*meshconfig.MeshConfig_ExtensionProvider{
+			{
+				Name: "my-sds",
+				Provider: &meshconfig.MeshConfig_ExtensionProvider_Sds{
+					Sds: &meshconfig.MeshConfig_ExtensionProvider_SDSProvider{
+						Service: "default/sds.default.svc.cluster.local",
+						Port:    1234,
+					},
+				},
+			},
+		},
+	}
+	push.ServiceIndex.HostnameAndNamespace[host.Name("sds.default.svc.cluster.local")] = map[string]*model.Service{
+		"default": {
+			Hostname: host.Name("sds.default.svc.cluster.local"),
+			Attributes: model.ServiceAttributes{
+				Name:      "sds",
+				Namespace: "default",
+			},
+		},
+	}
+
+	cb := NewClusterBuilder(proxy, &model.PushRequest{Push: push}, model.DisabledCache{})
+
+	opts := &buildClusterOpts{
+		mutable: newClusterWrapper(&cluster.Cluster{
+			Name:                 "outbound|1234||foo.default.svc.cluster.local",
+			ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS},
+		}),
+		mesh: push.Mesh,
+		push: push,
+	}
+
+	tlsSettings := &networking.ClientTLSSettings{
+		Mode:           networking.ClientTLSSettings_MUTUAL,
+		CredentialName: "sds://my-cert",
+	}
+
+	t.Run("with push context", func(t *testing.T) {
+		opts.push = push
+		ctx, err := cb.buildUpstreamClusterTLSContext(opts, tlsSettings)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if ctx == nil {
+			t.Fatal("expected tls context")
+		}
+
+		sdsConfig := ctx.CommonTlsContext.TlsCertificateSdsSecretConfigs[0]
+		if sdsConfig.Name != "my-cert" {
+			t.Errorf("expected SDS name my-cert, got %s", sdsConfig.Name)
+		}
+
+		apiConfig := sdsConfig.SdsConfig.GetApiConfigSource()
+		if apiConfig == nil {
+			t.Fatal("expected api config source")
+		}
+
+		clusterName := apiConfig.GetGrpcServices()[0].GetEnvoyGrpc().GetClusterName()
+		expectedClusterName := "outbound|1234||sds.default.svc.cluster.local"
+		if clusterName != expectedClusterName {
+			t.Errorf("expected cluster name %s, got %s", expectedClusterName, clusterName)
+		}
+	})
+
+	t.Run("without push context", func(t *testing.T) {
+		opts.push = nil
+		ctx, err := cb.buildUpstreamClusterTLSContext(opts, tlsSettings)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if ctx == nil {
+			t.Fatal("expected tls context")
+		}
+
+		sdsConfig := ctx.CommonTlsContext.TlsCertificateSdsSecretConfigs[0]
+		// Should fall back to kubernetes:// prefix (ADS)
+		expectedName := "kubernetes://my-cert"
+		if sdsConfig.Name != expectedName {
+			t.Errorf("expected SDS name %s, got %s", expectedName, sdsConfig.Name)
+		}
+
+		if sdsConfig.SdsConfig.GetAds() == nil {
+			t.Error("expected ADS config source")
+		}
+	})
+}

--- a/pilot/pkg/security/model/authentication.go
+++ b/pilot/pkg/security/model/authentication.go
@@ -229,12 +229,12 @@ func constructSdsSecretConfig(maybeFileName string, fallbackName string, customF
 
 // ApplyCustomSDSToClientCommonTLSContext applies the customized sds to CommonTlsContext
 func ApplyCustomSDSToClientCommonTLSContext(tlsContext *tls.CommonTlsContext,
-	tlsOpts *networking.ClientTLSSettings, credentialSocketExist bool,
+	tlsOpts *networking.ClientTLSSettings, credentialSocketExist bool, push *model.PushContext,
 ) {
 	if tlsOpts.Mode == networking.ClientTLSSettings_MUTUAL {
 		// create SDS config for gateway to fetch key/cert from agent.
 		tlsContext.TlsCertificateSdsSecretConfigs = []*tls.SdsSecretConfig{
-			ConstructSdsSecretConfigForCredential(tlsOpts.CredentialName, credentialSocketExist, nil),
+			ConstructSdsSecretConfigForCredential(tlsOpts.CredentialName, credentialSocketExist, push),
 		}
 	}
 
@@ -252,7 +252,7 @@ func ApplyCustomSDSToClientCommonTLSContext(tlsContext *tls.CommonTlsContext,
 		CombinedValidationContext: &tls.CommonTlsContext_CombinedCertificateValidationContext{
 			DefaultValidationContext: defaultValidationContext,
 			ValidationContextSdsSecretConfig: ConstructSdsSecretConfigForCredential(
-				tlsOpts.CredentialName+SdsCaSuffix, credentialSocketExist, nil),
+				tlsOpts.CredentialName+SdsCaSuffix, credentialSocketExist, push),
 		},
 	}
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

Issue :
 A user configures a DestinationRule with credentialName using the sds:// prefix (e.g., sds://my-provider) to fetch certificates from an external SDS extension provider defined in MeshConfig.
 The configuration fails to take effect. Envoy incorrectly attempts to fetch the credential from Istiod via ADS (as a Kubernetes Secret) instead of connecting to the external SDS server. 
This typically results in TLS handshake failures and traffic disruption because the required certificates cannot be found.
  
Expected Behavior:
      When a sds:// prefix is used, Istio should check the extensionProviders in the MeshConfig. If a matching provider exists, it should generate an  Envoy configuration that points to the specific external SDS cluster.
 
Root Cause:
      The core security helper function ApplyCustomSDSToClientCommonTLSContext was being called with a nil PushContext during the DestinationRule cluster-building process. Since MeshConfig and its extension providers are stored within the PushContext, the code was unable to find the external  provider and silently fell back to the default ADS behavior.