### PR TITLE
add istioctl analyzer for gateway api crds below minimum version

### DIFF
--- a/pkg/config/analysis/analyzers/all.go
+++ b/pkg/config/analysis/analyzers/all.go
@@ -62,6 +62,7 @@ func All() []analysis.Analyzer {
 		&injection.ImageAnalyzer{},
 		&injection.ImageAutoAnalyzer{},
 		&k8sgateway.SelectorAnalyzer{},
+		&k8sgateway.CRDVersionAnalyzer{},
 		&multicluster.MeshNetworksAnalyzer{},
 		&multicluster.ServiceAnalyzer{},
 		&service.PortNameAnalyzer{},

--- a/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/pkg/config/analysis/analyzers/analyzers_test.go
@@ -1001,6 +1001,14 @@ var testGrid = []testCase{
 		},
 	},
 	{
+		name:       "GatewayAPICRDVersionBelowMinimum",
+		inputFiles: []string{"testdata/gateway-api-crd-version-old.yaml"},
+		analyzer:   &k8sgateway.CRDVersionAnalyzer{},
+		expected: []message{
+			{msg.GatewayAPICRDVersionBelowMinimum, "CustomResourceDefinition tlsroutes.gateway.networking.k8s.io"},
+		},
+	},
+	{
 		name:       "ServiceEntry Addresses Required Lowercase Protocol",
 		inputFiles: []string{"testdata/serviceentry-address-required-lowercase.yaml"},
 		analyzer:   &serviceentry.ProtocolAddressesAnalyzer{},

--- a/pkg/config/analysis/analyzers/k8sgateway/crdversion.go
+++ b/pkg/config/analysis/analyzers/k8sgateway/crdversion.go
@@ -1,0 +1,78 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sgateway
+
+import (
+	"github.com/Masterminds/semver/v3"
+	"sigs.k8s.io/gateway-api/pkg/consts"
+
+	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/analysis"
+	"istio.io/istio/pkg/config/analysis/msg"
+	"istio.io/istio/pkg/config/resource"
+	"istio.io/istio/pkg/config/schema/gatewayapi"
+	"istio.io/istio/pkg/config/schema/gvk"
+)
+
+// CRDVersionAnalyzer flags Gateway API CRDs whose installed bundle version is
+// below the minimum required by this Istio binary. When CRDs are too old, the
+// CRD watcher silently filters them out so the matching resources are never
+// processed (e.g. TLSRoute v1.4 with Istio 1.30 causes TLS passthrough Gateways
+// to report attachedRoutes: 0 and never program a listener).
+type CRDVersionAnalyzer struct{}
+
+var _ analysis.Analyzer = &CRDVersionAnalyzer{}
+
+func (*CRDVersionAnalyzer) Metadata() analysis.Metadata {
+	return analysis.Metadata{
+		Name:        "k8sgateway.CRDVersionAnalyzer",
+		Description: "Checks Gateway API CRDs are at the minimum version required by this Istio version",
+		Inputs: []config.GroupVersionKind{
+			gvk.CustomResourceDefinition,
+		},
+	}
+}
+
+func (a *CRDVersionAnalyzer) Analyze(ctx analysis.Context) {
+	ctx.ForEach(gvk.CustomResourceDefinition, func(r *resource.Instance) bool {
+		a.analyzeCRD(r, ctx)
+		return true
+	})
+}
+
+func (*CRDVersionAnalyzer) analyzeCRD(r *resource.Instance, ctx analysis.Context) {
+	name := r.Metadata.FullName.Name.String()
+	minimum, ok := gatewayapi.MinimumCRDVersions[name]
+	if !ok {
+		return
+	}
+	bv, ok := r.Metadata.Annotations[consts.BundleVersionAnnotation]
+	if !ok {
+		// Watcher will surface this case with an error log of its own.
+		return
+	}
+	installed, err := semver.NewVersion(bv)
+	if err != nil {
+		return
+	}
+	stripped, err := installed.SetPrerelease("")
+	if err != nil {
+		return
+	}
+	if stripped.LessThan(minimum) {
+		ctx.Report(gvk.CustomResourceDefinition,
+			msg.NewGatewayAPICRDVersionBelowMinimum(r, name, installed.String(), minimum.String()))
+	}
+}

--- a/pkg/config/analysis/analyzers/testdata/gateway-api-crd-version-old.yaml
+++ b/pkg/config/analysis/analyzers/testdata/gateway-api-crd-version-old.yaml
@@ -1,0 +1,45 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: tlsroutes.gateway.networking.k8s.io
+  annotations:
+    gateway.networking.k8s.io/bundle-version: v1.4.1
+    gateway.networking.k8s.io/channel: experimental
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    kind: TLSRoute
+    listKind: TLSRouteList
+    plural: tlsroutes
+    singular: tlsroute
+  scope: Namespaced
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: grpcroutes.gateway.networking.k8s.io
+  annotations:
+    gateway.networking.k8s.io/bundle-version: v1.4.1
+    gateway.networking.k8s.io/channel: standard
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    kind: GRPCRoute
+    listKind: GRPCRouteList
+    plural: grpcroutes
+    singular: grpcroute
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object

--- a/pkg/config/analysis/msg/messages.gen.go
+++ b/pkg/config/analysis/msg/messages.gen.go
@@ -271,6 +271,10 @@ var (
 	// JwksUriFetchUnrestricted defines a diag.MessageType for message "JwksUriFetchUnrestricted".
 	// Description: RequestAuthentication resources exist but BLOCKED_CIDRS_IN_JWKS_URIS is not configured on istiod.
 	JwksUriFetchUnrestricted = diag.NewMessageType(diag.Warning, "IST0175", "BLOCKED_CIDRS_IN_JWKS_URIS is not configured but %d RequestAuthentication resource(s) exist (%s). Consider configuring it to restrict JWKS URI fetches to trusted networks.")
+
+	// GatewayAPICRDVersionBelowMinimum defines a diag.MessageType for message "GatewayAPICRDVersionBelowMinimum".
+	// Description: A Gateway API CRD is installed at a version below the minimum required by this Istio version. Resources of this kind will not be processed.
+	GatewayAPICRDVersionBelowMinimum = diag.NewMessageType(diag.Warning, "IST0176", "Gateway API CRD %q is at version %q but Istio requires at least %q; resources of this kind will not be processed. Upgrade the Gateway API CRDs to satisfy the minimum version.")
 )
 
 // All returns a list of all known message types.
@@ -342,6 +346,7 @@ func All() []*diag.MessageType {
 		DestinationRuleSubsetNotSelectPods,
 		UnknownDestinationRuleHost,
 		JwksUriFetchUnrestricted,
+		GatewayAPICRDVersionBelowMinimum,
 	}
 }
 
