### PR TITLE
Gateway API: sort "/" catch-all routes last so regex routes are not dropped

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -474,6 +474,16 @@ func sortHTTPRoutes(routes []*istio.HTTPRoute) {
 		}
 		// Only look at match[0], we always generate only one match
 		m1, m2 := routes[i].Match[0], routes[j].Match[0]
+		// A catch-all match ("/" prefix or ".*" regex with no method, header, or
+		// query-param constraints) is the least specific match and must sort last.
+		// Istio ranks Prefix above Regex, so a "/" catch-all would otherwise sort
+		// ahead of a more specific regex route; BuildHTTPRoutesForVirtualService
+		// then treats the catch-all as terminal and truncates every route after it.
+		// "Catch-all" is a cross-field property of the whole match, not a URI match
+		// type, so it is handled here rather than in getURIRank.
+		if c1, c2 := isCatchAll(m1), isCatchAll(m2); c1 != c2 {
+			return c2
+		}
 		r1, r2 := getURIRank(m1), getURIRank(m2)
 		len1, len2 := getURILength(m1), getURILength(m2)
 		switch {
@@ -520,6 +530,25 @@ func getURIRank(match *istio.HTTPMatchRequest) int {
 	}
 	// should not happen
 	return -1
+}
+
+// isCatchAll reports whether m matches every request: a "/" prefix or a ".*"
+// regex with no method, header, or query-param constraints. Mirrors
+// route.IsCatchAllRoute on the generated Envoy route.
+func isCatchAll(m *istio.HTTPMatchRequest) bool {
+	if m.Method != nil || len(m.Headers) > 0 || len(m.QueryParams) > 0 {
+		return false
+	}
+	if m.Uri == nil {
+		return false
+	}
+	switch m.Uri.MatchType.(type) {
+	case *istio.StringMatch_Prefix:
+		return m.Uri.GetPrefix() == "/"
+	case *istio.StringMatch_Regex:
+		return m.Uri.GetRegex() == ".*"
+	}
+	return false
 }
 
 func getURILength(match *istio.HTTPMatchRequest) int {

--- a/pilot/pkg/config/kube/gateway/conversion_test.go
+++ b/pilot/pkg/config/kube/gateway/conversion_test.go
@@ -894,6 +894,20 @@ func TestSortHTTPRoutes(t *testing.T) {
 		out  []*istio.HTTPRoute
 	}{
 		{
+			// Regression: a specific regex must sort before a "/" catch-all.
+			// If it sorts after, BuildHTTPRoutesForVirtualService treats the
+			// catch-all as terminal and drops the regex route entirely.
+			"specific regex sorts before catch-all prefix",
+			[]*istio.HTTPRoute{
+				{Match: []*istio.HTTPMatchRequest{{Uri: &istio.StringMatch{MatchType: &istio.StringMatch_Prefix{Prefix: "/"}}}}},
+				{Match: []*istio.HTTPMatchRequest{{Uri: &istio.StringMatch{MatchType: &istio.StringMatch_Regex{Regex: "^/reservations/[^/]+/charges/deposit$"}}}}},
+			},
+			[]*istio.HTTPRoute{
+				{Match: []*istio.HTTPMatchRequest{{Uri: &istio.StringMatch{MatchType: &istio.StringMatch_Regex{Regex: "^/reservations/[^/]+/charges/deposit$"}}}}},
+				{Match: []*istio.HTTPMatchRequest{{Uri: &istio.StringMatch{MatchType: &istio.StringMatch_Prefix{Prefix: "/"}}}}},
+			},
+		},
+		{
 			"match is preferred over no match",
 			[]*istio.HTTPRoute{
 				{
@@ -929,7 +943,7 @@ func TestSortHTTPRoutes(t *testing.T) {
 			},
 		},
 		{
-			"path matching exact > prefix  > regex",
+			"exact > regex > catch-all prefix (catch-all sorts last)",
 			[]*istio.HTTPRoute{
 				{
 					Match: []*istio.HTTPMatchRequest{
@@ -981,8 +995,8 @@ func TestSortHTTPRoutes(t *testing.T) {
 					Match: []*istio.HTTPMatchRequest{
 						{
 							Uri: &istio.StringMatch{
-								MatchType: &istio.StringMatch_Prefix{
-									Prefix: "/",
+								MatchType: &istio.StringMatch_Regex{
+									Regex: ".*foo",
 								},
 							},
 						},
@@ -992,8 +1006,8 @@ func TestSortHTTPRoutes(t *testing.T) {
 					Match: []*istio.HTTPMatchRequest{
 						{
 							Uri: &istio.StringMatch{
-								MatchType: &istio.StringMatch_Regex{
-									Regex: ".*foo",
+								MatchType: &istio.StringMatch_Prefix{
+									Prefix: "/",
 								},
 							},
 						},
@@ -1271,7 +1285,7 @@ func TestSortHTTPRoutes(t *testing.T) {
 						{
 							Uri: &istio.StringMatch{
 								MatchType: &istio.StringMatch_Prefix{
-									Prefix: "/",
+									Prefix: "/foo",
 								},
 							},
 						},
@@ -1319,7 +1333,7 @@ func TestSortHTTPRoutes(t *testing.T) {
 						{
 							Uri: &istio.StringMatch{
 								MatchType: &istio.StringMatch_Prefix{
-									Prefix: "/",
+									Prefix: "/foo",
 								},
 							},
 						},

--- a/pilot/pkg/config/kube/gateway/testdata/route-precedence.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/route-precedence.yaml.golden
@@ -162,20 +162,20 @@ spec:
           number: 80
   - match:
     - uri:
-        prefix: /
-    name: allowed-2.http.2
-    route:
-    - destination:
-        host: svc3.allowed-2.svc.domain.suffix
-        port:
-          number: 80
-  - match:
-    - uri:
         regex: /foo((\/).*)?
     name: allowed-1.http.1
     route:
     - destination:
         host: svc2.allowed-1.svc.domain.suffix
+        port:
+          number: 80
+  - match:
+    - uri:
+        prefix: /
+    name: allowed-2.http.2
+    route:
+    - destination:
+        host: svc3.allowed-2.svc.domain.suffix
         port:
           number: 80
 ---

--- a/releasenotes/notes/60695.yaml
+++ b/releasenotes/notes/60695.yaml
@@ -1,0 +1,12 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 60695
+releaseNotes:
+  - |
+    **Fixed** a Gateway API bug where a `RegularExpression` `HTTPRoute` path match
+    was dropped from the generated configuration when a `PathPrefix: /` catch-all
+    route also existed on the same parent, causing matching requests to fall
+    through to the catch-all. Catch-all matches now sort last so they no longer
+    shadow more specific routes.


### PR DESCRIPTION
**Please provide a description of this PR:**

`getURIRank` ranks path match types `Exact(3) > Prefix(2) > Regex(1)`, so a `PathPrefix: /` catch-all sorts **ahead** of a more specific `RegularExpression` route. `BuildHTTPRoutesForVirtualService` then reaches the catch-all (`IsCatchAllRoute`), marks it terminal, and `break`s — "Routes are matched in order, so we will never go beyond this match." Every route after the catch-all, including the regex route, is truncated. The regex route is silently dropped (no error, `HTTPRoute` status stays `Accepted: True`) and matching requests fall through to the catch-all.

This is a recurrence of #50108 and revives the never-merged #50109 (closed by the lifecycle bot on `needs-rebase`). Still reproduces on 1.29.x, 1.30, and master.

**Fix:** in `sortHTTPRoutes`, a catch-all match (`/` prefix or `.*` regex with no method/header/query constraints) sorts last, so it can no longer shadow or truncate more specific routes.

**Addressing the review on #50109** ([r1556070572](https://github.com/istio/istio/pull/50109#discussion_r1556070572)):
- @howardjohn: *"why is a URI match [getURIRank] looking at method, headers, query param?"* — Agreed; "catch-all" is a cross-field property of the whole match, not a URI match type. So this PR keeps `getURIRank` URI-only and does the catch-all check in the `sortHTTPRoutes` comparator instead.
- *"why doesn't sortHTTPRoutes account for catch-all implicitly?"* — It can't with the current tiers: Istio ranks `Prefix > Regex`, so a `/` catch-all outranks **any** regex, and the length tie-break only applies within a rank (never across prefix-vs-regex). An explicit catch-all-lowest rule is therefore required.
- `isCatchAll` mirrors `route.IsCatchAllRoute` (`/` prefix or `.*` regex); unlike #50109 it does not treat `Exact "/"` as a catch-all (exact `/` only matches the root path).

On the deeper per-match sorting point ([r1550699408](https://github.com/istio/istio/pull/50109#discussion_r1550699408)): multi-match rules are **already** split into single-match routes before sorting (`route_collections.go`: `// split the rule to make sure each rule has up to one match`, for both HTTP and GRPC), so sorting is already per-match — not on `Match[0]` of a multi-match rule. The bug fixed here is independent: it is the catch-all rank inversion plus the catch-all truncation, and it reproduces with plain single-match rules.

- Added a `TestSortHTTPRoutes` regression case (specific regex must precede a `/` catch-all).
- Updated the `route-precedence` golden: the regex route now precedes the `/` catch-all.

Fixes #60695

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
