### PR TITLE
networking: fix unbalanced multi-network endpoint weights with multi-locality remote clusters

### DIFF
--- a/pilot/pkg/xds/endpoints/ep_filters.go
+++ b/pilot/pkg/xds/endpoints/ep_filters.go
@@ -85,6 +85,21 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocalityEndpoint
 		scaleFactor = 1
 	}
 
+	// Create a map to keep track of the gateways used and their aggregate weights.
+	// The weights are aggregated across all locality groups: a gateway that proxies
+	// for endpoints spread over multiple localities must be emitted only once, with
+	// the total weight, because Envoy deduplicates endpoints by address within a
+	// cluster - it keeps the first copy and silently drops the weight of the others.
+	// Emitting one copy per locality collapses the effective remote weight to a
+	// single locality's endpoint count. See https://github.com/istio/istio/issues/56355.
+	gatewayWeights := make(map[model.NetworkGateway]uint32)
+
+	// The locality group each gateway endpoint will be emitted into: the first group
+	// that routed an endpoint through it. Locality groups arrive in deterministic
+	// (sorted) order, and this matches the copy Envoy previously kept implicitly via
+	// its dedup-keep-first behavior, so only the weight changes.
+	gatewayGroups := make(map[model.NetworkGateway]*LocalityEndpoints)
+
 	// Go through all cluster endpoints and add those with the same network as the sidecar
 	// to the result. Also count the number of endpoints per each remote network while
 	// iterating so that it can be used as the weight for the gateway endpoint
@@ -96,9 +111,6 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocalityEndpoint
 				// Endpoints and weight will be reset below.
 			},
 		}
-
-		// Create a map to keep track of the gateways used and their aggregate weights.
-		gatewayWeights := make(map[model.NetworkGateway]uint32)
 
 		// Process all the endpoints.
 		for i, lbEp := range ep.llbEndpoints.LbEndpoints {
@@ -177,108 +189,121 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocalityEndpoint
 				continue
 			}
 
+			// Remember which locality group each gateway endpoint will be emitted
+			// into: the first group that routes an endpoint through it.
+			for _, gw := range reachableGateways {
+				if _, found := gatewayGroups[gw]; !found {
+					gatewayGroups[gw] = lbEndpoints
+				}
+			}
+
 			// Apply the weight for this endpoint to the network gateways.
 			splitWeightAmongGateways(weight, reachableGateways, gatewayWeights)
