### PR TITLE
Secure Metrics: auto-annotate prometheus.istio.io/secure-port

### DIFF
--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -89,6 +89,7 @@ const (
 	prometheusPortAnnotation               = "prometheus_io_port"
 	prometheusPathAnnotation               = "prometheus_io_path"
 	prometheusIstioScrapeTargetsAnnotation = "prometheus_istio_io_scrape_targets"
+	prometheusIstioSecurePortAnnotation    = "prometheus_istio_io_secure_port"
 
 	watchDebounceDelay = 100 * time.Millisecond
 )
@@ -752,6 +753,8 @@ func postProcessPod(pod *corev1.Pod, injectedPod corev1.Pod, req InjectionParame
 		return err
 	}
 
+	applySecurePrometheusAnnotation(pod)
+
 	if err := applyRewrite(pod, req); err != nil {
 		return err
 	}
@@ -878,6 +881,37 @@ func mergeOrAppendProbers(previouslyInjected bool, envVars []corev1.EnvVar, newP
 		}
 	}
 	return append(envVars, corev1.EnvVar{Name: status.KubeAppProberEnvName, Value: newProbers})
+}
+
+// applySecurePrometheusAnnotation auto-populates the "prometheus.istio.io/secure-port"
+// annotation when the istio-proxy container has ENVOY_SECURE_MERGED_METRICS_PORT set.
+// This mirrors applyPrometheusMerge's handling of the plain-text port so that users only
+// need to configure the env variable and Prometheus discovery is wired up automatically.
+//
+// The env var is present at postProcessPod time for both sidecars (where proxyMetadata
+// is expanded into the container env by the injection template) and for injected gateway
+// pods (where the env var is set directly on the istio-proxy container).
+//
+// If the user has already set the annotation explicitly it is left unchanged.
+func applySecurePrometheusAnnotation(pod *corev1.Pod) {
+	// User already opted in explicitly.
+	for k := range pod.Annotations {
+		if strutil.SanitizeLabelName(k) == prometheusIstioSecurePortAnnotation {
+			return
+		}
+	}
+
+	sidecar := FindSidecar(pod)
+	if sidecar == nil {
+		return
+	}
+
+	for _, env := range sidecar.Env {
+		if env.Name == "ENVOY_SECURE_MERGED_METRICS_PORT" && env.Value != "" && env.Value != "0" {
+			pod.Annotations["prometheus.istio.io/secure-port"] = env.Value
+			return
+		}
+	}
 }
 
 // applyPrometheusMerge configures prometheus scraping annotations for the "metrics merge" feature.

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -1770,3 +1770,91 @@ func TestApplyPrometheusMergeScrapeTargets(t *testing.T) {
 		}
 	})
 }
