### PR TITLE
Use original destination in HBONE access logs

### DIFF
--- a/pilot/pkg/networking/core/accesslog.go
+++ b/pilot/pkg/networking/core/accesslog.go
@@ -15,6 +15,7 @@
 package core
 
 import (
+	"strings"
 	"sync"
 
 	accesslog "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
@@ -24,11 +25,14 @@ import (
 	grpcaccesslog "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/grpc/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	tcp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking"
 	"istio.io/istio/pilot/pkg/util/protoconv"
+	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
+	"istio.io/istio/pkg/util/protomarshal"
 	"istio.io/istio/pkg/wellknown"
 )
 
@@ -79,7 +83,7 @@ func newAccessLogBuilder() *AccessLogBuilder {
 		// We add ResponseFlagFilter here, as we want to get listener access logs only on scenarios where we might
 		// not get filter Access Logs like in cases like NR to upstream.
 		listenerAccessLog:         newCachedMeshConfigAccessLog(listenerAccessLogFilter()),
-		hboneOriginationAccessLog: newCachedMeshConfigAccessLog(hboneOriginationAccessLogFilter()),
+		hboneOriginationAccessLog: newCachedMeshConfigAccessLogWithBuilder(hboneOriginationAccessLogFilter(), hboneOriginationFileAccessLogFromMeshConfig),
 		hboneTerminationAccessLog: newCachedMeshConfigAccessLog(hboneTerminationAccessLogFilter()),
 	}
 }
@@ -302,12 +306,57 @@ func buildAccessLogFilter(f ...*accesslog.AccessLogFilter) *accesslog.AccessLogF
 	}
 }
 
+const hboneOriginationUpstreamHostFormat = "%FILTER_STATE(" + xdsfilters.OriginalDstFilterStateKey + ":PLAIN)%"
+
+func hboneOriginationTextLogFormat() string {
+	return strings.Replace(model.EnvoyTextLogFormat, "%UPSTREAM_HOST%", hboneOriginationUpstreamHostFormat, 1)
+}
+
+func hboneOriginationJSONLogFormat() string {
+	jsonLogStruct := &structpb.Struct{
+		Fields: make(map[string]*structpb.Value, len(model.EnvoyJSONLogFormatIstio.Fields)),
+	}
+	for key, value := range model.EnvoyJSONLogFormatIstio.Fields {
+		jsonLogStruct.Fields[key] = value
+	}
+	jsonLogStruct.Fields["upstream_host"] = structpb.NewStringValue(hboneOriginationUpstreamHostFormat)
+	jsonLogFormat, err := protomarshal.ToJSON(jsonLogStruct)
+	if err != nil {
+		return ""
+	}
+	return jsonLogFormat
+}
+
+func hboneOriginationFileAccessLogFromMeshConfig(path string, mesh *meshconfig.MeshConfig) *accesslog.AccessLog {
+	if mesh.AccessLogFormat != "" {
+		return model.FileAccessLogFromMeshConfig(path, mesh)
+	}
+	hboneMesh := *mesh
+	switch mesh.AccessLogEncoding {
+	case meshconfig.MeshConfig_TEXT:
+		hboneMesh.AccessLogFormat = hboneOriginationTextLogFormat()
+	case meshconfig.MeshConfig_JSON:
+		if jsonLogFormat := hboneOriginationJSONLogFormat(); jsonLogFormat != "" {
+			hboneMesh.AccessLogFormat = jsonLogFormat
+		}
+	}
+	return model.FileAccessLogFromMeshConfig(path, &hboneMesh)
+}
+
 func newCachedMeshConfigAccessLog(filter *accesslog.AccessLogFilter) cachedMeshConfigAccessLog {
-	return cachedMeshConfigAccessLog{filter: filter}
+	return newCachedMeshConfigAccessLogWithBuilder(filter, model.FileAccessLogFromMeshConfig)
+}
+
+func newCachedMeshConfigAccessLogWithBuilder(
+	filter *accesslog.AccessLogFilter,
+	build func(string, *meshconfig.MeshConfig) *accesslog.AccessLog,
+) cachedMeshConfigAccessLog {
+	return cachedMeshConfigAccessLog{filter: filter, build: build}
 }
 
 type cachedMeshConfigAccessLog struct {
 	filter *accesslog.AccessLogFilter
+	build  func(string, *meshconfig.MeshConfig) *accesslog.AccessLog
 	mutex  sync.RWMutex
 	cached *accesslog.AccessLog
 }
@@ -323,7 +372,7 @@ func (b *cachedMeshConfigAccessLog) buildOrFetch(mesh *meshconfig.MeshConfig) *a
 		return c
 	}
 	// We need to build access log. This is needed either on first access or when mesh config changes.