-		}
-
-		// Sort the gateways into an ordered list so that the generated endpoints are deterministic.
-		gateways := maps.Keys(gatewayWeights)
-		gateways = model.SortGateways(gateways)
-
-		// Create endpoints for the gateways.
-		for _, gw := range gateways {
-			epWeight := gatewayWeights[gw]
-			if epWeight == 0 {
-				log.Warnf("gateway weight must be greater than 0, scaleFactor is %d", scaleFactor)
-				epWeight = 1
-			}
-			// Generate a fake IstioEndpoint to carry network and cluster information.
-			gwIstioEp := &model.IstioEndpoint{
-				Network: gw.Network,
-				Locality: model.Locality{
-					ClusterID: gw.Cluster,
-				},
-				Labels: labelutil.AugmentLabels(nil, gw.Cluster, "", "", gw.Network),
-			}
-
-			// Here we generate the EDS endpoint for the E/W gateways that replace the original endpoint.
-			// Depending on whether we operate in ambient mode or not, we generated endpoints for E/W
-			// gateways differently as we use somewhat different protocols in those two distinct cases.
-			var gwEp *endpoint.LbEndpoint
-
-			if features.EnableAmbientMultiNetwork && !isSidecarProxy(b.proxy) {
-				gwAddr := gw.Addr
-				gwPort := int(gw.HBONEPort)
-
-				addr := net.JoinHostPort(gwAddr, strconv.Itoa(gwPort))
-				svcPort := b.servicePort(b.port)
-
-				gwEp = &endpoint.LbEndpoint{
-					HostIdentifier: &endpoint.LbEndpoint_Endpoint{
-						Endpoint: &endpoint.Endpoint{
-							// We need to redirect to an internal listener that will tunnel the data through
-							// a double-HBONE, we still use the E/W gateway address though for the endpoint
-							// id.
-							Address: util.BuildInternalAddressWithIdentifier(innerConnectOriginate, addr),
-						},
-					},
-					LoadBalancingWeight: &wrappers.UInt32Value{
-						Value: epWeight,
-					},
-					Metadata: &core.Metadata{},
-				}
-
-				// TODO: figure out a way to extract locality data from the gateway public endpoints in meshNetworks
-				util.AppendLbEndpointMetadata(&model.EndpointMetadata{
-					Network: gw.Network,
-					// I don't think that TLSMode affects anythig downstream of this code anymore, but for ambient
-					// mode we do not rely on the legacy Istio mTLS, so I explicitly mark it as disabled.
-					TLSMode:   model.DisabledTLSModeLabel,
-					ClusterID: gw.Cluster,
-					Labels:    labels.Instance{},
-				}, gwEp.Metadata)
-
-				// We need to add original dst metadata key with the actual E/W gateway address that we will connect to
-				gwEp.Metadata.FilterMetadata[util.OriginalDstMetadataKey] = util.BuildTunnelMetadataStruct(gwAddr, gwPort, "")
-				// and we need the original service domain name and port that to put in the :authority of the HTTP2 CONNECT.
-				util.AppendDoubleHBONEMetadata(string(b.service.Hostname), svcPort.Port, gwEp.Metadata)
-				if b.dir != model.TrafficDirectionInboundVIP {
-					gwEp.Metadata.FilterMetadata[util.EnvoyTransportSocketMetadataKey] = &structpb.Struct{
-						Fields: map[string]*structpb.Value{
-							model.TunnelLabelShortName: {Kind: &structpb.Value_StringValue{StringValue: model.TunnelHTTP}},
-						},
-					}
-				}
-			} else {
-				epAddr := util.BuildAddress(gw.Addr, gw.Port)
-				gwEp = &endpoint.LbEndpoint{
-					HostIdentifier: &endpoint.LbEndpoint_Endpoint{
-						Endpoint: &endpoint.Endpoint{
-							Address: epAddr,
-						},
-					},
-					LoadBalancingWeight: &wrappers.UInt32Value{
-						Value: epWeight,
-					},
-					Metadata: &core.Metadata{},
-				}
-
-				// TODO: figure out a way to extract locality data from the gateway public endpoints in meshNetworks
-				util.AppendLbEndpointMetadata(&model.EndpointMetadata{
-					Network:   gw.Network,
-					TLSMode:   model.IstioMutualTLSModeLabel,
-					ClusterID: gw.Cluster,
-					Labels:    labels.Instance{},
-				}, gwEp.Metadata)
-			}
-
-			// Currently gateway endpoint does not support tunnel.
-			lbEndpoints.append(gwIstioEp, gwEp)
 		}
 
 		// Endpoint members could be stripped or aggregated by network. Adjust weight value here.
 		lbEndpoints.refreshWeight()
 		filtered = append(filtered, lbEndpoints)
