### PR TITLE
feat: allow to disable agent merge envoy stats

### DIFF
--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -50,6 +50,7 @@ import (
 	"istio.io/istio/pilot/cmd/pilot-agent/metrics"
 	"istio.io/istio/pilot/cmd/pilot-agent/status/grpcready"
 	"istio.io/istio/pilot/cmd/pilot-agent/status/ready"
+	"istio.io/istio/pilot/pkg/features"
 	dnsProto "istio.io/istio/pkg/dns/proto"
 	"istio.io/istio/pkg/env"
 	commonFeatures "istio.io/istio/pkg/features"
@@ -652,7 +653,7 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	// Gather all the metrics we will merge
-	if !s.config.NoEnvoy {
+	if !s.config.NoEnvoy && features.AgentMergeEnvoyStats {
 		scrapeURL := fmt.Sprintf("http://localhost:%d/stats/prometheus", s.envoyStatsPort)
 		if r.URL != nil && len(r.URL.RawQuery) > 0 {
 			scrapeURL = fmt.Sprintf("%s?%s", scrapeURL, r.URL.RawQuery)

--- a/pilot/pkg/features/telemetry.go
+++ b/pilot/pkg/features/telemetry.go
@@ -72,4 +72,7 @@ var (
 
 	SpawnUpstreamSpanForGateway = env.Register("PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY", true,
 		"If true, separate tracing span for each upstream request for gateway. This is only available when using Telemetry API.").Get()
+
+	AgentMergeEnvoyStats = env.Register("AGENT_MERGE_ENVOY_STATS", true,
+		"If false, pilot agent will not merge Envoy stats in the agent stats endpoint.").Get()
 )

--- a/releasenotes/notes/agent-merge-envoy-stats-flag.yaml
+++ b/releasenotes/notes/agent-merge-envoy-stats-flag.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+releaseNotes:
+- |
+    **Added** a new environment variable `PILOT_AGENT_MERGE_ENVOY_STATS` to control whether pilot-agent merges Envoy stats
+    into its stats endpoint. Set to `false` to disable merging Envoy stats with agent stats.


### PR DESCRIPTION
**Please provide a description of this PR:**

This patch add  a new environment variable `PILOT_AGENT_MERGE_ENVOY_STATS` to control whether pilot-agent merges Envoy stats into its stats endpoint. This will help users to scrape agent alone.

This also help on https://github.com/istio/istio/issues/60322