### PR TITLE
feat: make pilot-agent wait timeout configurable for holdApplicationUntilProxyStarts

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
@@ -26,6 +26,12 @@
 {{- end }}
 {{- $containers := list }}
 {{- range $index, $container := .Spec.Containers }}{{ if not (eq $container.Name "istio-proxy") }}{{ $containers = append $containers $container.Name }}{{end}}{{- end}}
+{{- $holdWaitSec := .Values.global.proxy.holdApplicationUntilProxyStartsTimeoutSeconds | default 60 | int }}
+{{- if lt $holdWaitSec 1 }}{{- $holdWaitSec = 60 }}{{- end }}
+{{- if isset .ObjectMeta.Annotations `sidecar.istio.io/holdApplicationUntilProxyStartsTimeoutSeconds` }}
+{{- $annoWait := index .ObjectMeta.Annotations `sidecar.istio.io/holdApplicationUntilProxyStartsTimeoutSeconds` }}
+{{- if $annoWait }}{{- $parsedWait := atoi $annoWait }}{{- if gt $parsedWait 0 }}{{- $holdWaitSec = $parsedWait }}{{- end }}{{- end }}
+{{- end }}
 metadata:
   labels:
     {{/* security.istio.io/tlsMode: istio must be set by user, if gRPC is using mTLS initialization code. We can't set it automatically. */}}
@@ -75,6 +81,7 @@ spec:
           command:
           - pilot-agent
           - wait
+          - --timeoutSeconds={{ $holdWaitSec }}
           - --url=http://localhost:15020/healthz/ready
     env:
     - name: ISTIO_META_GENERATOR

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -71,6 +71,12 @@ spec:
   {{- $holdProxy := and
       (or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts)
       (not $nativeSidecar) }}
+  {{- $holdWaitSec := .Values.global.proxy.holdApplicationUntilProxyStartsTimeoutSeconds | default 60 | int }}
+  {{- if lt $holdWaitSec 1 }}{{- $holdWaitSec = 60 }}{{- end }}
+  {{- if isset .ObjectMeta.Annotations `sidecar.istio.io/holdApplicationUntilProxyStartsTimeoutSeconds` }}
+  {{- $annoWait := index .ObjectMeta.Annotations `sidecar.istio.io/holdApplicationUntilProxyStartsTimeoutSeconds` }}
+  {{- if $annoWait }}{{- $parsedWait := atoi $annoWait }}{{- if gt $parsedWait 0 }}{{- $holdWaitSec = $parsedWait }}{{- end }}{{- end }}
+  {{- end }}
   {{- $noInitContainer := and
       (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE`)
       (not $nativeSidecar) }}
@@ -222,6 +228,7 @@ spec:
           command:
           - pilot-agent
           - wait
+          - --timeoutSeconds={{ $holdWaitSec }}
   {{- else if $nativeSidecar }}
     {{- /* preStop is called when the pod starts shutdown. Initialize drain. We will get SIGTERM once applications are torn down. */}}
     lifecycle:

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -407,6 +407,13 @@ _internal_defaults_do_not_set:
       # Default port for Pilot agent health checks. A value of 0 will disable health checking.
       statusPort: 15020
 
+      # Maximum seconds to wait for Envoy to become ready when holdApplicationUntilProxyStarts
+      # is enabled. The postStart hook runs `pilot-agent wait --timeoutSeconds=<value>`.
+      # Values below 1 are treated as 60 (pilot-agent's built-in default).
+      # Can be overridden per-pod with annotation:
+      # sidecar.istio.io/holdApplicationUntilProxyStartsTimeoutSeconds
+      holdApplicationUntilProxyStartsTimeoutSeconds: 60
+
       # Specify which tracer to use. One of: zipkin, lightstep, datadog, stackdriver, none.
       # If using stackdriver tracer outside GCP, set env GOOGLE_APPLICATION_CREDENTIALS to the GCP credential file.
       tracer: "none"

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -18618,6 +18618,12 @@ data:
           {{- $holdProxy := and
               (or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts)
               (not $nativeSidecar) }}
+          {{- $holdWaitSec := .Values.global.proxy.holdApplicationUntilProxyStartsTimeoutSeconds | default 60 | int }}
+          {{- if lt $holdWaitSec 1 }}{{- $holdWaitSec = 60 }}{{- end }}
+          {{- if isset .ObjectMeta.Annotations `sidecar.istio.io/holdApplicationUntilProxyStartsTimeoutSeconds` }}
+          {{- $annoWait := index .ObjectMeta.Annotations `sidecar.istio.io/holdApplicationUntilProxyStartsTimeoutSeconds` }}
+          {{- if $annoWait }}{{- $parsedWait := atoi $annoWait }}{{- if gt $parsedWait 0 }}{{- $holdWaitSec = $parsedWait }}{{- end }}{{- end }}
+          {{- end }}
           {{- $noInitContainer := and
               (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE`)
               (not $nativeSidecar) }}
