### PR TITLE
[release 1.27] telemetry: add bootstrap annotations for stats flush and eviction

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/docker/cli v28.1.1+incompatible
 	github.com/envoyproxy/go-control-plane/contrib v1.32.5-0.20250627145903-197b96a9c7f8
-	github.com/envoyproxy/go-control-plane/envoy v1.32.5-0.20250627145903-197b96a9c7f8
+	github.com/envoyproxy/go-control-plane/envoy v1.32.5-0.20250921184633-9a6a6e1d1741
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/fatih/color v1.18.0
 	github.com/felixge/fgprof v0.9.5

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/envoyproxy/go-control-plane v0.13.5-0.20250724022422-2c98449a79c3 h1:
 github.com/envoyproxy/go-control-plane v0.13.5-0.20250724022422-2c98449a79c3/go.mod h1:whHrEUXbTAzBJlzd3Gz4us5zEFP1gL6o3LbfA+a/xbg=
 github.com/envoyproxy/go-control-plane/contrib v1.32.5-0.20250627145903-197b96a9c7f8 h1:KXgXPtBofHkRHr+8dO058dGZnLHapW7m0yJEgSYdAFA=
 github.com/envoyproxy/go-control-plane/contrib v1.32.5-0.20250627145903-197b96a9c7f8/go.mod h1:Nx/YcyEeIcgjT13QwKHdcPmS060urxZ835MeO8cLOrg=
-github.com/envoyproxy/go-control-plane/envoy v1.32.5-0.20250627145903-197b96a9c7f8 h1:/F9jLyfDeNr4iZxyibtKlZxCDqCFEhoYiLdc9VOZT2E=
-github.com/envoyproxy/go-control-plane/envoy v1.32.5-0.20250627145903-197b96a9c7f8/go.mod h1:09qwbGVuSWWAyN5t/b3iyVfz5+z8QWGrzkoqm/8SbEs=
+github.com/envoyproxy/go-control-plane/envoy v1.32.5-0.20250921184633-9a6a6e1d1741 h1:cihocN3Y1vol5fNBh5Zxbk0s72PWbDL9WuKIVpCCkTI=
+github.com/envoyproxy/go-control-plane/envoy v1.32.5-0.20250921184633-9a6a6e1d1741/go.mod h1:2LcmvJoXsDSrsGZIxGM0Gah9ykiwTn/kgjyQdnNH8Jc=
 github.com/envoyproxy/go-control-plane/ratelimit v0.1.0 h1:/G9QYbddjL25KvtKTv3an9lx6VBE2cnb8wp1vEGNYGI=
 github.com/envoyproxy/go-control-plane/ratelimit v0.1.0/go.mod h1:Wk+tMFAFbCXaJPzVVHnPgRKdUdwW/KdbRt94AzgRee4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -313,7 +314,7 @@ func getStatsOptions(meta *model.BootstrapNodeMetadata) []option.Instance {
 		compression = statsCompression
 	}
 
-	return []option.Instance{
+	options := []option.Instance{
 		option.EnvoyStatsMatcherInclusionPrefix(parseOption(prefixAnno,
 			requiredEnvoyStatsMatcherInclusionPrefixes, proxyConfigPrefixes)),
 		option.EnvoyStatsMatcherInclusionSuffix(parseOption(suffixAnno,
@@ -323,6 +324,30 @@ func getStatsOptions(meta *model.BootstrapNodeMetadata) []option.Instance {
 		option.EnvoyHistogramBuckets(buckets),
 		option.EnvoyStatsCompression(compression),
 	}
+
+	statsFlushInterval := 5 * time.Second // Default value is 5s.
+	if v, exits := meta.Annotations[annotation.SidecarStatsFlushInterval.Name]; exits {
+		d, err := time.ParseDuration(v)
+		if err == nil {
+			statsFlushInterval = d
+			options = append(options, option.EnvoyStatsFlushInterval(statsFlushInterval))
+		} else {
+			log.Warnf("Failed to parse stats flush interval %v: %v", v, err)
+		}
+	}
+
+	if eviction, exits := meta.Annotations[annotation.SidecarStatsEvictionInterval.Name]; exits {
+		statsEvictionInterval, err := time.ParseDuration(eviction)
+		if err != nil {
+			log.Warnf("Failed to parse stats eviction interval %v: %v", eviction, err)
+		} else if statsEvictionInterval%statsFlushInterval != 0 {
+			log.Warnf("StatsEvictionInterval must be a multiple of the StatsFlushInterval")
+		} else {
+			options = append(options, option.EnvoyStatsEvictionInterval(statsEvictionInterval))
+		}
+	}
+
+	return options
 }
 
 func lightstepAccessTokenFile(config string) string {

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"istio.io/api/annotation"
@@ -343,7 +344,8 @@ func getStatsOptions(meta *model.BootstrapNodeMetadata) []option.Instance {
 		} else if statsEvictionInterval%statsFlushInterval != 0 {
 			log.Warnf("StatsEvictionInterval must be a multiple of the StatsFlushInterval")
 		} else {
-			options = append(options, option.EnvoyStatsEvictionInterval(statsEvictionInterval))
+			duration := &durationpb.Duration{Seconds: int64(statsEvictionInterval.Seconds())}
+			options = append(options, option.EnvoyStatsEvictionInterval(duration))
 		}
 	}
 

--- a/pkg/bootstrap/instance_test.go
+++ b/pkg/bootstrap/instance_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package bootstrap
 
 import (
@@ -222,6 +223,31 @@ func TestGolden(t *testing.T) {
 			base: "stats_compression_unknown",
 			annotations: map[string]string{
 				"sidecar.istio.io/statsCompression": "unknown",
+			},
+		},
+		{
+			base: "stats_flush_interval",
+			annotations: map[string]string{
+				"sidecar.istio.io/statsFlushInterval": "10s",
+			},
+		},
+		{
+			base: "stats_eviction_interval",
+			annotations: map[string]string{
+				"sidecar.istio.io/statsEvictionInterval": "10s",
+			},
+		},
+		{
+			base: "invalid_stats_eviction_interval",
+			annotations: map[string]string{
+				"sidecar.istio.io/statsEvictionInterval": "11s",
+			},
+		},
+		{
+			base: "stats_interval",
+			annotations: map[string]string{
+				"sidecar.istio.io/statsFlushInterval":    "10s",
+				"sidecar.istio.io/statsEvictionInterval": "20s",
 			},
 		},
 	}

--- a/pkg/bootstrap/option/instance.go
+++ b/pkg/bootstrap/option/instance.go
@@ -123,8 +123,15 @@ func newOptionOrSkipIfZero(name Name, value any) *instance {
 	return newOption(name, value)
 }
 
+// Create an option with a time.Duration-compatible stringified format (hours, minutes, seconds, etc)
 func newDurationOption(name Name, value *durationpb.Duration) *instance {
 	return newOptionOrSkipIfZero(name, value).withConvert(durationConverter(value))
+}
+
+// Create an option with a protobuf Duration-compatible stringified format
+// (seconds and nanoseconds) as accepted by Envoy's protobuf json parser
+func newEnvoyDurationOption(name Name, value *durationpb.Duration) *instance {
+	return newOptionOrSkipIfZero(name, value).withConvert(envoyDurationConverter(value))
 }
 
 func newTCPKeepaliveOption(name Name, value *networkingAPI.ConnectionPoolSettings_TCPSettings_TcpKeepalive) *instance {

--- a/pkg/bootstrap/option/instances.go
+++ b/pkg/bootstrap/option/instances.go
@@ -16,6 +16,7 @@ package option
 
 import (
 	"strings"
+	"time"
 
 	"google.golang.org/protobuf/types/known/durationpb"
 
@@ -301,4 +302,12 @@ func EnvoyHistogramBuckets(value []HistogramBucket) Instance {
 
 func EnvoyStatsCompression(value string) Instance {
 	return newOption("stats_compression", value)
+}
+
+func EnvoyStatsFlushInterval(interval time.Duration) Instance {
+	return newOption("stats_flush_interval", interval)
+}
+
+func EnvoyStatsEvictionInterval(interval time.Duration) Instance {
+	return newOption("stats_eviction_interval", interval)
 }

--- a/pkg/bootstrap/option/instances.go
+++ b/pkg/bootstrap/option/instances.go
@@ -308,6 +308,6 @@ func EnvoyStatsFlushInterval(interval time.Duration) Instance {
 	return newOption("stats_flush_interval", interval)
 }
 
-func EnvoyStatsEvictionInterval(interval time.Duration) Instance {
-	return newOption("stats_eviction_interval", interval)
+func EnvoyStatsEvictionInterval(interval *durationpb.Duration) Instance {
+	return newEnvoyDurationOption("stats_eviction_interval", interval)
 }

--- a/pkg/bootstrap/option/instances_test.go
+++ b/pkg/bootstrap/option/instances_test.go
@@ -647,6 +647,24 @@ func TestOptions(t *testing.T) {
 			}, &model.BootstrapNodeMetadata{}, false),
 			expected: `{"name":"envoy.transport_sockets.tls","typed_config":{"@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext","common_tls_context":{"combined_validation_context":{"default_validation_context":{},"validation_context_sds_secret_config":{"name":"file-root:/etc/tracing/ca.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}}}}}`,
 		},
+		{
+			testName: "stats eviction interval normal",
+			key:      "stats_eviction_interval",
+			option:   option.EnvoyStatsEvictionInterval(durationpb.New(time.Second * 10)),
+			expected: "10s",
+		},
+		{
+			testName: "stats eviction interval fractional",
+			key:      "stats_eviction_interval",
+			option:   option.EnvoyStatsEvictionInterval(durationpb.New(time.Second*2 + time.Millisecond*5)),
+			expected: "2.005000000s",
+		},
+		{
+			testName: "stats eviction interval longer than 60s",
+			key:      "stats_eviction_interval",
+			option:   option.EnvoyStatsEvictionInterval(durationpb.New(time.Second * 120)),
+			expected: "120s",
+		},
 	}
 
 	for _, c := range cases {

--- a/pkg/bootstrap/testdata/invalid_stats_eviction_interval.proxycfg
+++ b/pkg/bootstrap/testdata/invalid_stats_eviction_interval.proxycfg
@@ -1,0 +1,14 @@
+config_path:                      "/etc/istio/proxy"
+binary_path:                      "/usr/local/bin/envoy"
+service_cluster:                  "istio-proxy"
+drain_duration:                   {seconds: 5}
+discovery_address:                "mypilot:15011"
+statsd_udp_address:               "10.1.1.1:9125"
+envoy_metrics_service:            {address: "metrics-service:15000", tls_settings: { mode: MUTUAL, client_certificate: "/etc/istio/ms/client.pem", private_key: "/etc/istio/ms/key.pem", ca_certificates: "/etc/istio/ms/ca.pem"}}
+envoy_access_log_service:         {address: "accesslog-service:15000"}
+proxy_admin_port:                 15005
+control_plane_auth_policy:        MUTUAL_TLS
+stat_name_length:                 200
+tracing:                          { zipkin: { address: "localhost:6000" } }
+
+# Sets all relevant options to values different than default

--- a/pkg/bootstrap/testdata/invalid_stats_eviction_interval_golden.json
+++ b/pkg/bootstrap/testdata/invalid_stats_eviction_interval_golden.json
@@ -1,47 +1,21 @@
 {
   "application_log_config": {
     "log_format": {
-{{- if .log_json }}
-      "json_format": {
-        "time": "%Y-%m-%dT%T.%fZ",
-        "level": "%l",
-        "scope": "envoy %n",
-        "msg": "%j",
-        "caller": "%g:%#",
-        "thread": "%t"
-      }
-{{- else }}
       "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
-{{- end }}
     }
   },
   "node": {
-    "id": "{{ .nodeID }}",
-    "cluster": "{{ .cluster }}",
+    "id": "sidecar~1.2.3.4~foo~bar",
+    "cluster": "istio-proxy",
     "locality": {
-      {{- if .region }}
-      "region": "{{ .region }}"
-      {{- end }}
-      {{- if .zone }}
-      {{- if .region }}
-      ,
-      {{- end }}
-      "zone": "{{ .zone }}"
-      {{- end }}
-      {{- if .sub_zone }}
-      {{- if or .region .zone }}
-      ,
-      {{- end }}
-      "sub_zone": "{{ .sub_zone }}"
-      {{- end }}
     },
-    "metadata": {{ .meta_json_str }}
+    "metadata": {"ANNOTATIONS":{"sidecar.istio.io/statsEvictionInterval":"11s"},"ENVOY_PROMETHEUS_PORT":15090,"ENVOY_STATUS_PORT":15021,"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","ISTIO_VERSION":"binary-1.0","METADATA_DISCOVERY":"false","OUTLIER_LOG_PATH":"/dev/stdout","PILOT_SAN":["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"],"PROXY_CONFIG":{"binaryPath":"/usr/local/bin/envoy","configPath":"/tmp/bootstrap/invalid_stats_eviction_interval","controlPlaneAuthPolicy":"MUTUAL_TLS","customConfigFile":"envoy_bootstrap.json","discoveryAddress":"mypilot:15011","drainDuration":"5s","envoyAccessLogService":{"address":"accesslog-service:15000"},"envoyMetricsService":{"address":"metrics-service:15000","tlsSettings":{"caCertificates":"/etc/istio/ms/ca.pem","clientCertificate":"/etc/istio/ms/client.pem","mode":"MUTUAL","privateKey":"/etc/istio/ms/key.pem"}},"proxyAdminPort":15005,"serviceCluster":"istio-proxy","statNameLength":200,"statsdUdpAddress":"10.1.1.1:9125","statusPort":15020,"tracing":{"zipkin":{"address":"localhost:6000"}}},"WORKLOAD_IDENTITY_SOCKET_FILE":"test.sock","sidecar.istio.io/statsEvictionInterval":"11s"}
   },
   "layered_runtime": {
     "layers": [
       {
         "name": "global config",
-        "static_layer": {{ .runtime_flags }}
+        "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
       },
       {
         "name": "admin",
@@ -50,18 +24,6 @@
     ]
   },
   "bootstrap_extensions": [
-    {{- if .metadata_discovery }}
-    {
-      "name": "metadata_discovery",
-      "typed_config": {
-        "@type": "type.googleapis.com/udpa.type.v1.TypedStruct",
-        "type_url": "type.googleapis.com/istio.workload.BootstrapExtension",
-        "value": {
-          "config_source": { "ads": {} }
-        }
-      }
-    },
-    {{- end }}
     {
       "name": "envoy.bootstrap.internal_listener",
       "typed_config": {
@@ -73,12 +35,6 @@
       }
     }
   ],
-  {{- if .stats_flush_interval }}
-  "stats_flush_interval": "{{ .stats_flush_interval }}",
-  {{- end }}
-  {{- if .stats_eviction_interval }}
-  "stats_eviction_interval": "{{ .stats_eviction_interval }}",
-  {{- end }}
   "stats_config": {
     "use_all_default_tags": false,
     "stats_tags": [
@@ -118,12 +74,6 @@
         "tag_name": "mongo_prefix",
         "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
       },
-      {{- range $a, $tag := .extraStatTags }}
-      {
-        "regex": "({{ $tag }}=\\.=(.*?);\\.;)",
-        "tag_name": "{{ $tag }}"
-      },
-      {{- end }}
       {
         "regex": "(cache\\.(.+?)\\.)",
         "tag_name": "cache"
@@ -153,35 +103,42 @@
         "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
-    {{- if .histogram_buckets }}
-    "histogram_bucket_settings": {{ toJson .histogram_buckets }},
-    {{- end }}
     "stats_matcher": {
       "inclusion_list": {
         "patterns": [
           {
           "prefix": "reporter="
           },
-          {{- if .metadata_discovery }}
           {
-          "prefix": "workload_discovery"
+          "prefix": "cluster_manager"
           },
-          {{- end }}
-          {{- range $a, $s := .inclusionPrefix }}
           {
-          "prefix": "{{$s}}"
+          "prefix": "listener_manager"
           },
-          {{- end }}
-          {{- range $a, $s := .inclusionSuffix }}
           {
-          "suffix": "{{$s}}"
+          "prefix": "server"
           },
-          {{- end }}
-          {{- range $a, $s := .inclusionRegexps }}
           {
-          "safe_regex": {"regex":"{{js $s}}"}
+          "prefix": "cluster.xds-grpc"
           },
-          {{- end }}
+          {
+          "prefix": "wasm"
+          },
+          {
+          "suffix": "rbac.allowed"
+          },
+          {
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
+          },
+          {
+          "safe_regex": {"regex":"vhost\\..*\\.route\\..*"}
+          },
           {
           "prefix": "component"
           },
@@ -205,8 +162,8 @@
     "profile_path": "/var/lib/istio/data/envoy.prof",
     "address": {
       "socket_address": {
-        "address": "{{ .localhost }}",
-        "port_value": {{ .config.ProxyAdminPort }}
+        "address": "127.0.0.1",
+        "port_value": 15005
       }
     }
   },
@@ -222,7 +179,7 @@
       "resource_api_version": "V3"
     },
     "ads_config": {
-      "api_type": "{{ .xds_type }}",
+      "api_type": "DELTA_GRPC",
       "set_node_on_first_message_only": true,
       "transport_api_version": "V3",
       "grpc_services": [
@@ -250,8 +207,8 @@
                 "address":{
                   "socket_address": {
                     "protocol": "TCP",
-                    "address": "{{ .localhost }}",
-                    "port_value": {{ .config.ProxyAdminPort }}
+                    "address": "127.0.0.1",
+                    "port_value": 15005
                   }
                 }
               }
@@ -273,8 +230,8 @@
                 "address":{
                   "socket_address": {
                     "protocol": "TCP",
-                    "address": "{{ .localhost }}",
-                    "port_value": {{ .config.StatusPort }}
+                    "address": "127.0.0.1",
+                    "port_value": 15020
                   }
                 }
               }
@@ -303,7 +260,7 @@
               "endpoint": {
                 "address":{
                   "pipe": {
-                    "path": "./var/run/secrets/workload-spiffe-uds/{{ .workload_identity_socket_file }}"
+                    "path": "./var/run/secrets/workload-spiffe-uds/test.sock"
                   }
                 }
               }
@@ -311,37 +268,6 @@
           }]
         }
       },
-      {{- if .custom_file_path }}
-      {
-        "name": "sds-files-grpc",
-        "alt_stat_name": "sds-files-grpc;",
-        "type": "STATIC",
-        "typed_extension_protocol_options": {
-          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-           "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-           "explicit_http_config": {
-            "http2_protocol_options": {}
-           }
-          }
-        },
-        "connect_timeout": "1s",
-        "lb_policy": "ROUND_ROBIN",
-        "load_assignment": {
-          "cluster_name": "sds-files-grpc",
-          "endpoints": [{
-            "lb_endpoints": [{
-              "endpoint": {
-                "address":{
-                  "pipe": {
-                    "path": "{{ .custom_file_path }}"
-                  }
-                }
-              }
-            }]
-          }]
-        }
-      },
-      {{- end }}
       {
         "name": "xds-grpc",
         "alt_stat_name": "xds-grpc;",
@@ -355,7 +281,7 @@
               "endpoint": {
                 "address":{
                   "pipe": {
-                    "path": "{{ .config.ConfigPath }}/XDS"
+                    "path": "/tmp/XDS"
                   }
                 }
               }
@@ -393,17 +319,14 @@
           }
         }
       }
-      {{ if .zipkin }}
+      
       ,
       {
         "name": "zipkin",
         "alt_stat_name": "zipkin;",
-        {{- if .tracing_tls }}
-        "transport_socket": {{ .tracing_tls }},
-        {{- end }}
         "type": "STRICT_DNS",
         "respect_dns_ttl": true,
-        "dns_lookup_family": "{{ .dns_lookup_family }}",
+        "dns_lookup_family": "V4_ONLY",
         "dns_refresh_rate": "30s",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -413,88 +336,22 @@
             "lb_endpoints": [{
               "endpoint": {
                 "address":{
-                  "socket_address": {{ .zipkin }}
+                  "socket_address": {"address": "localhost", "port_value": 6000}
                 }
               }
             }]
           }]
         }
       }
