### PR TITLE
Fix ztunnel shutdown race

### DIFF
--- a/cni/pkg/nodeagent/ztunnelserver.go
+++ b/cni/pkg/nodeagent/ztunnelserver.go
@@ -341,6 +341,15 @@ type ZtunnelConnection interface {
 	Done() chan struct{}
 }
 
+func (c *connMgr) snapshotConns() []ZtunnelConnection {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// return a copy of the slice, so that the caller can iterate over it without holding the lock
+	conns := make([]ZtunnelConnection, len(c.connectionSet))
+	copy(conns, c.connectionSet)
+	return conns
+}
+
 // PodDeleted sends a pod deletion notification to connected ztunnels.
 //
 // Note that unlike PodAdded, this deletion event is broadcast to *all*
@@ -360,9 +369,7 @@ func (z *ztunnelServer) PodDeleted(ctx context.Context, uid string) error {
 
 	var delErr []error
 
-	z.conns.mu.Lock()
-	defer z.conns.mu.Unlock()
-	for _, conn := range z.conns.connectionSet {
+	for _, conn := range z.conns.snapshotConns() {
 		log := log.WithLabels("conn_uuid", conn.UUID())
 		log.Debug("sending msg to connected ztunnel")
 		_, err := conn.Send(ctx, r, nil)

--- a/cni/pkg/nodeagent/ztunnelserver.go
+++ b/cni/pkg/nodeagent/ztunnelserver.go
@@ -38,27 +38,6 @@ var readWriteDeadline = 5 * time.Second
 var ztunnelConnected = monitoring.NewGauge("ztunnel_connected",
 	"number of connections to ztunnel")
 
-// raceTestDelay is TEST-ONLY fault injection for reproducing istio/ztunnel#1674.
-// If the named env var is set to a valid Go duration (e.g. "24h", "6s"), it sleeps
-// that long or until ctx is done. When unset (the default) it is a no-op, so normal
-// behavior is unchanged and the image is safe to ship.
-func raceTestDelay(ctx context.Context, envVar string) {
-	v := os.Getenv(envVar)
-	if v == "" {
-		return
-	}
-	d, err := time.ParseDuration(v)
-	if err != nil {
-		log.Errorf("racetest: invalid duration %q for %s: %v", v, envVar, err)
-		return
-	}
-	log.Warnf("racetest: %s set, sleeping %s before proceeding", envVar, d)
-	select {
-	case <-time.After(d):
-	case <-ctx.Done():
-	}
-}
-
 type ZtunnelServer interface {
 	Run(ctx context.Context)
 	PodDeleted(ctx context.Context, uid string) error
@@ -203,7 +182,6 @@ func (z *ztunnelServer) handleConn(ctx context.Context, conn ZtunnelConnection) 
 	}
 
 	log.WithLabels("version", m.Version).Infof("received hello from ztunnel")
-	raceTestDelay(ctx, "ZTUNNEL_RACE_PRESNAPSHOT_DELAY")
 	log.Debug("sending snapshot to ztunnel")
 	if err := z.sendSnapshot(ctx, conn); err != nil {
 		return err
@@ -284,10 +262,9 @@ func podToWorkload(pod *v1.Pod) *zdsapi.WorkloadInfo {
 	}
 }
 
-func (z *ztunnelServer) sendSnapshot(ctx context.Context, conn ZtunnelConnection) error {
+func (z *ztunnelServer) sendSnapshot(_ context.Context, conn ZtunnelConnection) error {
 	snap := z.pods.ReadCurrentPodSnapshot()
 	for uid, wl := range snap {
-		raceTestDelay(ctx, "ZTUNNEL_RACE_PERPOD_DELAY")
 		var resp *zdsapi.WorkloadResponse
 		var err error
 		log := log.WithLabels("uid", uid)
@@ -325,7 +302,6 @@ func (z *ztunnelServer) sendSnapshot(ctx context.Context, conn ZtunnelConnection
 			log.Errorf("add-workload: got ack error: %s", resp.GetAck().GetError())
 		}
 	}
-	raceTestDelay(ctx, "ZTUNNEL_RACE_SNAPSHOT_DELAY")
 	resp, err := conn.SendMsgAndWaitForAck(&zdsapi.WorkloadRequest{
 		Payload: &zdsapi.WorkloadRequest_SnapshotSent{
 			SnapshotSent: &zdsapi.SnapshotSent{},

--- a/cni/pkg/nodeagent/ztunnelserver.go
+++ b/cni/pkg/nodeagent/ztunnelserver.go
@@ -38,6 +38,27 @@ var readWriteDeadline = 5 * time.Second
 var ztunnelConnected = monitoring.NewGauge("ztunnel_connected",
 	"number of connections to ztunnel")
 
+// raceTestDelay is TEST-ONLY fault injection for reproducing istio/ztunnel#1674.
+// If the named env var is set to a valid Go duration (e.g. "24h", "6s"), it sleeps
+// that long or until ctx is done. When unset (the default) it is a no-op, so normal
+// behavior is unchanged and the image is safe to ship.
+func raceTestDelay(ctx context.Context, envVar string) {
+	v := os.Getenv(envVar)
+	if v == "" {
+		return
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		log.Errorf("racetest: invalid duration %q for %s: %v", v, envVar, err)
+		return
+	}
+	log.Warnf("racetest: %s set, sleeping %s before proceeding", envVar, d)
+	select {
+	case <-time.After(d):
+	case <-ctx.Done():
+	}
+}
+
 type ZtunnelServer interface {
 	Run(ctx context.Context)
 	PodDeleted(ctx context.Context, uid string) error
@@ -84,6 +105,7 @@ func (c *connMgr) LatestConn() (ZtunnelConnection, error) {
 
 func (c *connMgr) deleteConn(conn ZtunnelConnection) {
 	log.Debug("ztunnel disconnected")
+	close(conn.Done())
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	log := log.WithLabels("conn_uuid", conn.UUID())
@@ -181,6 +203,7 @@ func (z *ztunnelServer) handleConn(ctx context.Context, conn ZtunnelConnection) 
 	}
 
 	log.WithLabels("version", m.Version).Infof("received hello from ztunnel")
+	raceTestDelay(ctx, "ZTUNNEL_RACE_PRESNAPSHOT_DELAY")
 	log.Debug("sending snapshot to ztunnel")
 	if err := z.sendSnapshot(ctx, conn); err != nil {
 		return err
@@ -261,9 +284,10 @@ func podToWorkload(pod *v1.Pod) *zdsapi.WorkloadInfo {
 	}
 }
 
-func (z *ztunnelServer) sendSnapshot(_ context.Context, conn ZtunnelConnection) error {
+func (z *ztunnelServer) sendSnapshot(ctx context.Context, conn ZtunnelConnection) error {
 	snap := z.pods.ReadCurrentPodSnapshot()
 	for uid, wl := range snap {
+		raceTestDelay(ctx, "ZTUNNEL_RACE_PERPOD_DELAY")
 		var resp *zdsapi.WorkloadResponse
 		var err error
 		log := log.WithLabels("uid", uid)
@@ -301,6 +325,7 @@ func (z *ztunnelServer) sendSnapshot(_ context.Context, conn ZtunnelConnection) 
 			log.Errorf("add-workload: got ack error: %s", resp.GetAck().GetError())
 		}
 	}
+	raceTestDelay(ctx, "ZTUNNEL_RACE_SNAPSHOT_DELAY")
 	resp, err := conn.SendMsgAndWaitForAck(&zdsapi.WorkloadRequest{
 		Payload: &zdsapi.WorkloadRequest_SnapshotSent{
 			SnapshotSent: &zdsapi.SnapshotSent{},
@@ -337,6 +362,7 @@ type ZtunnelConnection interface {
 	ReadHello() (*zdsapi.ZdsHello, error)
 	Send(ctx context.Context, data *zdsapi.WorkloadRequest, fd *int) (*zdsapi.WorkloadResponse, error)
 	SendMsgAndWaitForAck(msg *zdsapi.WorkloadRequest, fd *int) (*zdsapi.WorkloadResponse, error)
+	Done() chan struct{}
 }
 
 // PodDeleted sends a pod deletion notification to connected ztunnels.

--- a/cni/pkg/nodeagent/ztunnelserver_linux.go
+++ b/cni/pkg/nodeagent/ztunnelserver_linux.go
@@ -182,7 +182,7 @@ func (z ztunnelUDSConnection) Send(ctx context.Context, data *zdsapi.WorkloadReq
 	case <-ctx.Done():
 		return nil, fmt.Errorf("context expired before response received: %v", ctx.Err())
 	case <-z.done:
-		return nil, fmt.Errorf("connection closed before request sent")
+		return nil, fmt.Errorf("connection closed before response received")
 	}
 }
 

--- a/cni/pkg/nodeagent/ztunnelserver_linux.go
+++ b/cni/pkg/nodeagent/ztunnelserver_linux.go
@@ -32,6 +32,7 @@ type ztunnelUDSConnection struct {
 	uuid    uuid.UUID
 	u       *net.UnixConn
 	updates chan UpdateRequest
+	done    chan struct{}
 }
 
 type updateRequest struct {
@@ -69,7 +70,11 @@ func (ur updateRequest) Resp() chan updateResponse {
 
 func newZtunnelConnection(u net.Conn) ZtunnelConnection {
 	unixConn := u.(*net.UnixConn)
-	return &ztunnelUDSConnection{uuid: uuid.New(), u: unixConn, updates: make(chan UpdateRequest, 100)}
+	return &ztunnelUDSConnection{uuid: uuid.New(), u: unixConn, updates: make(chan UpdateRequest, 100), done: make(chan struct{})}
+}
+
+func (z *ztunnelUDSConnection) Done() chan struct{} {
+	return z.done
 }
 
 func (z *ztunnelUDSConnection) SendDataAndWaitForAck(data []byte, fd *int) (*zdsapi.WorkloadResponse, error) {
@@ -167,6 +172,8 @@ func (z ztunnelUDSConnection) Send(ctx context.Context, data *zdsapi.WorkloadReq
 	case z.updates <- req:
 	case <-ctx.Done():
 		return nil, fmt.Errorf("context expired before request sent: %v", ctx.Err())
+	case <-z.done:
+		return nil, fmt.Errorf("connection closed before request sent")
 	}
 
 	select {
@@ -174,6 +181,8 @@ func (z ztunnelUDSConnection) Send(ctx context.Context, data *zdsapi.WorkloadReq
 		return r.resp, r.err
 	case <-ctx.Done():
 		return nil, fmt.Errorf("context expired before response received: %v", ctx.Err())
+	case <-z.done:
+		return nil, fmt.Errorf("connection closed before request sent")
 	}
 }
 

--- a/cni/pkg/nodeagent/ztunnelserver_linux_test.go
+++ b/cni/pkg/nodeagent/ztunnelserver_linux_test.go
@@ -567,6 +567,92 @@ func TestZtunnelRemovePod(t *testing.T) {
 	mt.Assert(ztunnelConnected.Name(), nil, monitortest.Exactly(1))
 }
 
+// TestZtunnelPodDeletedDeadlockOnNonDrainingConn reproduces the quiet, permanent
+// "ztunnel stuck NotReady while the CNI reports Ready" deadlock behind istio/ztunnel#1674.
+//
+// PodDeleted holds z.conns.mu while calling conn.Send(...) on every connection, and Send blocks
+// until that connection's handleConn drains its `updates` channel and acks the message. PodDeleted
+// is invoked with the long-lived server context (see the s.ctx calls in informers.go), so there is
+// no per-operation timeout.
+//
+// If a connection is still in the connection set but nothing is draining its `updates` channel,
+// Send blocks forever while holding z.conns.mu. That is exactly the transient state produced when
+// an old ztunnel disconnects (e.g. a ztunnel pod restart on an established node): handleConn returns
+// and its deferred deleteConn() parks on z.conns.mu, so the dead connection is momentarily still in
+// connectionSet. A concurrent pod delete then grabs the mutex first and Sends to that dead
+// connection.
+//
+// Once PodDeleted is wedged holding z.conns.mu, addConn() blocks too, so a *reconnecting* ztunnel
+// hangs at the very first step of handleConn -- before ReadHello/sendSnapshot -- and therefore never
+// receives a snapshot. It stays NotReady (HTTP 500 "pending: workload proxy manager") indefinitely,
+// quietly, while the CNI pod still reports Ready.
+func TestZtunnelPodDeletedDeadlockOnNonDrainingConn(t *testing.T) {
+	setupLogging()
+
+	ztServ, err := newZtunnelServer(
+		fmt.Sprintf("@testaddr-deadlock%d", ztunnelTestCounter.Add(1)),
+		fakePodCache{},
+		time.Second/10,
+	)
+	assert.NoError(t, err)
+	defer ztServ.Close()
+
+	// A connection that is in the set but whose handleConn is not draining `updates` (the dead,
+	// not-yet-reaped state described above). Send() only touches the `updates` and per-request
+	// response channels -- never the socket -- so a nil socket is fine for exercising the real
+	// Send() code path here.
+	orphan := &ztunnelUDSConnection{uuid: uuid.New(), updates: make(chan UpdateRequest, 100)}
+	ztServ.conns.addConn(orphan)
+
+	// In production PodDeleted is called with the long-lived server ctx (no per-op timeout). Use a
+	// cancellable ctx so we can model "restart the CNI pod" (the issue's documented workaround) as
+	// the only escape, and so the test cleans up its goroutines.
+	ctx, cancel := context.WithCancel(context.Background())
+
+	podDeletedDone := make(chan error, 1)
+	go func() { podDeletedDone <- ztServ.PodDeleted(ctx, "some-deleted-pod-uid") }()
+
+	// PodDeleted enqueues the Del to orphan.updates then blocks on an ack that never comes, holding
+	// z.conns.mu the whole time.
+	select {
+	case <-podDeletedDone:
+		t.Fatal("PodDeleted returned, but it should block waiting for an ack from a non-draining connection")
+	case <-time.After(2 * time.Second):
+		// expected: still blocked, holding z.conns.mu
+	}
+
+	// Because PodDeleted holds z.conns.mu, a reconnecting ztunnel's addConn -- the first thing
+	// handleConn does, before ReadHello/sendSnapshot -- is also blocked. That is the quiet, permanent
+	// NotReady: the new ztunnel connects but never gets its snapshot.
+	reconnectAdded := make(chan struct{})
+	go func() {
+		ztServ.conns.addConn(&ztunnelUDSConnection{uuid: uuid.New(), updates: make(chan UpdateRequest, 100)})
+		close(reconnectAdded)
+	}()
+	select {
+	case <-reconnectAdded:
+		t.Fatal("a reconnecting ztunnel's addConn completed, but it should be blocked on z.conns.mu held by the wedged PodDeleted")
+	case <-time.After(2 * time.Second):
+		// expected: the reconnecting ztunnel is wedged at addConn -> stuck NotReady forever
+	}
+
+	// The only escape is cancelling the server context, i.e. restarting the CNI pod. Confirm that
+	// frees the deadlock (both PodDeleted and the blocked addConn proceed).
+	cancel()
+	select {
+	case <-podDeletedDone:
+		// PodDeleted's Send observed ctx cancellation and returned, releasing z.conns.mu.
+	case <-time.After(2 * time.Second):
+		t.Fatal("PodDeleted did not return after the server context was cancelled")
+	}
+	select {
+	case <-reconnectAdded:
+		// addConn proceeded once the mutex was released.
+	case <-time.After(2 * time.Second):
+		t.Fatal("addConn did not proceed after PodDeleted released z.conns.mu")
+	}
+}
+
 func TestZtunnelPodAdded(t *testing.T) {
 	mt := monitortest.New(t)
 	setupLogging()

--- a/cni/pkg/nodeagent/ztunnelserver_linux_test.go
+++ b/cni/pkg/nodeagent/ztunnelserver_linux_test.go
@@ -580,27 +580,25 @@ func TestZtunnelPodDeletedDoesNotDeadlockOnDisconnectingConn(t *testing.T) {
 	defer ztServ.Close()
 
 	// No socket is ok here
-	conn := &ztunnelUDSConnection{
-		uuid:    uuid.New(),
-		updates: make(chan UpdateRequest, 100),
-		done:    make(chan struct{}),
-	}
+	conn := newZtunnelConnection((*net.UnixConn)(nil))
 	ztServ.conns.addConn(conn)
 
 	// We don't cancel this context
 	ctx := context.Background()
 
-	podDeletedDone := make(chan error, 1)
-	go func() { podDeletedDone <- ztServ.PodDeleted(ctx, "some-deleted-pod-uid") }()
+	var podDeleteReturned atomic.Bool
+	go func() {
+		// PodDeleted returns a non-nil error here (Send returns "connection closed before
+		// response received" once done is closed); we only care that it returns at all.
+		_ = ztServ.PodDeleted(ctx, "some-deleted-pod-uid")
+		podDeleteReturned.Store(true)
+	}()
 
 	// PodDeleted enqueues the Del to conn.updates then blocks waiting for an ack that never comes
-	// from the non-draining connection, holding z.conns.mu the whole time.
-	select {
-	case <-podDeletedDone:
-		t.Fatal("PodDeleted returned before the connection was reaped; test did not exercise the deadlock path")
-	case <-time.After(500 * time.Millisecond):
-		// expected: still blocked, holding z.conns.mu
-	}
+	// from the non-draining connection, holding z.conns.mu the whole time. Confirm it stays blocked
+	// for a window, so we know we exercised the deadlock path (PodDeleted grabbed the mutex before
+	// the reap below).
+	assert.Consistently(t, podDeleteReturned.Load, false, 500*time.Millisecond)
 
 	// Simulate handleConn exiting and reaping the connection. deleteConn() closes conn.done
 	// *before* taking z.conns.mu.  The Send blocked above observes <-done, returns,
@@ -608,30 +606,16 @@ func TestZtunnelPodDeletedDoesNotDeadlockOnDisconnectingConn(t *testing.T) {
 	go ztServ.conns.deleteConn(conn)
 
 	// The fix: PodDeleted unblocks promptly, WITHOUT the server context being cancelled.
-	select {
-	case <-podDeletedDone:
-		// good: the blocked broadcast was released when the connection was reaped.
-	case <-time.After(2 * time.Second):
-		t.Fatal("PodDeleted did not return after the connection was reaped -- deadlock not fixed")
-	}
+	assert.EventuallyEqual(t, podDeleteReturned.Load, true)
 
 	// And because the mutex was released, a reconnecting ztunnel's addConn is not blocked -- so a
 	// fresh ztunnel can register and receive its snapshot.
-	reconnectAdded := make(chan struct{})
+	var reconnectAdded atomic.Bool
 	go func() {
-		ztServ.conns.addConn(&ztunnelUDSConnection{
-			uuid:    uuid.New(),
-			updates: make(chan UpdateRequest, 100),
-			done:    make(chan struct{}),
-		})
-		close(reconnectAdded)
+		ztServ.conns.addConn(newZtunnelConnection((*net.UnixConn)(nil)))
+		reconnectAdded.Store(true)
 	}()
-	select {
-	case <-reconnectAdded:
-		// good: z.conns.mu is free.
-	case <-time.After(2 * time.Second):
-		t.Fatal("a reconnecting ztunnel's addConn blocked -- z.conns.mu is still held")
-	}
+	assert.EventuallyEqual(t, reconnectAdded.Load, true)
 }
 
 func TestZtunnelPodAdded(t *testing.T) {

--- a/cni/pkg/nodeagent/ztunnelserver_linux_test.go
+++ b/cni/pkg/nodeagent/ztunnelserver_linux_test.go
@@ -567,26 +567,8 @@ func TestZtunnelRemovePod(t *testing.T) {
 	mt.Assert(ztunnelConnected.Name(), nil, monitortest.Exactly(1))
 }
 
-// TestZtunnelPodDeletedDeadlockOnNonDrainingConn reproduces the quiet, permanent
-// "ztunnel stuck NotReady while the CNI reports Ready" deadlock behind istio/ztunnel#1674.
-//
-// PodDeleted holds z.conns.mu while calling conn.Send(...) on every connection, and Send blocks
-// until that connection's handleConn drains its `updates` channel and acks the message. PodDeleted
-// is invoked with the long-lived server context (see the s.ctx calls in informers.go), so there is
-// no per-operation timeout.
-//
-// If a connection is still in the connection set but nothing is draining its `updates` channel,
-// Send blocks forever while holding z.conns.mu. That is exactly the transient state produced when
-// an old ztunnel disconnects (e.g. a ztunnel pod restart on an established node): handleConn returns
-// and its deferred deleteConn() parks on z.conns.mu, so the dead connection is momentarily still in
-// connectionSet. A concurrent pod delete then grabs the mutex first and Sends to that dead
-// connection.
-//
-// Once PodDeleted is wedged holding z.conns.mu, addConn() blocks too, so a *reconnecting* ztunnel
-// hangs at the very first step of handleConn -- before ReadHello/sendSnapshot -- and therefore never
-// receives a snapshot. It stays NotReady (HTTP 500 "pending: workload proxy manager") indefinitely,
-// quietly, while the CNI pod still reports Ready.
-func TestZtunnelPodDeletedDeadlockOnNonDrainingConn(t *testing.T) {
+// Test that a simulataneus pod delete and ztunnel disconenect does not deadlock
+func TestZtunnelPodDeletedDoesNotDeadlockOnDisconnectingConn(t *testing.T) {
 	setupLogging()
 
 	ztServ, err := newZtunnelServer(
@@ -597,59 +579,58 @@ func TestZtunnelPodDeletedDeadlockOnNonDrainingConn(t *testing.T) {
 	assert.NoError(t, err)
 	defer ztServ.Close()
 
-	// A connection that is in the set but whose handleConn is not draining `updates` (the dead,
-	// not-yet-reaped state described above). Send() only touches the `updates` and per-request
-	// response channels -- never the socket -- so a nil socket is fine for exercising the real
-	// Send() code path here.
-	orphan := &ztunnelUDSConnection{uuid: uuid.New(), updates: make(chan UpdateRequest, 100)}
-	ztServ.conns.addConn(orphan)
+	// No socket is ok here
+	conn := &ztunnelUDSConnection{
+		uuid:    uuid.New(),
+		updates: make(chan UpdateRequest, 100),
+		done:    make(chan struct{}),
+	}
+	ztServ.conns.addConn(conn)
 
-	// In production PodDeleted is called with the long-lived server ctx (no per-op timeout). Use a
-	// cancellable ctx so we can model "restart the CNI pod" (the issue's documented workaround) as
-	// the only escape, and so the test cleans up its goroutines.
-	ctx, cancel := context.WithCancel(context.Background())
+	// We don't cancel this context
+	ctx := context.Background()
 
 	podDeletedDone := make(chan error, 1)
 	go func() { podDeletedDone <- ztServ.PodDeleted(ctx, "some-deleted-pod-uid") }()
 
-	// PodDeleted enqueues the Del to orphan.updates then blocks on an ack that never comes, holding
-	// z.conns.mu the whole time.
+	// PodDeleted enqueues the Del to conn.updates then blocks waiting for an ack that never comes
+	// from the non-draining connection, holding z.conns.mu the whole time.
 	select {
 	case <-podDeletedDone:
-		t.Fatal("PodDeleted returned, but it should block waiting for an ack from a non-draining connection")
-	case <-time.After(2 * time.Second):
+		t.Fatal("PodDeleted returned before the connection was reaped; test did not exercise the deadlock path")
+	case <-time.After(500 * time.Millisecond):
 		// expected: still blocked, holding z.conns.mu
 	}
 
-	// Because PodDeleted holds z.conns.mu, a reconnecting ztunnel's addConn -- the first thing
-	// handleConn does, before ReadHello/sendSnapshot -- is also blocked. That is the quiet, permanent
-	// NotReady: the new ztunnel connects but never gets its snapshot.
+	// Simulate handleConn exiting and reaping the connection. deleteConn() closes conn.done
+	// *before* taking z.conns.mu.  The Send blocked above observes <-done, returns,
+	// and PodDeleted releases the mutex (letting deleteConn then acquire it).
+	go ztServ.conns.deleteConn(conn)
+
+	// The fix: PodDeleted unblocks promptly, WITHOUT the server context being cancelled.
+	select {
+	case <-podDeletedDone:
+		// good: the blocked broadcast was released when the connection was reaped.
+	case <-time.After(2 * time.Second):
+		t.Fatal("PodDeleted did not return after the connection was reaped -- deadlock not fixed")
+	}
+
+	// And because the mutex was released, a reconnecting ztunnel's addConn is not blocked -- so a
+	// fresh ztunnel can register and receive its snapshot.
 	reconnectAdded := make(chan struct{})
 	go func() {
-		ztServ.conns.addConn(&ztunnelUDSConnection{uuid: uuid.New(), updates: make(chan UpdateRequest, 100)})
+		ztServ.conns.addConn(&ztunnelUDSConnection{
+			uuid:    uuid.New(),
+			updates: make(chan UpdateRequest, 100),
+			done:    make(chan struct{}),
+		})
 		close(reconnectAdded)
 	}()
 	select {
 	case <-reconnectAdded:
-		t.Fatal("a reconnecting ztunnel's addConn completed, but it should be blocked on z.conns.mu held by the wedged PodDeleted")
+		// good: z.conns.mu is free.
 	case <-time.After(2 * time.Second):
-		// expected: the reconnecting ztunnel is wedged at addConn -> stuck NotReady forever
-	}
-
-	// The only escape is cancelling the server context, i.e. restarting the CNI pod. Confirm that
-	// frees the deadlock (both PodDeleted and the blocked addConn proceed).
-	cancel()
-	select {
-	case <-podDeletedDone:
-		// PodDeleted's Send observed ctx cancellation and returned, releasing z.conns.mu.
-	case <-time.After(2 * time.Second):
-		t.Fatal("PodDeleted did not return after the server context was cancelled")
-	}
-	select {
-	case <-reconnectAdded:
-		// addConn proceeded once the mutex was released.
-	case <-time.After(2 * time.Second):
-		t.Fatal("addConn did not proceed after PodDeleted released z.conns.mu")
+		t.Fatal("a reconnecting ztunnel's addConn blocked -- z.conns.mu is still held")
 	}
 }
 

--- a/cni/pkg/nodeagent/ztunnelserver_mocks.go
+++ b/cni/pkg/nodeagent/ztunnelserver_mocks.go
@@ -26,14 +26,19 @@ import (
 
 type MockedZtunnelConnection struct {
 	mock.Mock
+	done chan struct{}
 }
 
 func FakeZtunnelConnection() *MockedZtunnelConnection {
-	return &MockedZtunnelConnection{}
+	return &MockedZtunnelConnection{done: make(chan struct{})}
 }
 
 func (m *MockedZtunnelConnection) Close() {
 	m.Called()
+}
+
+func (m *MockedZtunnelConnection) Done() chan struct{} {
+	return m.done
 }
 
 func (m *MockedZtunnelConnection) UUID() uuid.UUID {

--- a/releasenotes/notes/cni-ztunnel-poddeleted-deadlock.yaml
+++ b/releasenotes/notes/cni-ztunnel-poddeleted-deadlock.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - https://github.com/istio/ztunnel/issues/1674
+releaseNotes:
+  - |
+    **Fixed** a deadlock in the ambient CNI node agent where a pod deletion event
+    concurrent with a ztunnel (re)connection could permanently block the ZDS server.


### PR DESCRIPTION
There is a race condition. The two protagonists are

```go
func (z *ztunnelServer) PodDeleted(ctx context.Context, uid string) error {
        ...
	z.conns.mu.Lock()
	defer z.conns.mu.Unlock()
	for _, conn := range z.conns.connectionSet {
		log := log.WithLabels("conn_uuid", conn.UUID())
		_, err := conn.Send(ctx, r, nil)
		if err != nil {
			delErr = append(delErr, err)
		}
	}
	return errors.Join(delErr...)
}

func (z *ztunnelServer) Run(ctx context.Context) {
	context.AfterFunc(ctx, func() { _ = z.Close() })

	// Allow at most 5 requests per second. This is still a ridiculous amount; at most we should have 2 ztunnels on our node,
	// and they will only connect once and persist.
	// However, if they do get in a state where they call us in a loop, we will quickly OOM
	limit := rate.NewLimiter(rate.Limit(5), 1)
	for {
		log.Debug("accepting conn")
		if err := limit.Wait(ctx); err != nil {
			log.Errorf("failed to wait for ztunnel connection: %v", err)
			return
		}
		conn, err := z.accept()
		if err != nil {
			...
		}
		log.Debug("connection accepted")
		go func() {
			log := log.WithLabels("conn_uuid", conn.UUID())
			log.Debug("handling conn")
			if err := z.handleConn(ctx, conn); err != nil {
				log.Errorf("failed to handle conn: %v", err)
			}
		}()
	}
}

func (c *connMgr) deleteConn(conn ZtunnelConnection) {
	log.Debug("ztunnel disconnected")
	close(conn.Done())
	c.mu.Lock()
	defer c.mu.Unlock()
	log := log.WithLabels("conn_uuid", conn.UUID())

	// Loop over the slice, keeping non-deleted conn but
	// filtering out the deleted one.
	var retainedConns []ZtunnelConnection
	for _, existingConn := range c.connectionSet {
		// Not conn that was deleted? Keep it.
		if existingConn != conn {
			retainedConns = append(retainedConns, existingConn)
		}
	}
	c.connectionSet = retainedConns
	log.Infof("ztunnel disconnected, total connected %s", len(c.connectionSet))
	ztunnelConnected.RecordInt(int64(len(c.connectionSet)))
}
```

So the connection flow goes as follows. The CNI gets a new ztunnel connection.  `handleConn` will loop waiting for update messages in the update channel, responding to the updates

```go
			update.Resp() <- updateResponse{
				err:  err,
				resp: resp,
			}
```
and forwarding the corresponding info to ztunnel. The problem is if there is if `PodDeleted` runs right before `deleteConn`. in `PodDelete`, `conn.Send` will wait for a reply while holding the lock. However, the loop that responds to messages in the update channel has exited. So the `conn.Send` is stuck holding the mutex forever.

Each ztunnel connection has its own lifetime and we should have a corresponding channel for it.