### PR TITLE
Fix runtime error index out of range when merging http routes

### DIFF
--- a/pilot/pkg/config/kube/gateway/route_collections.go
+++ b/pilot/pkg/config/kube/gateway/route_collections.go
@@ -809,6 +809,9 @@ func mergeHTTPRoutes(baseVirtualServices krt.Collection[RouteWithKey], opts ...k
 	}).AsCollection(opts...)
 	finalVirtualServices := krt.NewCollection(idx, func(ctx krt.HandlerContext, object krt.IndexObject[string, RouteWithKey]) *config.Config {
 		configs := object.Objects
+		if len(configs) == 0 {
+			return nil
+		}
 		if len(configs) == 1 {
 			base := configs[0].Config
 			nm := base.Meta.DeepCopy()


### PR DESCRIPTION
**Please provide a description of this PR:**

I was reading through issue
[60462](https://github.com/istio/istio/issues/60462), we get an index out of range exception.

I think that the issue above is a race condition that I wasn't able to replicate. 
However, while investigating I saw that we're not checking for when len(configs) is empty. 
Which, if we were to call configs[0].DeepCopy when configs is empty, we'd get the error.

I don't know the codebase well enough to know if nil is the right value to return here either.

The error in the linked issue:

> panic: runtime error: index out of range [0] with length 0