### PR TITLE
optimize: pre-compute virtual service exportTo

### DIFF
--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -15,7 +15,6 @@
 package model
 
 import (
-	"slices"
 	"strings"
 
 	udpa "github.com/cncf/xds/go/udpa/type/v1"
@@ -25,6 +24,7 @@ import (
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/hash"
 	netutil "istio.io/istio/pkg/util/net"
 	"istio.io/istio/pkg/util/sets"

--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -15,8 +15,7 @@
 package model
 
 import (
-	"cmp"
-	"sort"
+	"slices"
 	"strings"
 
 	udpa "github.com/cncf/xds/go/udpa/type/v1"
@@ -317,17 +316,19 @@ func mostSpecificHostWildcardMatch[V any](needle string, wildcard map[host.Name]
 
 // sortConfigByCreationTime sorts the list of config objects in ascending order by their creation time (if available)
 func sortConfigByCreationTime(configs []config.Config) []config.Config {
-	sort.Slice(configs, func(i, j int) bool {
-		if r := configs[i].CreationTimestamp.Compare(configs[j].CreationTimestamp); r != 0 {
-			return r == -1 // -1 means i is less than j, so return true
-		}
-		// If creation time is the same, then behavior is nondeterministic. In this case, we can
-		// pick an arbitrary but consistent ordering based on name and namespace, which is unique.
-		// CreationTimestamp is stored in seconds, so this is not uncommon.
-		if r := cmp.Compare(configs[i].Name, configs[j].Name); r != 0 {
-			return r == -1
-		}
-		return cmp.Compare(configs[i].Namespace, configs[j].Namespace) == -1
-	})
+	slices.SortFunc(configs, configCompareByCreationTime)
 	return configs
+}
+
+func configCompareByCreationTime(a, b config.Config) int {
+	if r := a.CreationTimestamp.Compare(b.CreationTimestamp); r != 0 {
+		return r
+	}
+	// If creation time is the same, then behavior is nondeterministic. In this case, we can
+	// pick an arbitrary but consistent ordering based on name and namespace, which is unique.
+	// CreationTimestamp is stored in seconds, so this is not uncommon.
+	if r := strings.Compare(a.Name, b.Name); r != 0 {
+		return r
+	}
+	return strings.Compare(a.Namespace, b.Namespace)
 }

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1763,15 +1763,10 @@ func (ps *PushContext) initVirtualServices(env *Environment) {
 			}
 		} else if !exportToSet.Contains(visibility.None) {
 			// . or other namespaces
-			includesPrivate := false
 			for exportTo := range exportToSet {
 				key := string(exportTo)
-				if exportTo == visibility.Private || key == ns {
+				if key == ns {
 					// exportTo with same namespace is effectively private
-					if includesPrivate {
-						continue
-					}
-					includesPrivate = true
 					private := ps.virtualServiceIndex.privateByNamespaceAndGateway
 					for _, gw := range gwNames {
 						n := types.NamespacedName{Namespace: ns, Name: gw}
@@ -2041,7 +2036,7 @@ func (ps *PushContext) setDestinationRules(configs []config.Config) {
 				exportToSet.Insert(visibility.Instance(e))
 			}
 		} else {
-			exportToSet = sets.New[visibility.Instance](visibility.Private)
+			exportToSet = sets.New(visibility.Private)
 		}
 
 		// add only if the dest rule is exported with . or * or explicit exportTo containing this namespace

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1751,10 +1751,7 @@ func (ps *PushContext) initVirtualServices(env *Environment) {
 		gwNames := getGatewayNames(rule)
 		exportToSet := ps.exportToDefaults.virtualService
 		if len(rule.ExportTo) > 0 {
-			exportToSet = sets.NewWithLength[visibility.Instance](len(rule.ExportTo))
-			for _, e := range rule.ExportTo {
-				exportToSet.Insert(visibility.Instance(e))
-			}
+			exportToSet = virtualService.ExportTo
 		}
 
 		// if vs has exportTo ~ - i.e. not visible to anyone, ignore all exportTos
@@ -1762,7 +1759,7 @@ func (ps *PushContext) initVirtualServices(env *Environment) {
 		// if vs has exportTo ., replace with current namespace
 		if exportToSet.Contains(visibility.Public) {
 			for _, gw := range gwNames {
-				ps.virtualServiceIndex.publicByGateway[gw] = append(ps.virtualServiceIndex.publicByGateway[gw], virtualService)
+				ps.virtualServiceIndex.publicByGateway[gw] = append(ps.virtualServiceIndex.publicByGateway[gw], virtualService.Config)
 			}
 		} else if !exportToSet.Contains(visibility.None) {
 			// . or other namespaces
@@ -1778,13 +1775,13 @@ func (ps *PushContext) initVirtualServices(env *Environment) {
 					private := ps.virtualServiceIndex.privateByNamespaceAndGateway
 					for _, gw := range gwNames {
 						n := types.NamespacedName{Namespace: ns, Name: gw}
-						private[n] = append(private[n], virtualService)
+						private[n] = append(private[n], virtualService.Config)
 					}
 				} else {
 					exported := ps.virtualServiceIndex.exportedToNamespaceByGateway
 					for _, gw := range gwNames {
 						n := types.NamespacedName{Namespace: key, Name: gw}
-						exported[n] = append(exported[n], virtualService)
+						exported[n] = append(exported[n], virtualService.Config)
 					}
 				}
 			}

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1756,13 +1756,13 @@ func (ps *PushContext) initVirtualServices(env *Environment) {
 
 		// if vs has exportTo ~ - i.e. not visible to anyone, ignore all exportTos
 		// if vs has exportTo *, make public and ignore all other exportTos
-		// if vs has exportTo ., replace with current namespace
+		// virtualService.ExportTo will never have visibility.Private, it's converted in the controller into the private namespace name.
 		if exportToSet.Contains(visibility.Public) {
 			for _, gw := range gwNames {
 				ps.virtualServiceIndex.publicByGateway[gw] = append(ps.virtualServiceIndex.publicByGateway[gw], virtualService.Config)
 			}
 		} else if !exportToSet.Contains(visibility.None) {
-			// . or other namespaces
+			// other namespaces
 			for exportTo := range exportToSet {
 				key := string(exportTo)
 				if key == ns {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1750,7 +1750,7 @@ func (ps *PushContext) initVirtualServices(env *Environment) {
 		rule := virtualService.Spec.(*networking.VirtualService)
 		gwNames := getGatewayNames(rule)
 		exportToSet := ps.exportToDefaults.virtualService
-		if len(rule.ExportTo) > 0 {
+		if len(virtualService.ExportTo) > 0 {
 			exportToSet = virtualService.ExportTo
 		}
 

--- a/pilot/pkg/model/virtualservice_controller.go
+++ b/pilot/pkg/model/virtualservice_controller.go
@@ -187,27 +187,11 @@ func delegateVirtualServices(
 			return nil
 		}
 
-		var exportToSet sets.Set[visibility.Instance]
-		if len(spec.ExportTo) == 0 {
+		exportToSet := convertExportToSet(spec.ExportTo, cfg.Namespace)
+		if len(exportToSet) == 0 {
 			// No exportTo in virtualService. Use the global default
 			defaultExportTo := krt.FetchOne(ctx, defaultExportTo).Set
-			exportToSet = sets.NewWithLength[visibility.Instance](defaultExportTo.Len())
-			for v := range defaultExportTo {
-				if v == visibility.Private {
-					exportToSet.Insert(visibility.Instance(cfg.Namespace))
-				} else {
-					exportToSet.Insert(v)
-				}
-			}
-		} else {
-			exportToSet = sets.NewWithLength[visibility.Instance](len(spec.ExportTo))
-			for _, e := range spec.ExportTo {
-				if e == string(visibility.Private) {
-					exportToSet.Insert(visibility.Instance(cfg.Namespace))
-				} else {
-					exportToSet.Insert(visibility.Instance(e))
-				}
-			}
+			exportToSet = copyDefaultExportToSet(defaultExportTo, cfg.Namespace)
 		}
 
 		return &DelegateVirtualService{

--- a/pilot/pkg/model/virtualservice_controller.go
+++ b/pilot/pkg/model/virtualservice_controller.go
@@ -283,14 +283,7 @@ func mergeVirtualServices(
 			exportToSet := convertExportToSet(spec.ExportTo, cfg.Namespace)
 			if len(exportToSet) == 0 {
 				defaultExportTo := krt.FetchOne(ctx, defaultExportTo).Set
-				exportToSet = sets.NewWithLength[visibility.Instance](defaultExportTo.Len())
-				for v := range defaultExportTo {
-					if v == visibility.Private {
-						exportToSet.Insert(visibility.Instance(cfg.Namespace))
-					} else {
-						exportToSet.Insert(v)
-					}
-				}
+				exportToSet = copyDefaultExportToSet(defaultExportTo, cfg.Namespace)
 			}
 			return &MergedVirtualService{
 				Config:   cfg,
@@ -304,14 +297,7 @@ func mergeVirtualServices(
 		exportToSet := convertExportToSet(spec.ExportTo, cfg.Namespace)
 		if len(exportToSet) == 0 {
 			defaultExportTo := krt.FetchOne(ctx, defaultExportTo).Set
-			exportToSet = sets.NewWithLength[visibility.Instance](defaultExportTo.Len())
-			for v := range defaultExportTo {
-				if v == visibility.Private {
-					exportToSet.Insert(visibility.Instance(cfg.Namespace))
-				} else {
-					exportToSet.Insert(v)
-				}
-			}
+			exportToSet = copyDefaultExportToSet(defaultExportTo, cfg.Namespace)
 		}
 
 		// if this is an Ingress VS, we don't need to perform any merging
@@ -379,6 +365,10 @@ func mergeVirtualServices(
 }
 
 func convertExportToSet(exportTo []string, namespace string) sets.Set[visibility.Instance] {
+	if len(exportTo) == 0 {
+		return nil
+	}
+
 	exportToSet := sets.NewWithLength[visibility.Instance](len(exportTo))
 	for _, e := range exportTo {
 		v := visibility.Instance(e)
@@ -386,6 +376,18 @@ func convertExportToSet(exportTo []string, namespace string) sets.Set[visibility
 			v = visibility.Instance(namespace)
 		}
 		exportToSet.Insert(v)
+	}
+	return exportToSet
+}
+
+func copyDefaultExportToSet(defaultExportTo sets.Set[visibility.Instance], namespace string) sets.Set[visibility.Instance] {
+	exportToSet := sets.NewWithLength[visibility.Instance](defaultExportTo.Len())
+	for v := range defaultExportTo {
+		if v == visibility.Private {
+			exportToSet.Insert(visibility.Instance(namespace))
+		} else {
+			exportToSet.Insert(v)
+		}
 	}
 	return exportToSet
 }

--- a/pilot/pkg/model/virtualservice_controller.go
+++ b/pilot/pkg/model/virtualservice_controller.go
@@ -15,8 +15,6 @@
 package model
 
 import (
-	"slices"
-
 	"k8s.io/apimachinery/pkg/types"
 
 	networking "istio.io/api/networking/v1alpha3"
@@ -27,6 +25,7 @@ import (
 	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/config/visibility"
 	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/protomarshal"
 	"istio.io/istio/pkg/util/sets"
 )

--- a/pilot/pkg/model/virtualservice_controller.go
+++ b/pilot/pkg/model/virtualservice_controller.go
@@ -15,6 +15,8 @@
 package model
 
 import (
+	"slices"
+
 	"k8s.io/apimachinery/pkg/types"
 
 	networking "istio.io/api/networking/v1alpha3"
@@ -32,7 +34,7 @@ import (
 type MeshConfig = meshwatcher.MeshConfigResource
 
 type Outputs struct {
-	MergedVirtualServices krt.Collection[config.Config]
+	MergedVirtualServices krt.Collection[MergedVirtualService]
 }
 
 type VSControllerOptions struct {
@@ -82,6 +84,7 @@ func NewVirtualServiceController(
 	MergedVirtualServices := mergeVirtualServices(
 		VirtualServices,
 		DelegateVirtualServices,
+		DefaultExportTo.AsCollection(),
 		opts,
 	)
 
@@ -100,14 +103,14 @@ func NewVirtualServiceController(
 // logic as NeedsPush: skip updates where the spec is unchanged AND no istio.io
 // label/annotation changed. Non-istio.io metadata changes (Helm, Argo CD,
 // kubectl annotations) are not sufficient to trigger a push.
-func (c *VirtualServiceController) xdsPush(events []krt.Event[config.Config]) {
+func (c *VirtualServiceController) xdsPush(events []krt.Event[MergedVirtualService]) {
 	if c.xdsUpdater == nil {
 		return
 	}
 
 	cu := sets.New[ConfigKey]()
 	for _, e := range events {
-		if e.Old != nil && e.New != nil && !NeedsPush(*e.Old, *e.New) {
+		if e.Old != nil && e.New != nil && !NeedsPush(e.Old.Config, e.New.Config) {
 			continue
 		}
 		for _, vs := range e.Items() {
@@ -129,11 +132,11 @@ func (c *VirtualServiceController) xdsPush(events []krt.Event[config.Config]) {
 	})
 }
 
-func (c *VirtualServiceController) MergedVirtualServices() []config.Config {
-	return sortConfigByCreationTime(c.outputs.MergedVirtualServices.List())
+func (c *VirtualServiceController) MergedVirtualServices() []MergedVirtualService {
+	return sortMergedVirtualServicesByCreationTime(c.outputs.MergedVirtualServices.List())
 }
 
-func (c *VirtualServiceController) Collection() krt.Collection[config.Config] {
+func (c *VirtualServiceController) Collection() krt.Collection[MergedVirtualService] {
 	return c.outputs.MergedVirtualServices
 }
 
@@ -249,33 +252,82 @@ func defaultExportTo(
 	}, opts.WithName("DefaultExportTo")...)
 }
 
+type MergedVirtualService struct {
+	config.Config
+	ExportTo sets.Set[visibility.Instance]
+}
+
+func (m MergedVirtualService) ResourceName() string {
+	return m.Namespace + "/" + m.Name
+}
+
+func (m MergedVirtualService) Equals(other MergedVirtualService) bool {
+	return m.Config.Equals(&other.Config)
+}
+
 func mergeVirtualServices(
 	virtualServices krt.Collection[config.Config],
 	delegateVirtualServices krt.Collection[DelegateVirtualService],
+	defaultExportTo krt.Collection[DefaultExportToSet],
 	opts krt.OptionsBuilder,
-) krt.Collection[config.Config] {
-	return krt.NewCollection(virtualServices, func(ctx krt.HandlerContext, cfg config.Config) *config.Config {
+) krt.Collection[MergedVirtualService] {
+	return krt.NewCollection(virtualServices, func(ctx krt.HandlerContext, cfg config.Config) *MergedVirtualService {
 		// this is a Delegate VS, we won't add these to the collection directly
-		if len(cfg.Spec.(*networking.VirtualService).Hosts) == 0 {
+		spec := cfg.Spec.(*networking.VirtualService)
+		if len(spec.Hosts) == 0 {
 			return nil
 		}
 
 		// if this is a Gateway VS, we don't need to perform any merging or short name resolving
 		if UseGatewaySemantics(cfg) {
-			return &cfg
+			exportToSet := convertExportToSet(spec.ExportTo, cfg.Namespace)
+			if len(exportToSet) == 0 {
+				defaultExportTo := krt.FetchOne(ctx, defaultExportTo).Set
+				exportToSet = sets.NewWithLength[visibility.Instance](defaultExportTo.Len())
+				for v := range defaultExportTo {
+					if v == visibility.Private {
+						exportToSet.Insert(visibility.Instance(cfg.Namespace))
+					} else {
+						exportToSet.Insert(v)
+					}
+				}
+			}
+			return &MergedVirtualService{
+				Config:   cfg,
+				ExportTo: exportToSet,
+			}
 		}
 
 		root := ResolveVirtualServiceShortnames(cfg)
-		spec := root.Spec.(*networking.VirtualService)
+		spec = root.Spec.(*networking.VirtualService)
+
+		exportToSet := convertExportToSet(spec.ExportTo, cfg.Namespace)
+		if len(exportToSet) == 0 {
+			defaultExportTo := krt.FetchOne(ctx, defaultExportTo).Set
+			exportToSet = sets.NewWithLength[visibility.Instance](defaultExportTo.Len())
+			for v := range defaultExportTo {
+				if v == visibility.Private {
+					exportToSet.Insert(visibility.Instance(cfg.Namespace))
+				} else {
+					exportToSet.Insert(v)
+				}
+			}
+		}
 
 		// if this is an Ingress VS, we don't need to perform any merging
 		if UseIngressSemantics(cfg) {
-			return &root
+			return &MergedVirtualService{
+				Config:   root,
+				ExportTo: exportToSet,
+			}
 		}
 
 		// if this VS does not reference any delegate, we don't need to perform any merging
 		if !isRootVs(spec) {
-			return &root
+			return &MergedVirtualService{
+				Config:   root,
+				ExportTo: exportToSet,
+			}
 		}
 
 		mergedRoutes := []*networking.HTTPRoute{}
@@ -319,6 +371,29 @@ func mergeVirtualServices(
 			log.Debugf("merged virtualService: %s", vsString)
 		}
 
-		return &root
+		return &MergedVirtualService{
+			Config:   root,
+			ExportTo: exportToSet,
+		}
 	}, opts.WithName("MergedVirtualServices")...)
+}
+
+func convertExportToSet(exportTo []string, namespace string) sets.Set[visibility.Instance] {
+	exportToSet := sets.NewWithLength[visibility.Instance](len(exportTo))
+	for _, e := range exportTo {
+		v := visibility.Instance(e)
+		if v == visibility.Private {
+			v = visibility.Instance(namespace)
+		}
+		exportToSet.Insert(v)
+	}
+	return exportToSet
+}
+
+// sortMergedVirtualServicesByCreationTime sorts the list of merged virtual services in ascending order by their creation time (if available)
+func sortMergedVirtualServicesByCreationTime(configs []MergedVirtualService) []MergedVirtualService {
+	slices.SortFunc(configs, func(a, b MergedVirtualService) int {
+		return configCompareByCreationTime(a.Config, b.Config)
+	})
+	return configs
 }

--- a/pilot/pkg/model/virtualservice_controller_test.go
+++ b/pilot/pkg/model/virtualservice_controller_test.go
@@ -737,7 +737,9 @@ func TestControllerMergeVirtualServices(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			controller := setupController(t, tc.defaultExportTo, tc.virtualServices...)
-			got := controller.MergedVirtualServices()
+			got := slices.Map(controller.MergedVirtualServices(), func(mvs MergedVirtualService) config.Config {
+				return mvs.Config
+			})
 			assert.Equal(t, got, tc.expectedVirtualServices)
 		})
 	}
@@ -764,12 +766,16 @@ func TestControllerMergeVirtualServices(t *testing.T) {
 
 		vses := []config.Config{root, delegate, normal}
 		controller1 := setupController(t, sets.New(visibility.Public), vses...)
-		got := controller1.MergedVirtualServices()
+		got := slices.Map(controller1.MergedVirtualServices(), func(mvs MergedVirtualService) config.Config {
+			return mvs.Config
+		})
 		checkOrder(got)
 
 		vses = []config.Config{normal, delegate, root}
 		controller2 := setupController(t, sets.New(visibility.Public), vses...)
-		got = controller2.MergedVirtualServices()
+		got = slices.Map(controller2.MergedVirtualServices(), func(mvs MergedVirtualService) config.Config {
+			return mvs.Config
+		})
 		checkOrder(got)
 	})
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
Pre-compute `ExportTo` sets in VirtualServiceController, this avoids computing `ExportTo` for every VS on every virtual service index rebuild.
This is similar to what is already done for Services which store pre-computed `ExportTo` in `Service.Attributes.ExportTo`.

Also rewrote `sortConfigByCreationTime` to use `slices.Sort` which is more efficient and allows us to reuse the sort function.