### PR TITLE
fix dns service entries when abmient multinetwork is enabled

### DIFF
--- a/pilot/pkg/serviceregistry/ambient/services.go
+++ b/pilot/pkg/serviceregistry/ambient/services.go
@@ -519,6 +519,7 @@ func serviceEntriesInfo(
 			LabelSelector:      sel,
 			Source:             MakeSource(s),
 			Waypoint:           waypoint,
+			Scope:              model.Global,
 			DNSConnectStrategy: model.GetDNSConnectStrategy(s.Annotations),
 			CreationTime:       s.CreationTimestamp.Time,
 		})

--- a/pilot/pkg/serviceregistry/ambient/services_test.go
+++ b/pilot/pkg/serviceregistry/ambient/services_test.go
@@ -968,6 +968,93 @@ func TestServiceEntryServices(t *testing.T) {
 	}
 }
 
+func TestServiceEntryServicesScope(t *testing.T) {
+	cases := []struct {
+		name string
+		se   *networkingclient.ServiceEntry
+	}{
+		{
+			name: "DNS resolution ServiceEntry has global scope",
+			se: &networkingclient.ServiceEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dns-se",
+					Namespace: "ns",
+				},
+				Spec: networking.ServiceEntry{
+					Addresses: []string{"1.2.3.4"},
+					Hosts:     []string{"example.com"},
+					Ports: []*networking.ServicePort{{
+						Number:   443,
+						Name:     "https",
+						Protocol: "HTTPS",
+					}},
+					Resolution: networking.ServiceEntry_DNS,
+					Location:   networking.ServiceEntry_MESH_EXTERNAL,
+				},
+			},
+		},
+		{
+			name: "STATIC resolution ServiceEntry has global scope",
+			se: &networkingclient.ServiceEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "static-se",
+					Namespace: "ns",
+				},
+				Spec: networking.ServiceEntry{
+					Addresses: []string{"1.2.3.4"},
+					Hosts:     []string{"static.example.com"},
+					Ports: []*networking.ServicePort{{
+						Number:   80,
+						Name:     "http",
+						Protocol: "HTTP",
+					}},
+					Resolution: networking.ServiceEntry_STATIC,
+					Location:   networking.ServiceEntry_MESH_EXTERNAL,
+					Endpoints: []*networking.WorkloadEntry{{
+						Address: "2.2.2.2",
+					}},
+				},
+			},
+		},
+		{
+			name: "NONE resolution ServiceEntry has global scope",
+			se: &networkingclient.ServiceEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "none-se",
+					Namespace: "ns",
+				},
+				Spec: networking.ServiceEntry{
+					Hosts: []string{"none.example.com"},
+					Ports: []*networking.ServicePort{{
+						Number:   80,
+						Name:     "http",
+						Protocol: "HTTP",
+					}},
+					Resolution: networking.ServiceEntry_NONE,
+					Location:   networking.ServiceEntry_MESH_EXTERNAL,
+				},
+			},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := krttest.NewMock(t, []any{})
+			a := newAmbientUnitTest(t)
+			builder := a.serviceEntryServiceBuilder(
+				krttest.GetMockCollection[Waypoint](mock),
+				krttest.GetMockCollection[*v1.Namespace](mock),
+			)
+			wrapper := builder(krt.TestingDummyContext{}, tt.se)
+			for _, tsi := range wrapper {
+				if tsi.Scope != model.Global {
+					t.Errorf("ServiceEntry %s/%s: expected Scope=%q, got Scope=%q",
+						tt.se.Namespace, tt.se.Name, model.Global, tsi.Scope)
+				}
+			}
+		})
+	}
+}
+
 func TestServiceServices(t *testing.T) {
 	waypointAddr := &workloadapi.GatewayAddress{
 		Destination: &workloadapi.GatewayAddress_Hostname{

--- a/pilot/pkg/xds/cds_test.go
+++ b/pilot/pkg/xds/cds_test.go
@@ -24,14 +24,17 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pilot/test/xds"
 	"istio.io/istio/pilot/test/xdstest"
+	istiocluster "istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/slices"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/util/sets"
 )
@@ -325,4 +328,86 @@ spec:
 			"example.com:80",
 		},
 	})
