### PR TITLE
skip pushes for virtual service metadata-only changes

### DIFF
--- a/pilot/pkg/bootstrap/config_compare.go
+++ b/pilot/pkg/bootstrap/config_compare.go
@@ -15,50 +15,11 @@
 package bootstrap
 
 import (
-	"strings"
-
-	"google.golang.org/protobuf/proto"
-
+	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config"
 )
 
-// needsPush checks whether the passed in config has same spec and hence push needs
-// to be triggered. This is to avoid unnecessary pushes only when labels have changed
-// for example.
+// needsPush delegates to model.NeedsPush.
 func needsPush(prev config.Config, curr config.Config) bool {
-	if prev.GroupVersionKind != curr.GroupVersionKind {
-		// This should never happen.
-		return true
-	}
-	// If the config is not Istio, let us just push.
-	if !strings.HasSuffix(prev.GroupVersionKind.Group, "istio.io") {
-		return true
-	}
-	// If current/previous metadata has "*istio.io" label/annotation, just push
-	for label := range curr.Meta.Labels {
-		if strings.Contains(label, "istio.io") {
-			return true
-		}
-	}
-	for annotation := range curr.Meta.Annotations {
-		if strings.Contains(annotation, "istio.io") {
-			return true
-		}
-	}
-	for label := range prev.Meta.Labels {
-		if strings.Contains(label, "istio.io") {
-			return true
-		}
-	}
-	for annotation := range prev.Meta.Annotations {
-		if strings.Contains(annotation, "istio.io") {
-			return true
-		}
-	}
-	prevspecProto, okProtoP := prev.Spec.(proto.Message)
-	currspecProto, okProtoC := curr.Spec.(proto.Message)
-	if okProtoP && okProtoC {
-		return !proto.Equal(prevspecProto, currspecProto)
-	}
-	return true
+	return model.NeedsPush(prev, curr)
 }

--- a/pilot/pkg/model/config_compare.go
+++ b/pilot/pkg/model/config_compare.go
@@ -1,0 +1,66 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"strings"
+
+	"google.golang.org/protobuf/proto"
+
+	"istio.io/istio/pkg/config"
+)
+
+// NeedsPush checks whether a config update event requires an XDS push.
+// Returns false only when the spec is unchanged AND neither old nor new config
+// has any istio.io label or annotation — i.e. a pure non-Istio metadata change
+// (Helm annotations, Argo CD labels, kubectl.kubernetes.io/last-applied-configuration)
+// that has no effect on XDS state.
+func NeedsPush(prev config.Config, curr config.Config) bool {
+	if prev.GroupVersionKind != curr.GroupVersionKind {
+		// This should never happen.
+		return true
+	}
+	// If the config is not Istio, let us just push.
+	if !strings.HasSuffix(prev.GroupVersionKind.Group, "istio.io") {
+		return true
+	}
+	// If current/previous metadata has "*istio.io" label/annotation, just push
+	for label := range curr.Meta.Labels {
+		if strings.Contains(label, "istio.io") {
+			return true
+		}
+	}
+	for annotation := range curr.Meta.Annotations {
+		if strings.Contains(annotation, "istio.io") {
+			return true
+		}
+	}
+	for label := range prev.Meta.Labels {
+		if strings.Contains(label, "istio.io") {
+			return true
+		}
+	}
+	for annotation := range prev.Meta.Annotations {
+		if strings.Contains(annotation, "istio.io") {
+			return true
+		}
+	}
+	prevspecProto, okProtoP := prev.Spec.(proto.Message)
+	currspecProto, okProtoC := curr.Spec.(proto.Message)
+	if okProtoP && okProtoC {
+		return !proto.Equal(prevspecProto, currspecProto)
+	}
+	return true
+}

