### PR TITLE
fix: authorize -cacert for OPTIONAL_MUTUAL gateway listeners

### DIFF
--- a/pilot/pkg/model/gateway.go
+++ b/pilot/pkg/model/gateway.go
@@ -248,13 +248,15 @@ func mergeGateways(gateways []gatewayWithInstances, proxy *Proxy, ps *PushContex
 					if err == nil && configAndProxyAllowed && parse.Namespace == lookupNamespace {
 						// Same namespace is always allowed
 						verifiedCertificateReferences.Insert(rn)
-						if s.GetTls().GetMode() == networking.ServerTLSSettings_MUTUAL {
+						if s.GetTls().GetMode() == networking.ServerTLSSettings_MUTUAL ||
+							s.GetTls().GetMode() == networking.ServerTLSSettings_OPTIONAL_MUTUAL {
 							verifiedCertificateReferences.Insert(rn + credentials.SdsCaSuffix)
 						}
 					} else if ps.SecretAllowed(gwKind, rn, lookupNamespace) {
 						// Explicitly allowed by some policy
 						verifiedCertificateReferences.Insert(rn)
-						if s.GetTls().GetMode() == networking.ServerTLSSettings_MUTUAL {
+						if s.GetTls().GetMode() == networking.ServerTLSSettings_MUTUAL ||
+							s.GetTls().GetMode() == networking.ServerTLSSettings_OPTIONAL_MUTUAL {
 							verifiedCertificateReferences.Insert(rn + credentials.SdsCaSuffix)
 						}
 					}

--- a/pilot/pkg/model/gateway_test.go
+++ b/pilot/pkg/model/gateway_test.go
@@ -55,6 +55,8 @@ func TestMergeGateways(t *testing.T) {
 	gwMutualCredInNotAllowedNS := makeConfig("foo1", "ns", "foo.bar.com", "name1", "http", 7, "ingressgateway", "", networking.ServerTLSSettings_MUTUAL, []string{fmt.Sprintf("kubernetes-gateway://%s/foo", NotAllowedNamespace)}, "sa")
 	// Even if we allow any SA name, we still should do namespace checks
 	gwMutualCredInNotAllowedNSNoSA := makeConfig("foo1", "ns", "foo.bar.com", "name1", "http", 7, "ingressgateway", "", networking.ServerTLSSettings_MUTUAL, []string{fmt.Sprintf("kubernetes-gateway://%s/foo", NotAllowedNamespace)}, "")
+	// OPTIONAL_MUTUAL must authorize the -cacert resource just like MUTUAL, otherwise the validation context is never allowed via SDS.
+	gwOptionalMutualCredInAllowedNS := makeConfig("foo1", "ns", "foo.bar.com", "name1", "http", 7, "ingressgateway", "", networking.ServerTLSSettings_OPTIONAL_MUTUAL, []string{fmt.Sprintf("kubernetes-gateway://%s/foo", AllowedNamespace)}, "sa")
 
 	proxyNoInput := makeProxy(func() *spiffe.Identity { return nil })
 	proxyIdentity := makeProxy(func() *spiffe.Identity {
@@ -255,6 +257,16 @@ func TestMergeGateways(t *testing.T) {
 		{
 			"mutual-cred-in-allowed-ns",
 			[]config.Config{gwMutualCredInAllowedNS},
+			proxyIdentity,
+			1,
+			1,
+			map[string]int{"http.7": 1},
+			1,
+			2,
+		},
+		{
+			"optional-mutual-cred-in-allowed-ns",
+			[]config.Config{gwOptionalMutualCredInAllowedNS},
 			proxyIdentity,
 			1,
 			1,

--- a/releasenotes/notes/60618.yaml
+++ b/releasenotes/notes/60618.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 60618
+releaseNotes:
+- |
+  **Fixed** a bug where Gateway API listeners using the OPTIONAL_MUTUAL TLS
+  termination mode failed to authorize the client CA secret for SDS, leaving the
+  validation context stuck in a WARMING state. The CA certificate reference is now
+  authorized for OPTIONAL_MUTUAL the same way it already was for MUTUAL.


### PR DESCRIPTION
Fixes #60618

## What this does

A Gateway API listener using the OPTIONAL_MUTUAL TLS termination mode builds the same -cacert validation context as MUTUAL: ApplyCredentialSDSToServerCommonTLSContext wires the -cacert SDS resource when the mode is MUTUAL or OPTIONAL_MUTUAL.

However mergeGateways only added the -cacert resource (rn + SdsCaSuffix) to VerifiedCertificateReferences when the mode was MUTUAL, in both the same-namespace branch and the policy-allowed branch. For OPTIONAL_MUTUAL the -cacert resource was therefore never authorized, so SDS denied it (attempted to access unauthorized certificates ...-cacert) and the validation context stayed in WARMING, breaking the handshake. A ReferenceGrant did not help because both branches gated on MUTUAL.

This change authorizes the -cacert resource for OPTIONAL_MUTUAL exactly the way it is already authorized for MUTUAL, in both branches. It is the OPTIONAL_MUTUAL analog of #55623, which was fixed for MUTUAL in #55859.

## Tests

Added an optional-mutual-cred-in-allowed-ns case to TestMergeGateways that expects the cert and the -cacert resource to both be authorized (verifiedCertNum 2), mirroring the existing mutual-cred-in-allowed-ns case. Verified the case fails without the fix (Expected 2 Got 1) and passes with it.

## Release notes

Added releasenotes/notes/60618.yaml.
