### PR TITLE
Add ConnectionSettings support to ProxyConfig with EDGE profile for gateways

### DIFF
--- a/pilot/pkg/networking/core/connection_settings.go
+++ b/pilot/pkg/networking/core/connection_settings.go
@@ -1,0 +1,203 @@
+// Copyright Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"time"
+
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"google.golang.org/protobuf/types/known/durationpb"
+	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
+
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/util/protomarshal"
+)
+
+// applyEdgeProfileDefaults fills in nil fields with Envoy edge best-practice defaults
+// when the ConnectionSettings profile is EDGE and the proxy is a Router (gateway).
+// Returns the original ConnectionSettings unchanged for non-EDGE profiles or non-Router proxies.
+func applyEdgeProfileDefaults(cs *meshconfig.ProxyConfig_ConnectionSettings, nodeType model.NodeType) *meshconfig.ProxyConfig_ConnectionSettings {
+	if cs == nil || cs.GetProfile() != meshconfig.ProxyConfig_ConnectionSettings_EDGE {
+		return cs
+	}
+	if nodeType != model.Router {
+		return cs
+	}
+
+	// Clone to avoid mutating the shared ProxyConfig (e.g., MeshConfig.DefaultConfig).
+	cs = protomarshal.Clone(cs)
+
+	if cs.ListenerPerConnectionBufferLimitBytes == nil {
+		cs.ListenerPerConnectionBufferLimitBytes = &wrappers.Int32Value{Value: 32768} // 32 KiB
+	}
+	if cs.HttpIdleTimeout == nil {
+		cs.HttpIdleTimeout = durationpb.New(time.Hour)
+	}
+	if cs.HttpStreamIdleTimeout == nil {
+		cs.HttpStreamIdleTimeout = durationpb.New(5 * time.Minute)
+	}
+	if cs.HttpRequestTimeout == nil {
+		cs.HttpRequestTimeout = durationpb.New(5 * time.Minute)
+	}
+	if cs.HttpRequestHeadersTimeout == nil {
+		cs.HttpRequestHeadersTimeout = durationpb.New(60 * time.Second)
+	}
+	if cs.HttpMaxConcurrentStreams == nil {
+		cs.HttpMaxConcurrentStreams = &wrappers.Int32Value{Value: 100}
+	}
+	if cs.Http2InitialStreamWindowSize == nil {
+		cs.Http2InitialStreamWindowSize = &wrappers.Int32Value{Value: 65536} // 64 KiB
+	}
+	if cs.Http2InitialConnectionWindowSize == nil {
+		cs.Http2InitialConnectionWindowSize = &wrappers.Int32Value{Value: 1048576} // 1 MiB
+	}
+	if cs.HttpHeadersWithUnderscoresAction == meshconfig.ProxyConfig_ConnectionSettings_HEADERS_WITH_UNDERSCORES_UNSPECIFIED {
+		cs.HttpHeadersWithUnderscoresAction = meshconfig.ProxyConfig_ConnectionSettings_HEADERS_WITH_UNDERSCORES_REJECT_REQUEST
+	}
+	if cs.HttpMergeSlashes == nil {
+		cs.HttpMergeSlashes = &wrappers.BoolValue{Value: true}
+	}
+	if cs.HttpPathWithEscapedSlashesAction == meshconfig.ProxyConfig_ConnectionSettings_PATH_WITH_ESCAPED_SLASHES_UNSPECIFIED {
+		cs.HttpPathWithEscapedSlashesAction = meshconfig.ProxyConfig_ConnectionSettings_UNESCAPE_AND_REDIRECT
+	}
+
+	return cs
+}
+
+// resolveConnectionSettings returns the effective ConnectionSettings for a proxy,
+// with EDGE profile defaults applied for Router proxies. The result is safe to
+// use without further cloning (applyEdgeProfileDefaults clones internally).
+func resolveConnectionSettings(node *model.Proxy, push *model.PushContext) *meshconfig.ProxyConfig_ConnectionSettings {
+	cs := node.Metadata.ProxyConfigOrDefault(push.Mesh.GetDefaultConfig()).GetConnectionSettings()
+	if cs == nil {
+		cs = push.Mesh.GetDefaultConfig().GetConnectionSettings()
+	}
+	if cs != nil {
+		cs = applyEdgeProfileDefaults(cs, node.Type)
+	}
+	return cs
+}
+
+// safeUint32 converts an Int32Value to a UInt32Value, returning nil if the input is nil or negative.
+// This guards against negative values becoming ~4 GiB values after an unsigned cast.
+func safeUint32(v *wrappers.Int32Value) *wrappers.UInt32Value {
+	if v == nil || v.GetValue() < 0 {
+		return nil
+	}
+	return &wrappers.UInt32Value{Value: uint32(v.GetValue())}
+}
+
+// applyConnectionSettingsToHCM applies ConnectionSettings fields to an HTTP Connection Manager.
+// When ConnectionSettings normalization fields are set, they take precedence over MeshConfig values.
+func applyConnectionSettingsToHCM(connectionManager *hcm.HttpConnectionManager, cs *meshconfig.ProxyConfig_ConnectionSettings) {
+	if cs == nil {
+		return
+	}
+
+	// --- Timeouts ---
+
+	if cs.GetHttpIdleTimeout() != nil || cs.GetHttpMaxConnectionDuration() != nil || cs.GetHttpMaxStreamDuration() != nil {
+		if connectionManager.CommonHttpProtocolOptions == nil {
+			connectionManager.CommonHttpProtocolOptions = &core.HttpProtocolOptions{}
+		}
+	}
+	if cs.GetHttpIdleTimeout() != nil {
+		connectionManager.CommonHttpProtocolOptions.IdleTimeout = cs.GetHttpIdleTimeout()
+	}
+	if cs.GetHttpMaxConnectionDuration() != nil {
+		connectionManager.CommonHttpProtocolOptions.MaxConnectionDuration = cs.GetHttpMaxConnectionDuration()
+	}
+	if cs.GetHttpMaxStreamDuration() != nil {
+		connectionManager.CommonHttpProtocolOptions.MaxStreamDuration = cs.GetHttpMaxStreamDuration()
+	}
+
+	if cs.GetHttpStreamIdleTimeout() != nil {
+		connectionManager.StreamIdleTimeout = cs.GetHttpStreamIdleTimeout()
+	}
+	if cs.GetHttpRequestTimeout() != nil {
+		connectionManager.RequestTimeout = cs.GetHttpRequestTimeout()
+	}
+	if cs.GetHttpRequestHeadersTimeout() != nil {
+		connectionManager.RequestHeadersTimeout = cs.GetHttpRequestHeadersTimeout()
+	}
+	if cs.GetHttpDrainTimeout() != nil {
+		connectionManager.DrainTimeout = cs.GetHttpDrainTimeout()
+	}
+
+	// --- HTTP/2 options ---
+
+	if cs.GetHttpMaxConcurrentStreams() != nil || cs.GetHttp2InitialStreamWindowSize() != nil || cs.GetHttp2InitialConnectionWindowSize() != nil {
+		if connectionManager.Http2ProtocolOptions == nil {
+			connectionManager.Http2ProtocolOptions = &core.Http2ProtocolOptions{}
+		}
+		if v := safeUint32(cs.GetHttpMaxConcurrentStreams()); v != nil {
+			connectionManager.Http2ProtocolOptions.MaxConcurrentStreams = v
+		}
+		if v := safeUint32(cs.GetHttp2InitialStreamWindowSize()); v != nil {
+			connectionManager.Http2ProtocolOptions.InitialStreamWindowSize = v
+		}
+		if v := safeUint32(cs.GetHttp2InitialConnectionWindowSize()); v != nil {
+			connectionManager.Http2ProtocolOptions.InitialConnectionWindowSize = v
+		}
+	}
+
+	// --- Header/path normalization ---
+	// ProxyConfig ConnectionSettings take precedence over MeshConfig when set.
+
+	if cs.GetHttpHeadersWithUnderscoresAction() != meshconfig.ProxyConfig_ConnectionSettings_HEADERS_WITH_UNDERSCORES_UNSPECIFIED {
+		if connectionManager.CommonHttpProtocolOptions == nil {
+			connectionManager.CommonHttpProtocolOptions = &core.HttpProtocolOptions{}
+		}
+		connectionManager.CommonHttpProtocolOptions.HeadersWithUnderscoresAction = toEnvoyHeadersWithUnderscoresAction(cs.GetHttpHeadersWithUnderscoresAction())
+	}
+	if cs.GetHttpMergeSlashes() != nil {
+		connectionManager.MergeSlashes = cs.GetHttpMergeSlashes().GetValue()
+	}
+	if cs.GetHttpPathWithEscapedSlashesAction() != meshconfig.ProxyConfig_ConnectionSettings_PATH_WITH_ESCAPED_SLASHES_UNSPECIFIED {
+		connectionManager.PathWithEscapedSlashesAction = toEnvoyPathWithEscapedSlashesAction(cs.GetHttpPathWithEscapedSlashesAction())
+	}
+}
+
+// toEnvoyHeadersWithUnderscoresAction converts the Istio API enum to the Envoy core proto enum.
+func toEnvoyHeadersWithUnderscoresAction(
+	action meshconfig.ProxyConfig_ConnectionSettings_HeadersWithUnderscoresAction,
+) core.HttpProtocolOptions_HeadersWithUnderscoresAction {
+	switch action {
+	case meshconfig.ProxyConfig_ConnectionSettings_HEADERS_WITH_UNDERSCORES_REJECT_REQUEST:
+		return core.HttpProtocolOptions_REJECT_REQUEST
+	case meshconfig.ProxyConfig_ConnectionSettings_HEADERS_WITH_UNDERSCORES_DROP_HEADER:
+		return core.HttpProtocolOptions_DROP_HEADER
+	default:
+		return core.HttpProtocolOptions_ALLOW
+	}
+}
+
+// toEnvoyPathWithEscapedSlashesAction converts the Istio API enum to the Envoy HCM proto enum.
+func toEnvoyPathWithEscapedSlashesAction(
+	action meshconfig.ProxyConfig_ConnectionSettings_PathWithEscapedSlashesAction,
+) hcm.HttpConnectionManager_PathWithEscapedSlashesAction {
+	switch action {
+	case meshconfig.ProxyConfig_ConnectionSettings_REJECT_REQUEST:
+		return hcm.HttpConnectionManager_REJECT_REQUEST
+	case meshconfig.ProxyConfig_ConnectionSettings_UNESCAPE_AND_REDIRECT:
+		return hcm.HttpConnectionManager_UNESCAPE_AND_REDIRECT
+	case meshconfig.ProxyConfig_ConnectionSettings_UNESCAPE_AND_FORWARD:
+		return hcm.HttpConnectionManager_UNESCAPE_AND_FORWARD
+	default:
+		return hcm.HttpConnectionManager_KEEP_UNCHANGED
+	}
+}

