### PR TITLE
[release-1.29] Sidecars prior to 1.29.2 break on upgrade

### DIFF
--- a/pilot/pkg/networking/core/listener.go
+++ b/pilot/pkg/networking/core/listener.go
@@ -1401,6 +1401,11 @@ type listenerKey struct {
 // 1. It uses TCP Proxy network filter to establish a CONNECT tunnel
 // 2. It captures and propagates metadata about the actual destination and service name required for double-HBONE.
 func buildInnerConnectOriginateListener(push *model.PushContext, proxy *model.Proxy) *listener.Listener {
+	// TODO: Remove in 1.32
+	factoryKey := "istio.hashable_string"
+	if !proxy.VersionGreaterOrEqual(&model.IstioVersion{Major: 1, Minor: 29, Patch: 2}) {
+		factoryKey = "envoy.string"
+	}
 	setFilterState := &sfsnetwork.Config{
 		OnNewConnection: []*sfsvalue.FilterStateValue{
 			{
@@ -1435,7 +1440,7 @@ func buildInnerConnectOriginateListener(push *model.PushContext, proxy *model.Pr
 						},
 					},
 				},
-				FactoryKey:         "istio.hashable_string",
+				FactoryKey:         factoryKey,
 				SharedWithUpstream: sfsvalue.FilterStateValue_TRANSITIVE,
 			},
 		},

--- a/pilot/pkg/networking/core/listener_test.go
+++ b/pilot/pkg/networking/core/listener_test.go
@@ -37,6 +37,7 @@ import (
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
 	extensions "istio.io/api/extensions/v1alpha1"
+	"istio.io/api/label"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	security "istio.io/api/security/v1beta1"
@@ -60,6 +61,7 @@ import (
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/util/protomarshal"
+	"istio.io/istio/pkg/util/sets"
 	"istio.io/istio/pkg/wellknown"
 )
 
@@ -375,6 +377,76 @@ func TestInboundListenerConfig(t *testing.T) {
 			},
 		})
 	})
+}
+
+func TestBuildListener_FactoryKey(t *testing.T) {
+	test.SetForTest(t, &features.EnableHBONESend, true)
+	test.SetForTest(t, &features.EnableAmbientMultiNetwork, true)
+	test.SetForTest(t, &features.EnableAmbientWaypointMultiNetwork, true)
+	cg := NewConfigGenTest(t, TestOptions{})
+
+	waypoint := cg.SetupProxy(&model.Proxy{
+		Type:            model.Waypoint,
+		ConfigNamespace: "not-default",
+		Labels: map[string]string{
+			label.GatewayManaged.Name: constants.ManagedGatewayMeshControllerLabel,
+		},
+		IstioVersion: &model.IstioVersion{Major: 1, Minor: 29, Patch: 2},
+	})
+	type expectedCounts struct {
+		hashableString int
+		envoyString    int
+	}
+	for _, tt := range []struct {
+		version  *model.IstioVersion
+		expected map[string]expectedCounts
+	}{
+		{
+			&model.IstioVersion{Major: 1, Minor: 30, Patch: 0},
+			map[string]expectedCounts{
+				"connect_terminate":       {3, 0},
+				"inner_connect_originate": {1, 0},
+			},
+		},
+		{
+			&model.IstioVersion{Major: 1, Minor: 29, Patch: 2},
+			map[string]expectedCounts{
+				"connect_terminate":       {3, 0},
+				"inner_connect_originate": {1, 0},
+			},
+		},
+		{
+			&model.IstioVersion{Major: 1, Minor: 29, Patch: 1},
+			map[string]expectedCounts{
+				"connect_terminate":       {0, 3},
+				"inner_connect_originate": {0, 1},
+			},
+		},
+	} {
+		waypoint.IstioVersion = tt.version
+		listeners := cg.Listeners(waypoint)
+
+		if len(listeners) == 0 {
+			t.Errorf("%s: missing listeners", tt.version)
+			continue
+		}
+		names := sets.String{}
+		for _, l := range listeners {
+			names.Insert(l.Name)
+			counts := tt.expected[l.Name]
+			text := l.String()
+			assert.Equal(t, strings.Count(text, `factory_key:"istio.hashable_string"`), counts.hashableString, tt.version.String(),
+				l.Name, "istio.hashable_string")
+			assert.Equal(t, strings.Count(text, `factory_key:"envoy.string"`), counts.envoyString, tt.version.String(),
+				l.Name, "envoy.string")
+		}
+
+		for k := range tt.expected {
+			if !names.Contains(k) {
+				t.Errorf("%s: no listener for count, %s", tt.version, k)
+			}
+		}
+	}
 }
 
 func TestOutboundListenerConflict_HTTPWithCurrentUnknown(t *testing.T) {

--- a/pilot/pkg/networking/core/listener_waypoint.go
+++ b/pilot/pkg/networking/core/listener_waypoint.go
@@ -186,15 +186,25 @@ func (lb *ListenerBuilder) buildHCMConnectTerminateChain(routes []*route.Route) 
 		// If we put them as a network filter, we get poor logs and cannot return an error at the CONNECT level
 		filters = authzBuilder.BuildTCPRulesAsHTTPFilter()
 	}
