### PR TITLE
EF: add new MERGE_AND_REPLACE_LIST support

### DIFF
--- a/pilot/pkg/networking/core/envoyfilter/cluster_patch.go
+++ b/pilot/pkg/networking/core/envoyfilter/cluster_patch.go
@@ -52,7 +52,8 @@ func ApplyClusterMerge(pctx networking.EnvoyFilter_PatchContext, efw *model.Merg
 			clusterMatch(c, cp, hosts) {
 			return nil
 		}
-		if cp.Operation != networking.EnvoyFilter_Patch_MERGE {
+		if cp.Operation != networking.EnvoyFilter_Patch_MERGE &&
+			cp.Operation != networking.EnvoyFilter_Patch_MERGE_AND_REPLACE_LIST {
 			IncrementEnvoyFilterMetric(cp.Key(), Cluster, applied)
 			continue
 		}
@@ -64,7 +65,7 @@ func ApplyClusterMerge(pctx networking.EnvoyFilter_PatchContext, efw *model.Merg
 			}
 			applied = true
 			if !tsMerged {
-				merge.Merge(c, cp.Value)
+				mergePatchValue(cp.Operation, c, cp.Value)
 			}
 		}
 		IncrementEnvoyFilterMetric(cp.Key(), Cluster, applied)

--- a/pilot/pkg/networking/core/envoyfilter/cluster_patch.go
+++ b/pilot/pkg/networking/core/envoyfilter/cluster_patch.go
@@ -52,8 +52,7 @@ func ApplyClusterMerge(pctx networking.EnvoyFilter_PatchContext, efw *model.Merg
 			clusterMatch(c, cp, hosts) {
 			return nil
 		}
-		if cp.Operation != networking.EnvoyFilter_Patch_MERGE &&
-			cp.Operation != networking.EnvoyFilter_Patch_MERGE_AND_REPLACE_LIST {
+		if !isMergeOperation(cp.Operation) {
 			IncrementEnvoyFilterMetric(cp.Key(), Cluster, applied)
 			continue
 		}

--- a/pilot/pkg/networking/core/envoyfilter/listener_patch.go
+++ b/pilot/pkg/networking/core/envoyfilter/listener_patch.go
@@ -112,8 +112,7 @@ func patchListener(patchContext networking.EnvoyFilter_PatchContext,
 			// empty name means this listener will be removed, we can return directly.
 			lis.Name = ""
 			return
-		} else if lp.Operation == networking.EnvoyFilter_Patch_MERGE ||
-			lp.Operation == networking.EnvoyFilter_Patch_MERGE_AND_REPLACE_LIST {
+		} else if isMergeOperation(lp.Operation) {
 			mergePatchValue(lp.Operation, lis, lp.Value)
 		}
 	}
@@ -260,8 +259,7 @@ func patchFilterChain(patchContext networking.EnvoyFilter_PatchContext,
 			// nil means this filter chain will be removed, we can return directly.
 			fc.Filters = nil
 			return
-		} else if lp.Operation == networking.EnvoyFilter_Patch_MERGE ||
-			lp.Operation == networking.EnvoyFilter_Patch_MERGE_AND_REPLACE_LIST {
+		} else if isMergeOperation(lp.Operation) {
 			merged, err := mergeTransportSocketListener(fc, lp)
 			if err != nil {
 				log.Debugf("merge of transport socket failed for listener: %v", err)

--- a/pilot/pkg/networking/core/envoyfilter/listener_patch.go
+++ b/pilot/pkg/networking/core/envoyfilter/listener_patch.go
@@ -112,8 +112,9 @@ func patchListener(patchContext networking.EnvoyFilter_PatchContext,
 			// empty name means this listener will be removed, we can return directly.
 			lis.Name = ""
 			return
-		} else if lp.Operation == networking.EnvoyFilter_Patch_MERGE {
-			merge.Merge(lis, lp.Value)
+		} else if lp.Operation == networking.EnvoyFilter_Patch_MERGE ||
+			lp.Operation == networking.EnvoyFilter_Patch_MERGE_AND_REPLACE_LIST {
+			mergePatchValue(lp.Operation, lis, lp.Value)
 		}
 	}
 	patchListenerFilters(patchContext, patches[networking.EnvoyFilter_LISTENER_FILTER], lis)
@@ -259,14 +260,15 @@ func patchFilterChain(patchContext networking.EnvoyFilter_PatchContext,
 			// nil means this filter chain will be removed, we can return directly.
 			fc.Filters = nil
 			return
-		} else if lp.Operation == networking.EnvoyFilter_Patch_MERGE {
+		} else if lp.Operation == networking.EnvoyFilter_Patch_MERGE ||
+			lp.Operation == networking.EnvoyFilter_Patch_MERGE_AND_REPLACE_LIST {
 			merged, err := mergeTransportSocketListener(fc, lp)
 			if err != nil {
 				log.Debugf("merge of transport socket failed for listener: %v", err)
 				continue
 			}
 			if !merged {
-				merge.Merge(fc, lp.Value)
+				mergePatchValue(lp.Operation, fc, lp.Value)
 			}
 		}
 	}

--- a/pilot/pkg/networking/core/envoyfilter/rc_patch.go
+++ b/pilot/pkg/networking/core/envoyfilter/rc_patch.go
@@ -53,8 +53,7 @@ func ApplyRouteConfigurationPatches(
 
 	// only merge is applicable for route configuration.
 	for _, rp := range efw.Patches[networking.EnvoyFilter_ROUTE_CONFIGURATION] {
-		if rp.Operation != networking.EnvoyFilter_Patch_MERGE &&
-			rp.Operation != networking.EnvoyFilter_Patch_MERGE_AND_REPLACE_LIST {
+		if !isMergeOperation(rp.Operation) {
 			continue
 		}
 		if commonConditionMatch(patchContext, rp) &&
@@ -117,8 +116,7 @@ func patchVirtualHost(patchContext networking.EnvoyFilter_PatchContext,
 			applied = true
 			if rp.Operation == networking.EnvoyFilter_Patch_REMOVE {
 				return true
-			} else if rp.Operation == networking.EnvoyFilter_Patch_MERGE ||
-				rp.Operation == networking.EnvoyFilter_Patch_MERGE_AND_REPLACE_LIST {
+			} else if isMergeOperation(rp.Operation) {
 				mergePatchValue(rp.Operation, virtualHosts[idx], rp.Value)
 			} else if rp.Operation == networking.EnvoyFilter_Patch_REPLACE {
 				virtualHosts[idx] = proto.Clone(rp.Value).(*route.VirtualHost)
@@ -252,8 +250,7 @@ func patchHTTPRoute(patchContext networking.EnvoyFilter_PatchContext,
 				virtualHost.Routes[routeIndex] = nil
 				*routesRemoved = true
 				return
-			} else if rp.Operation == networking.EnvoyFilter_Patch_MERGE ||
-				rp.Operation == networking.EnvoyFilter_Patch_MERGE_AND_REPLACE_LIST {
+			} else if isMergeOperation(rp.Operation) {
 				cloneVhostRouteByRouteIndex(virtualHost, routeIndex)
 				mergePatchValue(rp.Operation, virtualHost.Routes[routeIndex], rp.Value)
 			}

--- a/pilot/pkg/networking/core/envoyfilter/rc_patch.go
+++ b/pilot/pkg/networking/core/envoyfilter/rc_patch.go
@@ -25,7 +25,6 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/util/runtime"
 	"istio.io/istio/pkg/log"
-	"istio.io/istio/pkg/proto/merge"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/protomarshal"
 	"istio.io/istio/pkg/util/sets"
@@ -54,12 +53,13 @@ func ApplyRouteConfigurationPatches(
 
 	// only merge is applicable for route configuration.
 	for _, rp := range efw.Patches[networking.EnvoyFilter_ROUTE_CONFIGURATION] {
-		if rp.Operation != networking.EnvoyFilter_Patch_MERGE {
+		if rp.Operation != networking.EnvoyFilter_Patch_MERGE &&
+			rp.Operation != networking.EnvoyFilter_Patch_MERGE_AND_REPLACE_LIST {
 			continue
 		}
 		if commonConditionMatch(patchContext, rp) &&
 			routeConfigurationMatch(patchContext, routeConfiguration, rp, portMap) {
-			merge.Merge(routeConfiguration, rp.Value)
+			mergePatchValue(rp.Operation, routeConfiguration, rp.Value)
 			IncrementEnvoyFilterMetric(rp.Key(), Route, true)
 		} else {
 			IncrementEnvoyFilterMetric(rp.Key(), Route, false)
@@ -117,8 +117,9 @@ func patchVirtualHost(patchContext networking.EnvoyFilter_PatchContext,
 			applied = true
 			if rp.Operation == networking.EnvoyFilter_Patch_REMOVE {
 				return true
-			} else if rp.Operation == networking.EnvoyFilter_Patch_MERGE {
-				merge.Merge(virtualHosts[idx], rp.Value)
+			} else if rp.Operation == networking.EnvoyFilter_Patch_MERGE ||
+				rp.Operation == networking.EnvoyFilter_Patch_MERGE_AND_REPLACE_LIST {
+				mergePatchValue(rp.Operation, virtualHosts[idx], rp.Value)
 			} else if rp.Operation == networking.EnvoyFilter_Patch_REPLACE {
 				virtualHosts[idx] = proto.Clone(rp.Value).(*route.VirtualHost)
 			}
@@ -251,9 +252,10 @@ func patchHTTPRoute(patchContext networking.EnvoyFilter_PatchContext,
 				virtualHost.Routes[routeIndex] = nil
 				*routesRemoved = true
 				return
-			} else if rp.Operation == networking.EnvoyFilter_Patch_MERGE {
+			} else if rp.Operation == networking.EnvoyFilter_Patch_MERGE ||
+				rp.Operation == networking.EnvoyFilter_Patch_MERGE_AND_REPLACE_LIST {
 				cloneVhostRouteByRouteIndex(virtualHost, routeIndex)
-				merge.Merge(virtualHost.Routes[routeIndex], rp.Value)
+				mergePatchValue(rp.Operation, virtualHost.Routes[routeIndex], rp.Value)
 			}
 			applied = true
 		}

--- a/pilot/pkg/networking/core/envoyfilter/rc_patch_test.go
+++ b/pilot/pkg/networking/core/envoyfilter/rc_patch_test.go
@@ -971,6 +971,89 @@ func TestReplaceVhost(t *testing.T) {
 	}
 }
 
+// TestMergeAndReplaceListVhost contrasts the list-handling of MERGE (append) and
+// MERGE_AND_REPLACE_LIST (replace) on a virtual host's repeated `domains` field.
+func TestMergeAndReplaceListVhost(t *testing.T) {
+	vhostPatch := func(op networking.EnvoyFilter_Patch_Operation) []*networking.EnvoyFilter_EnvoyConfigObjectPatch {
+		return []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
+			{
+				ApplyTo: networking.EnvoyFilter_VIRTUAL_HOST,
+				Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
+					Context: networking.EnvoyFilter_SIDECAR_INBOUND,
+					ObjectTypes: &networking.EnvoyFilter_EnvoyConfigObjectMatch_RouteConfiguration{
+						RouteConfiguration: &networking.EnvoyFilter_RouteConfigurationMatch{
+							Vhost: &networking.EnvoyFilter_RouteConfigurationMatch_VirtualHostMatch{
+								Name: "vhost1",
+							},
+						},
+					},
+				},
+				Patch: &networking.EnvoyFilter_Patch{
+					Operation: op,
+					Value:     buildPatchStruct(`{"domains":["patched.com"]}`),
+				},
+			},
+		}
+	}
+
+	inputRC := func() *route.RouteConfiguration {
+		return &route.RouteConfiguration{
+			Name: "inbound|http|80",
+			VirtualHosts: []*route.VirtualHost{
+				{
+					Name:    "vhost1",
+					Domains: []string{"original.com"},
+				},
+			},
+		}
+	}
+	wantRC := func(domains ...string) *route.RouteConfiguration {
+		return &route.RouteConfiguration{
+			Name: "inbound|http|80",
+			VirtualHosts: []*route.VirtualHost{
+				{
+					Name:    "vhost1",
+					Domains: domains,
+				},
+			},
+		}
+	}
+
+	sidecarNode := &model.Proxy{Type: model.SidecarProxy, ConfigNamespace: "not-default"}
+
+	tests := []struct {
+		name      string
+		operation networking.EnvoyFilter_Patch_Operation
+		want      *route.RouteConfiguration
+	}{
+		{
+			name:      "MERGE appends to domains list",
+			operation: networking.EnvoyFilter_Patch_MERGE,
+			want:      wantRC("original.com", "patched.com"),
+		},
+		{
+			name:      "MERGE_AND_REPLACE_LIST replaces domains list",
+			operation: networking.EnvoyFilter_Patch_MERGE_AND_REPLACE_LIST,
+			want:      wantRC("patched.com"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			serviceDiscovery := memory.NewServiceDiscovery()
+			env := newTestEnvironment(t, serviceDiscovery, testMesh, buildEnvoyFilterConfigStore(vhostPatch(tt.operation)))
+			push := model.NewPushContext()
+			push.InitContext(env, nil, nil)
+
+			efw := push.EnvoyFilters(sidecarNode)
+			got := ApplyRouteConfigurationPatches(networking.EnvoyFilter_SIDECAR_INBOUND, sidecarNode, efw, inputRC())
+			if diff := cmp.Diff(tt.want, got, protocmp.Transform()); diff != "" {
+				t.Errorf("%s mismatch (-want +got):\n%s", tt.name, diff)
+			}
+		})
+	}
+}
+
 func Test_routeMatch(t *testing.T) {
 	type args struct {
 		httpRoute *route.Route

--- a/pilot/pkg/networking/core/envoyfilter/util.go
+++ b/pilot/pkg/networking/core/envoyfilter/util.go
@@ -14,6 +14,28 @@
 
 package envoyfilter
 
+import (
+	"google.golang.org/protobuf/proto"
+
+	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pkg/proto/merge"
+)
+
+// mergePatchValue merges src into dst using the semantics of the given patch operation.
+// MERGE appends repeated (list) fields, while MERGE_AND_REPLACE_LIST replaces them
+// wholesale. Both operations merge scalar and message fields identically.
+//
+// Note: this only governs the top-level proto merge. Filter-level merges of Any-typed
+// configs (HTTP/network/listener filters and transport sockets) go through
+// util.MergeAnyWithAny and are not affected by the replace-list semantics.
+func mergePatchValue(operation networking.EnvoyFilter_Patch_Operation, dst, src proto.Message) {
+	if operation == networking.EnvoyFilter_Patch_MERGE_AND_REPLACE_LIST {
+		merge.MergeWithReplaceList(dst, src)
+		return
+	}
+	merge.Merge(dst, src)
+}
+
 // replaceFunc find and replace the first matching element.
 // If the f function returns true, the returned value will be used for replacement.
 func replaceFunc[E any](s []E, f func(e E) (bool, E)) ([]E, bool) {

--- a/pilot/pkg/networking/core/envoyfilter/util.go
+++ b/pilot/pkg/networking/core/envoyfilter/util.go
@@ -21,6 +21,14 @@ import (
 	"istio.io/istio/pkg/proto/merge"
 )
 
+// isMergeOperation reports whether the operation merges the patch value into the
+// existing config. Both MERGE and MERGE_AND_REPLACE_LIST are merge operations; they
+// differ only in how repeated (list) fields are handled (see mergePatchValue).
+func isMergeOperation(operation networking.EnvoyFilter_Patch_Operation) bool {
+	return operation == networking.EnvoyFilter_Patch_MERGE ||
+		operation == networking.EnvoyFilter_Patch_MERGE_AND_REPLACE_LIST
+}
+
 // mergePatchValue merges src into dst using the semantics of the given patch operation.
 // MERGE appends repeated (list) fields, while MERGE_AND_REPLACE_LIST replaces them
 // wholesale. Both operations merge scalar and message fields identically.

--- a/pkg/proto/merge/merge.go
+++ b/pkg/proto/merge/merge.go
@@ -35,6 +35,9 @@ type (
 	MergeFunction func(dst, src protoreflect.Message) protoreflect.Message
 	mergeOptions  struct {
 		customMergeFn map[protoreflect.FullName]MergeFunction
+		// replaceList, when true, makes repeated (list) fields present in src
+		// fully replace the corresponding list in dst instead of being appended.
+		replaceList bool
 	}
 )
 type OptionFn func(options mergeOptions) mergeOptions
@@ -52,6 +55,15 @@ var ReplaceMergeFn MergeFunction = func(dst, src protoreflect.Message) protorefl
 	return src
 }
 
+// ReplaceListOptionFn makes repeated (list) fields present in src fully replace
+// the corresponding list in dst instead of being appended to it. Singular and
+// map fields retain normal merge semantics. The replacement is recursive: any
+// list set by src at any nesting level replaces the matching list in dst.
+var ReplaceListOptionFn OptionFn = func(options mergeOptions) mergeOptions {
+	options.replaceList = true
+	return options
+}
+
 var options = []OptionFn{
 	// Workaround https://github.com/golang/protobuf/issues/1359, merge duration properly
 	MergeFunctionOptionFn((&durationpb.Duration{}).ProtoReflect().Descriptor().FullName(), ReplaceMergeFn),
@@ -59,6 +71,14 @@ var options = []OptionFn{
 
 func Merge(dst, src proto.Message) {
 	merge(dst, src, options...)
+}
+
+// MergeWithReplaceList behaves like Merge, except that repeated (list) fields
+// present in src fully replace the corresponding list in dst rather than being
+// appended. This is useful for callers that want proto merge semantics for
+// scalar and message fields while overwriting arrays wholesale.
+func MergeWithReplaceList(dst, src proto.Message) {
+	merge(dst, src, append(append([]OptionFn{}, options...), ReplaceListOptionFn)...)
 }
 
 // Merge Code of proto.Merge with modifications to support custom types
@@ -87,7 +107,13 @@ func (o mergeOptions) mergeMessage(dst, src protoreflect.Message) {
 	src.Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
 		switch {
 		case fd.IsList():
-			o.mergeList(dst.Mutable(fd).List(), v.List(), fd)
+			dstList := dst.Mutable(fd).List()
+			if o.replaceList {
+				// Replace semantics: drop the existing entries so the src list
+				// fully overwrites dst instead of being appended.
+				dstList.Truncate(0)
+			}
+			o.mergeList(dstList, v.List(), fd)
 		case fd.IsMap():
 			o.mergeMap(dst.Mutable(fd).Map(), v.Map(), fd.MapValue())
 		case fd.Message() != nil:

--- a/pkg/proto/merge/merge_test.go
+++ b/pkg/proto/merge/merge_test.go
@@ -37,3 +37,71 @@ func TestMerge(t *testing.T) {
 	// dst duration not changed after merge
 	assert.Equal(t, dst, &durationpb.Duration{Seconds: 789, Nanos: 999})
 }
+
+func filterNames(filters []*listener.ListenerFilter) []string {
+	names := make([]string, 0, len(filters))
+	for _, f := range filters {
+		names = append(names, f.GetName())
+	}
+	return names
+}
+
+// TestMerge_AppendsList verifies the default Merge semantics: repeated fields are appended.
+func TestMerge_AppendsList(t *testing.T) {
+	dst := &listener.Listener{ListenerFilters: []*listener.ListenerFilter{{Name: "a"}, {Name: "b"}}}
+	src := &listener.Listener{ListenerFilters: []*listener.ListenerFilter{{Name: "c"}}}
+
+	Merge(dst, src)
+
+	assert.Equal(t, filterNames(dst.ListenerFilters), []string{"a", "b", "c"})
+}
+
+// TestMergeWithReplaceList verifies that lists in src fully replace lists in dst.
+func TestMergeWithReplaceList(t *testing.T) {
+	dst := &listener.Listener{
+		Name:            "keep-me",
+		ListenerFilters: []*listener.ListenerFilter{{Name: "a"}, {Name: "b"}},
+	}
+	src := &listener.Listener{ListenerFilters: []*listener.ListenerFilter{{Name: "c"}}}
+
+	MergeWithReplaceList(dst, src)
+
+	// The list is replaced, not appended.
+	assert.Equal(t, filterNames(dst.ListenerFilters), []string{"c"})
+	// Scalar fields not set by src are left untouched (sparse merge).
+	assert.Equal(t, dst.Name, "keep-me")
+}
+
+// TestMergeWithReplaceList_EmptyListNotCleared verifies that a list absent from src
+// leaves the dst list untouched (src.Range only visits set fields).
+func TestMergeWithReplaceList_EmptyListNotCleared(t *testing.T) {
+	dst := &listener.Listener{ListenerFilters: []*listener.ListenerFilter{{Name: "a"}}}
+	src := &listener.Listener{Name: "set-name"}
+
+	MergeWithReplaceList(dst, src)
+
+	assert.Equal(t, filterNames(dst.ListenerFilters), []string{"a"})
+	assert.Equal(t, dst.Name, "set-name")
+}
+
+// TestMergeWithReplaceList_Nested verifies replace semantics apply recursively into
+// nested messages.
+func TestMergeWithReplaceList_Nested(t *testing.T) {
+	dst := &listener.Listener{
+		FilterChains: []*listener.FilterChain{{
+			Filters: []*listener.Filter{{Name: "f1"}, {Name: "f2"}},
+		}},
+	}
+	src := &listener.Listener{
+		FilterChains: []*listener.FilterChain{{
+			Filters: []*listener.Filter{{Name: "f3"}},
+		}},
+	}
+
+	MergeWithReplaceList(dst, src)
+
+	// Top-level FilterChains list is replaced wholesale.
+	assert.Equal(t, len(dst.FilterChains), 1)
+	assert.Equal(t, dst.FilterChains[0].Filters[0].GetName(), "f3")
+	assert.Equal(t, len(dst.FilterChains[0].Filters), 1)
+}

--- a/releasenotes/notes/envoyfilter-merge-and-replace-list.yaml
+++ b/releasenotes/notes/envoyfilter-merge-and-replace-list.yaml
@@ -1,7 +1,8 @@
 apiVersion: release-notes/v2
 kind: feature
 area: traffic-management
-
+issues:
+  - 60498
 releaseNotes:
   - |
     **Added** a new `MERGE_AND_REPLACE_LIST` patch operation to `EnvoyFilter`. It behaves like

--- a/releasenotes/notes/envoyfilter-merge-and-replace-list.yaml
+++ b/releasenotes/notes/envoyfilter-merge-and-replace-list.yaml
@@ -1,0 +1,13 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+releaseNotes:
+  - |
+    **Added** a new `MERGE_AND_REPLACE_LIST` patch operation to `EnvoyFilter`. It behaves like
+    `MERGE`, except that repeated (list) fields present in the patch fully replace the
+    corresponding list in the generated configuration instead of being appended to it. This
+    applies to the `CLUSTER`, `LISTENER`, `FILTER_CHAIN`, `ROUTE_CONFIGURATION`, `VIRTUAL_HOST`,
+    and `HTTP_ROUTE` patch targets. Lists nested inside `Any`-typed filter configurations (HTTP,
+    network, and listener filters, and transport sockets) are not affected and continue to follow
+    `MERGE` semantics.


### PR DESCRIPTION
**Please provide a description of this PR:**

This PR added implementation to the MERGE_AND_REPLACE_LIST API. With this new API and implementation, now we could replace whole list value with EnvoyFilter rather than appending items to list end. This makes it's possible to customize the ALPN list, upgrade config list very easily and needn't to replace whole filter chain or HCM.