### PR TITLE
feat(#24309): add --service and --response-code flags to metrics CLI

### DIFF
--- a/istioctl/pkg/metrics/metrics.go
+++ b/istioctl/pkg/metrics/metrics.go
@@ -39,11 +39,15 @@ import (
 var (
 	metricsOpts     clioptions.ControlPlaneOptions
 	metricsDuration time.Duration
+	serviceFilter   string
+	responseCode    string
 )
 
 const (
 	destWorkloadLabel          = "destination_workload"
 	destWorkloadNamespaceLabel = "destination_workload_namespace"
+	destServiceLabel           = "destination_service"
+	responseCodeLabel          = "response_code"
 	reqTot                     = "istio_requests_total"
 	reqDur                     = "istio_request_duration_milliseconds"
 )
@@ -73,7 +77,13 @@ calculated over a time interval of 1 minute.
   istioctl experimental metrics productpage-v1 -d 2m
 
   # Retrieve workload metrics for various services in the different namespaces
-  istioctl experimental metrics productpage-v1.foo reviews-v1.bar ratings-v1.baz`,
+  istioctl experimental metrics productpage-v1.foo reviews-v1.bar ratings-v1.baz
+
+  # Retrieve workload metrics filtered by destination service
+  istioctl experimental metrics productpage-v1 --service "reviews.default.svc.cluster.local"
+
+  # Retrieve workload metrics filtered by response code (regex supported)
+  istioctl experimental metrics productpage-v1 --response-code "2[0-9]{2}"`,
 		// nolint: goimports
 		Aliases: []string{"m"},
 		Args: func(cmd *cobra.Command, args []string) error {
@@ -91,6 +101,8 @@ calculated over a time interval of 1 minute.
 	}
 
 	cmd.PersistentFlags().DurationVarP(&metricsDuration, "duration", "d", time.Minute, "Duration of query metrics, default value is 1m.")
+	cmd.PersistentFlags().StringVarP(&serviceFilter, "service", "s", "", "Filter metrics by destination service name (regex supported).")
+	cmd.PersistentFlags().StringVarP(&responseCode, "response-code", "r", "", "Filter metrics by response code (regex supported, e.g. \"2[0-9]{2}\").")
 
 	return cmd
 }
@@ -144,7 +156,7 @@ func run(c *cobra.Command, ctx cli.Context, args []string) error {
 
 	workloads := args
 	for _, workload := range workloads {
-		sm, err := metrics(promAPI, workload, metricsDuration)
+		sm, err := metrics(promAPI, workload, metricsDuration, serviceFilter, responseCode)
 		if err != nil {
 			return fmt.Errorf("could not build metrics for workload '%s': %v", workload, err)
 		}
@@ -162,7 +174,22 @@ func prometheusAPI(address string) (promv1.API, error) {
 	return promv1.NewAPI(promClient), nil
 }
 
-func metrics(promAPI promv1.API, workload string, duration time.Duration) (workloadMetrics, error) {
+func buildLabelMatchers(workloadName, workloadNamespace, service, respCode string) string {
+	matchers := []string{
+		fmt.Sprintf(`%s=~"%s.*"`, destWorkloadLabel, workloadName),
+		fmt.Sprintf(`%s=~"%s.*"`, destWorkloadNamespaceLabel, workloadNamespace),
+		`reporter="destination"`,
+	}
+	if service != "" {
+		matchers = append(matchers, fmt.Sprintf(`%s=~"%s"`, destServiceLabel, service))
+	}
+	if respCode != "" {
+		matchers = append(matchers, fmt.Sprintf(`%s=~"%s"`, responseCodeLabel, respCode))
+	}
+	return strings.Join(matchers, ",")
+}
+
+func metrics(promAPI promv1.API, workload string, duration time.Duration, service, respCode string) (workloadMetrics, error) {
 	parts := strings.Split(workload, ".")
 	wname := parts[0]
 	wns := ""
@@ -170,10 +197,11 @@ func metrics(promAPI promv1.API, workload string, duration time.Duration) (workl
 		wns = parts[1]
 	}
 
-	rpsQuery := fmt.Sprintf(`sum(rate(%s{%s=~"%s.*", %s=~"%s.*",reporter="destination"}[%s]))`,
-		reqTot, destWorkloadLabel, wname, destWorkloadNamespaceLabel, wns, duration)
-	errRPSQuery := fmt.Sprintf(`sum(rate(%s{%s=~"%s.*", %s=~"%s.*",reporter="destination",response_code=~"[45][0-9]{2}"}[%s]))`,
-		reqTot, destWorkloadLabel, wname, destWorkloadNamespaceLabel, wns, duration)
+	baseMatchers := buildLabelMatchers(wname, wns, service, respCode)
+	rpsQuery := fmt.Sprintf(`sum(rate(%s{%s}[%s]))`, reqTot, baseMatchers, duration)
+
+	errMatchers := buildLabelMatchers(wname, wns, service, "[45][0-9]{2}")
+	errRPSQuery := fmt.Sprintf(`sum(rate(%s{%s}[%s]))`, reqTot, errMatchers, duration)
 
 	var me *multierror.Error
 	var err error
@@ -188,19 +216,19 @@ func metrics(promAPI promv1.API, workload string, duration time.Duration) (workl
 		me = multierror.Append(me, err)
 	}
 
-	p50Latency, err := getLatency(promAPI, wname, wns, duration, 0.5)
+	p50Latency, err := getLatency(promAPI, wname, wns, duration, 0.5, service)
 	if err != nil {
 		me = multierror.Append(me, err)
 	}
 	sm.p50Latency = p50Latency
 
-	p90Latency, err := getLatency(promAPI, wname, wns, duration, 0.9)
+	p90Latency, err := getLatency(promAPI, wname, wns, duration, 0.9, service)
 	if err != nil {
 		me = multierror.Append(me, err)
 	}
 	sm.p90Latency = p90Latency
 
-	p99Latency, err := getLatency(promAPI, wname, wns, duration, 0.99)
+	p99Latency, err := getLatency(promAPI, wname, wns, duration, 0.99, service)
 	if err != nil {
 		me = multierror.Append(me, err)
 	}
@@ -213,9 +241,10 @@ func metrics(promAPI promv1.API, workload string, duration time.Duration) (workl
 	return sm, nil
 }
 
-func getLatency(promAPI promv1.API, workloadName, workloadNamespace string, duration time.Duration, quantile float64) (time.Duration, error) {
-	latencyQuery := fmt.Sprintf(`histogram_quantile(%f, sum(rate(%s_bucket{%s=~"%s.*", %s=~"%s.*",reporter="destination"}[%s])) by (le))`,
-		quantile, reqDur, destWorkloadLabel, workloadName, destWorkloadNamespaceLabel, workloadNamespace, duration)
+func getLatency(promAPI promv1.API, workloadName, workloadNamespace string, duration time.Duration, quantile float64, service string) (time.Duration, error) {
+	matchers := buildLabelMatchers(workloadName, workloadNamespace, service, "")
+	latencyQuery := fmt.Sprintf(`histogram_quantile(%f, sum(rate(%s_bucket{%s}[%s])) by (le))`,
+		quantile, reqDur, matchers, duration)
 
 	letency, err := vectorValue(promAPI, latencyQuery)
 	if err != nil {

--- a/istioctl/pkg/metrics/metrics_test.go
+++ b/istioctl/pkg/metrics/metrics_test.go
@@ -101,24 +101,24 @@ var _ promv1.API = mockPromAPI{}
 func TestPrintMetrics(t *testing.T) {
 	mockProm := mockPromAPI{
 		cannedResponse: map[string]prometheus_model.Value{
-			"sum(rate(istio_requests_total{destination_workload=~\"details.*\", destination_workload_namespace=~\".*\",reporter=\"destination\"}[1m0s]))": prometheus_model.Vector{ // nolint: lll
+			`sum(rate(istio_requests_total{destination_workload=~"details.*",destination_workload_namespace=~".*",reporter="destination"}[1m0s]))`: prometheus_model.Vector{ // nolint: lll
 				&prometheus_model.Sample{Value: 0.04},
 			},
-			"sum(rate(istio_requests_total{destination_workload=~\"details.*\", destination_workload_namespace=~\".*\",reporter=\"destination\",response_code=~\"[45][0-9]{2}\"}[1m0s]))": prometheus_model.Vector{}, // nolint: lll
-			"histogram_quantile(0.500000, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~\"details.*\", destination_workload_namespace=~\".*\",reporter=\"destination\"}[1m0s])) by (le))": prometheus_model.Vector{ // nolint: lll
+			`sum(rate(istio_requests_total{destination_workload=~"details.*",destination_workload_namespace=~".*",reporter="destination",response_code=~"[45][0-9]{2}"}[1m0s]))`: prometheus_model.Vector{}, // nolint: lll
+			`histogram_quantile(0.500000, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~"details.*",destination_workload_namespace=~".*",reporter="destination"}[1m0s])) by (le))`: prometheus_model.Vector{ // nolint: lll
 				&prometheus_model.Sample{Value: 2.5},
 			},
-			"histogram_quantile(0.900000, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~\"details.*\", destination_workload_namespace=~\".*\",reporter=\"destination\"}[1m0s])) by (le))": prometheus_model.Vector{ // nolint: lll
+			`histogram_quantile(0.900000, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~"details.*",destination_workload_namespace=~".*",reporter="destination"}[1m0s])) by (le))`: prometheus_model.Vector{ // nolint: lll
 				&prometheus_model.Sample{Value: 4.5},
 			},
-			"histogram_quantile(0.990000, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~\"details.*\", destination_workload_namespace=~\".*\",reporter=\"destination\"}[1m0s])) by (le))": prometheus_model.Vector{ // nolint: lll
+			`histogram_quantile(0.990000, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~"details.*",destination_workload_namespace=~".*",reporter="destination"}[1m0s])) by (le))`: prometheus_model.Vector{ // nolint: lll
 				&prometheus_model.Sample{Value: 4.95},
 			},
 		},
 	}
 	workload := "details"
 
-	sm, err := metrics(mockProm, workload, time.Minute)
+	sm, err := metrics(mockProm, workload, time.Minute, "", "")
 	if err != nil {
 		t.Fatalf("Unwanted exception %v", err)
 	}
@@ -133,6 +133,66 @@ func TestPrintMetrics(t *testing.T) {
 `
 	if output != expectedOutput {
 		t.Fatalf("Unexpected output; got:\n %q\nwant:\n %q", output, expectedOutput)
+	}
+}
+
+func TestPrintMetricsWithServiceFilter(t *testing.T) {
+	mockProm := mockPromAPI{
+		cannedResponse: map[string]prometheus_model.Value{
+			`sum(rate(istio_requests_total{destination_workload=~"details.*",destination_workload_namespace=~".*",reporter="destination",destination_service=~"reviews.default.svc.cluster.local"}[1m0s]))`: prometheus_model.Vector{ // nolint: lll
+				&prometheus_model.Sample{Value: 0.02},
+			},
+			`sum(rate(istio_requests_total{destination_workload=~"details.*",destination_workload_namespace=~".*",reporter="destination",destination_service=~"reviews.default.svc.cluster.local",response_code=~"[45][0-9]{2}"}[1m0s]))`: prometheus_model.Vector{}, // nolint: lll
+			`histogram_quantile(0.500000, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~"details.*",destination_workload_namespace=~".*",reporter="destination",destination_service=~"reviews.default.svc.cluster.local"}[1m0s])) by (le))`: prometheus_model.Vector{ // nolint: lll
+				&prometheus_model.Sample{Value: 1.5},
+			},
+			`histogram_quantile(0.900000, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~"details.*",destination_workload_namespace=~".*",reporter="destination",destination_service=~"reviews.default.svc.cluster.local"}[1m0s])) by (le))`: prometheus_model.Vector{ // nolint: lll
+				&prometheus_model.Sample{Value: 3.0},
+			},
+			`histogram_quantile(0.990000, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~"details.*",destination_workload_namespace=~".*",reporter="destination",destination_service=~"reviews.default.svc.cluster.local"}[1m0s])) by (le))`: prometheus_model.Vector{ // nolint: lll
+				&prometheus_model.Sample{Value: 4.0},
+			},
+		},
+	}
+	workload := "details"
+
+	sm, err := metrics(mockProm, workload, time.Minute, "reviews.default.svc.cluster.local", "")
+	if err != nil {
+		t.Fatalf("Unwanted exception %v", err)
+	}
+
+	if sm.totalRPS != 0.02 {
+		t.Fatalf("Expected totalRPS 0.02, got %f", sm.totalRPS)
+	}
+}
+
+func TestPrintMetricsWithResponseCodeFilter(t *testing.T) {
+	mockProm := mockPromAPI{
+		cannedResponse: map[string]prometheus_model.Value{
+			`sum(rate(istio_requests_total{destination_workload=~"details.*",destination_workload_namespace=~".*",reporter="destination",response_code=~"2[0-9]{2}"}[1m0s]))`: prometheus_model.Vector{ // nolint: lll
+				&prometheus_model.Sample{Value: 0.03},
+			},
+			`sum(rate(istio_requests_total{destination_workload=~"details.*",destination_workload_namespace=~".*",reporter="destination",response_code=~"[45][0-9]{2}"}[1m0s]))`: prometheus_model.Vector{}, // nolint: lll
+			`histogram_quantile(0.500000, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~"details.*",destination_workload_namespace=~".*",reporter="destination"}[1m0s])) by (le))`: prometheus_model.Vector{ // nolint: lll
+				&prometheus_model.Sample{Value: 2.0},
+			},
+			`histogram_quantile(0.900000, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~"details.*",destination_workload_namespace=~".*",reporter="destination"}[1m0s])) by (le))`: prometheus_model.Vector{ // nolint: lll
+				&prometheus_model.Sample{Value: 3.5},
+			},
+			`histogram_quantile(0.990000, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~"details.*",destination_workload_namespace=~".*",reporter="destination"}[1m0s])) by (le))`: prometheus_model.Vector{ // nolint: lll
+				&prometheus_model.Sample{Value: 4.5},
+			},
+		},
+	}
+	workload := "details"
+
+	sm, err := metrics(mockProm, workload, time.Minute, "", "2[0-9]{2}")
+	if err != nil {
+		t.Fatalf("Unwanted exception %v", err)
+	}
+
+	if sm.totalRPS != 0.03 {
+		t.Fatalf("Expected totalRPS 0.03, got %f", sm.totalRPS)
 	}
 }
 

--- a/releasenotes/notes/24309.yaml
+++ b/releasenotes/notes/24309.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue:
+  - 24309
+releaseNotes:
+  - |
+    **Added** `--service` and `--response-code` flags to `istioctl experimental metrics` for filtering metrics by destination service and HTTP response code.


### PR DESCRIPTION
## Summary

Adds filtering capabilities to `istioctl experimental metrics`:
- `--service` / `-s`: filter metrics by destination service name (regex supported)
- `--response-code` / `-r`: filter metrics by HTTP response code (regex supported)

Introduces a `buildLabelMatchers()` helper to compose PromQL label matchers cleanly, replacing repetitive `fmt.Sprintf` calls.

Fixes #24309

## Changes

- `istioctl/pkg/metrics/metrics.go`: Added two new CLI flags, `buildLabelMatchers()` function, and updated query construction
- `istioctl/pkg/metrics/metrics_test.go`: Added `TestPrintMetricsWithServiceFilter` and `TestPrintMetricsWithResponseCodeFilter`
- `releasenotes/notes/24309.yaml`: Release note for the new feature

## Usage Examples

```bash
# Filter by destination service
istioctl experimental metrics productpage-v1 --service "reviews.default.svc.cluster.local"

# Filter by response code (regex)
istioctl experimental metrics productpage-v1 --response-code "2[0-9]{2}"

# Combine with existing flags
istioctl experimental metrics productpage-v1 -s "reviews.*" -r "5[0-9]{2}" -d 5m
```

## Test Plan

- [x] `go test -race ./istioctl/pkg/metrics/...` — all 6 tests pass
- [x] `go build -o /tmp/istioctl ./istioctl/cmd/istioctl` — binary builds clean
- [x] `istioctl experimental metrics --help` — new flags visible
- [x] Manual test against Istio cluster with bookinfo sample (needs cluster)