### PR TITLE
gatewayapi: support HTTPRouteRetryConnectionError

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -186,7 +186,7 @@ func convertHTTPRoute(ctx RouteContext, r k8s.HTTPRouteRule,
 	if r.Retry != nil {
 		// "Implementations SHOULD retry on connection errors (disconnect, reset, timeout,
 		// TCP failure) if a retry stanza is configured."
-		retryOn := []string{"connect-failure", "refused-stream", "unavailable", "cancelled"}
+		retryOn := []string{"connect-failure", "refused-stream", "unavailable", "cancelled", "reset"}
 		for _, codes := range r.Retry.Codes {
 			retryOn = append(retryOn, strconv.Itoa(int(codes)))
 		}

--- a/pilot/pkg/config/kube/gateway/testdata/http.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/http.yaml.golden
@@ -363,7 +363,7 @@ spec:
     retries:
       attempts: 3
       backoff: 0.003s
-      retryOn: connect-failure,refused-stream,unavailable,cancelled,503,429
+      retryOn: connect-failure,refused-stream,unavailable,cancelled,reset,503,429
     route:
     - destination:
         host: httpbin.default.svc.domain.suffix
@@ -385,7 +385,7 @@ spec:
     name: default.http-retry-request.1
     retries:
       attempts: 2
-      retryOn: connect-failure,refused-stream,unavailable,cancelled
+      retryOn: connect-failure,refused-stream,unavailable,cancelled,reset
     route:
     - destination:
         host: httpbin.default.svc.domain.suffix

--- a/releasenotes/notes/60375.yaml
+++ b/releasenotes/notes/60375.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 60375
+releaseNotes:
+  - |
+    - **Fixed** On Gateway API, support HTTPRoute retries when the
+    backend issues a connection reset


### PR DESCRIPTION
**Please provide a description of this PR:**

Add support for HTTPRouteRetryConnectionError, retrying connections when the backend issues a connection reset

Fixes: #60375

