### PR TITLE
fixing analyzer virtualservice gateway lookup bug

### DIFF
--- a/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/pkg/config/analysis/analyzers/analyzers_test.go
@@ -475,10 +475,13 @@ var testGrid = []testCase{
 		analyzer:   &virtualservice.GatewayAnalyzer{},
 		expected: []message{
 			{msg.ReferencedResourceNotFound, "VirtualService httpbin-bogus"},
+			{msg.ReferencedResourceNotFound, "VirtualService httpbin-k8s-gateway-bogus"},
 
 			{msg.VirtualServiceHostNotFoundInGateway, "VirtualService default/cross-test"},
 			{msg.VirtualServiceHostNotFoundInGateway, "VirtualService httpbin-bogus"},
 			{msg.VirtualServiceHostNotFoundInGateway, "VirtualService httpbin"},
+			{msg.VirtualServiceHostNotFoundInGateway, "VirtualService httpbin-k8s-gateway-bogus"},
+			{msg.VirtualServiceHostNotFoundInGateway, "VirtualService httpbin-k8s-gateway"},
 		},
 	},
 	{

--- a/pkg/config/analysis/analyzers/testdata/virtualservice_gateways.yaml
+++ b/pkg/config/analysis/analyzers/testdata/virtualservice_gateways.yaml
@@ -57,3 +57,30 @@ spec:
   - "*"
   gateways:
   - another/crossnamespace-gw  # No validation error expected
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: k8s-gateway
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: httpbin-k8s-gateway
+spec:
+  hosts:
+    - "*"
+  gateways:
+    - k8s-gateway   # References a gateway.networking.k8s.io Gateway — must NOT produce an error
+---
+# --- K8s Gateway API: bogus reference (error expected) ---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: httpbin-k8s-gateway-bogus
+spec:
+  hosts:
+    - "*"
+  gateways:
+    - k8s-gateway-does-not-exist   # Neither Istio nor K8s Gateway — MUST produce an error
+

--- a/pkg/config/analysis/analyzers/virtualservice/gateways.go
+++ b/pkg/config/analysis/analyzers/virtualservice/gateways.go
@@ -41,6 +41,7 @@ func (s *GatewayAnalyzer) Metadata() analysis.Metadata {
 		Description: "Checks the gateways associated with each virtual service",
 		Inputs: []config.GroupVersionKind{
 			gvk.Gateway,
+			gvk.KubernetesGateway,
 			gvk.VirtualService,
 		},
 	}
@@ -78,7 +79,10 @@ func (s *GatewayAnalyzer) analyzeVirtualService(r *resource.Instance, c analysis
 
 		gwFullName := resource.NewShortOrFullName(vsNs, gwName)
 
-		if !c.Exists(gvk.Gateway, gwFullName) {
+		istioGwExists := c.Exists(gvk.Gateway, gwFullName)
+		k8sGwExists := c.Exists(gvk.KubernetesGateway, gwFullName)
+
+		if !istioGwExists && !k8sGwExists {
 			m := msg.NewReferencedResourceNotFound(r, "gateway", gwName)
 
 			if line, ok := util.ErrorLine(r, fmt.Sprintf(util.VSGateway, i)); ok {


### PR DESCRIPTION
istioctl analyze incorrectly reports ReferencedResourceNotFound for VirtualServices that reference a gateway.networking.k8s.io Gateway.
The analyzer only checked the Istio Gateway collection (networking.istio.io). The fix adds KubernetesGatewayApiV1Gateways to the analyzer inputs and adds a fallback existence check against that collection before reporting the error.

fixes #60708