### PR TITLE
[release-1.30] Support trustDomains and notTrustDomains in AuthorizationPolicy source

### DIFF
--- a/manifests/charts/base/templates/defaultrevision-validatingadmissionpolicy.yaml
+++ b/manifests/charts/base/templates/defaultrevision-validatingadmissionpolicy.yaml
@@ -31,6 +31,8 @@ spec:
       expression: "object.kind == 'ProxyConfig'"
     - name: isTelemetry
       expression: "object.kind == 'Telemetry'"
+    - name: isAuthorizationPolicy
+      expression: "object.kind == 'AuthorizationPolicy'"
   validations:
     - expression: "!variables.isEnvoyFilter"
     - expression: "!variables.isWasmPlugin"
@@ -41,6 +43,16 @@ spec:
             (has(object.spec.tracing) ? object.spec.tracing : {}).exists(t, has(t.useRequestIdForTraceSampling)) ||
             (has(object.spec.metrics) ? object.spec.metrics : {}).exists(m, has(m.reportingInterval)) ||
             (has(object.spec.accessLogging) ? object.spec.accessLogging : {}).exists(l, has(l.filter))
+          )
+        )
+    - expression: |
+        !(
+          variables.isAuthorizationPolicy &&
+          has(object.spec.rules) &&
+          object.spec.rules.exists(r,
+            has(r.from) && r.from.exists(f,
+              has(f.source) && (has(f.source.trustDomains) || has(f.source.notTrustDomains))
+            )
           )
         )
 ---

--- a/manifests/charts/istio-control/istio-discovery/templates/validatingadmissionpolicy.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/validatingadmissionpolicy.yaml
@@ -40,6 +40,8 @@ spec:
       expression: "object.kind == 'ProxyConfig'"
     - name: isTelemetry
       expression: "object.kind == 'Telemetry'"
+    - name: isAuthorizationPolicy
+      expression: "object.kind == 'AuthorizationPolicy'"
   validations:
     - expression: "!variables.isEnvoyFilter"
     - expression: "!variables.isWasmPlugin"
@@ -50,6 +52,16 @@ spec:
             (has(object.spec.tracing) ? object.spec.tracing : {}).exists(t, has(t.useRequestIdForTraceSampling)) ||
             (has(object.spec.metrics) ? object.spec.metrics : {}).exists(m, has(m.reportingInterval)) ||
             (has(object.spec.accessLogging) ? object.spec.accessLogging : {}).exists(l, has(l.filter))
+          )
+        )
+    - expression: |
+        !(
+          variables.isAuthorizationPolicy &&
+          has(object.spec.rules) &&
+          object.spec.rules.exists(r,
+            has(r.from) && r.from.exists(f,
+              has(f.source) && (has(f.source.trustDomains) || has(f.source.notTrustDomains))
+            )
           )
         )
 ---

--- a/pilot/pkg/security/authz/builder/builder_test.go
+++ b/pilot/pkg/security/authz/builder/builder_test.go
@@ -248,6 +248,11 @@ func TestGenerator_GenerateHTTP(t *testing.T) {
 			input:    "td-aliases-source-principal-in.yaml",
 			want:     []string{"td-aliases-source-principal-out.yaml"},
 		},
+		{
+			name:  "trust-domains-field",
+			input: "trust-domains-in.yaml",
+			want:  []string{"trust-domains-out.yaml"},
+		},
 	}
 
 	baseDir := "http/"

--- a/pilot/pkg/security/authz/builder/testdata/http/extended-trust-domains-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/extended-trust-domains-out.yaml
@@ -1,0 +1,34 @@
+name: envoy.filters.http.rbac
+typedConfig:
+  '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC
+  rules:
+    policies:
+      ns[foo]-policy[httpbin]-rule[0]:
+        permissions:
+        - andRules:
+            rules:
+            - any: true
+        principals:
+        - andIds:
+            ids:
+            - orIds:
+                ids:
+                - authenticated:
+                    principalName:
+                      prefix: spiffe://cluster.local/
+                - authenticated:
+                    principalName:
+                      prefix: spiffe://another.local/
+        - andIds:
+            ids:
+            - notId:
+                orIds:
+                  ids:
+                  - authenticated:
+                      principalName:
+                        safeRegex:
+                          regex: spiffe://bad[^/]*/.*
+                  - authenticated:
+                      principalName:
+                        prefix: spiffe://untrusted/
+  shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/http/trust-domains-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/trust-domains-in.yaml
@@ -1,0 +1,16 @@
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: httpbin
+  namespace: foo
+spec:
+  selector:
+    matchLabels:
+      app: httpbin
+      version: v1
+  rules:
+    - from:
+        - source:
+            trustDomains: ["cluster.local", "another.local"]
+        - source:
+            notTrustDomains: ["bad*", "untrusted"]

--- a/pilot/pkg/security/authz/builder/testdata/http/trust-domains-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/trust-domains-out.yaml
@@ -1,0 +1,34 @@
+name: envoy.filters.http.rbac
+typedConfig:
+  '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC
+  rules:
+    policies:
+      ns[foo]-policy[httpbin]-rule[0]:
+        permissions:
+        - andRules:
+            rules:
+            - any: true
+        principals:
+        - andIds:
+            ids:
+            - orIds:
+                ids:
+                - authenticated:
+                    principalName:
+                      prefix: spiffe://cluster.local/
+                - authenticated:
+                    principalName:
+                      prefix: spiffe://another.local/
+        - andIds:
+            ids:
+            - notId:
+                orIds:
+                  ids:
+                  - authenticated:
+                      principalName:
+                        safeRegex:
+                          regex: spiffe://bad[^/]*/.*
+                  - authenticated:
+                      principalName:
+                        prefix: spiffe://untrusted/
+  shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/model/generator.go
+++ b/pilot/pkg/security/authz/model/generator.go
@@ -217,6 +217,30 @@ func serviceAccountRegex(defaultNamespace string, value string) string {
 	return fmt.Sprintf("spiffe://.+/ns/%s/(.+/|)sa/%s(/.+)?", regexp.QuoteMeta(ns), regexp.QuoteMeta(sa))
 }
 
+type srcTrustDomainGenerator struct{}
+
+func (srcTrustDomainGenerator) permission(_, _ string, _ bool) (*rbacpb.Permission, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+
+func (srcTrustDomainGenerator) principal(_, value string, _ bool, useAuthenticated bool) (*rbacpb.Principal, error) {
+	var m *matcherpb.StringMatcher
+	switch {
+	case value == "*":
+		// Presence match - any trust domain is accepted
+		m = matcher.StringMatcherPrefix("spiffe://", false)
+	case !strings.Contains(value, "*"):
+		// Exact match — no regex needed
+		m = matcher.StringMatcherPrefix("spiffe://"+value+"/", false)
+	default:
+		// Prefix/Suffix match - need regex, but escape metacharacters first
+		parts := strings.SplitN(value, "*", 2)
+		escaped := regexp.QuoteMeta(parts[0]) + "[^/]*" + regexp.QuoteMeta(parts[1])
+		m = matcher.StringMatcherRegex(fmt.Sprintf("spiffe://%s/.*", escaped))
+	}
+	return principalAuthenticated(m, useAuthenticated), nil
+}
+
 type srcPrincipalGenerator struct{}
 
 func (srcPrincipalGenerator) permission(_, _ string, _ bool) (*rbacpb.Permission, error) {

--- a/pilot/pkg/security/authz/model/generator_test.go
+++ b/pilot/pkg/security/authz/model/generator_test.go
@@ -344,6 +344,48 @@ func TestGenerator(t *testing.T) {
               regex: .*/ns/foo/.*`),
 		},
 		{
+			name:  "srcTrustDomainGenerator-exact",
+			g:     srcTrustDomainGenerator{},
+			value: "cluster.local",
+			want: yamlPrincipal(t, `
+         filter_state:
+           key: io.istio.peer_principal
+           string_match:
+            prefix: spiffe://cluster.local/`),
+		},
+		{
+			name:  "srcTrustDomainGenerator-wildcard",
+			g:     srcTrustDomainGenerator{},
+			value: "*",
+			want: yamlPrincipal(t, `
+         filter_state:
+           key: io.istio.peer_principal
+           string_match:
+            prefix: spiffe://`),
+		},
+		{
+			name:  "srcTrustDomainGenerator-prefix-wildcard",
+			g:     srcTrustDomainGenerator{},
+			value: "cluster.*",
+			want: yamlPrincipal(t, `
+         filter_state:
+           key: io.istio.peer_principal
+           string_match:
+            safeRegex:
+              regex: spiffe://cluster\.[^/]*/.*`),
+		},
+		{
+			name:  "srcTrustDomainGenerator-suffix-wildcard",
+			g:     srcTrustDomainGenerator{},
+			value: "*local",
+			want: yamlPrincipal(t, `
+         filter_state:
+           key: io.istio.peer_principal
+           string_match:
+            safeRegex:
+              regex: spiffe://[^/]*local/.*`),
+		},
+		{
 			name:  "srcPrincipalGenerator-http",
 			g:     srcPrincipalGenerator{},
 			key:   "source.principal",

--- a/pilot/pkg/security/authz/model/model.go
+++ b/pilot/pkg/security/authz/model/model.go
@@ -38,6 +38,7 @@ const (
 	attrRemoteIP          = "remote.ip"                   // original client ip determined from x-forwarded-for or proxy protocol.
 	attrSrcNamespace      = "source.namespace"            // e.g. "default".
 	attrSrcServiceAccount = "source.serviceAccount"       // e.g. "default/productpage".
+	attrSrcTrustDomain    = "source.trustDomain"          // trust domain portion of the source SPIFFE identity.
 	attrSrcPrincipal      = "source.principal"            // source identity, e,g, "cluster.local/ns/default/sa/productpage".
 	attrRequestPrincipal  = "request.auth.principal"      // authenticated principal of the request.
 	attrRequestAudiences  = "request.auth.audiences"      // intended audience(s) for this authentication information.
@@ -99,6 +100,8 @@ func New(policyName types.NamespacedName, r *authzpb.Rule) (*Model, error) {
 			basePrincipal.appendLast(remoteIPGenerator{}, k, when.Values, when.NotValues)
 		case k == attrSrcNamespace:
 			basePrincipal.appendLast(srcNamespaceGenerator{}, k, when.Values, when.NotValues)
+		case k == attrSrcTrustDomain:
+			basePrincipal.appendLast(srcTrustDomainGenerator{}, k, when.Values, when.NotValues)
 		case k == attrSrcServiceAccount:
 			basePrincipal.appendLast(srcServiceAccountGenerator{policyName: policyName}, k, when.Values, when.NotValues)
 		case k == attrSrcPrincipal:
@@ -124,6 +127,7 @@ func New(policyName types.NamespacedName, r *authzpb.Rule) (*Model, error) {
 			merged.insertFront(srcIPGenerator{}, attrSrcIP, s.IpBlocks, s.NotIpBlocks)
 			merged.insertFront(remoteIPGenerator{}, attrRemoteIP, s.RemoteIpBlocks, s.NotRemoteIpBlocks)
 			merged.insertFront(srcNamespaceGenerator{}, attrSrcNamespace, s.Namespaces, s.NotNamespaces)
+			merged.insertFront(srcTrustDomainGenerator{}, attrSrcTrustDomain, s.TrustDomains, s.NotTrustDomains)
 			merged.insertFront(srcServiceAccountGenerator{policyName: policyName}, attrSrcServiceAccount, s.ServiceAccounts, s.NotServiceAccounts)
 			merged.insertFrontExtended(requestPrincipalGenerator{}, attrRequestPrincipal, s.RequestPrincipals, s.NotRequestPrincipals)
 			merged.insertFront(srcPrincipalGenerator{}, attrSrcPrincipal, s.Principals, s.NotPrincipals)
@@ -161,6 +165,13 @@ func (m *Model) MigrateTrustDomain(tdBundle trustdomain.Bundle) {
 				}
 				if len(r.notValues) != 0 {
 					r.notValues = tdBundle.ReplaceTrustDomainAliases(r.notValues)
+				}
+			} else if r.key == attrSrcTrustDomain {
+				if len(r.values) != 0 {
+					r.values = tdBundle.ExpandTrustDomainAliases(r.values)
+				}
+				if len(r.notValues) != 0 {
+					r.notValues = tdBundle.ExpandTrustDomainAliases(r.notValues)
 				}
 			}
 		}

--- a/pilot/pkg/security/trustdomain/bundle.go
+++ b/pilot/pkg/security/trustdomain/bundle.go
@@ -21,6 +21,7 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/config/constants"
 	istiolog "istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/slices"
 )
 
 var authzLog = istiolog.RegisterScope("authorization", "Istio Authorization Policy")
@@ -116,6 +117,20 @@ func (t Bundle) replaceTrustDomains(principal, trustDomainFromPrincipal string) 
 		}
 	}
 	return principalsForAliases
+}
+
+// ExpandTrustDomainAliases takes a list of trust domain values and expands any value that matches
+// a known trust domain to include all trust domain aliases.
+func (t Bundle) ExpandTrustDomainAliases(values []string) []string {
+	result := make([]string, 0, len(values))
+	for _, v := range values {
+		if slices.Contains(t.TrustDomains, v) {
+			result = append(result, t.TrustDomains...)
+		} else {
+			result = append(result, v)
+		}
+	}
+	return slices.FilterDuplicates(result)
 }
 
 // replaceTrustDomainInPrincipal returns a new SPIFFE identity with the new trust domain.

