### PR TITLE
fix: mismatched environment variable name registration for merging stats

### DIFF
--- a/pilot/pkg/features/telemetry.go
+++ b/pilot/pkg/features/telemetry.go
@@ -73,6 +73,6 @@ var (
 	SpawnUpstreamSpanForGateway = env.Register("PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY", true,
 		"If true, separate tracing span for each upstream request for gateway. This is only available when using Telemetry API.").Get()
 
-	AgentMergeEnvoyStats = env.Register("AGENT_MERGE_ENVOY_STATS", true,
+	AgentMergeEnvoyStats = env.Register("PILOT_AGENT_MERGE_ENVOY_STATS", true,
 		"If false, pilot agent will not merge Envoy stats in the agent stats endpoint.").Get()
 )


### PR DESCRIPTION
**Please provide a description of this PR:**

PR #60365 registered environment variable name as  AGENT_MERGE_ENVOY_STATS  in code instead of documented  PILOT_AGENT_MERGE_ENVOY_STATS .


```
    **Added** a new environment variable `PILOT_AGENT_MERGE_ENVOY_STATS` to control whether pilot-agent merges Envoy stats
    into its stats endpoint. Set to `false` to disable merging Envoy stats with agent stats.
```