-      {{ else if .lightstep }}
-      ,
-      {
-        "name": "lightstep",
-        "alt_stat_name": "lightstep;",
-        {{- if .tracing_tls }}
-        "transport_socket": {{ .tracing_tls }},
-        {{- end }}
-        "typed_extension_protocol_options": {
-          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-           "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-           "explicit_http_config": {
-            "http2_protocol_options": {}
-           }
-          }
-        },
-        "type": "STRICT_DNS",
-        "respect_dns_ttl": true,
-        "dns_lookup_family": "{{ .dns_lookup_family }}",
-        "connect_timeout": "1s",
-        "lb_policy": "ROUND_ROBIN",
-        "load_assignment": {
-          "cluster_name": "lightstep",
-          "endpoints": [{
-            "lb_endpoints": [{
-              "endpoint": {
-                "address":{
-                  "socket_address": {{ .lightstep }}
-                }
-              }
-            }]
-          }]
-        }
-      }
-      {{ else if .datadog }}
-      ,
-      {
-        "name": "datadog_agent",
-        "alt_stat_name": "datadog_agent;",
-        {{- if .tracing_tls }}
-        "transport_socket": {{ .tracing_tls }},
-        {{- end }}
-        "connect_timeout": "1s",
-        "type": "STRICT_DNS",
-        "respect_dns_ttl": true,
-        "dns_lookup_family": "{{ .dns_lookup_family }}",
-        "lb_policy": "ROUND_ROBIN",
-        "load_assignment": {
-          "cluster_name": "datadog_agent",
-          "endpoints": [{
-            "lb_endpoints": [{
-              "endpoint": {
-                "address":{
-                  "socket_address": {{ .datadog }}
-                }
-              }
-            }]
-          }]
-        }
-      }
-      {{ end }}
-      {{- if .envoy_metrics_service_address }}
+      
       ,
       {
         "name": "envoy_metrics_service",
         "alt_stat_name": "envoy_metrics_service;",
         "type": "STRICT_DNS",
-      {{- if .envoy_metrics_service_tls }}
-        "transport_socket": {{ .envoy_metrics_service_tls }},
-      {{- end }}
-      {{- if .envoy_metrics_service_tcp_keepalive }}
-        "upstream_connection_options": {{ .envoy_metrics_service_tcp_keepalive }},
-      {{- end }}
+        "transport_socket": {"name":"envoy.transport_sockets.tls","typed_config":{"@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext","common_tls_context":{"alpn_protocols":["h2"],"combined_validation_context":{"default_validation_context":{},"validation_context_sds_secret_config":{"name":"file-root:/etc/istio/ms/ca.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}},"tls_certificate_sds_secret_configs":[{"name":"file-cert:/etc/istio/ms/client.pem~/etc/istio/ms/key.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}]}}},
         "respect_dns_ttl": true,
-        "dns_lookup_family": "{{ .dns_lookup_family }}",
+        "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
         "typed_extension_protocol_options": {
@@ -511,28 +368,22 @@
             "lb_endpoints": [{
               "endpoint": {
                 "address":{
-                  "socket_address": {{ .envoy_metrics_service_address }}
+                  "socket_address": {"address": "metrics-service", "port_value": 15000}
                 }
               }
             }]
           }]
         }
       }
