### PR TITLE
Mpuncel/http2 ping destination rule

### DIFF
--- a/pilot/pkg/networking/core/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/cluster_builder_test.go
@@ -414,6 +414,28 @@ func TestApplyDestinationRule(t *testing.T) {
 			expectedSubsetClusters: []*cluster.Cluster{},
 		},
 		{
+			name:        "destination rule with http2 keepalive",
+			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
+			clusterMode: DefaultClusterMode,
+			service:     http2Service,
+			port:        http2ServicePort[0],
+			proxyView:   model.ProxyViewAll,
+			destRule: &networking.DestinationRule{
+				Host: "foo.default.svc.cluster.local",
+				TrafficPolicy: &networking.TrafficPolicy{
+					ConnectionPool: &networking.ConnectionPoolSettings{
+						Http: &networking.ConnectionPoolSettings_HTTPSettings{
+							Http2KeepAlive: &networking.ConnectionPoolSettings_HTTPSettings_ConnectionKeepalive{
+								Interval: &durationpb.Duration{Seconds: 15},
+								Timeout:  &durationpb.Duration{Seconds: 5},
+							},
+						},
+					},
+				},
+			},
+			expectedSubsetClusters: []*cluster.Cluster{},
+		},
+		{
 			name:        "destination rule with http2UpgradePolicy and maxConcurrentStreams",
 			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
 			clusterMode: DefaultClusterMode,
@@ -1037,6 +1059,25 @@ func TestApplyDestinationRule(t *testing.T) {
 				if ec.httpProtocolOptions.GetExplicitHttpConfig().GetHttp2ProtocolOptions().GetMaxConcurrentStreams().GetValue() !=
 					uint32(tt.destRule.TrafficPolicy.GetConnectionPool().GetHttp().MaxConcurrentStreams) {
 					t.Errorf("Unexpected max_concurrent_streams found")
+				}
+			}
+			if keepalive := tt.destRule.GetTrafficPolicy().GetConnectionPool().GetHttp().GetHttp2KeepAlive(); keepalive != nil {
+				if ec.httpProtocolOptions == nil {
+					t.Errorf("Expected cluster %s to have http protocol options but not found", tt.cluster.Name)
+				}
+				if ec.httpProtocolOptions.GetExplicitHttpConfig() == nil {
+					t.Errorf("Expected cluster %s to have explicit http config but not found", tt.cluster.Name)
+				}
+				http2ProtocolOptions := ec.httpProtocolOptions.GetExplicitHttpConfig().GetHttp2ProtocolOptions()
+				if http2ProtocolOptions == nil {
+					t.Errorf("Expected cluster %s to have HTTP2 protocol options but not found", tt.cluster.Name)
+				} else {
+					if http2ProtocolOptions.GetConnectionKeepalive().GetInterval() != keepalive.GetInterval() {
+						t.Errorf("Unexpected HTTP2 connection keepalive interval found")
+					}
+					if http2ProtocolOptions.GetConnectionKeepalive().GetTimeout() != keepalive.GetTimeout() {
+						t.Errorf("Unexpected HTTP2 connection keepalive timeout found")
+					}
 				}
 			}
 

--- a/pilot/pkg/networking/core/cluster_traffic_policy.go
+++ b/pilot/pkg/networking/core/cluster_traffic_policy.go
@@ -106,6 +106,7 @@ func (cb *ClusterBuilder) applyConnectionPool(mesh *meshconfig.MeshConfig,
 	var maxRequestsPerConnection uint32
 	var maxConcurrentStreams uint32
 	var maxConnectionDuration *durationpb.Duration
+	var connectionKeepalive *networking.ConnectionPoolSettings_HTTPSettings_ConnectionKeepalive
 
 	if settings.Http != nil {
 		if settings.Http.Http2MaxRequests > 0 {
@@ -123,6 +124,7 @@ func (cb *ClusterBuilder) applyConnectionPool(mesh *meshconfig.MeshConfig,
 		idleTimeout = settings.Http.IdleTimeout
 		maxRequestsPerConnection = uint32(settings.Http.MaxRequestsPerConnection)
 		maxConcurrentStreams = uint32(settings.Http.MaxConcurrentStreams)
+		connectionKeepalive = settings.Http.GetHttp2KeepAlive()
 	}
 
 	cb.applyDefaultConnectionPool(mc.cluster)
@@ -147,7 +149,7 @@ func (cb *ClusterBuilder) applyConnectionPool(mesh *meshconfig.MeshConfig,
 		Thresholds: []*cluster.CircuitBreakers_Thresholds{threshold},
 	}
 
-	if maxConnectionDuration != nil || idleTimeout != nil || maxRequestsPerConnection > 0 || maxConcurrentStreams > 0 {
+	if maxConnectionDuration != nil || idleTimeout != nil || maxRequestsPerConnection > 0 || maxConcurrentStreams > 0 || connectionKeepalive != nil {
 		if mc.httpProtocolOptions == nil {
 			mc.httpProtocolOptions = &http.HttpProtocolOptions{}
 		}
@@ -169,6 +171,12 @@ func (cb *ClusterBuilder) applyConnectionPool(mesh *meshconfig.MeshConfig,
 		http2ProtocolOptions := options.GetExplicitHttpConfig().GetHttp2ProtocolOptions()
 		if http2ProtocolOptions != nil && maxConcurrentStreams > 0 {
 			http2ProtocolOptions.MaxConcurrentStreams = &wrapperspb.UInt32Value{Value: maxConcurrentStreams}
+		}
+		if http2ProtocolOptions != nil && connectionKeepalive != nil {
+			http2ProtocolOptions.ConnectionKeepalive = &core.KeepaliveSettings{
+				Interval: connectionKeepalive.Interval,
+				Timeout:  connectionKeepalive.Timeout,
+			}
 		}
 	}
 	if settings.Http != nil && settings.Http.UseClientProtocol {

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1155,6 +1155,18 @@ func validateConnectionPool(settings *networking.ConnectionPoolSettings) (errs e
 		if httpSettings.MaxConcurrentStreams < 0 {
 			errs = appendErrors(errs, fmt.Errorf("max concurrent streams must be non-negative"))
 		}
+		if keepalive := httpSettings.GetHttp2KeepAlive(); keepalive != nil {
+			if keepalive.Interval == nil {
+				errs = appendErrors(errs, fmt.Errorf("http2 keepalive interval is required"))
+			} else {
+				errs = appendErrors(errs, agent.ValidateDuration(keepalive.Interval))
+			}
+			if keepalive.Timeout == nil {
+				errs = appendErrors(errs, fmt.Errorf("http2 keepalive timeout is required"))
+			} else {
+				errs = appendErrors(errs, agent.ValidateDuration(keepalive.Timeout))
+			}
+		}
 	}
 
 	if tcp := settings.Tcp; tcp != nil {

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -3445,6 +3445,17 @@ func TestValidateConnectionPool(t *testing.T) {
 			},
 			valid: true,
 		},
+		{
+			name: "valid connection pool, http2 keepalive", in: &networking.ConnectionPoolSettings{
+				Http: &networking.ConnectionPoolSettings_HTTPSettings{
+					Http2KeepAlive: &networking.ConnectionPoolSettings_HTTPSettings_ConnectionKeepalive{
+						Interval: &durationpb.Duration{Seconds: 15},
+						Timeout:  &durationpb.Duration{Seconds: 5},
+					},
+				},
+			},
+			valid: true,
+		},
 
 		{name: "invalid connection pool, empty", in: &networking.ConnectionPoolSettings{}, valid: false},
 
@@ -3509,6 +3520,37 @@ func TestValidateConnectionPool(t *testing.T) {
 		{
 			name: "invalid connection pool, bad max concurrent streams", in: &networking.ConnectionPoolSettings{
 				Http: &networking.ConnectionPoolSettings_HTTPSettings{MaxConcurrentStreams: -1},
+			},
+			valid: false,
+		},
+		{
+			name: "invalid connection pool, http2 keepalive without interval", in: &networking.ConnectionPoolSettings{
+				Http: &networking.ConnectionPoolSettings_HTTPSettings{
+					Http2KeepAlive: &networking.ConnectionPoolSettings_HTTPSettings_ConnectionKeepalive{
+						Timeout: &durationpb.Duration{Seconds: 5},
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "invalid connection pool, http2 keepalive without timeout", in: &networking.ConnectionPoolSettings{
+				Http: &networking.ConnectionPoolSettings_HTTPSettings{
+					Http2KeepAlive: &networking.ConnectionPoolSettings_HTTPSettings_ConnectionKeepalive{
+						Interval: &durationpb.Duration{Seconds: 15},
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "invalid connection pool, bad http2 keepalive interval", in: &networking.ConnectionPoolSettings{
+				Http: &networking.ConnectionPoolSettings_HTTPSettings{
+					Http2KeepAlive: &networking.ConnectionPoolSettings_HTTPSettings_ConnectionKeepalive{
+						Interval: &durationpb.Duration{Seconds: 15, Nanos: 5},
+						Timeout:  &durationpb.Duration{Seconds: 5},
+					},
+				},
 			},
 			valid: false,
 		},

--- a/releasenotes/notes/http2-keepalive-destinationrule.yaml
+++ b/releasenotes/notes/http2-keepalive-destinationrule.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 55640
+
+releaseNotes:
+  - |
+    **Added** support for configuring HTTP/2 keepalive PING settings on upstream connections through `DestinationRule`.

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -27,6 +27,9 @@ import (
 	"strings"
 	"time"
 
+	envoyadmin "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
+	envoycluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	envoyupstreamhttp "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	"google.golang.org/grpc/codes"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 	corev1 "k8s.io/api/core/v1"
@@ -36,6 +39,7 @@ import (
 
 	"istio.io/api/annotation"
 	"istio.io/istio/pilot/pkg/model"
+	xdsv3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/security"
@@ -1642,6 +1646,98 @@ func destinationRuleCases(t TrafficContext) {
 			Check: check.OK(),
 		},
 	})
+	t.NewSubTest("http2 keepalive in DR").Run(func(ctx framework.TestContext) {
+		if ctx.Settings().Ambient {
+			ctx.Skip("requires sidecar Envoy cluster config")
+		}
+
+		ctx.ConfigIstio().YAML(
+			t.Apps.Namespace.Name(),
+			http2KeepaliveDestinationRule("http2-keepalive-dr", to.Config().Service),
+		).ApplyOrFail(ctx)
+
+		from[0].CallOrFail(ctx, echo.CallOptions{
+			To:    to,
+			Port:  ports.HTTP2,
+			Count: 1,
+			HTTP: echo.HTTP{
+				HTTP2: true,
+			},
+			Check: check.And(
+				check.OK(),
+				check.Protocol("HTTP/2.0"),
+			),
+		})
+
+		verifyHTTP2Keepalive(ctx, from[0], to)
+	})
+}
+
+func verifyHTTP2Keepalive(t framework.TestContext, from echo.Instance, to echo.Instances) {
+	t.Helper()
+
+	clusterName := fmt.Sprintf("outbound|%d||%s", ports.HTTP2.ServicePort, to.Config().ClusterLocalFQDN())
+	workloads := from.WorkloadsOrFail(t)
+	if len(workloads) == 0 {
+		t.Fatal("source has no workloads")
+	}
+	sidecar := workloads[0].Sidecar()
+	if sidecar == nil {
+		t.Fatal("source workload has no sidecar")
+	}
+
+	sidecar.WaitForConfigOrFail(t, func(cfg *envoyadmin.ConfigDump) (bool, error) {
+		return hasHTTP2Keepalive(cfg, clusterName)
+	}, retry.Timeout(30*time.Second))
+}
+
+func hasHTTP2Keepalive(cfg *envoyadmin.ConfigDump, clusterName string) (bool, error) {
+	for _, config := range cfg.GetConfigs() {
+		if config.GetTypeUrl() != "type.googleapis.com/envoy.admin.v3.ClustersConfigDump" {
+			continue
+		}
+
+		clusterDump := &envoyadmin.ClustersConfigDump{}
+		if err := config.UnmarshalTo(clusterDump); err != nil {
+			return false, err
+		}
+		for _, dynamicCluster := range clusterDump.GetDynamicActiveClusters() {
+			cluster := &envoycluster.Cluster{}
+			if err := dynamicCluster.GetCluster().UnmarshalTo(cluster); err != nil {
+				return false, err
+			}
+			if cluster.GetName() != clusterName {
+				continue
+			}
+
+			httpOptionsAny := cluster.GetTypedExtensionProtocolOptions()[xdsv3.HttpProtocolOptionsType]
+			if httpOptionsAny == nil {
+				return false, fmt.Errorf("cluster %q has no %s typed extension protocol options", clusterName, xdsv3.HttpProtocolOptionsType)
+			}
+
+			httpOptions := &envoyupstreamhttp.HttpProtocolOptions{}
+			if err := httpOptionsAny.UnmarshalTo(httpOptions); err != nil {
+				return false, err
+			}
+			http2Options := httpOptions.GetExplicitHttpConfig().GetHttp2ProtocolOptions()
+			if http2Options == nil {
+				return false, fmt.Errorf("cluster %q has no HTTP/2 protocol options", clusterName)
+			}
+			keepalive := http2Options.GetConnectionKeepalive()
+			if keepalive == nil {
+				return false, fmt.Errorf("cluster %q has no HTTP/2 keepalive", clusterName)
+			}
+			if keepalive.GetInterval().GetSeconds() != 15 || keepalive.GetInterval().GetNanos() != 0 {
+				return false, fmt.Errorf("cluster %q has unexpected HTTP/2 keepalive interval: %v", clusterName, keepalive.GetInterval())
+			}
+			if keepalive.GetTimeout().GetSeconds() != 5 || keepalive.GetTimeout().GetNanos() != 0 {
+				return false, fmt.Errorf("cluster %q has unexpected HTTP/2 keepalive timeout: %v", clusterName, keepalive.GetTimeout())
+			}
+			return true, nil
+		}
+	}
+
+	return false, fmt.Errorf("cluster %q not found", clusterName)
 }
 
 // trafficLoopCases contains tests to ensure traffic does not loop through the sidecar
@@ -4014,6 +4110,25 @@ spec:
     connectionPool:
       http:
         idleTimeout: 100s
+---
+`, name, app)
+}
+
+func http2KeepaliveDestinationRule(name, app string) string {
+	return fmt.Sprintf(`apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: %s
+spec:
+  host: %s
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+    connectionPool:
+      http:
+        http2KeepAlive:
+          interval: 15s
+          timeout: 5s
 ---
 `, name, app)
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

This PR implements HTTP/2 ping configured via DestinationRule, leveraging Envoy's underlying feature set. This feature can be used to keep connections alive between middle proxies, or detect and tear down half closed connections.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ x ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions