### PR TITLE
Allow traffic extensions from other namespaces

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -2172,8 +2172,17 @@ func (ps *PushContext) TrafficExtensions(proxy *Proxy) map[extensions.TrafficExt
 
 func (ps *PushContext) TrafficExtensionsByName(proxy *Proxy, names []types.NamespacedName) []*TrafficExtensionWrapper {
 	res := make([]*TrafficExtensionWrapper, 0, len(names))
+	// With more plumbing, there is probably a better way of doing this.
+	allowedNamespaces := sets.New(proxy.ConfigNamespace, ps.Mesh.RootNamespace)
+	// We allow cross namespace for waypoints
+	if proxy.IsWaypointProxy() {
+		for _, si := range ps.ServicesForWaypoint(WaypointKeyForProxy(proxy)) {
+			allowedNamespaces.Insert(si.GetNamespace())
+		}
+	}
+
 	for _, n := range names {
-		if n.Namespace != proxy.ConfigNamespace && n.Namespace != ps.Mesh.RootNamespace {
+		if !allowedNamespaces.Contains(n.Namespace) {
 			log.Warnf("proxy requested invalid TrafficExtension configuration: %v", n)
 			continue
 		}

--- a/releasenotes/notes/wasmplugin-cross-namespace-waypoint.yaml
+++ b/releasenotes/notes/wasmplugin-cross-namespace-waypoint.yaml
@@ -1,0 +1,13 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: extensibility
+
+issue:
+  - https://github.com/istio/istio/issues/60530
+
+releaseNotes:
+  - |
+    **Fixed** a bug where a `WasmPlugin` in an application namespace targeting a `Service` via `targetRefs`
+    would cause a waypoint proxy to crash-loop on startup. The LDS path correctly included the plugin for
+    the waypoint, but the ECDS lookup path rejected it as cross-namespace, leaving Envoy waiting for a
+    resource that would never arrive.


### PR DESCRIPTION
**Please provide a description of this PR:**

(Only if allowed by the Gateway).
Note that we check elsewhere that the traffic extension and the target service live in the same ns