### PR TITLE
Treat the waypoint inbound route more like a sidecar outbound route

### DIFF
--- a/pilot/pkg/networking/core/httproute.go
+++ b/pilot/pkg/networking/core/httproute.go
@@ -113,7 +113,13 @@ func (configgen *ConfigGeneratorImpl) BuildHTTPRoutes(
 // TODO: trace decorators, inbound timeouts
 func buildSidecarInboundHTTPRouteConfig(svc *model.Service, lb *ListenerBuilder, cc inboundChainConfig) *route.RouteConfiguration {
 	traceOperation := telemetry.TraceOperation(string(cc.telemetryMetadata.InstanceHostname), cc.port.Port)
-	defaultRoute := istio_route.BuildDefaultHTTPInboundRoute(lb.node, cc.clusterName, traceOperation, cc.port.Protocol)
+	var defaultRoute *route.Route
+	if lb.node.IsWaypointProxy() {
+		// the inbound route of a Waypoint is more like the outbound route
+		defaultRoute = istio_route.BuildDefaultHTTPOutboundRoute(cc.clusterName, traceOperation, lb.push.Mesh)
+	} else {
+		defaultRoute = istio_route.BuildDefaultHTTPInboundRoute(lb.node, cc.clusterName, traceOperation, cc.port.Protocol)
+	}
 
 	inboundVHost := &route.VirtualHost{
 		Name:    inboundVirtualHostPrefix + strconv.Itoa(cc.port.Port), // Format: "inbound|http|%d"

--- a/pilot/pkg/networking/core/httproute.go
+++ b/pilot/pkg/networking/core/httproute.go
@@ -26,6 +26,7 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	anypb "google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
@@ -114,9 +115,11 @@ func (configgen *ConfigGeneratorImpl) BuildHTTPRoutes(
 func buildSidecarInboundHTTPRouteConfig(svc *model.Service, lb *ListenerBuilder, cc inboundChainConfig) *route.RouteConfiguration {
 	traceOperation := telemetry.TraceOperation(string(cc.telemetryMetadata.InstanceHostname), cc.port.Port)
 	var defaultRoute *route.Route
+	var responseBodySize *wrapperspb.UInt32Value
 	if lb.node.IsWaypointProxy() {
 		// the inbound route of a Waypoint is more like the outbound route
 		defaultRoute = istio_route.BuildDefaultHTTPOutboundRoute(cc.clusterName, traceOperation, lb.push.Mesh)
+		responseBodySize = istio_route.DefaultMaxDirectResponseBodySizeBytes
 	} else {
 		defaultRoute = istio_route.BuildDefaultHTTPInboundRoute(lb.node, cc.clusterName, traceOperation, cc.port.Protocol)
 	}
@@ -128,9 +131,10 @@ func buildSidecarInboundHTTPRouteConfig(svc *model.Service, lb *ListenerBuilder,
 	}
 
 	r := &route.RouteConfiguration{
-		Name:             cc.clusterName,
-		VirtualHosts:     []*route.VirtualHost{inboundVHost},
-		ValidateClusters: proto.BoolFalse,
+		Name:                           cc.clusterName,
+		VirtualHosts:                   []*route.VirtualHost{inboundVHost},
+		MaxDirectResponseBodySizeBytes: responseBodySize,
+		ValidateClusters:               proto.BoolFalse,
 	}
 	efw := lb.push.EnvoyFilters(lb.node)
 	r = envoyfilter.ApplyRouteConfigurationPatches(networking.EnvoyFilter_SIDECAR_INBOUND, lb.node, efw, r)

--- a/pilot/pkg/networking/core/httproute_test.go
+++ b/pilot/pkg/networking/core/httproute_test.go
@@ -26,11 +26,15 @@ import (
 	cookiev3 "github.com/envoyproxy/go-control-plane/envoy/extensions/http/stateful_session/cookie/v3"
 	headerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/http/stateful_session/header/v3"
 	httpv3 "github.com/envoyproxy/go-control-plane/envoy/type/http/v3"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	meshapi "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/core/route/retry"
+	"istio.io/istio/pilot/pkg/networking/telemetry"
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pilot/test/xdstest"
@@ -2033,4 +2037,58 @@ func buildHTTPService(hostname string, v visibility.Instance, ip, namespace stri
 
 	service.Ports = Ports
 	return service
+}
+
+func TestInboundHTTPRouteConfig(t *testing.T) {
+	svc := buildHTTPService("service-A.default.svc.cluster.local", visibility.Public, "", "default", 8080)
+
+	cases := []struct {
+		name          string
+		proxy         *model.Proxy
+		validateRoute bool
+		expectedRetry *route.RetryPolicy
+	}{
+		{
+			name:          "sidecar",
+			proxy:         &model.Proxy{Type: model.SidecarProxy},
+			validateRoute: false,
+			expectedRetry: &route.RetryPolicy{
+				NumRetries: wrapperspb.UInt32(2),
+				RetryOn:    "reset-before-request",
+			},
+		},
+		{
+			name:          "waypoint",
+			proxy:         &model.Proxy{Type: model.Waypoint},
+			validateRoute: true,
+			expectedRetry: retry.DefaultPolicy(),
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			cg := NewConfigGenTest(t, TestOptions{})
+			proxy := cg.SetupProxy(tt.proxy)
+			lb := NewListenerBuilder(proxy, cg.PushContext())
+
+			cc := inboundChainConfig{
+				telemetryMetadata: telemetry.FilterChainMetadata{InstanceHostname: svc.Hostname},
+				port:              model.ServiceInstancePort{ServicePort: &model.Port{Port: 8080}, TargetPort: 8080},
+				clusterName:       model.BuildInboundSubsetKey(8080),
+				hbone:             lb.node.IsWaypointProxy(),
+			}
+			routeCfg := buildSidecarInboundHTTPRouteConfig(svc, lb, cc)
+			if tt.validateRoute {
+				xdstest.ValidateRouteConfiguration(t, routeCfg)
+			}
+
+			for _, vh := range routeCfg.VirtualHosts {
+				for _, r := range vh.Routes {
+					if a, e := r.GetRoute().RetryPolicy, tt.expectedRetry; !proto.Equal(a, e) {
+						t.Errorf("retry policy mismatch got: %v want: %v", a, e)
+					}
+				}
+			}
+		})
+	}
 }

--- a/releasenotes/notes/60682.yaml
+++ b/releasenotes/notes/60682.yaml
@@ -5,5 +5,5 @@ issue:
   - https://github.com/istio/istio/issues/60682
 releaseNotes:
   - |
-    **Fixed** default http retries for inbound routes of waypoints. The mesh config's defaulHTTPRetry will apply to
+    **Fixed** default http retries for inbound routes of waypoints. The mesh config's defaultHttpRetryPolicy will apply to
     local services attached to waypoints.

--- a/releasenotes/notes/60682.yaml
+++ b/releasenotes/notes/60682.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - https://github.com/istio/istio/issues/60682
+releaseNotes:
+  - |
+    **Fixed** default http retries for inbound routes of waypoints. The mesh config's defaulHTTPRetry will apply to
+    local services attached to waypoints.


### PR DESCRIPTION
Local services attached to a waypoint have the sidecar inbound retry which is just reset-before-request.
It should really follow the sidecar outbound which picks up the default http retry.
If an HTTPRoute is created for the service, it will pick up the default http retry.
We should be consistent and apply it regardless.

**Please provide a description of this PR:**






fixes #60682 