### PR TITLE
conformance: fix empty backendRefs response for HTTPRouteNoBackendRefs test

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -227,16 +227,10 @@ func convertHTTPRoute(ctx RouteContext, r k8s.HTTPRouteRule,
 		}
 	}
 	if weightSum(r.BackendRefs) == 0 && vs.Redirect == nil {
-		if len(r.BackendRefs) == 0 {
-			// No backends specified at all; per the Gateway API spec return 404
-			vs.DirectResponse = &istio.HTTPDirectResponse{
-				Status: 404,
-			}
-		} else {
-			// Backends exist but all have zero weight; per the Gateway API spec return 500
-			vs.DirectResponse = &istio.HTTPDirectResponse{
-				Status: 500,
-			}
+		// Per the Gateway API spec, when there are no >0 weight backends return
+		// 500.
+		vs.DirectResponse = &istio.HTTPDirectResponse{
+			Status: 500,
 		}
 	} else {
 		route, ipCfg, backendErr, err := buildHTTPDestination(ctx, r.BackendRefs, obj.Namespace, enforceRefGrant)

--- a/pilot/pkg/config/kube/gateway/testdata/empty-backend-refs.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/empty-backend-refs.yaml
@@ -24,10 +24,7 @@ spec:
       namespaces:
         from: All
 ---
-# Test case for https://github.com/istio/istio/issues/59356
-# HTTPRoute with empty backendRefs should return 404 (not 500).
-# Currently the code does not distinguish between empty backendRefs
-# (no backends at all) and zero-weight backendRefs.
+# HTTPRoute with empty or omitted backendRefs should return 500.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -39,12 +36,12 @@ spec:
     namespace: istio-system
   hostnames: ["no-backend.domain.example"]
   rules:
-  # Rule with no backendRefs at all - should return 404 per spec, but currently returns 500
+  # Rule with no backendRefs at all - returns 500 per spec
   - matches:
     - path:
         type: PathPrefix
         value: /no-backend
-  # Rule with empty backendRefs list - should also return 404 per spec, but currently returns 500
+  # Rule with empty backendRefs list - also returns 500 per spec
   - matches:
     - path:
         type: PathPrefix

--- a/pilot/pkg/config/kube/gateway/testdata/empty-backend-refs.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/empty-backend-refs.yaml.golden
@@ -32,13 +32,13 @@ spec:
   - no-backend.domain.example
   http:
   - directResponse:
-      status: 404
+      status: 500
     match:
     - uri:
         prefix: /no-backend
     name: default.no-backend.0
   - directResponse:
-      status: 404
+      status: 500
     match:
     - uri:
         prefix: /empty-list

--- a/pilot/pkg/config/kube/gateway/testdata/invalid.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/invalid.yaml.golden
@@ -88,7 +88,7 @@ spec:
         port:
           number: 80
   - directResponse:
-      status: 404
+      status: 500
     mirrors:
     - destination:
         host: httpbin.default.svc.domain.suffix

--- a/releasenotes/notes/60787.yaml
+++ b/releasenotes/notes/60787.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed** an issue where an `HTTPRoute` with empty or omitted `backendRefs`
+    returned an HTTP 404 status code instead of 500. This matches the behavior
+    enforced by the `HTTPRouteNoBackendRefs` Gateway API conformance test,
+    introduced in v1.6.0.

--- a/tests/integration/ambient/gateway_conformance_test.go
+++ b/tests/integration/ambient/gateway_conformance_test.go
@@ -80,7 +80,6 @@ var skippedTests = map[string]string{
 	"MeshHTTPRoute307Redirect": "TODO",
 
 	// The following tests were added in v1.6.0
-	"HTTPRouteNoBackendRefs":             "TODO",
 	"GatewayInvalidParametersRef":        "TODO",
 	"GatewayListenerUnsupportedProtocol": "TODO",
 }

--- a/tests/integration/pilot/agentgateway/gateway_conformance_test.go
+++ b/tests/integration/pilot/agentgateway/gateway_conformance_test.go
@@ -100,7 +100,6 @@ var skippedTests = map[string]string{
 	"TLSRouteMixedTerminationSameNamespace": "TODO",
 
 	// The following tests were added in v1.6.0
-	"HTTPRouteNoBackendRefs":             "TODO",
 	"GatewayInvalidParametersRef":        "TODO",
 	"GatewayListenerUnsupportedProtocol": "TODO",
 }

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -79,7 +79,6 @@ var skippedTests = map[string]string{
 	"MeshHTTPRoute307Redirect": "TODO",
 
 	// The following tests were added in v1.6.0
-	"HTTPRouteNoBackendRefs":             "TODO",
 	"GatewayInvalidParametersRef":        "TODO",
 	"GatewayListenerUnsupportedProtocol": "TODO",
 	"TCPRouteWeightedRouting":            "TODO: flaky in dual-stack and multicluster environments",


### PR DESCRIPTION
**Please provide a description of this PR:**

For Gateway API v1.6 conformance, it looks like guidance referenced in #59356 has changed, and now Gateway API expects a 500 to be returned for empty backendRefs, not 404: https://gateway-api.sigs.k8s.io/reference/api-types/httproute/#backendrefs-optional

> If unspecified and no filters are specified that would result in a response being sent, a 500 error code is returned.

Reenables the HTTPRouteNoBackendRefs test that we are skipping currently.