### PR TITLE
feat: Implement JWTRule required field for multi-token JWT validation (#60823)

### DIFF
--- a/pilot/pkg/security/authn/policy_applier.go
+++ b/pilot/pkg/security/authn/policy_applier.go
@@ -249,32 +249,42 @@ func convertToEnvoyJwtConfig(jwtRules []*v1beta1.JWTRule, push *model.PushContex
 
 		name := fmt.Sprintf("origins-%d", i)
 		providers[name] = provider
-		innerAndList = append(innerAndList, &envoy_jwt.JwtRequirement{
-			RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
-				RequiresAny: &envoy_jwt.JwtRequirementOrList{
-					Requirements: []*envoy_jwt.JwtRequirement{
-						{
-							RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
-								ProviderName: name,
-							},
-						},
-						{
-							RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
-								AllowMissing: &emptypb.Empty{},
+
+		providerRequirement := &envoy_jwt.JwtRequirement{
+			RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+				ProviderName: name,
+			},
+		}
+
+		if jwtRule.GetRequired() {
+			// Required providers must be present and valid; no allow_missing wrapper.
+			innerAndList = append(innerAndList, providerRequirement)
+		} else {
+			innerAndList = append(innerAndList, &envoy_jwt.JwtRequirement{
+				RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
+					RequiresAny: &envoy_jwt.JwtRequirementOrList{
+						Requirements: []*envoy_jwt.JwtRequirement{
+							providerRequirement,
+							{
+								RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
+									AllowMissing: &emptypb.Empty{},
+								},
 							},
 						},
 					},
 				},
-			},
-		})
-		outterOrList = append(outterOrList, &envoy_jwt.JwtRequirement{
-			RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
-				ProviderName: name,
-			},
-		})
+			})
+			// Only optional providers participate in the outer OR shortcut.
+			outterOrList = append(outterOrList, &envoy_jwt.JwtRequirement{
+				RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+					ProviderName: name,
+				},
+			})
+		}
 	}
 
-	// If there is only one provider, simply use an OR of {provider, `allow_missing`}.
+	// If there is only one provider, use its requirement directly (either a bare
+	// ProviderName when required=true, or OR{provider, allow_missing} otherwise).
 	if len(innerAndList) == 1 {
 		return &envoy_jwt.JwtAuthentication{
 			Rules: []*envoy_jwt.RequirementRule{
@@ -294,18 +304,33 @@ func convertToEnvoyJwtConfig(jwtRules []*v1beta1.JWTRule, push *model.PushContex
 		}
 	}
 
-	// If there are more than one provider, filter should OR of
-	// {P1, P2 .., AND of {OR{P1, allow_missing}, OR{P2, allow_missing} ...}}
-	// where the innerAnd enforce a token, if provided, must be valid, and the
-	// outer OR aids the case where providers share the same location (as
-	// it will always fail with the innerAND).
-	outterOrList = append(outterOrList, &envoy_jwt.JwtRequirement{
+	// Build the AND requirement over all providers. For required providers the
+	// entry is a bare ProviderName; for optional ones it is OR{provider, allow_missing}.
+	andRequirement := &envoy_jwt.JwtRequirement{
 		RequiresType: &envoy_jwt.JwtRequirement_RequiresAll{
 			RequiresAll: &envoy_jwt.JwtRequirementAndList{
 				Requirements: innerAndList,
 			},
 		},
-	})
+	}
+
+	// When all providers are required, outterOrList is empty. Emit just the AND
+	// requirement so that every token must be present and valid.
+	// When some providers are optional, OR the individual optional providers with
+	// the AND list to handle the case where providers share the same token location.
+	var finalRequirement *envoy_jwt.JwtRequirement
+	if len(outterOrList) == 0 {
+		finalRequirement = andRequirement
+	} else {
+		outterOrList = append(outterOrList, andRequirement)
+		finalRequirement = &envoy_jwt.JwtRequirement{
+			RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
+				RequiresAny: &envoy_jwt.JwtRequirementOrList{
+					Requirements: outterOrList,
+				},
+			},
+		}
+	}
 
 	return &envoy_jwt.JwtAuthentication{
 		Rules: []*envoy_jwt.RequirementRule{
@@ -316,13 +341,7 @@ func convertToEnvoyJwtConfig(jwtRules []*v1beta1.JWTRule, push *model.PushContex
 					},
 				},
 				RequirementType: &envoy_jwt.RequirementRule_Requires{
-					Requires: &envoy_jwt.JwtRequirement{
-						RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
-							RequiresAny: &envoy_jwt.JwtRequirementOrList{
-								Requirements: outterOrList,
-							},
-						},
-					},
+					Requires: finalRequirement,
 				},
 			},
 		},

