### PR TITLE
test(cni): use retry.UntilOrFail instead of 1s sleep loops in nodeagent tests

### DIFF
--- a/cni/pkg/nodeagent/informers_test.go
+++ b/cni/pkg/nodeagent/informers_test.go
@@ -34,6 +34,7 @@ import (
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/monitoring/monitortest"
 	"istio.io/istio/pkg/test/util/assert"
+	"istio.io/istio/pkg/test/util/retry"
 )
 
 func TestInformerExistingPodAddedWhenNsLabeled(t *testing.T) {
@@ -1554,45 +1555,33 @@ func TestInformerLabeledPodInExcludedNsNotEnrolled(t *testing.T) {
 }
 
 func assertPodAnnotated(t *testing.T, client kube.Client, pod *corev1.Pod) {
-	for i := 0; i < 5; i++ {
+	retry.UntilOrFail(t, func() bool {
 		p, err := client.Kube().CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
-		if p.Annotations[annotation.AmbientRedirection.Name] == constants.AmbientRedirectionEnabled {
-			return
-		}
-		time.Sleep(1 * time.Second)
-	}
-	t.Fatal("Pod not annotated")
+		return p.Annotations[annotation.AmbientRedirection.Name] == constants.AmbientRedirectionEnabled
+	}, retry.Timeout(5*time.Second), retry.Delay(50*time.Millisecond), retry.Message("Pod not annotated"))
 }
 
 func assertPodAnnotatedPending(t *testing.T, client kube.Client, pod *corev1.Pod) {
-	for i := 0; i < 5; i++ {
+	retry.UntilOrFail(t, func() bool {
 		p, err := client.Kube().CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
-		if p.Annotations[annotation.AmbientRedirection.Name] == constants.AmbientRedirectionPending {
-			return
-		}
-		time.Sleep(1 * time.Second)
-	}
-	t.Fatal("Pod not annotated with pending status")
+		return p.Annotations[annotation.AmbientRedirection.Name] == constants.AmbientRedirectionPending
+	}, retry.Timeout(5*time.Second), retry.Delay(50*time.Millisecond), retry.Message("Pod not annotated with pending status"))
 }
 
 func assertPodNotAnnotated(t *testing.T, client kube.Client, pod *corev1.Pod) {
-	for i := 0; i < 5; i++ {
+	retry.UntilOrFail(t, func() bool {
 		p, err := client.Kube().CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
-		if p.Annotations[annotation.AmbientRedirection.Name] != constants.AmbientRedirectionEnabled {
-			return
-		}
-		time.Sleep(1 * time.Second)
-	}
-	t.Fatal("Pod annotated")
+		return p.Annotations[annotation.AmbientRedirection.Name] != constants.AmbientRedirectionEnabled
+	}, retry.Timeout(5*time.Second), retry.Delay(50*time.Millisecond), retry.Message("Pod annotated"))
 }
 
 // nolint: lll

--- a/cni/pkg/nodeagent/net_test.go
+++ b/cni/pkg/nodeagent/net_test.go
@@ -33,6 +33,7 @@ import (
 	"istio.io/istio/cni/pkg/config"
 	"istio.io/istio/cni/pkg/iptables"
 	"istio.io/istio/pkg/test/util/assert"
+	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/tools/istio-iptables/pkg/dependencies"
 )
 
@@ -607,11 +608,5 @@ func TestGetPodLevelOverrides(t *testing.T) {
 // and it is flake-prone to check for closure after calling it, this retries for a bit to make
 // sure the netns is closed eventually.
 func assertNSClosed(t *testing.T, closed *atomic.Bool) {
-	for i := 0; i < 5; i++ {
-		if closed.Load() {
-			return
-		}
-		time.Sleep(1 * time.Second)
-	}
-	t.Fatal("NS not closed")
+	retry.UntilOrFail(t, closed.Load, retry.Timeout(5*time.Second), retry.Delay(20*time.Millisecond), retry.Message("NS not closed"))
 }


### PR DESCRIPTION
In `cni/pkg/nodeagent`, `assertPodAnnotated` / `assertPodAnnotatedPending` / `assertPodNotAnnotated` (used at ~28 call sites) and `assertNSClosed` polled with a loop of 5 × `time.Sleep(1 * time.Second)`. When the awaited state was slow to appear, each miss cost a full second, so a test could burn up to 5s per assertion.

This swaps those loops for the repo's own `retry.UntilOrFail` helper (5s timeout, 50ms/20ms delay), so they return at poll granularity as soon as the condition holds. The `assertPodNotAnnotated` helper keeps its existing early-return-on-absent semantics (the pod starts unannotated), so no absence check is weakened.

Test-only; no CNI behaviour changed. Built/verified in a privileged `golang` Linux container (the package is Linux-gated); `gofmt`/`go vet` clean.

Assisted-by: Claude Code (Anthropic, Opus 4.8)