### PR TITLE
correctly filter traffic extension configs

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -954,6 +954,10 @@ func (s *Server) initRegistryEventHandlers() {
 			if schema.GroupVersionKind() == gvk.VirtualService {
 				continue
 			}
+			// Traffic extension controller already emits TrafficExtension events, we should supress WasmPlugin events
+			if schema.GroupVersionKind() == gvk.WasmPlugin {
+				continue
+			}
 
 			s.configController.RegisterEventHandler(schema.GroupVersionKind(), configHandler)
 		}

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -954,7 +954,7 @@ func (s *Server) initRegistryEventHandlers() {
 			if schema.GroupVersionKind() == gvk.VirtualService {
 				continue
 			}
-			// Traffic extension controller already emits TrafficExtension events, we should supress WasmPlugin events
+			// Traffic extension controller already emits TrafficExtension events, we should suppress WasmPlugin events
 			if schema.GroupVersionKind() == gvk.WasmPlugin {
 				continue
 			}

--- a/pilot/pkg/xds/cds.go
+++ b/pilot/pkg/xds/cds.go
@@ -40,6 +40,7 @@ var skippedCdsConfigs = sets.New(
 	kind.Secret,
 	kind.Telemetry,
 	kind.WasmPlugin,
+	kind.TrafficExtension,
 	kind.ProxyConfig,
 	kind.DNSName,
 	kind.Endpoints,

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -104,6 +104,7 @@ var skippedEdsConfigs = sets.New(
 	kind.Secret,
 	kind.Telemetry,
 	kind.WasmPlugin,
+	kind.TrafficExtension,
 	kind.ProxyConfig,
 	kind.DNSName,
 	kind.Sidecar,

--- a/pilot/pkg/xds/nds.go
+++ b/pilot/pkg/xds/nds.go
@@ -50,6 +50,7 @@ var skippedNdsConfigs = sets.New(
 	kind.RequestAuthentication,
 	kind.PeerAuthentication,
 	kind.WasmPlugin,
+	kind.TrafficExtension,
 	kind.ProxyConfig,
 	kind.MeshConfig,
 	kind.Endpoints,

--- a/pilot/pkg/xds/rds.go
+++ b/pilot/pkg/xds/rds.go
@@ -36,6 +36,7 @@ var skippedRdsConfigs = sets.New(
 	kind.PeerAuthentication,
 	kind.Secret,
 	kind.WasmPlugin,
+	kind.TrafficExtension,
 	kind.Telemetry,
 	kind.ProxyConfig,
 	kind.DNSName,

--- a/releasenotes/notes/60638.yaml
+++ b/releasenotes/notes/60638.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed** Duplicate and excessive pushes when using WasmPlugins due to TrafficExtension conversions.


### PR DESCRIPTION
**Please provide a description of this PR:**
Found this while trying to understand causes for https://github.com/istio/istio/issues/60629, not sure it's actually the culprit, but it's definitely an oversight.
When `TrafficExtension` was introduced we introduced new `TrafficExtension` events, but we never suppressed `WasmPlugin` events, so now we get duplicate events. Also, `TrafficExtension` was not added to config generators that exclude `WasmPlugin`.