### PR TITLE
Don't filter out remote endpoints for ServiceEntry

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1376,10 +1376,6 @@ const (
 	// cluster's east/west gateway. Istio will also automatically share globally matching endpoints with the cluster's
 	// local dataplane that are in the local and remote clusters.
 	Global ServiceScope = "GLOBAL"
-	// Unscoped ServiceScope specifies that the service does not have an explicitly assigned scope. For most intents
-	// and purposes this is similar to Local, but it allows to distinguish the cases where the scope cannot be
-	// explicitly assigned at all (e.g., ServiceEntry does not have a scope) and treat them specially.
-	Unscoped ServiceScope = ""
 )
 
 type WorkloadInfo struct {

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1376,6 +1376,10 @@ const (
 	// cluster's east/west gateway. Istio will also automatically share globally matching endpoints with the cluster's
 	// local dataplane that are in the local and remote clusters.
 	Global ServiceScope = "GLOBAL"
+	// Unscoped ServiceScope specifies that the service does not have an explicitly assigned scope. For most intents
+	// and purposes this is similar to Local, but it allows to distinguish the cases where the scope cannot be
+	// explicitly assigned at all (e.g., ServiceEntry does not have a scope) and treat them specially.
+	Unscoped ServiceScope = ""
 )
 
 type WorkloadInfo struct {

--- a/pilot/pkg/xds/endpoints/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder.go
@@ -572,9 +572,14 @@ func (b *EndpointBuilder) filterIstioEndpoint(ep *model.IstioEndpoint) bool {
 			return false
 		}
 	}
-	// If we are in ambient mode, the service is not global and the endpoint is in a different cluster
-	// we filter it out.
-	if b.serviceInfo != nil && b.serviceInfo.Scope != model.Global && b.clusterID != ep.Locality.ClusterID {
+	// If we are operating in ambient mode, producing configuration for a waypoint or E/W gateway, the service
+	// is not global and the endpoint is in a different cluster we filter it out.
+	//
+	// NOTE: istiod itself can serve both ambient (e.g., waypoint and ztunnel) and sidecar proxies at the same time,
+	// and when we are generating configuration for a sidecar, we should not filter out endpoints that sidecar would
+	// normally see, just because we also serve ambient proxies from the same istiod as well. That's the reason why
+	// we have to check here that the node type is actually a waypoint and not a sidecar when generating EDS.
+	if b.nodeType == model.Waypoint && b.serviceInfo != nil && b.serviceInfo.Scope != model.Global && b.clusterID != ep.Locality.ClusterID {
 		return false
 	}
 

--- a/pilot/pkg/xds/endpoints/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder.go
@@ -572,39 +572,17 @@ func (b *EndpointBuilder) filterIstioEndpoint(ep *model.IstioEndpoint) bool {
 			return false
 		}
 	}
-	// When multi-cluster ambeint mode of operation is enabled, services will have a scope. Scope can be local
-	// or global. In ambient, when service is local, we want to filter out endpoints from different clusters.
+	// ServiceEntry is a bit special, in ambient multi-cluster service entries are never global and are never
+	// read from a remote cluster, so they are by nature local to the cluster where istiod is running.
 	//
-	// This semantics makes sense, but it creates a bit of problem when it comes to sidecar mode of operation:
-	// - Service scope concept didn't exist in sidecar mode (there are some lose equivalents of that, but they are
-	//   not identical to service scope)
-	// - The same istiod can serve both sidecar and ambient workloads at the same time (IOW, we can't always
-	//   clearly tell that istiod is operating in sidecar mode or ambient mode, because it could be both or nerither)
-	// - Like istiod, some proxies are not sidecar or ambient either (e.g., we can't say that ingress gateway is in
-        //   sidecar mode or ambient mode - that's just not the distinction that makes sense for ingress gateway).
+	// However, istio in general supports remote primary deployment, where the same istiod might serve different
+	// clusters. In this case ServiceEntry, because it's visible to the istiod, will affect all the clsuters and
+	// not just the one where ServiceEntry is defined.
 	//
-	// As a result, when `AMBIENT_ENABLE_MULTI_NETWORK` feature flag and we start considering service scope, it also
-	// changes the behavior of ingress gateways, which are not sidecar or ambient and serve both sidecar and ambient
-	// use cases (potentially even at the same time).
-	//
-	// We cannot ignore service scope when generating Envoy configuration, so users that want endpoints from all
-	// clusters to be available will have to explicitly mark services as global or not enable
-	// `AMBIENT_ENABLE_MULTI_NETWORK` if they don't want to apply service scope semantics.
-
-	// However, ServiceEntries are special. We cannot label ServiceEntries as local or global like regular services,
-	// and they don't have a scope, which for many practical purposes is treated as if the scope was local. When we
-	// operate in "remote primary" mode that's not the expected behavior.
-	//
-	// With that in mind, when service scope is not assigned, we don't filter out endpoints from other clusters. This
-	// case only applies to ServiceEntries, so the only situation in which endpoint cluster is different from the
-	// proxy cluster is when we are operating in a "remote primary" mode where the same istiod is responsible for
-	// generating configuration for proxies in remote clusters.
-	//
-	// NOTE: Scope could be model.Local, model.Global or unassigned, checking here for explicit model.Local excludes
-	// both cases:
-	// - when scope is explicitly set to model.Global and therefore we don't want to filter the endoint
-	// - when scope is not explicitly set and therefore we don't want to filter the endpoint either.
-	if b.serviceInfo != nil && b.serviceInfo.Scope == model.Local && b.clusterID != ep.Locality.ClusterID {
+	// While ambient specifically does not support this type of deployment, we don't want to introduce unncessary
+	// incompatibility here either. So below we hanbdle service entries in a special way and ignore the scope of
+	// the ServiceEntry allowing endpoints from remote clusters.
+	if b.serviceInfo != nil && b.serviceInfo.Source.Kind != kind.ServiceEntry && b.serviceInfo.Scope == model.Local && b.clusterID != ep.Locality.ClusterID {
 		return false
 	}
 

--- a/pilot/pkg/xds/endpoints/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder.go
@@ -572,14 +572,39 @@ func (b *EndpointBuilder) filterIstioEndpoint(ep *model.IstioEndpoint) bool {
 			return false
 		}
 	}
-	// If we are operating in ambient mode, producing configuration for a waypoint or E/W gateway, the service
-	// is not global and the endpoint is in a different cluster we filter it out.
+	// When multi-cluster ambeint mode of operation is enabled, services will have a scope. Scope can be local
+	// or global. In ambient, when service is local, we want to filter out endpoints from different clusters.
 	//
-	// NOTE: istiod itself can serve both ambient (e.g., waypoint and ztunnel) and sidecar proxies at the same time,
-	// and when we are generating configuration for a sidecar, we should not filter out endpoints that sidecar would
-	// normally see, just because we also serve ambient proxies from the same istiod as well. That's the reason why
-	// we have to check here that the node type is actually a waypoint and not a sidecar when generating EDS.
-	if b.nodeType == model.Waypoint && b.serviceInfo != nil && b.serviceInfo.Scope != model.Global && b.clusterID != ep.Locality.ClusterID {
+	// This semantics makes sense, but it creates a bit of problem when it comes to sidecar mode of operation:
+	// - Service scope concept didn't exist in sidecar mode (there are some lose equivalents of that, but they are
+	//   not identical to service scope)
+	// - The same istiod can serve both sidecar and ambient workloads at the same time (IOW, we can't always
+	//   clearly tell that istiod is operating in sidecar mode or ambient mode, because it could be both or nerither)
+	// - Like istiod, some proxies are not sidecar or ambient either (e.g., we can't say that ingress gateway is in
+        //   sidecar mode or ambient mode - that's just not the distinction that makes sense for ingress gateway).
+	//
+	// As a result, when `AMBIENT_ENABLE_MULTI_NETWORK` feature flag and we start considering service scope, it also
+	// changes the behavior of ingress gateways, which are not sidecar or ambient and serve both sidecar and ambient
+	// use cases (potentially even at the same time).
+	//
+	// We cannot ignore service scope when generating Envoy configuration, so users that want endpoints from all
+	// clusters to be available will have to explicitly mark services as global or not enable
+	// `AMBIENT_ENABLE_MULTI_NETWORK` if they don't want to apply service scope semantics.
+
+	// However, ServiceEntries are special. We cannot label ServiceEntries as local or global like regular services,
+	// and they don't have a scope, which for many practical purposes is treated as if the scope was local. When we
+	// operate in "remote primary" mode that's not the expected behavior.
+	//
+	// With that in mind, when service scope is not assigned, we don't filter out endpoints from other clusters. This
+	// case only applies to ServiceEntries, so the only situation in which endpoint cluster is different from the
+	// proxy cluster is when we are operating in a "remote primary" mode where the same istiod is responsible for
+	// generating configuration for proxies in remote clusters.
+	//
+	// NOTE: Scope could be model.Local, model.Global or unassigned, checking here for explicit model.Local excludes
+	// both cases:
+	// - when scope is explicitly set to model.Global and therefore we don't want to filter the endoint
+	// - when scope is not explicitly set and therefore we don't want to filter the endpoint either.
+	if b.serviceInfo != nil && b.serviceInfo.Scope == model.Local && b.clusterID != ep.Locality.ClusterID {
 		return false
 	}
 

--- a/pilot/pkg/xds/endpoints/endpoint_builder_test.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder_test.go
@@ -467,6 +467,22 @@ func TestFilterIstioEndpoint(t *testing.T) {
 			expected: false,
 		},
 		{
+			// In remote-primary setup in sidecar, sidecar proxies may see service
+			// entries defined in the remote cluster (e.g., cluster where istiod is
+			// actually running).
+			//
+			// We don't (yet) support the same mode of operation for ambient, that's
+			// why this test and the test above are expected to produce different
+			// results - when we generate configuration for sidecar proxies we don't
+			// filter a remote endpoint and when we generate configuration for ambient
+			// waypoint we do filter the remote endpoint out for non-global services.
+			name:     "test endpoint in remote cluster for local service and sidecar proxy",
+			proxy:    sidecar,
+			ep:       remoteEp,
+			svcInfo:  localSvc,
+			expected: true,
+		},
+		{
 			name:     "test ambient endpoint in local cluster for global service",
 			proxy:    ingressGw,
 			ep:       localEp,

--- a/pilot/pkg/xds/endpoints/endpoint_builder_test.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder_test.go
@@ -34,6 +34,7 @@ import (
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/mesh/meshwatcher"
 	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/test"
@@ -328,6 +329,19 @@ func makeService(namespace, hostname string, scope model.ServiceScope) *model.Se
 	}
 }
 
+func makeServiceEntry(namespace, hostname string) *model.ServiceInfo {
+	svc := &workloadapi.Service{
+		Namespace: namespace,
+		Hostname:  hostname,
+	}
+	return &model.ServiceInfo{
+		Service: svc,
+		Source: model.TypedObject{
+			Kind: kind.ServiceEntry,
+		},
+	}
+}
+
 func TestFilterIstioEndpoint(t *testing.T) {
 	svc := &model.Service{
 		Hostname: "example.ns.svc.cluster.local",
@@ -343,7 +357,7 @@ func TestFilterIstioEndpoint(t *testing.T) {
 	}
 	localSvc := makeService("ns", "example.ns.svc.cluster.local", model.Local)
 	globalSvc := makeService("ns", "example.ns.svc.cluster.local", model.Global)
-	unscopedSvc := makeService("ns", "example.ns.svc.cluster.local", model.Unscoped)
+	serviceEntry := makeServiceEntry("ns", "example.ns.svc.cluster.local")
 	sidecar := &model.Proxy{
 		Type:        model.SidecarProxy,
 		IPAddresses: []string{"111.111.111.111", "1111:2222::1"},
@@ -472,7 +486,7 @@ func TestFilterIstioEndpoint(t *testing.T) {
 			name:     "test endpoint in remote cluster for local service and sidecar proxy",
 			proxy:    waypoint,
 			ep:       remoteEp,
-			svcInfo:  unscopedSvc,
+			svcInfo:  serviceEntry,
 			expected: true,
 		},
 		{

--- a/pilot/pkg/xds/endpoints/endpoint_builder_test.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder_test.go
@@ -343,6 +343,7 @@ func TestFilterIstioEndpoint(t *testing.T) {
 	}
 	localSvc := makeService("ns", "example.ns.svc.cluster.local", model.Local)
 	globalSvc := makeService("ns", "example.ns.svc.cluster.local", model.Global)
+	unscopedSvc := makeService("ns", "example.ns.svc.cluster.local", model.Unscoped)
 	sidecar := &model.Proxy{
 		Type:        model.SidecarProxy,
 		IPAddresses: []string{"111.111.111.111", "1111:2222::1"},
@@ -351,6 +352,7 @@ func TestFilterIstioEndpoint(t *testing.T) {
 		Metadata: &model.NodeMetadata{
 			Namespace: "not-default",
 			NodeName:  "example",
+			ClusterID: "local",
 		},
 		ConfigNamespace: "not-default",
 	}
@@ -467,19 +469,10 @@ func TestFilterIstioEndpoint(t *testing.T) {
 			expected: false,
 		},
 		{
-			// In remote-primary setup in sidecar, sidecar proxies may see service
-			// entries defined in the remote cluster (e.g., cluster where istiod is
-			// actually running).
-			//
-			// We don't (yet) support the same mode of operation for ambient, that's
-			// why this test and the test above are expected to produce different
-			// results - when we generate configuration for sidecar proxies we don't
-			// filter a remote endpoint and when we generate configuration for ambient
-			// waypoint we do filter the remote endpoint out for non-global services.
 			name:     "test endpoint in remote cluster for local service and sidecar proxy",
-			proxy:    sidecar,
+			proxy:    waypoint,
 			ep:       remoteEp,
-			svcInfo:  localSvc,
+			svcInfo:  unscopedSvc,
 			expected: true,
 		},
 		{

--- a/releasenotes/notes/60343.yaml
+++ b/releasenotes/notes/60343.yaml
@@ -1,0 +1,14 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 60343
+releaseNotes:
+- |
+  **Fixed** an issue when istiod operating in mixed mode (e.g., ambient enabled and sidecar proxies present),
+  incorrectly filters out entries in remote cluster when generating a configuration for a sidecar proxy.
+  In ambient mode, istiod is expected to filter out endpoints in remote clusters, unless the services those
+  endpoints belong to are explictly marked as global. In sidecar mode this logic is not needed, but it was
+  triggering regardless when ambient multi-network mode was enabled. That's because istiod didn't check that
+  the proxy is a sidecar proxy before, now we check the type of proxy and don't filter out endpoints based
+  on the cluster when generating configuration for a sidecar proxy.


### PR DESCRIPTION
**Please provide a description of this PR:**

In ambient mode of operation, when generating waypoint or E/W gateway configuration we only allow endpoints from remote clusters if the service they belong to is explicitly marked as global.

Service entries cannot be marked as global or local - it would not make much sense to begin with, given that we don't ever read remote cluster service entries, so they kind of treated as local.

However, in sidecar mode the situation is a bit different. In sidecar mode, we support the multi-cluster mode of operation called "remote primary". In this mode we run a single istiod for multiple clusters. And in such mode of operation even though we don't read ServiceEntries in remote clusters, because all the clusters use the same istiod, it essentially works as if all clusters have the ServiceEntry.

Now, when you use the same control plane for both ambient multi-cluster and sidecar multi-cluster those two things conflict with each other. While we don't officially support such a mixed mode of operation, we can still special case handling of ServiceEntries to avoid the conflict in this case.

This change should not affect any other supported deployment because a ServiceEntry can only have remote endpoints when we operate in remote-primary mode, because istiod never reads ServiceEntries from remote clusters in the first place.

Fixes #60343

+cc @ramaraochavali @keithmattix @jaellio @Stevenjin8 @grnmeira @wenpincui