--- a/pilot/pkg/model/config_compare_test.go
+++ b/pilot/pkg/model/config_compare_test.go
@@ -1,0 +1,204 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"testing"
+
+	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/config/schema/gvk"
+)
+
+func TestNeedsPush(t *testing.T) {
+	cases := []struct {
+		name     string
+		prev     config.Config
+		curr     config.Config
+		expected bool
+	}{
+		{
+			name: "different gvk",
+			prev: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.VirtualService,
+					Name:             "acme2-v1",
+					Namespace:        "not-default",
+				},
+				Spec: &networking.VirtualService{},
+			},
+			curr: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.DestinationRule,
+					Name:             "acme2-v1",
+					Namespace:        "not-default",
+				},
+				Spec: &networking.VirtualService{},
+			},
+			expected: true,
+		},
+		{
+			name: "same gvk label change",
+			prev: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.VirtualService,
+					Name:             "acme2-v1",
+					Namespace:        "not-default",
+					Labels:           map[string]string{"test": "test-v1"},
+				},
+				Spec: &networking.VirtualService{},
+			},
+			curr: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.VirtualService,
+					Name:             "acme2-v1",
+					Namespace:        "not-default",
+					Labels:           map[string]string{"test": "test-v2"},
+				},
+				Spec: &networking.VirtualService{},
+			},
+			expected: false,
+		},
+		{
+			name: "same gvk spec change",
+			prev: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.VirtualService,
+					Name:             "acme2-v1",
+					Namespace:        "not-default",
+					Labels:           map[string]string{"test": "test-v1"},
+				},
+				Spec: &networking.VirtualService{Hosts: []string{"test-host"}},
+			},
+			curr: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.VirtualService,
+					Name:             "acme2-v1",
+					Namespace:        "not-default",
+					Labels:           map[string]string{"test": "test-v1"},
+				},
+				Spec: &networking.VirtualService{Hosts: []string{"test-host", "test-host2"}},
+			},
+			expected: true,
+		},
+		{
+			name: "current config with istio.io label",
+			prev: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.Ingress,
+					Name:             "acme2-v1",
+					Namespace:        "not-default",
+				},
+			},
+			curr: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.Ingress,
+					Name:             "acme2-v1",
+					Namespace:        "not-default",
+					Labels:           map[string]string{constants.AlwaysPushLabel: "true"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "previous config with istio.io label",
+			prev: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.Ingress,
+					Name:             "acme2-v1",
+					Namespace:        "not-default",
+					Labels:           map[string]string{constants.AlwaysPushLabel: "true"},
+				},
+			},
+			curr: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.Ingress,
+					Name:             "acme2-v1",
+					Namespace:        "not-default",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "current config with istio.io annotation",
+			prev: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.Ingress,
+					Name:             "acme2-v1",
+					Namespace:        "not-default",
+				},
+			},
+			curr: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.Ingress,
+					Name:             "acme2-v1",
+					Namespace:        "not-default",
+					Annotations:      map[string]string{constants.AlwaysPushLabel: "true"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "previous config with istio.io annotation",
+			prev: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.Ingress,
+					Name:             "acme2-v1",
+					Namespace:        "not-default",
+					Annotations:      map[string]string{constants.AlwaysPushLabel: "true"},
+				},
+			},
+			curr: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.Ingress,
+					Name:             "acme2-v1",
+					Namespace:        "not-default",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "non istio resources",
+			prev: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.TCPRoute,
+					Name:             "acme2-v1",
+					Namespace:        "not-default",
+					Labels:           map[string]string{"test": "test-v1"},
+				},
+				Spec: &networking.VirtualService{},
+			},
+			curr: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.TCPRoute,
+					Name:             "acme2-v1",
+					Namespace:        "not-default",
+					Labels:           map[string]string{"test": "test-v2"},
+				},
+				Spec: &networking.VirtualService{},
+			},
+			expected: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := NeedsPush(c.prev, c.curr); got != c.expected {
+				t.Errorf("unexpected NeedsPush result. expected: %v got: %v", c.expected, got)
+			}
+		})
+	}
+}

