### PR TITLE
Remove redundant GOMAXPROCS var from charts

### DIFF
--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -186,11 +186,6 @@ spec:
                 resourceFieldRef:
                   resource: limits.memory
                   divisor: "1"
-            - name: GOMAXPROCS
-              valueFrom:
-                resourceFieldRef:
-                  resource: limits.cpu
-                  divisor: "1"
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
@@ -110,11 +110,6 @@ spec:
         resourceFieldRef:
           resource: limits.memory
           divisor: "1"
-    - name: GOMAXPROCS
-      valueFrom:
-        resourceFieldRef:
-          resource: limits.cpu
-          divisor: "1"
     {{- if .CompliancePolicy }}
     - name: COMPLIANCE_POLICY
       value: "{{ .CompliancePolicy }}"

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -295,11 +295,6 @@ spec:
         resourceFieldRef:
           resource: limits.memory
           divisor: "1"
-    - name: GOMAXPROCS
-      valueFrom:
-        resourceFieldRef:
-          resource: limits.cpu
-          divisor: "1"
     {{- if .CompliancePolicy }}
     - name: COMPLIANCE_POLICY
       value: "{{ .CompliancePolicy }}"

--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -182,11 +182,6 @@ spec:
             resourceFieldRef:
               resource: limits.memory
               divisor: "1"
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.cpu
-              divisor: "1"
         - name: ISTIO_META_CLUSTER_ID
           value: "{{ valueOrDefault .Values.global.multiCluster.clusterName .ClusterID }}"
         - name: ISTIO_META_NODE_NAME

--- a/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
@@ -181,11 +181,6 @@ spec:
             resourceFieldRef:
               resource: limits.memory
               divisor: "1"
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.cpu
-              divisor: "1"
         - name: ISTIO_META_CLUSTER_ID
           value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
         {{- $network := valueOrDefault (index .InfrastructureLabels `topology.istio.io/network`) .Values.global.network }}

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -224,11 +224,6 @@ spec:
             value: "{{ .Values.global.istiod.enableAnalysis }}"
           - name: CLUSTER_ID
             value: "{{ $.Values.global.multiCluster.clusterName | default `Kubernetes` }}"
-          - name: GOMAXPROCS
-            valueFrom:
-              resourceFieldRef:
-                resource: limits.cpu
-                divisor: "1"
           - name: PLATFORM
             value: "{{ coalesce .Values.global.platform .Values.platform }}"
           resources:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_env_var_from.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_env_var_from.golden.yaml
@@ -89,11 +89,6 @@ spec:
           value: "false"
         - name: CLUSTER_ID
           value: Kubernetes
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: PLATFORM
           value: ""
         image: registry.istio.io/testing/pilot:latest

--- a/operator/pkg/helm/testdata/output/istiod-waypoint-workload-socket.golden.yaml
+++ b/operator/pkg/helm/testdata/output/istiod-waypoint-workload-socket.golden.yaml
@@ -465,11 +465,6 @@ data:
                 resourceFieldRef:
                   resource: limits.memory
                   divisor: "1"
-            - name: GOMAXPROCS
-              valueFrom:
-                resourceFieldRef:
-                  resource: limits.cpu
-                  divisor: "1"
             {{- if .CompliancePolicy }}
             - name: COMPLIANCE_POLICY
               value: "{{ .CompliancePolicy }}"
@@ -841,11 +836,6 @@ data:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
-                  divisor: "1"
-            - name: GOMAXPROCS
-              valueFrom:
-                resourceFieldRef:
-                  resource: limits.cpu
                   divisor: "1"
             {{- if .CompliancePolicy }}
             - name: COMPLIANCE_POLICY
@@ -1580,11 +1570,6 @@ data:
                     resourceFieldRef:
                       resource: limits.memory
                       divisor: "1"
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      resource: limits.cpu
-                      divisor: "1"
                 - name: ISTIO_META_CLUSTER_ID
                   value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
                 {{- $network := valueOrDefault (index .InfrastructureLabels `topology.istio.io/network`) .Values.global.network }}
@@ -1988,11 +1973,6 @@ data:
                   valueFrom:
                     resourceFieldRef:
                       resource: limits.memory
-                      divisor: "1"
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      resource: limits.cpu
                       divisor: "1"
                 - name: ISTIO_META_CLUSTER_ID
                   value: "{{ valueOrDefault .Values.global.multiCluster.clusterName .ClusterID }}"

