### PR TITLE
Add trafficDistribution to revision tag svc as well

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags-svc.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags-svc.yaml
@@ -53,6 +53,9 @@ spec:
   - {{ . }}
   {{- end }}
   {{- end }}
+  {{- if $.Values.trafficDistribution }}
+  trafficDistribution: {{ $.Values.trafficDistribution }}
+  {{- end }}
 ---
 {{- end -}}
 {{- end }}

--- a/operator/pkg/helm/helm_test.go
+++ b/operator/pkg/helm/helm_test.go
@@ -325,6 +325,13 @@ func TestRender(t *testing.T) {
 			chartName:   "istio-control/istio-discovery",
 			diffSelect:  "ConfigMap:*:istio-sidecar-injector",
 		},
+		{
+			desc:        "istiod-rev-traffic-distribution",
+			releaseName: "istiod",
+			namespace:   "istio-system",
+			chartName:   "istio-control/istio-discovery",
+			diffSelect:  "Service:*:istiod-revision-tag-green",
+		},
 	}
 
 	for _, tc := range cases {

--- a/operator/pkg/helm/testdata/input/istiod-rev-traffic-distribution.yaml
+++ b/operator/pkg/helm/testdata/input/istiod-rev-traffic-distribution.yaml
@@ -1,0 +1,5 @@
+spec:
+  values:
+    trafficDistribution: PreferClose
+    revisionTags:
+      - green

--- a/operator/pkg/helm/testdata/output/istiod-rev-traffic-distribution.golden.yaml
+++ b/operator/pkg/helm/testdata/output/istiod-rev-traffic-distribution.golden.yaml
@@ -1,0 +1,41 @@
+# Adapted from istio-discovery/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: istiod-revision-tag-green
+  namespace: istio-system
+  labels:
+    istio.io/rev: "default"
+    istio.io/tag: green
+    install.operator.istio.io/owning-resource: unknown
+    operator.istio.io/component: "Pilot"
+    app: istiod
+    istio: pilot
+    release: istiod
+    app.kubernetes.io/name: "istiod"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "istiod"
+    app.kubernetes.io/part-of: "istio"
+    app.kubernetes.io/version: "1.0.0"
+    helm.sh/chart: istiod-1.0.0
+spec:
+  ports:
+    - port: 15010
+      name: grpc-xds # plaintext
+      protocol: TCP
+    - port: 15012
+      name: https-dns # mTLS with k8s-signed cert
+      protocol: TCP
+    - port: 443
+      name: https-webhook # validation and injection
+      targetPort: 15017
+      protocol: TCP
+    - port: 15014
+      name: http-monitoring # prometheus stats
+      protocol: TCP
+  selector:
+    app: istiod
+    # Label used by the 'default' service. For versioned deployments we match with app and version.
+    # This avoids default deployment picking the canary
+    istio: pilot
+  trafficDistribution: PreferClose

--- a/releasenotes/notes/pilot-rev-svc-trafficDistribution.yaml
+++ b/releasenotes/notes/pilot-rev-svc-trafficDistribution.yaml
@@ -1,0 +1,48 @@
+apiVersion: release-notes/v2
+
+# This YAML file describes the format for specifying a release notes entry for Istio.
+# This should be filled in for all user facing changes.
+
+# kind describes the type of change that this represents.
+# Valid Values are:
+# - bug-fix -- Used to specify that this change represents a bug fix.
+# - security-fix -- Used to specify that this change represents a vulnerability fix.
+# - feature -- Used to specify a new feature that has been added.
+# - test -- Used to describe additional testing added. This file is optional for
+#   tests, but included for completeness.
+kind: feature
+
+# area describes the area that this change affects.
+# Valid values are:
+# - traffic-management
+# - security
+# - telemetry
+# - installation
+# - istioctl
+# - documentation
+area: traffic-management
+
+# issue is a list of GitHub issues resolved in this note.
+# If issue is not in the current repo, specify its full URL instead.
+issue: []
+
+# releaseNotes is a markdown listing of any user facing changes. This will appear in the
+# release notes.
+releaseNotes:
+  - |
+    **Added** support to specify traffic distribution mode for revision tag services.
+
+# upgradeNotes is a markdown listing of any changes that will affect the upgrade
+# process. This will appear in the release notes.
+upgradeNotes:
+  - title: Traffic Distribution Mode for Revision Tags
+    content: |
+      **Added** support to specify traffic distribution mode for revision tag services.
+
+# docs is a list of related docs to the change.
+docs:
+  - https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution
+
+# securityNotes is a markdown listing of any changes related to the security of
+# Istio.
+securityNotes: []


### PR DESCRIPTION
**Please provide a description of this PR:**

This is a follow-up for https://github.com/istio/istio/pull/56556, which added trafficDistribution for the pilot service.
This adds it for the revision-tag services as well.  I tried to model it on the above PR as closely as possible.