### PR TITLE
networking: support prefix_rewrite in HTTPRedirect

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -1404,7 +1404,7 @@ func createRedirectFilter(filter *k8s.HTTPRequestRedirectFilter) *istio.HTTPRedi
 		case k8s.FullPathHTTPPathModifier:
 			resp.Uri = *filter.Path.ReplaceFullPath
 		case k8s.PrefixMatchHTTPPathModifier:
-			resp.Uri = "%PREFIX()%" + *filter.Path.ReplacePrefixMatch
+			resp.PrefixRewrite = *filter.Path.ReplacePrefixMatch
 		}
 	}
 	return resp

--- a/pilot/pkg/config/kube/gateway/testdata/http.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/http.yaml.golden
@@ -338,9 +338,9 @@ spec:
     name: default.redirect-prefix-replace.0
     redirect:
       port: 8080
+      prefixRewrite: /replacement
       redirectCode: 302
       scheme: https
-      uri: '%PREFIX()%/replacement'
 ---
 apiVersion: networking.istio.io/v1
 kind: VirtualService

--- a/pilot/pkg/networking/core/route/route.go
+++ b/pilot/pkg/networking/core/route/route.go
@@ -546,7 +546,7 @@ func TranslateRoute(
 		})
 	}
 	if in.Redirect != nil {
-		ApplyRedirect(out, in.Redirect, listenPort, opts.IsTLS, model.UseGatewaySemantics(virtualService))
+		ApplyRedirect(out, in.Redirect, listenPort, opts.IsTLS)
 	} else if in.DirectResponse != nil {
 		ApplyDirectResponse(out, in.DirectResponse)
 	} else {
@@ -776,21 +776,20 @@ func processWeightedDestination(
 	return clusterWeight, hostname
 }
 
-func ApplyRedirect(out *route.Route, redirect *networking.HTTPRedirect, port int, isTLS bool, useGatewaySemantics bool) {
+func ApplyRedirect(out *route.Route, redirect *networking.HTTPRedirect, port int, isTLS bool) {
 	action := &route.Route_Redirect{
 		Redirect: &route.RedirectAction{
 			HostRedirect: redirect.Authority,
-			PathRewriteSpecifier: &route.RedirectAction_PathRedirect{
-				PathRedirect: redirect.Uri,
-			},
 		},
 	}
 
-	if useGatewaySemantics {
-		if uri, isPrefixReplace := cutPrefix(redirect.Uri, "%PREFIX()%"); isPrefixReplace {
-			action.Redirect.PathRewriteSpecifier = &route.RedirectAction_PrefixRewrite{
-				PrefixRewrite: uri,
-			}
+	if redirect.PrefixRewrite != "" {
+		action.Redirect.PathRewriteSpecifier = &route.RedirectAction_PrefixRewrite{
+			PrefixRewrite: redirect.PrefixRewrite,
+		}
+	} else {
+		action.Redirect.PathRewriteSpecifier = &route.RedirectAction_PathRedirect{
+			PathRedirect: redirect.Uri,
 		}
 	}
 
@@ -1646,13 +1645,6 @@ func IsCatchAllRoute(r *route.Route) bool {
 	}
 
 	return catchall && len(r.Match.Headers) == 0 && len(r.Match.QueryParameters) == 0 && len(r.Match.DynamicMetadata) == 0
-}
-
-func cutPrefix(s, prefix string) (after string, found bool) {
-	if !strings.HasPrefix(s, prefix) {
-		return s, false
-	}
-	return s[len(prefix):], true
 }
 
 // CheckAndGetInferencePoolConfigs extracts inference pool configurations from a VirtualService's Extra field.

--- a/pilot/pkg/networking/core/route/route_test.go
+++ b/pilot/pkg/networking/core/route/route_test.go
@@ -1230,22 +1230,6 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(ok).To(BeFalse())
 	})
 
-	t.Run("for path prefix redirect", func(t *testing.T) {
-		g := NewWithT(t)
-		cg := core.NewConfigGenTest(t, core.TestOptions{})
-
-		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithRedirectPathPrefix, 8080, gatewayNames, routeOpts)
-		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(len(routes)).To(Equal(1))
-
-		redirectAction, ok := routes[0].Action.(*envoyroute.Route_Redirect)
-		g.Expect(ok).NotTo(BeFalse())
-		g.Expect(redirectAction.Redirect.PathRewriteSpecifier).To(Equal(&envoyroute.RedirectAction_PrefixRewrite{
-			PrefixRewrite: "/replace-prefix",
-		}))
-	})
-
 	t.Run("for host rewrite", func(t *testing.T) {
 		g := NewWithT(t)
 		cg := core.NewConfigGenTest(t, core.TestOptions{})
@@ -1401,24 +1385,6 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(routeAction.Route.AppendXForwardedHost).To(Equal(true))
 	})
 
-	t.Run("for redirect uri prefix '%PREFIX()%' that is without gateway semantics", func(t *testing.T) {
-		g := NewWithT(t)
-		cg := core.NewConfigGenTest(t, core.TestOptions{})
-
-		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg),
-			virtualServiceWithRedirectPathPrefixNoGatewaySematics,
-			8080, gatewayNames, routeOpts)
-		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(len(routes)).To(Equal(1))
-
-		redirectAction, ok := routes[0].Action.(*envoyroute.Route_Redirect)
-		g.Expect(ok).NotTo(BeFalse())
-		g.Expect(redirectAction.Redirect.PathRewriteSpecifier).To(Equal(&envoyroute.RedirectAction_PathRedirect{
-			PathRedirect: "%PREFIX()%/replace-full",
-		}))
-	})
-
 	t.Run("for full path redirect", func(t *testing.T) {
 		g := NewWithT(t)
 		cg := core.NewConfigGenTest(t, core.TestOptions{})
@@ -1432,6 +1398,23 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(ok).NotTo(BeFalse())
 		g.Expect(redirectAction.Redirect.PathRewriteSpecifier).To(Equal(&envoyroute.RedirectAction_PathRedirect{
 			PathRedirect: "/replace-full-path",
+		}))
+	})
+
+	t.Run("for prefix_rewrite redirect", func(t *testing.T) {
+		g := NewWithT(t)
+		cg := core.NewConfigGenTest(t, core.TestOptions{})
+
+		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithRedirectPrefixRewrite, 8080, gatewayNames, routeOpts)
+		xdstest.ValidateRoutes(t, routes)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
+
+		redirectAction, ok := routes[0].Action.(*envoyroute.Route_Redirect)
+		g.Expect(ok).NotTo(BeFalse())
+		g.Expect(redirectAction.Redirect.HostRedirect).To(Equal("foo.example.com"))
+		g.Expect(redirectAction.Redirect.PathRewriteSpecifier).To(Equal(&envoyroute.RedirectAction_PrefixRewrite{
+			PrefixRewrite: "/",
 		}))
 	})
 
