### PR TITLE
fix startup issue with health probes

### DIFF
--- a/cni/pkg/nodeagent/helpers_test.go
+++ b/cni/pkg/nodeagent/helpers_test.go
@@ -56,6 +56,11 @@ func (f *fakeServer) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod, isD
 	return args.Error(0)
 }
 
+func (f *fakeServer) SyncHostProbeIPSet(pod *corev1.Pod, podIPs []netip.Addr) error {
+	args := f.Called(pod, podIPs)
+	return args.Error(0)
+}
+
 func (f *fakeServer) Start(ctx context.Context) {
 }
 

--- a/cni/pkg/nodeagent/informers.go
+++ b/cni/pkg/nodeagent/informers.go
@@ -299,6 +299,22 @@ func (s *InformerHandlers) reconcilePod(input any) error {
 			return nil
 		}
 
+		// Self-heal the host probe ipset for an already-enrolled pod. A startup snapshot
+		// that ran before this pod's IP was observable (e.g. right after a node/kubelet
+		// restart) will have skipped and pruned its probe-ipset entry. Such a pod hits
+		// changeNeeded=false below and would otherwise never be re-added, leaving its
+		// kubelet probes to be SNAT-bypassed -> redirected to ztunnel -> rejected by
+		// AuthorizationPolicy indefinitely. SyncHostProbeIPSet is an idempotent upsert,
+		// so re-asserting membership on each update for an enrolled pod is cheap and safe.
+		if isEnrolled && shouldBeEnabled && !isTerminated {
+			if podIPs := util.GetPodIPsIfPresent(currentPod); len(podIPs) > 0 {
+				if err := s.dataplane.SyncHostProbeIPSet(currentPod, podIPs); err != nil {
+					log.Warnf("failed to sync host probe ipset for enrolled pod, will retry: %v", err)
+					return err
+				}
+			}
+		}
+
 		if !changeNeeded || isTerminated {
 			log.Debugf("pod update event skipped: no change needed")
 			return nil

--- a/cni/pkg/nodeagent/meshdataplane_linux.go
+++ b/cni/pkg/nodeagent/meshdataplane_linux.go
@@ -237,6 +237,18 @@ func (s *meshDataplane) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod, 
 	return nil
 }
 
+// SyncHostProbeIPSet re-asserts an already-enrolled pod's probe IPs in the host ipset.
+// This is the self-heal path for the informer: a startup snapshot that ran before a
+// pod's IP was observable (e.g. right after a node/kubelet restart) will have skipped
+// and pruned that pod, and steady-state informer events hit changeNeeded=false and would
+// never re-add it - leaving its kubelet probes to be rejected by ztunnel indefinitely.
+// addPodToHostAddrSet is an idempotent upsert, so calling this on each update for an
+// enrolled pod is cheap and safe.
+func (s *meshDataplane) SyncHostProbeIPSet(pod *corev1.Pod, podIPs []netip.Addr) error {
+	_, err := s.addPodToHostAddrSet(pod, podIPs)
+	return err
+}
+
 // syncHostAddrSets is called after the host node ipset has been created (or found + flushed)
 // during initial snapshot creation, it will insert every snapshotted pod's IP into the set.
 //

--- a/cni/pkg/nodeagent/net_linux.go
+++ b/cni/pkg/nodeagent/net_linux.go
@@ -87,6 +87,12 @@ func (s *NetServer) Stop(_ bool) {
 	s.ztunnelServer.Close()
 }
 
+// SyncHostProbeIPSet is a no-op for the inner NetServer: the host probe ipset is owned
+// and managed by the meshDataplane wrapper, which implements the real behavior.
+func (s *NetServer) SyncHostProbeIPSet(_ *corev1.Pod, _ []netip.Addr) error {
+	return nil
+}
+
 // AddPodToMesh adds a pod to mesh by
 // 1. Getting the netns (and making sure the netns is cached in the ztunnel state of the world snapshot)
 // 2. Adding the pod's IPs to the hostnetns ipsets for node probe checks

--- a/cni/pkg/nodeagent/server.go
+++ b/cni/pkg/nodeagent/server.go
@@ -47,6 +47,12 @@ type MeshDataplane interface {
 	AddPodToMesh(ctx context.Context, pod *corev1.Pod, podIPs []netip.Addr, netNs string) error
 	RemovePodFromMesh(ctx context.Context, pod *corev1.Pod, isDelete bool) error
 
+	// SyncHostProbeIPSet ensures an already-enrolled pod's probe IPs are present in the
+	// host probe ipset. It is an idempotent upsert used by the informer to self-heal
+	// entries that may have been pruned by a startup snapshot that ran before the pod's
+	// IP was observable (e.g. right after a node/kubelet restart).
+	SyncHostProbeIPSet(pod *corev1.Pod, podIPs []netip.Addr) error
+
 	Stop(skipCleanup bool)
 }
 

