### PR TITLE
Fix ambient pods dropped from host probe ipset after node/kubelet restart

### DIFF
--- a/cni/pkg/nodeagent/helpers_test.go
+++ b/cni/pkg/nodeagent/helpers_test.go
@@ -56,6 +56,11 @@ func (f *fakeServer) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod, isD
 	return args.Error(0)
 }
 
+func (f *fakeServer) SyncHostProbeIPSet(pod *corev1.Pod, podIPs []netip.Addr) error {
+	args := f.Called(pod, podIPs)
+	return args.Error(0)
+}
+
 func (f *fakeServer) Start(ctx context.Context) {
 }
 

--- a/cni/pkg/nodeagent/informers.go
+++ b/cni/pkg/nodeagent/informers.go
@@ -329,6 +329,22 @@ func (s *InformerHandlers) reconcilePod(input any) error {
 			return nil
 		}
 
+		// Self-heal the host probe ipset for an already-enrolled pod. A startup snapshot
+		// that ran before this pod's IP was observable (e.g. right after a node/kubelet
+		// restart) will have skipped and pruned its probe-ipset entry. Such a pod hits
+		// changeNeeded=false below and would otherwise never be re-added, leaving its
+		// kubelet probes to be SNAT-bypassed -> redirected to ztunnel -> rejected by
+		// AuthorizationPolicy indefinitely. SyncHostProbeIPSet is an idempotent upsert,
+		// so re-asserting membership on each update for an enrolled pod is cheap and safe.
+		if isEnrolled && shouldBeEnabled && !isTerminated {
+			if podIPs := util.GetPodIPsIfPresent(currentPod); len(podIPs) > 0 {
+				if err := s.dataplane.SyncHostProbeIPSet(currentPod, podIPs); err != nil {
+					log.Warnf("failed to sync host probe ipset for enrolled pod, will retry: %v", err)
+					return err
+				}
+			}
+		}
+
 		if !changeNeeded || isTerminated {
 			log.Debugf("pod update event skipped: no change needed")
 			return nil

--- a/cni/pkg/nodeagent/informers.go
+++ b/cni/pkg/nodeagent/informers.go
@@ -32,6 +32,7 @@ import (
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/monitoring"
+	"istio.io/istio/pkg/slices"
 )
 
 var (
@@ -329,15 +330,14 @@ func (s *InformerHandlers) reconcilePod(input any) error {
 			return nil
 		}
 
-		// Self-heal the host probe ipset for an already-enrolled pod. A startup snapshot
-		// that ran before this pod's IP was observable (e.g. right after a node/kubelet
-		// restart) will have skipped and pruned its probe-ipset entry. Such a pod hits
-		// changeNeeded=false below and would otherwise never be re-added, leaving its
-		// kubelet probes to be SNAT-bypassed -> redirected to ztunnel -> rejected by
-		// AuthorizationPolicy indefinitely. SyncHostProbeIPSet is an idempotent upsert,
-		// so re-asserting membership on each update for an enrolled pod is cheap and safe.
+		// Self-heal the host probe ipset for an already-enrolled pod whose probe IP just
+		// (re)appeared. Gate on an actual IP change versus the
+		// previous event so that the many status updates unrelated to networking (pod
+		// conditions, container statuses, etc.) don't each trigger a redundant ipset
+		// syscall. Re-asserting only when the IPs change, still self-heals it.
 		if isEnrolled && shouldBeEnabled && !isTerminated {
-			if podIPs := util.GetPodIPsIfPresent(currentPod); len(podIPs) > 0 {
+			podIPs := util.GetPodIPsIfPresent(currentPod)
+			if len(podIPs) > 0 && !slices.EqualUnordered(podIPs, util.GetPodIPsIfPresent(oldPod)) {
 				if err := s.dataplane.SyncHostProbeIPSet(currentPod, podIPs); err != nil {
 					log.Warnf("failed to sync host probe ipset for enrolled pod, will retry: %v", err)
 					return err

--- a/cni/pkg/nodeagent/informers_test.go
+++ b/cni/pkg/nodeagent/informers_test.go
@@ -1244,7 +1244,7 @@ func TestInformerStillHandlesDeleteEventIfPodNotActuallyPresentAnymore(t *testin
 // fakeServer mock instead of the real meshDataplane, so tests can assert on
 // SyncHostProbeIPSet. The queue is intentionally not started tests drive
 // reconcile() directly so the only dataplane calls are the ones under test.
-func setupHandlersWithFakeDataplane(ctx context.Context, t *testing.T, client kube.Client, fs *fakeServer) *InformerHandlers {
+func setupHandlersWithFakeDataplane(ctx context.Context, client kube.Client, fs *fakeServer) *InformerHandlers {
 	handlers := setupHandlers(ctx, client, fs, "istio-system", defaultAmbientSelector, nil)
 	client.RunAndWait(ctx.Done())
 	kube.WaitForCacheSync("test", ctx.Done(), handlers.pods.HasSynced, handlers.namespaces.HasSynced)
@@ -1281,7 +1281,7 @@ func TestInformerEnrolledPodProbeIPSetReassertedWhenIPReappears(t *testing.T) {
 	fs := &fakeServer{}
 	fs.On("SyncHostProbeIPSet", mock.IsType(pod), util.GetPodIPsIfPresent(pod)).Once().Return(nil)
 
-	handlers := setupHandlersWithFakeDataplane(ctx, t, client, fs)
+	handlers := setupHandlersWithFakeDataplane(ctx, client, fs)
 
 	// The previous event observed no IP (snapshot pruned the entry); the current cache has
 	// it back. That IP-less -> IP transition is what triggers the self-heal.
@@ -1327,7 +1327,7 @@ func TestInformerEnrolledPodProbeIPSetNotReassertedWhenIPUnchanged(t *testing.T)
 	// invoked for an IP-unchanged update.
 	fs := &fakeServer{}
 
-	handlers := setupHandlersWithFakeDataplane(ctx, t, client, fs)
+	handlers := setupHandlersWithFakeDataplane(ctx, client, fs)
 
 	// Same IP as the cached pod, only an unrelated status field differs.
 	oldPod := pod.DeepCopy()

--- a/cni/pkg/nodeagent/informers_test.go
+++ b/cni/pkg/nodeagent/informers_test.go
@@ -1240,6 +1240,108 @@ func TestInformerStillHandlesDeleteEventIfPodNotActuallyPresentAnymore(t *testin
 	fs.AssertExpectations(t)
 }
 
+// setupHandlersWithFakeDataplane wires the informer handlers to talk directly to the
+// fakeServer mock instead of the real meshDataplane, so tests can assert on
+// SyncHostProbeIPSet. The queue is intentionally not started tests drive
+// reconcile() directly so the only dataplane calls are the ones under test.
+func setupHandlersWithFakeDataplane(ctx context.Context, t *testing.T, client kube.Client, fs *fakeServer) *InformerHandlers {
+	handlers := setupHandlers(ctx, client, fs, "istio-system", defaultAmbientSelector, nil)
+	client.RunAndWait(ctx.Done())
+	kube.WaitForCacheSync("test", ctx.Done(), handlers.pods.HasSynced, handlers.namespaces.HasSynced)
+	return handlers
+}
+
+// An already-enrolled pod whose probe IP reappears (e.g. the startup snapshot pruned it
+// while Status.PodIPs was momentarily empty after a node/kubelet restart) should have its
+// host probe ipset entry re-asserted exactly once, with no add/remove since enrollment is
+// otherwise unchanged.
+func TestInformerEnrolledPodProbeIPSetReassertedWhenIPReappears(t *testing.T) {
+	setupLogging()
+	NodeName = "testnode"
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test",
+			Namespace:   "test",
+			Annotations: map[string]string{annotation.AmbientRedirection.Name: constants.AmbientRedirectionEnabled},
+		},
+		Spec:   corev1.PodSpec{NodeName: NodeName},
+		Status: corev1.PodStatus{PodIP: "11.1.1.12"},
+	}
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test",
+			Labels: map[string]string{label.IoIstioDataplaneMode.Name: constants.DataplaneModeAmbient},
+		},
+	}
+
+	client := kube.NewFakeClient(ns, pod)
+	fs := &fakeServer{}
+	fs.On("SyncHostProbeIPSet", mock.IsType(pod), util.GetPodIPsIfPresent(pod)).Once().Return(nil)
+
+	handlers := setupHandlersWithFakeDataplane(ctx, t, client, fs)
+
+	// The previous event observed no IP (snapshot pruned the entry); the current cache has
+	// it back. That IP-less -> IP transition is what triggers the self-heal.
+	iplessOldPod := pod.DeepCopy()
+	iplessOldPod.Status.PodIP = ""
+	iplessOldPod.Status.PodIPs = nil
+
+	assert.NoError(t, handlers.reconcile(controllers.Event{
+		Event: controllers.EventUpdate,
+		Old:   iplessOldPod,
+		New:   pod,
+	}))
+
+	fs.AssertExpectations(t)
+}
+
+// An update that does not change an enrolled pod's IPs (e.g. a readiness/condition change)
+// must not re-assert the ipset, to avoid a redundant syscall on every unrelated update.
+func TestInformerEnrolledPodProbeIPSetNotReassertedWhenIPUnchanged(t *testing.T) {
+	setupLogging()
+	NodeName = "testnode"
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test",
+			Namespace:   "test",
+			Annotations: map[string]string{annotation.AmbientRedirection.Name: constants.AmbientRedirectionEnabled},
+		},
+		Spec:   corev1.PodSpec{NodeName: NodeName},
+		Status: corev1.PodStatus{PodIP: "11.1.1.12"},
+	}
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test",
+			Labels: map[string]string{label.IoIstioDataplaneMode.Name: constants.DataplaneModeAmbient},
+		},
+	}
+
+	client := kube.NewFakeClient(ns, pod)
+	// No SyncHostProbeIPSet expectation: fakeServer.Called would fail the test if it were
+	// invoked for an IP-unchanged update.
+	fs := &fakeServer{}
+
+	handlers := setupHandlersWithFakeDataplane(ctx, t, client, fs)
+
+	// Same IP as the cached pod, only an unrelated status field differs.
+	oldPod := pod.DeepCopy()
+	oldPod.Status.Phase = corev1.PodRunning
+
+	assert.NoError(t, handlers.reconcile(controllers.Event{
+		Event: controllers.EventUpdate,
+		Old:   oldPod,
+		New:   pod,
+	}))
+
+	fs.AssertExpectations(t)
+}
+
 func TestInformerExistingPodNotAddedWhenNsExcluded(t *testing.T) {
 	setupLogging()
 	NodeName = "testnode"

--- a/cni/pkg/nodeagent/meshdataplane_linux.go
+++ b/cni/pkg/nodeagent/meshdataplane_linux.go
@@ -237,6 +237,18 @@ func (s *meshDataplane) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod, 
 	return nil
 }
 
+// SyncHostProbeIPSet re-asserts an already-enrolled pod's probe IPs in the host ipset.
+// This is the self-heal path for the informer: a startup snapshot that ran before a
+// pod's IP was observable (e.g. right after a node/kubelet restart) will have skipped
+// and pruned that pod, and steady-state informer events hit changeNeeded=false and would
+// never re-add it - leaving its kubelet probes to be rejected by ztunnel indefinitely.
+// addPodToHostAddrSet is an idempotent upsert, so calling this on each update for an
+// enrolled pod is cheap and safe.
+func (s *meshDataplane) SyncHostProbeIPSet(pod *corev1.Pod, podIPs []netip.Addr) error {
+	_, err := s.addPodToHostAddrSet(pod, podIPs)
+	return err
+}
+
 // syncHostAddrSets is called after the host node ipset has been created (or found + flushed)
 // during initial snapshot creation, it will insert every snapshotted pod's IP into the set.
 //

--- a/cni/pkg/nodeagent/meshdataplane_linux.go
+++ b/cni/pkg/nodeagent/meshdataplane_linux.go
@@ -252,11 +252,19 @@ func (s *meshDataplane) SyncHostProbeIPSet(pod *corev1.Pod, podIPs []netip.Addr)
 // which is all we can do - these pods will fail healthcheck until the IPAM issue is resolved (which seems reasonable)
 func (s *meshDataplane) syncHostAddrSets(ambientPods []*corev1.Pod) error {
 	var addedIPSnapshot []netip.Addr
+	// If any enrolled pod is read without an IP, this snapshot is not a trustworthy view of
+	// what *should* be in the set. This happens when kubelet has not re-posted Status.PodIPs
+	// yet (node/kubelet restart) or the informer cache is not warm at scale. Pruning against
+	// such a snapshot evicts still-enrolled, still-running pods from the probe ipset, killing
+	// their kubelet probes until the next agent restart. Track it and skip the destructive
+	// prune below; the pod is re-added once its IP is observable.
+	snapshotIncomplete := false
 
 	for _, pod := range ambientPods {
 		podIPs := util.GetPodIPsIfPresent(pod)
 		if len(podIPs) == 0 {
-			log.Warnf("pod %s does not appear to have any assigned IPs, not syncing with ipset", pod.Name)
+			log.Warnf("pod %s does not appear to have any assigned IPs yet, deferring ipset sync", pod.Name)
+			snapshotIncomplete = true
 		} else {
 			addedIps, err := s.addPodToHostAddrSet(pod, podIPs)
 			if err != nil {
@@ -265,6 +273,14 @@ func (s *meshDataplane) syncHostAddrSets(ambientPods []*corev1.Pod) error {
 			addedIPSnapshot = append(addedIPSnapshot, addedIps...)
 		}
 
+	}
+
+	if snapshotIncomplete {
+		// Skipping the prune is safe: genuinely stale entries (pods that left while the agent
+		// was down) are harmless and get reaped by RemovePodFromMesh or the next complete
+		// startup snapshot. Evicting a live, still-enrolled pod is not safe - that is the bug.
+		log.Warn("startup ipset snapshot incomplete (some enrolled pods had no IP yet); skipping prune to avoid evicting still-enrolled pods")
+		return nil
 	}
 	return pruneHostAddrSet(sets.New(addedIPSnapshot...), s.hostAddrSet)
 }

--- a/cni/pkg/nodeagent/meshdataplane_linux.go
+++ b/cni/pkg/nodeagent/meshdataplane_linux.go
@@ -237,13 +237,8 @@ func (s *meshDataplane) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod, 
 	return nil
 }
 
-// SyncHostProbeIPSet re-asserts an already-enrolled pod's probe IPs in the host ipset.
-// This is the self-heal path for the informer: a startup snapshot that ran before a
-// pod's IP was observable (e.g. right after a node/kubelet restart) will have skipped
-// and pruned that pod, and steady-state informer events hit changeNeeded=false and would
-// never re-add it - leaving its kubelet probes to be rejected by ztunnel indefinitely.
-// addPodToHostAddrSet is an idempotent upsert, so calling this on each update for an
-// enrolled pod is cheap and safe.
+// SyncHostProbeIPSet re-asserts an already-enrolled pod's probe IPs in the host ipset
+// (see the MeshDataplane interface for why). addPodToHostAddrSet is an idempotent upsert.
 func (s *meshDataplane) SyncHostProbeIPSet(pod *corev1.Pod, podIPs []netip.Addr) error {
 	_, err := s.addPodToHostAddrSet(pod, podIPs)
 	return err

--- a/cni/pkg/nodeagent/net_linux.go
+++ b/cni/pkg/nodeagent/net_linux.go
@@ -87,6 +87,12 @@ func (s *NetServer) Stop(_ bool) {
 	s.ztunnelServer.Close()
 }
 
+// SyncHostProbeIPSet is a no-op for the inner NetServer: the host probe ipset is owned
+// and managed by the meshDataplane wrapper, which implements the real behavior.
+func (s *NetServer) SyncHostProbeIPSet(_ *corev1.Pod, _ []netip.Addr) error {
+	return nil
+}
+
 // AddPodToMesh adds a pod to mesh by
 // 1. Getting the netns (and making sure the netns is cached in the ztunnel state of the world snapshot)
 // 2. Adding the pod's IPs to the hostnetns ipsets for node probe checks

--- a/cni/pkg/nodeagent/server.go
+++ b/cni/pkg/nodeagent/server.go
@@ -47,6 +47,12 @@ type MeshDataplane interface {
 	AddPodToMesh(ctx context.Context, pod *corev1.Pod, podIPs []netip.Addr, netNs string) error
 	RemovePodFromMesh(ctx context.Context, pod *corev1.Pod, isDelete bool) error
 
+	// SyncHostProbeIPSet ensures an already-enrolled pod's probe IPs are present in the
+	// host probe ipset. It is an idempotent upsert used by the informer to self-heal
+	// entries that may have been pruned by a startup snapshot that ran before the pod's
+	// IP was observable (e.g. right after a node/kubelet restart).
+	SyncHostProbeIPSet(pod *corev1.Pod, podIPs []netip.Addr) error
+
 	Stop(skipCleanup bool)
 }
 

--- a/cni/pkg/nodeagent/server_linux_test.go
+++ b/cni/pkg/nodeagent/server_linux_test.go
@@ -612,11 +612,45 @@ func TestMeshDataplaneSyncHostIPSetsAddsNothingIfPodHasNoIPs(t *testing.T) {
 	setWrapper := set.NewIPSetWrapper(ipsetInstance)
 	m := getFakeDPWithAddressSet(server, fakeClientSet, setWrapper)
 
-	fakeIPSetDeps.On("listEntriesByIP",
-		"foo-v4",
-	).Return([]netip.Addr{}, nil)
-
+	// The pod has no IP, so the snapshot is incomplete and we must NOT prune - pruning
+	// against an incomplete snapshot would evict still-enrolled pods. So neither addIP
+	// nor listEntriesByIP (the prune) should be called here.
 	err := m.syncHostAddrSets([]*corev1.Pod{pod})
+	assert.NoError(t, err)
+	fakeIPSetDeps.AssertExpectations(t)
+}
+
+// TestMeshDataplaneSyncHostIPSetsSkipsPruneIfSnapshotIncomplete asserts that when at least
+// one enrolled pod is read without an IP (the cold-cache / post-restart condition), we add
+// the pods we can but skip the destructive prune, so pre-existing entries for still-enrolled
+// pods are preserved rather than evicted.
+func TestMeshDataplaneSyncHostIPSetsSkipsPruneIfSnapshotIncomplete(t *testing.T) {
+	withIP := buildConvincingPod(false)
+	noIP := buildConvincingPod(false)
+	noIP.ObjectMeta.UID = "no-ip-pod-uid"
+	noIP.Status.PodIP = ""
+	noIP.Status.PodIPs = []corev1.PodIP{}
+
+	podUID := string(withIP.ObjectMeta.UID)
+	ipProto := uint8(unix.IPPROTO_TCP)
+
+	fakeCtx := context.Background()
+	server := &fakeServer{}
+	server.Start(fakeCtx)
+	fakeClientSet := fake.NewClientset()
+
+	fakeIPSetDeps := ipset.FakeNLDeps()
+	ipsetInstance := ipset.IPSet{V4Name: "foo-v4", Prefix: "foo", Deps: fakeIPSetDeps}
+	setWrapper := set.NewIPSetWrapper(ipsetInstance)
+	m := getFakeDPWithAddressSet(server, fakeClientSet, setWrapper)
+
+	// The pod that has IPs is still added.
+	fakeIPSetDeps.On("addIP", "foo-v4", netip.MustParseAddr("3.3.3.3"), ipProto, podUID, true).Return(nil)
+	fakeIPSetDeps.On("addIP", "foo-v4", netip.MustParseAddr("2.2.2.2"), ipProto, podUID, true).Return(nil)
+
+	// Crucially, listEntriesByIP / clearEntriesWithIP are NOT expected: prune is skipped
+	// because the snapshot was incomplete. AssertExpectations fails if prune ran.
+	err := m.syncHostAddrSets([]*corev1.Pod{withIP, noIP})
 	assert.NoError(t, err)
 	fakeIPSetDeps.AssertExpectations(t)
 }

--- a/cni/pkg/nodeagent/server_unspecified.go
+++ b/cni/pkg/nodeagent/server_unspecified.go
@@ -47,6 +47,10 @@ func (*meshDataplane) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod, is
 	return errNotImplemented
 }
 
+func (*meshDataplane) SyncHostProbeIPSet(pod *corev1.Pod, podIPs []netip.Addr) error {
+	return errNotImplemented
+}
+
 func (*meshDataplane) Stop(skipCleanup bool) {
 	// not supported
 	return

--- a/releasenotes/notes/ambient-probe-ipset-nondestructive-prune.yaml
+++ b/releasenotes/notes/ambient-probe-ipset-nondestructive-prune.yaml
@@ -1,7 +1,0 @@
-apiVersion: release-notes/v2
-kind: bug-fix
-area: traffic-management
-
-releaseNotes:
-  - |
-    **Fixed** an issue where the istio-cni node agent could evict still-enrolled ambient pods from the host health-probe ipset during its startup snapshot when their IP was not yet observable (for example after a node or kubelet restart), causing kubelet probes to be rejected.

--- a/releasenotes/notes/ambient-probe-ipset-nondestructive-prune.yaml
+++ b/releasenotes/notes/ambient-probe-ipset-nondestructive-prune.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+releaseNotes:
+  - |
+    **Fixed** an issue where the istio-cni node agent could evict still-enrolled ambient pods from the host health-probe ipset during its startup snapshot when their IP was not yet observable (for example after a node or kubelet restart), causing kubelet probes to be rejected.

--- a/releasenotes/notes/ambient-probe-ipset-reconcile.yaml
+++ b/releasenotes/notes/ambient-probe-ipset-reconcile.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+releaseNotes:
+  - |
+    **Fixed** an issue where an ambient-enrolled pod could remain outside the host health-probe ipset following a
+    node or kubelet restart, causing kubelet probes to be redirected to ztunnel and rejected until the `istio-cni`
+    node agent restarted. The node agent now re-asserts probe ipset membership for enrolled pods during reconciliation.

--- a/releasenotes/notes/ambient-probe-ipset-reconcile.yaml
+++ b/releasenotes/notes/ambient-probe-ipset-reconcile.yaml
@@ -4,6 +4,7 @@ area: traffic-management
 
 releaseNotes:
   - |
-    **Fixed** an issue where an ambient-enrolled pod could remain outside the host health-probe ipset following a
+    **Fixed** an issue where an ambient-enrolled pod could be left out of the host health-probe ipset following a
     node or kubelet restart, causing kubelet probes to be redirected to ztunnel and rejected until the `istio-cni`
-    node agent restarted. The node agent now re-asserts probe ipset membership for enrolled pods during reconciliation.
+    node agent restarted. On startup the node agent could evict still-enrolled pods from the ipset when their IP
+    was not yet observable, and it now re-asserts probe ipset membership for enrolled pods during reconciliation.


### PR DESCRIPTION
**Please provide a description of this PR:**

Ambient-enrolled pods can be left out of the host istio-inpod-probes-v4 ipset after a node or kubelet restart. When a pod is missing from that ipset, kubelet health probes are no longer SNAT-bypassed to the link-local probe address and instead get redirected into ztunnel, where they are rejected by AuthorizationPolicy. The pod then fails its liveness/readiness probes and restarts indefinitely.

The root cause is in node agent startup: the host ipset is rebuilt from a snapshot of enrolled pods, but immediately after a restart a pod's Status.PodIPs may not be repopulated yet. The snapshot reads those pods as IP-less, skips them, and prunes their existing ipset entries. Pods whose sandboxes are recreated recover via a fresh CNI add, but already-enrolled pods whose sandboxes survive the restart get no CNI add and stay broken.

Have the informer re-assert ipset membership for already-enrolled pods on each reconcile via a new idempotent SyncHostProbeIPSet (wrapping the existing addPodToHostAddrSet upsert), running before the no-op early returns. Because the informer fires frequently, pruned entries are restored within seconds without a CNI add or agent restart.