@@ -2261,49 +2244,6 @@ var virtualServiceWithInvalidRedirect = config.Config{
 	},
 }
 
-var virtualServiceWithRedirectPathPrefix = config.Config{
-	Meta: config.Meta{
-		GroupVersionKind: gvk.VirtualService,
-		Name:             "acme",
-		Annotations: map[string]string{
-			"internal.istio.io/route-semantics": "gateway",
-		},
-	},
-	Spec: &networking.VirtualService{
-		Hosts:    []string{},
-		Gateways: []string{"some-gateway"},
-		Http: []*networking.HTTPRoute{
-			{
-				Redirect: &networking.HTTPRedirect{
-					Uri:          "%PREFIX()%/replace-prefix",
-					Authority:    "some-authority.default.svc.cluster.local",
-					RedirectCode: 308,
-				},
-			},
-		},
-	},
-}
-
-var virtualServiceWithRedirectPathPrefixNoGatewaySematics = config.Config{
-	Meta: config.Meta{
-		GroupVersionKind: gvk.VirtualService,
-		Name:             "acme",
-	},
-	Spec: &networking.VirtualService{
-		Hosts:    []string{},
-		Gateways: []string{"some-gateway"},
-		Http: []*networking.HTTPRoute{
-			{
-				Redirect: &networking.HTTPRedirect{
-					Uri:          "%PREFIX()%/replace-full",
-					Authority:    "some-authority.default.svc.cluster.local",
-					RedirectCode: 308,
-				},
-			},
-		},
-	},
-}
-
 var virtualServiceWithRedirectFullPath = config.Config{
 	Meta: config.Meta{
 		GroupVersionKind: gvk.VirtualService,
@@ -2318,6 +2258,26 @@ var virtualServiceWithRedirectFullPath = config.Config{
 					Uri:          "/replace-full-path",
 					Authority:    "some-authority.default.svc.cluster.local",
 					RedirectCode: 308,
+				},
+			},
+		},
+	},
+}
+
+var virtualServiceWithRedirectPrefixRewrite = config.Config{
+	Meta: config.Meta{
+		GroupVersionKind: gvk.VirtualService,
+		Name:             "acme",
+	},
+	Spec: &networking.VirtualService{
+		Hosts:    []string{},
+		Gateways: []string{"some-gateway"},
+		Http: []*networking.HTTPRoute{
+			{
+				Redirect: &networking.HTTPRedirect{
+					Authority:     "foo.example.com",
+					PrefixRewrite: "/",
+					RedirectCode:  301,
 				},
 			},
 		},

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -2649,11 +2649,24 @@ func validateHTTPRetry(retries *networking.HTTPRetry) (errs error) {
 	return errs
 }
 
-func validateHTTPRedirect(redirect *networking.HTTPRedirect) error {
+func validateHTTPRedirect(redirect *networking.HTTPRedirect, matches []*networking.HTTPMatchRequest) error {
 	if redirect == nil {
 		return nil
 	}
-	if redirect.Uri == "" && redirect.Authority == "" && redirect.RedirectPort == nil && redirect.Scheme == "" {
+
+	if redirect.Uri != "" && redirect.PrefixRewrite != "" {
+		return errors.New("redirect may only specify one of uri or prefix_rewrite")
+	}
+
+	if redirect.PrefixRewrite != "" {
+		for _, match := range matches {
+			if _, isPrefix := match.GetUri().GetMatchType().(*networking.StringMatch_Prefix); match.Uri != nil && !isPrefix {
+				return errors.New("redirect prefix_rewrite requires all URI matches to use prefix match type")
+			}
+		}
+	}
+
+	if redirect.Uri == "" && redirect.PrefixRewrite == "" && redirect.Authority == "" && redirect.RedirectPort == nil && redirect.Scheme == "" {
 		return errors.New("redirect must specify URI, authority, scheme, or port")
 	}
 

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -1677,11 +1677,34 @@ func TestValidateHTTPRedirect(t *testing.T) {
 			},
 			valid: true,
 		},
+		{
+			name: "prefix_rewrite alone",
+			redirect: &networking.HTTPRedirect{
+				PrefixRewrite: "/bar",
+			},
+			valid: true,
+		},
+		{
+			name: "prefix_rewrite with authority",
+			redirect: &networking.HTTPRedirect{
+				Authority:     "foo.example.com",
+				PrefixRewrite: "/",
+			},
+			valid: true,
+		},
+		{
+			name: "uri and prefix_rewrite mutually exclusive",
+			redirect: &networking.HTTPRedirect{
+				Uri:           "/old",
+				PrefixRewrite: "/new",
+			},
+			valid: false,
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := validateHTTPRedirect(tc.redirect); (err == nil) != tc.valid {
+			if err := validateHTTPRedirect(tc.redirect, nil); (err == nil) != tc.valid {
 				t.Fatalf("got valid=%v but wanted valid=%v: %v", err == nil, tc.valid, err)
 			}
 		})
@@ -1895,6 +1918,40 @@ func TestValidateHTTPRoute(t *testing.T) {
 			Redirect: &networking.HTTPRedirect{
 				Uri:       "/lerp",
 				Authority: "foo.biz",
+			},
+		}, valid: true},
+		{name: "prefix_rewrite redirect with prefix URI match", route: &networking.HTTPRoute{
+			Match: []*networking.HTTPMatchRequest{{
+				Uri: &networking.StringMatch{MatchType: &networking.StringMatch_Prefix{Prefix: "/foo"}},
+			}},
+			Redirect: &networking.HTTPRedirect{
+				PrefixRewrite: "/bar",
+			},
+		}, valid: true},
+		{name: "prefix_rewrite redirect with exact URI match is invalid", route: &networking.HTTPRoute{
+			Match: []*networking.HTTPMatchRequest{{
+				Uri: &networking.StringMatch{MatchType: &networking.StringMatch_Exact{Exact: "/foo"}},
+			}},
+			Redirect: &networking.HTTPRedirect{
+				PrefixRewrite: "/bar",
+			},
+		}, valid: false},
+		{name: "prefix_rewrite redirect with regex URI match is invalid", route: &networking.HTTPRoute{
+			Match: []*networking.HTTPMatchRequest{{
+				Uri: &networking.StringMatch{MatchType: &networking.StringMatch_Regex{Regex: "/foo.*"}},
+			}},
+			Redirect: &networking.HTTPRedirect{
+				PrefixRewrite: "/bar",
+			},
+		}, valid: false},
+		{name: "prefix_rewrite redirect with no URI match (wildcard) is valid", route: &networking.HTTPRoute{
+			Match: []*networking.HTTPMatchRequest{{
+				Headers: map[string]*networking.StringMatch{
+					"x-foo": {MatchType: &networking.StringMatch_Exact{Exact: "bar"}},
+				},
+			}},
+			Redirect: &networking.HTTPRedirect{
+				PrefixRewrite: "/bar",
 			},
 		}, valid: true},
 		{name: "conflicting redirect and route", route: &networking.HTTPRoute{

--- a/pkg/config/validation/virtualservice.go
+++ b/pkg/config/validation/virtualservice.go
@@ -98,7 +98,7 @@ func validateHTTPRoute(http *networking.HTTPRoute, delegate, gatewaySemantics bo
 
 	errs = AppendValidation(errs, validateDestination(http.Mirror))
 	errs = AppendValidation(errs, validateHTTPMirrors(http.Mirrors))
-	errs = AppendValidation(errs, validateHTTPRedirect(http.Redirect))
+	errs = AppendValidation(errs, validateHTTPRedirect(http.Redirect, http.Match))
 	errs = AppendValidation(errs, validateHTTPDirectResponse(http.DirectResponse))
 	errs = AppendValidation(errs, validateHTTPRetry(http.Retries))
 	errs = AppendValidation(errs, validateHTTPRewrite(http.Rewrite))

--- a/releasenotes/notes/60385.yaml
+++ b/releasenotes/notes/60385.yaml
@@ -1,0 +1,14 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+issue:
+  - https://github.com/istio/istio/issues/47500
+  - https://github.com/istio/istio/issues/47777
+  - https://github.com/istio/istio/issues/52521
+
+releaseNotes:
+- |
+  **Added** `prefix_rewrite` field to `HTTPRedirect`, enabling prefix-aware path rewriting
+  in redirect rules. This allows stripping or replacing the matched path prefix while
+  redirecting, e.g. redirecting `example.com/foo/bar` to `foo.example.com/bar`.

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -624,6 +624,43 @@ spec:
 			},
 		},
 	})
+	t.RunTraffic(TrafficTestCase{
+		name: "redirect prefix_rewrite",
+		config: `
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: default
+spec:
+  hosts:
+    - {{ .dstSvc }}
+  http:
+  - match:
+    - uri:
+        prefix: /foo/
+    redirect:
+      prefixRewrite: /new/
+  - match:
+    - uri:
+        prefix: /new/
+    route:
+    - destination:
+        host: {{ .dstSvc }}`,
+		opts: echo.CallOptions{
+			Port: echo.Port{
+				Name: "http",
+			},
+			HTTP: echo.HTTP{
+				Path:            "/foo/bar",
+				FollowRedirects: true,
+			},
+			Count: 1,
+			Check: check.And(
+				check.OK(),
+				check.URL("/new/bar")),
+		},
+		workloadAgnostic: true,
+	})
 	// Contain ever special char allowed in a header
 	absurdHeader := "a!#$%&'*+-.^_`|~z"
 	t.RunTraffic(TrafficTestCase{


### PR DESCRIPTION
**Please provide a description of this PR:**

Adds `prefix_rewrite` field to `HTTPRedirect`, allowing prefix-aware path rewriting in redirect rules. This enables use cases like stripping a path prefix while changing the host, e.g. `example.com/foo/bar` → `foo.example.com/bar`.

Validation enforces mutual exclusion of `uri` and `prefix_rewrite`, and requires that all URI matches use prefix match type when `prefix_rewrite` is set.

Depends on: https://github.com/istio/api/pull/3708

Fixes: https://github.com/istio/istio/issues/47500
Fixes: https://github.com/istio/istio/issues/47777
Fixes: https://github.com/istio/istio/issues/52521

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.