### PR TITLE
pilot: add PILOT_PATH_NORMALIZATION_SCOPE feature flag

### DIFF
--- a/pilot/pkg/features/experimental.go
+++ b/pilot/pkg/features/experimental.go
@@ -169,6 +169,10 @@ var (
 	EnableHCMInternalNetworks = env.Register("ENABLE_HCM_INTERNAL_NETWORKS", false,
 		"If enable, endpoints defined in mesh networks will be configured as internal addresses in Http Connection Manager").Get()
 
+	PathNormalizationScope = env.Register("PILOT_PATH_NORMALIZATION_SCOPE", "FORWARDING",
+		"Controls how mesh pathNormalization is applied. FORWARDING preserves existing behavior and forwards the normalized path. "+
+			"HTTP_FILTERS applies normalization for Envoy HTTP filters, routing, and matching, while preserving the original path forwarded upstream.").Get()
+
 	EnableLeaderElection = env.Register("ENABLE_LEADER_ELECTION", true,
 		"If enabled (default), starts a leader election client and gains leadership before executing controllers. "+
 			"If false, it assumes that only one instance of istiod is running and skips leader election.").Get()

--- a/pilot/pkg/networking/core/listener_builder.go
+++ b/pilot/pkg/networking/core/listener_builder.go
@@ -15,6 +15,7 @@
 package core
 
 import (
+	"strings"
 	"time"
 
 	accesslog "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
@@ -22,6 +23,7 @@ import (
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	tcp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
+	httpv3 "github.com/envoyproxy/go-control-plane/envoy/type/http/v3"
 	"google.golang.org/protobuf/types/known/durationpb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 	"k8s.io/apimachinery/pkg/types"
@@ -336,21 +338,7 @@ func (lb *ListenerBuilder) buildHTTPConnectionManager(httpOpts *httpListenerOpts
 	connectionManager.StatPrefix = httpOpts.statPrefix
 	connectionManager.AppendXForwardedPort = ph.GetXForwardedPort().GetEnabled().GetValue()
 
-	// Setup normalization
-	connectionManager.PathWithEscapedSlashesAction = hcm.HttpConnectionManager_KEEP_UNCHANGED
-	switch lb.push.Mesh.GetPathNormalization().GetNormalization() {
-	case meshconfig.MeshConfig_ProxyPathNormalization_NONE:
-		connectionManager.NormalizePath = proto.BoolFalse
-	case meshconfig.MeshConfig_ProxyPathNormalization_BASE, meshconfig.MeshConfig_ProxyPathNormalization_DEFAULT:
-		connectionManager.NormalizePath = proto.BoolTrue
-	case meshconfig.MeshConfig_ProxyPathNormalization_MERGE_SLASHES:
-		connectionManager.NormalizePath = proto.BoolTrue
-		connectionManager.MergeSlashes = true
-	case meshconfig.MeshConfig_ProxyPathNormalization_DECODE_AND_MERGE_SLASHES:
-		connectionManager.NormalizePath = proto.BoolTrue
-		connectionManager.MergeSlashes = true
-		connectionManager.PathWithEscapedSlashesAction = hcm.HttpConnectionManager_UNESCAPE_AND_FORWARD
-	}
+	configurePathNormalization(connectionManager, lb.push.Mesh.GetPathNormalization().GetNormalization())
 
 	if httpOpts.useRemoteAddress {
 		connectionManager.UseRemoteAddress = proto.BoolTrue
@@ -477,6 +465,85 @@ func (lb *ListenerBuilder) buildHTTPConnectionManager(httpOpts *httpListenerOpts
 	}
 	connectionManager.Proxy_100Continue = features.Enable100ContinueHeaders
 	return connectionManager
+}
+
+func configurePathNormalization(connectionManager *hcm.HttpConnectionManager, normalization meshconfig.MeshConfig_ProxyPathNormalization_NormalizationType) {
+	connectionManager.PathWithEscapedSlashesAction = hcm.HttpConnectionManager_KEEP_UNCHANGED
+
+	if strings.EqualFold(features.PathNormalizationScope, "HTTP_FILTERS") {
+		configureHTTPFilterPathNormalization(connectionManager, normalization)
+		return
+	}
+
+	switch normalization {
+	case meshconfig.MeshConfig_ProxyPathNormalization_NONE:
+		connectionManager.NormalizePath = proto.BoolFalse
+	case meshconfig.MeshConfig_ProxyPathNormalization_BASE, meshconfig.MeshConfig_ProxyPathNormalization_DEFAULT:
+		connectionManager.NormalizePath = proto.BoolTrue
+	case meshconfig.MeshConfig_ProxyPathNormalization_MERGE_SLASHES:
+		connectionManager.NormalizePath = proto.BoolTrue
+		connectionManager.MergeSlashes = true
+	case meshconfig.MeshConfig_ProxyPathNormalization_DECODE_AND_MERGE_SLASHES:
+		connectionManager.NormalizePath = proto.BoolTrue
+		connectionManager.MergeSlashes = true
+		connectionManager.PathWithEscapedSlashesAction = hcm.HttpConnectionManager_UNESCAPE_AND_FORWARD
+	}
+}
+
+func configureHTTPFilterPathNormalization(connectionManager *hcm.HttpConnectionManager, normalization meshconfig.MeshConfig_ProxyPathNormalization_NormalizationType) {
+	filterTransformation := pathTransformation(normalization)
+	if filterTransformation == nil {
+		connectionManager.NormalizePath = proto.BoolFalse
+		return
+	}
+
+	connectionManager.PathNormalizationOptions = &hcm.HttpConnectionManager_PathNormalizationOptions{
+		// Override Envoy's default forwarding normalization so the upstream :path is preserved.
+		ForwardingTransformation: &httpv3.PathTransformation{},
+		HttpFilterTransformation: filterTransformation,
+	}
+	if normalization == meshconfig.MeshConfig_ProxyPathNormalization_DECODE_AND_MERGE_SLASHES {
+		connectionManager.PathWithEscapedSlashesAction = hcm.HttpConnectionManager_UNESCAPE_AND_FORWARD
+	}
+}
+
+func pathTransformation(normalization meshconfig.MeshConfig_ProxyPathNormalization_NormalizationType) *httpv3.PathTransformation {
+	switch normalization {
+	case meshconfig.MeshConfig_ProxyPathNormalization_NONE:
+		return nil
+	case meshconfig.MeshConfig_ProxyPathNormalization_BASE, meshconfig.MeshConfig_ProxyPathNormalization_DEFAULT:
+		return &httpv3.PathTransformation{
+			Operations: []*httpv3.PathTransformation_Operation{normalizePathRFC3986()},
+		}
+	case meshconfig.MeshConfig_ProxyPathNormalization_MERGE_SLASHES,
+		meshconfig.MeshConfig_ProxyPathNormalization_DECODE_AND_MERGE_SLASHES:
+		return &httpv3.PathTransformation{
+			Operations: []*httpv3.PathTransformation_Operation{
+				normalizePathRFC3986(),
+				mergeSlashes(),
+			},
+		}
+	default:
+		return &httpv3.PathTransformation{
+			Operations: []*httpv3.PathTransformation_Operation{normalizePathRFC3986()},
+		}
+	}
+}
+
+func normalizePathRFC3986() *httpv3.PathTransformation_Operation {
+	return &httpv3.PathTransformation_Operation{
+		OperationSpecifier: &httpv3.PathTransformation_Operation_NormalizePathRfc_3986{
+			NormalizePathRfc_3986: &httpv3.PathTransformation_Operation_NormalizePathRFC3986{},
+		},
+	}
+}
+
+func mergeSlashes() *httpv3.PathTransformation_Operation {
+	return &httpv3.PathTransformation_Operation{
+		OperationSpecifier: &httpv3.PathTransformation_Operation_MergeSlashes_{
+			MergeSlashes: &httpv3.PathTransformation_Operation_MergeSlashes{},
+		},
+	}
 }
 
 func appendMxFilter(httpOpts *httpListenerOpts, filters []*hcm.HttpFilter) []*hcm.HttpFilter {

--- a/pilot/pkg/networking/core/listener_builder_test.go
+++ b/pilot/pkg/networking/core/listener_builder_test.go
@@ -872,6 +872,81 @@ spec:
 `, m)
 }
 
+func TestPathNormalizationScope(t *testing.T) {
+	cases := []struct {
+		name                         string
+		scope                        string
+		normalization                 meshconfig.MeshConfig_ProxyPathNormalization_NormalizationType
+		wantNormalizePath             bool
+		wantMergeSlashes              bool
+		wantEscapedSlashesAction      hcm.HttpConnectionManager_PathWithEscapedSlashesAction
+		wantPathNormalizationOptions  bool
+		wantHTTPFilterOperations      int
+		wantForwardingTransformation  bool
+		wantNormalizePathRfc3986First bool
+		wantMergeSlashesLast          bool
+	}{
+		{
+			name:                    "default forwarding scope preserves existing decode and merge behavior",
+			scope:                   "FORWARDING",
+			normalization:           meshconfig.MeshConfig_ProxyPathNormalization_DECODE_AND_MERGE_SLASHES,
+			wantNormalizePath:       true,
+			wantMergeSlashes:        true,
+			wantEscapedSlashesAction: hcm.HttpConnectionManager_UNESCAPE_AND_FORWARD,
+		},
+		{
+			name:                         "http filters scope preserves forwarded path",
+			scope:                        "HTTP_FILTERS",
+			normalization:                meshconfig.MeshConfig_ProxyPathNormalization_DECODE_AND_MERGE_SLASHES,
+			wantEscapedSlashesAction:     hcm.HttpConnectionManager_UNESCAPE_AND_FORWARD,
+			wantPathNormalizationOptions: true,
+			wantHTTPFilterOperations:     2,
+			wantForwardingTransformation: true,
+			wantNormalizePathRfc3986First: true,
+			wantMergeSlashesLast:         true,
+		},
+		{
+			name:                    "http filters scope with none disables normalization",
+			scope:                   "HTTP_FILTERS",
+			normalization:           meshconfig.MeshConfig_ProxyPathNormalization_NONE,
+			wantEscapedSlashesAction: hcm.HttpConnectionManager_KEEP_UNCHANGED,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			test.SetForTest(t, &features.PathNormalizationScope, tt.scope)
+			httpConnManager := &hcm.HttpConnectionManager{}
+			configurePathNormalization(httpConnManager, tt.normalization)
+
+			assert.Equal(t, tt.wantNormalizePath, httpConnManager.GetNormalizePath().GetValue())
+			assert.Equal(t, tt.wantMergeSlashes, httpConnManager.GetMergeSlashes())
+			assert.Equal(t, tt.wantEscapedSlashesAction, httpConnManager.GetPathWithEscapedSlashesAction())
+
+			pathNormalizationOptions := httpConnManager.GetPathNormalizationOptions()
+			if !tt.wantPathNormalizationOptions {
+				assert.Equal(t, true, pathNormalizationOptions == nil)
+				return
+			}
+
+			if pathNormalizationOptions == nil {
+				t.Fatal("expected path normalization options")
+			}
+			assert.Equal(t, tt.wantForwardingTransformation, pathNormalizationOptions.GetForwardingTransformation() != nil)
+			assert.Equal(t, 0, len(pathNormalizationOptions.GetForwardingTransformation().GetOperations()))
+
+			operations := pathNormalizationOptions.GetHttpFilterTransformation().GetOperations()
+			assert.Equal(t, tt.wantHTTPFilterOperations, len(operations))
+			if tt.wantNormalizePathRfc3986First && operations[0].GetNormalizePathRfc_3986() == nil {
+				t.Fatal("expected first operation to normalize path per RFC 3986")
+			}
+			if tt.wantMergeSlashesLast && operations[len(operations)-1].GetMergeSlashes() == nil {
+				t.Fatal("expected last operation to merge slashes")
+			}
+		})
+	}
+}
+
 func TestHCMInternalAddressConfig(t *testing.T) {
 	cg := NewConfigGenTest(t, TestOptions{})
 	sidecarProxy := cg.SetupProxy(&model.Proxy{ConfigNamespace: "not-default"})


### PR DESCRIPTION
Adds a new HTTP_FILTERS scope that applies path normalization only
within Envoy HTTP filters (for AuthorizationPolicy evaluation) while
preserving the original :path forwarded to upstream services.

Fixes #60431
