### PR TITLE
[DO-NOT-MERGE][WIP] PoC allow clients to reach out to global services even without local service definition

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1179,6 +1179,8 @@ type ServiceInfo struct {
 	// CreationTime is the time when the service was created. Note this is used internally only
 	// for conflict resolution.
 	CreationTime time.Time
+	// List of clusters where this service is present.
+	Clusters sets.Set[cluster.ID]
 }
 
 func (i ServiceInfo) GetLabelSelector() map[string]string {

--- a/pilot/pkg/serviceregistry/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex.go
@@ -121,6 +121,8 @@ type index struct {
 	revision        string
 	Debugger        *krt.DebugHandler
 
+	globalServiceDiscovery *globalServiceDiscovery
+
 	mcController *multicluster.Controller
 	meshConfig   meshwatcher.WatcherCollection
 	stop         chan struct{}
@@ -232,6 +234,10 @@ func New(options Options) Index {
 			opts,
 		)
 
+		localNetworkGetter := func(ctx krt.HandlerContext) network.ID {
+			return a.networks.FetchLocalNetworkID(ctx)
+		}
+		a.globalServiceDiscovery = newGlobalServiceDiscovery(client, options.SystemNamespace, localNetworkGetter, a.services.Collection, opts)
 		return a
 	}
 
@@ -823,6 +829,11 @@ func (a *index) Run(stop <-chan struct{}) {
 		go func() {
 			kubeclient.WaitForCacheSync("ambient-status-queue", stop, a.HasSynced)
 			a.statusQueue.Run(stop)
+		}()
+	}
+	if a.globalServiceDiscovery != nil {
+		go func() {
+			a.globalServiceDiscovery.Run(stop)
 		}()
 	}
 	<-stop

--- a/pilot/pkg/serviceregistry/ambient/multicluster.go
+++ b/pilot/pkg/serviceregistry/ambient/multicluster.go
@@ -364,12 +364,24 @@ func (a *index) buildGlobalCollections(
 
 			capacity := uint32(0)
 			for _, wl := range i.Objects {
+				if !svc.Clusters.Contains(cluster.ID(wl.Workload.ClusterId)) {
+					// This workload is in a cluster where the service is not marked as global,
+					// so we shouldn't count it.
+					continue
+				}
 				if wl.Workload.GetCapacity().GetValue() == 0 {
 					capacity++
 				} else {
 					capacity += wl.Workload.Capacity.GetValue()
 				}
 			}
+
+			if capacity == 0 {
+				// Didn't find any workloads in clusters where the service is global?
+				// Don't generate the split horizon workload as there is nowhere to route to on the remote network.
+				return nil
+			}
+
 			gws := LookupNetworkGateway(ctx, networkID, GlobalNetworks.GatewaysByNetwork)
 			meshCfg := krt.FetchOne(ctx, a.meshConfig.AsCollection())
 			if meshCfg == nil {
@@ -486,6 +498,9 @@ func (a *index) buildGlobalCollections(
 				if wl.Workload.Network == localNetwork {
 					continue
 				}
+				if !svc.Clusters.Contains(cluster.ID(wl.Workload.ClusterId)) {
+					continue
+				}
 				sans.Insert(spiffe.MustGenSpiffeURI(meshCfg.MeshConfig, wl.Workload.Namespace, wl.Workload.ServiceAccount))
 			}
 			if sans.IsEmpty() {
@@ -498,6 +513,7 @@ func (a *index) buildGlobalCollections(
 				Scope:              svc.Scope,
 				CreationTime:       svc.CreationTime,
 				DNSConnectStrategy: svc.DNSConnectStrategy,
+				Clusters:           svc.Clusters.Copy(),
 			}
 			newSvcInfo.Service.SubjectAltNames = sans.UnsortedList()
 			return precomputeServicePtr(newSvcInfo)
@@ -619,6 +635,8 @@ func networkAddressToSimple(a *workloadapi.NetworkAddress) simpleNetworkAddress 
 	}
 }
 
+// The highlevel merge logic is that we merge all the "global" service infos with whatever is defined in the local cluster.
+// We never merge service entries with anything, because they are special.
 func mergeServiceInfosWithCluster(
 	localClusterID cluster.ID,
 ) func(serviceInfos []krt.ObjectWithCluster[model.ServiceInfo]) *krt.ObjectWithCluster[model.ServiceInfo] {
@@ -628,51 +646,55 @@ func mergeServiceInfosWithCluster(
 			return nil
 		}
 
-		// Precompute the svc info here
-		if svcInfosLen == 1 {
-			obj := serviceInfos[0]
+		// We don't read ServiceEntries from remote clusters, so if we find a service entry it must be from the local
+		// cluster, but it probably will cause less confusion for the reader if we check both cluster name and the
+		// source kind.
+		for _, obj := range serviceInfos {
+			if obj.ClusterID != localClusterID {
+				continue
+			}
+			if obj.Object.Source.Kind != kind.ServiceEntry {
+				continue
+			}
+			// We found a local cluster service entry - skip the merge and just return it as authoritative.
 			return &krt.ObjectWithCluster[model.ServiceInfo]{
 				ClusterID: obj.ClusterID,
 				Object:    precomputeServicePtr(obj.Object),
 			}
 		}
 
-		// If we can't find a local serviceinfo, we just take the first one.
-		base := serviceInfos[0]
+		relevantServiceInfos := make([]krt.ObjectWithCluster[model.ServiceInfo], 0, svcInfosLen)
 		for _, obj := range serviceInfos {
-			if obj.ClusterID == localClusterID {
-				base = obj
-				// If there's a service entry that's considered external to the mesh, we
-				// prioritize that
-				if obj.Object.Source.Kind == kind.ServiceEntry {
-					break
-				}
+			// Never merge service entries. This condition should never be true because we never read remote
+			// cluster service entries, but let's be explicit for now.
+			if obj.Object.Source.Kind == kind.ServiceEntry {
+				continue
 			}
+			// We are interested in local service definitions plus all the service definitions in remote clusters
+			// that are marked as global.
+			if obj.Object.Scope != model.Global && obj.ClusterID != localClusterID {
+				continue
+			}
+
+			relevantServiceInfos = append(relevantServiceInfos, obj)
 		}
 
-		// If we have a locally scoped service
-		if base.Object != nil && base.Object.Scope != model.Global {
-			// and we did not find one in the local cluster, skip it
-			if base.ClusterID != localClusterID {
-				return nil
-			}
-			// otherwise, skip merging
-			return &krt.ObjectWithCluster[model.ServiceInfo]{
-				ClusterID: base.ClusterID,
-				Object:    precomputeServicePtr(base.Object),
-			}
+		if len(relevantServiceInfos) == 0 {
+			return nil
 		}
 
-		vips := sets.NewWithLength[simpleNetworkAddress](svcInfosLen)
-		sans := sets.NewWithLength[string](svcInfosLen)
+		relevantSvcInfosLen := len(relevantServiceInfos)
+		vips := sets.NewWithLength[simpleNetworkAddress](relevantSvcInfosLen)
+		sans := sets.NewWithLength[string](relevantSvcInfosLen)
 		ports := map[portKey]sets.Set[simplePort]{}
+		serviceScope := model.Local
 		workloadPortsToSimplePort := func(p *workloadapi.Port) simplePort {
 			return simplePort{
 				servicePort: p.ServicePort,
 				targetPort:  p.TargetPort,
 			}
 		}
-		for _, obj := range serviceInfos {
+		for _, obj := range relevantServiceInfos {
 			if obj.Object == nil {
 				continue
 			}
@@ -686,8 +708,14 @@ func mergeServiceInfosWithCluster(
 			vips.InsertAll(slices.Map(obj.Object.Service.GetAddresses(), networkAddressToSimple)...)
 			sans.InsertAll(obj.Object.Service.GetSubjectAltNames()...)
 
+			// NOTE: Service scope (global or local) does not make terribly a lot of sense anymore.
+			// However, the scope is checked in a few places after the merge, so I preserve it for now.
+			if obj.Object.Scope == model.Global {
+				serviceScope = model.Global
+			}
 		}
 
+		base := relevantServiceInfos[0]
 		basePorts := sets.New(slices.Map(base.Object.Service.Ports, workloadPortsToSimplePort)...)
 		for source, portSet := range ports {
 			if !basePorts.Equals(portSet) {
@@ -715,10 +743,14 @@ func mergeServiceInfosWithCluster(
 			return na
 		})
 		base.Object.Service.SubjectAltNames = sans.UnsortedList()
+		base.Object.Scope = serviceScope
+		base.Object.Clusters = sets.New(slices.Map(relevantServiceInfos, func(obj krt.ObjectWithCluster[model.ServiceInfo]) cluster.ID {
+			return obj.ClusterID
+		})...)
 
 		// Remember, we have to re-precompute the serviceinfo since we changed it
 		return &krt.ObjectWithCluster[model.ServiceInfo]{
-			ClusterID: base.ClusterID,
+			ClusterID: localClusterID,
 			Object:    precomputeServicePtr(base.Object),
 		}
 	}

--- a/pilot/pkg/serviceregistry/ambient/multicluster.go
+++ b/pilot/pkg/serviceregistry/ambient/multicluster.go
@@ -21,6 +21,10 @@ import (
 
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	v1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"istio.io/api/label"
@@ -34,6 +38,7 @@ import (
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/kube/multicluster"
@@ -47,6 +52,15 @@ import (
 	"istio.io/istio/pkg/util/sets"
 	"istio.io/istio/pkg/workloadapi"
 )
+
+type globalServiceAddresses struct {
+	name      types.NamespacedName
+	addresses []*workloadapi.NetworkAddress
+}
+
+func (a globalServiceAddresses) ResourceName() string {
+	return a.name.Namespace + "/" + a.name.Name
+}
 
 func (a *index) buildGlobalCollections(
 	localCluster *multicluster.Cluster,
@@ -472,6 +486,36 @@ func (a *index) buildGlobalCollections(
 		return []networkAddress{netaddr}
 	})
 
+	globalServiceVIPs := krt.NewCollection(LocalServices, func(ctx krt.HandlerContext, svc *v1.Service) *globalServiceAddresses {
+		serviceLabels := labels.Set(svc.Labels)
+		name, ok := serviceLabels.Lookup("istio.io/original-service-name")
+		if !ok || name == "" {
+			return nil
+		}
+		namespace, ok := serviceLabels.Lookup("istio.io/original-service-namespace")
+		if !ok || namespace == "" {
+			return nil
+		}
+		serviceName := types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		}
+		addresses, err := slices.MapErr(getVIPs(svc), func(a string) (*workloadapi.NetworkAddress, error) {
+			return toNetworkAddress(ctx, a, GlobalNetworks.FetchLocalNetworkID)
+		})
+		if err != nil {
+			log.Warnf("fail to parse service %v: %v", name, err)
+			return nil
+		}
+		return &globalServiceAddresses{
+			name:      serviceName,
+			addresses: addresses,
+		}
+	}, opts.WithName("GlobalServiceAddresses")...)
+	globalServiceVIPIndex := krt.NewIndex[types.NamespacedName, globalServiceAddresses](globalServiceVIPs, "globalServiceAdresses", func(gsa globalServiceAddresses) []types.NamespacedName {
+		return []types.NamespacedName{gsa.name}
+	})
+
 	SplitHorizonServices := krt.NewCollection(
 		GlobalMergedWorkloadServices,
 		func(ctx krt.HandlerContext, svc model.ServiceInfo) *model.ServiceInfo {
@@ -508,6 +552,16 @@ func (a *index) buildGlobalCollections(
 			}
 			sans = sans.Union(sets.New(svc.Service.SubjectAltNames...))
 
+			vips := sets.New[simpleNetworkAddress]()
+			vips.InsertAll(slices.Map(svc.Service.GetAddresses(), networkAddressToSimple)...)
+			gsa := globalServiceVIPIndex.Fetch(ctx, types.NamespacedName{Name: svc.Service.Name, Namespace: svc.Service.Namespace})
+			for _, gs := range gsa {
+				vips.InsertAll(slices.Map(gs.addresses, networkAddressToSimple)...)
+			}
+			orderedVips := slices.SortBy(vips.UnsortedList(), func(a simpleNetworkAddress) string {
+				return a.network + "/" + a.ip.String()
+			})
+
 			newSvcInfo := &model.ServiceInfo{
 				Service:            protomarshal.Clone(svc.Service),
 				Scope:              svc.Scope,
@@ -516,6 +570,16 @@ func (a *index) buildGlobalCollections(
 				Clusters:           svc.Clusters.Copy(),
 			}
 			newSvcInfo.Service.SubjectAltNames = sans.UnsortedList()
+			newSvcInfo.Service.Addresses = slices.Map(orderedVips, func(a simpleNetworkAddress) *workloadapi.NetworkAddress {
+				na := &workloadapi.NetworkAddress{
+					Network: a.network,
+					Address: a.ip.Addr().AsSlice(),
+				}
+				if !a.ip.IsSingleIP() {
+					na.Length = ptr.Of(uint32(a.ip.Bits()))
+				}
+				return na
+			})
 			return precomputeServicePtr(newSvcInfo)
 		},
 		opts.WithName("SplitHorizonServices")...)
@@ -850,4 +914,101 @@ func (a *index) createSplitHorizonWorkload(
 		Labels:   labelutil.AugmentLabels(nil, networkGateway.Cluster, "", "", networkGateway.Network),
 	}
 	return precomputeWorkload(wi)
+}
+
+type globalService types.NamespacedName
+
+func (g globalService) ResourceName() string {
+	return g.Namespace + "/" + g.Name
+}
+
+type globalServiceDiscovery struct {
+	servicesWithoutLocalIP krt.Collection[globalService]
+	queue                  controllers.Queue
+	systemNamespace        string
+	client                 kclient.Writer[*v1.Service]
+}
+
+func newGlobalServiceDiscovery(client kube.Client, systemNamespace string, networkGetter func(ctx krt.HandlerContext) network.ID, globalServices krt.Collection[model.ServiceInfo], opts krt.OptionsBuilder) *globalServiceDiscovery {
+	servicesWithoutLocalIP := krt.NewCollection(globalServices, func(ctx krt.HandlerContext, svc model.ServiceInfo) *globalService {
+		if svc.Scope != model.Global {
+			return nil
+		}
+		return &globalService{
+			Namespace: svc.Service.Namespace,
+			Name:      svc.Service.Name,
+		}
+	}, opts.WithName("GlobalServices")...)
+
+	gsd := &globalServiceDiscovery{
+		servicesWithoutLocalIP: servicesWithoutLocalIP,
+		systemNamespace:        systemNamespace,
+		client:                 kclient.NewWriteClient[*v1.Service](client),
+	}
+	gsd.queue = controllers.NewQueue("globalServiceDiscoveryController", controllers.WithGenericReconciler(gsd.reconcile))
+
+	servicesWithoutLocalIP.RegisterBatch(func(es []krt.Event[globalService]) {
+		for _, e := range es {
+			switch e.Event {
+			case controllers.EventAdd, controllers.EventDelete:
+				gsd.queue.Add(e)
+			default:
+				// TODO: I think we only need to care about Add and Delete events, but let's check
+				// that we don't need to handle Update events as well and if we need to handle
+				// somehow unknown even types on top of that.
+			}
+		}
+	}, false)
+	return gsd
+}
+
+func (gsd *globalServiceDiscovery) Run(stop <-chan struct{}) {
+	gsd.servicesWithoutLocalIP.WaitUntilSynced(stop)
+	gsd.queue.Run(stop)
+}
+
+func replacementServiceName(name, namespace string) string {
+	// TODO: generate a unique name that fits the limit of 63 characters
+	return fmt.Sprintf("%s-%s", namespace, name)
+}
+
+func replacementService(name, namespace, systemNamespace string) *v1.Service {
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      replacementServiceName(name, namespace),
+			Namespace: systemNamespace,
+			Labels: map[string]string{
+				"istio.io/original-service-name":      name,
+				"istio.io/original-service-namespace": namespace,
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{Port: 80}},
+		},
+	}
+}
+
+func (gsd *globalServiceDiscovery) reconcile(obj any) error {
+	event := obj.(krt.Event[globalService])
+	switch event.Event {
+	case controllers.EventAdd:
+		svc := event.New
+		s, err := gsd.client.Create(replacementService(svc.Name, svc.Namespace, gsd.systemNamespace))
+		if err == nil || kerrors.IsAlreadyExists(err) {
+			log.Errorf("krinkin: successfully created replacement service for %s/%s: %+v", svc.Namespace, svc.Name, s)
+			return nil
+		}
+		log.Errorf("krinkin: failed to create replacement service for %s/%s: %v", svc.Namespace, svc.Name, err)
+		return err
+	case controllers.EventDelete:
+		svc := event.Old
+		err := gsd.client.Delete(replacementServiceName(svc.Name, svc.Namespace), gsd.systemNamespace)
+		if err == nil || kerrors.IsNotFound(err) {
+			log.Errorf("krinkin: successfully deleted replacement service for %s/%s", svc.Namespace, svc.Name)
+			return nil
+		}
+		log.Errorf("krinkin: failed to delete replacement service for %s/%s: %v", svc.Namespace, svc.Name, err)
+		return err
+	}
+	return nil
 }

--- a/pilot/pkg/serviceregistry/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/ambient/workloads.go
@@ -315,10 +315,19 @@ func MergedGlobalWorkloadsCollection(
 				krt.WithName(fmt.Sprintf("NodeLocality[%s]", c.ID)),
 			)...)
 
-			globalWorkloadServicesWithCluster := *workloadServicesPtr
-			globalWorkloadServices := krt.MapCollection(
-				globalWorkloadServicesWithCluster,
-				unwrapObjectWithCluster[model.ServiceInfo],
+			globalWorkloadServices := krt.NewCollection(
+				*workloadServicesPtr,
+				func(ctx krt.HandlerContext, obj krt.ObjectWithCluster[model.ServiceInfo]) *model.ServiceInfo {
+					svc := unwrapObjectWithCluster(obj)
+					if svc.Source.Kind == kind.ServiceEntry {
+						return &svc
+					}
+					// Let's filter the list of services to those that are globally scoped in the cluster
+					if svc.Scope != model.Global {
+						return nil
+					}
+					return &svc
+				},
 				append(
 					opts,
 					krt.WithName(fmt.Sprintf("WorkloadServices[%s]", c.ID)),

--- a/pilot/pkg/xds/endpoints/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder.go
@@ -574,8 +574,8 @@ func (b *EndpointBuilder) filterIstioEndpoint(ep *model.IstioEndpoint) bool {
 	}
 	// If we are in ambient mode, the service is not global and the endpoint is in a different cluster
 	// we filter it out.
-	if b.serviceInfo != nil && b.serviceInfo.Scope != model.Global && b.clusterID != ep.Locality.ClusterID {
-		return false
+	if b.serviceInfo != nil && b.serviceInfo.Scope == model.Global {
+		return b.serviceInfo.Clusters.Contains(ep.Locality.ClusterID)
 	}
 
 	return true


### PR DESCRIPTION
**Please provide a description of this PR:**

Until now, the service has to be defined in all clusters where there are clients that may need to access it, so it wasn't enoough to make a service global in a remote cluster for it to be accessible in the local cluster. The ultimate reason why it was the case is that unless the service is defined on a local network, it would not have a local network IP address.

As a result of it, when client would try to resolve service name to an IP, ztunnel would not be able to fine an address on the local network and as a result, it would not be able to resolve the service name. Returning an address from a remote network while might work sometimes, strictly speaking is not correct, because addresses on different networks are allowed to overlap.

This early PoC PR does a few things to deal with the problem:

1. It changes merging logic for services - we will merge local service definition with all global service definitions from remote clusters (before we just checked if the local service definition is globally scoped or not and if it's, we assume that the service is global and we merge them, otherwise we assumed the service to be local and didn't merge)
2. Adds a "controller", that for each global service creates a "replacement" service - "replacement" service is a dummy service that I create just to allocate an IP, but I attach lables to it to reference the service this IP will belong to; I add the repalcement service IP to the list of VIPs of global service.

This is a very early, quite ugly, not well tested implementation, but I was able to confirm that I can actually send a request to a remote cluster without having a local cluster definition.


+cc @therealmitchconnors @Stevenjin8 