### PR TITLE
scope ambient address pushes to affected waypoints

### DIFF
--- a/pilot/pkg/features/ambient.go
+++ b/pilot/pkg/features/ambient.go
@@ -86,6 +86,14 @@ var (
 		false,
 		"If enabled, selector based authorization policies will be enforced as L4 policies in front of the waypoint.").Get()
 
+	// Registered unconditionally (not via registerAmbient) so the default applies in environments
+	// where ambient is enabled at runtime rather than via PILOT_ENABLE_AMBIENT; without ambient no
+	// Address updates are produced, so this has no effect.
+	ScopedAddressPushes = env.Register("AMBIENT_SCOPED_ADDRESS_PUSHES", true,
+		"If enabled, ambient Address updates only trigger pushes for waypoints whose attached services or workloads changed, "+
+			"and are skipped entirely for sidecar and gateway proxies. If disabled, every Address update triggers a "+
+			"full LDS/CDS/EDS push to all waypoints and an RDS push to all proxies.").Get()
+
 	EnableWdsDryRunAuthzPol = registerAmbient("AMBIENT_ENABLE_DRY_RUN_AUTHORIZATION_POLICY", false, false,
 		"If enabled, ztunnel will be configured with dry-run authorizationPolicies. "+
 			"Ensure ztunnel is 1.29 or above before enabling this feature. "+

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -366,6 +366,13 @@ type PushRequest struct {
 
 	AddressesUpdated sets.Set[string]
 
+	// WaypointsUpdated keeps track of the waypoints that the services/workloads behind the
+	// kind.Address entries in ConfigsUpdated are attached to, including waypoints they were
+	// attached to before the update. This is used to scope Address pushes to the waypoint
+	// proxies actually affected; Address updates that reference no waypoint (e.g. ordinary
+	// pod churn) leave this empty so waypoints can skip them entirely.
+	WaypointsUpdated sets.Set[WaypointReference]
+
 	// Push stores the push context to use for the update. This may initially be nil, as we will
 	// debounce changes before a PushContext is eventually created.
 	Push *PushContext
@@ -519,6 +526,12 @@ func (pr *PushRequest) Merge(other *PushRequest) *PushRequest {
 		pr.AddressesUpdated.Merge(other.AddressesUpdated)
 	}
 
+	if pr.WaypointsUpdated == nil {
+		pr.WaypointsUpdated = other.WaypointsUpdated
+	} else {
+		pr.WaypointsUpdated.Merge(other.WaypointsUpdated)
+	}
+
 	return pr
 }
 
@@ -565,6 +578,12 @@ func (pr *PushRequest) CopyMerge(other *PushRequest) *PushRequest {
 		merged.AddressesUpdated = make(sets.Set[string], len(pr.AddressesUpdated)+len(other.AddressesUpdated))
 		merged.AddressesUpdated.Merge(pr.AddressesUpdated)
 		merged.AddressesUpdated.Merge(other.AddressesUpdated)
+	}
+
+	if len(pr.WaypointsUpdated) > 0 || len(other.WaypointsUpdated) > 0 {
+		merged.WaypointsUpdated = make(sets.Set[WaypointReference], len(pr.WaypointsUpdated)+len(other.WaypointsUpdated))
+		merged.WaypointsUpdated.Merge(pr.WaypointsUpdated)
+		merged.WaypointsUpdated.Merge(other.WaypointsUpdated)
 	}
 
 	return merged

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1054,6 +1054,45 @@ func waypointKeyForProxy(node *Proxy, externalAddresses bool) WaypointKey {
 	return key
 }
 
+// WaypointReference identifies the waypoint a service or workload is attached to, mirroring
+// workloadapi.GatewayAddress: either by namespaced hostname or by network address.
+type WaypointReference struct {
+	// Namespace and Hostname are set for hostname-based references.
+	Namespace string
+	Hostname  string
+	// Network and Address are set for address-based references.
+	Network string
+	Address string
+}
+
+// WaypointReferenceFromGatewayAddress converts a workloadapi waypoint reference, returning
+// false if there is no reference or it has no usable destination.
+func WaypointReferenceFromGatewayAddress(addr *workloadapi.GatewayAddress) (WaypointReference, bool) {
+	switch d := addr.GetDestination().(type) {
+	case *workloadapi.GatewayAddress_Hostname:
+		return WaypointReference{Namespace: d.Hostname.Namespace, Hostname: d.Hostname.Hostname}, true
+	case *workloadapi.GatewayAddress_Address:
+		ip, ok := netip.AddrFromSlice(d.Address.Address)
+		if !ok {
+			return WaypointReference{}, false
+		}
+		return WaypointReference{Network: d.Address.Network, Address: ip.String()}, true
+	}
+	return WaypointReference{}, false
+}
+
+// Matches reports whether the referenced waypoint is the one identified by key.
+// This mirrors the hostname and address lookups used by the ambient index's
+// ServicesForWaypoint/WorkloadsForWaypoint.
+func (ref WaypointReference) Matches(key WaypointKey) bool {
+	if ref.Hostname != "" {
+		return ref.Namespace == key.Namespace && slices.Contains(key.Hostnames, ref.Hostname)
+	}
+	return ref.Network == key.Network && slices.Contains(key.Addresses, ref.Address)
+}
+
+var _ AmbientIndexes = NoopAmbientIndexes{}
+
 // NoopAmbientIndexes provides an implementation of AmbientIndexes that always returns nil, to easily "skip" it.
 type NoopAmbientIndexes struct{}
 
@@ -1361,6 +1400,11 @@ func (i ServiceInfo) ResourceName() string {
 	return serviceResourceName(i.Service)
 }
 
+// WaypointRef returns the waypoint this service is attached to, if any.
+func (i ServiceInfo) WaypointRef() *workloadapi.GatewayAddress {
+	return i.Service.GetWaypoint()
+}
+
 func serviceResourceName(s *workloadapi.Service) string {
 	return s.Namespace + "/" + s.Hostname
 }
@@ -1443,6 +1487,11 @@ func (i WorkloadInfo) GetConditions(currentConditions map[string]Condition) Cond
 
 func (i WorkloadInfo) ResourceName() string {
 	return workloadResourceName(i.Workload)
+}
+
+// WaypointRef returns the waypoint this workload is attached to, if any.
+func (i WorkloadInfo) WaypointRef() *workloadapi.GatewayAddress {
+	return i.Workload.GetWaypoint()
 }
 
 type WaypointPolicyStatus struct {

--- a/pilot/pkg/serviceregistry/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex.go
@@ -349,7 +349,7 @@ func New(options Options) Index {
 				DNSConnectStrategy: a.DNSConnectStrategy,
 			}
 		},
-		PushXdsAddress(a.XDSUpdater, model.ServiceInfo.ResourceName),
+		PushXdsAddress(a.XDSUpdater, model.ServiceInfo.ResourceName, model.ServiceInfo.WaypointRef),
 	), false)
 
 	NamespacesInfo := krt.NewCollection(Namespaces, func(ctx krt.HandlerContext, i *corev1.Namespace) *model.NamespaceInfo {
@@ -443,7 +443,7 @@ func New(options Options) Index {
 			// Only trigger push if the XDS object changed; the rest is just for computation of others
 			return a.Workload
 		},
-		PushXdsAddress(a.XDSUpdater, model.WorkloadInfo.ResourceName),
+		PushXdsAddress(a.XDSUpdater, model.WorkloadInfo.ResourceName, model.WorkloadInfo.WaypointRef),
 	), false)
 
 	if features.EnableIngressWaypointRouting {
@@ -858,14 +858,20 @@ func PushXds[T any](xds model.XDSUpdater, f func(T) model.ConfigKey) func(events
 	}
 }
 
