### PR TITLE
eds: don't explicitly delete resources

### DIFF
--- a/pilot/pkg/xds/delta_test.go
+++ b/pilot/pkg/xds/delta_test.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"testing"
 
+	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
 	"istio.io/istio/pilot/pkg/features"
@@ -229,12 +230,20 @@ func TestDeltaEDS(t *testing.T) {
 	// delete svc, only send eds for this service
 	s.MemRegistry.RemoveService(edsIncSvc)
 
+	// service deletion pushes and EDS update for the service with empty endpoints
 	resp = ads.ExpectResponse()
-	if len(resp.RemovedResources) != 1 || resp.RemovedResources[0] != "outbound|8080||"+edsIncSvc {
-		t.Fatalf("received unexpected removed eds resource %v", resp.RemovedResources)
-	}
-	if len(resp.Resources) != 0 {
+	if len(resp.Resources) != 1 || resp.Resources[0].Name != "outbound|8080||"+edsIncSvc {
 		t.Fatalf("received unexpected eds resource %v", resp.Resources)
+	}
+	cla := &endpoint.ClusterLoadAssignment{}
+	if err := resp.Resources[0].Resource.UnmarshalTo(cla); err != nil {
+		t.Fatalf("invalid eds push: %s", err)
+	}
+	if len(cla.Endpoints) > 0 {
+		t.Fatalf("received non-empty endpoints for service: %v", cla)
+	}
+	if len(resp.RemovedResources) != 0 {
+		t.Fatalf("received unexpected removed eds resource %v", resp.RemovedResources)
 	}
 }
 

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -201,7 +201,6 @@ func (eds *EdsGenerator) buildEndpoints(proxy *model.Proxy,
 		}
 	}
 	var resources model.Resources
-	var removed model.DeletedResources
 	empty := 0
 	cached := 0
 	regenerated := 0
@@ -217,12 +216,6 @@ func (eds *EdsGenerator) buildEndpoints(proxy *model.Proxy,
 
 		dir, subsetName, hostname, port := model.ParseSubsetKey(clusterName)
 		svc := req.Push.ServiceForHostname(proxy, hostname)
-
-		// In delta mode, if a service is not found, it means the cluster is removed
-		if delta && svc == nil {
-			removed = append(removed, clusterName)
-			continue
-		}
 
 		var dr *model.ConsolidatedDestRule
 		if svc != nil {
@@ -251,12 +244,6 @@ func (eds *EdsGenerator) buildEndpoints(proxy *model.Proxy,
 		}
 
 		l := builder.BuildClusterLoadAssignment(eds.EndpointIndex)
-		if l == nil {
-			if delta {
-				removed = append(removed, clusterName)
-			}
-			continue
-		}
 		regenerated++
 
 		if len(l.Endpoints) == 0 {
@@ -269,7 +256,7 @@ func (eds *EdsGenerator) buildEndpoints(proxy *model.Proxy,
 		resources = append(resources, resource)
 		eds.Cache.Add(&builder, req, resource)
 	}
-	return resources, removed, model.XdsLogDetails{
+	return resources, nil, model.XdsLogDetails{
 		Incremental:    len(edsUpdatedServices) != 0,
 		AdditionalInfo: fmt.Sprintf("empty:%v cached:%v/%v", empty, cached, cached+regenerated),
 	}

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -140,7 +140,7 @@ func (eds *EdsGenerator) Generate(proxy *model.Proxy, w *model.WatchedResource, 
 		return nil, model.DefaultXdsLogDetails, nil
 	}
 
-	resources, _, logDetails := eds.buildEndpoints(proxy, req, w, false, canSendPartialFullPushes(req))
+	resources, logDetails := eds.buildEndpoints(proxy, req, w, canSendPartialFullPushes(req))
 	return resources, logDetails, nil
 }
 
@@ -152,8 +152,8 @@ func (eds *EdsGenerator) GenerateDeltas(proxy *model.Proxy, req *model.PushReque
 	}
 
 	partialPush := canSendPartialFullPushes(req)
-	resources, removed, logs := eds.buildEndpoints(proxy, req, w, partialPush, partialPush)
-	return resources, removed, logs, partialPush, nil
+	resources, logs := eds.buildEndpoints(proxy, req, w, partialPush)
+	return resources, nil, logs, partialPush, nil
 }
 
 func canSendPartialFullPushes(req *model.PushRequest) bool {
@@ -178,9 +178,8 @@ func canSendPartialFullPushes(req *model.PushRequest) bool {
 func (eds *EdsGenerator) buildEndpoints(proxy *model.Proxy,
 	req *model.PushRequest,
 	w *model.WatchedResource,
-	delta bool,
 	partialPush bool,
-) (model.Resources, model.DeletedResources, model.XdsLogDetails) {
+) (model.Resources, model.XdsLogDetails) {
 	var edsUpdatedServices sets.Set[string]
 	var changedDrs sets.Set[types.NamespacedName]
 	var changedAuthnNs sets.Set[string]
@@ -256,7 +255,7 @@ func (eds *EdsGenerator) buildEndpoints(proxy *model.Proxy,
 		resources = append(resources, resource)
 		eds.Cache.Add(&builder, req, resource)
 	}
-	return resources, nil, model.XdsLogDetails{
+	return resources, model.XdsLogDetails{
 		Incremental:    len(edsUpdatedServices) != 0,
 		AdditionalInfo: fmt.Sprintf("empty:%v cached:%v/%v", empty, cached, cached+regenerated),
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**
This is mostly a cleanup of unnecessary work being done.
We should not delete resources from EDS, envoy will unsubscribe when clusters stop existing, instead we just continue and end up sending an empty cluster load assignement.
Also, `builder.BuildClusterLoadAssignment(eds.EndpointIndex)` never returns nil, so that `if` was never actually doing anything.