### PR TITLE
feat: wire cluster buffer limit from ConnectionSettings

### DIFF
--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -30,7 +30,6 @@ import (
 	http "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	metadatav3 "github.com/envoyproxy/go-control-plane/envoy/type/metadata/v3"
-	"google.golang.org/protobuf/proto"
 	anypb "google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -189,7 +188,7 @@ func NewClusterBuilder(proxy *model.Proxy, req *model.PushRequest, cache model.X
 			cb.fileCredentialSocketExist = true
 		}
 	}
-	cb.connectionSettings = cb.resolveConnectionSettings()
+	cb.connectionSettings = resolveConnectionSettings(proxy, req.Push)
 	return cb
 }
 
@@ -488,8 +487,8 @@ func (cb *ClusterBuilder) buildCluster(name string, discoveryType cluster.Cluste
 		CommonLbConfig:       &cluster.Cluster_CommonLbConfig{},
 	}
 	if cs := cb.connectionSettings; cs != nil {
-		if v := cs.GetClusterPerConnectionBufferLimitBytes(); v != nil && v.GetValue() > 0 {
-			c.PerConnectionBufferLimitBytes = wrappers.UInt32(uint32(v.GetValue()))
+		if v := safeUint32(cs.GetClusterPerConnectionBufferLimitBytes()); v != nil {
+			c.PerConnectionBufferLimitBytes = v
 		}
 	}
 
@@ -553,25 +552,6 @@ func (cb *ClusterBuilder) buildCluster(name string, discoveryType cluster.Cluste
 	}
 
 	return ec
-}
-
-func (cb *ClusterBuilder) resolveConnectionSettings() *meshconfig.ProxyConfig_ConnectionSettings {
-	defaultConfig := cb.req.Push.Mesh.GetDefaultConfig()
-	proxyConfig := defaultConfig
-	if cb.proxyMetadata != nil {
-		proxyConfig = cb.proxyMetadata.ProxyConfigOrDefault(defaultConfig)
-	}
-	if proxyConfig == nil || proxyConfig.GetConnectionSettings() == nil {
-		return nil
-	}
-
-	cs := proto.Clone(proxyConfig.GetConnectionSettings()).(*meshconfig.ProxyConfig_ConnectionSettings)
-	if cb.proxyType == model.Router &&
-		cs.GetProfile() == meshconfig.ProxyConfig_ConnectionSettings_EDGE &&
-		cs.ClusterPerConnectionBufferLimitBytes == nil {
-		cs.ClusterPerConnectionBufferLimitBytes = wrappers.Int32(32768)
-	}
-	return cs
 }
 
 // buildAllowAnyDFPCluster builds the DFP cluster for ALLOW_ANY_DYNAMIC_DNS mode.

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -150,6 +150,7 @@ type ClusterBuilder struct {
 	cache                     model.XdsCache
 	credentialSocketExist     bool
 	fileCredentialSocketExist bool
+	connectionSettings        *meshconfig.ProxyConfig_ConnectionSettings
 }
 
 // NewClusterBuilder builds an instance of ClusterBuilder.
@@ -188,6 +189,7 @@ func NewClusterBuilder(proxy *model.Proxy, req *model.PushRequest, cache model.X
 			cb.fileCredentialSocketExist = true
 		}
 	}
+	cb.connectionSettings = cb.resolveConnectionSettings()
 	return cb
 }
 
@@ -485,8 +487,8 @@ func (cb *ClusterBuilder) buildCluster(name string, discoveryType cluster.Cluste
 		ClusterDiscoveryType: &cluster.Cluster_Type{Type: discoveryType},
 		CommonLbConfig:       &cluster.Cluster_CommonLbConfig{},
 	}
