### PR TITLE
ambient: don't mutate shared preferSame{Zone,Node}LoadBalancer presets

### DIFF
--- a/pilot/pkg/serviceregistry/ambient/services.go
+++ b/pilot/pkg/serviceregistry/ambient/services.go
@@ -575,9 +575,9 @@ func constructServiceEntries(
 		trafficDistribution := model.GetTrafficDistribution(nil, svc.Annotations, nsAnnotations)
 		switch trafficDistribution {
 		case model.TrafficDistributionPreferSameZone:
-			lb = preferSameZoneLoadBalancer
+			lb = preferSameZoneLoadBalancer()
 		case model.TrafficDistributionPreferSameNode:
-			lb = preferSameNodeLoadBalancer
+			lb = preferSameNodeLoadBalancer()
 		}
 	}
 
@@ -658,9 +658,9 @@ func constructService(
 		trafficDistribution := model.GetTrafficDistribution(svc.Spec.TrafficDistribution, svc.Annotations, nsAnnotations)
 		switch trafficDistribution {
 		case model.TrafficDistributionPreferSameZone:
-			lb = preferSameZoneLoadBalancer
+			lb = preferSameZoneLoadBalancer()
 		case model.TrafficDistributionPreferSameNode:
-			lb = preferSameNodeLoadBalancer
+			lb = preferSameNodeLoadBalancer()
 		}
 	}
 
@@ -699,26 +699,39 @@ func constructService(
 	}
 }
 
