### PR TITLE
Allow Telemetry from other namespace

### DIFF
--- a/pilot/pkg/model/telemetry.go
+++ b/pilot/pkg/model/telemetry.go
@@ -81,7 +81,9 @@ type Telemetries struct {
 type telemetryKey struct {
 	// Root stores the Telemetry in the root namespace, if any
 	Root types.NamespacedName
-	// Namespace stores the Telemetry in the root namespace, if any
+	// Proxy stores the Telemetry in the proxy namespace, if any
+	Proxy types.NamespacedName
+	// Namespace stores the Telemetry in the Telemtry namespace, if any
 	Namespace types.NamespacedName
 	// Workload stores the Telemetry in the root namespace, if any
 	Workload types.NamespacedName
@@ -409,7 +411,6 @@ func (t *Telemetries) applicableTelemetries(proxy *Proxy, svc *Service) computed
 		return computedTelemetries{}
 	}
 
-	namespace := proxy.ConfigNamespace
 	// Order here matters. The latter elements will override the first elements
 	ms := []*tpb.Metrics{}
 	ls := []*computedAccessLogging{}
@@ -432,7 +433,26 @@ func (t *Telemetries) applicableTelemetries(proxy *Proxy, svc *Service) computed
 		}
 	}
 
+	namespace := proxy.ConfigNamespace
 	if namespace != t.RootNamespace {
+		telemetry := t.namespaceWideTelemetryConfig(namespace)
+		if telemetry != (Telemetry{}) {
+			key.Proxy = types.NamespacedName{Name: telemetry.Name, Namespace: telemetry.Namespace}
+			ms = append(ms, telemetry.Spec.GetMetrics()...)
+			if len(telemetry.Spec.GetAccessLogging()) != 0 {
+				ls = append(ls, &computedAccessLogging{
+					telemetryKey: telemetryKey{
+						Namespace: key.Namespace,
+					},
+					Logging: telemetry.Spec.GetAccessLogging(),
+				})
+			}
+			ts = append(ts, telemetry.Spec.GetTracing()...)
+		}
+	}
+
+	if proxy.IsWaypointProxy() && svc != nil && namespace != svc.Attributes.Namespace {
+		namespace = svc.Attributes.Namespace
 		telemetry := t.namespaceWideTelemetryConfig(namespace)
 		if telemetry != (Telemetry{}) {
 			key.Namespace = types.NamespacedName{Name: telemetry.Name, Namespace: telemetry.Namespace}

--- a/pilot/pkg/model/telemetry_test.go
+++ b/pilot/pkg/model/telemetry_test.go
@@ -617,6 +617,22 @@ func TestTelemetryFilters(t *testing.T) {
 			},
 		},
 	}}
+	overridesOther := []*tpb.MetricsOverrides{{
+		Match: &tpb.MetricSelector{
+			MetricMatch: &tpb.MetricSelector_Metric{
+				Metric: tpb.MetricSelector_REQUEST_DURATION,
+			},
+		},
+		TagOverrides: map[string]*tpb.MetricsOverrides_TagOverride{
+			"removeOther": {
+				Operation: tpb.MetricsOverrides_TagOverride_REMOVE,
+			},
+			"add": {
+				Operation: tpb.MetricsOverrides_TagOverride_UPSERT,
+				Value:     "otherBar",
+			},
+		},
+	}}
 	sidecar := &Proxy{
 		ConfigNamespace: "default",
 		Labels:          map[string]string{"app": "test"},
@@ -721,6 +737,20 @@ func TestTelemetryFilters(t *testing.T) {
 		Metrics: []*tpb.Metrics{
 			{
 				Overrides: overrides,
+			},
+		},
+	}
+
+	targetRefsOther := &tpb.Telemetry{
+		TargetRefs: []*v1beta1.PolicyTargetReference{{
+			Group:     gvk.Service.Group,
+			Kind:      gvk.Service.Kind,
+			Namespace: "other",
+			Name:      "sample-svc",
+		}},
+		Metrics: []*tpb.Metrics{
+			{
+				Overrides: overridesOther,
 			},
 		},
 	}
@@ -1097,6 +1127,63 @@ func TestTelemetryFilters(t *testing.T) {
 			want: map[string]string{
 				"istio.stats": `{"disable_host_header_fallback":true,"metrics":[{"dimensions":{"add":"bar"},"name":"requests_total"` +
 					`,"tags_to_remove":["remove"]}],"reporter":"SERVER_GATEWAY"}`,
+			},
+		},
+		{
+			name: "targetRef match cross namespace",
+			cfgs: []config.Config{
+				newTelemetry("default", targetRefs),
+				{
+					Meta: config.Meta{
+						GroupVersionKind: gvk.Telemetry,
+						Name:             "default",
+						Namespace:        "other",
+					},
+					Spec: targetRefsOther,
+				},
+			},
+			service: &Service{
+				Attributes: ServiceAttributes{
+					Name:            "sample-svc",
+					Namespace:       "other",
+					ServiceRegistry: provider.Kubernetes,
+				},
+			},
+			proxy:            waypoint,
+			class:            networking.ListenerClassSidecarInbound,
+			protocol:         networking.ListenerProtocolHTTP,
+			defaultProviders: &meshconfig.MeshConfig_DefaultProviders{Metrics: []string{"prometheus"}},
+			want: map[string]string{
+				"istio.stats": `{"disable_host_header_fallback":true,"metrics":[{"dimensions":{"add":"otherBar"}` +
+					`,"name":"request_duration_milliseconds","tags_to_remove":["removeOther"]}],"reporter":"SERVER_GATEWAY"}`,
+			},
+		},
+		{
+			name: "cross namespace wide",
+			cfgs: []config.Config{
+				{
+					Meta: config.Meta{
+						GroupVersionKind: gvk.Telemetry,
+						Name:             "default",
+						Namespace:        "other",
+					},
+					Spec: overridesPrometheus,
+				},
+			},
+			service: &Service{
+				Attributes: ServiceAttributes{
+					Name:            "sample-svc",
+					Namespace:       "other",
+					ServiceRegistry: provider.Kubernetes,
+				},
+			},
+			proxy:            waypoint,
+			class:            networking.ListenerClassSidecarInbound,
+			protocol:         networking.ListenerProtocolHTTP,
+			defaultProviders: &meshconfig.MeshConfig_DefaultProviders{Metrics: []string{"prometheus"}},
+			want: map[string]string{
+				"istio.stats": `{"disable_host_header_fallback":true,"metrics":[{"dimensions":{"add":"bar"}` +
+					`,"name":"requests_total","tags_to_remove":["remove"]}],"reporter":"SERVER_GATEWAY"}`,
 			},
 		},
 	}

--- a/releasenotes/notes/60665.yaml
+++ b/releasenotes/notes/60665.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: extensibility
+issue:
+  - https://github.com/istio/istio/issues/60665
+releaseNotes:
+  - |
+    **Fixed** a bug where a Service referring to a Waypoint in a different namespace did not have the namespace wide Telemetry resource included as part of its configuration.


### PR DESCRIPTION
When a service refers to a waypoint in a different namespace, the namespace wide Telemetry in the service's namespace should be included if present.

The telemetry key must account for Telemetry in either or both the waypoint and service namespace.

**Please provide a description of this PR:**

fixes #60665 