### PR TITLE
pilot: improve the listener for TCP headless service

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -27,6 +27,13 @@ import (
 )
 
 var (
+	MergeHeadlessTCPListeners = env.Register(
+		"PILOT_MERGE_HEADLESS_TCP_LISTENERS",
+		false,
+		"If enabled, Istio merges all pod IPs for headless TCP services into a single listener using "+
+			"Envoy's additional_addresses, reducing Envoy config size. Disable to revert to one listener per pod IP.",
+	).Get()
+
 	// HTTP10 will add "accept_http_10" to http outbound listeners. Can also be set only for specific sidecars via meta.
 	HTTP10 = env.Register(
 		"PILOT_HTTP10",

--- a/pilot/pkg/networking/core/listener.go
+++ b/pilot/pkg/networking/core/listener.go
@@ -515,32 +515,62 @@ func (lb *ListenerBuilder) buildSidecarOutboundListeners(node *model.Proxy,
 							lb.buildSidecarOutboundListener(listenerOpts, listenerMap, virtualServices, actualWildcards)
 							continue
 						}
-						for _, instance := range instances {
-							// Make sure each endpoint address is a valid address
-							// as service entries could have NONE resolution with label selectors for workload
-							// entries (which could technically have hostnames).
-							isValidInstance := true
-							for _, addr := range instance.Addresses {
-								if !netutil.IsValidIPAddress(addr) {
-									isValidInstance = false
-									break
+						if features.MergeHeadlessTCPListeners {
+							// Collect all valid non-self pod addresses and merge them into a single
+							// listener using AdditionalAddresses, rather than one listener per pod IP.
+							var allAddresses []string
+							for _, instance := range instances {
+								// Make sure each endpoint address is a valid address
+								// as service entries could have NONE resolution with label selectors for workload
+								// entries (which could technically have hostnames).
+								isValidInstance := true
+								for _, addr := range instance.Addresses {
+									if !netutil.IsValidIPAddress(addr) {
+										isValidInstance = false
+										break
+									}
 								}
+								if !isValidInstance {
+									continue
+								}
+								// Skip build outbound listener to the node itself,
+								// as when app access itself by pod ip will not flow through this listener.
+								// Simultaneously, it will be duplicate with inbound listener.
+								// should continue if current IstioEndpoint instance has the same ip with the
+								// first ip of node IPaddresses.
+								// The comparison works because both IstioEndpoint and Proxy always use the first PodIP (as provided by Kubernetes)
+								// as the first entry of their respective lists.
+								if instance.FirstAddressOrNil() == node.IPAddresses[0] {
+									continue
+								}
+								allAddresses = append(allAddresses, instance.Addresses...)
 							}
-							if !isValidInstance {
-								continue
+							if len(allAddresses) > 0 {
+								// Sort for deterministic LDS output — endpoint shard iteration is map-based and
+								// non-deterministic, so without sorting the primary address can flip between
+								// pushes and trigger unnecessary listener drains.
+								sort.Strings(allAddresses)
+								listenerOpts.bind.binds = allAddresses
+								lb.buildSidecarOutboundListener(listenerOpts, listenerMap, virtualServices, actualWildcards)
 							}
-							// Skip build outbound listener to the node itself,
-							// as when app access itself by pod ip will not flow through this listener.
-							// Simultaneously, it will be duplicate with inbound listener.
-							// should continue if current IstioEndpoint instance has the same ip with the
-							// first ip of node IPaddresses.
-							// The comparison works because both IstioEndpoint and Proxy always use the first PodIP (as provided by Kubernetes)
-							// as the first entry of their respective lists.
-							if instance.FirstAddressOrNil() == node.IPAddresses[0] {
-								continue
+						} else {
+							for _, instance := range instances {
+								isValidInstance := true
+								for _, addr := range instance.Addresses {
+									if !netutil.IsValidIPAddress(addr) {
+										isValidInstance = false
+										break
+									}
+								}
+								if !isValidInstance {
+									continue
+								}
+								if instance.FirstAddressOrNil() == node.IPAddresses[0] {
+									continue
+								}
+								listenerOpts.bind.binds = instance.Addresses
+								lb.buildSidecarOutboundListener(listenerOpts, listenerMap, virtualServices, actualWildcards)
 							}
-							listenerOpts.bind.binds = instance.Addresses
-							lb.buildSidecarOutboundListener(listenerOpts, listenerMap, virtualServices, actualWildcards)
 						}
 					} else {
 						// Standard logic for headless and non headless services

--- a/pilot/pkg/networking/core/listener_test.go
+++ b/pilot/pkg/networking/core/listener_test.go
@@ -1036,10 +1036,13 @@ func TestOutboundListenerForHeadlessServices(t *testing.T) {
 	extSvcSelector.Attributes.LabelSelectors = map[string]string{"foo": "bar"}
 
 	tests := []struct {
-		name                      string
-		instances                 []*model.ServiceInstance
-		services                  []*model.Service
-		numListenersOnServicePort int
+		name                        string
+		instances                   []*model.ServiceInstance
+		services                    []*model.Service
+		mergeEnabled                bool
+		numListenersOnServicePort   int
+		expectedPrimaryAddress      string
+		expectedAdditionalAddresses []string
 	}{
 		{
 			name: "gen a listener per IP instance",
@@ -1052,6 +1055,21 @@ func TestOutboundListenerForHeadlessServices(t *testing.T) {
 			},
 			services:                  []*model.Service{svc},
 			numListenersOnServicePort: 3,
+		},
+		{
+			name: "merge all pod IPs into one listener with additional addresses",
+			instances: []*model.ServiceInstance{
+				// This instance is the proxy itself, will not gen a outbound listener for it.
+				buildServiceInstance(services[0], "1.1.1.1"),
+				buildServiceInstance(services[0], "10.10.10.10"),
+				buildServiceInstance(services[0], "11.11.11.11"),
+				buildServiceInstance(services[0], "12.11.11.11"),
+			},
+			services:                    []*model.Service{svc},
+			mergeEnabled:                true,
+			numListenersOnServicePort:   1,
+			expectedPrimaryAddress:      "10.10.10.10",
+			expectedAdditionalAddresses: []string{"11.11.11.11", "12.11.11.11"},
 		},
 		{
 			name:                      "no listeners for empty services",
@@ -1089,6 +1107,16 @@ func TestOutboundListenerForHeadlessServices(t *testing.T) {
 			numListenersOnServicePort: 2,
 		},
 		{
+			name: "external service with selector and endpoints merged",
+			instances: []*model.ServiceInstance{
+				buildServiceInstance(extSvcSelector, "10.10.10.10"),
+				buildServiceInstance(extSvcSelector, "11.11.11.11"),
+			},
+			services:                  []*model.Service{extSvcSelector},
+			mergeEnabled:              true,
+			numListenersOnServicePort: 1,
+		},
+		{
 			name:                      "no listeners for empty Kubernetes auto protocol",
 			instances:                 []*model.ServiceInstance{},
 			services:                  []*model.Service{autoSvc},
@@ -1103,9 +1131,20 @@ func TestOutboundListenerForHeadlessServices(t *testing.T) {
 			services:                  []*model.Service{autoSvc},
 			numListenersOnServicePort: 2,
 		},
+		{
+			name: "merge pod IPs into one listener for Kubernetes auto protocol",
+			instances: []*model.ServiceInstance{
+				buildServiceInstance(autoSvc, "10.10.10.10"),
+				buildServiceInstance(autoSvc, "11.11.11.11"),
+			},
+			services:                  []*model.Service{autoSvc},
+			mergeEnabled:              true,
+			numListenersOnServicePort: 1,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			test.SetForTest(t, &features.MergeHeadlessTCPListeners, tt.mergeEnabled)
 			cg := NewConfigGenTest(t, TestOptions{
 				Services:  tt.services,
 				Instances: tt.instances,
@@ -1129,6 +1168,24 @@ func TestOutboundListenerForHeadlessServices(t *testing.T) {
 
 			if len(listenersToCheck) != tt.numListenersOnServicePort {
 				t.Errorf("Expected %d listeners on service port 9999, got %d (%v)", tt.numListenersOnServicePort, len(listenersToCheck), listenersToCheck)
+			}
+
+			if tt.expectedPrimaryAddress != "" && len(listenersToCheck) == 1 {
+				for _, l := range listeners {
+					if l.Address.GetSocketAddress().GetPortValue() != 9999 {
+						continue
+					}
+					if got := l.Address.GetSocketAddress().GetAddress(); got != tt.expectedPrimaryAddress {
+						t.Errorf("Expected primary address %s, got %s", tt.expectedPrimaryAddress, got)
+					}
+					gotExtra := make([]string, 0, len(l.AdditionalAddresses))
+					for _, a := range l.AdditionalAddresses {
+						gotExtra = append(gotExtra, a.GetAddress().GetSocketAddress().GetAddress())
+					}
+					if !reflect.DeepEqual(gotExtra, tt.expectedAdditionalAddresses) {
+						t.Errorf("Expected additional addresses %v, got %v", tt.expectedAdditionalAddresses, gotExtra)
+					}
+				}
 			}
 		})
 	}

--- a/releasenotes/notes/headless-tcp-listener-merge.yaml
+++ b/releasenotes/notes/headless-tcp-listener-merge.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+releaseNotes:
+  - |
+    **Added** support for merging all pod IPs for headless TCP services into a single Envoy listener using
+    `additional_addresses`, reducing Envoy config size. This behavior is opt-in and can be enabled by setting
+    the `PILOT_MERGE_HEADLESS_TCP_LISTENERS` environment variable to `true`.


### PR DESCRIPTION
**Please provide a description of this PR:**

xref: https://github.com/istio/istio/issues/60552

For headless TCP services, Istio was generating one outbound Envoy listener per pod IP. This is wasteful and may cause memory spikes.

Istio now generated one outbound listener per pod IP for headless TCP services. All pod IPs are now merged into a single listener using Envoy's `additional_addresses`, reducing Envoy config size.

Although LDS may be updated frequently during rolling updates, but I think this's a good improvement.