### PR TITLE
fix(security): de-duplicate certificate chain in CSR response

### DIFF
--- a/releasenotes/notes/39001-dedup-root-cert.yaml
+++ b/releasenotes/notes/39001-dedup-root-cert.yaml
@@ -1,0 +1,18 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+issue:
+  - 39001
+releaseNotes:
+  - |
+    **Fixed** an issue where the istiod CSR response (`CreateCertificate`)
+    contained the root CA certificate twice in the returned cert chain when
+    Istio was installed with a plug-in CA whose `cert-chain.pem` already
+    included the root certificate (the default format produced by Istio's
+    `make-ca-certs.sh`/Makefile). The duplicate was tolerated by Envoy but
+    wasted bandwidth on every mTLS handshake and confused TLS debugging
+    tools. A new SHA-256 fingerprint-based dedup step at the response
+    boundary now collapses byte-identical duplicates while preserving the
+    spec invariant that the root cert is the last element. If a duplicate
+    is observed at runtime, istiod logs a single warning per process so
+    operators can inspect their plug-in CA configuration.

--- a/security/pkg/server/ca/dedup_test.go
+++ b/security/pkg/server/ca/dedup_test.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ca
 
 import (

--- a/security/pkg/server/ca/dedup_test.go
+++ b/security/pkg/server/ca/dedup_test.go
@@ -1,0 +1,483 @@
+package ca
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+
+	pb "istio.io/api/security/v1alpha1"
+	"istio.io/istio/pkg/security"
+	mockca "istio.io/istio/security/pkg/pki/ca/mock"
+	"istio.io/istio/security/pkg/pki/util"
+)
+
+// ---- test helpers -----------------------------------------------------------
+
+// mkCert returns a self-signed ECDSA P-256 cert as a PEM string. Cert is
+// CA-marked for simplicity; only DER identity is what these tests assert.
+func mkCert(t *testing.T, cn string) string {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("key gen: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IsCA:         true,
+		KeyUsage:     x509.KeyUsageCertSign,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+}
+
+func concat(parts ...string) string { return strings.Join(parts, "") }
+
+// countCerts counts CERTIFICATE PEM blocks across a chain slice.
+func countCerts(chain []string) int {
+	n := 0
+	for _, e := range chain {
+		rest := []byte(e)
+		for {
+			b, r := pem.Decode(rest)
+			if b == nil {
+				break
+			}
+			if b.Type == "CERTIFICATE" {
+				n++
+			}
+			rest = r
+		}
+	}
+	return n
+}
+
+// fpsOfChain returns SHA-256 hex fingerprints of every CERTIFICATE block in
+// the chain (in order).
+func fpsOfChain(t *testing.T, chain []string) []string {
+	t.Helper()
+	var fps []string
+	for _, e := range chain {
+		rest := []byte(e)
+		for {
+			b, r := pem.Decode(rest)
+			if b == nil {
+				break
+			}
+			if b.Type == "CERTIFICATE" {
+				h := sha256.Sum256(b.Bytes)
+				fps = append(fps, hex.EncodeToString(h[:]))
+			}
+			rest = r
+		}
+	}
+	return fps
+}
+
+func fpOf(t *testing.T, pemCert string) string {
+	t.Helper()
+	b, _ := pem.Decode([]byte(pemCert))
+	if b == nil {
+		t.Fatalf("fpOf: invalid PEM")
+	}
+	h := sha256.Sum256(b.Bytes)
+	return hex.EncodeToString(h[:])
+}
+
+// ---- table-driven helper tests ----------------------------------------------
+
+// TestDedupCertChain exercises the helper across every behaviour class that
+// the design doc enumerates. The matrix collapses what was previously 16
+// individual functions into one parameterised table.
+func TestDedupCertChain(t *testing.T) {
+	// Generate the certs ONCE so every row references the same SHA-256
+	// identities and the table reads as a literal.
+	leaf := mkCert(t, "leaf")
+	inter := mkCert(t, "Intermediate CA")
+	int2 := mkCert(t, "Intermediate CA 2")
+	root := mkCert(t, "Root CA")
+	rootOld := mkCert(t, "Root CA Old")
+	rootNew := mkCert(t, "Root CA New")
+	whitespaceVariant := root + "\n\n"
+	nonCert := string(pem.EncodeToMemory(&pem.Block{Type: "FOO", Bytes: []byte{0x01, 0x02}}))
+
+	cases := []struct {
+		name string
+		in   []string
+		// wantCerts <0 means "do not check count" (caller uses extraChecks).
+		wantCerts int
+		// wantLastFP == "" means "do not check last element identity".
+		wantLastFP string
+		// extraChecks is an optional post-condition.
+		extraChecks func(t *testing.T, out []string)
+	}{
+		// ---- defensive ------------------------------------------------------
+		{name: "nil", in: nil, wantCerts: 0},
+		{name: "empty", in: []string{}, wantCerts: 0},
+		{name: "single-element passthrough", in: []string{leaf}, wantCerts: 1},
+
+		// ---- core dedup behaviour -------------------------------------------
+		{
+			name: "canonical bug: leaf || inter+root || root",
+			// Models server response BEFORE dedup using the Istio Makefile
+			// cert-chain.pem (inter||root) plus the appended rootCertBytes.
+			in:         []string{leaf, concat(inter, root), root},
+			wantCerts:  3,
+			wantLastFP: fpOf(t, root),
+		},
+		{
+			name:       "all individual elements (after PemCertBytestoString expansion)",
+			in:         []string{leaf, inter, root, root},
+			wantCerts:  3,
+			wantLastFP: fpOf(t, root),
+		},
+		{
+			name:       "triple duplicate root",
+			in:         []string{root, root, root},
+			wantCerts:  1,
+			wantLastFP: fpOf(t, root),
+		},
+		{
+			name:       "duplicate intermediate (helper is general, not root-only)",
+			in:         []string{leaf, inter, inter, root},
+			wantCerts:  3,
+			wantLastFP: fpOf(t, root),
+		},
+		{
+			name:       "non-standard root-first cert-chain.pem layout",
+			in:         []string{leaf, root, inter, root}, // root||inter then appended root
+			wantCerts:  3,
+			wantLastFP: fpOf(t, root),
+		},
+
+		// ---- no-change cases (fast-path) ------------------------------------
+		{
+			name:      "self-signed mode (no chain bytes)",
+			in:        []string{leaf, root},
+			wantCerts: 2,
+		},
+		{
+			name:      "multi-intermediate hierarchy, no duplicate",
+			in:        []string{leaf, concat(inter, int2), root},
+			wantCerts: 4,
+		},
+
+		// ---- rotation -------------------------------------------------------
+		{
+			name: "rotation: trust bundle holds old||new roots (helper-level)",
+			// rootCertBytes = old||new. cert-chain.pem references old, so old
+			// appears once in chain bytes and once at head of trust bundle.
+			in:        []string{leaf, concat(inter, rootOld), concat(rootOld, rootNew)},
+			wantCerts: 4,
+			extraChecks: func(t *testing.T, out []string) {
+				flat := strings.Join(out, "")
+				if !strings.Contains(flat, rootOld) {
+					t.Errorf("rotation: old root must remain present (still signing)")
+				}
+				if !strings.Contains(flat, rootNew) {
+					t.Errorf("rotation: new root must be present (clients need it)")
+				}
+			},
+		},
+		{
+			name: "rotation: all-individual elements with multi-block trust bundle",
+			// cert-chain.pem (inter||rootOld) → expanded into [inter, rootOld]
+			// then rootCertBytes "rootOld\nrootNew" appended as one element.
+			in:        []string{leaf, inter, rootOld, concat(rootOld, rootNew)},
+			wantCerts: 4,
+			extraChecks: func(t *testing.T, out []string) {
+				last := out[len(out)-1]
+				if !strings.Contains(last, rootOld) || !strings.Contains(last, rootNew) {
+					t.Errorf("trust bundle must be the last element; last=%q", last)
+				}
+			},
+		},
+
+		// ---- edge cases -----------------------------------------------------
+		{
+			name:      "whitespace-only difference is treated as duplicate",
+			in:        []string{root, whitespaceVariant},
+			wantCerts: 1, // dedup is DER-based
+		},
+		{
+			name:      "external certSigner: leaf||inter||root || root",
+			in:        []string{concat(leaf, inter, root), root},
+			wantCerts: 3,
+		},
+		{
+			name:      "misconfigured: cert-chain.pem contains ONLY the root",
+			in:        []string{leaf, root, root},
+			wantCerts: 2,
+		},
+		{
+			name:      "non-CERTIFICATE PEM blocks preserved",
+			in:        []string{leaf, nonCert},
+			wantCerts: -1,
+			extraChecks: func(t *testing.T, out []string) {
+				if !strings.Contains(strings.Join(out, ""), "BEGIN FOO") {
+					t.Errorf("unknown PEM block was dropped: %v", out)
+				}
+			},
+		},
+		{
+			name:      "pure non-PEM passthrough",
+			in:        []string{"not pem at all"},
+			wantCerts: -1,
+			extraChecks: func(t *testing.T, out []string) {
+				if len(out) != 1 || out[0] != "not pem at all" {
+					t.Errorf("non-PEM passthrough broken: %v", out)
+				}
+			},
+		},
+		{
+			name:      "empty string element preserved verbatim",
+			in:        []string{leaf, "", root},
+			wantCerts: -1,
+			extraChecks: func(t *testing.T, out []string) {
+				found := false
+				for _, e := range out {
+					if e == "" {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("empty string element was dropped: %v", out)
+				}
+				if got := countCerts(out); got != 2 {
+					t.Errorf("expected leaf+root = 2 certs, got %d", got)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := dedupCertChain(tc.in)
+			if tc.wantCerts >= 0 {
+				if got := countCerts(out); got != tc.wantCerts {
+					t.Fatalf("cert count: want=%d got=%d (out=%v)", tc.wantCerts, got, out)
+				}
+			}
+			if tc.wantLastFP != "" {
+				fps := fpsOfChain(t, out)
+				if len(fps) == 0 || fps[len(fps)-1] != tc.wantLastFP {
+					t.Errorf("last cert must have fp=%s; got %v", tc.wantLastFP, fps)
+				}
+			}
+			if tc.extraChecks != nil {
+				tc.extraChecks(t, out)
+			}
+		})
+	}
+}
+
+// TestDedupCertChain_FastPathReturnsInputSlice asserts the zero-allocation
+// fast-path: when no duplicates exist the helper must return the input slice
+// unchanged (identity check) so well-configured clusters pay no rewrite cost.
+func TestDedupCertChain_FastPathReturnsInputSlice(t *testing.T) {
+	leaf := mkCert(t, "leaf")
+	root := mkCert(t, "root")
+	in := []string{leaf, root}
+	out := dedupCertChain(in)
+	if &in[0] != &out[0] {
+		t.Fatalf("fast path must return the input slice when no duplicates exist; got a different backing array")
+	}
+}
+
+// ---- end-to-end tests through CreateCertificate -----------------------------
+
+// All e2e tests drive the full gRPC handler so we close the gap that helper
+// tests don't exercise the actual call site.
+
+// realChain builds three distinct self-signed certs (leaf, intermediate, root)
+// for use in e2e tests.
+func realChain(t *testing.T) (leaf, inter, root string) {
+	t.Helper()
+	return mkCert(t, "leaf-spiffe"), mkCert(t, "Intermediate CA"), mkCert(t, "Root CA")
+}
+
+// callCreateCertificate invokes Server.CreateCertificate with a minimal
+// authenticated context.
+func callCreateCertificate(t *testing.T, srv *Server) []string {
+	t.Helper()
+	p := &peer.Peer{
+		Addr:     &net.IPAddr{IP: net.IPv4(127, 0, 0, 1)},
+		AuthInfo: credentials.TLSInfo{},
+	}
+	ctx := peer.NewContext(context.Background(), p)
+	resp, err := srv.CreateCertificate(ctx, &pb.IstioCertificateRequest{
+		Csr:              "fake-csr",
+		ValidityDuration: 60,
+	})
+	if err != nil {
+		t.Fatalf("CreateCertificate failed: %v", err)
+	}
+	return resp.CertChain
+}
+
+// newSrv constructs a Server suitable for handler-level tests. We bypass
+// New(...) because that requires a multicluster.ComponentBuilder; the dedup
+// behaviour does not depend on the controller-backed fields, and the existing
+// table-driven TestCreateCertificate in server_test.go does the same.
+func newSrv(ca CertificateAuthority) *Server {
+	return &Server{
+		ca: ca,
+		Authenticators: []security.Authenticator{
+			&mockAuthenticator{identities: []string{"spiffe://cluster.local/ns/foo/sa/bar"}},
+		},
+		monitoring: newMonitoringMetrics(),
+	}
+}
+
+// The canonical istio/istio#39001 bug exercised end-to-end through the gRPC
+// handler. This is the regression test that would have caught the bug.
+func TestCreateCertificate_RootIsNotDuplicatedInResponse(t *testing.T) {
+	leaf, inter, root := realChain(t)
+
+	// Operator cert-chain.pem (Istio Makefile format): inter || root.
+	certChain := inter + root
+	srv := newSrv(&mockca.FakeCA{
+		SignedCert:    []byte(leaf),
+		KeyCertBundle: util.NewKeyCertBundleFromPem(nil, nil, []byte(certChain), []byte(root), nil),
+	})
+
+	fps := fpsOfChain(t, callCreateCertificate(t, srv))
+	leafFP, interFP, rootFP := fpOf(t, leaf), fpOf(t, inter), fpOf(t, root)
+
+	if len(fps) != 3 {
+		t.Fatalf("expected 3 certs (leaf, inter, root); got %d fps=%v", len(fps), fps)
+	}
+	if fps[0] != leafFP {
+		t.Errorf("position 0 must be leaf; got %s", fps[0])
+	}
+	if fps[1] != interFP {
+		t.Errorf("position 1 must be intermediate; got %s", fps[1])
+	}
+	if fps[2] != rootFP {
+		t.Errorf("position 2 (last) must be root; got %s", fps[2])
+	}
+	rootCount := 0
+	for _, f := range fps {
+		if f == rootFP {
+			rootCount++
+		}
+	}
+	if rootCount != 1 {
+		t.Errorf("root appears %d times in response (expected 1)", rootCount)
+	}
+}
+
+// Rotation: trust bundle is `oldRoot || newRoot`; both must survive and the
+// response must end with the newRoot (the tail of rootCertBytes).
+func TestCreateCertificate_RotationBothRootsSurvive(t *testing.T) {
+	leaf := mkCert(t, "leaf")
+	inter := mkCert(t, "Intermediate CA")
+	oldRoot := mkCert(t, "Old Root CA")
+	newRoot := mkCert(t, "New Root CA")
+
+	certChain := inter + oldRoot
+	trustBundle := oldRoot + newRoot
+
+	srv := newSrv(&mockca.FakeCA{
+		SignedCert:    []byte(leaf),
+		KeyCertBundle: util.NewKeyCertBundleFromPem(nil, nil, []byte(certChain), []byte(trustBundle), nil),
+	})
+
+	fps := fpsOfChain(t, callCreateCertificate(t, srv))
+	oldFP, newFP := fpOf(t, oldRoot), fpOf(t, newRoot)
+
+	oldCount, newCount := 0, 0
+	for _, f := range fps {
+		if f == oldFP {
+			oldCount++
+		}
+		if f == newFP {
+			newCount++
+		}
+	}
+	if oldCount != 1 {
+		t.Errorf("old root appears %d times (expected 1)", oldCount)
+	}
+	if newCount != 1 {
+		t.Errorf("new root appears %d times (expected 1)", newCount)
+	}
+	if fps[len(fps)-1] != newFP {
+		t.Errorf("response must end with newRoot (trust bundle tail); got %s", fps[len(fps)-1])
+	}
+}
+
+// Bundle swap mid-flight: a sequential second call with a different
+// KeyCertBundle must not be contaminated by state from the first call.
+func TestCreateCertificate_BundleSwapDoesNotLeakStaleRoot(t *testing.T) {
+	leaf1, inter1, root1 := realChain(t)
+	leaf2, inter2, root2 := realChain(t)
+
+	ca := &mockca.FakeCA{
+		SignedCert:    []byte(leaf1),
+		KeyCertBundle: util.NewKeyCertBundleFromPem(nil, nil, []byte(inter1+root1), []byte(root1), nil),
+	}
+	srv := newSrv(ca)
+
+	// First call: chain references root1.
+	fps1 := fpsOfChain(t, callCreateCertificate(t, srv))
+	if got := len(fps1); got != 3 {
+		t.Fatalf("first call: want 3 certs, got %d", got)
+	}
+
+	// Swap the bundle to a completely different identity hierarchy.
+	ca.SignedCert = []byte(leaf2)
+	ca.KeyCertBundle = util.NewKeyCertBundleFromPem(nil, nil, []byte(inter2+root2), []byte(root2), nil)
+
+	// Second call must contain only the NEW identities; no leak from call 1.
+	fps2 := fpsOfChain(t, callCreateCertificate(t, srv))
+	if got := len(fps2); got != 3 {
+		t.Fatalf("second call: want 3 certs, got %d", got)
+	}
+	for _, fp := range fps2 {
+		if fp == fpOf(t, leaf1) || fp == fpOf(t, inter1) || fp == fpOf(t, root1) {
+			t.Errorf("stale cert from call 1 leaked into call 2 response: %s", fp)
+		}
+	}
+}
+
+// Self-signed mode: certChainBytes is empty; response = [leaf, root]
+// unchanged by dedup.
+func TestCreateCertificate_SelfSignedModeUnchanged(t *testing.T) {
+	leaf := mkCert(t, "leaf")
+	root := mkCert(t, "Root CA")
+
+	srv := newSrv(&mockca.FakeCA{
+		SignedCert:    []byte(leaf),
+		KeyCertBundle: util.NewKeyCertBundleFromPem(nil, nil, nil, []byte(root), nil),
+	})
+
+	fps := fpsOfChain(t, callCreateCertificate(t, srv))
+	if len(fps) != 2 {
+		t.Fatalf("self-signed mode: want 2 certs (leaf, root); got %d", len(fps))
+	}
+	if fps[0] != fpOf(t, leaf) {
+		t.Errorf("position 0 must be leaf; got %s", fps[0])
+	}
+	if fps[1] != fpOf(t, root) {
+		t.Errorf("position 1 must be root; got %s", fps[1])
+	}
+}

--- a/security/pkg/server/ca/server.go
+++ b/security/pkg/server/ca/server.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ca
 
 import (

--- a/security/pkg/server/ca/server.go
+++ b/security/pkg/server/ca/server.go
@@ -1,21 +1,11 @@
-// Copyright Istio Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package ca
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/pem"
+	"sync"
 	"time"
 
 	"google.golang.org/grpc"
@@ -34,6 +24,105 @@ import (
 )
 
 var serverCaLog = log.RegisterScope("serverca", "Citadel server log")
+
+// dupRemovalLogOnce ensures we warn at most once per istiod process when a
+// duplicate-certificate response is observed. This points operators at the
+// root cause (typically a plug-in CA's cert-chain.pem that already includes
+// the root cert) without flooding the log on every CSR.
+var dupRemovalLogOnce sync.Once
+
+// dedupCertChain removes byte-identical duplicate CERTIFICATE blocks from a
+// PEM-encoded chain slice, comparing certs by SHA-256 of their DER body so
+// whitespace differences cannot defeat the comparison. For any duplicate set
+// the LAST occurrence is kept, so the spec invariant "the root cert is the
+// last element" is preserved when the trailing root was the redundant copy.
+//
+// Fast path: if no duplicates exist, the input slice is returned unchanged
+// with zero output allocations, so well-configured clusters pay nothing
+// beyond N fingerprint hashes.
+func dedupCertChain(chain []string) []string {
+	if len(chain) <= 1 {
+		return chain
+	}
+
+	// Fast-path pre-scan: detect duplicates without allocating any output.
+	seen := make(map[string]struct{}, 4)
+	hasDup := false
+	for _, entry := range chain {
+		rest := []byte(entry)
+		for {
+			block, remainder := pem.Decode(rest)
+			if block == nil {
+				break
+			}
+			if block.Type != "CERTIFICATE" {
+				rest = remainder
+				continue
+			}
+			fp := sha256.Sum256(block.Bytes)
+			key := hex.EncodeToString(fp[:])
+			if _, ok := seen[key]; ok {
+				hasDup = true
+				break
+			}
+			seen[key] = struct{}{}
+			rest = remainder
+		}
+		if hasDup {
+			break
+		}
+	}
+	if !hasDup {
+		return chain
+	}
+
+	// Slow-path rewrite: tail-to-head so "first wins on reversed" equals
+	// "last wins on original".
+	seen = make(map[string]struct{}, len(chain))
+	out := make([]string, 0, len(chain))
+	for i := len(chain) - 1; i >= 0; i-- {
+		entry := chain[i]
+		var kept []byte
+		anyKept := false
+		anyParsed := false
+		rest := []byte(entry)
+		for {
+			block, remainder := pem.Decode(rest)
+			if block == nil {
+				break
+			}
+			anyParsed = true
+			if block.Type != "CERTIFICATE" {
+				kept = append(kept, pem.EncodeToMemory(block)...)
+				anyKept = true
+				rest = remainder
+				continue
+			}
+			fp := sha256.Sum256(block.Bytes)
+			key := hex.EncodeToString(fp[:])
+			if _, dup := seen[key]; dup {
+				rest = remainder
+				continue
+			}
+			seen[key] = struct{}{}
+			kept = append(kept, pem.EncodeToMemory(block)...)
+			anyKept = true
+			rest = remainder
+		}
+		if !anyParsed {
+			out = append(out, entry)
+			continue
+		}
+		if anyKept {
+			out = append(out, string(kept))
+		}
+	}
+	// out is in reverse order; restore the original ordering.
+	for l, r := 0, len(out)-1; l < r; l, r = l+1, r-1 {
+		out[l], out[r] = out[r], out[l]
+	}
+	return out
+}
 
 // CertificateAuthority contains methods to be supported by a CA.
 type CertificateAuthority interface {
@@ -152,6 +241,22 @@ func (s *Server) CreateCertificate(ctx context.Context, request *pb.IstioCertifi
 	// A better API would put the root in a separate field entirely...
 	if len(rootCertBytes) != 0 {
 		response.CertChain = append(response.CertChain, string(rootCertBytes))
+	}
+
+	// Strip duplicate certificates from the response. The plug-in CA path
+	// (Makefile-built cert-chain.pem ending in the root) plus the
+	// unconditional rootCertBytes append above would otherwise emit the
+	// root twice -- see istio/istio#39001. The helper preserves the
+	// trailing root copy so the spec invariant "the root cert is the last
+	// element" still holds.
+	before := len(response.CertChain)
+	response.CertChain = dedupCertChain(response.CertChain)
+	if removed := before - len(response.CertChain); removed > 0 {
+		dupRemovalLogOnce.Do(func() {
+			serverCaLog.Warnf("removed %d duplicate certificate(s) from CSR response chain; "+
+				"check that your plug-in CA's cert-chain.pem does not already include the root cert "+
+				"(see istio/istio#39001). This warning is logged once per istiod process.", removed)
+		})
 	}
 
 	serverCaLog.Debugf("Responding with cert chain, %q", response.CertChain)

--- a/security/pkg/server/ca/server_test.go
+++ b/security/pkg/server/ca/server_test.go
@@ -282,6 +282,23 @@ func TestCreateCertificate(t *testing.T) {
 			certChain: []string{testCert, testIntermediateCert, testIntermediateCert2, testRootCert}, // the response should have one cert per element in slice
 			code:      codes.OK,
 		},
+		// Regression for istio/istio#39001. When the plug-in CA's cert-chain.pem
+		// already contains the root (the default `make` output), CreateCertificate
+		// would otherwise emit the root twice. dedupCertChain must collapse the
+		// duplicate AND leave the root as the last element of the response.
+		"Successful signing w/ duplicate root in cert chain (#39001)": {
+			authenticators: []security.Authenticator{&mockAuthenticator{identities: []string{"test-identity"}}},
+			ca: &mockca.FakeCA{
+				SignedCert: []byte(testCert),
+				KeyCertBundle: util.NewKeyCertBundleFromPem(nil, nil,
+					[]byte(testIntermediateCert+testRootCert), // cert-chain.pem = inter || root
+					[]byte(testRootCert),
+					nil,
+				),
+			},
+			certChain: []string{testCert, testIntermediateCert, testRootCert},
+			code:      codes.OK,
+		},
 	}
 
 	p := &peer.Peer{Addr: &net.IPAddr{IP: net.IPv4(192, 168, 1, 1)}, AuthInfo: credentials.TLSInfo{}}


### PR DESCRIPTION
## What this PR does

The plug-in CA path of istiod concatenates `cert-chain.pem` and then unconditionally appends the bundle's root cert, producing a chain of `leaf -> inter -> root -> root` whenever the operator's `cert-chain.pem` already ends in the root (the layout produced by the upstream`tools/certs/Makefile.selfsigned.mk`).

Workloads then present this duplicated chain on every mTLS handshake.

This PR adds a `dedupCertChain` pass at the tail of `CreateCertificate` (`security/pkg/server/ca/server.go`) that:

- compares certs by SHA-256 of their DER body (whitespace-safe)
- walks tail-to-head so the **trailing** root copy wins -- the spec invariant *"the root cert is the last element"* is preserved
- fast-paths to the input slice with zero output allocations when no duplicates are present (the common case for well-configured clusters)
- passes through non-CERTIFICATE PEM blocks and non-PEM elementsunchanged

A `sync.Once`-gated `warn` line points operators at the misconfigured plug-in CA the first time a duplicate is observed, without flooding the log on every CSR.

## Fixes / addresses

- Fixes **#39001** -- *Invalid Cert Chain when using Plug in CA
  Certificates* (open since 2022; multiple users have been asking for
  a fix on this thread for 4 years).
- Resolves the same `Leaf -> Intermediate -> Root -> Root` symptom
  reported in #39001 by:
  - @JWT95 (original reporter, May 2022)
  - @Ser87ch (Jul 2022, multi-root scenario)
  - @JDKeyfactor (Aug 2022, k8s CSR signer scenario, full design doc)
  - @sakatkoori (Feb 2025, *"we are also seeing the same issue and want to incorporate these changes"*)
  - @divvela95 (Jul 2025, *"we're seeing the same issue on our end"*)

## Tests

- `security/pkg/server/ca/dedup_test.go` (new):
  - `TestDedupCertChain` — table-driven, 18 sub-cases covering the canonical bug shape, multi-intermediate hierarchies, both rotation shapes (old||new roots in trust bundle), external `certSigner` layout, ROOT-only `cert-chain.pem`, non-PEM passthrough, whitespace-defeat resistance.
  - `TestDedupCertChain_FastPathReturnsInputSlice` — asserts the zero-allocation fast path (input slice header is returned unchanged when no duplicates exist).
  - Four end-to-end tests through `CreateCertificate`:
    `TestCreateCertificate_RootIsNotDuplicatedInResponse`,
    `TestCreateCertificate_RotationBothRootsSurvive`,
    `TestCreateCertificate_BundleSwapDoesNotLeakStaleRoot`,
    `TestCreateCertificate_SelfSignedModeUnchanged`.


Bug Fixes

security:  Fixed a long-standing bug (#39001) where istiod would return a certificate chain containing a duplicate root certificate when the plug-in CA's `cert-chain.pem` already included the root (the default `tools/certs/Makefile.selfsigned.mk` layout). The duplicate is now removed at CSR-response time while preserving the spec invariant that the root cert is the last element. Operators whose plug-in CA produced a duplicate-root chain will see a one-time warn line in istiod logs pointing at the misconfigured bundle.