--- a/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/cluster-ip.yaml
+++ b/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/cluster-ip.yaml
@@ -114,11 +114,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/copy-labels-annotations-disabled-infra-nil.yaml
+++ b/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/copy-labels-annotations-disabled-infra-nil.yaml
@@ -111,11 +111,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/copy-labels-annotations-disabled-infra-set.yaml
+++ b/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/copy-labels-annotations-disabled-infra-set.yaml
@@ -117,11 +117,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/copy-labels-annotations-enabled-infra-nil.yaml
+++ b/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/copy-labels-annotations-enabled-infra-nil.yaml
@@ -117,11 +117,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/custom-class.yaml
+++ b/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/custom-class.yaml
@@ -111,11 +111,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/customizations.yaml
+++ b/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/customizations.yaml
@@ -116,11 +116,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/infrastructure-labels-annotations.yaml
+++ b/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/infrastructure-labels-annotations.yaml
@@ -117,11 +117,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/istio-east-west.yaml
+++ b/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/istio-east-west.yaml
@@ -118,11 +118,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NETWORK

--- a/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/istio-upgrade-to-1.24.yaml
+++ b/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/istio-upgrade-to-1.24.yaml
@@ -120,11 +120,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NETWORK

--- a/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/kube-gateway-ambient-redirect-infra.yaml
+++ b/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/kube-gateway-ambient-redirect-infra.yaml
@@ -111,11 +111,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/kube-gateway-ambient-redirect.yaml
+++ b/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/kube-gateway-ambient-redirect.yaml
@@ -111,11 +111,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/kube-gateway-resources-null.yaml
+++ b/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/kube-gateway-resources-null.yaml
@@ -111,11 +111,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/manual-ip.yaml
+++ b/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/manual-ip.yaml
@@ -111,11 +111,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/manual-sa.yaml
+++ b/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/manual-sa.yaml
@@ -111,11 +111,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/multinetwork.yaml
+++ b/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/multinetwork.yaml
@@ -114,11 +114,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/proxy-config-crd.yaml
+++ b/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/proxy-config-crd.yaml
@@ -111,11 +111,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/quic-disabled.yaml
+++ b/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/quic-disabled.yaml
@@ -111,11 +111,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/quic-enabled.yaml
+++ b/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/quic-enabled.yaml
@@ -111,11 +111,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/simple.yaml
+++ b/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/simple.yaml
@@ -117,11 +117,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/waypoint-no-network-label.yaml
+++ b/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/waypoint-no-network-label.yaml
@@ -118,11 +118,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NETWORK

--- a/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/waypoint-resources-null.yaml
+++ b/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/waypoint-resources-null.yaml
@@ -115,11 +115,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_INTERCEPTION_MODE

--- a/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/waypoint.yaml
+++ b/pilot/pkg/config/kube/gatewaycommon/testdata/deployment/waypoint.yaml
@@ -118,11 +118,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NETWORK

--- a/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -130,11 +130,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -130,11 +130,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/cronjob-old-version.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/cronjob-old-version.yaml.injected
@@ -81,11 +81,6 @@ spec:
                 resourceFieldRef:
                   divisor: "1"
                   resource: limits.memory
-            - name: GOMAXPROCS
-              valueFrom:
-                resourceFieldRef:
-                  divisor: "1"
-                  resource: limits.cpu
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
             - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -123,11 +123,6 @@ spec:
                 resourceFieldRef:
                   divisor: "1"
                   resource: limits.memory
-            - name: GOMAXPROCS
-              valueFrom:
-                resourceFieldRef:
-                  divisor: "1"
-                  resource: limits.cpu
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
             - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/daemonset-old-version.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/daemonset-old-version.yaml.injected
@@ -86,11 +86,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -128,11 +128,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -143,11 +143,6 @@ items:
               resourceFieldRef:
                 divisor: "1"
                 resource: limits.memory
-          - name: GOMAXPROCS
-            valueFrom:
-              resourceFieldRef:
-                divisor: "1"
-                resource: limits.cpu
           - name: ISTIO_META_CLUSTER_ID
             value: Kubernetes
           - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-with-canonical-service-label.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-with-canonical-service-label.yaml.injected
@@ -129,11 +129,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -128,11 +128,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -130,11 +130,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/explicit-security-context.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/explicit-security-context.yaml.injected
@@ -121,11 +121,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -130,11 +130,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -147,11 +147,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/gateway-spire.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/gateway-spire.yaml.injected
@@ -73,11 +73,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_APP_CONTAINERS
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes

--- a/pkg/kube/inject/testdata/inject/gateway-with-default-container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/gateway-with-default-container.yaml.injected
@@ -101,11 +101,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_APP_CONTAINERS
           value: httpbin
         - name: ISTIO_META_CLUSTER_ID

--- a/pkg/kube/inject/testdata/inject/gateway.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/gateway.yaml.injected
@@ -73,11 +73,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_APP_CONTAINERS
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes

--- a/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -131,11 +131,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello-cncf-networks.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-cncf-networks.yaml.injected
@@ -134,11 +134,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks-json.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks-json.yaml.injected
@@ -135,11 +135,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks.yaml.injected
@@ -134,11 +134,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello-fips-140-3.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-fips-140-3.yaml.injected
@@ -130,11 +130,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: COMPLIANCE_POLICY
           value: fips-140-3
         - name: GODEBUG

--- a/pkg/kube/inject/testdata/inject/hello-image-pull-secret.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-image-pull-secret.yaml.injected
@@ -132,11 +132,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello-image-secrets-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-image-secrets-in-values.yaml.injected
@@ -132,11 +132,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
@@ -130,11 +130,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
@@ -130,11 +130,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -132,11 +132,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME
@@ -387,11 +382,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello-multiple-image-secrets.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multiple-image-secrets.yaml.injected
@@ -133,11 +133,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello-multiport-metrics.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multiport-metrics.yaml.injected
@@ -117,11 +117,6 @@ spec:
         resourceFieldRef:
           divisor: "1"
           resource: limits.memory
-    - name: GOMAXPROCS
-      valueFrom:
-        resourceFieldRef:
-          divisor: "1"
-          resource: limits.cpu
     - name: ISTIO_META_CLUSTER_ID
       value: Kubernetes
     - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -131,11 +131,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -131,11 +131,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello-old-version.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-old-version.yaml.injected
@@ -88,11 +88,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello-openshift-custom-injection.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-openshift-custom-injection.yaml.injected
@@ -140,11 +140,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello-openshift-tproxy.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-openshift-tproxy.yaml.injected
@@ -136,11 +136,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello-openshift.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-openshift.yaml.injected
@@ -136,11 +136,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello-otel-semconv.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-otel-semconv.yaml.injected
@@ -128,11 +128,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello-probes-localhost.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-localhost.yaml.injected
@@ -156,11 +156,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.injected
@@ -155,11 +155,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello-probes-proxyHoldApplication-ProxyConfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-proxyHoldApplication-ProxyConfig.yaml.injected
@@ -155,11 +155,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -155,11 +155,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -152,11 +152,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello-probes.proxyHoldsApplication.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes.proxyHoldsApplication.yaml.injected
@@ -163,11 +163,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes.yaml.injected
@@ -163,11 +163,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -131,11 +131,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello-readiness.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-readiness.yaml.injected
@@ -134,11 +134,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
@@ -130,11 +130,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -130,11 +130,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello-tracing-disabled.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-tracing-disabled.yaml.injected
@@ -130,11 +130,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello.proxyHoldsApplication.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.proxyHoldsApplication.yaml.injected
@@ -130,11 +130,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
@@ -134,11 +134,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -130,11 +130,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello.yaml.proxyImageName.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.proxyImageName.injected
@@ -130,11 +130,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/hello.yaml.proxyInitImageName.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.proxyInitImageName.injected
@@ -130,11 +130,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/https-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/https-probes.yaml.injected
@@ -155,11 +155,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/init-no-intercept-no-native-sidecar.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/init-no-intercept-no-native-sidecar.yaml.injected
@@ -90,11 +90,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/job-old-version.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/job-old-version.yaml.injected
@@ -80,11 +80,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -122,11 +122,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -133,11 +133,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -133,11 +133,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -148,11 +148,6 @@ items:
               resourceFieldRef:
                 divisor: "1"
                 resource: limits.memory
-          - name: GOMAXPROCS
-            valueFrom:
-              resourceFieldRef:
-                divisor: "1"
-                resource: limits.cpu
           - name: ISTIO_META_CLUSTER_ID
             value: Kubernetes
           - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -134,11 +134,6 @@ items:
               resourceFieldRef:
                 divisor: "1"
                 resource: limits.memory
-          - name: GOMAXPROCS
-            valueFrom:
-              resourceFieldRef:
-                divisor: "1"
-                resource: limits.cpu
           - name: ISTIO_META_CLUSTER_ID
             value: Kubernetes
           - name: ISTIO_META_NODE_NAME
@@ -388,11 +383,6 @@ items:
               resourceFieldRef:
                 divisor: "1"
                 resource: limits.memory