-      {{ end }}
-      {{ if .envoy_accesslog_service_address }}
+      
+      
       ,
       {
         "name": "envoy_accesslog_service",
         "alt_stat_name": "envoy_accesslog_service;",
         "type": "STRICT_DNS",
-      {{- if .envoy_accesslog_service_tls }}
-        "transport_socket": {{ .envoy_accesslog_service_tls }},
-      {{- end }}
-      {{- if .envoy_accesslog_service_tcp_keepalive }}
-        "upstream_connection_options": {{ .envoy_accesslog_service_tcp_keepalive }},
-      {{ end }}
         "respect_dns_ttl": true,
-        "dns_lookup_family": "{{ .dns_lookup_family }}",
+        "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
         "typed_extension_protocol_options": {
@@ -549,52 +400,29 @@
             "lb_endpoints": [{
               "endpoint": {
                 "address":{
-                  "socket_address": {{ .envoy_accesslog_service_address }}
+                  "socket_address": {"address": "accesslog-service", "port_value": 15000}
                 }
               }
             }]
           }]
         }
       }
-      {{ end }}
+      
     ],
     "listeners":[
       {
-        {{- if .metrics_localhost_access_only }}
-        "name": "{{ .localhost }}_{{ .envoy_prometheus_port }}",
-        {{ else }}
-        "name": "{{ .wildcard }}_{{ .envoy_prometheus_port }}",
-        {{ end }}
+        "name": "0.0.0.0_15090",
+        
         "address": {
           "socket_address": {
             "protocol": "TCP",
-            {{- if .metrics_localhost_access_only }}
-            "address": "{{ .localhost }}",
-            {{ else }}
-            "address": "{{ .wildcard }}",
-            {{ end }}
-            "port_value": {{ .envoy_prometheus_port }}
+            "address": "0.0.0.0",
+            
+            "port_value": 15090
           }
         },
         "ignore_global_conn_limit": true,
         "bypass_overload_manager": true,
-        {{- if .dual_stack }}
-        "additionalAddresses": [
-          {
-            "address": {
-              "socket_address": {
-                "protocol": "TCP",
-                {{- if .metrics_localhost_access_only }}
-                "address": "{{ .additional_localhost }}",
-                {{ else }}
-                "address": "{{ .additional_wildcard }}",
-                {{ end }}
-                "port_value": {{ .envoy_prometheus_port }}
-              }
-            }
-          }
-        ],
-        {{- end}}
         "filter_chains": [
           {
             "filters": [
@@ -625,36 +453,6 @@
                     ]
                   },
                   "http_filters": [
-                  {{- if .stats_compression }}
-                  {
-                    "name": "envoy.filters.http.compressor",
-                    "typed_config": {
-                      "@type": "type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor",
-                      {{- if eq .stats_compression "gzip"}}
-                      "compressor_library": {
-                        "name": "text_optimized",
-                        "typed_config": {
-                          "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
-                        }
-                      }
-                      {{- else if eq .stats_compression "zstd"}}
-                      "compressor_library": {
-                        "name": "text_optimized",
-                        "typed_config": {
-                          "@type": "type.googleapis.com/envoy.extensions.compression.zstd.compressor.v3.Zstd"
-                        }
-                      }
-                      {{- else if eq .stats_compression "brotli"}}
-                      "compressor_library": {
-                        "name": "text_optimized",
-                        "typed_config": {
-                          "@type": "type.googleapis.com/envoy.extensions.compression.brotli.compressor.v3.Brotli"
-                        }
-                      }
-                      {{- end }}
-                    }
-                  },
-                  {{- end }}
                   {
                     "name": "envoy.filters.http.router",
                     "typed_config": {
@@ -668,40 +466,16 @@
         ]
       },
       {
-        "name": "{{ .wildcard }}_{{ .envoy_status_port }}",
+        "name": "0.0.0.0_15021",
         "address": {
            "socket_address": {
              "protocol": "TCP",
-             "address": "{{ .wildcard }}",
-             "port_value": {{ .envoy_status_port }}
+             "address": "0.0.0.0",
+             "port_value": 15021
            }
         },
         "ignore_global_conn_limit": true,
         "bypass_overload_manager": true,
-        {{- if .dual_stack }}
-        "additionalAddresses": [
-          {
-            "address": {
-              "socket_address": {
-                "protocol": "TCP",
-                "address": "{{ .additional_wildcard }}",
-                "port_value": {{ .envoy_status_port }}
-              }
-            }
-          }
-        ],
-        {{- end}}
-        {{- if .envoy_status_port_enable_proxy_protocol }}
-        "listener_filters": [
-          {
-            "name": "envoy.listener.proxy_protocol",
-            "typed_config": {
-              "@type": "type.googleapis.com/envoy.extensions.filters.listener.proxy_protocol.v3.ProxyProtocol",
-              "allow_requests_without_proxy_protocol": true,
-            }
-          }
-        ],
-        {{- end }}
         "filter_chains": [
           {
             "filters": [
@@ -745,7 +519,6 @@
       }
     ]
   }
-  {{- if .zipkin }}
   ,
   "tracing": {
     "http": {
@@ -760,35 +533,10 @@
       }
     }
   }
-  {{- else if .lightstep }}
-  ,
-  "tracing": {
-    "http": {
-      "name": "envoy.tracers.lightstep",
-      "typed_config": {
-        "@type": "type.googleapis.com/envoy.config.trace.v3.LightstepConfig",
-        "collector_cluster": "lightstep",
-        "access_token_file": "{{ .lightstepToken}}"
-      }
-    }
-  }
-  {{- else if .datadog }}
-  ,
-  "tracing": {
-    "http": {
-      "name": "envoy.tracers.datadog",
-      "typed_config": {
-        "@type": "type.googleapis.com/envoy.config.trace.v3.DatadogConfig",
-        "collector_cluster": "datadog_agent",
-        "service_name": "{{ .cluster }}"
-      }
-    }
-  }
-  {{ end }}
-  {{ if or .envoy_metrics_service_address .statsd }}
+  
   ,
   "stats_sinks": [
-    {{ if .envoy_metrics_service_address }}
+    
     {
       "name": "envoy.stat_sinks.metrics_service",
       "typed_config": {
@@ -801,40 +549,31 @@
         }
       }
     }
-    {{ end }}
-    {{ if and .envoy_metrics_service_address .statsd }}
+    
+    
     ,
-    {{ end }}
-    {{ if .statsd }}
+    
+    
     {
       "name": "envoy.stat_sinks.statsd",
       "typed_config": {
         "@type": "type.googleapis.com/envoy.config.metrics.v3.StatsdSink",
         "address": {
-          "socket_address": {{ .statsd }}
+          "socket_address": {"address": "10.1.1.1", "port_value": 9125}
         }
       }
     }
-    {{ end }}
+    
   ]
-  {{ end }}
-  {{ if or .outlier_log_path .load_stats_config_json_str}}
+  
+  
   ,
   "cluster_manager": {
     "enable_deferred_cluster_creation": true,
-    {{- if .outlier_log_path}}
     "outlier_detection": {
-      "event_log_path": "{{ .outlier_log_path }}"
+      "event_log_path": "/dev/stdout"
     }
-    {{- end}}
-    {{- if and .outlier_log_path .load_stats_config_json_str }}
-    ,
-    {{- end}}
-    {{- if .load_stats_config_json_str }}
-    "load_stats_config": {{- .load_stats_config_json_str }}
-    {{- end }}
   }
-  {{- end }}
   ,
   "deferred_stat_options": {
     "enable_deferred_creation_stats": true

--- a/pkg/bootstrap/testdata/stats_eviction_interval.proxycfg
+++ b/pkg/bootstrap/testdata/stats_eviction_interval.proxycfg
@@ -1,0 +1,14 @@
+config_path:                      "/etc/istio/proxy"
+binary_path:                      "/usr/local/bin/envoy"
+service_cluster:                  "istio-proxy"
+drain_duration:                   {seconds: 5}
+discovery_address:                "mypilot:15011"
+statsd_udp_address:               "10.1.1.1:9125"
+envoy_metrics_service:            {address: "metrics-service:15000", tls_settings: { mode: MUTUAL, client_certificate: "/etc/istio/ms/client.pem", private_key: "/etc/istio/ms/key.pem", ca_certificates: "/etc/istio/ms/ca.pem"}}
+envoy_access_log_service:         {address: "accesslog-service:15000"}
+proxy_admin_port:                 15005
+control_plane_auth_policy:        MUTUAL_TLS
+stat_name_length:                 200
+tracing:                          { zipkin: { address: "localhost:6000" } }
+
+# Sets all relevant options to values different than default

--- a/pkg/bootstrap/testdata/stats_eviction_interval_golden.json
+++ b/pkg/bootstrap/testdata/stats_eviction_interval_golden.json
@@ -1,47 +1,21 @@
 {
   "application_log_config": {
     "log_format": {
-{{- if .log_json }}
-      "json_format": {
-        "time": "%Y-%m-%dT%T.%fZ",
-        "level": "%l",
-        "scope": "envoy %n",
-        "msg": "%j",
-        "caller": "%g:%#",
-        "thread": "%t"
-      }
-{{- else }}
       "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
-{{- end }}
     }
   },
   "node": {
-    "id": "{{ .nodeID }}",
-    "cluster": "{{ .cluster }}",
+    "id": "sidecar~1.2.3.4~foo~bar",
+    "cluster": "istio-proxy",
     "locality": {
-      {{- if .region }}
-      "region": "{{ .region }}"
-      {{- end }}
-      {{- if .zone }}
-      {{- if .region }}
-      ,
-      {{- end }}
-      "zone": "{{ .zone }}"
-      {{- end }}
-      {{- if .sub_zone }}
-      {{- if or .region .zone }}
-      ,
-      {{- end }}
-      "sub_zone": "{{ .sub_zone }}"
-      {{- end }}
     },
-    "metadata": {{ .meta_json_str }}
+    "metadata": {"ANNOTATIONS":{"sidecar.istio.io/statsEvictionInterval":"10s"},"ENVOY_PROMETHEUS_PORT":15090,"ENVOY_STATUS_PORT":15021,"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","ISTIO_VERSION":"binary-1.0","METADATA_DISCOVERY":"false","OUTLIER_LOG_PATH":"/dev/stdout","PILOT_SAN":["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"],"PROXY_CONFIG":{"binaryPath":"/usr/local/bin/envoy","configPath":"/tmp/bootstrap/stats_eviction_interval","controlPlaneAuthPolicy":"MUTUAL_TLS","customConfigFile":"envoy_bootstrap.json","discoveryAddress":"mypilot:15011","drainDuration":"5s","envoyAccessLogService":{"address":"accesslog-service:15000"},"envoyMetricsService":{"address":"metrics-service:15000","tlsSettings":{"caCertificates":"/etc/istio/ms/ca.pem","clientCertificate":"/etc/istio/ms/client.pem","mode":"MUTUAL","privateKey":"/etc/istio/ms/key.pem"}},"proxyAdminPort":15005,"serviceCluster":"istio-proxy","statNameLength":200,"statsdUdpAddress":"10.1.1.1:9125","statusPort":15020,"tracing":{"zipkin":{"address":"localhost:6000"}}},"WORKLOAD_IDENTITY_SOCKET_FILE":"test.sock","sidecar.istio.io/statsEvictionInterval":"10s"}
   },
   "layered_runtime": {
     "layers": [
       {
         "name": "global config",
-        "static_layer": {{ .runtime_flags }}
+        "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
       },
       {
         "name": "admin",
@@ -50,18 +24,6 @@
     ]
   },
   "bootstrap_extensions": [
-    {{- if .metadata_discovery }}
-    {
-      "name": "metadata_discovery",
-      "typed_config": {
-        "@type": "type.googleapis.com/udpa.type.v1.TypedStruct",
-        "type_url": "type.googleapis.com/istio.workload.BootstrapExtension",
-        "value": {
-          "config_source": { "ads": {} }
-        }
-      }
-    },
-    {{- end }}
     {
       "name": "envoy.bootstrap.internal_listener",
       "typed_config": {
@@ -73,12 +35,7 @@
       }
     }
   ],
-  {{- if .stats_flush_interval }}
-  "stats_flush_interval": "{{ .stats_flush_interval }}",
-  {{- end }}
-  {{- if .stats_eviction_interval }}
-  "stats_eviction_interval": "{{ .stats_eviction_interval }}",
-  {{- end }}
+  "stats_eviction_interval": "10s",
   "stats_config": {
     "use_all_default_tags": false,
     "stats_tags": [
@@ -118,12 +75,6 @@
         "tag_name": "mongo_prefix",
         "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
       },
-      {{- range $a, $tag := .extraStatTags }}
-      {
-        "regex": "({{ $tag }}=\\.=(.*?);\\.;)",
-        "tag_name": "{{ $tag }}"
-      },
-      {{- end }}
       {
         "regex": "(cache\\.(.+?)\\.)",
         "tag_name": "cache"
@@ -153,35 +104,42 @@
         "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
-    {{- if .histogram_buckets }}
-    "histogram_bucket_settings": {{ toJson .histogram_buckets }},
-    {{- end }}
     "stats_matcher": {
       "inclusion_list": {
         "patterns": [
           {
           "prefix": "reporter="
           },
-          {{- if .metadata_discovery }}
           {
-          "prefix": "workload_discovery"
+          "prefix": "cluster_manager"
           },
-          {{- end }}
-          {{- range $a, $s := .inclusionPrefix }}
           {
-          "prefix": "{{$s}}"
+          "prefix": "listener_manager"
           },
-          {{- end }}
-          {{- range $a, $s := .inclusionSuffix }}
           {
-          "suffix": "{{$s}}"
+          "prefix": "server"
           },
-          {{- end }}
-          {{- range $a, $s := .inclusionRegexps }}
           {
-          "safe_regex": {"regex":"{{js $s}}"}
+          "prefix": "cluster.xds-grpc"
           },
-          {{- end }}
+          {
+          "prefix": "wasm"
+          },
+          {
+          "suffix": "rbac.allowed"
+          },
+          {
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
+          },
+          {
+          "safe_regex": {"regex":"vhost\\..*\\.route\\..*"}
+          },
           {
           "prefix": "component"
           },
@@ -205,8 +163,8 @@
     "profile_path": "/var/lib/istio/data/envoy.prof",
     "address": {
       "socket_address": {
-        "address": "{{ .localhost }}",
-        "port_value": {{ .config.ProxyAdminPort }}
+        "address": "127.0.0.1",
+        "port_value": 15005
       }
     }
   },
@@ -222,7 +180,7 @@
       "resource_api_version": "V3"
     },
     "ads_config": {
-      "api_type": "{{ .xds_type }}",
+      "api_type": "DELTA_GRPC",
       "set_node_on_first_message_only": true,
       "transport_api_version": "V3",
       "grpc_services": [
@@ -250,8 +208,8 @@
                 "address":{
                   "socket_address": {
                     "protocol": "TCP",
-                    "address": "{{ .localhost }}",
-                    "port_value": {{ .config.ProxyAdminPort }}
+                    "address": "127.0.0.1",
+                    "port_value": 15005
                   }
                 }
               }
@@ -273,8 +231,8 @@
                 "address":{
                   "socket_address": {
                     "protocol": "TCP",
-                    "address": "{{ .localhost }}",
-                    "port_value": {{ .config.StatusPort }}
+                    "address": "127.0.0.1",
+                    "port_value": 15020
                   }
                 }
               }
@@ -303,7 +261,7 @@
               "endpoint": {
                 "address":{
                   "pipe": {
-                    "path": "./var/run/secrets/workload-spiffe-uds/{{ .workload_identity_socket_file }}"
+                    "path": "./var/run/secrets/workload-spiffe-uds/test.sock"
                   }
                 }
               }
@@ -311,37 +269,6 @@
           }]
         }
       },
-      {{- if .custom_file_path }}
-      {
-        "name": "sds-files-grpc",
-        "alt_stat_name": "sds-files-grpc;",
-        "type": "STATIC",
-        "typed_extension_protocol_options": {
-          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-           "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-           "explicit_http_config": {
-            "http2_protocol_options": {}
-           }
-          }
-        },
-        "connect_timeout": "1s",
-        "lb_policy": "ROUND_ROBIN",
-        "load_assignment": {
-          "cluster_name": "sds-files-grpc",
-          "endpoints": [{
-            "lb_endpoints": [{
-              "endpoint": {
-                "address":{
-                  "pipe": {
-                    "path": "{{ .custom_file_path }}"
-                  }
-                }
-              }
-            }]
-          }]
-        }
-      },
-      {{- end }}
       {
         "name": "xds-grpc",
         "alt_stat_name": "xds-grpc;",
@@ -355,7 +282,7 @@
               "endpoint": {
                 "address":{
                   "pipe": {
-                    "path": "{{ .config.ConfigPath }}/XDS"
+                    "path": "/tmp/XDS"
                   }
                 }
               }
@@ -393,17 +320,14 @@
           }
         }
       }
-      {{ if .zipkin }}
+      
       ,
       {
         "name": "zipkin",
         "alt_stat_name": "zipkin;",
-        {{- if .tracing_tls }}
-        "transport_socket": {{ .tracing_tls }},
-        {{- end }}
         "type": "STRICT_DNS",
         "respect_dns_ttl": true,
-        "dns_lookup_family": "{{ .dns_lookup_family }}",
+        "dns_lookup_family": "V4_ONLY",
         "dns_refresh_rate": "30s",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -413,88 +337,22 @@
             "lb_endpoints": [{
               "endpoint": {
                 "address":{
-                  "socket_address": {{ .zipkin }}
+                  "socket_address": {"address": "localhost", "port_value": 6000}
                 }
               }
             }]
           }]
         }
       }
