### PR TITLE
allow dnsConfig and dnsPolicy overrides in gateway helm chart

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -135,6 +135,13 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.dnsPolicy }}
+      dnsPolicy: {{ . }}
+      {{- end }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ $.Values.terminationGracePeriodSeconds }}
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -334,6 +334,12 @@
             }
           }
         },
+        "dnsPolicy": {
+          "type": "string"
+        },
+        "dnsConfig": {
+          "type": "object"
+        },
         "terminationGracePeriodSeconds": {
           "type": "number"
         },

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -104,10 +104,10 @@ _internal_defaults_do_not_set:
 
   # Deployment Update strategy
   strategy: {}
-  
+
   # Sets the Deployment minReadySeconds value
   minReadySeconds:
-  
+
   # Optionally configure a custom readinessProbe. By default the control plane
   # automatically injects the readinessProbe. If you wish to override that
   # behavior, you may define your own readinessProbe here.
@@ -185,6 +185,14 @@ _internal_defaults_do_not_set:
   # podDisruptionBudget: {}
   #
   podDisruptionBudget: {}
+
+  # Configure the DNS policy for the gateway pods. See
+  # https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+  dnsPolicy: ""
+
+  # Configure DNS settings for the gateway pods. See
+  # https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
+  dnsConfig: {}
 
   # Sets the per-pod terminationGracePeriodSeconds setting.
   terminationGracePeriodSeconds: 30

--- a/operator/pkg/helm/helm_test.go
+++ b/operator/pkg/helm/helm_test.go
@@ -222,6 +222,13 @@ func TestRender(t *testing.T) {
 			diffSelect:  "Service:*:istio-eastwest",
 		},
 		{
+			desc:        "gateway-dns-config",
+			releaseName: "istio-ingress",
+			namespace:   "istio-ingress",
+			chartName:   "gateway",
+			diffSelect:  "Deployment:*:istio-ingress",
+		},
+		{
 			desc:        "ztunnel-dns-config",
 			releaseName: "ztunnel",
 			namespace:   "istio-system",

--- a/operator/pkg/helm/testdata/input/gateway-dns-config.yaml
+++ b/operator/pkg/helm/testdata/input/gateway-dns-config.yaml
@@ -1,0 +1,17 @@
+spec:
+  values:
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 111.222.123.234
+      options:
+      - name: ndots
+        value: "2"
+      - name: timeout
+        value: "2"
+      - name: attempts
+        value: "5"
+      searches:
+      - istio-ingress.svc.cluster.local
+      - svc.cluster.local
+      - cluster.local

--- a/operator/pkg/helm/testdata/output/gateway-dns-config.golden.yaml
+++ b/operator/pkg/helm/testdata/output/gateway-dns-config.golden.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: istio-ingress
+  namespace: istio-ingress
+  labels:
+    app.kubernetes.io/name: istio-ingress
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "istio-ingress"
+    app.kubernetes.io/part-of: "istio"
+    app.kubernetes.io/version: "1.0.0"
+    helm.sh/chart: gateway-1.0.0
+    app: istio-ingress
+    istio: ingress
+    "istio.io/dataplane-mode": "none"
+  annotations:
+    {}
+spec:
+  selector:
+    matchLabels:
+      app: istio-ingress
+      istio: ingress
+  template:
+    metadata:
+      annotations:
+        inject.istio.io/templates: gateway
+        prometheus.io/path: /stats/prometheus
+        prometheus.io/port: "15020"
+        prometheus.io/scrape: "true"
+        sidecar.istio.io/inject: "true"
+      labels:
+        sidecar.istio.io/inject: "true"
+        app: istio-ingress
+        istio: ingress
+        app.kubernetes.io/name: istio-ingress
+        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/instance: "istio-ingress"
+        app.kubernetes.io/part-of: "istio"
+        app.kubernetes.io/version: "1.0.0"
+        helm.sh/chart: gateway-1.0.0
+        "istio.io/dataplane-mode": "none"
+    spec:
+      serviceAccountName: istio-ingress
+      securityContext:
+        # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+        sysctls:
+        - name: net.ipv4.ip_unprivileged_port_start
+          value: "0"
+      containers:
+        - name: istio-proxy
+          # "auto" will be populated at runtime by the mutating webhook. See https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#customizing-injection
+          image: auto
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          env:
+          ports:
+          - containerPort: 15090
+            protocol: TCP
+            name: http-envoy-prom
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 1024Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - 111.222.123.234
+        options:
+        - name: ndots
+          value: "2"
+        - name: timeout
+          value: "2"
+        - name: attempts
+          value: "5"
+        searches:
+        - istio-ingress.svc.cluster.local
+        - svc.cluster.local
+        - cluster.local
+      terminationGracePeriodSeconds: 30

--- a/releasenotes/notes/gateway-dns-config.yaml
+++ b/releasenotes/notes/gateway-dns-config.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+
+kind: feature
+
+area: installation
+
+releaseNotes:
+- |
+  **Added** `dnsPolicy` and `dnsConfig` fields to the gateway Helm chart for custom DNS configuration in environments with non-standard DNS requirements.


### PR DESCRIPTION
**Please provide a description of this PR:**

Allow `dnsPolicy` and `dnsConfig` to be configured on gateway pods through the `gateway` Helm chart, mirroring the support that already exists in the `ztunnel` chart #58711.