### PR TITLE
xds: never explicitly delete resources on non-wildcard delta type urls

### DIFF
--- a/pilot/pkg/networking/core/cluster.go
+++ b/pilot/pkg/networking/core/cluster.go
@@ -149,6 +149,7 @@ func (configgen *ConfigGeneratorImpl) BuildDeltaClusters(proxy *model.Proxy, upd
 	}
 	envoyFilterPatches := updates.Push.EnvoyFilters(proxy)
 	clusters, log := configgen.buildClusters(proxy, updates, services, envoyFilterPatches)
+	log.Incremental = true
 	// DeletedClusters contains list of all subset clusters for the deleted DR or updated DR.
 	// When clusters are rebuilt, we rebuild the subset clusters as well. So, we know what
 	// subset clusters are really needed. So if deleted cluster is not rebuilt, then it is really deleted.

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -514,15 +514,20 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection, w *model.WatchedResource
 		Nonce:             nonce(req.Push.PushVersion),
 		Resources:         res,
 	}
-	if usedDelta {
-		resp.RemovedResources = deletedRes
-	} else if !logdata.Incremental {
-		// similar to sotw
-		removed := w.ResourceNames.Copy()
-		for _, r := range res {
-			removed.Delete(r.Name)
+	if xds.IsWildcardTypeURL(w.TypeUrl) {
+		// we should only ever remove resources on wildcard subscriptions,
+		// in non-wildcard subscriptions, envoy will automatically unsubscribe from resources
+		// also avoids https://github.com/envoyproxy/envoy/issues/32823 in ECDS
+		if usedDelta {
+			resp.RemovedResources = deletedRes
+		} else if !logdata.Incremental {
+			// sotw style resource diffing for calculating removed resources
+			removed := w.ResourceNames.Copy()
+			for _, r := range res {
+				removed.Delete(r.Name)
+			}
+			resp.RemovedResources = sets.SortedList(removed)
 		}
-		resp.RemovedResources = sets.SortedList(removed)
 	}
 	var newResourceNames sets.String
 	if shouldSetWatchedResources(w) {
@@ -537,9 +542,6 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection, w *model.WatchedResource
 		} else {
 			newResourceNames = resourceNamesSet(res)
 		}
-	}
-	if neverRemoveDelta(w.TypeUrl) {
-		resp.RemovedResources = nil
 	}
 	if len(resp.RemovedResources) > 0 {
 		deltaLog.Debugf("ADS:%v REMOVE for node:%s %v", v3.GetShortType(w.TypeUrl), con.ID(), resp.RemovedResources)
@@ -602,13 +604,6 @@ func resourceNamesSet(res model.Resources) sets.Set[string] {
 // This is used when resources are spontaneously pushed during Delta XDS
 func requiresResourceNamesModification(url string) bool {
 	return url == v3.AddressType || url == v3.WorkloadType
-}
-
-// neverRemoveDelta checks if a type should never remove resources
-func neverRemoveDelta(url string) bool {
-	// https://github.com/envoyproxy/envoy/issues/32823
-	// We want to garbage collect extensions when they are no longer referenced, rather than delete immediately
-	return url == v3.ExtensionConfigurationType
 }
 
 // shouldSetWatchedResources indicates whether we should set the watched resources for a given type.

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -528,6 +528,9 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection, w *model.WatchedResource
 			}
 			resp.RemovedResources = sets.SortedList(removed)
 		}
+		if len(resp.RemovedResources) > 0 {
+			deltaLog.Debugf("ADS:%v REMOVE for node:%s %v", v3.GetShortType(w.TypeUrl), con.ID(), resp.RemovedResources)
+		}
 	}
 	var newResourceNames sets.String
 	if shouldSetWatchedResources(w) {
@@ -542,9 +545,6 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection, w *model.WatchedResource
 		} else {
 			newResourceNames = resourceNamesSet(res)
 		}
-	}
-	if len(resp.RemovedResources) > 0 {
-		deltaLog.Debugf("ADS:%v REMOVE for node:%s %v", v3.GetShortType(w.TypeUrl), con.ID(), resp.RemovedResources)
 	}
 
 	configSize := ResourceSize(res)

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -257,7 +257,7 @@ func (eds *EdsGenerator) buildEndpoints(proxy *model.Proxy,
 		eds.Cache.Add(&builder, req, resource)
 	}
 	return resources, model.XdsLogDetails{
-		Incremental:    len(edsUpdatedServices) != 0,
+		Incremental:    partialPush,
 		AdditionalInfo: fmt.Sprintf("empty:%v cached:%v/%v", empty, cached, cached+regenerated),
 	}
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
We should avoid sending RemovedResources in Non-Wildcard TypeUrls, this was already the case in EDS in which we never set `RemovedResources` and is also the case for `ECDS` where we always overwrote `RemovedResources=nil`, but this can be also extended to SDS and RDS which are actually known to just ignore deletions.
Ref: https://github.com/envoyproxy/envoy/issues/32823

Also modified `BuildDeltaClusters` and `buildEndpoints` to set `Incremental: true` on their logs whenever they're actually performing resource diff as opposed to a full rebuild, this makes push logs more correct and useful.