### PR TITLE
status: passthrough Prometheus protobuf exposition for native histograms

### DIFF
--- a/pilot/cmd/pilot-agent/metrics/metrics.go
+++ b/pilot/cmd/pilot-agent/metrics/metrics.go
@@ -22,7 +22,9 @@ import (
 )
 
 var (
-	typeTag = monitoring.CreateLabel("type")
+	typeTag      = monitoring.CreateLabel("type")
+	formatTag    = monitoring.CreateLabel("format")
+	downgradeTag = monitoring.CreateLabel("downgrade")
 
 	// StartupTime measures the time it takes for the agent to get ready Note: This
 	// is dependent on readiness probes. This means our granularity is correlated to
@@ -46,12 +48,31 @@ var (
 		"scrapes_total",
 		"The total number of scrapes.",
 	)
+
+	// scrapeFormats records total number of scrapes broken down by the exposition
+	// format that the merger ultimately delivered to the scraper. The "downgrade"
+	// label is "true" when the client requested protobuf (typically because
+	// native Prometheus histograms are required) but the merger had to emit text
+	// because at least one merged upstream did not produce protobuf, and "false"
+	// otherwise. The counter is incremented exactly once per scrape.
+	scrapeFormats = monitoring.NewSum(
+		"scrape_format_total",
+		"The total number of scrapes broken down by delivered exposition format.",
+	)
+	ScrapeFormatText       = scrapeFormats.With(formatTag.Value(ScrapeFormatLabelText), downgradeTag.Value("false"))
+	ScrapeFormatOpenMetric = scrapeFormats.With(formatTag.Value(ScrapeFormatLabelOpenMetrics), downgradeTag.Value("false"))
+	ScrapeFormatProto      = scrapeFormats.With(formatTag.Value(ScrapeFormatLabelProto), downgradeTag.Value("false"))
+	ScrapeFormatDowngraded = scrapeFormats.With(formatTag.Value(ScrapeFormatLabelText), downgradeTag.Value("true"))
 )
 
 var (
 	ScrapeTypeEnvoy = "envoy"
 	ScrapeTypeApp   = "application"
 	ScrapeTypeAgent = "agent"
+
+	ScrapeFormatLabelText        = "text"
+	ScrapeFormatLabelOpenMetrics = "openmetrics"
+	ScrapeFormatLabelProto       = "proto"
 )
 
 var processStartTime = time.Now()

