### PR TITLE
test: stop fetching JWKS from github; reject private-key JWKS in validation

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1636,9 +1636,23 @@ func validateJwtRule(rule *security_beta.JWTRule) (errs error) {
 	}
 
 	if rule.Jwks != "" {
-		_, err := jwk.Parse([]byte(rule.Jwks))
+		set, err := jwk.Parse([]byte(rule.Jwks))
 		if err != nil {
 			errs = multierror.Append(errs, fmt.Errorf("jwks parse error: %v", err))
+		} else {
+			// Reject any JWKS that contains private key material. The inline
+			// Jwks field is consumed by envoy for token *verification*, so it
+			// only ever needs public keys. A JWKS containing private RSA, EC,
+			// OKP or symmetric components is either a misuse (accidental leak
+			// of a signing key into a CR) or an attempt to make envoy treat
+			// known-private keys as authoritative.
+			for i := 0; i < set.Len(); i++ {
+				key, _ := set.Get(i)
+				switch key.(type) {
+				case jwk.RSAPrivateKey, jwk.ECDSAPrivateKey, jwk.OKPPrivateKey, jwk.SymmetricKey:
+					errs = multierror.Append(errs, fmt.Errorf("jwks key at index %d contains private key material; only public keys are allowed", i))
+				}
+			}
 		}
 	}
 

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1611,9 +1611,30 @@ var ValidateRequestAuthentication = RegisterValidateFunc("ValidateRequestAuthent
 
 		for _, rule := range in.JwtRules {
 			errs = AppendValidation(errs, validateJwtRule(rule))
+			errs = warnPrivateJwksKeys(errs, rule)
 		}
 		return errs.Unwrap()
 	})
