### PR TITLE
add mesh-wide default traffic policy for connection pool and outlier detection

### DIFF
--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -352,6 +352,10 @@ func (cb *ClusterBuilder) applyDestinationRule(mc *clusterWrapper, clusterMode C
 	destinationRule := CastDestinationRule(destRule)
 	// merge applicable port level traffic policy settings
 	trafficPolicy, _ := util.GetPortLevelTrafficPolicy(destinationRule.GetTrafficPolicy(), port)
+	// Seed the mesh-wide baseline so per-host clusters (including those with no matching
+	// DestinationRule) inherit it for any connectionPool / outlierDetection block the DR
+	// leaves unset. Subset / portLevelSettings still override on top via the merge below.
+	trafficPolicy = applyDefaultTrafficPolicy(cb.req.Push.Mesh.GetDefaultTrafficPolicy(), trafficPolicy)
 	opts := buildClusterOpts{
 		mesh:                      cb.req.Push.Mesh,
 		mutable:                   mc,
@@ -679,6 +683,10 @@ func (cb *ClusterBuilder) buildInboundCluster(clusterPort int, bind string,
 			util.AddConfigInfoMetadata(localCluster.cluster.Metadata, cfg.Meta)
 		}
 	}
+	// Seed the mesh-wide baseline below the DR (and below the Sidecar override applied next).
+	// connectionPool is set server-side too so the receiver has capacity matching client volume;
+	// outlierDetection seeded here is inert for inbound (applyTrafficPolicy skips it).
+	opts.policy = applyDefaultTrafficPolicy(cb.req.Push.Mesh.GetDefaultTrafficPolicy(), opts.policy)
 	// If there's a connection pool set on the Sidecar then override any settings derived from the DestinationRule
 	// with those set by Sidecar resource. This allows the user to resolve any ambiguity, e.g. in the case that
 	// multiple services are listening on the same port.
@@ -793,7 +801,14 @@ func (cb *ClusterBuilder) buildDefaultPassthroughCluster() *cluster.Cluster {
 		},
 	}
 	cluster.AltStatName = util.DelimitedStatsPrefix(util.PassthroughCluster)
-	cb.applyConnectionPool(cb.req.Push.Mesh, newClusterWrapper(cluster), &networking.ConnectionPoolSettings{}, nil)
+	// Cap the otherwise unbounded ALLOW_ANY passthrough egress with the mesh-wide baseline
+	// connectionPool when configured. outlierDetection is intentionally not applied here:
+	// on an ORIGINAL_DST catch-all there is no LB pool to shed to.
+	passthroughConnPool := cb.req.Push.Mesh.GetDefaultTrafficPolicy().GetConnectionPool()
+	if passthroughConnPool == nil {
+		passthroughConnPool = &networking.ConnectionPoolSettings{}
+	}
+	cb.applyConnectionPool(cb.req.Push.Mesh, newClusterWrapper(cluster), passthroughConnPool, nil)
 	cb.applyMetadataExchange(cluster)
 	return cluster
 }

--- a/pilot/pkg/networking/core/cluster_test.go
+++ b/pilot/pkg/networking/core/cluster_test.go
@@ -302,6 +302,80 @@ func TestConnectionPoolSettings(t *testing.T) {
 	}
 }
 
