### PR TITLE
fix chiron readSignedCsr list+watch race

### DIFF
--- a/security/pkg/k8s/chiron/utils.go
+++ b/security/pkg/k8s/chiron/utils.go
@@ -231,29 +231,28 @@ func readSignedCertificate(client clientset.Interface, csr *cert.CertificateSign
 // Return signed CSR through a watcher. If no CSR is read, return nil.
 func readSignedCsr(client clientset.Interface, csr string, watchTimeout time.Duration) ([]byte, error) {
 	selector := fields.OneTermEqualSelector("metadata.name", csr).String()
-	// Setup a List+Watch, like informers do
-	// A simple Watch will fail if the cert is signed too quickly
-	l, _ := client.CertificatesV1().CertificateSigningRequests().List(context.Background(), metav1.ListOptions{
-		FieldSelector: selector,
-	})
-	if l != nil && len(l.Items) > 0 {
-		reqSigned := l.Items[0]
-		if reqSigned.Status.Certificate != nil {
-			return reqSigned.Status.Certificate, nil
-		}
-	}
-	var rv string
-	if l != nil {
-		rv = l.ResourceVersion
-	}
+	// Subscribe to the watch first, then List. A List-then-Watch ordering
+	// has a window where an update can fire between the two calls and be lost.
+	// The client-go fake's tracker ignores the ResourceVersion passed to Watch,
+	// so a status update that landed before we subscribed is never replayed.
+	// Subscribing first closes the window: the List right after covers the
+	// case where the CSR was already signed before we got a chance to watch.
 	watcher, err := client.CertificatesV1().CertificateSigningRequests().Watch(context.Background(), metav1.ListOptions{
-		ResourceVersion: rv,
-		FieldSelector:   selector,
+		FieldSelector: selector,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to watch CSR %v", csr)
 	}
 	defer watcher.Stop()
+
+	l, _ := client.CertificatesV1().CertificateSigningRequests().List(context.Background(), metav1.ListOptions{
+		FieldSelector: selector,
+	})
+	if l != nil && len(l.Items) > 0 {
+		if l.Items[0].Status.Certificate != nil {
+			return l.Items[0].Status.Certificate, nil
+		}
+	}
 
 	// Set a timeout
 	timer := time.After(watchTimeout)

--- a/security/pkg/k8s/chiron/utils_test.go
+++ b/security/pkg/k8s/chiron/utils_test.go
@@ -319,9 +319,6 @@ func initFakeKubeClient(t test.Failer, certificate []byte) kube.CLIClient {
 					continue
 				}
 				if approved(csr) {
-					// This is a pretty terrible hack, but client-go fake doesn't properly support list+watch,
-					// so any updates in between the list and watch would be missed. So give some time for the watch to start
-					time.Sleep(time.Millisecond * 25)
 					csr.Status.Certificate = certificate
 					_, err := client.Kube().CertificatesV1().CertificateSigningRequests().UpdateStatus(ctx, csr, metav1.UpdateOptions{})
 					log.Debugf("test signer sign %v: %v", csr.Name, err)

--- a/security/pkg/pki/ra/k8s_ra_test.go
+++ b/security/pkg/pki/ra/k8s_ra_test.go
@@ -314,9 +314,6 @@ func initFakeKubeClient(t test.Failer, certificate []byte) kube.CLIClient {
 					continue
 				}
 				csr.Status.Certificate = certificate
-				// fake clientset doesn't handle resource version, so we need to delay the update
-				// to make sure watchers can catch the event
-				time.Sleep(time.Millisecond)
 				client.Kube().CertificatesV1().CertificateSigningRequests().UpdateStatus(ctx, csr, metav1.UpdateOptions{})
 			}
 		}


### PR DESCRIPTION
readSignedCsr did List then Watch using the ResourceVersion from the list to seek. The client-go fake's tracker ignores that ResourceVersion, so a status update that lands between the two calls is never replayed and the watcher hangs until certWatchTimeout (60s) fires. This caused TestK8sSign and TestGenKeyCertK8sCA flakes on arm64 runners. Subscribe to the watch first, then List for any state that already settled. Also removes the time.Sleep workarounds in the test signers that papered over the same race.