### PR TITLE
test(xds): use EnsureSynced instead of a fixed sleep in TestSplitHorizonEds

### DIFF
--- a/pilot/pkg/xds/eds_sh_test.go
+++ b/pilot/pkg/xds/eds_sh_test.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"sort"
 	"testing"
-	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
@@ -78,7 +77,7 @@ func TestSplitHorizonEds(t *testing.T) {
 
 	// Push contexts needs to be updated
 	s.Discovery.ConfigUpdate(&model.PushRequest{Forced: true})
-	time.Sleep(time.Millisecond * 200) // give time for cache to clear
+	s.EnsureSynced(t)
 
 	tests := []struct {
 		network   string


### PR DESCRIPTION
TestSplitHorizonEds triggers an async `ConfigUpdate` and then sleeps a fixed 200ms (`// give time for cache to clear`) before running EDS queries, hoping `PushContext` has been recomputed by then.

`FakeDiscoveryServer.EnsureSynced(t)` is the purpose-built signal for exactly this: it blocks until `Discovery.CommittedUpdates` catches up to `Discovery.InboundUpdates`. Since `ConfigUpdate` increments `InboundUpdates` synchronously before enqueuing to the async `pushChannel`, calling `EnsureSynced` immediately after guarantees it waits on this update (no early exit). It is already the established idiom for this situation across `eds_test.go` and `delta_test.go`.

This replaces the fixed sleep with `s.EnsureSynced(t)` (and drops the now-unused `time` import). It removes the unconditional 200ms floor per run and, more importantly, the race when the push commit takes longer than 200ms under load.

Test-only; no behaviour change. `go test ./pilot/pkg/xds/ -run TestSplitHorizonEds` passes; `gofmt` clean.