-      {{ else if .lightstep }}
-      ,
-      {
-        "name": "lightstep",
-        "alt_stat_name": "lightstep;",
-        {{- if .tracing_tls }}
-        "transport_socket": {{ .tracing_tls }},
-        {{- end }}
-        "typed_extension_protocol_options": {
-          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-           "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-           "explicit_http_config": {
-            "http2_protocol_options": {}
-           }
-          }
-        },
-        "type": "STRICT_DNS",
-        "respect_dns_ttl": true,
-        "dns_lookup_family": "{{ .dns_lookup_family }}",
-        "connect_timeout": "1s",
-        "lb_policy": "ROUND_ROBIN",
-        "load_assignment": {
-          "cluster_name": "lightstep",
-          "endpoints": [{
-            "lb_endpoints": [{
-              "endpoint": {
-                "address":{
-                  "socket_address": {{ .lightstep }}
-                }
-              }
-            }]
-          }]
-        }
-      }
-      {{ else if .datadog }}
-      ,
-      {
-        "name": "datadog_agent",
-        "alt_stat_name": "datadog_agent;",
-        {{- if .tracing_tls }}
-        "transport_socket": {{ .tracing_tls }},
-        {{- end }}
-        "connect_timeout": "1s",
-        "type": "STRICT_DNS",
-        "respect_dns_ttl": true,
-        "dns_lookup_family": "{{ .dns_lookup_family }}",
-        "lb_policy": "ROUND_ROBIN",
-        "load_assignment": {
-          "cluster_name": "datadog_agent",
-          "endpoints": [{
-            "lb_endpoints": [{
-              "endpoint": {
-                "address":{
-                  "socket_address": {{ .datadog }}
-                }
-              }
-            }]
-          }]
-        }
-      }
-      {{ end }}
-      {{- if .envoy_metrics_service_address }}
+      
       ,
       {
         "name": "envoy_metrics_service",
         "alt_stat_name": "envoy_metrics_service;",
         "type": "STRICT_DNS",
-      {{- if .envoy_metrics_service_tls }}
-        "transport_socket": {{ .envoy_metrics_service_tls }},
-      {{- end }}
-      {{- if .envoy_metrics_service_tcp_keepalive }}
-        "upstream_connection_options": {{ .envoy_metrics_service_tcp_keepalive }},
-      {{- end }}
+        "transport_socket": {"name":"envoy.transport_sockets.tls","typed_config":{"@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext","common_tls_context":{"alpn_protocols":["h2"],"combined_validation_context":{"default_validation_context":{},"validation_context_sds_secret_config":{"name":"file-root:/etc/istio/ms/ca.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}},"tls_certificate_sds_secret_configs":[{"name":"file-cert:/etc/istio/ms/client.pem~/etc/istio/ms/key.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}]}}},
         "respect_dns_ttl": true,
-        "dns_lookup_family": "{{ .dns_lookup_family }}",
+        "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
         "typed_extension_protocol_options": {
@@ -511,28 +369,22 @@
             "lb_endpoints": [{
               "endpoint": {
                 "address":{
-                  "socket_address": {{ .envoy_metrics_service_address }}
+                  "socket_address": {"address": "metrics-service", "port_value": 15000}
                 }
               }
             }]
           }]
         }
       }
-      {{ end }}
-      {{ if .envoy_accesslog_service_address }}
+      
+      
       ,
       {
         "name": "envoy_accesslog_service",
         "alt_stat_name": "envoy_accesslog_service;",
         "type": "STRICT_DNS",
-      {{- if .envoy_accesslog_service_tls }}
-        "transport_socket": {{ .envoy_accesslog_service_tls }},
-      {{- end }}
-      {{- if .envoy_accesslog_service_tcp_keepalive }}
-        "upstream_connection_options": {{ .envoy_accesslog_service_tcp_keepalive }},
-      {{ end }}
         "respect_dns_ttl": true,
-        "dns_lookup_family": "{{ .dns_lookup_family }}",
+        "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
         "typed_extension_protocol_options": {
@@ -549,52 +401,29 @@
             "lb_endpoints": [{
               "endpoint": {
                 "address":{
-                  "socket_address": {{ .envoy_accesslog_service_address }}
+                  "socket_address": {"address": "accesslog-service", "port_value": 15000}
                 }
               }
             }]
           }]
         }
       }
