### PR TITLE
during auto-registration, add tunnel label for hbone compatible proxies

### DIFF
--- a/pilot/pkg/autoregistration/controller.go
+++ b/pilot/pkg/autoregistration/controller.go
@@ -704,6 +704,16 @@ func workloadEntryFromGroup(name string, proxy *model.Proxy, groupCfg *config.Co
 		delete(entry.Labels, pm.LocalityLabel)
 	}
 
+	// If the proxy accepts HBONE, set the tunnel label so istiod marks the workload HBONE-capable
+	if proxy.EnableHBONEListen() {
+		if entry.Labels == nil {
+			entry.Labels = map[string]string{}
+		}
+		if _, ok := entry.Labels[model.TunnelLabel]; !ok {
+			entry.Labels[model.TunnelLabel] = model.TunnelHTTP
+		}
+	}
+
 	annotations := map[string]string{annotation.IoIstioAutoRegistrationGroup.Name: groupCfg.Name}
 	if group.Metadata != nil && group.Metadata.Annotations != nil {
 		annotations = mergeLabels(annotations, group.Metadata.Annotations)

--- a/pilot/pkg/autoregistration/controller_test.go
+++ b/pilot/pkg/autoregistration/controller_test.go
@@ -490,6 +490,67 @@ func TestWorkloadEntryFromGroup(t *testing.T) {
 	assert.Equal(t, got, &want)
 }
 
+func TestWorkloadEntryFromGroupHBONE(t *testing.T) {
+	// EnableHBONEListen() requires the sidecar HBONE listening feature, which only
+	// defaults on under ambient; force it so the labeling path is actually exercised.
+	test.SetForTest(t, &features.EnableSidecarHBONEListening, true)
+
+	baseGroup := func() config.Config {
+		return config.Config{
+			Meta: config.Meta{
+				GroupVersionKind: gvk.WorkloadGroup,
+				Namespace:        "a",
+				Name:             "wg-a",
+			},
+			Spec: &v1alpha3.WorkloadGroup{
+				Template: &v1alpha3.WorkloadEntry{
+					Ports:          map[string]uint32{"http": 80},
+					Labels:         map[string]string{"app": "a"},
+					ServiceAccount: "sa-a",
+				},
+			},
+		}
+	}
+
+	cases := []struct {
+		name        string
+		enableHBONE bool
+		tmplLabels  map[string]string
+		wantTunnel  string // expected value of the tunnel label ("" means absent)
+	}{
+		{
+			name:        "EnableHBONE sets tunnel label",
+			enableHBONE: true,
+			wantTunnel:  model.TunnelHTTP,
+		},
+		{
+			name:        "EnableHBONE false leaves label absent",
+			enableHBONE: false,
+			wantTunnel:  "",
+		},
+		{
+			name:        "explicit tunnel label not overwritten",
+			enableHBONE: true,
+			tmplLabels:  map[string]string{"app": "a", model.TunnelLabel: "other"},
+			wantTunnel:  "other",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			group := baseGroup()
+			if tc.tmplLabels != nil {
+				group.Spec.(*v1alpha3.WorkloadGroup).Template.Labels = tc.tmplLabels
+			}
+			proxy := fakeProxy("10.0.0.1", group, "nw1", "sa")
+			proxy.Metadata.EnableHBONE = model.StringBool(tc.enableHBONE)
+
+			got := workloadEntryFromGroup("test-we", proxy, &group)
+			assert.Equal(t, got.Labels[model.TunnelLabel], tc.wantTunnel)
+		})
+	}
+}
+
 func TestNonAutoregisteredWorkloads_UnsuitableForHealthChecks_WorkloadEntryNotFound(t *testing.T) {
 	store := memory.NewController(memory.Make(collections.All))
 	stop := test.NewStop(t)

--- a/pilot/pkg/serviceregistry/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/ambient/workloads_test.go
@@ -915,6 +915,60 @@ func TestWorkloadEntryWorkloads(t *testing.T) {
 			},
 		},
 		{
+			name: "we with tunnel label is HBONE",
+			inputs: []any{
+				model.ServiceInfo{
+					Service: &workloadapi.Service{
+						Name:      "svc",
+						Namespace: "ns",
+						Hostname:  "hostname",
+						Ports: []*workloadapi.Port{{
+							ServicePort: 80,
+							TargetPort:  8080,
+						}},
+					},
+					LabelSelector: model.NewSelector(map[string]string{"app": "foo"}),
+				},
+			},
+			we: &networkingclient.WorkloadEntry{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "ns",
+					Labels: map[string]string{
+						"app":             "foo",
+						model.TunnelLabel: model.TunnelHTTP,
+					},
+				},
+				Spec: networking.WorkloadEntry{
+					Address: "1.2.3.4",
+				},
+			},
+			result: &workloadapi.Workload{
+				Uid:               "cluster0/networking.istio.io/WorkloadEntry/ns/name",
+				Name:              "name",
+				Namespace:         "ns",
+				Addresses:         [][]byte{netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice()},
+				Network:           testNW,
+				CanonicalName:     "foo",
+				CanonicalRevision: "latest",
+				WorkloadType:      workloadapi.WorkloadType_POD,
+				WorkloadName:      "name",
+				Status:            workloadapi.WorkloadStatus_HEALTHY,
+				ClusterId:         testC,
+				TunnelProtocol:    workloadapi.TunnelProtocol_HBONE,
+				NativeTunnel:      true,
+				Services: map[string]*workloadapi.PortList{
+					"ns/hostname": {
+						Ports: []*workloadapi.Port{{
+							ServicePort: 80,
+							TargetPort:  8080,
+						}},
+					},
+				},
+			},
+		},
+		{
 			name: "we without labels",
 			inputs: []any{
 				model.ServiceInfo{

--- a/releasenotes/notes/60788.yaml
+++ b/releasenotes/notes/60788.yaml
@@ -1,0 +1,18 @@
+apiVersion: release-notes/v2
+
+kind: bug-fix
+
+area: traffic-management
+
+releaseNotes:
+- |
+  **Fixed** an issue where the advertised HBONE capability was not
+  propagated onto auto-registered WorkloadEntries for non-Kubernetes workloads.
+
+upgradeNotes:
+  - title: Existing auto-registered WorkloadEntries need re-registration or a manual label for HBONE
+    content: |
+      The HBONE tunnel label is applied only when a WorkloadEntry is auto-created, so workloads
+      auto-registered before upgrading continue to be reached over plaintext until either they
+      re-register (reconnect a fresh instance) or the label (`networking.istio.io/tunnel=http`)
+      is added to their existing WorkloadEntry.


### PR DESCRIPTION
Fixed an issue where the advertised HBONE capability was not propagated onto auto-registered WorkloadEntries for non-Kubernetes workloads.