--- a/pilot/pkg/networking/core/connection_settings_test.go
+++ b/pilot/pkg/networking/core/connection_settings_test.go
@@ -1,0 +1,229 @@
+// Copyright Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"testing"
+	"time"
+
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"google.golang.org/protobuf/types/known/durationpb"
+	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
+
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/test/util/assert"
+)
+
+func TestApplyEdgeProfileDefaults(t *testing.T) {
+	tests := []struct {
+		name     string
+		cs       *meshconfig.ProxyConfig_ConnectionSettings
+		nodeType model.NodeType
+		verify   func(t *testing.T, cs *meshconfig.ProxyConfig_ConnectionSettings)
+	}{
+		{
+			name:     "nil ConnectionSettings returns nil",
+			cs:       nil,
+			nodeType: model.Router,
+			verify: func(t *testing.T, cs *meshconfig.ProxyConfig_ConnectionSettings) {
+				assert.Equal(t, (*meshconfig.ProxyConfig_ConnectionSettings)(nil), cs)
+			},
+		},
+		{
+			name:     "empty ConnectionSettings passes through without error",
+			cs:       &meshconfig.ProxyConfig_ConnectionSettings{},
+			nodeType: model.Router,
+			verify: func(t *testing.T, cs *meshconfig.ProxyConfig_ConnectionSettings) {
+				// No profile set (zero value), so no defaults applied
+				assert.Equal(t, (*wrappers.Int32Value)(nil), cs.GetListenerPerConnectionBufferLimitBytes())
+			},
+		},
+		{
+			name: "SIDECAR profile returns unchanged",
+			cs: &meshconfig.ProxyConfig_ConnectionSettings{
+				Profile: meshconfig.ProxyConfig_ConnectionSettings_SIDECAR,
+			},
+			nodeType: model.Router,
+			verify: func(t *testing.T, cs *meshconfig.ProxyConfig_ConnectionSettings) {
+				assert.Equal(t, (*wrappers.Int32Value)(nil), cs.GetListenerPerConnectionBufferLimitBytes())
+			},
+		},
+		{
+			name: "EDGE profile on sidecar does not apply defaults",
+			cs: &meshconfig.ProxyConfig_ConnectionSettings{
+				Profile: meshconfig.ProxyConfig_ConnectionSettings_EDGE,
+			},
+			nodeType: model.SidecarProxy,
+			verify: func(t *testing.T, cs *meshconfig.ProxyConfig_ConnectionSettings) {
+				assert.Equal(t, (*wrappers.Int32Value)(nil), cs.GetListenerPerConnectionBufferLimitBytes())
+			},
+		},
+		{
+			name: "EDGE profile on Router applies all defaults",
+			cs: &meshconfig.ProxyConfig_ConnectionSettings{
+				Profile: meshconfig.ProxyConfig_ConnectionSettings_EDGE,
+			},
+			nodeType: model.Router,
+			verify: func(t *testing.T, cs *meshconfig.ProxyConfig_ConnectionSettings) {
+				assert.Equal(t, int32(32768), cs.GetListenerPerConnectionBufferLimitBytes().GetValue())
+				assert.Equal(t, time.Hour, cs.GetHttpIdleTimeout().AsDuration())
+				assert.Equal(t, int32(100), cs.GetHttpMaxConcurrentStreams().GetValue())
+				assert.Equal(t, int32(65536), cs.GetHttp2InitialStreamWindowSize().GetValue())
+				assert.Equal(t, int32(1048576), cs.GetHttp2InitialConnectionWindowSize().GetValue())
+				assert.Equal(t, true, cs.GetHttpMergeSlashes().GetValue())
+				assert.Equal(t, meshconfig.ProxyConfig_ConnectionSettings_UNESCAPE_AND_REDIRECT, cs.GetHttpPathWithEscapedSlashesAction())
+				assert.Equal(t, meshconfig.ProxyConfig_ConnectionSettings_HEADERS_WITH_UNDERSCORES_REJECT_REQUEST, cs.GetHttpHeadersWithUnderscoresAction())
+			},
+		},
+		{
+			name: "EDGE profile on Router preserves explicit overrides",
+			cs: &meshconfig.ProxyConfig_ConnectionSettings{
+				Profile:                               meshconfig.ProxyConfig_ConnectionSettings_EDGE,
+				ListenerPerConnectionBufferLimitBytes: &wrappers.Int32Value{Value: 16384},
+				HttpMaxConcurrentStreams:              &wrappers.Int32Value{Value: 50},
+				HttpHeadersWithUnderscoresAction:      meshconfig.ProxyConfig_ConnectionSettings_HEADERS_WITH_UNDERSCORES_DROP_HEADER,
+				HttpPathWithEscapedSlashesAction:      meshconfig.ProxyConfig_ConnectionSettings_UNESCAPE_AND_FORWARD,
+			},
+			nodeType: model.Router,
+			verify: func(t *testing.T, cs *meshconfig.ProxyConfig_ConnectionSettings) {
+				// Explicit overrides preserved
+				assert.Equal(t, int32(16384), cs.GetListenerPerConnectionBufferLimitBytes().GetValue())
+				assert.Equal(t, int32(50), cs.GetHttpMaxConcurrentStreams().GetValue())
+				assert.Equal(t, meshconfig.ProxyConfig_ConnectionSettings_HEADERS_WITH_UNDERSCORES_DROP_HEADER, cs.GetHttpHeadersWithUnderscoresAction())
+				assert.Equal(t, meshconfig.ProxyConfig_ConnectionSettings_UNESCAPE_AND_FORWARD, cs.GetHttpPathWithEscapedSlashesAction())
+				// Defaults still applied for unset fields
+				assert.Equal(t, true, cs.GetHttpMergeSlashes().GetValue())
+			},
+		},
+		{
+			name: "EDGE profile preserves explicit ALLOW and KEEP_UNCHANGED enum values",
+			cs: &meshconfig.ProxyConfig_ConnectionSettings{
+				Profile:                          meshconfig.ProxyConfig_ConnectionSettings_EDGE,
+				HttpHeadersWithUnderscoresAction: meshconfig.ProxyConfig_ConnectionSettings_HEADERS_WITH_UNDERSCORES_ALLOW,
+				HttpPathWithEscapedSlashesAction: meshconfig.ProxyConfig_ConnectionSettings_KEEP_UNCHANGED,
+			},
+			nodeType: model.Router,
+			verify: func(t *testing.T, cs *meshconfig.ProxyConfig_ConnectionSettings) {
+				// Explicit ALLOW / KEEP_UNCHANGED must NOT be overridden to EDGE defaults
+				assert.Equal(t, meshconfig.ProxyConfig_ConnectionSettings_HEADERS_WITH_UNDERSCORES_ALLOW, cs.GetHttpHeadersWithUnderscoresAction())
+				assert.Equal(t, meshconfig.ProxyConfig_ConnectionSettings_KEEP_UNCHANGED, cs.GetHttpPathWithEscapedSlashesAction())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := applyEdgeProfileDefaults(tt.cs, tt.nodeType)
+			tt.verify(t, result)
+		})
+	}
+}
+
+func TestApplyConnectionSettingsToHCM(t *testing.T) {
+	tests := []struct {
+		name   string
+		cs     *meshconfig.ProxyConfig_ConnectionSettings
+		verify func(t *testing.T, cm *hcm.HttpConnectionManager)
+	}{
+		{
+			name: "nil ConnectionSettings is a no-op",
+			cs:   nil,
+			verify: func(t *testing.T, cm *hcm.HttpConnectionManager) {
+				assert.Equal(t, (*core.HttpProtocolOptions)(nil), cm.CommonHttpProtocolOptions)
+			},
+		},
+		{
+			name: "idle timeout sets CommonHttpProtocolOptions",
+			cs: &meshconfig.ProxyConfig_ConnectionSettings{
+				HttpIdleTimeout: durationpb.New(time.Hour),
+			},
+			verify: func(t *testing.T, cm *hcm.HttpConnectionManager) {
+				assert.Equal(t, int64(3600), cm.CommonHttpProtocolOptions.IdleTimeout.GetSeconds())
+			},
+		},
+		{
+			name: "stream idle timeout overrides HCM default",
+			cs: &meshconfig.ProxyConfig_ConnectionSettings{
+				HttpStreamIdleTimeout: durationpb.New(5 * time.Minute),
+			},
+			verify: func(t *testing.T, cm *hcm.HttpConnectionManager) {
+				assert.Equal(t, int64(300), cm.StreamIdleTimeout.GetSeconds())
+			},
+		},
+		{
+			name: "HTTP/2 settings create Http2ProtocolOptions",
+			cs: &meshconfig.ProxyConfig_ConnectionSettings{
+				HttpMaxConcurrentStreams:         &wrappers.Int32Value{Value: 100},
+				Http2InitialStreamWindowSize:     &wrappers.Int32Value{Value: 65536},
+				Http2InitialConnectionWindowSize: &wrappers.Int32Value{Value: 1048576},
+			},
+			verify: func(t *testing.T, cm *hcm.HttpConnectionManager) {
+				assert.Equal(t, uint32(100), cm.Http2ProtocolOptions.MaxConcurrentStreams.GetValue())
+				assert.Equal(t, uint32(65536), cm.Http2ProtocolOptions.InitialStreamWindowSize.GetValue())
+				assert.Equal(t, uint32(1048576), cm.Http2ProtocolOptions.InitialConnectionWindowSize.GetValue())
+			},
+		},
+		{
+			name: "merge slashes and escaped slashes action",
+			cs: &meshconfig.ProxyConfig_ConnectionSettings{
+				HttpMergeSlashes:                 &wrappers.BoolValue{Value: true},
+				HttpPathWithEscapedSlashesAction: meshconfig.ProxyConfig_ConnectionSettings_UNESCAPE_AND_REDIRECT,
+			},
+			verify: func(t *testing.T, cm *hcm.HttpConnectionManager) {
+				assert.Equal(t, true, cm.MergeSlashes)
+				assert.Equal(t, hcm.HttpConnectionManager_UNESCAPE_AND_REDIRECT, cm.PathWithEscapedSlashesAction)
+			},
+		},
+		{
+			name: "headers with underscores action sets CommonHttpProtocolOptions",
+			cs: &meshconfig.ProxyConfig_ConnectionSettings{
+				HttpHeadersWithUnderscoresAction: meshconfig.ProxyConfig_ConnectionSettings_HEADERS_WITH_UNDERSCORES_REJECT_REQUEST,
+			},
+			verify: func(t *testing.T, cm *hcm.HttpConnectionManager) {
+				assert.Equal(t, core.HttpProtocolOptions_REJECT_REQUEST, cm.CommonHttpProtocolOptions.HeadersWithUnderscoresAction)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cm := &hcm.HttpConnectionManager{}
+			applyConnectionSettingsToHCM(cm, tt.cs)
+			tt.verify(t, cm)
+		})
+	}
+}
+
+func TestToEnvoyHeadersWithUnderscoresAction(t *testing.T) {
+	assert.Equal(t, core.HttpProtocolOptions_ALLOW,
+		toEnvoyHeadersWithUnderscoresAction(meshconfig.ProxyConfig_ConnectionSettings_HEADERS_WITH_UNDERSCORES_ALLOW))
+	assert.Equal(t, core.HttpProtocolOptions_REJECT_REQUEST,
+		toEnvoyHeadersWithUnderscoresAction(meshconfig.ProxyConfig_ConnectionSettings_HEADERS_WITH_UNDERSCORES_REJECT_REQUEST))
+	assert.Equal(t, core.HttpProtocolOptions_DROP_HEADER,
+		toEnvoyHeadersWithUnderscoresAction(meshconfig.ProxyConfig_ConnectionSettings_HEADERS_WITH_UNDERSCORES_DROP_HEADER))
+}
+
+func TestToEnvoyPathWithEscapedSlashesAction(t *testing.T) {
+	assert.Equal(t, hcm.HttpConnectionManager_KEEP_UNCHANGED,
+		toEnvoyPathWithEscapedSlashesAction(meshconfig.ProxyConfig_ConnectionSettings_KEEP_UNCHANGED))
+	assert.Equal(t, hcm.HttpConnectionManager_REJECT_REQUEST,
+		toEnvoyPathWithEscapedSlashesAction(meshconfig.ProxyConfig_ConnectionSettings_REJECT_REQUEST))
+	assert.Equal(t, hcm.HttpConnectionManager_UNESCAPE_AND_REDIRECT,
+		toEnvoyPathWithEscapedSlashesAction(meshconfig.ProxyConfig_ConnectionSettings_UNESCAPE_AND_REDIRECT))
+	assert.Equal(t, hcm.HttpConnectionManager_UNESCAPE_AND_FORWARD,
+		toEnvoyPathWithEscapedSlashesAction(meshconfig.ProxyConfig_ConnectionSettings_UNESCAPE_AND_FORWARD))
+}

