### PR TITLE
Fix stat_prefix collision on inbound filter chains under permissive mTLS

### DIFF
--- a/pilot/pkg/networking/core/listener_inbound.go
+++ b/pilot/pkg/networking/core/listener_inbound.go
@@ -84,6 +84,11 @@ type inboundChainConfig struct {
 	// hbone determines if this is coming from an HBONE request originally
 	hbone bool
 
+	// transportProtocol is the transport protocol of the filter chain match option
+	// that produced this chain (e.g. "tls" or "raw_buffer"). Used to disambiguate
+	// stat_prefix when multiple filter chains share the same base prefix.
+	transportProtocol string
+
 	// telemetryMetadata defines additional information about the chain for telemetry purposes.
 	telemetryMetadata telemetry.FilterChainMetadata
 
@@ -102,6 +107,9 @@ func (cc inboundChainConfig) StatPrefix() string {
 		statPrefix = cc.clusterName
 	} else {
 		statPrefix = "inbound_" + cc.Name(istionetworking.ListenerProtocolHTTP)
+	}
+	if cc.transportProtocol == xdsfilters.RawBufferTransportProtocol {
+		statPrefix += "_plaintext"
 	}
 
 	statPrefix = util.DelimitedStatsPrefix(statPrefix)
@@ -327,23 +335,25 @@ func (lb *ListenerBuilder) buildInboundListener(name string, addresses []string,
 func (lb *ListenerBuilder) inboundChainForOpts(cc inboundChainConfig, mtls authn.MTLSSettings, opts []FilterChainMatchOptions) []*listener.FilterChain {
 	chains := make([]*listener.FilterChain, 0, len(opts))
 	for _, opt := range opts {
+		chainCC := cc
+		chainCC.transportProtocol = opt.TransportProtocol
 		var filterChain *listener.FilterChain
 		switch opt.Protocol {
 		// Switch on the protocol. Note: we do not need to handle Auto protocol as it will already be split into a TCP and HTTP option.
 		case istionetworking.ListenerProtocolHTTP:
 			filterChain = &listener.FilterChain{
-				FilterChainMatch: cc.ToFilterChainMatch(opt),
-				Filters:          lb.buildInboundNetworkFiltersForHTTP(cc),
+				FilterChainMatch: chainCC.ToFilterChainMatch(opt),
+				Filters:          lb.buildInboundNetworkFiltersForHTTP(chainCC),
 				TransportSocket:  buildDownstreamTLSTransportSocket(opt.ToTransportSocket(mtls)),
-				Name:             cc.Name(opt.Protocol),
+				Name:             chainCC.Name(opt.Protocol),
 			}
 
 		case istionetworking.ListenerProtocolTCP:
 			filterChain = &listener.FilterChain{
-				FilterChainMatch: cc.ToFilterChainMatch(opt),
-				Filters:          lb.buildInboundNetworkFilters(cc),
+				FilterChainMatch: chainCC.ToFilterChainMatch(opt),
+				Filters:          lb.buildInboundNetworkFilters(chainCC),
 				TransportSocket:  buildDownstreamTLSTransportSocket(opt.ToTransportSocket(mtls)),
-				Name:             cc.Name(opt.Protocol),
+				Name:             chainCC.Name(opt.Protocol),
 			}
 
 		}
@@ -894,6 +904,9 @@ func (lb *ListenerBuilder) buildInboundNetworkFilters(fcc inboundChainConfig) []
 	// If stat name is configured, build the stat prefix from configured pattern.
 	if len(lb.push.Mesh.InboundClusterStatName) != 0 {
 		statPrefix = telemetry.BuildInboundStatPrefix(lb.push.Mesh.InboundClusterStatName, fcc.telemetryMetadata, "", uint32(fcc.port.Port), fcc.port.Name)
+	}
+	if fcc.transportProtocol == xdsfilters.RawBufferTransportProtocol {
+		statPrefix += "_plaintext"
 	}
 	tcpProxy := &tcp.TcpProxy{
 		StatPrefix:       statPrefix,

--- a/pilot/pkg/networking/core/listener_inbound_test.go
+++ b/pilot/pkg/networking/core/listener_inbound_test.go
@@ -1,0 +1,91 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"testing"
+
+	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	tcp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/test/xdstest"
+	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/wellknown"
+)
+
+// TestInboundStatPrefixUniqueness verifies that no stat_prefix is shared across
+// filter chains with different transport protocols on the virtualInbound listener.
+// Under permissive mTLS, Istiod generates both TLS and plaintext filter chains that
+// previously shared the same stat_prefix, causing gauge collisions in Envoy's stats.
+func TestInboundStatPrefixUniqueness(t *testing.T) {
+	services := []*model.Service{
+		buildService("test.com", wildcardIPv4, protocol.HTTP, tnow),
+		buildService("tcp.example.com", wildcardIPv4, protocol.TCP, tnow),
+	}
+
+	listeners := buildListeners(t, TestOptions{
+		Services: services,
+	}, nil)
+
+	l := xdstest.ExtractListener(model.VirtualInboundListenerName, listeners)
+	if l == nil {
+		t.Fatal("virtualInbound listener not found")
+	}
+
+	// Map each stat_prefix to the set of transport protocols that use it.
+	seen := make(map[string]map[string]bool) // stat_prefix -> transport -> true
+	for _, fc := range l.GetFilterChains() {
+		transport := fc.GetFilterChainMatch().GetTransportProtocol()
+		if transport == "" {
+			transport = "unset"
+		}
+
+		var statPrefix string
+		for _, f := range fc.GetFilters() {
+			switch f.GetName() {
+			case wellknown.HTTPConnectionManager:
+				hcmConfig := &hcm.HttpConnectionManager{}
+				if err := f.GetTypedConfig().UnmarshalTo(hcmConfig); err == nil {
+					statPrefix = hcmConfig.GetStatPrefix()
+				}
+			case wellknown.TCPProxy:
+				tcpConfig := &tcp.TcpProxy{}
+				if err := f.GetTypedConfig().UnmarshalTo(tcpConfig); err == nil {
+					statPrefix = tcpConfig.GetStatPrefix()
+				}
+			}
+			if statPrefix != "" {
+				break
+			}
+		}
+
+		if statPrefix == "" {
+			continue
+		}
+
+		if seen[statPrefix] == nil {
+			seen[statPrefix] = make(map[string]bool)
+		}
+		seen[statPrefix][transport] = true
+	}
+
+	for prefix, transports := range seen {
+		if len(transports) > 1 {
+			t.Errorf("stat_prefix %q is shared across transport protocols %v; "+
+				"this causes gauge collisions in Envoy's stats internals", prefix, transports)
+		}
+	}
+}

--- a/pilot/pkg/networking/core/listener_test.go
+++ b/pilot/pkg/networking/core/listener_test.go
@@ -1171,6 +1171,7 @@ func TestInboundHTTPListenerConfig(t *testing.T) {
 						{
 							TotalMatch: true,
 							Port:       8080,
+							Type:       listenertest.MTLSHTTP,
 							HTTPFilters: []string{
 								xdsfilters.MxFilterName, xdsfilters.GrpcStats.Name, xdsfilters.Fault.Name,
 								xdsfilters.Cors.Name, wellknown.Router,

--- a/pilot/pkg/networking/core/networkfilter_test.go
+++ b/pilot/pkg/networking/core/networkfilter_test.go
@@ -66,17 +66,38 @@ func TestInboundNetworkFilterStatPrefix(t *testing.T) {
 	cases := []struct {
 		name               string
 		statPattern        string
+		transportProtocol  string
 		expectedStatPrefix string
 	}{
 		{
 			"no pattern",
+			"",
 			"",
 			"inbound|8888||",
 		},
 		{
 			"service only pattern",
 			"%SERVICE%",
+			"",
 			"v0.default.example.org",
+		},
+		{
+			"no pattern with raw_buffer transport",
+			"",
+			"raw_buffer",
+			"inbound|8888||_plaintext",
+		},
+		{
+			"service only pattern with raw_buffer transport",
+			"%SERVICE%",
+			"raw_buffer",
+			"v0.default.example.org_plaintext",
+		},
+		{
+			"no pattern with tls transport",
+			"",
+			"tls",
+			"inbound|8888||",
 		},
 	}
 
@@ -99,6 +120,7 @@ func TestInboundNetworkFilterStatPrefix(t *testing.T) {
 				port: model.ServiceInstancePort{
 					ServicePort: &model.Port{},
 				},
+				transportProtocol: tt.transportProtocol,
 			}
 
 			listenerFilters := NewListenerBuilder(cg.SetupProxy(nil), cg.PushContext()).buildInboundNetworkFilters(fcc)


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/60415

Previously 


clanker generated below

---


## Summary

Under permissive mTLS (the default), Istiod generates both TLS and `raw_buffer` filter chains for every inbound port on `virtualInbound`. These chain pairs share the same `stat_prefix`, causing Envoy to intern them to the same stats scope. Any filter that maintains per-chain state using gauges (e.g. the adaptive concurrency controller) sees its state overwritten by the other chain on every worker flush cycle.

This appends `_plaintext` to the `stat_prefix` of `raw_buffer` chains. TLS chains retain their original prefix for backward compatibility.

**Before:**
| Chain type | Transport | stat_prefix |
|---|---|---|
| Passthrough HTTP | TLS | `InboundPassthroughCluster;` |
| Passthrough HTTP | raw_buffer | `InboundPassthroughCluster;` |
| Per-service HTTP | TLS | `inbound_0.0.0.0_8080;` |
| Per-service HTTP | raw_buffer | `inbound_0.0.0.0_8080;` |

**After:**
| Chain type | Transport | stat_prefix |
|---|---|---|
| Passthrough HTTP | TLS | `InboundPassthroughCluster;` |
| Passthrough HTTP | raw_buffer | `InboundPassthroughCluster_plaintext;` |
| Per-service HTTP | TLS | `inbound_0.0.0.0_8080;` |
| Per-service HTTP | raw_buffer | `inbound_0.0.0.0_8080_plaintext;` |

## Why this matters

The collision only manifests for **gauges** that represent instantaneous state — monotonic counters (request counts, error rates) are unaffected because additive increments from either chain are semantically correct. The most visible symptom is adaptive concurrency's `concurrency_limit` gauge flapping between two values at the stats flush interval.

This is hard to notice because:
1. Counters are unaffected, so most dashboards look fine
2. The gauge flapping resembles legitimate load-driven adaptation
3. Strict mTLS masks it (only TLS chains exist), so "works in staging, flaps in prod" during migration
4. Envoy has no runtime check for stat_prefix collisions

## Changes

- `pilot/pkg/networking/core/listener_inbound.go`: Add `transportProtocol` field to `inboundChainConfig`, set from `opt.TransportProtocol` in `inboundChainForOpts`, append `_plaintext` in `StatPrefix()` and `buildInboundNetworkFilters()` for `raw_buffer` chains
- `pilot/pkg/networking/core/listener_inbound_test.go` (new): Structural test asserting no stat_prefix is shared across transport protocols
- `pilot/pkg/networking/core/networkfilter_test.go`: Expanded to 5 cases covering the `_plaintext` suffix
- `pilot/pkg/networking/core/listener_test.go`: Narrow existing test to mTLS chain (unchanged prefix)

The condition uses `== raw_buffer` rather than `!= tls` so that code paths constructing `inboundChainConfig` with an unset `transportProtocol` (empty string) retain their original prefix.