### PR TITLE
Avoid panic when Envoy drain admin POST fails

### DIFF
--- a/pkg/envoy/admin.go
+++ b/pkg/envoy/admin.go
@@ -37,8 +37,11 @@ func DrainListeners(adminPort uint32, inboundonly bool, skipExit bool) error {
 		drainURL += "&skip_exit"
 	}
 	res, err := doEnvoyPost(drainURL, "", "", adminPort)
+	if err != nil {
+		return err
+	}
 	log.Debugf("Drain listener endpoint response : %s", res.String())
-	return err
+	return nil
 }
 
 func doEnvoyPost(path, contentType, body string, adminPort uint32) (*bytes.Buffer, error) {

--- a/pkg/envoy/admin_test.go
+++ b/pkg/envoy/admin_test.go
@@ -1,0 +1,41 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy
+
+import (
+	"net"
+	"testing"
+)
+
+func TestDrainListenersReturnsErrorIfAdminPostFails(t *testing.T) {
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to allocate local port: %v", err)
+	}
+	adminPort := listener.Addr().(*net.TCPAddr).Port
+	if err := listener.Close(); err != nil {
+		t.Fatalf("failed to close local listener: %v", err)
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("DrainListeners panicked: %v", r)
+		}
+	}()
+
+	if err := DrainListeners(uint32(adminPort), true, false); err == nil {
+		t.Fatal("expected error from closed admin port")
+	}
+}

--- a/releasenotes/notes/60494.yaml
+++ b/releasenotes/notes/60494.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed** an issue where proxy draining could panic instead of returning an error when the Envoy admin endpoint was unavailable.


### PR DESCRIPTION
## What

Check the error returned by the Envoy drain admin POST before logging the response body.

This also adds a regression test that posts to a closed local admin port and verifies `DrainListeners` returns the connection error instead of panicking.

## Why

`doEnvoyPost` returns a nil response buffer when `http.Post` fails. `DrainListeners` logged `res.String()` before checking that error, so an admin connection failure could panic and hide the original error.

## Tests

`go test ./pkg/envoy`