-func PushXdsAddress[T any](xds model.XDSUpdater, f func(T) string) func(events []krt.Event[T]) {
+func PushXdsAddress[T any](xds model.XDSUpdater, f func(T) string, waypointRef func(T) *workloadapi.GatewayAddress) func(events []krt.Event[T]) {
 	return func(events []krt.Event[T]) {
 		au := sets.New[string]()
+		wu := sets.New[model.WaypointReference]()
 		for _, e := range events {
+			// Items() includes the old state on updates and deletes, so detaching from a
+			// waypoint still records that waypoint as updated.
 			for _, i := range e.Items() {
 				c := f(i)
 				if c != "" {
 					au.Insert(c)
+				}
+				if ref, ok := model.WaypointReferenceFromGatewayAddress(waypointRef(i)); ok {
+					wu.Insert(ref)
 				}
 			}
 		}
@@ -882,6 +888,7 @@ func PushXdsAddress[T any](xds model.XDSUpdater, f func(T) string) func(events [
 		xds.ConfigUpdate(&model.PushRequest{
 			AddressesUpdated: au,
 			ConfigsUpdated:   cu,
+			WaypointsUpdated: wu,
 			Reason:           model.NewReasonStats(model.AmbientUpdate),
 		})
 	}

--- a/pilot/pkg/serviceregistry/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex_test.go
@@ -3204,3 +3204,63 @@ func generateService(name, namespace string, labels, annotations map[string]stri
 		},
 	}
 }
+
+// pushRequestRecorder captures the PushRequest produced by event handlers under test.
+type pushRequestRecorder struct {
+	req *model.PushRequest
+}
+
+func (p *pushRequestRecorder) EDSUpdate(model.ShardKey, string, string, []*model.IstioEndpoint) {}
+func (p *pushRequestRecorder) EDSCacheUpdate(model.ShardKey, string, string, []*model.IstioEndpoint) {
+}
+func (p *pushRequestRecorder) SvcUpdate(model.ShardKey, string, string, model.Event) {}
+func (p *pushRequestRecorder) ConfigUpdate(req *model.PushRequest)                   { p.req = req }
+func (p *pushRequestRecorder) ProxyUpdate(cluster.ID, string)                        {}
+func (p *pushRequestRecorder) RemoveShard(model.ShardKey)                            {}
+
+func TestPushXdsAddressWaypointRefs(t *testing.T) {
+	waypoint := &workloadapi.GatewayAddress{
+		Destination: &workloadapi.GatewayAddress_Hostname{
+			Hostname: &workloadapi.NamespacedHostname{Namespace: "default", Hostname: "waypoint.default.svc.cluster.local"},
+		},
+	}
+	waypointRef := model.WaypointReference{Namespace: "default", Hostname: "waypoint.default.svc.cluster.local"}
+	attached := model.WorkloadInfo{Workload: &workloadapi.Workload{Uid: "cluster0//Pod/default/a", Waypoint: waypoint}}
+	unattached := model.WorkloadInfo{Workload: &workloadapi.Workload{Uid: "cluster0//Pod/default/a"}}
+
+	cases := []struct {
+		name  string
+		event krt.Event[model.WorkloadInfo]
+		want  sets.Set[model.WaypointReference]
+	}{
+		{
+			name:  "workload without waypoint",
+			event: krt.Event[model.WorkloadInfo]{New: &unattached, Event: controllers.EventAdd},
+			want:  sets.New[model.WaypointReference](),
+		},
+		{
+			name:  "workload attached to waypoint",
+			event: krt.Event[model.WorkloadInfo]{New: &attached, Event: controllers.EventAdd},
+			want:  sets.New(waypointRef),
+		},
+		{
+			// The waypoint a workload detaches from must still see the change to drop its config
+			name:  "workload detached from waypoint",
+			event: krt.Event[model.WorkloadInfo]{Old: &attached, New: &unattached, Event: controllers.EventUpdate},
+			want:  sets.New(waypointRef),
+		},
+		{
+			name:  "attached workload deleted",
+			event: krt.Event[model.WorkloadInfo]{Old: &attached, Event: controllers.EventDelete},
+			want:  sets.New(waypointRef),
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := &pushRequestRecorder{}
+			PushXdsAddress(rec, model.WorkloadInfo.ResourceName, model.WorkloadInfo.WaypointRef)([]krt.Event[model.WorkloadInfo]{tt.event})
+			assert.Equal(t, rec.req.WaypointsUpdated, tt.want)
+			assert.Equal(t, rec.req.AddressesUpdated, sets.New("cluster0//Pod/default/a"))
+		})
+	}
+}

--- a/pilot/pkg/serviceregistry/ambient/multicluster.go
+++ b/pilot/pkg/serviceregistry/ambient/multicluster.go
@@ -411,7 +411,7 @@ func (a *index) buildGlobalCollections(
 			// Only trigger push if the XDS object changed; the rest is just for computation of others
 			return a.Workload
 		},
-		PushXdsAddress(a.XDSUpdater, model.WorkloadInfo.ResourceName),
+		PushXdsAddress(a.XDSUpdater, model.WorkloadInfo.ResourceName, model.WorkloadInfo.WaypointRef),
 	), false)
 
 	SplitHorizonWorkloadAddressIndex := krt.NewIndex[networkAddress, model.WorkloadInfo](SplitHorizonWorkloads, "networkAddress", networkAddressFromWorkload)