-var preferSameZoneLoadBalancer = &workloadapi.LoadBalancing{
-	// Prefer endpoints in close zones, but allow spilling over to further endpoints where required.
-	RoutingPreference: []workloadapi.LoadBalancing_Scope{
-		workloadapi.LoadBalancing_NETWORK,
-		workloadapi.LoadBalancing_REGION,
-		workloadapi.LoadBalancing_ZONE,
-	},
-	Mode: workloadapi.LoadBalancing_FAILOVER,
+// preferSameZoneLoadBalancer returns a fresh LoadBalancing config for PreferSameZone
+// traffic distribution. It must return a new pointer on every call because callers
+// (notably constructService) may mutate the returned object in place (for example,
+// setting HealthPolicy when PublishNotReadyAddresses is true). Returning a shared
+// package-level pointer here previously caused those mutations to leak across
+// services, poisoning the preset for every other service in the cluster.
+func preferSameZoneLoadBalancer() *workloadapi.LoadBalancing {
+	return &workloadapi.LoadBalancing{
+		// Prefer endpoints in close zones, but allow spilling over to further endpoints where required.
+		RoutingPreference: []workloadapi.LoadBalancing_Scope{
+			workloadapi.LoadBalancing_NETWORK,
+			workloadapi.LoadBalancing_REGION,
+			workloadapi.LoadBalancing_ZONE,
+		},
+		Mode: workloadapi.LoadBalancing_FAILOVER,
+	}
 }
 
-var preferSameNodeLoadBalancer = &workloadapi.LoadBalancing{
-	// Prefer endpoints in close zones, but allow spilling over to further endpoints where required.
-	RoutingPreference: []workloadapi.LoadBalancing_Scope{
-		workloadapi.LoadBalancing_NETWORK,
-		workloadapi.LoadBalancing_REGION,
-		workloadapi.LoadBalancing_ZONE,
-		workloadapi.LoadBalancing_SUBZONE,
-		workloadapi.LoadBalancing_NODE,
-	},
-	Mode: workloadapi.LoadBalancing_FAILOVER,
+// preferSameNodeLoadBalancer returns a fresh LoadBalancing config for PreferSameNode
+// traffic distribution. See preferSameZoneLoadBalancer for why this must not be a
+// shared package-level pointer.
+func preferSameNodeLoadBalancer() *workloadapi.LoadBalancing {
+	return &workloadapi.LoadBalancing{
+		// Prefer endpoints in close zones, but allow spilling over to further endpoints where required.
+		RoutingPreference: []workloadapi.LoadBalancing_Scope{
+			workloadapi.LoadBalancing_NETWORK,
+			workloadapi.LoadBalancing_REGION,
+			workloadapi.LoadBalancing_ZONE,
+			workloadapi.LoadBalancing_SUBZONE,
+			workloadapi.LoadBalancing_NODE,
+		},
+		Mode: workloadapi.LoadBalancing_FAILOVER,
+	}
 }
 
 func getVIPs(svc *v1.Service) []string {

--- a/pilot/pkg/serviceregistry/ambient/services_test.go
+++ b/pilot/pkg/serviceregistry/ambient/services_test.go
@@ -1620,6 +1620,64 @@ func TestServiceServices(t *testing.T) {
 	}
 }
 
+// TestPreferSamePresetNotMutated is a regression test for a bug where the
+// preferSameZoneLoadBalancer / preferSameNodeLoadBalancer presets were stored
+// as package-level *workloadapi.LoadBalancing pointers. When a Service combined
+// PublishNotReadyAddresses=true with PreferSameZone/PreferSameNode traffic
+// distribution, the code path:
+//
+//	lb = preferSameZoneLoadBalancer
+//	if svc.Spec.PublishNotReadyAddresses { lb.HealthPolicy = ALLOW_ALL }
+//
+// mutated the shared global pointer in place, permanently leaking
+// HealthPolicy=ALLOW_ALL to every subsequent Service that used the same preset.
+// This caused ztunnel to route to not-ready endpoints cluster-wide.
+//
+// The fix turned the presets into functions that return a fresh value each call.
+func TestPreferSamePresetNotMutated(t *testing.T) {
+	a := newAmbientUnitTest(t)
+	mock := krttest.NewMock(t, []any{})
+	builder := a.serviceServiceBuilder(
+		krttest.GetMockCollection[Waypoint](mock),
+		krttest.GetMockCollection[*v1.Namespace](mock),
+		krttest.GetMockSingleton[MeshConfig](mock),
+		true,
+	)
+
+	mkSvc := func(name, ip, td string, pnra bool) *v1.Service {
+		return &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "ns",
+				Annotations: map[string]string{
+					"networking.istio.io/traffic-distribution": td,
+				},
+			},
+			Spec: v1.ServiceSpec{
+				ClusterIP:                ip,
+				PublishNotReadyAddresses: pnra,
+				Ports:                    []v1.ServicePort{{Port: 80, Name: "http"}},
+			},
+		}
+	}
+
+	ctx := krt.TestingDummyContext{}
+
+	// Process a "poisoner" Service (PreferSameZone + PNRA) before a plain Service
+	// using PreferSameZone. The plain Service must NOT inherit ALLOW_ALL.
+	_ = builder(ctx, mkSvc("poisoner-zone", "1.2.3.4", "PreferSameZone", true))
+	victimZone := builder(ctx, mkSvc("victim-zone", "1.2.3.5", "PreferSameZone", false))
+
+	// Same scenario for PreferSameNode.
+	_ = builder(ctx, mkSvc("poisoner-node", "1.2.3.6", "PreferSameNode", true))
+	victimNode := builder(ctx, mkSvc("victim-node", "1.2.3.7", "PreferSameNode", false))
+
+	assert.Equal(t,
+		victimZone.Service.LoadBalancing.HealthPolicy, workloadapi.LoadBalancing_ONLY_HEALTHY)
+	assert.Equal(t,
+		victimNode.Service.LoadBalancing.HealthPolicy, workloadapi.LoadBalancing_ONLY_HEALTHY)
+}
+
 func TestServiceConditions(t *testing.T) {
 	waypointAddr := &workloadapi.GatewayAddress{
 		Destination: &workloadapi.GatewayAddress_Hostname{

--- a/releasenotes/notes/60423.yaml
+++ b/releasenotes/notes/60423.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 60422
+releaseNotes:
+  - |
+    **Fixed** an ambient mode bug where a single Service combining `publishNotReadyAddresses: true` with a `PreferSameZone` or `PreferSameNode` traffic distribution caused ztunnel to receive `healthPolicy: AllowAll` for every other Service using the same traffic-distribution preset, leading to traffic being routed to not-ready endpoints cluster-wide.


### PR DESCRIPTION
Fixes #60422.

## Problem

`preferSameZoneLoadBalancer` and `preferSameNodeLoadBalancer` are package-level `*workloadapi.LoadBalancing` pointers shared across all calls to `constructService` / `constructServiceEntries`. When a Service has `PublishNotReadyAddresses: true` together with a matching `trafficDistribution`, the code aliases the preset pointer and then writes `lb.HealthPolicy = ALLOW_ALL` through it, permanently mutating the shared global. Every subsequent Service using the same preset then renders with `HealthPolicy: ALLOW_ALL`, causing ztunnel to route to not-ready endpoints cluster-wide.

## Fix

Convert the presets from package-level `*workloadapi.LoadBalancing` variables to functions that return a fresh `*workloadapi.LoadBalancing` on each call. Both callsites (`constructServiceEntries` and `constructService`) are updated to invoke the functions.

## Test

Added `TestPreferSamePresetNotMutated` which:

1. Builds a "poisoner" Service with `PublishNotReadyAddresses=true` AND `PreferSameZone` annotation.
2. Builds a plain Service with only the `PreferSameZone` annotation.
3. Processes the poisoner first, then the plain Service.
4. Asserts the plain Service has `HealthPolicy: ONLY_HEALTHY`.

Repeats the same scenario for `PreferSameNode`. Verified the test fails on the unmodified code and passes with this change.

## Release Notes

```yaml
releaseNotes:
- area: ambient
  type: bug-fix
  releaseNotes:
  - |
    **Fixed** an ambient mode bug where a single Service combining
    `publishNotReadyAddresses: true` with `PreferSameZone` / `PreferSameNode`
    traffic distribution would cause every other Service using the same
    traffic distribution preset to be published with `HealthPolicy: ALLOW_ALL`,
    allowing ztunnel to route traffic to not-ready endpoints cluster-wide.
```
