### PR TITLE
fix: skip per-service RBAC on east-west gateway for cross-network ambient traffic

### DIFF
--- a/pilot/pkg/networking/core/listener_waypoint.go
+++ b/pilot/pkg/networking/core/listener_waypoint.go
@@ -482,6 +482,9 @@ func (lb *ListenerBuilder) buildWaypointInternal(wls []model.WorkloadInfo, svcs 
 			if len(svcAddresses) > 0 && features.EnableAmbientMultiNetwork && !isAmbientEastWestGateway {
 				filters = []*listener.Filter{getOrigDstSfs(origDst, false)}
 			}
+			if isAmbientEastWestGateway {
+				cc.policyService = nil
+			}
 			tcpChain = &listener.FilterChain{
 				Filters: append(slices.Clone(filters), lb.buildWaypointNetworkFilters(svc, cc)...),
 				Name:    cc.clusterName,

--- a/releasenotes/notes/60806.yaml
+++ b/releasenotes/notes/60806.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 60806
+releaseNotes:
+  - |
+    **Fixed** cross-network traffic through the east-west gateway being blocked by a spurious
+    deny-all RBAC filter when the destination service has L7 AuthorizationPolicies.

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -1094,9 +1094,17 @@ func TestAuthorizationServiceAttached(t *testing.T) {
 		// make another target use our waypoint, but don't expect authz there
 		ambient.SetWaypointForService(t, apps.Namespace, otherDst.ServiceName(), authzDst.Config().ServiceWaypointProxy)
 
-		t.ConfigIstio().Eval(apps.Namespace.Name(), map[string]string{
-			"Destination": authzDst.Config().Service,
-		}, `
+		// Mark the service as global so cross-network endpoints are populated
+		// in multi-network deployments. No-op for single-cluster.
+		labelServiceGlobal(t, authzDst.Config().Service, t.AllClusters()...)
+		t.Cleanup(func() {
+			unlabelServiceGlobal(t, authzDst.Config().Service, t.AllClusters()...)
+		})
+
+		t.NewSubTest("principal").Run(func(t framework.TestContext) {
+			t.ConfigIstio().Eval(apps.Namespace.Name(), map[string]string{
+				"Destination": authzDst.Config().Service,
+			}, `
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
@@ -1112,30 +1120,84 @@ spec:
         principals: ["cluster.local/ns/something/sa/else"]
   `).ApplyOrFail(t)
 
-		for _, src := range src.Instances() {
-			t.NewSubTest(src.Config().Cluster.StableName()).Run(func(t framework.TestContext) {
-				t.NewSubTest("authz target deny").RunParallel(func(t framework.TestContext) {
-					opts := echo.CallOptions{
-						To:     authzDst,
-						Check:  CheckDeny,
-						Port:   echo.Port{Name: "http"},
-						Scheme: scheme.HTTP,
-						Count:  10,
-					}
-					src.CallOrFail(t, opts)
+			for _, src := range src.Instances() {
+				t.NewSubTest(src.Config().Cluster.StableName()).Run(func(t framework.TestContext) {
+					t.NewSubTest("authz target deny").RunParallel(func(t framework.TestContext) {
+						opts := echo.CallOptions{
+							To:     authzDst,
+							Check:  CheckDeny,
+							Port:   echo.Port{Name: "http"},
+							Scheme: scheme.HTTP,
+							Count:  10,
+						}
+						src.CallOrFail(t, opts)
+					})
+					t.NewSubTest("non-authz target allow").RunParallel(func(t framework.TestContext) {
+						opts := echo.CallOptions{
+							To:     otherDst,
+							Check:  check.OK(),
+							Port:   echo.Port{Name: "http"},
+							Scheme: scheme.HTTP,
+							Count:  10,
+						}
+						src.CallOrFail(t, opts)
+					})
 				})
-				t.NewSubTest("non-authz target allow").RunParallel(func(t framework.TestContext) {
-					opts := echo.CallOptions{
-						To:     otherDst,
-						Check:  check.OK(),
-						Port:   echo.Port{Name: "http"},
-						Scheme: scheme.HTTP,
-						Count:  10,
-					}
-					src.CallOrFail(t, opts)
+			}
+		})
+
+		t.NewSubTest("header").Run(func(t framework.TestContext) {
+			t.ConfigIstio().Eval(apps.Namespace.Name(), map[string]string{
+				"Destination": authzDst.Config().Service,
+			}, `
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: policy-header-match
+spec:
+  targetRefs:
+  - kind: Service
+    group: ""
+    name: "{{ .Destination }}"
+  action: ALLOW
+  rules:
+  - when:
+    - key: request.headers[x-foo]
+      values: ["x-bar"]
+  `).ApplyOrFail(t)
+
+			for _, src := range src.Instances() {
+				t.NewSubTest(src.Config().Cluster.StableName()).Run(func(t framework.TestContext) {
+					t.NewSubTest("allow with matching header").RunParallel(func(t framework.TestContext) {
+						opts := echo.CallOptions{
+							To:                      authzDst,
+							Check:                   check.And(check.OK(), check.ReachedTargetClusters(t)),
+							Port:                    echo.Port{Name: "http"},
+							Scheme:                  scheme.HTTP,
+							Count:                   10,
+							NewConnectionPerRequest: true,
+							HTTP: echo.HTTP{
+								Headers: headers.New().With("x-foo", "x-bar").Build(),
+							},
+						}
+						src.CallOrFail(t, opts)
+					})
+					t.NewSubTest("deny without matching header").RunParallel(func(t framework.TestContext) {
+						opts := echo.CallOptions{
+							To:     authzDst,
+							Check:  CheckDeny,
+							Port:   echo.Port{Name: "http"},
+							Scheme: scheme.HTTP,
+							Count:  10,
+							HTTP: echo.HTTP{
+								Headers: headers.New().With("x-foo", "wrong-value").Build(),
+							},
+						}
+						src.CallOrFail(t, opts)
+					})
 				})
-			})
-		}
+			}
+		})
 	})
 }
 


### PR DESCRIPTION
The east-west gateway only handles double-HBONE (L4) traffic and never performs L7 processing. 
When a destination service has L7 AuthorizationPolicies, the authz builder emits an L4 RBAC filter with
empty rules (deny-all). This blocks the cross-network traffic through the east-west gateway when the `x-istio-source` is set to `waypoint` 


Fixes #60806 