### PR TITLE
multicluster: make kubeController.Close idempotent with sync.Once

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -17,6 +17,7 @@ package controller
 import (
 	"context"
 	"strings"
+	"sync"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,22 +54,30 @@ type kubeController struct {
 	*Controller
 	workloadEntryController *serviceentry.Controller
 	stop                    chan struct{}
+	// closeOnce ensures Close is idempotent. During rapid credential rotation two
+	// update goroutines can race: both capture the same previous kubeController and
+	// both call Close on it. Without this guard the second call panics with
+	// "close of closed channel". Cleanup is side-effect-free on repeat calls so
+	// running it only once is correct.
+	closeOnce sync.Once
 }
 
 func (k *kubeController) Close() {
-	close(k.stop)
-	clusterID := k.Controller.clusterID
-	k.MeshServiceController.UnRegisterHandlersForCluster(clusterID)
-	k.MeshServiceController.DeleteRegistry(clusterID, provider.Kubernetes)
-	if k.workloadEntryController != nil {
-		k.MeshServiceController.DeleteRegistry(clusterID, provider.External)
-	}
-	if err := k.Controller.Cleanup(); err != nil {
-		log.Warnf("failed cleaning up services in %s: %v", clusterID, err)
-	}
-	if k.opts.XDSUpdater != nil {
-		k.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{Full: true, Reason: model.NewReasonStats(model.ClusterUpdate), Forced: true})
-	}
+	k.closeOnce.Do(func() {
+		close(k.stop)
+		clusterID := k.Controller.clusterID
+		k.MeshServiceController.UnRegisterHandlersForCluster(clusterID)
+		k.MeshServiceController.DeleteRegistry(clusterID, provider.Kubernetes)
+		if k.workloadEntryController != nil {
+			k.MeshServiceController.DeleteRegistry(clusterID, provider.External)
+		}
+		if err := k.Controller.Cleanup(); err != nil {
+			log.Warnf("failed cleaning up services in %s: %v", clusterID, err)
+		}
+		if k.opts.XDSUpdater != nil {
+			k.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{Full: true, Reason: model.NewReasonStats(model.ClusterUpdate), Forced: true})
+		}
+	})
 }
 
 // Multicluster structure holds the remote kube Controllers and multicluster specific attributes.

--- a/releasenotes/notes/multicluster-kubecontroller-double-close.yaml
+++ b/releasenotes/notes/multicluster-kubecontroller-double-close.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 60520
+releaseNotes:
+  - |
+    **Fixed** a panic (`close of closed channel`) in the multicluster secret controller that
+    could occur when a remote cluster's kubeconfig secret was updated twice in rapid succession.


### PR DESCRIPTION
**Please provide a description of this PR:**

During rapid credential rotation two update goroutines can race: both capture the same previous `kubeController` and both call `Close` on it, causing a panic on the second `close(k.stop)` call (`panic: close of closed channel`).

Wrap the `Close` body in a `sync.Once` so the second call is a no-op. Cleanup operations are side-effect-free on repeat calls so running them only once is correct.

Fixes #60520

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [x] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.