### PR TITLE
fix: recognize Kubernetes Gateway API gateways in analyze

### DIFF
--- a/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/pkg/config/analysis/analyzers/analyzers_test.go
@@ -482,6 +482,14 @@ var testGrid = []testCase{
 		},
 	},
 	{
+		name:       "virtualServiceKubernetesGateways",
+		inputFiles: []string{"testdata/virtualservice_kubernetes_gateways.yaml"},
+		analyzer:   &virtualservice.GatewayAnalyzer{},
+		expected: []message{
+			{msg.VirtualServiceHostNotFoundInGateway, "VirtualService default/my-vs-host-mismatch"},
+		},
+	},
+	{
 		name:       "virtualServiceJWTClaimRoute",
 		inputFiles: []string{"testdata/virtualservice_jwtclaimroute.yaml"},
 		analyzer:   &virtualservice.JWTClaimRouteAnalyzer{},

--- a/pkg/config/analysis/analyzers/testdata/virtualservice_kubernetes_gateways.yaml
+++ b/pkg/config/analysis/analyzers/testdata/virtualservice_kubernetes_gateways.yaml
@@ -1,0 +1,59 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: my-gateway
+  namespace: default
+spec:
+  gatewayClassName: istio
+  listeners:
+  - name: http
+    hostname: example.com
+    port: 80
+    protocol: HTTP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+  selector:
+    app: my-service
+---
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: my-vs
+  namespace: default
+spec:
+  hosts:
+  - example.com
+  gateways:
+  - default/my-gateway
+  http:
+  - route:
+    - destination:
+        host: my-service
+        port:
+          number: 80
+---
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: my-vs-host-mismatch
+  namespace: default
+spec:
+  hosts:
+  - wrong.example.com
+  gateways:
+  - default/my-gateway
+  http:
+  - route:
+    - destination:
+        host: my-service
+        port:
+          number: 80

--- a/pkg/config/analysis/analyzers/virtualservice/gateways.go
+++ b/pkg/config/analysis/analyzers/virtualservice/gateways.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"strings"
 
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
 	"istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/analysis"
@@ -41,6 +43,7 @@ func (s *GatewayAnalyzer) Metadata() analysis.Metadata {
 		Description: "Checks the gateways associated with each virtual service",
 		Inputs: []config.GroupVersionKind{
 			gvk.Gateway,
+			gvk.KubernetesGateway,
 			gvk.VirtualService,
 		},
 	}
@@ -77,8 +80,14 @@ func (s *GatewayAnalyzer) analyzeVirtualService(r *resource.Instance, c analysis
 		}
 
 		gwFullName := resource.NewShortOrFullName(vsNs, gwName)
+		exists := c.Exists(gvk.Gateway, gwFullName)
+		isKubernetesGateway := false
+		if !exists {
+			exists = c.Exists(gvk.KubernetesGateway, gwFullName)
+			isKubernetesGateway = exists
+		}
 
-		if !c.Exists(gvk.Gateway, gwFullName) {
+		if !exists {
 			m := msg.NewReferencedResourceNotFound(r, "gateway", gwName)
 
 			if line, ok := util.ErrorLine(r, fmt.Sprintf(util.VSGateway, i)); ok {
@@ -88,7 +97,14 @@ func (s *GatewayAnalyzer) analyzeVirtualService(r *resource.Instance, c analysis
 			c.Report(gvk.VirtualService, m)
 		}
 
-		if !vsHostInGateway(c, gwFullName, vs.Hosts, vsNs.String()) {
+		var hostsMatch bool
+		if isKubernetesGateway {
+			hostsMatch = vsHostInKubernetesGateway(c, gwFullName, vs.Hosts)
+		} else {
+			hostsMatch = vsHostInGateway(c, gwFullName, vs.Hosts, vsNs.String())
+		}
+
+		if !hostsMatch {
 			m := msg.NewVirtualServiceHostNotFoundInGateway(r, vs.Hosts, vsName.String(), gwFullName.String())
 
 			if line, ok := util.ErrorLine(r, fmt.Sprintf(util.VSGateway, i)); ok {
@@ -124,6 +140,43 @@ func vsHostInGateway(c analysis.Context, gateway resource.FullName, vsHosts []st
 			vsHost := host.Name(vsh)
 
 			if gatewayHost.Matches(vsHost) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func vsHostInKubernetesGateway(c analysis.Context, gateway resource.FullName, vsHosts []string) bool {
+	var gatewayHosts []string
+	matchAllHosts := false
+
+	c.ForEach(gvk.KubernetesGateway, func(r *resource.Instance) bool {
+		if r.Metadata.FullName != gateway {
+			return true
+		}
+
+		s := r.Message.(*gatewayv1.GatewaySpec)
+		for _, listener := range s.Listeners {
+			if listener.Hostname == nil || *listener.Hostname == "" {
+				matchAllHosts = true
+				return false
+			}
+			gatewayHosts = append(gatewayHosts, string(*listener.Hostname))
+		}
+
+		return true
+	})
+
+	if matchAllHosts {
+		return true
+	}
+
+	for _, gh := range gatewayHosts {
+		gatewayHost := host.Name(gh)
+		for _, vsh := range vsHosts {
+			if gatewayHost.Matches(host.Name(vsh)) {
 				return true
 			}
 		}

--- a/releasenotes/notes/virtualservice-kubernetes-gateway-analyze.yaml
+++ b/releasenotes/notes/virtualservice-kubernetes-gateway-analyze.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+issue:
+  - 60708
+releaseNotes:
+  - |
+    **Fixed** `istioctl analyze` so `VirtualService` references to Kubernetes Gateway API `Gateway` resources no longer produce false `ReferencedResourceNotFound` errors.


### PR DESCRIPTION
Fixes #60708

**Please provide a description of this PR:**

`istioctl analyze` was only checking Istio `Gateway` resources here, so a `VirtualService` that points at a valid Gateway API `Gateway` still got a fake `Referenced gateway not found` error. Kinda noisy, and just wrong.

This makes `GatewayAnalyzer` read `gvk.KubernetesGateway` too, and it validates hosts from Gateway API listener hostnames on that path. Added a regression test and a small release note.

Repro:
1. Save this as `repro.yaml`:
```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: my-gateway
  namespace: default
spec:
  gatewayClassName: istio
  listeners:
  - name: http
    hostname: example.com
    port: 80
    protocol: HTTP
---
apiVersion: v1
kind: Service
metadata:
  name: my-service
  namespace: default
spec:
  ports:
  - name: http
    port: 80
    targetPort: 8080
  selector:
    app: my-service
---
apiVersion: networking.istio.io/v1
kind: VirtualService
metadata:
  name: my-vs
  namespace: default
spec:
  hosts:
  - example.com
  gateways:
  - default/my-gateway
  http:
  - route:
    - destination:
        host: my-service
        port:
          number: 80
```
2. Run `istioctl analyze --use-kube=false repro.yaml`
3. Before this patch, analyze yells `Referenced gateway not found: "default/my-gateway"`
4. After this patch, that bogus error is gone.