### PR TITLE
Do not parse dry-run if there is no value

### DIFF
--- a/pilot/pkg/serviceregistry/ambient/authorization.go
+++ b/pilot/pkg/serviceregistry/ambient/authorization.go
@@ -397,10 +397,13 @@ func convertPeerAuthentication(rootNamespace string, cfg, nsCfg, rootCfg *securi
 func convertAuthorizationPolicy(rootns string, obj *securityclient.AuthorizationPolicy) (*security.Authorization, *model.StatusMessage) {
 	pol := &obj.Spec
 
-	dryRun, convErr := strconv.ParseBool(obj.Annotations[annotation.IoIstioDryRun.Name])
-	if convErr != nil {
-		// proceed anyway?
-		log.Errorf("Unable to parse dry run annotation, encountered error %v", convErr)
+	var dryRun bool
+	if val := obj.Annotations[annotation.IoIstioDryRun.Name]; val != "" {
+		var convErr error
+		if dryRun, convErr = strconv.ParseBool(val); convErr != nil {
+			// proceed anyway?
+			log.Errorf("Unable to parse dry run annotation, encountered error %v", convErr)
+		}
 	}
 
 	if dryRun && !features.EnableWdsDryRunAuthzPol {


### PR DESCRIPTION
Errors are being emitted for AuthorizationPolicies when no dry-run annotation is present.

error   Unable to parse dry run annotation, encountered error strconv.ParseBool: parsing "": invalid syntax