### PR TITLE
istioctl: add global --revision flag

### DIFF
--- a/istioctl/pkg/cli/context.go
+++ b/istioctl/pkg/cli/context.go
@@ -99,6 +99,7 @@ func NewCLIContext(rootFlags *RootFlags) Context {
 			impersonateGroup: nil,
 			namespace:        ptr.Of[string](""),
 			istioNamespace:   ptr.Of[string](""),
+			revision:         ptr.Of[string](""),
 			defaultNamespace: "",
 			kubeTimeout:      ptr.Of[string](""),
 		}
@@ -139,7 +140,10 @@ func (i *instance) CLIClientWithRevision(rev string) (kube.CLIClient, error) {
 }
 
 func (i *instance) CLIClient() (kube.CLIClient, error) {
-	return i.CLIClientWithRevision("")
+	// Honor the global --revision flag so subcommands that just call CLIClient()
+	// pick it up without registering their own flag. Empty when unset, which keeps
+	// the prior behavior of a client not scoped to any revision.
+	return i.CLIClientWithRevision(i.Revision())
 }
 
 func (i *instance) CLIClientsForContexts(contexts []string) ([]kube.CLIClient, error) {
@@ -285,7 +289,7 @@ func (f *fakeInstance) CLIClientWithRevision(rev string) (kube.CLIClient, error)
 }
 
 func (f *fakeInstance) CLIClient() (kube.CLIClient, error) {
-	return f.CLIClientWithRevision("")
+	return f.CLIClientWithRevision(f.rootFlags.Revision())
 }
 
 func (f *fakeInstance) CLIClientsForContexts(contexts []string) ([]kube.CLIClient, error) {
@@ -335,6 +339,7 @@ func (f *fakeInstance) RevisionOrDefault(rev string) string {
 type NewFakeContextOption struct {
 	Namespace      string
 	IstioNamespace string
+	Revision       string
 	Results        map[string][]byte
 	// Objects are the objects to be applied to the fake client
 	Objects []runtime.Object
@@ -348,6 +353,7 @@ func NewFakeContext(opts *NewFakeContextOption) Context {
 	}
 	ns := opts.Namespace
 	ins := opts.IstioNamespace
+	rev := opts.Revision
 	return &fakeInstance{
 		clients: map[string]kube.CLIClient{},
 		rootFlags: &RootFlags{
@@ -355,6 +361,7 @@ func NewFakeContext(opts *NewFakeContextOption) Context {
 			configContext:    ptr.Of[string](""),
 			namespace:        &ns,
 			istioNamespace:   &ins,
+			revision:         &rev,
 			impersonate:      ptr.Of[string](""),
 			impersonateUID:   ptr.Of[string](""),
 			impersonateGroup: nil,

--- a/istioctl/pkg/cli/context_test.go
+++ b/istioctl/pkg/cli/context_test.go
@@ -80,3 +80,34 @@ func TestRevisionOrDefault(t *testing.T) {
 		})
 	}
 }
+
+func TestCLIClientUsesGlobalRevision(t *testing.T) {
+	tests := []struct {
+		description  string
+		revision     string
+		wantRevision string
+	}{
+		{
+			description:  "client inherits the global revision",
+			revision:     "canary",
+			wantRevision: "canary",
+		},
+		{
+			description:  "no revision keeps the client unscoped",
+			revision:     "",
+			wantRevision: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			ctx := NewFakeContext(&NewFakeContextOption{Revision: tt.revision})
+			c, err := ctx.CLIClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := c.Revision(); got != tt.wantRevision {
+				t.Fatalf("unexpected revision: wanted %q got %q", tt.wantRevision, got)
+			}
+		})
+	}
+}

--- a/istioctl/pkg/cli/option.go
+++ b/istioctl/pkg/cli/option.go
@@ -33,6 +33,7 @@ const (
 	FlagImpersonateGroup = "as-group"
 	FlagNamespace        = "namespace"
 	FlagIstioNamespace   = "istioNamespace"
+	FlagRevision         = "revision"
 	FlagKubeTimeout      = "kubeclient-timeout"
 )
 
@@ -44,6 +45,7 @@ type RootFlags struct {
 	impersonateGroup *[]string
 	namespace        *string
 	istioNamespace   *string
+	revision         *string
 	kubeTimeout      *string
 
 	defaultNamespace string
@@ -58,6 +60,7 @@ func AddRootFlags(flags *pflag.FlagSet) *RootFlags {
 		impersonateGroup: ptr.Of[[]string](nil),
 		namespace:        ptr.Of[string](""),
 		istioNamespace:   ptr.Of[string](""),
+		revision:         ptr.Of[string](""),
 		kubeTimeout:      ptr.Of[string](""),
 	}
 	flags.StringVarP(r.kubeconfig, FlagKubeConfig, "c", "",
@@ -73,6 +76,9 @@ func AddRootFlags(flags *pflag.FlagSet) *RootFlags {
 		"Kubernetes namespace")
 	flags.StringVarP(r.istioNamespace, FlagIstioNamespace, "i", viper.GetString(FlagIstioNamespace),
 		"Istio system namespace")
+	// No -r shorthand here: it is already claimed by the per-subcommand --revision registrations
+	// (clioptions.ControlPlaneOptions, tag, waypoint, analyze). Long flag only until those migrate.
+	flags.StringVar(r.revision, FlagRevision, "", "Control plane revision")
 	flags.StringVar(r.kubeTimeout, FlagKubeTimeout, "15s", "Kubernetes client timeout as a time.Duration string, defaults to 15 seconds.")
 
 	return r
@@ -101,6 +107,14 @@ func (r *RootFlags) KubeClientTimeout() (time.Duration, error) {
 // IstioNamespace returns the istioNamespace flag value.
 func (r *RootFlags) IstioNamespace() string {
 	return *r.istioNamespace
+}
+
+// Revision returns the revision flag value, empty if the flag was not set.
+func (r *RootFlags) Revision() string {
+	if r.revision == nil {
+		return ""
+	}
+	return *r.revision
 }
 
 // DefaultNamespace returns the default namespace to use.

--- a/istioctl/pkg/cli/option_test.go
+++ b/istioctl/pkg/cli/option_test.go
@@ -32,3 +32,23 @@ func Test_AddRootFlags(t *testing.T) {
 	assert.Equal(t, *r.impersonateGroup, impersonateConfig.Groups)
 	assert.Equal(t, *r.kubeTimeout, "15s")
 }
+
+func Test_AddRootFlags_Revision(t *testing.T) {
+	flags := &pflag.FlagSet{}
+	r := AddRootFlags(flags)
+
+	f := flags.Lookup(FlagRevision)
+	if f == nil {
+		t.Fatalf("expected %q flag to be registered", FlagRevision)
+	}
+	// -r is claimed by per-subcommand --revision registrations, so the root flag is long-only.
+	if f.Shorthand != "" {
+		t.Fatalf("expected no shorthand for root %q flag, got %q", FlagRevision, f.Shorthand)
+	}
+	assert.Equal(t, r.Revision(), "")
+
+	if err := flags.Set(FlagRevision, "canary"); err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, r.Revision(), "canary")
+}

--- a/releasenotes/notes/59882.yaml
+++ b/releasenotes/notes/59882.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue:
+  - 59882
+releaseNotes:
+- |
+  **Added** a global `--revision` flag to `istioctl`. Subcommands that target the control plane
+  through the default client now inherit the revision without each one registering its own flag.


### PR DESCRIPTION
adds a root \`--revision\` flag and routes the default \`ctx.CLIClient()\` through it, so subcommands that build a client that way inherit the revision instead of each registering their own flag.

scope is just the mechanism, per the discussion in the issue. kept it long-flag only: \`-r\` is already taken by the per-subcommand registrations (\`clioptions.ControlPlaneOptions\`, tag, waypoint, analyze) so a root \`-r\` would collide in Cobra. when the flag is unset \`Revision()\` returns empty, so \`CLIClient()\` behaves exactly as before. didn't wrap it in \`RevisionOrDefault\` on purpose, that would add a default-revision cluster lookup on every command even without the flag.

follow-ups can migrate the \`ControlPlaneOptions\` consumers and reclaim \`-r\` once they no longer register it locally. tag/waypoint/analyze stay local since their \`--revision\` is the data being operated on, not the client target.

Fixes #59882