--- a/pilot/pkg/model/virtualservice_controller.go
+++ b/pilot/pkg/model/virtualservice_controller.go
@@ -96,6 +96,10 @@ func NewVirtualServiceController(
 	return c
 }
 
+// xdsPush fires a config push for VirtualService events, applying the same suppression
+// logic as NeedsPush: skip updates where the spec is unchanged AND no istio.io
+// label/annotation changed. Non-istio.io metadata changes (Helm, Argo CD,
+// kubectl annotations) are not sufficient to trigger a push.
 func (c *VirtualServiceController) xdsPush(events []krt.Event[config.Config]) {
 	if c.xdsUpdater == nil {
 		return
@@ -103,6 +107,9 @@ func (c *VirtualServiceController) xdsPush(events []krt.Event[config.Config]) {
 
 	cu := sets.New[ConfigKey]()
 	for _, e := range events {
+		if e.Old != nil && e.New != nil && !NeedsPush(*e.Old, *e.New) {
+			continue
+		}
 		for _, vs := range e.Items() {
 			cu.Insert(ConfigKey{
 				Kind:      kind.VirtualService,

--- a/pilot/pkg/model/virtualservice_controller_test.go
+++ b/pilot/pkg/model/virtualservice_controller_test.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	"fmt"
+	"sync/atomic"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,6 +24,7 @@ import (
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/mesh/meshwatcher"
 	"istio.io/istio/pkg/config/schema/gvk"
@@ -770,4 +772,138 @@ func TestControllerMergeVirtualServices(t *testing.T) {
 		got = controller2.MergedVirtualServices()
 		checkOrder(got)
 	})
+}
+
+// fakeXDSUpdater counts ConfigUpdate calls for push suppression tests.
+type fakeXDSUpdater struct {
+	pushCount atomic.Int32
+}
+
+func (f *fakeXDSUpdater) ConfigUpdate(*PushRequest)                                 { f.pushCount.Add(1) }
+func (f *fakeXDSUpdater) EDSUpdate(ShardKey, string, string, []*IstioEndpoint)      {}
+func (f *fakeXDSUpdater) EDSCacheUpdate(ShardKey, string, string, []*IstioEndpoint) {}
+func (f *fakeXDSUpdater) SvcUpdate(ShardKey, string, string, Event)                 {}
+func (f *fakeXDSUpdater) ProxyUpdate(cluster.ID, string)                            {}
+func (f *fakeXDSUpdater) RemoveShard(ShardKey)                                      {}
+
+func setupControllerWithXDS(t *testing.T, xds XDSUpdater, objs ...config.Config) (*VirtualServiceController, *FakeStore) {
+	stop := test.NewStop(t)
+	meshHolder := meshwatcher.NewTestWatcher(&meshconfig.MeshConfig{})
+	store := NewFakeStore()
+	for _, o := range objs {
+		store.Create(o)
+	}
+	controller := NewVirtualServiceController(
+		store,
+		VSControllerOptions{KrtDebugger: krt.GlobalDebugHandler, XDSUpdater: xds},
+		meshHolder,
+	)
+	go store.Run(stop)
+	go controller.Run(stop)
+	kube.WaitForCacheSync("test", stop, store.HasSynced)
+	kube.WaitForCacheSync("test", stop, controller.HasSynced)
+	return controller, store
+}
+
+// TestXDSPushSuppression verifies that xdsPush suppresses pushes for metadata-only
+// changes (the regression introduced in PR #59435) while still firing for spec changes
+// and istio.io label/annotation changes.
+func TestXDSPushSuppression(t *testing.T) {
+	baseVS := config.Config{
+		Meta: config.Meta{
+			Name:             "test-vs",
+			Namespace:        "default",
+			GroupVersionKind: gvk.VirtualService,
+			Labels:           map[string]string{"app": "test"},
+			Annotations:      map[string]string{"meta.helm.sh/release-name": "my-release"},
+		},
+		Spec: &v1alpha3.VirtualService{
+			Hosts: []string{"example.org"},
+			Http: []*v1alpha3.HTTPRoute{
+				{Route: []*v1alpha3.HTTPRouteDestination{
+					{Destination: &v1alpha3.Destination{Host: "example.org"}},
+				}},
+			},
+		},
+	}
+
+	cases := []struct {
+		name     string
+		update   func(vs config.Config) config.Config
+		wantPush bool
+	}{
+		{
+			name: "non-istio annotation change does not push",
+			update: func(vs config.Config) config.Config {
+				vs.Annotations = map[string]string{
+					"meta.helm.sh/release-name":                        "my-release",
+					"kubectl.kubernetes.io/last-applied-configuration": `{"new":"value"}`,
+				}
+				return vs
+			},
+			wantPush: false,
+		},
+		{
+			name: "non-istio label change does not push",
+			update: func(vs config.Config) config.Config {
+				vs.Labels = map[string]string{"app": "test", "argocd.argoproj.io/app": "myapp"}
+				return vs
+			},
+			wantPush: false,
+		},
+		{
+			name: "spec change pushes",
+			update: func(vs config.Config) config.Config {
+				vs.Spec = &v1alpha3.VirtualService{
+					Hosts: []string{"example.org", "other.org"},
+					Http: []*v1alpha3.HTTPRoute{
+						{Route: []*v1alpha3.HTTPRouteDestination{
+							{Destination: &v1alpha3.Destination{Host: "example.org"}},
+						}},
+					},
+				}
+				return vs
+			},
+			wantPush: true,
+		},
+		{
+			name: "istio.io annotation change pushes",
+			update: func(vs config.Config) config.Config {
+				vs.Annotations = map[string]string{
+					"meta.helm.sh/release-name":    "my-release",
+					"networking.istio.io/exportTo": ".",
+				}
+				return vs
+			},
+			wantPush: true,
+		},
+		{
+			name: "istio.io label change pushes",
+			update: func(vs config.Config) config.Config {
+				vs.Labels = map[string]string{"app": "test", "istio.io/rev": "canary"}
+				return vs
+			},
+			wantPush: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			xds := &fakeXDSUpdater{}
+			_, store := setupControllerWithXDS(t, xds, baseVS.DeepCopy())
+
+			// Wait for initial sync pushes to settle, then reset the counter.
+			assert.EventuallyEqual(t, xds.pushCount.Load, int32(1))
+			xds.pushCount.Store(0)
+
+			updated := tc.update(baseVS.DeepCopy())
+			store.Update(updated)
+
+			if tc.wantPush {
+				assert.EventuallyEqual(t, xds.pushCount.Load, int32(1))
+			} else {
+				assert.Consistently(t, xds.pushCount.Load, int32(0))
+			}
+		})
+	}
 }

--- a/releasenotes/notes/60629-vs-push-suppression.yaml
+++ b/releasenotes/notes/60629-vs-push-suppression.yaml
@@ -1,0 +1,14 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - https://github.com/istio/istio/issues/60629
+
+releaseNotes:
+  - |
+    **Fixed** an issue introduced in Istio 1.30 where metadata-only changes to VirtualService objects
+    (e.g. Helm annotations, Argo CD labels, or `kubectl.kubernetes.io/last-applied-configuration`)
+    triggered unnecessary XDS pushes to all proxies. This could cause a significant increase in
+    control plane CPU usage and push latency in clusters with many VirtualServices managed by GitOps
+    tooling. The fix restores the pre-1.30 behavior where only spec changes or `istio.io`
+    label/annotation changes trigger a push.


### PR DESCRIPTION
Looking for possible reasons for this [issue](https://github.com/istio/istio/issues/60629), found this change. I think this got introduced in https://github.com/istio/istio/pull/59435

The new test is generated by Claude but I reviewed it

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [x] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions