### PR TITLE
fix: ListenerSet condition reporting when no listeners are accepted

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -1875,13 +1875,14 @@ func reportListenerSetStatus(
 	gatewayServices []string,
 	servers []*istio.Server,
 	gatewayErr *ConfigError,
+	listenersValid bool,
 ) {
 	internal, _, _, _, warnings, allUsable := r.ResolveGatewayInstances(parentGwObj.Namespace, gatewayServices, servers)
 
 	// Setup initial conditions to the success state. If we encounter errors, we will update this.
 	// We have two status
-	// Accepted: is the configuration valid. We only have errors in listeners, and the status is not supposed to
-	// be tied to listeners, so this is always accepted
+	// Accepted: is the configuration valid. Unlike a Gateway, a ListenerSet is only Accepted if at least
+	// one of its listeners is valid; otherwise we report ListenersNotValid.
 	// Programmed: is the data plane "ready" (note: eventually consistent)
 	gatewayConditions := map[string]*condition{
 		string(k8s.GatewayConditionAccepted): {
@@ -1893,12 +1894,28 @@ func reportListenerSetStatus(
 			message: "Resource programmed",
 		},
 	}
+	var listenersErr *ConfigError
+	if !listenersValid {
+		listenersErr = &ConfigError{
+			Reason:  string(k8s.ListenerSetReasonListenersNotValid),
+			Message: "None of the ListenerSet's listeners are valid",
+		}
+	}
+
 	if gatewayErr != nil {
 		gatewayErr.Message = "Parent not accepted: " + gatewayErr.Message
 		gatewayConditions[string(k8s.GatewayConditionAccepted)].error = gatewayErr
+	} else if listenersErr != nil {
+		gatewayConditions[string(k8s.GatewayConditionAccepted)].error = listenersErr
 	}
 
 	setProgrammedCondition(gatewayConditions, internal, gatewayServices, warnings, allUsable)
+
+	// A ListenerSet with no valid listeners cannot be programmed; this takes precedence over any
+	// address-related programming status.
+	if listenersErr != nil {
+		gatewayConditions[string(k8s.GatewayConditionProgrammed)].error = listenersErr
+	}
 
 	// Prune stale listener status entries whose listener was removed from the spec,
 	// mirroring reportGatewayStatus. ListenerSetCollection threads the previous status

--- a/pilot/pkg/config/kube/gateway/gateway_collection.go
+++ b/pilot/pkg/config/kube/gateway/gateway_collection.go
@@ -141,11 +141,12 @@ func ListenerSetCollection(
 			gatewayServices, err := extractGatewayServices(domainSuffix, parentGwObj, classInfo)
 			if len(gatewayServices) == 0 && err != nil {
 				// Short circuit if it's a hard failure
-				reportListenerSetStatus(context, parentGwObj, obj, status, gatewayServices, nil, err)
+				reportListenerSetStatus(context, parentGwObj, obj, status, gatewayServices, nil, err, true)
 				return status, nil
 			}
 
 			servers := []*istio.Server{}
+			validListeners := 0
 			for i, l := range ls.Listeners {
 				port, portErr := detectListenerPortNumber(l)
 				l.Port = port
@@ -155,6 +156,9 @@ func ListenerSetCollection(
 					obj, originalStatus, parentGwObj.Spec, standardListener, i, controllerName, portErr)
 				status.Listeners = slices.Map(updatedStatus, convertStandardStatusToListenerSetStatus(l))
 
+				if programmed {
+					validListeners++
+				}
 				servers = append(servers, server)
 				if controllerName == constants.ManagedGatewayMeshController {
 					// Waypoint doesn't convert routes to VirtualServices.
@@ -223,7 +227,7 @@ func ListenerSetCollection(
 				result = append(result, res)
 			}
 
-			reportListenerSetStatus(context, parentGwObj, obj, status, gatewayServices, servers, err)
+			reportListenerSetStatus(context, parentGwObj, obj, status, gatewayServices, servers, err, validListeners > 0)
 			return status, result
 		}, opts.WithName("ListenerSets")...)
 

--- a/pilot/pkg/config/kube/gateway/testdata/listenerset-cross-namespace.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/listenerset-cross-namespace.status.yaml.golden
@@ -49,6 +49,56 @@ status:
 apiVersion: gateway.networking.k8s.io/v1
 kind: ListenerSet
 metadata:
+  name: all-denied
+  namespace: ns2
+spec: null
+status:
+  conditions:
+  - lastTransitionTime: fake
+    message: None of the ListenerSet's listeners are valid
+    reason: ListenersNotValid
+    status: "False"
+    type: Accepted
+  - lastTransitionTime: fake
+    message: None of the ListenerSet's listeners are valid
+    reason: ListenersNotValid
+    status: "False"
+    type: Programmed
+  listeners:
+  - attachedRoutes: 0
+    conditions:
+    - lastTransitionTime: fake
+      message: certificateRef ns4-cert/ns4 not accessible to a Gateway in namespace
+        "ns2" (missing a ReferenceGrant?)
+      reason: NoValidCACertificate
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: No errors found
+      reason: NoConflicts
+      status: "False"
+      type: Conflicted
+    - lastTransitionTime: fake
+      message: Bad TLS configuration
+      reason: Invalid
+      status: "False"
+      type: Programmed
+    - lastTransitionTime: fake
+      message: certificateRef ns4-cert/ns4 not accessible to a Gateway in namespace
+        "ns2" (missing a ReferenceGrant?)
+      reason: RefNotPermitted
+      status: "False"
+      type: ResolvedRefs
+    name: only
+    supportedKinds:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+    - group: gateway.networking.k8s.io
+      kind: GRPCRoute
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
   name: cross-ns-cert
   namespace: ns2
 spec: null
@@ -195,7 +245,7 @@ status:
   addresses:
   - type: IPAddress
     value: 1.2.3.4
-  attachedListenerSets: 3
+  attachedListenerSets: 4
   conditions:
   - lastTransitionTime: fake
     message: Resource accepted

--- a/pilot/pkg/config/kube/gateway/testdata/listenerset-cross-namespace.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/listenerset-cross-namespace.yaml
@@ -99,6 +99,30 @@ spec:
             name: ns4-cert
             namespace: ns4
 ---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: all-denied
+  namespace: ns2
+spec:
+  parentRef:
+    name: parent-gateway
+    namespace: istio-system
+    kind: Gateway
+    group: gateway.networking.k8s.io
+  listeners:
+    - name: only
+      hostname: only.foo.com
+      protocol: HTTPS
+      port: 443
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            group: ""
+            name: ns4-cert
+            namespace: ns4
+---
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:

--- a/releasenotes/notes/listenerset-listeners-not-valid.yaml
+++ b/releasenotes/notes/listenerset-listeners-not-valid.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed** ListenerSet status reporting so that a ListenerSet with no valid listeners now
+    reports the `Accepted` and `Programmed` conditions as `False` with reason `ListenersNotValid`.
+    Previously the ListenerSet-level conditions could remain `True` even when none of its listeners
+    were usable.

--- a/tests/integration/ambient/gateway_conformance_test.go
+++ b/tests/integration/ambient/gateway_conformance_test.go
@@ -76,7 +76,6 @@ var skippedTests = map[string]string{
 
 	"ListenerSetHostnameConflict": "TODO",
 	"ListenerSetProtocolConflict": "TODO",
-	"ListenerSetReferenceGrant":   "TODO",
 
 	// Fixed upstream, waiting for new gateway api release to pick up fix
 	"MeshHTTPRoute307Redirect": "TODO",

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -75,7 +75,6 @@ var skippedTests = map[string]string{
 
 	"ListenerSetHostnameConflict": "TODO",
 	"ListenerSetProtocolConflict": "TODO",
-	"ListenerSetReferenceGrant":   "TODO",
 
 	// Fixed upstream, waiting for new gateway api release to pick up fix
 	"MeshHTTPRoute307Redirect": "TODO",


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes the `Accepted` and `Programmed` aggregate conditions to report `ListenerSetReasonListenersNotValid` when a ListenerSet has no valid listeners. This fix passes the `ListenerSetReferenceGrant` Gateway API v1.5 conformance test as well. It won't run though because the ListenerSet feature is still disabled. (Two other tests are broken still, `ListenerSetHostnameConflict` and `ListenerSetProtocolConflict`)