### PR TITLE
tests: add integration test case for workload with user namespace

### DIFF
--- a/pkg/test/framework/components/echo/common/deployment/echos.go
+++ b/pkg/test/framework/components/echo/common/deployment/echos.go
@@ -617,3 +617,4 @@ func Setup(apps *Echos, cfg Config) resource.SetupFn {
 		return nil
 	}
 }
+

--- a/pkg/test/framework/components/echo/common/deployment/echos.go
+++ b/pkg/test/framework/components/echo/common/deployment/echos.go
@@ -617,4 +617,3 @@ func Setup(apps *Echos, cfg Config) resource.SetupFn {
 		return nil
 	}
 }
-

--- a/pkg/test/framework/components/echo/config.go
+++ b/pkg/test/framework/components/echo/config.go
@@ -187,6 +187,9 @@ type Config struct {
 
 	// Specify IP family to which echo will bind
 	BindFamily string
+
+	// UserNamespace indicates the pod should run in a user namespace (hostUsers: false).
+	UserNamespace bool
 }
 
 // Getter for a custom echo deployment
@@ -383,6 +386,10 @@ func (c Config) IsAmbient() bool {
 
 func (c Config) IsVM() bool {
 	return c.DeployAsVM
+}
+
+func (c Config) IsUserNamespace() bool {
+	return c.UserNamespace
 }
 
 func (c Config) IsSotw() bool {
@@ -618,6 +625,8 @@ func (c Config) WorkloadClass() WorkloadClass {
 		return Waypoint
 	} else if c.ZTunnelCaptured() && !c.HasAnyWaypointProxy() {
 		return Captured
+	} else if c.IsUserNamespace() {
+		return UserNamespace
 	}
 	if c.IsHeadless() {
 		return Headless

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -440,6 +440,7 @@ func deploymentParams(ctx resource.Context, cfg echo.Config, settings *resource.
 		"Ambient":                 settings.Ambient,
 		"BindFamily":              cfg.BindFamily,
 		"OpenShift":               settings.OpenShift,
+		"UserNamespace":           cfg.UserNamespace,
 	}
 
 	vmIstioHost, vmIstioIP := "", ""

--- a/pkg/test/framework/components/echo/kube/templates/deployment.yaml
+++ b/pkg/test/framework/components/echo/kube/templates/deployment.yaml
@@ -71,6 +71,9 @@ spec:
       imagePullSecrets:
       - name: {{ $.ImagePullSecretName }}
 {{- end }}
+{{- if $.UserNamespace }}
+      hostUsers: false
+{{- end }}
       containers:
 {{- if and
   (ne (index $subset.Annotations "sidecar.istio.io/inject") "false")

--- a/pkg/test/framework/components/echo/workloadclass.go
+++ b/pkg/test/framework/components/echo/workloadclass.go
@@ -18,15 +18,16 @@ package echo
 type WorkloadClass = string
 
 const (
-	Proxyless   WorkloadClass = "proxyless"
-	VM          WorkloadClass = "vm"
-	Sotw        WorkloadClass = "sotw"
-	TProxy      WorkloadClass = "tproxy"
-	Naked       WorkloadClass = "naked"
-	External    WorkloadClass = "external"
-	StatefulSet WorkloadClass = "statefulset"
-	Headless    WorkloadClass = "headless"
-	Captured    WorkloadClass = "captured"
-	Waypoint    WorkloadClass = "waypoint"
-	Standard    WorkloadClass = "standard"
+	Proxyless     WorkloadClass = "proxyless"
+	VM            WorkloadClass = "vm"
+	Sotw          WorkloadClass = "sotw"
+	TProxy        WorkloadClass = "tproxy"
+	Naked         WorkloadClass = "naked"
+	External      WorkloadClass = "external"
+	StatefulSet   WorkloadClass = "statefulset"
+	Headless      WorkloadClass = "headless"
+	Captured      WorkloadClass = "captured"
+	Waypoint      WorkloadClass = "waypoint"
+	Standard      WorkloadClass = "standard"
+	UserNamespace WorkloadClass = "userns"
 )

--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -61,6 +61,9 @@ func SettingsFromCommandLine(testID string) (*Settings, error) {
 	if s.SkipTProxy {
 		s.SkipWorkloadClasses = append(s.SkipWorkloadClasses, "tproxy")
 	}
+	if s.SkipUserNamespace {
+		s.SkipWorkloadClasses = append(s.SkipWorkloadClasses, "userns")
+	}
 	// Allow passing a single CSV flag as well
 	normalized := make(ArrayFlags, 0)
 	for _, sk := range s.SkipWorkloadClasses {
@@ -190,6 +193,9 @@ func init() {
 
 	flag.BoolVar(&settingsFromCommandLine.SkipTProxy, "istio.test.skipTProxy", settingsFromCommandLine.SkipTProxy,
 		"Skip TProxy related parts in all tests.")
+
+	flag.BoolVar(&settingsFromCommandLine.SkipUserNamespace, "istio.test.skipUserNs", true,
+		"Skip user namespace related parts in all tests.")
 
 	flag.BoolVar(&settingsFromCommandLine.Ambient, "istio.test.ambient", settingsFromCommandLine.Ambient,
 		"Indicate the use of ambient mesh.")

--- a/pkg/test/framework/resource/settings.go
+++ b/pkg/test/framework/resource/settings.go
@@ -139,6 +139,9 @@ type Settings struct {
 	// Skip TProxy related parts for all the tests.
 	SkipTProxy bool
 
+	// Skip user namespace related parts for all the tests.
+	SkipUserNamespace bool
+
 	// Ambient mesh is being used
 	Ambient bool
 

--- a/tests/integration/pilot/userns_test.go
+++ b/tests/integration/pilot/userns_test.go
@@ -48,7 +48,7 @@ func TestUserNamespace(t *testing.T) {
 			}
 
 			var userns echo.Instance
-			deployment.New(t, t.Clusters().Primaries().Default()).
+			deployment.New(t).
 				With(&userns, echo.Config{
 					Service:        "userns",
 					Namespace:      ns,
@@ -80,7 +80,7 @@ func annotateNamespaceForHostUsers(t framework.TestContext, nsName string) {
 	for _, c := range t.Clusters() {
 		ns, err := c.Kube().CoreV1().Namespaces().Get(context.TODO(), nsName, metav1.GetOptions{})
 		if err != nil {
-			t.Fatalf("failed to get namespace %s: %v", nsName, err)
+			t.Fatalf("failed to get namespace %s on cluster %s: %v", nsName, c.Name(), err)
 		}
 		if ns.Annotations == nil {
 			ns.Annotations = make(map[string]string)
@@ -88,7 +88,7 @@ func annotateNamespaceForHostUsers(t framework.TestContext, nsName string) {
 		ns.Annotations["openshift.io/sa.scc.uid-range"] = "1000/10000"
 		ns.Annotations["openshift.io/sa.scc.supplemental-groups"] = "1000/10000"
 		if _, err := c.Kube().CoreV1().Namespaces().Update(context.TODO(), ns, metav1.UpdateOptions{}); err != nil {
-			t.Fatalf("failed to annotate namespace %s: %v", nsName, err)
+			t.Fatalf("failed to annotate namespace %s on cluster %s: %v", nsName, c.Name(), err)
 		}
 	}
 }

--- a/tests/integration/pilot/userns_test.go
+++ b/tests/integration/pilot/userns_test.go
@@ -60,10 +60,19 @@ func TestUserNamespace(t *testing.T) {
 				BuildOrFail(t)
 
 			src := apps.A[0]
-			src.CallOrFail(t, echo.CallOptions{
-				To:    userns,
-				Port:  echo.Port{Name: "http"},
-				Check: check.OK(),
+			t.NewSubTest("from standard to userns").Run(func(t framework.TestContext) {
+				src.CallOrFail(t, echo.CallOptions{
+					To:    userns,
+					Port:  echo.Port{Name: "http"},
+					Check: check.OK(),
+				})
+			})
+			t.NewSubTest("from userns to standard").Run(func(t framework.TestContext) {
+				userns.CallOrFail(t, echo.CallOptions{
+					To:    src,
+					Port:  echo.Port{Name: "http"},
+					Check: check.OK(),
+				})
 			})
 		})
 }

--- a/tests/integration/pilot/userns_test.go
+++ b/tests/integration/pilot/userns_test.go
@@ -1,0 +1,94 @@
+//go:build integ
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pilot
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/check"
+	"istio.io/istio/pkg/test/framework/components/echo/common/ports"
+	"istio.io/istio/pkg/test/framework/components/echo/deployment"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+)
+
+func TestUserNamespace(t *testing.T) {
+	framework.
+		NewTest(t).
+		Run(func(t framework.TestContext) {
+			if t.Settings().Skip(echo.UserNamespace) {
+				t.Skip("user namespace tests are disabled")
+			}
+
+			ns := namespace.NewOrFail(t, namespace.Config{
+				Prefix: "userns",
+				Inject: true,
+			})
+
+			if t.Settings().OpenShift {
+				annotateNamespaceForHostUsers(t, ns.Name())
+			}
+
+			var userns echo.Instance
+			deployment.New(t, t.Clusters().Primaries().Default()).
+				With(&userns, echo.Config{
+					Service:        "userns",
+					Namespace:      ns,
+					ServiceAccount: true,
+					Ports:          ports.All(),
+					Subsets:        []echo.SubsetConfig{{}},
+					UserNamespace:  true,
+				}).
+				BuildOrFail(t)
+
+			src := apps.A[0]
+			src.CallOrFail(t, echo.CallOptions{
+				To:    userns,
+				Port:  echo.Port{Name: "http"},
+				Check: check.OK(),
+			})
+		})
+}
+
+// annotateNamespaceForHostUsers overrides the OpenShift project's default UID/GID allocation
+// to a range below 65,535, which is required for Linux User Namespaces (hostUsers: false).
+//
+// OpenShift's default project allocation assigns IDs starting at ~1,000,000,000. For user namespaces,
+// the kernel and CRI-O require container-side IDs to fit within POSIX boundaries (< 65,535).
+// Without this override, pods with hostUsers: false will be rejected by the SCC admission webhook
+// (validation mismatch against the project's billion-level range) or fail at the Kubelet/CRI-O level
+// (unable to map host IDs into a 16-bit user namespace slot).
+func annotateNamespaceForHostUsers(t framework.TestContext, nsName string) {
+	for _, c := range t.Clusters() {
+		ns, err := c.Kube().CoreV1().Namespaces().Get(context.TODO(), nsName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to get namespace %s: %v", nsName, err)
+		}
+		if ns.Annotations == nil {
+			ns.Annotations = make(map[string]string)
+		}
+		ns.Annotations["openshift.io/sa.scc.uid-range"] = "1000/10000"
+		ns.Annotations["openshift.io/sa.scc.supplemental-groups"] = "1000/10000"
+		if _, err := c.Kube().CoreV1().Namespaces().Update(context.TODO(), ns, metav1.UpdateOptions{}); err != nil {
+			t.Fatalf("failed to annotate namespace %s: %v", nsName, err)
+		}
+	}
+}


### PR DESCRIPTION
**Please provide a description of this PR:**

This test covers recently added support for Kubernetes User Namespaces: https://github.com/istio/istio/pull/59448.

Currently, the test is skipped by default and needs to be explicitly unskipped to run it, because there were some issues in KIND related to `hostUsers: false`. We can unskip it later once the feature is stable in KIND.