### PR TITLE
block redirects to internal addresses in wasm http fetcher

### DIFF
--- a/pkg/wasm/httpfetcher.go
+++ b/pkg/wasm/httpfetcher.go
@@ -22,6 +22,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"time"
 
@@ -57,15 +58,35 @@ func NewHTTPFetcher(requestTimeout time.Duration, requestMaxRetry int) *HTTPFetc
 	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	return &HTTPFetcher{
 		client: &http.Client{
-			Timeout: requestTimeout,
+			Timeout:       requestTimeout,
+			CheckRedirect: denyInternalRedirect,
 		},
 		insecureClient: &http.Client{
-			Timeout:   requestTimeout,
-			Transport: transport,
+			Timeout:       requestTimeout,
+			Transport:     transport,
+			CheckRedirect: denyInternalRedirect,
 		},
 		initialBackoff:  time.Millisecond * 500,
 		requestMaxRetry: requestMaxRetry,
 	}
+}
+
+// denyInternalRedirect stops the module fetch from following a redirect whose
+// target host is a loopback, private, link-local, or unspecified address (or
+// localhost / the GCP metadata name). The module URL is trusted config, but the
+// server it points at is not: without this a malicious or compromised wasm
+// server can 30x-redirect the fetch to a cluster-internal service or to
+// 169.254.169.254.
+func denyInternalRedirect(req *http.Request, _ []*http.Request) error {
+	host := req.URL.Hostname()
+	if host == "localhost" || host == "metadata.google.internal" {
+		return fmt.Errorf("redirect to %q blocked: internal host", req.URL.Host)
+	}
+	if ip := net.ParseIP(host); ip != nil &&
+		(ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsUnspecified()) {
+		return fmt.Errorf("redirect to %q blocked: private/loopback/link-local address", req.URL.Host)
+	}
+	return nil
 }
 
 // Fetch downloads a wasm module with HTTP get.

--- a/pkg/wasm/httpfetcher_test.go
+++ b/pkg/wasm/httpfetcher_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http/httptest"
 	"regexp"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -166,6 +167,34 @@ func TestWasmHTTPInsecureServer(t *testing.T) {
 				t.Errorf("downloaded wasm module got %v, want wasm", string(b))
 			}
 		})
+	}
+}
+
+func TestWasmHTTPFetchBlocksInternalRedirect(t *testing.T) {
+	var internalHits int32
+	// Stands in for a cluster-internal service or the cloud metadata endpoint.
+	internal := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&internalHits, 1)
+		fmt.Fprintln(w, "wasm")
+	}))
+	defer internal.Close()
+
+	// The configured module server, now malicious, redirects the fetch inward.
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, internal.URL+"/latest/meta-data/", http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	fetcher := NewHTTPFetcher(DefaultHTTPRequestTimeout, DefaultHTTPRequestMaxRetries)
+	fetcher.initialBackoff = time.Microsecond
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if _, err := fetcher.Fetch(ctx, redirector.URL, false); err == nil {
+		t.Fatal("expected fetch to fail when redirected to an internal address")
+	}
+	if got := atomic.LoadInt32(&internalHits); got != 0 {
+		t.Fatalf("internal endpoint was reached %d times; redirect should have been blocked", got)
 	}
 }
 

--- a/releasenotes/notes/60820.yaml
+++ b/releasenotes/notes/60820.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: security-fix
+area: security
+issue:
+  - 60820
+releaseNotes:
+  - |
+    **Fixed** the remote wasm module HTTP fetcher following HTTP redirects to
+    internal addresses. A malicious or compromised module server can no longer
+    redirect the fetch to loopback, private, link-local, or cloud metadata
+    endpoints.


### PR DESCRIPTION
**Please provide a description of this PR:**

1. NewHTTPFetcher builds both http.Clients with no CheckRedirect, so a 30x response from the module server is followed to any host.
2. a malicious or compromised wasm server can then steer the fetch to 127.0.0.1, 169.254.169.254, or a cluster-internal service (blind SSRF from the agent's network position).

Added a CheckRedirect that rejects redirect targets on loopback/private/link-local/unspecified ranges, plus localhost and metadata.google.internal. The OCI path already blocks these for its bearer realm; the plain-HTTP module download had no redirect guard, so this covers that gap. Only redirect hops are checked, so the configured module URL and non-internal redirects are unaffected. Test drives a module server that 302s to a local endpoint and asserts the fetch fails without hitting it.