### PR TITLE
fix: align warmup aggression validation with envoy configuration

### DIFF
--- a/pkg/config/validation/testdata/crds/destinationrule-valid.yaml
+++ b/pkg/config/validation/testdata/crds/destinationrule-valid.yaml
@@ -37,6 +37,18 @@ spec:
 apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
+  name: bookinfo-ratings-warmup-aggression-less-than-one
+spec:
+  host: ratings.prod.svc.cluster.local
+  trafficPolicy:
+    loadBalancer:
+      warmup:
+        duration: 300s
+        aggression: 0.5
+---
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
   name: bookinfo-ratings-http2-ping
 spec:
   host: ratings.prod.svc.cluster.local

--- a/pkg/config/validation/testdata/crds/destinationrule-valid.yaml
+++ b/pkg/config/validation/testdata/crds/destinationrule-valid.yaml
@@ -37,18 +37,6 @@ spec:
 apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
-  name: bookinfo-ratings-warmup-aggression-less-than-one
-spec:
-  host: ratings.prod.svc.cluster.local
-  trafficPolicy:
-    loadBalancer:
-      warmup:
-        duration: 300s
-        aggression: 0.5
----
-apiVersion: networking.istio.io/v1
-kind: DestinationRule
-metadata:
   name: bookinfo-ratings-http2-ping
 spec:
   host: ratings.prod.svc.cluster.local

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1255,8 +1255,8 @@ func validateLoadBalancer(settings *networking.LoadBalancerSettings, outlier *ne
 		if warm.MinimumPercent.GetValue() > 100 {
 			errs = AppendValidation(errs, fmt.Errorf("minimumPercent value should be less than or equal to 100"))
 		}
-		if warm.Aggression != nil && warm.Aggression.GetValue() < 1 {
-			errs = AppendValidation(errs, fmt.Errorf("aggression should be greater than or equal to 1"))
+		if warm.Aggression != nil && warm.Aggression.GetValue() <= 0 {
+			errs = AppendValidation(errs, fmt.Errorf("aggression should be greater than 0"))
 		}
 	}
 	return errs

--- a/releasenotes/notes/60611.yaml
+++ b/releasenotes/notes/60611.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - https://github.com/istio/api/issues/3395
+  - https://github.com/istio/istio/issues/55153
+releaseNotes:
+  - |
+    **Fixed** DestinationRule validation incorrectly rejecting warmup aggression values between 0 and 1.


### PR DESCRIPTION
The webhook validation for warmup `aggression` rejects values less than 1, but Envoy supports (0, +inf).
The istio/api was already updated in https://github.com/istio/api/pull/3602 and the CRD schema has `minimum: 0`,
but the Go validation logic was not aligned. This fixes the validation to reject only values <= 0.

Fixes https://github.com/istio/api/issues/3395