-          - name: GOMAXPROCS
-            valueFrom:
-              resourceFieldRef:
-                divisor: "1"
-                resource: limits.cpu
           - name: ISTIO_META_CLUSTER_ID
             value: Kubernetes
           - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/merge-probers.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/merge-probers.yaml.injected
@@ -173,11 +173,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
@@ -132,11 +132,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -130,11 +130,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/multiple-templates.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multiple-templates.yaml.injected
@@ -123,11 +123,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/named_port.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/named_port.yaml.injected
@@ -134,11 +134,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/native-sidecar-old-version.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/native-sidecar-old-version.yaml.injected
@@ -75,11 +75,6 @@ spec:
         resourceFieldRef:
           divisor: "1"
           resource: limits.memory
-    - name: GOMAXPROCS
-      valueFrom:
-        resourceFieldRef:
-          divisor: "1"
-          resource: limits.cpu
     - name: ISTIO_META_CLUSTER_ID
       value: Kubernetes
     - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/native-sidecar-opt-in.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/native-sidecar-opt-in.yaml.injected
@@ -118,11 +118,6 @@ spec:
         resourceFieldRef:
           divisor: "1"
           resource: limits.memory
-    - name: GOMAXPROCS
-      valueFrom:
-        resourceFieldRef:
-          divisor: "1"
-          resource: limits.cpu
     - name: ISTIO_META_CLUSTER_ID
       value: Kubernetes
     - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/native-sidecar-opt-out.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/native-sidecar-opt-out.yaml.injected
@@ -76,11 +76,6 @@ spec:
         resourceFieldRef:
           divisor: "1"
           resource: limits.memory
-    - name: GOMAXPROCS
-      valueFrom:
-        resourceFieldRef:
-          divisor: "1"
-          resource: limits.cpu
     - name: ISTIO_META_CLUSTER_ID
       value: Kubernetes
     - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/native-sidecar.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/native-sidecar.yaml.injected
@@ -117,11 +117,6 @@ spec:
         resourceFieldRef:
           divisor: "1"
           resource: limits.memory
-    - name: GOMAXPROCS
-      valueFrom:
-        resourceFieldRef:
-          divisor: "1"
-          resource: limits.cpu
     - name: ISTIO_META_CLUSTER_ID
       value: Kubernetes
     - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/one_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/one_container.yaml.injected
@@ -138,11 +138,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/only-proxy-container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/only-proxy-container.yaml.injected
@@ -116,11 +116,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/pod-old-version.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/pod-old-version.yaml.injected
@@ -75,11 +75,6 @@ spec:
         resourceFieldRef:
           divisor: "1"
           resource: limits.memory
-    - name: GOMAXPROCS
-      valueFrom:
-        resourceFieldRef:
-          divisor: "1"
-          resource: limits.cpu
     - name: ISTIO_META_CLUSTER_ID
       value: Kubernetes
     - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -117,11 +117,6 @@ spec:
         resourceFieldRef:
           divisor: "1"
           resource: limits.memory
-    - name: GOMAXPROCS
-      valueFrom:
-        resourceFieldRef:
-          divisor: "1"
-          resource: limits.cpu
     - name: ISTIO_META_CLUSTER_ID
       value: Kubernetes
     - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/prometheus-scrape.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/prometheus-scrape.yaml.injected
@@ -115,11 +115,6 @@ spec:
         resourceFieldRef:
           divisor: "1"
           resource: limits.memory
-    - name: GOMAXPROCS
-      valueFrom:
-        resourceFieldRef:
-          divisor: "1"
-          resource: limits.cpu
     - name: ISTIO_META_CLUSTER_ID
       value: Kubernetes
     - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/prometheus-scrape2.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/prometheus-scrape2.yaml.injected
@@ -115,11 +115,6 @@ spec:
         resourceFieldRef:
           divisor: "1"
           resource: limits.memory
-    - name: GOMAXPROCS
-      valueFrom:
-        resourceFieldRef:
-          divisor: "1"
-          resource: limits.cpu
     - name: ISTIO_META_CLUSTER_ID
       value: Kubernetes
     - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/proxy-override-args-native.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-override-args-native.yaml.injected