--- a/pilot/pkg/networking/core/gateway.go
+++ b/pilot/pkg/networking/core/gateway.go
@@ -206,9 +206,18 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(builder *ListenerBui
 			}
 		}
 	}
+	// Use the connection settings already resolved and cached in NewListenerBuilder.
+	cs := builder.connectionSettings
+
 	listeners := make([]*listener.Listener, 0)
 	for _, ml := range mutableopts {
 		ml.mutable.Listener = buildGatewayListener(*ml.opts, ml.transport)
+
+		// Set listener-level buffer limit from ConnectionSettings.
+		if v := safeUint32(cs.GetListenerPerConnectionBufferLimitBytes()); v != nil {
+			ml.mutable.Listener.PerConnectionBufferLimitBytes = v
+		}
+
 		log.Debugf("buildGatewayListeners: marshaling listener %q with %d filter chains",
 			ml.mutable.Listener.GetName(), len(ml.mutable.Listener.GetFilterChains()))
 

--- a/pilot/pkg/networking/core/gateway_test.go
+++ b/pilot/pkg/networking/core/gateway_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
@@ -56,6 +57,7 @@ import (
 	"istio.io/istio/pkg/proto"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/util/sets"
 	"istio.io/istio/pkg/wellknown"
 )
@@ -5133,6 +5135,109 @@ func TestGatewayExternalSDSProvider(t *testing.T) {
 					t.Error("expected combined validation context for MUTUAL TLS")
 				}
 			}