+}
+
+// TestDNSServiceEntryCrossClusterWithAmbientMultiNetwork verifies that DNS-resolution
+// ServiceEntries produce CDS clusters for sidecar proxies in remote clusters when
+// AMBIENT_ENABLE_MULTI_NETWORK is true. Regression test for
+// https://github.com/istio/istio/issues/60343
+func TestDNSServiceEntryCrossClusterWithAmbientMultiNetwork(t *testing.T) {
+	test.SetForTest(t, &features.EnableAmbient, true)
+	test.SetForTest(t, &features.EnableAmbientMultiNetwork, true)
+
+	seYAML := `
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: dns-se
+  namespace: default
+spec:
+  hosts:
+  - repro-dns.example.invalid
+  exportTo: ["*"]
+  ports:
+  - number: 443
+    protocol: HTTPS
+    name: https-443
+  resolution: DNS
+  location: MESH_EXTERNAL
+  endpoints:
+  - address: dns-endpoint.example.invalid
+`
+
+	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
+		DefaultClusterName: "cluster1",
+		KubernetesObjectsByCluster: map[istiocluster.ID][]runtime.Object{
+			"cluster1": {},
+			"cluster2": {},
+		},
+		// ConfigString feeds the serviceentry controller (creates model.Service + endpoints)
+		ConfigString: seYAML,
+		// KubernetesObjectString feeds the kube informers (ambient index picks it up for ServiceInfo)
+		KubernetesObjectString: seYAML,
+	})
+
+	// Sidecar proxy in cluster2 (the remote cluster)
+	remoteProxy := s.SetupProxy(&model.Proxy{
+		Metadata: &model.NodeMetadata{
+			ClusterID: "cluster2",
+			Namespace: "default",
+		},
+		ConfigNamespace: "default",
+	})
+
+	// Sidecar proxy in cluster1 (the primary/config cluster)
+	localProxy := s.SetupProxy(&model.Proxy{
+		Metadata: &model.NodeMetadata{
+			ClusterID: "cluster1",
+			Namespace: "default",
+		},
+		ConfigNamespace: "default",
+	})
+
+	clusterName := "outbound|443||repro-dns.example.invalid"
+
+	// The local proxy should always see the cluster
+	localClusters := xdstest.ExtractClusters(s.Clusters(localProxy))
+	if localClusters[clusterName] == nil {
+		t.Fatalf("expected cluster %q for local proxy in cluster1, but it was missing", clusterName)
+	}
+
+	// The remote proxy must also see the cluster — this is the regression case.
+	// Without the fix, the DNS cluster is dropped because cross-cluster endpoints are
+	// filtered out when ServiceEntry scope is unset, leaving zero endpoints which causes
+	// STRICT_DNS clusters to be omitted from CDS.
+	remoteClusters := xdstest.ExtractClusters(s.Clusters(remoteProxy))
+	if remoteClusters[clusterName] == nil {
+		t.Fatalf("expected cluster %q for remote proxy in cluster2, but it was missing", clusterName)
+	}
+
+	// Verify the cluster has endpoints (DNS address inlined in LoadAssignment)
+	remoteEps := xdstest.ExtractClusterEndpoints(s.Clusters(remoteProxy))
+	if eps := remoteEps[clusterName]; len(eps) == 0 {
+		t.Fatalf("expected endpoints in cluster %q for remote proxy, got none", clusterName)
+	}
 }

--- a/pilot/pkg/xds/endpoints/endpoint_builder_test.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder_test.go
@@ -354,6 +354,18 @@ func TestFilterIstioEndpoint(t *testing.T) {
 		},
 		ConfigNamespace: "not-default",
 	}
+	remoteSidecar := &model.Proxy{
+		Type:        model.SidecarProxy,
+		IPAddresses: []string{"111.111.111.111"},
+		ID:          "v0.test-app",
+		DNSDomain:   "example.org",
+		Metadata: &model.NodeMetadata{
+			Namespace: "test-app",
+			NodeName:  "example",
+			ClusterID: "remote",
+		},
+		ConfigNamespace: "test-app",
+	}
 	waypoint := &model.Proxy{
 		Type: model.Waypoint,
 		Metadata: &model.NodeMetadata{
@@ -491,6 +503,20 @@ func TestFilterIstioEndpoint(t *testing.T) {
 			name:     "test ambient endpoint in remote cluster for local service",
 			proxy:    ingressGw,
 			ep:       remoteEp,
+			svcInfo:  localSvc,
+			expected: false,
+		},
+		{
+			name:     "test sidecar in remote cluster with ServiceEntry (global scope) should see cross-cluster endpoints",
+			proxy:    remoteSidecar,
+			ep:       localEp,
+			svcInfo:  globalSvc,
+			expected: true,
+		},
+		{
+			name:     "test sidecar in remote cluster with local service should not see cross-cluster endpoints",
+			proxy:    remoteSidecar,
+			ep:       localEp,
 			svcInfo:  localSvc,
 			expected: false,
 		},

--- a/releasenotes/notes/60343.yaml
+++ b/releasenotes/notes/60343.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue: [60343]
+releaseNotes:
+- |
+  **Fixed** an issue where DNS-resolution `ServiceEntry` clusters were not generated for sidecar
+  proxies in remote clusters when `AMBIENT_ENABLE_MULTI_NETWORK=true`. The ambient multi-network
+  endpoint filter incorrectly dropped cross-cluster endpoints for ServiceEntries because their
+  scope was unset, causing `STRICT_DNS` clusters to be omitted from CDS pushes.


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/60343

It is because for Service Entries we do not set the Scope. I have set it to GLOBAL

(Used Claude to generate tests)

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions