### PR TITLE
fix: skip CIDR ServiceEntry listener on reserved proxy ports

### DIFF
--- a/pilot/pkg/networking/core/listener.go
+++ b/pilot/pkg/networking/core/listener.go
@@ -864,6 +864,23 @@ func (lb *ListenerBuilder) buildSidecarOutboundListener(listenerOpts outboundLis
 					// filter chain match
 					listenerOpts.bind.binds = actualWildcards
 					listenerOpts.cidr = append([]string{svcListenAddress}, svcExtraListenAddresses...)
+					// Now that we are binding to the wildcard address, this listener can
+					// collide with a reserved listener (for example the virtualOutbound
+					// listener on the proxy outbound port). Unlike a service with a concrete
+					// VIP, the conflict cannot be detected earlier from the service address,
+					// so re-check here and skip the port if it conflicts.
+					wildcard := actualWildcards[0]
+					if canbind, knownlistener := lb.node.CanBindToPort(listenerOpts.bind.bindToPort, listenerOpts.proxy,
+						listenerOpts.push, wildcard, listenerOpts.port.Port, listenerOpts.port.Protocol, wildcard); !canbind {
+						if knownlistener {
+							log.Warnf("buildSidecarOutboundListener: skipping CIDR service port %d for node %s as it conflicts with reserved listener",
+								listenerOpts.port.Port, lb.node.ID)
+						} else {
+							log.Warnf("buildSidecarOutboundListener: skipping privileged CIDR service port %d for node %s as it is an unprivileged proxy",
+								listenerOpts.port.Port, lb.node.ID)
+						}
+						return
+					}
 				}
 			}
 		}

--- a/pilot/pkg/networking/core/listener.go
+++ b/pilot/pkg/networking/core/listener.go
@@ -870,15 +870,10 @@ func (lb *ListenerBuilder) buildSidecarOutboundListener(listenerOpts outboundLis
 					// VIP, the conflict cannot be detected earlier from the service address,
 					// so re-check here and skip the port if it conflicts.
 					wildcard := actualWildcards[0]
-					if canbind, knownlistener := lb.node.CanBindToPort(listenerOpts.bind.bindToPort, listenerOpts.proxy,
+					if canbind, _ := lb.node.CanBindToPort(listenerOpts.bind.bindToPort, listenerOpts.proxy,
 						listenerOpts.push, wildcard, listenerOpts.port.Port, listenerOpts.port.Protocol, wildcard); !canbind {
-						if knownlistener {
-							log.Warnf("buildSidecarOutboundListener: skipping CIDR service port %d for node %s as it conflicts with reserved listener",
-								listenerOpts.port.Port, lb.node.ID)
-						} else {
-							log.Warnf("buildSidecarOutboundListener: skipping privileged CIDR service port %d for node %s as it is an unprivileged proxy",
-								listenerOpts.port.Port, lb.node.ID)
-						}
+						log.Warnf("buildSidecarOutboundListener: skipping CIDR service port %d for node %s as it conflicts with reserved listener",
+							listenerOpts.port.Port, lb.node.ID)
 						return
 					}
 				}

--- a/pilot/pkg/networking/core/listener_test.go
+++ b/pilot/pkg/networking/core/listener_test.go
@@ -672,6 +672,53 @@ func TestOutboundListenerConflictWithReservedListener(t *testing.T) {
 	}
 }
 
+// TestOutboundListenerCIDRServiceEntryReservedPort verifies that a ServiceEntry whose
+// address is a CIDR (so the outbound listener falls back to the 0.0.0.0 wildcard) does
+// not generate a listener on a reserved proxy port. Such a listener binds to
+// 0.0.0.0:15001 and collides with the virtualOutbound listener, which rejects the whole
+// LDS update and breaks the sidecar. A service on a non-reserved port must still get its
+// wildcard listener.
+func TestOutboundListenerCIDRServiceEntryReservedPort(t *testing.T) {
+	buildCIDRServiceEntry := func(hostname string, port int) *model.Service {
+		return &model.Service{
+			CreationTime:   tnow,
+			Hostname:       host.Name(hostname),
+			DefaultAddress: "10.80.68.0/29",
+			Ports: model.PortList{
+				&model.Port{Name: "tls", Port: port, Protocol: protocol.TLS},
+			},
+			Resolution: model.Passthrough,
+			Attributes: model.ServiceAttributes{
+				Namespace:       "default",
+				ServiceRegistry: provider.External,
+			},
+		}
+	}
+
+	cases := []struct {
+		name         string
+		port         int
+		expectListen bool
+	}{
+		{"cidr service on reserved outbound port is skipped", 15001, false},
+		{"cidr service on reserved inbound port is skipped", 15006, false},
+		{"cidr service on a normal port still listens", 15010, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := buildCIDRServiceEntry("redis.example.com", tc.port)
+			listeners := buildOutboundListeners(t, getProxy(), nil, nil, svc)
+			l := findListenerByPort(listeners, uint32(tc.port))
+			if tc.expectListen && l == nil {
+				t.Fatalf("expected a listener on port %d, found none", tc.port)
+			}
+			if !tc.expectListen && l != nil {
+				t.Fatalf("expected no listener on reserved port %d, but found %s", tc.port, l.Name)
+			}
+		})
+	}
+}
+
 func TestOutboundListenerDualStackWildcard(t *testing.T) {
 	test.SetForTest(t, &features.EnableDualStack, true)
 	service := buildService("test1.com", "0.0.0.0", protocol.TCP, tnow.Add(1*time.Second))

--- a/releasenotes/notes/60666.yaml
+++ b/releasenotes/notes/60666.yaml
@@ -1,0 +1,13 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 60666
+releaseNotes:
+- |
+  **Fixed** a bug where a ServiceEntry whose address is a CIDR generated an outbound
+  listener on the 0.0.0.0 wildcard for a reserved proxy port (for example the
+  outbound capture port 15001). The wildcard listener collided with the
+  virtualOutbound listener, the whole listener update was rejected, and the sidecar
+  failed to start. Such ports are now skipped, matching the behavior for services
+  with a concrete address.


### PR DESCRIPTION
Fixes #60666

## What this does

When a ServiceEntry address is a CIDR, the outbound listener cannot bind to a service VIP and falls back to the 0.0.0.0 wildcard with a filter chain match for the CIDR. For a service with a concrete address, a conflict with a reserved proxy port is detected up front and the port is skipped. For a CIDR the conflict cannot be detected from the service address, so a ServiceEntry whose port equals a reserved proxy port (for example the outbound capture port 15001) generated a 0.0.0.0:15001 listener that collided with the virtualOutbound listener. Envoy rejected the listener update (has duplicate address 0.0.0.0:15001 as existing listener) and the sidecar failed to start, while the same addresses written as explicit single-host entries worked.

This change re-checks the reserved-port conflict once the listener falls back to the wildcard address, and skips the port if it conflicts, matching the existing behavior for services with a concrete address.

## Tests

Added TestOutboundListenerCIDRServiceEntryReservedPort: a CIDR ServiceEntry on reserved ports 15001 and 15006 generates no listener, while a CIDR ServiceEntry on a normal port still gets its wildcard listener. Verified the reserved-port cases fail without the fix (a 0.0.0.0 listener is produced) and pass with it.

## Release notes

Added releasenotes/notes/60666.yaml.
