### PR TITLE
fix: avoid CNI kubeconfig deadlock for sidecar node agent pod

### DIFF
--- a/cni/pkg/plugin/plugin.go
+++ b/cni/pkg/plugin/plugin.go
@@ -173,16 +173,16 @@ func CmdAdd(args *skel.CmdArgs) (err error) {
 	// by the CNI pod or it is invalid which cause the CNI pod to be unable to start if
 	// on the creation of a new K8s client. We preemptively check if the pod is a CNI pod
 	// to avoid a deadlock on the kubeconfig when the k8s client is unnecessary to process
-	// the CNI add event for the CNI pod itself.
-	if conf.AmbientEnabled {
-		k8sArgs := K8sArgs{}
-		if err := types.LoadArgs(args.Args, &k8sArgs); err != nil {
-			return fmt.Errorf("failed to load args: %v", err)
-		}
-		if isCNIPod(conf, &k8sArgs) {
-			// If we are in a degraded state and this is our own agent pod, skip
-			return pluginResponse(conf)
-		}
+	// the CNI add event for the CNI pod itself. This applies to both ambient and sidecar
+	// mode, since newK8sClient below runs unconditionally and would otherwise deadlock the
+	// CNI pod when its kubeconfig is not yet present (for example after a node reboot).
+	k8sArgs := K8sArgs{}
+	if err := types.LoadArgs(args.Args, &k8sArgs); err != nil {
+		return fmt.Errorf("failed to load args: %v", err)
+	}
+	if isCNIPod(conf, &k8sArgs) {
+		// If we are in a degraded state and this is our own agent pod, skip
+		return pluginResponse(conf)
 	}
 
 	// Create a kube client

--- a/cni/pkg/plugin/plugin.go
+++ b/cni/pkg/plugin/plugin.go
@@ -431,6 +431,6 @@ func isCNIPod(conf *Config, k8sArgs *K8sArgs) bool {
 		log.Infof("in a degraded state and %v looks like our own agent pod, skipping", k8sArgs.K8S_POD_NAME)
 		return true
 	}
-	log.Warnf("not a CNI pod, podName: %s, podNamespace: %s, conf pod namespace: %s", k8sArgs.K8S_POD_NAME, k8sArgs.K8S_POD_NAMESPACE, conf.PodNamespace)
+	log.Debugf("not a CNI pod, podName: %s, podNamespace: %s, conf pod namespace: %s", k8sArgs.K8S_POD_NAME, k8sArgs.K8S_POD_NAMESPACE, conf.PodNamespace)
 	return false
 }

--- a/cni/pkg/plugin/plugin.go
+++ b/cni/pkg/plugin/plugin.go
@@ -181,7 +181,9 @@ func CmdAdd(args *skel.CmdArgs) (err error) {
 		return fmt.Errorf("failed to load args: %v", err)
 	}
 	if isCNIPod(conf, &k8sArgs) {
-		// If we are in a degraded state and this is our own agent pod, skip
+		// This is our own agent pod, so the kube client is not needed to process the
+		// event. Skip it rather than block on a kubeconfig that may not exist yet.
+		log.Infof("%v looks like our own agent pod, skipping", k8sArgs.K8S_POD_NAME)
 		return pluginResponse(conf)
 	}
 
@@ -300,7 +302,14 @@ func doAddRun(args *skel.CmdArgs, conf *Config, kClient kubernetes.Interface, ru
 		//
 		// TODO NRI could probably give us more identifying information here OOB from k8s.
 		if isCNIPod(conf, &k8sArgs) {
+			log.Infof("in a degraded state and %v looks like our own agent pod, skipping", k8sArgs.K8S_POD_NAME)
 			return nil
+		}
+		if attempt == 1 {
+			// Only warn once: this loop retries up to podRetrievalMaxRetries times and the
+			// verdict does not change between attempts.
+			log.Warnf("in a degraded state and %s is not a CNI pod, podNamespace: %s, conf pod namespace: %s",
+				k8sArgs.K8S_POD_NAME, k8sArgs.K8S_POD_NAMESPACE, conf.PodNamespace)
 		}
 
 		time.Sleep(podRetrievalInterval)
@@ -425,12 +434,11 @@ func isAmbientPod(client kubernetes.Interface, podName, podNamespace string, sel
 	return compiledSelectors.Matches(pod.Labels, pod.Annotations, ns.Labels), nil
 }
 
+// isCNIPod reports whether the CNI args look like our own istio-cni node agent pod.
+// It deliberately does not log: it is called both on the normal path for every ADD,
+// where a false result is unremarkable, and from the degraded failsafe, where a false
+// result is worth a warning. The caller has the context to pick the right level.
 func isCNIPod(conf *Config, k8sArgs *K8sArgs) bool {
-	if strings.HasPrefix(string(k8sArgs.K8S_POD_NAME), "istio-cni-node-") &&
-		string(k8sArgs.K8S_POD_NAMESPACE) == conf.PodNamespace {
-		log.Infof("in a degraded state and %v looks like our own agent pod, skipping", k8sArgs.K8S_POD_NAME)
-		return true
-	}
-	log.Debugf("not a CNI pod, podName: %s, podNamespace: %s, conf pod namespace: %s", k8sArgs.K8S_POD_NAME, k8sArgs.K8S_POD_NAMESPACE, conf.PodNamespace)
-	return false
+	return strings.HasPrefix(string(k8sArgs.K8S_POD_NAME), "istio-cni-node-") &&
+		string(k8sArgs.K8S_POD_NAMESPACE) == conf.PodNamespace
 }

--- a/cni/pkg/plugin/plugin_test.go
+++ b/cni/pkg/plugin/plugin_test.go
@@ -422,6 +422,24 @@ func TestCmdAdd(t *testing.T) {
 	testDoAddRun(t, buildMockConf(true), testNSName, pod, ns)
 }
 
+// TestCmdAddCNIPodSkipsK8sClient verifies that the istio-cni node agent pod itself is
+// detected and skipped before a kube client is created, in both ambient and sidecar mode.
+// Otherwise the CNI pod deadlocks waiting on a kubeconfig it has not written yet (for
+// example after a node reboot). The mock kubeconfig does not exist, so reaching
+// newK8sClient would surface an error; an early return proves the deadlock is avoided.
+func TestCmdAddCNIPodSkipsK8sClient(t *testing.T) {
+	for _, ambientEnabled := range []bool{true, false} {
+		t.Run(fmt.Sprintf("ambient=%t", ambientEnabled), func(t *testing.T) {
+			// conf.PodNamespace is empty in the mock conf, so a pod in the empty namespace
+			// whose name has the istio-cni-node- prefix is treated as the CNI pod itself.
+			args := buildCmdArgs(buildMockConf(ambientEnabled), "istio-cni-node-abcde", "")
+			if err := CmdAdd(args); err != nil {
+				t.Fatalf("expected the CNI pod to be skipped without creating a kube client, got error: %v", err)
+			}
+		})
+	}
+}
+
 func TestCmdAddTwoContainersWithAnnotation(t *testing.T) {
 	pod, ns := buildFakePodAndNSForClient()
 

--- a/cni/pkg/plugin/plugin_test.go
+++ b/cni/pkg/plugin/plugin_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -435,6 +436,34 @@ func TestCmdAddCNIPodSkipsK8sClient(t *testing.T) {
 			args := buildCmdArgs(buildMockConf(ambientEnabled), "istio-cni-node-abcde", "")
 			if err := CmdAdd(args); err != nil {
 				t.Fatalf("expected the CNI pod to be skipped without creating a kube client, got error: %v", err)
+			}
+		})
+	}
+}
+
+// TestIsCNIPod covers the identity check on its own. It is called both on the normal
+// path for every ADD and from the degraded failsafe, so it must stay a pure predicate
+// and leave the logging level to the caller.
+func TestIsCNIPod(t *testing.T) {
+	conf := &Config{PodNamespace: "istio-system"}
+	cases := []struct {
+		name     string
+		podName  string
+		podNS    string
+		expected bool
+	}{
+		{"agent pod in the conf namespace", "istio-cni-node-abcde", "istio-system", true},
+		{"agent pod in another namespace", "istio-cni-node-abcde", "default", false},
+		{"workload pod in the conf namespace", "productpage-v1-abcde", "istio-system", false},
+		{"workload pod in another namespace", "productpage-v1-abcde", "default", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			k8sArgs := K8sArgs{}
+			k8sArgs.K8S_POD_NAME = types.UnmarshallableString(c.podName)
+			k8sArgs.K8S_POD_NAMESPACE = types.UnmarshallableString(c.podNS)
+			if got := isCNIPod(conf, &k8sArgs); got != c.expected {
+				t.Fatalf("isCNIPod = %t, want %t", got, c.expected)
 			}
 		})
 	}

