### PR TITLE
dr: fallback to dr tls mode when subset tls mode not specified

### DIFF
--- a/pilot/pkg/xds/endpoints/ep_filters_test.go
+++ b/pilot/pkg/xds/endpoints/ep_filters_test.go
@@ -476,6 +476,60 @@ var mtlsCases = map[string]map[string]struct {
 			IsMtlsDisabled: false,
 			SubsetName:     "enable-tls",
 		},
+		"mtls-off-subset-fallback-to-destination": {
+			Config: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.DestinationRule,
+					Name:             "mtls-off-fallback",
+					Namespace:        "ns",
+				},
+				Spec: &networking.DestinationRule{
+					Host: "example.ns.svc.cluster.local",
+					TrafficPolicy: &networking.TrafficPolicy{
+						// subset has no TLS setting, so this DR-level mode must be used
+						Tls: &networking.ClientTLSSettings{Mode: networking.ClientTLSSettings_DISABLE},
+					},
+					Subsets: []*networking.Subset{{
+						Name:   "no-tls",
+						Labels: map[string]string{"app": "example"},
+						// TrafficPolicy present but sets no TLS mode -> fall back to DR level
+						TrafficPolicy: &networking.TrafficPolicy{
+							ConnectionPool: &networking.ConnectionPoolSettings{
+								Tcp: &networking.ConnectionPoolSettings_TCPSettings{MaxConnections: 100},
+							},
+						},
+					}},
+				},
+			},
+			IsMtlsDisabled: true,
+			SubsetName:     "no-tls",
+		},
+		"mtls-on-subset-fallback-to-destination": {
+			Config: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.DestinationRule,
+					Name:             "mtls-on-fallback",
+					Namespace:        "ns",
+				},
+				Spec: &networking.DestinationRule{
+					Host: "example.ns.svc.cluster.local",
+					TrafficPolicy: &networking.TrafficPolicy{
+						Tls: &networking.ClientTLSSettings{Mode: networking.ClientTLSSettings_ISTIO_MUTUAL},
+					},
+					Subsets: []*networking.Subset{{
+						Name:   "no-tls",
+						Labels: map[string]string{"app": "example"},
+						TrafficPolicy: &networking.TrafficPolicy{
+							ConnectionPool: &networking.ConnectionPoolSettings{
+								Tcp: &networking.ConnectionPoolSettings_TCPSettings{MaxConnections: 100},
+							},
+						},
+					}},
+				},
+			},
+			IsMtlsDisabled: false,
+			SubsetName:     "no-tls",
+		},
 	},
 }
 

--- a/pilot/pkg/xds/endpoints/mtls_checker.go
+++ b/pilot/pkg/xds/endpoints/mtls_checker.go
@@ -82,7 +82,13 @@ func tlsModeForDestinationRule(drc *config.Config, subset string, port int) *net
 		if ss.Name != subset {
 			continue
 		}
-		return trafficPolicyTLSModeForPort(ss.GetTrafficPolicy(), port)
+
+		if mode := trafficPolicyTLSModeForPort(ss.GetTrafficPolicy(), port); mode != nil {
+			return mode
+		}
+
+		// fallback to the destination rule traffic policy if the subset does not have a TLS mode for this port
+		return trafficPolicyTLSModeForPort(dr.GetTrafficPolicy(), port)
 	}
 	return nil
 }

--- a/releasenotes/notes/dr-subset-tls-mode-fallback.yaml
+++ b/releasenotes/notes/dr-subset-tls-mode-fallback.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed** an issue where endpoint mTLS mode was not derived from the DestinationRule's
+    top-level traffic policy when a targeted subset did not specify a TLS mode for the port.
+    The subset traffic policy now correctly falls back to the DestinationRule-level TLS setting.


### PR DESCRIPTION
**Please provide a description of this PR:**
When finding TLSMode for an Endpoint, if Subset existed but it didn't specify a TLSMode we failed to fallback to the main DR TLSMode setting.