### PR TITLE
istiod: Reload CA bundle when the root cert file rotates

### DIFF
--- a/pilot/pkg/bootstrap/certcontroller.go
+++ b/pilot/pkg/bootstrap/certcontroller.go
@@ -233,8 +233,7 @@ func (s *Server) initFileCertificateWatches(tlsOptions TLSOptions) error {
 	if err := s.istiodCertBundleWatcher.SetFromFilesAndNotify(tlsOptions.KeyFile, tlsOptions.CertFile, tlsOptions.CaCertFile); err != nil {
 		return fmt.Errorf("set keyCertBundle failed: %v", err)
 	}
-	// TODO: Setup watcher for root and restart server if it changes.
-	for _, file := range []string{tlsOptions.CertFile, tlsOptions.KeyFile} {
+	for _, file := range []string{tlsOptions.CertFile, tlsOptions.KeyFile, tlsOptions.CaCertFile} {
 		log.Infof("adding watcher for certificate %s", file)
 		if err := s.fileWatcher.Add(file); err != nil {
 			return fmt.Errorf("could not watch %v: %v", file, err)
@@ -258,10 +257,16 @@ func (s *Server) initFileCertificateWatches(tlsOptions TLSOptions) error {
 					if keyCertTimerC == nil {
 						keyCertTimerC = time.After(watchDebounceDelay)
 					}
+				case <-s.fileWatcher.Events(tlsOptions.CaCertFile):
+					if keyCertTimerC == nil {
+						keyCertTimerC = time.After(watchDebounceDelay)
+					}
 				case err := <-s.fileWatcher.Errors(tlsOptions.CertFile):
 					log.Errorf("error watching %v: %v", tlsOptions.CertFile, err)
 				case err := <-s.fileWatcher.Errors(tlsOptions.KeyFile):
 					log.Errorf("error watching %v: %v", tlsOptions.KeyFile, err)
+				case err := <-s.fileWatcher.Errors(tlsOptions.CaCertFile):
+					log.Errorf("error watching %v: %v", tlsOptions.CaCertFile, err)
 				case <-stop:
 					return
 				}

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -337,6 +337,69 @@ func TestReloadIstiodCert(t *testing.T) {
 	}, "10s", "100ms").Should(BeTrue())
 }
 
+// TestReloadIstiodCABundle verifies that rotating only the CA (root) cert file, leaving the serving
+// cert and key untouched, is picked up by the file watcher. This is the path used when istiod's TLS
+// is provided via files (e.g. an external CA such as istio-csr); a missed root reload leaves stale
+// CA bundles in webhook configs that istiod manages.
+func TestReloadIstiodCABundle(t *testing.T) {
+	dir := t.TempDir()
+	stop := make(chan struct{})
+	s := &Server{
+		fileWatcher:             filewatcher.NewWatcher(),
+		server:                  server.New(),
+		istiodCertBundleWatcher: keycertbundle.NewWatcher(),
+	}
+
+	defer func() {
+		close(stop)
+		_ = s.fileWatcher.Close()
+	}()
+
+	certFile := filepath.Join(dir, "cert-file.yaml")
+	keyFile := filepath.Join(dir, "key-file.yaml")
+	caFile := filepath.Join(dir, "ca-file.yaml")
+
+	if err := os.WriteFile(certFile, testcerts.ServerCert, 0o644); err != nil { // nolint: vetshadow
+		t.Fatalf("WriteFile(%v) failed: %v", certFile, err)
+	}
+	if err := os.WriteFile(keyFile, testcerts.ServerKey, 0o644); err != nil { // nolint: vetshadow
+		t.Fatalf("WriteFile(%v) failed: %v", keyFile, err)
+	}
+	if err := os.WriteFile(caFile, testcerts.CACert, 0o644); err != nil { // nolint: vetshadow
+		t.Fatalf("WriteFile(%v) failed: %v", caFile, err)
+	}
+
+	tlsOptions := TLSOptions{
+		CertFile:   certFile,
+		KeyFile:    keyFile,
+		CaCertFile: caFile,
+	}
+
+	if err := s.initFileCertificateWatches(tlsOptions); err != nil {
+		t.Fatalf("initFileCertificateWatches failed: %v", err)
+	}
+	if err := s.server.Start(stop); err != nil {
+		t.Fatalf("Could not invoke startFuncs: %v", err)
+	}
+
+	g := NewWithT(t)
+	g.Expect(s.istiodCertBundleWatcher.GetCABundle()).To(Equal(testcerts.CACert))
+
+	// Rotate only the CA bundle.
+	if err := os.WriteFile(caFile, testcerts.RotatedCert, 0o644); err != nil { // nolint: vetshadow
+		t.Fatalf("WriteFile(%v) failed: %v", caFile, err)
+	}
+
+	g.Eventually(func() bool {
+		return bytes.Equal(s.istiodCertBundleWatcher.GetCABundle(), testcerts.RotatedCert)
+	}, "10s", "100ms").Should(BeTrue())
+
+	// The serving cert and key are unaffected by a CA-only rotation.
+	kc := s.istiodCertBundleWatcher.GetKeyCertBundle()
+	g.Expect(kc.CertPem).To(Equal(testcerts.ServerCert))
+	g.Expect(kc.KeyPem).To(Equal(testcerts.ServerKey))
+}
+
 func TestReloadcacerts(t *testing.T) {
 	var err error
 

--- a/releasenotes/notes/istiod-root-cert-file-watch.yaml
+++ b/releasenotes/notes/istiod-root-cert-file-watch.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+releaseNotes:
+  - |
+    **Fixed** a bug where istiod did not reload its CA root certificate when it rotated if the
+    certificate is provided via files (for example, when using an external CA such as istio-csr).


### PR DESCRIPTION
**Please provide a description of this PR:**

When istiod's DNS serving certificate is supplied via files rather than signed by istiod's own CA
e.g. with an external CA such as istio-csr, `initFileCertificateWatches` watched only the
certificate and key files, never the root (CA) file, which was read once at startup and refreshed
only as a side effect of a cert or key change. This meant a standalone CA rotation was never picked
up by a running istiod and can create a race condition between old and new pods reporting different 
CAs to the Kube API server for it to trust when calling istiod's webhook.

Fix (resolves the long-standing `// TODO: Setup watcher for root` comment) by adding the CA file to
the existing file watch and reuses the existing debounced reload, so a root rotation triggers
`SetFromFilesAndNotify` and propagates to all bundle watchers, which the same mechanism already 
used for cert/key rotation and by the `/etc/cacerts` CA-server path.