### PR TITLE
fix: merge DestinationRule over backend policy as client side override

### DIFF
--- a/pilot/pkg/model/destination_rule.go
+++ b/pilot/pkg/model/destination_rule.go
@@ -22,6 +22,7 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/visibility"
@@ -38,6 +39,10 @@ import (
 // 2. If the original rule did not have any top level traffic policy, traffic policies from the new rule will be
 // used.
 // 3. If the original rule did not have any exportTo, exportTo settings from the new rule will be used.
+//
+// When a user authored DestinationRule and a DestinationRule synthesized from a Gateway API backend policy
+// (BackendTLSPolicy/XBackendTrafficPolicy) target the same host, the user fields win and the backend policy
+// only fills in fields the user rule leaves unset, regardless of creation order.
 func (ps *PushContext) mergeDestinationRule(p *consolidatedDestRules, destRuleConfig config.Config, exportToSet sets.Set[visibility.Instance]) {
 	rule := destRuleConfig.Spec.(*networking.DestinationRule)
 	resolvedHost := host.Name(rule.Host)
@@ -111,10 +116,24 @@ func (ps *PushContext) mergeDestinationRule(p *consolidatedDestRules, destRuleCo
 				}
 			}
 
-			// If there is no top level policy and the incoming rule has top level
-			// traffic policy, use the one from the incoming rule.
-			if mergedRule.TrafficPolicy == nil && rule.TrafficPolicy != nil {
-				mergedRule.TrafficPolicy = rule.TrafficPolicy
+			existingIsBackendPolicy := isBackendPolicyDestinationRule(&copied)
+			incomingIsBackendPolicy := isBackendPolicyDestinationRule(&destRuleConfig)
+			switch {
+			case existingIsBackendPolicy == incomingIsBackendPolicy:
+				// Both rules have the same origin (both user authored or both synthesized).
+				// Keep the first-wins behavior: only adopt the incoming top level policy when
+				// the merged rule does not have one yet.
+				if mergedRule.TrafficPolicy == nil && rule.TrafficPolicy != nil {
+					mergedRule.TrafficPolicy = rule.TrafficPolicy
+				}
+			case incomingIsBackendPolicy:
+				// The merged rule is user authored and the incoming one is synthesized from a
+				// backend policy. User fields win; the backend policy fills the gaps.
+				mergedRule.TrafficPolicy = mergeBackendPolicyTrafficPolicy(mergedRule.TrafficPolicy, rule.TrafficPolicy)
+			default:
+				// The merged rule is synthesized from a backend policy and the incoming one is
+				// user authored. Same precedence: user fields win.
+				mergedRule.TrafficPolicy = mergeBackendPolicyTrafficPolicy(rule.TrafficPolicy, mergedRule.TrafficPolicy)
 			}
 		}
 		if appendSeparately {
@@ -124,6 +143,84 @@ func (ps *PushContext) mergeDestinationRule(p *consolidatedDestRules, destRuleCo
 	}
 	// DestinationRule does not exist for the resolved host so add it
 	destRules[resolvedHost] = append(destRules[resolvedHost], ConvertConsolidatedDestRule(&destRuleConfig, exportToSet))
+}
+
+// isBackendPolicyDestinationRule reports whether a DestinationRule was synthesized by Istio from a
+// Gateway API backend policy rather than authored directly by a user. Synthesized rules carry the
+// internal parents annotation, which users are not permitted to set.
+func isBackendPolicyDestinationRule(cfg *config.Config) bool {
+	_, ok := cfg.Annotations[constants.InternalParentNames]
+	return ok
+}
+
+// mergeBackendPolicyTrafficPolicy merges a backend-policy-synthesized traffic policy underneath a user
+// authored one. Fields set on the user policy take precedence; the backend policy only supplies fields
+// the user policy leaves unset.
+func mergeBackendPolicyTrafficPolicy(user, backend *networking.TrafficPolicy) *networking.TrafficPolicy {
+	if user == nil {
+		return backend
+	}
+	if backend == nil {
+		return user
+	}
+	merged := user.DeepCopy()
+	if merged.LoadBalancer == nil {
+		merged.LoadBalancer = backend.LoadBalancer
+	}
+	if merged.ConnectionPool == nil {
+		merged.ConnectionPool = backend.ConnectionPool
+	}
+	if merged.OutlierDetection == nil {
+		merged.OutlierDetection = backend.OutlierDetection
+	}
+	if merged.Tls == nil {
+		merged.Tls = backend.Tls
+	}
+	if merged.Tunnel == nil {
+		merged.Tunnel = backend.Tunnel
+	}
+	if merged.ProxyProtocol == nil {
+		merged.ProxyProtocol = backend.ProxyProtocol
+	}
+	if merged.RetryBudget == nil {
+		merged.RetryBudget = backend.RetryBudget
+	}
+	merged.PortLevelSettings = mergeBackendPolicyPortLevelSettings(merged.PortLevelSettings, backend.PortLevelSettings)
+	return merged
+}
+
+// mergeBackendPolicyPortLevelSettings overlays user port settings on top of the backend ones. For a port
+// configured by both, the user fields win and the backend fills the gaps; ports only the backend sets are
+// appended.
+func mergeBackendPolicyPortLevelSettings(user, backend []*networking.TrafficPolicy_PortTrafficPolicy) []*networking.TrafficPolicy_PortTrafficPolicy {
+	if len(backend) == 0 {
+		return user
+	}
+	byPort := make(map[uint32]*networking.TrafficPolicy_PortTrafficPolicy, len(user))
+	for _, p := range user {
+		byPort[p.GetPort().GetNumber()] = p
+	}
+	merged := user
+	for _, bp := range backend {
+		up, ok := byPort[bp.GetPort().GetNumber()]
+		if !ok {
+			merged = append(merged, bp)
+			continue
+		}
+		if up.LoadBalancer == nil {
+			up.LoadBalancer = bp.LoadBalancer
+		}
+		if up.ConnectionPool == nil {
+			up.ConnectionPool = bp.ConnectionPool
+		}
+		if up.OutlierDetection == nil {
+			up.OutlierDetection = bp.OutlierDetection
+		}
+		if up.Tls == nil {
+			up.Tls = bp.Tls
+		}
+	}
+	return merged
 }
 
 func ConvertConsolidatedDestRule(cfg *config.Config, exportToSet sets.Set[visibility.Instance]) *ConsolidatedDestRule {

--- a/pilot/pkg/model/destination_rule.go
+++ b/pilot/pkg/model/destination_rule.go
@@ -163,30 +163,59 @@ func mergeBackendPolicyTrafficPolicy(user, backend *networking.TrafficPolicy) *n
 	if backend == nil {
 		return user
 	}
-	merged := user.DeepCopy()
-	if merged.LoadBalancer == nil {
-		merged.LoadBalancer = backend.LoadBalancer
-	}
-	if merged.ConnectionPool == nil {
-		merged.ConnectionPool = backend.ConnectionPool
-	}
-	if merged.OutlierDetection == nil {
-		merged.OutlierDetection = backend.OutlierDetection
-	}
-	if merged.Tls == nil {
-		merged.Tls = backend.Tls
-	}
-	if merged.Tunnel == nil {
-		merged.Tunnel = backend.Tunnel
-	}
-	if merged.ProxyProtocol == nil {
-		merged.ProxyProtocol = backend.ProxyProtocol
-	}
-	if merged.RetryBudget == nil {
-		merged.RetryBudget = backend.RetryBudget
-	}
-	merged.PortLevelSettings = mergeBackendPolicyPortLevelSettings(merged.PortLevelSettings, backend.PortLevelSettings)
+	// Start from the backend policy and let the user fields override it. hasPortLevel is false so only the
+	// fields the user actually sets win; the rest fall back to the backend policy. ShallowCopyTrafficPolicy
+	// drops port level settings, so they are merged back in separately below.
+	merged := MergeTrafficPolicy(ShallowCopyTrafficPolicy(backend), user, false)
+	merged.PortLevelSettings = mergeBackendPolicyPortLevelSettings(user.PortLevelSettings, backend.PortLevelSettings)
 	return merged
+}
+
+// MergeTrafficPolicy overrides mergedPolicy with the fields set on subsetPolicy and returns mergedPolicy.
+// When hasPortLevel is true, port level settings replace the destination level settings wholesale, so a
+// field omitted in the port level policy falls back to its default rather than being inherited.
+// Lives here rather than pilot/pkg/networking/util to avoid an import cycle (that package imports model);
+// it is also used by util.MergeSubsetTrafficPolicy and mergeBackendPolicyTrafficPolicy.
+func MergeTrafficPolicy(mergedPolicy, subsetPolicy *networking.TrafficPolicy, hasPortLevel bool) *networking.TrafficPolicy {
+	if subsetPolicy.ConnectionPool != nil || hasPortLevel {
+		mergedPolicy.ConnectionPool = subsetPolicy.ConnectionPool
+	}
+	if subsetPolicy.OutlierDetection != nil || hasPortLevel {
+		mergedPolicy.OutlierDetection = subsetPolicy.OutlierDetection
+	}
+	if subsetPolicy.LoadBalancer != nil || hasPortLevel {
+		mergedPolicy.LoadBalancer = subsetPolicy.LoadBalancer
+	}
+	if subsetPolicy.Tls != nil || hasPortLevel {
+		mergedPolicy.Tls = subsetPolicy.Tls
+	}
+	if subsetPolicy.Tunnel != nil {
+		mergedPolicy.Tunnel = subsetPolicy.Tunnel
+	}
+	if subsetPolicy.ProxyProtocol != nil {
+		mergedPolicy.ProxyProtocol = subsetPolicy.ProxyProtocol
+	}
+	if subsetPolicy.RetryBudget != nil {
+		mergedPolicy.RetryBudget = subsetPolicy.RetryBudget
+	}
+	return mergedPolicy
+}
+
+// ShallowCopyTrafficPolicy shallow copies a traffic policy. Port level settings are ignored.
+// Lives here rather than pilot/pkg/networking/util to avoid an import cycle (that package imports model).
+func ShallowCopyTrafficPolicy(original *networking.TrafficPolicy) *networking.TrafficPolicy {
+	if original == nil {
+		return nil
+	}
+	ret := &networking.TrafficPolicy{}
+	ret.ConnectionPool = original.ConnectionPool
+	ret.LoadBalancer = original.LoadBalancer
+	ret.OutlierDetection = original.OutlierDetection
+	ret.Tls = original.Tls
+	ret.Tunnel = original.Tunnel
+	ret.ProxyProtocol = original.ProxyProtocol
+	ret.RetryBudget = original.RetryBudget
+	return ret
 }
 
 // mergeBackendPolicyPortLevelSettings overlays user port settings on top of the backend ones. For a port

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -2471,6 +2471,79 @@ func TestSetDestinationRuleMerging(t *testing.T) {
 	}
 }
 