+func TestDefaultTrafficPolicy(t *testing.T) {
+	meshConnPool := &networking.ConnectionPoolSettings{
+		Tcp: &networking.ConnectionPoolSettings_TCPSettings{MaxConnections: 33},
+	}
+	meshOutlier := &networking.OutlierDetection{
+		Consecutive_5XxErrors: &wrappers.UInt32Value{Value: 7},
+	}
+	drConnPool := &networking.ConnectionPoolSettings{
+		Tcp: &networking.ConnectionPoolSettings_TCPSettings{MaxConnections: 99},
+	}
+
+	cases := map[string]struct {
+		defaultTrafficPolicy *meshconfig.MeshConfig_DefaultTrafficPolicy
+		destRule             *networking.DestinationRule
+		wantMaxConnections   uint32
+		wantOutlier          bool
+		// passthrough cluster connection pool is seeded from the baseline connectionPool only
+		wantPassthroughMaxConnections uint32
+	}{
+		"baseline applied with no destination rule": {
+			defaultTrafficPolicy: &meshconfig.MeshConfig_DefaultTrafficPolicy{
+				ConnectionPool:   meshConnPool,
+				OutlierDetection: meshOutlier,
+			},
+			destRule:                      &networking.DestinationRule{Host: "*.example.org"},
+			wantMaxConnections:            33,
+			wantOutlier:                   true,
+			wantPassthroughMaxConnections: 33,
+		},
+		"destination rule overrides connectionPool, inherits outlier": {
+			defaultTrafficPolicy: &meshconfig.MeshConfig_DefaultTrafficPolicy{
+				ConnectionPool:   meshConnPool,
+				OutlierDetection: meshOutlier,
+			},
+			destRule: &networking.DestinationRule{
+				Host:          "*.example.org",
+				TrafficPolicy: &networking.TrafficPolicy{ConnectionPool: drConnPool},
+			},
+			wantMaxConnections:            99,
+			wantOutlier:                   true,
+			wantPassthroughMaxConnections: 33,
+		},
+	}
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			g := NewWithT(t)
+			mesh := testMesh()
+			mesh.DefaultTrafficPolicy = tt.defaultTrafficPolicy
+			clusters := xdstest.ExtractClusters(buildTestClusters(clusterTest{
+				t:               t,
+				serviceHostname: "*.example.org",
+				nodeType:        model.SidecarProxy,
+				mesh:            mesh,
+				destRule:        tt.destRule,
+			}))
+
+			outbound, ok := clusters["outbound|8080||*.example.org"]
+			g.Expect(ok).To(BeTrue())
+			g.Expect(outbound.CircuitBreakers.Thresholds[0].MaxConnections.GetValue()).To(Equal(tt.wantMaxConnections))
+			if tt.wantOutlier {
+				g.Expect(outbound.OutlierDetection).NotTo(BeNil())
+				g.Expect(outbound.OutlierDetection.Consecutive_5Xx.GetValue()).To(Equal(uint32(7)))
+			} else {
+				g.Expect(outbound.OutlierDetection).To(BeNil())
+			}
+
+			passthrough, ok := clusters[util.PassthroughCluster]
+			g.Expect(ok).To(BeTrue())
+			g.Expect(passthrough.CircuitBreakers.Thresholds[0].MaxConnections.GetValue()).
+				To(Equal(tt.wantPassthroughMaxConnections))
+		})
+	}
+}
+
 func TestBuildClustersForInferencePoolServices(t *testing.T) {
 	cases := []struct {
 		testName             string

--- a/pilot/pkg/networking/core/cluster_traffic_policy.go
+++ b/pilot/pkg/networking/core/cluster_traffic_policy.go
@@ -68,6 +68,39 @@ func (cb *ClusterBuilder) applyTrafficPolicy(service *model.Service, opts buildC
 	}
 }
 
+// applyDefaultTrafficPolicy overlays the resolved DestinationRule policy on top of the
+// mesh-wide MeshConfig.DefaultTrafficPolicy baseline, per block. A DR that sets a
+// connectionPool / outlierDetection block overrides that whole block; an unset block
+// inherits the mesh baseline. Returns policy unchanged when no mesh baseline is set.
+func applyDefaultTrafficPolicy(meshDefault *meshconfig.MeshConfig_DefaultTrafficPolicy,
+	policy *networking.TrafficPolicy,
+) *networking.TrafficPolicy {
+	defaultConnPool := meshDefault.GetConnectionPool()
+	defaultOutlier := meshDefault.GetOutlierDetection()
+	if defaultConnPool == nil && defaultOutlier == nil {
+		return policy
+	}
+	needConnPool := defaultConnPool != nil && policy.GetConnectionPool() == nil
+	needOutlier := defaultOutlier != nil && policy.GetOutlierDetection() == nil
+	if !needConnPool && !needOutlier {
+		return policy
+	}
+	// Copy so we never mutate the cached DestinationRule policy. portLevelSettings are
+	// already resolved for this port by the caller, so dropping them here is safe.
+	if policy == nil {
+		policy = &networking.TrafficPolicy{}
+	} else {
+		policy = model.ShallowCopyTrafficPolicy(policy)
+	}
+	if needConnPool {
+		policy.ConnectionPool = defaultConnPool
+	}
+	if needOutlier {
+		policy.OutlierDetection = defaultOutlier
+	}
+	return policy
+}
+
 // selectTrafficPolicyComponents returns the components of TrafficPolicy that should be used for given port.
 func selectTrafficPolicyComponents(policy *networking.TrafficPolicy) (
 	*networking.ConnectionPoolSettings,

--- a/pilot/pkg/networking/core/cluster_traffic_policy_test.go
+++ b/pilot/pkg/networking/core/cluster_traffic_policy_test.go
@@ -23,12 +23,94 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	proxyprotocol "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/proxy_protocol/v3"
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
+	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pkg/test/util/assert"
 )
+
+func TestApplyDefaultTrafficPolicy(t *testing.T) {
+	meshConnPool := &networking.ConnectionPoolSettings{
+		Tcp: &networking.ConnectionPoolSettings_TCPSettings{MaxConnections: 100},
+	}
+	meshOutlier := &networking.OutlierDetection{
+		Consecutive_5XxErrors: &wrappers.UInt32Value{Value: 5},
+	}
+	drConnPool := &networking.ConnectionPoolSettings{
+		Tcp: &networking.ConnectionPoolSettings_TCPSettings{MaxConnections: 7},
+	}
+	drOutlier := &networking.OutlierDetection{
+		Consecutive_5XxErrors: &wrappers.UInt32Value{Value: 9},
+	}
+	bothDefault := &meshconfig.MeshConfig_DefaultTrafficPolicy{
+		ConnectionPool:   meshConnPool,
+		OutlierDetection: meshOutlier,
+	}
+
+	tests := []struct {
+		name         string
+		meshDefault  *meshconfig.MeshConfig_DefaultTrafficPolicy
+		policy       *networking.TrafficPolicy
+		wantConnPool *networking.ConnectionPoolSettings
+		wantOutlier  *networking.OutlierDetection
+		wantNil      bool
+	}{
+		{
+			name:        "no mesh default, nil policy stays nil",
+			meshDefault: nil,
+			policy:      nil,
+			wantNil:     true,
+		},
+		{
+			name:         "no mesh default leaves DR policy untouched",
+			meshDefault:  &meshconfig.MeshConfig_DefaultTrafficPolicy{},
+			policy:       &networking.TrafficPolicy{ConnectionPool: drConnPool},
+			wantConnPool: drConnPool,
+		},
+		{
+			name:         "no DR inherits both baseline blocks",
+			meshDefault:  bothDefault,
+			policy:       nil,
+			wantConnPool: meshConnPool,
+			wantOutlier:  meshOutlier,
+		},
+		{
+			name:         "DR connectionPool overrides, outlier inherited",
+			meshDefault:  bothDefault,
+			policy:       &networking.TrafficPolicy{ConnectionPool: drConnPool},
+			wantConnPool: drConnPool,
+			wantOutlier:  meshOutlier,
+		},
+		{
+			name:         "DR sets both, baseline ignored",
+			meshDefault:  bothDefault,
+			policy:       &networking.TrafficPolicy{ConnectionPool: drConnPool, OutlierDetection: drOutlier},
+			wantConnPool: drConnPool,
+			wantOutlier:  drOutlier,
+		},
+		{
+			name:         "baseline only connectionPool, DR sets outlier",
+			meshDefault:  &meshconfig.MeshConfig_DefaultTrafficPolicy{ConnectionPool: meshConnPool},
+			policy:       &networking.TrafficPolicy{OutlierDetection: drOutlier},
+			wantConnPool: meshConnPool,
+			wantOutlier:  drOutlier,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := applyDefaultTrafficPolicy(tt.meshDefault, tt.policy)
+			if tt.wantNil {
+				assert.Equal(t, got == nil, true)
+				return
+			}
+			assert.Equal(t, got.GetConnectionPool(), tt.wantConnPool)
+			assert.Equal(t, got.GetOutlierDetection(), tt.wantOutlier)
+		})
+	}
+}
 
 func TestApplyUpstreamProxyProtocol(t *testing.T) {
 	istioMutualTLSSettings := &networking.ClientTLSSettings{

--- a/pkg/config/validation/agent/validation.go
+++ b/pkg/config/validation/agent/validation.go
@@ -806,6 +806,86 @@ func ValidateMeshTLSDefaults(mesh *meshconfig.MeshConfig) (v Validation) {
 	return v
 }
 
+// validateMeshConfigDefaultTrafficPolicy validates the value constraints of the mesh-wide
+// baseline traffic policy. It mirrors the connectionPool / outlierDetection checks applied to
+// a DestinationRule traffic policy, since the field reuses the same sub-types.
+func validateMeshConfigDefaultTrafficPolicy(dtp *meshconfig.MeshConfig_DefaultTrafficPolicy) (errs Validation) {
+	if dtp == nil {
+		return errs
+	}
+	if cp := dtp.GetConnectionPool(); cp != nil {
+		if cp.Http == nil && cp.Tcp == nil {
+			errs = AppendValidation(errs, errors.New("connection pool must have at least one field"))
+		}
+		if http := cp.Http; http != nil {
+			if http.Http1MaxPendingRequests < 0 {
+				errs = AppendValidation(errs, errors.New("http1 max pending requests must be non-negative"))
+			}
+			if http.Http2MaxRequests < 0 {
+				errs = AppendValidation(errs, errors.New("http2 max requests must be non-negative"))
+			}
+			if http.MaxRequestsPerConnection < 0 {
+				errs = AppendValidation(errs, errors.New("max requests per connection must be non-negative"))
+			}
+			if http.MaxRetries < 0 {
+				errs = AppendValidation(errs, errors.New("max retries must be non-negative"))
+			}
+			if http.MaxConcurrentStreams < 0 {
+				errs = AppendValidation(errs, errors.New("max concurrent streams must be non-negative"))
+			}
+			if http.IdleTimeout != nil {
+				errs = AppendValidation(errs, ValidateDuration(http.IdleTimeout))
+			}
+			if http.H2UpgradePolicy == networking.ConnectionPoolSettings_HTTPSettings_UPGRADE && http.UseClientProtocol {
+				errs = AppendValidation(errs, errors.New("use client protocol must not be true when H2UpgradePolicy is UPGRADE"))
+			}
+		}
+		if tcp := cp.Tcp; tcp != nil {
+			if tcp.MaxConnections < 0 {
+				errs = AppendValidation(errs, errors.New("max connections must be non-negative"))
+			}
+			if tcp.ConnectTimeout != nil {
+				errs = AppendValidation(errs, ValidateDuration(tcp.ConnectTimeout))
+			}
+			if tcp.MaxConnectionDuration != nil {
+				errs = AppendValidation(errs, ValidateDuration(tcp.MaxConnectionDuration))
+			}
+			if tcp.IdleTimeout != nil && tcp.IdleTimeout.AsDuration().Milliseconds() != 0 {
+				errs = AppendValidation(errs, ValidateDuration(tcp.IdleTimeout))
+			}
+			if ka := tcp.TcpKeepalive; ka != nil {
+				if ka.Time != nil {
+					errs = AppendValidation(errs, ValidateDuration(ka.Time))
+				}
+				if ka.Interval != nil {
+					errs = AppendValidation(errs, ValidateDuration(ka.Interval))
+				}
+			}
+		}
+	}
+	if od := dtp.GetOutlierDetection(); od != nil {
+		if od.BaseEjectionTime != nil {
+			errs = AppendValidation(errs, ValidateDuration(od.BaseEjectionTime))
+		}
+		if od.Interval != nil {
+			errs = AppendValidation(errs, ValidateDuration(od.Interval))
+		}
+		if !od.SplitExternalLocalOriginErrors && od.ConsecutiveLocalOriginFailures.GetValue() > 0 {
+			errs = AppendValidation(errs, errors.New("outlier detection consecutive local origin failures is specified, "+
+				"but split external local origin errors is set to false"))
+		}
+		errs = AppendValidation(errs, validatePercent(od.MaxEjectionPercent), validatePercent(od.MinHealthPercent))
+	}
+	return errs
+}
+
+func validatePercent(val int32) error {
+	if val < 0 || val > 100 {
+		return fmt.Errorf("percentage %v is not in range 0..100", val)
+	}
+	return nil
+}
+
 // ValidateMeshConfig checks that the mesh config is well-formed
 func ValidateMeshConfig(mesh *meshconfig.MeshConfig) (Warning, error) {
 	v := Validation{}
@@ -838,6 +918,8 @@ func ValidateMeshConfig(mesh *meshconfig.MeshConfig) (Warning, error) {
 	v = AppendValidation(v, ValidateMeshTLSConfig(mesh))
 
 	v = AppendValidation(v, ValidateMeshTLSDefaults(mesh))
+
+	v = AppendValidation(v, validateMeshConfigDefaultTrafficPolicy(mesh.GetDefaultTrafficPolicy()))
 
 	return v.Unwrap()
 }

--- a/pkg/config/validation/agent/validation_test.go
+++ b/pkg/config/validation/agent/validation_test.go
@@ -1055,6 +1055,61 @@ func TestValidateProtocolDetectionTimeout(t *testing.T) {
 	}
 }
 
+func TestValidateMeshConfigDefaultTrafficPolicy(t *testing.T) {
+	cases := []struct {
+		name    string
+		dtp     *meshconfig.MeshConfig_DefaultTrafficPolicy
+		wantErr bool
+	}{
+		{
+			name: "nil",
+			dtp:  nil,
+		},
+		{
+			name: "valid connectionPool and outlierDetection",
+			dtp: &meshconfig.MeshConfig_DefaultTrafficPolicy{
+				ConnectionPool: &networking.ConnectionPoolSettings{
+					Tcp: &networking.ConnectionPoolSettings_TCPSettings{MaxConnections: 100},
+				},
+				OutlierDetection: &networking.OutlierDetection{
+					MaxEjectionPercent: 50,
+				},
+			},
+		},
+		{
+			name: "empty connectionPool",
+			dtp: &meshconfig.MeshConfig_DefaultTrafficPolicy{
+				ConnectionPool: &networking.ConnectionPoolSettings{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative max connections",
+			dtp: &meshconfig.MeshConfig_DefaultTrafficPolicy{
+				ConnectionPool: &networking.ConnectionPoolSettings{
+					Tcp: &networking.ConnectionPoolSettings_TCPSettings{MaxConnections: -1},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "outlier ejection percent out of range",
+			dtp: &meshconfig.MeshConfig_DefaultTrafficPolicy{
+				OutlierDetection: &networking.OutlierDetection{MaxEjectionPercent: 101},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := validateMeshConfigDefaultTrafficPolicy(tt.dtp).Unwrap()
+			if tt.wantErr != (err != nil) {
+				t.Fatalf("wantErr=%v got err=%v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
 func TestValidateMeshConfig(t *testing.T) {
 	if _, err := ValidateMeshConfig(&meshconfig.MeshConfig{}); err == nil {
 		t.Error("expected an error on an empty mesh config")

--- a/releasenotes/notes/mesh-default-traffic-policy.yaml
+++ b/releasenotes/notes/mesh-default-traffic-policy.yaml
@@ -1,0 +1,12 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue: []
+releaseNotes:
+  - |
+    **Added** `defaultTrafficPolicy` to `MeshConfig`, a mesh-wide baseline `connectionPool` and
+    `outlierDetection` that outbound clusters inherit. A `DestinationRule` that sets one of these
+    blocks overrides the baseline for that block; a block the `DestinationRule` leaves unset now
+    inherits the mesh baseline instead of Istio's built-in defaults. When no baseline is configured,
+    behavior is unchanged. The baseline `connectionPool` is also applied to inbound clusters and the
+    passthrough cluster.


### PR DESCRIPTION
adds `MeshConfig.defaultTrafficPolicy`, a mesh-wide baseline `connectionPool` and `outlierDetection` that outbound clusters inherit and a `DestinationRule` overrides per block (an unset block inherits the baseline instead of dropping to istio's built-in defaults). baseline connectionPool also applies to inbound and passthrough clusters. api added in istio/api#3720.