### PR TITLE
feat(tracing): add opentelemetry always_on sampler support

### DIFF
--- a/pilot/pkg/networking/core/tracing.go
+++ b/pilot/pkg/networking/core/tracing.go
@@ -424,6 +424,10 @@ func otelConfig(serviceName string, otelProvider *meshconfig.MeshConfig_Extensio
 				return nil, false, err
 			}
 			oc.Sampler = dts
+		case *meshconfig.MeshConfig_ExtensionProvider_OpenTelemetryTracingProvider_AlwaysOnSampler_:
+			oc.Sampler = &core.TypedExtensionConfig{
+				Name: "envoy.tracers.opentelemetry.samplers.always_on",
+			}
 		}
 
 		// If any sampler is configured for the OpenTelemetryTracingProvider

--- a/releasenotes/notes/60529.yaml
+++ b/releasenotes/notes/60529.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 60500
+releaseNotes:
+  - |
+    **Added** Support for OpenTelemetry AlwaysOn trace sampler.


### PR DESCRIPTION
Fixes: https://github.com/istio/istio/issues/60500

**Please provide a description of this PR:**

This PR adds support for configuring the Always On sampler for OpenTelemetry extension provider. 


## Depends on:
- https://github.com/istio/api/pull/3722