+func TestSetDestinationRuleBackendPolicyMerging(t *testing.T) {
+	testhost := "backend.test.svc.cluster.local"
+	userLb := &networking.LoadBalancerSettings{
+		LbPolicy: &networking.LoadBalancerSettings_Simple{Simple: networking.LoadBalancerSettings_ROUND_ROBIN},
+	}
+	userConnPool := &networking.ConnectionPoolSettings{
+		Tcp: &networking.ConnectionPoolSettings_TCPSettings{MaxConnections: 7},
+	}
+	backendLb := &networking.LoadBalancerSettings{
+		LbPolicy: &networking.LoadBalancerSettings_Simple{Simple: networking.LoadBalancerSettings_LEAST_REQUEST},
+	}
+	backendTLS := &networking.ClientTLSSettings{Mode: networking.ClientTLSSettings_SIMPLE}
+	backendRetryBudget := &networking.TrafficPolicy_RetryBudget{MinRetryConcurrency: 10}
+
+	userRule := config.Config{
+		Meta: config.Meta{Name: "user-dr", Namespace: "test", CreationTimestamp: time.Unix(2, 0)},
+		Spec: &networking.DestinationRule{
+			Host: testhost,
+			TrafficPolicy: &networking.TrafficPolicy{
+				LoadBalancer:   userLb,
+				ConnectionPool: userConnPool,
+			},
+			Subsets: []*networking.Subset{{Name: "v1"}},
+		},
+	}
+	backendRule := config.Config{
+		Meta: config.Meta{
+			Name:        "backend.test~istio-gateway",
+			Namespace:   "test",
+			Annotations: map[string]string{constants.InternalParentNames: "XBackendTrafficPolicy/policy.test"},
+		},
+		Spec: &networking.DestinationRule{
+			Host: testhost,
+			TrafficPolicy: &networking.TrafficPolicy{
+				LoadBalancer: backendLb,
+				Tls:          backendTLS,
+				RetryBudget:  backendRetryBudget,
+			},
+		},
+	}
+
+	// The user DestinationRule fields must win over the backend policy regardless of which one
+	// was created first, and the backend policy fills in the fields the user rule leaves unset.
+	cases := []struct {
+		name      string
+		backendTS time.Time
+	}{
+		{name: "backend created first", backendTS: time.Unix(1, 0)},
+		{name: "backend created last", backendTS: time.Unix(3, 0)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ps := NewPushContext()
+			ps.exportToDefaults.destinationRule = sets.New(visibility.Public)
+			backend := backendRule.DeepCopy()
+			backend.CreationTimestamp = tc.backendTS
+			ps.setDestinationRules([]config.Config{userRule, backend})
+
+			merged := ps.destinationRuleIndex.namespaceLocal["test"].specificDestRules[host.Name(testhost)]
+			assert.Equal(t, len(merged), 1)
+			tp := merged[0].rule.Spec.(*networking.DestinationRule).TrafficPolicy
+			// user fields win
+			assert.Equal(t, tp.LoadBalancer, userLb)
+			assert.Equal(t, tp.ConnectionPool, userConnPool)
+			// backend fills the gaps
+			assert.Equal(t, tp.Tls, backendTLS)
+			assert.Equal(t, tp.RetryBudget, backendRetryBudget)
+			// user subsets carry through
+			assert.Equal(t, len(merged[0].rule.Spec.(*networking.DestinationRule).Subsets), 1)
+		})
+	}
+}
+
 func TestSetDestinationRuleWithExportTo(t *testing.T) {
 	ps := NewPushContext()
 	ps.Mesh = &meshconfig.MeshConfig{RootNamespace: "istio-system"}

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -2479,11 +2479,16 @@ func TestSetDestinationRuleBackendPolicyMerging(t *testing.T) {
 	userConnPool := &networking.ConnectionPoolSettings{
 		Tcp: &networking.ConnectionPoolSettings_TCPSettings{MaxConnections: 7},
 	}
+	// TLS and RetryBudget are set by both the user rule and the backend policy; the user values must win.
+	userTLS := &networking.ClientTLSSettings{Mode: networking.ClientTLSSettings_MUTUAL}
+	userRetryBudget := &networking.TrafficPolicy_RetryBudget{MinRetryConcurrency: 5}
 	backendLb := &networking.LoadBalancerSettings{
 		LbPolicy: &networking.LoadBalancerSettings_Simple{Simple: networking.LoadBalancerSettings_LEAST_REQUEST},
 	}
 	backendTLS := &networking.ClientTLSSettings{Mode: networking.ClientTLSSettings_SIMPLE}
 	backendRetryBudget := &networking.TrafficPolicy_RetryBudget{MinRetryConcurrency: 10}
+	// OutlierDetection is set only by the backend policy, so it should fill in.
+	backendOutlier := &networking.OutlierDetection{Consecutive_5XxErrors: &wrapperspb.UInt32Value{Value: 3}}
 
 	userRule := config.Config{
 		Meta: config.Meta{Name: "user-dr", Namespace: "test", CreationTimestamp: time.Unix(2, 0)},
@@ -2492,6 +2497,8 @@ func TestSetDestinationRuleBackendPolicyMerging(t *testing.T) {
 			TrafficPolicy: &networking.TrafficPolicy{
 				LoadBalancer:   userLb,
 				ConnectionPool: userConnPool,
+				Tls:            userTLS,
+				RetryBudget:    userRetryBudget,
 			},
 			Subsets: []*networking.Subset{{Name: "v1"}},
 		},
@@ -2505,9 +2512,10 @@ func TestSetDestinationRuleBackendPolicyMerging(t *testing.T) {
 		Spec: &networking.DestinationRule{
 			Host: testhost,
 			TrafficPolicy: &networking.TrafficPolicy{
-				LoadBalancer: backendLb,
-				Tls:          backendTLS,
-				RetryBudget:  backendRetryBudget,
+				LoadBalancer:     backendLb,
+				Tls:              backendTLS,
+				RetryBudget:      backendRetryBudget,
+				OutlierDetection: backendOutlier,
 			},
 		},
 	}
@@ -2532,12 +2540,13 @@ func TestSetDestinationRuleBackendPolicyMerging(t *testing.T) {
 			merged := ps.destinationRuleIndex.namespaceLocal["test"].specificDestRules[host.Name(testhost)]
 			assert.Equal(t, len(merged), 1)
 			tp := merged[0].rule.Spec.(*networking.DestinationRule).TrafficPolicy
-			// user fields win
+			// user fields win, including where both set the same field (Tls, RetryBudget)
 			assert.Equal(t, tp.LoadBalancer, userLb)
 			assert.Equal(t, tp.ConnectionPool, userConnPool)
-			// backend fills the gaps
-			assert.Equal(t, tp.Tls, backendTLS)
-			assert.Equal(t, tp.RetryBudget, backendRetryBudget)
+			assert.Equal(t, tp.Tls, userTLS)
+			assert.Equal(t, tp.RetryBudget, userRetryBudget)
+			// backend fills the gaps the user rule leaves unset
+			assert.Equal(t, tp.OutlierDetection, backendOutlier)
 			// user subsets carry through
 			assert.Equal(t, len(merged[0].rule.Spec.(*networking.DestinationRule).Subsets), 1)
 		})

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -658,7 +658,7 @@ func (cb *ClusterBuilder) buildInboundCluster(clusterPort int, bind string,
 			opts.policy = &networking.TrafficPolicy{}
 		} else {
 			// copy policy to prevent mutating the original destinationRule trafficPolicy
-			opts.policy = util.ShallowCopyTrafficPolicy(opts.policy)
+			opts.policy = model.ShallowCopyTrafficPolicy(opts.policy)
 		}
 		opts.policy.ConnectionPool = sidecarConnPool
 	}

--- a/pilot/pkg/networking/util/fuzz_test.go
+++ b/pilot/pkg/networking/util/fuzz_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/fuzz"
 	"istio.io/istio/pkg/test/util/assert"
 )
