### PR TITLE
ambient: cross-network interop between sidecar and ambient workloads (experimental)

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -246,6 +246,12 @@ const (
 	// allowing sidecars to connect to gateways that present their own identity.
 	GatewayTLSModeLabel = "gateway"
 
+	// SidecarBridgeSubsetName is the inbound-vip cluster subset used by ambient east-west
+	// gateways to bridge terminated sidecar mTLS traffic into ambient. Unlike the "tcp"
+	// subset, which forwards double-HBONE inner streams opaquely to their destination,
+	// this subset originates a new HBONE tunnel toward the service (or its waypoint).
+	SidecarBridgeSubsetName = "sidecar"
+
 	// IstioCanonicalServiceLabelName is the name of label for the Istio Canonical Service for a workload instance.
 	IstioCanonicalServiceLabelName = pm.IstioCanonicalServiceLabelName
 

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -241,6 +241,11 @@ const (
 	// IstioMutualTLSModeLabel implies that the endpoint is ready to receive Istio mTLS connections.
 	IstioMutualTLSModeLabel = "istio"
 
+	// GatewayTLSModeLabel indicates cross-network gateway endpoints.
+	// These use trust domain prefix matching instead of exact SAN validation,
+	// allowing sidecars to connect to gateways that present their own identity.
+	GatewayTLSModeLabel = "gateway"
+
 	// IstioCanonicalServiceLabelName is the name of label for the Istio Canonical Service for a workload instance.
 	IstioCanonicalServiceLabelName = pm.IstioCanonicalServiceLabelName
 

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -259,6 +259,22 @@ const (
 	IstioCanonicalServiceRevisionLabelName = pm.IstioCanonicalServiceRevisionLabelName
 )
 
+// SidecarBridgeSubsetOf returns the inbound-vip subset name carrying sidecar-bridge
+// semantics for the given DestinationRule subset ("" for the default subset).
+// Mirrors the "http/<subset>" and "tcp/<subset>" convention used by waypoint VIP clusters.
+func SidecarBridgeSubsetOf(subset string) string {
+	if subset == "" {
+		return SidecarBridgeSubsetName
+	}
+	return SidecarBridgeSubsetName + "/" + subset
+}
+
+// IsSidecarBridgeSubset reports whether an inbound-vip subset name carries
+// sidecar-bridge semantics (the default bridge subset or a DR-subset variant).
+func IsSidecarBridgeSubset(subsetName string) bool {
+	return subsetName == SidecarBridgeSubsetName || strings.HasPrefix(subsetName, SidecarBridgeSubsetName+"/")
+}
+
 func SupportsTunnel(labels map[string]string, tunnelType string) bool {
 	tl, f := labels[TunnelLabel]
 	if !f {

--- a/pilot/pkg/networking/core/cluster.go
+++ b/pilot/pkg/networking/core/cluster.go
@@ -342,7 +342,7 @@ func (configgen *ConfigGeneratorImpl) buildClusters(proxy *model.Proxy, req *mod
 		inboundPatcher := clusterPatcher{efw: envoyFilterPatches, pctx: networking.EnvoyFilter_SIDECAR_INBOUND}
 		clusters = append(clusters, configgen.buildInboundClusters(cb, proxy, instances, inboundPatcher)...)
 		if proxy.EnableHBONEListen() {
-			clusters = append(clusters, configgen.buildInboundHBONEClusters())
+			clusters = append(clusters, configgen.buildInboundHBONEClusters(proxy)...)
 		}
 		// Pass through clusters for inbound traffic. These cluster bind loopback-ish src address to access node local service.
 		clusters = inboundPatcher.conditionallyAppend(clusters, nil, cb.buildInboundPassthroughCluster())

--- a/pilot/pkg/networking/core/cluster_tls.go
+++ b/pilot/pkg/networking/core/cluster_tls.go
@@ -23,6 +23,7 @@ import (
 	dfpcluster "github.com/envoyproxy/go-control-plane/envoy/extensions/clusters/dynamic_forward_proxy/v3"
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	http "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
+	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -40,12 +41,22 @@ import (
 	pm "istio.io/istio/pkg/model"
 	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/security"
+	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/wellknown"
 )
 
 var istioMtlsTransportSocketMatch = &structpb.Struct{
 	Fields: map[string]*structpb.Value{
 		model.TLSModeLabelShortname: {Kind: &structpb.Value_StringValue{StringValue: model.IstioMutualTLSModeLabel}},
+	},
+}
+
+// gatewayMtlsTransportSocketMatch matches cross-network gateway endpoints.
+// These endpoints use trust domain prefix matching instead of exact SAN validation,
+// allowing sidecars to connect to gateways that present their own identity.
+var gatewayMtlsTransportSocketMatch = &structpb.Struct{
+	Fields: map[string]*structpb.Value{
+		model.TLSModeLabelShortname: {Kind: &structpb.Value_StringValue{StringValue: model.GatewayTLSModeLabel}},
 	},
 }
 
@@ -66,6 +77,61 @@ func hboneOrPlaintextSocket() []*cluster.Cluster_TransportSocketMatch {
 		hboneTransportSocket(xdsfilters.RawBufferTransportSocket),
 		defaultTransportSocketMatch(),
 	}
+}
+
+// buildGatewayMtlsTLSContext builds an ISTIO_MUTUAL TLS context for cross-network gateway connections.
+// Instead of exact SAN matching against target service accounts, it uses trust domain prefix matching,
+// allowing the sidecar to accept the gateway's identity (which is different from the target service).
+func (cb *ClusterBuilder) buildGatewayMtlsTLSContext(sni string) *tlsv3.UpstreamTlsContext {
+	trustDomain := cb.req.Push.Mesh.GetTrustDomain()
+
+	// Cluster names use the pipe-delimited format (outbound|80||host), but E/W gateway
+	// filter chains match the DNS SRV SNI format (outbound_.80_._.host), which is what
+	// sidecars send for in-mesh mTLS. Convert so the gateway can route by SNI.
+	if dir, subset, hostname, port := model.ParseSubsetKey(sni); hostname != "" {
+		sni = model.BuildDNSSrvSubsetKey(dir, subset, hostname, port)
+	}
+
+	// Use trust domain prefix matching to accept any identity from the mesh
+	sanMatcher := &matcher.StringMatcher{
+		MatchPattern: &matcher.StringMatcher_Prefix{
+			Prefix: spiffe.URIPrefix + trustDomain + "/",
+		},
+	}
+
+	tlsContext := &tlsv3.UpstreamTlsContext{
+		CommonTlsContext: defaultUpstreamCommonTLSContext(),
+		Sni:              sni,
+	}
+
+	tlsContext.CommonTlsContext.TlsCertificateSdsSecretConfigs = append(
+		tlsContext.CommonTlsContext.TlsCertificateSdsSecretConfigs,
+		sec_model.ConstructSdsSecretConfig(sec_model.SDSDefaultResourceName),
+	)
+
+	tlsContext.CommonTlsContext.ValidationContextType = &tlsv3.CommonTlsContext_CombinedValidationContext{
+		CombinedValidationContext: &tlsv3.CommonTlsContext_CombinedCertificateValidationContext{
+			DefaultValidationContext: &tlsv3.CertificateValidationContext{
+				MatchTypedSubjectAltNames: []*tlsv3.SubjectAltNameMatcher{
+					{
+						SanType: tlsv3.SubjectAltNameMatcher_URI,
+						Matcher: sanMatcher,
+					},
+				},
+			},
+			ValidationContextSdsSecretConfig: sec_model.ConstructSdsSecretConfig(sec_model.SDSRootResourceName),
+		},
+	}
+
+	// Use standard in-mesh ALPN
+	if features.MetadataExchange && !features.DisableMxALPN {
+		tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNInMeshWithMxc
+	} else {
+		tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNInMesh
+	}
+
+	sec_model.EnforceCompliance(tlsContext.CommonTlsContext)
+	return tlsContext
 }
 
 // applyUpstreamTLSSettings applies upstream tls context to the cluster
@@ -98,11 +164,25 @@ func (cb *ClusterBuilder) applyUpstreamTLSSettings(
 			// convert to transport socket matcher if the mode was auto detected
 			transportSocket := c.cluster.TransportSocket
 			c.cluster.TransportSocket = nil
+
+			// Build gateway transport socket with trust domain prefix matching
+			// for cross-network gateway connections
+			gatewayTLSContext := cb.buildGatewayMtlsTLSContext(c.cluster.Name)
+			gatewayTransportSocket := &core.TransportSocket{
+				Name:       wellknown.TransportSocketTLS,
+				ConfigType: &core.TransportSocket_TypedConfig{TypedConfig: protoconv.MessageToAny(gatewayTLSContext)},
+			}
+
 			c.cluster.TransportSocketMatches = []*cluster.Cluster_TransportSocketMatch{
 				{
 					Name:            "tlsMode-" + model.IstioMutualTLSModeLabel,
 					Match:           istioMtlsTransportSocketMatch,
 					TransportSocket: transportSocket,
+				},
+				{
+					Name:            "tlsMode-" + model.GatewayTLSModeLabel,
+					Match:           gatewayMtlsTransportSocketMatch,
+					TransportSocket: gatewayTransportSocket,
 				},
 				defaultTransportSocketMatch(),
 			}
@@ -350,12 +430,26 @@ func (cb *ClusterBuilder) applyHBONETransportSocketMatches(c *cluster.Cluster, t
 		if istioAutoDetectedMtls {
 			transportSocket := c.TransportSocket
 			c.TransportSocket = nil
+
+			// Build gateway transport socket with trust domain prefix matching
+			// for cross-network gateway connections
+			gatewayTLSContext := cb.buildGatewayMtlsTLSContext(c.Name)
+			gatewayTransportSocket := &core.TransportSocket{
+				Name:       wellknown.TransportSocketTLS,
+				ConfigType: &core.TransportSocket_TypedConfig{TypedConfig: protoconv.MessageToAny(gatewayTLSContext)},
+			}
+
 			c.TransportSocketMatches = []*cluster.Cluster_TransportSocketMatch{
 				hboneTransportSocket(xdsfilters.RawBufferTransportSocket),
 				{
 					Name:            "tlsMode-" + model.IstioMutualTLSModeLabel,
 					Match:           istioMtlsTransportSocketMatch,
 					TransportSocket: transportSocket,
+				},
+				{
+					Name:            "tlsMode-" + model.GatewayTLSModeLabel,
+					Match:           gatewayMtlsTransportSocketMatch,
+					TransportSocket: gatewayTransportSocket,
 				},
 				defaultTransportSocketMatch(),
 			}

--- a/pilot/pkg/networking/core/cluster_waypoint.go
+++ b/pilot/pkg/networking/core/cluster_waypoint.go
@@ -108,6 +108,9 @@ func (configgen *ConfigGeneratorImpl) buildWaypointInboundClusters(
 	if features.EnableAmbientMultiNetwork && isAmbientEastWestGateway(proxy) {
 		// Creates "blackhole" cluster to avoid failures if no globally scoped services exist
 		clusters = append(clusters, cb.buildWaypointForwardInnerConnect(), cb.buildBlackHoleCluster())
+		// E/W gateway needs connect_originate for traffic that needs to establish new HBONE tunnels
+		// (e.g., sidecar mTLS traffic bridging to ambient workloads via service waypoints)
+		clusters = append(clusters, cb.buildWaypointConnectOriginate(proxy, push))
 	} else {
 		clusters = append(clusters, cb.buildWaypointConnectOriginate(proxy, push))
 	}
@@ -199,8 +202,10 @@ func (cb *ClusterBuilder) buildWaypointInboundVIPCluster(
 	}
 
 	if terminate {
-		// We're tunneling double HBONE as raw TCP, so no need for HTTP settings
-		// or h2 upgrade
+		// For E/W gateway: traffic is tunneled to waypoint via HBONE.
+		// We don't set HTTP protocol options here because the upstream goes through
+		// internal_upstream which passes raw bytes to connect_originate for HBONE tunneling.
+		// HCM at the listener level will parse HTTP, but the cluster connection is raw TCP.
 		connectionPool.Http = nil
 		cb.applyConnectionPool(mesh, localCluster, connectionPool, retryBudget)
 		applyOutlierDetection(nil, localCluster.cluster, outlierDetection)
@@ -214,6 +219,11 @@ func (cb *ClusterBuilder) buildWaypointInboundVIPCluster(
 		// Set a transport socket since we're going to an internal listener
 		transportSocket := util.RawBufferTransport()
 		localCluster.cluster.TransportSocket = util.FullMetadataPassthroughInternalUpstreamTransportSocket(transportSocket)
+		// The connect_originate listener's peer_metadata filter injects a metadata-exchange
+		// blob into the response stream (synthesized from the HBONE CONNECT response baggage).
+		// Attach the consuming cluster filter so it is stripped before the response reaches
+		// the HTTP codec; without this the codec fails with a protocol error.
+		cb.maybeApplyBaggageMetadataDiscovery(localCluster.cluster)
 		return localCluster.build()
 	}
 

--- a/pilot/pkg/networking/core/cluster_waypoint.go
+++ b/pilot/pkg/networking/core/cluster_waypoint.go
@@ -15,6 +15,7 @@
 package core
 
 import (
+	"fmt"
 	"time"
 
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -45,6 +46,7 @@ import (
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/util/protomarshal"
+	"istio.io/istio/pkg/util/sets"
 	"istio.io/istio/pkg/wellknown"
 )
 
@@ -87,8 +89,49 @@ var (
 	}
 )
 
-func (configgen *ConfigGeneratorImpl) buildInboundHBONEClusters() *cluster.Cluster {
-	return GetMainInternalCluster()
+func (configgen *ConfigGeneratorImpl) buildInboundHBONEClusters(proxy *model.Proxy) []*cluster.Cluster {
+	clusters := []*cluster.Cluster{GetMainInternalCluster()}
+	clusters = append(clusters, buildMainInternalPodClusters(proxy)...)
+	return clusters
+}
+
+// buildMainInternalPodClusters builds one cluster per inbound target port that re-enters
+// main_internal with the restored destination overridden to this workload's own address.
+// Used to terminate cross-network double-HBONE inner tunnels whose CONNECT authority is the
+// service hostname, which cannot be restored into an original destination address.
+func buildMainInternalPodClusters(proxy *model.Proxy) []*cluster.Cluster {
+	if !features.EnableAmbientMultiNetwork || len(proxy.IPAddresses) == 0 {
+		return nil
+	}
+	ip := proxy.IPAddresses[0]
+	ports := sets.New[int]()
+	for _, st := range proxy.ServiceTargets {
+		ports.Insert(int(st.Port.TargetPort))
+	}
+	clusters := make([]*cluster.Cluster, 0, ports.Len())
+	for _, port := range sets.SortedList(ports) {
+		name := mainInternalPodCluster(port)
+		meta := &core.Metadata{FilterMetadata: map[string]*structpb.Struct{
+			util.OriginalDstMetadataKey: util.BuildTunnelMetadataStruct(ip, port, ""),
+		}}
+		c := &cluster.Cluster{
+			Name:                 name,
+			ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_STATIC},
+			CircuitBreakers:      &cluster.CircuitBreakers{Thresholds: []*cluster.CircuitBreakers_Thresholds{getDefaultCircuitBreakerThresholds()}},
+			LoadAssignment: &endpoint.ClusterLoadAssignment{
+				ClusterName: name,
+				Endpoints:   util.BuildInternalEndpoint(MainInternalName, meta),
+			},
+			TransportSocket: util.WaypointInternalUpstreamTransportSocket(util.RawBufferTransport()),
+		}
+		c.AltStatName = util.DelimitedStatsPrefix(name)
+		clusters = append(clusters, c)
+	}
+	return clusters
+}
+
+func mainInternalPodCluster(targetPort int) string {
+	return fmt.Sprintf("%s_pod_%d", MainInternalName, targetPort)
 }
 
 func (configgen *ConfigGeneratorImpl) buildWaypointInboundClusters(

--- a/pilot/pkg/networking/core/cluster_waypoint.go
+++ b/pilot/pkg/networking/core/cluster_waypoint.go
@@ -268,7 +268,7 @@ func (cb *ClusterBuilder) buildWaypointInboundVIPCluster(
 		// the HTTP codec; without this the codec fails with a protocol error. Only the
 		// sidecar-bridge subset goes through connect_originate; the "tcp" subset forwards
 		// opaque double-HBONE bytes and must not have a consumer reading the stream.
-		if subset == model.SidecarBridgeSubsetName {
+		if model.IsSidecarBridgeSubset(subset) {
 			cb.maybeApplyBaggageMetadataDiscovery(localCluster.cluster)
 		}
 		return localCluster.build()
@@ -391,13 +391,22 @@ func (cb *ClusterBuilder) buildWaypointInboundVIP(proxy *model.Proxy, svcs map[h
 				continue
 			}
 			if isAmbientEastWestGateway(proxy) {
-				// East-west gateways don't respect DestinationRule, so don't read it here
+				// East-west gateways don't respect DestinationRule traffic policy, so pass nil here.
 				// TODO: Confirm this decision
 				clusters = append(clusters, cb.buildWaypointInboundVIPCluster(proxy, svc, *port, "tcp", mesh, nil, nil))
 				// Separate subset for bridging terminated sidecar mTLS (15443) traffic into
 				// ambient. The "tcp" subset must keep forwarding double-HBONE inner streams
 				// opaquely, so the new-HBONE-origination semantics live on their own cluster.
 				clusters = append(clusters, cb.buildWaypointInboundVIPCluster(proxy, svc, *port, model.SidecarBridgeSubsetName, mesh, nil, nil))
+				// DR subsets do get bridge clusters, mirroring classic AUTO_PASSTHROUGH's
+				// per-subset SNI chains: remote sidecar clients route VS subset traffic with the
+				// subset embedded in the SNI, and EDS filters endpoints by the subset labels.
+				// Only endpoint selection is honored; traffic policy is still ignored.
+				drCfg := cb.sidecarScope.DestinationRule(model.TrafficDirectionInbound, proxy, svc.Hostname).GetRule()
+				for _, ss := range CastDestinationRule(drCfg).GetSubsets() {
+					clusters = append(clusters,
+						cb.buildWaypointInboundVIPCluster(proxy, svc, *port, model.SidecarBridgeSubsetOf(ss.Name), mesh, nil, nil))
+				}
 				continue
 			}
 			cfg := cb.sidecarScope.DestinationRule(model.TrafficDirectionInbound, proxy, svc.Hostname).GetRule()

--- a/pilot/pkg/networking/core/cluster_waypoint.go
+++ b/pilot/pkg/networking/core/cluster_waypoint.go
@@ -222,8 +222,12 @@ func (cb *ClusterBuilder) buildWaypointInboundVIPCluster(
 		// The connect_originate listener's peer_metadata filter injects a metadata-exchange
 		// blob into the response stream (synthesized from the HBONE CONNECT response baggage).
 		// Attach the consuming cluster filter so it is stripped before the response reaches
-		// the HTTP codec; without this the codec fails with a protocol error.
-		cb.maybeApplyBaggageMetadataDiscovery(localCluster.cluster)
+		// the HTTP codec; without this the codec fails with a protocol error. Only the
+		// sidecar-bridge subset goes through connect_originate; the "tcp" subset forwards
+		// opaque double-HBONE bytes and must not have a consumer reading the stream.
+		if subset == model.SidecarBridgeSubsetName {
+			cb.maybeApplyBaggageMetadataDiscovery(localCluster.cluster)
+		}
 		return localCluster.build()
 	}
 
@@ -347,6 +351,10 @@ func (cb *ClusterBuilder) buildWaypointInboundVIP(proxy *model.Proxy, svcs map[h
 				// East-west gateways don't respect DestinationRule, so don't read it here
 				// TODO: Confirm this decision
 				clusters = append(clusters, cb.buildWaypointInboundVIPCluster(proxy, svc, *port, "tcp", mesh, nil, nil))
+				// Separate subset for bridging terminated sidecar mTLS (15443) traffic into
+				// ambient. The "tcp" subset must keep forwarding double-HBONE inner streams
+				// opaquely, so the new-HBONE-origination semantics live on their own cluster.
+				clusters = append(clusters, cb.buildWaypointInboundVIPCluster(proxy, svc, *port, model.SidecarBridgeSubsetName, mesh, nil, nil))
 				continue
 			}
 			cfg := cb.sidecarScope.DestinationRule(model.TrafficDirectionInbound, proxy, svc.Hostname).GetRule()

--- a/pilot/pkg/networking/core/gateway.go
+++ b/pilot/pkg/networking/core/gateway.go
@@ -1105,9 +1105,10 @@ func builtAutoPassthroughFilterChainsWithTLS(push *model.PushContext, proxy *mod
 			// The underscore format (outbound_.80_._.host) is DNS-compatible.
 			sniHost := model.BuildDNSSrvSubsetKey(model.TrafficDirectionOutbound, "", service.Hostname, port.Port)
 
-			// Route to inbound-vip cluster which has EDS endpoints with HBONE tunnel settings.
-			// E/W gateways create inbound-vip clusters with "tcp" subset for all services.
-			inboundVIPCluster := model.BuildSubsetKey(model.TrafficDirectionInboundVIP, "tcp", service.Hostname, port.Port)
+			// Route to the sidecar-bridge inbound-vip cluster, whose EDS endpoints originate a
+			// new HBONE tunnel toward the service (or its waypoint). The "tcp" subset cannot be
+			// used here: it forwards double-HBONE inner streams opaquely for the 15008 path.
+			inboundVIPCluster := model.BuildSubsetKey(model.TrafficDirectionInboundVIP, model.SidecarBridgeSubsetName, service.Hostname, port.Port)
 			statPrefix := inboundVIPCluster
 
 			// For HTTP and unsupported (sniffing) protocols, use HCM to properly handle

--- a/pilot/pkg/networking/core/gateway.go
+++ b/pilot/pkg/networking/core/gateway.go
@@ -27,6 +27,7 @@ import (
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	statefulsession "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/stateful_session/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	tcp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/hashicorp/go-multierror"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -834,6 +835,12 @@ func (lb *ListenerBuilder) createGatewayTCPFilterChainOpts(
 				},
 			}
 		}
+		// For ISTIO_MUTUAL mode on E/W gateways without VirtualServices, use auto-routing like AUTO_PASSTHROUGH
+		// but with TLS termination. This enables sidecar-to-ambient cross-network traffic where the gateway
+		// terminates the mTLS from the sidecar and forwards via HBONE to ambient workloads.
+		if server.Tls.Mode == networking.ServerTLSSettings_ISTIO_MUTUAL && isAmbientEastWestGateway(lb.node) {
+			return builtAutoPassthroughFilterChainsWithTLS(lb.push, lb.node, server, lb.node.MergedGateway.TLSServerInfo[server].SNIHosts)
+		}
 		log.Warnf("gateway %s:%d listener missed network filter", gatewayName, server.Port.Number)
 	} else {
 		// Passthrough server.
@@ -1051,6 +1058,160 @@ func builtAutoPassthroughFilterChains(push *model.PushContext, proxy *model.Prox
 		}
 	}
 	return filterChains
+}
+
+// builtAutoPassthroughFilterChainsWithTLS builds filter chains similar to builtAutoPassthroughFilterChains
+// but with TLS termination instead of passthrough. This is used for E/W gateways with ISTIO_MUTUAL mode
+// to support sidecar-to-ambient cross-network traffic, where the gateway terminates the mTLS from the
+// sidecar and forwards the plaintext traffic via HBONE to ambient workloads.
+//
+// The filter chains match on the cluster name SNI format (outbound|port||hostname with pipes).
+// This is because sidecars use the cluster name as the SNI when connecting with ISTIO_MUTUAL mode.
+// The filter chains route to inbound-vip clusters which have EDS endpoints with HBONE tunnel settings.
+//
+// For HTTP protocols, we use HCM (HTTP Connection Manager) instead of TCP proxy to properly handle
+// HTTP/1.1 request-response semantics. TCP proxy doesn't understand HTTP half-close behavior where
+// the client sends FIN after the request body but expects a response. Using HCM ensures the upstream
+// connection stays open until the response is received from the waypoint.
+func builtAutoPassthroughFilterChainsWithTLS(push *model.PushContext, proxy *model.Proxy, server *networking.Server, hosts []string) []*filterChainOpts {
+	// We do not want any authz here, so build a new LB without it set
+	lb := &ListenerBuilder{
+		node: proxy,
+		push: push,
+	}
+	filterChains := make([]*filterChainOpts, 0)
+	tlsContext := buildGatewayListenerTLSContext(push, server, proxy, istionetworking.TransportProtocolTCP)
+
+	for _, service := range proxy.SidecarScope.Services() {
+		if service.MeshExternal {
+			continue
+		}
+		for _, port := range service.Ports {
+			if port.Protocol == protocol.UDP {
+				continue
+			}
+			matchFound := false
+			for _, h := range hosts {
+				if service.Hostname.SubsetOf(host.Name(h)) {
+					matchFound = true
+					break
+				}
+			}
+			if !matchFound {
+				continue
+			}
+			// SNI hosts use the DNS SRV format (with underscores) - this is what sidecars send
+			// for mTLS SNI because DNS doesn't allow pipes in domain names.
+			// The underscore format (outbound_.80_._.host) is DNS-compatible.
+			sniHost := model.BuildDNSSrvSubsetKey(model.TrafficDirectionOutbound, "", service.Hostname, port.Port)
+
+			// Route to inbound-vip cluster which has EDS endpoints with HBONE tunnel settings.
+			// E/W gateways create inbound-vip clusters with "tcp" subset for all services.
+			inboundVIPCluster := model.BuildSubsetKey(model.TrafficDirectionInboundVIP, "tcp", service.Hostname, port.Port)
+			statPrefix := inboundVIPCluster
+
+			// For HTTP and unsupported (sniffing) protocols, use HCM to properly handle
+			// request-response semantics. This prevents the upstream HBONE tunnel from
+			// closing prematurely when the sidecar half-closes after sending the request.
+			var networkFilters []*listener.Filter
+			if port.Protocol.IsHTTP() || port.Protocol.IsUnsupported() {
+				networkFilters = buildHTTPPassthroughNetworkFilter(lb, statPrefix, inboundVIPCluster, port)
+			} else {
+				// For non-HTTP protocols (true TCP), use TCP proxy
+				networkFilters = buildSimpleTCPProxyNetworkFilter(lb, statPrefix, inboundVIPCluster)
+			}
+
+			// Build filter chain with TLS termination for ISTIO_MUTUAL mode.
+			// The gateway terminates mTLS from sidecar and forwards via inbound-vip cluster
+			// which uses HBONE to reach ambient workloads.
+			filterChains = append(filterChains, &filterChainOpts{
+				sniHosts:             []string{sniHost},
+				applicationProtocols: allIstioMtlsALPNs,
+				tlsContext:           tlsContext,
+				networkFilters:       networkFilters,
+			})
+		}
+	}
+	return filterChains
+}
+
+// buildSimpleTCPProxyNetworkFilter builds a simple TCP proxy filter that routes to the given cluster.
+func buildSimpleTCPProxyNetworkFilter(lb *ListenerBuilder, statPrefix, clusterName string) []*listener.Filter {
+	tcpProxy := &tcp.TcpProxy{
+		StatPrefix:       statPrefix,
+		ClusterSpecifier: &tcp.TcpProxy_Cluster{Cluster: clusterName},
+	}
+	class := istionetworking.ListenerClassSidecarInbound
+	tcpFilter := setAccessLogAndBuildTCPFilter(lb.push, lb.node, tcpProxy, class, nil)
+	return []*listener.Filter{tcpFilter}
+}
+
+// buildHTTPPassthroughNetworkFilter builds an HTTP Connection Manager filter that routes all
+// HTTP traffic to the given cluster. Unlike TCP proxy, HCM properly handles HTTP/1.1 request-response
+// semantics where the client may half-close (send FIN) after the request body but still expects
+// a response. This is critical for cross-network sidecar-to-ambient traffic where the upstream
+// uses HBONE tunneling - TCP proxy would propagate the half-close as end_stream causing the
+// tunnel to close before the response is received.
+func buildHTTPPassthroughNetworkFilter(lb *ListenerBuilder, statPrefix, clusterName string, port *model.Port) []*listener.Filter {
+	// Build a simple catch-all route to the target cluster
+	defaultRoute := &route.Route{
+		Name: "default",
+		Match: &route.RouteMatch{
+			PathSpecifier: &route.RouteMatch_Prefix{Prefix: "/"},
+		},
+		Action: &route.Route_Route{
+			Route: &route.RouteAction{
+				ClusterSpecifier: &route.RouteAction_Cluster{Cluster: clusterName},
+				// No timeout - let upstream handle it
+				Timeout: istio_route.Notimeout,
+			},
+		},
+	}
+
+	routeConfig := &route.RouteConfiguration{
+		Name:             statPrefix,
+		ValidateClusters: proto.BoolFalse,
+		VirtualHosts: []*route.VirtualHost{
+			{
+				Name:    "default",
+				Domains: []string{"*"},
+				Routes:  []*route.Route{defaultRoute},
+			},
+		},
+	}
+
+	httpOpts := &httpListenerOpts{
+		routeConfig:       routeConfig,
+		rds:               "", // inline route config, no RDS
+		useRemoteAddress:  false,
+		connectionManager: &hcm.HttpConnectionManager{
+			// No special server settings needed for passthrough
+		},
+		protocol:   port.Protocol,
+		class:      istionetworking.ListenerClassSidecarInbound,
+		statPrefix: statPrefix,
+	}
+
+	// Enable HTTP/2 for HTTP2/gRPC protocols
+	if port.Protocol.IsHTTP2() {
+		httpOpts.connectionManager.Http2ProtocolOptions = &core.Http2ProtocolOptions{}
+	}
+
+	// Enable HTTP/1.0 if configured
+	if features.HTTP10 || enableHTTP10(lb.node.Metadata.HTTP10) {
+		httpOpts.connectionManager.HttpProtocolOptions = &core.Http1ProtocolOptions{
+			AcceptHttp_10: true,
+		}
+	}
+
+	h := lb.buildHTTPConnectionManager(httpOpts)
+
+	return []*listener.Filter{
+		{
+			Name:       wellknown.HTTPConnectionManager,
+			ConfigType: &listener.Filter_TypedConfig{TypedConfig: protoconv.MessageToAny(h)},
+		},
+	}
 }
 
 // Select the virtualService's hosts that match the ones specified in the gateway server's hosts

--- a/pilot/pkg/networking/core/gateway.go
+++ b/pilot/pkg/networking/core/gateway.go
@@ -1100,37 +1100,50 @@ func builtAutoPassthroughFilterChainsWithTLS(push *model.PushContext, proxy *mod
 			if !matchFound {
 				continue
 			}
-			// SNI hosts use the DNS SRV format (with underscores) - this is what sidecars send
-			// for mTLS SNI because DNS doesn't allow pipes in domain names.
-			// The underscore format (outbound_.80_._.host) is DNS-compatible.
-			sniHost := model.BuildDNSSrvSubsetKey(model.TrafficDirectionOutbound, "", service.Hostname, port.Port)
-
-			// Route to the sidecar-bridge inbound-vip cluster, whose EDS endpoints originate a
-			// new HBONE tunnel toward the service (or its waypoint). The "tcp" subset cannot be
-			// used here: it forwards double-HBONE inner streams opaquely for the 15008 path.
-			inboundVIPCluster := model.BuildSubsetKey(model.TrafficDirectionInboundVIP, model.SidecarBridgeSubsetName, service.Hostname, port.Port)
-			statPrefix := inboundVIPCluster
-
-			// For HTTP and unsupported (sniffing) protocols, use HCM to properly handle
-			// request-response semantics. This prevents the upstream HBONE tunnel from
-			// closing prematurely when the sidecar half-closes after sending the request.
-			var networkFilters []*listener.Filter
-			if port.Protocol.IsHTTP() || port.Protocol.IsUnsupported() {
-				networkFilters = buildHTTPPassthroughNetworkFilter(lb, statPrefix, inboundVIPCluster, port)
-			} else {
-				// For non-HTTP protocols (true TCP), use TCP proxy
-				networkFilters = buildSimpleTCPProxyNetworkFilter(lb, statPrefix, inboundVIPCluster)
+			// One chain for the default subset plus one per DestinationRule subset,
+			// mirroring classic AUTO_PASSTHROUGH: remote sidecar clients embed the VS-selected
+			// subset in the SNI, and each subset gets its own bridge cluster whose EDS filters
+			// endpoints by the subset labels.
+			destinationRule := CastDestinationRule(proxy.SidecarScope.DestinationRule(
+				model.TrafficDirectionOutbound, proxy, service.Hostname).GetRule())
+			subsetNames := []string{""}
+			for _, ss := range destinationRule.GetSubsets() {
+				subsetNames = append(subsetNames, ss.Name)
 			}
+			for _, subsetName := range subsetNames {
+				// SNI hosts use the DNS SRV format (with underscores) - this is what sidecars send
+				// for mTLS SNI because DNS doesn't allow pipes in domain names.
+				// The underscore format (outbound_.80_.<subset>_.host) is DNS-compatible.
+				sniHost := model.BuildDNSSrvSubsetKey(model.TrafficDirectionOutbound, subsetName, service.Hostname, port.Port)
 
-			// Build filter chain with TLS termination for ISTIO_MUTUAL mode.
-			// The gateway terminates mTLS from sidecar and forwards via inbound-vip cluster
-			// which uses HBONE to reach ambient workloads.
-			filterChains = append(filterChains, &filterChainOpts{
-				sniHosts:             []string{sniHost},
-				applicationProtocols: allIstioMtlsALPNs,
-				tlsContext:           tlsContext,
-				networkFilters:       networkFilters,
-			})
+				// Route to the sidecar-bridge inbound-vip cluster, whose EDS endpoints originate a
+				// new HBONE tunnel toward the service (or its waypoint). The "tcp" subset cannot be
+				// used here: it forwards double-HBONE inner streams opaquely for the 15008 path.
+				inboundVIPCluster := model.BuildSubsetKey(model.TrafficDirectionInboundVIP,
+					model.SidecarBridgeSubsetOf(subsetName), service.Hostname, port.Port)
+				statPrefix := inboundVIPCluster
+
+				// For HTTP and unsupported (sniffing) protocols, use HCM to properly handle
+				// request-response semantics. This prevents the upstream HBONE tunnel from
+				// closing prematurely when the sidecar half-closes after sending the request.
+				var networkFilters []*listener.Filter
+				if port.Protocol.IsHTTP() || port.Protocol.IsUnsupported() {
+					networkFilters = buildHTTPPassthroughNetworkFilter(lb, statPrefix, inboundVIPCluster, port)
+				} else {
+					// For non-HTTP protocols (true TCP), use TCP proxy
+					networkFilters = buildSimpleTCPProxyNetworkFilter(lb, statPrefix, inboundVIPCluster)
+				}
+
+				// Build filter chain with TLS termination for ISTIO_MUTUAL mode.
+				// The gateway terminates mTLS from sidecar and forwards via inbound-vip cluster
+				// which uses HBONE to reach ambient workloads.
+				filterChains = append(filterChains, &filterChainOpts{
+					sniHosts:             []string{sniHost},
+					applicationProtocols: allIstioMtlsALPNs,
+					tlsContext:           tlsContext,
+					networkFilters:       networkFilters,
+				})
+			}
 		}
 	}
 	return filterChains

--- a/pilot/pkg/networking/core/listener_inbound.go
+++ b/pilot/pkg/networking/core/listener_inbound.go
@@ -23,6 +23,7 @@ import (
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	tcp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
+	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	envoytype "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -134,7 +135,13 @@ func (cc inboundChainConfig) ToFilterChainMatch(opt FilterChainMatchOptions) *li
 }
 
 func (lb *ListenerBuilder) buildInboundHBONEListeners() []*listener.Listener {
-	routes := []*route.Route{{
+	// Cross-network double-HBONE inner tunnels carry the service hostname as the CONNECT
+	// authority (cluster-local addresses are meaningless on the remote network), which cannot
+	// be restored into an original destination address for main_internal chain matching.
+	// Route those by exact authority match to per-target-port clusters that re-enter
+	// main_internal with the destination overridden to this workload's own address.
+	routes := buildHostnameAuthorityRoutes(lb.node)
+	routes = append(routes, &route.Route{
 		Match: &route.RouteMatch{
 			PathSpecifier: &route.RouteMatch_ConnectMatcher_{ConnectMatcher: &route.RouteMatch_ConnectMatcher{}},
 		},
@@ -146,7 +153,7 @@ func (lb *ListenerBuilder) buildInboundHBONEListeners() []*listener.Listener {
 
 			ClusterSpecifier: &route.RouteAction_Cluster{Cluster: MainInternalName},
 		}},
-	}}
+	})
 	terminate := lb.buildConnectTerminateListener(routes)
 	// Now we have top level listener... but we must have an internal listener for each standard filter chain
 	// 1 listener per port; that listener will do protocol detection.
@@ -197,6 +204,48 @@ func (lb *ListenerBuilder) buildInboundHBONEListeners() []*listener.Listener {
 	// TODO: Exclude inspectors from some inbound ports.
 	l.ListenerFilters = append(l.ListenerFilters, populateListenerFilters(lb.node, l, true)...)
 	return []*listener.Listener{terminate, l}
+}
+
+// buildHostnameAuthorityRoutes builds CONNECT routes matching the hostname:port form of this
+// workload's services on the :authority header. See buildInboundHBONEListeners for context.
+func buildHostnameAuthorityRoutes(node *model.Proxy) []*route.Route {
+	if !features.EnableAmbientMultiNetwork {
+		return nil
+	}
+	routes := []*route.Route{}
+	seen := sets.New[string]()
+	for _, st := range node.ServiceTargets {
+		if st.Service == nil || st.Port.ServicePort == nil {
+			continue
+		}
+		authority := fmt.Sprintf("%s:%d", st.Service.Hostname, st.Port.ServicePort.Port)
+		if seen.InsertContains(authority) {
+			continue
+		}
+		routes = append(routes, &route.Route{
+			Match: &route.RouteMatch{
+				PathSpecifier: &route.RouteMatch_ConnectMatcher_{ConnectMatcher: &route.RouteMatch_ConnectMatcher{}},
+				Headers: []*route.HeaderMatcher{{
+					Name: ":authority",
+					HeaderMatchSpecifier: &route.HeaderMatcher_StringMatch{
+						StringMatch: &matcher.StringMatcher{
+							MatchPattern: &matcher.StringMatcher_Exact{Exact: authority},
+						},
+					},
+				}},
+			},
+			Action: &route.Route_Route{Route: &route.RouteAction{
+				UpgradeConfigs: []*route.RouteAction_UpgradeConfig{{
+					UpgradeType:   ConnectUpgradeType,
+					ConnectConfig: &route.RouteAction_UpgradeConfig_ConnectConfig{},
+				}},
+				ClusterSpecifier: &route.RouteAction_Cluster{
+					Cluster: mainInternalPodCluster(int(st.Port.TargetPort)),
+				},
+			}},
+		})
+	}
+	return routes
 }
 
 func (lb *ListenerBuilder) sanitizeFilterChainForHBONE(c *listener.FilterChain) {

--- a/pilot/pkg/networking/core/listener_waypoint.go
+++ b/pilot/pkg/networking/core/listener_waypoint.go
@@ -207,6 +207,9 @@ func (lb *ListenerBuilder) buildWaypointInbound() []*listener.Listener {
 
 	if features.EnableAmbientMultiNetwork && isAmbientEastWestGateway(lb.node) {
 		listeners = append(listeners, buildWaypointForwardInnerConnectListener(lb.push, lb.node))
+		// E/W gateway needs connect_originate for traffic that needs to establish new HBONE tunnels
+		// (e.g., sidecar mTLS traffic bridging to ambient workloads via service waypoints)
+		listeners = append(listeners, buildWaypointConnectOriginateListener(lb.push, lb.node))
 		listeners = append(listeners, lb.buildEastWestTLSPassthroughListeners()...)
 	} else {
 		listeners = append(listeners, buildWaypointConnectOriginateListener(lb.push, lb.node))

--- a/pilot/pkg/xds/endpoints/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder.go
@@ -376,10 +376,13 @@ func (b *EndpointBuilder) BuildClusterLoadAssignment(endpointIndex *model.Endpoi
 		return buildEmptyClusterLoadAssignment(b.clusterName)
 	}
 
-	// features.EnableIngressWaypointRouting only makes sense for ingress gateways and for E/W gateways
-	// we don't want this behavior, so additionally check that we are not generating endpoints for the
-	// E/W gateway.
-	if features.EnableIngressWaypointRouting && !isEastWestGateway(b.proxy) {
+	// features.EnableIngressWaypointRouting enables waypoint routing for ingress gateways.
+	// For E/W gateways with inbound-vip direction (handling sidecar traffic to ambient workloads),
+	// we also need to route to waypoints to enable proper L7 processing.
+	enableWaypointRouting := features.EnableIngressWaypointRouting && !isEastWestGateway(b.proxy)
+	// E/W gateway inbound-vip direction handles sidecar traffic that needs to be routed to waypoints
+	ewGatewayInboundVIP := isEastWestGateway(b.proxy) && b.dir == model.TrafficDirectionInboundVIP
+	if enableWaypointRouting || ewGatewayInboundVIP {
 		if waypointEps, f := b.findServiceWaypoint(endpointIndex); f {
 			// endpoints are from waypoint service but the envoy endpoint is different envoy cluster
 			locLbEps := b.generate(waypointEps, true)
@@ -764,7 +767,11 @@ func buildEnvoyLbEndpoint(b *EndpointBuilder, e *model.IstioEndpoint, mtlsEnable
 		// Setup tunnel metadata so requests will go through the tunnel
 		target := ptr.NonEmptyOrDefault(waypoint, net.JoinHostPort(address, strconv.Itoa(port)))
 		innerAddressName := connectOriginate
-		if isEastWestGateway(b.proxy) {
+		// For E/W gateway, use forwardInnerConnect only when NOT handling inbound-vip traffic.
+		// Inbound-vip traffic comes from the 15443 listener (sidecar mTLS) and needs to originate
+		// a new HBONE tunnel to the ambient workload. Double-HBONE traffic (forwarding an existing
+		// inner tunnel) uses forwardInnerConnect.
+		if isEastWestGateway(b.proxy) && b.dir != model.TrafficDirectionInboundVIP {
 			innerAddressName = forwardInnerConnect
 		}
 		ep.HostIdentifier = &endpoint.LbEndpoint_Endpoint{Endpoint: &endpoint.Endpoint{

--- a/pilot/pkg/xds/endpoints/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder.go
@@ -78,6 +78,9 @@ type EndpointBuilder struct {
 	// These fields are provided for convenience only
 	subsetName   string
 	subsetLabels labels.Instance
+	// sidecarBridge marks inbound-vip clusters carrying east-west gateway
+	// sidecar-bridge semantics (see model.SidecarBridgeSubsetName).
+	sidecarBridge bool
 	hostname     host.Name
 	port         int
 	push         *model.PushContext
@@ -166,6 +169,12 @@ func (b *EndpointBuilder) WithSubset(subset string) *EndpointBuilder {
 
 func (b *EndpointBuilder) populateSubsetInfo() {
 	if b.dir == model.TrafficDirectionInboundVIP {
+		b.sidecarBridge = model.IsSidecarBridgeSubset(b.subsetName)
+		if b.sidecarBridge {
+			// Strip the bridge marker so the remaining name is the DR subset ("" for default),
+			// letting the standard subset-label endpoint filtering below apply.
+			b.subsetName = strings.TrimPrefix(strings.TrimPrefix(b.subsetName, model.SidecarBridgeSubsetName), "/")
+		}
 		b.subsetName = strings.TrimPrefix(b.subsetName, "http/")
 		b.subsetName = strings.TrimPrefix(b.subsetName, "tcp/")
 	}
@@ -382,7 +391,7 @@ func (b *EndpointBuilder) BuildClusterLoadAssignment(endpointIndex *model.Endpoi
 	// subset keeps its opaque double-HBONE forwarding semantics and must not be redirected.
 	enableWaypointRouting := features.EnableIngressWaypointRouting && !isEastWestGateway(b.proxy)
 	ewGatewaySidecarBridge := isEastWestGateway(b.proxy) &&
-		b.dir == model.TrafficDirectionInboundVIP && b.subsetName == model.SidecarBridgeSubsetName
+		b.dir == model.TrafficDirectionInboundVIP && b.sidecarBridge
 	if enableWaypointRouting || ewGatewaySidecarBridge {
 		if waypointEps, f := b.findServiceWaypoint(endpointIndex); f {
 			// endpoints are from waypoint service but the envoy endpoint is different envoy cluster
@@ -773,7 +782,7 @@ func buildEnvoyLbEndpoint(b *EndpointBuilder, e *model.IstioEndpoint, mtlsEnable
 		// comes from the 15443 listener (terminated sidecar mTLS) and needs the gateway to
 		// originate a new HBONE tunnel to the ambient workload.
 		if isEastWestGateway(b.proxy) &&
-			!(b.dir == model.TrafficDirectionInboundVIP && b.subsetName == model.SidecarBridgeSubsetName) {
+			!(b.dir == model.TrafficDirectionInboundVIP && b.sidecarBridge) {
 			innerAddressName = forwardInnerConnect
 		}
 		ep.HostIdentifier = &endpoint.LbEndpoint_Endpoint{Endpoint: &endpoint.Endpoint{

--- a/pilot/pkg/xds/endpoints/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder.go
@@ -377,12 +377,13 @@ func (b *EndpointBuilder) BuildClusterLoadAssignment(endpointIndex *model.Endpoi
 	}
 
 	// features.EnableIngressWaypointRouting enables waypoint routing for ingress gateways.
-	// For E/W gateways with inbound-vip direction (handling sidecar traffic to ambient workloads),
-	// we also need to route to waypoints to enable proper L7 processing.
+	// For the E/W gateway sidecar-bridge subset (terminated sidecar mTLS destined for ambient
+	// workloads), we also need to route to waypoints to enable proper L7 processing. The "tcp"
+	// subset keeps its opaque double-HBONE forwarding semantics and must not be redirected.
 	enableWaypointRouting := features.EnableIngressWaypointRouting && !isEastWestGateway(b.proxy)
-	// E/W gateway inbound-vip direction handles sidecar traffic that needs to be routed to waypoints
-	ewGatewayInboundVIP := isEastWestGateway(b.proxy) && b.dir == model.TrafficDirectionInboundVIP
-	if enableWaypointRouting || ewGatewayInboundVIP {
+	ewGatewaySidecarBridge := isEastWestGateway(b.proxy) &&
+		b.dir == model.TrafficDirectionInboundVIP && b.subsetName == model.SidecarBridgeSubsetName
+	if enableWaypointRouting || ewGatewaySidecarBridge {
 		if waypointEps, f := b.findServiceWaypoint(endpointIndex); f {
 			// endpoints are from waypoint service but the envoy endpoint is different envoy cluster
 			locLbEps := b.generate(waypointEps, true)
@@ -767,11 +768,12 @@ func buildEnvoyLbEndpoint(b *EndpointBuilder, e *model.IstioEndpoint, mtlsEnable
 		// Setup tunnel metadata so requests will go through the tunnel
 		target := ptr.NonEmptyOrDefault(waypoint, net.JoinHostPort(address, strconv.Itoa(port)))
 		innerAddressName := connectOriginate
-		// For E/W gateway, use forwardInnerConnect only when NOT handling inbound-vip traffic.
-		// Inbound-vip traffic comes from the 15443 listener (sidecar mTLS) and needs to originate
-		// a new HBONE tunnel to the ambient workload. Double-HBONE traffic (forwarding an existing
-		// inner tunnel) uses forwardInnerConnect.
-		if isEastWestGateway(b.proxy) && b.dir != model.TrafficDirectionInboundVIP {
+		// E/W gateways forward existing (double-HBONE) inner tunnels opaquely via
+		// forwardInnerConnect. The one exception is the sidecar-bridge subset: that traffic
+		// comes from the 15443 listener (terminated sidecar mTLS) and needs the gateway to
+		// originate a new HBONE tunnel to the ambient workload.
+		if isEastWestGateway(b.proxy) &&
+			!(b.dir == model.TrafficDirectionInboundVIP && b.subsetName == model.SidecarBridgeSubsetName) {
 			innerAddressName = forwardInnerConnect
 		}
 		ep.HostIdentifier = &endpoint.LbEndpoint_Endpoint{Endpoint: &endpoint.Endpoint{

--- a/pilot/pkg/xds/endpoints/ep_filters.go
+++ b/pilot/pkg/xds/endpoints/ep_filters.go
@@ -25,11 +25,13 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
+	"istio.io/api/label"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 	labelutil "istio.io/istio/pilot/pkg/serviceregistry/util/label"
 	"istio.io/istio/pkg/cluster"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/network"
@@ -39,6 +41,12 @@ import (
 // innerConnectOriginate is the name for the resources associated with establishing double-HBONE connection.
 // Duplicated from networking/core/waypoint.go to avoid import cycle
 const innerConnectOriginate = "inner_connect_originate"
+
+// isAmbientWorkload returns true if the endpoint represents an ambient workload.
+// Ambient workloads are identified by the istio.io/dataplane-mode=ambient label.
+func isAmbientWorkload(ep *model.IstioEndpoint) bool {
+	return ep.Labels[label.IoIstioDataplaneMode.Name] == constants.DataplaneModeAmbient
+}
 
 // EndpointsByNetworkFilter is a network filter function to support Split Horizon EDS - filter the endpoints based on the network
 // of the connected sidecar. The filter will filter out all endpoints which are not present within the
@@ -172,8 +180,10 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocalityEndpoint
 			// Cross-network traffic relies on mTLS for SNI routing in sidecar mode.
 			// So if we are not in ambient multi-network mode and mTLS is not enabled for the target endpoint on a remote
 			// network we skip it altogether.
+			// However, for sidecar proxies accessing ambient workloads, we can route via the cross-network
+			// gateway which handles the HBONE connection to the ambient workload.
 			// TODO BTS may allow us to work around this
-			if (!features.EnableAmbientMultiNetwork || isSidecarProxy(b.proxy)) && !isMtlsEnabled(lbEp) {
+			if (!features.EnableAmbientMultiNetwork || isSidecarProxy(b.proxy)) && !isMtlsEnabled(lbEp) && !isAmbientWorkload(istioEndpoint) {
 				continue
 			}
 
@@ -264,9 +274,12 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocalityEndpoint
 				}
 
 				// TODO: figure out a way to extract locality data from the gateway public endpoints in meshNetworks
+				// Use GatewayTLSModeLabel for cross-network gateway endpoints.
+				// This allows trust domain prefix matching instead of exact SAN validation,
+				// since gateways present their own identity rather than the target service's identity.
 				util.AppendLbEndpointMetadata(&model.EndpointMetadata{
 					Network:   gw.Network,
-					TLSMode:   model.IstioMutualTLSModeLabel,
+					TLSMode:   model.GatewayTLSModeLabel,
 					ClusterID: gw.Cluster,
 					Labels:    labels.Instance{},
 				}, gwEp.Metadata)

--- a/releasenotes/notes/sidecar-ambient-crossnetwork.yaml
+++ b/releasenotes/notes/sidecar-ambient-crossnetwork.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue: []
+releaseNotes:
+  - |
+    **Added** experimental support for cross-network traffic between sidecar and ambient workloads
+    through the ambient east-west gateway (requires `AMBIENT_ENABLE_MULTI_NETWORK`). Sidecar
+    clients can reach global services backed by ambient workloads on a remote network via an
+    `ISTIO_MUTUAL` listener on the east-west gateway, and ambient clients can reach global services
+    backed by HBONE-capable sidecar workloads (`networking.istio.io/tunnel=http`) on a remote network.


### PR DESCRIPTION
#### Please provide a description of this PR:

This PR adds experimental support for cross-network traffic between sidecar and ambient workloads through the ambient east-west gateway, in both directions. Today, with `AMBIENT_ENABLE_MULTI_NETWORK`, only ambient-to-ambient traffic can cross networks; mixed-dataplane meshes (some clusters/workloads on sidecars, some on ambient) have no supported path.

**Direction 1: sidecar client → remote ambient workload** (commit 1 + 2)

- `ep_filters`: for sidecar proxies, remote ambient endpoints are no longer dropped; they are replaced with the cross-network gateway address using a new `tlsMode=gateway` endpoint metadata (instead of `tlsMode=istio`).
- `cluster_tls`: sidecar clusters get a `tlsMode-gateway` transport socket match. It uses trust-domain-prefix SAN validation (the gateway presents its own identity, not the target service's) and the DNS SRV SNI format (`outbound_.80_._.host`) that east-west gateway filter chains match on.
- `gateway`: for `ISTIO_MUTUAL` servers on ambient east-west gateways, per-service filter chains are auto-generated (similar to `AUTO_PASSTHROUGH`, but terminating). HTTP protocols use HCM to preserve request/response semantics; other protocols use tcp_proxy.
- The bridged traffic uses a dedicated `inbound-vip` subset (`sidecar`) whose EDS resolves to the service waypoint (or the workload's ztunnel) and originates a fresh HBONE tunnel via `connect_originate`. The existing `tcp` subset keeps its opaque double-HBONE forwarding semantics untouched.

**Direction 2: ambient client → remote HBONE-capable sidecar workload** (commit 3)

Cross-network double-HBONE inner tunnels carry the service hostname as the CONNECT authority (cluster-local VIPs/pod IPs are meaningless on the remote network). HBONE-terminating sidecars (`networking.istio.io/tunnel=http`) could not handle this: the restored original destination must be the workload's own address for `main_internal` filter chain matching, and a hostname fails to parse. This PR teaches the sidecar HBONE path to accept hostname authorities: for each service/port the workload is a member of, a CONNECT route matching the `hostname:port` authority routes to a per-target-port cluster that re-enters `main_internal` with the destination overridden (via `original_dst` endpoint metadata) to the workload's own address. Unknown authorities keep the existing IP-authority behavior.

**Verification**

Verified end-to-end on a two-cluster (kind, multi-primary, separate networks) setup:
- sidecar curl (cluster2) → east-west gateway mTLS 15443 → HBONE → waypoint → ambient nginx (cluster1): 10/10 HTTP 200
- ambient curl (cluster1) → ztunnel → waypoint → double HBONE → east-west gateway (cluster2) → inner HBONE terminated by the destination sidecar: 8/8 HTTP 200
- ambient double-HBONE (`tcp` subset) forwarding validated unaffected after the subset split.

**Known limitations / open questions (hence draft)**

- The `tlsMode-gateway` SAN validation is trust-domain-prefix wide; it likely should be narrowed to east-west gateway identities. Feedback welcome on the right scoping.
- Sidecar→ambient for plain TCP protocol ports doesn't work yet: sidecar TCP clusters send the metadata-exchange preamble (ALPN `istio-peer-exchange`) which the gateway's tcp_proxy chain doesn't consume.
- `EndpointsByNetworkFilter`'s ambient-workload detection relies on the explicit `istio.io/dataplane-mode=ambient` pod label and misses namespace-level enrollment; needs a better signal.
- Tests to be added (looking for guidance on the preferred harness — extending `tests/integration/ambient/multinetwork_test.go`?).

A release note is included in `releasenotes/notes/sidecar-ambient-crossnetwork.yaml`.
