### PR TITLE
fix: istioctl tag remove deletes istiod-default-validator Validating WebhookConfiguration

### DIFF
--- a/istioctl/pkg/tag/tag.go
+++ b/istioctl/pkg/tag/tag.go
@@ -393,6 +393,13 @@ func removeTag(ctx context.Context, kubeClient kubernetes.Interface, tagName str
 		}
 	}
 
+	// the default tag also creates a ValidatingWebhookConfiguration; remove it too
+	if tagName == DefaultRevisionName {
+		if err = DeleteValidatingWebhook(ctx, kubeClient, vwhBaseTemplateName); err != nil {
+			return fmt.Errorf("failed to delete Istio revision tag ValidatingWebhookConfiguration: %v", err)
+		}
+	}
+
 	if tagServiceExists {
 		err = DeleteTagServices(ctx, kubeClient, istioNS, tagName)
 		if err != nil {

--- a/istioctl/pkg/tag/tag.go
+++ b/istioctl/pkg/tag/tag.go
@@ -393,11 +393,8 @@ func removeTag(ctx context.Context, kubeClient kubernetes.Interface, tagName str
 		}
 	}
 
-	// the default tag also creates a ValidatingWebhookConfiguration; remove it too
-	if tagName == DefaultRevisionName {
-		if err = DeleteValidatingWebhook(ctx, kubeClient, vwhBaseTemplateName); err != nil {
-			return fmt.Errorf("failed to delete Istio revision tag ValidatingWebhookConfiguration: %v", err)
-		}
+	if err = DeleteTagValidatingWebhooks(ctx, kubeClient, tagName); err != nil {
+		return fmt.Errorf("failed to delete Istio revision tag ValidatingWebhookConfiguration: %v", err)
 	}
 
 	if tagServiceExists {

--- a/istioctl/pkg/tag/tag_test.go
+++ b/istioctl/pkg/tag/tag_test.go
@@ -691,6 +691,36 @@ func TestRemoveTag(t *testing.T) {
 	}
 }
 
+func TestRemoveDefaultTagDeletesValidatingWebhook(t *testing.T) {
+	mwh := &admitv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "istio-revision-tag-default",
+			Labels: map[string]string{label.IoIstioTag.Name: "default"},
+		},
+	}
+	vwh := &admitv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: vwhBaseTemplateName,
+		},
+	}
+	client := fake.NewClientset(mwh, vwh)
+
+	var out bytes.Buffer
+	if err := removeTag(context.Background(), client, "default", true, "istio-system", &out); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	mwhs, _ := client.AdmissionregistrationV1().MutatingWebhookConfigurations().List(context.Background(), metav1.ListOptions{})
+	if len(mwhs.Items) != 0 {
+		t.Errorf("expected MutatingWebhookConfiguration to be deleted, got %d", len(mwhs.Items))
+	}
+
+	vwhs, _ := client.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(context.Background(), metav1.ListOptions{})
+	if len(vwhs.Items) != 0 {
+		t.Errorf("expected ValidatingWebhookConfiguration %q to be deleted, got %d", vwhBaseTemplateName, len(vwhs.Items))
+	}
+}
+
 func TestSetTagErrors(t *testing.T) {
 	serviceBefore := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/istioctl/pkg/tag/tag_test.go
+++ b/istioctl/pkg/tag/tag_test.go
@@ -700,7 +700,8 @@ func TestRemoveDefaultTagDeletesValidatingWebhook(t *testing.T) {
 	}
 	vwh := &admitv1.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: vwhBaseTemplateName,
+			Name:   vwhBaseTemplateName,
+			Labels: map[string]string{label.IoIstioTag.Name: "default"},
 		},
 	}
 	client := fake.NewClientset(mwh, vwh)

--- a/istioctl/pkg/tag/util.go
+++ b/istioctl/pkg/tag/util.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	admitv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -154,13 +153,19 @@ func DeleteTagWebhooks(ctx context.Context, client kubernetes.Interface, tag str
 	return result
 }
 
-// DeleteValidatingWebhook deletes a ValidatingWebhookConfiguration by name, ignoring not-found errors.
-func DeleteValidatingWebhook(ctx context.Context, client kubernetes.Interface, name string) error {
-	err := client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(ctx, name, metav1.DeleteOptions{})
-	if err != nil && !errors.IsNotFound(err) {
+// DeleteTagValidatingWebhooks deletes ValidatingWebhookConfigurations tagged with istio.io/tag=<tag>.
+func DeleteTagValidatingWebhooks(ctx context.Context, client kubernetes.Interface, tag string) error {
+	vwhs, err := client.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", label.IoIstioTag.Name, tag),
+	})
+	if err != nil {
 		return err
 	}
-	return nil
+	var result error
+	for _, vwh := range vwhs.Items {
+		result = multierror.Append(result, client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(ctx, vwh.Name, metav1.DeleteOptions{})).ErrorOrNil()
+	}
+	return result
 }
 
 // DeleteTagServices deletes the given tag services

--- a/istioctl/pkg/tag/util.go
+++ b/istioctl/pkg/tag/util.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	admitv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -151,6 +152,15 @@ func DeleteTagWebhooks(ctx context.Context, client kubernetes.Interface, tag str
 		result = multierror.Append(result, client.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(ctx, wh.Name, metav1.DeleteOptions{})).ErrorOrNil()
 	}
 	return result
+}
+
+// DeleteValidatingWebhook deletes a ValidatingWebhookConfiguration by name, ignoring not-found errors.
+func DeleteValidatingWebhook(ctx context.Context, client kubernetes.Interface, name string) error {
+	err := client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	return nil
 }
 
 // DeleteTagServices deletes the given tag services

--- a/istioctl/pkg/tag/util.go
+++ b/istioctl/pkg/tag/util.go
@@ -163,7 +163,8 @@ func DeleteTagValidatingWebhooks(ctx context.Context, client kubernetes.Interfac
 	}
 	var result error
 	for _, vwh := range vwhs.Items {
-		result = multierror.Append(result, client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(ctx, vwh.Name, metav1.DeleteOptions{})).ErrorOrNil()
+		err = client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(ctx, vwh.Name, metav1.DeleteOptions{})
+		result = multierror.Append(result, err).ErrorOrNil()
 	}
 	return result
 }

--- a/releasenotes/notes/60537.yaml
+++ b/releasenotes/notes/60537.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+issue:
+  - 60537
+releaseNotes:
+  - |
+    **Fixed** `istioctl tag remove` not deleting the `istiod-default-validator` ValidatingWebhookConfiguration when removing the default revision tag.


### PR DESCRIPTION

Fixes #60537

**Please provide a description of this PR:**

istioctl tag remove only deleted the MutatingWebhookConfiguration (istio-revision-tag-default) but not the ValidatingWebhookConfiguration (istiod-default-validator), leftover ValidatingWebhookConfiguration continued acting as if the default revision was still active, so gateways without a revision label remained programmed after tag was removed. 