+	// TODO: Remove in 1.32
+	pre1_29_2 := !lb.node.VersionGreaterOrEqual(&model.IstioVersion{Major: 1, Minor: 29, Patch: 2})
+	connectAuthorityFilter := xdsfilters.ConnectAuthorityFilter
+	if pre1_29_2 {
+		connectAuthorityFilter = xdsfilters.ConnectAuthorityFilterPre1_29_2
+	}
 	filters = append(filters,
 		xdsfilters.GenerateWaypointDownstreamMetadataFilter(),
-		xdsfilters.ConnectAuthorityFilter)
+		connectAuthorityFilter)
 
 	// This filter checks whether the request went through a waypoint already and thefore whether L7 policies have
 	// been applied already. We put that information into filter state for later use when we decide whether to
 	// send the request to a waypoint or skip it.
 	if features.EnableAmbientMultiNetwork && isEastWestGateway(lb.node) {
-		filters = append(filters, xdsfilters.RequestSourceFilter)
+		requestSourceFilter := xdsfilters.RequestSourceFilter
+		if pre1_29_2 {
+			requestSourceFilter = xdsfilters.RequestSourceFilterPre1_29_2
+		}
+		filters = append(filters, requestSourceFilter)
 	}
 
 	// Filters needed to propagate the tunnel metadata to the inner streams.

--- a/pilot/pkg/xds/filters/filters.go
+++ b/pilot/pkg/xds/filters/filters.go
@@ -348,6 +348,127 @@ var (
 		},
 	}
 