@@ -28,7 +29,7 @@ func FuzzShallowCopyTrafficPolicy(f *testing.F) {
 		r := fuzz.Struct[*networking.TrafficPolicy](fg)
 		// We do not copy these, so ignore them
 		r.PortLevelSettings = nil
-		copied := ShallowCopyTrafficPolicy(r)
+		copied := model.ShallowCopyTrafficPolicy(r)
 		assert.Equal(fg.T(), r, copied)
 	})
 }
@@ -57,11 +58,11 @@ func FuzzMergeTrafficPolicy(f *testing.F) {
 		checkFrom.PortLevelSettings = nil
 
 		empty1 := &networking.TrafficPolicy{}
-		copied := mergeTrafficPolicy(empty1, copyFrom, true)
+		copied := model.MergeTrafficPolicy(empty1, copyFrom, true)
 		assert.Equal(fg.T(), checkFrom, copied)
 
 		empty2 := &networking.TrafficPolicy{}
-		copied = mergeTrafficPolicy(empty2, copied, true)
+		copied = model.MergeTrafficPolicy(empty2, copied, true)
 		assert.Equal(fg.T(), checkFrom, copied)
 	})
 }

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -848,38 +848,9 @@ func MergeSubsetTrafficPolicy(original, subsetPolicy *networking.TrafficPolicy, 
 
 	// merge DR with subset traffic policy
 	// Override with subset values.
-	mergedPolicy := ShallowCopyTrafficPolicy(original)
+	mergedPolicy := model.ShallowCopyTrafficPolicy(original)
 
-	return mergeTrafficPolicy(mergedPolicy, subsetPolicy, hasPortLevel)
-}
-
-// Note that port-level settings will override the destination-level settings.
-// Traffic settings specified at the destination-level will not be inherited when overridden by port-level settings,
-// i.e. default values will be applied to fields omitted in port-level traffic policies.
-func mergeTrafficPolicy(mergedPolicy, subsetPolicy *networking.TrafficPolicy, hasPortLevel bool) *networking.TrafficPolicy {
-	if subsetPolicy.ConnectionPool != nil || hasPortLevel {
-		mergedPolicy.ConnectionPool = subsetPolicy.ConnectionPool
-	}
-	if subsetPolicy.OutlierDetection != nil || hasPortLevel {
-		mergedPolicy.OutlierDetection = subsetPolicy.OutlierDetection
-	}
-	if subsetPolicy.LoadBalancer != nil || hasPortLevel {
-		mergedPolicy.LoadBalancer = subsetPolicy.LoadBalancer
-	}
-	if subsetPolicy.Tls != nil || hasPortLevel {
-		mergedPolicy.Tls = subsetPolicy.Tls
-	}
-
-	if subsetPolicy.Tunnel != nil {
-		mergedPolicy.Tunnel = subsetPolicy.Tunnel
-	}
-	if subsetPolicy.ProxyProtocol != nil {
-		mergedPolicy.ProxyProtocol = subsetPolicy.ProxyProtocol
-	}
-	if subsetPolicy.RetryBudget != nil {
-		mergedPolicy.RetryBudget = subsetPolicy.RetryBudget
-	}
-	return mergedPolicy
+	return model.MergeTrafficPolicy(mergedPolicy, subsetPolicy, hasPortLevel)
 }
 
 func shadowCopyPortTrafficPolicy(portTrafficPolicy *networking.TrafficPolicy_PortTrafficPolicy) *networking.TrafficPolicy {
@@ -891,22 +862,6 @@ func shadowCopyPortTrafficPolicy(portTrafficPolicy *networking.TrafficPolicy_Por
 	ret.LoadBalancer = portTrafficPolicy.LoadBalancer
 	ret.OutlierDetection = portTrafficPolicy.OutlierDetection
 	ret.Tls = portTrafficPolicy.Tls
-	return ret
-}
-
-// ShallowCopyTrafficPolicy shallow copy a traffic policy, portLevelSettings are ignored.
-func ShallowCopyTrafficPolicy(original *networking.TrafficPolicy) *networking.TrafficPolicy {
-	if original == nil {
-		return nil
-	}
-	ret := &networking.TrafficPolicy{}
-	ret.ConnectionPool = original.ConnectionPool
-	ret.LoadBalancer = original.LoadBalancer
-	ret.OutlierDetection = original.OutlierDetection
-	ret.Tls = original.Tls
-	ret.Tunnel = original.Tunnel
-	ret.ProxyProtocol = original.ProxyProtocol
-	ret.RetryBudget = original.RetryBudget
 	return ret
 }
 

--- a/releasenotes/notes/60358.yaml
+++ b/releasenotes/notes/60358.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 60358
+releaseNotes:
+  - |
+    **Fixed** a `DestinationRule` and a Gateway API backend policy (`BackendTLSPolicy` or `XBackendTrafficPolicy`)
+    targeting the same host so that the `DestinationRule` fields now take precedence and the backend policy only
+    fills in fields the `DestinationRule` leaves unset, regardless of which was created first.


### PR DESCRIPTION
when a user DestinationRule and a DestinationRule synthesized from a Gateway API backend policy (BackendTLSPolicy/XBackendTrafficPolicy) target the same host, this merges them at the field level so the user fields win and the backend policy only fills in the fields the DestinationRule leaves unset. previously the merge in `mergeDestinationRule` was first-wins on the whole top level TrafficPolicy, so whichever config was created first kept its policy and the other was dropped.

the precedence now holds regardless of creation order: synthesized rules are detected via the `internal.istio.io/parents` annotation (which users cannot set), and the user rule always overrides. user subsets carry through unchanged since the policy translation does not generate subsets.

Fixes #60358