### PR TITLE
perf: use pointer config in vs controller

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -99,11 +99,11 @@ type exportToDefaults struct {
 
 // virtualServiceIndex is the index of virtual services by various fields.
 type virtualServiceIndex struct {
-	exportedToNamespaceByGateway map[types.NamespacedName][]config.Config
+	exportedToNamespaceByGateway map[types.NamespacedName][]*config.Config
 	// this contains all the virtual services with exportTo "." and current namespace. The keys are namespace,gateway.
-	privateByNamespaceAndGateway map[types.NamespacedName][]config.Config
+	privateByNamespaceAndGateway map[types.NamespacedName][]*config.Config
 	// This contains all virtual services whose exportTo is "*", keyed by gateway
-	publicByGateway map[string][]config.Config
+	publicByGateway map[string][]*config.Config
 
 	// This contains destination hosts of virtual services, keyed by gateway's namespace/name,
 	// only used when PILOT_FILTER_GATEWAY_CLUSTER_CONFIG is enabled
@@ -115,9 +115,9 @@ type virtualServiceIndex struct {
 
 func newVirtualServiceIndex() virtualServiceIndex {
 	out := virtualServiceIndex{
-		publicByGateway:              map[string][]config.Config{},
-		privateByNamespaceAndGateway: map[types.NamespacedName][]config.Config{},
-		exportedToNamespaceByGateway: map[types.NamespacedName][]config.Config{},
+		publicByGateway:              map[string][]*config.Config{},
+		privateByNamespaceAndGateway: map[types.NamespacedName][]*config.Config{},
+		exportedToNamespaceByGateway: map[types.NamespacedName][]*config.Config{},
 		referencedDestinations:       map[string]sets.String{},
 	}
 	if features.FilterGatewayClusterConfig {
@@ -1087,21 +1087,21 @@ func (ps *PushContext) VirtualServicesForGateway(proxyNamespace, gateway string)
 		len(ps.virtualServiceIndex.publicByGateway[gateway]))
 	// Use index-based iteration to get stable pointers to slice elements
 	for i := range ps.virtualServiceIndex.privateByNamespaceAndGateway[name] {
-		res = append(res, &ps.virtualServiceIndex.privateByNamespaceAndGateway[name][i])
+		res = append(res, ps.virtualServiceIndex.privateByNamespaceAndGateway[name][i])
 	}
 	for i := range ps.virtualServiceIndex.exportedToNamespaceByGateway[name] {
-		res = append(res, &ps.virtualServiceIndex.exportedToNamespaceByGateway[name][i])
+		res = append(res, ps.virtualServiceIndex.exportedToNamespaceByGateway[name][i])
 	}
 	// Favor same-namespace Gateway routes, to give the "consumer override" preference.
 	// We do 2 iterations here to avoid extra allocations.
 	for i := range ps.virtualServiceIndex.publicByGateway[gateway] {
-		vs := &ps.virtualServiceIndex.publicByGateway[gateway][i]
+		vs := ps.virtualServiceIndex.publicByGateway[gateway][i]
 		if UseGatewaySemantics(*vs) && vs.Namespace == proxyNamespace {
 			res = append(res, vs)
 		}
 	}
 	for i := range ps.virtualServiceIndex.publicByGateway[gateway] {
-		vs := &ps.virtualServiceIndex.publicByGateway[gateway][i]
+		vs := ps.virtualServiceIndex.publicByGateway[gateway][i]
 		if !(UseGatewaySemantics(*vs) && vs.Namespace == proxyNamespace) {
 			res = append(res, vs)
 		}
@@ -1732,9 +1732,9 @@ func (ps *PushContext) initAuthnPolicies(env *Environment) {
 
 // Caches list of virtual services
 func (ps *PushContext) initVirtualServices(env *Environment) {
-	ps.virtualServiceIndex.exportedToNamespaceByGateway = map[types.NamespacedName][]config.Config{}
-	ps.virtualServiceIndex.privateByNamespaceAndGateway = map[types.NamespacedName][]config.Config{}
-	ps.virtualServiceIndex.publicByGateway = map[string][]config.Config{}
+	ps.virtualServiceIndex.exportedToNamespaceByGateway = map[types.NamespacedName][]*config.Config{}
+	ps.virtualServiceIndex.privateByNamespaceAndGateway = map[types.NamespacedName][]*config.Config{}
+	ps.virtualServiceIndex.publicByGateway = map[string][]*config.Config{}
 	ps.virtualServiceIndex.referencedDestinations = map[string]sets.String{}
 
 	if features.FilterGatewayClusterConfig {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1086,22 +1086,16 @@ func (ps *PushContext) VirtualServicesForGateway(proxyNamespace, gateway string)
 		len(ps.virtualServiceIndex.exportedToNamespaceByGateway[name])+
 		len(ps.virtualServiceIndex.publicByGateway[gateway]))
 	// Use index-based iteration to get stable pointers to slice elements
-	for i := range ps.virtualServiceIndex.privateByNamespaceAndGateway[name] {
-		res = append(res, ps.virtualServiceIndex.privateByNamespaceAndGateway[name][i])
-	}
-	for i := range ps.virtualServiceIndex.exportedToNamespaceByGateway[name] {
-		res = append(res, ps.virtualServiceIndex.exportedToNamespaceByGateway[name][i])
-	}
+	res = append(res, ps.virtualServiceIndex.privateByNamespaceAndGateway[name]...)
+	res = append(res, ps.virtualServiceIndex.exportedToNamespaceByGateway[name]...)
 	// Favor same-namespace Gateway routes, to give the "consumer override" preference.
 	// We do 2 iterations here to avoid extra allocations.
-	for i := range ps.virtualServiceIndex.publicByGateway[gateway] {
-		vs := ps.virtualServiceIndex.publicByGateway[gateway][i]
+	for _, vs := range ps.virtualServiceIndex.publicByGateway[gateway] {
 		if UseGatewaySemantics(*vs) && vs.Namespace == proxyNamespace {
 			res = append(res, vs)
 		}
 	}
-	for i := range ps.virtualServiceIndex.publicByGateway[gateway] {
-		vs := ps.virtualServiceIndex.publicByGateway[gateway][i]
+	for _, vs := range ps.virtualServiceIndex.publicByGateway[gateway] {
 		if !(UseGatewaySemantics(*vs) && vs.Namespace == proxyNamespace) {
 			res = append(res, vs)
 		}

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -3347,7 +3347,7 @@ func TestContainsEgressDependencies(t *testing.T) {
 					Attributes: ServiceAttributes{Namespace: nsName},
 				},
 			}
-			virtualServices := []config.Config{
+			virtualServices := []*config.Config{
 				{
 					Meta: config.Meta{
 						Name:      vsName,
@@ -3984,9 +3984,9 @@ func BenchmarkConvertIstioListenerToWrapper(b *testing.B) {
 
 func benchmarkConvertIstioListenerToWrapper(b *testing.B, vsNum int, hostNum int, wildcard string, matchAll bool) {
 	// virtual service
-	cfgs := make([]config.Config, 0)
+	cfgs := make([]*config.Config, 0)
 	for i := 0; i < vsNum; i++ {
-		cfgs = append(cfgs, config.Config{
+		cfgs = append(cfgs, &config.Config{
 			Meta: config.Meta{
 				GroupVersionKind: gvk.VirtualService,
 				Name:             "vs-name-" + strconv.Itoa(i),

--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -64,12 +64,11 @@ func SelectVirtualServices(vsidx virtualServiceIndex, configNamespace string, ho
 		}
 	}
 
-	var loopAndAdd func(vses []config.Config)
+	var loopAndAdd func(vses []*config.Config)
 	if features.UnifiedSidecarScoping {
-		loopAndAdd = func(vses []config.Config) {
+		loopAndAdd = func(vses []*config.Config) {
 			for _, gwMatch := range []bool{true, false} {
-				for i := range vses {
-					c := &vses[i]
+				for _, c := range vses {
 					useGatewaySemantics := UseGatewaySemantics(*c)
 					gwExact := useGatewaySemantics && c.Namespace == configNamespace
 					if gwMatch != gwExact {
@@ -95,9 +94,8 @@ func SelectVirtualServices(vsidx virtualServiceIndex, configNamespace string, ho
 		}
 	} else {
 		// Legacy path
-		loopAndAdd = func(vses []config.Config) {
-			for i := range vses {
-				c := &vses[i]
+		loopAndAdd = func(vses []*config.Config) {
+			for _, c := range vses {
 				vsNamespace := c.Namespace
 				useGatewaySemantics := UseGatewaySemantics(*c)
 				// Selection algorithm:

--- a/pilot/pkg/model/virtualservice_controller.go
+++ b/pilot/pkg/model/virtualservice_controller.go
@@ -109,7 +109,7 @@ func (c *VirtualServiceController) xdsPush(events []krt.Event[MergedVirtualServi
 
 	cu := sets.New[ConfigKey]()
 	for _, e := range events {
-		if e.Old != nil && e.New != nil && !NeedsPush(e.Old.Config, e.New.Config) {
+		if e.Old != nil && e.New != nil && !NeedsPush(*e.Old.Config, *e.New.Config) {
 			continue
 		}
 		for _, vs := range e.Items() {
@@ -236,7 +236,7 @@ func defaultExportTo(
 }
 
 type MergedVirtualService struct {
-	config.Config
+	*config.Config
 	ExportTo sets.Set[visibility.Instance]
 }
 
@@ -245,7 +245,7 @@ func (m MergedVirtualService) ResourceName() string {
 }
 
 func (m MergedVirtualService) Equals(other MergedVirtualService) bool {
-	return m.Config.Equals(&other.Config)
+	return m.Config.Equals(other.Config)
 }
 
 func mergeVirtualServices(
@@ -269,7 +269,7 @@ func mergeVirtualServices(
 				exportToSet = copyDefaultExportToSet(defaultExportTo, cfg.Namespace)
 			}
 			return &MergedVirtualService{
-				Config:   cfg,
+				Config:   &cfg,
 				ExportTo: exportToSet,
 			}
 		}
@@ -286,7 +286,7 @@ func mergeVirtualServices(
 		// if this is an Ingress VS, we don't need to perform any merging
 		if UseIngressSemantics(cfg) {
 			return &MergedVirtualService{
-				Config:   root,
+				Config:   &root,
 				ExportTo: exportToSet,
 			}
 		}
@@ -294,7 +294,7 @@ func mergeVirtualServices(
 		// if this VS does not reference any delegate, we don't need to perform any merging
 		if !isRootVs(spec) {
 			return &MergedVirtualService{
-				Config:   root,
+				Config:   &root,
 				ExportTo: exportToSet,
 			}
 		}
@@ -341,7 +341,7 @@ func mergeVirtualServices(
 		}
 
 		return &MergedVirtualService{
-			Config:   root,
+			Config:   &root,
 			ExportTo: exportToSet,
 		}
 	}, opts.WithName("MergedVirtualServices")...)
@@ -378,7 +378,7 @@ func copyDefaultExportToSet(defaultExportTo sets.Set[visibility.Instance], names
 // sortMergedVirtualServicesByCreationTime sorts the list of merged virtual services in ascending order by their creation time (if available)
 func sortMergedVirtualServicesByCreationTime(configs []MergedVirtualService) []MergedVirtualService {
 	slices.SortFunc(configs, func(a, b MergedVirtualService) int {
-		return configCompareByCreationTime(a.Config, b.Config)
+		return configCompareByCreationTime(*a.Config, *b.Config)
 	})
 	return configs
 }

--- a/pilot/pkg/model/virtualservice_controller_test.go
+++ b/pilot/pkg/model/virtualservice_controller_test.go
@@ -738,7 +738,7 @@ func TestControllerMergeVirtualServices(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			controller := setupController(t, tc.defaultExportTo, tc.virtualServices...)
 			got := slices.Map(controller.MergedVirtualServices(), func(mvs MergedVirtualService) config.Config {
-				return mvs.Config
+				return *mvs.Config
 			})
 			assert.Equal(t, got, tc.expectedVirtualServices)
 		})
@@ -767,14 +767,14 @@ func TestControllerMergeVirtualServices(t *testing.T) {
 		vses := []config.Config{root, delegate, normal}
 		controller1 := setupController(t, sets.New(visibility.Public), vses...)
 		got := slices.Map(controller1.MergedVirtualServices(), func(mvs MergedVirtualService) config.Config {
-			return mvs.Config
+			return *mvs.Config
 		})
 		checkOrder(got)
 
 		vses = []config.Config{normal, delegate, root}
 		controller2 := setupController(t, sets.New(visibility.Public), vses...)
 		got = slices.Map(controller2.MergedVirtualServices(), func(mvs MergedVirtualService) config.Config {
-			return mvs.Config
+			return *mvs.Config
 		})
 		checkOrder(got)
 	})

--- a/pilot/pkg/model/virtualservice_test.go
+++ b/pilot/pkg/model/virtualservice_test.go
@@ -1551,7 +1551,7 @@ func TestSelectVirtualService(t *testing.T) {
 			},
 		},
 	}
-	virtualService1 := config.Config{
+	virtualService1 := &config.Config{
 		Meta: config.Meta{
 			GroupVersionKind: gvk.VirtualService,
 			Name:             "acme2-v1",
@@ -1559,7 +1559,7 @@ func TestSelectVirtualService(t *testing.T) {
 		},
 		Spec: virtualServiceSpec1,
 	}
-	virtualService2 := config.Config{
+	virtualService2 := &config.Config{
 		Meta: config.Meta{
 			GroupVersionKind: gvk.VirtualService,
 			Name:             "acme-v2",
@@ -1567,7 +1567,7 @@ func TestSelectVirtualService(t *testing.T) {
 		},
 		Spec: virtualServiceSpec2,
 	}
-	virtualService3 := config.Config{
+	virtualService3 := &config.Config{
 		Meta: config.Meta{
 			GroupVersionKind: gvk.VirtualService,
 			Name:             "acme-v3",
@@ -1575,7 +1575,7 @@ func TestSelectVirtualService(t *testing.T) {
 		},
 		Spec: virtualServiceSpec3,
 	}
-	virtualService4 := config.Config{
+	virtualService4 := &config.Config{
 		Meta: config.Meta{
 			GroupVersionKind: gvk.VirtualService,
 			Name:             "acme-v4",
@@ -1583,7 +1583,7 @@ func TestSelectVirtualService(t *testing.T) {
 		},
 		Spec: virtualServiceSpec4,
 	}
-	virtualService5 := config.Config{
+	virtualService5 := &config.Config{
 		Meta: config.Meta{
 			GroupVersionKind: gvk.VirtualService,
 			Name:             "acme-v3",
@@ -1591,7 +1591,7 @@ func TestSelectVirtualService(t *testing.T) {
 		},
 		Spec: virtualServiceSpec5,
 	}
-	virtualService6 := config.Config{
+	virtualService6 := &config.Config{
 		Meta: config.Meta{
 			GroupVersionKind: gvk.VirtualService,
 			Name:             "acme-v3",
@@ -1599,7 +1599,7 @@ func TestSelectVirtualService(t *testing.T) {
 		},
 		Spec: virtualServiceSpec6,
 	}
-	virtualService7 := config.Config{
+	virtualService7 := &config.Config{
 		Meta: config.Meta{
 			GroupVersionKind: gvk.VirtualService,
 			Name:             "acme2-v1",
@@ -1607,7 +1607,7 @@ func TestSelectVirtualService(t *testing.T) {
 		},
 		Spec: virtualServiceSpec7,
 	}
-	virtualService8 := config.Config{
+	virtualService8 := &config.Config{
 		Meta: config.Meta{
 			GroupVersionKind: gvk.VirtualService,
 			Name:             "vs-wildcard-v1",
@@ -1615,7 +1615,7 @@ func TestSelectVirtualService(t *testing.T) {
 		},
 		Spec: virtualServiceSpec8,
 	}
-	virtualService9 := config.Config{
+	virtualService9 := &config.Config{
 		Meta: config.Meta{
 			GroupVersionKind: gvk.VirtualService,
 			Name:             "service-wildcard-v1",
@@ -1625,7 +1625,7 @@ func TestSelectVirtualService(t *testing.T) {
 	}
 
 	index := virtualServiceIndex{
-		publicByGateway: map[string][]config.Config{
+		publicByGateway: map[string][]*config.Config{
 			constants.IstioMeshGateway: {
 				virtualService1,
 				virtualService2,
@@ -1656,14 +1656,14 @@ func TestSelectVirtualService(t *testing.T) {
 }
 
 func TestSelectVirtualServicesExclusion(t *testing.T) {
-	mkVS := func(name, ns string, hosts ...string) config.Config {
-		return config.Config{
+	mkVS := func(name, ns string, hosts ...string) *config.Config {
+		return &config.Config{
 			Meta: config.Meta{GroupVersionKind: gvk.VirtualService, Name: name, Namespace: ns},
 			Spec: &networking.VirtualService{Hosts: hosts, Gateways: []string{"mesh"}},
 		}
 	}
 	index := virtualServiceIndex{
-		publicByGateway: map[string][]config.Config{
+		publicByGateway: map[string][]*config.Config{
 			constants.IstioMeshGateway: {
 				mkVS("vs-a", "a", "a.com"),
 				mkVS("vs-b", "b", "b.com"),
@@ -1740,14 +1740,14 @@ func TestSelectVirtualServicesExclusion(t *testing.T) {
 // a wildcard exclusion covers exact hosts, but an exact exclusion does not drop a
 // wildcard route that still serves other hosts.
 func TestSelectVirtualServicesExclusionWildcard(t *testing.T) {
-	mkVS := func(name string, hosts ...string) config.Config {
-		return config.Config{
+	mkVS := func(name string, hosts ...string) *config.Config {
+		return &config.Config{
 			Meta: config.Meta{GroupVersionKind: gvk.VirtualService, Name: name, Namespace: "a"},
 			Spec: &networking.VirtualService{Hosts: hosts, Gateways: []string{"mesh"}},
 		}
 	}
 	index := virtualServiceIndex{
-		publicByGateway: map[string][]config.Config{
+		publicByGateway: map[string][]*config.Config{
 			constants.IstioMeshGateway: {
 				mkVS("vs-exact", "a.com"),
 				mkVS("vs-wild", "*.com"),
@@ -1882,7 +1882,7 @@ func BenchmarkSelectVirtualServices(b *testing.B) {
 			}
 
 			// Build virtual services spread across namespaces
-			virtualServices := make([]config.Config, 0, sc.numVSPerNS*sc.numNamespaces)
+			virtualServices := make([]*config.Config, 0, sc.numVSPerNS*sc.numNamespaces)
 			for i := 0; i < sc.numVSPerNS*sc.numNamespaces; i++ {
 				ns := namespaces[i%sc.numNamespaces]
 				var vsHost string
@@ -1895,7 +1895,7 @@ func BenchmarkSelectVirtualServices(b *testing.B) {
 				} else {
 					vsHost = fmt.Sprintf("external-%d.example.com", i)
 				}
-				vs := config.Config{
+				vs := &config.Config{
 					Meta: config.Meta{
 						GroupVersionKind: gvk.VirtualService,
 						Name:             fmt.Sprintf("vs-%d", i),
@@ -1923,11 +1923,11 @@ func BenchmarkSelectVirtualServices(b *testing.B) {
 			}
 
 			index := virtualServiceIndex{
-				publicByGateway: map[string][]config.Config{
+				publicByGateway: map[string][]*config.Config{
 					constants.IstioMeshGateway: virtualServices,
 				},
-				privateByNamespaceAndGateway: map[types.NamespacedName][]config.Config{},
-				exportedToNamespaceByGateway: map[types.NamespacedName][]config.Config{},
+				privateByNamespaceAndGateway: map[types.NamespacedName][]*config.Config{},
+				exportedToNamespaceByGateway: map[types.NamespacedName][]*config.Config{},
 			}
 
 			b.ReportAllocs()

--- a/pilot/pkg/networking/core/cluster_test.go
+++ b/pilot/pkg/networking/core/cluster_test.go
@@ -3263,7 +3263,7 @@ func applyConfigDiff(t *testing.T, cg *ConfigGenTest, prevConfigs, configs []con
 			assert.EventuallyEqual(t, func() config.Spec {
 				c := cg.env.VirtualServiceController.Collection().GetKey(cfg.NamespacedName().String())
 				if c == nil {
-					return config.Config{}
+					return nil
 				}
 				return c.Spec
 			}, cfg.Spec)


### PR DESCRIPTION
**Please provide a description of this PR:**
Make VS Controller hold and return `*config.Config` instead of the whole struct, `SelectVirtualServices` and other code paths end up creating `[]*config.Config` so it's just better to always use pointers.
This should reduce allocation sizes.