### PR TITLE
dependabot: drop release-1.28, ignore helm on release-1.30

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,6 +50,7 @@ updates:
       - dependency-name: "sigs.k8s.io/*"
       - dependency-name: "github.com/envoyproxy/go-control-plane/*"
       - dependency-name: "github.com/prometheus/prometheus"
+      - dependency-name: "helm.sh/helm/v3"
     groups:
       all-dependencies:
         patterns:
@@ -60,6 +61,7 @@ updates:
           - "sigs.k8s.io/*"
           - "github.com/envoyproxy/go-control-plane/*"
           - "github.com/prometheus/prometheus"
+          - "helm.sh/helm/v3"
 
   - package-ecosystem: "gomod"
     directories:
@@ -91,41 +93,6 @@ updates:
           - "github.com/prometheus/prometheus"
           - "helm.sh/helm/v3"
           - "google.golang.org/grpc"
-
-  - package-ecosystem: "gomod"
-    directories:
-      - "/"
-      - "!/samples/**"
-    schedule:
-      interval: "daily"
-    labels:
-      - "release-notes-none"
-    target-branch: "release-1.28"
-    # See master stanza above for why both ignore and exclude-patterns are required.
-    ignore:
-      - dependency-name: "istio.io/*"
-      - dependency-name: "k8s.io/*"
-      - dependency-name: "sigs.k8s.io/*"
-      - dependency-name: "github.com/envoyproxy/go-control-plane/*"
-      - dependency-name: "github.com/prometheus/prometheus"
-      - dependency-name: "helm.sh/helm/v3"
-      - dependency-name: "google.golang.org/grpc"
-      - dependency-name: "github.com/quic-go/quic-go"
-      - dependency-name: "github.com/containernetworking/plugins"
-    groups:
-      all-dependencies:
-        patterns:
-          - "*"
-        exclude-patterns:
-          - "istio.io/*"
-          - "k8s.io/*"
-          - "sigs.k8s.io/*"
-          - "github.com/envoyproxy/go-control-plane/*"
-          - "github.com/prometheus/prometheus"
-          - "helm.sh/helm/v3"
-          - "google.golang.org/grpc"
-          - "github.com/quic-go/quic-go"
-          - "github.com/containernetworking/plugins"
 
   # Ignore all dependency updates in samples/
   # We do not care about the dependencies in the samples/ directory as they are not meant


### PR DESCRIPTION
release branches should not get go directive bumps from dep updates. helm 3.21.1 forces go 1.26 which breaks vet on release-1.30 (see #60572). same ignore release-1.29 and release-1.28 already have. also drops the release-1.28 stanza since release branches only take security fixes.