### PR TITLE
Support configuration of agw as a waypoint

### DIFF
--- a/pilot/pkg/config/kube/agentgateway/agentgateway_controller.go
+++ b/pilot/pkg/config/kube/agentgateway/agentgateway_controller.go
@@ -19,7 +19,7 @@ package agentgateway
 import (
 	"errors"
 	"fmt"
-	"strconv"
+	"strings"
 
 	"github.com/agentgateway/agentgateway/api"
 	"go.uber.org/atomic"
@@ -57,6 +57,7 @@ import (
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/kube/kubetypes"
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/revisions"
 	"istio.io/istio/pkg/slices"
@@ -340,7 +341,7 @@ func (c *Controller) buildResourceCollections(opts krt.OptionsBuilder) {
 	gatewayFinalStatus := c.buildFinalGatewayStatus(gatewayInitialStatus, routeAttachments, opts)
 	status.RegisterStatus(c.status, gatewayFinalStatus, GetStatus, c.tagWatcher.AccessUnprotected())
 
-	listenerSetFinalStatus := c.buildFinalListenerSetStatus(listenerSetIntialStatus, routeAttachments, opts)
+	listenerSetFinalStatus := c.buildFinalListenerSetStatus(gateways, listenerSetIntialStatus, routeAttachments, opts)
 	status.RegisterStatus(c.status, listenerSetFinalStatus, GetStatus, c.tagWatcher.AccessUnprotected())
 
 	httpRoutesByInferencePool := krt.NewIndex(c.inputs.HTTPRoutes, "inferencepool-route", indexHTTPRouteByInferencePool)
@@ -369,22 +370,92 @@ func (c *Controller) buildResourceCollections(opts krt.OptionsBuilder) {
 	c.outputs.Addresses = addresses
 }
 
+type SectionedNamespacedName struct {
+	types.NamespacedName
+	SectionName gatewayv1.SectionName
+}
+
+var sectionedNamespacedNameIndexCollectionFunc = krt.WithIndexCollectionFromString(func(s string) SectionedNamespacedName {
+	parts := strings.Split(s, "/")
+	if len(parts) != 3 {
+		panic("invalid SectionedNamespacedName: " + s)
+	}
+	return SectionedNamespacedName{
+		NamespacedName: types.NamespacedName{
+			Namespace: parts[0],
+			Name:      parts[1],
+		},
+		SectionName: gatewayv1.SectionName(parts[2]),
+	}
+})
+
 func (c *Controller) buildFinalListenerSetStatus(
+	gateways krt.Collection[*GatewayListener],
 	listenerSetStatuses krt.StatusCollection[*gatewayv1.ListenerSet, gatewayv1.ListenerSetStatus],
 	routeAttachments krt.Collection[*RouteAttachment],
 	opts krt.OptionsBuilder,
 ) krt.StatusCollection[*gatewayv1.ListenerSet, gatewayv1.ListenerSetStatus] {
+	gatewayIndex := krt.NewIndex(gateways, "gateway-parent-section-name", func(gwl *GatewayListener) []SectionedNamespacedName {
+		return []SectionedNamespacedName{{
+			NamespacedName: types.NamespacedName{
+				Namespace: gwl.ParentObject.Namespace,
+				Name:      gwl.ParentObject.Name,
+			},
+			SectionName: gwl.ParentInfo.SectionName,
+		}}
+	}).AsCollection(append(opts.WithName("translator/ListenerSetListenersByParentSection"), sectionedNamespacedNameIndexCollectionFunc)...)
 	routeAttachmentsIndex := krt.NewIndex(routeAttachments, "to", func(o *RouteAttachment) []types.NamespacedName {
 		return []types.NamespacedName{o.To}
 	})
-	return gatewaycommon.FinalListenerSetStatusCollection(
+	return krt.NewCollection(
 		listenerSetStatuses,
-		func(ctx krt.HandlerContext, obj *gatewayv1.ListenerSet) []*RouteAttachment {
-			return routeAttachmentsIndex.Fetch(ctx, config.NamespacedName(obj))
-		},
-		func(r *RouteAttachment) string { return r.ListenerName },
-		opts,
-	)
+		func(
+			ctx krt.HandlerContext, i krt.ObjectWithStatus[*gatewayv1.ListenerSet, gatewayv1.ListenerSetStatus],
+		) *krt.ObjectWithStatus[*gatewayv1.ListenerSet, gatewayv1.ListenerSetStatus] {
+			routes := routeAttachmentsIndex.Fetch(ctx, config.NamespacedName(i.Obj))
+			status := i.Status.DeepCopy()
+			counts := map[string]int32{}
+			for _, r := range routes {
+				counts[r.ListenerName]++
+			}
+			invalidListenerCount := 0
+			for idx, l := range i.Obj.Spec.Listeners {
+				gatewayListeners := krt.FetchIndexObjects(ctx, gatewayIndex, SectionedNamespacedName{
+					NamespacedName: types.NamespacedName{
+						Namespace: i.Obj.Namespace,
+						Name:      i.Obj.Name,
+					},
+					SectionName: l.Name,
+				})
+				if len(gatewayListeners) == 0 {
+					continue
+				}
+
+				obj := gatewayListeners[0]
+				if !obj.Valid {
+					invalidListenerCount++
+				} else {
+					if obj.Conflict == ListenerConflictHostname {
+						invalidListenerCount++
+						reportListenerSetListenerConflicts(&status.Listeners[idx], i.Obj, string(gatewayv1.ListenerReasonHostnameConflict), "Found conflicting hostnames on listeners, all listeners on a single port must have unique hostnames")
+					} else if obj.Conflict == ListenerConflictProtocol {
+						invalidListenerCount++
+						ListenerMessageProtocolConflict := "Found conflicting protocols on listeners, a single port can only contain listeners with compatible protocols"
+						reportListenerSetListenerConflicts(&status.Listeners[idx], i.Obj, string(gatewayv1.ListenerReasonProtocolConflict), ListenerMessageProtocolConflict)
+					}
+				}
+				status.Listeners[idx].AttachedRoutes = counts[string(l.Name)]
+			}
+
+			if invalidListenerCount > 0 {
+				listenerSetAccepted := invalidListenerCount < len(i.Obj.Spec.Listeners)
+				reportListenerSetWithConflicts(status, i.Obj, listenerSetAccepted)
+			}
+			return &krt.ObjectWithStatus[*gatewayv1.ListenerSet, gatewayv1.ListenerSetStatus]{
+				Obj:    i.Obj,
+				Status: *status,
+			}
+		}, opts.WithName("ListenerSetFinalStatus")...)
 }
 
 func (c *Controller) buildFinalGatewayStatus(
@@ -642,38 +713,13 @@ func (c *Controller) buildAgwResources(
 	krt.Collection[AgwResource],
 	krt.Collection[*RouteAttachment],
 ) {
-	// Build ports and binds
-	ports := krt.UnnamedIndex(gateways, func(l *GatewayListener) []string {
-		return []string{fmt.Sprint(l.ParentInfo.Port)}
-	}).AsCollection(opts.WithName("PortBindings")...)
+	// Build binds
+	gatewayParents := krt.UnnamedIndex(gateways, func(l *GatewayListener) []string {
+		return []string{l.ParentInfo.ParentGateway.String()}
+	}).AsCollection(opts.WithName("GatewayParents")...)
 
-	binds := krt.NewManyCollection(ports, func(ctx krt.HandlerContext, object krt.IndexObject[string, *GatewayListener]) []AgwResource {
-		port, _ := strconv.Atoi(object.Key)
-		uniq := sets.New[types.NamespacedName]()
-		protocol := api.Bind_Protocol(0)
-		tunnelProtocol := api.Bind_DIRECT
-		for _, gw := range object.Objects {
-			uniq.Insert(gw.ParentGateway)
-			// TODO: better handle conflicts of protocols. For now, we arbitrarily treat TLS > plain
-			// TODO(jaellio): handle conflict
-			if gw.Valid {
-				protocol = max(protocol, c.getBindProtocol(gw))
-				if tp := c.getTunnelProtocol(gw); tp != api.Bind_DIRECT {
-					tunnelProtocol = tp
-				}
-			}
-		}
-		return slices.Map(uniq.UnsortedList(), func(e types.NamespacedName) AgwResource {
-			bind := AgwBind{
-				&api.Bind{
-					Key:            object.Key + "/" + e.String(),
-					Port:           uint32(port), //nolint:gosec // G115: port is always in valid port range
-					Protocol:       protocol,
-					TunnelProtocol: tunnelProtocol,
-				},
-			}
-			return ToResourceForGateway(e, bind)
-		})
+	binds := krt.NewManyCollection(gatewayParents, func(ctx krt.HandlerContext, object krt.IndexObject[string, *GatewayListener]) []AgwResource {
+		return c.buildBindsFromGateway(object.Objects)
 	}, opts.WithName("Binds")...)
 
 	// Build listeners
@@ -711,6 +757,54 @@ func (c *Controller) buildAgwResources(
 	}, opts.WithName("Resources")...)
 
 	return allAgwResources, routeAttachments
+}
+
+// buildBindsFromGateway creates a bind resources from a list of gateway listeners belonging to the same parent gateway
+func (c *Controller) buildBindsFromGateway(listeners []*GatewayListener) []AgwResource {
+	if len(listeners) == 0 {
+		return nil
+	}
+	parentGateway := listeners[0].ParentGateway
+
+	type bindInfo struct {
+		protocol       api.Bind_Protocol
+		tunnelProtocol api.Bind_TunnelProtocol
+	}
+	byPort := map[uint32]*bindInfo{}
+	for _, listener := range listeners {
+		port := uint32(listener.ParentInfo.Port) //nolint:gosec // G115: port is always in valid port range
+		bi, ok := byPort[port]
+		if !ok {
+			// Initialize bindInfo with default zero values of protocol and tunnelProtocol enums
+			bi = &bindInfo{}
+			byPort[port] = bi
+		}
+		// If a single gateway has GatewayListeners with the same port, the "winner" is the one without a conflict
+		// There may be multiple valid GatewayListeners with the same port, as long as the hostnames are
+		// non-overlapping. This case doesn't need to be handled here since the generated bind is independent of
+		// hostname
+		if listener.Conflict == "" {
+			bi.protocol = c.getBindProtocol(listener)
+			if tp := c.getTunnelProtocol(listener); tp != api.Bind_DIRECT {
+				bi.tunnelProtocol = tp
+			}
+		}
+	}
+
+	binds := make([]AgwResource, 0, len(byPort))
+	for _, port := range slices.Sort(maps.Keys(byPort)) { // sorted for deterministic output
+		bi := byPort[port]
+		bind := AgwBind{
+			Bind: &api.Bind{
+				Key:            fmt.Sprint(port) + "/" + parentGateway.String(),
+				Port:           port,
+				Protocol:       bi.protocol,
+				TunnelProtocol: bi.tunnelProtocol,
+			},
+		}
+		binds = append(binds, ToResourceForGateway(parentGateway, bind))
+	}
+	return binds
 }
 
 func listenerName(listener *GatewayListener) *api.ListenerName {

--- a/pilot/pkg/config/kube/agentgateway/agentgateway_controller.go
+++ b/pilot/pkg/config/kube/agentgateway/agentgateway_controller.go
@@ -46,6 +46,7 @@ import (
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/mesh"
+	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
@@ -252,7 +253,7 @@ func (c *Controller) buildResourceCollections(opts krt.OptionsBuilder) {
 		if !builtInClass {
 			return nil
 		}
-		if controller != constants.ManagedAgentgatewayController {
+		if controller != constants.ManagedAgentgatewayController && controller != constants.ManagedAgentgatewayWaypointController {
 			return nil
 		}
 		agwClass := class.DeepCopy()
@@ -306,8 +307,19 @@ func (c *Controller) buildResourceCollections(opts krt.OptionsBuilder) {
 	// Build agw resources for gateway
 	inferencePolicies := InferencePolicyCollection(c.inputs.InferencePools, c.domainSuffix, opts)
 
+	// Build waypoint service bindings: maps services to their AGW waypoint gateways
+	// if they are defined
+	// TODO(jaellio): Handle waypoint workload bindings
+	waypointBindings := BuildWaypointServiceBindings(
+		c.inputs.Services,
+		c.inputs.Namespaces,
+		c.inputs.Gateways,
+		gatewayClasses,
+		opts,
+	)
+
 	// Build ancestor backends (backend→gateway mapping) for BackendTLSPolicy status
-	ancestorBackends := BuildAncestorBackends(c.inputs.HTTPRoutes, c.inputs.GRPCRoutes, opts)
+	ancestorBackends := BuildAncestorBackends(c.inputs.HTTPRoutes, c.inputs.GRPCRoutes, waypointBindings, opts)
 
 	// Build BackendTLS policies
 	backendTLSInputs := BackendTLSPolicyInputs{
@@ -323,7 +335,7 @@ func (c *Controller) buildResourceCollections(opts krt.OptionsBuilder) {
 	backendTLSStatus, backendTLSPolicies := BackendTLSPolicyCollection(backendTLSInputs, opts)
 	status.RegisterStatus(c.status, backendTLSStatus, GetStatus, c.tagWatcher.AccessUnprotected())
 
-	agwResources, routeAttachments := c.buildAgwResources(gateways, referenceGrants, inferencePolicies, backendTLSPolicies, opts)
+	agwResources, routeAttachments := c.buildAgwResources(gateways, referenceGrants, inferencePolicies, backendTLSPolicies, waypointBindings, opts)
 
 	gatewayFinalStatus := c.buildFinalGatewayStatus(gatewayInitialStatus, routeAttachments, opts)
 	status.RegisterStatus(c.status, gatewayFinalStatus, GetStatus, c.tagWatcher.AccessUnprotected())
@@ -347,6 +359,7 @@ func (c *Controller) buildResourceCollections(opts krt.OptionsBuilder) {
 	// TODO(jaellio): Source addresses from the ambientindex so the agentgateway proxies get the same
 	// representation of addresses as ambient proxies (for multicluster)
 	// Build address collections
+	// TODO(jaellio): Scope addresses for waypoint gateways to only fronted + outbound services
 	addresses := c.buildAddressCollections(opts)
 
 	// Build XDS collection
@@ -474,6 +487,7 @@ func (c *Controller) buildXDSCollection(
 	agwResourcesByGateway := func(resource AgwResource) types.NamespacedName {
 		return resource.Gateway
 	}
+
 	c.Registrations = append(c.Registrations, xds.Collection[Address, *workloadapi.Address](xdsAddresses, opts),
 		xds.PerGatewayCollection[AgwResource, *api.Resource](agwResources, agwResourcesByGateway, opts))
 }
@@ -622,6 +636,7 @@ func (c *Controller) buildAgwResources(
 	refGrants gatewaycommon.ReferenceGrants,
 	inferencePolicies krt.Collection[AgwResource],
 	backendTLSPolicies krt.Collection[AgwResource],
+	waypointBindings krt.Collection[WaypointServiceBinding],
 	opts krt.OptionsBuilder,
 ) (
 	krt.Collection[AgwResource],
@@ -636,19 +651,25 @@ func (c *Controller) buildAgwResources(
 		port, _ := strconv.Atoi(object.Key)
 		uniq := sets.New[types.NamespacedName]()
 		protocol := api.Bind_Protocol(0)
+		tunnelProtocol := api.Bind_DIRECT
 		for _, gw := range object.Objects {
 			uniq.Insert(gw.ParentGateway)
 			// TODO: better handle conflicts of protocols. For now, we arbitrarily treat TLS > plain
+			// TODO(jaellio): handle conflict
 			if gw.Valid {
 				protocol = max(protocol, c.getBindProtocol(gw))
+				if tp := c.getTunnelProtocol(gw); tp != api.Bind_DIRECT {
+					tunnelProtocol = tp
+				}
 			}
 		}
 		return slices.Map(uniq.UnsortedList(), func(e types.NamespacedName) AgwResource {
 			bind := AgwBind{
 				&api.Bind{
-					Key:      object.Key + "/" + e.String(),
-					Port:     uint32(port), //nolint:gosec // G115: port is always in valid port range
-					Protocol: protocol,
+					Key:            object.Key + "/" + e.String(),
+					Port:           uint32(port), //nolint:gosec // G115: port is always in valid port range
+					Protocol:       protocol,
+					TunnelProtocol: tunnelProtocol,
 				},
 			}
 			return ToResourceForGateway(e, bind)
@@ -661,12 +682,11 @@ func (c *Controller) buildAgwResources(
 	}, opts.WithName("Listeners")...)
 
 	// Build routes
-	routeParents := BuildRouteParents(gateways)
+	routeParents := BuildRouteParents(gateways, waypointBindings)
 
 	routeInputs := RouteContextInputs{
 		Grants:         refGrants,
 		RouteParents:   routeParents,
-		ControllerName: constants.ManagedAgentgatewayController,
 		DomainSuffix:   c.domainSuffix,
 		Services:       c.inputs.Services,
 		Namespaces:     c.inputs.Namespaces,
@@ -773,6 +793,8 @@ func (c *Controller) getProtocolAndTLSConfig(obj *GatewayListener) (api.Protocol
 		return api.Protocol_TLS, tlsConfig, true
 	case gatewayv1.TCPProtocolType:
 		return api.Protocol_TCP, nil, true
+	case gatewayv1.ProtocolType(protocol.HBONE):
+		return api.Protocol_HBONE, nil, true
 	default:
 		return api.Protocol_HTTP, nil, false // Unsupported protocol
 	}
@@ -789,7 +811,29 @@ func (c *Controller) getBindProtocol(obj *GatewayListener) api.Bind_Protocol {
 		return api.Bind_TLS
 	case gatewayv1.TCPProtocolType:
 		return api.Bind_TCP
+	case gatewayv1.ProtocolType(protocol.HBONE):
+		// The bind protocol is not used for HBONE_GATEWAY in the data plane;
+		// the actual inner protocol is determined at runtime from the other
+		// listeners on the same port. Return HTTP as a placeholder.
+		return api.Bind_HTTP
 	default:
 		return api.Bind_HTTP
+	}
+}
+
+// getTunnelProtocol maps a Gateway listener protocol to its tunnel protocol.
+// HBONE listeners use HBONE_GATEWAY mode when agw is a gateway: the proxy terminates inbound HBONE
+// and routes CONNECT requests to local binds.
+// HBONE listeners use HBONE_WAYPOINT mode when agw is a waypoint: the proxy terminates inbound HBONE
+// and routes CONNECT requests to the waypoint.
+func (c *Controller) getTunnelProtocol(obj *GatewayListener) api.Bind_TunnelProtocol {
+	switch obj.ParentInfo.Protocol {
+	case gatewayv1.ProtocolType(protocol.HBONE):
+		if obj.ParentInfo.IsWaypoint() {
+			return api.Bind_HBONE_WAYPOINT
+		}
+		return api.Bind_HBONE_GATEWAY
+	default:
+		return api.Bind_DIRECT
 	}
 }

--- a/pilot/pkg/config/kube/agentgateway/agentgateway_controller.go
+++ b/pilot/pkg/config/kube/agentgateway/agentgateway_controller.go
@@ -375,6 +375,10 @@ type SectionedNamespacedName struct {
 	SectionName gatewayv1.SectionName
 }
 
+func (s SectionedNamespacedName) String() string {
+	return s.Namespace + "/" + s.Name + "/" + string(s.SectionName)
+}
+
 var sectionedNamespacedNameIndexCollectionFunc = krt.WithIndexCollectionFromString(func(s string) SectionedNamespacedName {
 	parts := strings.Split(s, "/")
 	if len(parts) != 3 {

--- a/pilot/pkg/config/kube/agentgateway/agentgateway_controller.go
+++ b/pilot/pkg/config/kube/agentgateway/agentgateway_controller.go
@@ -437,7 +437,8 @@ func (c *Controller) buildFinalListenerSetStatus(
 				} else {
 					if obj.Conflict == ListenerConflictHostname {
 						invalidListenerCount++
-						reportListenerSetListenerConflicts(&status.Listeners[idx], i.Obj, string(gatewayv1.ListenerReasonHostnameConflict), "Found conflicting hostnames on listeners, all listeners on a single port must have unique hostnames")
+						reportListenerSetListenerConflicts(&status.Listeners[idx], i.Obj, string(gatewayv1.ListenerReasonHostnameConflict),
+							"Found conflicting hostnames on listeners, all listeners on a single port must have unique hostnames")
 					} else if obj.Conflict == ListenerConflictProtocol {
 						invalidListenerCount++
 						ListenerMessageProtocolConflict := "Found conflicting protocols on listeners, a single port can only contain listeners with compatible protocols"

--- a/pilot/pkg/config/kube/agentgateway/agentgateway_controller_test.go
+++ b/pilot/pkg/config/kube/agentgateway/agentgateway_controller_test.go
@@ -30,13 +30,13 @@ import (
 // buildBindsFromGateway reads: the parent gateway identity and the parent
 // listener info (port, protocol, gateway class, and any conflict).
 func agwBindListener(
-	gwNs, gwName string,
+	gwName string,
 	port gatewayv1.PortNumber,
 	proto gatewayv1.ProtocolType,
 	className string,
 	conflict ListenerConflict,
 ) *GatewayListener {
-	pg := types.NamespacedName{Namespace: gwNs, Name: gwName}
+	pg := types.NamespacedName{Namespace: "default", Name: gwName}
 	return &GatewayListener{
 		ParentGateway: pg,
 		ParentInfo: AgwParentInfo{
@@ -84,8 +84,8 @@ func TestBuildBindsFromGateway(t *testing.T) {
 		{
 			name: "different gateways share a port with different protocols",
 			gateways: [][]*GatewayListener{
-				{agwBindListener("default", "gateway-http", 8080, gatewayv1.HTTPProtocolType, constants.AgentgatewayClassName, "")},
-				{agwBindListener("default", "gateway-https", 8080, gatewayv1.HTTPSProtocolType, constants.AgentgatewayClassName, "")},
+				{agwBindListener("gateway-http", 8080, gatewayv1.HTTPProtocolType, constants.AgentgatewayClassName, "")},
+				{agwBindListener("gateway-https", 8080, gatewayv1.HTTPSProtocolType, constants.AgentgatewayClassName, "")},
 			},
 			want: []bindResult{
 				{key: "8080/default/gateway-http", gateway: "default/gateway-http", port: 8080, protocol: api.Bind_HTTP, tunnel: api.Bind_DIRECT},
@@ -95,8 +95,8 @@ func TestBuildBindsFromGateway(t *testing.T) {
 		{
 			name: "different gateways share a port with different tunnel protocols",
 			gateways: [][]*GatewayListener{
-				{agwBindListener("default", "waypoint", 15008, hboneProtocol, constants.AgentgatewayWaypointClassName, "")},
-				{agwBindListener("default", "gateway", 15008, hboneProtocol, constants.AgentgatewayClassName, "")},
+				{agwBindListener("waypoint", 15008, hboneProtocol, constants.AgentgatewayWaypointClassName, "")},
+				{agwBindListener("gateway", 15008, hboneProtocol, constants.AgentgatewayClassName, "")},
 			},
 			want: []bindResult{
 				{key: "15008/default/waypoint", gateway: "default/waypoint", port: 15008, protocol: api.Bind_HTTP, tunnel: api.Bind_HBONE_WAYPOINT},
@@ -107,9 +107,9 @@ func TestBuildBindsFromGateway(t *testing.T) {
 			name: "single gateway multiple non-conflicting listeners on the same port collapse to one bind",
 			gateways: [][]*GatewayListener{
 				{
-					agwBindListener("default", "gw", 8080, gatewayv1.HTTPProtocolType, constants.AgentgatewayClassName, ""),
-					agwBindListener("default", "gw", 8080, gatewayv1.HTTPProtocolType, constants.AgentgatewayClassName, ""),
-					agwBindListener("default", "gw", 443, gatewayv1.HTTPSProtocolType, constants.AgentgatewayClassName, ""),
+					agwBindListener("gw", 8080, gatewayv1.HTTPProtocolType, constants.AgentgatewayClassName, ""),
+					agwBindListener("gw", 8080, gatewayv1.HTTPProtocolType, constants.AgentgatewayClassName, ""),
+					agwBindListener("gw", 443, gatewayv1.HTTPSProtocolType, constants.AgentgatewayClassName, ""),
 				},
 			},
 			want: []bindResult{
@@ -121,8 +121,8 @@ func TestBuildBindsFromGateway(t *testing.T) {
 			name: "conflicting listener does not determine the bind protocol",
 			gateways: [][]*GatewayListener{
 				{
-					agwBindListener("default", "gw", 8080, gatewayv1.HTTPProtocolType, constants.AgentgatewayClassName, ""),
-					agwBindListener("default", "gw", 8080, gatewayv1.HTTPSProtocolType, constants.AgentgatewayClassName, ListenerConflictProtocol),
+					agwBindListener("gw", 8080, gatewayv1.HTTPProtocolType, constants.AgentgatewayClassName, ""),
+					agwBindListener("gw", 8080, gatewayv1.HTTPSProtocolType, constants.AgentgatewayClassName, ListenerConflictProtocol),
 				},
 			},
 			want: []bindResult{

--- a/pilot/pkg/config/kube/agentgateway/agentgateway_controller_test.go
+++ b/pilot/pkg/config/kube/agentgateway/agentgateway_controller_test.go
@@ -19,11 +19,11 @@ import (
 	"testing"
 
 	"github.com/agentgateway/agentgateway/api"
+	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/types"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"istio.io/istio/pkg/config/constants"
-	"istio.io/istio/pkg/test/util/assert"
 )
 
 // agwBindListener builds a minimal GatewayListener with only the fields
@@ -145,7 +145,9 @@ func TestBuildBindsFromGateway(t *testing.T) {
 					})
 				}
 			}
-			assert.Equal(t, sortBinds(got), sortBinds(tt.want))
+			if diff := cmp.Diff(sortBinds(got), sortBinds(tt.want), cmp.AllowUnexported(bindResult{})); diff != "" {
+				t.Fatalf("unexpected binds (-got +want):\n%s", diff)
+			}
 		})
 	}
 }

--- a/pilot/pkg/config/kube/agentgateway/agentgateway_controller_test.go
+++ b/pilot/pkg/config/kube/agentgateway/agentgateway_controller_test.go
@@ -1,0 +1,151 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentgateway
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/agentgateway/agentgateway/api"
+	"k8s.io/apimachinery/pkg/types"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/test/util/assert"
+)
+
+// agwBindListener builds a minimal GatewayListener with only the fields
+// buildBindsFromGateway reads: the parent gateway identity and the parent
+// listener info (port, protocol, gateway class, and any conflict).
+func agwBindListener(
+	gwNs, gwName string,
+	port gatewayv1.PortNumber,
+	proto gatewayv1.ProtocolType,
+	className string,
+	conflict ListenerConflict,
+) *GatewayListener {
+	pg := types.NamespacedName{Namespace: gwNs, Name: gwName}
+	return &GatewayListener{
+		ParentGateway: pg,
+		ParentInfo: AgwParentInfo{
+			Port:                   port,
+			Protocol:               proto,
+			ParentGatewayClassName: className,
+		},
+		Conflict: conflict,
+	}
+}
+
+// bindResult is a flattened, comparable view of a generated bind resource.
+type bindResult struct {
+	key      string
+	gateway  string
+	port     uint32
+	protocol api.Bind_Protocol
+	tunnel   api.Bind_TunnelProtocol
+}
+
+func sortBinds(binds []bindResult) []bindResult {
+	sort.Slice(binds, func(i, j int) bool { return binds[i].key < binds[j].key })
+	return binds
+}
+
+// TestBuildBindsFromGateway verifies bind generation, with an emphasis on the
+// fact that different gateways may share a port as long as each gateway gets its
+// own bind keyed by "port/namespace/name". This means two gateways can bind the
+// same port with different protocols or different tunnel protocols.
+func TestBuildBindsFromGateway(t *testing.T) {
+	c := &Controller{}
+	tests := []struct {
+		name string
+		// each entry is the set of listeners belonging to a single parent
+		// gateway; buildBindsFromGateway is called once per group, mirroring how
+		// the controller groups listeners by parent gateway.
+		gateways [][]*GatewayListener
+		want     []bindResult
+	}{
+		{
+			name:     "no listeners produces no binds",
+			gateways: [][]*GatewayListener{{}},
+			want:     nil,
+		},
+		{
+			name: "different gateways share a port with different protocols",
+			gateways: [][]*GatewayListener{
+				{agwBindListener("default", "gateway-http", 8080, gatewayv1.HTTPProtocolType, constants.AgentgatewayClassName, "")},
+				{agwBindListener("default", "gateway-https", 8080, gatewayv1.HTTPSProtocolType, constants.AgentgatewayClassName, "")},
+			},
+			want: []bindResult{
+				{key: "8080/default/gateway-http", gateway: "default/gateway-http", port: 8080, protocol: api.Bind_HTTP, tunnel: api.Bind_DIRECT},
+				{key: "8080/default/gateway-https", gateway: "default/gateway-https", port: 8080, protocol: api.Bind_TLS, tunnel: api.Bind_DIRECT},
+			},
+		},
+		{
+			name: "different gateways share a port with different tunnel protocols",
+			gateways: [][]*GatewayListener{
+				{agwBindListener("default", "waypoint", 15008, hboneProtocol, constants.AgentgatewayWaypointClassName, "")},
+				{agwBindListener("default", "gateway", 15008, hboneProtocol, constants.AgentgatewayClassName, "")},
+			},
+			want: []bindResult{
+				{key: "15008/default/waypoint", gateway: "default/waypoint", port: 15008, protocol: api.Bind_HTTP, tunnel: api.Bind_HBONE_WAYPOINT},
+				{key: "15008/default/gateway", gateway: "default/gateway", port: 15008, protocol: api.Bind_HTTP, tunnel: api.Bind_HBONE_GATEWAY},
+			},
+		},
+		{
+			name: "single gateway multiple non-conflicting listeners on the same port collapse to one bind",
+			gateways: [][]*GatewayListener{
+				{
+					agwBindListener("default", "gw", 8080, gatewayv1.HTTPProtocolType, constants.AgentgatewayClassName, ""),
+					agwBindListener("default", "gw", 8080, gatewayv1.HTTPProtocolType, constants.AgentgatewayClassName, ""),
+					agwBindListener("default", "gw", 443, gatewayv1.HTTPSProtocolType, constants.AgentgatewayClassName, ""),
+				},
+			},
+			want: []bindResult{
+				{key: "8080/default/gw", gateway: "default/gw", port: 8080, protocol: api.Bind_HTTP, tunnel: api.Bind_DIRECT},
+				{key: "443/default/gw", gateway: "default/gw", port: 443, protocol: api.Bind_TLS, tunnel: api.Bind_DIRECT},
+			},
+		},
+		{
+			name: "conflicting listener does not determine the bind protocol",
+			gateways: [][]*GatewayListener{
+				{
+					agwBindListener("default", "gw", 8080, gatewayv1.HTTPProtocolType, constants.AgentgatewayClassName, ""),
+					agwBindListener("default", "gw", 8080, gatewayv1.HTTPSProtocolType, constants.AgentgatewayClassName, ListenerConflictProtocol),
+				},
+			},
+			want: []bindResult{
+				{key: "8080/default/gw", gateway: "default/gw", port: 8080, protocol: api.Bind_HTTP, tunnel: api.Bind_DIRECT},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got []bindResult
+			for _, listeners := range tt.gateways {
+				for _, res := range c.buildBindsFromGateway(listeners) {
+					b := res.Resource.GetBind()
+					got = append(got, bindResult{
+						key:      b.GetKey(),
+						gateway:  res.Gateway.String(),
+						port:     b.GetPort(),
+						protocol: b.GetProtocol(),
+						tunnel:   b.GetTunnelProtocol(),
+					})
+				}
+			}
+			assert.Equal(t, sortBinds(got), sortBinds(tt.want))
+		})
+	}
+}

--- a/pilot/pkg/config/kube/agentgateway/conditions.go
+++ b/pilot/pkg/config/kube/agentgateway/conditions.go
@@ -24,36 +24,11 @@ import (
 	"istio.io/istio/pilot/pkg/config/kube/gatewaycommon"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/schema/gvk"
-	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/sets"
 )
-
-func reportListenerCondition(index int, l k8s.Listener, obj controllers.Object,
-	statusListeners []k8s.ListenerStatus, conditions map[string]*Condition,
-) []k8s.ListenerStatus {
-	for index >= len(statusListeners) {
-		statusListeners = append(statusListeners, k8s.ListenerStatus{})
-	}
-	cond := statusListeners[index].Conditions
-	supported, valid := gatewaycommon.GenerateAgentgatewaySupportedKinds(l)
-	if !valid {
-		conditions[string(k8s.ListenerConditionResolvedRefs)] = &Condition{
-			reason:  string(k8s.ListenerReasonInvalidRouteKinds),
-			status:  metav1.ConditionFalse,
-			message: "Invalid route kinds",
-		}
-	}
-	statusListeners[index] = k8s.ListenerStatus{
-		Name:           l.Name,
-		AttachedRoutes: 0, // this will be reported later
-		SupportedKinds: supported,
-		Conditions:     gatewaycommon.SetListenerConditions(obj.GetGeneration(), cond, toSharedConditions(conditions)),
-	}
-	return statusListeners
-}
 
 func FilterInPlaceByIndex[E any](s []E, keep func(int) bool) []E {
 	i := 0

--- a/pilot/pkg/config/kube/agentgateway/conditions.go
+++ b/pilot/pkg/config/kube/agentgateway/conditions.go
@@ -21,57 +21,38 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8s "sigs.k8s.io/gateway-api/apis/v1"
 
-	"istio.io/istio/pilot/pkg/model/kstatus"
+	"istio.io/istio/pilot/pkg/config/kube/gatewaycommon"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/sets"
 )
 
-// setConditions sets the existingConditions with the new conditions
-func setConditions(generation int64, existingConditions []metav1.Condition, conditions map[string]*Condition) []metav1.Condition {
-	// Sort keys for deterministic ordering
-	for _, k := range slices.Sort(maps.Keys(conditions)) {
-		cond := conditions[k]
-		setter := kstatus.UpdateConditionIfChanged
-		if cond.setOnce != "" {
-			setter = func(conditions []metav1.Condition, condition metav1.Condition) []metav1.Condition {
-				return kstatus.CreateCondition(conditions, condition, cond.setOnce)
-			}
-		}
-		// A condition can be "negative polarity" (ex: ListenerInvalid) or "positive polarity" (ex:
-		// ListenerValid), so in order to determine the status we should set each `condition` defines its
-		// default positive status. When there is an error, we will invert that. Example: If we have
-		// condition ListenerInvalid, the status will be set to StatusFalse. If an error is reported, it
-		// will be inverted to StatusTrue to indicate listeners are invalid. See
-		// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
-		// for more information
-		if cond.error != nil {
-			existingConditions = setter(existingConditions, metav1.Condition{
-				Type:               k,
-				Status:             kstatus.InvertStatus(cond.status),
-				ObservedGeneration: generation,
-				LastTransitionTime: metav1.Now(),
-				Reason:             cond.error.Reason,
-				Message:            cond.error.Message,
-			})
-		} else {
-			status := cond.status
-			if status == "" {
-				status = kstatus.StatusTrue
-			}
-			existingConditions = setter(existingConditions, metav1.Condition{
-				Type:               k,
-				Status:             status,
-				ObservedGeneration: generation,
-				LastTransitionTime: metav1.Now(),
-				Reason:             cond.reason,
-				Message:            cond.message,
-			})
+func reportListenerCondition(index int, l k8s.Listener, obj controllers.Object,
+	statusListeners []k8s.ListenerStatus, conditions map[string]*Condition,
+) []k8s.ListenerStatus {
+	for index >= len(statusListeners) {
+		statusListeners = append(statusListeners, k8s.ListenerStatus{})
+	}
+	cond := statusListeners[index].Conditions
+	supported, valid := gatewaycommon.GenerateAgentgatewaySupportedKinds(l)
+	if !valid {
+		conditions[string(k8s.ListenerConditionResolvedRefs)] = &Condition{
+			reason:  string(k8s.ListenerReasonInvalidRouteKinds),
+			status:  metav1.ConditionFalse,
+			message: "Invalid route kinds",
 		}
 	}
-	return existingConditions
+	statusListeners[index] = k8s.ListenerStatus{
+		Name:           l.Name,
+		AttachedRoutes: 0, // this will be reported later
+		SupportedKinds: supported,
+		Conditions:     gatewaycommon.SetListenerConditions(obj.GetGeneration(), cond, toSharedConditions(conditions)),
+	}
+	return statusListeners
 }
 
 func FilterInPlaceByIndex[E any](s []E, keep func(int) bool) []E {
@@ -95,6 +76,8 @@ type RouteParentResult struct {
 	DeniedReason *ParentError
 	// RouteError, if present, indicates a route-level error (e.g. unresolved backend refs)
 	RouteError *Condition
+	// ControllerName is the name of the controller that generated the result
+	ControllerName string
 }
 
 // createRouteStatus builds the RouteParentStatus slice from route parent results.
@@ -104,14 +87,14 @@ func createRouteStatus(
 	parentResults []RouteParentResult,
 	objectNamespace string,
 	generation int64,
-	controllerName string,
 	currentParents []k8s.RouteParentStatus,
 ) []k8s.RouteParentStatus {
 	parents := slices.Clone(currentParents)
 	parentIndexes := map[string]int{}
 	for idx, p := range parents {
 		// Only consider our own
-		if p.ControllerName != k8s.GatewayController(controllerName) {
+		if p.ControllerName != constants.ManagedAgentgatewayController &&
+			p.ControllerName != constants.ManagedAgentgatewayWaypointController {
 			continue
 		}
 		rs := parentRefStringWithNS(p.ParentRef, objectNamespace)
@@ -209,15 +192,15 @@ func createRouteStatus(
 		var currentConditions []metav1.Condition
 		cs := slices.FindFunc(currentParents, func(s k8s.RouteParentStatus) bool {
 			return parentRefStringWithNS(s.ParentRef, objectNamespace) == myRef &&
-				s.ControllerName == k8s.GatewayController(controllerName)
+				s.ControllerName == k8s.GatewayController(gw.ControllerName)
 		})
 		if cs != nil {
 			currentConditions = cs.Conditions
 		}
 		ns := k8s.RouteParentStatus{
 			ParentRef:      gw.OriginalReference,
-			ControllerName: k8s.GatewayController(controllerName),
-			Conditions:     setConditions(generation, currentConditions, conds),
+			ControllerName: k8s.GatewayController(gw.ControllerName),
+			Conditions:     gatewaycommon.SetListenerConditions(generation, currentConditions, toSharedConditions(conds)),
 		}
 		if idx, f := parentIndexes[myRef]; f {
 			parents[idx] = ns

--- a/pilot/pkg/config/kube/agentgateway/gateway_collection.go
+++ b/pilot/pkg/config/kube/agentgateway/gateway_collection.go
@@ -93,6 +93,10 @@ func (g AgwParentInfo) Equals(other AgwParentInfo) bool {
 		slices.Equal(g.Hostnames, other.Hostnames)
 }
 
+func (g AgwParentInfo) IsWaypoint() bool {
+	return g.ParentGatewayClassName == constants.AgentgatewayWaypointClassName
+}
+
 // Borrowed from kgateway
 type ListenerSet struct {
 	Name string `json:"name"`
@@ -220,7 +224,7 @@ func ListenerSetCollection(
 				standardListener := gatewaycommon.ConvertListenerSetToListener(l)
 
 				if reason, ok := conflicts[l.Name]; ok {
-					standardStatus = gatewaycommon.ReportListenerConflict(i, standardListener, obj, standardStatus, reason)
+					standardStatus = gatewaycommon.ReportListenerConflict(i, standardListener, obj, standardStatus, reason, gatewaycommon.GenerateAgentgatewaySupportedKinds)
 					continue
 				}
 
@@ -244,7 +248,7 @@ func ListenerSetCollection(
 				}
 				name := InternalGatewayName(obj.Namespace, obj.Name, string(l.Name))
 
-				allowed, _ := gatewaycommon.GenerateSupportedKinds(standardListener)
+				allowed, _ := gatewaycommon.GenerateAgentgatewaySupportedKinds(standardListener)
 				pri := AgwParentInfo{
 					ParentGateway:    config.NamespacedName(parentGwObj),
 					InternalName:     obj.Namespace + "/" + name,
@@ -358,7 +362,7 @@ func GatewayCollection(
 
 		for i, l := range kgw.Listeners {
 			if reason, ok := gwListenerConflicts[l.Name]; ok {
-				status.Listeners = gatewaycommon.ReportListenerConflict(i, l, obj, status.Listeners, reason)
+				status.Listeners = gatewaycommon.ReportListenerConflict(i, l, obj, status.Listeners, reason, gatewaycommon.GenerateAgentgatewaySupportedKinds)
 				continue
 			}
 
@@ -378,7 +382,7 @@ func GatewayCollection(
 			servers = append(servers, server)
 
 			// Generate supported kinds for the listener
-			allowed, _ := gatewaycommon.GenerateSupportedKinds(l)
+			allowed, _ := gatewaycommon.GenerateAgentgatewaySupportedKinds(l)
 
 			name := InternalGatewayName(obj.Namespace, obj.Name, string(l.Name))
 			pri := AgwParentInfo{
@@ -450,24 +454,71 @@ func InternalGatewayName(gwNamespace, gwName, lName string) string {
 
 // TODO(jaellio): Move these definitions to route collection (?)
 // RouteParents holds information about things routes can reference as parents.
+// For ingress gateways, parents are Gateway/ListenerSet resources.
+// For waypoint gateways, routes can also reference Services as parents.
+// TODO(jaellio)
 type RouteParents struct {
+	// TODO(jaellio): Are the Gateway listeners just for the listeners with parents refs of
+	// type Gateway or listenerSet? Or could the listeners with a service parent ref also be included?
+	// Are they already included?
 	gatewayIndex krt.Index[AgwParentKey, *GatewayListener]
+
+	// waypointBindings maps services to their AGW waypoint gateways.
+	// When a route references a Service as parentRef, this collection is used to
+	// resolve the service to its waypoint gateway, enabling route attachment.
+	// TODO(jaellio): Consider if this is the best way to handle waypoint bindings,
+	// or if there's a more efficient approach. Also consider changing the name of this field to match
+	// gatewayIndex.
+	// TODO(jaellio): Do an equivalend to the agwParentKey for the waypointBindings?
+	waypointBindings krt.Collection[WaypointServiceBinding]
 }
 
 func (p RouteParents) fetch(ctx krt.HandlerContext, pk AgwParentKey) []*AgwParentInfo {
+	if pk.Kind == gvk.Service.Kubernetes() || pk.Kind == gvk.ServiceEntry.Kubernetes() {
+		return p.fetchServiceParent(ctx, pk)
+	}
 	return slices.Map(p.gatewayIndex.Fetch(ctx, pk), func(gw *GatewayListener) *AgwParentInfo {
+		return &gw.ParentInfo
+	})
+}
+
+// fetchServiceParent resolves a Service parentRef to the waypoint gateway that fronts it.
+// If the service has a use-waypoint label pointing to an AGW waypoint gateway, the route
+// is attached to that waypoint gateway's listeners.
+func (p RouteParents) fetchServiceParent(ctx krt.HandlerContext, pk AgwParentKey) []*AgwParentInfo {
+	if p.waypointBindings == nil {
+		return nil
+	}
+
+	// Look up the waypoint binding for this service
+	svcKey := pk.Namespace + "/" + pk.Name
+	binding := krt.FetchOne(ctx, p.waypointBindings, krt.FilterKey(svcKey))
+	if binding == nil {
+		return nil
+	}
+
+	// Found a waypoint binding — look up the waypoint gateway's listeners
+	wpKey := AgwParentKey{
+		Kind:      gvk.KubernetesGateway.Kubernetes(),
+		Name:      binding.WaypointGateway.Name,
+		Namespace: binding.WaypointGateway.Namespace,
+	}
+	return slices.Map(p.gatewayIndex.Fetch(ctx, wpKey), func(gw *GatewayListener) *AgwParentInfo {
 		return &gw.ParentInfo
 	})
 }
 
 func BuildRouteParents(
 	gateways krt.Collection[*GatewayListener],
+	waypointBindings krt.Collection[WaypointServiceBinding],
 ) RouteParents {
 	idx := krt.NewIndex(gateways, "parent", func(o *GatewayListener) []AgwParentKey {
 		return []AgwParentKey{o.ParentObject}
 	})
 	return RouteParents{
 		gatewayIndex: idx,
+		// waypointBindings maps services to their AGW waypoint gateways
+		waypointBindings: waypointBindings,
 	}
 }
 

--- a/pilot/pkg/config/kube/agentgateway/gateway_collection.go
+++ b/pilot/pkg/config/kube/agentgateway/gateway_collection.go
@@ -466,7 +466,8 @@ type RouteParents struct {
 }
 
 func (p RouteParents) fetch(ctx krt.HandlerContext, pk AgwParentKey) []*AgwParentInfo {
-	if pk.Kind == gvk.Service.Kubernetes() || pk.Kind == gvk.ServiceEntry.Kubernetes() {
+	// TODO(jaellio): support ServiceEntry for fetchServiceParent
+	if pk.Kind == gvk.Service.Kubernetes() {
 		return p.fetchServiceParent(ctx, pk)
 	}
 	return slices.Map(p.gatewayIndex.Fetch(ctx, pk), func(gw *GatewayListener) *AgwParentInfo {

--- a/pilot/pkg/config/kube/agentgateway/gateway_collection.go
+++ b/pilot/pkg/config/kube/agentgateway/gateway_collection.go
@@ -456,20 +456,12 @@ func InternalGatewayName(gwNamespace, gwName, lName string) string {
 // RouteParents holds information about things routes can reference as parents.
 // For ingress gateways, parents are Gateway/ListenerSet resources.
 // For waypoint gateways, routes can also reference Services as parents.
-// TODO(jaellio)
 type RouteParents struct {
-	// TODO(jaellio): Are the Gateway listeners just for the listeners with parents refs of
-	// type Gateway or listenerSet? Or could the listeners with a service parent ref also be included?
-	// Are they already included?
 	gatewayIndex krt.Index[AgwParentKey, *GatewayListener]
 
 	// waypointBindings maps services to their AGW waypoint gateways.
 	// When a route references a Service as parentRef, this collection is used to
 	// resolve the service to its waypoint gateway, enabling route attachment.
-	// TODO(jaellio): Consider if this is the best way to handle waypoint bindings,
-	// or if there's a more efficient approach. Also consider changing the name of this field to match
-	// gatewayIndex.
-	// TODO(jaellio): Do an equivalend to the agwParentKey for the waypointBindings?
 	waypointBindings krt.Collection[WaypointServiceBinding]
 }
 
@@ -497,7 +489,7 @@ func (p RouteParents) fetchServiceParent(ctx krt.HandlerContext, pk AgwParentKey
 		return nil
 	}
 
-	// Found a waypoint binding — look up the waypoint gateway's listeners
+	// Found a waypoint binding, look up the waypoint's listeners
 	wpKey := AgwParentKey{
 		Kind:      gvk.KubernetesGateway.Kubernetes(),
 		Name:      binding.WaypointGateway.Name,

--- a/pilot/pkg/config/kube/agentgateway/gateway_collection.go
+++ b/pilot/pkg/config/kube/agentgateway/gateway_collection.go
@@ -21,6 +21,7 @@ import (
 	"github.com/agentgateway/agentgateway/api"
 	"go.uber.org/atomic"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -35,6 +36,7 @@ import (
 	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/revisions"
 	"istio.io/istio/pkg/slices"
+	"istio.io/istio/pkg/util/sets"
 )
 
 // Used by agentgateway controller
@@ -43,6 +45,40 @@ type TLSInfo struct {
 	Cert   []byte
 	CaCert []byte
 	Key    []byte `json:"-"`
+}
+
+type portProtocol struct {
+	hostnames sets.String
+	protocol  gatewayv1.ProtocolType
+}
+
+type ListenerConflict string
+
+const (
+	ListenerConflictHostname = "hostname"
+	ListenerConflictProtocol = "protocol"
+)
+
+func validateListenerConflicts(listeners []*GatewayListener) {
+	portMap := make(map[gatewayv1.PortNumber]*portProtocol)
+	for _, listener := range listeners {
+		if p, ok := portMap[listener.ParentInfo.Port]; ok {
+			if p.protocol == listener.ParentInfo.Protocol {
+				if slices.ContainsFunc(listener.ParentInfo.Hostnames, p.hostnames.Contains) {
+					listener.Conflict = ListenerConflictHostname
+				} else {
+					p.hostnames.InsertAll(listener.ParentInfo.Hostnames...)
+				}
+			} else {
+				listener.Conflict = ListenerConflictProtocol
+			}
+		} else {
+			portMap[listener.ParentInfo.Port] = &portProtocol{
+				hostnames: sets.New(listener.ParentInfo.Hostnames...),
+				protocol:  listener.ParentInfo.Protocol,
+			}
+		}
+	}
 }
 
 // Used by agentgateway controller
@@ -54,7 +90,10 @@ type GatewayListener struct {
 	ParentObject AgwParentKey
 	ParentInfo   AgwParentInfo
 	TLSInfo      *TLSInfo
-	Valid        bool
+	// Indicates if a listener built successfully independently of other listeners
+	Valid bool
+	// Indicates if a listener has any conflicts with other listeners
+	Conflict ListenerConflict
 }
 
 func (g GatewayListener) ResourceName() string {
@@ -73,6 +112,7 @@ func (g GatewayListener) Equals(other GatewayListener) bool {
 		}
 	}
 	return g.Valid == other.Valid &&
+		g.Conflict == other.Conflict &&
 		g.Name == other.Name &&
 		g.ParentGateway == other.ParentGateway &&
 		g.ParentObject == other.ParentObject &&
@@ -106,7 +146,8 @@ type ListenerSet struct {
 	ParentInfo    AgwParentInfo        `json:"parentInfo"`
 	TLSInfo       *TLSInfo             `json:"tlsInfo"`
 	GatewayParent types.NamespacedName `json:"gatewayParent"`
-	Valid         bool                 `json:"valid"`
+	// Indicates if a listener built successfully independently of other listeners
+	Valid bool `json:"valid"`
 }
 
 func (g ListenerSet) ResourceName() string {
@@ -287,6 +328,66 @@ func listenerSetParentErr(err *Condition) *gatewaycommon.ListenerStatusConfigErr
 	return &gatewaycommon.ListenerStatusConfigError{Reason: err.error.Reason, Message: err.error.Message}
 }
 
+// reportListenerSetWithConflicts sets the ListenerSet-level (top-level) Accepted and Programmed
+// conditions when one or more of its listeners are unusable (invalid or conflicting). It is called
+// once per ListenerSet, after every listener entry has been evaluated. The accepted argument carries
+// partial-acceptance semantics: it is true when at least one listener is still usable (so the
+// ListenerSet as a whole is Accepted/Programmed=True even though some entries are not), and false
+// when no listener is usable. For the per-listener Conflicted condition, see
+// reportListenerSetListenerConflicts.
+func reportListenerSetWithConflicts(status *gatewayv1.ListenerSetStatus, obj *gatewayv1.ListenerSet, accepted bool) {
+	condition := metav1.ConditionFalse
+	if accepted {
+		condition = metav1.ConditionTrue
+	}
+	programmedReason := gatewayv1.ListenerSetReasonListenersNotValid
+	if accepted {
+		programmedReason = gatewayv1.ListenerSetReasonProgrammed
+	}
+	// In case any listeners are invalid, this status should be set even if the gateway / listenerset is accepted
+	// https://github.com/kubernetes-sigs/gateway-api/blob/8fe8316f5792a7830a49c800f89fe689e0df042e/apisx/v1alpha1/xlistenerset_types.go#L396
+	gatewayConditions := map[string]*Condition{
+		string(gatewayv1.GatewayConditionAccepted): {
+			status: condition,
+			reason: string(gatewayv1.ListenerSetReasonListenersNotValid),
+		},
+		string(gatewayv1.GatewayConditionProgrammed): {
+			status: condition,
+			reason: string(programmedReason),
+		},
+	}
+
+	status.Conditions = gatewaycommon.SetResourceConditions(obj.Generation, status.Conditions, toSharedConditions(gatewayConditions))
+}
+
+// reportListenerSetListenerConflicts sets the conditions for a single listener entry that conflicts
+// with another listener (e.g. hostname or protocol clash on a shared port). It is called once per
+// conflicting listener and operates on that entry's ListenerEntryStatus, setting Conflicted=True
+// along with Accepted=False and Programmed=False, using the given conflict reason/message. This is
+// the per-listener counterpart to reportListenerSetWithConflicts, which reports the aggregate
+// ListenerSet-level status.
+func reportListenerSetListenerConflicts(status *gatewayv1.ListenerEntryStatus, obj *gatewayv1.ListenerSet, reason string, message string) {
+	gatewayConditions := map[string]*Condition{
+		string(gatewayv1.ListenerConditionConflicted): {
+			status:  metav1.ConditionTrue,
+			reason:  reason,
+			message: message,
+		},
+		string(gatewayv1.GatewayConditionAccepted): {
+			status:  metav1.ConditionFalse,
+			reason:  reason,
+			message: message,
+		},
+		string(gatewayv1.GatewayConditionProgrammed): {
+			status:  metav1.ConditionFalse,
+			reason:  reason,
+			message: message,
+		},
+	}
+
+	status.Conditions = gatewaycommon.SetResourceConditions(obj.Generation, status.Conditions, toSharedConditions(gatewayConditions))
+}
+
 // GatewayCollection builds the collection of Gateways. This is responsible for translating from the Kubernetes Gateway API
 // types to the internal representation used by the agent gateway, as well as computing the status for the Gateways. The
 // listeners are processed in a separate collection (ListenerSetCollection) since they have their own status that needs to
@@ -434,7 +535,8 @@ func GatewayCollection(
 				Valid:      ls.Valid,
 			})
 		}
-
+		validateListenerConflicts(result)
+		// TODO(jaellio): include unique listener sets in status after validating listener conflicts
 		reportGatewayStatus(context, obj, status, classInfo, gatewayServices, servers, len(listenerSets), gatewayErr, validListeners)
 		return status, result
 	}, opts.WithName("KubernetesGateway")...)

--- a/pilot/pkg/config/kube/agentgateway/gateway_status.go
+++ b/pilot/pkg/config/kube/agentgateway/gateway_status.go
@@ -176,7 +176,7 @@ func reportGatewayStatus(
 		}
 	}
 	gs.Listeners = listeners
-	gs.Conditions = setConditions(obj.Generation, gs.Conditions, gatewayConditions)
+	gs.Conditions = gatewaycommon.SetListenerConditions(obj.Generation, gs.Conditions, toSharedConditions(gatewayConditions))
 }
 
 func setProgrammedCondition(gatewayConditions map[string]*Condition, internal []string, gatewayServices []string, warnings []string, allUsable bool) {
@@ -186,6 +186,16 @@ func setProgrammedCondition(gatewayConditions map[string]*Condition, internal []
 	}
 	gatewaycommon.SetProgrammedCondition(mapped, internal, gatewayServices, warnings, allUsable)
 	applyAgentgatewayConditionFromListenerStatus(programmed, mapped[string(gatewayv1.GatewayConditionProgrammed)])
+}
+
+// toSharedConditions converts a map of local conditions into the
+// shared gatewaycommon representation used by gatewaycommon.SetListenerConditions.
+func toSharedConditions(in map[string]*Condition) map[string]*gatewaycommon.ListenerStatusCondition {
+	out := make(map[string]*gatewaycommon.ListenerStatusCondition, len(in))
+	for k, c := range in {
+		out[k] = agentgatewayListenerStatusCondition(c)
+	}
+	return out
 }
 
 func agentgatewayListenerStatusCondition(c *Condition) *gatewaycommon.ListenerStatusCondition {

--- a/pilot/pkg/config/kube/agentgateway/inferencepool_collection.go
+++ b/pilot/pkg/config/kube/agentgateway/inferencepool_collection.go
@@ -213,10 +213,10 @@ func calculateSingleParentStatus(
 			Namespace: inferencev1.Namespace(gatewayParent.Namespace),
 			Name:      inferencev1.ObjectName(gatewayParent.Name),
 		},
-		Conditions: setConditions(pool.Generation, filteredConditions, map[string]*Condition{
+		Conditions: gatewaycommon.SetListenerConditions(pool.Generation, filteredConditions, toSharedConditions(map[string]*Condition{
 			string(inferencev1.InferencePoolConditionAccepted):     acceptedStatus,
 			string(inferencev1.InferencePoolConditionResolvedRefs): resolvedRefsStatus,
-		}),
+		})),
 	}
 }
 

--- a/pilot/pkg/config/kube/agentgateway/listener.go
+++ b/pilot/pkg/config/kube/agentgateway/listener.go
@@ -133,6 +133,15 @@ func buildListener(
 		ok = false
 	}
 
+	if controllerName == constants.ManagedAgentgatewayWaypointController {
+		if unexpectedWaypointListener(l) {
+			listenerConditions[string(gatewayv1.ListenerConditionAccepted)].Error = &gatewaycommon.ListenerStatusConfigError{
+				Reason:  string(gatewayv1.ListenerReasonUnsupportedProtocol),
+				Message: `Expected a single listener on port 15008 with protocol "HBONE"`,
+			}
+		}
+	}
+
 	server := &istio.Server{
 		Port: &istio.Port{
 			// Name is required. We only have one server per Gateway, so we can just name them all the same
@@ -142,8 +151,23 @@ func buildListener(
 		Hosts: hostnames,
 	}
 
-	updatedStatus := gatewaycommon.ReportListenerCondition(listenerIndex, l, obj, status, listenerConditions)
+	updatedStatus := gatewaycommon.ReportListenerCondition(listenerIndex, l, obj, status, listenerConditions, gatewaycommon.GenerateAgentgatewaySupportedKinds)
 	return server, tlsInfo, updatedStatus, ok
+}
+
+// Gateway currently requires a listener (https://github.com/kubernetes-sigs/gateway-api/pull/1596).
+// We don't *really* care about the listener, but it may make sense to add a warning if users do not
+// configure it in an expected way so that we have consistency and can make changes in the future as needed.
+// We could completely reject but that seems more likely to cause pain.
+// TODO(jaellio): do we want to enforce only having a single listener?
+func unexpectedWaypointListener(l gatewayv1.Listener) bool {
+	if l.Port != 15008 {
+		return true
+	}
+	if l.Protocol != gatewayv1.ProtocolType(protocol.HBONE) {
+		return true
+	}
+	return false
 }
 
 func listenerProtocolToIstio(name gatewayv1.GatewayController, p gatewayv1.ProtocolType) (string, error) {
@@ -159,7 +183,8 @@ func listenerProtocolToIstio(name gatewayv1.GatewayController, p gatewayv1.Proto
 		return string(p), nil
 	// Our own custom types
 	case gatewayv1.ProtocolType(protocol.HBONE):
-		if name != constants.ManagedGatewayMeshController && name != constants.ManagedGatewayEastWestController {
+		if name != constants.ManagedGatewayMeshController && name != constants.ManagedGatewayEastWestController &&
+			name != constants.ManagedAgentgatewayWaypointController && name != constants.ManagedAgentgatewayController {
 			return "", fmt.Errorf("protocol %q is only supported for waypoint proxies", p)
 		}
 		return string(p), nil

--- a/pilot/pkg/config/kube/agentgateway/listener.go
+++ b/pilot/pkg/config/kube/agentgateway/listener.go
@@ -30,6 +30,7 @@ import (
 	istio "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/config/kube/gatewaycommon"
 	kubecreds "istio.io/istio/pilot/pkg/credentials/kube"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model/kstatus"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
@@ -180,6 +181,9 @@ func listenerProtocolToIstio(name gatewayv1.GatewayController, p gatewayv1.Proto
 	case gatewayv1.TLSProtocolType:
 		return string(p), nil
 	case gatewayv1.TCPProtocolType:
+		if !features.EnableAlphaGatewayAPI {
+			return "", fmt.Errorf("protocol %q is only supported when the alpha Gateway API is enabled", p)
+		}
 		return string(p), nil
 	// Our own custom types
 	case gatewayv1.ProtocolType(protocol.HBONE):

--- a/pilot/pkg/config/kube/agentgateway/listener.go
+++ b/pilot/pkg/config/kube/agentgateway/listener.go
@@ -185,7 +185,7 @@ func listenerProtocolToIstio(name gatewayv1.GatewayController, p gatewayv1.Proto
 	case gatewayv1.ProtocolType(protocol.HBONE):
 		if name != constants.ManagedGatewayMeshController && name != constants.ManagedGatewayEastWestController &&
 			name != constants.ManagedAgentgatewayWaypointController && name != constants.ManagedAgentgatewayController {
-			return "", fmt.Errorf("protocol %q is only supported for waypoint proxies", p)
+			return "", fmt.Errorf("protocol %q is only supported for HBONE-enabled gateways/waypoints", p)
 		}
 		return string(p), nil
 	}

--- a/pilot/pkg/config/kube/agentgateway/parentref.go
+++ b/pilot/pkg/config/kube/agentgateway/parentref.go
@@ -43,12 +43,13 @@ type RouteParentReference struct {
 	// OriginalReference contains the original reference
 	OriginalReference gatewayv1.ParentReference
 	// Hostname is the hostname match of the Parent, if any
-	Hostname        string
-	BannedHostnames sets.Set[string]
-	ParentKey       AgwParentKey
-	ParentSection   gatewayv1.SectionName
-	Accepted        bool
-	ParentGateway   types.NamespacedName
+	Hostname               string
+	BannedHostnames        sets.Set[string]
+	ParentKey              AgwParentKey
+	ParentSection          gatewayv1.SectionName
+	Accepted               bool
+	ParentGateway          types.NamespacedName
+	ParentGatewayClassName string
 }
 
 var allowedParentReferences = sets.New(
@@ -237,16 +238,17 @@ func extractParentReferenceInfo(ctx RouteContext, parents RouteParents, obj cont
 			deniedReason := ReferenceAllowed(ctx, pr, kind.Kubernetes(), pk, hostnames, localNamespace)
 
 			rpi := RouteParentReference{
-				ParentGateway:     pr.ParentGateway,
-				InternalName:      pr.InternalName,
-				InternalKind:      ir.Kind,
-				Hostname:          pr.OriginalHostname,
-				DeniedReason:      deniedReason,
-				OriginalReference: ref,
-				BannedHostnames:   bannedHostnames.Copy().Delete(pr.OriginalHostname),
-				ParentKey:         ir,
-				ParentSection:     pr.SectionName,
-				Accepted:          deniedReason == nil,
+				ParentGateway:          pr.ParentGateway,
+				InternalName:           pr.InternalName,
+				InternalKind:           ir.Kind,
+				Hostname:               pr.OriginalHostname,
+				DeniedReason:           deniedReason,
+				OriginalReference:      ref,
+				BannedHostnames:        bannedHostnames.Copy().Delete(pr.OriginalHostname),
+				ParentKey:              ir,
+				ParentSection:          pr.SectionName,
+				Accepted:               deniedReason == nil,
+				ParentGatewayClassName: pr.ParentGatewayClassName,
 			}
 			parentRefs = append(parentRefs, rpi)
 		}

--- a/pilot/pkg/config/kube/agentgateway/policy_collection.go
+++ b/pilot/pkg/config/kube/agentgateway/policy_collection.go
@@ -465,13 +465,22 @@ func btlsMergeAncestors(
 // BuildAncestorBackends extracts backend→gateway relationships from routes.
 // This is used to determine which gateways reference a given backend Service,
 // which is needed for BackendTLSPolicy status reporting.
+// For routes with Gateway parentRefs, the gateway is extracted directly.
+// For routes with Service parentRefs, the gateway is resolved via WaypointServiceBinding
+// (the service's use-waypoint label points to the waypoint gateway).
 // TODO(jaellio): support TCPRoute
 func BuildAncestorBackends(
 	httpRoutes krt.Collection[*gatewayv1.HTTPRoute],
 	grpcRoutes krt.Collection[*gatewayv1.GRPCRoute],
+	waypointBindings krt.Collection[WaypointServiceBinding],
 	opts krt.OptionsBuilder,
 ) krt.Collection[*AncestorBackend] {
-	httpAncestors := krt.NewManyCollection(httpRoutes, func(_ krt.HandlerContext, obj *gatewayv1.HTTPRoute) []*AncestorBackend {
+	// Index waypoint bindings by service key so we can resolve Service parentRef → waypoint gateway
+	bindingsByService := krt.NewIndex(waypointBindings, "btls-by-service", func(b WaypointServiceBinding) []types.NamespacedName {
+		return []types.NamespacedName{b.ServiceKey}
+	})
+
+	httpAncestors := krt.NewManyCollection(httpRoutes, func(ctx krt.HandlerContext, obj *gatewayv1.HTTPRoute) []*AncestorBackend {
 		source := TypedResource{
 			Kind: gvk.HTTPRoute,
 			Name: types.NamespacedName{
@@ -480,6 +489,8 @@ func BuildAncestorBackends(
 			},
 		}
 		gateways := extractGatewayRefs(obj.Namespace, obj.Spec.ParentRefs)
+		// Also resolve Service parentRefs to waypoint gateways via WaypointServiceBinding
+		gateways.Merge(extractWaypointGatewayRefs(ctx, obj.Namespace, obj.Spec.ParentRefs, bindingsByService))
 		backends := sets.New[types.NamespacedName]()
 		for _, rule := range obj.Spec.Rules {
 			for _, ref := range rule.BackendRefs {
@@ -496,7 +507,7 @@ func BuildAncestorBackends(
 		return buildAncestorPairs(gateways, backends, source)
 	}, opts.WithName("HTTPRouteAncestorBackends")...)
 
-	grpcAncestors := krt.NewManyCollection(grpcRoutes, func(_ krt.HandlerContext, obj *gatewayv1.GRPCRoute) []*AncestorBackend {
+	grpcAncestors := krt.NewManyCollection(grpcRoutes, func(ctx krt.HandlerContext, obj *gatewayv1.GRPCRoute) []*AncestorBackend {
 		source := TypedResource{
 			Kind: gvk.HTTPRoute,
 			Name: types.NamespacedName{
@@ -505,6 +516,8 @@ func BuildAncestorBackends(
 			},
 		}
 		gateways := extractGatewayRefs(obj.Namespace, obj.Spec.ParentRefs)
+		// Also resolve Service parentRefs to waypoint gateways via WaypointServiceBinding
+		gateways.Merge(extractWaypointGatewayRefs(ctx, obj.Namespace, obj.Spec.ParentRefs, bindingsByService))
 		backends := sets.New[types.NamespacedName]()
 		for _, rule := range obj.Spec.Rules {
 			for _, ref := range rule.BackendRefs {
@@ -539,6 +552,35 @@ func extractGatewayRefs(defaultNS string, refs []gatewayv1.ParentReference) sets
 			ns = string(*r.Namespace)
 		}
 		gateways.Insert(types.NamespacedName{Namespace: ns, Name: string(r.Name)})
+	}
+	return gateways
+}
+
+// extractWaypointGatewayRefs resolves Service parentRefs to waypoint gateways via WaypointServiceBinding.
+// For each Service parentRef, if the service has a use-waypoint label pointing to a waypoint gateway,
+// that gateway is included in the result set.
+func extractWaypointGatewayRefs(
+	ctx krt.HandlerContext,
+	defaultNS string,
+	refs []gatewayv1.ParentReference,
+	bindingsByService krt.Index[types.NamespacedName, WaypointServiceBinding],
+) sets.Set[types.NamespacedName] {
+	gateways := sets.New[types.NamespacedName]()
+	for _, r := range refs {
+		if r.Kind == nil || *r.Kind != "Service" {
+			continue
+		}
+		if r.Group != nil && *r.Group != "" {
+			continue
+		}
+		ns := defaultNS
+		if r.Namespace != nil {
+			ns = string(*r.Namespace)
+		}
+		svcKey := types.NamespacedName{Namespace: ns, Name: string(r.Name)}
+		for _, b := range bindingsByService.Fetch(ctx, svcKey) {
+			gateways.Insert(b.WaypointGateway)
+		}
 	}
 	return gateways
 }

--- a/pilot/pkg/config/kube/agentgateway/policy_collection.go
+++ b/pilot/pkg/config/kube/agentgateway/policy_collection.go
@@ -509,7 +509,7 @@ func BuildAncestorBackends(
 
 	grpcAncestors := krt.NewManyCollection(grpcRoutes, func(ctx krt.HandlerContext, obj *gatewayv1.GRPCRoute) []*AncestorBackend {
 		source := TypedResource{
-			Kind: gvk.HTTPRoute,
+			Kind: gvk.GRPCRoute,
 			Name: types.NamespacedName{
 				Namespace: obj.Namespace,
 				Name:      obj.Name,

--- a/pilot/pkg/config/kube/agentgateway/route_collections.go
+++ b/pilot/pkg/config/kube/agentgateway/route_collections.go
@@ -52,7 +52,6 @@ type RouteContext struct {
 type RouteContextInputs struct {
 	Grants         gatewaycommon.ReferenceGrants
 	RouteParents   RouteParents
-	ControllerName string
 	DomainSuffix   string
 	Services       krt.Collection[*corev1.Service]
 	Namespaces     krt.Collection[*corev1.Namespace]
@@ -93,6 +92,8 @@ func (r RouteAttachment) Equals(other RouteAttachment) bool {
 
 // gatewayRouteAttachmentCountCollection holds the generic logic to determine the parents a route is attached to, used for
 // computing the aggregated `attachedRoutes` status in Gateway.
+// TODO(jaellio): update to support attachment to services and mapping from gateways (that are waypoints) to
+// routes belonging to services from by the respective gateways/waypoints
 func gatewayRouteAttachmentCountCollection[T controllers.Object](
 	inputs RouteContextInputs,
 	col krt.Collection[T],
@@ -217,7 +218,10 @@ func AgwRouteCollection(
 
 	// Join all the route types into a single collection
 	routes := krt.JoinCollection([]krt.Collection[AgwResource]{httpRoutes, grpcRoutes, tcpRoutes, tlsRoutes}, krtopts.WithName("ADPRoutes")...)
-
+	// TODO(jaellio): Up until this point, we have just found and translated all of the routes - need to verify this included routes
+	// attached to services at their parents.
+	// This is where the actual gateway mapping happens I think. For gateways that are waypoints, I need this to
+	// also include the waypoint bindings/routes belonging to services using those gateways(waypoints)
 	routeAttachments := krt.JoinCollection([]krt.Collection[*RouteAttachment]{
 		gatewayRouteAttachmentCountCollection(inputs, httpRouteCol, gvk.HTTPRoute, krtopts),
 		gatewayRouteAttachmentCountCollection(inputs, grpcRouteCol, gvk.GRPCRoute, krtopts),
@@ -329,7 +333,6 @@ func ToResourceForGateway(gw types.NamespacedName, resource any) AgwResource {
 	}
 }
 
-// TODO(jaellio): Handle Route conditions
 // ProcessParentReferences processes filtered parent references and builds resources per gateway.
 // It emits exactly one ParentStatus per Gateway (aggregate across listeners).
 // If no listeners are allowed, the Accepted reason is:
@@ -442,9 +445,10 @@ func createRouteCollectionGeneric[T controllers.Object, R comparable, ST any](
 				OriginalReference: r.OriginalReference,
 				DeniedReason:      r.DeniedReason,
 				RouteError:        gwResult.Error,
+				ControllerName:    gatewaycommon.GetControllerForAgentgatewayClass(r.ParentGatewayClassName),
 			}
 		})
-		parents := createRouteStatus(rpResults, obj.GetNamespace(), obj.GetGeneration(), inputs.ControllerName, GetCommonRouteStateParents(obj))
+		parents := createRouteStatus(rpResults, obj.GetNamespace(), obj.GetGeneration(), GetCommonRouteStateParents(obj))
 		routeStatus := gatewayv1.RouteStatus{Parents: parents}
 		return ptr.Of(buildStatus(routeStatus)), resources
 	}, krtopts.WithName(collectionName)...)

--- a/pilot/pkg/config/kube/agentgateway/route_collections.go
+++ b/pilot/pkg/config/kube/agentgateway/route_collections.go
@@ -92,8 +92,6 @@ func (r RouteAttachment) Equals(other RouteAttachment) bool {
 
 // gatewayRouteAttachmentCountCollection holds the generic logic to determine the parents a route is attached to, used for
 // computing the aggregated `attachedRoutes` status in Gateway.
-// TODO(jaellio): update to support attachment to services and mapping from gateways (that are waypoints) to
-// routes belonging to services from by the respective gateways/waypoints
 func gatewayRouteAttachmentCountCollection[T controllers.Object](
 	inputs RouteContextInputs,
 	col krt.Collection[T],
@@ -109,15 +107,22 @@ func gatewayRouteAttachmentCountCollection[T controllers.Object](
 
 		parentRefs := extractParentReferenceInfo(ctx, inputs.RouteParents, obj)
 		return slices.MapFilter(FilteredReferences(parentRefs), func(e RouteParentReference) **RouteAttachment {
+			// For Gateway/ListenerSet parentRefs, use ParentKey directly.
+			// For Service/ServiceEntry parentRefs (waypoint routes), use ParentGateway
+			// which is the resolved waypoint gateway.
+			to := types.NamespacedName{
+				Name:      e.ParentKey.Name,
+				Namespace: e.ParentKey.Namespace,
+			}
 			if e.ParentKey.Kind != gvk.KubernetesGateway.Kubernetes() && e.ParentKey.Kind != gvk.ListenerSet.Kubernetes() {
-				return nil
+				if e.ParentGateway == (types.NamespacedName{}) {
+					return nil
+				}
+				to = e.ParentGateway
 			}
 			return ptr.Of(&RouteAttachment{
-				From: from,
-				To: types.NamespacedName{
-					Name:      e.ParentKey.Name,
-					Namespace: e.ParentKey.Namespace,
-				},
+				From:         from,
+				To:           to,
 				ListenerName: string(e.ParentSection),
 			})
 		})
@@ -218,10 +223,6 @@ func AgwRouteCollection(
 
 	// Join all the route types into a single collection
 	routes := krt.JoinCollection([]krt.Collection[AgwResource]{httpRoutes, grpcRoutes, tcpRoutes, tlsRoutes}, krtopts.WithName("ADPRoutes")...)
-	// TODO(jaellio): Up until this point, we have just found and translated all of the routes - need to verify this included routes
-	// attached to services at their parents.
-	// This is where the actual gateway mapping happens I think. For gateways that are waypoints, I need this to
-	// also include the waypoint bindings/routes belonging to services using those gateways(waypoints)
 	routeAttachments := krt.JoinCollection([]krt.Collection[*RouteAttachment]{
 		gatewayRouteAttachmentCountCollection(inputs, httpRouteCol, gvk.HTTPRoute, krtopts),
 		gatewayRouteAttachmentCountCollection(inputs, grpcRouteCol, gvk.GRPCRoute, krtopts),

--- a/pilot/pkg/config/kube/agentgateway/waypoint_collections.go
+++ b/pilot/pkg/config/kube/agentgateway/waypoint_collections.go
@@ -54,7 +54,7 @@ func BuildWaypointServiceBindings(
 	opts krt.OptionsBuilder,
 ) krt.Collection[WaypointServiceBinding] {
 	return krt.NewCollection(services, func(ctx krt.HandlerContext, svc *corev1.Service) *WaypointServiceBinding {
-		// check if the service or it's namespace has the use-waypoint label
+		// check if the service or its namespace has the use-waypoint label
 		wpRef := resolveUseWaypoint(ctx, svc.ObjectMeta, namespaces)
 		if wpRef == nil {
 			return nil

--- a/pilot/pkg/config/kube/agentgateway/waypoint_collections.go
+++ b/pilot/pkg/config/kube/agentgateway/waypoint_collections.go
@@ -1,0 +1,106 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentgateway
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"istio.io/istio/pilot/pkg/config/kube/gatewaycommon"
+	"istio.io/istio/pilot/pkg/serviceregistry/ambient"
+	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/ptr"
+)
+
+// WaypointServiceBinding maps a fronted service to the AGW waypoint Gateway that fronts it.
+type WaypointServiceBinding struct {
+	// ServiceKey is the NamespacedName of the fronted service
+	ServiceKey types.NamespacedName
+	// WaypointGateway is the NamespacedName of the waypoint Gateway
+	WaypointGateway types.NamespacedName
+}
+
+func (w WaypointServiceBinding) ResourceName() string {
+	return w.ServiceKey.String()
+}
+
+func (w WaypointServiceBinding) Equals(other WaypointServiceBinding) bool {
+	return w.ServiceKey == other.ServiceKey && w.WaypointGateway == other.WaypointGateway
+}
+
+// BuildWaypointServiceBindings creates a collection mapping services to their AGW waypoint gateways.
+// For each k8s Service with a use-waypoint label (or inheriting from namespace) pointing to an
+// agentgateway-waypoint class Gateway, a WaypointServiceBinding is created.
+func BuildWaypointServiceBindings(
+	services krt.Collection[*corev1.Service],
+	namespaces krt.Collection[*corev1.Namespace],
+	gateways krt.Collection[*gatewayv1.Gateway],
+	gatewayClasses krt.Collection[gatewaycommon.GatewayClass],
+	opts krt.OptionsBuilder,
+) krt.Collection[WaypointServiceBinding] {
+	return krt.NewCollection(services, func(ctx krt.HandlerContext, svc *corev1.Service) *WaypointServiceBinding {
+		// check if the service or it's namespace has the use-waypoint label
+		wpRef := resolveUseWaypoint(ctx, svc.ObjectMeta, namespaces)
+		if wpRef == nil {
+			return nil
+		}
+
+		// Check if the referenced gateway exists. Ignore otherwise
+		gw := ptr.Flatten(krt.FetchOne(ctx, gateways, krt.FilterKey(wpRef.ResourceName())))
+		if gw == nil {
+			return nil
+		}
+
+		// Check that the gateway has an AGW waypoint class. Ignore otherwise
+		class := gatewaycommon.FetchAgentgatewayClass(ctx, gatewayClasses, gw.Spec.GatewayClassName)
+		if class == nil || class.Controller != constants.ManagedAgentgatewayWaypointController {
+			return nil
+		}
+
+		return &WaypointServiceBinding{
+			ServiceKey:      types.NamespacedName{Namespace: svc.Namespace, Name: svc.Name},
+			WaypointGateway: types.NamespacedName{Namespace: wpRef.Namespace, Name: wpRef.Name},
+		}
+	}, opts.WithName("WaypointServiceBindings")...)
+}
+
+// resolveUseWaypoint looks up the use-waypoint label on a service or its namespace
+// and returns the referenced waypoint gateway, if any.
+func resolveUseWaypoint(
+	ctx krt.HandlerContext,
+	meta metav1.ObjectMeta,
+	namespaces krt.Collection[*corev1.Namespace],
+) *krt.Named {
+	// Check object labels first
+	// These labels take precedence over namespace labels
+	wp, isNone := ambient.GetUseWaypoint(meta, meta.Namespace)
+	if isNone {
+		return nil
+	}
+	if wp != nil {
+		return wp
+	}
+
+	// Fall back to namespace labels
+	ns := ptr.Flatten(krt.FetchOne(ctx, namespaces, krt.FilterKey(meta.Namespace)))
+	if ns == nil {
+		return nil
+	}
+	wp, _ = ambient.GetUseWaypoint(ns.ObjectMeta, meta.Namespace)
+	return wp
+}

--- a/pilot/pkg/config/kube/agentgateway/waypoint_test.go
+++ b/pilot/pkg/config/kube/agentgateway/waypoint_test.go
@@ -1,0 +1,528 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentgateway
+
+import (
+	"testing"
+
+	"github.com/agentgateway/agentgateway/api"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"istio.io/api/label"
+	"istio.io/istio/pilot/pkg/config/kube/gatewaycommon"
+	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/kube/krt/krttest"
+	"istio.io/istio/pkg/ptr"
+	"istio.io/istio/pkg/slices"
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/assert"
+)
+
+func init() {
+	// The agentgateway and waypoint classes are only registered when these features are enabled.
+	// Recompute the package-level class map so the waypoint class is resolvable in tests.
+	features.EnableAgentgateway = true
+	features.EnableAmbientWaypoints = true
+	gatewaycommon.AgentgatewayClasses = gatewaycommon.GetAgentGatewayClasses()
+}
+
+var hboneProtocol = gatewayv1.ProtocolType(protocol.HBONE)
+
+func TestUnexpectedWaypointListener(t *testing.T) {
+	tests := []struct {
+		name string
+		l    gatewayv1.Listener
+		want bool
+	}{
+		{
+			name: "valid HBONE on 15008",
+			l:    gatewayv1.Listener{Port: 15008, Protocol: hboneProtocol},
+			want: false,
+		},
+		{
+			name: "wrong port",
+			l:    gatewayv1.Listener{Port: 8080, Protocol: hboneProtocol},
+			want: true,
+		},
+		{
+			name: "wrong protocol",
+			l:    gatewayv1.Listener{Port: 15008, Protocol: gatewayv1.HTTPProtocolType},
+			want: true,
+		},
+		{
+			name: "wrong port and protocol",
+			l:    gatewayv1.Listener{Port: 80, Protocol: gatewayv1.HTTPProtocolType},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, unexpectedWaypointListener(tt.l), tt.want)
+		})
+	}
+}
+
+func TestListenerProtocolToIstio(t *testing.T) {
+	tests := []struct {
+		name       string
+		controller gatewayv1.GatewayController
+		protocol   gatewayv1.ProtocolType
+		alphaAPI   bool
+		want       string
+		wantErr    bool
+	}{
+		{
+			name:       "HTTP",
+			controller: constants.ManagedAgentgatewayController,
+			protocol:   gatewayv1.HTTPProtocolType,
+			want:       "HTTP",
+		},
+		{
+			name:       "HTTPS",
+			controller: constants.ManagedAgentgatewayController,
+			protocol:   gatewayv1.HTTPSProtocolType,
+			want:       "HTTPS",
+		},
+		{
+			name:       "TLS",
+			controller: constants.ManagedAgentgatewayController,
+			protocol:   gatewayv1.TLSProtocolType,
+			want:       "TLS",
+		},
+		{
+			name:       "HBONE allowed for agentgateway waypoint controller",
+			controller: constants.ManagedAgentgatewayWaypointController,
+			protocol:   hboneProtocol,
+			want:       string(hboneProtocol),
+		},
+		{
+			name:       "HBONE allowed for agentgateway controller",
+			controller: constants.ManagedAgentgatewayController,
+			protocol:   hboneProtocol,
+			want:       string(hboneProtocol),
+		},
+		{
+			name:       "HBONE rejected for unrelated controller",
+			controller: gatewayv1.GatewayController("example.com/other"),
+			protocol:   hboneProtocol,
+			wantErr:    true,
+		},
+		{
+			name:       "TCP allowed when alpha API enabled",
+			controller: constants.ManagedAgentgatewayController,
+			protocol:   gatewayv1.TCPProtocolType,
+			alphaAPI:   true,
+			want:       "TCP",
+		},
+		{
+			name:       "TCP rejected when alpha API disabled",
+			controller: constants.ManagedAgentgatewayController,
+			protocol:   gatewayv1.TCPProtocolType,
+			alphaAPI:   false,
+			wantErr:    true,
+		},
+		{
+			name:       "lowercase protocol returns uppercase hint",
+			controller: constants.ManagedAgentgatewayController,
+			protocol:   gatewayv1.ProtocolType("http"),
+			wantErr:    true,
+		},
+		{
+			name:       "unsupported protocol",
+			controller: constants.ManagedAgentgatewayController,
+			protocol:   gatewayv1.UDPProtocolType,
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			test.SetForTest(t, &features.EnableAlphaGatewayAPI, tt.alphaAPI)
+			got, err := listenerProtocolToIstio(tt.controller, tt.protocol)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}
+
+func TestGetTunnelProtocol(t *testing.T) {
+	c := &Controller{}
+	tests := []struct {
+		name      string
+		protocol  gatewayv1.ProtocolType
+		className string
+		want      api.Bind_TunnelProtocol
+	}{
+		{
+			name:      "HBONE waypoint uses HBONE_WAYPOINT",
+			protocol:  hboneProtocol,
+			className: constants.AgentgatewayWaypointClassName,
+			want:      api.Bind_HBONE_WAYPOINT,
+		},
+		{
+			name:      "HBONE non-waypoint uses HBONE_GATEWAY",
+			protocol:  hboneProtocol,
+			className: constants.AgentgatewayClassName,
+			want:      api.Bind_HBONE_GATEWAY,
+		},
+		{
+			name:      "non-HBONE uses DIRECT",
+			protocol:  gatewayv1.HTTPProtocolType,
+			className: constants.AgentgatewayClassName,
+			want:      api.Bind_DIRECT,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := &GatewayListener{
+				ParentInfo: AgwParentInfo{
+					Protocol:               tt.protocol,
+					ParentGatewayClassName: tt.className,
+				},
+			}
+			assert.Equal(t, c.getTunnelProtocol(obj), tt.want)
+		})
+	}
+}
+
+func TestGetBindProtocol(t *testing.T) {
+	c := &Controller{}
+	tests := []struct {
+		name     string
+		protocol gatewayv1.ProtocolType
+		want     api.Bind_Protocol
+	}{
+		{name: "HTTP", protocol: gatewayv1.HTTPProtocolType, want: api.Bind_HTTP},
+		{name: "HTTPS", protocol: gatewayv1.HTTPSProtocolType, want: api.Bind_TLS},
+		{name: "TLS", protocol: gatewayv1.TLSProtocolType, want: api.Bind_TLS},
+		{name: "TCP", protocol: gatewayv1.TCPProtocolType, want: api.Bind_TCP},
+		{name: "HBONE placeholder is HTTP", protocol: hboneProtocol, want: api.Bind_HTTP},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := &GatewayListener{ParentInfo: AgwParentInfo{Protocol: tt.protocol}}
+			assert.Equal(t, c.getBindProtocol(obj), tt.want)
+		})
+	}
+}
+
+func TestAgwParentInfoIsWaypoint(t *testing.T) {
+	tests := []struct {
+		name      string
+		className string
+		want      bool
+	}{
+		{name: "waypoint class", className: constants.AgentgatewayWaypointClassName, want: true},
+		{name: "regular agentgateway class", className: constants.AgentgatewayClassName, want: false},
+		{name: "empty class", className: "", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := AgwParentInfo{ParentGatewayClassName: tt.className}
+			assert.Equal(t, info.IsWaypoint(), tt.want)
+		})
+	}
+}
+
+// test helpers for building inputs
+
+func testService(ns, name string, labels map[string]string) *corev1.Service {
+	return &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name, Labels: labels}}
+}
+
+func testNamespace(name string, labels map[string]string) *corev1.Namespace {
+	return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels}}
+}
+
+func testGateway(ns, name, class string) *gatewayv1.Gateway {
+	return &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
+		Spec:       gatewayv1.GatewaySpec{GatewayClassName: gatewayv1.ObjectName(class)},
+	}
+}
+
+func staticCol[T any](opts krt.OptionsBuilder, name string, items ...T) krt.Collection[T] {
+	return krt.NewStaticCollection(nil, items, opts.WithName(name)...)
+}
+
+func TestBuildWaypointServiceBindings(t *testing.T) {
+	useWaypoint := func(wp string) map[string]string {
+		return map[string]string{label.IoIstioUseWaypoint.Name: wp}
+	}
+	tests := []struct {
+		name       string
+		services   []*corev1.Service
+		namespaces []*corev1.Namespace
+		gateways   []*gatewayv1.Gateway
+		want       []WaypointServiceBinding
+	}{
+		{
+			name:       "service labeled with existing waypoint gateway",
+			services:   []*corev1.Service{testService("ns1", "svc1", useWaypoint("wp"))},
+			namespaces: []*corev1.Namespace{testNamespace("ns1", nil)},
+			gateways:   []*gatewayv1.Gateway{testGateway("ns1", "wp", constants.AgentgatewayWaypointClassName)},
+			want: []WaypointServiceBinding{{
+				ServiceKey:      types.NamespacedName{Namespace: "ns1", Name: "svc1"},
+				WaypointGateway: types.NamespacedName{Namespace: "ns1", Name: "wp"},
+			}},
+		},
+		{
+			name:       "service without label produces no binding",
+			services:   []*corev1.Service{testService("ns1", "svc1", nil)},
+			namespaces: []*corev1.Namespace{testNamespace("ns1", nil)},
+			gateways:   []*gatewayv1.Gateway{testGateway("ns1", "wp", constants.AgentgatewayWaypointClassName)},
+			want:       nil,
+		},
+		{
+			name:       "labeled service but waypoint gateway missing",
+			services:   []*corev1.Service{testService("ns1", "svc1", useWaypoint("wp"))},
+			namespaces: []*corev1.Namespace{testNamespace("ns1", nil)},
+			gateways:   nil,
+			want:       nil,
+		},
+		{
+			name:       "labeled service but gateway is not a waypoint class",
+			services:   []*corev1.Service{testService("ns1", "svc1", useWaypoint("wp"))},
+			namespaces: []*corev1.Namespace{testNamespace("ns1", nil)},
+			gateways:   []*gatewayv1.Gateway{testGateway("ns1", "wp", constants.AgentgatewayClassName)},
+			want:       nil,
+		},
+		{
+			name:       "namespace label inherited by service",
+			services:   []*corev1.Service{testService("ns1", "svc1", nil)},
+			namespaces: []*corev1.Namespace{testNamespace("ns1", useWaypoint("wp"))},
+			gateways:   []*gatewayv1.Gateway{testGateway("ns1", "wp", constants.AgentgatewayWaypointClassName)},
+			want: []WaypointServiceBinding{{
+				ServiceKey:      types.NamespacedName{Namespace: "ns1", Name: "svc1"},
+				WaypointGateway: types.NamespacedName{Namespace: "ns1", Name: "wp"},
+			}},
+		},
+		{
+			name:       "use-waypoint none opts out",
+			services:   []*corev1.Service{testService("ns1", "svc1", useWaypoint("none"))},
+			namespaces: []*corev1.Namespace{testNamespace("ns1", useWaypoint("wp"))},
+			gateways:   []*gatewayv1.Gateway{testGateway("ns1", "wp", constants.AgentgatewayWaypointClassName)},
+			want:       nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := krttest.Options(t)
+			gatewayClasses := staticCol[gatewaycommon.GatewayClass](opts, "GatewayClasses")
+			bindings := BuildWaypointServiceBindings(
+				staticCol(opts, "Services", tt.services...),
+				staticCol(opts, "Namespaces", tt.namespaces...),
+				staticCol(opts, "Gateways", tt.gateways...),
+				gatewayClasses,
+				opts,
+			)
+			bindings.WaitUntilSynced(test.NewStop(t))
+			got := slices.SortBy(bindings.List(), func(b WaypointServiceBinding) string { return b.ResourceName() })
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}
+
+func TestExtractWaypointGatewayRefs(t *testing.T) {
+	opts := krttest.Options(t)
+	bindings := staticCol(opts, "Bindings",
+		WaypointServiceBinding{
+			ServiceKey:      types.NamespacedName{Namespace: "ns1", Name: "svc1"},
+			WaypointGateway: types.NamespacedName{Namespace: "ns1", Name: "wp1"},
+		},
+		WaypointServiceBinding{
+			ServiceKey:      types.NamespacedName{Namespace: "ns2", Name: "svc2"},
+			WaypointGateway: types.NamespacedName{Namespace: "ns2", Name: "wp2"},
+		},
+	)
+	bindings.WaitUntilSynced(test.NewStop(t))
+	idx := krt.NewIndex(bindings, "by-service", func(b WaypointServiceBinding) []types.NamespacedName {
+		return []types.NamespacedName{b.ServiceKey}
+	})
+
+	serviceRef := func(ns, name string) gatewayv1.ParentReference {
+		ref := gatewayv1.ParentReference{Kind: ptr.Of(gatewayv1.Kind("Service")), Name: gatewayv1.ObjectName(name)}
+		if ns != "" {
+			ref.Namespace = ptr.Of(gatewayv1.Namespace(ns))
+		}
+		return ref
+	}
+
+	tests := []struct {
+		name      string
+		defaultNS string
+		refs      []gatewayv1.ParentReference
+		want      []types.NamespacedName
+	}{
+		{
+			name:      "service ref in default namespace resolves to waypoint",
+			defaultNS: "ns1",
+			refs:      []gatewayv1.ParentReference{serviceRef("", "svc1")},
+			want:      []types.NamespacedName{{Namespace: "ns1", Name: "wp1"}},
+		},
+		{
+			name:      "cross-namespace service ref resolves to waypoint",
+			defaultNS: "ns1",
+			refs:      []gatewayv1.ParentReference{serviceRef("ns2", "svc2")},
+			want:      []types.NamespacedName{{Namespace: "ns2", Name: "wp2"}},
+		},
+		{
+			name:      "gateway kind ref is ignored",
+			defaultNS: "ns1",
+			refs:      []gatewayv1.ParentReference{{Kind: ptr.Of(gatewayv1.Kind("Gateway")), Name: "gw"}},
+			want:      nil,
+		},
+		{
+			name:      "service ref with non-core group is ignored",
+			defaultNS: "ns1",
+			refs: []gatewayv1.ParentReference{{
+				Group: ptr.Of(gatewayv1.Group("example.com")),
+				Kind:  ptr.Of(gatewayv1.Kind("Service")),
+				Name:  "svc1",
+			}},
+			want: nil,
+		},
+		{
+			name:      "service ref without binding resolves to nothing",
+			defaultNS: "ns1",
+			refs:      []gatewayv1.ParentReference{serviceRef("", "unbound")},
+			want:      nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractWaypointGatewayRefs(krt.TestingDummyContext{}, tt.defaultNS, tt.refs, idx)
+			gotList := slices.SortBy(got.UnsortedList(), func(n types.NamespacedName) string { return n.String() })
+			assert.Equal(t, gotList, tt.want)
+		})
+	}
+}
+
+func TestRouteParentsFetchServiceParent(t *testing.T) {
+	opts := krttest.Options(t)
+	wpParentInfo := AgwParentInfo{
+		ParentGateway:          types.NamespacedName{Namespace: "ns1", Name: "wp"},
+		ParentGatewayClassName: constants.AgentgatewayWaypointClassName,
+		Protocol:               hboneProtocol,
+		Port:                   15008,
+	}
+	wpKey := AgwParentKey{Kind: gvk.KubernetesGateway.Kubernetes(), Namespace: "ns1", Name: "wp"}
+	gateways := staticCol(opts, "Gateways", &GatewayListener{
+		Name:          "ns1/wp",
+		ParentGateway: types.NamespacedName{Namespace: "ns1", Name: "wp"},
+		ParentObject:  wpKey,
+		ParentInfo:    wpParentInfo,
+		Valid:         true,
+	})
+	gateways.WaitUntilSynced(test.NewStop(t))
+	bindings := staticCol(opts, "Bindings", WaypointServiceBinding{
+		ServiceKey:      types.NamespacedName{Namespace: "ns1", Name: "svc1"},
+		WaypointGateway: types.NamespacedName{Namespace: "ns1", Name: "wp"},
+	})
+	bindings.WaitUntilSynced(test.NewStop(t))
+	parents := BuildRouteParents(gateways, bindings)
+
+	t.Run("service parent resolves to waypoint listeners", func(t *testing.T) {
+		svcKey := AgwParentKey{Kind: gvk.Service.Kubernetes(), Namespace: "ns1", Name: "svc1"}
+		got := parents.fetch(krt.TestingDummyContext{}, svcKey)
+		assert.Equal(t, len(got), 1)
+		assert.Equal(t, got[0].ParentGateway, types.NamespacedName{Namespace: "ns1", Name: "wp"})
+	})
+
+	t.Run("service parent without binding resolves to nothing", func(t *testing.T) {
+		svcKey := AgwParentKey{Kind: gvk.Service.Kubernetes(), Namespace: "ns1", Name: "other"}
+		got := parents.fetch(krt.TestingDummyContext{}, svcKey)
+		assert.Equal(t, len(got), 0)
+	})
+
+	t.Run("gateway parent resolves via gateway index", func(t *testing.T) {
+		got := parents.fetch(krt.TestingDummyContext{}, wpKey)
+		assert.Equal(t, len(got), 1)
+		assert.Equal(t, got[0].ParentGateway, types.NamespacedName{Namespace: "ns1", Name: "wp"})
+	})
+}
+
+func TestBuildAncestorBackends(t *testing.T) {
+	gatewayRef := gatewayv1.ParentReference{Kind: ptr.Of(gatewayv1.Kind("Gateway")), Name: "gw"}
+	serviceRef := gatewayv1.ParentReference{Kind: ptr.Of(gatewayv1.Kind("Service")), Name: "svc1"}
+	backend := func(name string, kind *gatewayv1.Kind) gatewayv1.BackendRef {
+		return gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: gatewayv1.ObjectName(name), Kind: kind}}
+	}
+
+	httpRoute := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "httproute"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			// The route targets a Service that is assigned (via use-waypoint) to a waypoint gateway.
+			// It must resolve to that waypoint gateway, not a directly-referenced Gateway.
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{ParentRefs: []gatewayv1.ParentReference{serviceRef}},
+			Rules: []gatewayv1.HTTPRouteRule{{
+				BackendRefs: []gatewayv1.HTTPBackendRef{
+					{BackendRef: backend("be", nil)},
+					{BackendRef: backend("ignored", ptr.Of(gatewayv1.Kind("ServiceImport")))},
+				},
+			}},
+		},
+	}
+	grpcRoute := &gatewayv1.GRPCRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "grpcroute"},
+		Spec: gatewayv1.GRPCRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{ParentRefs: []gatewayv1.ParentReference{gatewayRef}},
+			Rules: []gatewayv1.GRPCRouteRule{{
+				BackendRefs: []gatewayv1.GRPCBackendRef{{BackendRef: backend("be", nil)}},
+			}},
+		},
+	}
+
+	opts := krttest.Options(t)
+	bindings := staticCol(opts, "Bindings", WaypointServiceBinding{
+		ServiceKey:      types.NamespacedName{Namespace: "ns1", Name: "svc1"},
+		WaypointGateway: types.NamespacedName{Namespace: "ns1", Name: "wp"},
+	})
+	bindings.WaitUntilSynced(test.NewStop(t))
+
+	ancestors := BuildAncestorBackends(
+		staticCol(opts, "HTTPRoutes", httpRoute),
+		staticCol(opts, "GRPCRoutes", grpcRoute),
+		bindings,
+		opts,
+	)
+	ancestors.WaitUntilSynced(test.NewStop(t))
+
+	got := slices.Sort(slices.Map(ancestors.List(), func(a *AncestorBackend) string { return a.ResourceName() }))
+
+	gw := types.NamespacedName{Namespace: "ns1", Name: "gw"}
+	wp := types.NamespacedName{Namespace: "ns1", Name: "wp"}
+	be := types.NamespacedName{Namespace: "ns1", Name: "be"}
+	httpSrc := TypedResource{Kind: gvk.HTTPRoute, Name: types.NamespacedName{Namespace: "ns1", Name: "httproute"}}
+	grpcSrc := TypedResource{Kind: gvk.GRPCRoute, Name: types.NamespacedName{Namespace: "ns1", Name: "grpcroute"}}
+
+	want := slices.Sort([]string{
+		// HTTPRoute: Service parentRef resolved to the waypoint gateway, paired with the be backend.
+		AncestorBackend{Gateway: wp, Backend: be, Source: httpSrc}.ResourceName(),
+		// GRPCRoute: Gateway parentRef paired with the be backend.
+		AncestorBackend{Gateway: gw, Backend: be, Source: grpcSrc}.ResourceName(),
+	})
+	assert.Equal(t, got, want)
+}

--- a/pilot/pkg/config/kube/agentgateway/waypoint_test.go
+++ b/pilot/pkg/config/kube/agentgateway/waypoint_test.go
@@ -246,19 +246,19 @@ func TestAgwParentInfoIsWaypoint(t *testing.T) {
 	}
 }
 
-// test helpers for building inputs
+// test helpers for building inputs. All inputs live in the "ns1" namespace.
 
-func testService(ns, name string, labels map[string]string) *corev1.Service {
-	return &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name, Labels: labels}}
+func testService(name string, labels map[string]string) *corev1.Service {
+	return &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: name, Labels: labels}}
 }
 
-func testNamespace(name string, labels map[string]string) *corev1.Namespace {
-	return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels}}
+func testNamespace(labels map[string]string) *corev1.Namespace {
+	return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns1", Labels: labels}}
 }
 
-func testGateway(ns, name, class string) *gatewayv1.Gateway {
+func testGateway(name, class string) *gatewayv1.Gateway {
 	return &gatewayv1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: name},
 		Spec:       gatewayv1.GatewaySpec{GatewayClassName: gatewayv1.ObjectName(class)},
 	}
 }
@@ -280,9 +280,9 @@ func TestBuildWaypointServiceBindings(t *testing.T) {
 	}{
 		{
 			name:       "service labeled with existing waypoint gateway",
-			services:   []*corev1.Service{testService("ns1", "svc1", useWaypoint("wp"))},
-			namespaces: []*corev1.Namespace{testNamespace("ns1", nil)},
-			gateways:   []*gatewayv1.Gateway{testGateway("ns1", "wp", constants.AgentgatewayWaypointClassName)},
+			services:   []*corev1.Service{testService("svc1", useWaypoint("wp"))},
+			namespaces: []*corev1.Namespace{testNamespace(nil)},
+			gateways:   []*gatewayv1.Gateway{testGateway("wp", constants.AgentgatewayWaypointClassName)},
 			want: []WaypointServiceBinding{{
 				ServiceKey:      types.NamespacedName{Namespace: "ns1", Name: "svc1"},
 				WaypointGateway: types.NamespacedName{Namespace: "ns1", Name: "wp"},
@@ -290,30 +290,30 @@ func TestBuildWaypointServiceBindings(t *testing.T) {
 		},
 		{
 			name:       "service without label produces no binding",
-			services:   []*corev1.Service{testService("ns1", "svc1", nil)},
-			namespaces: []*corev1.Namespace{testNamespace("ns1", nil)},
-			gateways:   []*gatewayv1.Gateway{testGateway("ns1", "wp", constants.AgentgatewayWaypointClassName)},
+			services:   []*corev1.Service{testService("svc1", nil)},
+			namespaces: []*corev1.Namespace{testNamespace(nil)},
+			gateways:   []*gatewayv1.Gateway{testGateway("wp", constants.AgentgatewayWaypointClassName)},
 			want:       nil,
 		},
 		{
 			name:       "labeled service but waypoint gateway missing",
-			services:   []*corev1.Service{testService("ns1", "svc1", useWaypoint("wp"))},
-			namespaces: []*corev1.Namespace{testNamespace("ns1", nil)},
+			services:   []*corev1.Service{testService("svc1", useWaypoint("wp"))},
+			namespaces: []*corev1.Namespace{testNamespace(nil)},
 			gateways:   nil,
 			want:       nil,
 		},
 		{
 			name:       "labeled service but gateway is not a waypoint class",
-			services:   []*corev1.Service{testService("ns1", "svc1", useWaypoint("wp"))},
-			namespaces: []*corev1.Namespace{testNamespace("ns1", nil)},
-			gateways:   []*gatewayv1.Gateway{testGateway("ns1", "wp", constants.AgentgatewayClassName)},
+			services:   []*corev1.Service{testService("svc1", useWaypoint("wp"))},
+			namespaces: []*corev1.Namespace{testNamespace(nil)},
+			gateways:   []*gatewayv1.Gateway{testGateway("wp", constants.AgentgatewayClassName)},
 			want:       nil,
 		},
 		{
 			name:       "namespace label inherited by service",
-			services:   []*corev1.Service{testService("ns1", "svc1", nil)},
-			namespaces: []*corev1.Namespace{testNamespace("ns1", useWaypoint("wp"))},
-			gateways:   []*gatewayv1.Gateway{testGateway("ns1", "wp", constants.AgentgatewayWaypointClassName)},
+			services:   []*corev1.Service{testService("svc1", nil)},
+			namespaces: []*corev1.Namespace{testNamespace(useWaypoint("wp"))},
+			gateways:   []*gatewayv1.Gateway{testGateway("wp", constants.AgentgatewayWaypointClassName)},
 			want: []WaypointServiceBinding{{
 				ServiceKey:      types.NamespacedName{Namespace: "ns1", Name: "svc1"},
 				WaypointGateway: types.NamespacedName{Namespace: "ns1", Name: "wp"},
@@ -321,9 +321,9 @@ func TestBuildWaypointServiceBindings(t *testing.T) {
 		},
 		{
 			name:       "use-waypoint none opts out",
-			services:   []*corev1.Service{testService("ns1", "svc1", useWaypoint("none"))},
-			namespaces: []*corev1.Namespace{testNamespace("ns1", useWaypoint("wp"))},
-			gateways:   []*gatewayv1.Gateway{testGateway("ns1", "wp", constants.AgentgatewayWaypointClassName)},
+			services:   []*corev1.Service{testService("svc1", useWaypoint("none"))},
+			namespaces: []*corev1.Namespace{testNamespace(useWaypoint("wp"))},
+			gateways:   []*gatewayv1.Gateway{testGateway("wp", constants.AgentgatewayWaypointClassName)},
 			want:       nil,
 		},
 	}

--- a/pilot/pkg/config/kube/agentgateway/waypoint_test.go
+++ b/pilot/pkg/config/kube/agentgateway/waypoint_test.go
@@ -248,8 +248,8 @@ func TestAgwParentInfoIsWaypoint(t *testing.T) {
 
 // test helpers for building inputs. All inputs live in the "ns1" namespace.
 
-func testService(name string, labels map[string]string) *corev1.Service {
-	return &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: name, Labels: labels}}
+func testService(labels map[string]string) *corev1.Service {
+	return &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "svc1", Labels: labels}}
 }
 
 func testNamespace(labels map[string]string) *corev1.Namespace {
@@ -280,7 +280,7 @@ func TestBuildWaypointServiceBindings(t *testing.T) {
 	}{
 		{
 			name:       "service labeled with existing waypoint gateway",
-			services:   []*corev1.Service{testService("svc1", useWaypoint("wp"))},
+			services:   []*corev1.Service{testService(useWaypoint("wp"))},
 			namespaces: []*corev1.Namespace{testNamespace(nil)},
 			gateways:   []*gatewayv1.Gateway{testGateway("wp", constants.AgentgatewayWaypointClassName)},
 			want: []WaypointServiceBinding{{
@@ -290,28 +290,28 @@ func TestBuildWaypointServiceBindings(t *testing.T) {
 		},
 		{
 			name:       "service without label produces no binding",
-			services:   []*corev1.Service{testService("svc1", nil)},
+			services:   []*corev1.Service{testService(nil)},
 			namespaces: []*corev1.Namespace{testNamespace(nil)},
 			gateways:   []*gatewayv1.Gateway{testGateway("wp", constants.AgentgatewayWaypointClassName)},
 			want:       nil,
 		},
 		{
 			name:       "labeled service but waypoint gateway missing",
-			services:   []*corev1.Service{testService("svc1", useWaypoint("wp"))},
+			services:   []*corev1.Service{testService(useWaypoint("wp"))},
 			namespaces: []*corev1.Namespace{testNamespace(nil)},
 			gateways:   nil,
 			want:       nil,
 		},
 		{
 			name:       "labeled service but gateway is not a waypoint class",
-			services:   []*corev1.Service{testService("svc1", useWaypoint("wp"))},
+			services:   []*corev1.Service{testService(useWaypoint("gw"))},
 			namespaces: []*corev1.Namespace{testNamespace(nil)},
-			gateways:   []*gatewayv1.Gateway{testGateway("wp", constants.AgentgatewayClassName)},
+			gateways:   []*gatewayv1.Gateway{testGateway("gw", constants.AgentgatewayClassName)},
 			want:       nil,
 		},
 		{
 			name:       "namespace label inherited by service",
-			services:   []*corev1.Service{testService("svc1", nil)},
+			services:   []*corev1.Service{testService(nil)},
 			namespaces: []*corev1.Namespace{testNamespace(useWaypoint("wp"))},
 			gateways:   []*gatewayv1.Gateway{testGateway("wp", constants.AgentgatewayWaypointClassName)},
 			want: []WaypointServiceBinding{{
@@ -321,7 +321,7 @@ func TestBuildWaypointServiceBindings(t *testing.T) {
 		},
 		{
 			name:       "use-waypoint none opts out",
-			services:   []*corev1.Service{testService("svc1", useWaypoint("none"))},
+			services:   []*corev1.Service{testService(useWaypoint("none"))},
 			namespaces: []*corev1.Namespace{testNamespace(useWaypoint("wp"))},
 			gateways:   []*gatewayv1.Gateway{testGateway("wp", constants.AgentgatewayWaypointClassName)},
 			want:       nil,

--- a/pilot/pkg/config/kube/gateway/backend_policies.go
+++ b/pilot/pkg/config/kube/gateway/backend_policies.go
@@ -700,7 +700,7 @@ func setAncestorStatus(
 	return gw.PolicyAncestorStatus{
 		AncestorRef:    pr,
 		ControllerName: controller,
-		Conditions:     setConditions(generation, currentConds, conds),
+		Conditions:     gatewaycommon.SetResourceConditions(generation, currentConds, toSharedConditions(conds)),
 	}
 }
 

--- a/pilot/pkg/config/kube/gateway/conditions.go
+++ b/pilot/pkg/config/kube/gateway/conditions.go
@@ -21,8 +21,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8s "sigs.k8s.io/gateway-api/apis/v1"
 
+	"istio.io/istio/pilot/pkg/config/kube/gatewaycommon"
 	"istio.io/istio/pilot/pkg/features"
-	"istio.io/istio/pilot/pkg/model/kstatus"
 	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/sets"
@@ -191,7 +191,7 @@ func createRouteStatus(
 		ns := k8s.RouteParentStatus{
 			ParentRef:      gw.OriginalReference,
 			ControllerName: k8s.GatewayController(features.ManagedGatewayController),
-			Conditions:     setConditions(generation, currentConditions, conds),
+			Conditions:     gatewaycommon.SetListenerConditions(generation, currentConditions, toSharedConditions(conds)),
 		}
 		// Parent ref already exists, insert in the same place
 		if idx, f := parentIndexes[myRef]; f {
@@ -307,51 +307,6 @@ type condition struct {
 	error *ConfigError
 	// setOnce, if enabled, will only set the condition if it is not yet present or set to this reason
 	setOnce string
-}
-
-// setConditions sets the existingConditions with the new conditions
-func setConditions(generation int64, existingConditions []metav1.Condition, conditions map[string]*condition) []metav1.Condition {
-	// Sort keys for deterministic ordering
-	for _, k := range slices.Sort(maps.Keys(conditions)) {
-		cond := conditions[k]
-		setter := kstatus.UpdateConditionIfChanged
-		if cond.setOnce != "" {
-			setter = func(conditions []metav1.Condition, condition metav1.Condition) []metav1.Condition {
-				return kstatus.CreateCondition(conditions, condition, cond.setOnce)
-			}
-		}
-		// A condition can be "negative polarity" (ex: ListenerInvalid) or "positive polarity" (ex:
-		// ListenerValid), so in order to determine the status we should set each `condition` defines its
-		// default positive status. When there is an error, we will invert that. Example: If we have
-		// condition ListenerInvalid, the status will be set to StatusFalse. If an error is reported, it
-		// will be inverted to StatusTrue to indicate listeners are invalid. See
-		// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
-		// for more information
-		if cond.error != nil {
-			existingConditions = setter(existingConditions, metav1.Condition{
-				Type:               k,
-				Status:             kstatus.InvertStatus(cond.status),
-				ObservedGeneration: generation,
-				LastTransitionTime: metav1.Now(),
-				Reason:             cond.error.Reason,
-				Message:            cond.error.Message,
-			})
-		} else {
-			status := cond.status
-			if status == "" {
-				status = kstatus.StatusTrue
-			}
-			existingConditions = setter(existingConditions, metav1.Condition{
-				Type:               k,
-				Status:             status,
-				ObservedGeneration: generation,
-				LastTransitionTime: metav1.Now(),
-				Reason:             cond.reason,
-				Message:            cond.message,
-			})
-		}
-	}
-	return existingConditions
 }
 
 func FilterInPlaceByIndex[E any](s []E, keep func(int) bool) []E {

--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -1873,7 +1873,7 @@ func reportGatewayStatus(
 		}
 	}
 	gs.Listeners = listeners
-	gs.Conditions = setConditions(obj.Generation, gs.Conditions, gatewayConditions)
+	gs.Conditions = gatewaycommon.SetListenerConditions(obj.Generation, gs.Conditions, toSharedConditions(gatewayConditions))
 }
 
 func setProgrammedCondition(gatewayConditions map[string]*condition, internal []string, gatewayServices []string, warnings []string, allUsable bool) {
@@ -1883,6 +1883,16 @@ func setProgrammedCondition(gatewayConditions map[string]*condition, internal []
 	}
 	gatewaycommon.SetProgrammedCondition(mapped, internal, gatewayServices, warnings, allUsable)
 	applyConditionFromListenerStatus(programmed, mapped[string(k8s.GatewayConditionProgrammed)])
+}
+
+// toSharedConditions converts a map of local conditions into the
+// shared gatewaycommon representation used by SetListenerConditions.
+func toSharedConditions(in map[string]*condition) map[string]*gatewaycommon.ListenerStatusCondition {
+	out := make(map[string]*gatewaycommon.ListenerStatusCondition, len(in))
+	for k, c := range in {
+		out[k] = listenerStatusConditionFromCondition(c)
+	}
+	return out
 }
 
 func listenerStatusConditionFromCondition(c *condition) *gatewaycommon.ListenerStatusCondition {
@@ -1923,15 +1933,15 @@ func reportUnmanagedGatewayStatus(
 	status *k8s.GatewayStatus,
 	obj *k8s.Gateway,
 ) {
-	gatewayConditions := map[string]*condition{
+	gatewayConditions := map[string]*gatewaycommon.ListenerStatusCondition{
 		string(k8s.GatewayConditionAccepted): {
-			reason:  string(k8s.GatewayReasonAccepted),
-			message: "Resource accepted",
+			Reason:  string(k8s.GatewayReasonAccepted),
+			Message: "Resource accepted",
 		},
 		string(k8s.GatewayConditionProgrammed): {
-			reason: string(k8s.GatewayReasonProgrammed),
+			Reason: string(k8s.GatewayReasonProgrammed),
 			// Set to true anyway since this is basically declaring it as valid
-			message: "This Gateway is remote; Istio will not program it",
+			Message: "This Gateway is remote; Istio will not program it",
 		},
 	}
 
@@ -1939,7 +1949,7 @@ func reportUnmanagedGatewayStatus(
 		return k8s.GatewayStatusAddress(e)
 	})
 	status.Listeners = nil
-	status.Conditions = setConditions(obj.Generation, status.Conditions, gatewayConditions)
+	status.Conditions = gatewaycommon.SetListenerConditions(obj.Generation, status.Conditions, gatewayConditions)
 }
 
 func extractGatewayServices(domainSuffix string, kgw *k8s.Gateway, info gatewaycommon.ClassInfo) ([]string, *ConfigError) {
@@ -2091,7 +2101,7 @@ func buildListener(
 		}
 	}
 
-	updatedStatus := gatewaycommon.ReportListenerCondition(listenerIndex, l, obj, status, listenerConditions)
+	updatedStatus := gatewaycommon.ReportListenerCondition(listenerIndex, l, obj, status, listenerConditions, gatewaycommon.GenerateGatewaySupportedKinds)
 	return server, updatedStatus, ok
 }
 

--- a/pilot/pkg/config/kube/gateway/gateway_collection.go
+++ b/pilot/pkg/config/kube/gateway/gateway_collection.go
@@ -164,7 +164,7 @@ func ListenerSetCollection(
 				standardListener := gatewaycommon.ConvertListenerSetToListener(l)
 
 				if reason, ok := conflicts[l.Name]; ok {
-					standardStatus = gatewaycommon.ReportListenerConflict(i, standardListener, obj, standardStatus, reason)
+					standardStatus = gatewaycommon.ReportListenerConflict(i, standardListener, obj, standardStatus, reason, gatewaycommon.GenerateGatewaySupportedKinds)
 					continue
 				}
 
@@ -221,7 +221,7 @@ func ListenerSetCollection(
 					},
 				}
 
-				allowed, _ := gatewaycommon.GenerateSupportedKinds(standardListener)
+				allowed, _ := gatewaycommon.GenerateGatewaySupportedKinds(standardListener)
 				ref := parentKey{
 					Kind:      gvk.ListenerSet,
 					Name:      obj.Name,
@@ -341,7 +341,7 @@ func GatewayCollection(
 
 		for i, l := range kgw.Listeners {
 			if reason, ok := gwListenerConflicts[l.Name]; ok {
-				status.Listeners = gatewaycommon.ReportListenerConflict(i, l, obj, status.Listeners, reason)
+				status.Listeners = gatewaycommon.ReportListenerConflict(i, l, obj, status.Listeners, reason, gatewaycommon.GenerateGatewaySupportedKinds)
 				continue
 			}
 
@@ -387,7 +387,7 @@ func GatewayCollection(
 				},
 			}
 
-			allowed, _ := gatewaycommon.GenerateSupportedKinds(l)
+			allowed, _ := gatewaycommon.GenerateGatewaySupportedKinds(l)
 			ref := parentKey{
 				Kind:      gvk.KubernetesGateway,
 				Name:      obj.Name,

--- a/pilot/pkg/config/kube/gateway/inferencepool_collection.go
+++ b/pilot/pkg/config/kube/gateway/inferencepool_collection.go
@@ -337,10 +337,10 @@ func calculateSingleParentStatus(
 			Namespace: inferencev1.Namespace(gatewayParent.Namespace),
 			Name:      inferencev1.ObjectName(gatewayParent.Name),
 		},
-		Conditions: setConditions(pool.Generation, filteredConditions, map[string]*condition{
+		Conditions: gatewaycommon.SetResourceConditions(pool.Generation, filteredConditions, toSharedConditions(map[string]*condition{
 			string(inferencev1.InferencePoolConditionAccepted):     acceptedStatus,
 			string(inferencev1.InferencePoolConditionResolvedRefs): resolvedRefsStatus,
-		}),
+		})),
 	}
 }
 

--- a/pilot/pkg/config/kube/gatewaycommon/classinfo.go
+++ b/pilot/pkg/config/kube/gatewaycommon/classinfo.go
@@ -104,6 +104,14 @@ func GetAllClasses() map[gateway.ObjectName]gateway.GatewayController {
 	return res
 }
 
+// GetControllerForAgentgatewayClass returns the controller for a given agentgateway class.
+func GetControllerForAgentgatewayClass(className string) string {
+	if controller, ok := AgentgatewayClasses[gateway.ObjectName(className)]; ok {
+		return string(controller)
+	}
+	return string(constants.ManagedAgentgatewayController) // fallback
+}
+
 // GetClassInfos returns the full mapping of gateway controller to ClassInfo.
 func GetClassInfos() map[gateway.GatewayController]ClassInfo {
 	m := map[gateway.GatewayController]ClassInfo{

--- a/pilot/pkg/config/kube/gatewaycommon/conversion.go
+++ b/pilot/pkg/config/kube/gatewaycommon/conversion.go
@@ -24,6 +24,7 @@ import (
 	istio "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model/kstatus"
 	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/krt"
@@ -48,7 +49,12 @@ type ListenerStatusCondition struct {
 	SetOnce string
 }
 
-func setListenerConditions(
+// SupportedKindsFetcher returns route kinds supported by a listener and whether
+// the listener's allowedRoutes kinds are valid. Injected per controller so
+// gateway and agentgateway can apply their own protocol semantics (e.g. HBONE).
+type SupportedKindsFetcher func(l gatewayv1.Listener) ([]gatewayv1.RouteGroupKind, bool)
+
+func SetListenerConditions(
 	generation int64,
 	existingConditions []metav1.Condition,
 	conditions map[string]*ListenerStatusCondition,
@@ -95,7 +101,7 @@ func SetResourceConditions(
 	existingConditions []metav1.Condition,
 	conditions map[string]*ListenerStatusCondition,
 ) []metav1.Condition {
-	return setListenerConditions(generation, existingConditions, conditions)
+	return SetListenerConditions(generation, existingConditions, conditions)
 }
 
 // HumanReadableJoin formats a slice of strings for human-readable status messages.
@@ -159,6 +165,7 @@ func ReportListenerConflict(
 	obj controllers.Object,
 	statusListeners []gatewayv1.ListenerStatus,
 	reason gatewayv1.ListenerConditionReason,
+	supportedKinds SupportedKindsFetcher,
 ) []gatewayv1.ListenerStatus {
 	msg := "Listener has a conflict with another listener attached to the same Gateway"
 	conditions := map[string]*ListenerStatusCondition{
@@ -180,7 +187,7 @@ func ReportListenerConflict(
 			Status:  kstatus.StatusTrue,
 		},
 	}
-	return ReportListenerCondition(index, l, obj, statusListeners, conditions)
+	return ReportListenerCondition(index, l, obj, statusListeners, conditions, supportedKinds)
 }
 
 // ReportListenerCondition applies listener condition updates and supported route kinds.
@@ -190,12 +197,13 @@ func ReportListenerCondition(
 	obj controllers.Object,
 	statusListeners []gatewayv1.ListenerStatus,
 	conditions map[string]*ListenerStatusCondition,
+	supportedKinds SupportedKindsFetcher,
 ) []gatewayv1.ListenerStatus {
 	for index >= len(statusListeners) {
 		statusListeners = append(statusListeners, gatewayv1.ListenerStatus{})
 	}
 	cond := statusListeners[index].Conditions
-	supported, valid := GenerateSupportedKinds(l)
+	supported, valid := supportedKinds(l)
 	if !valid {
 		conditions[string(gatewayv1.ListenerConditionResolvedRefs)] = &ListenerStatusCondition{
 			Reason:  string(gatewayv1.ListenerReasonInvalidRouteKinds),
@@ -207,13 +215,13 @@ func ReportListenerCondition(
 		Name:           l.Name,
 		AttachedRoutes: 0, // reported later
 		SupportedKinds: supported,
-		Conditions:     setListenerConditions(obj.GetGeneration(), cond, conditions),
+		Conditions:     SetListenerConditions(obj.GetGeneration(), cond, conditions),
 	}
 	return statusListeners
 }
 
-// GenerateSupportedKinds returns route kinds supported by a listener and whether allowedRoutes kinds are valid.
-func GenerateSupportedKinds(l gatewayv1.Listener) ([]gatewayv1.RouteGroupKind, bool) {
+// generateGatewaySupportedKinds returns route kinds supported by a listener and whether allowedRoutes kinds are valid.
+func GenerateGatewaySupportedKinds(l gatewayv1.Listener) ([]gatewayv1.RouteGroupKind, bool) {
 	supported := []gatewayv1.RouteGroupKind{}
 	switch l.Protocol {
 	case gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType:
@@ -230,6 +238,52 @@ func GenerateSupportedKinds(l gatewayv1.Listener) ([]gatewayv1.RouteGroupKind, b
 		}
 	}
 	if l.AllowedRoutes != nil && len(l.AllowedRoutes.Kinds) > 0 {
+		intersection := []gatewayv1.RouteGroupKind{}
+		for _, s := range supported {
+			for _, kind := range l.AllowedRoutes.Kinds {
+				if RouteGroupKindEqual(s, kind) {
+					intersection = append(intersection, s)
+					break
+				}
+			}
+		}
+		return intersection, len(intersection) == len(l.AllowedRoutes.Kinds)
+	}
+	return supported, true
+}
+
+
+// GenerateAgentgatewaySupportedKinds generates the supported kinds for a listener based on its protocol and allowedRoutes.
+// The boolean return indicates whether all allowed routes were supported.
+func GenerateAgentgatewaySupportedKinds(l gatewayv1.Listener) ([]gatewayv1.RouteGroupKind, bool) {
+	supported := []gatewayv1.RouteGroupKind{}
+	switch l.Protocol {
+	case gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType:
+		// Only terminate allowed, so its always HTTP
+		supported = []gatewayv1.RouteGroupKind{
+			ToRouteKind(gvk.HTTPRoute),
+			ToRouteKind(gvk.GRPCRoute),
+		}
+	case gatewayv1.TCPProtocolType:
+		supported = []gatewayv1.RouteGroupKind{ToRouteKind(gvk.TCPRoute)}
+	case gatewayv1.TLSProtocolType:
+		supported = []gatewayv1.RouteGroupKind{ToRouteKind(gvk.TLSRoute)}
+		if l.TLS != nil && l.TLS.Mode != nil && *l.TLS.Mode == gatewayv1.TLSModeTerminate {
+			supported = append(supported, ToRouteKind(gvk.TCPRoute))
+		}
+		// UDP route not support
+	case gatewayv1.ProtocolType(protocol.HBONE):
+		// HBONE is a tunnel protocol used by waypoint proxies; it can carry any application protocol
+		// TODO(jaellio): verify this is correct
+		supported = []gatewayv1.RouteGroupKind{
+			ToRouteKind(gvk.HTTPRoute),
+			ToRouteKind(gvk.GRPCRoute),
+			ToRouteKind(gvk.TCPRoute),
+			ToRouteKind(gvk.TLSRoute),
+		}
+	}
+	if l.AllowedRoutes != nil && len(l.AllowedRoutes.Kinds) > 0 {
+		// We need to filter down to only ones we actually support
 		intersection := []gatewayv1.RouteGroupKind{}
 		for _, s := range supported {
 			for _, kind := range l.AllowedRoutes.Kinds {

--- a/pilot/pkg/config/kube/gatewaycommon/conversion.go
+++ b/pilot/pkg/config/kube/gatewaycommon/conversion.go
@@ -252,7 +252,6 @@ func GenerateGatewaySupportedKinds(l gatewayv1.Listener) ([]gatewayv1.RouteGroup
 	return supported, true
 }
 
-
 // GenerateAgentgatewaySupportedKinds generates the supported kinds for a listener based on its protocol and allowedRoutes.
 // The boolean return indicates whether all allowed routes were supported.
 func GenerateAgentgatewaySupportedKinds(l gatewayv1.Listener) ([]gatewayv1.RouteGroupKind, bool) {

--- a/pilot/pkg/serviceregistry/ambient/waypoints.go
+++ b/pilot/pkg/serviceregistry/ambient/waypoints.go
@@ -105,7 +105,7 @@ func fetchWaypointForTarget(
 	// namespace to be used when the annotation doesn't include a namespace
 	fallbackNamespace := o.Namespace
 	// try fetching the waypoint defined on the object itself
-	wp, isNone := getUseWaypoint(o, fallbackNamespace)
+	wp, isNone := GetUseWaypoint(o, fallbackNamespace)
 	if isNone {
 		// we've got a local override here opting out of waypoint
 		return nil, nil
@@ -131,7 +131,7 @@ func fetchWaypointForTarget(
 	// this probably should never be nil. How would o exist in a namespace we know nothing about? maybe edge case of starting the controller or ns delete?
 	if namespace != nil {
 		// toss isNone, we don't need to know /why/ we got nil
-		wp, _ := getUseWaypoint(namespace.ObjectMeta, fallbackNamespace)
+		wp, _ := GetUseWaypoint(namespace.ObjectMeta, fallbackNamespace)
 		if wp != nil {
 			w := krt.FetchOne[Waypoint](ctx, waypoints, krt.FilterKey(wp.ResourceName()))
 			if w != nil {
@@ -193,11 +193,11 @@ func fetchWaypointForWorkload(ctx krt.HandlerContext, Waypoints krt.Collection[W
 	return nil, ReportWaypointUnsupportedTrafficType(w.ResourceName(), constants.WorkloadTraffic)
 }
 
-// getUseWaypoint takes objectMeta and a defaultNamespace
+// GetUseWaypoint takes objectMeta and a defaultNamespace
 // it looks for the istio.io/use-waypoint label and parses it
 // if there is no namespace provided in the label the default namespace will be used
 // defaultNamespace avoids the need to infer when object meta from a namespace was given
-func getUseWaypoint(meta metav1.ObjectMeta, defaultNamespace string) (named *krt.Named, isNone bool) {
+func GetUseWaypoint(meta metav1.ObjectMeta, defaultNamespace string) (named *krt.Named, isNone bool) {
 	if labelValue, ok := meta.Labels[label.IoIstioUseWaypoint.Name]; ok {
 		// NOTE: this means Istio reserves the word "none" in this field with a special meaning
 		// a waypoint named "none" cannot be used and will be ignored

--- a/pkg/kube/krt/index.go
+++ b/pkg/kube/krt/index.go
@@ -309,3 +309,12 @@ func UnnamedIndex[K comparable, O any](
 
 	return NewIndex(c, key, extract)
 }
+
+// FetchIndexObjects fetches all objects from the index that match the given key.
+func FetchIndexObjects[K comparable, O any](ctx HandlerContext, index IndexCollection[K, O], name K) []O {
+	res := FetchOne(ctx, index, FilterKey(toString(name)))
+	if res == nil {
+		return nil
+	}
+	return res.Objects
+}

--- a/tests/integration/ambient/agentgateway/main_test.go
+++ b/tests/integration/ambient/agentgateway/main_test.go
@@ -1,0 +1,122 @@
+//go:build integ
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentgateway
+
+import (
+	"testing"
+
+	ilabel "istio.io/api/label"
+	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	deploy "istio.io/istio/pkg/test/framework/components/echo/deployment"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
+	kubetest "istio.io/istio/pkg/test/kube"
+	"istio.io/istio/tests/integration/security/util/cert"
+)
+
+var i istio.Instance
+
+// TestMain installs an ambient control plane with the agentgateway controller enabled so that
+// agentgateway can be deployed as a waypoint. It mirrors the ambient waypoint suite, adding the
+// PILOT_ENABLE_AGENTGATEWAY flag which (together with the ambient defaults) registers the
+// istio-agentgateway-waypoint GatewayClass.
+func TestMain(m *testing.M) {
+	framework.
+		NewSuite(m).
+		Label(label.CustomSetup).
+		Setup(func(t resource.Context) error {
+			t.Settings().Ambient = true
+			t.Settings().SkipTProxy = true
+			return nil
+		}).
+		Setup(istio.Setup(&i, func(ctx resource.Context, cfg *istio.Config) {
+			ctx.Settings().SkipVMs()
+			ctx.Settings().SkipTProxy = true
+			cfg.EnableCNI = false
+			cfg.DeployEastWestGW = false
+			cfg.DeployGatewayAPI = true
+			cfg.ControlPlaneValues = `
+profile: ambient
+meshConfig:
+  accessLogFile: "/dev/stdout"
+values:
+  pilot:
+    env:
+      PILOT_SKIP_VALIDATE_TRUST_DOMAIN: "true"
+      PILOT_ENABLE_AGENTGATEWAY: "true"
+  ztunnel:
+    terminationGracePeriodSeconds: 5
+  gateways:
+    istio-ingressgateway:
+      enabled: false
+    istio-egressgateway:
+      enabled: false
+      `
+			if ctx.Settings().NativeNftables {
+				cfg.ControlPlaneValues += `
+  global:
+    nativeNftables: true
+`
+			}
+		}, cert.CreateCASecretAlt)).
+		Run()
+}
+
+// setupSmallTrafficTest deploys a minimal client/server pair into an ambient namespace, rather than
+// using the full echo suite, so the agentgateway waypoint tests stay self-contained and fast.
+func setupSmallTrafficTest(t framework.TestContext) (namespace.Instance, echo.Instance, echo.Instance) {
+	var client, server echo.Instance
+	testNs := namespace.NewOrFail(t, namespace.Config{
+		Prefix: "default",
+		Inject: false,
+		Labels: map[string]string{
+			ilabel.IoIstioDataplaneMode.Name: "ambient",
+			"istio-injection":                "disabled",
+		},
+	})
+	deploy.New(t).
+		With(&client, echo.Config{
+			Service:   "client",
+			Namespace: testNs,
+			Ports:     []echo.Port{},
+		}).
+		With(&server, echo.Config{
+			Service:   "server",
+			Namespace: testNs,
+			Ports: []echo.Port{
+				{
+					Name:         "http",
+					Protocol:     protocol.HTTP,
+					WorkloadPort: 8090,
+				},
+			},
+		}).
+		BuildOrFail(t)
+
+	return testNs, client, server
+}
+
+// checkWaypointIsReady returns nil once the waypoint's pod is ready.
+func checkWaypointIsReady(t framework.TestContext, ns, name string) error {
+	fetch := kubetest.NewPodFetch(t.AllClusters()[0], ns, ilabel.IoK8sNetworkingGatewayGatewayName.Name+"="+name)
+	_, err := kubetest.CheckPodsAreReady(fetch)
+	return err
+}

--- a/tests/integration/ambient/agentgateway/waypoint_test.go
+++ b/tests/integration/ambient/agentgateway/waypoint_test.go
@@ -41,7 +41,7 @@ const agentgatewayWaypointName = "agentgateway-waypoint"
 // traffic is redirected through the waypoint. Traversal is proven the same way the istio waypoint
 // tests do it: an HTTPRoute injects a marker response header, and the request is confirmed to have
 // been processed at L7.
-func gitTestAgentgatewayWaypointTraffic(t *testing.T) {
+func TestAgentgatewayWaypointTraffic(t *testing.T) {
 	framework.
 		NewTest(t).
 		Run(func(t framework.TestContext) {

--- a/tests/integration/ambient/agentgateway/waypoint_test.go
+++ b/tests/integration/ambient/agentgateway/waypoint_test.go
@@ -1,0 +1,149 @@
+//go:build integ
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentgateway
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ilabel "istio.io/api/label"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/test/echo/common/scheme"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/crd"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/check"
+	"istio.io/istio/pkg/test/util/retry"
+)
+
+const agentgatewayWaypointName = "agentgateway-waypoint"
+
+// TestAgentgatewayWaypointTraffic deploys an agentgateway as a waypoint (via the
+// istio-agentgateway-waypoint GatewayClass), binds a service to it, and verifies that captured
+// traffic is redirected through the waypoint. Traversal is proven the same way the istio waypoint
+// tests do it: an HTTPRoute injects a marker response header, and the request is confirmed to have
+// been processed at L7.
+func TestAgentgatewayWaypointTraffic(t *testing.T) {
+	framework.
+		NewTest(t).
+		Run(func(t framework.TestContext) {
+			if !t.Settings().Agentgateway {
+				t.Skip("Only run agentgateway tests when explicitly enabled")
+			}
+			// pre-req setup instead of using the full echo suite
+			crd.DeployGatewayAPIOrSkip(t)
+			testNs, client, server := setupSmallTrafficTest(t)
+
+			// Deploy the agentgateway waypoint into the same namespace as the server.
+			t.ConfigIstio().YAML(testNs.Name(), fmt.Sprintf(`
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: %s
+  namespace: %s
+  annotations:
+    networking.istio.io/service-type: ClusterIP
+spec:
+  gatewayClassName: istio-agentgateway-waypoint
+  listeners:
+  - allowedRoutes:
+      namespaces:
+        from: All
+    name: mesh
+    port: 15008
+    protocol: HBONE
+`, agentgatewayWaypointName, testNs.Name())).ApplyOrFail(t)
+
+			retry.UntilSuccessOrFail(t, func() error {
+				return checkWaypointIsReady(t, testNs.Name(), agentgatewayWaypointName)
+			}, retry.Timeout(2*time.Minute))
+
+			// Apply a route that adds a custom response header when the request goes through the
+			// waypoint. This prevents the test from prematurely succeeding due to the configuration
+			// not being processed before the request is sent.
+			t.ConfigIstio().YAML(testNs.Name(), fmt.Sprintf(`
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute
+  namespace: %s
+spec:
+  parentRefs:
+    - name: server
+      kind: Service
+      group: ""
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: server
+          port: 80
+      filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            add:
+              - name: X-Custom-Traversed-Waypoint
+                value: %s
+`, testNs.Name(), agentgatewayWaypointName)).ApplyOrFail(t)
+
+			// Bind the server service to the agentgateway waypoint.
+			svc, err := t.Clusters().Default().Kube().CoreV1().Services(server.NamespaceName()).Get(context.Background(), server.ServiceName(), metav1.GetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			svc.Labels[ilabel.IoIstioUseWaypoint.Name] = agentgatewayWaypointName
+			_, err = t.Clusters().Default().Kube().CoreV1().Services(server.NamespaceName()).Update(context.Background(), svc, metav1.UpdateOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Wait for the waypoint binding to be successfully applied to the service.
+			retry.UntilSuccessOrFail(t, func() error {
+				s, err := t.Clusters().Default().Kube().CoreV1().Services(server.NamespaceName()).Get(context.Background(), server.ServiceName(), metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				for _, cond := range s.Status.Conditions {
+					if cond.Type == string(model.WaypointBound) {
+						if cond.Status == metav1.ConditionTrue {
+							return nil
+						}
+						return fmt.Errorf("waypoint bound status does not equal true")
+					}
+				}
+				return fmt.Errorf("waypoint condition not found on service")
+			}, retry.Timeout(1*time.Minute))
+
+			// Send a request from within the mesh and confirm it traversed the agentgateway waypoint.
+			client.CallOrFail(t, echo.CallOptions{
+				To:      server,
+				Address: fmt.Sprintf("%s.%s.svc.cluster.local", server.ServiceName(), server.NamespaceName()),
+				Port:    server.PortForName("http"),
+				Scheme:  scheme.HTTP,
+				Count:   5,
+				Check: check.And(
+					check.OK(),
+					check.ResponseHeader("X-Custom-Traversed-Waypoint", agentgatewayWaypointName),
+				),
+			})
+		})

--- a/tests/integration/ambient/agentgateway/waypoint_test.go
+++ b/tests/integration/ambient/agentgateway/waypoint_test.go
@@ -41,7 +41,7 @@ const agentgatewayWaypointName = "agentgateway-waypoint"
 // traffic is redirected through the waypoint. Traversal is proven the same way the istio waypoint
 // tests do it: an HTTPRoute injects a marker response header, and the request is confirmed to have
 // been processed at L7.
-func TestAgentgatewayWaypointTraffic(t *testing.T) {
+func gitTestAgentgatewayWaypointTraffic(t *testing.T) {
 	framework.
 		NewTest(t).
 		Run(func(t framework.TestContext) {
@@ -147,3 +147,4 @@ spec:
 				),
 			})
 		})
+}


### PR DESCRIPTION
**Please provide a description of this PR:**
- unscoped addresses (not filtered to fronted services and outbound vips)
- applies routes referencing services with waypoints
- same enrollment behavior as envoy based waypoint
- sets controller name per route
- binds routes referencing serivces to agw waypoints

Part of #60024 

TODO
- [x] additional tests
- [ ] scope addresses (Deferring to follow up PR)