### PR TITLE
pilot: prune stale ListenerSet listener status when a listener is removed

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -1900,6 +1900,25 @@ func reportListenerSetStatus(
 
 	setProgrammedCondition(gatewayConditions, internal, gatewayServices, warnings, allUsable)
 
+	// Prune stale listener status entries whose listener was removed from the spec,
+	// mirroring reportGatewayStatus. ListenerSetCollection threads the previous status
+	// forward to preserve per-listener data across reconciles, but only refreshes entries
+	// for listeners still in the spec. Without this pruning, a removed listener's status
+	// entry is orphaned forever (len(status.Listeners) > len(spec.Listeners)), which also
+	// wedges observedGeneration once the recomputed status stops differing from the stored one.
+	haveListeners := sets.New[k8s.SectionName]()
+	for _, l := range obj.Spec.Listeners {
+		haveListeners.Insert(l.Name)
+	}
+	listeners := make([]k8s.ListenerEntryStatus, 0, len(gs.Listeners))
+	for _, l := range gs.Listeners {
+		if haveListeners.Contains(l.Name) {
+			haveListeners.Delete(l.Name)
+			listeners = append(listeners, l)
+		}
+	}
+	gs.Listeners = listeners
+
 	gs.Conditions = setConditions(obj.Generation, gs.Conditions, gatewayConditions)
 }
 

--- a/pilot/pkg/config/kube/gateway/conversion_test.go
+++ b/pilot/pkg/config/kube/gateway/conversion_test.go
@@ -57,6 +57,7 @@ import (
 	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/util/sets"
 )
 
@@ -1985,4 +1986,96 @@ func kubernetesObjectsFromString(s string) ([]runtime.Object, error) {
 
 func firstValue[T, U any](val T, _ U) T {
 	return val
+}
+
+// TestListenerSetStatusTruncatesOnListenerRemoval is a regression test for a bug where a
+// listener removed from a ListenerSet's spec left an orphaned entry in status.Listeners
+// forever. ListenerSetCollection threads the previous status forward (to preserve
+// per-listener data across reconciles) but only refreshes entries for listeners still in
+// the spec, and reportListenerSetStatus did not prune the stale ones the way
+// reportGatewayStatus does for Gateways. The leftover entry left
+// len(status.Listeners) > len(spec.Listeners) and eventually wedged observedGeneration.
+//
+// The ListenerSet is created with a spec of 2 listeners but a status that already carries
+// 3 (one stale entry), simulating the post-removal state. A correct reconcile must prune
+// the status back to the 2 listeners that are still in the spec.
+func TestListenerSetStatusTruncatesOnListenerRemoval(t *testing.T) {
+	test.SetForTest(t, &features.EnableGatewayAPIGatewayClassController, false)
+	stop := test.NewStop(t)
+	kc := kube.NewFakeClient()
+	setupClientCRDs(t, kc)
+	cg := core.NewConfigGenTest(t, core.TestOptions{})
+
+	gatewayClasses := clienttest.NewWriter[*k8s.GatewayClass](t, kc)
+	gateways := clienttest.NewWriter[*k8s.Gateway](t, kc)
+	listenerSets := clienttest.NewWriter[*k8s.ListenerSet](t, kc)
+
+	ctrl := NewController(kc, AlwaysReady, controller.Options{DomainSuffix: "domain.suffix", KrtDebugger: &krt.DebugHandler{}}, nil)
+	sq := &TestStatusQueue{state: map[status.Resource]any{}}
+	go ctrl.Run(stop)
+	kc.RunAndWait(stop)
+	ctrl.Reconcile(cg.PushContext())
+	kube.WaitForCacheSync("test", stop, ctrl.HasSynced)
+	ctrl.status.SetQueue(sq)
+
+	gatewayClasses.Create(&k8s.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "istio"},
+		Spec:       k8s.GatewayClassSpec{ControllerName: "istio.io/gateway-controller"},
+	})
+	gateways.Create(&k8s.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "parent", Namespace: "istio-system"},
+		Spec: k8s.GatewaySpec{
+			GatewayClassName: "istio",
+			AllowedListeners: &k8s.AllowedListeners{
+				Namespaces: &k8s.ListenerNamespaces{From: ptr.Of(k8s.NamespacesFromAll)},
+			},
+			Listeners: []k8s.Listener{{
+				Name:     "default",
+				Hostname: ptr.Of(k8s.Hostname("example.com")),
+				Protocol: k8s.HTTPProtocolType,
+				Port:     80,
+			}},
+		},
+	})
+
+	entry := func(n string) k8s.ListenerEntry {
+		return k8s.ListenerEntry{
+			Name:     k8s.SectionName(n),
+			Hostname: ptr.Of(k8s.Hostname(n + ".example.com")),
+			Protocol: k8s.HTTPProtocolType,
+			Port:     80,
+		}
+	}
+	listenerSets.Create(&k8s.ListenerSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "set", Namespace: "istio-system"},
+		Spec: k8s.ListenerSetSpec{
+			ParentRef: k8s.ParentGatewayReference{
+				Group:     ptr.Of(k8s.Group("gateway.networking.k8s.io")),
+				Kind:      ptr.Of(k8s.Kind("Gateway")),
+				Name:      "parent",
+				Namespace: ptr.Of(k8s.Namespace("istio-system")),
+			},
+			Listeners: []k8s.ListenerEntry{entry("a"), entry("b")},
+		},
+		// Stale status: a previous, larger spec left an orphaned "stale" listener entry.
+		Status: k8s.ListenerSetStatus{
+			Listeners: []k8s.ListenerEntryStatus{{Name: "a"}, {Name: "b"}, {Name: "stale"}},
+		},
+	})
+
+	statusListenerCount := func() int {
+		for _, s := range sq.Statuses() {
+			switch st := s.(type) {
+			case *k8s.ListenerSetStatus:
+				return len(st.Listeners)
+			case k8s.ListenerSetStatus:
+				return len(st.Listeners)
+			}
+		}
+		return -1
+	}
+
+	// With the fix, the orphaned "stale" entry is pruned and status matches the 2 spec
+	// listeners. Without the fix, status stays at 3.
+	assert.EventuallyEqual(t, statusListenerCount, 2)
 }

