### PR TITLE
Add 0.5s bucket to more pilot xds metrics

### DIFF
--- a/pilot/pkg/xds/monitoring.go
+++ b/pilot/pkg/xds/monitoring.go
@@ -57,19 +57,19 @@ var (
 	debounceTime = monitoring.NewDistribution(
 		"pilot_debounce_time",
 		"Delay in seconds between the first config enters debouncing and the merged push request is pushed into the push queue (includes pushcontext_init_seconds).",
-		[]float64{.01, .1, 1, 3, 5, 10, 20, 30},
+		[]float64{.01, .1, .5, 1, 3, 5, 10, 20, 30},
 	)
 
 	pushContextInitTime = monitoring.NewDistribution(
 		"pilot_pushcontext_init_seconds",
 		"Total time in seconds Pilot takes to init pushContext.",
-		[]float64{.01, .1, 0.5, 1, 3, 5},
+		[]float64{.01, .1, .5, 1, 3, 5},
 	)
 
 	pushTime = monitoring.NewDistribution(
 		"pilot_xds_push_time",
 		"Total time in seconds Pilot takes to push lds, rds, cds and eds.",
-		[]float64{.01, .1, 1, 3, 5, 10, 20, 30},
+		[]float64{.01, .1, .5, 1, 3, 5, 10, 20, 30},
 	)
 
 	proxiesQueueTime = monitoring.NewDistribution(


### PR DESCRIPTION
**Please provide a description of this PR:**

We've found a lot of the metrics buckets don't well represent the actual distribution of the data they represent.  This makes it difficult for `histogram_quantile` functions to approximate the actual time taken.
Tuning has been done a couple times in the past, e.g. https://github.com/istio/istio/pull/17456

This adds a `.5` seconds bucket to the two metrics defined in `pilot/pkg/xds/monitoring.go` which were missing it.  As istio performance improves, it may be worth continuing to reevaluate these and swap larger buckets for more granularity <1s.