-      {{ end }}
+      
     ],
     "listeners":[
       {
-        {{- if .metrics_localhost_access_only }}
-        "name": "{{ .localhost }}_{{ .envoy_prometheus_port }}",
-        {{ else }}
-        "name": "{{ .wildcard }}_{{ .envoy_prometheus_port }}",
-        {{ end }}
+        "name": "0.0.0.0_15090",
+        
         "address": {
           "socket_address": {
             "protocol": "TCP",
-            {{- if .metrics_localhost_access_only }}
-            "address": "{{ .localhost }}",
-            {{ else }}
-            "address": "{{ .wildcard }}",
-            {{ end }}
-            "port_value": {{ .envoy_prometheus_port }}
+            "address": "0.0.0.0",
+            
+            "port_value": 15090
           }
         },
         "ignore_global_conn_limit": true,
         "bypass_overload_manager": true,
-        {{- if .dual_stack }}
-        "additionalAddresses": [
-          {
-            "address": {
-              "socket_address": {
-                "protocol": "TCP",
-                {{- if .metrics_localhost_access_only }}
-                "address": "{{ .additional_localhost }}",
-                {{ else }}
-                "address": "{{ .additional_wildcard }}",
-                {{ end }}
-                "port_value": {{ .envoy_prometheus_port }}
-              }
-            }
-          }
-        ],
-        {{- end}}
         "filter_chains": [
           {
             "filters": [
@@ -625,36 +454,6 @@
                     ]
                   },
                   "http_filters": [
-                  {{- if .stats_compression }}
-                  {
-                    "name": "envoy.filters.http.compressor",
-                    "typed_config": {
-                      "@type": "type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor",
-                      {{- if eq .stats_compression "gzip"}}
-                      "compressor_library": {
-                        "name": "text_optimized",
-                        "typed_config": {
-                          "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
-                        }
-                      }
-                      {{- else if eq .stats_compression "zstd"}}
-                      "compressor_library": {
-                        "name": "text_optimized",
-                        "typed_config": {
-                          "@type": "type.googleapis.com/envoy.extensions.compression.zstd.compressor.v3.Zstd"
-                        }
-                      }
-                      {{- else if eq .stats_compression "brotli"}}
-                      "compressor_library": {
-                        "name": "text_optimized",
-                        "typed_config": {
-                          "@type": "type.googleapis.com/envoy.extensions.compression.brotli.compressor.v3.Brotli"
-                        }
-                      }
-                      {{- end }}
-                    }
-                  },
-                  {{- end }}
                   {
                     "name": "envoy.filters.http.router",
                     "typed_config": {
@@ -668,40 +467,16 @@
         ]
       },
       {
-        "name": "{{ .wildcard }}_{{ .envoy_status_port }}",
+        "name": "0.0.0.0_15021",
         "address": {
            "socket_address": {
              "protocol": "TCP",
-             "address": "{{ .wildcard }}",
-             "port_value": {{ .envoy_status_port }}
+             "address": "0.0.0.0",
+             "port_value": 15021
            }
         },
         "ignore_global_conn_limit": true,
         "bypass_overload_manager": true,
-        {{- if .dual_stack }}
-        "additionalAddresses": [
-          {
-            "address": {
-              "socket_address": {
-                "protocol": "TCP",
-                "address": "{{ .additional_wildcard }}",
-                "port_value": {{ .envoy_status_port }}
-              }
-            }
-          }
-        ],
-        {{- end}}
-        {{- if .envoy_status_port_enable_proxy_protocol }}
-        "listener_filters": [
-          {
-            "name": "envoy.listener.proxy_protocol",
-            "typed_config": {
-              "@type": "type.googleapis.com/envoy.extensions.filters.listener.proxy_protocol.v3.ProxyProtocol",
-              "allow_requests_without_proxy_protocol": true,
-            }
-          }
-        ],
-        {{- end }}
         "filter_chains": [
           {
             "filters": [
@@ -745,7 +520,6 @@
       }
     ]
   }
-  {{- if .zipkin }}
   ,
   "tracing": {
     "http": {
@@ -760,35 +534,10 @@
       }
     }
   }
-  {{- else if .lightstep }}
-  ,
-  "tracing": {
-    "http": {
-      "name": "envoy.tracers.lightstep",
-      "typed_config": {
-        "@type": "type.googleapis.com/envoy.config.trace.v3.LightstepConfig",
-        "collector_cluster": "lightstep",
-        "access_token_file": "{{ .lightstepToken}}"
-      }
-    }
-  }
-  {{- else if .datadog }}
-  ,
-  "tracing": {
-    "http": {
-      "name": "envoy.tracers.datadog",
-      "typed_config": {
-        "@type": "type.googleapis.com/envoy.config.trace.v3.DatadogConfig",
-        "collector_cluster": "datadog_agent",
-        "service_name": "{{ .cluster }}"
-      }
-    }
-  }
-  {{ end }}
-  {{ if or .envoy_metrics_service_address .statsd }}
+  
   ,
   "stats_sinks": [
-    {{ if .envoy_metrics_service_address }}
+    
     {
       "name": "envoy.stat_sinks.metrics_service",
       "typed_config": {
@@ -801,40 +550,31 @@
         }
       }
     }
-    {{ end }}
-    {{ if and .envoy_metrics_service_address .statsd }}
+    
+    
     ,
-    {{ end }}
-    {{ if .statsd }}
+    
+    
     {
       "name": "envoy.stat_sinks.statsd",
       "typed_config": {
         "@type": "type.googleapis.com/envoy.config.metrics.v3.StatsdSink",
         "address": {
-          "socket_address": {{ .statsd }}
+          "socket_address": {"address": "10.1.1.1", "port_value": 9125}
         }
       }
     }
-    {{ end }}
+    
   ]
-  {{ end }}
-  {{ if or .outlier_log_path .load_stats_config_json_str}}
+  
+  
   ,
   "cluster_manager": {
     "enable_deferred_cluster_creation": true,
-    {{- if .outlier_log_path}}
     "outlier_detection": {
-      "event_log_path": "{{ .outlier_log_path }}"
+      "event_log_path": "/dev/stdout"
     }
-    {{- end}}
-    {{- if and .outlier_log_path .load_stats_config_json_str }}
-    ,
-    {{- end}}
-    {{- if .load_stats_config_json_str }}
-    "load_stats_config": {{- .load_stats_config_json_str }}
-    {{- end }}
   }
-  {{- end }}
   ,
   "deferred_stat_options": {
     "enable_deferred_creation_stats": true

--- a/pkg/bootstrap/testdata/stats_flush_interval.proxycfg
+++ b/pkg/bootstrap/testdata/stats_flush_interval.proxycfg
@@ -1,0 +1,14 @@
+config_path:                      "/etc/istio/proxy"
+binary_path:                      "/usr/local/bin/envoy"
+service_cluster:                  "istio-proxy"
+drain_duration:                   {seconds: 5}
+discovery_address:                "mypilot:15011"
+statsd_udp_address:               "10.1.1.1:9125"
+envoy_metrics_service:            {address: "metrics-service:15000", tls_settings: { mode: MUTUAL, client_certificate: "/etc/istio/ms/client.pem", private_key: "/etc/istio/ms/key.pem", ca_certificates: "/etc/istio/ms/ca.pem"}}
+envoy_access_log_service:         {address: "accesslog-service:15000"}
+proxy_admin_port:                 15005
+control_plane_auth_policy:        MUTUAL_TLS
+stat_name_length:                 200
+tracing:                          { zipkin: { address: "localhost:6000" } }
+
+# Sets all relevant options to values different than default

--- a/pkg/bootstrap/testdata/stats_flush_interval_golden.json
+++ b/pkg/bootstrap/testdata/stats_flush_interval_golden.json
@@ -1,47 +1,21 @@
 {
   "application_log_config": {
     "log_format": {
-{{- if .log_json }}
-      "json_format": {
-        "time": "%Y-%m-%dT%T.%fZ",
-        "level": "%l",
-        "scope": "envoy %n",
-        "msg": "%j",
-        "caller": "%g:%#",
-        "thread": "%t"
-      }
-{{- else }}
       "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
-{{- end }}
     }
   },
   "node": {
-    "id": "{{ .nodeID }}",
-    "cluster": "{{ .cluster }}",
+    "id": "sidecar~1.2.3.4~foo~bar",
+    "cluster": "istio-proxy",
     "locality": {
-      {{- if .region }}
-      "region": "{{ .region }}"
-      {{- end }}
-      {{- if .zone }}
-      {{- if .region }}
-      ,
-      {{- end }}
-      "zone": "{{ .zone }}"
-      {{- end }}
-      {{- if .sub_zone }}
-      {{- if or .region .zone }}
-      ,
-      {{- end }}
-      "sub_zone": "{{ .sub_zone }}"
-      {{- end }}
     },
-    "metadata": {{ .meta_json_str }}
+    "metadata": {"ANNOTATIONS":{"sidecar.istio.io/statsFlushInterval":"10s"},"ENVOY_PROMETHEUS_PORT":15090,"ENVOY_STATUS_PORT":15021,"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","ISTIO_VERSION":"binary-1.0","METADATA_DISCOVERY":"false","OUTLIER_LOG_PATH":"/dev/stdout","PILOT_SAN":["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"],"PROXY_CONFIG":{"binaryPath":"/usr/local/bin/envoy","configPath":"/tmp/bootstrap/stats_flush_interval","controlPlaneAuthPolicy":"MUTUAL_TLS","customConfigFile":"envoy_bootstrap.json","discoveryAddress":"mypilot:15011","drainDuration":"5s","envoyAccessLogService":{"address":"accesslog-service:15000"},"envoyMetricsService":{"address":"metrics-service:15000","tlsSettings":{"caCertificates":"/etc/istio/ms/ca.pem","clientCertificate":"/etc/istio/ms/client.pem","mode":"MUTUAL","privateKey":"/etc/istio/ms/key.pem"}},"proxyAdminPort":15005,"serviceCluster":"istio-proxy","statNameLength":200,"statsdUdpAddress":"10.1.1.1:9125","statusPort":15020,"tracing":{"zipkin":{"address":"localhost:6000"}}},"WORKLOAD_IDENTITY_SOCKET_FILE":"test.sock","sidecar.istio.io/statsFlushInterval":"10s"}
   },
   "layered_runtime": {
     "layers": [
       {
         "name": "global config",
-        "static_layer": {{ .runtime_flags }}
+        "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
       },
       {
         "name": "admin",
@@ -50,18 +24,6 @@
     ]
   },
   "bootstrap_extensions": [
-    {{- if .metadata_discovery }}
-    {
-      "name": "metadata_discovery",
-      "typed_config": {
-        "@type": "type.googleapis.com/udpa.type.v1.TypedStruct",
-        "type_url": "type.googleapis.com/istio.workload.BootstrapExtension",
-        "value": {
-          "config_source": { "ads": {} }
-        }
-      }
-    },
-    {{- end }}
     {
       "name": "envoy.bootstrap.internal_listener",
       "typed_config": {
@@ -73,12 +35,7 @@
       }
     }
   ],
-  {{- if .stats_flush_interval }}
-  "stats_flush_interval": "{{ .stats_flush_interval }}",
-  {{- end }}
-  {{- if .stats_eviction_interval }}
-  "stats_eviction_interval": "{{ .stats_eviction_interval }}",
-  {{- end }}
+  "stats_flush_interval": "10s",
   "stats_config": {
     "use_all_default_tags": false,
     "stats_tags": [
@@ -118,12 +75,6 @@
         "tag_name": "mongo_prefix",
         "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
       },
-      {{- range $a, $tag := .extraStatTags }}
-      {
-        "regex": "({{ $tag }}=\\.=(.*?);\\.;)",
-        "tag_name": "{{ $tag }}"
-      },
-      {{- end }}
       {
         "regex": "(cache\\.(.+?)\\.)",
         "tag_name": "cache"
@@ -153,35 +104,42 @@
         "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
-    {{- if .histogram_buckets }}
-    "histogram_bucket_settings": {{ toJson .histogram_buckets }},
-    {{- end }}
     "stats_matcher": {
       "inclusion_list": {
         "patterns": [
           {
           "prefix": "reporter="
           },
-          {{- if .metadata_discovery }}
           {
-          "prefix": "workload_discovery"
+          "prefix": "cluster_manager"
           },
-          {{- end }}
-          {{- range $a, $s := .inclusionPrefix }}
           {
-          "prefix": "{{$s}}"
+          "prefix": "listener_manager"
           },
-          {{- end }}
-          {{- range $a, $s := .inclusionSuffix }}
           {
-          "suffix": "{{$s}}"
+          "prefix": "server"
           },
-          {{- end }}
-          {{- range $a, $s := .inclusionRegexps }}
           {
-          "safe_regex": {"regex":"{{js $s}}"}
+          "prefix": "cluster.xds-grpc"
           },
-          {{- end }}
+          {
+          "prefix": "wasm"
+          },
+          {
+          "suffix": "rbac.allowed"
+          },
+          {
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
+          },
+          {
+          "safe_regex": {"regex":"vhost\\..*\\.route\\..*"}
+          },
           {
           "prefix": "component"
           },
@@ -205,8 +163,8 @@
     "profile_path": "/var/lib/istio/data/envoy.prof",
     "address": {
       "socket_address": {
-        "address": "{{ .localhost }}",
-        "port_value": {{ .config.ProxyAdminPort }}
+        "address": "127.0.0.1",
+        "port_value": 15005
       }
     }
   },
@@ -222,7 +180,7 @@
       "resource_api_version": "V3"
     },
     "ads_config": {
-      "api_type": "{{ .xds_type }}",
+      "api_type": "DELTA_GRPC",
       "set_node_on_first_message_only": true,
       "transport_api_version": "V3",
       "grpc_services": [
@@ -250,8 +208,8 @@
                 "address":{
                   "socket_address": {
                     "protocol": "TCP",
-                    "address": "{{ .localhost }}",
-                    "port_value": {{ .config.ProxyAdminPort }}
+                    "address": "127.0.0.1",
+                    "port_value": 15005
                   }
                 }
               }
@@ -273,8 +231,8 @@
                 "address":{
                   "socket_address": {
                     "protocol": "TCP",
-                    "address": "{{ .localhost }}",
-                    "port_value": {{ .config.StatusPort }}
+                    "address": "127.0.0.1",
+                    "port_value": 15020
                   }
                 }
               }
@@ -303,7 +261,7 @@
               "endpoint": {
                 "address":{
                   "pipe": {
-                    "path": "./var/run/secrets/workload-spiffe-uds/{{ .workload_identity_socket_file }}"
+                    "path": "./var/run/secrets/workload-spiffe-uds/test.sock"
                   }
                 }
               }
@@ -311,37 +269,6 @@
           }]
         }
       },
-      {{- if .custom_file_path }}
-      {
-        "name": "sds-files-grpc",
-        "alt_stat_name": "sds-files-grpc;",
-        "type": "STATIC",
-        "typed_extension_protocol_options": {
-          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-           "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-           "explicit_http_config": {
-            "http2_protocol_options": {}
-           }
-          }
-        },
-        "connect_timeout": "1s",
-        "lb_policy": "ROUND_ROBIN",
-        "load_assignment": {
-          "cluster_name": "sds-files-grpc",
-          "endpoints": [{
-            "lb_endpoints": [{
-              "endpoint": {
-                "address":{
-                  "pipe": {
-                    "path": "{{ .custom_file_path }}"
-                  }
-                }
-              }
-            }]
-          }]
-        }
-      },
-      {{- end }}
       {
         "name": "xds-grpc",
         "alt_stat_name": "xds-grpc;",
@@ -355,7 +282,7 @@
               "endpoint": {
                 "address":{
                   "pipe": {
-                    "path": "{{ .config.ConfigPath }}/XDS"
+                    "path": "/tmp/XDS"
                   }
                 }
               }
@@ -393,17 +320,14 @@
           }
         }
       }
-      {{ if .zipkin }}
+      
       ,
       {
         "name": "zipkin",
         "alt_stat_name": "zipkin;",
-        {{- if .tracing_tls }}
-        "transport_socket": {{ .tracing_tls }},
-        {{- end }}
         "type": "STRICT_DNS",
         "respect_dns_ttl": true,
-        "dns_lookup_family": "{{ .dns_lookup_family }}",
+        "dns_lookup_family": "V4_ONLY",
         "dns_refresh_rate": "30s",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -413,88 +337,22 @@
             "lb_endpoints": [{
               "endpoint": {
                 "address":{
-                  "socket_address": {{ .zipkin }}
+                  "socket_address": {"address": "localhost", "port_value": 6000}
                 }
               }
             }]
           }]
         }
       }