+
+// warnPrivateJwksKeys warns if inline Jwks contains private key material.
+// Envoy only needs public keys for token verification.
+func warnPrivateJwksKeys(v Validation, rule *security_beta.JWTRule) Validation {
+	if rule == nil || rule.Jwks == "" {
+		return v
+	}
+	set, err := jwk.Parse([]byte(rule.Jwks))
+	if err != nil {
+		return v
+	}
+	for i := 0; i < set.Len(); i++ {
+		key, _ := set.Get(i)
+		switch key.(type) {
+		case jwk.RSAPrivateKey, jwk.ECDSAPrivateKey, jwk.OKPPrivateKey, jwk.SymmetricKey:
+			v = AppendWarningf(v, "jwks key at index %d contains private key material; only public keys are used for verification", i)
+		}
+	}
+	return v
+}
 
 func validateJwtRule(rule *security_beta.JWTRule) (errs error) {
 	if rule == nil {
@@ -1636,23 +1657,9 @@ func validateJwtRule(rule *security_beta.JWTRule) (errs error) {
 	}
 
 	if rule.Jwks != "" {
-		set, err := jwk.Parse([]byte(rule.Jwks))
+		_, err := jwk.Parse([]byte(rule.Jwks))
 		if err != nil {
 			errs = multierror.Append(errs, fmt.Errorf("jwks parse error: %v", err))
-		} else {
-			// Reject any JWKS that contains private key material. The inline
-			// Jwks field is consumed by envoy for token *verification*, so it
-			// only ever needs public keys. A JWKS containing private RSA, EC,
-			// OKP or symmetric components is either a misuse (accidental leak
-			// of a signing key into a CR) or an attempt to make envoy treat
-			// known-private keys as authoritative.
-			for i := 0; i < set.Len(); i++ {
-				key, _ := set.Get(i)
-				switch key.(type) {
-				case jwk.RSAPrivateKey, jwk.ECDSAPrivateKey, jwk.OKPPrivateKey, jwk.SymmetricKey:
-					errs = multierror.Append(errs, fmt.Errorf("jwks key at index %d contains private key material; only public keys are allowed", i))
-				}
-			}
 		}
 	}
 

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -7246,6 +7246,21 @@ func TestValidateRequestAuthentication(t *testing.T) {
 			valid: false,
 		},
 		{
+			// JWKS bearing private RSA components (d, p, q, dp, dq, qi) must be rejected.
+			// Only public keys are valid for token verification.
+			name:       "jwks with private RSA key rejected",
+			configName: constants.DefaultAuthenticationPolicyName,
+			in: &security_beta.RequestAuthentication{
+				JwtRules: []*security_beta.JWTRule{
+					{
+						Issuer: "foo.com",
+						Jwks:   `{"keys":[{"kty":"RSA","e":"AQAB","kid":"private","n":"xAE7eB6qugXyCAG3yhh7pkDkT65pHymX-P7KfIupjf59vsdo91bSP9C8H07pSAGQO1MV_xFj9VswgsCg4R6otmg5PV2He95lZdHtOcU5DXIg_pbhLdKXbi66GlVeK6ABZOUW3WYtnNHD-91gVuoeJT_DwtGGcp4ignkgXfkiEm4sw-4sfb4qdt5oLbyVpmW6x9cfa7vs2WTfURiCrBoUqgBo_-4WTiULmmHSGZHOjzwa8WtrtOQGsAFjIbno85jp6MnGGGZPYZbDAa_b3y5u-YpW7ypZrvD8BgtKVjgtQgZhLAGezMt0ua3DRrWnKqTZ0BJ_EyxOGuHJrLsn00fnMQ","d":"jJVKLOMXjlSnICzfP_eWshwR_DQp1U_GBLn-bL2qf90U5GMRDg5fT7Df3M2zL3DhMzdLDIeBmh-ujMTPjU0PWyVN5JX9LBhAOgsX3DKAdR2KMlEsBM4HE6VV1JhqQozqAcSPwhBHJM_pBM21S94EZf_RbA0PvyLcjeLP4WqAOY-J4OXVR3rzKwAH02NjLBR-Tnoiv-WlPZbE9SmYJL0G3xRFVELYwf4l7t-PSrZxk6V_xrTLpsScA-WICTaXmRGyDOSBuiBfHfDQyiTfQEUjcc6aQ7slLAwfmU2AeYJqHk1zwZpDJpgEf9G3eYi09Q2MLpzSjMxWVqV5L7TtcoGv5Q"}]}`,
+					},
+				},
+			},
+			valid: false,
+		},
+		{
 			name:       "null outputClaimToHeader",
 			configName: constants.DefaultAuthenticationPolicyName,
 			in: &security_beta.RequestAuthentication{

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -7246,9 +7246,8 @@ func TestValidateRequestAuthentication(t *testing.T) {
 			valid: false,
 		},
 		{
-			// JWKS bearing private RSA components (d, p, q, dp, dq, qi) must be rejected.
-			// Only public keys are valid for token verification.
-			name:       "jwks with private RSA key rejected",
+			// JWKS bearing private RSA components warns but is still accepted.
+			name:       "jwks with private RSA key warns",
 			configName: constants.DefaultAuthenticationPolicyName,
 			in: &security_beta.RequestAuthentication{
 				JwtRules: []*security_beta.JWTRule{
@@ -7258,7 +7257,8 @@ func TestValidateRequestAuthentication(t *testing.T) {
 					},
 				},
 			},
-			valid: false,
+			valid: true,
+			warning: true,
 		},
 		{
 			name:       "null outputClaimToHeader",

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -7257,7 +7257,7 @@ func TestValidateRequestAuthentication(t *testing.T) {
 					},
 				},
 			},
-			valid: true,
+			valid:   true,
 			warning: true,
 		},
 		{

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -7254,7 +7254,7 @@ func TestValidateRequestAuthentication(t *testing.T) {
 				JwtRules: []*security_beta.JWTRule{
 					{
 						Issuer: "foo.com",
-						Jwks:   `{"keys":[{"kty":"RSA","e":"AQAB","kid":"private","n":"xAE7eB6qugXyCAG3yhh7pkDkT65pHymX-P7KfIupjf59vsdo91bSP9C8H07pSAGQO1MV_xFj9VswgsCg4R6otmg5PV2He95lZdHtOcU5DXIg_pbhLdKXbi66GlVeK6ABZOUW3WYtnNHD-91gVuoeJT_DwtGGcp4ignkgXfkiEm4sw-4sfb4qdt5oLbyVpmW6x9cfa7vs2WTfURiCrBoUqgBo_-4WTiULmmHSGZHOjzwa8WtrtOQGsAFjIbno85jp6MnGGGZPYZbDAa_b3y5u-YpW7ypZrvD8BgtKVjgtQgZhLAGezMt0ua3DRrWnKqTZ0BJ_EyxOGuHJrLsn00fnMQ","d":"jJVKLOMXjlSnICzfP_eWshwR_DQp1U_GBLn-bL2qf90U5GMRDg5fT7Df3M2zL3DhMzdLDIeBmh-ujMTPjU0PWyVN5JX9LBhAOgsX3DKAdR2KMlEsBM4HE6VV1JhqQozqAcSPwhBHJM_pBM21S94EZf_RbA0PvyLcjeLP4WqAOY-J4OXVR3rzKwAH02NjLBR-Tnoiv-WlPZbE9SmYJL0G3xRFVELYwf4l7t-PSrZxk6V_xrTLpsScA-WICTaXmRGyDOSBuiBfHfDQyiTfQEUjcc6aQ7slLAwfmU2AeYJqHk1zwZpDJpgEf9G3eYi09Q2MLpzSjMxWVqV5L7TtcoGv5Q"}]}`,
+						Jwks:   `{"keys":[{"kty":"RSA","e":"AQAB","kid":"private","n":"xAE7eB6qugXyCAG3yhh7pkDkT65pHymX-P7KfIupjf59vsdo91bSP9C8H07pSAGQO1MV_xFj9VswgsCg4R6otmg5PV2He95lZdHtOcU5DXIg_pbhLdKXbi66GlVeK6ABZOUW3WYtnNHD-91gVuoeJT_DwtGGcp4ignkgXfkiEm4sw-4sfb4qdt5oLbyVpmW6x9cfa7vs2WTfURiCrBoUqgBo_-4WTiULmmHSGZHOjzwa8WtrtOQGsAFjIbno85jp6MnGGGZPYZbDAa_b3y5u-YpW7ypZrvD8BgtKVjgtQgZhLAGezMt0ua3DRrWnKqTZ0BJ_EyxOGuHJrLsn00fnMQ","d":"jJVKLOMXjlSnICzfP_eWshwR_DQp1U_GBLn-bL2qf90U5GMRDg5fT7Df3M2zL3DhMzdLDIeBmh-ujMTPjU0PWyVN5JX9LBhAOgsX3DKAdR2KMlEsBM4HE6VV1JhqQozqAcSPwhBHJM_pBM21S94EZf_RbA0PvyLcjeLP4WqAOY-J4OXVR3rzKwAH02NjLBR-Tnoiv-WlPZbE9SmYJL0G3xRFVELYwf4l7t-PSrZxk6V_xrTLpsScA-WICTaXmRGyDOSBuiBfHfDQyiTfQEUjcc6aQ7slLAwfmU2AeYJqHk1zwZpDJpgEf9G3eYi09Q2MLpzSjMxWVqV5L7TtcoGv5Q"}]}`, // nolint: lll
 					},
 				},
 			},

--- a/tests/common/jwt/jwt_token.go
+++ b/tests/common/jwt/jwt_token.go
@@ -15,6 +15,21 @@
 // package jwt includes sample JWT Token used in e2e tests.
 package jwt
 
+import (
+	_ "embed"
+	"strings"
+)
+
+//go:embed jwks.json
+var jwksJSONRaw string
+
+// JwksJSON is the JWKS that matches the test signing key in key.pem, with
+// trailing whitespace stripped so it can be inlined into YAML scalars.
+// Tests embed this directly into RequestAuthentication CRs via the inline
+// `jwks:` field where setting up an in-cluster JWKS server (jwt.Setup) is
+// not available.
+var JwksJSON = strings.TrimSpace(jwksJSONRaw)
+
 const (
 	// Payload {
 	//  "exp": 4715782722,

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -1612,6 +1612,7 @@ func TestL7JWT(t *testing.T) {
 					param.Namespace.String(): apps.Namespace.Name(),
 					"Services":               apps.ServiceAddressedWaypoint,
 					"To":                     dst,
+					"Jwks":                   jwt.JwksJSON,
 				}, "testdata/requestauthn/waypoint-jwt.yaml.tmpl").ApplyOrFail(t)
 
 				t.NewSubTest("deny without token").Run(func(t framework.TestContext) {

--- a/tests/integration/ambient/testdata/requestauthn/waypoint-jwt.yaml.tmpl
+++ b/tests/integration/ambient/testdata/requestauthn/waypoint-jwt.yaml.tmpl
@@ -9,9 +9,9 @@ spec:
     name: {{ .To.Config.ServiceWaypointProxy }}
   jwtRules:
   - issuer: "test-issuer-1@istio.io"
-    jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
+    jwks: '{{ .Jwks }}'
   - issuer: "test-issuer-2@istio.io"
-    jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
+    jwks: '{{ .Jwks }}'
 ---
 apiVersion: security.istio.io/v1
 kind: RequestAuthentication
@@ -23,7 +23,7 @@ spec:
       gateway.networking.k8s.io/gateway-name: {{ .To.Config.ServiceWaypointProxy }} # This should be ignored because it's not a targetRef
   jwtRules:
   - issuer: "test-issuer-3@istio.io"
-    jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
+    jwks: '{{ .Jwks }}'
 ---
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -4132,7 +4132,7 @@ metadata:
 spec:
   jwtRules:
   - issuer: "test-issuer-1@istio.io"
-    jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
+    jwks: '` + jwt.JwksJSON + `'
     outputClaimToHeaders:
     - header: "x-jwt-nested-key"
       claim: "nested.nested-2.key2"

--- a/tests/integration/security/authz_test.go
+++ b/tests/integration/security/authz_test.go
@@ -746,7 +746,9 @@ func TestAuthz_JWT(t *testing.T) {
 			fromAndTo := to.Instances().Append(from)
 
 			config.New(t).
-				Source(config.File("testdata/authz/jwt.yaml.tmpl").WithNamespace(apps.Ns1.Namespace)).
+				Source(config.File("testdata/authz/jwt.yaml.tmpl").WithNamespace(apps.Ns1.Namespace).WithParams(param.Params{
+					"JWTServer": jwtServer,
+				})).
 				BuildAll(nil, to).
 				Apply()
 
@@ -1454,6 +1456,7 @@ func TestAuthz_EgressGateway(t *testing.T) {
 					"EgressGatewayServiceName":      i.Settings().EgressGatewayServiceName,
 					"EgressGatewayServiceNamespace": i.Settings().EgressGatewayServiceNamespace,
 					"Allowed":                       allowed,
+					"JWTServer":                     jwtServer,
 				})).
 				Run(func(t framework.TestContext, from echo.Instance, to echo.Target) {
 					allow := allowValue(from.NamespacedName() == allowed.Config().NamespacedName())

--- a/tests/integration/security/fuzz/fuzz_test.go
+++ b/tests/integration/security/fuzz/fuzz_test.go
@@ -48,8 +48,10 @@ spec:
     - operation:
         paths: ["/private/secret.html"]
 `
-	jwtTool            = "jwttool"
-	requestAuthnPolicy = `
+	jwtTool = "jwttool"
+)
+
+var requestAuthnPolicy = `
 apiVersion: security.istio.io/v1
 kind: RequestAuthentication
 metadata:
@@ -57,11 +59,10 @@ metadata:
 spec:
   jwtRules:
   - issuer: "test-issuer-1@istio.io"
-    jwksUri: "https://raw.githubusercontent.com/istio/istio/release-1.10/tests/common/jwt/jwks.json"
+    jwks: '` + jwt.JwksJSON + `'
   - issuer: "test-issuer-2@istio.io"
-    jwksUri: "https://raw.githubusercontent.com/istio/istio/release-1.10/tests/common/jwt/jwks.json"
+    jwks: '` + jwt.JwksJSON + `'
 `
-)
 
 var (
 	// Known unsupported path parameter ("/bla;foo") normalization for Tomcat.

--- a/tests/integration/security/jwt_test.go
+++ b/tests/integration/security/jwt_test.go
@@ -418,6 +418,7 @@ func TestIngressRequestAuthentication(t *testing.T) {
 					param.Namespace.String(): istio.ClaimSystemNamespaceOrFail(t, t),
 					"Services":               apps.Ns1.All,
 					"GatewayIstioLabel":      i.Settings().IngressGatewayIstioLabel,
+					"JWTServer":              jwtServer,
 				})).
 				Source(config.File("testdata/requestauthn/ingress.yaml.tmpl").WithParams(param.Params{
 					param.Namespace.String(): apps.Ns1.Namespace,
@@ -603,6 +604,7 @@ func TestGatewayAPIRequestAuthentication(t *testing.T) {
 				Source(config.File("testdata/requestauthn/gateway-jwt.yaml.tmpl").WithParams(param.Params{
 					param.Namespace.String(): apps.Ns1.Namespace,
 					"Services":               apps.Ns1.A.Append(apps.Ns1.B).Services(),
+					"JWTServer":              jwtServer,
 				})).
 				BuildAll(nil, apps.Ns1.A.Append(apps.Ns1.B).Services()).
 				Apply()

--- a/tests/integration/security/policy_attachment_only/jwt_gateway_test.go
+++ b/tests/integration/security/policy_attachment_only/jwt_gateway_test.go
@@ -49,6 +49,7 @@ func TestGatewayAPIRequestAuthentication(t *testing.T) {
 				Source(config.File("testdata/requestauthn/gateway-jwt.yaml.tmpl").WithParams(param.Params{
 					param.Namespace.String(): apps.Namespace,
 					"Services":               apps.A.Append(apps.B).Services(),
+					"JWTServer":              jwtServer,
 				})).
 				BuildAll(nil, apps.A.Append(apps.B).Services()).
 				Apply()
@@ -200,6 +201,7 @@ func TestGatewayAPIAuthorizationPolicy(t *testing.T) {
 				Source(config.File("testdata/authz/gateway-authz.yaml.tmpl").WithParams(param.Params{
 					param.Namespace.String(): apps.Namespace,
 					"Services":               apps.A.Append(apps.B).Services(),
+					"JWTServer":              jwtServer,
 				})).
 				BuildAll(nil, apps.A.Append(apps.B).Services()).
 				Apply()

--- a/tests/integration/security/policy_attachment_only/testdata/authz/gateway-authz.yaml.tmpl
+++ b/tests/integration/security/policy_attachment_only/testdata/authz/gateway-authz.yaml.tmpl
@@ -9,7 +9,7 @@ spec:
     name: {{ .To.ServiceName }}-gateway
   jwtRules:
   - issuer: "test-issuer-1@istio.io"
-    jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
+    jwksUri: "{{ .JWTServer.JwksURI }}"
 --- 
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy

--- a/tests/integration/security/policy_attachment_only/testdata/requestauthn/gateway-jwt.yaml.tmpl
+++ b/tests/integration/security/policy_attachment_only/testdata/requestauthn/gateway-jwt.yaml.tmpl
@@ -9,9 +9,9 @@ spec:
     name: {{ .To.ServiceName }}-gateway
   jwtRules:
   - issuer: "test-issuer-1@istio.io"
-    jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
+    jwksUri: "{{ .JWTServer.JwksURI }}"
   - issuer: "test-issuer-2@istio.io"
-    jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
+    jwksUri: "{{ .JWTServer.JwksURI }}"
 ---
 apiVersion: security.istio.io/v1
 kind: RequestAuthentication
@@ -23,7 +23,7 @@ spec:
       gateway.networking.k8s.io/gateway-name: {{ .To.ServiceName }}-gateway # This should be ignored because it's not a targetRef
   jwtRules:
   - issuer: "test-issuer-3@istio.io"
-    jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
+    jwksUri: "{{ .JWTServer.JwksURI }}"
 ---
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy

--- a/tests/integration/security/testdata/authz/egress-gateway.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/egress-gateway.yaml.tmpl
@@ -6,9 +6,9 @@ metadata:
 spec:
   jwtRules:
     - issuer: "test-issuer-1@istio.io"
-      jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
+      jwksUri: "{{ .JWTServer.JwksURI }}"
     - issuer: "test-issuer-2@istio.io"
-      jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
+      jwksUri: "{{ .JWTServer.JwksURI }}"
 ---
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy

--- a/tests/integration/security/testdata/authz/jwt.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/jwt.yaml.tmpl
@@ -9,9 +9,9 @@ metadata:
 spec:
   jwtRules:
   - issuer: "test-issuer-1@istio.io"
-    jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
+    jwksUri: "{{ .JWTServer.JwksURI }}"
   - issuer: "test-issuer-2@istio.io"
-    jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
+    jwksUri: "{{ .JWTServer.JwksURI }}"
     spaceDelimitedClaims: ["custom_scope", "teams"]
 ---
 

--- a/tests/integration/security/testdata/requestauthn/aud.yaml.tmpl
+++ b/tests/integration/security/testdata/requestauthn/aud.yaml.tmpl
@@ -8,11 +8,11 @@ spec:
       app: {{ .To.ServiceName }}
   jwtRules:
   - issuer: "test-issuer-1@istio.io"
-    jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
+    jwksUri: "{{ .JWTServer.JwksURI }}"
     audiences:
     - "foo"
   - issuer: "test-issuer-2@istio.io"
-    jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
+    jwksUri: "{{ .JWTServer.JwksURI }}"
     audiences:
     - "bar"
 ---
@@ -26,4 +26,4 @@ spec:
       app: {{ .To.ServiceName }}
   jwtRules:
   - issuer: "test-issuer-2@istio.io"
-    jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
+    jwksUri: "{{ .JWTServer.JwksURI }}"

--- a/tests/integration/security/testdata/requestauthn/authn-authz.yaml.tmpl
+++ b/tests/integration/security/testdata/requestauthn/authn-authz.yaml.tmpl
@@ -8,7 +8,7 @@ spec:
       app: {{ .To.ServiceName }}
   jwtRules:
   - issuer: "test-issuer-1@istio.io"
-    jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
+    jwksUri: "{{ .JWTServer.JwksURI }}"
 ---
 # The following policy enables authorization on workload dst.
 apiVersion: security.istio.io/v1

--- a/tests/integration/security/testdata/requestauthn/authn-only.yaml.tmpl
+++ b/tests/integration/security/testdata/requestauthn/authn-only.yaml.tmpl
@@ -8,7 +8,7 @@ spec:
       app: {{ .To.ServiceName }}
   jwtRules:
   - issuer: "test-issuer-1@istio.io"
-    jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
+    jwksUri: "{{ .JWTServer.JwksURI }}"
     outputPayloadToHeader: "x-test-payload"
     outputClaimToHeaders:
     - header: "x-jwt-iss"
@@ -18,5 +18,5 @@ spec:
     - header: "x-jwt-nested-claim"
       claim: "nested.nested-2.key2"
   - issuer: "test-issuer-2@istio.io"
-    jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
+    jwksUri: "{{ .JWTServer.JwksURI }}"
     outputPayloadToHeader: "x-test-payload"

--- a/tests/integration/security/testdata/requestauthn/forward.yaml.tmpl
+++ b/tests/integration/security/testdata/requestauthn/forward.yaml.tmpl
@@ -8,6 +8,6 @@ spec:
       app: {{ .To.ServiceName }}
   jwtRules:
   - issuer: "test-issuer-1@istio.io"
-    jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
+    jwksUri: "{{ .JWTServer.JwksURI }}"
     outputPayloadToHeader: "x-test-payload"
     forwardOriginalToken: true

--- a/tests/integration/security/testdata/requestauthn/gateway-jwt.yaml.tmpl
+++ b/tests/integration/security/testdata/requestauthn/gateway-jwt.yaml.tmpl
@@ -9,9 +9,9 @@ spec:
     name: {{ .To.ServiceName }}-gateway
   jwtRules:
   - issuer: "test-issuer-1@istio.io"
-    jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
+    jwksUri: "{{ .JWTServer.JwksURI }}"
   - issuer: "test-issuer-2@istio.io"
-    jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
+    jwksUri: "{{ .JWTServer.JwksURI }}"
 ---
 apiVersion: security.istio.io/v1
 kind: RequestAuthentication
@@ -23,7 +23,7 @@ spec:
       gateway.networking.k8s.io/gateway-name: {{ .To.ServiceName }}-gateway # This would be ignored (not a targetRef) but the feature flag isn't on, so it's applied
   jwtRules:
   - issuer: "test-issuer-3@istio.io"
-    jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
+    jwksUri: "{{ .JWTServer.JwksURI }}"
 ---
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy

--- a/tests/integration/security/testdata/requestauthn/global-jwt.yaml.tmpl
+++ b/tests/integration/security/testdata/requestauthn/global-jwt.yaml.tmpl
@@ -5,9 +5,9 @@ metadata:
 spec:
   jwtRules:
   - issuer: "test-issuer-1@istio.io"
-    jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
+    jwksUri: "{{ .JWTServer.JwksURI }}"
   - issuer: "test-issuer-2@istio.io"
-    jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
+    jwksUri: "{{ .JWTServer.JwksURI }}"
 ---
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy

--- a/tests/integration/security/testdata/requestauthn/headers-params.yaml.tmpl
+++ b/tests/integration/security/testdata/requestauthn/headers-params.yaml.tmpl
@@ -8,7 +8,7 @@ spec:
       app: {{ .To.ServiceName }}
   jwtRules:
   - issuer: "test-issuer-1@istio.io"
-    jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
+    jwksUri: "{{ .JWTServer.JwksURI }}"
     fromHeaders:
     - name: "x-jwt-token"
       prefix: "Value "


### PR DESCRIPTION
Drops the remote raw.githubusercontent.com/istio/istio fetch in 14 RequestAuthentication test fixtures. 
- where a jwtServer is already wired in the suite (12 files in tests/integration/security/...), uses {{ .JWTServer.JwksURI }}
- where it is not (routing.go, fuzz_test.go, ambient waypoint-jwt), inlines a public-only JWKS from a new `go:embed` const in tests/common/jwt. 
- also adds a validation guard in pkg/config/validation that rejects `RequestAuthentication.Jwks` containing __private__ RSA, EC, OKP, or symmetric key material, with a new test case. 

Fixes JWT test flakes that depended on GitHub egress from inside kind clusters.