### PR TITLE
fix: pilot-agent stuck in reconnect loop after CA connection reset

### DIFF
--- a/releasenotes/notes/60326.yaml
+++ b/releasenotes/notes/60326.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+issue:
+  - 60326
+releaseNotes:
+  - |
+    **Fixed** an issue where pilot-agent could get permanently stuck retrying CSR signing after istiod closed the gRPC connection, requiring a manual pod restart to recover.

--- a/security/pkg/credentialfetcher/plugin/token.go
+++ b/security/pkg/credentialfetcher/plugin/token.go
@@ -17,13 +17,19 @@ package plugin
 import (
 	"os"
 	"strings"
+	"sync"
+	"syscall"
+	"time"
 
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/security"
 )
 
 type KubernetesTokenPlugin struct {
-	path string
+	path      string
+	mu        sync.Mutex
+	lastMTime time.Time
+	lastInode uint64
 }
 
 var _ security.CredFetcher = &KubernetesTokenPlugin{}
@@ -34,10 +40,30 @@ func CreateTokenPlugin(path string) *KubernetesTokenPlugin {
 	}
 }
 
-func (t KubernetesTokenPlugin) GetPlatformCredential() (string, error) {
+func (t *KubernetesTokenPlugin) GetPlatformCredential() (string, error) {
 	if t.path == "" {
 		return "", nil
 	}
+
+	info, err := os.Stat(t.path)
+	if err != nil {
+		log.Warnf("failed to stat token file %q: %v", t.path, err)
+	} else {
+		mtime := info.ModTime()
+		inode := fileInode(info)
+		t.mu.Lock()
+		if t.lastMTime.IsZero() {
+			t.lastMTime = mtime
+			t.lastInode = inode
+		} else if !mtime.Equal(t.lastMTime) || inode != t.lastInode {
+			log.Infof("istio-token rotated: old_mtime=%v new_mtime=%v old_inode=%d new_inode=%d",
+				t.lastMTime, mtime, t.lastInode, inode)
+			t.lastMTime = mtime
+			t.lastInode = inode
+		}
+		t.mu.Unlock()
+	}
+
 	tok, err := os.ReadFile(t.path)
 	if err != nil {
 		log.Warnf("failed to fetch token from file: %v", err)
@@ -46,9 +72,16 @@ func (t KubernetesTokenPlugin) GetPlatformCredential() (string, error) {
 	return strings.TrimSpace(string(tok)), nil
 }
 
-func (t KubernetesTokenPlugin) GetIdentityProvider() string {
+func (t *KubernetesTokenPlugin) GetIdentityProvider() string {
 	return ""
 }
 
-func (t KubernetesTokenPlugin) Stop() {
+func (t *KubernetesTokenPlugin) Stop() {
+}
+
+func fileInode(info os.FileInfo) uint64 {
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+		return stat.Ino
+	}
+	return 0
 }

--- a/security/pkg/nodeagent/caclient/providers/citadel/client.go
+++ b/security/pkg/nodeagent/caclient/providers/citadel/client.go
@@ -155,7 +155,7 @@ func (c *CitadelClient) buildConnection() (*grpc.ClientConn, error) {
 
 func (c *CitadelClient) reconnect() error {
 	if err := c.conn.Close(); err != nil {
-		return fmt.Errorf("failed to close connection: %v", err)
+		citadelClientLog.Warnf("error closing old CA connection: %v", err)
 	}
 
 	conn, err := c.buildConnection()


### PR DESCRIPTION
  **Please provide a description of this PR:**
  Fixes #60326 
  
When istiod closes a gRPC connection such as KEEPALIVE_MAX_SERVER_CONNECTION_AGE, conn.Close() inside reconnect() returns ErrClientConnClosing because the connection is already down. Previous code treated this as a hard error and returned early without calling buildConnection(), leaving c.conn permanently pointing at a dead channel. Every subsequent CSR hit the same dead connection, reconnect() failed the same way, and pilot-agent was stuck in an infinite loop. 

client.go: reconnect() now logs the Close() error as a warning and always proceeds to buildConnection().

token.go: KubernetesTokenPlugin tracks the token file's mtime and inode on every credential read. When kubelet rotates the projected token (symlink swap), it logs the change. If CSRs keep failing and this log line never appears, it confirms kubelet has stopped rotating the token.


  
  **To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**
  
  - [ ] Ambient
  - [ ] Configuration Infrastructure
  - [ ] Docs
  - [ ] Dual Stack
  - [] Installation
  - [X] Networking
  - [ ] Performance and Scalability
  - [ ] Extensions and Telemetry
  - [X] Security
  - [ ] Test and Release
  - [ ] User Experience
  - [ ] Developer Infrastructure
  - [ ] Upgrade
  - [ ] Multi Cluster
  - [ ] Virtual Machine
  - [ ] Control Plane Revisions
  
  **Please check any characteristics that apply to this pull request.**
  
  - [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
