### PR TITLE
[bug] pilot-agent: exclude protobufs content type when scraping metrics (#60622)

### DIFF
--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -27,6 +27,7 @@ import (
 	"net/http/pprof"
 	"os"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -104,6 +105,21 @@ var (
 	ProbeKeepaliveConnections = env.Register("ENABLE_PROBE_KEEPALIVE_CONNECTIONS", false,
 		"If enabled, readiness probes will keep the connection from pilot-agent to the application alive. "+
 			"This mirrors older Istio versions' behaviors, but not kubelet's.").Get()
+)
+
+var (
+	// When scraping Envoy metrics we can't use neither protobuf nor openmetrics format.
+	// The logic implemented for stats merged basically concatenates the outputs from multiple targets - it does not
+	// work well if you need to merge metrics of multiple formats.
+	//
+	// NOTE: There is limited support for handling openmetrics format, but only when scraping from application, Envoy
+	// stats are written as-is without removing the EOF marker, and therefore we cannot use openmetrics format for
+	// Envoy.
+	allowedEnvoyTypes = []string{"text/*", "text/plain"}
+	allowedAppTypes   = []string{"text/*", "text/plain", "application/openmetrics-text"}
+
+	prometheusText004  = encoding{mediatype: "text/plain", params: map[string]string{"version": "0.0.4"}}
+	openMetricsText001 = encoding{mediatype: "application/openmetrics-text", params: map[string]string{"version": "0.0.1"}}
 )
 
 // KubeAppProbers holds the information about a Kubernetes pod prober.
@@ -554,7 +570,8 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 		if r.URL != nil && len(r.URL.RawQuery) > 0 {
 			scrapeURL = fmt.Sprintf("%s?%s", scrapeURL, r.URL.RawQuery)
 		}
-		if envoy, envoyCancel, _, err = s.scrape(scrapeURL, r.Header); err != nil {
+		acceptHeader := allowedContentTypes(r.Header.Get("Accept"), allowedEnvoyTypes)
+		if envoy, envoyCancel, _, err = s.scrape(scrapeURL, r.Header, acceptHeader); err != nil {
 			log.Errorf("failed scraping envoy metrics: %v", err)
 			metrics.EnvoyScrapeErrors.Increment()
 		}
@@ -564,8 +581,9 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 	var format expfmt.Format
 	if s.prometheus != nil {
 		var contentType string
+		acceptHeader := allowedContentTypes(r.Header.Get("Accept"), allowedAppTypes)
 		url := fmt.Sprintf("http://localhost:%s%s", s.prometheus.Port, s.prometheus.Path)
-		if application, appCancel, contentType, err = s.scrape(url, r.Header); err != nil {
+		if application, appCancel, contentType, err = s.scrape(url, r.Header, acceptHeader); err != nil {
 			log.Errorf("failed scraping application metrics: %v", err)
 			metrics.AppScrapeErrors.Increment()
 		}
@@ -623,6 +641,108 @@ func negotiateMetricsFormat(contentType string) expfmt.Format {
 	return FmtText
 }
 
+type encoding struct {
+	mediatype string
+	params    map[string]string
+}
+
+func (e encoding) String() string {
+	var params []string
+	for k, v := range e.params {
+		params = append(params, fmt.Sprintf("%s=%s", k, v))
+	}
+	sort.Strings(params)
+	return strings.Join(append([]string{e.mediatype}, params...), ";")
+}
+
+func parseAcceptHeader(acceptedTypes string) ([]encoding, error) {
+	var encodings []encoding
+	for _, e := range strings.Split(acceptedTypes, ",") {
+		mediatype, params, err := mime.ParseMediaType(e)
+		if err != nil {
+			return nil, fmt.Errorf("bad encoding %q: %w", e, err)
+		}
+		delete(params, "q") // quality values are not relevant for this parsing
+		encodings = append(encodings, encoding{mediatype: mediatype, params: params})
+	}
+	return encodings, nil
+}
+
+// allowedContentTypes parses the accepted header and excludes all the content types that are not on the list of allowed
+// content types.
+//
+// A few caveats to keep in mind:
+//  1. The Accept header may have wildecards and MIME ranges in principle (though proper Prometheus clients should only
+//     use wildcards as a fallback)
+//     - This function replaces * and */* with text/plain version 0.0.4 and replaces application/* with
+//     application/openmetrics-text version 0.0.1 - those are the most basic content types matching the wildecard/range
+//     and therefore the clients asking for them should be able to support those types at least
+//  2. If after filtering we don't have any encodings left, we fallback to text/plain version 0.0.4
+//  3. If for some reason we fail to parse the Accept header, we again fallback to text/plain version 0.0.4
+func allowedContentTypes(acceptHeader string, acceptedTypes []string) string {
+	encodings, err := parseAcceptHeader(acceptHeader)
+	if err != nil {
+		log.Warnf("Failed to parse Accept header %q: %v", acceptHeader, err)
+		return prometheusText004.String()
+	}
+
+	var acceptedEncodings []encoding
+	used := map[string]bool{}
+	for _, e := range encodings {
+		// This would include protobuf, all the Prometheus's OpenMetricsText and PrometheusText encodings
+		if e.mediatype == "*/*" || e.mediatype == "*" {
+			if !slices.Contains(acceptedTypes, prometheusText004.mediatype) {
+				continue
+			}
+
+			key := prometheusText004.String()
+			if _, present := used[key]; present {
+				continue
+			}
+			used[key] = true
+			acceptedEncodings = append(acceptedEncodings, prometheusText004)
+			continue
+		}
+
+		// This would include protobuf and all the Prometheus's OpenMetricsText encodings
+		if e.mediatype == "application/*" {
+			if !slices.Contains(acceptedTypes, openMetricsText001.mediatype) {
+				continue
+			}
+
+			key := openMetricsText001.String()
+			if _, present := used[key]; present {
+				continue
+			}
+			used[key] = true
+			acceptedEncodings = append(acceptedEncodings, openMetricsText001)
+			continue
+		}
+
+		if !slices.Contains(acceptedTypes, e.mediatype) {
+			continue
+		}
+
+		key := e.String()
+		used[key] = true
+		acceptedEncodings = append(acceptedEncodings, e)
+	}
+
+	total := len(acceptedEncodings)
+	if total == 0 {
+		log.Warnf("No recognized encodings found in Accept header %q", acceptHeader)
+		return prometheusText004.String()
+	}
+
+	var parts []string
+	for i, e := range acceptedEncodings {
+		e.params["q"] = fmt.Sprintf("0.%d", total-i)
+		parts = append(parts, mime.FormatMediaType(e.mediatype, e.params))
+	}
+
+	return strings.Join(parts, ",")
+}
+
 func scrapeAndWriteAgentMetrics(registry prometheus.Gatherer, w io.Writer) error {
 	mfs, err := registry.Gather()
 	enc := expfmt.NewEncoder(w, FmtText)
@@ -660,7 +780,7 @@ func getHeaderTimeout(timeout string) (time.Duration, error) {
 // This will attempt to mimic some of Prometheus functionality by passing some of the headers through
 // such as accept, timeout, and user agent
 // Returns the scraped metrics reader as well as the response's "Content-Type" header to determine the metrics format
-func (s *Server) scrape(url string, header http.Header) (io.ReadCloser, context.CancelFunc, string, error) {
+func (s *Server) scrape(url string, header http.Header, acceptHeader string) (io.ReadCloser, context.CancelFunc, string, error) {
 	var cancel context.CancelFunc
 	ctx := context.Background()
 	if timeoutString := header.Get("X-Prometheus-Scrape-Timeout-Seconds"); timeoutString != "" {
@@ -675,10 +795,12 @@ func (s *Server) scrape(url string, header http.Header) (io.ReadCloser, context.
 	if err != nil {
 		return nil, cancel, "", err
 	}
-	applyHeaders(req.Header, header, "Accept",
-		"User-Agent",
+	applyHeaders(req.Header, header, "User-Agent",
 		"X-Prometheus-Scrape-Timeout-Seconds",
 	)
+	if acceptHeader != "" {
+		req.Header.Set("Accept", acceptHeader)
+	}
 
 	resp, err := s.http.Do(req)
 	if err != nil {

--- a/pilot/cmd/pilot-agent/status/server_test.go
+++ b/pilot/cmd/pilot-agent/status/server_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -31,6 +32,8 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
@@ -525,6 +528,136 @@ func TestHTTPCompressionOnStats(t *testing.T) {
 			}
 			if resp.Header.Get("Content-Encoding") != tt.expectContentEncoding {
 				t.Errorf("[%v] unexpected content encoding, want = %v, got = %v", "/stats/prometheus", tt.expectContentEncoding, resp.Header.Get("Content-Encoding"))
+			}
+		})
+	}
+}
+
+func TestExcludeProtobufEncoding(t *testing.T) {
+	envoyReg := prometheus.NewRegistry()
+	envoyCounter := promauto.With(envoyReg).NewCounter(prometheus.CounterOpts{
+		Name: "counter1",
+		Help: "help1",
+	})
+	envoyCounter.Inc()
+	envoyHandler := promhttp.HandlerFor(envoyReg, promhttp.HandlerOpts{EnableOpenMetrics: true})
+	envoyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		envoyHandler.ServeHTTP(w, r)
+	}))
+	t.Cleanup(envoyServer.Close)
+	envoyPort, err := strconv.Atoi(strings.Split(envoyServer.URL, ":")[2])
+	if err != nil {
+		t.Fatalf("Failed to parse test envoy server URL %q: %v", envoyServer.URL, err)
+	}
+
+	appReg := prometheus.NewRegistry()
+	appCounter := promauto.With(appReg).NewCounter(prometheus.CounterOpts{
+		Name: "counter2",
+		Help: "help2",
+	})
+	appCounter.Inc()
+	appHandler := promhttp.HandlerFor(appReg, promhttp.HandlerOpts{EnableOpenMetrics: true})
+	appServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		appHandler.ServeHTTP(w, r)
+	}))
+	t.Cleanup(appServer.Close)
+	appPort, err := strconv.Atoi(strings.Split(appServer.URL, ":")[2])
+	if err != nil {
+		t.Fatalf("Failed to parse test app server URL %q: %v", appServer.URL, err)
+	}
+
+	server := &Server{
+		prometheus: &PrometheusScrapeConfiguration{
+			Port: fmt.Sprintf("%d", appPort),
+		},
+		envoyStatsPort: envoyPort,
+		http:           &http.Client{},
+		registry:       TestingRegistry(t),
+	}
+
+	tests := []struct {
+		name         string
+		acceptHeader string
+		want         string
+	}{
+		{
+			name: "typical accept header without protobuf",
+			acceptHeader: "application/openmetrics-text;version=1.0.0;escaping=allow-utf-8;q=0.5," +
+				"application/openmetrics-text;version=0.0.1;q=0.4," +
+				"text/plain;version=1.0.0;escaping=allow-utf-8;q=0.3," +
+				"text/plain;version=0.0.4;q=0.2," +
+				"*/*;q=0.1",
+			want: "application/openmetrics-text",
+		},
+		{
+			name: "typical accept header without protobuf and wildcard",
+			acceptHeader: "application/openmetrics-text;version=1.0.0;escaping=allow-utf-8;q=0.4," +
+				"application/openmetrics-text;version=0.0.1;q=0.3," +
+				"text/plain;version=1.0.0;escaping=allow-utf-8;q=0.2," +
+				"text/plain;version=0.0.4;q=0.1",
+			want: "application/openmetrics-text",
+		},
+		{
+			name: "typical accept header with protobuf",
+			acceptHeader: "application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.6," +
+				"application/openmetrics-text;version=1.0.0;escaping=allow-utf-8;q=0.5," +
+				"application/openmetrics-text;version=0.0.1;q=0.4," +
+				"text/plain;version=1.0.0;escaping=allow-utf-8;q=0.3," +
+				"text/plain;version=0.0.4;q=0.2," +
+				"*/*;q=0.1",
+			want: "application/openmetrics-text",
+		},
+		{
+			name:         "protobuf only",
+			acceptHeader: "application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited",
+			want:         "text/plain",
+		},
+		{
+			name:         "openmetrics text only",
+			acceptHeader: "application/openmetrics-text;version=1.0.0;escaping=allow-utf-8",
+			want:         "application/openmetrics-text",
+		},
+		{
+			name: "plain text only",
+			acceptHeader: "text/plain;version=1.0.0;escaping=allow-utf-8;q=0.2," +
+				"text/plain;version=0.0.4;q=0.1",
+			want: "text/plain",
+		},
+		{
+			name:         "expand MIME wildcard",
+			acceptHeader: "*/*",
+			want:         "text/plain",
+		},
+		{
+			name:         "expand MIME range",
+			acceptHeader: "application/*",
+			want:         "application/openmetrics-text",
+		},
+		{
+			name:         "invalid accept header",
+			acceptHeader: "/",
+			want:         "text/plain",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := &http.Request{}
+			req.Header = make(http.Header)
+			req.Header.Set("Accept", test.acceptHeader)
+			server.handleStats(rec, req)
+			res := rec.Result()
+			if res.StatusCode != http.StatusOK {
+				t.Errorf("Unexpected status code, want = %v, got = %v", http.StatusOK, res.StatusCode)
+			}
+			contentType := res.Header.Get("Content-Type")
+			mediaType, _, err := mime.ParseMediaType(contentType)
+			if err != nil {
+				t.Fatalf("Failed to parse Content-Type %q: %v", contentType, err)
+			}
+			if mediaType != test.want {
+				t.Errorf("Unexpected Content-Type, want = %q, got = %q", test.want, mediaType)
 			}
 		})
 	}

--- a/releasenotes/notes/60322.yaml
+++ b/releasenotes/notes/60322.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: telemetry
+issue:
+- 60322
+releaseNotes:
+- |
+  **Fixed** an issue when pilot-agent metric merging produces incorrect result when Envoy reports metrics using protobuf
+  content type. The logic currently implemented in pilot-agent cannot handle protobuf content type correctly, so the change
+  restrict allowed content types to text/plain and application/openmetrics-text only.


### PR DESCRIPTION
* [bug] pilot-agent: exclude protobufs content type when scraping metrics

Fixes #60322 and #60675

Envoy relatively recently (a few months ago) added support for protocol buffers as a content type when scraping stats, before that it only supported openmetrics and native prometheus plain text format.

Envoy only uses protobuf content type when it's explicitly requested by the client. However, because protobuf content type wasn't supported in Envoy it was basically ignored.

Additional relevant factor here is that pilot-agent merging logic is a bit simplistic and basically boils down to concatenating responses from multiple sources (e.g., Envoy and the actual app behind the Envoy) with some limited handling for openmetrics content type.

The limited handling implemented at the moment boils down to stripping EOF marker from metrics response. This logic only triggers for app targets and does not apply to Envoy.

As a result of the above, the merging logic only works correctly if:

1. protobuf content type is not used - concatenating protobuf with either text or openmetrics format does not produce a valid result
2. envoy uses plain text encoding for metrics

NOTE: the actual application could use either plain text or openmetrics format with the current implementation.

With the above context in mind, and assuming an official Prometheus client that just enumerates all the supported content types in the Accept header of the request in order of priortiy starting with protobuf, you can see how adding support of protobuf content type in Envoy could break some users.

What does this PR do to fix the issue?

First of all, when scraping Envoy, it removes both protobuf and openmetrics content types from the request Accept header, and only allows plain text.

NOTE: Envoy currently only supports protobuf and plain text encodings, but given that our merging logic does not support anything other than plain text, we probably should set Accept header explicitly.

Sencondly, when scraping everything else, we remove the protobuf content type from the original request Accept header.

The logic that removes content types from the Accept header handles wildcards and MIME ranges. I'm not absolutely convincend that it's required, but still decided to handle them.

The logic for handling wildcards and MIME ranges goes as follows:

1. * and */* are replaced to explicitly include plain text 0.0.4 and openmetrics 0.0.1
2. application/* are replaced to explicitly include only openmetrics 0.0.1
3. text/* is left as is without expansion

This way misguided clients that use wildcards and don't support all the latest Prometheus formats will get something older and supported.

NOTE: I checked how Prometheus official golang client library behaves and it seems to implement even simpler approach - when presented with a wildcard or MIME range it just falls back to plain text 0.0.4, even if it does not match MIME range.



* Add release note for the bug fix



* Fix lints



---------

**Please provide a description of this PR:**