### PR TITLE
test: add port-forward reconnect to prometheus and registry-redirector

### DIFF
--- a/pkg/test/framework/components/prometheus/kube.go
+++ b/pkg/test/framework/components/prometheus/kube.go
@@ -63,7 +63,7 @@ type kubeComponent struct {
 	stopOnce sync.Once
 	stop     chan struct{}
 
-	api      map[string]prometheusApiV1.API
+	api       map[string]prometheusApiV1.API
 	forwarder map[string]istioKube.PortForwarder
 	connInfo  map[string]*clusterConnInfo
 	clusters  cluster.Clusters

--- a/pkg/test/framework/components/prometheus/kube.go
+++ b/pkg/test/framework/components/prometheus/kube.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	prometheusApi "github.com/prometheus/client_golang/api"
@@ -49,11 +50,22 @@ var (
 	_ io.Closer = &kubeComponent{}
 )
 
-type kubeComponent struct {
-	id resource.ID
+type clusterConnInfo struct {
+	cls     cluster.Cluster
+	podName string
+	podNS   string
+	port    int
+}
 
-	api       map[string]prometheusApiV1.API
+type kubeComponent struct {
+	id       resource.ID
+	mu       sync.RWMutex
+	stopOnce sync.Once
+	stop     chan struct{}
+
+	api      map[string]prometheusApiV1.API
 	forwarder map[string]istioKube.PortForwarder
+	connInfo  map[string]*clusterConnInfo
 	clusters  cluster.Clusters
 }
 
@@ -91,6 +103,8 @@ func newKube(ctx resource.Context, cfgIn Config) (Instance, error) {
 	c.id = ctx.TrackResource(c)
 	c.api = make(map[string]prometheusApiV1.API)
 	c.forwarder = make(map[string]istioKube.PortForwarder)
+	c.connInfo = make(map[string]*clusterConnInfo)
+	c.stop = make(chan struct{})
 	cfg, err := istio.DefaultConfig(ctx)
 	if err != nil {
 		return nil, err
@@ -115,9 +129,9 @@ func newKube(ctx resource.Context, cfgIn Config) (Instance, error) {
 		if err != nil {
 			return nil, err
 		}
-		port := uint16(svc.Spec.Ports[0].Port)
+		port := int(svc.Spec.Ports[0].Port)
 
-		forwarder, err := cls.NewPortForwarder(pod.Name, pod.Namespace, "", 0, int(port))
+		forwarder, err := cls.NewPortForwarder(pod.Name, pod.Namespace, "", 0, port)
 		if err != nil {
 			return nil, err
 		}
@@ -136,6 +150,13 @@ func newKube(ctx resource.Context, cfgIn Config) (Instance, error) {
 		}
 
 		c.api[cls.Name()] = prometheusApiV1.NewAPI(client)
+		c.connInfo[cls.Name()] = &clusterConnInfo{
+			cls:     cls,
+			podName: pod.Name,
+			podNS:   pod.Namespace,
+			port:    port,
+		}
+		go c.watchForwarder(cls.Name())
 	}
 	return c, nil
 }
@@ -146,17 +167,87 @@ func (c *kubeComponent) ID() resource.ID {
 
 // API implements environment.DeployedPrometheus.
 func (c *kubeComponent) API() prometheusApiV1.API {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	return c.api[c.clusters.Default().Name()]
 }
 
 func (c *kubeComponent) APIForCluster(cluster cluster.Cluster) prometheusApiV1.API {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	return c.api[cluster.Name()]
+}
+
+func (c *kubeComponent) isConnected(clsName string) bool {
+	fwd := c.forwarder[clsName]
+	if fwd == nil {
+		return false
+	}
+	select {
+	case <-fwd.ErrChan():
+		return false
+	default:
+		return true
+	}
+}
+
+func (c *kubeComponent) reconnect(clsName string) error {
+	info := c.connInfo[clsName]
+	if fwd := c.forwarder[clsName]; fwd != nil {
+		fwd.Close()
+		c.forwarder[clsName] = nil
+	}
+	fwd, err := info.cls.NewPortForwarder(info.podName, info.podNS, "", 0, info.port)
+	if err != nil {
+		return err
+	}
+	if err := fwd.Start(); err != nil {
+		fwd.Close()
+		return err
+	}
+	c.forwarder[clsName] = fwd
+
+	address := fmt.Sprintf("http://%s", fwd.Address())
+	client, err := prometheusApi.NewClient(prometheusApi.Config{Address: address})
+	if err != nil {
+		fwd.Close()
+		c.forwarder[clsName] = nil
+		return err
+	}
+	c.api[clsName] = prometheusApiV1.NewAPI(client)
+	return nil
+}
+
+func (c *kubeComponent) watchForwarder(clsName string) {
+	t := time.NewTicker(500 * time.Millisecond)
+	defer t.Stop()
+	for {
+		select {
+		case <-c.stop:
+			return
+		case <-t.C:
+			c.mu.Lock()
+			if !c.isConnected(clsName) {
+				scopes.Framework.Warnf("prometheus port forward for cluster %s terminated, reconnecting", clsName)
+				if err := c.reconnect(clsName); err != nil {
+					scopes.Framework.Warnf("prometheus port forward reconnect for cluster %s failed: %v", clsName, err)
+				} else {
+					scopes.Framework.Warnf("prometheus port forward for cluster %s reconnected", clsName)
+				}
+			}
+			c.mu.Unlock()
+		}
+	}
 }
 
 func (c *kubeComponent) RawQuery(cluster cluster.Cluster, promQL string) (model.Value, error) {
 	scopes.Framework.Debugf("Query running: %s", promQL)
 
-	v, _, err := c.api[cluster.Name()].Query(context.Background(), promQL, time.Now())
+	c.mu.RLock()
+	api := c.api[cluster.Name()]
+	c.mu.RUnlock()
+
+	v, _, err := api.Query(context.Background(), promQL, time.Now())
 	if err != nil {
 		return nil, fmt.Errorf("error querying Prometheus: %v", err)
 	}
@@ -214,8 +305,13 @@ func Sum(val model.Value) (float64, error) {
 
 // Close implements io.Closer.
 func (c *kubeComponent) Close() error {
+	c.stopOnce.Do(func() { close(c.stop) })
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	for _, forwarder := range c.forwarder {
-		forwarder.Close()
+		if forwarder != nil {
+			forwarder.Close()
+		}
 	}
 	return nil
 }

--- a/pkg/test/framework/components/registryredirector/kube.go
+++ b/pkg/test/framework/components/registryredirector/kube.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"sync"
 	"time"
 
 	"istio.io/istio/pkg/kube"
@@ -50,7 +51,12 @@ type kubeComponent struct {
 	ns        namespace.Instance
 	cluster   cluster.Cluster
 	address   string
+	mu        sync.Mutex
+	stopOnce  sync.Once
+	stop      chan struct{}
 	forwarder kube.PortForwarder
+	podName   string
+	podNS     string
 }
 
 func newKube(ctx resource.Context, cfg Config) (Instance, error) {
@@ -126,6 +132,9 @@ func newKube(ctx resource.Context, cfg Config) (Instance, error) {
 	}
 
 	thePod := pods[0]
+	c.podName = thePod.Name
+	c.podNS = thePod.Namespace
+	c.stop = make(chan struct{})
 
 	portForwarder, err := c.cluster.NewPortForwarder(thePod.Name, thePod.Namespace, "", 0, 1338)
 	if err != nil {
@@ -137,8 +146,60 @@ func newKube(ctx resource.Context, cfg Config) (Instance, error) {
 	}
 
 	c.forwarder = portForwarder
+	go c.watchForwarder()
 
 	return c, nil
+}
+
+func (c *kubeComponent) isConnected() bool {
+	if c.forwarder == nil {
+		return false
+	}
+	select {
+	case <-c.forwarder.ErrChan():
+		return false
+	default:
+		return true
+	}
+}
+
+func (c *kubeComponent) reconnect() error {
+	if c.forwarder != nil {
+		c.forwarder.Close()
+		c.forwarder = nil
+	}
+	fwd, err := c.cluster.NewPortForwarder(c.podName, c.podNS, "", 0, 1338)
+	if err != nil {
+		return err
+	}
+	if err := fwd.Start(); err != nil {
+		fwd.Close()
+		return err
+	}
+	c.forwarder = fwd
+	return nil
+}
+
+func (c *kubeComponent) watchForwarder() {
+	t := time.NewTicker(500 * time.Millisecond)
+	defer t.Stop()
+	for {
+		select {
+		case <-c.stop:
+			return
+		case <-t.C:
+			c.mu.Lock()
+			if !c.isConnected() {
+				scopes.Framework.Warn("registry-redirector port forward terminated, reconnecting")
+				if err := c.reconnect(); err != nil {
+					scopes.Framework.Warnf("registry-redirector port forward reconnect failed: %v", err)
+				} else {
+					scopes.Framework.Warn("registry-redirector port forward reconnected")
+				}
+			}
+			c.mu.Unlock()
+		}
+	}
 }
 
 func (c *kubeComponent) ID() resource.ID {
@@ -147,6 +208,17 @@ func (c *kubeComponent) ID() resource.ID {
 
 // Close implements io.Closer.
 func (c *kubeComponent) Close() error {
+	c.stopOnce.Do(func() {
+		if c.stop != nil {
+			close(c.stop)
+		}
+	})
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.forwarder != nil {
+		c.forwarder.Close()
+		c.forwarder = nil
+	}
 	return nil
 }
 
@@ -164,7 +236,10 @@ func (c *kubeComponent) SetupTagMap(tagMap map[string]string) error {
 	}
 
 	err = retry.UntilSuccess(func() error {
-		_, err := client.Post(fmt.Sprintf("http://%s/admin/v1/tagmap", c.forwarder.Address()), "application/json", bytes.NewBuffer(body))
+		c.mu.Lock()
+		addr := c.forwarder.Address()
+		c.mu.Unlock()
+		_, err := client.Post(fmt.Sprintf("http://%s/admin/v1/tagmap", addr), "application/json", bytes.NewBuffer(body))
 		return err
 	}, retry.Delay(100*time.Millisecond), retry.Timeout(20*time.Second))
 	if err != nil {


### PR DESCRIPTION
**Please provide a description of this PR:**
integ-k8s-133_istio_postsubmit has been failing 90% of the time for the last month (As far as I can see in the prow job [history](https://prow.istio.io/job-history/s3/istio-prow/logs/integ-k8s-133_istio_postsubmit)). For some reason, on K8s 1.33, all port-forwards drop mid-suite simultaneously. The echo workload already survives this via watchPortForward in echo/kube/workload.go, but prometheus and registry-redirector had no reconnect logic, causing them to remain permanently disconnected after the first drop.

Affected tests:
  - TestWasmPluginConfigurations
  - TestZtunnelSecureMetrics, TestCustomizeMetrics, TestL4Telemetry, TestL7Telemetry

Fix

Apply the same 500ms ticker-based reconnect goroutine pattern from [echo/kube/workload.go](https://github.com/istio/istio/blob/a13d72f9ba58f5125ca2022c5e2b8b505693c8e7/pkg/test/framework/components/echo/kube/workload.go#L85) to both components. On disconnect, the goroutine reestablishes the port-forward and, in the case of Prometheus, rebuilds the API client pointing to the new address.

Also fixes registryredirector.Close() which was a no-op and never released the forwarder.

Note: I ran the test several times locally, and I never got the error, but locally I had to use a different image to run locally the cluster because I ran on macOS and it has the arm chip `docker.io/kindest/node:v1.33.2`