### PR TITLE
cni: don't prune probe ipset for still-enrolled pods on incomplete startup snapshot

### DIFF
--- a/cni/pkg/nodeagent/meshdataplane_linux.go
+++ b/cni/pkg/nodeagent/meshdataplane_linux.go
@@ -245,11 +245,19 @@ func (s *meshDataplane) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod, 
 // which is all we can do - these pods will fail healthcheck until the IPAM issue is resolved (which seems reasonable)
 func (s *meshDataplane) syncHostAddrSets(ambientPods []*corev1.Pod) error {
 	var addedIPSnapshot []netip.Addr
+	// If any enrolled pod is read without an IP, this snapshot is not a trustworthy view of
+	// what *should* be in the set. This happens when kubelet has not re-posted Status.PodIPs
+	// yet (node/kubelet restart) or the informer cache is not warm at scale. Pruning against
+	// such a snapshot evicts still-enrolled, still-running pods from the probe ipset, killing
+	// their kubelet probes until the next agent restart. Track it and skip the destructive
+	// prune below; the pod is re-added once its IP is observable.
+	snapshotIncomplete := false
 
 	for _, pod := range ambientPods {
 		podIPs := util.GetPodIPsIfPresent(pod)
 		if len(podIPs) == 0 {
-			log.Warnf("pod %s does not appear to have any assigned IPs, not syncing with ipset", pod.Name)
+			log.Warnf("pod %s does not appear to have any assigned IPs yet, deferring ipset sync", pod.Name)
+			snapshotIncomplete = true
 		} else {
 			addedIps, err := s.addPodToHostAddrSet(pod, podIPs)
 			if err != nil {
@@ -258,6 +266,14 @@ func (s *meshDataplane) syncHostAddrSets(ambientPods []*corev1.Pod) error {
 			addedIPSnapshot = append(addedIPSnapshot, addedIps...)
 		}
 
+	}
+
+	if snapshotIncomplete {
+		// Skipping the prune is safe: genuinely stale entries (pods that left while the agent
+		// was down) are harmless and get reaped by RemovePodFromMesh or the next complete
+		// startup snapshot. Evicting a live, still-enrolled pod is not safe - that is the bug.
+		log.Warn("startup ipset snapshot incomplete (some enrolled pods had no IP yet); skipping prune to avoid evicting still-enrolled pods")
+		return nil
 	}
 	return pruneHostAddrSet(sets.New(addedIPSnapshot...), s.hostAddrSet)
 }

--- a/cni/pkg/nodeagent/server_linux_test.go
+++ b/cni/pkg/nodeagent/server_linux_test.go
@@ -612,11 +612,45 @@ func TestMeshDataplaneSyncHostIPSetsAddsNothingIfPodHasNoIPs(t *testing.T) {
 	setWrapper := set.NewIPSetWrapper(ipsetInstance)
 	m := getFakeDPWithAddressSet(server, fakeClientSet, setWrapper)
 
-	fakeIPSetDeps.On("listEntriesByIP",
-		"foo-v4",
-	).Return([]netip.Addr{}, nil)
-
+	// The pod has no IP, so the snapshot is incomplete and we must NOT prune - pruning
+	// against an incomplete snapshot would evict still-enrolled pods. So neither addIP
+	// nor listEntriesByIP (the prune) should be called here.
 	err := m.syncHostAddrSets([]*corev1.Pod{pod})
+	assert.NoError(t, err)
+	fakeIPSetDeps.AssertExpectations(t)
+}
+
+// TestMeshDataplaneSyncHostIPSetsSkipsPruneIfSnapshotIncomplete asserts that when at least
+// one enrolled pod is read without an IP (the cold-cache / post-restart condition), we add
+// the pods we can but skip the destructive prune, so pre-existing entries for still-enrolled
+// pods are preserved rather than evicted.
+func TestMeshDataplaneSyncHostIPSetsSkipsPruneIfSnapshotIncomplete(t *testing.T) {
+	withIP := buildConvincingPod(false)
+	noIP := buildConvincingPod(false)
+	noIP.ObjectMeta.UID = "no-ip-pod-uid"
+	noIP.Status.PodIP = ""
+	noIP.Status.PodIPs = []corev1.PodIP{}
+
+	podUID := string(withIP.ObjectMeta.UID)
+	ipProto := uint8(unix.IPPROTO_TCP)
+
+	fakeCtx := context.Background()
+	server := &fakeServer{}
+	server.Start(fakeCtx)
+	fakeClientSet := fake.NewClientset()
+
+	fakeIPSetDeps := ipset.FakeNLDeps()
+	ipsetInstance := ipset.IPSet{V4Name: "foo-v4", Prefix: "foo", Deps: fakeIPSetDeps}
+	setWrapper := set.NewIPSetWrapper(ipsetInstance)
+	m := getFakeDPWithAddressSet(server, fakeClientSet, setWrapper)
+
+	// The pod that has IPs is still added.
+	fakeIPSetDeps.On("addIP", "foo-v4", netip.MustParseAddr("3.3.3.3"), ipProto, podUID, true).Return(nil)
+	fakeIPSetDeps.On("addIP", "foo-v4", netip.MustParseAddr("2.2.2.2"), ipProto, podUID, true).Return(nil)
+
+	// Crucially, listEntriesByIP / clearEntriesWithIP are NOT expected: prune is skipped
+	// because the snapshot was incomplete. AssertExpectations fails if prune ran.
+	err := m.syncHostAddrSets([]*corev1.Pod{withIP, noIP})
 	assert.NoError(t, err)
 	fakeIPSetDeps.AssertExpectations(t)
 }

--- a/releasenotes/notes/ambient-probe-ipset-nondestructive-prune.yaml
+++ b/releasenotes/notes/ambient-probe-ipset-nondestructive-prune.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+releaseNotes:
+  - |
+    **Fixed** an issue where the istio-cni node agent could evict still-enrolled ambient pods from the host health-probe ipset during its startup snapshot when their IP was not yet observable (for example after a node or kubelet restart), causing kubelet probes to be rejected.


### PR DESCRIPTION
Complements #60471. That PR re-adds a dropped entry on reconcile; this prevents the drop: when the startup snapshot reads an enrolled pod without an IP (kubelet has not re-posted Status.PodIPs after a node/kubelet restart, or the informer cache is not warm at scale), the snapshot is incomplete, so pruning against it evicts still-enrolled, still-running pods and their kubelet probes get rejected until the agent restarts. Skip the prune when the snapshot is incomplete. The non-destructive-prune approach was suggested by @nmnellis. Validated on kind + Antrea + ambient: a node reboot no longer leaves pods stuck out of the probe ipset.