### PR TITLE
feat: support excluding hosts in sidecar egress listener

### DIFF
--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -40,6 +40,7 @@ const (
 	wildcardNamespace = "*"
 	currentNamespace  = "."
 	wildcardService   = host.Name("*")
+	excludePrefix     = "~"
 )
 
 var (
@@ -65,8 +66,19 @@ var (
 )
 
 type hostClassification struct {
-	exactHosts sets.Set[host.Name]
-	allHosts   []host.Name
+	exactHosts    sets.Set[host.Name]
+	allHosts      []host.Name
+	excludedHosts []host.Name
+}
+
+// Excluded reports whether h matches any ~-prefixed exclusion entry scoped to this namespace.
+func (hc hostClassification) Excluded(h host.Name) bool {
+	for _, excluded := range hc.excludedHosts {
+		if h.SubsetOf(excluded) {
+			return true
+		}
+	}
+	return false
 }
 
 // Matches checks if the hostClassification(sidecar egress hosts) matches the Service's hostname
@@ -491,6 +503,14 @@ func convertIstioListenerToWrapper(ps *PushContext, configNamespace string,
 			continue
 		}
 		ns, name, _ := strings.Cut(h, "/")
+
+		excluded := strings.HasPrefix(ns, excludePrefix)
+		if excluded {
+			ns = strings.TrimPrefix(ns, excludePrefix)
+			if ns == "" {
+				ns = wildcardNamespace
+			}
+		}
 		if ns == currentNamespace {
 			ns = configNamespace
 		}
@@ -499,6 +519,12 @@ func convertIstioListenerToWrapper(ps *PushContext, configNamespace string,
 		hc, exists := hostsByNamespace[ns]
 		if !exists {
 			hc = hostClassification{exactHosts: sets.New[host.Name](), allHosts: make([]host.Name, 0)}
+		}
+
+		if excluded {
+			hc.excludedHosts = append(hc.excludedHosts, hName)
+			hostsByNamespace[ns] = hc
+			continue
 		}
 
 		// exact hosts are saved separately for map lookup
@@ -774,10 +800,16 @@ func (ilw *IstioEgressListenerWrapper) selectServices(services []*Service, confi
 	wildcardHosts, wnsFound := hostsByNamespace[wildcardNamespace]
 	for _, s := range services {
 		configNamespace := s.Attributes.Namespace
+		nsHosts, nsFound := hostsByNamespace[configNamespace]
+
+		// Skip services excluded by a ~-prefixed host in the service's namespace or wildcard scope.
+		if (nsFound && nsHosts.Excluded(s.Hostname)) || (wnsFound && wildcardHosts.Excluded(s.Hostname)) {
+			continue
+		}
 
 		// Check if there is an explicit import of form ns/* or ns/host
-		if importedHosts, nsFound := hostsByNamespace[configNamespace]; nsFound {
-			if svc := matchingAliasService(importedHosts, matchingService(importedHosts, s, ilw)); svc != nil {
+		if nsFound {
+			if svc := matchingAliasService(nsHosts, matchingService(nsHosts, s, ilw)); svc != nil {
 				importedServices = append(importedServices, svc)
 				continue
 			}

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -3234,6 +3234,44 @@ func TestIstioEgressListenerWrapper(t *testing.T) {
 			expected:  []*Service{serviceBWildcard},
 			namespace: "b",
 		},
+		{
+			name: "*/* excludes whole namespace b via ~b/*",
+			listenerHosts: map[string]hostClassification{
+				wildcardNamespace: {allHosts: []host.Name{wildcardService}, exactHosts: sets.New[host.Name]()},
+				"b":               {excludedHosts: []host.Name{wildcardService}},
+			},
+			services:  allServices,
+			expected:  []*Service{serviceA8000, serviceA9000, serviceAalt},
+			namespace: "a",
+		},
+		{
+			name: "*/* excludes exact host (all ports) from all namespaces via ~/host",
+			listenerHosts: map[string]hostClassification{
+				wildcardNamespace: {allHosts: []host.Name{wildcardService}, exactHosts: sets.New[host.Name](), excludedHosts: []host.Name{"host"}},
+			},
+			services:  allServices,
+			expected:  []*Service{serviceAalt},
+			namespace: "a",
+		},
+		{
+			name: "wildcard exclusion ~b/*.wildcard.com drops matching service",
+			listenerHosts: map[string]hostClassification{
+				"b": {allHosts: []host.Name{wildcardService}, exactHosts: sets.New[host.Name](), excludedHosts: []host.Name{"*.wildcard.com"}},
+			},
+			services:  []*Service{serviceBWildcard},
+			expected:  []*Service{},
+			namespace: "b",
+		},
+		{
+			name: "ns-scoped exclusion does not affect other namespace",
+			listenerHosts: map[string]hostClassification{
+				wildcardNamespace: {allHosts: []host.Name{wildcardService}, exactHosts: sets.New[host.Name]()},
+				"a":               {excludedHosts: []host.Name{wildcardService}},
+			},
+			services:  []*Service{serviceB8000, serviceB9000, serviceBalt},
+			expected:  []*Service{serviceB8000, serviceB9000, serviceBalt},
+			namespace: "b",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -39,23 +39,31 @@ func SelectVirtualServices(vsidx virtualServiceIndex, configNamespace string, ho
 	importedVirtualServices := make([]*config.Config, 0, estimatedCap)
 	vsset := sets.New[types.NamespacedName]()
 
-	addVirtualService := func(vs *config.Config, hc hostClassification, useGatewaySemantics bool) {
+	wnsImportedHosts, wnsFound := hostsByNamespace[wildcardNamespace]
+
+	addVirtualService := func(vs *config.Config, hc hostClassification, useGatewaySemantics bool, vsNamespace string) {
 		key := vs.NamespacedName()
 		if vsset.Contains(key) {
 			return
 		}
 
+		nsExcl, nsExclFound := hostsByNamespace[vsNamespace]
 		rule := vs.Spec.(*networking.VirtualService)
 		for _, vh := range rule.Hosts {
-			if hc.VSMatches(host.Name(vh), useGatewaySemantics) {
-				importedVirtualServices = append(importedVirtualServices, vs)
-				vsset.Insert(key)
-				return
+			h := host.Name(vh)
+			if !hc.VSMatches(h, useGatewaySemantics) {
+				continue
 			}
+			// Skip a matched host excluded by a ~-prefixed entry; another host may still select the VS.
+			if (nsExclFound && nsExcl.Excluded(h)) || (wnsFound && wnsImportedHosts.Excluded(h)) {
+				continue
+			}
+			importedVirtualServices = append(importedVirtualServices, vs)
+			vsset.Insert(key)
+			return
 		}
 	}
 
-	wnsImportedHosts, wnsFound := hostsByNamespace[wildcardNamespace]
 	var loopAndAdd func(vses []config.Config)
 	if features.UnifiedSidecarScoping {
 		loopAndAdd = func(vses []config.Config) {
@@ -75,12 +83,12 @@ func SelectVirtualServices(vsidx virtualServiceIndex, configNamespace string, ho
 
 					// Check if there is an explicit import of form ns/* or ns/host
 					if importedHosts, nsFound := hostsByNamespace[vsNamespace]; nsFound {
-						addVirtualService(c, importedHosts, useGatewaySemantics)
+						addVirtualService(c, importedHosts, useGatewaySemantics, vsNamespace)
 					}
 
 					// Check if there is an import of form */host or */*
 					if wnsFound {
-						addVirtualService(c, wnsImportedHosts, useGatewaySemantics)
+						addVirtualService(c, wnsImportedHosts, useGatewaySemantics, vsNamespace)
 					}
 				}
 			}
@@ -99,12 +107,12 @@ func SelectVirtualServices(vsidx virtualServiceIndex, configNamespace string, ho
 
 				// Check if there is an explicit import of form ns/* or ns/host
 				if importedHosts, nsFound := hostsByNamespace[vsNamespace]; nsFound {
-					addVirtualService(c, importedHosts, useGatewaySemantics)
+					addVirtualService(c, importedHosts, useGatewaySemantics, vsNamespace)
 				}
 
 				// Check if there is an import of form */host or */*
 				if wnsFound {
-					addVirtualService(c, wnsImportedHosts, useGatewaySemantics)
+					addVirtualService(c, wnsImportedHosts, useGatewaySemantics, vsNamespace)
 				}
 			}
 		}

--- a/pilot/pkg/model/virtualservice_test.go
+++ b/pilot/pkg/model/virtualservice_test.go
@@ -1655,6 +1655,139 @@ func TestSelectVirtualService(t *testing.T) {
 	}
 }
 
+func TestSelectVirtualServicesExclusion(t *testing.T) {
+	mkVS := func(name, ns string, hosts ...string) config.Config {
+		return config.Config{
+			Meta: config.Meta{GroupVersionKind: gvk.VirtualService, Name: name, Namespace: ns},
+			Spec: &networking.VirtualService{Hosts: hosts, Gateways: []string{"mesh"}},
+		}
+	}
+	index := virtualServiceIndex{
+		publicByGateway: map[string][]config.Config{
+			constants.IstioMeshGateway: {
+				mkVS("vs-a", "a", "a.com"),
+				mkVS("vs-b", "b", "b.com"),
+				mkVS("vs-multi", "a", "drop.com", "keep.com"),
+			},
+		},
+	}
+
+	includeAll := hostClassification{exactHosts: sets.New[host.Name](), allHosts: []host.Name{wildcardService}}
+	includeAllExcept := func(excluded ...host.Name) hostClassification {
+		return hostClassification{exactHosts: sets.New[host.Name](), allHosts: []host.Name{wildcardService}, excludedHosts: excluded}
+	}
+
+	tests := []struct {
+		name      string
+		hostsByNS map[string]hostClassification
+		expected  []string
+	}{
+		{
+			name:      "no exclusion selects all",
+			hostsByNS: map[string]hostClassification{wildcardNamespace: includeAll},
+			expected:  []string{"vs-a", "vs-b", "vs-multi"},
+		},
+		{
+			name: "~b/* excludes namespace b",
+			hostsByNS: map[string]hostClassification{
+				wildcardNamespace: includeAll,
+				"b":               {excludedHosts: []host.Name{wildcardService}},
+			},
+			expected: []string{"vs-a", "vs-multi"},
+		},
+		{
+			name:      "~/a.com excludes the VS whose only host is a.com",
+			hostsByNS: map[string]hostClassification{wildcardNamespace: includeAllExcept("a.com")},
+			expected:  []string{"vs-b", "vs-multi"},
+		},
+		{
+			name:      "multi-host VS survives when only one host excluded",
+			hostsByNS: map[string]hostClassification{wildcardNamespace: includeAllExcept("drop.com")},
+			expected:  []string{"vs-a", "vs-b", "vs-multi"},
+		},
+		{
+			name:      "multi-host VS dropped when all hosts excluded",
+			hostsByNS: map[string]hostClassification{wildcardNamespace: includeAllExcept("drop.com", "keep.com")},
+			expected:  []string{"vs-a", "vs-b"},
+		},
+		{
+			name: "exclusion via ns scope while include via wildcard scope",
+			hostsByNS: map[string]hostClassification{
+				wildcardNamespace: includeAll,
+				"a":               {excludedHosts: []host.Name{"a.com"}},
+			},
+			expected: []string{"vs-b", "vs-multi"},
+		},
+		{
+			name:      "exclusion with no include matches nothing",
+			hostsByNS: map[string]hostClassification{wildcardNamespace: {exactHosts: sets.New[host.Name](), excludedHosts: []host.Name{wildcardService}}},
+			expected:  []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SelectVirtualServices(index, "some-ns", tt.hostsByNS)
+			gotNames := make([]string, 0, len(got))
+			for _, c := range got {
+				gotNames = append(gotNames, c.Name)
+			}
+			assert.Equal(t, gotNames, tt.expected)
+		})
+	}
+}
+
+// TestSelectVirtualServicesExclusionWildcard pins the directional SubsetOf semantics:
+// a wildcard exclusion covers exact hosts, but an exact exclusion does not drop a
+// wildcard route that still serves other hosts.
+func TestSelectVirtualServicesExclusionWildcard(t *testing.T) {
+	mkVS := func(name string, hosts ...string) config.Config {
+		return config.Config{
+			Meta: config.Meta{GroupVersionKind: gvk.VirtualService, Name: name, Namespace: "a"},
+			Spec: &networking.VirtualService{Hosts: hosts, Gateways: []string{"mesh"}},
+		}
+	}
+	index := virtualServiceIndex{
+		publicByGateway: map[string][]config.Config{
+			constants.IstioMeshGateway: {
+				mkVS("vs-exact", "a.com"),
+				mkVS("vs-wild", "*.com"),
+			},
+		},
+	}
+	includeAllExcept := func(excluded ...host.Name) map[string]hostClassification {
+		return map[string]hostClassification{
+			wildcardNamespace: {exactHosts: sets.New[host.Name](), allHosts: []host.Name{wildcardService}, excludedHosts: excluded},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		hostsByNS map[string]hostClassification
+		expected  []string
+	}{
+		{
+			name:      "wildcard exclusion covers exact host",
+			hostsByNS: includeAllExcept("*.com"),
+			expected:  []string{},
+		},
+		{
+			name:      "exact exclusion does not drop wildcard route",
+			hostsByNS: includeAllExcept("a.com"),
+			expected:  []string{"vs-wild"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SelectVirtualServices(index, "some-ns", tt.hostsByNS)
+			gotNames := make([]string, 0, len(got))
+			for _, c := range got {
+				gotNames = append(gotNames, c.Name)
+			}
+			assert.Equal(t, gotNames, tt.expected)
+		})
+	}
+}
+
 func buildHTTPService(hostname string, v visibility.Instance, ip, namespace string, ports ...int) *Service {
 	service := &Service{
 		CreationTime:   time.Now(),

--- a/pkg/config/validation/agent/validation.go
+++ b/pkg/config/validation/agent/validation.go
@@ -894,19 +894,16 @@ func ValidateNamespaceSlashWildcardHostname(hostname string, isGateway bool, gat
 	}
 
 	if !isGateway {
-		// namespace can be * or . or ~ or a valid DNS label in sidecars
-		if parts[0] != "*" && parts[0] != "." && parts[0] != "~" {
-			if !labels.IsDNS1123Label(parts[0]) {
-				errs = AppendErrors(errs, fmt.Errorf("invalid namespace value %q in sidecar", parts[0]))
-			}
+		// namespace can be *, ., or a valid DNS label, optionally ~-prefixed to exclude it.
+		ns := strings.TrimPrefix(parts[0], "~")
+		if ns != "" && ns != "*" && ns != "." && !labels.IsDNS1123Label(ns) {
+			errs = AppendErrors(errs, fmt.Errorf("invalid namespace value %q in sidecar", parts[0]))
 		}
-	} else {
+	} else if parts[0] != "*" && parts[0] != "." && (parts[0] != "~" || !gatewaySemantics) {
 		// namespace can be * or . or a valid DNS label in gateways
 		// namespace can be ~ in gateways converted from Gateway API when no routes match
-		if parts[0] != "*" && parts[0] != "." && (parts[0] != "~" || !gatewaySemantics) {
-			if !labels.IsDNS1123Label(parts[0]) {
-				errs = AppendErrors(errs, fmt.Errorf("invalid namespace value %q in gateway", parts[0]))
-			}
+		if !labels.IsDNS1123Label(parts[0]) {
+			errs = AppendErrors(errs, fmt.Errorf("invalid namespace value %q in gateway", parts[0]))
 		}
 	}
 	errs = AppendErrors(errs, validateSidecarOrGatewayHostnamePart(parts[1], isGateway))

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -933,7 +933,7 @@ var ValidateSidecar = RegisterValidateFunc("ValidateSidecar",
 				nssSvcs := map[string]map[string]bool{}
 				for _, hostname := range egress.Hosts {
 					parts := strings.SplitN(hostname, "/", 2)
-					if len(parts) == 2 {
+					if len(parts) == 2 && !strings.HasPrefix(parts[0], "~") {
 						ns := parts[0]
 						svc := parts[1]
 						if ns == "." {

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -5974,6 +5974,27 @@ func TestValidateSidecar(t *testing.T) {
 				},
 			},
 		}, true, false},
+		{"import all except a namespace", &networking.Sidecar{
+			Egress: []*networking.IstioEgressListener{
+				{
+					Hosts: []string{"*/*", "~ns1/*"},
+				},
+			},
+		}, true, false},
+		{"import all except an exact host", &networking.Sidecar{
+			Egress: []*networking.IstioEgressListener{
+				{
+					Hosts: []string{"*/*", "~/foo.com"},
+				},
+			},
+		}, true, false},
+		{"exclude with invalid namespace", &networking.Sidecar{
+			Egress: []*networking.IstioEgressListener{
+				{
+					Hosts: []string{"*/*", "~Invalid_NS/*"},
+				},
+			},
+		}, false, false},
 		{"bad egress host 1", &networking.Sidecar{
 			Egress: []*networking.IstioEgressListener{
 				{

--- a/releasenotes/notes/60139.yaml
+++ b/releasenotes/notes/60139.yaml
@@ -1,0 +1,12 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 60139
+releaseNotes:
+- |
+  **Added** support for excluding namespaces and hosts from a `Sidecar` egress listener's `hosts`
+  using a `~` prefix on the namespace. Entries without a prefix are imported as before, and
+  `~`-prefixed entries subtract from them: `~ns1/*` excludes all hosts in `ns1`, and `~/foo.com`
+  excludes `foo.com` from every namespace. This lets large meshes import everything except a few
+  namespaces (e.g. `*/*` plus `~ns1/*`) without enumerating a long allowlist.


### PR DESCRIPTION
**Please provide a description of this PR:**
- Adds support for excluding namespaces and hosts from a Sidecar egress listener's hosts, using a `~` prefix on the namespace. Chose this prefix since `~/*` is already supported today and this logically extends the same convention.
- Semantics:
  - `~ns/*` exclude every host in namespace `ns`.
  - `~ns/host` exclude `host` within `ns`.
  - `~/host`exclude `host` across all namespaces (`~` alone maps to the wildcard namespace).
  - `~/*` import nothing, already supported.
- Exclusion is applied over inclusion: a host is selected if `included && !excluded`. Affects both `selectServices` (clusters) and `SelectVirtualServices` (routes).
- For multi-host VirtualServices, a host excluded on one entry doesn't drop the VS if another host still qualifies, the VS is removed only when all matching hosts are excluded.
- Validation changes to support the new semantics.

Related #60139 