--- a/pilot/pkg/security/authn/policy_applier.go
+++ b/pilot/pkg/security/authn/policy_applier.go
@@ -142,22 +142,24 @@ func (a policyApplier) InboundMTLSSettings(
 
 // convertToEnvoyJwtConfig converts a list of JWT rules into Envoy JWT filter config to enforce it.
 // Each rule is expected corresponding to one JWT issuer (provider).
-// The behavior of the filter should reject all requests with invalid token. On the other hand,
-// if no token provided, the request is allowed.
+// The filter rejects requests with invalid tokens. Missing tokens are allowed unless a rule has
+// required set to true, in which case that token must be present and valid.
 func convertToEnvoyJwtConfig(jwtRules []*v1beta1.JWTRule, push *model.PushContext, clearRouteCache bool) *envoy_jwt.JwtAuthentication {
 	if len(jwtRules) == 0 {
 		return nil
 	}
 
 	providers := map[string]*envoy_jwt.JwtProvider{}
-	// Each element of innerAndList is the requirement for each provider, in the form of
-	// {provider OR `allow_missing`}
-	// This list will be ANDed (if have more than one provider) for the final requirement.
+	// Each element of innerAndList is the per-provider requirement: a bare ProviderName when
+	// required is true, or OR{provider, allow_missing} otherwise. Multiple entries are ANDed.
 	innerAndList := []*envoy_jwt.JwtRequirement{}
 
-	// This is an (or) list for all providers. This will be OR with the innerAndList above so
-	// it can pass the requirement in the case that providers share the same location.
+	// Optional providers are added here so the final requirement can OR them with the AND list.
+	// This handles providers that share the same token extraction location. The outer OR is
+	// skipped when any provider is required, since it would let a single optional token bypass
+	// required providers on distinct headers.
 	outterOrList := []*envoy_jwt.JwtRequirement{}
+	hasRequired := false
 
 	for i, jwtRule := range jwtRules {
 		provider := &envoy_jwt.JwtProvider{
@@ -257,6 +259,7 @@ func convertToEnvoyJwtConfig(jwtRules []*v1beta1.JWTRule, push *model.PushContex
 		}
 
 		if jwtRule.GetRequired() {
+			hasRequired = true
 			// Required providers must be present and valid; no allow_missing wrapper.
 			innerAndList = append(innerAndList, providerRequirement)
 		} else {
@@ -314,10 +317,14 @@ func convertToEnvoyJwtConfig(jwtRules []*v1beta1.JWTRule, push *model.PushContex
 		},
 	}
 
-	// When all providers are required, outterOrList is empty. Emit just the AND
-	// requirement so that every token must be present and valid.
-	// When some providers are optional, OR the individual optional providers with
-	// the AND list to handle the case where providers share the same token location.
+	// When any provider is required, skip the outer OR shortcut so optional tokens cannot
+	// satisfy the requirement without the required token(s).
+	if hasRequired {
+		outterOrList = nil
+	}
+
+	// When outterOrList is empty, emit just the AND requirement. Otherwise OR optional
+	// provider shortcuts with the AND list for shared token extraction locations.
 	var finalRequirement *envoy_jwt.JwtRequirement
 	if len(outterOrList) == 0 {
 		finalRequirement = andRequirement

--- a/pilot/pkg/security/authn/policy_applier.go
+++ b/pilot/pkg/security/authn/policy_applier.go
@@ -155,9 +155,12 @@ func convertToEnvoyJwtConfig(jwtRules []*v1beta1.JWTRule, push *model.PushContex
 	innerAndList := []*envoy_jwt.JwtRequirement{}
 
 	// Optional providers are added here so the final requirement can OR them with the AND list.
-	// This handles providers that share the same token extraction location. The outer OR is
-	// skipped when any provider is required, since it would let a single optional token bypass
-	// required providers on distinct headers.
+	// This handles providers that share the same token extraction location (e.g., both reading
+	// from Authorization). The outer OR is skipped when any provider is required, since it would
+	// let a single optional token bypass required providers.
+	// Note: if a required provider and an optional provider both extract from the same header,
+	// the optional provider will reject the request when the header contains a token from a
+	// different issuer (allow_missing only applies to absent tokens, not wrong-issuer ones).
 	outterOrList := []*envoy_jwt.JwtRequirement{}
 	hasRequired := false
 

--- a/pilot/pkg/security/authn/policy_applier.go
+++ b/pilot/pkg/security/authn/policy_applier.go
@@ -142,22 +142,27 @@ func (a policyApplier) InboundMTLSSettings(
 
 // convertToEnvoyJwtConfig converts a list of JWT rules into Envoy JWT filter config to enforce it.
 // Each rule is expected corresponding to one JWT issuer (provider).
-// The behavior of the filter should reject all requests with invalid token. On the other hand,
-// if no token provided, the request is allowed.
+// The filter rejects requests with invalid tokens. Missing tokens are allowed unless a rule has
+// presence set to REQUIRED, in which case that token must be present and valid.
 func convertToEnvoyJwtConfig(jwtRules []*v1beta1.JWTRule, push *model.PushContext, clearRouteCache bool) *envoy_jwt.JwtAuthentication {
 	if len(jwtRules) == 0 {
 		return nil
 	}
 
 	providers := map[string]*envoy_jwt.JwtProvider{}
-	// Each element of innerAndList is the requirement for each provider, in the form of
-	// {provider OR `allow_missing`}
-	// This list will be ANDed (if have more than one provider) for the final requirement.
+	// Each element of innerAndList is the per-provider requirement: a bare ProviderName when
+	// presence is REQUIRED, or OR{provider, allow_missing} otherwise. Multiple entries are ANDed.
 	innerAndList := []*envoy_jwt.JwtRequirement{}
 
-	// This is an (or) list for all providers. This will be OR with the innerAndList above so
-	// it can pass the requirement in the case that providers share the same location.
+	// Optional providers are added here so the final requirement can OR them with the AND list.
+	// This handles providers that share the same token extraction location (e.g., both reading
+	// from Authorization). The outer OR is skipped when any provider is REQUIRED, since it would
+	// let a single optional token bypass required providers.
+	// Note: if a required provider and an optional provider both extract from the same header,
+	// the optional provider will reject the request when the header contains a token from a
+	// different issuer (allow_missing only applies to absent tokens, not wrong-issuer ones).
 	outterOrList := []*envoy_jwt.JwtRequirement{}
+	hasRequired := false
 
 	for i, jwtRule := range jwtRules {
 		provider := &envoy_jwt.JwtProvider{
@@ -249,32 +254,43 @@ func convertToEnvoyJwtConfig(jwtRules []*v1beta1.JWTRule, push *model.PushContex
 
 		name := fmt.Sprintf("origins-%d", i)
 		providers[name] = provider
-		innerAndList = append(innerAndList, &envoy_jwt.JwtRequirement{
-			RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
-				RequiresAny: &envoy_jwt.JwtRequirementOrList{
-					Requirements: []*envoy_jwt.JwtRequirement{
-						{
-							RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
-								ProviderName: name,
-							},
-						},
-						{
-							RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
-								AllowMissing: &emptypb.Empty{},
+
+		providerRequirement := &envoy_jwt.JwtRequirement{
+			RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+				ProviderName: name,
+			},
+		}
+
+		if jwtRule.GetPresence() == v1beta1.JWTRule_REQUIRED {
+			hasRequired = true
+			// REQUIRED providers must be present and valid; no allow_missing wrapper.
+			innerAndList = append(innerAndList, providerRequirement)
+		} else {
+			innerAndList = append(innerAndList, &envoy_jwt.JwtRequirement{
+				RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
+					RequiresAny: &envoy_jwt.JwtRequirementOrList{
+						Requirements: []*envoy_jwt.JwtRequirement{
+							providerRequirement,
+							{
+								RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
+									AllowMissing: &emptypb.Empty{},
+								},
 							},
 						},
 					},
 				},
-			},
-		})
-		outterOrList = append(outterOrList, &envoy_jwt.JwtRequirement{
-			RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
-				ProviderName: name,
-			},
-		})
+			})
+			// Only optional providers participate in the outer OR shortcut.
+			outterOrList = append(outterOrList, &envoy_jwt.JwtRequirement{
+				RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+					ProviderName: name,
+				},
+			})
+		}
 	}
 
-	// If there is only one provider, simply use an OR of {provider, `allow_missing`}.
+	// If there is only one provider, use its requirement directly (either a bare
+	// ProviderName when presence=REQUIRED, or OR{provider, allow_missing} otherwise).
 	if len(innerAndList) == 1 {
 		return &envoy_jwt.JwtAuthentication{
 			Rules: []*envoy_jwt.RequirementRule{
@@ -294,18 +310,37 @@ func convertToEnvoyJwtConfig(jwtRules []*v1beta1.JWTRule, push *model.PushContex
 		}
 	}
 
-	// If there are more than one provider, filter should OR of
-	// {P1, P2 .., AND of {OR{P1, allow_missing}, OR{P2, allow_missing} ...}}
-	// where the innerAnd enforce a token, if provided, must be valid, and the
-	// outer OR aids the case where providers share the same location (as
-	// it will always fail with the innerAND).
-	outterOrList = append(outterOrList, &envoy_jwt.JwtRequirement{
+	// Build the AND requirement over all providers. For REQUIRED providers the
+	// entry is a bare ProviderName; for OPTIONAL ones it is OR{provider, allow_missing}.
+	andRequirement := &envoy_jwt.JwtRequirement{
 		RequiresType: &envoy_jwt.JwtRequirement_RequiresAll{
 			RequiresAll: &envoy_jwt.JwtRequirementAndList{
 				Requirements: innerAndList,
 			},
 		},
-	})
+	}
+
+	// When any provider is REQUIRED, skip the outer OR shortcut so optional tokens cannot
+	// satisfy the requirement without the required token(s).
+	if hasRequired {
+		outterOrList = nil
+	}
+
+	// When outterOrList is empty, emit just the AND requirement. Otherwise OR optional
+	// provider shortcuts with the AND list for shared token extraction locations.
+	var finalRequirement *envoy_jwt.JwtRequirement
+	if len(outterOrList) == 0 {
+		finalRequirement = andRequirement
+	} else {
+		outterOrList = append(outterOrList, andRequirement)
+		finalRequirement = &envoy_jwt.JwtRequirement{
+			RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
+				RequiresAny: &envoy_jwt.JwtRequirementOrList{
+					Requirements: outterOrList,
+				},
+			},
+		}
+	}
 
 	return &envoy_jwt.JwtAuthentication{
 		Rules: []*envoy_jwt.RequirementRule{
@@ -316,13 +351,7 @@ func convertToEnvoyJwtConfig(jwtRules []*v1beta1.JWTRule, push *model.PushContex
 					},
 				},
 				RequirementType: &envoy_jwt.RequirementRule_Requires{
-					Requires: &envoy_jwt.JwtRequirement{
-						RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
-							RequiresAny: &envoy_jwt.JwtRequirementOrList{
-								Requirements: outterOrList,
-							},
-						},
-					},
+					Requires: finalRequirement,
 				},
 			},
 		},

--- a/pilot/pkg/security/authn/policy_applier_test.go
+++ b/pilot/pkg/security/authn/policy_applier_test.go
@@ -1407,7 +1407,7 @@ func TestConvertToEnvoyJwtConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "Multiple JWT rules, mixed required/optional — OR(P2, AND(P1, OR(P2, allow_missing)))",
+			name: "Multiple JWT rules, mixed required/optional — AND(P1, OR(P2, allow_missing))",
 			in: []*v1beta1.JWTRule{
 				{
 					Issuer:   "https://idp.example.com",
@@ -1430,41 +1430,26 @@ func TestConvertToEnvoyJwtConfig(t *testing.T) {
 						},
 						RequirementType: &envoy_jwt.RequirementRule_Requires{
 							Requires: &envoy_jwt.JwtRequirement{
-								RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
-									RequiresAny: &envoy_jwt.JwtRequirementOrList{
+								RequiresType: &envoy_jwt.JwtRequirement_RequiresAll{
+									RequiresAll: &envoy_jwt.JwtRequirementAndList{
 										Requirements: []*envoy_jwt.JwtRequirement{
-											// Optional provider P2 shortcut
 											{
 												RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
-													ProviderName: "origins-1",
+													ProviderName: "origins-0",
 												},
 											},
-											// AND list: P1 bare (required) + OR(P2, allow_missing)
 											{
-												RequiresType: &envoy_jwt.JwtRequirement_RequiresAll{
-													RequiresAll: &envoy_jwt.JwtRequirementAndList{
+												RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
+													RequiresAny: &envoy_jwt.JwtRequirementOrList{
 														Requirements: []*envoy_jwt.JwtRequirement{
 															{
 																RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
-																	ProviderName: "origins-0",
+																	ProviderName: "origins-1",
 																},
 															},
 															{
-																RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
-																	RequiresAny: &envoy_jwt.JwtRequirementOrList{
-																		Requirements: []*envoy_jwt.JwtRequirement{
-																			{
-																				RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
-																					ProviderName: "origins-1",
-																				},
-																			},
-																			{
-																				RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
-																					AllowMissing: &emptypb.Empty{},
-																				},
-																			},
-																		},
-																	},
+																RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
+																	AllowMissing: &emptypb.Empty{},
 																},
 															},
 														},
@@ -1502,6 +1487,109 @@ func TestConvertToEnvoyJwtConfig(t *testing.T) {
 									InlineString: "jwks-scope",
 								},
 							},
+						},
+						Forward:           false,
+						PayloadInMetadata: "payload",
+						NormalizePayloadInMetadata: &envoy_jwt.JwtProvider_NormalizePayload{
+							SpaceDelimitedClaims: buildSpaceDelimitedClaims(nil),
+						},
+					},
+				},
+				BypassCorsPreflight: true,
+			},
+		},
+		{
+			name: "Multiple JWT rules, mixed required/optional with distinct headers — AND(P1, OR(P2, allow_missing))",
+			in: []*v1beta1.JWTRule{
+				{
+					Issuer:   "https://idp.example.com",
+					Jwks:     "jwks-idp",
+					Required: true,
+					FromHeaders: []*v1beta1.JWTHeader{
+						{Name: "Authorization", Prefix: "Bearer "},
+					},
+				},
+				{
+					Issuer: "https://scope.example.com",
+					Jwks:   "jwks-scope",
+					FromHeaders: []*v1beta1.JWTHeader{
+						{Name: "x-scope-token"},
+					},
+				},
+			},
+			expected: &envoy_jwt.JwtAuthentication{
+				Rules: []*envoy_jwt.RequirementRule{
+					{
+						Match: &route.RouteMatch{
+							PathSpecifier: &route.RouteMatch_Prefix{
+								Prefix: "/",
+							},
+						},
+						RequirementType: &envoy_jwt.RequirementRule_Requires{
+							Requires: &envoy_jwt.JwtRequirement{
+								RequiresType: &envoy_jwt.JwtRequirement_RequiresAll{
+									RequiresAll: &envoy_jwt.JwtRequirementAndList{
+										Requirements: []*envoy_jwt.JwtRequirement{
+											{
+												RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+													ProviderName: "origins-0",
+												},
+											},
+											{
+												RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
+													RequiresAny: &envoy_jwt.JwtRequirementOrList{
+														Requirements: []*envoy_jwt.JwtRequirement{
+															{
+																RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+																	ProviderName: "origins-1",
+																},
+															},
+															{
+																RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
+																	AllowMissing: &emptypb.Empty{},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Providers: map[string]*envoy_jwt.JwtProvider{
+					"origins-0": {
+						Issuer: "https://idp.example.com",
+						JwksSourceSpecifier: &envoy_jwt.JwtProvider_LocalJwks{
+							LocalJwks: &core.DataSource{
+								Specifier: &core.DataSource_InlineString{
+									InlineString: "jwks-idp",
+								},
+							},
+						},
+						FromHeaders: []*envoy_jwt.JwtHeader{
+							{Name: "Authorization", ValuePrefix: "Bearer "},
+						},
+						Forward:           false,
+						PayloadInMetadata: "payload",
+						NormalizePayloadInMetadata: &envoy_jwt.JwtProvider_NormalizePayload{
+							SpaceDelimitedClaims: buildSpaceDelimitedClaims(nil),
+						},
+					},
+					"origins-1": {
+						Issuer: "https://scope.example.com",
+						JwksSourceSpecifier: &envoy_jwt.JwtProvider_LocalJwks{
+							LocalJwks: &core.DataSource{
+								Specifier: &core.DataSource_InlineString{
+									InlineString: "jwks-scope",
+								},
+							},
+						},
+						FromHeaders: []*envoy_jwt.JwtHeader{
+							{Name: "x-scope-token"},
 						},
 						Forward:           false,
 						PayloadInMetadata: "payload",

--- a/pilot/pkg/security/authn/policy_applier_test.go
+++ b/pilot/pkg/security/authn/policy_applier_test.go
@@ -1282,6 +1282,238 @@ func TestConvertToEnvoyJwtConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "Single JWT rule with required=true",
+			in: []*v1beta1.JWTRule{
+				{
+					Issuer:   "https://secret.foo.com",
+					Jwks:     "jwks-inline-data",
+					Required: true,
+				},
+			},
+			expected: &envoy_jwt.JwtAuthentication{
+				Rules: []*envoy_jwt.RequirementRule{
+					{
+						Match: &route.RouteMatch{
+							PathSpecifier: &route.RouteMatch_Prefix{
+								Prefix: "/",
+							},
+						},
+						RequirementType: &envoy_jwt.RequirementRule_Requires{
+							Requires: &envoy_jwt.JwtRequirement{
+								RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+									ProviderName: "origins-0",
+								},
+							},
+						},
+					},
+				},
+				Providers: map[string]*envoy_jwt.JwtProvider{
+					"origins-0": {
+						Issuer: "https://secret.foo.com",
+						JwksSourceSpecifier: &envoy_jwt.JwtProvider_LocalJwks{
+							LocalJwks: &core.DataSource{
+								Specifier: &core.DataSource_InlineString{
+									InlineString: "jwks-inline-data",
+								},
+							},
+						},
+						Forward:           false,
+						PayloadInMetadata: "payload",
+						NormalizePayloadInMetadata: &envoy_jwt.JwtProvider_NormalizePayload{
+							SpaceDelimitedClaims: buildSpaceDelimitedClaims(nil),
+						},
+					},
+				},
+				BypassCorsPreflight: true,
+			},
+		},
+		{
+			name: "Multiple JWT rules, all required — AND(P1, P2)",
+			in: []*v1beta1.JWTRule{
+				{
+					Issuer:   "https://idp.example.com",
+					Jwks:     "jwks-idp",
+					Required: true,
+				},
+				{
+					Issuer:   "https://scope.example.com",
+					Jwks:     "jwks-scope",
+					Required: true,
+				},
+			},
+			expected: &envoy_jwt.JwtAuthentication{
+				Rules: []*envoy_jwt.RequirementRule{
+					{
+						Match: &route.RouteMatch{
+							PathSpecifier: &route.RouteMatch_Prefix{
+								Prefix: "/",
+							},
+						},
+						RequirementType: &envoy_jwt.RequirementRule_Requires{
+							Requires: &envoy_jwt.JwtRequirement{
+								RequiresType: &envoy_jwt.JwtRequirement_RequiresAll{
+									RequiresAll: &envoy_jwt.JwtRequirementAndList{
+										Requirements: []*envoy_jwt.JwtRequirement{
+											{
+												RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+													ProviderName: "origins-0",
+												},
+											},
+											{
+												RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+													ProviderName: "origins-1",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Providers: map[string]*envoy_jwt.JwtProvider{
+					"origins-0": {
+						Issuer: "https://idp.example.com",
+						JwksSourceSpecifier: &envoy_jwt.JwtProvider_LocalJwks{
+							LocalJwks: &core.DataSource{
+								Specifier: &core.DataSource_InlineString{
+									InlineString: "jwks-idp",
+								},
+							},
+						},
+						Forward:           false,
+						PayloadInMetadata: "payload",
+						NormalizePayloadInMetadata: &envoy_jwt.JwtProvider_NormalizePayload{
+							SpaceDelimitedClaims: buildSpaceDelimitedClaims(nil),
+						},
+					},
+					"origins-1": {
+						Issuer: "https://scope.example.com",
+						JwksSourceSpecifier: &envoy_jwt.JwtProvider_LocalJwks{
+							LocalJwks: &core.DataSource{
+								Specifier: &core.DataSource_InlineString{
+									InlineString: "jwks-scope",
+								},
+							},
+						},
+						Forward:           false,
+						PayloadInMetadata: "payload",
+						NormalizePayloadInMetadata: &envoy_jwt.JwtProvider_NormalizePayload{
+							SpaceDelimitedClaims: buildSpaceDelimitedClaims(nil),
+						},
+					},
+				},
+				BypassCorsPreflight: true,
+			},
+		},
+		{
+			name: "Multiple JWT rules, mixed required/optional — OR(P2, AND(P1, OR(P2, allow_missing)))",
+			in: []*v1beta1.JWTRule{
+				{
+					Issuer:   "https://idp.example.com",
+					Jwks:     "jwks-idp",
+					Required: true,
+				},
+				{
+					Issuer: "https://scope.example.com",
+					Jwks:   "jwks-scope",
+					// Required defaults to false
+				},
+			},
+			expected: &envoy_jwt.JwtAuthentication{
+				Rules: []*envoy_jwt.RequirementRule{
+					{
+						Match: &route.RouteMatch{
+							PathSpecifier: &route.RouteMatch_Prefix{
+								Prefix: "/",
+							},
+						},
+						RequirementType: &envoy_jwt.RequirementRule_Requires{
+							Requires: &envoy_jwt.JwtRequirement{
+								RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
+									RequiresAny: &envoy_jwt.JwtRequirementOrList{
+										Requirements: []*envoy_jwt.JwtRequirement{
+											// Optional provider P2 shortcut
+											{
+												RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+													ProviderName: "origins-1",
+												},
+											},
+											// AND list: P1 bare (required) + OR(P2, allow_missing)
+											{
+												RequiresType: &envoy_jwt.JwtRequirement_RequiresAll{
+													RequiresAll: &envoy_jwt.JwtRequirementAndList{
+														Requirements: []*envoy_jwt.JwtRequirement{
+															{
+																RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+																	ProviderName: "origins-0",
+																},
+															},
+															{
+																RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
+																	RequiresAny: &envoy_jwt.JwtRequirementOrList{
+																		Requirements: []*envoy_jwt.JwtRequirement{
+																			{
+																				RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+																					ProviderName: "origins-1",
+																				},
+																			},
+																			{
+																				RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
+																					AllowMissing: &emptypb.Empty{},
+																				},
+																			},
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Providers: map[string]*envoy_jwt.JwtProvider{
+					"origins-0": {
+						Issuer: "https://idp.example.com",
+						JwksSourceSpecifier: &envoy_jwt.JwtProvider_LocalJwks{
+							LocalJwks: &core.DataSource{
+								Specifier: &core.DataSource_InlineString{
+									InlineString: "jwks-idp",
+								},
+							},
+						},
+						Forward:           false,
+						PayloadInMetadata: "payload",
+						NormalizePayloadInMetadata: &envoy_jwt.JwtProvider_NormalizePayload{
+							SpaceDelimitedClaims: buildSpaceDelimitedClaims(nil),
+						},
+					},
+					"origins-1": {
+						Issuer: "https://scope.example.com",
+						JwksSourceSpecifier: &envoy_jwt.JwtProvider_LocalJwks{
+							LocalJwks: &core.DataSource{
+								Specifier: &core.DataSource_InlineString{
+									InlineString: "jwks-scope",
+								},
+							},
+						},
+						Forward:           false,
+						PayloadInMetadata: "payload",
+						NormalizePayloadInMetadata: &envoy_jwt.JwtProvider_NormalizePayload{
+							SpaceDelimitedClaims: buildSpaceDelimitedClaims(nil),
+						},
+					},
+				},
+				BypassCorsPreflight: true,
+			},
+		},
+		{
 			name: "Single JWT policy with custom space delimited claims",
 			in: []*v1beta1.JWTRule{
 				{

--- a/pilot/pkg/security/authn/policy_applier_test.go
+++ b/pilot/pkg/security/authn/policy_applier_test.go
@@ -1282,6 +1282,478 @@ func TestConvertToEnvoyJwtConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "Single JWT rule with presence=REQUIRED",
+			in: []*v1beta1.JWTRule{
+				{
+					Issuer:   "https://secret.foo.com",
+					Jwks:     "jwks-inline-data",
+					Presence: v1beta1.JWTRule_REQUIRED,
+				},
+			},
+			expected: &envoy_jwt.JwtAuthentication{
+				Rules: []*envoy_jwt.RequirementRule{
+					{
+						Match: &route.RouteMatch{
+							PathSpecifier: &route.RouteMatch_Prefix{
+								Prefix: "/",
+							},
+						},
+						RequirementType: &envoy_jwt.RequirementRule_Requires{
+							Requires: &envoy_jwt.JwtRequirement{
+								RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+									ProviderName: "origins-0",
+								},
+							},
+						},
+					},
+				},
+				Providers: map[string]*envoy_jwt.JwtProvider{
+					"origins-0": {
+						Issuer: "https://secret.foo.com",
+						JwksSourceSpecifier: &envoy_jwt.JwtProvider_LocalJwks{
+							LocalJwks: &core.DataSource{
+								Specifier: &core.DataSource_InlineString{
+									InlineString: "jwks-inline-data",
+								},
+							},
+						},
+						Forward:           false,
+						PayloadInMetadata: "payload",
+						NormalizePayloadInMetadata: &envoy_jwt.JwtProvider_NormalizePayload{
+							SpaceDelimitedClaims: buildSpaceDelimitedClaims(nil),
+						},
+					},
+				},
+				BypassCorsPreflight: true,
+			},
+		},
+		{
+			name: "Single JWT rule with presence=OPTIONAL — OR(provider, allow_missing)",
+			in: []*v1beta1.JWTRule{
+				{
+					Issuer:   "https://secret.foo.com",
+					Jwks:     "jwks-inline-data",
+					Presence: v1beta1.JWTRule_OPTIONAL,
+				},
+			},
+			expected: &envoy_jwt.JwtAuthentication{
+				Rules: []*envoy_jwt.RequirementRule{
+					{
+						Match: &route.RouteMatch{
+							PathSpecifier: &route.RouteMatch_Prefix{
+								Prefix: "/",
+							},
+						},
+						RequirementType: &envoy_jwt.RequirementRule_Requires{
+							Requires: &envoy_jwt.JwtRequirement{
+								RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
+									RequiresAny: &envoy_jwt.JwtRequirementOrList{
+										Requirements: []*envoy_jwt.JwtRequirement{
+											{
+												RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+													ProviderName: "origins-0",
+												},
+											},
+											{
+												RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
+													AllowMissing: &emptypb.Empty{},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Providers: map[string]*envoy_jwt.JwtProvider{
+					"origins-0": {
+						Issuer: "https://secret.foo.com",
+						JwksSourceSpecifier: &envoy_jwt.JwtProvider_LocalJwks{
+							LocalJwks: &core.DataSource{
+								Specifier: &core.DataSource_InlineString{
+									InlineString: "jwks-inline-data",
+								},
+							},
+						},
+						Forward:           false,
+						PayloadInMetadata: "payload",
+						NormalizePayloadInMetadata: &envoy_jwt.JwtProvider_NormalizePayload{
+							SpaceDelimitedClaims: buildSpaceDelimitedClaims(nil),
+						},
+					},
+				},
+				BypassCorsPreflight: true,
+			},
+		},
+		{
+			name: "Multiple JWT rules, all REQUIRED — AND(P1, P2)",
+			in: []*v1beta1.JWTRule{
+				{
+					Issuer:   "https://idp.example.com",
+					Jwks:     "jwks-idp",
+					Presence: v1beta1.JWTRule_REQUIRED,
+				},
+				{
+					Issuer:   "https://scope.example.com",
+					Jwks:     "jwks-scope",
+					Presence: v1beta1.JWTRule_REQUIRED,
+				},
+			},
+			expected: &envoy_jwt.JwtAuthentication{
+				Rules: []*envoy_jwt.RequirementRule{
+					{
+						Match: &route.RouteMatch{
+							PathSpecifier: &route.RouteMatch_Prefix{
+								Prefix: "/",
+							},
+						},
+						RequirementType: &envoy_jwt.RequirementRule_Requires{
+							Requires: &envoy_jwt.JwtRequirement{
+								RequiresType: &envoy_jwt.JwtRequirement_RequiresAll{
+									RequiresAll: &envoy_jwt.JwtRequirementAndList{
+										Requirements: []*envoy_jwt.JwtRequirement{
+											{
+												RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+													ProviderName: "origins-0",
+												},
+											},
+											{
+												RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+													ProviderName: "origins-1",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Providers: map[string]*envoy_jwt.JwtProvider{
+					"origins-0": {
+						Issuer: "https://idp.example.com",
+						JwksSourceSpecifier: &envoy_jwt.JwtProvider_LocalJwks{
+							LocalJwks: &core.DataSource{
+								Specifier: &core.DataSource_InlineString{
+									InlineString: "jwks-idp",
+								},
+							},
+						},
+						Forward:           false,
+						PayloadInMetadata: "payload",
+						NormalizePayloadInMetadata: &envoy_jwt.JwtProvider_NormalizePayload{
+							SpaceDelimitedClaims: buildSpaceDelimitedClaims(nil),
+						},
+					},
+					"origins-1": {
+						Issuer: "https://scope.example.com",
+						JwksSourceSpecifier: &envoy_jwt.JwtProvider_LocalJwks{
+							LocalJwks: &core.DataSource{
+								Specifier: &core.DataSource_InlineString{
+									InlineString: "jwks-scope",
+								},
+							},
+						},
+						Forward:           false,
+						PayloadInMetadata: "payload",
+						NormalizePayloadInMetadata: &envoy_jwt.JwtProvider_NormalizePayload{
+							SpaceDelimitedClaims: buildSpaceDelimitedClaims(nil),
+						},
+					},
+				},
+				BypassCorsPreflight: true,
+			},
+		},
+		{
+			name: "Multiple JWT rules, mixed REQUIRED then explicit OPTIONAL — AND(P1, OR(P2, allow_missing))",
+			in: []*v1beta1.JWTRule{
+				{
+					Issuer:   "https://idp.example.com",
+					Jwks:     "jwks-idp",
+					Presence: v1beta1.JWTRule_REQUIRED,
+				},
+				{
+					Issuer:   "https://scope.example.com",
+					Jwks:     "jwks-scope",
+					Presence: v1beta1.JWTRule_OPTIONAL,
+				},
+			},
+			expected: &envoy_jwt.JwtAuthentication{
+				Rules: []*envoy_jwt.RequirementRule{
+					{
+						Match: &route.RouteMatch{
+							PathSpecifier: &route.RouteMatch_Prefix{
+								Prefix: "/",
+							},
+						},
+						RequirementType: &envoy_jwt.RequirementRule_Requires{
+							Requires: &envoy_jwt.JwtRequirement{
+								RequiresType: &envoy_jwt.JwtRequirement_RequiresAll{
+									RequiresAll: &envoy_jwt.JwtRequirementAndList{
+										Requirements: []*envoy_jwt.JwtRequirement{
+											{
+												RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+													ProviderName: "origins-0",
+												},
+											},
+											{
+												RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
+													RequiresAny: &envoy_jwt.JwtRequirementOrList{
+														Requirements: []*envoy_jwt.JwtRequirement{
+															{
+																RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+																	ProviderName: "origins-1",
+																},
+															},
+															{
+																RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
+																	AllowMissing: &emptypb.Empty{},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Providers: map[string]*envoy_jwt.JwtProvider{
+					"origins-0": {
+						Issuer: "https://idp.example.com",
+						JwksSourceSpecifier: &envoy_jwt.JwtProvider_LocalJwks{
+							LocalJwks: &core.DataSource{
+								Specifier: &core.DataSource_InlineString{
+									InlineString: "jwks-idp",
+								},
+							},
+						},
+						Forward:           false,
+						PayloadInMetadata: "payload",
+						NormalizePayloadInMetadata: &envoy_jwt.JwtProvider_NormalizePayload{
+							SpaceDelimitedClaims: buildSpaceDelimitedClaims(nil),
+						},
+					},
+					"origins-1": {
+						Issuer: "https://scope.example.com",
+						JwksSourceSpecifier: &envoy_jwt.JwtProvider_LocalJwks{
+							LocalJwks: &core.DataSource{
+								Specifier: &core.DataSource_InlineString{
+									InlineString: "jwks-scope",
+								},
+							},
+						},
+						Forward:           false,
+						PayloadInMetadata: "payload",
+						NormalizePayloadInMetadata: &envoy_jwt.JwtProvider_NormalizePayload{
+							SpaceDelimitedClaims: buildSpaceDelimitedClaims(nil),
+						},
+					},
+				},
+				BypassCorsPreflight: true,
+			},
+		},
+		{
+			name: "Multiple JWT rules, mixed OPTIONAL then REQUIRED — AND(OR(P1, allow_missing), P2)",
+			in: []*v1beta1.JWTRule{
+				{
+					Issuer:   "https://scope.example.com",
+					Jwks:     "jwks-scope",
+					Presence: v1beta1.JWTRule_OPTIONAL,
+				},
+				{
+					Issuer:   "https://idp.example.com",
+					Jwks:     "jwks-idp",
+					Presence: v1beta1.JWTRule_REQUIRED,
+				},
+			},
+			expected: &envoy_jwt.JwtAuthentication{
+				Rules: []*envoy_jwt.RequirementRule{
+					{
+						Match: &route.RouteMatch{
+							PathSpecifier: &route.RouteMatch_Prefix{
+								Prefix: "/",
+							},
+						},
+						RequirementType: &envoy_jwt.RequirementRule_Requires{
+							Requires: &envoy_jwt.JwtRequirement{
+								RequiresType: &envoy_jwt.JwtRequirement_RequiresAll{
+									RequiresAll: &envoy_jwt.JwtRequirementAndList{
+										Requirements: []*envoy_jwt.JwtRequirement{
+											{
+												RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
+													RequiresAny: &envoy_jwt.JwtRequirementOrList{
+														Requirements: []*envoy_jwt.JwtRequirement{
+															{
+																RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+																	ProviderName: "origins-0",
+																},
+															},
+															{
+																RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
+																	AllowMissing: &emptypb.Empty{},
+																},
+															},
+														},
+													},
+												},
+											},
+											{
+												RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+													ProviderName: "origins-1",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Providers: map[string]*envoy_jwt.JwtProvider{
+					"origins-0": {
+						Issuer: "https://scope.example.com",
+						JwksSourceSpecifier: &envoy_jwt.JwtProvider_LocalJwks{
+							LocalJwks: &core.DataSource{
+								Specifier: &core.DataSource_InlineString{
+									InlineString: "jwks-scope",
+								},
+							},
+						},
+						Forward:           false,
+						PayloadInMetadata: "payload",
+						NormalizePayloadInMetadata: &envoy_jwt.JwtProvider_NormalizePayload{
+							SpaceDelimitedClaims: buildSpaceDelimitedClaims(nil),
+						},
+					},
+					"origins-1": {
+						Issuer: "https://idp.example.com",
+						JwksSourceSpecifier: &envoy_jwt.JwtProvider_LocalJwks{
+							LocalJwks: &core.DataSource{
+								Specifier: &core.DataSource_InlineString{
+									InlineString: "jwks-idp",
+								},
+							},
+						},
+						Forward:           false,
+						PayloadInMetadata: "payload",
+						NormalizePayloadInMetadata: &envoy_jwt.JwtProvider_NormalizePayload{
+							SpaceDelimitedClaims: buildSpaceDelimitedClaims(nil),
+						},
+					},
+				},
+				BypassCorsPreflight: true,
+			},
+		},
+		{
+			name: "Multiple JWT rules, mixed REQUIRED/default OPTIONAL with distinct headers — AND(P1, OR(P2, allow_missing))",
+			in: []*v1beta1.JWTRule{
+				{
+					Issuer:   "https://idp.example.com",
+					Jwks:     "jwks-idp",
+					Presence: v1beta1.JWTRule_REQUIRED,
+					FromHeaders: []*v1beta1.JWTHeader{
+						{Name: "Authorization", Prefix: "Bearer "},
+					},
+				},
+				{
+					Issuer: "https://scope.example.com",
+					Jwks:   "jwks-scope",
+					// Presence unset defaults to OPTIONAL
+					FromHeaders: []*v1beta1.JWTHeader{
+						{Name: "x-scope-token"},
+					},
+				},
+			},
+			expected: &envoy_jwt.JwtAuthentication{
+				Rules: []*envoy_jwt.RequirementRule{
+					{
+						Match: &route.RouteMatch{
+							PathSpecifier: &route.RouteMatch_Prefix{
+								Prefix: "/",
+							},
+						},
+						RequirementType: &envoy_jwt.RequirementRule_Requires{
+							Requires: &envoy_jwt.JwtRequirement{
+								RequiresType: &envoy_jwt.JwtRequirement_RequiresAll{
+									RequiresAll: &envoy_jwt.JwtRequirementAndList{
+										Requirements: []*envoy_jwt.JwtRequirement{
+											{
+												RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+													ProviderName: "origins-0",
+												},
+											},
+											{
+												RequiresType: &envoy_jwt.JwtRequirement_RequiresAny{
+													RequiresAny: &envoy_jwt.JwtRequirementOrList{
+														Requirements: []*envoy_jwt.JwtRequirement{
+															{
+																RequiresType: &envoy_jwt.JwtRequirement_ProviderName{
+																	ProviderName: "origins-1",
+																},
+															},
+															{
+																RequiresType: &envoy_jwt.JwtRequirement_AllowMissing{
+																	AllowMissing: &emptypb.Empty{},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Providers: map[string]*envoy_jwt.JwtProvider{
+					"origins-0": {
+						Issuer: "https://idp.example.com",
+						JwksSourceSpecifier: &envoy_jwt.JwtProvider_LocalJwks{
+							LocalJwks: &core.DataSource{
+								Specifier: &core.DataSource_InlineString{
+									InlineString: "jwks-idp",
+								},
+							},
+						},
+						FromHeaders: []*envoy_jwt.JwtHeader{
+							{Name: "Authorization", ValuePrefix: "Bearer "},
+						},
+						Forward:           false,
+						PayloadInMetadata: "payload",
+						NormalizePayloadInMetadata: &envoy_jwt.JwtProvider_NormalizePayload{
+							SpaceDelimitedClaims: buildSpaceDelimitedClaims(nil),
+						},
+					},
+					"origins-1": {
+						Issuer: "https://scope.example.com",
+						JwksSourceSpecifier: &envoy_jwt.JwtProvider_LocalJwks{
+							LocalJwks: &core.DataSource{
+								Specifier: &core.DataSource_InlineString{
+									InlineString: "jwks-scope",
+								},
+							},
+						},
+						FromHeaders: []*envoy_jwt.JwtHeader{
+							{Name: "x-scope-token"},
+						},
+						Forward:           false,
+						PayloadInMetadata: "payload",
+						NormalizePayloadInMetadata: &envoy_jwt.JwtProvider_NormalizePayload{
+							SpaceDelimitedClaims: buildSpaceDelimitedClaims(nil),
+						},
+					},
+				},
+				BypassCorsPreflight: true,
+			},
+		},
+		{
 			name: "Single JWT policy with custom space delimited claims",
 			in: []*v1beta1.JWTRule{
 				{

--- a/releasenotes/notes/jwt-required-multi-token.yaml
+++ b/releasenotes/notes/jwt-required-multi-token.yaml
@@ -11,4 +11,4 @@ releaseNotes:
   Previously, configuring multiple `jwtRules` validated each token independently but allowed requests with only one valid token to pass. Setting `required: true` on each rule enforces that all configured tokens must be present and cryptographically valid.
   This is useful when workloads must receive tokens from multiple issuers on distinct headers, for example an identity token in `Authorization` and a scope token in a custom header.
   The field defaults to `false`, preserving existing behavior for current `RequestAuthentication` resources.
-  When multiple `required` rules are configured, request principal and JWT payload metadata are populated from one of the validated tokens. Use `AuthorizationPolicy` rules that match on claims from the token relevant to your authorization decision.
+  When multiple `required` rules are configured, claims from all validated tokens are accessible in `AuthorizationPolicy` via `request.auth.claims`. Each provider's payload is stored under its own metadata key, so authorization rules can reference claims from any of the required tokens.

--- a/releasenotes/notes/jwt-required-multi-token.yaml
+++ b/releasenotes/notes/jwt-required-multi-token.yaml
@@ -1,0 +1,14 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+
+issue:
+  - https://github.com/istio/istio/issues/60823
+
+releaseNotes:
+- |
+  **Added** a `required` field to `JWTRule` in `RequestAuthentication`. When set to `true`, the JWT token for that rule must be present and valid; requests without it are rejected with `401 Unauthorized`.
+  Previously, configuring multiple `jwtRules` validated each token independently but allowed requests with only one valid token to pass. Setting `required: true` on each rule enforces that all configured tokens must be present and cryptographically valid.
+  This is useful when workloads must receive tokens from multiple issuers on distinct headers, for example an identity token in `Authorization` and a scope token in a custom header.
+  The field defaults to `false`, preserving existing behavior for current `RequestAuthentication` resources.
+  When multiple `required` rules are configured, request principal and JWT payload metadata are populated from one of the validated tokens. Use `AuthorizationPolicy` rules that match on claims from the token relevant to your authorization decision.

--- a/releasenotes/notes/jwt-required-multi-token.yaml
+++ b/releasenotes/notes/jwt-required-multi-token.yaml
@@ -1,0 +1,14 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+
+issue:
+  - https://github.com/istio/istio/issues/60823
+
+releaseNotes:
+- |
+  **Added** a `presence` field to `JWTRule` in `RequestAuthentication`. When set to `REQUIRED`, the JWT token for that rule must be present and valid; requests without it are rejected with `401 Unauthorized`.
+  Previously, configuring multiple `jwtRules` validated each token independently but allowed requests with only one valid token to pass. Setting `presence: REQUIRED` on each rule enforces that all configured tokens must be present and cryptographically valid.
+  This is useful when workloads must receive tokens from multiple issuers on distinct headers, for example an identity token in `Authorization` and a scope token in a custom header.
+  The field defaults to `OPTIONAL`, preserving existing behavior for current `RequestAuthentication` resources.
+  When multiple `REQUIRED` rules are configured, claims from all validated tokens are accessible in `AuthorizationPolicy` via `request.auth.claims`. Each provider's payload is stored under its own metadata key, so authorization rules can reference claims from any of the required tokens.

--- a/tests/integration/security/jwt_test.go
+++ b/tests/integration/security/jwt_test.go
@@ -284,6 +284,31 @@ func TestRequestAuthentication(t *testing.T) {
 						opts.Check = check.Status(http.StatusUnauthorized)
 					},
 				},
+				{
+					// Required token is expired: Envoy rejects an expired token even when required=true.
+					name: "primary-expired-scope-optional-valid",
+					customizeCall: func(_ framework.TestContext, _ echo.Instance, opts *echo.CallOptions) {
+						opts.HTTP.Path = "/primary-expired-scope-optional-valid"
+						opts.HTTP.Headers = headers.New().
+							WithAuthz(jwt.TokenExpired).
+							With("x-scope-token", jwt.TokenIssuer2).
+							Build()
+						opts.Check = check.Status(http.StatusUnauthorized)
+					},
+				},
+				{
+					// Optional token is expired and present: allow_missing only covers absent tokens,
+					// not expired ones, so this must be rejected.
+					name: "primary-valid-scope-optional-expired",
+					customizeCall: func(_ framework.TestContext, _ echo.Instance, opts *echo.CallOptions) {
+						opts.HTTP.Path = "/primary-valid-scope-optional-expired"
+						opts.HTTP.Headers = headers.New().
+							WithAuthz(jwt.TokenIssuer1).
+							With("x-scope-token", jwt.TokenExpired).
+							Build()
+						opts.Check = check.Status(http.StatusUnauthorized)
+					},
+				},
 			}))
 
 			t.NewSubTest("authn-authz").Run(newTest("testdata/requestauthn/authn-authz.yaml.tmpl", []testCase{

--- a/tests/integration/security/jwt_test.go
+++ b/tests/integration/security/jwt_test.go
@@ -180,6 +180,112 @@ func TestRequestAuthentication(t *testing.T) {
 				},
 			}))
 
+			t.NewSubTest("required-multi-jwt").Run(newTest("testdata/requestauthn/required-multi-jwt.yaml.tmpl", []testCase{
+				{
+					name: "both-tokens-valid",
+					customizeCall: func(t framework.TestContext, from echo.Instance, opts *echo.CallOptions) {
+						opts.HTTP.Path = "/both-tokens-valid"
+						opts.HTTP.Headers = headers.New().
+							WithAuthz(jwt.TokenIssuer1).
+							With("x-scope-token", jwt.TokenIssuer2).
+							Build()
+						opts.Check = check.And(
+							check.OK(),
+							check.ReachedTargetClusters(t))
+					},
+				},
+				{
+					name: "only-primary-token",
+					customizeCall: func(_ framework.TestContext, _ echo.Instance, opts *echo.CallOptions) {
+						opts.HTTP.Path = "/only-primary-token"
+						opts.HTTP.Headers = headers.New().WithAuthz(jwt.TokenIssuer1).Build()
+						opts.Check = check.Status(http.StatusUnauthorized)
+					},
+				},
+				{
+					name: "only-scope-token",
+					customizeCall: func(_ framework.TestContext, _ echo.Instance, opts *echo.CallOptions) {
+						opts.HTTP.Path = "/only-scope-token"
+						opts.HTTP.Headers = headers.New().
+							With("x-scope-token", jwt.TokenIssuer2).
+							Build()
+						opts.Check = check.Status(http.StatusUnauthorized)
+					},
+				},
+				{
+					name: "no-tokens",
+					customizeCall: func(_ framework.TestContext, _ echo.Instance, opts *echo.CallOptions) {
+						opts.HTTP.Path = "/no-tokens"
+						opts.Check = check.Status(http.StatusUnauthorized)
+					},
+				},
+				{
+					name: "primary-valid-scope-expired",
+					customizeCall: func(_ framework.TestContext, _ echo.Instance, opts *echo.CallOptions) {
+						opts.HTTP.Path = "/primary-valid-scope-expired"
+						opts.HTTP.Headers = headers.New().
+							WithAuthz(jwt.TokenIssuer1).
+							With("x-scope-token", jwt.TokenExpired).
+							Build()
+						opts.Check = check.Status(http.StatusUnauthorized)
+					},
+				},
+				{
+					name: "primary-expired-scope-valid",
+					customizeCall: func(_ framework.TestContext, _ echo.Instance, opts *echo.CallOptions) {
+						opts.HTTP.Path = "/primary-expired-scope-valid"
+						opts.HTTP.Headers = headers.New().
+							WithAuthz(jwt.TokenExpired).
+							With("x-scope-token", jwt.TokenIssuer2).
+							Build()
+						opts.Check = check.Status(http.StatusUnauthorized)
+					},
+				},
+			}))
+
+			t.NewSubTest("required-mixed-jwt").Run(newTest("testdata/requestauthn/required-mixed-jwt.yaml.tmpl", []testCase{
+				{
+					name: "both-tokens-valid",
+					customizeCall: func(t framework.TestContext, from echo.Instance, opts *echo.CallOptions) {
+						opts.HTTP.Path = "/both-tokens-valid"
+						opts.HTTP.Headers = headers.New().
+							WithAuthz(jwt.TokenIssuer1).
+							With("x-scope-token", jwt.TokenIssuer2).
+							Build()
+						opts.Check = check.And(
+							check.OK(),
+							check.ReachedTargetClusters(t))
+					},
+				},
+				{
+					name: "only-primary-token",
+					customizeCall: func(t framework.TestContext, from echo.Instance, opts *echo.CallOptions) {
+						opts.HTTP.Path = "/only-primary-token"
+						opts.HTTP.Headers = headers.New().WithAuthz(jwt.TokenIssuer1).Build()
+						opts.Check = check.And(
+							check.OK(),
+							check.ReachedTargetClusters(t))
+					},
+				},
+				{
+					name: "only-scope-token",
+					customizeCall: func(_ framework.TestContext, _ echo.Instance, opts *echo.CallOptions) {
+						opts.HTTP.Path = "/only-scope-token"
+						opts.HTTP.Headers = headers.New().
+							With("x-scope-token", jwt.TokenIssuer2).
+							Build()
+						opts.Check = check.Status(http.StatusUnauthorized)
+					},
+				},
+				{
+					name: "no-tokens",
+					customizeCall: func(_ framework.TestContext, _ echo.Instance, opts *echo.CallOptions) {
+						opts.HTTP.Path = "/no-tokens"
+						opts.Check = check.Status(http.StatusUnauthorized)
+					},
+				},
+			}))
+
 			t.NewSubTest("authn-authz").Run(newTest("testdata/requestauthn/authn-authz.yaml.tmpl", []testCase{
 				{
 					name: "valid-token",

--- a/tests/integration/security/jwt_test.go
+++ b/tests/integration/security/jwt_test.go
@@ -180,6 +180,137 @@ func TestRequestAuthentication(t *testing.T) {
 				},
 			}))
 
+			t.NewSubTest("required-multi-jwt").Run(newTest("testdata/requestauthn/required-multi-jwt.yaml.tmpl", []testCase{
+				{
+					name: "both-tokens-valid",
+					customizeCall: func(t framework.TestContext, from echo.Instance, opts *echo.CallOptions) {
+						opts.HTTP.Path = "/both-tokens-valid"
+						opts.HTTP.Headers = headers.New().
+							WithAuthz(jwt.TokenIssuer1).
+							With("x-scope-token", jwt.TokenIssuer2).
+							Build()
+						opts.Check = check.And(
+							check.OK(),
+							check.ReachedTargetClusters(t))
+					},
+				},
+				{
+					name: "only-primary-token",
+					customizeCall: func(_ framework.TestContext, _ echo.Instance, opts *echo.CallOptions) {
+						opts.HTTP.Path = "/only-primary-token"
+						opts.HTTP.Headers = headers.New().WithAuthz(jwt.TokenIssuer1).Build()
+						opts.Check = check.Status(http.StatusUnauthorized)
+					},
+				},
+				{
+					name: "only-scope-token",
+					customizeCall: func(_ framework.TestContext, _ echo.Instance, opts *echo.CallOptions) {
+						opts.HTTP.Path = "/only-scope-token"
+						opts.HTTP.Headers = headers.New().
+							With("x-scope-token", jwt.TokenIssuer2).
+							Build()
+						opts.Check = check.Status(http.StatusUnauthorized)
+					},
+				},
+				{
+					name: "no-tokens",
+					customizeCall: func(_ framework.TestContext, _ echo.Instance, opts *echo.CallOptions) {
+						opts.HTTP.Path = "/no-tokens"
+						opts.Check = check.Status(http.StatusUnauthorized)
+					},
+				},
+				{
+					name: "primary-valid-scope-expired",
+					customizeCall: func(_ framework.TestContext, _ echo.Instance, opts *echo.CallOptions) {
+						opts.HTTP.Path = "/primary-valid-scope-expired"
+						opts.HTTP.Headers = headers.New().
+							WithAuthz(jwt.TokenIssuer1).
+							With("x-scope-token", jwt.TokenExpired).
+							Build()
+						opts.Check = check.Status(http.StatusUnauthorized)
+					},
+				},
+				{
+					name: "primary-expired-scope-valid",
+					customizeCall: func(_ framework.TestContext, _ echo.Instance, opts *echo.CallOptions) {
+						opts.HTTP.Path = "/primary-expired-scope-valid"
+						opts.HTTP.Headers = headers.New().
+							WithAuthz(jwt.TokenExpired).
+							With("x-scope-token", jwt.TokenIssuer2).
+							Build()
+						opts.Check = check.Status(http.StatusUnauthorized)
+					},
+				},
+			}))
+
+			t.NewSubTest("required-mixed-jwt").Run(newTest("testdata/requestauthn/required-mixed-jwt.yaml.tmpl", []testCase{
+				{
+					name: "both-tokens-valid",
+					customizeCall: func(t framework.TestContext, from echo.Instance, opts *echo.CallOptions) {
+						opts.HTTP.Path = "/both-tokens-valid"
+						opts.HTTP.Headers = headers.New().
+							WithAuthz(jwt.TokenIssuer1).
+							With("x-scope-token", jwt.TokenIssuer2).
+							Build()
+						opts.Check = check.And(
+							check.OK(),
+							check.ReachedTargetClusters(t))
+					},
+				},
+				{
+					name: "only-primary-token",
+					customizeCall: func(t framework.TestContext, from echo.Instance, opts *echo.CallOptions) {
+						opts.HTTP.Path = "/only-primary-token"
+						opts.HTTP.Headers = headers.New().WithAuthz(jwt.TokenIssuer1).Build()
+						opts.Check = check.And(
+							check.OK(),
+							check.ReachedTargetClusters(t))
+					},
+				},
+				{
+					name: "only-scope-token",
+					customizeCall: func(_ framework.TestContext, _ echo.Instance, opts *echo.CallOptions) {
+						opts.HTTP.Path = "/only-scope-token"
+						opts.HTTP.Headers = headers.New().
+							With("x-scope-token", jwt.TokenIssuer2).
+							Build()
+						opts.Check = check.Status(http.StatusUnauthorized)
+					},
+				},
+				{
+					name: "no-tokens",
+					customizeCall: func(_ framework.TestContext, _ echo.Instance, opts *echo.CallOptions) {
+						opts.HTTP.Path = "/no-tokens"
+						opts.Check = check.Status(http.StatusUnauthorized)
+					},
+				},
+				{
+					// Required token is expired: Envoy rejects an expired token even when presence=REQUIRED.
+					name: "primary-expired-scope-optional-valid",
+					customizeCall: func(_ framework.TestContext, _ echo.Instance, opts *echo.CallOptions) {
+						opts.HTTP.Path = "/primary-expired-scope-optional-valid"
+						opts.HTTP.Headers = headers.New().
+							WithAuthz(jwt.TokenExpired).
+							With("x-scope-token", jwt.TokenIssuer2).
+							Build()
+						opts.Check = check.Status(http.StatusUnauthorized)
+					},
+				},
+				{
+					// Optional token is expired and present: allow_missing only covers absent tokens,
+					// not expired ones, so this must be rejected.
+					name: "primary-valid-scope-optional-expired",
+					customizeCall: func(_ framework.TestContext, _ echo.Instance, opts *echo.CallOptions) {
+						opts.HTTP.Path = "/primary-valid-scope-optional-expired"
+						opts.HTTP.Headers = headers.New().
+							WithAuthz(jwt.TokenIssuer1).
+							With("x-scope-token", jwt.TokenExpired).
+							Build()
+						opts.Check = check.Status(http.StatusUnauthorized)
+					},
+				},
+			}))
+
 			t.NewSubTest("authn-authz").Run(newTest("testdata/requestauthn/authn-authz.yaml.tmpl", []testCase{
 				{
 					name: "valid-token",

--- a/tests/integration/security/testdata/requestauthn/required-mixed-jwt.yaml.tmpl
+++ b/tests/integration/security/testdata/requestauthn/required-mixed-jwt.yaml.tmpl
@@ -1,0 +1,19 @@
+apiVersion: security.istio.io/v1
+kind: RequestAuthentication
+metadata:
+  name: {{ .To.ServiceName }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .To.ServiceName }}
+  jwtRules:
+  - issuer: "test-issuer-1@istio.io"
+    jwksUri: "{{ .JWTServer.JwksURI }}"
+    required: true
+    fromHeaders:
+    - name: "authorization"
+      prefix: "Bearer "
+  - issuer: "test-issuer-2@istio.io"
+    jwksUri: "{{ .JWTServer.JwksURI }}"
+    fromHeaders:
+    - name: "x-scope-token"

--- a/tests/integration/security/testdata/requestauthn/required-mixed-jwt.yaml.tmpl
+++ b/tests/integration/security/testdata/requestauthn/required-mixed-jwt.yaml.tmpl
@@ -1,0 +1,20 @@
+apiVersion: security.istio.io/v1
+kind: RequestAuthentication
+metadata:
+  name: {{ .To.ServiceName }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .To.ServiceName }}
+  jwtRules:
+  - issuer: "test-issuer-1@istio.io"
+    jwksUri: "{{ .JWTServer.JwksURI }}"
+    presence: REQUIRED
+    fromHeaders:
+    - name: "authorization"
+      prefix: "Bearer "
+  - issuer: "test-issuer-2@istio.io"
+    jwksUri: "{{ .JWTServer.JwksURI }}"
+    presence: OPTIONAL
+    fromHeaders:
+    - name: "x-scope-token"

--- a/tests/integration/security/testdata/requestauthn/required-multi-jwt.yaml.tmpl
+++ b/tests/integration/security/testdata/requestauthn/required-multi-jwt.yaml.tmpl
@@ -1,0 +1,20 @@
+apiVersion: security.istio.io/v1
+kind: RequestAuthentication
+metadata:
+  name: {{ .To.ServiceName }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .To.ServiceName }}
+  jwtRules:
+  - issuer: "test-issuer-1@istio.io"
+    jwksUri: "{{ .JWTServer.JwksURI }}"
+    required: true
+    fromHeaders:
+    - name: "authorization"
+      prefix: "Bearer "
+  - issuer: "test-issuer-2@istio.io"
+    jwksUri: "{{ .JWTServer.JwksURI }}"
+    required: true
+    fromHeaders:
+    - name: "x-scope-token"

--- a/tests/integration/security/testdata/requestauthn/required-multi-jwt.yaml.tmpl
+++ b/tests/integration/security/testdata/requestauthn/required-multi-jwt.yaml.tmpl
@@ -1,0 +1,20 @@
+apiVersion: security.istio.io/v1
+kind: RequestAuthentication
+metadata:
+  name: {{ .To.ServiceName }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .To.ServiceName }}
+  jwtRules:
+  - issuer: "test-issuer-1@istio.io"
+    jwksUri: "{{ .JWTServer.JwksURI }}"
+    presence: REQUIRED
+    fromHeaders:
+    - name: "authorization"
+      prefix: "Bearer "
+  - issuer: "test-issuer-2@istio.io"
+    jwksUri: "{{ .JWTServer.JwksURI }}"
+    presence: REQUIRED
+    fromHeaders:
+    - name: "x-scope-token"


### PR DESCRIPTION
**Please provide a description of this PR:**
Implements support for the new `presence` field on `JWTRule` in `RequestAuthentication`.

When `presence: REQUIRED`, Istiod generates Envoy `jwt_authn` config that requires that token to be present and valid. With multiple rules marked `REQUIRED`, all configured tokens must be present and valid, so a single valid token cannot satisfy the policy.

Depends on: https://github.com/istio/api/pull/3737  
Closes #60823

Currently, with multiple `jwtRules`, Istio generates:
`OR(P1, P2, AND(OR(P1, allow_missing), OR(P2, allow_missing)))`

Any single valid token can pass. There is no way to require all tokens when they come from different issuers/headers.

## Solution
Update `convertToEnvoyJwtConfig` in `policy_applier.go`:

- `presence: REQUIRED` → bare `ProviderName` requirement (no `allow_missing`)
- `presence: OPTIONAL` (default) → existing `OR(provider, allow_missing)` behavior
- All `REQUIRED` → pure `AND(P1, P2, ...)`
- Mixed `REQUIRED`/`OPTIONAL` → `AND(P1, OR(P2, allow_missing), ...)`
- Skip the outer OR shortcut when any rule is `REQUIRED`, so an optional token alone cannot bypass a required token on a different header

Maps to Envoy's native `JwtRequirementAndList` (`requires_all`).

More information: https://github.com/istio/istio/issues/60823