@@ -119,11 +119,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/proxy-override-args.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-override-args.yaml.injected
@@ -119,11 +119,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/proxy-override-runas.yaml.cni.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-override-runas.yaml.cni.injected
@@ -125,11 +125,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/proxy-override-runas.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-override-runas.yaml.injected
@@ -122,11 +122,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/proxy-override-runas.yaml.tproxy.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-override-runas.yaml.tproxy.injected
@@ -122,11 +122,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/proxy-override.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-override.yaml.injected
@@ -107,11 +107,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/proxy-resources-memory-null.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-resources-memory-null.yaml.injected
@@ -120,11 +120,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/proxy-resources-mixed-null.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-resources-mixed-null.yaml.injected
@@ -121,11 +121,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/proxy-resources-null-no-init.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-resources-null-no-init.yaml.injected
@@ -120,11 +120,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/proxy-resources-null.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-resources-null.yaml.injected
@@ -120,11 +120,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/proxy-resources-zero.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-resources-zero.yaml.injected
@@ -122,11 +122,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/ready_live.yaml.injected
@@ -154,11 +154,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/ready_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/ready_only.yaml.injected
@@ -134,11 +134,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/replicaset-old-version.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicaset-old-version.yaml.injected
@@ -83,11 +83,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -125,11 +125,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -124,11 +124,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/reroute-virtual-interfaces.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/reroute-virtual-interfaces.yaml.injected
@@ -134,11 +134,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/reroute-virtual-interfaces_list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/reroute-virtual-interfaces_list.yaml.injected
@@ -133,11 +133,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/resource_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/resource_annotations.yaml.injected
@@ -130,11 +130,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/sidecar-spire.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/sidecar-spire.yaml.injected
@@ -137,11 +137,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/startup_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/startup_live.yaml.injected
@@ -154,11 +154,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/startup_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/startup_only.yaml.injected
@@ -134,11 +134,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/startup_ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/startup_ready_live.yaml.injected
@@ -162,11 +162,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/statefulset-old-version.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/statefulset-old-version.yaml.injected
@@ -91,11 +91,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -133,11 +133,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -131,11 +131,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/status_annotations_zeroport.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations_zeroport.yaml.injected
@@ -131,11 +131,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -126,11 +126,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/tcp-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/tcp-probes.yaml.injected
@@ -138,11 +138,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -130,11 +130,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -130,11 +130,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -141,11 +141,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -126,11 +126,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -126,11 +126,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/truncate-canonical-name-custom-controller-pod.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/truncate-canonical-name-custom-controller-pod.yaml.injected
@@ -124,11 +124,6 @@ spec:
         resourceFieldRef:
           divisor: "1"
           resource: limits.memory
-    - name: GOMAXPROCS
-      valueFrom:
-        resourceFieldRef:
-          divisor: "1"
-          resource: limits.cpu
     - name: ISTIO_META_CLUSTER_ID
       value: Kubernetes
     - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/truncate-canonical-name-pod.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/truncate-canonical-name-pod.yaml.injected
@@ -117,11 +117,6 @@ spec:
         resourceFieldRef:
           divisor: "1"
           resource: limits.memory
-    - name: GOMAXPROCS
-      valueFrom:
-        resourceFieldRef:
-          divisor: "1"
-          resource: limits.cpu
     - name: ISTIO_META_CLUSTER_ID
       value: Kubernetes
     - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/two_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/two_container.yaml.injected
@@ -145,11 +145,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/pkg/kube/inject/testdata/inject/user-volume.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/user-volume.yaml.injected
@@ -132,11 +132,6 @@ spec:
             resourceFieldRef:
               divisor: "1"
               resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "1"
-              resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME

--- a/releasenotes/notes/60235.yaml
+++ b/releasenotes/notes/60235.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v1alpha1
+kind: ReleaseNote
+area: installation
+issue:
+  - 60235
+releaseNotes:
+  - |
+    **Removed** `GOMAXPROCS` environment variable from all Istio charts,
+    Go 1.25 automatically sets `GOMAXPROCS` to match CPU limits.

--- a/releasenotes/notes/60235.yaml
+++ b/releasenotes/notes/60235.yaml
@@ -1,9 +1,9 @@
-apiVersion: release-notes/v1alpha1
-kind: ReleaseNote
+apiVersion: release-notes/v2
+kind: feature
 area: installation
 issue:
   - 60235
 releaseNotes:
   - |
-    **Removed** `GOMAXPROCS` environment variable from all Istio charts,
+    **Removed** `GOMAXPROCS` environment variable from all Istio charts.
     Go 1.25 automatically sets `GOMAXPROCS` to match CPU limits.


### PR DESCRIPTION
**Please provide a description of this PR:**

Go 1.25 automatically sets GOMAXPROCS based on container CPU limits, making explicit chart setting redundant. This PR removes GOMAXPROCS env var from Istio charts. Users can now set their own values. 

Continues the work from #60237 rebased onto
current master, golden test files regenerated.

Fixes #60235