@@ -18769,6 +18775,7 @@ data:
                   command:
                   - pilot-agent
                   - wait
+                  - --timeoutSeconds={{ $holdWaitSec }}
           {{- else if $nativeSidecar }}
             {{- /* preStop is called when the pod starts shutdown. Initialize drain. We will get SIGTERM once applications are torn down. */}}
             lifecycle:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -683,6 +683,12 @@ data:
           {{- $holdProxy := and
               (or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts)
               (not $nativeSidecar) }}
+          {{- $holdWaitSec := .Values.global.proxy.holdApplicationUntilProxyStartsTimeoutSeconds | default 60 | int }}
+          {{- if lt $holdWaitSec 1 }}{{- $holdWaitSec = 60 }}{{- end }}
+          {{- if isset .ObjectMeta.Annotations `sidecar.istio.io/holdApplicationUntilProxyStartsTimeoutSeconds` }}
+          {{- $annoWait := index .ObjectMeta.Annotations `sidecar.istio.io/holdApplicationUntilProxyStartsTimeoutSeconds` }}
+          {{- if $annoWait }}{{- $parsedWait := atoi $annoWait }}{{- if gt $parsedWait 0 }}{{- $holdWaitSec = $parsedWait }}{{- end }}{{- end }}
+          {{- end }}
           {{- $noInitContainer := and
               (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE`)
               (not $nativeSidecar) }}
@@ -834,6 +840,7 @@ data:
                   command:
                   - pilot-agent
                   - wait
+                  - --timeoutSeconds={{ $holdWaitSec }}
           {{- else if $nativeSidecar }}
             {{- /* preStop is called when the pod starts shutdown. Initialize drain. We will get SIGTERM once applications are torn down. */}}
             lifecycle:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/sidecar_template.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/sidecar_template.golden.yaml
@@ -87,6 +87,12 @@ data:
           {{- $holdProxy := and
               (or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts)
               (not $nativeSidecar) }}
+          {{- $holdWaitSec := .Values.global.proxy.holdApplicationUntilProxyStartsTimeoutSeconds | default 60 | int }}
+          {{- if lt $holdWaitSec 1 }}{{- $holdWaitSec = 60 }}{{- end }}
+          {{- if isset .ObjectMeta.Annotations `sidecar.istio.io/holdApplicationUntilProxyStartsTimeoutSeconds` }}
+          {{- $annoWait := index .ObjectMeta.Annotations `sidecar.istio.io/holdApplicationUntilProxyStartsTimeoutSeconds` }}
+          {{- if $annoWait }}{{- $parsedWait := atoi $annoWait }}{{- if gt $parsedWait 0 }}{{- $holdWaitSec = $parsedWait }}{{- end }}{{- end }}
+          {{- end }}
           {{- $noInitContainer := and
               (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE`)
               (not $nativeSidecar) }}
@@ -238,6 +244,7 @@ data:
                   command:
                   - pilot-agent
                   - wait
+                  - --timeoutSeconds={{ $holdWaitSec }}
           {{- else if $nativeSidecar }}
             {{- /* preStop is called when the pod starts shutdown. Initialize drain. We will get SIGTERM once applications are torn down. */}}
             lifecycle:

--- a/operator/pkg/apis/values_types.proto
+++ b/operator/pkg/apis/values_types.proto
@@ -1200,6 +1200,12 @@ message ProxyConfig {
   // Deprecated: replaced by ProxyConfig setting which allows per-pod configuration of this behavior.
   google.protobuf.BoolValue holdApplicationUntilProxyStarts = 37 [deprecated = true];
 
+  // Maximum seconds to wait for Envoy to become ready when holdApplicationUntilProxyStarts is enabled.
+  // The postStart hook runs `pilot-agent wait --timeoutSeconds=<value>`.
+  // Values below 1 are treated as 60 (pilot-agent's built-in default).
+  // Can be overridden per-pod with annotation sidecar.istio.io/holdApplicationUntilProxyStartsTimeoutSeconds.
+  uint32 holdApplicationUntilProxyStartsTimeoutSeconds = 43;
+
   // A comma separated list of inbound ports for which traffic is to be redirected to Envoy.
   // The wildcard character '*' can be used to configure redirection for all ports.
   string includeInboundPorts = 38;

--- a/pkg/kube/inject/testdata/inject/grpc-agent.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/grpc-agent.yaml.injected
@@ -115,6 +115,7 @@ spec:
               command:
               - pilot-agent
               - wait
+              - --timeoutSeconds=60
               - --url=http://localhost:15020/healthz/ready
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/merge-probers.yaml
+++ b/pkg/kube/inject/testdata/inject/merge-probers.yaml
@@ -103,6 +103,7 @@ spec:
               command:
               - pilot-agent
               - wait
+              - --timeoutSeconds=60
         name: istio-proxy
         ports:
         - containerPort: 15090

--- a/pkg/kube/inject/testdata/inject/merge-probers.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/merge-probers.yaml.injected
@@ -203,6 +203,7 @@ spec:
               command:
               - pilot-agent
               - wait
+              - --timeoutSeconds=60
           preStop:
             exec:
               command:

--- a/releasenotes/notes/hold-proxy-timeout.yaml
+++ b/releasenotes/notes/hold-proxy-timeout.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+releaseNotes:
+- |
+  **Added** `values.global.proxy.holdApplicationUntilProxyStartsTimeoutSeconds` Helm value and
+  `sidecar.istio.io/holdApplicationUntilProxyStartsTimeoutSeconds` pod annotation to configure
+  the maximum time the `pilot-agent wait` postStart hook will wait for Envoy to become ready
+  when `holdApplicationUntilProxyStarts` is enabled. The annotation takes precedence over the
+  Helm value. The default is 60 seconds (unchanged from previous behaviour).


### PR DESCRIPTION
## What this PR does / why we need it

When `holdApplicationUntilProxyStarts` is enabled, the sidecar injector adds a `postStart` lifecycle hook that calls `pilot-agent wait`. This command has a hardcoded default timeout of **60 seconds**, which is too short for applications in clusters with slow startup environments or resource-constrained nodes.

This PR makes the timeout configurable at two levels:

- **Global (Helm value)** — `values.global.proxy.holdApplicationUntilProxyStartsTimeoutSeconds` (default: `60`)
- **Per-pod (annotation)** — `sidecar.istio.io/holdApplicationUntilProxyStartsTimeoutSeconds` (overrides the Helm value)

The annotation takes precedence over the Helm value. Values below 1 fall back to 60 (the built-in pilot-agent default).

## Changes

- `manifests/charts/istio-control/istio-discovery/values.yaml` — new `holdApplicationUntilProxyStartsTimeoutSeconds` field under `global.proxy`
- `manifests/charts/istio-control/istio-discovery/files/injection-template.yaml` — resolve timeout from Helm value / annotation; pass `--timeoutSeconds` to `pilot-agent wait`
- `manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml` — same change for gRPC agent
- `operator/pkg/apis/values_types.proto` — new `uint32 holdApplicationUntilProxyStartsTimeoutSeconds = 43` field in `ProxyConfig` message
- Golden files updated (`pkg/kube/inject/testdata/inject/`, `operator/cmd/mesh/testdata/manifest-generate/output/`)
- `releasenotes/notes/hold-proxy-timeout.yaml` — release note

## Testing

- Existing inject golden tests updated to include `--timeoutSeconds=60`
- Operator manifest-generate golden tests updated
- `make gen` needed to regenerate `values_types.pb.go` from the updated proto (requires `protoc`/`buf`)

## Notes

- **No behaviour change for existing users** — the default is 60 s, matching the current hardcoded pilot-agent default
- The proto field number `43` was chosen to not conflict with any existing fields

Fixes: <!-- link any relevant issue here -->

Made with [Cursor](https://cursor.com)