--- a/releasenotes/notes/60578.yaml
+++ b/releasenotes/notes/60578.yaml
@@ -1,0 +1,14 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 60578
+releaseNotes:
+  - |
+    **Fixed** a bug where removing a listener from a `ListenerSet` left an orphaned entry
+    in the resource's `status.listeners` indefinitely. The stale entry made
+    `status.listeners` longer than `spec.listeners` and, after repeated listener add/remove
+    cycles, wedged the `ListenerSet`'s `observedGeneration` so later spec changes were no
+    longer reflected in its status. `reportListenerSetStatus` now prunes status entries for
+    listeners that are no longer present in the spec, matching the existing behavior for
+    `Gateway` resources.


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes #60578.

When a listener is removed from a `ListenerSet`'s `spec.listeners`, the corresponding entry in `status.listeners` was never removed, so `len(status.listeners)` stayed larger than `len(spec.listeners)` indefinitely. After repeated add/remove cycles this also wedged the resource's `observedGeneration` — once the recomputed status stopped differing from the stored stale status, istiod stopped writing status for the object, so later spec changes were no longer reflected. Consumers that read `status.listeners` (e.g. external-dns's `gateway-httproute` source) silently stopped seeing newly-added listeners, so DNS records for new hostnames were never created.

`reportListenerSetStatus` now prunes status entries for listeners that are no longer present in the spec, mirroring `reportGatewayStatus`, which already rebuilds the list from `getListenerNames(&obj.Spec)`. `Gateway` resources were already correct; only `ListenerSet` was affected.

Adds a regression test (`TestListenerSetStatusTruncatesOnListenerRemoval`) that reconciles a `ListenerSet` whose status carries an orphaned listener entry (spec `[a, b]`, status `[a, b, stale]`) and asserts it is pruned back to the spec listeners.