### PR TITLE
fix: skip TCPRoute tests for agentgateway

### DIFF
--- a/tests/integration/pilot/agentgateway/gateway_conformance_test.go
+++ b/tests/integration/pilot/agentgateway/gateway_conformance_test.go
@@ -103,6 +103,7 @@ var skippedTests = map[string]string{
 	"HTTPRouteNoBackendRefs":             "TODO",
 	"GatewayInvalidParametersRef":        "TODO",
 	"GatewayListenerUnsupportedProtocol": "TODO",
+	"TCPRouteWeightedRouting":            "TODO: flaky in dual-stack and multicluster environments",
 }
 
 func TestGatewayConformanceAgentgateway(t *testing.T) {

--- a/tests/integration/pilot/agentgateway/gateway_conformance_test.go
+++ b/tests/integration/pilot/agentgateway/gateway_conformance_test.go
@@ -104,6 +104,14 @@ var skippedTests = map[string]string{
 	"GatewayInvalidParametersRef":        "TODO",
 	"GatewayListenerUnsupportedProtocol": "TODO",
 	"TCPRouteWeightedRouting":            "TODO: flaky in dual-stack and multicluster environments",
+
+	// agentgateway does not yet route TCPRoute data-plane traffic, so the
+	// traffic-based TCPRoute conformance tests fail. The status/validation-only
+	// TCPRouteInvalid* tests still run and pass, so they are not skipped.
+	"TCPRouteMultipleRoutesAttachment":    "TODO: agentgateway does not yet support TCPRoute traffic",
+	"TCPRouteParentRefAttachAll":          "TODO: agentgateway does not yet support TCPRoute traffic",
+	"TCPRouteParentRefPortAndSectionName": "TODO: agentgateway does not yet support TCPRoute traffic",
+	"TCPRouteReferenceGrant":              "TODO: agentgateway does not yet support TCPRoute traffic",
 }
 
 func TestGatewayConformanceAgentgateway(t *testing.T) {


### PR DESCRIPTION
**Please provide a description of this PR:**

Skip the TCPRouteWeightedRouting + data-plane tcproute traffic conformance tests for agentgateway. 

TCPRouteWeightedRouting is causing the entire CI to hang for 30 minutes.

The other 4 tests are for TCPRoute traffic which is not yet supported by agentgateway with Istio.