### PR TITLE
fix: deadlock in multicluster update secret flow

### DIFF
--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -149,9 +149,9 @@ func (c *Controller) DeleteRegistry(clusterID cluster.ID, providerID provider.ID
 	log.Infof("%s registry for the cluster %s has been deleted.", providerID, clusterID)
 }
 
-// UpdateRegistry atomically replaces an existing registry with a new one.
-// This is used during credential rotation to avoid service disruption.
-// The new registry is started, then atomically swapped with the old one.
+// UpdateRegistry atomically replaces an existing registry with a new one, used
+// during credential rotation to avoid service disruption. The caller must have
+// already started the new registry; UpdateRegistry only performs the swap.
 func (c *Controller) UpdateRegistry(newRegistry serviceregistry.Instance, stop <-chan struct{}) {
 	if stop == nil {
 		log.Warnf("nil stop channel passed to UpdateRegistry for registry %s/%s", newRegistry.Provider(), newRegistry.Cluster())
@@ -172,11 +172,6 @@ func (c *Controller) UpdateRegistry(newRegistry serviceregistry.Instance, stop <
 		// No existing registry, just add
 		c.addRegistry(newRegistry, stop)
 		log.Infof("%s registry for cluster %s has been added (no previous registry).", providerID, clusterID)
-	}
-
-	// Start the new registry if we're already running
-	if c.running {
-		go newRegistry.Run(stop)
 	}
 }
 

--- a/pilot/pkg/serviceregistry/aggregate/controller_test.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller_test.go
@@ -500,8 +500,9 @@ func TestReplaceRegistry(t *testing.T) {
 		t.Fatalf("Expected cluster1, got %s", registries[0].Cluster())
 	}
 
-	// Replace with new registry
+	// Caller starts the new registry before swapping it in; UpdateRegistry only swaps.
 	newRegistry := runnableRegistry("cluster1")
+	go newRegistry.Run(stop)
 	ctrl.UpdateRegistry(newRegistry, stop)
 
 	// Verify replacement - should still have 1 registry with same cluster ID
@@ -535,11 +536,20 @@ func TestReplaceRegistryAddsIfNotExists(t *testing.T) {
 	defer close(stop)
 	ctrl := NewController(Options{})
 
-	// Start the controller with no registries
+	// Wait until the controller is running before swapping, so its startup loop
+	// doesn't also start the registry we start ourselves (double-run).
 	go ctrl.Run(stop)
+	retry.UntilSuccessOrFail(t, func() error {
+		ctrl.storeLock.RLock()
+		defer ctrl.storeLock.RUnlock()
+		if !ctrl.running {
+			return fmt.Errorf("controller not running yet")
+		}
+		return nil
+	}, retry.Timeout(time.Second))
 
-	// ReplaceRegistry should add if no existing registry
 	newRegistry := runnableRegistry("newCluster")
+	go newRegistry.Run(stop)
 	ctrl.UpdateRegistry(newRegistry, stop)
 
 	// Verify it was added

--- a/pilot/pkg/serviceregistry/aggregate/controller_test.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller_test.go
@@ -501,8 +501,15 @@ func TestReplaceRegistry(t *testing.T) {
 	}
 
 	// Caller starts the new registry before swapping it in; UpdateRegistry only swaps.
+	// Wait for it to actually be running so the swap models the real ordering.
 	newRegistry := runnableRegistry("cluster1")
 	go newRegistry.Run(stop)
+	retry.UntilSuccessOrFail(t, func() error {
+		if !newRegistry.running.Load() {
+			return fmt.Errorf("new registry should be running before swap")
+		}
+		return nil
+	}, retry.Timeout(time.Second))
 	ctrl.UpdateRegistry(newRegistry, stop)
 
 	// Verify replacement - should still have 1 registry with same cluster ID
@@ -548,8 +555,15 @@ func TestReplaceRegistryAddsIfNotExists(t *testing.T) {
 		return nil
 	}, retry.Timeout(time.Second))
 
+	// Wait for it to actually be running so the swap models the real ordering.
 	newRegistry := runnableRegistry("newCluster")
 	go newRegistry.Run(stop)
+	retry.UntilSuccessOrFail(t, func() error {
+		if !newRegistry.running.Load() {
+			return fmt.Errorf("new registry should be running before swap")
+		}
+		return nil
+	}, retry.Timeout(time.Second))
 	ctrl.UpdateRegistry(newRegistry, stop)
 
 	// Verify it was added

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -220,8 +220,9 @@ func (m *Multicluster) initializeCluster(cluster *multicluster.Cluster, kubeCont
 
 	// run after WorkloadHandler is added
 	if cluster.Action == multicluster.Update {
-		// For updates, wait for sync then atomically replace the registry.
-		// This ensures zero service disruption during credential rotation.
+		// Start the new registry here. The registry is swapped in only after it syncs,
+		// so the old registry keeps serving until then.
+		go kubeRegistry.Run(clusterStopCh)
 		go func() {
 			// Wait for the new cluster to sync
 			<-cluster.SyncedCh

--- a/releasenotes/notes/60612.yaml
+++ b/releasenotes/notes/60612.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - https://github.com/istio/istio/issues/60612
+releaseNotes:
+  - |
+    **Fixed** a bug where istiod did not pick up updated remote cluster secrets (e.g. during
+    credential/token rotation) until restarted. The new cluster registry could deadlock waiting
+    to sync, leaving the service registry stale for the affected remote cluster.


### PR DESCRIPTION
**Please provide a description of this PR:**
Fix deadlock in multicluster secret update flow. Moved cluster sync run from `UpdateRegistry` to `initializeCluster`. This is because on an update today `UpdateRegistry` was never called as it is waiting on cluster to sync, and cluster sync never ran as it is called inside `UpdateRegistry`.

Related #60612 