### PR TITLE
Istioctl analyze validation for conflicting ServiceEntries

### DIFF
--- a/pkg/config/analysis/analyzers/all.go
+++ b/pkg/config/analysis/analyzers/all.go
@@ -73,6 +73,7 @@ func All() []analysis.Analyzer {
 		&virtualservice.GatewayAnalyzer{},
 		&virtualservice.JWTClaimRouteAnalyzer{},
 		&serviceentry.ProtocolAddressesAnalyzer{},
+		&serviceentry.ConflictingServiceEntryProtocolAnalyzer{},
 		&webhook.Analyzer{},
 		&telemetry.ProviderAnalyzer{},
 		&telemetry.SelectorAnalyzer{},

--- a/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/pkg/config/analysis/analyzers/analyzers_test.go
@@ -1025,6 +1025,21 @@ var testGrid = []testCase{
 		},
 	},
 	{
+		name:       "ServiceEntry conflicting protocols on same host and port",
+		inputFiles: []string{"testdata/serviceentry-conflicting-protocol.yaml"},
+		analyzer:   &serviceentry.ConflictingServiceEntryProtocolAnalyzer{},
+		expected: []message{
+			{msg.ConflictingServiceEntryProtocol, "ServiceEntry default/se-http"},
+			{msg.ConflictingServiceEntryProtocol, "ServiceEntry default/se-https"},
+		},
+	},
+	{
+		name:       "ServiceEntry no conflict same protocol",
+		inputFiles: []string{"testdata/serviceentry-no-conflict-protocol.yaml"},
+		analyzer:   &serviceentry.ConflictingServiceEntryProtocolAnalyzer{},
+		expected:   []message{},
+	},
+	{
 		name:       "Condition Analyzer",
 		inputFiles: []string{"testdata/condition-analyzer.yaml"},
 		analyzer:   &conditions.ConditionAnalyzer{},

--- a/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/pkg/config/analysis/analyzers/analyzers_test.go
@@ -1040,6 +1040,12 @@ var testGrid = []testCase{
 		expected:   []message{},
 	},
 	{
+		name:       "ServiceEntry no conflict non-overlapping exportTo scopes",
+		inputFiles: []string{"testdata/serviceentry-conflicting-exportto.yaml"},
+		analyzer:   &serviceentry.ConflictingServiceEntryProtocolAnalyzer{},
+		expected:   []message{},
+	},
+	{
 		name:       "Condition Analyzer",
 		inputFiles: []string{"testdata/condition-analyzer.yaml"},
 		analyzer:   &conditions.ConditionAnalyzer{},

--- a/pkg/config/analysis/analyzers/serviceentry/conflictingserviceentries.go
+++ b/pkg/config/analysis/analyzers/serviceentry/conflictingserviceentries.go
@@ -26,15 +26,17 @@ import (
 	"istio.io/istio/pkg/config/analysis/msg"
 	"istio.io/istio/pkg/config/resource"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/util/sets"
 )
 
 type ConflictingServiceEntryProtocolAnalyzer struct{}
 
 var _ analysis.Analyzer = &ConflictingServiceEntryProtocolAnalyzer{}
 
-type hostPortKey struct {
-	host string
-	port uint32
+type scopedHostPortKey struct {
+	scope string
+	host  string
+	port  uint32
 }
 
 type protoEntry struct {
@@ -53,14 +55,19 @@ func (c *ConflictingServiceEntryProtocolAnalyzer) Metadata() analysis.Metadata {
 }
 
 func (c *ConflictingServiceEntryProtocolAnalyzer) Analyze(ctx analysis.Context) {
-	index := make(map[hostPortKey][]protoEntry)
+	index := make(map[scopedHostPortKey][]protoEntry)
 
 	ctx.ForEach(gvk.ServiceEntry, func(r *resource.Instance) bool {
 		se := r.Message.(*v1alpha3.ServiceEntry)
-		for _, h := range se.Hosts {
-			for _, p := range se.Ports {
-				key := hostPortKey{host: h, port: p.Number}
-				index[key] = append(index[key], protoEntry{protocol: p.Protocol, instance: r})
+		seNamespace := r.Metadata.FullName.Namespace.String()
+
+		scopes := exportToScopes(se.ExportTo, seNamespace)
+		for scope := range scopes {
+			for _, h := range se.Hosts {
+				for _, p := range se.Ports {
+					key := scopedHostPortKey{scope: scope, host: h, port: p.Number}
+					index[key] = append(index[key], protoEntry{protocol: p.Protocol, instance: r})
+				}
 			}
 		}
 		return true
@@ -69,6 +76,11 @@ func (c *ConflictingServiceEntryProtocolAnalyzer) Analyze(ctx analysis.Context) 
 	reported := make(map[resource.FullName]bool)
 
 	for key, entries := range index {
+		if key.scope != util.ExportToAllNamespaces {
+			starKey := scopedHostPortKey{scope: util.ExportToAllNamespaces, host: key.host, port: key.port}
+			entries = append(entries, index[starKey]...)
+		}
+
 		protocols := make(map[string]bool)
 		for _, e := range entries {
 			protocols[strings.ToUpper(e.protocol)] = true
@@ -108,4 +120,19 @@ func (c *ConflictingServiceEntryProtocolAnalyzer) Analyze(ctx analysis.Context) 
 			ctx.Report(gvk.ServiceEntry, m)
 		}
 	}
+}
+
+func exportToScopes(exportTo []string, seNamespace string) sets.String {
+	if util.IsExportToAllNamespaces(exportTo) {
+		return sets.New(util.ExportToAllNamespaces)
+	}
+	scopes := sets.New[string]()
+	for _, et := range exportTo {
+		if et == util.ExportToNamespaceLocal {
+			scopes.Insert(seNamespace)
+		} else {
+			scopes.Insert(et)
+		}
+	}
+	return scopes
 }

--- a/pkg/config/analysis/analyzers/serviceentry/conflictingserviceentries.go
+++ b/pkg/config/analysis/analyzers/serviceentry/conflictingserviceentries.go
@@ -1,0 +1,111 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serviceentry
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/analysis"
+	"istio.io/istio/pkg/config/analysis/analyzers/util"
+	"istio.io/istio/pkg/config/analysis/msg"
+	"istio.io/istio/pkg/config/resource"
+	"istio.io/istio/pkg/config/schema/gvk"
+)
+
+type ConflictingServiceEntryProtocolAnalyzer struct{}
+
+var _ analysis.Analyzer = &ConflictingServiceEntryProtocolAnalyzer{}
+
+type hostPortKey struct {
+	host string
+	port uint32
+}
+
+type protoEntry struct {
+	protocol string
+	instance *resource.Instance
+}
+
+func (c *ConflictingServiceEntryProtocolAnalyzer) Metadata() analysis.Metadata {
+	return analysis.Metadata{
+		Name:        "serviceentry.ConflictingServiceEntryProtocolAnalyzer",
+		Description: "Checks if multiple ServiceEntries define the same host and port with different protocols",
+		Inputs: []config.GroupVersionKind{
+			gvk.ServiceEntry,
+		},
+	}
+}
+
+func (c *ConflictingServiceEntryProtocolAnalyzer) Analyze(ctx analysis.Context) {
+	index := make(map[hostPortKey][]protoEntry)
+
+	ctx.ForEach(gvk.ServiceEntry, func(r *resource.Instance) bool {
+		se := r.Message.(*v1alpha3.ServiceEntry)
+		for _, h := range se.Hosts {
+			for _, p := range se.Ports {
+				key := hostPortKey{host: h, port: p.Number}
+				index[key] = append(index[key], protoEntry{protocol: p.Protocol, instance: r})
+			}
+		}
+		return true
+	})
+
+	reported := make(map[resource.FullName]bool)
+
+	for key, entries := range index {
+		protocols := make(map[string]bool)
+		for _, e := range entries {
+			protocols[strings.ToUpper(e.protocol)] = true
+		}
+		if len(protocols) < 2 {
+			continue
+		}
+
+		seenNames := make(map[string]bool)
+		names := make([]string, 0)
+		for _, e := range entries {
+			n := e.instance.Metadata.FullName.String()
+			if !seenNames[n] {
+				seenNames[n] = true
+				names = append(names, n)
+			}
+		}
+		sort.Strings(names)
+		namesStr := strings.Join(names, ", ")
+
+		protoList := make([]string, 0, len(protocols))
+		for p := range protocols {
+			protoList = append(protoList, p)
+		}
+		sort.Strings(protoList)
+		protocolsStr := strings.Join(protoList, ", ")
+
+		for _, e := range entries {
+			if reported[e.instance.Metadata.FullName] {
+				continue
+			}
+			reported[e.instance.Metadata.FullName] = true
+			m := msg.NewConflictingServiceEntryProtocol(e.instance, namesStr, key.host, int(key.port), protocolsStr)
+			if line, ok := util.ErrorLine(e.instance, fmt.Sprintf(util.MetadataName)); ok {
+				m.Line = line
+			}
+			ctx.Report(gvk.ServiceEntry, m)
+		}
+	}
+}

--- a/pkg/config/analysis/analyzers/testdata/serviceentry-conflicting-exportto.yaml
+++ b/pkg/config/analysis/analyzers/testdata/serviceentry-conflicting-exportto.yaml
@@ -1,5 +1,4 @@
-# No conflict: same host and port with different protocols, but non-overlapping exportTo scopes.
-apiVersion: networking.istio.io/v2
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: se-ns1
@@ -16,7 +15,7 @@ spec:
   exportTo:
   - "."
 ---
-apiVersion: networking.istio.io/v2
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: se-ns2

--- a/pkg/config/analysis/analyzers/testdata/serviceentry-conflicting-exportto.yaml
+++ b/pkg/config/analysis/analyzers/testdata/serviceentry-conflicting-exportto.yaml
@@ -1,0 +1,34 @@
+# No conflict: same host and port with different protocols, but non-overlapping exportTo scopes.
+apiVersion: networking.istio.io/v2
+kind: ServiceEntry
+metadata:
+  name: se-ns1
+  namespace: ns1
+spec:
+  hosts:
+  - example.com
+  ports:
+  - name: http-8080
+    number: 8080
+    protocol: HTTP
+  resolution: DNS
+  location: MESH_EXTERNAL
+  exportTo:
+  - "."
+---
+apiVersion: networking.istio.io/v2
+kind: ServiceEntry
+metadata:
+  name: se-ns2
+  namespace: ns2
+spec:
+  hosts:
+  - example.com
+  ports:
+  - name: https-8080
+    number: 8080
+    protocol: HTTPS
+  resolution: DNS
+  location: MESH_EXTERNAL
+  exportTo:
+  - "."

--- a/pkg/config/analysis/analyzers/testdata/serviceentry-conflicting-protocol.yaml
+++ b/pkg/config/analysis/analyzers/testdata/serviceentry-conflicting-protocol.yaml
@@ -1,0 +1,45 @@
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: se-https
+  namespace: default
+spec:
+  hosts:
+  - example.com
+  ports:
+  - name: https-13835
+    number: 13835
+    protocol: HTTPS
+  resolution: DNS
+  location: MESH_EXTERNAL
+---
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: se-http
+  namespace: default
+spec:
+  hosts:
+  - example.com
+  ports:
+  - name: http-13835
+    number: 13835
+    protocol: HTTP
+  resolution: DNS
+  location: MESH_EXTERNAL
+---
+# No conflict: same host, same port, same protocol
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: se-no-conflict
+  namespace: default
+spec:
+  hosts:
+  - other.com
+  ports:
+  - name: https-443
+    number: 443
+    protocol: HTTPS
+  resolution: DNS
+  location: MESH_EXTERNAL

--- a/pkg/config/analysis/analyzers/testdata/serviceentry-no-conflict-protocol.yaml
+++ b/pkg/config/analysis/analyzers/testdata/serviceentry-no-conflict-protocol.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: se-https-only
+  namespace: default
+spec:
+  hosts:
+  - example.com
+  ports:
+  - name: https-443
+    number: 443
+    protocol: HTTPS
+  resolution: DNS
+  location: MESH_EXTERNAL
+---
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: se-https-only-2
+  namespace: default
+spec:
+  hosts:
+  - example.com
+  ports:
+  - name: https-443-2
+    number: 443
+    protocol: HTTPS
+  resolution: DNS
+  location: MESH_EXTERNAL

--- a/pkg/config/analysis/msg/messages.gen.go
+++ b/pkg/config/analysis/msg/messages.gen.go
@@ -275,6 +275,10 @@ var (
 	// GatewayAPICRDVersionBelowMinimum defines a diag.MessageType for message "GatewayAPICRDVersionBelowMinimum".
 	// Description: A Gateway API CRD is installed at a version below the minimum required by this Istio version. Resources of this kind will not be processed.
 	GatewayAPICRDVersionBelowMinimum = diag.NewMessageType(diag.Warning, "IST0176", "Gateway API CRD %q is at version %q but Istio requires at least %q; resources of this kind will not be processed. Upgrade the Gateway API CRDs to satisfy the minimum version.")
+
+	// ConflictingServiceEntryProtocol defines a diag.MessageType for message "ConflictingServiceEntryProtocol".
+	// Description: Multiple ServiceEntries define the same host and port with conflicting protocols.
+	ConflictingServiceEntryProtocol = diag.NewMessageType(diag.Warning, "IST0177", "Multiple ServiceEntries (%s) define the same host %q and port %d with conflicting protocols (%s).")
 )
 
 // All returns a list of all known message types.
@@ -347,6 +351,7 @@ func All() []*diag.MessageType {
 		UnknownDestinationRuleHost,
 		JwksUriFetchUnrestricted,
 		GatewayAPICRDVersionBelowMinimum,
+		ConflictingServiceEntryProtocol,
 	}
 }
 
@@ -1007,5 +1012,17 @@ func NewGatewayAPICRDVersionBelowMinimum(r *resource.Instance, crd string, insta
 		crd,
 		installedVersion,
 		minimumVersion,
+	)
+}
+
+// NewConflictingServiceEntryProtocol returns a new diag.Message based on ConflictingServiceEntryProtocol.
+func NewConflictingServiceEntryProtocol(r *resource.Instance, serviceEntryNames string, host string, port int, protocols string) diag.Message {
+	return diag.NewMessage(
+		ConflictingServiceEntryProtocol,
+		r,
+		serviceEntryNames,
+		host,
+		port,
+		protocols,
 	)
 }

--- a/pkg/config/analysis/msg/messages.yaml
+++ b/pkg/config/analysis/msg/messages.yaml
@@ -724,3 +724,18 @@ messages:
       type: string
     - name: minimumVersion
       type: string
+
+  - name: "ConflictingServiceEntryProtocol"
+    code: IST0177
+    level: Warning
+    description: "Multiple ServiceEntries define the same host and port with conflicting protocols."
+    template: "Multiple ServiceEntries (%s) define the same host %q and port %d with conflicting protocols (%s)."
+    args:
+    - name: serviceEntryNames
+      type: string
+    - name: host
+      type: string
+    - name: port
+      type: int
+    - name: protocols
+      type: string

--- a/releasenotes/notes/60447.yaml
+++ b/releasenotes/notes/60447.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue:
+  - 60447
+
+releaseNotes:
+- |
+  **Added** `istioctl analyze` now warns (IST0177) when multiple ServiceEntries define the same host and port with conflicting protocols.


### PR DESCRIPTION
Istioctl analyze validation for conflicting ServiceEntries

**Please provide a description of this PR:**


Adds a new istioctl analyze analyzer (IST0177) that detects when multiple ServiceEntries define the same hostname and port number with different protocols. The analyzer reports a Warning for each conflicting ServiceEntry.

Fixes #60447