### PR TITLE
waypoint: normalize CLI warning messages

### DIFF
--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -237,7 +237,7 @@ func Cmd(ctx cli.Context) *cobra.Command {
 				if !overwrite && hasWaypoint {
 					// we don't want to error on the user when they don't explicitly overwrite namespaced Waypoints,
 					// we just warn them and provide a suggestion
-					fmt.Fprintf(cmd.OutOrStdout(), "⚠️ Warning: namespace (%s) already has an enrolled Waypoint. Consider "+
+					fmt.Fprintf(cmd.OutOrStdout(), "Warning: namespace (%s) already has an enrolled Waypoint. Consider "+
 						"adding the `"+"--overwrite"+"` flag to your apply command.\n", ns)
 					return nil
 				}
@@ -246,7 +246,7 @@ func Cmd(ctx cli.Context) *cobra.Command {
 					return fmt.Errorf("failed to check if namespace is labeled ambient: %v", err)
 				}
 				if !namespaceIsLabeledAmbient {
-					fmt.Fprintf(cmd.OutOrStdout(), "⚠️ Warning: namespace is not enrolled in ambient. Consider running\t"+
+					fmt.Fprintf(cmd.OutOrStdout(), "Warning: namespace is not enrolled in ambient. Consider running\t"+
 						"`"+"kubectl label namespace %s istio.io/dataplane-mode=ambient"+"`\n", ns)
 				}
 			}
@@ -270,7 +270,7 @@ func Cmd(ctx cli.Context) *cobra.Command {
 				return err
 			}
 
-			fmt.Fprintf(cmd.OutOrStdout(), "✅ waypoint %v/%v applied\n", gw.Namespace, gw.Name)
+			fmt.Fprintf(cmd.OutOrStdout(), "waypoint %v/%v applied\n", gw.Namespace, gw.Name)
 
 			if waitReady {
 				startTime := time.Now()
@@ -296,7 +296,7 @@ func Cmd(ctx cli.Context) *cobra.Command {
 					}
 				}
 
-				fmt.Fprintf(cmd.OutOrStdout(), "✅ waypoint %v/%v is ready!\n", gw.Namespace, gw.Name)
+				fmt.Fprintf(cmd.OutOrStdout(), "waypoint %v/%v is ready!\n", gw.Namespace, gw.Name)
 			}
 
 			// If a user decides to enroll their namespace with a waypoint, label the namespace with the waypoint name
@@ -306,7 +306,7 @@ func Cmd(ctx cli.Context) *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("failed to label namespace with waypoint: %v", err)
 				}
-				fmt.Fprintf(cmd.OutOrStdout(), "✅ namespace %v labeled with \"%v: %v\"\n", ctx.NamespaceOrDefault(ctx.Namespace()),
+				fmt.Fprintf(cmd.OutOrStdout(), "namespace %v labeled with \"%v: %v\"\n", ctx.NamespaceOrDefault(ctx.Namespace()),
 					label.IoIstioUseWaypoint.Name, gw.Name)
 			}
 			return nil


### PR DESCRIPTION
**Please provide a description of this PR:**
This change replaces Unicode warning symbols in waypoint CLI messages with plain-text warnings.

Example Message with Symbols: 

````
# istioctl waypoint apply --enroll-namespace --namespace istio-egress

⚠️ Warning: namespace is not enrolled in ambient. Consider running       `kubectl label namespace istio-egress istio.io/dataplane-mode=ambient`

✅ waypoint istio-egress/waypoint applied

✅ namespace istio-egress labeled with "istio.io/use-waypoint: waypoint" 

````
This is inconsistent with other istioctl CLI messages.

Using plain-text warning messages improves compatibility across different terminal environments, avoids Unicode rendering issues, and keeps the CLI output consistent with common Kubernetes tooling.