-      {{ else if .lightstep }}
-      ,
-      {
-        "name": "lightstep",
-        "alt_stat_name": "lightstep;",
-        {{- if .tracing_tls }}
-        "transport_socket": {{ .tracing_tls }},
-        {{- end }}
-        "typed_extension_protocol_options": {
-          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-           "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-           "explicit_http_config": {
-            "http2_protocol_options": {}
-           }
-          }
-        },
-        "type": "STRICT_DNS",
-        "respect_dns_ttl": true,
-        "dns_lookup_family": "{{ .dns_lookup_family }}",
-        "connect_timeout": "1s",
-        "lb_policy": "ROUND_ROBIN",
-        "load_assignment": {
-          "cluster_name": "lightstep",
-          "endpoints": [{
-            "lb_endpoints": [{
-              "endpoint": {
-                "address":{
-                  "socket_address": {{ .lightstep }}
-                }
-              }
-            }]
-          }]
-        }
-      }
-      {{ else if .datadog }}
-      ,
-      {
-        "name": "datadog_agent",
-        "alt_stat_name": "datadog_agent;",
-        {{- if .tracing_tls }}
-        "transport_socket": {{ .tracing_tls }},
-        {{- end }}
-        "connect_timeout": "1s",
-        "type": "STRICT_DNS",
-        "respect_dns_ttl": true,
-        "dns_lookup_family": "{{ .dns_lookup_family }}",
-        "lb_policy": "ROUND_ROBIN",
-        "load_assignment": {
-          "cluster_name": "datadog_agent",
-          "endpoints": [{
-            "lb_endpoints": [{
-              "endpoint": {
-                "address":{
-                  "socket_address": {{ .datadog }}
-                }
-              }
-            }]
-          }]
-        }
-      }
-      {{ end }}
-      {{- if .envoy_metrics_service_address }}
+      
       ,
       {
         "name": "envoy_metrics_service",
         "alt_stat_name": "envoy_metrics_service;",
         "type": "STRICT_DNS",
-      {{- if .envoy_metrics_service_tls }}
-        "transport_socket": {{ .envoy_metrics_service_tls }},
-      {{- end }}
-      {{- if .envoy_metrics_service_tcp_keepalive }}
-        "upstream_connection_options": {{ .envoy_metrics_service_tcp_keepalive }},
-      {{- end }}
+        "transport_socket": {"name":"envoy.transport_sockets.tls","typed_config":{"@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext","common_tls_context":{"alpn_protocols":["h2"],"combined_validation_context":{"default_validation_context":{},"validation_context_sds_secret_config":{"name":"file-root:/etc/istio/ms/ca.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}},"tls_certificate_sds_secret_configs":[{"name":"file-cert:/etc/istio/ms/client.pem~/etc/istio/ms/key.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}]}}},
         "respect_dns_ttl": true,
-        "dns_lookup_family": "{{ .dns_lookup_family }}",
+        "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
         "typed_extension_protocol_options": {
@@ -511,28 +369,22 @@
             "lb_endpoints": [{
               "endpoint": {
                 "address":{
-                  "socket_address": {{ .envoy_metrics_service_address }}
+                  "socket_address": {"address": "metrics-service", "port_value": 15000}
                 }
               }
             }]
           }]
         }
       }
-      {{ end }}
-      {{ if .envoy_accesslog_service_address }}
+      
+      
       ,
       {
         "name": "envoy_accesslog_service",
         "alt_stat_name": "envoy_accesslog_service;",
         "type": "STRICT_DNS",
-      {{- if .envoy_accesslog_service_tls }}
-        "transport_socket": {{ .envoy_accesslog_service_tls }},
-      {{- end }}
-      {{- if .envoy_accesslog_service_tcp_keepalive }}
-        "upstream_connection_options": {{ .envoy_accesslog_service_tcp_keepalive }},
-      {{ end }}
         "respect_dns_ttl": true,
-        "dns_lookup_family": "{{ .dns_lookup_family }}",
+        "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
         "typed_extension_protocol_options": {
@@ -549,52 +401,29 @@
             "lb_endpoints": [{
               "endpoint": {
                 "address":{
-                  "socket_address": {{ .envoy_accesslog_service_address }}
+                  "socket_address": {"address": "accesslog-service", "port_value": 15000}
                 }
               }
             }]
           }]
         }
       }