@@ -991,5 +996,16 @@ func NewJwksUriFetchUnrestricted(r *resource.Instance, count int, names string) 
 		r,
 		count,
 		names,
+	)
+}
+
+// NewGatewayAPICRDVersionBelowMinimum returns a new diag.Message based on GatewayAPICRDVersionBelowMinimum.
+func NewGatewayAPICRDVersionBelowMinimum(r *resource.Instance, crd string, installedVersion string, minimumVersion string) diag.Message {
+	return diag.NewMessage(
+		GatewayAPICRDVersionBelowMinimum,
+		r,
+		crd,
+		installedVersion,
+		minimumVersion,
 	)
 }

--- a/pkg/config/analysis/msg/messages.yaml
+++ b/pkg/config/analysis/msg/messages.yaml
@@ -711,3 +711,16 @@ messages:
       type: int
     - name: names
       type: string
+
+  - name: "GatewayAPICRDVersionBelowMinimum"
+    code: IST0176
+    level: Warning
+    description: "A Gateway API CRD is installed at a version below the minimum required by this Istio version. Resources of this kind will not be processed."
+    template: "Gateway API CRD %q is at version %q but Istio requires at least %q; resources of this kind will not be processed. Upgrade the Gateway API CRDs to satisfy the minimum version."
+    args:
+    - name: crd
+      type: string
+    - name: installedVersion
+      type: string
+    - name: minimumVersion
+      type: string