--- a/pkg/config/security/security.go
+++ b/pkg/config/security/security.go
@@ -112,6 +112,37 @@ func CheckEmptyValues(key string, values []string) error {
 	return nil
 }
 
+// CheckWildcardValues checks that values are non-empty and that any wildcard is only
+// at the start or end (exact, prefix foo*, suffix *foo, or presence *).
+func CheckWildcardValues(key string, values []string) error {
+	if err := CheckEmptyValues(key, values); err != nil {
+		return err
+	}
+	for _, value := range values {
+		count := strings.Count(value, "*")
+		if count > 1 {
+			return fmt.Errorf("at most one wildcard is allowed, found in %s: %q", key, value)
+		}
+		if count == 1 && value != "*" && !strings.HasPrefix(value, "*") && !strings.HasSuffix(value, "*") {
+			return fmt.Errorf("wildcard is only allowed at the start or end, found in %s: %q", key, value)
+		}
+	}
+	return nil
+}
+
+// CheckTrustDomainValues checks that trust domain values are valid wildcard values and do not contain '/'.
+func CheckTrustDomainValues(key string, values []string) error {
+	if err := CheckWildcardValues(key, values); err != nil {
+		return err
+	}
+	for _, value := range values {
+		if strings.Contains(value, "/") {
+			return fmt.Errorf("trust domain must not contain '/', found in %s: %q", key, value)
+		}
+	}
+	return nil
+}
+
 func CheckServiceAccount(key string, values []string) error {
 	if len(values) > 16 {
 		// Arbitrary limit to avoid unbounded configuration sizes
@@ -213,6 +244,7 @@ func ValidateAttribute(key string, values []string) error {
 		return CheckServiceAccount(key, values)
 	case isEqual(key, attrSrcPrincipal):
 	case isEqual(key, attrSrcTrustDomain):
+		return CheckWildcardValues(key, values)
 	case isEqual(key, attrRequestPrincipal):
 	case isEqual(key, attrRequestAudiences):
 	case isEqual(key, attrRequestPresenter):

--- a/pkg/config/security/security_test.go
+++ b/pkg/config/security/security_test.go
@@ -88,6 +88,54 @@ func TestParseJwksURI(t *testing.T) {
 	}
 }
 
+func TestCheckWildcardValues(t *testing.T) {
+	cases := []struct {
+		name      string
+		values    []string
+		wantError bool
+	}{
+		{name: "exact", values: []string{"foo"}},
+		{name: "presence", values: []string{"*"}},
+		{name: "prefix", values: []string{"foo*"}},
+		{name: "suffix", values: []string{"*foo"}},
+		{name: "empty", values: []string{""}, wantError: true},
+		{name: "middle wildcard", values: []string{"fo*-bar"}, wantError: true},
+		{name: "multiple wildcards", values: []string{"fo*bar*"}, wantError: true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := security.CheckWildcardValues("key", c.values)
+			if c.wantError == (err == nil) {
+				t.Fatalf("CheckWildcardValues(%v): want error (%v) but got (%v)", c.values, c.wantError, err)
+			}
+		})
+	}
+}
+
+func TestCheckTrustDomainValues(t *testing.T) {
+	cases := []struct {
+		name      string
+		values    []string
+		wantError bool
+	}{
+		{name: "exact", values: []string{"cluster.local"}},
+		{name: "presence wildcard", values: []string{"*"}},
+		{name: "prefix wildcard", values: []string{"cluster-*"}},
+		{name: "suffix wildcard", values: []string{"*-cluster"}},
+		{name: "empty", values: []string{""}, wantError: true},
+		{name: "slash", values: []string{"cluster.local/ns/foo"}, wantError: true},
+		{name: "spiffe uri", values: []string{"spiffe://cluster.local"}, wantError: true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := security.CheckTrustDomainValues("key", c.values)
+			if c.wantError == (err == nil) {
+				t.Fatalf("CheckTrustDomainValues(%v): want error (%v) but got (%v)", c.values, c.wantError, err)
+			}
+		})
+	}
+}
+
 func TestValidateCondition(t *testing.T) {
 	cases := []struct {
 		key       string
@@ -161,6 +209,37 @@ func TestValidateCondition(t *testing.T) {
 		{
 			key:    "source.serviceAccount",
 			values: []string{"sa"},
+		},
+		{
+			key:    "source.trustDomain",
+			values: []string{"cluster.local"},
+		},
+		{
+			key:    "source.trustDomain",
+			values: []string{"*"},
+		},
+		{
+			key:    "source.trustDomain",
+			values: []string{"foo*"},
+		},
+		{
+			key:    "source.trustDomain",
+			values: []string{"*bar"},
+		},
+		{
+			key:       "source.trustDomain",
+			values:    []string{"fo*-bar"},
+			wantError: true,
+		},
+		{
+			key:       "source.trustDomain",
+			values:    []string{"fo*bar*"},
+			wantError: true,
+		},
+		{
+			key:       "source.trustDomain",
+			values:    []string{""},
+			wantError: true,
 		},
 		{
 			key:    "request.auth.principal",

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1440,6 +1440,8 @@ var ValidateAuthorizationPolicy = RegisterValidateFunc("ValidateAuthorizationPol
 						errs = appendErrors(errs, check(len(src.NotNamespaces) != 0, "From.NotNamespaces"))
 						errs = appendErrors(errs, check(len(src.ServiceAccounts) != 0, "From.ServiceAccounts"))
 						errs = appendErrors(errs, check(len(src.NotServiceAccounts) != 0, "From.NotServiceAccounts"))
+						errs = appendErrors(errs, check(len(src.TrustDomains) != 0, "From.TrustDomains"))
+						errs = appendErrors(errs, check(len(src.NotTrustDomains) != 0, "From.NotTrustDomains"))
 						errs = appendErrors(errs, check(len(src.Principals) != 0, "From.Principals"))
 						errs = appendErrors(errs, check(len(src.NotPrincipals) != 0, "From.NotPrincipals"))
 						errs = appendErrors(errs, check(len(src.RequestPrincipals) != 0, "From.RequestPrincipals"))
@@ -1453,6 +1455,7 @@ var ValidateAuthorizationPolicy = RegisterValidateFunc("ValidateAuthorizationPol
 					}
 					errs = appendErrors(errs, check(when.Key == "source.namespace", when.Key))
 					errs = appendErrors(errs, check(when.Key == "source.serviceAccount", when.Key))
+					errs = appendErrors(errs, check(when.Key == "source.trustDomain", when.Key))
 					errs = appendErrors(errs, check(when.Key == "source.principal", when.Key))
 					errs = appendErrors(errs, check(strings.HasPrefix(when.Key, "request.auth."), when.Key))
 				}
@@ -1495,7 +1498,8 @@ var ValidateAuthorizationPolicy = RegisterValidateFunc("ValidateAuthorizationPol
 					}
 					if len(src.Principals) == 0 && len(src.RequestPrincipals) == 0 && len(src.Namespaces) == 0 && len(src.IpBlocks) == 0 &&
 						len(src.RemoteIpBlocks) == 0 && len(src.NotPrincipals) == 0 && len(src.NotRequestPrincipals) == 0 && len(src.NotNamespaces) == 0 &&
-						len(src.NotIpBlocks) == 0 && len(src.NotRemoteIpBlocks) == 0 && len(src.ServiceAccounts) == 0 && len(src.NotServiceAccounts) == 0 {
+						len(src.NotIpBlocks) == 0 && len(src.NotRemoteIpBlocks) == 0 && len(src.ServiceAccounts) == 0 && len(src.NotServiceAccounts) == 0 &&
+						len(src.TrustDomains) == 0 && len(src.NotTrustDomains) == 0 {
 						errs = appendErrors(errs, fmt.Errorf("`from.source` must not be empty, found at rule %d", i))
 					}
 					errs = appendErrors(errs, security.ValidateIPs(from.Source.GetIpBlocks()))
@@ -1506,12 +1510,14 @@ var ValidateAuthorizationPolicy = RegisterValidateFunc("ValidateAuthorizationPol
 					errs = appendErrors(errs, security.CheckEmptyValues("RequestPrincipals", src.RequestPrincipals))
 					errs = appendErrors(errs, security.CheckEmptyValues("Namespaces", src.Namespaces))
 					errs = appendErrors(errs, security.CheckServiceAccount("ServiceAccounts", src.ServiceAccounts))
+					errs = appendErrors(errs, security.CheckTrustDomainValues("TrustDomains", src.TrustDomains))
 					errs = appendErrors(errs, security.CheckEmptyValues("IpBlocks", src.IpBlocks))
 					errs = appendErrors(errs, security.CheckEmptyValues("RemoteIpBlocks", src.RemoteIpBlocks))
 					errs = appendErrors(errs, security.CheckEmptyValues("NotPrincipals", src.NotPrincipals))
 					errs = appendErrors(errs, security.CheckEmptyValues("NotRequestPrincipals", src.NotRequestPrincipals))
 					errs = appendErrors(errs, security.CheckEmptyValues("NotNamespaces", src.NotNamespaces))
 					errs = appendErrors(errs, security.CheckServiceAccount("NotServiceAccounts", src.NotServiceAccounts))
+					errs = appendErrors(errs, security.CheckTrustDomainValues("NotTrustDomains", src.NotTrustDomains))
 					errs = appendErrors(errs, security.CheckEmptyValues("NotIpBlocks", src.NotIpBlocks))
 					errs = appendErrors(errs, security.CheckEmptyValues("NotRemoteIpBlocks", src.NotRemoteIpBlocks))
 					if src.NotPrincipals != nil || src.Principals != nil || src.IpBlocks != nil ||

--- a/releasenotes/notes/add-trust-domains-to-authz-policy.yaml
+++ b/releasenotes/notes/add-trust-domains-to-authz-policy.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+
+releaseNotes:
+- |
+  **Added** `trustDomains` and `notTrustDomains` fields to the `Source` in `AuthorizationPolicy`,
+  allowing users to match or exclude requests based on the trust domain derived from the peer certificate.

--- a/tests/integration/security/authz_test.go
+++ b/tests/integration/security/authz_test.go
@@ -179,6 +179,73 @@ func TestAuthz_ServiceAccount(t *testing.T) {
 		})
 }
 
+func TestAuthz_TrustDomain(t *testing.T) {
+	framework.NewTest(t).
+		Run(func(t framework.TestContext) {
+			from := apps.Ns1.A.Append(apps.Ns2.A)
+			fromMatch := match.AnyServiceName(from.NamespacedNames())
+			toMatch := match.Not(fromMatch)
+			to := toMatch.GetServiceMatches(apps.Ns1.All)
+			fromAndTo := to.Instances().Append(from)
+
+			config.New(t).
+				Source(config.File("testdata/authz/mtls.yaml.tmpl")).
+				Source(config.File("testdata/authz/allow-trust-domain.yaml.tmpl")).
+				BuildAll(nil, to).
+				Apply()
+
+			newTrafficTest(t, fromAndTo).
+				FromMatch(fromMatch).
+				ToMatch(toMatch).
+				Run(func(t framework.TestContext, from echo.Instance, to echo.Target) {
+					cases := []struct {
+						ports []echo.Port
+						path  string
+						allow allowValue
+					}{
+						{
+							// All test instances are in cluster.local, so all should be allowed.
+							ports: []echo.Port{ports.GRPC, ports.TCP},
+							allow: true,
+						},
+						{
+							// trustDomains: ["cluster.local"] matches all test instances.
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
+							path:  "/allow",
+							allow: true,
+						},
+						{
+							// trustDomains: ["bad.example.com"] matches no test instance.
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
+							path:  "/deny",
+							allow: false,
+						},
+						{
+							// notTrustDomains: ["cluster.local"] excludes all test instances.
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
+							path:  "/not-trust-domain",
+							allow: false,
+						},
+						{
+							// notTrustDomains: ["bad.example.com"] excludes nothing, so cluster.local is allowed.
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
+							path:  "/not-deny",
+							allow: true,
+						},
+					}
+
+					for _, c := range cases {
+						newAuthzTest().
+							From(from).
+							To(to).
+							Allow(c.allow).
+							Path(c.path).
+							BuildAndRunForPorts(t, c.ports...)
+					}
+				})
+		})
+}
+
 func TestAuthz_DenyPrincipal(t *testing.T) {
 	framework.NewTest(t).
 		Run(func(t framework.TestContext) {
@@ -1571,6 +1638,17 @@ func TestAuthz_Conditions(t *testing.T) {
 						{
 							path:  "/source-principal-notValues",
 							allow: allow,
+						},
+
+						// Test source trust domain.
+						// All test instances are in cluster.local, so both cases always allow.
+						{
+							path:  "/source-trust-domain",
+							allow: true,
+						},
+						{
+							path:  "/source-trust-domain-notValues",
+							allow: true,
 						},
 
 						// Test destination IP

--- a/tests/integration/security/testdata/authz/allow-trust-domain.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/allow-trust-domain.yaml.tmpl
@@ -1,0 +1,56 @@
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ .To.ServiceName }}
+spec:
+  selector:
+    matchLabels:
+      "app": "{{ .To.ServiceName }}"
+  action: ALLOW
+  rules:
+    - to:
+        - operation: # HTTP - allow from cluster.local
+            ports: [ "{{ (.To.PortForName `http`).WorkloadPort }}", "{{ (.To.PortForName `http2`).WorkloadPort }}" ]
+            paths: [ "/allow" ]
+            methods: [ "GET" ]
+      from:
+        - source:
+            trustDomains: [ "cluster.local" ]
+    - to:
+        - operation: # HTTP - never matches (wrong trust domain)
+            ports: [ "{{ (.To.PortForName `http`).WorkloadPort }}", "{{ (.To.PortForName `http2`).WorkloadPort }}" ]
+            paths: [ "/deny" ]
+            methods: [ "GET" ]
+      from:
+        - source:
+            trustDomains: [ "bad.example.com" ]
+    - to:
+        - operation: # HTTP - never matches (cluster.local is excluded)
+            ports: [ "{{ (.To.PortForName `http`).WorkloadPort }}", "{{ (.To.PortForName `http2`).WorkloadPort }}" ]
+            paths: [ "/not-trust-domain" ]
+            methods: [ "GET" ]
+      from:
+        - source:
+            notTrustDomains: [ "cluster.local" ]
+    - to:
+        - operation: # HTTP - always matches (bad.example.com is excluded, cluster.local is not)
+            ports: [ "{{ (.To.PortForName `http`).WorkloadPort }}", "{{ (.To.PortForName `http2`).WorkloadPort }}" ]
+            paths: [ "/not-deny" ]
+            methods: [ "GET" ]
+      from:
+        - source:
+            notTrustDomains: [ "bad.example.com" ]
+    - to:
+        - operation: # GRPC
+            ports: [ "{{ (.To.PortForName `grpc`).WorkloadPort }}" ]
+            paths: [ "/proto.EchoTestService/Echo" ]
+            methods: [ "POST" ]
+      from:
+        - source:
+            trustDomains: [ "cluster.local" ]
+    - to:
+        - operation: # TCP
+            ports: [ "{{ (.To.PortForName `tcp`).WorkloadPort }}" ]
+      from:
+        - source:
+            trustDomains: [ "cluster.local" ]

--- a/tests/integration/security/testdata/authz/conditions.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/conditions.yaml.tmpl
@@ -93,6 +93,29 @@ spec:
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
+  name: {{ .To.ServiceName }}-source-trust-domain
+spec:
+  selector:
+    matchLabels:
+      app: "{{ .To.ServiceName }}"
+  rules:
+  - to:
+    - operation:
+        paths: [ "/source-trust-domain" ]
+    when:
+    - key: source.trustDomain
+      values: [ "cluster.local" ]
+  - to:
+      - operation:
+          paths: [ "/source-trust-domain-notValues" ]
+    when:
+      - key: source.trustDomain
+        notValues: [ "bad.example.com" ]
+---
+
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
   name: {{ .To.ServiceName }}-destination-ip
 spec:
   selector:


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/istio/istio/pull/59358
following failed automatic cherry pick: https://github.com/istio/istio/issues/60514

No conflicts required manual resolution when doing it manually.

API was [already merged](https://github.com/istio/api/pull/3665) and included in the `release-1.30` but this impl didn't make into the release.
Discussed this backporting with @keithmattix and @linsun to get an initial ok to proceed with backporting.