+	RequestSourceFilterPre1_29_2 = &hcm.HttpFilter{
+		Name: "request_source",
+		ConfigType: &hcm.HttpFilter_TypedConfig{
+			TypedConfig: protoconv.MessageToAny(&sfs.Config{
+				OnRequestHeaders: []*sfsvalue.FilterStateValue{
+					{
+						Key: &sfsvalue.FilterStateValue_ObjectKey{
+							ObjectKey: RequestSourceFilterStateKey,
+						},
+						Value: &sfsvalue.FilterStateValue_FormatString{
+							FormatString: &core.SubstitutionFormatString{
+								Format: &core.SubstitutionFormatString_TextFormatSource{
+									TextFormatSource: &core.DataSource{
+										Specifier: &core.DataSource_InlineString{
+											InlineString: "%REQ(x-istio-source)%",
+										},
+									},
+								},
+							},
+						},
+						FactoryKey:         "envoy.string",
+						SharedWithUpstream: sfsvalue.FilterStateValue_ONCE,
+					},
+				},
+			}),
+		},
+	}
+
+	ConnectAuthorityFilterPre1_29_2 = &hcm.HttpFilter{
+		Name: "connect_authority",
+		ConfigType: &hcm.HttpFilter_TypedConfig{
+			TypedConfig: protoconv.MessageToAny(&sfs.Config{
+				OnRequestHeaders: []*sfsvalue.FilterStateValue{
+					{
+						Key: &sfsvalue.FilterStateValue_ObjectKey{
+							ObjectKey: OriginalDstFilterStateKey,
+						},
+						Value: &sfsvalue.FilterStateValue_FormatString{
+							FormatString: &core.SubstitutionFormatString{
+								Format: &core.SubstitutionFormatString_TextFormatSource{
+									TextFormatSource: &core.DataSource{
+										Specifier: &core.DataSource_InlineString{
+											InlineString: "%REQ(:AUTHORITY)%",
+										},
+									},
+								},
+							},
+						},
+						SharedWithUpstream: sfsvalue.FilterStateValue_ONCE,
+					}, {
+						Key: &sfsvalue.FilterStateValue_ObjectKey{
+							ObjectKey: AuthorityFilterStateKey,
+						},
+						Value: &sfsvalue.FilterStateValue_FormatString{
+							FormatString: &core.SubstitutionFormatString{
+								Format: &core.SubstitutionFormatString_TextFormatSource{
+									TextFormatSource: &core.DataSource{
+										Specifier: &core.DataSource_InlineString{
+											InlineString: "%REQ(:AUTHORITY)%",
+										},
+									},
+								},
+							},
+						},
+						FactoryKey:         "envoy.string",
+						SharedWithUpstream: sfsvalue.FilterStateValue_ONCE,
+					}, {
+						Key: &sfsvalue.FilterStateValue_ObjectKey{
+							ObjectKey: "envoy.filters.listener.original_dst.remote_ip",
+						},
+						Value: &sfsvalue.FilterStateValue_FormatString{
+							FormatString: &core.SubstitutionFormatString{
+								Format: &core.SubstitutionFormatString_TextFormatSource{
+									TextFormatSource: &core.DataSource{
+										Specifier: &core.DataSource_InlineString{
+											InlineString: "%DOWNSTREAM_REMOTE_ADDRESS%",
+										},
+									},
+								},
+							},
+						},
+						SharedWithUpstream: sfsvalue.FilterStateValue_ONCE,
+					}, {
+						Key: &sfsvalue.FilterStateValue_ObjectKey{
+							ObjectKey: "io.istio.peer_principal",
+						},
+						FactoryKey: "envoy.string",
+						Value: &sfsvalue.FilterStateValue_FormatString{
+							FormatString: &core.SubstitutionFormatString{
+								Format: &core.SubstitutionFormatString_TextFormatSource{
+									TextFormatSource: &core.DataSource{
+										Specifier: &core.DataSource_InlineString{
+											InlineString: "%DOWNSTREAM_PEER_URI_SAN%",
+										},
+									},
+								},
+							},
+						},
+						SharedWithUpstream: sfsvalue.FilterStateValue_ONCE,
+					}, {
+						Key: &sfsvalue.FilterStateValue_ObjectKey{
+							ObjectKey: "io.istio.local_principal",
+						},
+						FactoryKey: "envoy.string",
+						Value: &sfsvalue.FilterStateValue_FormatString{
+							FormatString: &core.SubstitutionFormatString{
+								Format: &core.SubstitutionFormatString_TextFormatSource{
+									TextFormatSource: &core.DataSource{
+										Specifier: &core.DataSource_InlineString{
+											InlineString: "%DOWNSTREAM_LOCAL_URI_SAN%",
+										},
+									},
+								},
+							},
+						},
+						SharedWithUpstream: sfsvalue.FilterStateValue_ONCE,
+					},
+				},
+			}),
+		},
+	}
 	ConnectAuthorityNetworkFilter = &listener.Filter{
 		Name: "connect_authority",
 		ConfigType: &listener.Filter_TypedConfig{

--- a/releasenotes/notes/istio-hashable-string.yaml
+++ b/releasenotes/notes/istio-hashable-string.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed** config generation for sidecars prior to 1.29.2.


### PR DESCRIPTION
The switch to istio.hashable_string does not work for sidecars prior to 1.29.2.  Those generated configs need to continue to use envoy.string.

closes https://github.com/istio/istio/issues/60503