### PR TITLE
Fix for leaking indexes in KRT

### DIFF
--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -57,27 +57,16 @@ type extractorKey struct {
 }
 
 func (i dependencyState[I]) update(key Key[I], deps []*dependency) {
-	// We will override the current dependencies with the new ones
-	// at some point. So here we make sure we remove them from the
-	// reverse index (indexedDependencies). Otherwise, when I goes
-	// away, the delete operation won't have that reverse index to
-	// clear itself from the reverse index.
-	if old, f := i.objectDependencies[key]; f {
-		for _, d := range old {
-			if depKeys, typ, _, _, ok := d.filter.reverseIndexKey(); ok {
-				for _, depKey := range depKeys {
-					k := indexedDependency{
-						id:  d.id,
-						key: depKey,
-						typ: typ,
-					}
-					sets.DeleteCleanupLast(i.indexedDependencies, k, key)
-				}
-			}
-		}
-	}
+	// We will override the current dependencies with the new ones, so
+	// we first remove the existing dependencies from the reverse index
+	// (indexedDependencies). Otherwise, when "I" goes away, a delete
+	// operation might leave some reverse index behind.
+	i.delete(key)
 
-	// Update the I -> Dependency mapping
+	// Update the I -> Dependency mapping. Notice that we're overriding
+	// all dependencies for the key. That means that as the delete call
+	// above removes the key from objectDependencies, that doesn't matter
+	// as we reassign the key here once again.
 	i.objectDependencies[key] = deps
 	for _, d := range deps {
 		if depKeys, typ, extractor, filterID, ok := d.filter.reverseIndexKey(); ok {

--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -57,6 +57,21 @@ type extractorKey struct {
 }
 
 func (i dependencyState[I]) update(key Key[I], deps []*dependency) {
+	if old, f := i.objectDependencies[key]; f {
+		for _, d := range old {
+			if depKeys, typ, _, _, ok := d.filter.reverseIndexKey(); ok {
+				for _, depKey := range depKeys {
+					k := indexedDependency{
+						id:  d.id,
+						key: depKey,
+						typ: typ,
+					}
+					sets.DeleteCleanupLast(i.indexedDependencies, k, key)
+				}
+			}
+		}
+	}
+
 	// Update the I -> Dependency mapping
 	i.objectDependencies[key] = deps
 	for _, d := range deps {

--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -57,6 +57,11 @@ type extractorKey struct {
 }
 
 func (i dependencyState[I]) update(key Key[I], deps []*dependency) {
+	// We will override the current dependencies with the new ones
+	// at some point. So here we make sure we remove them from the
+	// reverse index (indexedDependencies). Otherwise, when I goes
+	// away, the delete operation won't have that reverse index to
+	// clear itself from the reverse index.
 	if old, f := i.objectDependencies[key]; f {
 		for _, d := range old {
 			if depKeys, typ, _, _, ok := d.filter.reverseIndexKey(); ok {

--- a/pkg/kube/krt/dependency_state_test.go
+++ b/pkg/kube/krt/dependency_state_test.go
@@ -1,0 +1,137 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package krt
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/kclient"
+	"istio.io/istio/pkg/kube/kclient/clienttest"
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/assert"
+)
+
+// TestCollectionChangingFilterKeyDependency is a regression test for a memory leak where changing
+// the FilterKey used in a Fetch (e.g., relabeling a pod's waypoint) left stale reverse-index
+// entries in dependencyState.indexedDependencies that were never cleaned up.
+func TestCollectionChangingFilterKeyDependency(t *testing.T) {
+	stop := test.NewStop(t)
+	opts := NewOptionsBuilder(stop, "test", GlobalDebugHandler)
+	c := kube.NewFakeClient()
+	kpc := kclient.New[*corev1.Pod](c)
+	kcc := kclient.New[*corev1.ConfigMap](c)
+	pc := clienttest.Wrap(t, kpc)
+	cc := clienttest.Wrap(t, kcc)
+	pods := WrapClient[*corev1.Pod](kpc, opts.WithName("Pods")...)
+	configMaps := WrapClient[*corev1.ConfigMap](kcc, opts.WithName("ConfigMaps")...)
+	c.RunAndWait(stop)
+
+	type WaypointBinding struct {
+		Named
+		WaypointData string
+	}
+
+	// Derived collection: each pod fetches a ConfigMap by key derived from its "use-waypoint" label.
+	Bindings := NewCollection(pods, func(ctx HandlerContext, p *corev1.Pod) *WaypointBinding {
+		wpName := p.Labels["use-waypoint"]
+		if wpName == "" {
+			return nil
+		}
+		key := p.Namespace + "/" + wpName
+		cms := Fetch(ctx, configMaps, FilterKey(key))
+		data := ""
+		if len(cms) == 1 {
+			data = cms[0].Data["value"]
+		}
+		return &WaypointBinding{
+			Named:        NewNamed(p),
+			WaypointData: data,
+		}
+	}, opts.WithName("WaypointBindings")...)
+
+	tt := assert.NewTracker[string](t)
+	Bindings.Register(func(o Event[WaypointBinding]) {
+		tt.Record(o.Event.String() + "/" + GetKey(o.Latest()))
+	})
+	Bindings.WaitUntilSynced(stop)
+
+	// Create two "waypoints" (ConfigMaps)
+	cc.Create(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "waypoint-old", Namespace: "ns"},
+		Data:       map[string]string{"value": "old"},
+	})
+	cc.Create(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "waypoint-new", Namespace: "ns"},
+		Data:       map[string]string{"value": "new"},
+	})
+
+	// Create a pod pointing to waypoint-old
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-pod",
+			Namespace: "ns",
+			Labels:    map[string]string{"use-waypoint": "waypoint-old"},
+		},
+		Status: corev1.PodStatus{PodIP: "10.0.0.1"},
+	}
+	pc.CreateOrUpdateStatus(pod)
+	tt.WaitOrdered("add/ns/my-pod")
+
+	// Relabel pod to point to waypoint-new
+	pod.Labels["use-waypoint"] = "waypoint-new"
+	pc.CreateOrUpdate(pod)
+	tt.WaitOrdered("update/ns/my-pod")
+
+	// Access the internal manyCollection to inspect indexedDependencies directly.
+	mc := Bindings.(*manyCollection[*corev1.Pod, WaypointBinding])
+
+	// Get the UID of the ConfigMaps collection (the secondary dependency).
+	configMapsUID := configMaps.(internalCollection[*corev1.ConfigMap]).uid()
+
+	// After relabeling, the reverse-index must only contain the new key, not the old one.
+	mc.mu.RLock()
+	podKey := Key[*corev1.Pod]("ns/my-pod")
+
+	oldIdxKey := indexedDependency{id: configMapsUID, key: "ns/waypoint-old", typ: getKeyType}
+	newIdxKey := indexedDependency{id: configMapsUID, key: "ns/waypoint-new", typ: getKeyType}
+
+	hasOld := mc.dependencyState.indexedDependencies[oldIdxKey].Contains(podKey)
+	hasNew := mc.dependencyState.indexedDependencies[newIdxKey].Contains(podKey)
+	mc.mu.RUnlock()
+
+	if hasOld {
+		t.Fatalf("stale reverse-index entry for 'ns/waypoint-old' still present after relabeling pod to waypoint-new")
+	}
+	if !hasNew {
+		t.Fatalf("expected reverse-index entry for 'ns/waypoint-new' after relabeling, but not found")
+	}
+
+	// Also verify after pod deletion nothing remains
+	pc.Delete("my-pod", "ns")
+	tt.WaitOrdered("delete/ns/my-pod")
+	assert.EventuallyEqual(t, Bindings.List, nil)
+
+	mc.mu.RLock()
+	hasNewAfterDelete := mc.dependencyState.indexedDependencies[newIdxKey].Contains(podKey)
+	mc.mu.RUnlock()
+
+	if hasNewAfterDelete {
+		t.Fatalf("reverse-index entry for 'ns/waypoint-new' still present after pod deletion")
+	}
+}

--- a/releasenotes/notes/krt-dependency-reverse-index-leak.yaml
+++ b/releasenotes/notes/krt-dependency-reverse-index-leak.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed** a memory leak in the `krt` controller framework where changing the key used in a `Fetch` filter
+    (for example, relabeling a pod to point to a different waypoint) left stale reverse-index entries that were 
+    never cleaned up. Over time this could grow memory usage and cause unnecessary recomputations.


### PR DESCRIPTION
**Please provide a description of this PR:**

There are some cases where KRT collection dependencies were being left behind in its dependencies mechanism. That happens because sometimes we index some of those dependencies using filters that may change, and once they change, we may lose a reference to clean up later.

A concrete example works as follows:

A collection of pods arrive with pod-a/label=1, pod-b/label=1, pod-c/label=2. Now let's say the transformation that receives that input will fetch services that match the pod labels using a filter. The way KRT will track these dependencies is basically creating a list of the direct dependencies (mapping pod to fetched collection and filter), and also a reverse index (mapping service and filter to the actual pod). 

After the fetch, this is what we see:

dependencies:
- pod-a -> service/label=1
- pod-b -> service/label=1
- pod-c -> service/label=2

reverse index:
- service/label=1 -> pod-a, pod-b
- service/label=2 -> pod-c

Now let's say an update arrives changing the label of pod-c to label=3. The current update implementation will simply override the dependencies and create a new entry in the reverse index.

dependencies:
- pod-a -> service/label=1
- pod-b -> service/label=1
- pod-c -> service/label=3

reverse index:
- service/label=1 -> pod-a, pod-b
- service/label=2 -> pod-c
- service/label=3 -> pod-c

The deletion operation in KRT relies on the dependencies list to remove objects from the reverse index. So now when pod-c is removed from the source collection, the deletion operation will only produce the index "service/label=3", leaving the "service/label=2" behind.

This PR creates a fix where whenever a dependency is updated, we make sure before overriding the dependencies list, we delete the corresponding items from the reverse index.