### PR TITLE
enable passing gwapi conformance tests for agentgateway

### DIFF
--- a/tests/integration/pilot/agentgateway/gateway_conformance_test.go
+++ b/tests/integration/pilot/agentgateway/gateway_conformance_test.go
@@ -74,24 +74,10 @@ var skippedTests = map[string]string{
 	"GatewayFrontendClientCertificateValidation":                 "TODO",
 	"GatewayInvalidFrontendClientCertificateValidation":          "TODO",
 
-	"HTTPRoute303Redirect":                            "TODO",
-	"HTTPRoute307Redirect":                            "TODO",
-	"HTTPRoute308Redirect":                            "TODO",
-	"HTTPRouteCORS":                                   "TODO",
 	"HTTPRouteHTTPSListenerDetectMisdirectedRequests": "TODO",
-
-	"ListenerSetReferenceGrant": "TODO",
-
-	"MeshHTTPRoute303Redirect": "TODO",
-	"MeshHTTPRoute307Redirect": "TODO",
-	"MeshHTTPRoute308Redirect": "TODO",
 
 	// The following tests were modified between v1.4.0 && v1.5.0
 	"BackendTLSPolicy": "TODO",
-
-	"GatewayWithAttachedRoutesWithPort8080": "TODO",
-
-	"MeshGRPCRouteWeight": "TODO",
 
 	// The following tests were added in v1.5.0
 	"TLSRouteTerminateSimpleSameNamespace":  "TODO",


### PR DESCRIPTION
**Please provide a description of this PR:**

Some gateway api conformance tests for agentgateway are already passing without any changes needed.

Will check these tests in #60795 once this is merged.