-      {{ end }}
+      
     ],
     "listeners":[
       {
-        {{- if .metrics_localhost_access_only }}
-        "name": "{{ .localhost }}_{{ .envoy_prometheus_port }}",
-        {{ else }}
-        "name": "{{ .wildcard }}_{{ .envoy_prometheus_port }}",
-        {{ end }}
+        "name": "0.0.0.0_15090",
+        
         "address": {
           "socket_address": {
             "protocol": "TCP",
-            {{- if .metrics_localhost_access_only }}
-            "address": "{{ .localhost }}",
-            {{ else }}
-            "address": "{{ .wildcard }}",
-            {{ end }}
-            "port_value": {{ .envoy_prometheus_port }}
+            "address": "0.0.0.0",
+            
+            "port_value": 15090
           }
         },
         "ignore_global_conn_limit": true,
         "bypass_overload_manager": true,
-        {{- if .dual_stack }}
-        "additionalAddresses": [
-          {
-            "address": {
-              "socket_address": {
-                "protocol": "TCP",
-                {{- if .metrics_localhost_access_only }}
-                "address": "{{ .additional_localhost }}",
-                {{ else }}
-                "address": "{{ .additional_wildcard }}",
-                {{ end }}
-                "port_value": {{ .envoy_prometheus_port }}
-              }
-            }
-          }
-        ],
-        {{- end}}
         "filter_chains": [
           {
             "filters": [
@@ -625,36 +454,6 @@
                     ]
                   },
                   "http_filters": [
-                  {{- if .stats_compression }}
-                  {
-                    "name": "envoy.filters.http.compressor",
-                    "typed_config": {
-                      "@type": "type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor",
-                      {{- if eq .stats_compression "gzip"}}
-                      "compressor_library": {
-                        "name": "text_optimized",
-                        "typed_config": {
-                          "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
-                        }
-                      }
-                      {{- else if eq .stats_compression "zstd"}}
-                      "compressor_library": {
-                        "name": "text_optimized",
-                        "typed_config": {
-                          "@type": "type.googleapis.com/envoy.extensions.compression.zstd.compressor.v3.Zstd"
-                        }
-                      }
-                      {{- else if eq .stats_compression "brotli"}}
-                      "compressor_library": {
-                        "name": "text_optimized",
-                        "typed_config": {
-                          "@type": "type.googleapis.com/envoy.extensions.compression.brotli.compressor.v3.Brotli"
-                        }
-                      }
-                      {{- end }}
-                    }
-                  },
-                  {{- end }}
                   {
                     "name": "envoy.filters.http.router",
                     "typed_config": {
@@ -668,40 +467,16 @@
         ]
       },
       {
-        "name": "{{ .wildcard }}_{{ .envoy_status_port }}",
+        "name": "0.0.0.0_15021",
         "address": {
            "socket_address": {
              "protocol": "TCP",
-             "address": "{{ .wildcard }}",
-             "port_value": {{ .envoy_status_port }}
+             "address": "0.0.0.0",
+             "port_value": 15021
            }
         },
         "ignore_global_conn_limit": true,
         "bypass_overload_manager": true,
-        {{- if .dual_stack }}
-        "additionalAddresses": [
-          {
-            "address": {
-              "socket_address": {
-                "protocol": "TCP",
-                "address": "{{ .additional_wildcard }}",
-                "port_value": {{ .envoy_status_port }}
-              }
-            }
-          }
-        ],
-        {{- end}}
-        {{- if .envoy_status_port_enable_proxy_protocol }}
-        "listener_filters": [
-          {
-            "name": "envoy.listener.proxy_protocol",
-            "typed_config": {
-              "@type": "type.googleapis.com/envoy.extensions.filters.listener.proxy_protocol.v3.ProxyProtocol",
-              "allow_requests_without_proxy_protocol": true,
-            }
-          }
-        ],
-        {{- end }}
         "filter_chains": [
           {
             "filters": [
@@ -745,7 +520,6 @@
       }
     ]
   }
-  {{- if .zipkin }}
   ,
   "tracing": {
     "http": {
@@ -760,35 +534,10 @@
       }
     }
   }
-  {{- else if .lightstep }}
-  ,
-  "tracing": {
-    "http": {
-      "name": "envoy.tracers.lightstep",
-      "typed_config": {
-        "@type": "type.googleapis.com/envoy.config.trace.v3.LightstepConfig",
-        "collector_cluster": "lightstep",
-        "access_token_file": "{{ .lightstepToken}}"
-      }
-    }
-  }
-  {{- else if .datadog }}
-  ,
-  "tracing": {
-    "http": {
-      "name": "envoy.tracers.datadog",
-      "typed_config": {
-        "@type": "type.googleapis.com/envoy.config.trace.v3.DatadogConfig",
-        "collector_cluster": "datadog_agent",
-        "service_name": "{{ .cluster }}"
-      }
-    }
-  }
-  {{ end }}
-  {{ if or .envoy_metrics_service_address .statsd }}
+  
   ,
   "stats_sinks": [
-    {{ if .envoy_metrics_service_address }}
+    
     {
       "name": "envoy.stat_sinks.metrics_service",
       "typed_config": {
@@ -801,40 +550,31 @@
         }
       }
     }
-    {{ end }}
-    {{ if and .envoy_metrics_service_address .statsd }}
+    
+    
     ,
-    {{ end }}
-    {{ if .statsd }}
+    
+    
     {
       "name": "envoy.stat_sinks.statsd",
       "typed_config": {
         "@type": "type.googleapis.com/envoy.config.metrics.v3.StatsdSink",
         "address": {
-          "socket_address": {{ .statsd }}
+          "socket_address": {"address": "10.1.1.1", "port_value": 9125}
         }
       }
     }
-    {{ end }}
+    
   ]
-  {{ end }}
-  {{ if or .outlier_log_path .load_stats_config_json_str}}
+  
+  
   ,
   "cluster_manager": {
     "enable_deferred_cluster_creation": true,
-    {{- if .outlier_log_path}}
     "outlier_detection": {
-      "event_log_path": "{{ .outlier_log_path }}"
+      "event_log_path": "/dev/stdout"
     }
-    {{- end}}
-    {{- if and .outlier_log_path .load_stats_config_json_str }}
-    ,
-    {{- end}}
-    {{- if .load_stats_config_json_str }}
-    "load_stats_config": {{- .load_stats_config_json_str }}
-    {{- end }}
   }
-  {{- end }}
   ,
   "deferred_stat_options": {
     "enable_deferred_creation_stats": true

--- a/pkg/bootstrap/testdata/stats_interval.proxycfg
+++ b/pkg/bootstrap/testdata/stats_interval.proxycfg
@@ -1,0 +1,14 @@
+config_path:                      "/etc/istio/proxy"
+binary_path:                      "/usr/local/bin/envoy"
+service_cluster:                  "istio-proxy"
+drain_duration:                   {seconds: 5}
+discovery_address:                "mypilot:15011"
+statsd_udp_address:               "10.1.1.1:9125"
+envoy_metrics_service:            {address: "metrics-service:15000", tls_settings: { mode: MUTUAL, client_certificate: "/etc/istio/ms/client.pem", private_key: "/etc/istio/ms/key.pem", ca_certificates: "/etc/istio/ms/ca.pem"}}
+envoy_access_log_service:         {address: "accesslog-service:15000"}
+proxy_admin_port:                 15005
+control_plane_auth_policy:        MUTUAL_TLS
+stat_name_length:                 200
+tracing:                          { zipkin: { address: "localhost:6000" } }
+
+# Sets all relevant options to values different than default

--- a/pkg/bootstrap/testdata/stats_interval_golden.json
+++ b/pkg/bootstrap/testdata/stats_interval_golden.json
@@ -1,47 +1,21 @@
 {
   "application_log_config": {
     "log_format": {
-{{- if .log_json }}
-      "json_format": {
-        "time": "%Y-%m-%dT%T.%fZ",
-        "level": "%l",
-        "scope": "envoy %n",
-        "msg": "%j",
-        "caller": "%g:%#",
-        "thread": "%t"
-      }
-{{- else }}
       "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
-{{- end }}
     }
   },
   "node": {
-    "id": "{{ .nodeID }}",
-    "cluster": "{{ .cluster }}",
+    "id": "sidecar~1.2.3.4~foo~bar",
+    "cluster": "istio-proxy",
     "locality": {
-      {{- if .region }}
-      "region": "{{ .region }}"
-      {{- end }}
-      {{- if .zone }}
-      {{- if .region }}
-      ,
-      {{- end }}
-      "zone": "{{ .zone }}"
-      {{- end }}
-      {{- if .sub_zone }}
-      {{- if or .region .zone }}
-      ,
-      {{- end }}
-      "sub_zone": "{{ .sub_zone }}"
-      {{- end }}
     },
-    "metadata": {{ .meta_json_str }}
+    "metadata": {"ANNOTATIONS":{"sidecar.istio.io/statsEvictionInterval":"20s","sidecar.istio.io/statsFlushInterval":"10s"},"ENVOY_PROMETHEUS_PORT":15090,"ENVOY_STATUS_PORT":15021,"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","ISTIO_VERSION":"binary-1.0","METADATA_DISCOVERY":"false","OUTLIER_LOG_PATH":"/dev/stdout","PILOT_SAN":["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"],"PROXY_CONFIG":{"binaryPath":"/usr/local/bin/envoy","configPath":"/tmp/bootstrap/stats_interval","controlPlaneAuthPolicy":"MUTUAL_TLS","customConfigFile":"envoy_bootstrap.json","discoveryAddress":"mypilot:15011","drainDuration":"5s","envoyAccessLogService":{"address":"accesslog-service:15000"},"envoyMetricsService":{"address":"metrics-service:15000","tlsSettings":{"caCertificates":"/etc/istio/ms/ca.pem","clientCertificate":"/etc/istio/ms/client.pem","mode":"MUTUAL","privateKey":"/etc/istio/ms/key.pem"}},"proxyAdminPort":15005,"serviceCluster":"istio-proxy","statNameLength":200,"statsdUdpAddress":"10.1.1.1:9125","statusPort":15020,"tracing":{"zipkin":{"address":"localhost:6000"}}},"WORKLOAD_IDENTITY_SOCKET_FILE":"test.sock","sidecar.istio.io/statsEvictionInterval":"20s","sidecar.istio.io/statsFlushInterval":"10s"}
   },
   "layered_runtime": {
     "layers": [
       {
         "name": "global config",
-        "static_layer": {{ .runtime_flags }}
+        "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
       },
       {
         "name": "admin",
@@ -50,18 +24,6 @@
     ]
   },
   "bootstrap_extensions": [
-    {{- if .metadata_discovery }}
-    {
-      "name": "metadata_discovery",
-      "typed_config": {
-        "@type": "type.googleapis.com/udpa.type.v1.TypedStruct",
-        "type_url": "type.googleapis.com/istio.workload.BootstrapExtension",
-        "value": {
-          "config_source": { "ads": {} }
-        }
-      }
-    },
-    {{- end }}
     {
       "name": "envoy.bootstrap.internal_listener",
       "typed_config": {
@@ -73,12 +35,8 @@
       }
     }
   ],
-  {{- if .stats_flush_interval }}
-  "stats_flush_interval": "{{ .stats_flush_interval }}",
-  {{- end }}
-  {{- if .stats_eviction_interval }}
-  "stats_eviction_interval": "{{ .stats_eviction_interval }}",
-  {{- end }}
+  "stats_flush_interval": "10s",
+  "stats_eviction_interval": "20s",
   "stats_config": {
     "use_all_default_tags": false,
     "stats_tags": [
@@ -118,12 +76,6 @@
         "tag_name": "mongo_prefix",
         "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
       },
-      {{- range $a, $tag := .extraStatTags }}
-      {
-        "regex": "({{ $tag }}=\\.=(.*?);\\.;)",
-        "tag_name": "{{ $tag }}"
-      },
-      {{- end }}
       {
         "regex": "(cache\\.(.+?)\\.)",
         "tag_name": "cache"
@@ -153,35 +105,42 @@
         "regex": "(\\.shadow_(allowed|denied))"
       }
     ],
-    {{- if .histogram_buckets }}
-    "histogram_bucket_settings": {{ toJson .histogram_buckets }},
-    {{- end }}
     "stats_matcher": {
       "inclusion_list": {
         "patterns": [
           {
           "prefix": "reporter="
           },
-          {{- if .metadata_discovery }}
           {
-          "prefix": "workload_discovery"
+          "prefix": "cluster_manager"
           },
-          {{- end }}
-          {{- range $a, $s := .inclusionPrefix }}
           {
-          "prefix": "{{$s}}"
+          "prefix": "listener_manager"
           },
-          {{- end }}
-          {{- range $a, $s := .inclusionSuffix }}
           {
-          "suffix": "{{$s}}"
+          "prefix": "server"
           },
-          {{- end }}
-          {{- range $a, $s := .inclusionRegexps }}
           {
-          "safe_regex": {"regex":"{{js $s}}"}
+          "prefix": "cluster.xds-grpc"
           },
-          {{- end }}
+          {
+          "prefix": "wasm"
+          },
+          {
+          "suffix": "rbac.allowed"
+          },
+          {
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
+          },
+          {
+          "safe_regex": {"regex":"vhost\\..*\\.route\\..*"}
+          },
           {
           "prefix": "component"
           },
@@ -205,8 +164,8 @@
     "profile_path": "/var/lib/istio/data/envoy.prof",
     "address": {
       "socket_address": {
-        "address": "{{ .localhost }}",
-        "port_value": {{ .config.ProxyAdminPort }}
+        "address": "127.0.0.1",
+        "port_value": 15005
       }
     }
   },
@@ -222,7 +181,7 @@
       "resource_api_version": "V3"
     },
     "ads_config": {
-      "api_type": "{{ .xds_type }}",
+      "api_type": "DELTA_GRPC",
       "set_node_on_first_message_only": true,
       "transport_api_version": "V3",
       "grpc_services": [
@@ -250,8 +209,8 @@
                 "address":{
                   "socket_address": {
                     "protocol": "TCP",
-                    "address": "{{ .localhost }}",
-                    "port_value": {{ .config.ProxyAdminPort }}
+                    "address": "127.0.0.1",
+                    "port_value": 15005
                   }
                 }
               }
@@ -273,8 +232,8 @@
                 "address":{
                   "socket_address": {
                     "protocol": "TCP",
-                    "address": "{{ .localhost }}",
-                    "port_value": {{ .config.StatusPort }}
+                    "address": "127.0.0.1",
+                    "port_value": 15020
                   }
                 }
               }
@@ -303,7 +262,7 @@
               "endpoint": {
                 "address":{
                   "pipe": {
-                    "path": "./var/run/secrets/workload-spiffe-uds/{{ .workload_identity_socket_file }}"
+                    "path": "./var/run/secrets/workload-spiffe-uds/test.sock"
                   }
                 }
               }
@@ -311,37 +270,6 @@
           }]
         }
       },
-      {{- if .custom_file_path }}
-      {
-        "name": "sds-files-grpc",
-        "alt_stat_name": "sds-files-grpc;",
-        "type": "STATIC",
-        "typed_extension_protocol_options": {
-          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-           "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-           "explicit_http_config": {
-            "http2_protocol_options": {}
-           }
-          }
-        },
-        "connect_timeout": "1s",
-        "lb_policy": "ROUND_ROBIN",
-        "load_assignment": {
-          "cluster_name": "sds-files-grpc",
-          "endpoints": [{
-            "lb_endpoints": [{
-              "endpoint": {
-                "address":{
-                  "pipe": {
-                    "path": "{{ .custom_file_path }}"
-                  }
-                }
-              }
-            }]
-          }]
-        }
-      },
-      {{- end }}
       {
         "name": "xds-grpc",
         "alt_stat_name": "xds-grpc;",
@@ -355,7 +283,7 @@
               "endpoint": {
                 "address":{
                   "pipe": {
-                    "path": "{{ .config.ConfigPath }}/XDS"
+                    "path": "/tmp/XDS"
                   }
                 }
               }
@@ -393,17 +321,14 @@
           }
         }
       }
-      {{ if .zipkin }}
+      
       ,
       {
         "name": "zipkin",
         "alt_stat_name": "zipkin;",
-        {{- if .tracing_tls }}
-        "transport_socket": {{ .tracing_tls }},
-        {{- end }}
         "type": "STRICT_DNS",
         "respect_dns_ttl": true,
-        "dns_lookup_family": "{{ .dns_lookup_family }}",
+        "dns_lookup_family": "V4_ONLY",
         "dns_refresh_rate": "30s",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -413,88 +338,22 @@
             "lb_endpoints": [{
               "endpoint": {
                 "address":{
-                  "socket_address": {{ .zipkin }}
+                  "socket_address": {"address": "localhost", "port_value": 6000}
                 }
               }
             }]
           }]
         }
       }
