### PR TITLE
handle keepalivemaxconnetionage properly in WLEs

### DIFF
--- a/pilot/pkg/autoregistration/controller.go
+++ b/pilot/pkg/autoregistration/controller.go
@@ -120,6 +120,11 @@ func NewController(store model.ConfigStoreController, instanceID string, maxConn
 		return nil
 	}
 
+	// Consistent with gRPC's keepalive.ServerParameters.MaxConnectionAge: a zero (or negative)
+	// value means "unset", which is treated as no limit rather than an immediate cutoff.
+	if maxConnAge <= 0 {
+		maxConnAge = time.Duration(math.MaxInt64)
+	}
 	if maxConnAge != math.MaxInt64 {
 		maxConnAge += maxConnAge / 2
 		// if overflow, set it to max int64

--- a/pilot/pkg/autoregistration/controller_test.go
+++ b/pilot/pkg/autoregistration/controller_test.go
@@ -189,6 +189,20 @@ func TestNonAutoRegisteredWorkloads(t *testing.T) {
 	}
 }
 
+// TestNewControllerZeroMaxConnAge ensures a zero (unset) maxConnAge is treated as "no limit",
+// consistent with gRPC's keepalive.ServerParameters.MaxConnectionAge, rather than as an
+// immediate cutoff that would cause connected WorkloadEntries to be treated as leaked.
+func TestNewControllerZeroMaxConnAge(t *testing.T) {
+	store := memory.NewController(memory.Make(collections.All))
+	stop := test.NewStop(t)
+	go store.Run(stop)
+	c := NewController(store, "pilot-1", 0)
+	go c.Run(stop)
+	if c.maxConnectionAge != time.Duration(math.MaxInt64) {
+		t.Fatalf("expected zero maxConnAge to result in no limit (MaxInt64), got %v", c.maxConnectionAge)
+	}
+}
+
 func TestAutoregistrationLifecycle(t *testing.T) {
 	maxConnAge := time.Hour
 	c1, c2, store := setup(t)


### PR DESCRIPTION
When we set MaxConnectionAge for gRPC for pilot->Envoy connections as 0, that inadvertently breaks the WLE max connection age logic and it is cleaned up.

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions