### PR TITLE
optimize: remove private from service index

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -64,8 +64,7 @@ var _ Metrics = &PushContext{}
 
 // serviceIndex is an index of all services by various fields for easy access during push.
 type serviceIndex struct {
-	// private are services that are reachable within the same namespace, with exportTo "."
-	private []*Service
+	count int
 	// public are services reachable within the mesh with exportTo "*"
 	public []*Service
 	// exportedToNamespace are services that were made visible to this namespace
@@ -83,8 +82,8 @@ type serviceIndex struct {
 
 func newServiceIndex() serviceIndex {
 	return serviceIndex{
+		count:                0,
 		public:               []*Service{},
-		private:              []*Service{},
 		exportedToNamespace:  map[string][]*Service{},
 		HostnameAndNamespace: map[host.Name]map[string]*Service{},
 		instancesByPort:      map[string]map[int][]*IstioEndpoint{},
@@ -1017,19 +1016,13 @@ func (ps *PushContext) extraServicesForProxy(proxy *Proxy, patches *MergedEnvoyF
 }
 
 // servicesExportedToNamespace returns the list of services that are visible to a namespace.
-// namespace "" indicates all namespaces
 func (ps *PushContext) servicesExportedToNamespace(ns string) []*Service {
 	var out []*Service
 
 	// First add private services and explicitly exportedTo services
-	if ns == NamespaceAll {
-		out = make([]*Service, 0, len(ps.ServiceIndex.private)+len(ps.ServiceIndex.public))
-		out = append(out, ps.ServiceIndex.private...)
-	} else {
-		exportedServices := ps.ServiceIndex.exportedToNamespace[ns]
-		out = make([]*Service, 0, len(exportedServices)+len(ps.ServiceIndex.public))
-		out = append(out, exportedServices...)
-	}
+	exportedServices := ps.ServiceIndex.exportedToNamespace[ns]
+	out = make([]*Service, 0, len(exportedServices)+len(ps.ServiceIndex.public))
+	out = append(out, exportedServices...)
 
 	// Second add public services
 	out = append(out, ps.ServiceIndex.public...)
@@ -1037,10 +1030,10 @@ func (ps *PushContext) servicesExportedToNamespace(ns string) []*Service {
 	return out
 }
 
-// GetAllServices returns the total services within the mesh.
+// GetTotalServiceCount returns the total services within the mesh.
 // Note: per proxy services should use SidecarScope.Services.
-func (ps *PushContext) GetAllServices() []*Service {
-	return ps.servicesExportedToNamespace(NamespaceAll)
+func (ps *PushContext) GetTotalServiceCount() int {
+	return ps.ServiceIndex.count
 }
 
 // ServiceForHostname returns the service associated with a given hostname following SidecarScope
@@ -1507,6 +1500,8 @@ func (ps *PushContext) initServiceRegistry(env *Environment, configsUpdate sets.
 	allServices := SortServicesByCreationTime(env.Services())
 	resolveServiceAliases(allServices, configsUpdate)
 
+	ps.ServiceIndex.count = len(allServices)
+
 	ps.ServiceIndex.instancesByPort = make(map[string]map[int][]*IstioEndpoint, len(allServices))
 	ps.serviceAccounts = make(map[serviceAccountKey][]string, len(allServices))
 	for _, s := range allServices {
@@ -1559,7 +1554,6 @@ func (ps *PushContext) initServiceRegistry(env *Environment, configsUpdate sets.
 		ns := s.Attributes.Namespace
 		if s.Attributes.ExportTo.IsEmpty() {
 			if ps.exportToDefaults.service.Contains(visibility.Private) {
-				ps.ServiceIndex.private = append(ps.ServiceIndex.private, s)
 				exportedServices, ok := ps.ServiceIndex.exportedToNamespace[ns]
 				if !ok {
 					exportedServices = make([]*Service, 0)
@@ -1581,10 +1575,9 @@ func (ps *PushContext) initServiceRegistry(env *Environment, configsUpdate sets.
 			// . or other namespaces
 			for exportTo := range s.Attributes.ExportTo {
 				key := string(exportTo)
-				if exportTo == visibility.Private || key == ns {
+				if exportTo == visibility.Private {
 					// exportTo with same namespace is effectively private
 					key = ns
-					ps.ServiceIndex.private = append(ps.ServiceIndex.private, s)
 				}
 
 				// exportTo is a specific target namespace

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1570,7 +1570,7 @@ func (ps *PushContext) initServiceRegistry(env *Environment, configsUpdate sets.
 				ps.ServiceIndex.public = append(ps.ServiceIndex.public, s)
 				continue
 			} else if s.Attributes.ExportTo.Contains(visibility.None) {
-				ps.ServiceIndex.count -= 1
+				ps.ServiceIndex.count--
 				continue
 			}
 			// . or other namespaces

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1570,6 +1570,7 @@ func (ps *PushContext) initServiceRegistry(env *Environment, configsUpdate sets.
 				ps.ServiceIndex.public = append(ps.ServiceIndex.public, s)
 				continue
 			} else if s.Attributes.ExportTo.Contains(visibility.None) {
+				ps.ServiceIndex.count -= 1
 				continue
 			}
 			// . or other namespaces

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -1551,9 +1551,6 @@ func TestServiceIndex(t *testing.T) {
 
 	g.Expect(serviceNames(si.public)).To(Equal([]string{"svc-public", "svc-unset"}))
 
-	// Should just have "test1"
-	g.Expect(si.private).To(HaveLen(1))
-	g.Expect(serviceNames(si.private)).To(Equal([]string{"svc-private"}))
 }
 
 func TestIsServiceVisible(t *testing.T) {

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -1550,7 +1550,6 @@ func TestServiceIndex(t *testing.T) {
 	g.Expect(serviceNames(si.exportedToNamespace["test1"])).To(Equal([]string{"svc-private"}))
 
 	g.Expect(serviceNames(si.public)).To(Equal([]string{"svc-public", "svc-unset"}))
-
 }
 
 func TestIsServiceVisible(t *testing.T) {

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -3002,7 +3002,6 @@ func TestSelectServicesExactParity(t *testing.T) {
 				key := string(exportTo)
 				if exportTo == visibility.Private {
 					key = s.Attributes.Namespace
-					ps.ServiceIndex.private = append(ps.ServiceIndex.private, s)
 				}
 				ps.ServiceIndex.exportedToNamespace[key] = append(ps.ServiceIndex.exportedToNamespace[key], s)
 			}

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -564,7 +564,7 @@ func AdsPushAll(s *DiscoveryServer) {
 
 // AdsPushAll will send updates to all nodes.
 func (s *DiscoveryServer) AdsPushAll(req *model.PushRequest) {
-	totalService := len(req.Push.GetAllServices())
+	totalService := req.Push.GetTotalServiceCount()
 	log.Infof("XDS: Pushing Services:%d ConnectedEndpoints:%d Version:%s",
 		totalService, s.adsClientCount(), req.Push.PushVersion)
 	monServices.Record(float64(totalService))


### PR DESCRIPTION
**Please provide a description of this PR:**
`serviceIndex.private` was only ever used to count the amount of services, which was done as `public+private` which doesn't really make sense.
I added a `serviceIndex.count` that holds the total amount of services in PushContext minus services that have `visibility.None`.