-      {{ else if .lightstep }}
-      ,
-      {
-        "name": "lightstep",
-        "alt_stat_name": "lightstep;",
-        {{- if .tracing_tls }}
-        "transport_socket": {{ .tracing_tls }},
-        {{- end }}
-        "typed_extension_protocol_options": {
-          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-           "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-           "explicit_http_config": {
-            "http2_protocol_options": {}
-           }
-          }
-        },
-        "type": "STRICT_DNS",
-        "respect_dns_ttl": true,
-        "dns_lookup_family": "{{ .dns_lookup_family }}",
-        "connect_timeout": "1s",
-        "lb_policy": "ROUND_ROBIN",
-        "load_assignment": {
-          "cluster_name": "lightstep",
-          "endpoints": [{
-            "lb_endpoints": [{
-              "endpoint": {
-                "address":{
-                  "socket_address": {{ .lightstep }}
-                }
-              }
-            }]
-          }]
-        }
-      }
-      {{ else if .datadog }}
-      ,
-      {
-        "name": "datadog_agent",
-        "alt_stat_name": "datadog_agent;",
-        {{- if .tracing_tls }}
-        "transport_socket": {{ .tracing_tls }},
-        {{- end }}
-        "connect_timeout": "1s",
-        "type": "STRICT_DNS",
-        "respect_dns_ttl": true,
-        "dns_lookup_family": "{{ .dns_lookup_family }}",
-        "lb_policy": "ROUND_ROBIN",
-        "load_assignment": {
-          "cluster_name": "datadog_agent",
-          "endpoints": [{
-            "lb_endpoints": [{
-              "endpoint": {
-                "address":{
-                  "socket_address": {{ .datadog }}
-                }
-              }
-            }]
-          }]
-        }
-      }
-      {{ end }}
-      {{- if .envoy_metrics_service_address }}
+      
       ,
       {
         "name": "envoy_metrics_service",
         "alt_stat_name": "envoy_metrics_service;",
         "type": "STRICT_DNS",
-      {{- if .envoy_metrics_service_tls }}
-        "transport_socket": {{ .envoy_metrics_service_tls }},
-      {{- end }}
-      {{- if .envoy_metrics_service_tcp_keepalive }}
-        "upstream_connection_options": {{ .envoy_metrics_service_tcp_keepalive }},
-      {{- end }}
+        "transport_socket": {"name":"envoy.transport_sockets.tls","typed_config":{"@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext","common_tls_context":{"alpn_protocols":["h2"],"combined_validation_context":{"default_validation_context":{},"validation_context_sds_secret_config":{"name":"file-root:/etc/istio/ms/ca.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}},"tls_certificate_sds_secret_configs":[{"name":"file-cert:/etc/istio/ms/client.pem~/etc/istio/ms/key.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}]}}},
         "respect_dns_ttl": true,
-        "dns_lookup_family": "{{ .dns_lookup_family }}",
+        "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
         "typed_extension_protocol_options": {
@@ -511,28 +370,22 @@
             "lb_endpoints": [{
               "endpoint": {
                 "address":{
-                  "socket_address": {{ .envoy_metrics_service_address }}
+                  "socket_address": {"address": "metrics-service", "port_value": 15000}
                 }
               }
             }]
           }]
         }
       }
-      {{ end }}
-      {{ if .envoy_accesslog_service_address }}
+      
+      
       ,
       {
         "name": "envoy_accesslog_service",
         "alt_stat_name": "envoy_accesslog_service;",
         "type": "STRICT_DNS",
-      {{- if .envoy_accesslog_service_tls }}
-        "transport_socket": {{ .envoy_accesslog_service_tls }},
-      {{- end }}
-      {{- if .envoy_accesslog_service_tcp_keepalive }}
-        "upstream_connection_options": {{ .envoy_accesslog_service_tcp_keepalive }},
-      {{ end }}
         "respect_dns_ttl": true,
-        "dns_lookup_family": "{{ .dns_lookup_family }}",
+        "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
         "typed_extension_protocol_options": {
@@ -549,52 +402,29 @@
             "lb_endpoints": [{
               "endpoint": {
                 "address":{
-                  "socket_address": {{ .envoy_accesslog_service_address }}
+                  "socket_address": {"address": "accesslog-service", "port_value": 15000}
                 }
               }
             }]
           }]
         }
       }
-      {{ end }}
+      
     ],
     "listeners":[
       {
-        {{- if .metrics_localhost_access_only }}
-        "name": "{{ .localhost }}_{{ .envoy_prometheus_port }}",
-        {{ else }}
-        "name": "{{ .wildcard }}_{{ .envoy_prometheus_port }}",
-        {{ end }}
+        "name": "0.0.0.0_15090",
+        
         "address": {
           "socket_address": {
             "protocol": "TCP",
-            {{- if .metrics_localhost_access_only }}
-            "address": "{{ .localhost }}",
-            {{ else }}
-            "address": "{{ .wildcard }}",
-            {{ end }}
-            "port_value": {{ .envoy_prometheus_port }}
+            "address": "0.0.0.0",
+            
+            "port_value": 15090
           }
         },
         "ignore_global_conn_limit": true,
         "bypass_overload_manager": true,
-        {{- if .dual_stack }}
-        "additionalAddresses": [
-          {
-            "address": {
-              "socket_address": {
-                "protocol": "TCP",
-                {{- if .metrics_localhost_access_only }}
-                "address": "{{ .additional_localhost }}",
-                {{ else }}
-                "address": "{{ .additional_wildcard }}",
-                {{ end }}
-                "port_value": {{ .envoy_prometheus_port }}
-              }
-            }
-          }
-        ],
-        {{- end}}
         "filter_chains": [
           {
             "filters": [
@@ -625,36 +455,6 @@
                     ]
                   },
                   "http_filters": [
-                  {{- if .stats_compression }}
-                  {
-                    "name": "envoy.filters.http.compressor",
-                    "typed_config": {
-                      "@type": "type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor",
-                      {{- if eq .stats_compression "gzip"}}
-                      "compressor_library": {
-                        "name": "text_optimized",
-                        "typed_config": {
-                          "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
-                        }
-                      }
-                      {{- else if eq .stats_compression "zstd"}}
-                      "compressor_library": {
-                        "name": "text_optimized",
-                        "typed_config": {
-                          "@type": "type.googleapis.com/envoy.extensions.compression.zstd.compressor.v3.Zstd"
-                        }
-                      }
-                      {{- else if eq .stats_compression "brotli"}}
-                      "compressor_library": {
-                        "name": "text_optimized",
-                        "typed_config": {
-                          "@type": "type.googleapis.com/envoy.extensions.compression.brotli.compressor.v3.Brotli"
-                        }
-                      }
-                      {{- end }}
-                    }
-                  },
-                  {{- end }}
                   {
                     "name": "envoy.filters.http.router",
                     "typed_config": {
@@ -668,40 +468,16 @@
         ]
       },
       {
-        "name": "{{ .wildcard }}_{{ .envoy_status_port }}",
+        "name": "0.0.0.0_15021",
         "address": {
            "socket_address": {
              "protocol": "TCP",
-             "address": "{{ .wildcard }}",
-             "port_value": {{ .envoy_status_port }}
+             "address": "0.0.0.0",
+             "port_value": 15021
            }
         },
         "ignore_global_conn_limit": true,
         "bypass_overload_manager": true,
-        {{- if .dual_stack }}
-        "additionalAddresses": [
-          {
-            "address": {
-              "socket_address": {
-                "protocol": "TCP",
-                "address": "{{ .additional_wildcard }}",
-                "port_value": {{ .envoy_status_port }}
-              }
-            }
-          }
-        ],
-        {{- end}}
-        {{- if .envoy_status_port_enable_proxy_protocol }}
-        "listener_filters": [
-          {
-            "name": "envoy.listener.proxy_protocol",
-            "typed_config": {
-              "@type": "type.googleapis.com/envoy.extensions.filters.listener.proxy_protocol.v3.ProxyProtocol",
-              "allow_requests_without_proxy_protocol": true,
-            }
-          }
-        ],
-        {{- end }}
         "filter_chains": [
           {
             "filters": [
@@ -745,7 +521,6 @@
       }
     ]
   }
-  {{- if .zipkin }}
   ,
   "tracing": {
     "http": {
@@ -760,35 +535,10 @@
       }
     }
   }
-  {{- else if .lightstep }}
-  ,
-  "tracing": {
-    "http": {
-      "name": "envoy.tracers.lightstep",
-      "typed_config": {
-        "@type": "type.googleapis.com/envoy.config.trace.v3.LightstepConfig",
-        "collector_cluster": "lightstep",
-        "access_token_file": "{{ .lightstepToken}}"
-      }
-    }
-  }
-  {{- else if .datadog }}
-  ,
-  "tracing": {
-    "http": {
-      "name": "envoy.tracers.datadog",
-      "typed_config": {
-        "@type": "type.googleapis.com/envoy.config.trace.v3.DatadogConfig",
-        "collector_cluster": "datadog_agent",
-        "service_name": "{{ .cluster }}"
-      }
-    }
-  }
-  {{ end }}
-  {{ if or .envoy_metrics_service_address .statsd }}
+  
   ,
   "stats_sinks": [
-    {{ if .envoy_metrics_service_address }}
+    
     {
       "name": "envoy.stat_sinks.metrics_service",
       "typed_config": {
@@ -801,40 +551,31 @@
         }
       }
     }
-    {{ end }}
-    {{ if and .envoy_metrics_service_address .statsd }}
+    
+    
     ,
-    {{ end }}
-    {{ if .statsd }}
+    
+    
     {
       "name": "envoy.stat_sinks.statsd",
       "typed_config": {
         "@type": "type.googleapis.com/envoy.config.metrics.v3.StatsdSink",
         "address": {
-          "socket_address": {{ .statsd }}
+          "socket_address": {"address": "10.1.1.1", "port_value": 9125}
         }
       }
     }
-    {{ end }}
+    
   ]
-  {{ end }}
-  {{ if or .outlier_log_path .load_stats_config_json_str}}
+  
+  
   ,
   "cluster_manager": {
     "enable_deferred_cluster_creation": true,
-    {{- if .outlier_log_path}}
     "outlier_detection": {
-      "event_log_path": "{{ .outlier_log_path }}"
+      "event_log_path": "/dev/stdout"
     }
-    {{- end}}
-    {{- if and .outlier_log_path .load_stats_config_json_str }}
-    ,
-    {{- end}}
-    {{- if .load_stats_config_json_str }}
-    "load_stats_config": {{- .load_stats_config_json_str }}
-    {{- end }}
   }
-  {{- end }}
   ,
   "deferred_stat_options": {
     "enable_deferred_creation_stats": true

--- a/pkg/config/xds/filter_types.gen.go
+++ b/pkg/config/xds/filter_types.gen.go
@@ -81,6 +81,8 @@ import (
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/stream/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/wasm/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/bootstrap/internal_listener/v3"
+	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/v3"
+	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/clusters/aggregate/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/clusters/common/dns/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/clusters/dns/v3"

--- a/releasenotes/notes/58518.yaml
+++ b/releasenotes/notes/58518.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: telemetry
+issue:
+  - https://github.com/istio/istio/issues/58500
+releaseNotes:
+- |
+  **Fixed** `sidecar.istio.io/statsEvictionInterval` annotation with values >= 60s
+  causing `istio-proxy` sidecars to fail to start.

--- a/releasenotes/notes/stats-flush-eviction.yaml
+++ b/releasenotes/notes/stats-flush-eviction.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+releaseNotes:
+  - |
+    **Added** support for annotation `sidecar.istio.io/statsFlushInterval`and `sidecar.istio.io/statsEvictionInterval`. 


### PR DESCRIPTION

Back port of #57736 & #58570 

This is part of a coordinated backport to back port stats eviction support from Envoy 1.36 / Istio 1.28 to Envoy 1.35 / Istio 1.27, to address unbounded metric memory growth in waypoint proxies. The full set of changes to be back ported across repositories:

- envoyproxy/envoy#40395
- envoyproxy/envoy#42168
- istio/proxy#6529
- istio/api#3562
- istio/istio#57736 (This PR)
- istio/istio#58570 (This PR)