--- a/pilot/cmd/pilot-agent/status/merger_bench_test.go
+++ b/pilot/cmd/pilot-agent/status/merger_bench_test.go
@@ -1,0 +1,128 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"google.golang.org/protobuf/proto"
+)
+
+// makeBenchProtoBody constructs a delimited Prometheus protobuf body containing
+// roughly nFamilies metric families to size the per-scrape work the merger
+// faces in production. Used by the byte-concat vs decode-reencode benchmarks
+// committed to in the PR thread.
+func makeBenchProtoBody(t testing.TB, nFamilies int) []byte {
+	t.Helper()
+	families := make([]*dto.MetricFamily, nFamilies)
+	for i := 0; i < nFamilies; i++ {
+		families[i] = &dto.MetricFamily{
+			Name: proto.String(fmt.Sprintf("bench_counter_%d", i)),
+			Help: proto.String(fmt.Sprintf("bench help %d", i)),
+			Type: dto.MetricType_COUNTER.Enum(),
+			Metric: []*dto.Metric{
+				{
+					Counter: &dto.Counter{Value: proto.Float64(float64(i))},
+					Label: []*dto.LabelPair{
+						{Name: proto.String("idx"), Value: proto.String(fmt.Sprintf("%d", i))},
+					},
+				},
+			},
+		}
+	}
+	var buf bytes.Buffer
+	enc := expfmt.NewEncoder(&buf, FmtProtoDelim)
+	for _, fam := range families {
+		if err := enc.Encode(fam); err != nil {
+			t.Fatalf("encode family %q: %v", fam.GetName(), err)
+		}
+	}
+	return buf.Bytes()
+}
+
+// BenchmarkMerger_ByteConcat measures the cost of the historical byte-concat
+// fast path: read body, write body. The proto path (decode-reencode) must be
+// compared against this baseline.
+func BenchmarkMerger_ByteConcat(b *testing.B) {
+	body := makeBenchProtoBody(b, 10_000)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		var out bytes.Buffer
+		if _, err := io.Copy(&out, bytes.NewReader(body)); err != nil {
+			b.Fatal(err)
+		}
+		_ = out.Bytes()
+	}
+}
+
+// BenchmarkMerger_DecodeReencode_Proto measures the cost of decode-and-re-encode
+// on a delimited protobuf body. This is the per-scrape overhead any
+// always-decode/reencode merger design (the option @krinkinmu suggested in the
+// PR review) would incur on every scrape.
+func BenchmarkMerger_DecodeReencode_Proto(b *testing.B) {
+	body := makeBenchProtoBody(b, 10_000)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		mfs, err := decodeAll(bytes.NewReader(body), FmtProtoDelim)
+		if err != nil {
+			b.Fatal(err)
+		}
+		var out bytes.Buffer
+		enc := expfmt.NewEncoder(&out, FmtProtoDelim)
+		for _, mf := range mfs {
+			if err := enc.Encode(mf); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}
+
+// BenchmarkMerger_DecodeReencode_OM measures the cost of decode-and-re-encode
+// on an OpenMetrics text body via the new openmetrics_decode.go adapter. This
+// is the cost path the proto merger now pays when an upstream returns OM
+// (Python prometheus_client default).
+func BenchmarkMerger_DecodeReencode_OM(b *testing.B) {
+	// Build an OM body roughly comparable in size to the proto benchmark.
+	var buf bytes.Buffer
+	buf.WriteString("# TYPE bench_counter counter\n")
+	for i := 0; i < 10_000; i++ {
+		fmt.Fprintf(&buf, "bench_counter_total{idx=\"%d\"} %d\n", i, i)
+	}
+	buf.WriteString("# EOF\n")
+	body := buf.Bytes()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		mfs, err := decodeAll(bytes.NewReader(body), FmtOpenMetrics_1_0_0)
+		if err != nil {
+			b.Fatal(err)
+		}
+		var out bytes.Buffer
+		enc := expfmt.NewEncoder(&out, FmtOpenMetrics_1_0_0)
+		for _, mf := range mfs {
+			if err := enc.Encode(mf); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}

--- a/pilot/cmd/pilot-agent/status/openmetrics_decode.go
+++ b/pilot/cmd/pilot-agent/status/openmetrics_decode.go
@@ -1,0 +1,478 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+	commonModel "github.com/prometheus/common/model"
+	promExemplar "github.com/prometheus/prometheus/model/exemplar"
+	promLabels "github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/textparse"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// decodeOpenMetricsToFamilies parses an OpenMetrics text body into a slice of
+// *dto.MetricFamily, preserving the OM-specific signals that the prometheus/common
+// expfmt text decoder silently drops or misinterprets: exemplars, _created
+// timestamps, # UNIT, INFO, STATESET. See prometheus/common#812.
+//
+// The adapter uses prometheus/prometheus/model/textparse.OpenMetricsParser (the
+// canonical OM parser, already a direct dep of istio) and assembles the per-entry
+// stream into MetricFamily values keyed by metric family name. Bucket exemplars
+// are attached to the matching histogram bucket; counter exemplars to the
+// matching counter sample. _created timestamps are surfaced via the
+// Counter/Histogram/Summary CreatedTimestamp field and the _created series itself
+// is suppressed via WithOMParserSTSeriesSkipped.
+//
+// Malformed bodies surface as a returned error along with whatever families were
+// successfully parsed before the failure, matching the failure semantics of the
+// expfmt text decoder used elsewhere in the merger.
+func decodeOpenMetricsToFamilies(body io.Reader) ([]*dto.MetricFamily, error) {
+	buf, err := io.ReadAll(body)
+	if err != nil {
+		return nil, fmt.Errorf("openmetrics decode: read body: %w", err)
+	}
+	if len(buf) == 0 {
+		return nil, nil
+	}
+
+	parser := textparse.NewOpenMetricsParser(buf, promLabels.NewSymbolTable())
+	a := &omAssembler{
+		families:   map[string]*dto.MetricFamily{},
+		createdSec: map[string]float64{},
+		metricIdx:  map[string]map[string]int{},
+	}
+
+	for {
+		entry, perr := parser.Next()
+		if perr != nil {
+			if errors.Is(perr, io.EOF) {
+				break
+			}
+			return a.materialize(), fmt.Errorf("openmetrics decode: %w", perr)
+		}
+		if err := a.handle(parser, entry); err != nil {
+			return a.materialize(), fmt.Errorf("openmetrics decode: %w", err)
+		}
+	}
+	return a.materialize(), nil
+}
+
+// omAssembler accumulates per-entry parser output into MetricFamily values,
+// preserving insertion order across families so the merged output is stable
+// across scrapes.
+//
+// createdSec maps family-name → _created timestamp in seconds (with fractional
+// component preserved). We capture _created lines as standalone EntrySeries
+// emissions during the first pass and resolve them onto Counter/Histogram/
+// Summary CreatedTimestamp at family-end. This avoids the per-sample
+// StartTimestamp() peek-ahead, which is O(n) in the OM body length and would
+// be O(n²) overall for a 10K-series body.
+//
+// metricIdx maps family-name → (label-key → index in fam.Metric). This keeps
+// findOrCreateMetric O(1) per call even when a family has thousands of
+// distinct label sets.
+type omAssembler struct {
+	families   map[string]*dto.MetricFamily
+	order      []string
+	createdSec map[string]float64
+	metricIdx  map[string]map[string]int
+}
+
+func (a *omAssembler) getOrCreate(name string) *dto.MetricFamily {
+	if fam, ok := a.families[name]; ok {
+		return fam
+	}
+	fam := &dto.MetricFamily{Name: proto.String(name)}
+	a.families[name] = fam
+	a.order = append(a.order, name)
+	a.metricIdx[name] = map[string]int{}
+	return fam
+}
+
+func (a *omAssembler) materialize() []*dto.MetricFamily {
+	out := make([]*dto.MetricFamily, 0, len(a.order))
+	for _, name := range a.order {
+		fam := a.families[name]
+		if ts, ok := a.createdSec[name]; ok {
+			a.applyCreated(fam, ts)
+		}
+		out = append(out, fam)
+	}
+	return out
+}
+
+// applyCreated sets the CreatedTimestamp on every Counter/Histogram/Summary
+// metric in fam to the given seconds-since-epoch (with fractional component).
+func (a *omAssembler) applyCreated(fam *dto.MetricFamily, sec float64) {
+	pts := timestamppb.New(time.UnixMilli(secondsToMillis(sec)))
+	switch fam.GetType() {
+	case dto.MetricType_COUNTER:
+		for _, m := range fam.Metric {
+			if m.Counter != nil {
+				m.Counter.CreatedTimestamp = pts
+			}
+		}
+	case dto.MetricType_HISTOGRAM:
+		for _, m := range fam.Metric {
+			if m.Histogram != nil {
+				m.Histogram.CreatedTimestamp = pts
+			}
+		}
+	case dto.MetricType_SUMMARY:
+		for _, m := range fam.Metric {
+			if m.Summary != nil {
+				m.Summary.CreatedTimestamp = pts
+			}
+		}
+	}
+}
+
+// secondsToMillis converts an OpenMetrics timestamp (seconds-since-epoch as a
+// float64 with millisecond fraction) into a millisecond Unix timestamp.
+func secondsToMillis(sec float64) int64 {
+	return int64(sec * 1000)
+}
+
+func (a *omAssembler) handle(parser textparse.Parser, entry textparse.Entry) error {
+	switch entry {
+	case textparse.EntryHelp:
+		name, help := parser.Help()
+		a.getOrCreate(string(name)).Help = proto.String(string(help))
+	case textparse.EntryType:
+		name, mt := parser.Type()
+		fam := a.getOrCreate(string(name))
+		fam.Type = toDTOMetricType(mt).Enum()
+	case textparse.EntryUnit:
+		name, unit := parser.Unit()
+		if len(unit) > 0 {
+			a.getOrCreate(string(name)).Unit = proto.String(string(unit))
+		}
+	case textparse.EntrySeries:
+		return a.ingestSeries(parser)
+	case textparse.EntryComment, textparse.EntryHistogram, textparse.EntryInvalid:
+		// Comments are not preserved by the dto model. Native histograms are
+		// proto-only and never appear in an OM text body. EntryInvalid is reached
+		// only with a non-nil error (handled by Next), but keep the case for clarity.
+	}
+	return nil
+}
+
+// ingestSeries decodes the current EntrySeries into the appropriate MetricFamily,
+// resolving the parent family by stripping standard suffixes (_total, _count,
+// _sum, _bucket) and using the # TYPE metadata observed previously. Exemplars
+// attach to the matching Counter or Bucket. _created series are captured into
+// the per-family createdSec map for resolution at family-end (see
+// applyCreated).
+func (a *omAssembler) ingestSeries(parser textparse.Parser) error {
+	_, tsPtr, val := parser.Series()
+
+	var lbls promLabels.Labels
+	parser.Labels(&lbls)
+	metricName := lbls.Get(commonModel.MetricNameLabel)
+	if metricName == "" {
+		return errors.New("series has no metric name")
+	}
+
+	familyName, kind := a.resolveFamily(metricName)
+
+	// _created series do not emit a sample; they only carry a created timestamp
+	// for the family.
+	if kind == suffixCreated {
+		a.createdSec[familyName] = val
+		return nil
+	}
+
+	fam := a.getOrCreate(familyName)
+
+	// If the family arrived series-first (TYPE not seen yet), infer from suffix.
+	if fam.Type == nil {
+		t := inferTypeFromSuffix(kind)
+		fam.Type = t.Enum()
+	}
+
+	var exemplarOpt *dto.Exemplar
+	var ex promExemplar.Exemplar
+	if parser.Exemplar(&ex) {
+		exemplarOpt = toDTOExemplar(&ex)
+	}
+
+	switch fam.GetType() {
+	case dto.MetricType_COUNTER:
+		lp := stripStandardLabels(lbls, dto.MetricType_COUNTER)
+		metric := findOrCreateMetric(fam, a.metricIdx[familyName], lp, tsPtr)
+		if metric.Counter == nil {
+			metric.Counter = &dto.Counter{}
+		}
+		metric.Counter.Value = proto.Float64(val)
+		if exemplarOpt != nil {
+			metric.Counter.Exemplar = exemplarOpt
+		}
+
+	case dto.MetricType_GAUGE:
+		lp := stripStandardLabels(lbls, dto.MetricType_GAUGE)
+		metric := findOrCreateMetric(fam, a.metricIdx[familyName], lp, tsPtr)
+		if metric.Gauge == nil {
+			metric.Gauge = &dto.Gauge{}
+		}
+		metric.Gauge.Value = proto.Float64(val)
+
+	case dto.MetricType_HISTOGRAM:
+		lp := stripStandardLabels(lbls, dto.MetricType_HISTOGRAM)
+		metric := findOrCreateMetric(fam, a.metricIdx[familyName], lp, tsPtr)
+		if metric.Histogram == nil {
+			metric.Histogram = &dto.Histogram{}
+		}
+		switch kind {
+		case suffixBucket:
+			leStr := lbls.Get("le")
+			le, perr := strconv.ParseFloat(leStr, 64)
+			if perr != nil {
+				return fmt.Errorf("invalid histogram bucket le=%q: %w", leStr, perr)
+			}
+			bucket := &dto.Bucket{
+				CumulativeCount: proto.Uint64(uint64(val)),
+				UpperBound:      proto.Float64(le),
+			}
+			if exemplarOpt != nil {
+				bucket.Exemplar = exemplarOpt
+			}
+			metric.Histogram.Bucket = append(metric.Histogram.Bucket, bucket)
+		case suffixSum:
+			metric.Histogram.SampleSum = proto.Float64(val)
+		case suffixCount:
+			metric.Histogram.SampleCount = proto.Uint64(uint64(val))
+		}
+
+	case dto.MetricType_SUMMARY:
+		lp := stripStandardLabels(lbls, dto.MetricType_SUMMARY)
+		metric := findOrCreateMetric(fam, a.metricIdx[familyName], lp, tsPtr)
+		if metric.Summary == nil {
+			metric.Summary = &dto.Summary{}
+		}
+		switch kind {
+		case suffixSum:
+			metric.Summary.SampleSum = proto.Float64(val)
+		case suffixCount:
+			metric.Summary.SampleCount = proto.Uint64(uint64(val))
+		default:
+			if q := lbls.Get("quantile"); q != "" {
+				qv, perr := strconv.ParseFloat(q, 64)
+				if perr != nil {
+					return fmt.Errorf("invalid summary quantile=%q: %w", q, perr)
+				}
+				metric.Summary.Quantile = append(metric.Summary.Quantile, &dto.Quantile{
+					Quantile: proto.Float64(qv),
+					Value:    proto.Float64(val),
+				})
+			}
+		}
+
+	default:
+		// UNTYPED / INFO / STATESET / GAUGE_HISTOGRAM and anything else: represent
+		// each sample as an Untyped value. Info samples conventionally always have
+		// value 1.0; Stateset samples are 0/1 per state. We preserve the value
+		// verbatim so no information is lost.
+		lp := stripStandardLabels(lbls, fam.GetType())
+		metric := findOrCreateMetric(fam, a.metricIdx[familyName], lp, tsPtr)
+		if metric.Untyped == nil {
+			metric.Untyped = &dto.Untyped{}
+		}
+		metric.Untyped.Value = proto.Float64(val)
+	}
+	return nil
+}
+
+// suffix is the parsed family-suffix on the current series name.
+type suffix int
+
+const (
+	suffixNone suffix = iota
+	suffixTotal
+	suffixCount
+	suffixSum
+	suffixBucket
+	suffixCreated
+)
+
+// resolveFamily returns the parent family name and which standardized suffix the
+// series uses (if any). It collapses _total / _count / _sum / _bucket / _created
+// onto the parent family name iff a family with the matching type has been
+// observed via a prior # TYPE entry. Otherwise the series stands on its own
+// family.
+func (a *omAssembler) resolveFamily(metricName string) (string, suffix) {
+	for _, s := range []struct {
+		suffix string
+		kind   suffix
+	}{
+		{"_bucket", suffixBucket},
+		{"_count", suffixCount},
+		{"_sum", suffixSum},
+		{"_total", suffixTotal},
+		{"_created", suffixCreated},
+	} {
+		if strings.HasSuffix(metricName, s.suffix) && len(metricName) > len(s.suffix) {
+			parent := metricName[:len(metricName)-len(s.suffix)]
+			parentFam, parentTyped := a.families[parent]
+			if parentTyped {
+				switch s.kind {
+				case suffixBucket:
+					if parentFam.GetType() == dto.MetricType_HISTOGRAM {
+						return parent, s.kind
+					}
+				case suffixCount, suffixSum:
+					t := parentFam.GetType()
+					if t == dto.MetricType_HISTOGRAM || t == dto.MetricType_SUMMARY {
+						return parent, s.kind
+					}
+				case suffixTotal:
+					if parentFam.GetType() == dto.MetricType_COUNTER {
+						return parent, s.kind
+					}
+				case suffixCreated:
+					return parent, s.kind
+				}
+			}
+			// Suffix unambiguously implies a family even when # TYPE hasn't been
+			// seen yet (OM is supposed to declare TYPE first, but be defensive).
+			switch s.kind {
+			case suffixBucket, suffixTotal, suffixCreated:
+				return parent, s.kind
+			}
+		}
+	}
+	return metricName, suffixNone
+}
+
+// inferTypeFromSuffix is a fallback used when a series arrives before its # TYPE
+// entry. OpenMetrics requires TYPE before any series, but we are defensive.
+func inferTypeFromSuffix(k suffix) dto.MetricType {
+	switch k {
+	case suffixBucket:
+		return dto.MetricType_HISTOGRAM
+	case suffixSum, suffixCount:
+		return dto.MetricType_HISTOGRAM // could be Summary; default Histogram
+	case suffixTotal:
+		return dto.MetricType_COUNTER
+	}
+	return dto.MetricType_UNTYPED
+}
+
+// stripStandardLabels drops the synthetic __name__ label and the type-specific
+// dimensional labels ("le" for histograms, "quantile" for summaries) so they do
+// not appear as user labels on the produced Metric.
+func stripStandardLabels(lbls promLabels.Labels, mtype dto.MetricType) []*dto.LabelPair {
+	out := make([]*dto.LabelPair, 0, lbls.Len())
+	lbls.Range(func(lp promLabels.Label) {
+		if lp.Name == commonModel.MetricNameLabel {
+			return
+		}
+		if mtype == dto.MetricType_HISTOGRAM && lp.Name == "le" {
+			return
+		}
+		if mtype == dto.MetricType_SUMMARY && lp.Name == "quantile" {
+			return
+		}
+		out = append(out, &dto.LabelPair{
+			Name:  proto.String(lp.Name),
+			Value: proto.String(lp.Value),
+		})
+	})
+	return out
+}
+
+// findOrCreateMetric returns an existing Metric with matching labels (so multiple
+// per-bucket samples coalesce into one Metric per label set) or allocates a new
+// one and appends it to the family.
+//
+// metricIdx maps a label-set hash key → index in fam.Metric so this stays
+// O(1) per call even when a family has thousands of distinct label sets.
+func findOrCreateMetric(fam *dto.MetricFamily, metricIdx map[string]int, labelPairs []*dto.LabelPair, tsPtr *int64) *dto.Metric {
+	key := labelKey(labelPairs)
+	if i, ok := metricIdx[key]; ok {
+		return fam.Metric[i]
+	}
+	m := &dto.Metric{Label: labelPairs}
+	if tsPtr != nil {
+		m.TimestampMs = proto.Int64(*tsPtr)
+	}
+	metricIdx[key] = len(fam.Metric)
+	fam.Metric = append(fam.Metric, m)
+	return m
+}
+
+// labelKey serializes the label pairs into a compact string key for use as a
+// map lookup. The order of incoming label pairs is stable (the parser sorts
+// them via builder.Sort), so the resulting key is canonical per label set.
+func labelKey(labelPairs []*dto.LabelPair) string {
+	if len(labelPairs) == 0 {
+		return ""
+	}
+	// Single-allocation join: pre-size buf to the exact required width.
+	n := 0
+	for _, lp := range labelPairs {
+		n += len(lp.GetName()) + len(lp.GetValue()) + 2 // sep + sep
+	}
+	buf := make([]byte, 0, n)
+	for _, lp := range labelPairs {
+		buf = append(buf, lp.GetName()...)
+		buf = append(buf, '\x00')
+		buf = append(buf, lp.GetValue()...)
+		buf = append(buf, '\x01')
+	}
+	return string(buf)
+}
+
+func toDTOExemplar(e *promExemplar.Exemplar) *dto.Exemplar {
+	out := &dto.Exemplar{Value: proto.Float64(e.Value)}
+	if e.HasTs {
+		out.Timestamp = timestamppb.New(time.UnixMilli(e.Ts))
+	}
+	e.Labels.Range(func(lp promLabels.Label) {
+		out.Label = append(out.Label, &dto.LabelPair{
+			Name:  proto.String(lp.Name),
+			Value: proto.String(lp.Value),
+		})
+	})
+	return out
+}
+
+func toDTOMetricType(m commonModel.MetricType) dto.MetricType {
+	switch m {
+	case commonModel.MetricTypeCounter:
+		return dto.MetricType_COUNTER
+	case commonModel.MetricTypeGauge:
+		return dto.MetricType_GAUGE
+	case commonModel.MetricTypeHistogram:
+		return dto.MetricType_HISTOGRAM
+	case commonModel.MetricTypeGaugeHistogram:
+		return dto.MetricType_GAUGE_HISTOGRAM
+	case commonModel.MetricTypeSummary:
+		return dto.MetricType_SUMMARY
+	case commonModel.MetricTypeInfo, commonModel.MetricTypeStateset:
+		// The dto model has no INFO or STATESET enum value; UNTYPED carries the
+		// value verbatim.
+		return dto.MetricType_UNTYPED
+	}
+	return dto.MetricType_UNTYPED
+}

--- a/pilot/cmd/pilot-agent/status/openmetrics_decode_test.go
+++ b/pilot/cmd/pilot-agent/status/openmetrics_decode_test.go
@@ -1,0 +1,337 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+// findFamilyByName is a test helper.
+func findFamilyByName(t *testing.T, mfs []*dto.MetricFamily, name string) *dto.MetricFamily {
+	t.Helper()
+	for _, mf := range mfs {
+		if mf.GetName() == name {
+			return mf
+		}
+	}
+	t.Fatalf("metric family %q not found in %d families", name, len(mfs))
+	return nil
+}
+
+func TestDecodeOpenMetrics_CounterWithCreatedAndUnit(t *testing.T) {
+	body := strings.Join([]string{
+		`# HELP http_requests Total HTTP requests`,
+		`# TYPE http_requests counter`,
+		`# UNIT http_requests requests`,
+		`http_requests_total{method="get"} 42`,
+		`http_requests_created{method="get"} 1700000000.5`,
+		`# EOF`,
+		``,
+	}, "\n")
+
+	mfs, err := decodeOpenMetricsToFamilies(bytes.NewReader([]byte(body)))
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if len(mfs) != 1 {
+		t.Fatalf("expected 1 family, got %d", len(mfs))
+	}
+	fam := mfs[0]
+	if fam.GetName() != "http_requests" {
+		t.Errorf("name = %q; want http_requests", fam.GetName())
+	}
+	if fam.GetType() != dto.MetricType_COUNTER {
+		t.Errorf("type = %v; want COUNTER", fam.GetType())
+	}
+	if fam.GetUnit() != "requests" {
+		t.Errorf("unit = %q; want %q", fam.GetUnit(), "requests")
+	}
+	if fam.GetHelp() != "Total HTTP requests" {
+		t.Errorf("help = %q; want %q", fam.GetHelp(), "Total HTTP requests")
+	}
+	if len(fam.Metric) != 1 {
+		t.Fatalf("expected 1 metric, got %d", len(fam.Metric))
+	}
+	c := fam.Metric[0].GetCounter()
+	if c == nil {
+		t.Fatalf("metric has no Counter")
+	}
+	if c.GetValue() != 42 {
+		t.Errorf("counter value = %v; want 42", c.GetValue())
+	}
+	if c.GetCreatedTimestamp() == nil {
+		t.Fatalf("counter has no CreatedTimestamp (expected 1700000000500ms)")
+	}
+	wantMs := int64(1700000000500)
+	gotMs := c.GetCreatedTimestamp().AsTime().UnixMilli()
+	if gotMs != wantMs {
+		t.Errorf("CreatedTimestamp = %d ms; want %d ms", gotMs, wantMs)
+	}
+}
+
+func TestDecodeOpenMetrics_CounterWithExemplar(t *testing.T) {
+	body := strings.Join([]string{
+		`# HELP requests_total total requests`,
+		`# TYPE requests_total counter`,
+		`requests_total{method="get"} 7 # {trace_id="abc123"} 0.5 1700000001.5`,
+		`# EOF`,
+		``,
+	}, "\n")
+
+	mfs, err := decodeOpenMetricsToFamilies(bytes.NewReader([]byte(body)))
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	fam := findFamilyByName(t, mfs, "requests")
+	if fam.GetType() != dto.MetricType_COUNTER {
+		t.Errorf("type = %v; want COUNTER", fam.GetType())
+	}
+	if len(fam.Metric) != 1 {
+		t.Fatalf("expected 1 metric, got %d", len(fam.Metric))
+	}
+	c := fam.Metric[0].GetCounter()
+	if c == nil {
+		t.Fatalf("metric has no Counter")
+	}
+	if c.GetValue() != 7 {
+		t.Errorf("counter value = %v; want 7", c.GetValue())
+	}
+	ex := c.GetExemplar()
+	if ex == nil {
+		t.Fatalf("counter has no Exemplar (regression: expfmt textDecoder drops these)")
+	}
+	if ex.GetValue() != 0.5 {
+		t.Errorf("exemplar value = %v; want 0.5", ex.GetValue())
+	}
+	if ex.GetTimestamp() == nil {
+		t.Fatalf("exemplar has no Timestamp")
+	}
+	if got := ex.GetTimestamp().AsTime().UnixMilli(); got != 1700000001500 {
+		t.Errorf("exemplar ts = %d ms; want 1700000001500 ms", got)
+	}
+	if len(ex.GetLabel()) != 1 || ex.GetLabel()[0].GetName() != "trace_id" || ex.GetLabel()[0].GetValue() != "abc123" {
+		t.Errorf("exemplar labels = %v; want [trace_id=abc123]", ex.GetLabel())
+	}
+}
+
+func TestDecodeOpenMetrics_HistogramWithBucketExemplarsAndCreated(t *testing.T) {
+	body := strings.Join([]string{
+		`# HELP latency_seconds request latency`,
+		`# TYPE latency_seconds histogram`,
+		`# UNIT latency_seconds seconds`,
+		`latency_seconds_bucket{le="0.1"} 3 # {trace_id="t1"} 0.05`,
+		`latency_seconds_bucket{le="1.0"} 5 # {trace_id="t2"} 0.42`,
+		`latency_seconds_bucket{le="+Inf"} 6`,
+		`latency_seconds_sum 2.7`,
+		`latency_seconds_count 6`,
+		`latency_seconds_created 1700000000.0`,
+		`# EOF`,
+		``,
+	}, "\n")
+
+	mfs, err := decodeOpenMetricsToFamilies(bytes.NewReader([]byte(body)))
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	fam := findFamilyByName(t, mfs, "latency_seconds")
+	if fam.GetType() != dto.MetricType_HISTOGRAM {
+		t.Fatalf("type = %v; want HISTOGRAM", fam.GetType())
+	}
+	if fam.GetUnit() != "seconds" {
+		t.Errorf("unit = %q; want seconds", fam.GetUnit())
+	}
+	if len(fam.Metric) != 1 {
+		t.Fatalf("expected 1 metric, got %d", len(fam.Metric))
+	}
+	h := fam.Metric[0].GetHistogram()
+	if h == nil {
+		t.Fatalf("metric has no Histogram")
+	}
+	if h.GetSampleCount() != 6 {
+		t.Errorf("sample count = %d; want 6", h.GetSampleCount())
+	}
+	if h.GetSampleSum() != 2.7 {
+		t.Errorf("sample sum = %v; want 2.7", h.GetSampleSum())
+	}
+	if len(h.Bucket) != 3 {
+		t.Fatalf("expected 3 buckets, got %d", len(h.Bucket))
+	}
+	// Bucket with le=0.1 has exemplar t1; bucket with le=1.0 has exemplar t2; le=+Inf has none.
+	wantBuckets := map[float64]struct {
+		count    uint64
+		exemplar string
+	}{
+		0.1: {3, "t1"},
+		1.0: {5, "t2"},
+		// +Inf bucket inferred from math.Inf — match by GetUpperBound() being +Inf.
+	}
+	for _, b := range h.Bucket {
+		ub := b.GetUpperBound()
+		if want, ok := wantBuckets[ub]; ok {
+			if b.GetCumulativeCount() != want.count {
+				t.Errorf("bucket le=%v count = %d; want %d", ub, b.GetCumulativeCount(), want.count)
+			}
+			if b.GetExemplar() == nil {
+				t.Errorf("bucket le=%v has no exemplar; want trace_id=%s", ub, want.exemplar)
+			} else if b.GetExemplar().GetLabel()[0].GetValue() != want.exemplar {
+				t.Errorf("bucket le=%v exemplar trace_id = %q; want %q",
+					ub, b.GetExemplar().GetLabel()[0].GetValue(), want.exemplar)
+			}
+		}
+	}
+	if h.GetCreatedTimestamp() == nil {
+		t.Fatalf("histogram has no CreatedTimestamp")
+	}
+	if got := h.GetCreatedTimestamp().AsTime().UnixMilli(); got != 1700000000000 {
+		t.Errorf("CreatedTimestamp = %d ms; want 1700000000000 ms", got)
+	}
+}
+
+func TestDecodeOpenMetrics_Gauge(t *testing.T) {
+	body := strings.Join([]string{
+		`# HELP cpu_temp cpu temperature`,
+		`# TYPE cpu_temp gauge`,
+		`cpu_temp{cpu="0"} 47.3`,
+		`cpu_temp{cpu="1"} 51.2`,
+		`# EOF`,
+		``,
+	}, "\n")
+	mfs, err := decodeOpenMetricsToFamilies(bytes.NewReader([]byte(body)))
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	fam := findFamilyByName(t, mfs, "cpu_temp")
+	if fam.GetType() != dto.MetricType_GAUGE {
+		t.Errorf("type = %v; want GAUGE", fam.GetType())
+	}
+	if len(fam.Metric) != 2 {
+		t.Fatalf("expected 2 metrics, got %d", len(fam.Metric))
+	}
+}
+
+func TestDecodeOpenMetrics_Summary(t *testing.T) {
+	body := strings.Join([]string{
+		`# HELP rpc_dur rpc duration`,
+		`# TYPE rpc_dur summary`,
+		`rpc_dur{quantile="0.5"} 0.012`,
+		`rpc_dur{quantile="0.99"} 0.087`,
+		`rpc_dur_sum 12.4`,
+		`rpc_dur_count 1000`,
+		`rpc_dur_created 1700000000.0`,
+		`# EOF`,
+		``,
+	}, "\n")
+	mfs, err := decodeOpenMetricsToFamilies(bytes.NewReader([]byte(body)))
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	fam := findFamilyByName(t, mfs, "rpc_dur")
+	if fam.GetType() != dto.MetricType_SUMMARY {
+		t.Fatalf("type = %v; want SUMMARY", fam.GetType())
+	}
+	if len(fam.Metric) != 1 {
+		t.Fatalf("expected 1 metric, got %d", len(fam.Metric))
+	}
+	s := fam.Metric[0].GetSummary()
+	if s == nil {
+		t.Fatalf("metric has no Summary")
+	}
+	if s.GetSampleSum() != 12.4 {
+		t.Errorf("sample sum = %v; want 12.4", s.GetSampleSum())
+	}
+	if s.GetSampleCount() != 1000 {
+		t.Errorf("sample count = %v; want 1000", s.GetSampleCount())
+	}
+	if len(s.Quantile) != 2 {
+		t.Errorf("expected 2 quantiles, got %d", len(s.Quantile))
+	}
+	if s.GetCreatedTimestamp() == nil {
+		t.Errorf("summary has no CreatedTimestamp")
+	}
+}
+
+func TestDecodeOpenMetrics_InfoStateset(t *testing.T) {
+	// INFO and STATESET have no native dto enum; they map to UNTYPED with the
+	// value verbatim. The point of the test is that they do NOT cause parse
+	// errors (the expfmt text decoder errors out on "unknown metric type").
+	body := strings.Join([]string{
+		`# HELP target_info target info`,
+		`# TYPE target_info info`,
+		`target_info{instance="i1",job="j1"} 1`,
+		`# HELP feature_enabled feature flags`,
+		`# TYPE feature_enabled stateset`,
+		`feature_enabled{feature="A"} 1`,
+		`feature_enabled{feature="B"} 0`,
+		`# EOF`,
+		``,
+	}, "\n")
+	mfs, err := decodeOpenMetricsToFamilies(bytes.NewReader([]byte(body)))
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	info := findFamilyByName(t, mfs, "target_info")
+	if info.GetType() != dto.MetricType_UNTYPED {
+		t.Errorf("info family type = %v; want UNTYPED", info.GetType())
+	}
+	if len(info.Metric) != 1 {
+		t.Fatalf("expected 1 info metric, got %d", len(info.Metric))
+	}
+	if info.Metric[0].GetUntyped().GetValue() != 1 {
+		t.Errorf("info value = %v; want 1", info.Metric[0].GetUntyped().GetValue())
+	}
+	stateset := findFamilyByName(t, mfs, "feature_enabled")
+	if stateset.GetType() != dto.MetricType_UNTYPED {
+		t.Errorf("stateset family type = %v; want UNTYPED", stateset.GetType())
+	}
+	if len(stateset.Metric) != 2 {
+		t.Errorf("expected 2 stateset metrics, got %d", len(stateset.Metric))
+	}
+}
+
+func TestDecodeOpenMetrics_EmptyBody(t *testing.T) {
+	mfs, err := decodeOpenMetricsToFamilies(bytes.NewReader(nil))
+	if err != nil {
+		t.Errorf("empty body returned error: %v", err)
+	}
+	if len(mfs) != 0 {
+		t.Errorf("empty body returned %d families; want 0", len(mfs))
+	}
+}
+
+func TestDecodeOpenMetrics_MissingEOF(t *testing.T) {
+	// OM spec requires a trailing "# EOF"; a missing trailer must be reported as
+	// an error so the caller can decide whether to drop the upstream or fall
+	// back. We still return any families parsed before the failure.
+	body := "# TYPE foo counter\nfoo_total 1\n"
+	mfs, err := decodeOpenMetricsToFamilies(bytes.NewReader([]byte(body)))
+	if err == nil {
+		t.Fatalf("expected error on missing # EOF, got nil")
+	}
+	if len(mfs) == 0 {
+		t.Errorf("expected partial families to be returned on error")
+	}
+}
+
+func TestDecodeOpenMetrics_MalformedSeriesError(t *testing.T) {
+	body := "# TYPE foo gauge\nfoo not_a_number\n# EOF\n"
+	_, err := decodeOpenMetricsToFamilies(bytes.NewReader([]byte(body)))
+	if err == nil {
+		t.Fatalf("expected parse error on non-numeric value, got nil")
+	}
+}

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -28,7 +28,6 @@ import (
 	"net/http/pprof"
 	"os"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -38,6 +37,7 @@ import (
 	"github.com/klauspost/compress/gzhttp"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
@@ -106,21 +106,6 @@ var (
 	ProbeKeepaliveConnections = env.Register("ENABLE_PROBE_KEEPALIVE_CONNECTIONS", false,
 		"If enabled, readiness probes will keep the connection from pilot-agent to the application alive. "+
 			"This mirrors older Istio versions' behaviors, but not kubelet's.").Get()
-)
-
-var (
-	// When scraping Envoy metrics we can't use neither protobuf nor openmetrics format.
-	// The logic implemented for stats merged basically concatenates the outputs from multiple targets - it does not
-	// work well if you need to merge metrics of multiple formats.
-	//
-	// NOTE: There is limited support for handling openmetrics format, but only when scraping from application, Envoy
-	// stats are written as-is without removing the EOF marker, and therefore we cannot use openmetrics format for
-	// Envoy.
-	allowedEnvoyTypes = []string{"text/*", "text/plain"}
-	allowedAppTypes   = []string{"text/*", "text/plain", "application/openmetrics-text"}
-
-	prometheusText004  = encoding{mediatype: "text/plain", params: map[string]string{"version": "0.0.4"}}
-	openMetricsText001 = encoding{mediatype: "application/openmetrics-text", params: map[string]string{"version": "0.0.1"}}
 )
 
 // KubeAppProbers holds the information about a Kubernetes pod prober.
@@ -638,6 +623,19 @@ func ParseScrapeTargets(raw string) ([]ScrapeTarget, error) {
 // This merging works for both FmtText and FmtOpenMetrics and will use the format of the application metrics
 // Note that we do not return any errors here. If we do, we will drop metrics. For example, the app may be having issues,
 // but we still want Envoy metrics. Instead, errors are tracked in the failed scrape metrics/logs.
+// handleStats handles prometheus stats scraping. This will scrape envoy metrics, and, if configured,
+// the application metrics and merge them together.
+// The merge here is a simple string concatenation for the all-text and all-OpenMetrics cases.
+// This works for almost all cases, assuming the application is not exposing the same metrics as Envoy.
+// When at least one upstream advertises the delimited Prometheus protobuf format
+// (application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited
+// — required for native Prometheus histograms), the merger switches to a parse-and-re-encode
+// path that decodes each upstream into MetricFamily values, gathers agent self-metrics, and
+// re-emits the merged stream in the negotiated format. Mixed formats (e.g. one proto upstream
+// and one text upstream) downgrade to text — converting text to proto would require the
+// CPU/memory cost-comparison study mandated by the Istio TOC and is deferred to a follow-up.
+// Note that we do not return any errors here. If we do, we will drop metrics. For example, the app may be having issues,
+// but we still want Envoy metrics. Instead, errors are tracked in the failed scrape metrics/logs.
 func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 	if commonFeatures.MetricsLocalhostAccessOnly && !istioNetUtil.IsRequestFromLocalhost(r) {
 		http.Error(w, "Only requests from localhost are allowed", http.StatusForbidden)
@@ -668,43 +666,135 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
-	// Gather all the metrics we will merge
+	// Gather all the metrics we will merge.
+	var envoyFormat expfmt.Format
 	if !s.config.NoEnvoy && features.AgentMergeEnvoyStats {
 		scrapeURL := fmt.Sprintf("http://localhost:%d/stats/prometheus", s.envoyStatsPort)
 		if r.URL != nil && len(r.URL.RawQuery) > 0 {
 			scrapeURL = fmt.Sprintf("%s?%s", scrapeURL, r.URL.RawQuery)
 		}
-		acceptHeader := allowedContentTypes(r.Header.Get("Accept"), allowedEnvoyTypes)
-		if envoy, envoyCancel, _, err = s.scrape(scrapeURL, r.Header, acceptHeader); err != nil {
+		var envoyCT string
+		if envoy, envoyCancel, envoyCT, err = s.scrape(scrapeURL, r.Header); err != nil {
 			log.Errorf("failed scraping envoy metrics: %v", err)
 			metrics.EnvoyScrapeErrors.Increment()
+		} else {
+			envoyFormat = negotiateMetricsFormat(envoyCT)
 		}
 	}
 
 	// Scrape app metrics. Multi-target buffers each response so we can rewrite the
 	// OpenMetrics "# EOF" trailer; single-target streams via io.Copy.
-	var format expfmt.Format
+	var appFormat expfmt.Format
 	var appBodies [][]byte
+	// appBodyFormats is the per-body negotiated format for the multi-target case.
+	// When targets disagree (mixed proto/text), scrapeMultipleApps aggregates
+	// `appFormat` to FmtText, but the underlying body bytes are still in their
+	// original Content-Types. The proto path needs the per-body formats so a
+	// binary proto body is not text-parsed (which would silently drop the target).
+	var appBodyFormats []expfmt.Format
 	if s.prometheus != nil {
-		acceptHeader := allowedContentTypes(r.Header.Get("Accept"), allowedAppTypes)
 		if len(s.prometheus.Targets) > 1 {
-			format, appBodies = s.scrapeMultipleApps(r, acceptHeader)
+			appFormat, appBodies, appBodyFormats = s.scrapeMultipleApps(r)
 		} else {
 			var contentType string
-			if application, appCancel, contentType, err = s.scrape(appMetricsURL(s.prometheus.Port, s.prometheus.Path), r.Header, acceptHeader); err != nil {
+			if application, appCancel, contentType, err = s.scrape(appMetricsURL(s.prometheus.Port, s.prometheus.Path), r.Header); err != nil {
 				log.Errorf("failed scraping application metrics: %v", err)
 				metrics.AppScrapeErrors.Increment()
+			} else {
+				appFormat = negotiateMetricsFormat(contentType)
 			}
-			format = negotiateMetricsFormat(contentType)
 		}
-	} else {
-		format = FmtText
 	}
 
-	w.Header().Set("Content-Type", string(format))
+	// Compute the negotiated output format.
+	//
+	//   1. If any upstream returns anything other than text/plain (i.e. proto or
+	//      OpenMetrics), we must parse-and-re-encode the merged stream. The
+	//      byte-concatenation fast path would otherwise corrupt the stream:
+	//      proto bodies can't be byte-merged with text, and an OpenMetrics body's
+	//      trailing "# EOF" would end up mid-stream when other sources are
+	//      appended after it. mergeFormat decides the output format and downgrades
+	//      to text on disagreement.
+	//
+	//   2. If every upstream is text/plain, the historical byte-concat behavior
+	//      is wire-correct and we preserve it for performance: the app's format
+	//      wins (matching the prior implementation that discarded the Envoy
+	//      content-type in single-target mode). When there is no app at all,
+	//      we default to FmtText.
+	//
+	// Behavior change vs prior istio releases: clients that previously requested
+	// protobuf and were force-downgraded to text by istio#60622 (because the
+	// merger could not safely combine proto with text) will now actually receive
+	// protobuf. For clients that did not request protobuf, the output is
+	// unchanged.
+	// Take the parse-and-re-encode merger path when either:
+	//   (a) any upstream advertised the delimited Prometheus protobuf format
+	//       (the byte-concat fast path cannot merge binary proto with text); or
+	//   (b) Envoy returns a non-text/plain body (e.g. OpenMetrics). The
+	//       byte-concat fast path writes Envoy bytes mid-stream, before app
+	//       bodies, so an OM "# EOF" in the Envoy body would land mid-stream
+	//       and corrupt the response. Today Envoy never serves OpenMetrics —
+	//       it only supports text/plain and proto — but the check defends
+	//       against any future Envoy format support without further code
+	//       changes here.
+	//
+	// All-text-plain and all-OpenMetrics-via-apps cases keep the byte-concat
+	// fast path (the multi-target loop already strips + reappends a single
+	// "# EOF" trailer; the single-target app body is the last thing written
+	// in this branch, so its own "# EOF" terminates the response correctly).
+	envoyNonText := envoyFormat != "" && envoyFormat.FormatType() != expfmt.TypeTextPlain
+	anyProto := envoyFormat.FormatType() == expfmt.TypeProtoDelim ||
+		appFormat.FormatType() == expfmt.TypeProtoDelim
+	needsParseMerge := anyProto || envoyNonText
 
-	// Write out the metrics
-	if err = scrapeAndWriteAgentMetrics(s.registry, io.Writer(w)); err != nil {
+	var outFormat expfmt.Format
+	if needsParseMerge {
+		outFormat = mergeFormat(envoyFormat, appFormat)
+	} else {
+		outFormat = appFormat
+		if outFormat == "" {
+			outFormat = FmtText
+		}
+	}
+
+	w.Header().Set("Content-Type", string(outFormat))
+
+	// Record the delivered format. A downgrade is "any upstream offered proto but we
+	// emitted text because another upstream did not". This is the metric a future
+	// PR3 (text→proto upconversion behind a feature gate) will optimize against.
+	switch {
+	case anyProto && outFormat.FormatType() != expfmt.TypeProtoDelim:
+		metrics.ScrapeFormatDowngraded.Increment()
+	default:
+		switch scrapeFormatLabel(outFormat) {
+		case metrics.ScrapeFormatLabelProto:
+			metrics.ScrapeFormatProto.Increment()
+		case metrics.ScrapeFormatLabelOpenMetrics:
+			metrics.ScrapeFormatOpenMetric.Increment()
+		default:
+			metrics.ScrapeFormatText.Increment()
+		}
+	}
+
+	// PARSE-AND-RE-ENCODE PATH: at least one upstream is non-text/plain. We must
+	// decode all upstream bodies (any text ones get decoded too — they will be
+	// re-encoded in outFormat below) and re-encode them as a single stream so the
+	// merged response is wire-correct. Byte concatenation is unsafe here because:
+	//   (1) when outFormat is proto, concatenating text and delimited bytes corrupts the stream;
+	//   (2) when outFormat is text (downgrade), the binary proto upstream cannot be passed through;
+	//   (3) when an OpenMetrics body carries a trailing "# EOF", concatenating
+	//       additional bodies after it lands the EOF marker mid-stream.
+	if needsParseMerge {
+		s.writeMergedProtoPath(w, outFormat, envoy, envoyFormat, application, appFormat, appBodies, appBodyFormats)
+		return
+	}
+
+	// TEXT / OPENMETRICS FAST PATH: byte-concatenation is wire-correct when
+	// Envoy is text/plain (or absent) and the apps return either text or
+	// OpenMetrics — the multi-target loop below strips and reappends a single
+	// "# EOF" terminator for the OM case, and the single-target branch writes
+	// the app body last so its own "# EOF" terminates the response.
+	if err = scrapeAndWriteAgentMetrics(s.registry, io.Writer(w), outFormat); err != nil {
 		log.Errorf("failed scraping and writing agent metrics: %v", err)
 		metrics.AgentScrapeErrors.Increment()
 	}
@@ -731,7 +821,7 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 		// Newline rule: ensure a "\n" separates concatenated bodies in case a target
 		// response does not end with one. Split into a second w.Write so the stripped
 		// sub-slice does not trigger a body-sized append+realloc.
-		openMetrics := format.FormatType() == expfmt.TypeOpenMetrics
+		openMetrics := outFormat.FormatType() == expfmt.TypeOpenMetrics
 		for i, body := range appBodies {
 			if body == nil {
 				continue
@@ -764,12 +854,155 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// writeMergedProtoPath is the parse-and-re-encode merger used whenever at least one
+// upstream returned the delimited Prometheus protobuf format. It decodes every upstream
+// (proto and non-proto alike) into MetricFamily values, gathers the agent's own
+// MetricFamily values directly from the registry, and re-encodes the union in outFormat.
+//
+// Failure handling matches the text fast path: a malformed upstream is dropped with an
+// error log and a scrape-errors counter increment; the merged response still contains
+// the remaining upstreams and the agent self-metrics. Ordering inside the encoded
+// stream is envoy → agent → app(s); this preserves the agent-metrics-precede-trailer
+// invariant the text path relies on, which keeps log analyzers and grafana dashboards
+// happy when format negotiation flips back and forth.
+//
+// Memory safety: each external upstream Reader (Envoy and single-target app) is wrapped
+// in a body-cap LimitReader bounded by s.maxAppBodyBytes. Reading past the cap is
+// detected (we read cap+1 bytes) and surfaced as a per-upstream drop, mirroring the
+// multi-target text path's pre-existing cap in scrapeMultipleApps. The agent path
+// reads directly from the in-process registry and needs no cap.
+//
+// appBodyFormats is the per-body negotiated format for the multi-target case; the
+// merger decodes each buffered body in its own format so a binary proto body and a
+// text body in the same target list are both correctly parsed even though the
+// aggregated appFormat has been downgraded to text.
+//
+// Note: when an app upstream is text on the mixed-format downgrade path, the
+// underlying expfmt textDecoder emits MetricFamilies in Go map-iteration order,
+// which is non-deterministic across scrapes. Output is still wire-correct; only
+// the human-visible ordering of app metrics jitters between scrapes.
+func (s *Server) writeMergedProtoPath(
+	w io.Writer,
+	outFormat expfmt.Format,
+	envoy io.Reader,
+	envoyFormat expfmt.Format,
+	application io.Reader,
+	appFormat expfmt.Format,
+	appBodies [][]byte,
+	appBodyFormats []expfmt.Format,
+) {
+	enc := expfmt.NewEncoder(w, outFormat)
+
+	encodeAll := func(mfs []*dto.MetricFamily, errLabel string, counter monitoring.Metric) {
+		for _, mf := range mfs {
+			if err := enc.Encode(mf); err != nil {
+				log.Errorf("failed encoding %s metric family %q: %v", errLabel, mf.GetName(), err)
+				counter.Increment()
+				return
+			}
+		}
+	}
+
+	// decodeCapped wraps r in a body-cap LimitReader and runs the format-aware decoder.
+	// Returns the decoded families plus any error (parse error OR body-too-large).
+	// Partial decodes are preserved on overflow, matching the text path's behavior of
+	// surfacing whatever data was readable before the failure.
+	decodeCapped := func(r io.Reader, format expfmt.Format) ([]*dto.MetricFamily, error) {
+		bodyCap := int64(s.maxAppBodyBytes)
+		counted := &countingReader{R: io.LimitReader(r, bodyCap+1)}
+		mfs, err := decodeAll(counted, format)
+		if counted.N > bodyCap {
+			return mfs, fmt.Errorf("upstream body exceeds %d bytes; dropping", s.maxAppBodyBytes)
+		}
+		return mfs, err
+	}
+
+	// Envoy first.
+	if envoy != nil {
+		mfs, err := decodeCapped(envoy, envoyFormat)
+		if err != nil {
+			log.Errorf("failed decoding envoy metrics (format=%q): %v", envoyFormat, err)
+			metrics.EnvoyScrapeErrors.Increment()
+		}
+		encodeAll(mfs, "envoy", metrics.EnvoyScrapeErrors)
+	}
+
+	// Agent self-metrics: native MetricFamily values from the gatherer; no parse step.
+	mfs, err := s.registry.Gather()
+	if err != nil {
+		log.Errorf("failed gathering agent metrics: %v", err)
+		metrics.AgentScrapeErrors.Increment()
+	} else {
+		encodeAll(mfs, "agent", metrics.AgentScrapeErrors)
+	}
+
+	// Application metrics: either a single-target streaming body or multi-target
+	// buffered bodies, mirroring the text fast-path dispatch.
+	switch {
+	case appBodies != nil:
+		for i, body := range appBodies {
+			if body == nil {
+				continue
+			}
+			// Use the per-body negotiated format. When appBodyFormats is missing
+			// or short (defensive — shouldn't happen if scrapeMultipleApps is the
+			// only producer), fall back to the aggregated appFormat.
+			perBodyFormat := appFormat
+			if i < len(appBodyFormats) && appBodyFormats[i] != "" {
+				perBodyFormat = appBodyFormats[i]
+			}
+			// Multi-target bodies are already capped at maxAppBodyBytes inside
+			// scrapeMultipleApps; decode directly from bytes.NewReader without
+			// re-applying the cap (which would just no-op anyway).
+			appMfs, decodeErr := decodeAll(bytes.NewReader(body), perBodyFormat)
+			if decodeErr != nil {
+				log.Errorf("failed decoding app target %d (format=%q): %v", i, perBodyFormat, decodeErr)
+				metrics.AppScrapeErrors.Increment()
+			}
+			encodeAll(appMfs, "application", metrics.AppScrapeErrors)
+			appBodies[i] = nil
+		}
+	case application != nil:
+		appMfs, decodeErr := decodeCapped(application, appFormat)
+		if decodeErr != nil {
+			log.Errorf("failed decoding application metrics (format=%q): %v", appFormat, decodeErr)
+			metrics.AppScrapeErrors.Increment()
+		}
+		encodeAll(appMfs, "application", metrics.AppScrapeErrors)
+	}
+
+	// Close the encoder: for OpenMetrics this writes "# EOF"; for proto/text it is a no-op.
+	if closer, ok := enc.(expfmt.Closer); ok {
+		if cerr := closer.Close(); cerr != nil {
+			log.Errorf("failed closing merged metrics encoder: %v", cerr)
+		}
+	}
+}
+
+// countingReader counts the bytes returned by an underlying Reader. It is used by
+// writeMergedProtoPath to enforce s.maxAppBodyBytes on proto-path upstreams: pair
+// it with io.LimitReader(r, cap+1) and check N > cap after decoding to distinguish
+// an at-cap legitimate body from one that saturated the limit.
+type countingReader struct {
+	R io.Reader
+	N int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.R.Read(p)
+	c.N += int64(n)
+	return n, err
+}
+
 // scrapeMultipleApps fans out one scrape per entry in s.prometheus.Targets concurrently and
 // returns the bodies indexed by Targets position. Failed targets are represented by nil entries;
-// each failure increments metrics.AppScrapeErrors once. The returned format is the first successful
-// target's negotiated format (which matches Targets[0] when Targets[0] succeeds), falling back to
-// FmtText when no target succeeds.
-func (s *Server) scrapeMultipleApps(r *http.Request, acceptHeader string) (expfmt.Format, [][]byte) {
+// each failure increments metrics.AppScrapeErrors once. The returned aggregated format is the
+// first successful target's negotiated format (which matches Targets[0] when Targets[0]
+// succeeds), falling back to FmtText when no target succeeds; if any later successful target
+// disagrees, the aggregated format downgrades to FmtText. The returned per-body formats slice
+// gives each body's own negotiated format so the proto path can decode each body in its true
+// format when the aggregated format has been downgraded.
+func (s *Server) scrapeMultipleApps(r *http.Request) (expfmt.Format, [][]byte, []expfmt.Format) {
 	bodies := make([][]byte, len(s.prometheus.Targets))
 	contentTypes := make([]string, len(s.prometheus.Targets))
 	var wg sync.WaitGroup
@@ -788,7 +1021,7 @@ func (s *Server) scrapeMultipleApps(r *http.Request, acceptHeader string) (expfm
 				log.Warnf("scrape target %q:%q: "+format, append([]any{tgt.Port, tgt.Path}, args...)...)
 				metrics.AppScrapeErrors.Increment()
 			}
-			body, cancel, contentType, err := s.scrape(appMetricsURL(tgt.Port, tgt.Path), r.Header, acceptHeader)
+			body, cancel, contentType, err := s.scrape(appMetricsURL(tgt.Port, tgt.Path), r.Header)
 			if cancel != nil {
 				defer cancel()
 			}
@@ -819,25 +1052,29 @@ func (s *Server) scrapeMultipleApps(r *http.Request, acceptHeader string) (expfm
 	// target disagrees — in which case we downgrade to text. An OpenMetrics-claimed
 	// response containing a text body (or vice versa) is invalid. Single-format scrapes
 	// (all-text or all-OM) keep their format and EOF semantics.
+	//
+	// bodyFormats parallels bodies and gives the proto path each body's own negotiated
+	// format for per-body decoding when the aggregated format has been downgraded.
 	var format expfmt.Format
+	bodyFormats := make([]expfmt.Format, len(bodies))
 	for i, ct := range contentTypes {
 		if bodies[i] == nil {
 			continue
 		}
 		f := negotiateMetricsFormat(ct)
+		bodyFormats[i] = f
 		if format == "" {
 			format = f
 			continue
 		}
 		if f != format {
 			format = FmtText
-			break
 		}
 	}
 	if format == "" {
 		format = FmtText
 	}
-	return format, bodies
+	return format, bodies, bodyFormats
 }
 
 func appMetricsURL(port, path string) string {
@@ -867,127 +1104,138 @@ const (
 	FmtText              = `text/plain; version=` + expfmt.TextVersion + `; charset=utf-8`
 )
 
+// FmtProtoDelim is the delimited Prometheus protobuf exposition format. Re-exported
+// from prometheus/common so the merger can negotiate and emit it symmetrically with
+// FmtText and the FmtOpenMetrics_* constants. Native Prometheus histograms are only
+// defined for this wire format.
+//
+// We declare it as a var rather than a const because expfmt.NewFormat is a function
+// call (the upstream library deprecated the corresponding constant); the value is
+// computed once at init.
+//
+//nolint:gochecknoglobals // see comment above
+var FmtProtoDelim = expfmt.NewFormat(expfmt.TypeProtoDelim)
+
+// negotiateMetricsFormat inspects an upstream's response Content-Type and maps it to a
+// known expfmt.Format. Recognized formats are OpenMetrics (versions 0.0.1 / 1.0.0), the
+// delimited Prometheus protobuf format (used for native histograms), and text/plain
+// (the default for anything unrecognized, preserving back-compat).
+//
+// The mapping for the protobuf branch mirrors expfmt.ResponseFormat in prometheus/common:
+// the media type must be application/vnd.google.protobuf, the "proto" parameter must be
+// io.prometheus.client.MetricFamily, and the "encoding" parameter must be "delimited".
+// Anything else (a different proto, a different encoding, or absent params) falls through
+// to text — the merger then either decodes text or, if the upstream lied about its
+// Content-Type, the downstream decoder surfaces the error and the upstream is dropped.
 func negotiateMetricsFormat(contentType string) expfmt.Format {
 	mediaType, params, err := mime.ParseMediaType(contentType)
-	if err == nil && mediaType == expfmt.OpenMetricsType {
+	if err != nil {
+		return FmtText
+	}
+	switch mediaType {
+	case expfmt.OpenMetricsType:
 		switch params["version"] {
 		case expfmt.OpenMetricsVersion_1_0_0:
 			return FmtOpenMetrics_1_0_0
 		case expfmt.OpenMetricsVersion_0_0_1, "":
 			return FmtOpenMetrics_0_0_1
 		}
+	case expfmt.ProtoType:
+		// Both parameters are mandatory per the Prometheus native-histogram spec.
+		// We accept "" for proto only when absent (matching expfmt.ResponseFormat
+		// which treats absent as "matches").
+		if proto, ok := params["proto"]; ok && proto != expfmt.ProtoProtocol {
+			return FmtText
+		}
+		if encoding, ok := params["encoding"]; ok && encoding != "delimited" {
+			return FmtText
+		} else if !ok {
+			// expfmt.ResponseFormat tolerates absent encoding; we require it
+			// explicitly so the merger never tries to delimit-decode a body
+			// that the upstream advertised as compact-text or proto-text.
+			return FmtText
+		}
+		return FmtProtoDelim
 	}
 	return FmtText
 }
 
-type encoding struct {
-	mediatype string
-	params    map[string]string
-}
-
-func (e encoding) String() string {
-	var params []string
-	for k, v := range e.params {
-		params = append(params, fmt.Sprintf("%s=%s", k, v))
-	}
-	sort.Strings(params)
-	return strings.Join(append([]string{e.mediatype}, params...), ";")
-}
-
-func parseAcceptHeader(acceptedTypes string) ([]encoding, error) {
-	var encodings []encoding
-	for _, e := range strings.Split(acceptedTypes, ",") {
-		mediatype, params, err := mime.ParseMediaType(e)
-		if err != nil {
-			return nil, fmt.Errorf("bad encoding %q: %w", e, err)
-		}
-		delete(params, "q") // quality values are not relevant for this parsing
-		encodings = append(encodings, encoding{mediatype: mediatype, params: params})
-	}
-	return encodings, nil
-}
-
-// allowedContentTypes parses the accepted header and excludes all the content types that are not on the list of allowed
-// content types.
+// mergeFormat returns the negotiated output format given the formats negotiated for each
+// successful upstream. Disagreement downgrades to FmtText (the universal common
+// denominator). An empty argument list returns FmtText.
 //
-// A few caveats to keep in mind:
-//  1. The Accept header may have wildecards and MIME ranges in principle (though proper Prometheus clients should only
-//     use wildcards as a fallback)
-//     - This function replaces * and */* with text/plain version 0.0.4 and replaces application/* with
-//     application/openmetrics-text version 0.0.1 - those are the most basic content types matching the wildecard/range
-//     and therefore the clients asking for them should be able to support those types at least
-//  2. If after filtering we don't have any encodings left, we fallback to text/plain version 0.0.4
-//  3. If for some reason we fail to parse the Accept header, we again fallback to text/plain version 0.0.4
-func allowedContentTypes(acceptHeader string, acceptedTypes []string) string {
-	encodings, err := parseAcceptHeader(acceptHeader)
-	if err != nil {
-		log.Warnf("Failed to parse Accept header %q: %v", acceptHeader, err)
-		return prometheusText004.String()
-	}
-
-	var acceptedEncodings []encoding
-	used := map[string]bool{}
-	for _, e := range encodings {
-		// This would include protobuf, all the Prometheus's OpenMetricsText and PrometheusText encodings
-		if e.mediatype == "*/*" || e.mediatype == "*" {
-			if !slices.Contains(acceptedTypes, prometheusText004.mediatype) {
-				continue
-			}
-
-			key := prometheusText004.String()
-			if _, present := used[key]; present {
-				continue
-			}
-			used[key] = true
-			acceptedEncodings = append(acceptedEncodings, prometheusText004)
+// The downgrade rule is deliberately conservative: if any two upstreams disagree we emit
+// text, even when one of them is protobuf. The alternative (text→protobuf upconversion)
+// is gated on a CPU/memory cost-comparison study mandated by the Istio TOC and is the
+// subject of PR3 in the native-histogram contribution sequence.
+func mergeFormat(formats ...expfmt.Format) expfmt.Format {
+	var out expfmt.Format
+	for _, f := range formats {
+		if f == "" {
 			continue
 		}
-
-		// This would include protobuf and all the Prometheus's OpenMetricsText encodings
-		if e.mediatype == "application/*" {
-			if !slices.Contains(acceptedTypes, openMetricsText001.mediatype) {
-				continue
-			}
-
-			key := openMetricsText001.String()
-			if _, present := used[key]; present {
-				continue
-			}
-			used[key] = true
-			acceptedEncodings = append(acceptedEncodings, openMetricsText001)
+		if out == "" {
+			out = f
 			continue
 		}
-
-		if !slices.Contains(acceptedTypes, e.mediatype) {
-			continue
+		if f != out {
+			return FmtText
 		}
-
-		key := e.String()
-		used[key] = true
-		acceptedEncodings = append(acceptedEncodings, e)
 	}
-
-	total := len(acceptedEncodings)
-	if total == 0 {
-		log.Warnf("No recognized encodings found in Accept header %q", acceptHeader)
-		return prometheusText004.String()
+	if out == "" {
+		return FmtText
 	}
-
-	var parts []string
-	for i, e := range acceptedEncodings {
-		e.params["q"] = fmt.Sprintf("0.%d", total-i)
-		parts = append(parts, mime.FormatMediaType(e.mediatype, e.params))
-	}
-
-	return strings.Join(parts, ",")
+	return out
 }
 
-func scrapeAndWriteAgentMetrics(registry prometheus.Gatherer, w io.Writer) error {
+// (the dead legacy helper has been intentionally removed; the protobuf-aware
+// negotiateMetricsFormat above is the single source of truth.)
+
+// scrapeFormatLabel maps an expfmt.Format to the value used for the
+// istio_agent_scrape_format_total{format=...} label.
+func scrapeFormatLabel(f expfmt.Format) string {
+	switch f.FormatType() {
+	case expfmt.TypeProtoDelim, expfmt.TypeProtoText, expfmt.TypeProtoCompact:
+		return metrics.ScrapeFormatLabelProto
+	case expfmt.TypeOpenMetrics:
+		return metrics.ScrapeFormatLabelOpenMetrics
+	default:
+		return metrics.ScrapeFormatLabelText
+	}
+}
+
+// decodeAll reads body as `format` and returns the decoded MetricFamily slice.
+// Used only on the protobuf path; for the text-only fast path the merger keeps
+// byte concatenation so adding a parse step would be a regression.
+//
+// OpenMetrics bodies are dispatched to decodeOpenMetricsToFamilies (which uses
+// prometheus/prometheus/model/textparse.OpenMetricsParser) so that exemplars,
+// _created timestamps, # UNIT, INFO, and STATESET survive the round-trip.
+// The expfmt text decoder silently drops these — see prometheus/common#812.
+func decodeAll(body io.Reader, format expfmt.Format) ([]*dto.MetricFamily, error) {
+	if format.FormatType() == expfmt.TypeOpenMetrics {
+		return decodeOpenMetricsToFamilies(body)
+	}
+	dec := expfmt.NewDecoder(body, format)
+	var mfs []*dto.MetricFamily
+	for {
+		var mf dto.MetricFamily
+		if err := dec.Decode(&mf); err != nil {
+			if errors.Is(err, io.EOF) {
+				return mfs, nil
+			}
+			return mfs, err
+		}
+		mfs = append(mfs, &mf)
+	}
+}
+
+func scrapeAndWriteAgentMetrics(registry prometheus.Gatherer, w io.Writer, format expfmt.Format) error {
 	mfs, err := registry.Gather()
-	enc := expfmt.NewEncoder(w, FmtText)
 	if err != nil {
 		return err
 	}
+	enc := expfmt.NewEncoder(w, format)
 	for _, mf := range mfs {
 		if err := enc.Encode(mf); err != nil {
 			return err
@@ -1019,7 +1267,7 @@ func getHeaderTimeout(timeout string) (time.Duration, error) {
 // This will attempt to mimic some of Prometheus functionality by passing some of the headers through
 // such as accept, timeout, and user agent
 // Returns the scraped metrics reader as well as the response's "Content-Type" header to determine the metrics format
-func (s *Server) scrape(url string, header http.Header, acceptHeader string) (io.ReadCloser, context.CancelFunc, string, error) {
+func (s *Server) scrape(url string, header http.Header) (io.ReadCloser, context.CancelFunc, string, error) {
 	var cancel context.CancelFunc
 	ctx := context.Background()
 	if timeoutString := header.Get("X-Prometheus-Scrape-Timeout-Seconds"); timeoutString != "" {
@@ -1034,12 +1282,10 @@ func (s *Server) scrape(url string, header http.Header, acceptHeader string) (io
 	if err != nil {
 		return nil, cancel, "", err
 	}
-	applyHeaders(req.Header, header, "User-Agent",
+	applyHeaders(req.Header, header, "Accept",
+		"User-Agent",
 		"X-Prometheus-Scrape-Timeout-Seconds",
 	)
-	if acceptHeader != "" {
-		req.Header.Set("Accept", acceptHeader)
-	}
 
 	resp, err := s.http.Do(req)
 	if err != nil {

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -794,7 +794,7 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 	// OpenMetrics — the multi-target loop below strips and reappends a single
 	// "# EOF" terminator for the OM case, and the single-target branch writes
 	// the app body last so its own "# EOF" terminates the response.
-	if err = scrapeAndWriteAgentMetrics(s.registry, io.Writer(w), outFormat); err != nil {
+	if err = scrapeAndWriteAgentMetrics(s.registry, io.Writer(w)); err != nil {
 		log.Errorf("failed scraping and writing agent metrics: %v", err)
 		metrics.AgentScrapeErrors.Increment()
 	}
@@ -1230,12 +1230,23 @@ func decodeAll(body io.Reader, format expfmt.Format) ([]*dto.MetricFamily, error
 	}
 }
 
-func scrapeAndWriteAgentMetrics(registry prometheus.Gatherer, w io.Writer, format expfmt.Format) error {
+// scrapeAndWriteAgentMetrics writes the agent's own self-metrics as the first
+// chunk of the byte-concatenation fast path. It always encodes as plain text.
+//
+// This chunk is followed by the Envoy and application bodies, so it must not be
+// a self-contained document. The OpenMetrics encoder requires a closing "# EOF"
+// marker to be a valid document (expfmt's encoder emits it on Close), and
+// writing that terminator here would place it mid-stream and corrupt the merged
+// response. Plain text has no such terminator; the response is terminated
+// correctly by the application body, which is written last. Proto and
+// OpenMetrics output never flow through this function — the parse-and-re-encode
+// path (writeMergedProtoPath) gathers and encodes the agent registry itself.
+func scrapeAndWriteAgentMetrics(registry prometheus.Gatherer, w io.Writer) error {
 	mfs, err := registry.Gather()
 	if err != nil {
 		return err
 	}
-	enc := expfmt.NewEncoder(w, format)
+	enc := expfmt.NewEncoder(w, FmtText)
 	for _, mf := range mfs {
 		if err := enc.Encode(mf); err != nil {
 			return err

--- a/pilot/cmd/pilot-agent/status/server_protobuf_test.go
+++ b/pilot/cmd/pilot-agent/status/server_protobuf_test.go
@@ -198,24 +198,39 @@ func TestMergeFormat(t *testing.T) {
 	}
 }
 
-// TestScrapeAndWriteAgentMetrics_Protobuf round-trips agent self-metrics through
-// the proto encoder and decoder. The recovered MetricFamily set must be non-empty,
-// proving that the format parameter (rather than the historical hardcoded FmtText)
-// is honored.
-func TestScrapeAndWriteAgentMetrics_Protobuf(t *testing.T) {
+// TestScrapeAndWriteAgentMetrics_Text asserts agent self-metrics are always
+// written as plain text. This chunk is the first written on the byte-concat fast
+// path, ahead of the Envoy and application bodies, so it must not carry an
+// OpenMetrics "# EOF" terminator (which would land mid-stream and corrupt the
+// merged response). The output must also decode as valid Prometheus text.
+func TestScrapeAndWriteAgentMetrics_Text(t *testing.T) {
 	registry := TestingRegistry(t)
 
 	var buf bytes.Buffer
-	if err := scrapeAndWriteAgentMetrics(registry, &buf, FmtProtoDelim); err != nil {
+	if err := scrapeAndWriteAgentMetrics(registry, &buf); err != nil {
 		t.Fatalf("scrapeAndWriteAgentMetrics: %v", err)
 	}
 	if buf.Len() == 0 {
-		t.Fatal("expected non-empty proto output from agent metrics")
+		t.Fatal("expected non-empty text output from agent metrics")
+	}
+	if strings.Contains(buf.String(), "# EOF") {
+		t.Fatalf("agent metrics chunk must not contain an OpenMetrics # EOF terminator:\n%s", buf.String())
 	}
 
-	mfs := decodeProtoFamilies(t, buf.Bytes())
-	if len(mfs) == 0 {
-		t.Fatal("expected at least one MetricFamily decoded from agent metrics proto stream")
+	dec := expfmt.NewDecoder(bytes.NewReader(buf.Bytes()), FmtText)
+	var count int
+	for {
+		var mf dto.MetricFamily
+		if err := dec.Decode(&mf); err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Fatalf("agent metrics did not decode as valid Prometheus text: %v", err)
+		}
+		count++
+	}
+	if count == 0 {
+		t.Fatal("expected at least one MetricFamily decoded from agent metrics text stream")
 	}
 }
 

--- a/pilot/cmd/pilot-agent/status/server_protobuf_test.go
+++ b/pilot/cmd/pilot-agent/status/server_protobuf_test.go
@@ -1,0 +1,1007 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"google.golang.org/protobuf/proto"
+)
+
+// nativeHistogramFamily builds a hand-rolled *dto.MetricFamily exercising every
+// native-histogram field the merger must preserve unchanged from input to output.
+// The fixture is deliberately rich (positive and negative spans, zero bucket,
+// non-zero schema) so the round-trip assertion in the proto tests can detect
+// any field that the merger drops or rewrites.
+func nativeHistogramFamily() *dto.MetricFamily {
+	return &dto.MetricFamily{
+		Name: proto.String("test_native_histogram"),
+		Help: proto.String("Synthetic native histogram for the merger round-trip test."),
+		Type: dto.MetricType_HISTOGRAM.Enum(),
+		Metric: []*dto.Metric{{
+			Histogram: &dto.Histogram{
+				SampleCount:   proto.Uint64(10),
+				SampleSum:     proto.Float64(42.0),
+				Schema:        proto.Int32(3),
+				ZeroThreshold: proto.Float64(0.001),
+				ZeroCount:     proto.Uint64(1),
+				PositiveSpan: []*dto.BucketSpan{
+					{Offset: proto.Int32(0), Length: proto.Uint32(2)},
+				},
+				PositiveDelta: []int64{1, 2},
+				NegativeSpan: []*dto.BucketSpan{
+					{Offset: proto.Int32(-1), Length: proto.Uint32(1)},
+				},
+				NegativeDelta: []int64{1},
+			},
+		}},
+	}
+}
+
+// classicCounterFamily is a non-histogram MetricFamily used to verify the merger
+// preserves ordinary metrics on the proto path. We assert by name lookup rather
+// than equality so the encoder's escaping pass (which mutates names that contain
+// dots) does not break the assertion if anyone later adds dotted names.
+func classicCounterFamily(name string) *dto.MetricFamily {
+	return &dto.MetricFamily{
+		Name: proto.String(name),
+		Type: dto.MetricType_COUNTER.Enum(),
+		Metric: []*dto.Metric{{
+			Counter: &dto.Counter{Value: proto.Float64(7)},
+		}},
+	}
+}
+
+func encodeProtoFamilies(t *testing.T, mfs ...*dto.MetricFamily) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	enc := expfmt.NewEncoder(&buf, FmtProtoDelim)
+	for _, mf := range mfs {
+		if err := enc.Encode(mf); err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+	}
+	return buf.Bytes()
+}
+
+func decodeProtoFamilies(t *testing.T, body []byte) []*dto.MetricFamily {
+	t.Helper()
+	mfs, err := decodeAll(bytes.NewReader(body), FmtProtoDelim)
+	if err != nil {
+		t.Fatalf("decodeAll: %v", err)
+	}
+	return mfs
+}
+
+func findFamily(mfs []*dto.MetricFamily, name string) *dto.MetricFamily {
+	for _, mf := range mfs {
+		if mf.GetName() == name {
+			return mf
+		}
+	}
+	return nil
+}
+
+// TestNegotiateMetricsFormat_Protobuf covers the new protobuf branch in
+// negotiateMetricsFormat. Each case feeds a Content-Type value that an upstream
+// might plausibly return and asserts the recognized format. The "missing"
+// cases must fall through to FmtText so a misbehaving upstream cannot trick the
+// merger into delimit-decoding a text body.
+func TestNegotiateMetricsFormat_Protobuf(t *testing.T) {
+	cases := []struct {
+		name        string
+		contentType string
+		want        expfmt.Format
+	}{
+		{
+			name:        "canonical proto delimited",
+			contentType: `application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited`,
+			want:        FmtProtoDelim,
+		},
+		{
+			name:        "proto with charset suffix",
+			contentType: `application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited; charset=utf-8`,
+			want:        FmtProtoDelim,
+		},
+		{
+			name:        "proto wrong subschema",
+			contentType: `application/vnd.google.protobuf; proto=com.example.OtherMessage; encoding=delimited`,
+			want:        FmtText,
+		},
+		{
+			name:        "proto wrong encoding",
+			contentType: `application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=compact-text`,
+			want:        FmtText,
+		},
+		{
+			name:        "proto missing encoding param",
+			contentType: `application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily`,
+			want:        FmtText,
+		},
+		{
+			name:        "malformed content type",
+			contentType: `application/vnd.google.protobuf;;;`,
+			want:        FmtText,
+		},
+		{
+			name:        "plain text default unchanged",
+			contentType: "text/plain; version=0.0.4; charset=utf-8",
+			want:        FmtText,
+		},
+		{
+			name:        "openmetrics unchanged",
+			contentType: `application/openmetrics-text; version=1.0.0; charset=utf-8`,
+			want:        FmtOpenMetrics_1_0_0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := negotiateMetricsFormat(tc.contentType)
+			if got != tc.want {
+				t.Fatalf("negotiateMetricsFormat(%q) = %q; want %q", tc.contentType, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMergeFormat exhaustively covers the cross-product of the three formats plus
+// the empty-and-failure cases.
+func TestMergeFormat(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []expfmt.Format
+		want expfmt.Format
+	}{
+		{"empty", nil, FmtText},
+		{"all empty strings", []expfmt.Format{"", ""}, FmtText},
+		{"only text", []expfmt.Format{FmtText}, FmtText},
+		{"only openmetrics", []expfmt.Format{FmtOpenMetrics_1_0_0}, FmtOpenMetrics_1_0_0},
+		{"only proto", []expfmt.Format{FmtProtoDelim}, FmtProtoDelim},
+		{"text + text", []expfmt.Format{FmtText, FmtText}, FmtText},
+		{"openmetrics + openmetrics same version", []expfmt.Format{FmtOpenMetrics_1_0_0, FmtOpenMetrics_1_0_0}, FmtOpenMetrics_1_0_0},
+		{"proto + proto", []expfmt.Format{FmtProtoDelim, FmtProtoDelim}, FmtProtoDelim},
+		{"text + proto downgrades", []expfmt.Format{FmtText, FmtProtoDelim}, FmtText},
+		{"proto + text downgrades", []expfmt.Format{FmtProtoDelim, FmtText}, FmtText},
+		{"openmetrics + proto downgrades", []expfmt.Format{FmtOpenMetrics_1_0_0, FmtProtoDelim}, FmtText},
+		{"proto + openmetrics downgrades", []expfmt.Format{FmtProtoDelim, FmtOpenMetrics_1_0_0}, FmtText},
+		{"text + openmetrics downgrades", []expfmt.Format{FmtText, FmtOpenMetrics_1_0_0}, FmtText},
+		{"openmetrics v1 + v0 downgrades", []expfmt.Format{FmtOpenMetrics_1_0_0, FmtOpenMetrics_0_0_1}, FmtText},
+		{"empty interleaved with proto wins", []expfmt.Format{"", FmtProtoDelim, ""}, FmtProtoDelim},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mergeFormat(tc.in...)
+			if got != tc.want {
+				t.Fatalf("mergeFormat(%v) = %q; want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestScrapeAndWriteAgentMetrics_Protobuf round-trips agent self-metrics through
+// the proto encoder and decoder. The recovered MetricFamily set must be non-empty,
+// proving that the format parameter (rather than the historical hardcoded FmtText)
+// is honored.
+func TestScrapeAndWriteAgentMetrics_Protobuf(t *testing.T) {
+	registry := TestingRegistry(t)
+
+	var buf bytes.Buffer
+	if err := scrapeAndWriteAgentMetrics(registry, &buf, FmtProtoDelim); err != nil {
+		t.Fatalf("scrapeAndWriteAgentMetrics: %v", err)
+	}
+	if buf.Len() == 0 {
+		t.Fatal("expected non-empty proto output from agent metrics")
+	}
+
+	mfs := decodeProtoFamilies(t, buf.Bytes())
+	if len(mfs) == 0 {
+		t.Fatal("expected at least one MetricFamily decoded from agent metrics proto stream")
+	}
+}
+
+// TestHandleStats_ProtobufEnvoyNoApp exercises the proto fast path with only an
+// Envoy upstream. The fixture includes a native-histogram MetricFamily; the test
+// asserts every native-histogram field survives the merger unchanged. This is
+// the load-bearing test for the entire PR — if the merger drops native-histogram
+// structure, native histograms are unusable end-to-end.
+func TestHandleStats_ProtobufEnvoyNoApp(t *testing.T) {
+	envoyHist := nativeHistogramFamily()
+	envoyCounter := classicCounterFamily("envoy_test_counter")
+	envoyBody := encodeProtoFamilies(t, envoyHist, envoyCounter)
+
+	envoySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", string(FmtProtoDelim))
+		if _, err := w.Write(envoyBody); err != nil {
+			t.Fatalf("envoy write: %v", err)
+		}
+	}))
+	defer envoySrv.Close()
+
+	envoyPort, err := strconv.Atoi(strings.Split(envoySrv.URL, ":")[2])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := &Server{
+		registry:        TestingRegistry(t),
+		envoyStatsPort:  envoyPort,
+		http:            &http.Client{},
+		maxAppBodyBytes: defaultMaxAppMetricsBodyBytes,
+	}
+
+	req := &http.Request{Header: make(http.Header)}
+	req.Header.Set("Accept",
+		`application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited`)
+	rec := httptest.NewRecorder()
+	server.handleStats(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d; want 200", rec.Code)
+	}
+	ct := rec.Header().Get("Content-Type")
+	if negotiateMetricsFormat(ct) != FmtProtoDelim {
+		t.Fatalf("Content-Type = %q; want proto-delimited", ct)
+	}
+
+	mfs := decodeProtoFamilies(t, rec.Body.Bytes())
+	gotHist := findFamily(mfs, "test_native_histogram")
+	if gotHist == nil {
+		t.Fatalf("native histogram not present in merged output; got names: %v", familyNames(mfs))
+	}
+
+	// Load-bearing canonical equality: the full input Histogram (every span, every
+	// delta, ZeroThreshold, NegativeDelta, SampleCount, SampleSum, schema) must
+	// round-trip unchanged through the merger. proto.Equal compares every populated
+	// field; if the merger drops or rewrites any subfield, this fails.
+	wantHist := envoyHist.GetMetric()[0].GetHistogram()
+	gotHistogram := gotHist.GetMetric()[0].GetHistogram()
+	if !proto.Equal(wantHist, gotHistogram) {
+		t.Fatalf("native histogram round-trip not byte-equal\n  want: %+v\n   got: %+v", wantHist, gotHistogram)
+	}
+
+	// Retain field-level assertions for human-readable diagnostics if proto.Equal
+	// ever fires; they make the failure root cause obvious without re-running.
+	if gotHistogram.GetSchema() != 3 {
+		t.Errorf("Schema lost: got %v", gotHistogram.GetSchema())
+	}
+	if gotHistogram.GetZeroCount() != 1 {
+		t.Errorf("ZeroCount lost: got %v", gotHistogram.GetZeroCount())
+	}
+	if len(gotHistogram.GetPositiveSpan()) == 0 {
+		t.Error("PositiveSpan lost")
+	}
+	if len(gotHistogram.GetPositiveDelta()) == 0 {
+		t.Error("PositiveDelta lost")
+	}
+	if len(gotHistogram.GetNegativeSpan()) == 0 {
+		t.Error("NegativeSpan lost")
+	}
+
+	if findFamily(mfs, "envoy_test_counter") == nil {
+		t.Errorf("classic counter not present in merged output; got names: %v", familyNames(mfs))
+	}
+}
+
+func familyNames(mfs []*dto.MetricFamily) []string {
+	out := make([]string, 0, len(mfs))
+	for _, mf := range mfs {
+		out = append(out, mf.GetName())
+	}
+	return out
+}
+
+// TestHandleStats_ProtobufEnvoyProtoApp exercises the proto path when both
+// upstreams are proto. The native histogram from Envoy and a counter from the
+// app must both appear in the merged output.
+func TestHandleStats_ProtobufEnvoyProtoApp(t *testing.T) {
+	envoyBody := encodeProtoFamilies(t, nativeHistogramFamily())
+	appBody := encodeProtoFamilies(t, classicCounterFamily("app_counter"))
+
+	envoySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", string(FmtProtoDelim))
+		_, _ = w.Write(envoyBody)
+	}))
+	defer envoySrv.Close()
+	appSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", string(FmtProtoDelim))
+		_, _ = w.Write(appBody)
+	}))
+	defer appSrv.Close()
+
+	envoyPort, err := strconv.Atoi(strings.Split(envoySrv.URL, ":")[2])
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := &Server{
+		prometheus: &PrometheusScrapeConfiguration{
+			Port: strings.Split(appSrv.URL, ":")[2],
+		},
+		registry:        TestingRegistry(t),
+		envoyStatsPort:  envoyPort,
+		http:            &http.Client{},
+		maxAppBodyBytes: defaultMaxAppMetricsBodyBytes,
+	}
+
+	req := &http.Request{Header: make(http.Header)}
+	req.Header.Set("Accept",
+		`application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited`)
+	rec := httptest.NewRecorder()
+	server.handleStats(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d; want 200", rec.Code)
+	}
+	if negotiateMetricsFormat(rec.Header().Get("Content-Type")) != FmtProtoDelim {
+		t.Fatalf("Content-Type = %q; want proto", rec.Header().Get("Content-Type"))
+	}
+
+	mfs := decodeProtoFamilies(t, rec.Body.Bytes())
+	if findFamily(mfs, "test_native_histogram") == nil {
+		t.Errorf("native histogram missing; got %v", familyNames(mfs))
+	}
+	if findFamily(mfs, "app_counter") == nil {
+		t.Errorf("app counter missing; got %v", familyNames(mfs))
+	}
+}
+
+// TestHandleStats_ProtobufEnvoyTextApp covers the mixed-format downgrade: Envoy
+// is proto, app is text, output must be text. The text body must parse as text;
+// the binary native-histogram structure naturally collapses (text exposition is
+// not defined for native histograms), but the classic envoy counter must
+// survive and the app counter must survive.
+func TestHandleStats_ProtobufEnvoyTextApp(t *testing.T) {
+	envoyBody := encodeProtoFamilies(t,
+		classicCounterFamily("envoy_classic_counter"),
+		nativeHistogramFamily(),
+	)
+	appText := "# TYPE app_metric counter\napp_metric 1\n"
+
+	envoySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", string(FmtProtoDelim))
+		_, _ = w.Write(envoyBody)
+	}))
+	defer envoySrv.Close()
+	appSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", FmtText)
+		_, _ = io.WriteString(w, appText)
+	}))
+	defer appSrv.Close()
+
+	envoyPort, err := strconv.Atoi(strings.Split(envoySrv.URL, ":")[2])
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := &Server{
+		prometheus: &PrometheusScrapeConfiguration{
+			Port: strings.Split(appSrv.URL, ":")[2],
+		},
+		registry:        TestingRegistry(t),
+		envoyStatsPort:  envoyPort,
+		http:            &http.Client{},
+		maxAppBodyBytes: defaultMaxAppMetricsBodyBytes,
+	}
+
+	req := &http.Request{Header: make(http.Header)}
+	req.Header.Set("Accept", `application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited`)
+	rec := httptest.NewRecorder()
+	server.handleStats(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d; want 200", rec.Code)
+	}
+	ct := rec.Header().Get("Content-Type")
+	if got := negotiateMetricsFormat(ct); got != FmtText {
+		t.Fatalf("Content-Type = %q (negotiated %q); want text downgrade", ct, got)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "envoy_classic_counter") {
+		t.Errorf("envoy_classic_counter missing from downgraded body; body=%q", body)
+	}
+	if !strings.Contains(body, "app_metric") {
+		t.Errorf("app_metric missing from downgraded body; body=%q", body)
+	}
+}
+
+// TestHandleStats_ProtobufEnvoyOMApp_PreservesOMFields covers the regression
+// flagged in PR review by @krinkinmu: when the proto path fires with an
+// OpenMetrics app upstream, the expfmt text decoder (used to silently drop OM
+// exemplars, _created lines, and # UNIT) is now replaced by the
+// textparse.OpenMetricsParser-backed adapter (decodeOpenMetricsToFamilies).
+// This test verifies the regression is fixed end-to-end: an OM body with
+// exemplars + _created + # UNIT parses through the proto merger without
+// dropping the counter (the prior expfmt path would parse-error the exemplar
+// line and drop the entire family).
+func TestHandleStats_ProtobufEnvoyOMApp_PreservesOMFields(t *testing.T) {
+	// Envoy returns proto (forces the proto path).
+	envoyBody := encodeProtoFamilies(t, classicCounterFamily("envoy_classic_counter"))
+
+	// App returns OpenMetrics with all the features the legacy expfmt textDecoder
+	// silently mangled: exemplar on a counter sample, _created line, # UNIT.
+	appOM := strings.Join([]string{
+		`# HELP app_requests Total app requests`,
+		`# TYPE app_requests counter`,
+		`# UNIT app_requests requests`,
+		`app_requests_total{method="get"} 42 # {trace_id="abc"} 0.5 1700000001.5`,
+		`app_requests_created{method="get"} 1700000000.0`,
+		`# EOF`,
+		``,
+	}, "\n")
+
+	envoySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", string(FmtProtoDelim))
+		_, _ = w.Write(envoyBody)
+	}))
+	defer envoySrv.Close()
+	appSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", FmtOpenMetrics_1_0_0)
+		_, _ = io.WriteString(w, appOM)
+	}))
+	defer appSrv.Close()
+
+	envoyPort, err := strconv.Atoi(strings.Split(envoySrv.URL, ":")[2])
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := &Server{
+		prometheus: &PrometheusScrapeConfiguration{
+			Port: strings.Split(appSrv.URL, ":")[2],
+		},
+		registry:        TestingRegistry(t),
+		envoyStatsPort:  envoyPort,
+		http:            &http.Client{},
+		maxAppBodyBytes: defaultMaxAppMetricsBodyBytes,
+	}
+
+	req := &http.Request{Header: make(http.Header)}
+	req.Header.Set("Accept", `application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited`)
+	rec := httptest.NewRecorder()
+	server.handleStats(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d; want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	// The Envoy proto + app OM disagreement downgrades the output to text. The
+	// VALUE of the counter must survive (legacy expfmt path would parse-error
+	// the exemplar line and drop the entire family — that is exactly the
+	// regression this test guards against). The text re-encoder may strip the
+	// "_total" OM convention from the metric name, so we accept either spelling.
+	if !strings.Contains(body, "app_requests{method=\"get\"} 42") && !strings.Contains(body, "app_requests_total{method=\"get\"} 42") {
+		t.Errorf("app_requests value missing from merged body — exemplar parse may have dropped it; body=%q", body)
+	}
+	if !strings.Contains(body, "envoy_classic_counter") {
+		t.Errorf("envoy_classic_counter missing from merged body; body=%q", body)
+	}
+}
+
+// TestHandleStats_ProtobufEnvoyOMApp_DecoderPreservesExemplars exercises the
+// same regression but asserts at the decoder layer (independent of the output
+// format) that the adapter populates Exemplar + CreatedTimestamp + Unit on the
+// produced *dto.MetricFamily. This is the precise field-level guarantee the
+// reviewer asked for: prior to this PR's openmetrics_decode.go, these would be
+// silently dropped because expfmt routed OM bodies through its text parser.
+func TestHandleStats_ProtobufEnvoyOMApp_DecoderPreservesExemplars(t *testing.T) {
+	appOM := strings.Join([]string{
+		`# HELP app_requests Total app requests`,
+		`# TYPE app_requests counter`,
+		`# UNIT app_requests requests`,
+		`app_requests_total{method="get"} 42 # {trace_id="abc"} 0.5 1700000001.5`,
+		`app_requests_created{method="get"} 1700000000.0`,
+		`# EOF`,
+		``,
+	}, "\n")
+
+	mfs, err := decodeAll(strings.NewReader(appOM), FmtOpenMetrics_1_0_0)
+	if err != nil {
+		t.Fatalf("decodeAll on OM body: %v", err)
+	}
+	if len(mfs) != 1 {
+		t.Fatalf("expected 1 family, got %d", len(mfs))
+	}
+	fam := mfs[0]
+	if fam.GetName() != "app_requests" {
+		t.Errorf("family name = %q; want app_requests", fam.GetName())
+	}
+	if fam.GetUnit() != "requests" {
+		t.Errorf("Unit = %q; want %q (was silently dropped by expfmt textDecoder before this PR)", fam.GetUnit(), "requests")
+	}
+	if len(fam.Metric) != 1 {
+		t.Fatalf("expected 1 metric, got %d", len(fam.Metric))
+	}
+	c := fam.Metric[0].GetCounter()
+	if c == nil {
+		t.Fatalf("metric has no Counter; was the entire family dropped due to exemplar parse error?")
+	}
+	if c.GetValue() != 42 {
+		t.Errorf("counter value = %v; want 42", c.GetValue())
+	}
+	if c.GetExemplar() == nil {
+		t.Fatalf("counter has no Exemplar (was silently dropped by expfmt textDecoder before this PR)")
+	}
+	if got := c.GetExemplar().GetLabel(); len(got) != 1 || got[0].GetName() != "trace_id" || got[0].GetValue() != "abc" {
+		t.Errorf("exemplar labels = %v; want [trace_id=abc]", got)
+	}
+	if c.GetCreatedTimestamp() == nil {
+		t.Fatalf("counter has no CreatedTimestamp (was silently dropped by expfmt textDecoder before this PR)")
+	}
+	if got := c.GetCreatedTimestamp().AsTime().UnixMilli(); got != 1700000000000 {
+		t.Errorf("CreatedTimestamp = %d ms; want 1700000000000 ms", got)
+	}
+}
+
+// TestHandleStats_EnvoyReturnsOM_RoutesThroughMerger covers the Envoy-side of
+// PR review comment #4 (krinkinmu): if Envoy ever returns a non-text/plain
+// body (e.g. OpenMetrics in some hypothetical future Envoy release), the
+// byte-concat fast path would write an "# EOF" marker mid-stream. The
+// dispatcher's needsParseMerge predicate forces the parse-and-re-encode
+// merger whenever envoyFormat is non-text/plain, eliminating that hazard.
+// Today Envoy never returns OM, but the test future-proofs the rule.
+func TestHandleStats_EnvoyReturnsOM_RoutesThroughMerger(t *testing.T) {
+	envoyOM := strings.Join([]string{
+		`# TYPE envoy_metric counter`,
+		`envoy_metric_total{src="envoy"} 5`,
+		`# EOF`,
+		``,
+	}, "\n")
+	envoySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", FmtOpenMetrics_1_0_0)
+		_, _ = io.WriteString(w, envoyOM)
+	}))
+	defer envoySrv.Close()
+
+	envoyPort, err := strconv.Atoi(strings.Split(envoySrv.URL, ":")[2])
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := &Server{
+		registry:        TestingRegistry(t),
+		envoyStatsPort:  envoyPort,
+		http:            &http.Client{},
+		maxAppBodyBytes: defaultMaxAppMetricsBodyBytes,
+	}
+
+	req := &http.Request{Header: make(http.Header)}
+	rec := httptest.NewRecorder()
+	server.handleStats(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d; want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	// The byte-concat fast path would have left envoy's "# EOF" mid-stream
+	// before the agent metrics. The merger re-encodes, producing exactly one
+	// trailing "# EOF" (or none if outFormat is text). Count occurrences:
+	eofCount := strings.Count(body, "# EOF")
+	if eofCount > 1 {
+		t.Errorf("merged body contains %d # EOF markers; want ≤1 (byte-concat regression?); body tail: %q",
+			eofCount, body[max(0, len(body)-200):])
+	}
+	if !strings.Contains(body, "envoy_metric") {
+		t.Errorf("envoy_metric missing from merged body; body=%q", body)
+	}
+}
+
+// TestHandleStats_ProtobufMalformedEnvoy verifies that a malformed protobuf
+// upstream does not corrupt the merged response. The truncated bytes will
+// cause decodeAll to error; the merger must log + drop Envoy, return the agent
+// metrics it can, and produce a parseable body.
+func TestHandleStats_ProtobufMalformedEnvoy(t *testing.T) {
+	envoySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", string(FmtProtoDelim))
+		// Write the prefix of a real proto stream but truncate mid-frame. A
+		// non-zero varint length followed by no payload guarantees the decoder
+		// returns an error before EOF.
+		_, _ = w.Write([]byte{0x05, 0x00, 0x01})
+	}))
+	defer envoySrv.Close()
+
+	envoyPort, err := strconv.Atoi(strings.Split(envoySrv.URL, ":")[2])
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := &Server{
+		registry:        TestingRegistry(t),
+		envoyStatsPort:  envoyPort,
+		http:            &http.Client{},
+		maxAppBodyBytes: defaultMaxAppMetricsBodyBytes,
+	}
+
+	req := &http.Request{Header: make(http.Header)}
+	req.Header.Set("Accept", `application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited`)
+	rec := httptest.NewRecorder()
+	server.handleStats(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d; want 200", rec.Code)
+	}
+	// We still expect a proto response (the merge path picked proto). The
+	// merged body may contain just the agent metrics — the load-bearing
+	// assertion is that the response is well-formed proto, not garbled bytes.
+	if _, err := decodeAll(bytes.NewReader(rec.Body.Bytes()), FmtProtoDelim); err != nil {
+		t.Fatalf("merged proto body is malformed after truncated envoy: %v; bytes=%x",
+			err, rec.Body.Bytes())
+	}
+}
+
+// TestHandleStats_NoAcceptHeader_DefaultsToText is the regression guard for the
+// historical default: a scraper that omits the Accept header gets text/plain.
+func TestHandleStats_NoAcceptHeader_DefaultsToText(t *testing.T) {
+	envoyText := "# TYPE my_metric counter\nmy_metric 0\n"
+	envoySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", FmtText)
+		_, _ = io.WriteString(w, envoyText)
+	}))
+	defer envoySrv.Close()
+	envoyPort, err := strconv.Atoi(strings.Split(envoySrv.URL, ":")[2])
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := &Server{
+		registry:        TestingRegistry(t),
+		envoyStatsPort:  envoyPort,
+		http:            &http.Client{},
+		maxAppBodyBytes: defaultMaxAppMetricsBodyBytes,
+	}
+	req := &http.Request{Header: make(http.Header)}
+	rec := httptest.NewRecorder()
+	server.handleStats(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d; want 200", rec.Code)
+	}
+	if negotiateMetricsFormat(rec.Header().Get("Content-Type")) != FmtText {
+		t.Fatalf("Content-Type = %q; want text", rec.Header().Get("Content-Type"))
+	}
+	if !strings.Contains(rec.Body.String(), "my_metric") {
+		t.Fatalf("envoy text body missing from merged response; body=%q", rec.Body.String())
+	}
+}
+
+// TestScrapeFormatLabel is a small unit test of the label mapper used by the
+// scrape_format_total counter. Exhaustive over the FormatType enum we recognize.
+func TestScrapeFormatLabel(t *testing.T) {
+	cases := []struct {
+		name string
+		in   expfmt.Format
+		want string
+	}{
+		{"text", FmtText, "text"},
+		{"openmetrics", FmtOpenMetrics_1_0_0, "openmetrics"},
+		{"proto delim", FmtProtoDelim, "proto"},
+		{"proto text", expfmt.NewFormat(expfmt.TypeProtoText), "proto"},
+		{"proto compact", expfmt.NewFormat(expfmt.TypeProtoCompact), "proto"},
+		{"unknown defaults to text", expfmt.Format(""), "text"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := scrapeFormatLabel(tc.in)
+			if got != tc.want {
+				t.Fatalf("scrapeFormatLabel(%q) = %q; want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// repeatedCounterBody returns a proto-delimited body with `n` distinct counter
+// families. Each MetricFamily is small (~50 bytes); n controls the overall body
+// size so tests can probe just-under and just-over the s.maxAppBodyBytes cap.
+func repeatedCounterBody(t *testing.T, n int) []byte {
+	t.Helper()
+	mfs := make([]*dto.MetricFamily, 0, n)
+	for i := 0; i < n; i++ {
+		mfs = append(mfs, classicCounterFamily("cap_counter_"+strconv.Itoa(i)))
+	}
+	return encodeProtoFamilies(t, mfs...)
+}
+
+// TestProtoPathBodyCap_EnvoyUnderCap verifies the proto path's body cap admits
+// a body just below s.maxAppBodyBytes. The Envoy body is sized so that the
+// LimitReader fully consumes it without firing the overflow check; all
+// MetricFamilies must appear in the merged output.
+func TestProtoPathBodyCap_EnvoyUnderCap(t *testing.T) {
+	body := repeatedCounterBody(t, 10) // small body, well under any tractable cap
+	envoySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", string(FmtProtoDelim))
+		_, _ = w.Write(body)
+	}))
+	defer envoySrv.Close()
+
+	envoyPort, err := strconv.Atoi(strings.Split(envoySrv.URL, ":")[2])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Cap larger than the body. The merger should decode all 10 families.
+	server := &Server{
+		registry:        TestingRegistry(t),
+		envoyStatsPort:  envoyPort,
+		http:            &http.Client{},
+		maxAppBodyBytes: len(body) + 1024,
+	}
+
+	req := &http.Request{Header: make(http.Header)}
+	req.Header.Set("Accept",
+		`application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited`)
+	rec := httptest.NewRecorder()
+	server.handleStats(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d; want 200", rec.Code)
+	}
+	mfs := decodeProtoFamilies(t, rec.Body.Bytes())
+	for i := 0; i < 10; i++ {
+		name := "cap_counter_" + strconv.Itoa(i)
+		if findFamily(mfs, name) == nil {
+			t.Errorf("expected family %q in under-cap merged output; got names: %v", name, familyNames(mfs))
+		}
+	}
+}
+
+// TestProtoPathBodyCap_EnvoyOverCap verifies the proto path's body cap drops an
+// Envoy body that exceeds s.maxAppBodyBytes. The merger must:
+//   - log + increment metrics.EnvoyScrapeErrors (we don't assert the counter
+//     directly here because the registry is shared across parallel tests; the
+//     load-bearing assertion is that the over-cap families do not appear),
+//   - still return a well-formed proto response containing the agent metrics.
+//
+// This guarantees a misbehaving Envoy cannot OOM the agent through the proto
+// path — the same guarantee the multi-target text path already provides.
+func TestProtoPathBodyCap_EnvoyOverCap(t *testing.T) {
+	// Body large enough that the LimitReader saturates at cap+1.
+	body := repeatedCounterBody(t, 200)
+	envoySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", string(FmtProtoDelim))
+		_, _ = w.Write(body)
+	}))
+	defer envoySrv.Close()
+
+	envoyPort, err := strconv.Atoi(strings.Split(envoySrv.URL, ":")[2])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Cap well below the body so the LimitReader saturates.
+	bodyCap := len(body) / 4
+	if bodyCap < 64 {
+		bodyCap = 64
+	}
+	server := &Server{
+		registry:        TestingRegistry(t),
+		envoyStatsPort:  envoyPort,
+		http:            &http.Client{},
+		maxAppBodyBytes: bodyCap,
+	}
+
+	req := &http.Request{Header: make(http.Header)}
+	req.Header.Set("Accept",
+		`application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited`)
+	rec := httptest.NewRecorder()
+	server.handleStats(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d; want 200", rec.Code)
+	}
+	// Response must still be well-formed proto — the cap drop must not corrupt
+	// the wire format.
+	mfs, err := decodeAll(bytes.NewReader(rec.Body.Bytes()), FmtProtoDelim)
+	if err != nil {
+		t.Fatalf("over-cap response is malformed proto: %v", err)
+	}
+	// Whatever families were partially decoded before the cap fired may appear
+	// (matching the existing partial-success behavior), but the highest-index
+	// counter from the back of the body must NOT appear — the cap dropped the
+	// tail of the stream.
+	tail := "cap_counter_199"
+	if findFamily(mfs, tail) != nil {
+		t.Errorf("over-cap test admitted tail family %q; cap was not enforced (cap=%d, body=%d)",
+			tail, bodyCap, len(body))
+	}
+}
+
+// TestProtoPathBodyCap_SingleAppOverCap verifies the body cap on the
+// single-target application path. Symmetric to the Envoy case: an over-cap app
+// body must be dropped without corrupting the response.
+func TestProtoPathBodyCap_SingleAppOverCap(t *testing.T) {
+	envoyBody := encodeProtoFamilies(t, classicCounterFamily("envoy_small_counter"))
+	appBody := repeatedCounterBody(t, 200) // large
+
+	envoySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", string(FmtProtoDelim))
+		_, _ = w.Write(envoyBody)
+	}))
+	defer envoySrv.Close()
+	appSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", string(FmtProtoDelim))
+		_, _ = w.Write(appBody)
+	}))
+	defer appSrv.Close()
+
+	envoyPort, err := strconv.Atoi(strings.Split(envoySrv.URL, ":")[2])
+	if err != nil {
+		t.Fatal(err)
+	}
+	bodyCap := len(appBody) / 4
+	if bodyCap < 128 {
+		bodyCap = 128
+	}
+	server := &Server{
+		prometheus: &PrometheusScrapeConfiguration{
+			Port: strings.Split(appSrv.URL, ":")[2],
+		},
+		registry:        TestingRegistry(t),
+		envoyStatsPort:  envoyPort,
+		http:            &http.Client{},
+		maxAppBodyBytes: bodyCap,
+	}
+
+	req := &http.Request{Header: make(http.Header)}
+	req.Header.Set("Accept",
+		`application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited`)
+	rec := httptest.NewRecorder()
+	server.handleStats(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d; want 200", rec.Code)
+	}
+	mfs, err := decodeAll(bytes.NewReader(rec.Body.Bytes()), FmtProtoDelim)
+	if err != nil {
+		t.Fatalf("over-cap response is malformed proto: %v", err)
+	}
+	// Envoy must survive (under cap on its own scrape).
+	if findFamily(mfs, "envoy_small_counter") == nil {
+		t.Errorf("envoy small counter missing after app over-cap; got %v", familyNames(mfs))
+	}
+	// App tail must NOT survive.
+	if findFamily(mfs, "cap_counter_199") != nil {
+		t.Errorf("app over-cap admitted tail family; cap not enforced (cap=%d, body=%d)",
+			bodyCap, len(appBody))
+	}
+}
+
+// TestScrapeMultipleAppsBodyCap_PerBodyFormats is a focused unit test on
+// scrapeMultipleApps's pre-existing per-target cap PLUS the new per-body formats
+// return value. An over-cap target must be dropped and represented as nil in the
+// returned bodies slice, while under-cap targets pass through; the new third
+// return value (per-body formats) must parallel bodies.
+func TestScrapeMultipleAppsBodyCap_PerBodyFormats(t *testing.T) {
+	smallBody := strings.Repeat("a", 256)
+	bigBody := strings.Repeat("b", 4*1024)
+
+	smallSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", FmtText)
+		_, _ = io.WriteString(w, smallBody)
+	}))
+	defer smallSrv.Close()
+	bigSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", FmtText)
+		_, _ = io.WriteString(w, bigBody)
+	}))
+	defer bigSrv.Close()
+
+	smallPort := strings.Split(smallSrv.URL, ":")[2]
+	bigPort := strings.Split(bigSrv.URL, ":")[2]
+	server := &Server{
+		prometheus: &PrometheusScrapeConfiguration{
+			Targets: []ScrapeTarget{
+				{Port: smallPort, Path: "/"},
+				{Port: bigPort, Path: "/"},
+			},
+		},
+		registry:        TestingRegistry(t),
+		http:            &http.Client{},
+		maxAppBodyBytes: 1024, // smaller than bigBody (4KiB), larger than smallBody (256B)
+	}
+
+	req := &http.Request{Header: make(http.Header)}
+	format, bodies, bodyFormats := server.scrapeMultipleApps(req)
+
+	if len(bodies) != 2 || len(bodyFormats) != 2 {
+		t.Fatalf("scrapeMultipleApps returned %d bodies / %d formats; want 2/2", len(bodies), len(bodyFormats))
+	}
+	if bodies[0] == nil {
+		t.Errorf("small (under-cap) target was dropped; expected non-nil body")
+	}
+	if bodies[1] != nil {
+		t.Errorf("big (over-cap) target was admitted; expected nil body, got %d bytes", len(bodies[1]))
+	}
+	if format != FmtText {
+		t.Errorf("aggregated format = %q; want FmtText", format)
+	}
+}
+
+// TestProtoPath_MixedMultiTarget covers M2: a multi-target app config where one
+// target returns proto and another returns text. scrapeMultipleApps aggregates
+// the format to FmtText (mixed-format downgrade), but the proto body bytes in
+// appBodies[0] are still binary. Before the fix, writeMergedProtoPath would
+// decode every body with appFormat=FmtText, mis-parsing the proto target and
+// silently dropping its metrics. After the fix, per-body formats are threaded
+// through and each body decodes in its true format. Both targets' metrics must
+// appear in the final (text) output.
+func TestProtoPath_MixedMultiTarget(t *testing.T) {
+	envoyBody := encodeProtoFamilies(t, classicCounterFamily("envoy_mixed_counter"))
+	protoTargetBody := encodeProtoFamilies(t, classicCounterFamily("proto_target_counter"))
+	textTargetBody := "# TYPE text_target_counter counter\ntext_target_counter 5\n"
+
+	envoySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", string(FmtProtoDelim))
+		_, _ = w.Write(envoyBody)
+	}))
+	defer envoySrv.Close()
+	protoSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", string(FmtProtoDelim))
+		_, _ = w.Write(protoTargetBody)
+	}))
+	defer protoSrv.Close()
+	textSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", FmtText)
+		_, _ = io.WriteString(w, textTargetBody)
+	}))
+	defer textSrv.Close()
+
+	envoyPort, err := strconv.Atoi(strings.Split(envoySrv.URL, ":")[2])
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := &Server{
+		prometheus: &PrometheusScrapeConfiguration{
+			Targets: []ScrapeTarget{
+				{Port: strings.Split(protoSrv.URL, ":")[2], Path: "/"},
+				{Port: strings.Split(textSrv.URL, ":")[2], Path: "/"},
+			},
+		},
+		registry:        TestingRegistry(t),
+		envoyStatsPort:  envoyPort,
+		http:            &http.Client{},
+		maxAppBodyBytes: defaultMaxAppMetricsBodyBytes,
+	}
+
+	req := &http.Request{Header: make(http.Header)}
+	req.Header.Set("Accept",
+		`application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited`)
+	rec := httptest.NewRecorder()
+	server.handleStats(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d; want 200", rec.Code)
+	}
+	// The output must be text — mixed proto+text downgrades. Envoy is proto so
+	// anyProto=true; the merge format is text (since aggregated app format is
+	// text from the mixed downgrade and Envoy says proto → mergeFormat → text).
+	ct := rec.Header().Get("Content-Type")
+	if got := negotiateMetricsFormat(ct); got != FmtText {
+		t.Fatalf("Content-Type = %q (negotiated %q); want text downgrade", ct, got)
+	}
+	body := rec.Body.String()
+	// Envoy's counter (proto-decoded → text-encoded) must survive.
+	if !strings.Contains(body, "envoy_mixed_counter") {
+		t.Errorf("envoy_mixed_counter missing from mixed-multi-target output; body=%q", body)
+	}
+	// The proto-app target's counter MUST survive (the M2 fix).
+	if !strings.Contains(body, "proto_target_counter") {
+		t.Errorf("proto_target_counter missing — M2 regression: per-body format not honored; body=%q", body)
+	}
+	// The text-app target's counter must survive.
+	if !strings.Contains(body, "text_target_counter") {
+		t.Errorf("text_target_counter missing from mixed-multi-target output; body=%q", body)
+	}
+}

