### PR TITLE
docs: fix insecure HTTP links and outdated gateway-api URL

### DIFF
--- a/architecture/networking/pilot.md
+++ b/architecture/networking/pilot.md
@@ -272,7 +272,7 @@ In addition to this conversion, `Ingress` requires writing the address it can be
 
 #### Gateway
 
-Gateway (referring to the [Kubernetes API](http://gateway-api.org/), not the same-named Istio type) works very similarly to [Ingress](#ingress). The Gateway controller also converts Gateway API types into `VirtualService` and `Gateway`, implementing the `ConfigStore` interface.
+Gateway (referring to the [Kubernetes API](https://gateway-api.sigs.k8s.io/), not the same-named Istio type) works very similarly to [Ingress](#ingress). The Gateway controller also converts Gateway API types into `VirtualService` and `Gateway`, implementing the `ConfigStore` interface.
 
 However, there is also a bit of additional logic. Gateway types have extensive status reporting. Unlike Ingress, this is status reporting is done inline in the main controller, allowing status generation to be done directly in the logic processing the resources.
 

--- a/samples/addons/README.md
+++ b/samples/addons/README.md
@@ -33,7 +33,7 @@ For more information about integrating with Prometheus, please see the [Promethe
 
 ### Grafana
 
-[Grafana](http://grafana.com/) is an open source monitoring solution that can be used to configure dashboards for Istio.
+[Grafana](https://grafana.com/) is an open source monitoring solution that can be used to configure dashboards for Istio.
 You can use Grafana to monitor the health of Istio and of applications within the service mesh.
 
 This sample provides the following dashboards:


### PR DESCRIPTION
Fix two documentation link issues:

1. **samples/addons/README.md**: Update Grafana link from HTTP to HTTPS
2. **architecture/networking/pilot.md**: Update gateway-api.org (dead) to the correct canonical URL gateway-api.sigs.k8s.io

The Gateway API project moved from gateway-api.org to gateway-api.sigs.k8s.io as part of the Kubernetes SIG Network hosting.