### PR TITLE
warn when gateway api crd is below minimum required version

### DIFF
--- a/pkg/kube/kclient/crdwatcher.go
+++ b/pkg/kube/kclient/crdwatcher.go
@@ -199,7 +199,9 @@ func minimumVersionFilter(t any) bool {
 	}
 	fv = &nv
 	if fv.LessThan(mv) {
-		log.Infof("CRD %v version %v is below minimum version %v, ignoring", crd.Name, fv, mv)
+		log.Warnf("CRD %v version %v is below minimum version %v required by this Istio version; "+
+			"resources of this kind will not be processed. Upgrade the Gateway API CRDs to satisfy the minimum version.",
+			crd.Name, fv, mv)
 		return false
 	}
 	return true

--- a/releasenotes/notes/gateway-api-crd-version-warn.yaml
+++ b/releasenotes/notes/gateway-api-crd-version-warn.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+- |
+  **Improved** logging when a Gateway API CRD installed in the cluster is below the minimum version
+  required by this Istio version. The message is now logged at `warn` level and explains that
+  resources of that kind will not be processed until the CRDs are upgraded. Previously, this was
+  logged at `info` level and easy to miss, which made TLS passthrough breakage after upgrading to
+  1.30 with stale CRDs hard to diagnose.


### PR DESCRIPTION
1.30 silently ignores Gateway API CRDs below the minimum required version (e.g. TLSRoute v1.4 when 1.5 is required), only logging at info level. Users upgrading to 1.30 without bumping their Gateway API CRDs see TLS passthrough listeners silently break with attachedRoutes: 0 and no clear signal. Bumps the log to warn with an actionable message.