+	}
+
+	// Sort the gateways into an ordered list so that the generated endpoints are deterministic.
+	gateways := maps.Keys(gatewayWeights)
+	gateways = model.SortGateways(gateways)
+
+	// Create endpoints for the gateways, each emitted exactly once with its total
+	// weight aggregated across all locality groups (see comment on gatewayWeights).
+	for _, gw := range gateways {
+		epWeight := gatewayWeights[gw]
+		if epWeight == 0 {
+			log.Warnf("gateway weight must be greater than 0, scaleFactor is %d", scaleFactor)
+			epWeight = 1
+		}
+		// Generate a fake IstioEndpoint to carry network and cluster information.
+		gwIstioEp := &model.IstioEndpoint{
+			Network: gw.Network,
+			Locality: model.Locality{
+				ClusterID: gw.Cluster,
+			},
+			Labels: labelutil.AugmentLabels(nil, gw.Cluster, "", "", gw.Network),
+		}
+
+		// Here we generate the EDS endpoint for the E/W gateways that replace the original endpoint.
+		// Depending on whether we operate in ambient mode or not, we generated endpoints for E/W
+		// gateways differently as we use somewhat different protocols in those two distinct cases.
+		var gwEp *endpoint.LbEndpoint
+
+		if features.EnableAmbientMultiNetwork && !isSidecarProxy(b.proxy) {
+			gwAddr := gw.Addr
+			gwPort := int(gw.HBONEPort)
+
+			addr := net.JoinHostPort(gwAddr, strconv.Itoa(gwPort))
+			svcPort := b.servicePort(b.port)
+
+			gwEp = &endpoint.LbEndpoint{
+				HostIdentifier: &endpoint.LbEndpoint_Endpoint{
+					Endpoint: &endpoint.Endpoint{
+						// We need to redirect to an internal listener that will tunnel the data through
+						// a double-HBONE, we still use the E/W gateway address though for the endpoint
+						// id.
+						Address: util.BuildInternalAddressWithIdentifier(innerConnectOriginate, addr),
+					},
+				},
+				LoadBalancingWeight: &wrappers.UInt32Value{
+					Value: epWeight,
+				},
+				Metadata: &core.Metadata{},
+			}
+
+			// TODO: figure out a way to extract locality data from the gateway public endpoints in meshNetworks
+			util.AppendLbEndpointMetadata(&model.EndpointMetadata{
+				Network: gw.Network,
+				// I don't think that TLSMode affects anythig downstream of this code anymore, but for ambient
+				// mode we do not rely on the legacy Istio mTLS, so I explicitly mark it as disabled.
+				TLSMode:   model.DisabledTLSModeLabel,
+				ClusterID: gw.Cluster,
+				Labels:    labels.Instance{},
+			}, gwEp.Metadata)
+
+			// We need to add original dst metadata key with the actual E/W gateway address that we will connect to
+			gwEp.Metadata.FilterMetadata[util.OriginalDstMetadataKey] = util.BuildTunnelMetadataStruct(gwAddr, gwPort, "")
+			// and we need the original service domain name and port that to put in the :authority of the HTTP2 CONNECT.
+			util.AppendDoubleHBONEMetadata(string(b.service.Hostname), svcPort.Port, gwEp.Metadata)
+			if b.dir != model.TrafficDirectionInboundVIP {
+				gwEp.Metadata.FilterMetadata[util.EnvoyTransportSocketMetadataKey] = &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						model.TunnelLabelShortName: {Kind: &structpb.Value_StringValue{StringValue: model.TunnelHTTP}},
+					},
+				}
+			}
+		} else {
+			epAddr := util.BuildAddress(gw.Addr, gw.Port)
+			gwEp = &endpoint.LbEndpoint{
+				HostIdentifier: &endpoint.LbEndpoint_Endpoint{
+					Endpoint: &endpoint.Endpoint{
+						Address: epAddr,
+					},
+				},
+				LoadBalancingWeight: &wrappers.UInt32Value{
+					Value: epWeight,
+				},
+				Metadata: &core.Metadata{},
+			}
+
+			// TODO: figure out a way to extract locality data from the gateway public endpoints in meshNetworks
+			util.AppendLbEndpointMetadata(&model.EndpointMetadata{
+				Network:   gw.Network,
+				TLSMode:   model.IstioMutualTLSModeLabel,
+				ClusterID: gw.Cluster,
+				Labels:    labels.Instance{},
+			}, gwEp.Metadata)
+		}
+
+		// Currently gateway endpoint does not support tunnel.
+		// Append into the first locality group that routed through this gateway
+		// and refresh that group's aggregate weight.
+		group := gatewayGroups[gw]
+		group.append(gwIstioEp, gwEp)
+		group.refreshWeight()
 	}
 
 	return filtered

