### PR TITLE
change service target not found log to warn

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -919,7 +919,7 @@ func (c *Controller) GetProxyServiceTargets(proxy *model.Proxy) []model.ServiceT
 		// attempt to read the real pod.
 		out, err := c.GetProxyServiceTargetsFromMetadata(proxy)
 		if err != nil {
-			log.Errorf("failed to get proxy service targets from metadata: %v", err)
+			log.Warnf("failed to get proxy service targets from metadata: %v", err)
 		}
 		if len(out) == 0 {
 			proxyNoSvcTargetFromMetadata.Increment()


### PR DESCRIPTION
**Please provide a description of this PR:**
This log can happen any time because of eventual consistency and can actually happen always when using `ServiceEntry` since there is no k8s native Service for those pods.