--- a/cni/pkg/nodeagent/server_unspecified.go
+++ b/cni/pkg/nodeagent/server_unspecified.go
@@ -47,6 +47,10 @@ func (*meshDataplane) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod, is
 	return errNotImplemented
 }
 
+func (*meshDataplane) SyncHostProbeIPSet(pod *corev1.Pod, podIPs []netip.Addr) error {
+	return errNotImplemented
+}
+
 func (*meshDataplane) Stop(skipCleanup bool) {
 	// not supported
 	return


### PR DESCRIPTION
Title: cni: self-heal the host probe ipset for enrolled pods on informer reconcile

## Problem

An ambient-enrolled pod can end up missing from the host `istio-inpod-probes-v4` ipset and stay that way until the istio-cni node agent is restarted. While it's missing, its kubelet probes are not SNAT'd to the link-local probe address, so they are redirected into ztunnel instead of bypassing it, and any `AuthorizationPolicy` on the workload rejects them (`connection closed due to policy rejection: allow policies exist, but none allowed`). The pod fails liveness/readiness and restarts indefinitely.

How an enrolled pod loses its ipset entry:

On startup the node agent rebuilds the host ipset from a one-shot snapshot of `PodFullyEnrolled` pods, reading each pod's `Status.PodIPs`, and then **prunes every entry not in that snapshot** (`syncHostAddrSets` → `pruneHostAddrSet`). Right after a node reboot or kubelet/containerd restart, enrolled pods exist (annotation persisted) but their `Status.PodIPs` is not yet repopulated, so the snapshot reads them IP-less, skips them, and prunes their existing entries:

```
warn  cni-agent  pod <name> does not appear to have any assigned IPs, not syncing with ipset
```

Pods whose sandbox is recreated recover via the CNI plugin add path. But a pod whose sandbox survives the restart never gets a fresh CNI add, and the steady-state informer ignores it because an already-enrolled pod hits `changeNeeded=false` and returns early. Nothing re-adds it, so it is broken until the next agent restart.

This is the residual path not covered by #5786: that PR gates the plugin add socket so a *new/recreated* pod's add can't be pruned during startup, but it does not help an *already-enrolled* pod that the snapshot pruned and that receives no subsequent add.

## Fix

Have the informer re-assert host probe ipset membership for an already-enrolled pod on every reconcile, before the `changeNeeded`/no-op early return:

```go
if isEnrolled && shouldBeEnabled && !isTerminated {
    if podIPs := util.GetPodIPsIfPresent(currentPod); len(podIPs) > 0 {
        if err := s.dataplane.SyncHostProbeIPSet(currentPod, podIPs); err != nil {
            log.Warnf("failed to sync host probe ipset for enrolled pod, will retry: %v", err)
            return err
        }
    }
}
```

`SyncHostProbeIPSet` is a new `MeshDataplane` method that wraps the existing `addPodToHostAddrSet` (already an idempotent upsert):
- `meshDataplane` (linux): re-adds the pod's IPs to the host ipset.
- `NetServer`: no-op (the inner dataplane does not own the host ipset).
- non-linux `meshDataplane`: stub.

Because the informer fires update events frequently (pod status changes, kubelet status re-posts, the startup `enqueueNamespace` that enqueues every pod on the node, and workqueue resyncs), a pruned entry is re-added within seconds — without needing a CNI add or an agent restart. The upsert is cheap and safe to repeat.

This is complementary to #5786, not a replacement. #5786 prevents the add-then-prune race for new/recreated pods during startup; this self-heals already-enrolled pods that were pruned and get no add. Both paths to the symptom are then covered.

## Testing

Manually validated on kind + Antrea CNI + ambient (the affected configuration), with many enrolled probe-bearing pods on one node behind a restrictive `AuthorizationPolicy`.

- **Node reboot** (without this change leaves pods permanently stuck): after the reboot the startup snapshot still skips IP-less pods, but they self-heal — the ipset returns to full membership, 0 ztunnel policy rejections, all pods Ready, with no manual agent restart, and stays stable.
- **Isolated self-heal** (proves the informer path, not a CNI add): remove one pod's entry with `ipset del` (sandbox untouched, so no add can re-add it), then trigger a benign pod update — the entry is re-added within seconds. This is the exact scenario that does not recover without the change.

Automated test follow-up (not yet included): the reconcile unit tests drive a `MeshDataplane` fake; they need a `SyncHostProbeIPSet` expectation added. A fake stub was added; existing expectations in `informers_test.go` still need updating, and a regression test asserting an enrolled pod missing from the ipset is re-added on update should be added.

## Release notes

```release-note
Fixed an issue where an ambient-enrolled pod could be left out of the host health-probe ipset after a node or kubelet restart, causing its kubelet probes to be rejected by ztunnel until the istio-cni node agent was restarted. The node agent now re-asserts probe ipset membership for enrolled pods during reconciliation.
```