--- a/pilot/pkg/xds/endpoints/ep_filters_test.go
+++ b/pilot/pkg/xds/endpoints/ep_filters_test.go
@@ -543,6 +543,96 @@ func TestEndpointsByNetworkFilter(t *testing.T) {
 	runNetworkFilterTest(t, env, networkFiltered, "")
 }
 
+// TestEndpointsByNetworkFilter_MultiLocalityRemoteNetwork verifies that when a
+// remote network has endpoints spread across multiple localities, the E/W
+// gateway endpoint is emitted exactly once per ClusterLoadAssignment with the
+// aggregated weight of all remote endpoints, rather than once per locality.
+// Envoy deduplicates endpoints by address within a cluster - it keeps the
+// first copy and silently drops the rest - so emitting per-locality copies
+// collapses the effective remote weight to a single locality's endpoint count.
+// Regression test for https://github.com/istio/istio/issues/56355.
+func TestEndpointsByNetworkFilter_MultiLocalityRemoteNetwork(t *testing.T) {
+	test.SetForTest(t, &features.MultiNetworkGatewayAPI, true)
+	ds := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
+		Services: []*model.Service{{
+			Hostname:   "example.ns.svc.cluster.local",
+			Attributes: model.ServiceAttributes{Name: "example", Namespace: "ns"},
+			Ports:      model.PortList{{Port: 80, Protocol: protocol.HTTP, Name: "http"}},
+		}},
+		Gateways: []model.NetworkGateway{{
+			Network: "network1",
+			Cluster: "cluster1",
+			Addr:    "1.1.1.1",
+			Port:    15443,
+		}},
+	})
+	ds.Env().InitNetworksManager(ds.Discovery)
+
+	// cluster1 (network1, remote) has endpoints spread across three zones;
+	// cluster2 (network2, local to the proxy) has two single-zone endpoints.
+	shards := map[model.ShardKey][]*model.IstioEndpoint{
+		{Cluster: "cluster1"}: {
+			{Network: "network1", Addresses: []string{"10.0.0.1"}, Locality: model.Locality{Label: "region1/zone-a"}},
+			{Network: "network1", Addresses: []string{"10.0.0.2"}, Locality: model.Locality{Label: "region1/zone-b"}},
+			{Network: "network1", Addresses: []string{"10.0.0.3"}, Locality: model.Locality{Label: "region1/zone-c"}},
+		},
+		{Cluster: "cluster2"}: {
+			{Network: "network2", Addresses: []string{"20.0.0.1"}, Locality: model.Locality{Label: "region2/zone-x"}},
+			{Network: "network2", Addresses: []string{"20.0.0.2"}, Locality: model.Locality{Label: "region2/zone-x"}},
+		},
+	}
+	index := model.NewEndpointIndex(model.NewXdsCache())
+	for sk, eps := range shards {
+		for _, ep := range eps {
+			ep.ServicePortName = "http"
+			ep.Namespace = "ns"
+			ep.HostName = "example.ns.svc.cluster.local"
+			ep.EndpointPort = 8080
+			ep.TLSMode = "istio"
+			ep.Labels = map[string]string{"app": "example"}
+			ep.Locality.ClusterID = sk.Cluster
+		}
+		svc, _ := index.GetOrCreateEndpointShard("example.ns.svc.cluster.local", "ns")
+		svc.Lock()
+		svc.Shards[sk] = eps
+		svc.Unlock()
+	}
+
+	proxy := ds.SetupProxy(makeProxy("network2", "cluster2"))
+	b := endpoints.NewEndpointBuilder("outbound|80||example.ns.svc.cluster.local", proxy, ds.PushContext())
+	filtered := b.BuildClusterLoadAssignment(index).Endpoints
+
+	// Collect every occurrence of the gateway endpoint across all locality groups.
+	var gwWeights []uint32
+	var localWeight uint32
+	for _, group := range filtered {
+		for _, lbEp := range group.LbEndpoints {
+			if util.GetEndpointHost(lbEp) == "1.1.1.1" {
+				gwWeights = append(gwWeights, lbEp.GetLoadBalancingWeight().GetValue())
+			} else {
+				localWeight += lbEp.GetLoadBalancingWeight().GetValue()
+			}
+		}
+	}
+
+	// The same gateway address must appear exactly once in the whole
+	// ClusterLoadAssignment. Envoy drops duplicate addresses (keeping only the
+	// first), so per-locality copies would silently lose the other localities'
+	// share of the remote weight.
+	if len(gwWeights) != 1 {
+		t.Fatalf("expected the E/W gateway endpoint to be emitted exactly once per ClusterLoadAssignment, got %d occurrences (weights %v)",
+			len(gwWeights), gwWeights)
+	}
+	// All three remote endpoints are behind the gateway: its weight must be the
+	// aggregate across all remote localities, not just one zone's share.
+	if gwWeights[0] != 3 {
+		t.Fatalf("expected aggregated gateway weight 3 (3 remote endpoints), got %d", gwWeights[0])
+	}
+	if localWeight != 2 {
+		t.Fatalf("expected total local weight 2, got %d", localWeight)
+	}
+}
+
 func TestEndpointsByNetworkFilter_WithConfig(t *testing.T) {
 	test.SetForTest(t, &features.MultiNetworkGatewayAPI, true)
 	test.SetForTest(t, &features.PreferHBONESend, true)

--- a/releasenotes/notes/56355-multinetwork-gateway-weight.yaml
+++ b/releasenotes/notes/56355-multinetwork-gateway-weight.yaml
@@ -1,0 +1,16 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+issue:
+  - 56355
+
+releaseNotes:
+  - |
+    **Fixed** unbalanced endpoint weights in multi-network deployments when a
+    remote cluster has workloads in multiple localities. The East-West gateway
+    endpoint is now emitted once per cluster load assignment with the weight
+    aggregated across all remote localities, instead of once per locality.
+    Envoy deduplicates endpoints by address, so the per-locality copies were
+    collapsed into the first (alphabetically lowest) locality's copy, and the
+    other localities' traffic share was silently dropped.


### PR DESCRIPTION
Fixes #56355

#### Problem

`EndpointsByNetworkFilter` emits one copy of the E/W gateway endpoint **per
locality group**, each weighted by that locality's endpoints only. Envoy
deduplicates endpoints by address within a cluster, keeping the first copy
(envoyproxy/envoy#22417). Since istiod sorts locality groups alphabetically,
when a remote cluster has workloads in more than one locality only the
alphabetically-first locality's gateway copy survives — the other localities'
weight is silently dropped, skewing cross-network load balancing. This
happens even with `localityLbSetting.enabled: false`.

This exactly reproduces the numbers reported in #56355: the reporter's
cluster-2 view programmed remote weight 12 (= 3 gateways x 4 pods in
us-east-1a only) instead of 45 (= 3 x 15 pods across all three zones).

#### Fix

Aggregate gateway weights across all locality groups and emit each gateway
address exactly once per ClusterLoadAssignment, into the first locality group
that routed through it. That group matches the copy Envoy previously kept via
its dedup-keep-first behavior, so only the weight changes — no change for
remote clusters whose endpoints live in a single locality.

#### Reproduction / verification

- New regression test `TestEndpointsByNetworkFilter_MultiLocalityRemoteNetwork`
  fails on master (`expected the E/W gateway endpoint to be emitted exactly
  once per ClusterLoadAssignment, got 3 occurrences (weights [1 1 1])`) and
  passes with this change.
- Full kind-based end-to-end reproduction (two clusters, multi-primary
  multi-network, Istio 1.30.2) with root-cause analysis:
  https://github.com/mayconritzmann/resolve-istio-56355
  On 1.30.2 a client in a single-zone cluster gets remote weight 2 instead of
  6 against a 3-zone remote cluster, and real traffic skews 75/25 instead of
  50/50.