--- a/releasenotes/notes/60668.yaml
+++ b/releasenotes/notes/60668.yaml
@@ -1,0 +1,12 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 60668
+releaseNotes:
+- |
+  **Fixed** a deadlock where the istio-cni node agent pod could fail to start (for
+  example after a node reboot) because the CNI plugin only skipped the kube client
+  creation for its own agent pod when ambient mode was enabled. The preemptive
+  check now runs in sidecar mode as well, so the agent pod no longer blocks on a
+  kubeconfig it has not written yet.


### PR DESCRIPTION
Fixes #60668

## What this does

The CNI plugin preemptively checks whether the pod being processed is the istio-cni node agent pod itself and returns early, to avoid creating a kube client that would block on a kubeconfig the agent has not written yet. That check was gated behind ambient mode (conf.AmbientEnabled), but newK8sClient runs unconditionally for both ambient and sidecar mode.

As a result, in sidecar mode the istio-cni node agent pod could deadlock on its own kubeconfig. This shows up after a node reboot, where all pods fail CmdAdd with the kubeconfig missing because the agent pod that is supposed to write it is itself stuck waiting on it.

This change runs the preemptive CNI pod check in both ambient and sidecar mode.

## Tests

Added TestCmdAddCNIPodSkipsK8sClient, which calls CmdAdd for a pod named like the node agent (istio-cni-node-) in both ambient and sidecar mode and asserts it returns without error (the mock kubeconfig does not exist, so reaching newK8sClient would error). Verified the sidecar-mode case fails without the fix and passes with it.

## Release notes

Added releasenotes/notes/60668.yaml.
