### PR TITLE
gateway: add support for VerticalPodAutoscaler

### DIFF
--- a/manifests/charts/gateway/templates/vpa.yaml
+++ b/manifests/charts/gateway/templates/vpa.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.vpa.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "gateway.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "gateway.name" . }}
+    {{- include "istio.labels" . | nindent 4}}
+    {{- include "gateway.labels" . | nindent 4 }}
+  annotations:
+    {{- .Values.annotations | toYaml | nindent 4 }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: {{ .Values.kind | default "Deployment" }}
+    name: {{ include "gateway.name" . }}
+  updatePolicy:
+    updateMode: {{ .Values.vpa.updateMode }}
+  resourcePolicy:
+    containerPolicies:
+    - containerName: "istio-proxy"
+      {{- with .Values.vpa.controlledResources }}
+      controlledResources:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.vpa.minAllowed }}
+      minAllowed:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.vpa.maxAllowed }}
+      maxAllowed:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -63,6 +63,45 @@
             }
           }
         },
+        "vpa": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "updateMode": {
+              "type": "string"
+            },
+            "controlledResources": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "minAllowed": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": "string"
+                },
+                "memory": {
+                  "type": "string"
+                }
+              }
+            },
+            "maxAllowed": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": "string"
+                },
+                "memory": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
         "env": {
           "type": "object"
         },

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -88,6 +88,19 @@ _internal_defaults_do_not_set:
     targetMemoryUtilizationPercentage: {}
     autoscaleBehavior: {}
 
+  vpa:
+    enabled: false
+    updateMode: InPlaceOrRecreate
+    controlledResources:
+      - "cpu"
+      - "memory"
+    minAllowed:
+      cpu: 100m
+      memory: 128Mi
+    maxAllowed:
+      cpu: 2000m
+      memory: 1024Mi
+
   # Pod environment variables
   env: {}
 


### PR DESCRIPTION
**Please provide a description of this PR:**
Adds support to `VerticalPodAutoscaler` on the `gateway` Helm Chart. By default `VerticalPodAutoscaler` is disabled through variable `vpa.enabled`.