-	accessLog := model.FileAccessLogFromMeshConfig(mesh.AccessLogFile, mesh)
+	accessLog := b.build(mesh.AccessLogFile, mesh)
 	accessLog.Filter = b.filter
 
 	b.mutex.Lock()

--- a/pilot/pkg/networking/core/accesslog_test.go
+++ b/pilot/pkg/networking/core/accesslog_test.go
@@ -179,6 +179,68 @@ func verify(t *testing.T, encoding meshconfig.MeshConfig_AccessLogEncoding, got 
 	}
 }
 
+func TestHboneOriginationFileAccessLogFromMeshConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		encoding   meshconfig.MeshConfig_AccessLogEncoding
+		format     string
+		wantFormat string
+	}{
+		{
+			name:       "default text uses original destination",
+			encoding:   meshconfig.MeshConfig_TEXT,
+			wantFormat: hboneOriginationTextLogFormat(),
+		},
+		{
+			name:       "custom text is unchanged",
+			encoding:   meshconfig.MeshConfig_TEXT,
+			format:     "custom %UPSTREAM_HOST%",
+			wantFormat: "custom %UPSTREAM_HOST%\n",
+		},
+		{
+			name:       "default json uses original destination",
+			encoding:   meshconfig.MeshConfig_JSON,
+			wantFormat: hboneOriginationJSONLogFormat(),
+		},
+		{
+			name:       "custom json is unchanged",
+			encoding:   meshconfig.MeshConfig_JSON,
+			format:     `{"upstream_host":"%UPSTREAM_HOST%"}`,
+			wantFormat: `{"upstream_host":"%UPSTREAM_HOST%"}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := mesh.DefaultMeshConfig()
+			m.AccessLogEncoding = tc.encoding
+			m.AccessLogFormat = tc.format
+
+			verify(t, tc.encoding, hboneOriginationFileAccessLogFromMeshConfig(model.DevStdout, m), tc.wantFormat)
+		})
+	}
+}
+
+func TestHboneOriginationFileAccessLogDoesNotMutateDefaultJSONFormat(t *testing.T) {
+	m := mesh.DefaultMeshConfig()
+	m.AccessLogEncoding = meshconfig.MeshConfig_JSON
+
+	hboneOriginationFileAccessLogFromMeshConfig(model.DevStdout, m)
+
+	if got := model.EnvoyJSONLogFormatIstio.Fields["upstream_host"].GetStringValue(); got != "%UPSTREAM_HOST%" {
+		t.Fatalf("default JSON upstream_host format mutated: %s", got)
+	}
+}
+
+func TestAccessLogBuilderUsesHboneOriginationFormat(t *testing.T) {
+	b := newAccessLogBuilder()
+	m := mesh.DefaultMeshConfig()
+	m.AccessLogFile = model.DevStdout
+
+	got := b.hboneOriginationAccessLog.buildOrFetch(m)
+
+	verify(t, meshconfig.MeshConfig_TEXT, got, hboneOriginationTextLogFormat())
+	assert.Equal(t, hboneOriginationAccessLogFilter(), got.Filter)
+}
+
 func TestAccessLogPatch(t *testing.T) {
 	// Regression test for https://github.com/istio/istio/issues/35778
 	cg := NewConfigGenTest(t, TestOptions{


### PR DESCRIPTION
Refs #50321.

This updates the default file access log format used by HBONE origination access logs so the `upstream_host` slot renders the original destination from filter state instead of the internal Envoy listener target.

For HBONE origination logs, `%UPSTREAM_HOST%` can expand to values such as `envoy://connect_originate/...`, even though Istio has already propagated the original destination in `envoy.filters.listener.original_dst.local_ip`. The new HBONE-specific default uses `%FILTER_STATE(envoy.filters.listener.original_dst.local_ip:PLAIN)%` for that field.

The change is scoped to the legacy mesh-config default format for HBONE origination logs:

- normal access logs keep the existing default format
- custom text and JSON access log formats are left unchanged
- both default text and default JSON formats are covered

This intentionally does not change `%UPSTREAM_LOCAL_ADDRESS%`; that is the separate internal local-address behavior discussed in the issue.

Testing:

- `go test ./pilot/pkg/networking/core -run ^TestHboneOrigination -count=1 -v`
- `go test ./pilot/pkg/networking/core -run ^TestAccessLogBuilderUsesHboneOriginationFormat$ -count=1 -v`
- `go test ./pilot/pkg/networking/core -run ^TestListenerAccessLog$ -count=1 -v`
- `go test ./pilot/pkg/networking/core -run ^TestSetTCPAccessLog$ -count=1 -v`
- `go test ./pilot/pkg/networking/core -run ^TestSetHttpAccessLog$ -count=1 -v`
- `go test ./pilot/pkg/networking/core -run ^TestSetListenerAccessLog$ -count=1 -v`