+		})
+	}
+}
+
+func TestGatewayListenerConnectionSettings(t *testing.T) {
+	tests := []struct {
+		name      string
+		cs        *meshconfig.ProxyConfig_ConnectionSettings
+		verifyBuf func(t *testing.T, buf *wrappers.UInt32Value)
+		verifyHCM func(t *testing.T, cm *hcm.HttpConnectionManager)
+	}{
+		{
+			name: "EDGE profile sets buffer limit and HCM defaults",
+			cs: &meshconfig.ProxyConfig_ConnectionSettings{
+				Profile: meshconfig.ProxyConfig_ConnectionSettings_EDGE,
+			},
+			verifyBuf: func(t *testing.T, buf *wrappers.UInt32Value) {
+				assert.Equal(t, uint32(32768), buf.GetValue())
+			},
+			verifyHCM: func(t *testing.T, cm *hcm.HttpConnectionManager) {
+				assert.Equal(t, int64(300), cm.StreamIdleTimeout.GetSeconds())
+				assert.Equal(t, true, cm.MergeSlashes)
+			},
+		},
+		{
+			name: "explicit buffer limit overrides EDGE",
+			cs: &meshconfig.ProxyConfig_ConnectionSettings{
+				Profile:                               meshconfig.ProxyConfig_ConnectionSettings_EDGE,
+				ListenerPerConnectionBufferLimitBytes: &wrappers.Int32Value{Value: 16384},
+			},
+			verifyBuf: func(t *testing.T, buf *wrappers.UInt32Value) {
+				assert.Equal(t, uint32(16384), buf.GetValue())
+			},
+			verifyHCM: func(t *testing.T, cm *hcm.HttpConnectionManager) {
+				// Other EDGE defaults still applied
+				assert.Equal(t, int64(300), cm.StreamIdleTimeout.GetSeconds())
+			},
+		},
+		{
+			name: "no connection settings does not set buffer limit",
+			cs:   nil,
+			verifyBuf: func(t *testing.T, buf *wrappers.UInt32Value) {
+				assert.Equal(t, (*wrappers.UInt32Value)(nil), buf)
+			},
+			verifyHCM: func(t *testing.T, cm *hcm.HttpConnectionManager) {
+				// Default 0s stream idle timeout
+				assert.Equal(t, time.Duration(0), cm.StreamIdleTimeout.AsDuration())
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mc := mesh.DefaultMeshConfig()
+			mc.DefaultConfig.ConnectionSettings = tc.cs
+
+			cg := NewConfigGenTest(t, TestOptions{
+				MeshConfig: mc,
+				Configs: []config.Config{
+					{
+						Meta: config.Meta{
+							GroupVersionKind: gvk.Gateway,
+							Name:             "test-gw",
+							Namespace:        "not-default",
+						},
+						Spec: &networking.Gateway{
+							Selector: map[string]string{"istio": "ingressgateway"},
+							Servers: []*networking.Server{
+								{
+									Port:  &networking.Port{Number: 80, Name: "http", Protocol: "HTTP"},
+									Hosts: []string{"*.example.com"},
+								},
+							},
+						},
+					},
+				},
+			})
+
+			proxy := cg.SetupProxy(&proxyGateway)
+			lb := NewListenerBuilder(proxy, cg.PushContext())
+			builder := cg.ConfigGen.buildGatewayListeners(lb)
+
+			// Find the gateway listener by port
+			var l *listener.Listener
+			for _, lst := range builder.gatewayListeners {
+				if strings.Contains(lst.Name, "_80") {
+					l = lst
+					break
+				}
+			}
+			if l == nil {
+				t.Fatal("expected to find gateway listener")
+			}
+
+			tc.verifyBuf(t, l.PerConnectionBufferLimitBytes)
+
+			// Verify HCM settings
+			// Single-server gateway produces one unnamed filter chain.
+			if len(l.GetFilterChains()) == 0 {
+				t.Fatalf("listener %q has no filter chains", l.Name)
+			}
+			hcmFilter := xdstest.ExtractHTTPConnectionManager(t, l.GetFilterChains()[0])
+			tc.verifyHCM(t, hcmFilter)
 		})
 	}
 }

