### PR TITLE
accesslog: fix synthetic envoy:// addresses in HBONE internal listener logs

### DIFF
--- a/pilot/pkg/model/telemetry_logging.go
+++ b/pilot/pkg/model/telemetry_logging.go
@@ -50,6 +50,11 @@ const (
 		"%UPSTREAM_CLUSTER_RAW% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% " +
 		"%DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME% %ROUTE_NAME%\n"
 
+	// hboneOriginalDstFilterStateKey is the filter state key populated by the original_dst
+	// listener filter and the ConnectAuthorityFilter on HBONE paths. It holds the real tunneled
+	// destination address (e.g. "10.244.0.10:80") rather than a synthetic envoy:// URI.
+	hboneOriginalDstFilterStateKey = "envoy.filters.listener.original_dst.local_ip"
+
 	HTTPEnvoyAccessLogFriendlyName = "http_envoy_accesslog"
 	TCPEnvoyAccessLogFriendlyName  = "tcp_envoy_accesslog"
 	OtelEnvoyAccessLogFriendlyName = "otel_envoy_accesslog"
@@ -119,6 +124,52 @@ var (
 		Name:        "envoy.formatter.req_without_query",
 		TypedConfig: protoconv.MessageToAny(&reqwithoutquery.ReqWithoutQuery{}),
 	}
+
+	// hboneFilterStateOperator is the Envoy access log operator that reads the real tunneled
+	// destination address from filter state, hiding the internal envoy:// URI scheme.
+	hboneFilterStateOperator = "%FILTER_STATE(" + hboneOriginalDstFilterStateKey + ":PLAIN)%"
+
+	// hboneOriginationTextLogFormat is derived from EnvoyTextLogFormat with the synthetic
+	// %DOWNSTREAM_REMOTE_ADDRESS% replaced. On the connect_originate internal listener the
+	// downstream address is always "envoy://internal_client_address/"; the filter state key
+	// holds the real tunneled destination set by the OriginalDestination listener filter.
+	hboneOriginationTextLogFormat = strings.NewReplacer(
+		"%DOWNSTREAM_REMOTE_ADDRESS%", hboneFilterStateOperator,
+	).Replace(EnvoyTextLogFormat)
+
+	// hboneTerminationTextLogFormat is derived from EnvoyTextLogFormat with %UPSTREAM_HOST%
+	// replaced. On the CONNECT-terminate HCM the upstream is the main_internal internal listener
+	// ("envoy://main_internal/<addr>"); the filter state key holds the real app destination set
+	// by the ConnectAuthorityFilter from the CONNECT :authority header.
+	hboneTerminationTextLogFormat = strings.NewReplacer(
+		"%UPSTREAM_HOST%", hboneFilterStateOperator,
+	).Replace(EnvoyTextLogFormat)
+
+	// hboneOriginationJSONLogFormatIstio is EnvoyJSONLogFormatIstio with the
+	// downstream_remote_address field replaced for HBONE origination paths.
+	hboneOriginationJSONLogFormatIstio = func() *structpb.Struct {
+		fields := make(map[string]*structpb.Value, len(EnvoyJSONLogFormatIstio.Fields))
+		for k, v := range EnvoyJSONLogFormatIstio.Fields {
+			fields[k] = v
+		}
+		fields["downstream_remote_address"] = &structpb.Value{
+			Kind: &structpb.Value_StringValue{StringValue: hboneFilterStateOperator},
+		}
+		return &structpb.Struct{Fields: fields}
+	}()
+
+	// hboneTerminationJSONLogFormatIstio is EnvoyJSONLogFormatIstio with the upstream_host
+	// field replaced for HBONE termination paths.
+	hboneTerminationJSONLogFormatIstio = func() *structpb.Struct {
+		fields := make(map[string]*structpb.Value, len(EnvoyJSONLogFormatIstio.Fields))
+		for k, v := range EnvoyJSONLogFormatIstio.Fields {
+			fields[k] = v
+		}
+		fields["upstream_host"] = &structpb.Value{
+			Kind: &structpb.Value_StringValue{StringValue: hboneFilterStateOperator},
+		}
+		return &structpb.Struct{Fields: fields}
+	}()
 )
 
 // configureFromProviderConfigHandled contains the number of providers we handle below.
@@ -370,14 +421,40 @@ func fileAccessLogFormat(formatString string) string {
 }
 
 func FileAccessLogFromMeshConfig(path string, mesh *meshconfig.MeshConfig) *accesslog.AccessLog {
-	// We need to build access log. This is needed either on first access or when mesh config changes.
+	return fileAccessLogWithDefaults(path, mesh, EnvoyTextLogFormat, EnvoyJSONLogFormatIstio)
+}
+
+// FileAccessLogFromMeshConfigForHboneOrigination creates an access log for the HBONE
+// origination path (connect_originate internal listener). It substitutes the synthetic
+// %DOWNSTREAM_REMOTE_ADDRESS% — which is "envoy://internal_client_address/" on internal
+// listeners — with the real tunneled destination from filter state. If the user has
+// configured a custom access log format it is used unchanged.
+func FileAccessLogFromMeshConfigForHboneOrigination(path string, mesh *meshconfig.MeshConfig) *accesslog.AccessLog {
+	return fileAccessLogWithDefaults(path, mesh, hboneOriginationTextLogFormat, hboneOriginationJSONLogFormatIstio)
+}
+
+// FileAccessLogFromMeshConfigForHboneTermination creates an access log for the HBONE
+// termination path (CONNECT-terminate HCM). It substitutes the synthetic %UPSTREAM_HOST%
+// — which is "envoy://main_internal/<addr>" when routing to the main_internal internal
+// listener — with the real app destination from filter state. If the user has configured
+// a custom access log format it is used unchanged.
+func FileAccessLogFromMeshConfigForHboneTermination(path string, mesh *meshconfig.MeshConfig) *accesslog.AccessLog {
+	return fileAccessLogWithDefaults(path, mesh, hboneTerminationTextLogFormat, hboneTerminationJSONLogFormatIstio)
+}
+
+// fileAccessLogWithDefaults builds a file access log using defaultText / defaultJSON as
+// the fallback format when the user has not set mesh.AccessLogFormat.
+func fileAccessLogWithDefaults(path string, mesh *meshconfig.MeshConfig, defaultText string, defaultJSON *structpb.Struct) *accesslog.AccessLog {
 	fl := &fileaccesslog.FileAccessLog{
 		Path: path,
 	}
 	var formatters []*core.TypedExtensionConfig
 	switch mesh.AccessLogEncoding {
 	case meshconfig.MeshConfig_TEXT:
-		formatString := fileAccessLogFormat(mesh.AccessLogFormat)
+		formatString := defaultText
+		if mesh.AccessLogFormat != "" {
+			formatString = fileAccessLogFormat(mesh.AccessLogFormat)
+		}
 		formatters = accessLogTextFormatters(formatString)
 		fl.AccessLogFormat = &fileaccesslog.FileAccessLog_LogFormat{
 			LogFormat: &core.SubstitutionFormatString{
@@ -391,7 +468,7 @@ func FileAccessLogFromMeshConfig(path string, mesh *meshconfig.MeshConfig) *acce
 			},
 		}
 	case meshconfig.MeshConfig_JSON:
-		jsonLogStruct := EnvoyJSONLogFormatIstio
+		jsonLogStruct := defaultJSON
 		if len(mesh.AccessLogFormat) > 0 {
 			parsedJSONLogStruct := structpb.Struct{}
 			if err := protomarshal.UnmarshalAllowUnknown([]byte(mesh.AccessLogFormat), &parsedJSONLogStruct); err != nil {
@@ -416,12 +493,10 @@ func FileAccessLogFromMeshConfig(path string, mesh *meshconfig.MeshConfig) *acce
 	if len(formatters) > 0 {
 		fl.GetLogFormat().Formatters = formatters
 	}
-	al := &accesslog.AccessLog{
+	return &accesslog.AccessLog{
 		Name:       wellknown.FileAccessLog,
 		ConfigType: &accesslog.AccessLog_TypedConfig{TypedConfig: protoconv.MessageToAny(fl)},
 	}
-
-	return al
 }
 
 func openTelemetryLog(pushCtx *PushContext,

--- a/pilot/pkg/model/telemetry_logging_test.go
+++ b/pilot/pkg/model/telemetry_logging_test.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	accesslog "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
@@ -70,6 +71,120 @@ func TestFileAccessLogFormat(t *testing.T) {
 			assert.Equal(t, tc.expected, got)
 		})
 	}
+}
+
+func getTextFormat(al *accesslog.AccessLog) string {
+	fl := &fileaccesslog.FileAccessLog{}
+	if err := al.GetTypedConfig().UnmarshalTo(fl); err != nil {
+		return ""
+	}
+	return fl.GetLogFormat().GetTextFormatSource().GetInlineString()
+}
+
+func getJSONField(al *accesslog.AccessLog, field string) string {
+	fl := &fileaccesslog.FileAccessLog{}
+	if err := al.GetTypedConfig().UnmarshalTo(fl); err != nil {
+		return ""
+	}
+	return fl.GetLogFormat().GetJsonFormat().GetFields()[field].GetStringValue()
+}
+
+func TestHboneOriginationAccessLogFormat(t *testing.T) {
+	filterStateOp := "%FILTER_STATE(" + hboneOriginalDstFilterStateKey + ":PLAIN)%"
+
+	t.Run("default text format hides internal downstream address", func(t *testing.T) {
+		mesh := &meshconfig.MeshConfig{
+			AccessLogFile:     DevStdout,
+			AccessLogEncoding: meshconfig.MeshConfig_TEXT,
+		}
+		al := FileAccessLogFromMeshConfigForHboneOrigination(DevStdout, mesh)
+		got := getTextFormat(al)
+		if strings.Contains(got, "%DOWNSTREAM_REMOTE_ADDRESS%") {
+			t.Errorf("HBONE origination format must not contain %%DOWNSTREAM_REMOTE_ADDRESS%%, got: %s", got)
+		}
+		if !strings.Contains(got, filterStateOp) {
+			t.Errorf("HBONE origination format must contain %s, got: %s", filterStateOp, got)
+		}
+	})
+
+	t.Run("default json format hides internal downstream address", func(t *testing.T) {
+		mesh := &meshconfig.MeshConfig{
+			AccessLogFile:     DevStdout,
+			AccessLogEncoding: meshconfig.MeshConfig_JSON,
+		}
+		al := FileAccessLogFromMeshConfigForHboneOrigination(DevStdout, mesh)
+		got := getJSONField(al, "downstream_remote_address")
+		if got != filterStateOp {
+			t.Errorf("downstream_remote_address want %s, got %s", filterStateOp, got)
+		}
+		// upstream_host should remain the standard operator (real ztunnel address)
+		if upstreamHost := getJSONField(al, "upstream_host"); upstreamHost != "%UPSTREAM_HOST%" {
+			t.Errorf("upstream_host should be unchanged, want %%UPSTREAM_HOST%%, got %s", upstreamHost)
+		}
+	})
+
+	t.Run("custom text format is passed through unchanged", func(t *testing.T) {
+		customFmt := "[%START_TIME%] %UPSTREAM_HOST% %DOWNSTREAM_REMOTE_ADDRESS%\n"
+		mesh := &meshconfig.MeshConfig{
+			AccessLogFile:     DevStdout,
+			AccessLogEncoding: meshconfig.MeshConfig_TEXT,
+			AccessLogFormat:   customFmt,
+		}
+		al := FileAccessLogFromMeshConfigForHboneOrigination(DevStdout, mesh)
+		got := getTextFormat(al)
+		if got != customFmt {
+			t.Errorf("custom format should be used unchanged, want %q, got %q", customFmt, got)
+		}
+	})
+}
+
+func TestHboneTerminationAccessLogFormat(t *testing.T) {
+	filterStateOp := "%FILTER_STATE(" + hboneOriginalDstFilterStateKey + ":PLAIN)%"
+
+	t.Run("default text format hides internal upstream host", func(t *testing.T) {
+		mesh := &meshconfig.MeshConfig{
+			AccessLogFile:     DevStdout,
+			AccessLogEncoding: meshconfig.MeshConfig_TEXT,
+		}
+		al := FileAccessLogFromMeshConfigForHboneTermination(DevStdout, mesh)
+		got := getTextFormat(al)
+		if strings.Contains(got, "%UPSTREAM_HOST%") {
+			t.Errorf("HBONE termination format must not contain %%UPSTREAM_HOST%%, got: %s", got)
+		}
+		if !strings.Contains(got, filterStateOp) {
+			t.Errorf("HBONE termination format must contain %s, got: %s", filterStateOp, got)
+		}
+	})
+
+	t.Run("default json format hides internal upstream host", func(t *testing.T) {
+		mesh := &meshconfig.MeshConfig{
+			AccessLogFile:     DevStdout,
+			AccessLogEncoding: meshconfig.MeshConfig_JSON,
+		}
+		al := FileAccessLogFromMeshConfigForHboneTermination(DevStdout, mesh)
+		got := getJSONField(al, "upstream_host")
+		if got != filterStateOp {
+			t.Errorf("upstream_host want %s, got %s", filterStateOp, got)
+		}
+		// downstream_remote_address should remain the standard operator (real ztunnel IP)
+		if downstreamRemote := getJSONField(al, "downstream_remote_address"); downstreamRemote != "%DOWNSTREAM_REMOTE_ADDRESS%" {
+			t.Errorf("downstream_remote_address should be unchanged, want %%DOWNSTREAM_REMOTE_ADDRESS%%, got %s", downstreamRemote)
+		}
+	})
+
+	t.Run("custom text format is passed through unchanged", func(t *testing.T) {
+		customFmt := "[%START_TIME%] %UPSTREAM_HOST% %DOWNSTREAM_REMOTE_ADDRESS%\n"
+		mesh := &meshconfig.MeshConfig{
+			AccessLogFile:     DevStdout,
+			AccessLogEncoding: meshconfig.MeshConfig_TEXT,
+			AccessLogFormat:   customFmt,
+		}
+		al := FileAccessLogFromMeshConfigForHboneTermination(DevStdout, mesh)
+		got := getTextFormat(al)
+		if got != customFmt {
+			t.Errorf("custom format should be used unchanged, want %q, got %q", customFmt, got)
+		}
+	})
 }
 
 func TestAccessLogging(t *testing.T) {

--- a/pilot/pkg/networking/core/accesslog.go
+++ b/pilot/pkg/networking/core/accesslog.go
@@ -79,8 +79,8 @@ func newAccessLogBuilder() *AccessLogBuilder {
 		// We add ResponseFlagFilter here, as we want to get listener access logs only on scenarios where we might
 		// not get filter Access Logs like in cases like NR to upstream.
 		listenerAccessLog:         newCachedMeshConfigAccessLog(listenerAccessLogFilter()),
-		hboneOriginationAccessLog: newCachedMeshConfigAccessLog(hboneOriginationAccessLogFilter()),
-		hboneTerminationAccessLog: newCachedMeshConfigAccessLog(hboneTerminationAccessLogFilter()),
+		hboneOriginationAccessLog: newCachedHboneOriginationAccessLog(hboneOriginationAccessLogFilter()),
+		hboneTerminationAccessLog: newCachedHboneTerminationAccessLog(hboneTerminationAccessLogFilter()),
 	}
 }
 
@@ -303,13 +303,22 @@ func buildAccessLogFilter(f ...*accesslog.AccessLogFilter) *accesslog.AccessLogF
 }
 
 func newCachedMeshConfigAccessLog(filter *accesslog.AccessLogFilter) cachedMeshConfigAccessLog {
-	return cachedMeshConfigAccessLog{filter: filter}
+	return cachedMeshConfigAccessLog{filter: filter, buildFn: model.FileAccessLogFromMeshConfig}
+}
+
+func newCachedHboneOriginationAccessLog(filter *accesslog.AccessLogFilter) cachedMeshConfigAccessLog {
+	return cachedMeshConfigAccessLog{filter: filter, buildFn: model.FileAccessLogFromMeshConfigForHboneOrigination}
+}
+
+func newCachedHboneTerminationAccessLog(filter *accesslog.AccessLogFilter) cachedMeshConfigAccessLog {
+	return cachedMeshConfigAccessLog{filter: filter, buildFn: model.FileAccessLogFromMeshConfigForHboneTermination}
 }
 
 type cachedMeshConfigAccessLog struct {
-	filter *accesslog.AccessLogFilter
-	mutex  sync.RWMutex
-	cached *accesslog.AccessLog
+	filter  *accesslog.AccessLogFilter
+	buildFn func(path string, mesh *meshconfig.MeshConfig) *accesslog.AccessLog
+	mutex   sync.RWMutex
+	cached  *accesslog.AccessLog
 }
 
 func (b *cachedMeshConfigAccessLog) getCached() *accesslog.AccessLog {
@@ -323,7 +332,7 @@ func (b *cachedMeshConfigAccessLog) buildOrFetch(mesh *meshconfig.MeshConfig) *a
 		return c
 	}
 	// We need to build access log. This is needed either on first access or when mesh config changes.
-	accessLog := model.FileAccessLogFromMeshConfig(mesh.AccessLogFile, mesh)
+	accessLog := b.buildFn(mesh.AccessLogFile, mesh)
 	accessLog.Filter = b.filter
 
 	b.mutex.Lock()


### PR DESCRIPTION
## Summary

Fixes #50321

On HBONE paths, two access log fields contain synthetic internal Envoy URIs instead of real network addresses:

- **Origination** (`connect_originate` internal listener): `%DOWNSTREAM_REMOTE_ADDRESS%` is always `envoy://internal_client_address/` rather than the real tunneled destination.
- **Termination** (CONNECT-terminate HCM): `%UPSTREAM_HOST%` is `envoy://main_internal/<addr>` rather than the real app destination.

Both fields are replaced with `%FILTER_STATE(envoy.filters.listener.original_dst.local_ip:PLAIN)%`, which is the filter state key populated by the `OriginalDestination` listener filter and `ConnectAuthorityFilter` with the real destination address.

**Changes:**
- `pilot/pkg/model/telemetry_logging.go`: Add `FileAccessLogFromMeshConfigForHboneOrigination` and `FileAccessLogFromMeshConfigForHboneTermination`; refactor `FileAccessLogFromMeshConfig` into a shared `fileAccessLogWithDefaults` helper. Custom `mesh.AccessLogFormat` values are passed through unchanged.
- `pilot/pkg/networking/core/accesslog.go`: Add `buildFn` field to `cachedMeshConfigAccessLog` and wire the new HBONE-specific builders.
- `pilot/pkg/model/telemetry_logging_test.go`: 6 new test cases covering default text, default JSON, and custom format passthrough for both origination and termination paths.

## Test plan

- [ ] `go test ./pilot/pkg/model/ -run TestHbone` — all 6 new subtests pass
- [ ] `go test ./pilot/pkg/model/ -count=1` — no regressions in existing tests
- [ ] `go test ./pilot/pkg/networking/core/ -count=1` — no regressions