### PR TITLE
enable detect misdirected requests for agentgateway

### DIFF
--- a/tests/integration/pilot/agentgateway/gateway_conformance_test.go
+++ b/tests/integration/pilot/agentgateway/gateway_conformance_test.go
@@ -74,8 +74,6 @@ var skippedTests = map[string]string{
 	"GatewayFrontendClientCertificateValidation":                 "TODO",
 	"GatewayInvalidFrontendClientCertificateValidation":          "TODO",
 
-	"HTTPRouteHTTPSListenerDetectMisdirectedRequests": "TODO",
-
 	// The following tests were modified between v1.4.0 && v1.5.0
 	"BackendTLSPolicy": "TODO",
 
@@ -125,7 +123,11 @@ func TestGatewayConformanceAgentgateway(t *testing.T) {
 			}
 
 			supportedFeatures := gateway.SupportedFeatures.Clone().
-				Delete(features.MeshClusterIPMatchingFeature) // https://github.com/istio/istio/issues/44702
+				Delete(features.MeshClusterIPMatchingFeature). // https://github.com/istio/istio/issues/44702
+				// The agentgateway data plane implements HTTP 421 detection for misdirected requests on
+				// HTTPS listeners sharing a port, unlike the Envoy-based sidecar/ambient data planes. This
+				// feature is disabled in the shared gateway.SupportedFeatures set, so opt back in here.
+				Insert(features.GatewayHTTPSListenerDetectMisdirectedRequestsFeature)
 			if ctx.Settings().GatewayConformanceStandardOnly {
 				for f := range supportedFeatures {
 					if f.Channel != features.FeatureChannelStandard {

--- a/tests/integration/pilot/agentgateway/gateway_conformance_test.go
+++ b/tests/integration/pilot/agentgateway/gateway_conformance_test.go
@@ -66,8 +66,6 @@ var skippedTests = map[string]string{
 	// The following tests were added in v1.5.0
 	"BackendTLSPolicyObservedGenerationBump": "TODO",
 
-	"HTTPRouteHTTPSListenerDetectMisdirectedRequests": "TODO",
-
 	// The following tests were modified between v1.4.0 && v1.5.0
 	"BackendTLSPolicy": "TODO",
 
@@ -105,7 +103,11 @@ func TestGatewayConformanceAgentgateway(t *testing.T) {
 			}
 
 			supportedFeatures := gateway.SupportedFeatures.Clone().
-				Delete(features.MeshClusterIPMatchingFeature) // https://github.com/istio/istio/issues/44702
+				Delete(features.MeshClusterIPMatchingFeature). // https://github.com/istio/istio/issues/44702
+				// The agentgateway data plane implements HTTP 421 detection for misdirected requests on
+				// HTTPS listeners sharing a port, unlike the Envoy-based sidecar/ambient data planes. This
+				// feature is disabled in the shared gateway.SupportedFeatures set, so opt back in here.
+				Insert(features.GatewayHTTPSListenerDetectMisdirectedRequestsFeature)
 			// Backend client certificate support (spec.tls.backend.clientCertificateRef) is implemented
 			// for agentgateway even though it is disabled in the shared gateway.SupportedFeatures.
 			supportedFeatures.Insert(features.GatewayBackendClientCertificateFeature)


### PR DESCRIPTION
**Please provide a description of this PR:**

This test already passes but was not being run because we use the shared `gateway.SupportedFeatures` which skips the feature.