### PR TITLE
gateway: add healthCheckNodePort to gateway chart service

### DIFF
--- a/manifests/charts/gateway/templates/service.yaml
+++ b/manifests/charts/gateway/templates/service.yaml
@@ -45,7 +45,7 @@ spec:
   internalTrafficPolicy: "{{ . }}"
 {{- end }}
 {{- with .Values.service.healthCheckNodePort }}
-  healthCheckNodePort: "{{ . }}"
+  healthCheckNodePort: {{ . }}
 {{- end }}
   type: {{ .Values.service.type }}
 {{- if not (eq .Values.service.clusterIP "") }}

--- a/manifests/charts/gateway/templates/service.yaml
+++ b/manifests/charts/gateway/templates/service.yaml
@@ -44,6 +44,9 @@ spec:
 {{- with .Values.service.internalTrafficPolicy }}
   internalTrafficPolicy: "{{ . }}"
 {{- end }}
+{{- with .Values.service.healthCheckNodePort }}
+  healthCheckNodePort: "{{ . }}"
+{{- end }}
   type: {{ .Values.service.type }}
 {{- if not (eq .Values.service.clusterIP "") }}
   clusterIP: {{ .Values.service.clusterIP }}

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -191,6 +191,9 @@
             "externalTrafficPolicy": {
               "type": "string"
             },
+            "healthCheckNodePort": {
+              "type": "integer"
+            },
             "loadBalancerIP": {
               "type": "string"
             },

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -63,6 +63,7 @@ _internal_defaults_do_not_set:
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
     externalTrafficPolicy: ""
+    healthCheckNodePort: ""
     externalIPs: []
     ipFamilyPolicy: ""
     ipFamilies: []

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -63,7 +63,7 @@ _internal_defaults_do_not_set:
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
     externalTrafficPolicy: ""
-    healthCheckNodePort: ""
+    healthCheckNodePort: 
     externalIPs: []
     ipFamilyPolicy: ""
     ipFamilies: []


### PR DESCRIPTION
**Please provide a description of this PR:**
This adds `healthCheckNodePort` optional property to the `gateway` chart `Service` resource.
https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip

This property is required by GKE to supply a load balancer health check.
https://docs.cloud.google.com/kubernetes-engine/docs/concepts/service-load-balancer-parameters#spd-hc-port