-	if cs := cb.getResolvedConnectionSettings(); cs != nil {
-		if v := cs.GetClusterPerConnectionBufferLimitBytes(); v != nil && v.GetValue() >= 0 {
+	if cs := cb.connectionSettings; cs != nil {
+		if v := cs.GetClusterPerConnectionBufferLimitBytes(); v != nil && v.GetValue() > 0 {
 			c.PerConnectionBufferLimitBytes = wrappers.UInt32(uint32(v.GetValue()))
 		}
 	}
@@ -553,7 +555,7 @@ func (cb *ClusterBuilder) buildCluster(name string, discoveryType cluster.Cluste
 	return ec
 }
 
-func (cb *ClusterBuilder) getResolvedConnectionSettings() *meshconfig.ProxyConfig_ConnectionSettings {
+func (cb *ClusterBuilder) resolveConnectionSettings() *meshconfig.ProxyConfig_ConnectionSettings {
 	defaultConfig := cb.req.Push.Mesh.GetDefaultConfig()
 	proxyConfig := defaultConfig
 	if cb.proxyMetadata != nil {

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -30,11 +30,13 @@ import (
 	http "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	metadatav3 "github.com/envoyproxy/go-control-plane/envoy/type/metadata/v3"
+	"google.golang.org/protobuf/proto"
 	anypb "google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
+	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
@@ -483,6 +485,11 @@ func (cb *ClusterBuilder) buildCluster(name string, discoveryType cluster.Cluste
 		ClusterDiscoveryType: &cluster.Cluster_Type{Type: discoveryType},
 		CommonLbConfig:       &cluster.Cluster_CommonLbConfig{},
 	}
+	if cs := cb.getResolvedConnectionSettings(); cs != nil {
+		if v := cs.GetClusterPerConnectionBufferLimitBytes(); v != nil && v.GetValue() >= 0 {
+			c.PerConnectionBufferLimitBytes = wrappers.UInt32(uint32(v.GetValue()))
+		}
+	}
 
 	// Build default alt stat name - This may be overwritten by the MeshConfig options.
 	c.AltStatName = util.DelimitedStatsPrefix(name)
@@ -544,6 +551,25 @@ func (cb *ClusterBuilder) buildCluster(name string, discoveryType cluster.Cluste
 	}
 
 	return ec
+}
+
+func (cb *ClusterBuilder) getResolvedConnectionSettings() *meshconfig.ProxyConfig_ConnectionSettings {
+	defaultConfig := cb.req.Push.Mesh.GetDefaultConfig()
+	proxyConfig := defaultConfig
+	if cb.proxyMetadata != nil {
+		proxyConfig = cb.proxyMetadata.ProxyConfigOrDefault(defaultConfig)
+	}
+	if proxyConfig == nil || proxyConfig.GetConnectionSettings() == nil {
+		return nil
+	}
+
+	cs := proto.Clone(proxyConfig.GetConnectionSettings()).(*meshconfig.ProxyConfig_ConnectionSettings)
+	if cb.proxyType == model.Router &&
+		cs.GetProfile() == meshconfig.ProxyConfig_ConnectionSettings_EDGE &&
+		cs.ClusterPerConnectionBufferLimitBytes == nil {
+		cs.ClusterPerConnectionBufferLimitBytes = wrappers.Int32(32768)
+	}
+	return cs
 }
 
 // buildAllowAnyDFPCluster builds the DFP cluster for ALLOW_ANY_DYNAMIC_DNS mode.

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -574,6 +574,11 @@ func (cb *ClusterBuilder) buildAllowAnyDFPCluster(tls *networking.ClientTLSSetti
 		ConnectTimeout: cb.req.Push.Mesh.ConnectTimeout,
 	}
 	c.AltStatName = util.DelimitedStatsPrefix(util.AllowAnyDynamicDNSCluster)
+	if cs := cb.connectionSettings; cs != nil {
+		if v := safeUint32(cs.GetClusterPerConnectionBufferLimitBytes()); v != nil {
+			c.PerConnectionBufferLimitBytes = v
+		}
+	}
 	// Use same protocol options as passthrough cluster
 	httpProtocolOptions := passthroughHttpProtocolOptions
 	if shouldPreserveHeaderCase(cb.proxyMetadata, cb.req.Push) {
@@ -627,6 +632,11 @@ func (cb *ClusterBuilder) buildDFPCluster(name string, service *model.Service, p
 
 	// TODO(keithmattix): Use figure out how to do happy eyeballs with dfp clusters
 	c.AltStatName = util.DelimitedStatsPrefix(name)
+	if cs := cb.connectionSettings; cs != nil {
+		if v := safeUint32(cs.GetClusterPerConnectionBufferLimitBytes()); v != nil {
+			c.PerConnectionBufferLimitBytes = v
+		}
+	}
 	ec := newDFPClusterWrapper(c)
 	cb.setUpstreamProtocol(ec, port)
 	return ec

--- a/pilot/pkg/networking/core/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/cluster_builder_test.go
@@ -2810,7 +2810,7 @@ func newH2TestCluster() *clusterWrapper {
 }
 
 func newDownstreamTestCluster() *clusterWrapper {
-	cb := NewClusterBuilder(newSidecarProxy(), nil, model.DisabledCache{})
+	cb := NewClusterBuilder(newSidecarProxy(), &model.PushRequest{Push: &model.PushContext{Mesh: &meshconfig.MeshConfig{}}}, model.DisabledCache{})
 	mc := newClusterWrapper(&cluster.Cluster{
 		Name: "test-cluster",
 	})

--- a/pilot/pkg/networking/core/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/cluster_builder_test.go
@@ -1536,6 +1536,111 @@ func TestClusterDnsConfig(t *testing.T) {
 	}
 }
 
+func TestClusterPerConnectionBufferLimitBytes(t *testing.T) {
+	servicePort := &model.Port{
+		Name:     "default",
+		Port:     8080,
+		Protocol: protocol.HTTP,
+	}
+	endpoints := []*endpoint.LocalityLbEndpoints{
+		{
+			Locality: &core.Locality{
+				Region:  "region1",
+				Zone:    "zone1",
+				SubZone: "subzone1",
+			},
+			LbEndpoints: []*endpoint.LbEndpoint{},
+			LoadBalancingWeight: &wrappers.UInt32Value{
+				Value: 1,
+			},
+			Priority: 0,
+		},
+	}
+	service := &model.Service{
+		Ports: model.PortList{
+			servicePort,
+		},
+		Hostname:     "host",
+		MeshExternal: false,
+		Attributes:   model.ServiceAttributes{Name: "svc", Namespace: "default"},
+	}
+
+	cases := []struct {
+		name             string
+		proxyType        model.NodeType
+		meshConnSettings *meshconfig.ProxyConfig_ConnectionSettings
+		want             *wrappers.UInt32Value
+	}{
+		{
+			name:             "no connection settings leaves buffer limit unset",
+			proxyType:        model.Router,
+			meshConnSettings: nil,
+			want:             nil,
+		},
+		{
+			name:      "edge profile sets default on router",
+			proxyType: model.Router,
+			meshConnSettings: &meshconfig.ProxyConfig_ConnectionSettings{
+				Profile: meshconfig.ProxyConfig_ConnectionSettings_EDGE,
+			},
+			want: wrappers.UInt32(32768),
+		},
+		{
+			name:      "edge profile does not set default on sidecar",
+			proxyType: model.SidecarProxy,
+			meshConnSettings: &meshconfig.ProxyConfig_ConnectionSettings{
+				Profile: meshconfig.ProxyConfig_ConnectionSettings_EDGE,
+			},
+			want: nil,
+		},
+		{
+			name:      "explicit value overrides edge default",
+			proxyType: model.Router,
+			meshConnSettings: &meshconfig.ProxyConfig_ConnectionSettings{
+				Profile:                              meshconfig.ProxyConfig_ConnectionSettings_EDGE,
+				ClusterPerConnectionBufferLimitBytes: wrappers.Int32(65536),
+			},
+			want: wrappers.UInt32(65536),
+		},
+		{
+			name:      "explicit value applies regardless of profile",
+			proxyType: model.SidecarProxy,
+			meshConnSettings: &meshconfig.ProxyConfig_ConnectionSettings{
+				Profile:                              meshconfig.ProxyConfig_ConnectionSettings_SIDECAR,
+				ClusterPerConnectionBufferLimitBytes: wrappers.Int32(4096),
+			},
+			want: wrappers.UInt32(4096),
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			mesh := testMesh()
+			mesh.DefaultConfig = &meshconfig.ProxyConfig{
+				ConnectionSettings: tt.meshConnSettings,
+			}
+			cb := &ClusterBuilder{
+				proxyType:     tt.proxyType,
+				proxyMetadata: &model.NodeMetadata{},
+				req: &model.PushRequest{
+					Push: &model.PushContext{
+						Mesh: mesh,
+					},
+				},
+			}
+
+			defaultCluster := cb.buildCluster("my-cluster", cluster.Cluster_STATIC, endpoints, model.TrafficDirectionOutbound, servicePort, service, nil, "")
+			if defaultCluster == nil {
+				t.Fatal("expected cluster to be built")
+			}
+
+			if diff := cmp.Diff(tt.want, defaultCluster.cluster.GetPerConnectionBufferLimitBytes(), protocmp.Transform()); diff != "" {
+				t.Fatalf("unexpected PerConnectionBufferLimitBytes diff (-want,+got): %v", diff)
+			}
+		})
+	}
+}
+
 func TestClusterDnsLookupFamily(t *testing.T) {
 	servicePort := &model.Port{
 		Name:     "default",

--- a/pilot/pkg/networking/core/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/cluster_builder_test.go
@@ -1628,6 +1628,7 @@ func TestClusterPerConnectionBufferLimitBytes(t *testing.T) {
 					},
 				},
 			}
+			cb.connectionSettings = cb.resolveConnectionSettings()
 
 			defaultCluster := cb.buildCluster("my-cluster", cluster.Cluster_STATIC, endpoints, model.TrafficDirectionOutbound, servicePort, service, nil, "")
 			if defaultCluster == nil {

--- a/pilot/pkg/networking/core/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/cluster_builder_test.go
@@ -1619,16 +1619,19 @@ func TestClusterPerConnectionBufferLimitBytes(t *testing.T) {
 			mesh.DefaultConfig = &meshconfig.ProxyConfig{
 				ConnectionSettings: tt.meshConnSettings,
 			}
+			proxy := &model.Proxy{
+				Type:     tt.proxyType,
+				Metadata: &model.NodeMetadata{},
+			}
+			push := &model.PushContext{Mesh: mesh}
 			cb := &ClusterBuilder{
 				proxyType:     tt.proxyType,
 				proxyMetadata: &model.NodeMetadata{},
 				req: &model.PushRequest{
-					Push: &model.PushContext{
-						Mesh: mesh,
-					},
+					Push: push,
 				},
 			}
-			cb.connectionSettings = cb.resolveConnectionSettings()
+			cb.connectionSettings = resolveConnectionSettings(proxy, push)
 
 			defaultCluster := cb.buildCluster("my-cluster", cluster.Cluster_STATIC, endpoints, model.TrafficDirectionOutbound, servicePort, service, nil, "")
 			if defaultCluster == nil {

--- a/pilot/pkg/networking/core/cluster_cache.go
+++ b/pilot/pkg/networking/core/cluster_cache.go
@@ -49,9 +49,10 @@ type clusterCache struct {
 	endpointBuilder         *endpoints.EndpointBuilder
 
 	// service attributes
-	http2          bool // http2 identifies if the cluster is for an http2 service
-	downstreamAuto bool
-	supportsIPv4   bool
+	http2              bool // http2 identifies if the cluster is for an http2 service
+	downstreamAuto     bool
+	supportsIPv4       bool
+	clusterBufferLimit int32 // per-connection buffer limit from ConnectionSettings
 
 	// dependent configs
 	service         *model.Service
@@ -86,6 +87,8 @@ func (t *clusterCache) Key() any {
 	h.WriteString(strconv.FormatBool(t.supportsIPv4))
 	h.Write(Separator)
 	h.WriteString(strconv.FormatBool(t.hbone))
+	h.Write(Separator)
+	h.WriteString(strconv.FormatInt(int64(t.clusterBufferLimit), 10))
 	h.Write(Separator)
 
 	if t.proxyView != nil {
@@ -203,6 +206,7 @@ func buildClusterKey(service *model.Service, port *model.Port, cb *ClusterBuilde
 		http2:                   port.Protocol.IsHTTP2(),
 		downstreamAuto:          cb.sidecarProxy() && port.Protocol.IsUnsupported(),
 		supportsIPv4:            cb.supportsIPv4,
+		clusterBufferLimit:      cb.connectionSettings.GetClusterPerConnectionBufferLimitBytes().GetValue(),
 		service:                 service,
 		destinationRule:         dr,
 		envoyFilterKeys:         efKeys,

--- a/pilot/pkg/networking/core/cluster_tls_test.go
+++ b/pilot/pkg/networking/core/cluster_tls_test.go
@@ -1743,7 +1743,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 			} else {
 				proxy = newSidecarProxy()
 			}
-			cb := NewClusterBuilder(proxy, nil, model.DisabledCache{})
+			cb := NewClusterBuilder(proxy, &model.PushRequest{Push: &model.PushContext{Mesh: &meshconfig.MeshConfig{}}}, model.DisabledCache{})
 			if tc.h2 {
 				setH2Options(tc.opts.mutable)
 			}
@@ -1955,7 +1955,7 @@ func TestBuildAutoMtlsSettings(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cb := NewClusterBuilder(tt.proxy, nil, nil)
+			cb := NewClusterBuilder(tt.proxy, &model.PushRequest{Push: &model.PushContext{Mesh: &meshconfig.MeshConfig{}}}, nil)
 			gotTLS, gotCtxType := cb.buildUpstreamTLSSettings(tt.tls, tt.sans, tt.sni, tt.autoMTLSEnabled, tt.meshExternal, tt.serviceMTLSMode)
 			if !reflect.DeepEqual(gotTLS, tt.want) {
 				t.Errorf("cluster TLS does not match expected result want %#v, got %#v", tt.want, gotTLS)

--- a/pilot/pkg/networking/core/connection_settings.go
+++ b/pilot/pkg/networking/core/connection_settings.go
@@ -44,6 +44,9 @@ func applyEdgeProfileDefaults(cs *meshconfig.ProxyConfig_ConnectionSettings, nod
 	if cs.ListenerPerConnectionBufferLimitBytes == nil {
 		cs.ListenerPerConnectionBufferLimitBytes = &wrappers.Int32Value{Value: 32768} // 32 KiB
 	}
+	if cs.ClusterPerConnectionBufferLimitBytes == nil {
+		cs.ClusterPerConnectionBufferLimitBytes = &wrappers.Int32Value{Value: 32768} // 32 KiB
+	}
 	if cs.HttpIdleTimeout == nil {
 		cs.HttpIdleTimeout = durationpb.New(time.Hour)
 	}

--- a/pilot/pkg/networking/core/connection_settings_test.go
+++ b/pilot/pkg/networking/core/connection_settings_test.go
@@ -79,6 +79,7 @@ func TestApplyEdgeProfileDefaults(t *testing.T) {
 			},
 			nodeType: model.Router,
 			verify: func(t *testing.T, cs *meshconfig.ProxyConfig_ConnectionSettings) {
+				assert.Equal(t, int32(32768), cs.GetClusterPerConnectionBufferLimitBytes().GetValue())
 				assert.Equal(t, int32(32768), cs.GetListenerPerConnectionBufferLimitBytes().GetValue())
 				assert.Equal(t, time.Hour, cs.GetHttpIdleTimeout().AsDuration())
 				assert.Equal(t, int32(100), cs.GetHttpMaxConcurrentStreams().GetValue())

--- a/pilot/pkg/networking/core/connection_settings_test.go
+++ b/pilot/pkg/networking/core/connection_settings_test.go
@@ -218,6 +218,65 @@ func TestToEnvoyHeadersWithUnderscoresAction(t *testing.T) {
 		toEnvoyHeadersWithUnderscoresAction(meshconfig.ProxyConfig_ConnectionSettings_HEADERS_WITH_UNDERSCORES_DROP_HEADER))
 }
 
+func TestResolveConnectionSettings(t *testing.T) {
+	meshCS := &meshconfig.ProxyConfig_ConnectionSettings{
+		ClusterPerConnectionBufferLimitBytes: &wrappers.Int32Value{Value: 1024},
+	}
+	proxyCS := &meshconfig.ProxyConfig_ConnectionSettings{
+		ClusterPerConnectionBufferLimitBytes: &wrappers.Int32Value{Value: 8192},
+	}
+
+	cases := []struct {
+		name        string
+		meshConfig  *meshconfig.ProxyConfig_ConnectionSettings
+		proxyConfig *model.NodeMetaProxyConfig
+		want        int32
+		wantNil     bool
+	}{
+		{
+			name:       "mesh default used when proxy config is nil",
+			meshConfig: meshCS,
+			want:       1024,
+		},
+		{
+			name:       "proxy-level overrides mesh default",
+			meshConfig: meshCS,
+			proxyConfig: &model.NodeMetaProxyConfig{
+				ConnectionSettings: proxyCS,
+			},
+			want: 8192,
+		},
+		{
+			name:    "nil when neither mesh nor proxy sets connection settings",
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			mesh := &meshconfig.MeshConfig{
+				DefaultConfig: &meshconfig.ProxyConfig{
+					ConnectionSettings: tt.meshConfig,
+				},
+			}
+			proxy := &model.Proxy{
+				Type: model.Router,
+				Metadata: &model.NodeMetadata{
+					ProxyConfig: tt.proxyConfig,
+				},
+			}
+			push := &model.PushContext{Mesh: mesh}
+
+			cs := resolveConnectionSettings(proxy, push)
+			if tt.wantNil {
+				assert.Equal(t, cs == nil, true)
+				return
+			}
+			assert.Equal(t, cs.GetClusterPerConnectionBufferLimitBytes().GetValue(), tt.want)
+		})
+	}
+}
+
 func TestToEnvoyPathWithEscapedSlashesAction(t *testing.T) {
 	assert.Equal(t, hcm.HttpConnectionManager_KEEP_UNCHANGED,
 		toEnvoyPathWithEscapedSlashesAction(meshconfig.ProxyConfig_ConnectionSettings_KEEP_UNCHANGED))

--- a/releasenotes/notes/cluster-connection-buffer-limit.yaml
+++ b/releasenotes/notes/cluster-connection-buffer-limit.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue: []
+releaseNotes:
+  - |
+    **Added** support for cluster-level connection buffer limits (`clusterPerConnectionBufferLimitBytes`)
+    via `connectionSettings` in `ProxyConfig`, including `EDGE` profile defaults for gateway proxies.


### PR DESCRIPTION
Implements additional wiring for the ConnectionSettings API added in https://github.com/istio/api/pull/3707

Related to open PR: #60576 

Apply ProxyConfig ConnectionSettings cluster_per_connection_buffer_limit_bytes to generated clusters, including EDGE profile defaults for gateway proxies and unit coverage for default and override behavior.
