### PR TITLE
Clarify `--tls-cipher-suites` flag with TLS 1.3

### DIFF
--- a/pilot/cmd/pilot-discovery/app/cmd.go
+++ b/pilot/cmd/pilot-discovery/app/cmd.go
@@ -178,7 +178,8 @@ func addFlags(c *cobra.Command) {
 		"File containing the x509 private key matching --tlsCertFile")
 	c.PersistentFlags().StringSliceVar(&serverArgs.ServerOptions.TLSOptions.TLSCipherSuites, "tls-cipher-suites", nil,
 		"Comma-separated list of cipher suites for istiod TLS server. "+
-			"If omitted, the default Go cipher suites will be used. \n"+
+			"If omitted, the default Go cipher suites will be used. "+
+			"If 'tls-min-version' is set to '1.3', these cipher suites will be ignored.\n"+
 			"Preferred values: "+strings.Join(secureTLSCipherNames(), ", ")+". \n"+
 			"Insecure values: "+strings.Join(insecureTLSCipherNames(), ", ")+".")
 	c.PersistentFlags().StringVar(&serverArgs.ServerOptions.TLSOptions.TLSMinVersion, "tls-min-version", bootstrap.TLSMinVersion1_2,


### PR DESCRIPTION
**Please provide a description of this PR:**
Updates the text on the istiod `--tls-cipher-suites` flag to explain that cipher suites are ignored when `--tls-min-version=1.3`. The cipher suites are ignored because they are not configurable in golang with TLS 1.3.

This should have been part of https://github.com/istio/istio/issues/58789 but was missed with the original PR.