--- a/pkg/config/schema/gatewayapi/minimumversions.go
+++ b/pkg/config/schema/gatewayapi/minimumversions.go
@@ -1,0 +1,32 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package gatewayapi exposes Gateway API CRD version requirements shared by the
+// CRD watcher (which filters CRDs below the minimum) and the istioctl analyzer
+// (which surfaces a clear finding when the cluster's CRDs are too old).
+package gatewayapi
+
+import (
+	"github.com/Masterminds/semver/v3"
+)
+
+// MinimumCRDVersions is the minimum Gateway API bundle version (the value of the
+// `gateway.networking.k8s.io/bundle-version` annotation on the CRD) required by
+// this Istio binary, keyed by CRD name. CRDs below the listed version are not
+// processed by istiod and will not be watched.
+var MinimumCRDVersions = map[string]*semver.Version{
+	"grpcroutes.gateway.networking.k8s.io":         semver.New(1, 1, 0, "", ""),
+	"backendtlspolicies.gateway.networking.k8s.io": semver.New(1, 4, 0, "", ""),
+	"tlsroutes.gateway.networking.k8s.io":          semver.New(1, 5, 0, "", ""),
+}

--- a/pkg/kube/kclient/crdwatcher.go
+++ b/pkg/kube/kclient/crdwatcher.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/gateway-api/pkg/consts"
 
 	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pkg/config/schema/gatewayapi"
 	"istio.io/istio/pkg/config/schema/gvr"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
@@ -71,12 +72,6 @@ func newCrdWatcher(client kube.Client) kubetypes.CrdWatcher {
 	})
 	c.crds.AddEventHandler(controllers.ObjectHandler(c.queue.AddObject))
 	return c
-}
-
-var minimumCRDVersions = map[string]*semver.Version{
-	"grpcroutes.gateway.networking.k8s.io":         semver.New(1, 1, 0, "", ""),
-	"backendtlspolicies.gateway.networking.k8s.io": semver.New(1, 4, 0, "", ""),
-	"tlsroutes.gateway.networking.k8s.io":          semver.New(1, 5, 0, "", ""),
 }
 
 // resourceFilterConfig contains a filter definition parsed from the flags. In case
@@ -177,7 +172,7 @@ func resourceMatchFilters(name string, filters []resourceFilterConfig) bool {
 func minimumVersionFilter(t any) bool {
 	// Setup a filter
 	crd := t.(*metav1.PartialObjectMetadata)
-	mv, f := minimumCRDVersions[crd.Name]
+	mv, f := gatewayapi.MinimumCRDVersions[crd.Name]
 	if !f {
 		return true
 	}

--- a/releasenotes/notes/gateway-api-crd-version-analyzer.yaml
+++ b/releasenotes/notes/gateway-api-crd-version-analyzer.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+releaseNotes:
+- |
+  **Added** `istioctl analyze` check `IST0176` that flags Gateway API CRDs installed at a
+  version below the minimum required by the current Istio version. Resources backed by such
+  CRDs are silently filtered by istiod, which previously made TLS passthrough breakage after
+  upgrading to Istio 1.30 with stale Gateway API CRDs hard to discover.


### PR DESCRIPTION
Adds IST0176 to istioctl analyze that warns when a Gateway API CRD's bundle-version is below the minimum required by this Istio version. Same data source as the crdwatcher silent filter; extracts the minimum-version map to a shared package so both stay in sync.