+
+// TestApplySecurePrometheusAnnotation verifies that applySecurePrometheusAnnotation
+// automatically sets "prometheus.istio.io/secure-port" when ENVOY_SECURE_MERGED_METRICS_PORT
+// is present on the istio-proxy container.
+func TestApplySecurePrometheusAnnotation(t *testing.T) {
+	newPod := func(proxyEnv []corev1.EnvVar, existingAnnotations map[string]string) *corev1.Pod {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Annotations: existingAnnotations},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "app"},
+					{Name: "istio-proxy", Env: proxyEnv},
+				},
+			},
+		}
+		if pod.Annotations == nil {
+			pod.Annotations = map[string]string{}
+		}
+		return pod
+	}
+
+	t.Run("sidecar: auto-annotates from ENVOY_SECURE_MERGED_METRICS_PORT", func(t *testing.T) {
+		pod := newPod([]corev1.EnvVar{
+			{Name: "ENVOY_SECURE_METRICS_PORT", Value: "15091"},
+			{Name: "ENVOY_SECURE_MERGED_METRICS_PORT", Value: "15092"},
+		}, nil)
+		applySecurePrometheusAnnotation(pod)
+		if got := pod.Annotations["prometheus.istio.io/secure-port"]; got != "15092" {
+			t.Errorf("prometheus.istio.io/secure-port = %q, want 15092", got)
+		}
+	})
+
+	t.Run("gateway: direct env var is picked up (no proxyMetadata annotation needed)", func(t *testing.T) {
+		// Simulates a gateway pod where env is set directly on the container.
+		pod := newPod([]corev1.EnvVar{
+			{Name: "ENVOY_SECURE_MERGED_METRICS_PORT", Value: "15092"},
+		}, nil)
+		applySecurePrometheusAnnotation(pod)
+		if got := pod.Annotations["prometheus.istio.io/secure-port"]; got != "15092" {
+			t.Errorf("prometheus.istio.io/secure-port = %q, want 15092", got)
+		}
+	})
+
+	t.Run("user-set annotation is not overwritten", func(t *testing.T) {
+		pod := newPod([]corev1.EnvVar{
+			{Name: "ENVOY_SECURE_MERGED_METRICS_PORT", Value: "15092"},
+		}, map[string]string{
+			"prometheus.istio.io/secure-port": "19999",
+		})
+		applySecurePrometheusAnnotation(pod)
+		if got := pod.Annotations["prometheus.istio.io/secure-port"]; got != "19999" {
+			t.Errorf("user annotation overwritten: got %q, want 19999", got)
+		}
+	})
+
+	t.Run("disabled (port=0) does not annotate", func(t *testing.T) {
+		pod := newPod([]corev1.EnvVar{
+			{Name: "ENVOY_SECURE_MERGED_METRICS_PORT", Value: "0"},
+		}, nil)
+		applySecurePrometheusAnnotation(pod)
+		if _, ok := pod.Annotations["prometheus.istio.io/secure-port"]; ok {
+			t.Error("expected no annotation when port is 0, but one was set")
+		}
+	})
+
+	t.Run("no env var: no annotation", func(t *testing.T) {
+		pod := newPod([]corev1.EnvVar{
+			{Name: "SOME_OTHER_VAR", Value: "value"},
+		}, nil)
+		applySecurePrometheusAnnotation(pod)
+		if _, ok := pod.Annotations["prometheus.istio.io/secure-port"]; ok {
+			t.Error("expected no annotation when ENVOY_SECURE_MERGED_METRICS_PORT is absent")
+		}
+	})
+
+	t.Run("no istio-proxy container: no annotation", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "app"}},
+			},
+		}
+		applySecurePrometheusAnnotation(pod)
+		if _, ok := pod.Annotations["prometheus.istio.io/secure-port"]; ok {
+			t.Error("expected no annotation without istio-proxy container")
+		}
+	})
+}

--- a/tests/integration/telemetry/api/metrics_port_test.go
+++ b/tests/integration/telemetry/api/metrics_port_test.go
@@ -17,7 +17,10 @@
 package api
 
 import (
+	"context"
 	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
@@ -62,6 +65,9 @@ func TestSecureMetricsPorts(t *testing.T) {
 		})
 		t.NewSubTest("15020-localhost-only").Run(func(t framework.TestContext) {
 			testHTTPBlocked(t, target, mergedMetricsPort)
+		})
+		t.NewSubTest("auto-annotation-secure-port").Run(func(t framework.TestContext) {
+			testAutoAnnotation(t, target, "prometheus.istio.io/secure-port", "15092")
 		})
 	})
 }
@@ -113,6 +119,27 @@ func testHTTPBlocked(t framework.TestContext, target echo.Instances, port int) {
 			Retry:      echo.Retry{NoRetry: true},
 		}); err != nil {
 			t.Errorf("port %d is accessible via plain HTTP but should not be: %v", port, err)
+		}
+	}
+}
+
+// testAutoAnnotation verifies that the sidecar injector automatically sets the given annotation
+// on the pod when ENVOY_SECURE_MERGED_METRICS_PORT is configured via proxyMetadata.
+// This exercises applySecurePrometheusAnnotation end-to-end in a real cluster.
+func testAutoAnnotation(t framework.TestContext, target echo.Instances, annotation, wantValue string) {
+	for _, inst := range target {
+		for _, w := range inst.WorkloadsOrFail(t) {
+			pod, err := inst.Config().Cluster.Kube().CoreV1().Pods(inst.NamespaceName()).Get(
+				context.TODO(), w.PodName(), metav1.GetOptions{},
+			)
+			if err != nil {
+				t.Fatalf("failed to get pod %s: %v", w.PodName(), err)
+			}
+			got := pod.Annotations[annotation]
+			if got != wantValue {
+				t.Errorf("pod %s: annotation %s = %q, want %q (should be auto-set by injector from ENVOY_SECURE_MERGED_METRICS_PORT)",
+					w.PodName(), annotation, got, wantValue)
+			}
 		}
 	}
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

When ENVOY_SECURE_MERGED_METRICS_PORT is configured on the istio-proxy container, the sidecar webhook now automatically sets prometheus.istio.io/secure-port on the pod at injection time. This mirrors the existing applyPrometheusMerge behaviour for the plain-text port . Users only need to configure the env variable and Prometheus service discovery is wired up automatically.

Follow up on: https://github.com/istio/istio/pull/60391