### PR TITLE
agent: exclude Envoy internal listeners from EXIT_ON_ZERO_ACTIVE_CONNECTIONS drain check

### DIFF
--- a/pkg/envoy/agent.go
+++ b/pkg/envoy/agent.go
@@ -259,6 +259,15 @@ func (a *Agent) activeProxyConnections() (int, error) {
 		if !strings.HasPrefix(parts[0], "listener.") || strings.Contains(parts[0], "worker_") {
 			continue
 		}
+		// Skip Envoy internal listeners (envoy.bootstrap.internal_listener). These are
+		// in-process plumbing — e.g. ambient HBONE connect_originate / connect_terminate /
+		// main_internal — with no client-facing semantics. Their downstream_cx_active counts
+		// pipe connections from other filter chains and stays positive as long as the
+		// upstream HBONE pool holds any tunnel open, which would otherwise prevent
+		// EXIT_ON_ZERO_ACTIVE_CONNECTIONS from ever firing on ambient gateways and waypoints.
+		if strings.HasPrefix(parts[0], "listener.envoy_internal_") {
+			continue
+		}
 		// If the stat is for a known Istio listener skip it.
 		if a.knownIstioListeners.Contains(parts[0]) {
 			continue

--- a/pkg/envoy/agent_test.go
+++ b/pkg/envoy/agent_test.go
@@ -38,7 +38,15 @@ var downstreamCxPositiveAcStats = "http.admin.downstream_cx_active: 2 \n" +
 	"listener.10.112.43.239_9043.downstream_cx_active: 2 \n" +
 	"listener.10.112.49.68_9043.downstream_cx_active: 1 \n" +
 	"listener.admin.downstream_cx_active: 2 \n" +
-	"listener.admin.main_thread.downstream_cx_active: 2"
+	"listener.admin.main_thread.downstream_cx_active: 2 \n" +
+	// Ambient HBONE internal listeners — must be excluded from the active count;
+	// otherwise EXIT_ON_ZERO_ACTIVE_CONNECTIONS can never fire on ambient gateways
+	// and waypoints. See activeProxyConnections in agent.go.
+	"listener.envoy_internal_connect_originate.downstream_cx_active: 2 \n" +
+	"listener.envoy_internal_connect_originate.worker_0.downstream_cx_active: 2 \n" +
+	"listener.envoy_internal_main_internal.downstream_cx_active: 3 \n" +
+	"listener.envoy_internal_inner_connect_originate.downstream_cx_active: 1 \n" +
+	"listener.envoy_internal_outer_connect_originate.downstream_cx_active: 1"
 
 var downstreamCxZeroAcStats = "http.admin.downstream_cx_active: 2 \n" +
 	"http.agent.downstream_cx_active: 0 \n" +
@@ -54,7 +62,22 @@ var downstreamCxZeroAcStats = "http.admin.downstream_cx_active: 2 \n" +
 	"listener.10.112.43.239_9043.downstream_cx_active: 0 \n" +
 	"listener.10.112.49.68_9043.downstream_cx_active: 0\n" +
 	"listener.admin.downstream_cx_active: 2 \n" +
-	"listener.admin.main_thread.downstream_cx_active: 2"
+	"listener.admin.main_thread.downstream_cx_active: 2 \n" +
+	// Real user-facing listeners are all 0, but internal HBONE listeners still hold
+	// in-process pipe connections. The drain loop must treat this as zero.
+	"listener.envoy_internal_connect_originate.downstream_cx_active: 5 \n" +
+	"listener.envoy_internal_main_internal.downstream_cx_active: 3"
+
+// Only excluded listeners (status/prom/admin) and ambient internal listeners are
+// present, all with non-zero counts. Models a quiesced ambient ingress gateway /
+// waypoint where the only remaining connections are internal plumbing.
+var downstreamCxAmbientOnlyStats = "listener.0.0.0.0_15021.downstream_cx_active: 1 \n" +
+	"listener.0.0.0.0_15009.downstream_cx_active: 1 \n" +
+	"listener.admin.downstream_cx_active: 1 \n" +
+	"listener.admin.main_thread.downstream_cx_active: 1 \n" +
+	"listener.envoy_internal_connect_originate.downstream_cx_active: 2 \n" +
+	"listener.envoy_internal_connect_terminate.downstream_cx_active: 4 \n" +
+	"listener.envoy_internal_main_internal.downstream_cx_active: 3"
 
 // TestProxy sample struct for proxy
 type TestProxy struct {
@@ -130,6 +153,16 @@ func TestActiveConnections(t *testing.T) {
 		{
 			"zero active connections",
 			downstreamCxZeroAcStats,
+			0,
+		},
+		{
+			// Regression test for ambient ingress gateways / waypoints: the only
+			// non-excluded listener stats reporting a positive value are Envoy
+			// internal listeners (envoy_internal_*) used for HBONE plumbing. The
+			// drain loop must ignore them so EXIT_ON_ZERO_ACTIVE_CONNECTIONS can
+			// fire instead of waiting until terminationGracePeriodSeconds.
+			"ambient internal listeners excluded",
+			downstreamCxAmbientOnlyStats,
 			0,
 		},
 	}

--- a/releasenotes/notes/60731.yaml
+++ b/releasenotes/notes/60731.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 60728
+releaseNotes:
+  - |
+    **Fixed** an issue where `EXIT_ON_ZERO_ACTIVE_CONNECTIONS` never fired on ambient ingress gateways and waypoints because pilot-agent's drain loop counted in-process connections on Envoy's HBONE internal listeners (`connect_originate`, `connect_terminate`, `main_internal`, etc.), preventing the active-connection count from reaching zero and forcing the proxy to wait until `terminationGracePeriodSeconds`.


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes #60728.

## Problem

`EXIT_ON_ZERO_ACTIVE_CONNECTIONS=true` never fires on ambient ingress gateways
and waypoints because pilot-agent's drain loop counts `downstream_cx_active` on
Envoy's internal listeners (`envoy.bootstrap.internal_listener`) used by HBONE
plumbing — `connect_originate`, `connect_terminate`, `main_internal`, and the
double-HBONE `inner_/outer_connect_originate` variants.

These listeners have no client-facing semantics: their `downstream_cx_active`
counts in-process pipe connections from other filter chains, and stays
positive for as long as the upstream HBONE pool holds any tunnel open. The
existing exclusion list (`knownIstioListeners`) only covers status/prometheus/
admin, so the active-connection count never reaches 0 and the proxy always runs
until `terminationGracePeriodSeconds` SIGKILLs it.

See #60728 for the full reproduction, including a real `?usedonly&filter=downstream_cx_active$`
dump from a terminating ambient ingress gateway showing
`listener.envoy_internal_connect_originate.downstream_cx_active: 2` as the only
non-excluded positive counter.

## Fix

Skip any stat whose listener name has the `envoy_internal_` prefix in
`activeProxyConnections`. Envoy auto-prefixes internal-listener stat names with
`envoy_internal_`, so this single check covers all current and future internal
listeners without coupling `pkg/envoy` to the listener-name constants in
`pilot/pkg/networking/core`.

## Correctness on waypoints

The fix is correct for waypoints as well as ingress gateways. The waypoint's
inbound HBONE termination listener (`connect_terminate`) is a socket-bound
listener on `0.0.0.0:15008` (see `buildConnectTerminateListener` in
`pilot/pkg/networking/core/listener_waypoint.go`, no `Listener_InternalListener`
specifier), so its stat key is `listener.connect_terminate.downstream_cx_active`
and remains counted by the drain loop. Only the in-process plumbing
(`main_internal`, `connect_originate`, `inner_/outer_connect_originate`) is
excluded by the prefix rule. Drain still waits for real peer-ztunnel HBONE
connections to GOAWAY and close.

## Tests

- Augmented `downstreamCxPositiveAcStats` and `downstreamCxZeroAcStats`
  fixtures with `envoy_internal_*` lines (including a `worker_*` variant);
  expected totals are unchanged (19 / 0), proving real listener traffic still
  counts and internal-listener counts are filtered out.
- Added `TestActiveConnections/ambient_internal_listeners_excluded` with a
  fixture containing only excluded socket listeners and ambient internal
  listeners with non-zero counts; expected 0. Without this fix it would return
  9, locking in the regression.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.