### PR TITLE
block unspecified and trailing-dot hosts in wasm realm ssrf check

### DIFF
--- a/pkg/wasm/imagefetcher.go
+++ b/pkg/wasm/imagefetcher.go
@@ -132,6 +132,9 @@ func validateRealmURL(realm string) error {
 	if host == "" {
 		return fmt.Errorf("realm missing host")
 	}
+	// a trailing dot is an equivalent FQDN form (localhost. resolves to localhost,
+	// 127.0.0.1. parses as 127.0.0.1), so strip it before the checks below
+	host = strings.TrimSuffix(host, ".")
 
 	// block known cloud metadata DNS names
 	if host == "metadata.google.internal" {
@@ -143,13 +146,14 @@ func validateRealmURL(realm string) error {
 		return fmt.Errorf("realm targets localhost")
 	}
 
-	// block private, loopback, and link-local IP ranges
+	// block private, loopback, link-local, and unspecified IP ranges
 	// covers 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 (private)
 	// covers 127.0.0.0/8, ::1 (loopback)
 	// covers 169.254.0.0/16, fe80::/10 (link-local, includes cloud metadata 169.254.169.254)
+	// covers 0.0.0.0, :: (unspecified, routed to loopback on Linux)
 	ip := net.ParseIP(host)
-	if ip != nil && (ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast()) {
-		return fmt.Errorf("realm targets private/loopback/link-local IP")
+	if ip != nil && (ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsUnspecified()) {
+		return fmt.Errorf("realm targets private/loopback/link-local/unspecified IP")
 	}
 
 	return nil

--- a/pkg/wasm/imagefetcher_test.go
+++ b/pkg/wasm/imagefetcher_test.go
@@ -727,6 +727,31 @@ func TestValidateAllRealms(t *testing.T) {
 			expectErr: true,
 		},
 		{
+			name:      "unspecified ipv4",
+			wwwAuth:   `Bearer realm="http://0.0.0.0:8080/admin",service="evil.com"`,
+			expectErr: true,
+		},
+		{
+			name:      "unspecified ipv6",
+			wwwAuth:   `Bearer realm="http://[::]/admin",service="evil.com"`,
+			expectErr: true,
+		},
+		{
+			name:      "localhost trailing dot",
+			wwwAuth:   `Bearer realm="http://localhost./admin",service="evil.com"`,
+			expectErr: true,
+		},
+		{
+			name:      "loopback trailing dot",
+			wwwAuth:   `Bearer realm="http://127.0.0.1./api",service="evil.com"`,
+			expectErr: true,
+		},
+		{
+			name:      "gcp metadata trailing dot",
+			wwwAuth:   `Bearer realm="http://metadata.google.internal./computeMetadata/v1/",service="evil.com"`,
+			expectErr: true,
+		},
+		{
 			name:      "no realm param",
 			wwwAuth:   `Bearer service="registry.example.com"`,
 			expectErr: false,

--- a/releasenotes/notes/60650.yaml
+++ b/releasenotes/notes/60650.yaml
@@ -1,0 +1,19 @@
+apiVersion: release-notes/v2
+
+kind: security-fix
+
+area: security
+
+releaseNotes:
+  - |
+    **Fixed** two bypasses in the Wasm image fetcher's bearer realm validation that
+    allowed a malicious OCI registry to redirect the authentication realm request to
+    the unspecified address (`0.0.0.0`, `[::]`) or to a trailing-dot form of a blocked
+    host (for example `localhost.` or `metadata.google.internal.`).
+
+securityNotes:
+  - |
+    The `WWW-Authenticate` bearer realm validator used when pulling Wasm modules from an
+    OCI registry did not block the unspecified address (routed to loopback on Linux) or
+    trailing-dot FQDN forms of loopback, private, link-local, and cloud metadata hosts,
+    allowing server-side request forgery against internal services.


### PR DESCRIPTION
**Please provide a description of this PR:**

validateRealmURL blocks loopback/private/link-local hosts in a bearer realm so a malicious registry can't pivot the realm fetch to internal services, but the denylist has two gaps:

- the unspecified address (`0.0.0.0`, `[::]`) is not blocked, and Linux routes it to loopback, so `realm="http://0.0.0.0:8080/admin"` reaches localhost services the localhost/loopback rules are meant to protect
- a trailing-dot host (`localhost.`, `127.0.0.1.`, `metadata.google.internal.`) is an equivalent FQDN that resolves the same but fails both the string compares and `net.ParseIP`

Strip a trailing dot before the checks and add `IsUnspecified()` to the blocked ranges (pilot-agent already treats unspecified as unsafe in its equivalent check). Added the matching cases to the realm table test.