--- a/pilot/pkg/networking/core/listener_builder.go
+++ b/pilot/pkg/networking/core/listener_builder.go
@@ -66,6 +66,10 @@ type ListenerBuilder struct {
 
 	envoyFilterWrapper *model.MergedEnvoyFilterWrapper
 
+	// connectionSettings caches the resolved ProxyConfig ConnectionSettings for this proxy,
+	// with EDGE profile defaults applied for Router proxies. Computed once in NewListenerBuilder.
+	connectionSettings *meshconfig.ProxyConfig_ConnectionSettings
+
 	// authnBuilder provides access to authn (mTLS) configuration for the given proxy.
 	authnBuilder *authn.Builder
 	// authzBuilder provides access to authz configuration for the given proxy.
@@ -82,8 +86,9 @@ type enabledInspector struct {
 
 func NewListenerBuilder(node *model.Proxy, push *model.PushContext) *ListenerBuilder {
 	builder := &ListenerBuilder{
-		node: node,
-		push: push,
+		node:               node,
+		push:               push,
+		connectionSettings: resolveConnectionSettings(node, push),
 	}
 	builder.authnBuilder = authn.NewBuilder(push, node)
 	builder.authzBuilder = authz.NewBuilder(authz.Local, push, node, node.Type == model.Waypoint)
@@ -433,6 +438,11 @@ func (lb *ListenerBuilder) buildHTTPConnectionManager(httpOpts *httpListenerOpts
 	}
 
 	connectionManager.StreamIdleTimeout = durationpb.New(0 * time.Second)
+
+	// Apply resolved ConnectionSettings (see resolveConnectionSettings; EDGE defaulting
+	// happens there). Explicit values override MeshConfig path normalization and the
+	// default StreamIdleTimeout above.
+	applyConnectionSettingsToHCM(connectionManager, lb.connectionSettings)
 
 	if httpOpts.rds != "" {
 		rds := &hcm.HttpConnectionManager_Rds{

--- a/pilot/pkg/networking/core/listener_builder_test.go
+++ b/pilot/pkg/networking/core/listener_builder_test.go
@@ -19,12 +19,14 @@ import (
 	"net/netip"
 	"reflect"
 	"testing"
+	"time"
 
 	matcher "github.com/cncf/xds/go/xds/type/matcher/v3"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	"k8s.io/apimachinery/pkg/types"
@@ -1584,5 +1586,112 @@ func TestDFPHTTPFilterInjectedInOutboundHCM(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+func TestBuildHTTPConnectionManagerWithConnectionSettings(t *testing.T) {
+	tests := []struct {
+		name          string
+		cs            *meshconfig.ProxyConfig_ConnectionSettings
+		nodeType      model.NodeType
+		pathNormalize *meshconfig.MeshConfig_ProxyPathNormalization
+		verify        func(t *testing.T, cm *hcm.HttpConnectionManager)
+	}{
+		{
+			name: "EDGE profile on gateway applies all defaults",
+			cs: &meshconfig.ProxyConfig_ConnectionSettings{
+				Profile: meshconfig.ProxyConfig_ConnectionSettings_EDGE,
+			},
+			nodeType: model.Router,
+			verify: func(t *testing.T, cm *hcm.HttpConnectionManager) {
+				assert.Equal(t, int64(300), cm.StreamIdleTimeout.GetSeconds())
+				assert.Equal(t, int64(300), cm.RequestTimeout.GetSeconds())
+				assert.Equal(t, int64(3600), cm.CommonHttpProtocolOptions.IdleTimeout.GetSeconds())
+				assert.Equal(t, true, cm.MergeSlashes)
+				assert.Equal(t, hcm.HttpConnectionManager_UNESCAPE_AND_REDIRECT, cm.PathWithEscapedSlashesAction)
+				assert.Equal(t, uint32(100), cm.Http2ProtocolOptions.MaxConcurrentStreams.GetValue())
+				assert.Equal(t, core.HttpProtocolOptions_REJECT_REQUEST, cm.CommonHttpProtocolOptions.HeadersWithUnderscoresAction)
+			},
+		},
+		{
+			name: "EDGE profile on sidecar does not apply defaults",
+			cs: &meshconfig.ProxyConfig_ConnectionSettings{
+				Profile: meshconfig.ProxyConfig_ConnectionSettings_EDGE,
+			},
+			nodeType: model.SidecarProxy,
+			verify: func(t *testing.T, cm *hcm.HttpConnectionManager) {
+				// StreamIdleTimeout should be the default 0s, not the EDGE 300s
+				assert.Equal(t, time.Duration(0), cm.StreamIdleTimeout.AsDuration())
+				assert.Equal(t, (*core.Http2ProtocolOptions)(nil), cm.Http2ProtocolOptions)
+			},
+		},
+		{
+			name: "explicit values on sidecar are applied",
+			cs: &meshconfig.ProxyConfig_ConnectionSettings{
+				Profile:               meshconfig.ProxyConfig_ConnectionSettings_SIDECAR,
+				HttpStreamIdleTimeout: durationpb.New(600 * time.Second),
+				HttpMergeSlashes:      &wrapperspb.BoolValue{Value: true},
+			},
+			nodeType: model.SidecarProxy,
+			verify: func(t *testing.T, cm *hcm.HttpConnectionManager) {
+				assert.Equal(t, int64(600), cm.StreamIdleTimeout.GetSeconds())
+				assert.Equal(t, true, cm.MergeSlashes)
+			},
+		},
+		{
+			name: "explicit overrides on gateway take precedence over EDGE defaults",
+			cs: &meshconfig.ProxyConfig_ConnectionSettings{
+				Profile:               meshconfig.ProxyConfig_ConnectionSettings_EDGE,
+				HttpStreamIdleTimeout: durationpb.New(120 * time.Second),
+				HttpMergeSlashes:      &wrapperspb.BoolValue{Value: false},
+			},
+			nodeType: model.Router,
+			verify: func(t *testing.T, cm *hcm.HttpConnectionManager) {
+				// Explicit override
+				assert.Equal(t, int64(120), cm.StreamIdleTimeout.GetSeconds())
+				assert.Equal(t, false, cm.MergeSlashes)
+				// EDGE defaults still applied for unset fields
+				assert.Equal(t, int64(3600), cm.CommonHttpProtocolOptions.IdleTimeout.GetSeconds())
+				assert.Equal(t, uint32(100), cm.Http2ProtocolOptions.MaxConcurrentStreams.GetValue())
+			},
+		},
+		{
+			name: "ConnectionSettings MergeSlashes=false overrides MeshConfig MERGE_SLASHES",
+			cs: &meshconfig.ProxyConfig_ConnectionSettings{
+				HttpMergeSlashes: &wrapperspb.BoolValue{Value: false},
+			},
+			nodeType: model.SidecarProxy,
+			pathNormalize: &meshconfig.MeshConfig_ProxyPathNormalization{
+				Normalization: meshconfig.MeshConfig_ProxyPathNormalization_MERGE_SLASHES,
+			},
+			verify: func(t *testing.T, cm *hcm.HttpConnectionManager) {
+				// MeshConfig sets MergeSlashes=true, but ConnectionSettings overrides to false
+				assert.Equal(t, false, cm.MergeSlashes)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := mesh.DefaultMeshConfig()
+			mc.DefaultConfig.ConnectionSettings = tt.cs
+			if tt.pathNormalize != nil {
+				mc.PathNormalization = tt.pathNormalize
+			}
+			cg := NewConfigGenTest(t, TestOptions{MeshConfig: mc})
+			proxy := cg.SetupProxy(nil)
+			proxy.Type = tt.nodeType
+			proxy.Metadata.ProxyConfig = nil // Force fallback to mesh default
+			push := cg.PushContext()
+			lb := &ListenerBuilder{
+				push:               push,
+				node:               proxy,
+				connectionSettings: resolveConnectionSettings(proxy, push),
+				authzCustomBuilder: &authz.Builder{},
+				authzBuilder:       &authz.Builder{},
+			}
+			cm := lb.buildHTTPConnectionManager(&httpListenerOpts{})
+			tt.verify(t, cm)
+		})
 	}
 }

--- a/pkg/config/validation/agent/validation.go
+++ b/pkg/config/validation/agent/validation.go
@@ -448,6 +448,12 @@ func ValidateMeshConfigProxyConfig(config *meshconfig.ProxyConfig) Validation {
 		}
 	}
 
+	if cs := config.GetConnectionSettings(); cs != nil {
+		if err := validateConnectionSettings(cs); err != nil {
+			errs = multierror.Append(errs, multierror.Prefix(err, "invalid connection settings:"))
+		}
+	}
+
 	return Validation{errs, warnings}
 }
 
@@ -960,6 +966,54 @@ func validateNetwork(network *meshconfig.Network) (errs error) {
 		if err := ValidatePort(int(n.Port)); err != nil {
 			errs = multierror.Append(errs, err)
 		}
+	}
+	return errs
+}
+
+func validateConnectionSettings(cs *meshconfig.ProxyConfig_ConnectionSettings) error {
+	var errs error
+	if v := cs.GetListenerPerConnectionBufferLimitBytes(); v != nil && v.GetValue() < 0 {
+		errs = multierror.Append(errs, errors.New("listener_per_connection_buffer_limit_bytes must be non-negative"))
+	}
+	if v := cs.GetClusterPerConnectionBufferLimitBytes(); v != nil && v.GetValue() < 0 {
+		errs = multierror.Append(errs, errors.New("cluster_per_connection_buffer_limit_bytes must be non-negative"))
+	}
+	if d := cs.GetHttpIdleTimeout(); d != nil && d.AsDuration() < 0 {
+		errs = multierror.Append(errs, errors.New("http_idle_timeout must be non-negative"))
+	}
+	if d := cs.GetHttpMaxConnectionDuration(); d != nil && d.AsDuration() < 0 {
+		errs = multierror.Append(errs, errors.New("http_max_connection_duration must be non-negative"))
+	}
+	if d := cs.GetHttpDrainTimeout(); d != nil && d.AsDuration() < 0 {
+		errs = multierror.Append(errs, errors.New("http_drain_timeout must be non-negative"))
+	}
+	if d := cs.GetHttpRequestTimeout(); d != nil && d.AsDuration() < 0 {
+		errs = multierror.Append(errs, errors.New("http_request_timeout must be non-negative"))
+	}
+	if d := cs.GetHttpRequestHeadersTimeout(); d != nil && d.AsDuration() < 0 {
+		errs = multierror.Append(errs, errors.New("http_request_headers_timeout must be non-negative"))
+	}
+	if d := cs.GetHttpStreamIdleTimeout(); d != nil && d.AsDuration() < 0 {
+		errs = multierror.Append(errs, errors.New("http_stream_idle_timeout must be non-negative"))
+	}
+	if d := cs.GetHttpMaxStreamDuration(); d != nil && d.AsDuration() < 0 {
+		errs = multierror.Append(errs, errors.New("http_max_stream_duration must be non-negative"))
+	}
+	if v := cs.GetHttpMaxConcurrentStreams(); v != nil && v.GetValue() <= 0 {
+		errs = multierror.Append(errs, errors.New("http_max_concurrent_streams must be positive"))
+	}
+	if v := cs.GetHttp2InitialStreamWindowSize(); v != nil && v.GetValue() < 65535 {
+		errs = multierror.Append(errs, errors.New("http2_initial_stream_window_size must be at least 65535"))
+	}
+	if v := cs.GetHttp2InitialConnectionWindowSize(); v != nil && v.GetValue() < 65535 {
+		errs = multierror.Append(errs, errors.New("http2_initial_connection_window_size must be at least 65535"))
+	}
+	// TODO: ListenerConnectionLimit and GlobalDownstreamConnectionLimit are validated here but wired in later PR (listener limits).
+	if v := cs.GetListenerConnectionLimit(); v != nil && v.GetValue() <= 0 {
+		errs = multierror.Append(errs, errors.New("listener_connection_limit must be positive"))
+	}
+	if v := cs.GetGlobalDownstreamConnectionLimit(); v != nil && v.GetValue() <= 0 {
+		errs = multierror.Append(errs, errors.New("global_downstream_connection_limit must be positive"))
 	}
 	return errs
 }

--- a/pkg/config/validation/agent/validation_test.go
+++ b/pkg/config/validation/agent/validation_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"google.golang.org/protobuf/types/known/durationpb"
+	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
@@ -1669,6 +1670,77 @@ func TestValidateMeshNetworks(t *testing.T) {
 			}
 			if err == nil && !tc.valid {
 				t.Errorf("expected an error on invalid meshnetworks: %v", tc.mn)
+			}
+		})
+	}
+}
+
+func TestValidateConnectionSettings(t *testing.T) {
+	tests := []struct {
+		name    string
+		cs      *meshconfig.ProxyConfig_ConnectionSettings
+		wantErr bool
+	}{
+		{
+			name: "valid EDGE settings",
+			cs: &meshconfig.ProxyConfig_ConnectionSettings{
+				Profile:                               meshconfig.ProxyConfig_ConnectionSettings_EDGE,
+				ListenerPerConnectionBufferLimitBytes: &wrappers.Int32Value{Value: 32768},
+				HttpIdleTimeout:                       durationpb.New(3600 * time.Second),
+				HttpMaxConcurrentStreams:              &wrappers.Int32Value{Value: 100},
+				Http2InitialStreamWindowSize:          &wrappers.Int32Value{Value: 65536},
+				Http2InitialConnectionWindowSize:      &wrappers.Int32Value{Value: 1048576},
+			},
+			wantErr: false,
+		},
+		{
+			name: "negative buffer limit",
+			cs: &meshconfig.ProxyConfig_ConnectionSettings{
+				ListenerPerConnectionBufferLimitBytes: &wrappers.Int32Value{Value: -1},
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero concurrent streams",
+			cs: &meshconfig.ProxyConfig_ConnectionSettings{
+				HttpMaxConcurrentStreams: &wrappers.Int32Value{Value: 0},
+			},
+			wantErr: true,
+		},
+		{
+			name: "small HTTP/2 window and negative duration",
+			cs: &meshconfig.ProxyConfig_ConnectionSettings{
+				Http2InitialStreamWindowSize: &wrappers.Int32Value{Value: 100},
+				HttpIdleTimeout:              durationpb.New(-1 * time.Second),
+			},
+			wantErr: true,
+		},
+		{
+			name: "HTTP/2 connection window size below minimum",
+			cs: &meshconfig.ProxyConfig_ConnectionSettings{
+				Http2InitialConnectionWindowSize: &wrappers.Int32Value{Value: 1000},
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative stream window size",
+			cs: &meshconfig.ProxyConfig_ConnectionSettings{
+				Http2InitialStreamWindowSize: &wrappers.Int32Value{Value: -1},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "empty ConnectionSettings validates clean",
+			cs:      &meshconfig.ProxyConfig_ConnectionSettings{},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateConnectionSettings(tt.cs)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateConnectionSettings() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/releasenotes/notes/connection-settings.yaml
+++ b/releasenotes/notes/connection-settings.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue: []
+releaseNotes:
+  - |
+    **Added** support for `connectionSettings` in `ProxyConfig`, allowing configuration of
+    listener buffer limits, HTTP timeouts, HTTP/2 settings, and path/header normalization.
+    The new `EDGE` profile applies opinionated Envoy edge-proxy defaults to gateway proxies.


### PR DESCRIPTION
Implements wiring for the `ConnectionSettings` API added in istio/api#3707 

`ProxyConfig.connectionSettings` lets users configure listener buffer limits, HTTP timeouts, HTTP/2 settings, and path/header normalization. Setting `profile: EDGE` applies opinionated Envoy edge-proxy defaults (https://www.envoyproxy.io/docs/envoy/latest/configuration/best_practices/edge) to gateway (Router) proxies only; sidecars are unaffected by the profile.

Behavior:
- Explicit field values always override profile defaults, including explicit ALLOW / KEEP_UNCHANGED enum values (via UNSPECIFIED sentinels from istio/api#3725).
- Per-proxy ProxyConfig takes precedence over the mesh-wide default.
- ConnectionSettings normalization fields take precedence over MeshConfig `pathNormalization` when set.
- Settings are resolved and cloned once per proxy in NewListenerBuilder.

Wired in this PR: listener perConnectionBufferLimitBytes (gateway listeners) and HCM timeouts, HTTP/2 options, and path/header normalization.

TODO in follow up PR(s): clusterPerConnectionBufferLimitBytes, listenerConnectionLimit, and globalDownstreamConnectionLimit (validated here, consumed in the next PR alongside cluster generation / listener limits).