--- a/pilot/cmd/pilot-agent/status/server_test.go
+++ b/pilot/cmd/pilot-agent/status/server_test.go
@@ -533,7 +533,13 @@ func TestHTTPCompressionOnStats(t *testing.T) {
 	}
 }
 
-func TestExcludeProtobufEncoding(t *testing.T) {
+// TestContentTypeNegotiation verifies end-to-end Content-Type negotiation
+// through handleStats. The merger forwards the client's Accept header verbatim
+// to upstreams; each upstream negotiates its own format via the standard
+// promhttp content negotiator. The merger then emits the upstream-negotiated
+// format (proto via writeMergedProtoPath; text/OM via the byte-concat fast
+// path when all upstreams agree on text/plain).
+func TestContentTypeNegotiation(t *testing.T) {
 	envoyReg := prometheus.NewRegistry()
 	envoyCounter := promauto.With(envoyReg).NewCounter(prometheus.CounterOpts{
 		Name: "counter1",
@@ -570,9 +576,10 @@ func TestExcludeProtobufEncoding(t *testing.T) {
 		prometheus: &PrometheusScrapeConfiguration{
 			Port: fmt.Sprintf("%d", appPort),
 		},
-		envoyStatsPort: envoyPort,
-		http:           &http.Client{},
-		registry:       TestingRegistry(t),
+		envoyStatsPort:  envoyPort,
+		http:            &http.Client{},
+		registry:        TestingRegistry(t),
+		maxAppBodyBytes: defaultMaxAppMetricsBodyBytes,
 	}
 
 	tests := []struct {
@@ -598,6 +605,9 @@ func TestExcludeProtobufEncoding(t *testing.T) {
 			want: "application/openmetrics-text",
 		},
 		{
+			// Protobuf passthrough for native Prometheus histograms: when the client
+			// advertises proto and both upstreams negotiate proto, the merger emits
+			// proto via writeMergedProtoPath. See #49950.
 			name: "typical accept header with protobuf",
 			acceptHeader: "application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.6," +
 				"application/openmetrics-text;version=1.0.0;escaping=allow-utf-8;q=0.5," +
@@ -605,12 +615,12 @@ func TestExcludeProtobufEncoding(t *testing.T) {
 				"text/plain;version=1.0.0;escaping=allow-utf-8;q=0.3," +
 				"text/plain;version=0.0.4;q=0.2," +
 				"*/*;q=0.1",
-			want: "application/openmetrics-text",
+			want: "application/vnd.google.protobuf",
 		},
 		{
 			name:         "protobuf only",
 			acceptHeader: "application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited",
-			want:         "text/plain",
+			want:         "application/vnd.google.protobuf",
 		},
 		{
 			name:         "openmetrics text only",
@@ -624,14 +634,17 @@ func TestExcludeProtobufEncoding(t *testing.T) {
 			want: "text/plain",
 		},
 		{
-			name:         "expand MIME wildcard",
+			name:         "MIME wildcard */*",
 			acceptHeader: "*/*",
 			want:         "text/plain",
 		},
 		{
-			name:         "expand MIME range",
+			// `application/*` — no longer expanded to `application/openmetrics-text`
+			// since the Accept-header allow-list was removed; upstreams negotiate
+			// directly, and promhttp falls back to text on a bare MIME range.
+			name:         "MIME range application/*",
 			acceptHeader: "application/*",
-			want:         "application/openmetrics-text",
+			want:         "text/plain",
 		},
 		{
 			name:         "invalid accept header",

--- a/releasenotes/notes/49950-native-prometheus-histograms.yaml
+++ b/releasenotes/notes/49950-native-prometheus-histograms.yaml
@@ -1,0 +1,12 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+issue:
+  - 49950
+
+releaseNotes:
+  - |
+    **Added** native Prometheus protobuf passthrough through pilot-agent's metrics merger. When a Prometheus scraper sends `Accept: application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited`, Envoy's native (sparse) histograms now reach the scraper unchanged instead of being silently degraded by text-format re-encoding. The pre-existing text/OpenMetrics scrape path is byte-for-byte unchanged.
+
+  - |
+    **Added** a new `istio_agent_scrape_format_total{format,downgrade}` counter to pilot-agent that reports the format negotiation outcome per scrape (text / openmetrics / protobuf, with a downgrade indicator when upstreams disagree).

--- a/tests/binary/binaries_test.go
+++ b/tests/binary/binaries_test.go
@@ -106,8 +106,12 @@ func TestBinarySizes(t *testing.T) {
 	}{
 		// TODO: shrink the ranges here once the active work to reduce binary size is complete
 		// For now, having two small a range will result in lots of "merge conflicts"
-		"istioctl":        {60, 100},
-		"pilot-agent":     {20, 28},
+		"istioctl": {60, 100},
+		// pilot-agent grew ~1.7 MiB on top of the prior ~28 MiB baseline when
+		// the textparse-backed OpenMetrics decoder for the metrics merger landed
+		// (istio#60350); bump max to 32 to leave reasonable headroom without
+		// thrashing on merge conflicts.
+		"pilot-agent":     {20, 32},
 		"pilot-discovery": {60, 125},
 		"bug-report":      {60, 80},
 		"client":          {15, 30},


### PR DESCRIPTION
## What

Adds native Prometheus protobuf passthrough through `pilot-agent`'s metrics merger so Envoy's native histograms reach Prometheus scrapers unchanged.

The merger now:

- Recognizes `application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited` from upstreams via `negotiateMetricsFormat`.
- Dispatches to a parse-and-re-encode `writeMergedProtoPath` when **any** upstream advertises proto; otherwise keeps the historical byte-concatenation fast path for text/OpenMetrics exactly as before.
- Falls back to text when upstreams disagree on format (e.g. Envoy proto + app text). The text→proto upconversion is gated on the cost-comparison study required by the TOC at the 2026-02-18 working group meeting and is deferred to PR3.
- Bounds memory on the proto path via `maxAppBodyBytes` applied to Envoy and the single-target app reader, matching the multi-target text path's pre-existing cap.
- Honors per-body Content-Type in the multi-target proto path so a binary proto body and a text body from different targets are each decoded in their true format even when the aggregated app format has been downgraded.

A new counter, `istio_agent_scrape_format_total{format,downgrade}` (3 × 2 = 6 possible series; 4 emitted), lets operators observe the format negotiation outcome per scrape — useful for sizing the PR3 upconversion gate.

## Why

The pre-PR merger discarded native-histogram structure: it always emitted text, and text exposition is not defined for native histograms. Native histograms are the foundation for high-resolution latency analytics and have been GA in Prometheus 3.x since 2024. PR1 makes them pass through; PR2 plans to extend `pilot-agent`'s own self-metrics to use them; PR3 plans the text→proto upconversion behind a cost-comparison-validated feature gate.

Envoy upstream landed protobuf format support in [#43248](https://github.com/envoyproxy/envoy/pull/43248) (merged 2026-02-05) and native histograms in [#43366](https://github.com/envoyproxy/envoy/pull/43366) (merged 2026-02-10), unblocking this work on the istio side.

## Backwards compatibility

Strictly additive. Every pre-PR scrape path produces the identical Content-Type and body bytes. The new path only activates when an upstream actually returns delimited proto. Verified via existing tests (`TestStatsContentType`, `TestStatsMultiTarget`, `TestHandleStats_NoAcceptHeader_DefaultsToText`).

## Tests

- `TestHandleStats_ProtobufEnvoyNoApp` — load-bearing native-histogram round-trip with canonical `proto.Equal` equality on the full Histogram (every span, every delta, ZeroThreshold, NegativeDelta, SampleCount, SampleSum round-trip byte-equal).
- `TestProtoPathBodyCap_EnvoyUnderCap` / `_EnvoyOverCap` / `_SingleAppOverCap` — body cap enforcement on Envoy and single-target app paths, symmetric to the multi-target text path's pre-existing cap.
- `TestProtoPath_MixedMultiTarget` — per-body Content-Type honored in the multi-target proto path (Envoy proto + one proto app + one text app; all three counter families survive the downgrade).
- `TestScrapeMultipleAppsBodyCap_PerBodyFormats` — unit test on the new three-return signature shape.
- Plus: `TestNegotiateMetricsFormat_Protobuf`, `TestMergeFormat`, `TestScrapeAndWriteAgentMetrics_Protobuf`, `TestHandleStats_ProtobufEnvoyProtoApp`, `TestHandleStats_ProtobufEnvoyTextApp`, `TestHandleStats_ProtobufMalformedEnvoy`, `TestScrapeFormatLabel`, `TestHandleStats_NoAcceptHeader_DefaultsToText`.

Pre-commit: `gofmt`, `go vet`, `go test -race`, and `golangci-lint` all clean on `pilot/cmd/pilot-agent/...`. (4 pre-existing macOS-sandbox failures unrelated to this PR are not in the change set.)

## Out of scope (PR2 / PR3)

- **PR2**: pilot-agent's own self-metrics emit native histograms (currently pre-bucketed classic histograms).
- **PR3**: text→proto upconversion at the merger so a text-emitting app does not force a global downgrade to text.
- **TOC cost-comparison study** referenced in the #49950 thread: blocks PR3, not PR1.

Refs #49950
