### PR TITLE
WIP: Update nftables version in the distroless images

### DIFF
--- a/docker/iptables.yaml
+++ b/docker/iptables.yaml
@@ -12,7 +12,7 @@ contents:
     - libnfnetlink
     - libmnl
     - libgcc
-    - nftables=1.1.1-r40
+    - nftables=1.1.5-r0
 archs:
   - x86_64
   - aarch64


### PR DESCRIPTION
The Wolfi repository has recently removed nftables version 1.1.1 from the APKINDEX, which is causing failures in the build-base-images job. This PR updates the pinned nftables version to 1.1.5-r0 to address the immediate build issue, while continuing to pin the version until the major distributions update their host nftables packages with the fix described in issue #[58492](https://github.com/istio/istio/issues/58492#issuecomment-4620880090).

One thing to note is that, as part of issue #60370, the code now falls back to iptables-nft when the nftables version does not support JSON output. Since nftables version 1.1.5-r0 does not include JSON support, distroless images running in ambient mode will use the iptables backend, even when nativeNftables is explicitly enabled.

Related to: https://github.com/istio/istio/issues/58492
