### PR TITLE
ambient: add waypoint SA SANs when merging cross-cluster service infos

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1315,6 +1315,8 @@ func (i ServiceInfo) GetConditions(currentConditions map[string]Condition) Condi
 type WaypointBindingStatus struct {
 	// ResourceName that clients should use when addressing traffic to this Service.
 	ResourceName string
+	// ServiceAccounts the waypoint service accounts
+	ServiceAccounts []string
 	// IngressUseWaypoint specifies whether ingress gateways should use the waypoint for this service.
 	IngressUseWaypoint bool
 	// IngressLabelPresent specifies whether the istio.io/ingress-use-waypoint label is set on the service.
@@ -1330,6 +1332,7 @@ type StatusMessage struct {
 
 func (i WaypointBindingStatus) Equals(other WaypointBindingStatus) bool {
 	return i.ResourceName == other.ResourceName &&
+		slices.Equal(i.ServiceAccounts, other.ServiceAccounts) &&
 		i.IngressUseWaypoint == other.IngressUseWaypoint &&
 		i.IngressLabelPresent == other.IngressLabelPresent &&
 		ptr.Equal(i.Error, other.Error)

--- a/pilot/pkg/serviceregistry/ambient/multicluster.go
+++ b/pilot/pkg/serviceregistry/ambient/multicluster.go
@@ -259,7 +259,7 @@ func (a *index) buildGlobalCollections(
 
 	GlobalMergedWorkloadServicesWithCluster := krt.NestedJoinWithMergeCollection(
 		GlobalWorkloadServicesWithCluster,
-		mergeServiceInfosWithCluster(localCluster.ID),
+		mergeServiceInfosWithCluster(localCluster.ID, LocalMeshConfig.Get().TrustDomain),
 		opts.WithName("GlobalMergedServiceInfosWithCluster")...,
 	)
 
@@ -466,7 +466,6 @@ func (a *index) buildGlobalCollections(
 			if svc.Scope != model.Global {
 				return &svc
 			}
-
 			wls := GlobalWorkloadServiceIndex.Fetch(ctx, svc.ResourceName())
 			if len(wls) == 0 {
 				return &svc
@@ -621,6 +620,7 @@ func networkAddressToSimple(a *workloadapi.NetworkAddress) simpleNetworkAddress 
 
 func mergeServiceInfosWithCluster(
 	localClusterID cluster.ID,
+	trustDomain string,
 ) func(serviceInfos []krt.ObjectWithCluster[model.ServiceInfo]) *krt.ObjectWithCluster[model.ServiceInfo] {
 	return func(serviceInfos []krt.ObjectWithCluster[model.ServiceInfo]) *krt.ObjectWithCluster[model.ServiceInfo] {
 		svcInfosLen := len(serviceInfos)
@@ -685,7 +685,14 @@ func mergeServiceInfosWithCluster(
 			// VIP uniqueness within a network
 			vips.InsertAll(slices.Map(obj.Object.Service.GetAddresses(), networkAddressToSimple)...)
 			sans.InsertAll(obj.Object.Service.GetSubjectAltNames()...)
-
+			// If the base service lacks waypoints but the remote service has them,
+			// add the remote service waypoint's Service Account (SA) to the Subject Alternative Names (SANs).
+			// This prevents identity verification failures during requests.
+			if obj.Object.Service.GetWaypoint() != nil && base.Object.Service.GetWaypoint() == nil {
+				for _, sa := range obj.Object.Waypoint.ServiceAccounts {
+					sans.Insert(spiffe.MustGenSpiffeURIForTrustDomain(trustDomain, obj.Object.Service.Namespace, sa))
+				}
+			}
 		}
 
 		basePorts := sets.New(slices.Map(base.Object.Service.Ports, workloadPortsToSimplePort)...)

--- a/pilot/pkg/serviceregistry/ambient/services.go
+++ b/pilot/pkg/serviceregistry/ambient/services.go
@@ -272,6 +272,7 @@ func serviceServiceBuilder(
 		waypoint, wperr := fetchWaypointForService(ctx, waypoints, namespaces, s.ObjectMeta)
 		if waypoint != nil {
 			waypointStatus.ResourceName = waypoint.ResourceName()
+			waypointStatus.ServiceAccounts = waypoint.ServiceAccounts
 			var nsLabels map[string]string
 			if ns != nil {
 				nsLabels = (*ns).Labels


### PR DESCRIPTION
When merging service info across clusters in multi-primary multi-network setups, if the remote service has a waypoint but the local one does not, the waypoint's service account SANs were not included in the merged SAN list. This caused ztunnel to reject cross-cluster connections with an identity verification error because the remote waypoint's SAN was unexpected.

Fix by propagating waypoint ServiceAccounts through WaypointBindingStatus and injecting the corresponding SPIFFE URIs into the SAN set during service info merging when only the remote side has a waypoint enrolled.

Fixes #60626

**Please provide a description of this PR:**