@@ -512,7 +512,7 @@ func (a *index) buildGlobalCollections(
 				DNSConnectStrategy: a.DNSConnectStrategy,
 			}
 		},
-		PushXdsAddress(a.XDSUpdater, model.ServiceInfo.ResourceName),
+		PushXdsAddress(a.XDSUpdater, model.ServiceInfo.ResourceName, model.ServiceInfo.WaypointRef),
 	), false)
 
 	SplitHorizonServiceAddressIndex := krt.NewIndex[networkAddress, model.ServiceInfo](SplitHorizonServices, "serviceAddress", networkAddressFromService)

--- a/pilot/pkg/xds/cds.go
+++ b/pilot/pkg/xds/cds.go
@@ -67,7 +67,7 @@ func cdsNeedsPush(req *model.PushRequest, proxy *model.Proxy) (*model.PushReques
 	if res, ok := xdsNeedsPush(req, proxy); ok {
 		return req, res
 	}
-	if proxy.Type == model.Waypoint && waypointNeedsPush(req) {
+	if proxy.Type == model.Waypoint && waypointNeedsPush(req, proxy) {
 		return req, true
 	}
 

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -125,7 +125,7 @@ func edsNeedsPush(req *model.PushRequest, proxy *model.Proxy) bool {
 		return res
 	}
 	// CDS needs to be pushed for waypoint proxies on kind.Address changes, so we need to push EDS as well.
-	if proxy.Type == model.Waypoint && waypointNeedsPush(req) {
+	if proxy.Type == model.Waypoint && waypointNeedsPush(req, proxy) {
 		return true
 	}
 	for config := range req.ConfigsUpdated {

--- a/pilot/pkg/xds/lds.go
+++ b/pilot/pkg/xds/lds.go
@@ -17,6 +17,7 @@ package xds
 import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core"
 	"istio.io/istio/pilot/pkg/util/protoconv"
@@ -52,22 +53,29 @@ var skippedLdsConfigs = map[model.NodeType]sets.Set[kind.Kind]{
 		kind.Endpoints,
 		kind.Address,
 	),
-	model.Waypoint: sets.New(
-		kind.Gateway,
-		kind.WorkloadGroup,
-		kind.WorkloadEntry,
-		kind.Secret,
-		kind.ProxyConfig,
-		kind.DNSName,
-		kind.Endpoints,
-	),
+	model.Waypoint: func() sets.Set[kind.Kind] {
+		s := sets.New(
+			kind.Gateway,
+			kind.WorkloadGroup,
+			kind.WorkloadEntry,
+			kind.Secret,
+			kind.ProxyConfig,
+			kind.DNSName,
+			kind.Endpoints,
+		)
+		if features.ScopedAddressPushes {
+			// Address changes are handled by waypointNeedsPush, scoped to the affected waypoints
+			s.Insert(kind.Address)
+		}
+		return s
+	}(),
 }
 
 func ldsNeedsPush(proxy *model.Proxy, req *model.PushRequest) bool {
 	if res, ok := xdsNeedsPush(req, proxy); ok {
 		return res
 	}
-	if proxy.Type == model.Waypoint && waypointNeedsPush(req) {
+	if proxy.Type == model.Waypoint && waypointNeedsPush(req, proxy) {
 		return true
 	}
 	for config := range req.ConfigsUpdated {

--- a/pilot/pkg/xds/nds.go
+++ b/pilot/pkg/xds/nds.go
@@ -17,6 +17,7 @@ package xds
 import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core"
 	"istio.io/istio/pilot/pkg/util/protoconv"
@@ -37,24 +38,32 @@ type NdsGenerator struct {
 var _ model.XdsResourceGenerator = &NdsGenerator{}
 
 // Map of all configs that do not impact NDS
-var skippedNdsConfigs = sets.New(
-	kind.Gateway,
-	kind.VirtualService,
-	kind.DestinationRule,
-	kind.Secret,
-	kind.Telemetry,
-	kind.EnvoyFilter,
-	kind.WorkloadEntry,
-	kind.WorkloadGroup,
-	kind.AuthorizationPolicy,
-	kind.RequestAuthentication,
-	kind.PeerAuthentication,
-	kind.WasmPlugin,
-	kind.TrafficExtension,
-	kind.ProxyConfig,
-	kind.MeshConfig,
-	kind.Endpoints,
-)
+var skippedNdsConfigs = func() sets.Set[kind.Kind] {
+	s := sets.New(
+		kind.Gateway,
+		kind.VirtualService,
+		kind.DestinationRule,
+		kind.Secret,
+		kind.Telemetry,
+		kind.EnvoyFilter,
+		kind.WorkloadEntry,
+		kind.WorkloadGroup,
+		kind.AuthorizationPolicy,
+		kind.RequestAuthentication,
+		kind.PeerAuthentication,
+		kind.WasmPlugin,
+		kind.TrafficExtension,
+		kind.ProxyConfig,
+		kind.MeshConfig,
+		kind.Endpoints,
+	)
+	if features.ScopedAddressPushes {
+		// The DNS name table is derived from services; ambient Address changes that matter
+		// to it arrive as ServiceEntry updates.
+		s.Insert(kind.Address)
+	}
+	return s
+}()
 
 func ndsNeedsPush(req *model.PushRequest, proxy *model.Proxy) bool {
 	if res, ok := xdsNeedsPush(req, proxy); ok {

--- a/pilot/pkg/xds/proxy_dependencies.go
+++ b/pilot/pkg/xds/proxy_dependencies.go
@@ -17,6 +17,7 @@ package xds
 import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
+	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/util/sets"
@@ -76,6 +77,12 @@ func proxyDependentOnConfig(proxy *model.Proxy, config model.ConfigKey, push *mo
 	// Skip config dependency check based on proxy type for certain configs.
 	if UnAffectedConfigKinds[proxy.Type].Contains(config.Kind) {
 		return false
+	}
+	// Ambient Address updates only matter to proxies subscribed to Workload Address resources;
+	// anything sidecars and gateways need from those changes is surfaced as ServiceEntry or
+	// Endpoints updates.
+	if features.ScopedAddressPushes && config.Kind == kind.Address {
+		return proxy.GetWatchedResource(v3.AddressType) != nil
 	}
 	// Detailed config dependencies check.
 	switch proxy.Type {

--- a/pilot/pkg/xds/proxy_dependencies_test.go
+++ b/pilot/pkg/xds/proxy_dependencies_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	"istio.io/api/label"
 	mesh "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	security "istio.io/api/security/v1beta1"
@@ -25,13 +26,17 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core"
+	v3 "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/config/visibility"
 	"istio.io/istio/pkg/jwt"
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/util/sets"
 )
 
@@ -68,6 +73,14 @@ func TestProxyNeedsPush(t *testing.T) {
 		Metadata:        &model.NodeMetadata{Namespace: nsName},
 		Labels:          map[string]string{"gateway": "gateway"},
 	}
+	// A sidecar-type proxy subscribed to Workload Address resources (e.g. WDS on-demand clients)
+	// must keep receiving Address pushes.
+	workloadClient := &model.Proxy{
+		Type: model.SidecarProxy, IPAddresses: []string{"127.0.0.2"}, Metadata: &model.NodeMetadata{},
+		SidecarScope:     &model.SidecarScope{Name: generalName, Namespace: nsName},
+		WatchedResources: map[string]*model.WatchedResource{},
+	}
+	workloadClient.NewWatchedResource(v3.AddressType, nil)
 
 	sidecarScopeKindNames := map[kind.Kind]string{
 		kind.ServiceEntry: svcName, kind.VirtualService: vsName, kind.DestinationRule: drName, kind.Sidecar: scName,
@@ -150,6 +163,27 @@ func TestProxyNeedsPush(t *testing.T) {
 				model.ConfigKey{Kind: kind.DestinationRule, Name: drName + invalidNameSuffix, Namespace: nsName},
 				model.ConfigKey{Kind: kind.ServiceEntry, Name: svcName + invalidNameSuffix, Namespace: nsName},
 			),
+		},
+		{
+			"address config for sidecar", sidecar,
+			sets.New(model.ConfigKey{Kind: kind.Address, Name: "Kubernetes//Pod/default/app"}),
+			false,
+			false,
+			sets.New[model.ConfigKey](),
+		},
+		{
+			"address config for workload-subscribed sidecar", workloadClient,
+			sets.New(model.ConfigKey{Kind: kind.Address, Name: "Kubernetes//Pod/default/app"}),
+			false,
+			true,
+			sets.New(model.ConfigKey{Kind: kind.Address, Name: "Kubernetes//Pod/default/app"}),
+		},
+		{
+			"address config for gateway", gateway,
+			sets.New(model.ConfigKey{Kind: kind.Address, Name: "Kubernetes//Pod/default/app"}),
+			false,
+			false,
+			sets.New[model.ConfigKey](),
 		},
 		{
 			"empty configsUpdated for sidecar",
@@ -548,4 +582,100 @@ func TestCheckConnectionIdentity(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWaypointNeedsPush(t *testing.T) {
+	const (
+		waypointHost = "waypoint.default.svc.cluster.local"
+		waypointVIP  = "3.0.0.0"
+	)
+	waypoint := &model.Proxy{
+		Type:            model.Waypoint,
+		ConfigNamespace: "default",
+		Metadata:        &model.NodeMetadata{ClusterID: "c1", Network: "net1"},
+		ServiceTargets: []model.ServiceTarget{{
+			Service: &model.Service{
+				Hostname:    waypointHost,
+				ClusterVIPs: model.AddressMap{Addresses: map[cluster.ID][]string{"c1": {waypointVIP}}},
+			},
+		}},
+	}
+	eastwest := &model.Proxy{
+		Type:            model.Waypoint,
+		ConfigNamespace: "default",
+		Metadata:        &model.NodeMetadata{ClusterID: "c1", Network: "net1"},
+		Labels: map[string]string{
+			label.GatewayManaged.Name: constants.ManagedGatewayEastWestControllerLabel,
+		},
+	}
+
+	addressUpdate := func(refs ...model.WaypointReference) *model.PushRequest {
+		return &model.PushRequest{
+			ConfigsUpdated:   sets.New(model.ConfigKey{Kind: kind.Address, Name: "Kubernetes//Pod/default/app"}),
+			WaypointsUpdated: sets.New(refs...),
+		}
+	}
+
+	cases := []struct {
+		name  string
+		proxy *model.Proxy
+		req   *model.PushRequest
+		want  bool
+	}{
+		{
+			name:  "no address updates",
+			proxy: waypoint,
+			req:   &model.PushRequest{ConfigsUpdated: sets.New(model.ConfigKey{Kind: kind.ServiceEntry, Name: "svc1.com", Namespace: "default"})},
+			want:  false,
+		},
+		{
+			// Ordinary pod churn: addresses changed but none of them attached to a waypoint
+			name:  "address update without waypoint references",
+			proxy: waypoint,
+			req:   addressUpdate(),
+			want:  false,
+		},
+		{
+			name:  "address update attached to this waypoint by hostname",
+			proxy: waypoint,
+			req:   addressUpdate(model.WaypointReference{Namespace: "default", Hostname: waypointHost}),
+			want:  true,
+		},
+		{
+			name:  "address update attached to another waypoint",
+			proxy: waypoint,
+			req:   addressUpdate(model.WaypointReference{Namespace: "other", Hostname: "waypoint.other.svc.cluster.local"}),
+			want:  false,
+		},
+		{
+			name:  "address update attached to this waypoint by address",
+			proxy: waypoint,
+			req:   addressUpdate(model.WaypointReference{Network: "net1", Address: waypointVIP}),
+			want:  true,
+		},
+		{
+			name:  "address update attached to the same address on another network",
+			proxy: waypoint,
+			req:   addressUpdate(model.WaypointReference{Network: "net2", Address: waypointVIP}),
+			want:  false,
+		},
+		{
+			// East-west gateways serve global services rather than attached ones, so they
+			// cannot be scoped by attachment
+			name:  "east-west gateway",
+			proxy: eastwest,
+			req:   addressUpdate(),
+			want:  true,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, waypointNeedsPush(tt.req, tt.proxy), tt.want)
+		})
+	}
+
+	t.Run("scoping disabled", func(t *testing.T) {
+		test.SetForTest(t, &features.ScopedAddressPushes, false)
+		assert.Equal(t, waypointNeedsPush(addressUpdate(), waypoint), true)
+	})
 }

--- a/pilot/pkg/xds/rds.go
+++ b/pilot/pkg/xds/rds.go
@@ -15,6 +15,7 @@
 package xds
 
 import (
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core"
 	"istio.io/istio/pkg/config/schema/kind"
@@ -28,24 +29,35 @@ type RdsGenerator struct {
 var _ model.XdsResourceGenerator = &RdsGenerator{}
 
 // Map of all configs that do not impact RDS
-var skippedRdsConfigs = sets.New(
-	kind.WorkloadEntry,
-	kind.WorkloadGroup,
-	kind.AuthorizationPolicy,
-	kind.RequestAuthentication,
-	kind.PeerAuthentication,
-	kind.Secret,
-	kind.WasmPlugin,
-	kind.TrafficExtension,
-	kind.Telemetry,
-	kind.ProxyConfig,
-	kind.DNSName,
-	kind.Endpoints,
-)
+var skippedRdsConfigs = func() sets.Set[kind.Kind] {
+	s := sets.New(
+		kind.WorkloadEntry,
+		kind.WorkloadGroup,
+		kind.AuthorizationPolicy,
+		kind.RequestAuthentication,
+		kind.PeerAuthentication,
+		kind.Secret,
+		kind.WasmPlugin,
+		kind.TrafficExtension,
+		kind.Telemetry,
+		kind.ProxyConfig,
+		kind.DNSName,
+		kind.Endpoints,
+	)
+	if features.ScopedAddressPushes {
+		// Sidecar and gateway routes don't depend on ambient Address data; service changes that
+		// affect them arrive as ServiceEntry/Endpoints updates. Waypoints are handled in rdsNeedsPush.
+		s.Insert(kind.Address)
+	}
+	return s
+}()
 
 func rdsNeedsPush(req *model.PushRequest, proxy *model.Proxy) bool {
 	if res, ok := xdsNeedsPush(req, proxy); ok {
 		return res
+	}
+	if proxy.Type == model.Waypoint && waypointNeedsPush(req, proxy) {
+		return true
 	}
 	for config := range req.ConfigsUpdated {
 		if !skippedRdsConfigs.Contains(config.Kind) {

--- a/pilot/pkg/xds/waypoint_test.go
+++ b/pilot/pkg/xds/waypoint_test.go
@@ -26,15 +26,20 @@ import (
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	upstream "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/api/label"
 	meshconfig "istio.io/api/mesh/v1alpha1"
+	networking "istio.io/api/networking/v1alpha3"
+	networkingclient "istio.io/client-go/pkg/apis/networking/v1"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
+	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pilot/test/xds"
 	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/mesh"
+	"istio.io/istio/pkg/kube/kclient/clienttest"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
@@ -1210,4 +1215,39 @@ spec:
 			}
 		})
 	}
+}
+
+func TestWaypointScopedAddressPush(t *testing.T) {
+	d, _ := setupWaypointTest(t,
+		waypointGateway, waypointSvc, waypointInstance, appServiceEntry)
+
+	ads := d.ConnectADS().WithType(v3.ListenerType).
+		WithID("waypoint~3.0.0.1~waypoint-pod.default~default.svc.cluster.local")
+	ads.RequestResponseAck(t, nil)
+
+	// Workload churn unrelated to any waypoint (pods scaling, nodes recycling, ...) only
+	// produces Address updates; the waypoint's config doesn't reference it, so its
+	// listeners must not be rebuilt.
+	clienttest.NewWriter[*networkingclient.WorkloadEntry](t, d.KubeClient()).Create(&networkingclient.WorkloadEntry{
+		ObjectMeta: metav1.ObjectMeta{Name: "unrelated", Namespace: "default"},
+		Spec:       networking.WorkloadEntry{Address: "9.9.9.9"},
+	})
+	ads.ExpectNoResponse(t)
+
+	// A service attaching to this waypoint arrives through the same Address update path and
+	// must still trigger a listener rebuild.
+	clienttest.NewWriter[*networkingclient.ServiceEntry](t, d.KubeClient()).Create(&networkingclient.ServiceEntry{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app2",
+			Namespace: "default",
+			Labels:    map[string]string{label.IoIstioUseWaypoint.Name: "waypoint"},
+		},
+		Spec: networking.ServiceEntry{
+			Hosts:      []string{"app2.com"},
+			Addresses:  []string{"1.2.3.5"},
+			Ports:      []*networking.ServicePort{{Number: 80, Name: "http", Protocol: "HTTP"}},
+			Resolution: networking.ServiceEntry_STATIC,
+		},
+	})
+	ads.ExpectResponse(t)
 }

--- a/pilot/pkg/xds/xdsgen.go
+++ b/pilot/pkg/xds/xdsgen.go
@@ -223,15 +223,31 @@ func xdsNeedsPush(req *model.PushRequest, proxy *model.Proxy) (needsPush, defini
 	return false, false
 }
 
-// waypointNeedsPush checks if a push is needed for CDS and LDS on incremental kind.Address changes.
-func waypointNeedsPush(req *model.PushRequest) bool {
-	// Waypoint proxies needs to be pushed for LDS and CDS on kind.Address changes.
-	// Waypoint proxies have a matcher against pod IPs in them.
-	// This allows waypoints only to push LDS on Address type changes which would otherwise be skipped.
-
-	// Waypoints need CDS updates on kind.Address changes
-	// after implementing use-waypoint which decouples waypoint creation, wl pod creation
-	// user specifying waypoint use. Without this we're not getting correct waypoint config
-	// in a timely manner
-	return model.HasConfigsOfKind(req.ConfigsUpdated, kind.Address)
+// waypointNeedsPush checks if a push is needed for a waypoint proxy on incremental kind.Address changes.
+// Waypoint listeners, clusters, and routes are built from the services and workloads attached to the
+// waypoint (e.g. the main_internal listener matches attached service VIPs and attached workload IPs),
+// and attachment is only surfaced through kind.Address updates (use-waypoint changes, VIP or pod IP
+// changes of attached resources).
+func waypointNeedsPush(req *model.PushRequest, proxy *model.Proxy) bool {
+	if !model.HasConfigsOfKind(req.ConfigsUpdated, kind.Address) {
+		return false
+	}
+	if !features.ScopedAddressPushes {
+		return true
+	}
+	if proxy.IsAmbientEastWestGateway() {
+		// East-west gateways serve the global services on their network rather than attached
+		// services, so attachment-based scoping does not apply to them.
+		return true
+	}
+	// Only push if one of the updated services/workloads is attached to this waypoint.
+	// Detachments are covered as well: the ambient index records the waypoints referenced by
+	// both the old and the new state of every updated object.
+	key := model.WaypointKeyForProxy(proxy)
+	for ref := range req.WaypointsUpdated {
+		if ref.Matches(key) {
+			return true
+		}
+	}
+	return false
 }

--- a/pilot/pkg/xds/xdsgen.go
+++ b/pilot/pkg/xds/xdsgen.go
@@ -232,12 +232,13 @@ func waypointNeedsPush(req *model.PushRequest, proxy *model.Proxy) bool {
 	if !model.HasConfigsOfKind(req.ConfigsUpdated, kind.Address) {
 		return false
 	}
-	if !features.ScopedAddressPushes {
-		return true
-	}
 	if proxy.IsAmbientEastWestGateway() {
 		// East-west gateways serve the global services on their network rather than attached
-		// services, so attachment-based scoping does not apply to them.
+		// services, so attachment-based scoping does not apply to them. This holds regardless of
+		// the ScopedAddressPushes feature.
+		return true
+	}
+	if !features.ScopedAddressPushes {
 		return true
 	}
 	// Only push if one of the updated services/workloads is attached to this waypoint.

--- a/releasenotes/notes/releasenote-waypoint-xds-scoping.yaml
+++ b/releasenotes/notes/releasenote-waypoint-xds-scoping.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Improved** istiod scalability in ambient mode by scoping XDS pushes from workload/service
+    `Address` changes to only the affected waypoints, instead of pushing to all waypoints and proxies.
+    Can be disabled with `AMBIENT_SCOPED_ADDRESS_PUSHES=false`.


### PR DESCRIPTION
Address updates currently trigger full LDS/CDS/EDS pushes to all waypoints and RDS to all proxies; this scopes them to the waypoints whose attached services/workloads changed and skips sidecars/gateways. Gated by AMBIENT_SCOPED_ADDRESS_PUSHES (default on).