### PR TITLE
Implement Safer ServiceEntry

### DIFF
--- a/istioctl/pkg/writer/ztunnel/configdump/api.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/api.go
@@ -116,6 +116,7 @@ type ZtunnelService struct {
 	SubjectAltNames []string                    `json:"subjectAltNames,omitempty"`
 	IPFamilies      string                      `json:"ipFamilies"`
 	Canonical       bool                        `json:"canonical,omitempty"`
+	Visibility      string                      `json:"visibility,omitempty"`
 }
 
 type PolicyMatch struct {

--- a/pilot/pkg/config/kube/agentgateway/agentgateway_controller.go
+++ b/pilot/pkg/config/kube/agentgateway/agentgateway_controller.go
@@ -508,6 +508,8 @@ func (c *Controller) buildAddressCollections(opts krt.OptionsBuilder) krt.Collec
 	}
 	// Dummy empty mesh config
 	meshConfig := krt.NewStatic[ambient.MeshConfig](&ambient.MeshConfig{MeshConfig: mesh.DefaultMeshConfig()}, true, opts.WithName("MeshConfig")...)
+	// TODO: AGW should probably understand  all this stuff? Dummy for now per the above being a dummy
+	serviceEntryVisibility := model.ServiceEntryVisibilityCollection(meshConfig.AsCollection(), opts)
 
 	waypoints := builder.WaypointsCollection(c.cluster, inputs.Gateways, inputs.GatewayClasses, inputs.Pods, opts)
 	services := builder.ServicesCollection(
@@ -517,6 +519,7 @@ func (c *Controller) buildAddressCollections(opts krt.OptionsBuilder) krt.Collec
 		waypoints,
 		inputs.Namespaces,
 		meshConfig,
+		serviceEntryVisibility,
 		opts,
 		true,
 	)

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1071,6 +1071,28 @@ func (ps *PushContext) ServiceForHostname(proxy *Proxy, hostname host.Name) *Ser
 	return nil
 }
 
+// serviceExportTo returns the effective exportTo set for a service: the declared exportTo (or the
+// mesh default when unset), capped by the service's resolved Visibility when
+// MeshConfig.serviceEntryVisibility.applyToSidecars is enabled. This is the visibility-safe way to
+// read a service's scope; callers must not read Attributes.ExportTo directly for scoping decisions.
+func (ps *PushContext) serviceExportTo(service *Service) sets.Set[visibility.Instance] {
+	exportToSet := ps.exportToDefaults.service
+	if !service.Attributes.ExportTo.IsEmpty() {
+		exportToSet = service.Attributes.ExportTo
+	}
+	// serviceEntryVisibility caps exportTo for classic (sidecar) proxies when opted in. It only
+	// ever narrows: NAMESPACE clamps to namespace-local, NONE hides the service entirely.
+	if ps.Mesh.GetServiceEntryVisibility().GetApplyToSidecars() {
+		switch service.Attributes.Visibility {
+		case ServiceVisibilityNamespace:
+			return sets.New(visibility.Private)
+		case ServiceVisibilityNone:
+			return sets.New(visibility.None)
+		}
+	}
+	return exportToSet
+}
+
 // IsServiceVisible returns true if the input service is visible to the given namespace.
 func (ps *PushContext) IsServiceVisible(service *Service, namespace string) bool {
 	if service == nil {
@@ -1078,10 +1100,7 @@ func (ps *PushContext) IsServiceVisible(service *Service, namespace string) bool
 	}
 
 	ns := service.Attributes.Namespace
-	exportToSet := ps.exportToDefaults.service
-	if !service.Attributes.ExportTo.IsEmpty() {
-		exportToSet = service.Attributes.ExportTo
-	}
+	exportToSet := ps.serviceExportTo(service)
 
 	return exportToSet.Contains(visibility.Public) ||
 		(exportToSet.Contains(visibility.Private) && ns == namespace) ||
@@ -1562,10 +1581,7 @@ func (ps *PushContext) initServiceRegistry(env *Environment, configsUpdate sets.
 		}
 
 		ns := s.Attributes.Namespace
-		exportToSet := ps.exportToDefaults.service
-		if !s.Attributes.ExportTo.IsEmpty() {
-			exportToSet = s.Attributes.ExportTo
-		}
+		exportToSet := ps.serviceExportTo(s)
 
 		// if service has exportTo *, make it public and ignore all other exportTos.
 		// if service does not have exportTo *, but has exportTo ~ - i.e. not visible to anyone, ignore all exportTos.

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1080,12 +1080,25 @@ func (ps *PushContext) serviceExportTo(service *Service) sets.Set[visibility.Ins
 	if !service.Attributes.ExportTo.IsEmpty() {
 		exportToSet = service.Attributes.ExportTo
 	}
+	// The user requested only None (~), so honor it; else run through the ServiceEntryVisibility logic
+	// to ensure we don't leak
+	if exportToSet.Len() == 1 && exportToSet.Contains(visibility.None) {
+		return exportToSet
+	}
 	// serviceEntryVisibility caps exportTo for classic (sidecar) proxies when opted in. It only
 	// ever narrows: NAMESPACE clamps to namespace-local, NONE hides the service entirely.
 	if ps.Mesh.GetServiceEntryVisibility().GetApplyToSidecars() {
 		switch service.Attributes.Visibility {
 		case ServiceVisibilityNamespace:
-			return sets.New(visibility.Private)
+			// Clamp to own-ns: keep Private only if the declared exportTo includes own namespace
+			// (*, ., or a literal own-ns entry); otherwise the intersection is None.
+			ns := service.Attributes.Namespace
+			if exportToSet.Contains(visibility.Public) ||
+				exportToSet.Contains(visibility.Private) ||
+				exportToSet.Contains(visibility.Instance(ns)) {
+				return sets.New(visibility.Private)
+			}
+			return sets.New(visibility.None)
 		case ServiceVisibilityNone:
 			return sets.New(visibility.None)
 		}

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -1893,6 +1893,215 @@ func TestIsServiceVisible(t *testing.T) {
 			expect: false,
 		},
 		{
+			name: "applyToSidecars: explicit exportTo=~ stays None under NAMESPACE visibility",
+			pushContext: &PushContext{
+				Mesh: &meshconfig.MeshConfig{
+					ServiceEntryVisibility: &meshconfig.ServiceEntryVisibility{ApplyToSidecars: true},
+				},
+			},
+			service: &Service{
+				Attributes: ServiceAttributes{
+					Namespace:  "foo",
+					ExportTo:   sets.New(visibility.None),
+					Visibility: ServiceVisibilityNamespace,
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "applyToSidecars: explicit exportTo=~ stays None even under PUBLIC visibility",
+			pushContext: &PushContext{
+				Mesh: &meshconfig.MeshConfig{
+					ServiceEntryVisibility: &meshconfig.ServiceEntryVisibility{ApplyToSidecars: true},
+				},
+			},
+			service: &Service{
+				Attributes: ServiceAttributes{
+					Namespace:  "foo",
+					ExportTo:   sets.New(visibility.None),
+					Visibility: ServiceVisibilityPublic,
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "applyToSidecars: exportTo=<own ns literal> under NAMESPACE stays visible in own namespace",
+			pushContext: &PushContext{
+				Mesh: &meshconfig.MeshConfig{
+					ServiceEntryVisibility: &meshconfig.ServiceEntryVisibility{ApplyToSidecars: true},
+				},
+			},
+			service: &Service{
+				Attributes: ServiceAttributes{
+					Namespace:  "foo",
+					ExportTo:   sets.New(visibility.Instance("foo")),
+					Visibility: ServiceVisibilityNamespace,
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "applyToSidecars: exportTo=<own ns literal> under PUBLIC stays visible in own namespace",
+			pushContext: &PushContext{
+				Mesh: &meshconfig.MeshConfig{
+					ServiceEntryVisibility: &meshconfig.ServiceEntryVisibility{ApplyToSidecars: true},
+				},
+			},
+			service: &Service{
+				Attributes: ServiceAttributes{
+					Namespace:  "foo",
+					ExportTo:   sets.New(visibility.Instance("foo")),
+					Visibility: ServiceVisibilityPublic,
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "applyToSidecars: NONE visibility hides service despite exportTo=.",
+			pushContext: &PushContext{
+				Mesh: &meshconfig.MeshConfig{
+					ServiceEntryVisibility: &meshconfig.ServiceEntryVisibility{ApplyToSidecars: true},
+				},
+			},
+			service: &Service{
+				Attributes: ServiceAttributes{
+					Namespace:  "foo",
+					ExportTo:   sets.New(visibility.Private),
+					Visibility: ServiceVisibilityNone,
+				},
+			},
+			expect: false,
+		},
+		{
+			// [*,~] resolves to public (* wins over ~), so it is clamped, not short-circuited by the ~.
+			name: "applyToSidecars: exportTo=[*,~] in foo is clamped to own namespace (visible in foo)",
+			pushContext: &PushContext{
+				Mesh: &meshconfig.MeshConfig{
+					ServiceEntryVisibility: &meshconfig.ServiceEntryVisibility{ApplyToSidecars: true},
+				},
+			},
+			service: &Service{
+				Attributes: ServiceAttributes{
+					Namespace:  "foo",
+					ExportTo:   sets.New(visibility.Public, visibility.None),
+					Visibility: ServiceVisibilityNamespace,
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "applyToSidecars: exportTo=[*,~] in bar is clamped, not visible cross-namespace in foo",
+			pushContext: &PushContext{
+				Mesh: &meshconfig.MeshConfig{
+					ServiceEntryVisibility: &meshconfig.ServiceEntryVisibility{ApplyToSidecars: true},
+				},
+			},
+			service: &Service{
+				Attributes: ServiceAttributes{
+					Namespace:  "bar",
+					ExportTo:   sets.New(visibility.Public, visibility.None),
+					Visibility: ServiceVisibilityNamespace,
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "applyToSidecars: exportTo=. under NAMESPACE stays visible in own namespace",
+			pushContext: &PushContext{
+				Mesh: &meshconfig.MeshConfig{
+					ServiceEntryVisibility: &meshconfig.ServiceEntryVisibility{ApplyToSidecars: true},
+				},
+			},
+			service: &Service{
+				Attributes: ServiceAttributes{
+					Namespace:  "foo",
+					ExportTo:   sets.New(visibility.Private),
+					Visibility: ServiceVisibilityNamespace,
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "applyToSidecars: exportTo=<other ns> under NAMESPACE is None (disjoint intersection)",
+			pushContext: &PushContext{
+				Mesh: &meshconfig.MeshConfig{
+					ServiceEntryVisibility: &meshconfig.ServiceEntryVisibility{ApplyToSidecars: true},
+				},
+			},
+			service: &Service{
+				Attributes: ServiceAttributes{
+					Namespace:  "foo",
+					ExportTo:   sets.New(visibility.Instance("baz")),
+					Visibility: ServiceVisibilityNamespace,
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "applyToSidecars: exportTo=[foo,baz] in foo stays visible in own namespace under NAMESPACE",
+			pushContext: &PushContext{
+				Mesh: &meshconfig.MeshConfig{
+					ServiceEntryVisibility: &meshconfig.ServiceEntryVisibility{ApplyToSidecars: true},
+				},
+			},
+			service: &Service{
+				Attributes: ServiceAttributes{
+					Namespace:  "foo",
+					ExportTo:   sets.New(visibility.Instance("foo"), visibility.Instance("baz")),
+					Visibility: ServiceVisibilityNamespace,
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "applyToSidecars: exportTo=[foo,baz] in baz - NAMESPACE clamps away the cross-namespace foo grant",
+			pushContext: &PushContext{
+				Mesh: &meshconfig.MeshConfig{
+					ServiceEntryVisibility: &meshconfig.ServiceEntryVisibility{ApplyToSidecars: true},
+				},
+			},
+			service: &Service{
+				Attributes: ServiceAttributes{
+					Namespace:  "baz",
+					ExportTo:   sets.New(visibility.Instance("foo"), visibility.Instance("baz")),
+					Visibility: ServiceVisibilityNamespace,
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "applyToSidecars: exportTo=[foo] in baz - NAMESPACE strips the explicit foo grant",
+			pushContext: &PushContext{
+				Mesh: &meshconfig.MeshConfig{
+					ServiceEntryVisibility: &meshconfig.ServiceEntryVisibility{ApplyToSidecars: true},
+				},
+			},
+			service: &Service{
+				Attributes: ServiceAttributes{
+					Namespace:  "baz",
+					ExportTo:   sets.New(visibility.Instance("foo")),
+					Visibility: ServiceVisibilityNamespace,
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "applyToSidecars: exportTo=[baz] (own ns) in baz is namespace-local, not visible in foo",
+			pushContext: &PushContext{
+				Mesh: &meshconfig.MeshConfig{
+					ServiceEntryVisibility: &meshconfig.ServiceEntryVisibility{ApplyToSidecars: true},
+				},
+			},
+			service: &Service{
+				Attributes: ServiceAttributes{
+					Namespace:  "baz",
+					ExportTo:   sets.New(visibility.Instance("baz")),
+					Visibility: ServiceVisibilityNamespace,
+				},
+			},
+			expect: false,
+		},
+		{
 			name: "applyToSidecars disabled: NAMESPACE visibility is ignored, exportTo=* governs",
 			pushContext: &PushContext{
 				Mesh: &meshconfig.MeshConfig{
@@ -1917,6 +2126,97 @@ func TestIsServiceVisible(t *testing.T) {
 			g := NewWithT(t)
 			g.Expect(isVisible).To(Equal(c.expect))
 		})
+	}
+}
+
+// TestServiceExportToNeverWidens asserts the ceiling invariant of serviceExportTo across its whole
+// input space: the clamp only ever narrows. Two properties, checked for every combination:
+//
+//  1. Never broader than declared: the effective set is not reachable in any namespace the declared
+//     exportTo is not.
+//  2. Never exceeds the visibility clamp (when applyToSidecars): NONE is reachable nowhere, NAMESPACE
+//     only in the service's own namespace.
+func TestServiceExportToNeverWidens(t *testing.T) {
+	// reachable mirrors IsServiceVisible's interpretation of an exportTo set for a target namespace.
+	reachable := func(set sets.Set[visibility.Instance], target, ownNs string) bool {
+		return set.Contains(visibility.Public) ||
+			(set.Contains(visibility.Private) && target == ownNs) ||
+			set.Contains(visibility.Instance(target))
+	}
+
+	// Atoms spanning every distinct exportTo value the clamp branches on: the three symbolic scopes,
+	// own-namespace (as serviceNamespaces vary over "foo"/"baz"), another mesh namespace, and an
+	// unrelated one. The invariants must hold for any declared set (many are invalid configs that
+	// validation rejects), so enumerate every non-empty subset rather than hand-picking forms.
+	baseSet := []visibility.Instance{
+		visibility.Public,
+		visibility.Private,
+		visibility.None,
+		visibility.Instance("foo"),
+		visibility.Instance("baz"),
+		visibility.Instance("qux"),
+	}
+	// Every non-empty subset of baseSet: start with the empty set and, for each atom, add it to a copy
+	// of every subset already collected (doubling the collection each round).
+	exportToForms := []sets.Set[visibility.Instance]{sets.New[visibility.Instance]()}
+	for _, atom := range baseSet {
+		n := len(exportToForms) // freeze before appending this round
+		for i := 0; i < n; i++ {
+			withAtom := exportToForms[i].Copy()
+			withAtom.Insert(atom)
+			exportToForms = append(exportToForms, withAtom)
+		}
+	}
+	exportToForms = exportToForms[1:] // drop the empty set: it selects the mesh default, not a clamp of the declared set
+	visibilities := map[string]ServiceVisibility{
+		"PUBLIC":    ServiceVisibilityPublic,
+		"NAMESPACE": ServiceVisibilityNamespace,
+		"NONE":      ServiceVisibilityNone,
+	}
+	serviceNamespaces := []string{"foo", "baz"}
+	clientNamespaces := []string{"foo", "baz", "qux"}
+
+	for _, apply := range []bool{true, false} {
+		for visName, vis := range visibilities {
+			for _, serviceNs := range serviceNamespaces {
+				for _, declared := range exportToForms {
+					ps := &PushContext{
+						Mesh: &meshconfig.MeshConfig{
+							ServiceEntryVisibility: &meshconfig.ServiceEntryVisibility{ApplyToSidecars: apply},
+						},
+					}
+					svc := &Service{Attributes: ServiceAttributes{
+						Namespace:  serviceNs,
+						ExportTo:   declared.Copy(),
+						Visibility: vis,
+					}}
+					effective := ps.serviceExportTo(svc)
+					for _, clientNs := range clientNamespaces {
+						// Invariant 1: never reachable where the declared exportTo is not.
+						if reachable(effective, clientNs, serviceNs) && !reachable(declared, clientNs, serviceNs) {
+							t.Errorf("widened past declared: apply=%v vis=%s serviceNs=%s client=%s: declared=%v effective=%v",
+								apply, visName, serviceNs, clientNs, sets.SortedList(declared), sets.SortedList(effective))
+						}
+						if !apply {
+							continue
+						}
+						// Invariant 2: with applyToSidecars, never exceed the visibility clamp.
+						switch vis {
+						case ServiceVisibilityNone:
+							if reachable(effective, clientNs, serviceNs) {
+								t.Errorf("NONE visibility reachable: serviceNs=%s clientNs=%s: declared=%v effective=%v",
+									serviceNs, clientNs, sets.SortedList(declared), sets.SortedList(effective))
+							}
+						case ServiceVisibilityNamespace:
+							if reachable(effective, clientNs, serviceNs) && clientNs != serviceNs {
+								t.Errorf("NAMESPACE visibility reachable outside own namespace: serviceNs=%s clientNs=%s: declared=%v effective=%v",
+									serviceNs, clientNs, sets.SortedList(declared), sets.SortedList(effective))
+							}
+						}
+					}
+				}
+			}
+		}
 	}
 }
 

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -1827,6 +1827,87 @@ func TestIsServiceVisible(t *testing.T) {
 			},
 			expect: true,
 		},
+		// --- serviceEntryVisibility applyToSidecars ceiling (PushContext.serviceExportTo) ---
+		{
+			name: "applyToSidecars: NAMESPACE service in foo is visible in its own namespace",
+			pushContext: &PushContext{
+				Mesh: &meshconfig.MeshConfig{
+					ServiceEntryVisibility: &meshconfig.ServiceEntryVisibility{ApplyToSidecars: true},
+				},
+			},
+			service: &Service{
+				Attributes: ServiceAttributes{
+					Namespace:  "foo",
+					ExportTo:   sets.New(visibility.Public),
+					Visibility: ServiceVisibilityNamespace,
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "applyToSidecars: NAMESPACE service in bar with exportTo=* is clamped, not visible in foo",
+			pushContext: &PushContext{
+				Mesh: &meshconfig.MeshConfig{
+					ServiceEntryVisibility: &meshconfig.ServiceEntryVisibility{ApplyToSidecars: true},
+				},
+			},
+			service: &Service{
+				Attributes: ServiceAttributes{
+					Namespace:  "bar",
+					ExportTo:   sets.New(visibility.Public),
+					Visibility: ServiceVisibilityNamespace,
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "applyToSidecars: PUBLIC service in bar keeps exportTo=* (visible cross-namespace in foo)",
+			pushContext: &PushContext{
+				Mesh: &meshconfig.MeshConfig{
+					ServiceEntryVisibility: &meshconfig.ServiceEntryVisibility{ApplyToSidecars: true},
+				},
+			},
+			service: &Service{
+				Attributes: ServiceAttributes{
+					Namespace:  "bar",
+					ExportTo:   sets.New(visibility.Public),
+					Visibility: ServiceVisibilityPublic,
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "applyToSidecars: NONE service is not visible even in its own namespace",
+			pushContext: &PushContext{
+				Mesh: &meshconfig.MeshConfig{
+					ServiceEntryVisibility: &meshconfig.ServiceEntryVisibility{ApplyToSidecars: true},
+				},
+			},
+			service: &Service{
+				Attributes: ServiceAttributes{
+					Namespace:  "foo",
+					ExportTo:   sets.New(visibility.Public),
+					Visibility: ServiceVisibilityNone,
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "applyToSidecars disabled: NAMESPACE visibility is ignored, exportTo=* governs",
+			pushContext: &PushContext{
+				Mesh: &meshconfig.MeshConfig{
+					ServiceEntryVisibility: &meshconfig.ServiceEntryVisibility{ApplyToSidecars: false},
+				},
+			},
+			service: &Service{
+				Attributes: ServiceAttributes{
+					Namespace:  "bar",
+					ExportTo:   sets.New(visibility.Public),
+					Visibility: ServiceVisibilityNamespace,
+				},
+			},
+			expect: true,
+		},
 	}
 
 	for _, c := range cases {

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -747,7 +747,22 @@ type ServiceAttributes struct {
 	Labels map[string]string
 	// ExportTo defines the visibility of Service in
 	// a namespace when the namespace is imported.
+	//
+	// WARNING: reading ExportTo directly is visibility-unsafe. When
+	// MeshConfig.serviceEntryVisibility.applyToSidecars is set, the effective scoping is the
+	// intersection of ExportTo and Visibility (below); ExportTo alone can over-expose a service.
+	// Consult effective scoping via PushContext.serviceExportTo / IsServiceVisible instead.
 	ExportTo sets.Set[visibility.Instance]
+
+	// Visibility is the scope resolved from MeshConfig.serviceEntryVisibility for a ServiceEntry
+	// (Public for everything else / when unset). It caps ExportTo when applyToSidecars is enabled;
+	// see PushContext.serviceExportTo. The zero value is Public (legacy behavior).
+	//
+	// WARNING: do not read this raw for scoping — it must be combined with ExportTo via
+	// PushContext.serviceExportTo / IsServiceVisible, or a service can be over-exposed. It stays
+	// exported only because ServiceAttributes is compared with go-cmp across the codebase, which
+	// panics on unexported fields; treat it as read-only outside the ServiceEntry conversion.
+	Visibility ServiceVisibility
 
 	// LabelSelectors are the labels used by the service to select workloads.
 	// Applicable to both Kubernetes and ServiceEntries.
@@ -913,7 +928,8 @@ func (s *ServiceAttributes) DeepCopy() ServiceAttributes {
 // Equals checks whether the attributes are equal from the passed in service.
 func (s *ServiceAttributes) Equals(other *ServiceAttributes) bool {
 	eql := s.Name == other.Name && s.Namespace == other.Namespace &&
-		s.ServiceRegistry == other.ServiceRegistry && s.K8sAttributes == other.K8sAttributes
+		s.ServiceRegistry == other.ServiceRegistry && s.K8sAttributes == other.K8sAttributes &&
+		s.Visibility == other.Visibility
 	if !eql {
 		return false
 	}

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1285,8 +1285,16 @@ const (
 	// It is used to inform the user that the ServiceEntry will not be active until it is bound to a waypoint.
 	WaypointMissing ConditionType = "istio.io/WaypointMissing"
 
+	// VisibilityApplied reports the visibility resolved for a ServiceEntry from
+	// MeshConfig.serviceEntryVisibility. Status is always true (informational); Reason carries the
+	// resolved value (VisibilityPublic / VisibilityNamespace).
+	VisibilityApplied ConditionType = "istio.io/VisibilityApplied"
+
 	NoWaypointForWildcardService          string = "NoWaypointForWildcardService"
 	NoWaypointForConnectStrategyCondition string = "NoWaypointForRacingConnectStrategy"
+
+	VisibilityPublic    string = "Public"
+	VisibilityNamespace string = "Namespace"
 )
 
 type ConditionSet = map[ConditionType]*Condition
@@ -1372,6 +1380,26 @@ func (i ServiceInfo) GetConditions(currentConditions map[string]Condition) Condi
 				Reason:  NoWaypointForConnectStrategyCondition,
 				Message: msg,
 			}
+		}
+	}
+
+	// Surface the visibility resolved from MeshConfig.serviceEntryVisibility. k8s Services are
+	// always PUBLIC, so this is only meaningful for ServiceEntry sources. The value is uniform
+	// across a ServiceEntry's hosts today, so this host-independent condition is idempotent across
+	// the per-host ServiceInfos that target the same object. If per-host matchers ever make
+	// visibility diverge within one ServiceEntry, this single fixed-type condition would need to
+	// aggregate across hosts instead.
+	if i.Source.Kind == kind.ServiceEntry {
+		reason, msg := VisibilityPublic, "ServiceEntry is visible to the entire mesh (PUBLIC)."
+		if i.Service.GetVisibility() == workloadapi.Service_NAMESPACE {
+			reason = VisibilityNamespace
+			msg = "ServiceEntry is visible only within its own namespace (NAMESPACE), " +
+				"per mesh serviceEntryVisibility."
+		}
+		set[VisibilityApplied] = &Condition{
+			Status:  true,
+			Reason:  reason,
+			Message: msg,
 		}
 	}
 

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1254,6 +1254,10 @@ type ServiceInfo struct {
 	// CreationTime is the time when the service was created. Note this is used internally only
 	// for conflict resolution.
 	CreationTime time.Time
+	// VisibilityConfigured reports whether MeshConfig.serviceEntryVisibility was set. Used internally
+	// only, to gate the VisibilityApplied status; the status value itself comes from Service.Visibility
+	// so it always reflects what the dataplane received.
+	VisibilityConfigured bool
 }
 
 func (i ServiceInfo) GetLabelSelector() map[string]string {
@@ -1399,23 +1403,25 @@ func (i ServiceInfo) GetConditions(currentConditions map[string]Condition) Condi
 		}
 	}
 
-	// Surface the visibility resolved from MeshConfig.serviceEntryVisibility. k8s Services are
-	// always PUBLIC, so this is only meaningful for ServiceEntry sources. The value is uniform
-	// across a ServiceEntry's hosts today, so this host-independent condition is idempotent across
-	// the per-host ServiceInfos that target the same object. If per-host matchers ever make
-	// visibility diverge within one ServiceEntry, this single fixed-type condition would need to
-	// aggregate across hosts instead.
+	// Surface the visibility resolved from MeshConfig.serviceEntryVisibility, only for ServiceEntry
+	// sources and only when the feature is configured (ResolvedVisibility non-nil) -- otherwise prune,
+	// so an unset mesh does not stamp a condition on every ServiceEntry. The value is uniform across a
+	// ServiceEntry's hosts today, so this host-independent condition is idempotent across the per-host
+	// ServiceInfos that target the same object.
 	if i.Source.Kind == kind.ServiceEntry {
-		reason, msg := VisibilityPublic, "ServiceEntry is visible to the entire mesh (PUBLIC)."
-		if i.Service.GetVisibility() == workloadapi.Service_NAMESPACE {
-			reason = VisibilityNamespace
-			msg = "ServiceEntry is visible only within its own namespace (NAMESPACE), " +
-				"per mesh serviceEntryVisibility."
-		}
-		set[VisibilityApplied] = &Condition{
-			Status:  true,
-			Reason:  reason,
-			Message: msg,
+		set[VisibilityApplied] = nil
+		if i.VisibilityConfigured {
+			reason, msg := VisibilityPublic, "ServiceEntry is visible to the entire mesh (PUBLIC)."
+			if i.Service.GetVisibility() == workloadapi.Service_NAMESPACE {
+				reason = VisibilityNamespace
+				msg = "ServiceEntry is visible only within its own namespace (NAMESPACE), " +
+					"per mesh serviceEntryVisibility."
+			}
+			set[VisibilityApplied] = &Condition{
+				Status:  true,
+				Reason:  reason,
+				Message: msg,
+			}
 		}
 	}
 
@@ -1464,7 +1470,8 @@ func (i ServiceInfo) Equals(other ServiceInfo) bool {
 		i.Source == other.Source &&
 		i.DNSConnectStrategy == other.DNSConnectStrategy &&
 		i.Scope == other.Scope &&
-		i.Waypoint.Equals(other.Waypoint)
+		i.Waypoint.Equals(other.Waypoint) &&
+		i.VisibilityConfigured == other.VisibilityConfigured
 }
 
 func (i ServiceInfo) ResourceName() string {

--- a/pilot/pkg/model/service_test.go
+++ b/pilot/pkg/model/service_test.go
@@ -1238,3 +1238,59 @@ func TestServiceInfoWaypointConditions(t *testing.T) {
 		}
 	})
 }
+
+func TestServiceInfoVisibilityCondition(t *testing.T) {
+	cases := []struct {
+		name       string
+		sourceKind kind.Kind
+		visibility workloadapi.Service_Visibility
+		// wantReason is the expected VisibilityApplied condition Reason; "" means the condition
+		// must not be set (pruned), e.g. for non-ServiceEntry sources.
+		wantReason string
+	}{
+		{
+			name:       "ServiceEntry PUBLIC",
+			sourceKind: kind.ServiceEntry,
+			visibility: workloadapi.Service_PUBLIC,
+			wantReason: VisibilityPublic,
+		},
+		{
+			name:       "ServiceEntry NAMESPACE",
+			sourceKind: kind.ServiceEntry,
+			visibility: workloadapi.Service_NAMESPACE,
+			wantReason: VisibilityNamespace,
+		},
+		{
+			// k8s Services are always PUBLIC and must not carry the condition, even if the field is set.
+			name:       "kube Service is not annotated",
+			sourceKind: kind.Service,
+			visibility: workloadapi.Service_NAMESPACE,
+			wantReason: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			si := ServiceInfo{
+				Service: &workloadapi.Service{
+					Name:       "svc",
+					Namespace:  "ns",
+					Hostname:   "svc.example.com",
+					Visibility: tc.visibility,
+				},
+				Source: TypedObject{Kind: tc.sourceKind},
+			}
+			got := si.GetConditions(nil)[VisibilityApplied]
+			if tc.wantReason == "" {
+				if got != nil {
+					t.Fatalf("expected no VisibilityApplied condition, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected VisibilityApplied condition, got none")
+			}
+			assert.Equal(t, got.Status, true)
+			assert.Equal(t, got.Reason, tc.wantReason)
+		})
+	}
+}

--- a/pilot/pkg/model/service_test.go
+++ b/pilot/pkg/model/service_test.go
@@ -1243,28 +1243,40 @@ func TestServiceInfoVisibilityCondition(t *testing.T) {
 	cases := []struct {
 		name       string
 		sourceKind kind.Kind
+		configured bool
 		visibility workloadapi.Service_Visibility
 		// wantReason is the expected VisibilityApplied condition Reason; "" means the condition
-		// must not be set (pruned), e.g. for non-ServiceEntry sources.
+		// must not be set (pruned): non-ServiceEntry sources, or the feature unconfigured.
 		wantReason string
 	}{
 		{
 			name:       "ServiceEntry PUBLIC",
 			sourceKind: kind.ServiceEntry,
+			configured: true,
 			visibility: workloadapi.Service_PUBLIC,
 			wantReason: VisibilityPublic,
 		},
 		{
 			name:       "ServiceEntry NAMESPACE",
 			sourceKind: kind.ServiceEntry,
+			configured: true,
 			visibility: workloadapi.Service_NAMESPACE,
 			wantReason: VisibilityNamespace,
 		},
 		{
-			// k8s Services are always PUBLIC and must not carry the condition, even if the field is set.
-			name:       "kube Service is not annotated",
+			// Feature unconfigured: the dataplane stays PUBLIC (legacy) and we write no condition.
+			name:       "ServiceEntry unconfigured",
+			sourceKind: kind.ServiceEntry,
+			configured: false,
+			visibility: workloadapi.Service_PUBLIC,
+			wantReason: "",
+		},
+		{
+			// The Source.Kind gate wins for a Kubernetes Service even if the flag were somehow set.
+			name:       "kube Service",
 			sourceKind: kind.Service,
-			visibility: workloadapi.Service_NAMESPACE,
+			configured: true,
+			visibility: workloadapi.Service_PUBLIC,
 			wantReason: "",
 		},
 	}
@@ -1277,7 +1289,8 @@ func TestServiceInfoVisibilityCondition(t *testing.T) {
 					Hostname:   "svc.example.com",
 					Visibility: tc.visibility,
 				},
-				Source: TypedObject{Kind: tc.sourceKind},
+				Source:               TypedObject{Kind: tc.sourceKind},
+				VisibilityConfigured: tc.configured,
 			}
 			got := si.GetConditions(nil)[VisibilityApplied]
 			if tc.wantReason == "" {

--- a/pilot/pkg/model/serviceentry_visibility.go
+++ b/pilot/pkg/model/serviceentry_visibility.go
@@ -20,6 +20,7 @@ import (
 
 	meshapi "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pkg/config/mesh"
+	"istio.io/istio/pkg/kube/krt"
 )
 
 // ServiceVisibility is the visibility resolved for a ServiceEntry from
@@ -128,6 +129,22 @@ func CompileServiceEntryVisibility(sev *meshapi.ServiceEntryVisibility) *Service
 		out.policies = append(out.policies, vp)
 	}
 	return out
+}
+
+// ServiceEntryVisibilityCollection derives the precompiled serviceEntryVisibility matcher as a krt
+// singleton from the mesh config, so both dataplanes (ambient and classic serviceentry) compile it
+// once and evaluate visibility identically. It recomputes only when the matcher changes (Equals).
+func ServiceEntryVisibilityCollection(
+	meshConfig krt.Collection[MeshConfig],
+	opts krt.OptionsBuilder,
+) krt.Singleton[ServiceEntryVisibilityMatcher] {
+	return krt.NewSingleton[ServiceEntryVisibilityMatcher](func(ctx krt.HandlerContext) *ServiceEntryVisibilityMatcher {
+		mc := krt.FetchOne(ctx, meshConfig)
+		if mc == nil {
+			return CompileServiceEntryVisibility(nil)
+		}
+		return CompileServiceEntryVisibility(mc.GetServiceEntryVisibility())
+	}, opts.WithName("ServiceEntryVisibility")...)
 }
 
 // compileVisibilityRule converts a single matcher into its precompiled form. Only namespaceSelector

--- a/pilot/pkg/model/serviceentry_visibility.go
+++ b/pilot/pkg/model/serviceentry_visibility.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 
 	meshapi "istio.io/api/mesh/v1alpha1"
-	"istio.io/istio/pkg/config/mesh"
+	"istio.io/istio/pkg/config/mesh/labelselector"
 	"istio.io/istio/pkg/kube/krt"
 )
 
@@ -164,7 +164,7 @@ func ServiceEntryVisibilityCollection(
 func compileVisibilityRule(rule *meshapi.ServiceEntryVisibility_MatchRule) (visibilityRule, bool) {
 	switch rule.GetMatcher().(type) {
 	case *meshapi.ServiceEntryVisibility_MatchRule_NamespaceSelector:
-		sel, err := mesh.LabelSelectorAsSelector(rule.GetNamespaceSelector())
+		sel, err := labelselector.LabelSelectorAsSelector(rule.GetNamespaceSelector())
 		if err != nil {
 			log.Errorf("failed to convert serviceEntryVisibility namespace selector: %v", err)
 			return visibilityRule{}, false

--- a/pilot/pkg/model/serviceentry_visibility.go
+++ b/pilot/pkg/model/serviceentry_visibility.go
@@ -100,6 +100,11 @@ func (m *ServiceEntryVisibilityMatcher) VisibilityFor(nsLabels map[string]string
 	return m.defaultVisibility
 }
 
+// Configured reports whether MeshConfig.serviceEntryVisibility was set at all.
+func (m *ServiceEntryVisibilityMatcher) Configured() bool {
+	return m != nil && m.source != nil
+}
+
 // matches reports whether all of a policy's rules match (AND semantics). An empty rule list matches
 // everything, making the policy a catch-all.
 func (p visibilityPolicy) matches(nsLabels labels.Set) bool {

--- a/pilot/pkg/model/serviceentry_visibility.go
+++ b/pilot/pkg/model/serviceentry_visibility.go
@@ -112,23 +112,28 @@ func (p visibilityPolicy) matches(nsLabels labels.Set) bool {
 }
 
 // CompileServiceEntryVisibility precompiles a serviceEntryVisibility config. A nil config is legacy
-// behavior: everything is Public.
-func CompileServiceEntryVisibility(sev *meshapi.ServiceEntryVisibility) *ServiceEntryVisibilityMatcher {
+// behavior: everything is Public. It always returns a usable best-effort matcher; ok is false if any
+// part of the config failed to compile, so callers that own the config can keep the last known good
+// matcher instead of applying a partially-compiled one.
+func CompileServiceEntryVisibility(sev *meshapi.ServiceEntryVisibility) (*ServiceEntryVisibilityMatcher, bool) {
 	if sev == nil {
-		return &ServiceEntryVisibilityMatcher{defaultVisibility: ServiceVisibilityPublic}
+		return &ServiceEntryVisibilityMatcher{defaultVisibility: ServiceVisibilityPublic}, true
 	}
 	out := &ServiceEntryVisibilityMatcher{
 		defaultVisibility: toServiceVisibility(sev.GetDefaultVisibility()),
 		source:            sev,
 	}
+	ok := true
 	for _, policy := range sev.GetPolicies() {
 		vp := visibilityPolicy{visibility: toServiceVisibility(policy.GetVisibility())}
 		for _, rule := range policy.GetMatchingRules() {
-			vp.rules = append(vp.rules, compileVisibilityRule(rule))
+			r, ruleOK := compileVisibilityRule(rule)
+			ok = ok && ruleOK
+			vp.rules = append(vp.rules, r)
 		}
 		out.policies = append(out.policies, vp)
 	}
-	return out
+	return out, ok
 }
 
 // ServiceEntryVisibilityCollection derives the precompiled serviceEntryVisibility matcher as a krt
@@ -139,28 +144,35 @@ func ServiceEntryVisibilityCollection(
 	opts krt.OptionsBuilder,
 ) krt.Singleton[ServiceEntryVisibilityMatcher] {
 	return krt.NewSingleton[ServiceEntryVisibilityMatcher](func(ctx krt.HandlerContext) *ServiceEntryVisibilityMatcher {
-		mc := krt.FetchOne(ctx, meshConfig)
-		if mc == nil {
-			return CompileServiceEntryVisibility(nil)
+		var sev *meshapi.ServiceEntryVisibility
+		if mc := krt.FetchOne(ctx, meshConfig); mc != nil {
+			sev = mc.GetServiceEntryVisibility()
 		}
-		return CompileServiceEntryVisibility(mc.GetServiceEntryVisibility())
+		m, ok := CompileServiceEntryVisibility(sev)
+		if !ok {
+			// The config failed to compile (logged above). Keep the last known good matcher rather
+			// than applying a partially-compiled one; a fresh instance falls back to best-effort.
+			ctx.DiscardResult()
+		}
+		return m
 	}, opts.WithName("ServiceEntryVisibility")...)
 }
 
 // compileVisibilityRule converts a single matcher into its precompiled form. Only namespaceSelector
-// is implemented today; future matchers (hostnameSuffix, addressInCidr) become new cases here.
-func compileVisibilityRule(rule *meshapi.ServiceEntryVisibility_MatchRule) visibilityRule {
+// is implemented today; future matchers (hostnameSuffix, addressInCidr) become new cases here. ok is
+// false if the matcher failed to compile; an unknown/unset matcher is not a failure (forward compat).
+func compileVisibilityRule(rule *meshapi.ServiceEntryVisibility_MatchRule) (visibilityRule, bool) {
 	switch rule.GetMatcher().(type) {
 	case *meshapi.ServiceEntryVisibility_MatchRule_NamespaceSelector:
 		sel, err := mesh.LabelSelectorAsSelector(rule.GetNamespaceSelector())
 		if err != nil {
-			log.Warnf("failed to convert serviceEntryVisibility namespace selector: %v", err)
-			return visibilityRule{}
+			log.Errorf("failed to convert serviceEntryVisibility namespace selector: %v", err)
+			return visibilityRule{}, false
 		}
-		return visibilityRule{namespaceSelector: sel}
+		return visibilityRule{namespaceSelector: sel}, true
 	default:
 		// Unknown or unset matcher never matches.
-		return visibilityRule{}
+		return visibilityRule{}, true
 	}
 }
 

--- a/pilot/pkg/model/serviceentry_visibility.go
+++ b/pilot/pkg/model/serviceentry_visibility.go
@@ -1,0 +1,212 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/proto"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+
+	meshapi "istio.io/api/mesh/v1alpha1"
+)
+
+// ServiceVisibility is the visibility resolved for a ServiceEntry from
+// MeshConfig.serviceEntryVisibility. It is the shared, dataplane-neutral result: the ambient path
+// maps it onto the WDS Service.Visibility field, and the sidecar path maps it onto exportTo scoping.
+// The zero value is Public so that services without a resolved visibility behave as legacy (public).
+type ServiceVisibility int
+
+const (
+	// ServiceVisibilityPublic is the legacy default: the service is visible per its exportTo /
+	// control-plane connectivity, unrestricted by this feature.
+	ServiceVisibilityPublic ServiceVisibility = iota
+	// ServiceVisibilityNamespace restricts the service to its own namespace.
+	ServiceVisibilityNamespace
+	// ServiceVisibilityNone hides the service entirely (published to no one).
+	ServiceVisibilityNone
+)
+
+func (v ServiceVisibility) String() string {
+	switch v {
+	case ServiceVisibilityNamespace:
+		return "Namespace"
+	case ServiceVisibilityNone:
+		return "None"
+	default:
+		return "Public"
+	}
+}
+
+// ServiceEntryVisibilityMatcher is the precompiled, dependency-narrowed projection of
+// MeshConfig.serviceEntryVisibility. Compile it once per serviceEntryVisibility change (label
+// selectors are converted only once) and reuse it to resolve visibility per ServiceEntry. It is
+// shared by the ambient and sidecar (serviceentry) registries so the policy is evaluated
+// identically for both dataplanes.
+type ServiceEntryVisibilityMatcher struct {
+	// defaultVisibility is applied when no policy matches.
+	defaultVisibility ServiceVisibility
+	policies          []visibilityPolicy
+	// source is retained only for equality, so a recompiled-but-identical value is not treated as a
+	// change by krt.
+	source *meshapi.ServiceEntryVisibility
+}
+
+type visibilityPolicy struct {
+	visibility ServiceVisibility
+	rules      []visibilityRule
+}
+
+type visibilityRule struct {
+	// namespaceSelector is set for a namespace_selector matcher. A nil selector never matches
+	// (unknown/unset matcher), so a malformed rule fails closed.
+	namespaceSelector labels.Selector
+}
+
+// ResourceName lets the matcher be used as a krt singleton value.
+func (m ServiceEntryVisibilityMatcher) ResourceName() string { return "ServiceEntryVisibility" }
+
+// Equals dedupes on the underlying config so an unrelated MeshConfig change that recompiles an
+// identical matcher is not seen as a change.
+func (m ServiceEntryVisibilityMatcher) Equals(other ServiceEntryVisibilityMatcher) bool {
+	return proto.Equal(m.source, other.source)
+}
+
+// VisibilityFor resolves the visibility for a ServiceEntry given its namespace labels: the first
+// policy whose rules all match wins, otherwise the default. A nil receiver (visibility not
+// configured/computed) is Public (legacy behavior).
+func (m *ServiceEntryVisibilityMatcher) VisibilityFor(nsLabels map[string]string) ServiceVisibility {
+	if m == nil {
+		return ServiceVisibilityPublic
+	}
+	set := labels.Set(nsLabels)
+	for _, p := range m.policies {
+		if p.matches(set) {
+			return p.visibility
+		}
+	}
+	return m.defaultVisibility
+}
+
+// matches reports whether all of a policy's rules match (AND semantics). An empty rule list matches
+// everything, making the policy a catch-all.
+func (p visibilityPolicy) matches(nsLabels labels.Set) bool {
+	for _, r := range p.rules {
+		if r.namespaceSelector == nil || !r.namespaceSelector.Matches(nsLabels) {
+			return false
+		}
+	}
+	return true
+}
+
+// CompileServiceEntryVisibility precompiles a serviceEntryVisibility config. A nil config is legacy
+// behavior: everything is Public.
+func CompileServiceEntryVisibility(sev *meshapi.ServiceEntryVisibility) *ServiceEntryVisibilityMatcher {
+	if sev == nil {
+		return &ServiceEntryVisibilityMatcher{defaultVisibility: ServiceVisibilityPublic}
+	}
+	out := &ServiceEntryVisibilityMatcher{
+		defaultVisibility: toServiceVisibility(sev.GetDefaultVisibility()),
+		source:            sev,
+	}
+	for _, policy := range sev.GetPolicies() {
+		vp := visibilityPolicy{visibility: toServiceVisibility(policy.GetVisibility())}
+		for _, rule := range policy.GetMatchingRules() {
+			vp.rules = append(vp.rules, compileVisibilityRule(rule))
+		}
+		out.policies = append(out.policies, vp)
+	}
+	return out
+}
+
+// compileVisibilityRule converts a single matcher into its precompiled form. Only namespaceSelector
+// is implemented today; future matchers (hostnameSuffix, addressInCidr) become new cases here.
+func compileVisibilityRule(rule *meshapi.ServiceEntryVisibility_MatchRule) visibilityRule {
+	switch rule.GetMatcher().(type) {
+	case *meshapi.ServiceEntryVisibility_MatchRule_NamespaceSelector:
+		sel, err := labelSelectorAsSelector(rule.GetNamespaceSelector())
+		if err != nil {
+			log.Warnf("failed to convert serviceEntryVisibility namespace selector: %v", err)
+			return visibilityRule{}
+		}
+		return visibilityRule{namespaceSelector: sel}
+	default:
+		// Unknown or unset matcher never matches.
+		return visibilityRule{}
+	}
+}
+
+// toServiceVisibility maps a MeshConfig visibility to the neutral ServiceVisibility. UNSPECIFIED is
+// Public (legacy default).
+func toServiceVisibility(v meshapi.ServiceEntryVisibility_Visibility) ServiceVisibility {
+	switch v {
+	case meshapi.ServiceEntryVisibility_NAMESPACE:
+		return ServiceVisibilityNamespace
+	case meshapi.ServiceEntryVisibility_NONE:
+		return ServiceVisibilityNone
+	default:
+		return ServiceVisibilityPublic
+	}
+}
+
+// labelSelectorAsSelector converts a mesh API LabelSelector to a labels.Selector. A nil selector
+// matches nothing; an empty selector matches everything.
+//
+// NOTE: this is a copy of the identical LabelSelectorAsSelector in pkg/kube/namespace (and
+// pilot/pkg/serviceregistry/ambient). It is copied, not imported, because pkg/kube/namespace pulls
+// in heavy kube-client machinery (kube/kclient/controllers) that the central model package must not
+// depend on. Importing ambient would be a cycle.
+// TODO: targeted DRY — lift this pure converter into a lean leaf package (e.g.
+// pkg/config/mesh, already imported by pkg/kube/namespace and cycle-free for model/ambient) so the
+// three call sites share one copy.
+func labelSelectorAsSelector(ps *meshapi.LabelSelector) (labels.Selector, error) {
+	if ps == nil {
+		return labels.Nothing(), nil
+	}
+	if len(ps.MatchLabels)+len(ps.MatchExpressions) == 0 {
+		return labels.Everything(), nil
+	}
+	requirements := make([]labels.Requirement, 0, len(ps.MatchLabels)+len(ps.MatchExpressions))
+	for k, v := range ps.MatchLabels {
+		r, err := labels.NewRequirement(k, selection.Equals, []string{v})
+		if err != nil {
+			return nil, err
+		}
+		requirements = append(requirements, *r)
+	}
+	for _, expr := range ps.MatchExpressions {
+		var op selection.Operator
+		switch metav1.LabelSelectorOperator(expr.Operator) {
+		case metav1.LabelSelectorOpIn:
+			op = selection.In
+		case metav1.LabelSelectorOpNotIn:
+			op = selection.NotIn
+		case metav1.LabelSelectorOpExists:
+			op = selection.Exists
+		case metav1.LabelSelectorOpDoesNotExist:
+			op = selection.DoesNotExist
+		default:
+			return nil, fmt.Errorf("%q is not a valid label selector operator", expr.Operator)
+		}
+		r, err := labels.NewRequirement(expr.Key, op, append([]string(nil), expr.Values...))
+		if err != nil {
+			return nil, err
+		}
+		requirements = append(requirements, *r)
+	}
+	return labels.NewSelector().Add(requirements...), nil
+}

--- a/pilot/pkg/model/serviceentry_visibility.go
+++ b/pilot/pkg/model/serviceentry_visibility.go
@@ -15,14 +15,11 @@
 package model
 
 import (
-	"fmt"
-
 	"google.golang.org/protobuf/proto"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 
 	meshapi "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pkg/config/mesh"
 )
 
 // ServiceVisibility is the visibility resolved for a ServiceEntry from
@@ -138,7 +135,7 @@ func CompileServiceEntryVisibility(sev *meshapi.ServiceEntryVisibility) *Service
 func compileVisibilityRule(rule *meshapi.ServiceEntryVisibility_MatchRule) visibilityRule {
 	switch rule.GetMatcher().(type) {
 	case *meshapi.ServiceEntryVisibility_MatchRule_NamespaceSelector:
-		sel, err := labelSelectorAsSelector(rule.GetNamespaceSelector())
+		sel, err := mesh.LabelSelectorAsSelector(rule.GetNamespaceSelector())
 		if err != nil {
 			log.Warnf("failed to convert serviceEntryVisibility namespace selector: %v", err)
 			return visibilityRule{}
@@ -161,52 +158,4 @@ func toServiceVisibility(v meshapi.ServiceEntryVisibility_Visibility) ServiceVis
 	default:
 		return ServiceVisibilityPublic
 	}
-}
-
-// labelSelectorAsSelector converts a mesh API LabelSelector to a labels.Selector. A nil selector
-// matches nothing; an empty selector matches everything.
-//
-// NOTE: this is a copy of the identical LabelSelectorAsSelector in pkg/kube/namespace (and
-// pilot/pkg/serviceregistry/ambient). It is copied, not imported, because pkg/kube/namespace pulls
-// in heavy kube-client machinery (kube/kclient/controllers) that the central model package must not
-// depend on. Importing ambient would be a cycle.
-// TODO: targeted DRY — lift this pure converter into a lean leaf package (e.g.
-// pkg/config/mesh, already imported by pkg/kube/namespace and cycle-free for model/ambient) so the
-// three call sites share one copy.
-func labelSelectorAsSelector(ps *meshapi.LabelSelector) (labels.Selector, error) {
-	if ps == nil {
-		return labels.Nothing(), nil
-	}
-	if len(ps.MatchLabels)+len(ps.MatchExpressions) == 0 {
-		return labels.Everything(), nil
-	}
-	requirements := make([]labels.Requirement, 0, len(ps.MatchLabels)+len(ps.MatchExpressions))
-	for k, v := range ps.MatchLabels {
-		r, err := labels.NewRequirement(k, selection.Equals, []string{v})
-		if err != nil {
-			return nil, err
-		}
-		requirements = append(requirements, *r)
-	}
-	for _, expr := range ps.MatchExpressions {
-		var op selection.Operator
-		switch metav1.LabelSelectorOperator(expr.Operator) {
-		case metav1.LabelSelectorOpIn:
-			op = selection.In
-		case metav1.LabelSelectorOpNotIn:
-			op = selection.NotIn
-		case metav1.LabelSelectorOpExists:
-			op = selection.Exists
-		case metav1.LabelSelectorOpDoesNotExist:
-			op = selection.DoesNotExist
-		default:
-			return nil, fmt.Errorf("%q is not a valid label selector operator", expr.Operator)
-		}
-		r, err := labels.NewRequirement(expr.Key, op, append([]string(nil), expr.Values...))
-		if err != nil {
-			return nil, err
-		}
-		requirements = append(requirements, *r)
-	}
-	return labels.NewSelector().Add(requirements...), nil
 }

--- a/pilot/pkg/model/serviceentry_visibility_test.go
+++ b/pilot/pkg/model/serviceentry_visibility_test.go
@@ -1,0 +1,71 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"testing"
+
+	meshapi "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pkg/test/util/assert"
+)
+
+func nsSelectorRule(sel *meshapi.LabelSelector) *meshapi.ServiceEntryVisibility_MatchRule {
+	return &meshapi.ServiceEntryVisibility_MatchRule{
+		Matcher: &meshapi.ServiceEntryVisibility_MatchRule_NamespaceSelector{NamespaceSelector: sel},
+	}
+}
+
+func TestCompileServiceEntryVisibility(t *testing.T) {
+	t.Run("nil config is Public and ok", func(t *testing.T) {
+		m, ok := CompileServiceEntryVisibility(nil)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, m.VisibilityFor(nil), ServiceVisibilityPublic)
+	})
+
+	t.Run("valid policy compiles and matches", func(t *testing.T) {
+		m, ok := CompileServiceEntryVisibility(&meshapi.ServiceEntryVisibility{
+			DefaultVisibility: meshapi.ServiceEntryVisibility_NAMESPACE,
+			Policies: []*meshapi.ServiceEntryVisibility_Policy{{
+				Visibility: meshapi.ServiceEntryVisibility_PUBLIC,
+				MatchingRules: []*meshapi.ServiceEntryVisibility_MatchRule{
+					nsSelectorRule(&meshapi.LabelSelector{MatchLabels: map[string]string{"se-visibility": "public"}}),
+				},
+			}},
+		})
+		assert.Equal(t, ok, true)
+		assert.Equal(t, m.VisibilityFor(map[string]string{"se-visibility": "public"}), ServiceVisibilityPublic)
+		// No policy matches -> default.
+		assert.Equal(t, m.VisibilityFor(map[string]string{"other": "x"}), ServiceVisibilityNamespace)
+	})
+
+	t.Run("invalid selector: ok is false, best-effort matcher drops the bad rule", func(t *testing.T) {
+		m, ok := CompileServiceEntryVisibility(&meshapi.ServiceEntryVisibility{
+			DefaultVisibility: meshapi.ServiceEntryVisibility_NAMESPACE,
+			Policies: []*meshapi.ServiceEntryVisibility_Policy{{
+				Visibility: meshapi.ServiceEntryVisibility_PUBLIC,
+				MatchingRules: []*meshapi.ServiceEntryVisibility_MatchRule{
+					// An invalid operator makes the selector fail to compile.
+					nsSelectorRule(&meshapi.LabelSelector{MatchExpressions: []*meshapi.LabelSelectorRequirement{{
+						Key:      "k",
+						Operator: "BadOperator",
+					}}}),
+				},
+			}},
+		})
+		assert.Equal(t, ok, false)
+		// The matcher is still usable; the dropped rule never matches, so everything falls to default.
+		assert.Equal(t, m.VisibilityFor(map[string]string{"se-visibility": "public"}), ServiceVisibilityNamespace)
+	})
+}

--- a/pilot/pkg/serviceregistry/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex.go
@@ -255,7 +255,8 @@ func New(options Options) Index {
 	serviceEntryVisibility := model.ServiceEntryVisibilityCollection(a.meshConfig.AsCollection(), opts)
 
 	// these are workloadapi-style services combined from kube services and service entries
-	WorkloadServices := builder.ServicesCollection(options.ClusterID, Services, ServiceEntries, Waypoints, Namespaces, a.meshConfig, serviceEntryVisibility, opts, true)
+	WorkloadServices := builder.ServicesCollection(options.ClusterID, Services, ServiceEntries, Waypoints,
+		Namespaces, a.meshConfig, serviceEntryVisibility, opts, true)
 
 	if features.EnableAmbientStatus {
 		serviceEntriesWriter := kclient.NewWriteClient[*networkingclient.ServiceEntry](client)

--- a/pilot/pkg/serviceregistry/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex.go
@@ -252,8 +252,10 @@ func New(options Options) Index {
 		Waypoints,
 		opts,
 	)
+	serviceEntryVisibility := model.ServiceEntryVisibilityCollection(a.meshConfig.AsCollection(), opts)
+
 	// these are workloadapi-style services combined from kube services and service entries
-	WorkloadServices := builder.ServicesCollection(options.ClusterID, Services, ServiceEntries, Waypoints, Namespaces, a.meshConfig, opts, true)
+	WorkloadServices := builder.ServicesCollection(options.ClusterID, Services, ServiceEntries, Waypoints, Namespaces, a.meshConfig, serviceEntryVisibility, opts, true)
 
 	if features.EnableAmbientStatus {
 		serviceEntriesWriter := kclient.NewWriteClient[*networkingclient.ServiceEntry](client)
@@ -267,6 +269,7 @@ func New(options Options) Index {
 			ServiceEntries,
 			GatewayClasses,
 			a.meshConfig,
+			serviceEntryVisibility,
 			Namespaces,
 			opts,
 		)

--- a/pilot/pkg/serviceregistry/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex_test.go
@@ -519,6 +519,21 @@ func TestAmbientIndex_ServiceOverlap(t *testing.T) {
 		s.assertCanonicalService(t, "svc1.ns1.svc.company.com", "se-2")
 		s.assertNoEvent(t)
 	})
+
+	t.Run("namespace-scoped serviceentry is not canonical", func(t *testing.T) {
+		s := newAmbientTestServer(t, testC, testNW, "")
+		// Scope every ServiceEntry to its own namespace.
+		s.meshConfig.Mesh().ServiceEntryVisibility = &v1alpha1.ServiceEntryVisibility{
+			DefaultVisibility: v1alpha1.ServiceEntryVisibility_NAMESPACE,
+		}
+
+		// The SE is still published (present in the registry)...
+		addServiceEntry(s, 1, "foo.com", testNS)
+		s.assertAddresses(t, testNW+"/10.255.0.1", "se-1")
+		// ...but a NAMESPACE-scoped service must never be promoted to the canonical
+		// cross-namespace service for its hostname (want == "" => no canonical service).
+		s.assertCanonicalService(t, "foo.com", "")
+	})
 }
 
 func TestAmbientIndex_ServiceAttachedWaypoints(t *testing.T) {

--- a/pilot/pkg/serviceregistry/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex_test.go
@@ -522,17 +522,27 @@ func TestAmbientIndex_ServiceOverlap(t *testing.T) {
 
 	t.Run("namespace-scoped serviceentry is not canonical", func(t *testing.T) {
 		s := newAmbientTestServer(t, testC, testNW, "")
-		// Scope every ServiceEntry to its own namespace.
-		s.meshConfig.Mesh().ServiceEntryVisibility = &v1alpha1.ServiceEntryVisibility{
+		// Scope every ServiceEntry to its own namespace. Set() (rather than in-place mutation)
+		// so the derived ServiceEntryVisibility collection is notified and recomputes.
+		mc := s.meshConfig.Mesh()
+		mc.ServiceEntryVisibility = &v1alpha1.ServiceEntryVisibility{
 			DefaultVisibility: v1alpha1.ServiceEntryVisibility_NAMESPACE,
 		}
+		s.meshConfig.(meshwatcher.TestWatcher).Set(mc)
 
 		// The SE is still published (present in the registry)...
 		addServiceEntry(s, 1, "foo.com", testNS)
 		s.assertAddresses(t, testNW+"/10.255.0.1", "se-1")
 		// ...but a NAMESPACE-scoped service must never be promoted to the canonical
-		// cross-namespace service for its hostname (want == "" => no canonical service).
-		s.assertCanonicalService(t, "foo.com", "")
+		// cross-namespace service for its hostname (eventually, no service is canonical).
+		assert.EventuallyEqual(t, func() string {
+			for _, si := range s.services.List() {
+				if si.Service.Hostname == "foo.com" && si.Service.Canonical {
+					return si.Service.Name
+				}
+			}
+			return ""
+		}, "")
 	})
 }
 

--- a/pilot/pkg/serviceregistry/ambient/authorization_test.go
+++ b/pilot/pkg/serviceregistry/ambient/authorization_test.go
@@ -242,6 +242,7 @@ func TestWaypointPolicyStatusCollection(t *testing.T) {
 		},
 	})
 	meshConfigCol := GetMeshConfig(meshConfigMock)
+	serviceEntryVisibility := model.ServiceEntryVisibilityCollection(meshConfigCol.AsCollection(), opts)
 
 	clientNs := kclient.New[*v1.Namespace](c)
 	nsCol := krt.WrapClient(clientNs, opts.WithName("nsCol")...)
@@ -273,7 +274,7 @@ func TestWaypointPolicyStatusCollection(t *testing.T) {
 		}
 	}, opts.WithName("waypoint")...)
 
-	wpsCollection := WaypointPolicyStatusCollection(authzPolCol, waypointCol, svcCol, seCol, gwClassCol, meshConfigCol, nsCol, opts)
+	wpsCollection := WaypointPolicyStatusCollection(authzPolCol, waypointCol, svcCol, seCol, gwClassCol, meshConfigCol, serviceEntryVisibility, nsCol, opts)
 	c.RunAndWait(ctx.Done())
 
 	_, err := clientNs.Create(&v1.Namespace{

--- a/pilot/pkg/serviceregistry/ambient/multicluster.go
+++ b/pilot/pkg/serviceregistry/ambient/multicluster.go
@@ -192,6 +192,7 @@ func (a *index) buildGlobalCollections(
 		LocalWaypoints,
 		opts,
 	)
+	LocalServiceEntryVisibility := model.ServiceEntryVisibilityCollection(LocalMeshConfig.AsCollection(), opts)
 
 	LocalWorkloadServices := builder.ServicesCollection(
 		localCluster.ID,
@@ -200,6 +201,7 @@ func (a *index) buildGlobalCollections(
 		LocalWaypoints,
 		LocalNamespaces,
 		LocalMeshConfig,
+		LocalServiceEntryVisibility,
 		opts,
 		false, // Don't precompute here; these will just get merged into the global collection later
 	)
@@ -216,6 +218,7 @@ func (a *index) buildGlobalCollections(
 			localServiceEntries,
 			localGatewayClasses,
 			LocalMeshConfig,
+			LocalServiceEntryVisibility,
 			localCluster.Namespaces(),
 			opts,
 		)

--- a/pilot/pkg/serviceregistry/ambient/policies.go
+++ b/pilot/pkg/serviceregistry/ambient/policies.go
@@ -42,6 +42,7 @@ func WaypointPolicyStatusCollection(
 	serviceEntries krt.Collection[*networkingclient.ServiceEntry],
 	gatewayClasses krt.Collection[*gatewayv1.GatewayClass],
 	meshConfig krt.Singleton[MeshConfig],
+	serviceEntryVisibility krt.Singleton[model.ServiceEntryVisibilityMatcher],
 	namespaces krt.Collection[*corev1.Namespace],
 	opts krt.OptionsBuilder,
 ) krt.Collection[model.WaypointPolicyStatus] {
@@ -105,7 +106,7 @@ func WaypointPolicyStatusCollection(
 				case gvk.Service.Kind:
 					fetchedServices := krt.Fetch(ctx, services, krt.FilterKey(key))
 					if len(fetchedServices) == 1 {
-						w, _ := fetchWaypointForService(ctx, waypoints, namespaces, fetchedServices[0].ObjectMeta)
+						w, _ := fetchWaypointForService(ctx, waypoints, namespaces, nil, fetchedServices[0].ObjectMeta)
 						if w != nil {
 							bound = true
 							reason = model.WaypointPolicyReasonAccepted
@@ -121,7 +122,7 @@ func WaypointPolicyStatusCollection(
 				case gvk.ServiceEntry.Kind:
 					fetchedServiceEntries := krt.Fetch(ctx, serviceEntries, krt.FilterKey(key))
 					if len(fetchedServiceEntries) == 1 {
-						w, _ := fetchWaypointForService(ctx, waypoints, namespaces, fetchedServiceEntries[0].ObjectMeta)
+						w, _ := fetchWaypointForService(ctx, waypoints, namespaces, serviceEntryVisibility, fetchedServiceEntries[0].ObjectMeta)
 						if w != nil {
 							bound = true
 							reason = model.WaypointPolicyReasonAccepted

--- a/pilot/pkg/serviceregistry/ambient/services.go
+++ b/pilot/pkg/serviceregistry/ambient/services.go
@@ -20,6 +20,7 @@ import (
 	"net/netip"
 	"strconv"
 
+	"google.golang.org/protobuf/proto"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -71,7 +72,8 @@ func (a Builder) ServicesCollection(
 			}),
 		)...)
 
-	ServiceEntriesInfo := krt.NewManyCollection(serviceEntries, a.serviceEntryServiceBuilder(waypoints, namespaces, meshConfig),
+	serviceEntryVisibility := ServiceEntryVisibilityCollection(meshConfig, opts)
+	ServiceEntriesInfo := krt.NewManyCollection(serviceEntries, a.serviceEntryServiceBuilder(waypoints, namespaces, serviceEntryVisibility),
 		append(
 			opts.WithName("ServiceEntriesInfo"),
 			krt.WithMetadata(krt.Metadata{
@@ -424,62 +426,130 @@ func matchServiceScope(ctx krt.HandlerContext, meshCfg *MeshConfig, namespaces k
 	return model.Local
 }
 
-// visibilityInput carries everything a serviceEntryVisibility MatchRule may need to
-// evaluate. Bundling the source ServiceEntry, the per-host translated Service, and the
-// namespace labels means adding a future matcher (e.g. hostnameSuffix, addressInCidr) is a
-// new case in visibilityRuleMatches, not a signature change.
+// visibilityInput carries everything a serviceEntryVisibility rule may need to evaluate.
+// Bundling the source ServiceEntry, the per-host translated Service, and the namespace
+// labels means adding a future matcher (e.g. hostnameSuffix, addressInCidr) is a new case in
+// compileVisibilityRule/compiledVisibilityRule.matches, not a signature change.
 type visibilityInput struct {
 	se       *networkingclient.ServiceEntry
 	svc      *workloadapi.Service
 	nsLabels labels.Set
 }
 
-// serviceEntryVisibility resolves the WDS visibility for a single ServiceEntry-derived
-// service by evaluating the mesh's serviceEntryVisibility policies: the first policy whose
-// rules all match wins, otherwise defaultVisibility applies. It returns nil when the
-// service should not be published at all (NONE). When serviceEntryVisibility is unset,
-// services are PUBLIC, preserving legacy behavior.
-func serviceEntryVisibility(meshCfg *MeshConfig, in visibilityInput) *workloadapi.Service_Visibility {
-	if meshCfg == nil || meshCfg.GetServiceEntryVisibility() == nil {
-		return ptr.Of(workloadapi.Service_PUBLIC)
-	}
-	sev := meshCfg.GetServiceEntryVisibility()
-	resolved := sev.GetDefaultVisibility()
-	for _, policy := range sev.GetPolicies() {
-		if visibilityPolicyMatches(policy, in) {
-			resolved = policy.GetVisibility()
-			break
-		}
-	}
-	return toWDSVisibility(resolved)
+// compiledVisibility is the precompiled, dependency-narrowed projection of
+// MeshConfig.serviceEntryVisibility. It is produced once per serviceEntryVisibility change
+// (see ServiceEntryVisibilityCollection) rather than per ServiceEntry/host, so label
+// selectors are converted only once and ServiceEntry processing recomputes only when the
+// visibility config actually changes.
+type compiledVisibility struct {
+	// defaultVisibility is applied when no policy matches (nil => NONE, i.e. do not publish).
+	defaultVisibility *workloadapi.Service_Visibility
+	policies          []compiledVisibilityPolicy
+	// source is retained only for equality, so krt dedupes on the underlying config and does
+	// not treat a recompiled-but-identical value as a change.
+	source *meshapi.ServiceEntryVisibility
 }
 
-// visibilityPolicyMatches reports whether all of a policy's rules match (AND semantics).
-// An empty rule list matches everything, making the policy a catch-all.
-func visibilityPolicyMatches(policy *meshapi.ServiceEntryVisibility_Policy, in visibilityInput) bool {
-	for _, rule := range policy.GetMatchingRules() {
-		if !visibilityRuleMatches(rule, in) {
+type compiledVisibilityPolicy struct {
+	visibility *workloadapi.Service_Visibility // nil => NONE (drop)
+	rules      []compiledVisibilityRule
+}
+
+type compiledVisibilityRule struct {
+	// namespaceSelector is set for a namespace_selector matcher. A nil selector never matches
+	// (unknown/unset matcher), so a malformed rule fails closed.
+	namespaceSelector labels.Selector
+}
+
+func (c compiledVisibility) ResourceName() string { return "ServiceEntryVisibility" }
+
+func (c compiledVisibility) Equals(other compiledVisibility) bool {
+	return proto.Equal(c.source, other.source)
+}
+
+// visibilityFor resolves the WDS visibility for one host: the first policy whose rules all
+// match wins, otherwise defaultVisibility. A nil result means the service is not published
+// (NONE). A nil receiver (visibility not yet computed) defaults to PUBLIC (legacy behavior).
+func (c *compiledVisibility) visibilityFor(in visibilityInput) *workloadapi.Service_Visibility {
+	if c == nil {
+		return ptr.Of(workloadapi.Service_PUBLIC)
+	}
+	for _, p := range c.policies {
+		if p.matches(in) {
+			return p.visibility
+		}
+	}
+	return c.defaultVisibility
+}
+
+// matches reports whether all of a policy's rules match (AND semantics). An empty rule list
+// matches everything, making the policy a catch-all.
+func (p compiledVisibilityPolicy) matches(in visibilityInput) bool {
+	for _, r := range p.rules {
+		if !r.matches(in) {
 			return false
 		}
 	}
 	return true
 }
 
-// visibilityRuleMatches evaluates a single matcher against the feature it concerns. Only
+func (r compiledVisibilityRule) matches(in visibilityInput) bool {
+	if r.namespaceSelector != nil {
+		return r.namespaceSelector.Matches(in.nsLabels)
+	}
+	return false
+}
+
+// ServiceEntryVisibilityCollection derives a precompiled serviceEntryVisibility singleton
+// from the mesh config. ServiceEntry processing depends on this narrow projection rather
+// than the full MeshConfig, so unrelated MeshConfig changes do not trigger a ServiceEntry
+// recompute, and label selectors are compiled once here instead of per host.
+func ServiceEntryVisibilityCollection(meshConfig krt.Singleton[MeshConfig], opts krt.OptionsBuilder) krt.Singleton[compiledVisibility] {
+	return krt.NewSingleton[compiledVisibility](func(ctx krt.HandlerContext) *compiledVisibility {
+		meshCfg := krt.FetchOne(ctx, meshConfig.AsCollection())
+		var sev *meshapi.ServiceEntryVisibility
+		if meshCfg != nil {
+			sev = meshCfg.GetServiceEntryVisibility()
+		}
+		return ptr.Of(compileServiceEntryVisibility(sev))
+	}, opts.WithName("ServiceEntryVisibility")...)
+}
+
+// compileServiceEntryVisibility precompiles a serviceEntryVisibility config into a reusable
+// form. A nil config is legacy behavior: everything is PUBLIC.
+func compileServiceEntryVisibility(sev *meshapi.ServiceEntryVisibility) compiledVisibility {
+	if sev == nil {
+		return compiledVisibility{defaultVisibility: ptr.Of(workloadapi.Service_PUBLIC)}
+	}
+	out := compiledVisibility{
+		defaultVisibility: toWDSVisibility(sev.GetDefaultVisibility()),
+		source:            sev,
+	}
+	for _, policy := range sev.GetPolicies() {
+		cp := compiledVisibilityPolicy{visibility: toWDSVisibility(policy.GetVisibility())}
+		for _, rule := range policy.GetMatchingRules() {
+			cp.rules = append(cp.rules, compileVisibilityRule(rule))
+		}
+		out.policies = append(out.policies, cp)
+	}
+	return out
+}
+
+// compileVisibilityRule converts a single matcher into its precompiled form. Only
 // namespaceSelector is implemented today; future matchers read in.svc (hostname, addresses)
 // or in.se.Spec (declared addresses) without changing the input shape.
-func visibilityRuleMatches(rule *meshapi.ServiceEntryVisibility_MatchRule, in visibilityInput) bool {
+func compileVisibilityRule(rule *meshapi.ServiceEntryVisibility_MatchRule) compiledVisibilityRule {
 	switch rule.GetMatcher().(type) {
 	case *meshapi.ServiceEntryVisibility_MatchRule_NamespaceSelector:
 		sel, err := LabelSelectorAsSelector(rule.GetNamespaceSelector())
 		if err != nil {
 			log.Warnf("failed to convert serviceEntryVisibility namespace selector: %v", err)
-			return false
+			return compiledVisibilityRule{}
 		}
-		return sel.Matches(in.nsLabels)
+		return compiledVisibilityRule{namespaceSelector: sel}
 	default:
-		// Unknown or unset matcher does not match.
-		return false
+		// Unknown or unset matcher never matches.
+		return compiledVisibilityRule{}
 	}
 }
 
@@ -539,7 +609,7 @@ func (t TypedServiceInfo) Equals(other TypedServiceInfo) bool {
 func (a Builder) serviceEntryServiceBuilder(
 	waypoints krt.Collection[Waypoint],
 	namespaces krt.Collection[*v1.Namespace],
-	meshConfig krt.Singleton[MeshConfig],
+	visibility krt.Singleton[compiledVisibility],
 ) krt.TransformationMulti[*networkingclient.ServiceEntry, TypedServiceInfo] {
 	return func(ctx krt.HandlerContext, s *networkingclient.ServiceEntry) []TypedServiceInfo {
 		waypoint, waypointError := fetchWaypointForService(ctx, waypoints, namespaces, s.ObjectMeta)
@@ -554,7 +624,7 @@ func (a Builder) serviceEntryServiceBuilder(
 
 		serviceInfos := serviceEntriesInfo(
 			ctx, s, waypoints, namespaces, waypoint, waypointError,
-			nsAnnotations, nsLabels, meshConfig, a.Networks.FetchLocalNetworkID,
+			nsAnnotations, nsLabels, visibility, a.Networks.FetchLocalNetworkID,
 		)
 		return slices.Map(serviceInfos, func(si model.ServiceInfo) TypedServiceInfo {
 			return TypedServiceInfo{ServiceInfo: si}
@@ -571,7 +641,7 @@ func serviceEntriesInfo(
 	wperr *model.StatusMessage,
 	nsAnnotations map[string]string,
 	nsLabels map[string]string,
-	meshConfig krt.Singleton[MeshConfig],
+	visibility krt.Singleton[compiledVisibility],
 	networkGetter func(ctx krt.HandlerContext) network.ID,
 ) []model.ServiceInfo {
 	sel := model.NewSelector(s.Spec.GetWorkloadSelector().GetLabels())
@@ -598,19 +668,19 @@ func serviceEntriesInfo(
 
 	weighted := buildWeightedWaypoints(ctx, waypoints, namespaces, s.ObjectMeta, w, &waypoint)
 
-	meshCfg := krt.FetchOne(ctx, meshConfig.AsCollection())
+	vis := krt.FetchOne(ctx, visibility.AsCollection())
 	services := constructServiceEntries(ctx, s, w, nsAnnotations, networkGetter)
 	result := make([]model.ServiceInfo, 0, len(services))
 	for _, e := range services {
-		// Resolve visibility per host from the mesh's serviceEntryVisibility policies.
+		// Resolve visibility per host from the precompiled serviceEntryVisibility.
 		// A nil result means NONE: the ServiceEntry may be written, but Istio configures no
 		// dataplane for this host, so it is not published to WDS.
-		visibility := serviceEntryVisibility(meshCfg, visibilityInput{se: s, svc: e, nsLabels: labels.Set(nsLabels)})
-		if visibility == nil {
+		hostVisibility := vis.visibilityFor(visibilityInput{se: s, svc: e, nsLabels: labels.Set(nsLabels)})
+		if hostVisibility == nil {
 			log.Debugf("ServiceEntry %s/%s host %s resolves to visibility NONE; not configuring", s.Namespace, s.Name, e.Hostname)
 			continue
 		}
-		e.Visibility = *visibility
+		e.Visibility = *hostVisibility
 		e.IngressUseWaypoint = waypoint.IngressUseWaypoint
 		e.WeightedWaypoints = weighted
 		result = append(result, precomputeService(model.ServiceInfo{

--- a/pilot/pkg/serviceregistry/ambient/services.go
+++ b/pilot/pkg/serviceregistry/ambient/services.go
@@ -21,9 +21,7 @@ import (
 	"strconv"
 
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 
 	"istio.io/api/label"
 	meshapi "istio.io/api/mesh/v1alpha1"
@@ -37,6 +35,7 @@ import (
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/host"
+	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/kind"
@@ -337,47 +336,6 @@ func typedServiceServiceBuilder(
 	}
 }
 
-// LabelSelectorAsSelector converts a mesh api LabelSelector to a labels.Selector.
-func LabelSelectorAsSelector(ps *meshapi.LabelSelector) (labels.Selector, error) {
-	if ps == nil {
-		return labels.Nothing(), nil
-	}
-	if len(ps.MatchLabels)+len(ps.MatchExpressions) == 0 {
-		return labels.Everything(), nil
-	}
-	requirements := make([]labels.Requirement, 0, len(ps.MatchLabels)+len(ps.MatchExpressions))
-	for k, v := range ps.MatchLabels {
-		r, err := labels.NewRequirement(k, selection.Equals, []string{v})
-		if err != nil {
-			return nil, err
-		}
-		requirements = append(requirements, *r)
-	}
-	for _, expr := range ps.MatchExpressions {
-		var op selection.Operator
-		switch metav1.LabelSelectorOperator(expr.Operator) {
-		case metav1.LabelSelectorOpIn:
-			op = selection.In
-		case metav1.LabelSelectorOpNotIn:
-			op = selection.NotIn
-		case metav1.LabelSelectorOpExists:
-			op = selection.Exists
-		case metav1.LabelSelectorOpDoesNotExist:
-			op = selection.DoesNotExist
-		default:
-			return nil, fmt.Errorf("%q is not a valid label selector operator", expr.Operator)
-		}
-		r, err := labels.NewRequirement(expr.Key, op, append([]string(nil), expr.Values...))
-		if err != nil {
-			return nil, err
-		}
-		requirements = append(requirements, *r)
-	}
-	selector := labels.NewSelector()
-	selector = selector.Add(requirements...)
-	return selector, nil
-}
-
 func matchServiceScope(ctx krt.HandlerContext, meshCfg *MeshConfig, namespaces krt.Collection[*v1.Namespace], s *v1.Service) model.ServiceScope {
 	// Apply label selectors from the MeshConfig's servieScopeConfig to determine the scope of the service based on the namespace
 	// or service label matches
@@ -385,7 +343,7 @@ func matchServiceScope(ctx krt.HandlerContext, meshCfg *MeshConfig, namespaces k
 	for _, scopeConfig := range meshCfg.ServiceScopeConfigs {
 		// Match namespace labels
 		// Treat Nothing selectors as Everything selectors
-		nss, err := LabelSelectorAsSelector(scopeConfig.NamespaceSelector)
+		nss, err := mesh.LabelSelectorAsSelector(scopeConfig.NamespaceSelector)
 		if err != nil {
 			log.Warnf("failed to convert namespace selector: %v", err)
 			continue
@@ -393,7 +351,7 @@ func matchServiceScope(ctx krt.HandlerContext, meshCfg *MeshConfig, namespaces k
 		if nss.String() == labels.Nothing().String() {
 			nss = labels.Everything()
 		}
-		ss, err := LabelSelectorAsSelector(scopeConfig.ServicesSelector)
+		ss, err := mesh.LabelSelectorAsSelector(scopeConfig.ServicesSelector)
 		if err != nil {
 			log.Warnf("failed to convert service selector: %v", err)
 			continue

--- a/pilot/pkg/serviceregistry/ambient/services.go
+++ b/pilot/pkg/serviceregistry/ambient/services.go
@@ -20,7 +20,6 @@ import (
 	"net/netip"
 	"strconv"
 
-	"google.golang.org/protobuf/proto"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -426,145 +425,31 @@ func matchServiceScope(ctx krt.HandlerContext, meshCfg *MeshConfig, namespaces k
 	return model.Local
 }
 
-// visibilityInput carries everything a serviceEntryVisibility rule may need to evaluate.
-// Bundling the source ServiceEntry, the per-host translated Service, and the namespace
-// labels means adding a future matcher (e.g. hostnameSuffix, addressInCidr) is a new case in
-// compileVisibilityRule/compiledVisibilityRule.matches, not a signature change.
-type visibilityInput struct {
-	se       *networkingclient.ServiceEntry
-	svc      *workloadapi.Service
-	nsLabels labels.Set
-}
-
-// compiledVisibility is the precompiled, dependency-narrowed projection of
-// MeshConfig.serviceEntryVisibility. It is produced once per serviceEntryVisibility change
-// (see ServiceEntryVisibilityCollection) rather than per ServiceEntry/host, so label
-// selectors are converted only once and ServiceEntry processing recomputes only when the
-// visibility config actually changes.
-type compiledVisibility struct {
-	// defaultVisibility is applied when no policy matches (nil => NONE, i.e. do not publish).
-	defaultVisibility *workloadapi.Service_Visibility
-	policies          []compiledVisibilityPolicy
-	// source is retained only for equality, so krt dedupes on the underlying config and does
-	// not treat a recompiled-but-identical value as a change.
-	source *meshapi.ServiceEntryVisibility
-}
-
-type compiledVisibilityPolicy struct {
-	visibility *workloadapi.Service_Visibility // nil => NONE (drop)
-	rules      []compiledVisibilityRule
-}
-
-type compiledVisibilityRule struct {
-	// namespaceSelector is set for a namespace_selector matcher. A nil selector never matches
-	// (unknown/unset matcher), so a malformed rule fails closed.
-	namespaceSelector labels.Selector
-}
-
-func (c compiledVisibility) ResourceName() string { return "ServiceEntryVisibility" }
-
-func (c compiledVisibility) Equals(other compiledVisibility) bool {
-	return proto.Equal(c.source, other.source)
-}
-
-// visibilityFor resolves the WDS visibility for one host: the first policy whose rules all
-// match wins, otherwise defaultVisibility. A nil result means the service is not published
-// (NONE). A nil receiver (visibility not yet computed) defaults to PUBLIC (legacy behavior).
-func (c *compiledVisibility) visibilityFor(in visibilityInput) *workloadapi.Service_Visibility {
-	if c == nil {
-		return ptr.Of(workloadapi.Service_PUBLIC)
-	}
-	for _, p := range c.policies {
-		if p.matches(in) {
-			return p.visibility
-		}
-	}
-	return c.defaultVisibility
-}
-
-// matches reports whether all of a policy's rules match (AND semantics). An empty rule list
-// matches everything, making the policy a catch-all.
-func (p compiledVisibilityPolicy) matches(in visibilityInput) bool {
-	for _, r := range p.rules {
-		if !r.matches(in) {
-			return false
-		}
-	}
-	return true
-}
-
-func (r compiledVisibilityRule) matches(in visibilityInput) bool {
-	if r.namespaceSelector != nil {
-		return r.namespaceSelector.Matches(in.nsLabels)
-	}
-	return false
-}
-
-// ServiceEntryVisibilityCollection derives a precompiled serviceEntryVisibility singleton
-// from the mesh config. ServiceEntry processing depends on this narrow projection rather
-// than the full MeshConfig, so unrelated MeshConfig changes do not trigger a ServiceEntry
-// recompute, and label selectors are compiled once here instead of per host.
-func ServiceEntryVisibilityCollection(meshConfig krt.Singleton[MeshConfig], opts krt.OptionsBuilder) krt.Singleton[compiledVisibility] {
-	return krt.NewSingleton[compiledVisibility](func(ctx krt.HandlerContext) *compiledVisibility {
+// ServiceEntryVisibilityCollection derives the shared, precompiled serviceEntryVisibility matcher
+// (model.ServiceEntryVisibilityMatcher) as a singleton from the mesh config. ServiceEntry
+// processing depends on this narrow projection rather than the full MeshConfig, so unrelated
+// MeshConfig changes do not trigger a ServiceEntry recompute, and label selectors are compiled
+// once here instead of per host. The same matcher type is used by the sidecar (serviceentry)
+// registry so both dataplanes evaluate visibility identically.
+func ServiceEntryVisibilityCollection(meshConfig krt.Singleton[MeshConfig], opts krt.OptionsBuilder) krt.Singleton[model.ServiceEntryVisibilityMatcher] {
+	return krt.NewSingleton[model.ServiceEntryVisibilityMatcher](func(ctx krt.HandlerContext) *model.ServiceEntryVisibilityMatcher {
 		meshCfg := krt.FetchOne(ctx, meshConfig.AsCollection())
 		var sev *meshapi.ServiceEntryVisibility
 		if meshCfg != nil {
 			sev = meshCfg.GetServiceEntryVisibility()
 		}
-		return ptr.Of(compileServiceEntryVisibility(sev))
+		return model.CompileServiceEntryVisibility(sev)
 	}, opts.WithName("ServiceEntryVisibility")...)
 }
 
-// compileServiceEntryVisibility precompiles a serviceEntryVisibility config into a reusable
-// form. A nil config is legacy behavior: everything is PUBLIC.
-func compileServiceEntryVisibility(sev *meshapi.ServiceEntryVisibility) compiledVisibility {
-	if sev == nil {
-		return compiledVisibility{defaultVisibility: ptr.Of(workloadapi.Service_PUBLIC)}
+// wdsVisibility maps the neutral resolved visibility to the WDS Service visibility field. NONE has
+// no WDS representation (such services are dropped before this is called), so only the
+// PUBLIC/NAMESPACE cases are relevant here.
+func wdsVisibility(v model.ServiceVisibility) workloadapi.Service_Visibility {
+	if v == model.ServiceVisibilityNamespace {
+		return workloadapi.Service_NAMESPACE
 	}
-	out := compiledVisibility{
-		defaultVisibility: toWDSVisibility(sev.GetDefaultVisibility()),
-		source:            sev,
-	}
-	for _, policy := range sev.GetPolicies() {
-		cp := compiledVisibilityPolicy{visibility: toWDSVisibility(policy.GetVisibility())}
-		for _, rule := range policy.GetMatchingRules() {
-			cp.rules = append(cp.rules, compileVisibilityRule(rule))
-		}
-		out.policies = append(out.policies, cp)
-	}
-	return out
-}
-
-// compileVisibilityRule converts a single matcher into its precompiled form. Only
-// namespaceSelector is implemented today; future matchers read in.svc (hostname, addresses)
-// or in.se.Spec (declared addresses) without changing the input shape.
-func compileVisibilityRule(rule *meshapi.ServiceEntryVisibility_MatchRule) compiledVisibilityRule {
-	switch rule.GetMatcher().(type) {
-	case *meshapi.ServiceEntryVisibility_MatchRule_NamespaceSelector:
-		sel, err := LabelSelectorAsSelector(rule.GetNamespaceSelector())
-		if err != nil {
-			log.Warnf("failed to convert serviceEntryVisibility namespace selector: %v", err)
-			return compiledVisibilityRule{}
-		}
-		return compiledVisibilityRule{namespaceSelector: sel}
-	default:
-		// Unknown or unset matcher never matches.
-		return compiledVisibilityRule{}
-	}
-}
-
-// toWDSVisibility maps a MeshConfig visibility to the WDS Service visibility, returning nil
-// when the service should not be published (NONE).
-func toWDSVisibility(v meshapi.ServiceEntryVisibility_Visibility) *workloadapi.Service_Visibility {
-	switch v {
-	case meshapi.ServiceEntryVisibility_NAMESPACE:
-		return ptr.Of(workloadapi.Service_NAMESPACE)
-	case meshapi.ServiceEntryVisibility_NONE:
-		return nil
-	default:
-		// PUBLIC and VISIBILITY_UNSPECIFIED both resolve to PUBLIC (legacy behavior).
-		return ptr.Of(workloadapi.Service_PUBLIC)
-	}
+	return workloadapi.Service_PUBLIC
 }
 
 func (a Builder) serviceServiceBuilder(
@@ -609,7 +494,7 @@ func (t TypedServiceInfo) Equals(other TypedServiceInfo) bool {
 func (a Builder) serviceEntryServiceBuilder(
 	waypoints krt.Collection[Waypoint],
 	namespaces krt.Collection[*v1.Namespace],
-	visibility krt.Singleton[compiledVisibility],
+	visibility krt.Singleton[model.ServiceEntryVisibilityMatcher],
 ) krt.TransformationMulti[*networkingclient.ServiceEntry, TypedServiceInfo] {
 	return func(ctx krt.HandlerContext, s *networkingclient.ServiceEntry) []TypedServiceInfo {
 		waypoint, waypointError := fetchWaypointForService(ctx, waypoints, namespaces, s.ObjectMeta)
@@ -641,7 +526,7 @@ func serviceEntriesInfo(
 	wperr *model.StatusMessage,
 	nsAnnotations map[string]string,
 	nsLabels map[string]string,
-	visibility krt.Singleton[compiledVisibility],
+	visibility krt.Singleton[model.ServiceEntryVisibilityMatcher],
 	networkGetter func(ctx krt.HandlerContext) network.ID,
 ) []model.ServiceInfo {
 	sel := model.NewSelector(s.Spec.GetWorkloadSelector().GetLabels())
@@ -669,6 +554,14 @@ func serviceEntriesInfo(
 	weighted := buildWeightedWaypoints(ctx, waypoints, namespaces, s.ObjectMeta, w, &waypoint)
 
 	vis := krt.FetchOne(ctx, visibility.AsCollection())
+	// Resolve the ServiceEntry's visibility once from the precompiled serviceEntryVisibility; it is
+	// uniform across the ServiceEntry's hosts. NONE means Istio configures no dataplane for it, so it
+	// is not published to WDS.
+	resolvedVisibility := vis.VisibilityFor(nsLabels)
+	if resolvedVisibility == model.ServiceVisibilityNone {
+		log.Debugf("ServiceEntry %s/%s resolves to visibility NONE; not configuring", s.Namespace, s.Name)
+		return nil
+	}
 	services := constructServiceEntries(ctx, s, w, nsAnnotations, networkGetter)
 	// A ServiceEntry host with NAMESPACE visibility must not bind to a waypoint in another
 	// namespace: that would expose the namespace-scoped service to the waypoint's namespace, a leak
@@ -678,20 +571,13 @@ func serviceEntriesInfo(
 	crossNamespaceWaypoint := w != nil && w.Namespace != s.Namespace
 	result := make([]model.ServiceInfo, 0, len(services))
 	for _, e := range services {
-		// Resolve visibility per host from the precompiled serviceEntryVisibility.
-		// A nil result means NONE: the ServiceEntry may be written, but Istio configures no
-		// dataplane for this host, so it is not published to WDS.
-		hostVisibility := vis.visibilityFor(visibilityInput{se: s, svc: e, nsLabels: labels.Set(nsLabels)})
-		if hostVisibility == nil {
-			log.Debugf("ServiceEntry %s/%s host %s resolves to visibility NONE; not configuring", s.Namespace, s.Name, e.Hostname)
-			continue
-		}
-		e.Visibility = *hostVisibility
+		e.Visibility = wdsVisibility(resolvedVisibility)
+
 		// Fail (never silently retarget to a same-named colocated waypoint) a cross-namespace
 		// waypoint binding for a namespace-scoped host: drop the binding for this host and surface
 		// the reason via status.
 		hostWaypoint := waypoint
-		if *hostVisibility == workloadapi.Service_NAMESPACE && crossNamespaceWaypoint {
+		if resolvedVisibility == model.ServiceVisibilityNamespace && crossNamespaceWaypoint {
 			log.Debugf("ServiceEntry %s/%s host %s has NAMESPACE visibility; refusing cross-namespace waypoint %s",
 				s.Namespace, s.Name, e.Hostname, w.ResourceName())
 			e.Waypoint = nil

--- a/pilot/pkg/serviceregistry/ambient/services.go
+++ b/pilot/pkg/serviceregistry/ambient/services.go
@@ -59,6 +59,7 @@ func (a Builder) ServicesCollection(
 	waypoints krt.Collection[Waypoint],
 	namespaces krt.Collection[*v1.Namespace],
 	meshConfig krt.Singleton[MeshConfig],
+	serviceEntryVisibility krt.Singleton[model.ServiceEntryVisibilityMatcher],
 	opts krt.OptionsBuilder,
 	precompute bool,
 ) krt.Collection[model.ServiceInfo] {
@@ -70,7 +71,6 @@ func (a Builder) ServicesCollection(
 			}),
 		)...)
 
-	serviceEntryVisibility := model.ServiceEntryVisibilityCollection(meshConfig.AsCollection(), opts)
 	ServiceEntriesInfo := krt.NewManyCollection(serviceEntries, a.serviceEntryServiceBuilder(waypoints, namespaces, serviceEntryVisibility),
 		append(
 			opts.WithName("ServiceEntriesInfo"),
@@ -277,7 +277,7 @@ func serviceServiceBuilder(
 		}
 		ns := krt.FetchOne(ctx, namespaces, krt.FilterKey(s.Namespace))
 		waypointStatus := model.WaypointBindingStatus{}
-		waypoint, wperr := fetchWaypointForService(ctx, waypoints, namespaces, s.ObjectMeta)
+		waypoint, wperr := fetchWaypointForService(ctx, waypoints, namespaces, nil, s.ObjectMeta)
 		if waypoint != nil {
 			waypointStatus.ResourceName = waypoint.ResourceName()
 			var nsLabels map[string]string
@@ -442,7 +442,7 @@ func (a Builder) serviceEntryServiceBuilder(
 	visibility krt.Singleton[model.ServiceEntryVisibilityMatcher],
 ) krt.TransformationMulti[*networkingclient.ServiceEntry, TypedServiceInfo] {
 	return func(ctx krt.HandlerContext, s *networkingclient.ServiceEntry) []TypedServiceInfo {
-		waypoint, waypointError := fetchWaypointForService(ctx, waypoints, namespaces, s.ObjectMeta)
+		waypoint, waypointError := fetchWaypointForService(ctx, waypoints, namespaces, visibility, s.ObjectMeta)
 
 		ns := krt.FetchOne(ctx, namespaces, krt.FilterKey(s.Namespace))
 		var nsAnnotations map[string]string
@@ -510,34 +510,17 @@ func serviceEntriesInfo(
 		return nil
 	}
 	services := constructServiceEntries(ctx, s, w, nsAnnotations, networkGetter)
-	// A ServiceEntry host with NAMESPACE visibility must not bind to a waypoint in another
-	// namespace: that would expose the namespace-scoped service to the waypoint's namespace, a leak
-	// the data plane can't currently contain. Only use-waypoint-namespace (on the ServiceEntry or
-	// inherited from its namespace) can resolve a waypoint outside the ServiceEntry's namespace, so
-	// a differing namespace is exactly that case. Detect it here; fail the binding per host below.
-	crossNamespaceWaypoint := w != nil && w.Namespace != s.Namespace
 	result := make([]model.ServiceInfo, 0, len(services))
 	for _, e := range services {
 		e.Visibility = wdsVisibility(resolvedVisibility)
-
-		// Fail (never silently retarget to a same-named colocated waypoint) a cross-namespace
-		// waypoint binding for a namespace-scoped host: drop the binding for this host and surface
-		// the reason via status.
-		hostWaypoint := waypoint
-		if resolvedVisibility == model.ServiceVisibilityNamespace && crossNamespaceWaypoint {
-			log.Debugf("ServiceEntry %s/%s host %s has NAMESPACE visibility; refusing cross-namespace waypoint %s",
-				s.Namespace, s.Name, e.Hostname, w.ResourceName())
-			e.Waypoint = nil
-			hostWaypoint = model.WaypointBindingStatus{Error: ReportWaypointCrossNamespaceForbidden(w.ResourceName())}
-		}
-		e.IngressUseWaypoint = hostWaypoint.IngressUseWaypoint
+		e.IngressUseWaypoint = waypoint.IngressUseWaypoint
 		e.WeightedWaypoints = weighted
 		result = append(result, precomputeService(model.ServiceInfo{
 			Service:            e,
 			PortNames:          portNames,
 			LabelSelector:      sel,
 			Source:             MakeSource(s),
-			Waypoint:           hostWaypoint,
+			Waypoint:           waypoint,
 			DNSConnectStrategy: model.GetDNSConnectStrategy(s.Annotations),
 			CreationTime:       s.CreationTimestamp.Time,
 		}))

--- a/pilot/pkg/serviceregistry/ambient/services.go
+++ b/pilot/pkg/serviceregistry/ambient/services.go
@@ -35,7 +35,7 @@ import (
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/host"
-	"istio.io/istio/pkg/config/mesh"
+	"istio.io/istio/pkg/config/mesh/labelselector"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/kind"
@@ -347,7 +347,7 @@ func matchServiceScope(ctx krt.HandlerContext, meshCfg *MeshConfig, namespaces k
 	for _, scopeConfig := range meshCfg.ServiceScopeConfigs {
 		// Match namespace labels
 		// Treat Nothing selectors as Everything selectors
-		nss, err := mesh.LabelSelectorAsSelector(scopeConfig.NamespaceSelector)
+		nss, err := labelselector.LabelSelectorAsSelector(scopeConfig.NamespaceSelector)
 		if err != nil {
 			log.Warnf("failed to convert namespace selector: %v", err)
 			continue
@@ -355,7 +355,7 @@ func matchServiceScope(ctx krt.HandlerContext, meshCfg *MeshConfig, namespaces k
 		if nss.String() == labels.Nothing().String() {
 			nss = labels.Everything()
 		}
-		ss, err := mesh.LabelSelectorAsSelector(scopeConfig.ServicesSelector)
+		ss, err := labelselector.LabelSelectorAsSelector(scopeConfig.ServicesSelector)
 		if err != nil {
 			log.Warnf("failed to convert service selector: %v", err)
 			continue

--- a/pilot/pkg/serviceregistry/ambient/services.go
+++ b/pilot/pkg/serviceregistry/ambient/services.go
@@ -509,6 +509,9 @@ func serviceEntriesInfo(
 		// https://github.com/istio/istio/issues/60908
 		return nil
 	}
+	// Gate the visibility status on whether the feature is configured; an unset mesh writes no
+	// condition. The status value itself comes from the WDS Service.Visibility set above.
+	visibilityConfigured := vis.Configured()
 	services := constructServiceEntries(ctx, s, w, nsAnnotations, networkGetter)
 	result := make([]model.ServiceInfo, 0, len(services))
 	for _, e := range services {
@@ -516,13 +519,14 @@ func serviceEntriesInfo(
 		e.IngressUseWaypoint = waypoint.IngressUseWaypoint
 		e.WeightedWaypoints = weighted
 		result = append(result, precomputeService(model.ServiceInfo{
-			Service:            e,
-			PortNames:          portNames,
-			LabelSelector:      sel,
-			Source:             MakeSource(s),
-			Waypoint:           waypoint,
-			DNSConnectStrategy: model.GetDNSConnectStrategy(s.Annotations),
-			CreationTime:       s.CreationTimestamp.Time,
+			Service:              e,
+			PortNames:            portNames,
+			LabelSelector:        sel,
+			Source:               MakeSource(s),
+			Waypoint:             waypoint,
+			DNSConnectStrategy:   model.GetDNSConnectStrategy(s.Annotations),
+			CreationTime:         s.CreationTimestamp.Time,
+			VisibilityConfigured: visibilityConfigured,
 		}))
 	}
 	return result

--- a/pilot/pkg/serviceregistry/ambient/services.go
+++ b/pilot/pkg/serviceregistry/ambient/services.go
@@ -71,7 +71,7 @@ func (a Builder) ServicesCollection(
 			}),
 		)...)
 
-	ServiceEntriesInfo := krt.NewManyCollection(serviceEntries, a.serviceEntryServiceBuilder(waypoints, namespaces),
+	ServiceEntriesInfo := krt.NewManyCollection(serviceEntries, a.serviceEntryServiceBuilder(waypoints, namespaces, meshConfig),
 		append(
 			opts.WithName("ServiceEntriesInfo"),
 			krt.WithMetadata(krt.Metadata{
@@ -120,6 +120,10 @@ func (a Builder) ServicesCollection(
 					bestByNamespace[tsiNamespace] = tsi.ServiceInfo
 				} else {
 					// if we are not the best for our namespace, then we don't need to worry about being canonical
+					continue
+				}
+				// namespace visibility should not take canonical
+				if tsi.Service.GetVisibility() == workloadapi.Service_NAMESPACE {
 					continue
 				}
 				if canonical == nil || isBetter(tsi.ServiceInfo, *canonical) {
@@ -420,6 +424,79 @@ func matchServiceScope(ctx krt.HandlerContext, meshCfg *MeshConfig, namespaces k
 	return model.Local
 }
 
+// visibilityInput carries everything a serviceEntryVisibility MatchRule may need to
+// evaluate. Bundling the source ServiceEntry, the per-host translated Service, and the
+// namespace labels means adding a future matcher (e.g. hostnameSuffix, addressInCidr) is a
+// new case in visibilityRuleMatches, not a signature change.
+type visibilityInput struct {
+	se       *networkingclient.ServiceEntry
+	svc      *workloadapi.Service
+	nsLabels labels.Set
+}
+
+// serviceEntryVisibility resolves the WDS visibility for a single ServiceEntry-derived
+// service by evaluating the mesh's serviceEntryVisibility policies: the first policy whose
+// rules all match wins, otherwise defaultVisibility applies. It returns nil when the
+// service should not be published at all (NONE). When serviceEntryVisibility is unset,
+// services are PUBLIC, preserving legacy behavior.
+func serviceEntryVisibility(meshCfg *MeshConfig, in visibilityInput) *workloadapi.Service_Visibility {
+	if meshCfg == nil || meshCfg.GetServiceEntryVisibility() == nil {
+		return ptr.Of(workloadapi.Service_PUBLIC)
+	}
+	sev := meshCfg.GetServiceEntryVisibility()
+	resolved := sev.GetDefaultVisibility()
+	for _, policy := range sev.GetPolicies() {
+		if visibilityPolicyMatches(policy, in) {
+			resolved = policy.GetVisibility()
+			break
+		}
+	}
+	return toWDSVisibility(resolved)
+}
+
+// visibilityPolicyMatches reports whether all of a policy's rules match (AND semantics).
+// An empty rule list matches everything, making the policy a catch-all.
+func visibilityPolicyMatches(policy *meshapi.ServiceEntryVisibility_Policy, in visibilityInput) bool {
+	for _, rule := range policy.GetMatchingRules() {
+		if !visibilityRuleMatches(rule, in) {
+			return false
+		}
+	}
+	return true
+}
+
+// visibilityRuleMatches evaluates a single matcher against the feature it concerns. Only
+// namespaceSelector is implemented today; future matchers read in.svc (hostname, addresses)
+// or in.se.Spec (declared addresses) without changing the input shape.
+func visibilityRuleMatches(rule *meshapi.ServiceEntryVisibility_MatchRule, in visibilityInput) bool {
+	switch rule.GetMatcher().(type) {
+	case *meshapi.ServiceEntryVisibility_MatchRule_NamespaceSelector:
+		sel, err := LabelSelectorAsSelector(rule.GetNamespaceSelector())
+		if err != nil {
+			log.Warnf("failed to convert serviceEntryVisibility namespace selector: %v", err)
+			return false
+		}
+		return sel.Matches(in.nsLabels)
+	default:
+		// Unknown or unset matcher does not match.
+		return false
+	}
+}
+
+// toWDSVisibility maps a MeshConfig visibility to the WDS Service visibility, returning nil
+// when the service should not be published (NONE).
+func toWDSVisibility(v meshapi.ServiceEntryVisibility_Visibility) *workloadapi.Service_Visibility {
+	switch v {
+	case meshapi.ServiceEntryVisibility_NAMESPACE:
+		return ptr.Of(workloadapi.Service_NAMESPACE)
+	case meshapi.ServiceEntryVisibility_NONE:
+		return nil
+	default:
+		// PUBLIC and VISIBILITY_UNSPECIFIED both resolve to PUBLIC (legacy behavior).
+		return ptr.Of(workloadapi.Service_PUBLIC)
+	}
+}
+
 func (a Builder) serviceServiceBuilder(
 	waypoints krt.Collection[Waypoint],
 	namespaces krt.Collection[*v1.Namespace],
@@ -462,6 +539,7 @@ func (t TypedServiceInfo) Equals(other TypedServiceInfo) bool {
 func (a Builder) serviceEntryServiceBuilder(
 	waypoints krt.Collection[Waypoint],
 	namespaces krt.Collection[*v1.Namespace],
+	meshConfig krt.Singleton[MeshConfig],
 ) krt.TransformationMulti[*networkingclient.ServiceEntry, TypedServiceInfo] {
 	return func(ctx krt.HandlerContext, s *networkingclient.ServiceEntry) []TypedServiceInfo {
 		waypoint, waypointError := fetchWaypointForService(ctx, waypoints, namespaces, s.ObjectMeta)
@@ -474,7 +552,10 @@ func (a Builder) serviceEntryServiceBuilder(
 			nsLabels = (*ns).Labels
 		}
 
-		serviceInfos := serviceEntriesInfo(ctx, s, waypoints, namespaces, waypoint, waypointError, nsAnnotations, nsLabels, a.Networks.FetchLocalNetworkID)
+		serviceInfos := serviceEntriesInfo(
+			ctx, s, waypoints, namespaces, waypoint, waypointError,
+			nsAnnotations, nsLabels, meshConfig, a.Networks.FetchLocalNetworkID,
+		)
 		return slices.Map(serviceInfos, func(si model.ServiceInfo) TypedServiceInfo {
 			return TypedServiceInfo{ServiceInfo: si}
 		})
@@ -490,6 +571,7 @@ func serviceEntriesInfo(
 	wperr *model.StatusMessage,
 	nsAnnotations map[string]string,
 	nsLabels map[string]string,
+	meshConfig krt.Singleton[MeshConfig],
 	networkGetter func(ctx krt.HandlerContext) network.ID,
 ) []model.ServiceInfo {
 	sel := model.NewSelector(s.Spec.GetWorkloadSelector().GetLabels())
@@ -516,10 +598,22 @@ func serviceEntriesInfo(
 
 	weighted := buildWeightedWaypoints(ctx, waypoints, namespaces, s.ObjectMeta, w, &waypoint)
 
-	return slices.Map(constructServiceEntries(ctx, s, w, nsAnnotations, networkGetter), func(e *workloadapi.Service) model.ServiceInfo {
+	meshCfg := krt.FetchOne(ctx, meshConfig.AsCollection())
+	services := constructServiceEntries(ctx, s, w, nsAnnotations, networkGetter)
+	result := make([]model.ServiceInfo, 0, len(services))
+	for _, e := range services {
+		// Resolve visibility per host from the mesh's serviceEntryVisibility policies.
+		// A nil result means NONE: the ServiceEntry may be written, but Istio configures no
+		// dataplane for this host, so it is not published to WDS.
+		visibility := serviceEntryVisibility(meshCfg, visibilityInput{se: s, svc: e, nsLabels: labels.Set(nsLabels)})
+		if visibility == nil {
+			log.Debugf("ServiceEntry %s/%s host %s resolves to visibility NONE; not configuring", s.Namespace, s.Name, e.Hostname)
+			continue
+		}
+		e.Visibility = *visibility
 		e.IngressUseWaypoint = waypoint.IngressUseWaypoint
 		e.WeightedWaypoints = weighted
-		return precomputeService(model.ServiceInfo{
+		result = append(result, precomputeService(model.ServiceInfo{
 			Service:            e,
 			PortNames:          portNames,
 			LabelSelector:      sel,
@@ -527,8 +621,9 @@ func serviceEntriesInfo(
 			Waypoint:           waypoint,
 			DNSConnectStrategy: model.GetDNSConnectStrategy(s.Annotations),
 			CreationTime:       s.CreationTimestamp.Time,
-		})
-	})
+		}))
+	}
+	return result
 }
 
 func constructServiceEntries(

--- a/pilot/pkg/serviceregistry/ambient/services.go
+++ b/pilot/pkg/serviceregistry/ambient/services.go
@@ -505,6 +505,8 @@ func serviceEntriesInfo(
 	resolvedVisibility := vis.VisibilityFor(nsLabels)
 	if resolvedVisibility == model.ServiceVisibilityNone {
 		log.Debugf("ServiceEntry %s/%s resolves to visibility NONE; not configuring", s.Namespace, s.Name)
+		// StatusBug: dropping the ServiceInfo means we can't write a condition that it was dropped.
+		// https://github.com/istio/istio/issues/60908
 		return nil
 	}
 	services := constructServiceEntries(ctx, s, w, nsAnnotations, networkGetter)

--- a/pilot/pkg/serviceregistry/ambient/services.go
+++ b/pilot/pkg/serviceregistry/ambient/services.go
@@ -70,7 +70,7 @@ func (a Builder) ServicesCollection(
 			}),
 		)...)
 
-	serviceEntryVisibility := ServiceEntryVisibilityCollection(meshConfig, opts)
+	serviceEntryVisibility := model.ServiceEntryVisibilityCollection(meshConfig.AsCollection(), opts)
 	ServiceEntriesInfo := krt.NewManyCollection(serviceEntries, a.serviceEntryServiceBuilder(waypoints, namespaces, serviceEntryVisibility),
 		append(
 			opts.WithName("ServiceEntriesInfo"),
@@ -381,23 +381,6 @@ func matchServiceScope(ctx krt.HandlerContext, meshCfg *MeshConfig, namespaces k
 	// Default to local scope if no match is found
 	log.Debugf("service %s/%s is locally scoped", s.Namespace, s.Name)
 	return model.Local
-}
-
-// ServiceEntryVisibilityCollection derives the shared, precompiled serviceEntryVisibility matcher
-// (model.ServiceEntryVisibilityMatcher) as a singleton from the mesh config. ServiceEntry
-// processing depends on this narrow projection rather than the full MeshConfig, so unrelated
-// MeshConfig changes do not trigger a ServiceEntry recompute, and label selectors are compiled
-// once here instead of per host. The same matcher type is used by the sidecar (serviceentry)
-// registry so both dataplanes evaluate visibility identically.
-func ServiceEntryVisibilityCollection(meshConfig krt.Singleton[MeshConfig], opts krt.OptionsBuilder) krt.Singleton[model.ServiceEntryVisibilityMatcher] {
-	return krt.NewSingleton[model.ServiceEntryVisibilityMatcher](func(ctx krt.HandlerContext) *model.ServiceEntryVisibilityMatcher {
-		meshCfg := krt.FetchOne(ctx, meshConfig.AsCollection())
-		var sev *meshapi.ServiceEntryVisibility
-		if meshCfg != nil {
-			sev = meshCfg.GetServiceEntryVisibility()
-		}
-		return model.CompileServiceEntryVisibility(sev)
-	}, opts.WithName("ServiceEntryVisibility")...)
 }
 
 // wdsVisibility maps the neutral resolved visibility to the WDS Service visibility field. NONE has

--- a/pilot/pkg/serviceregistry/ambient/services.go
+++ b/pilot/pkg/serviceregistry/ambient/services.go
@@ -94,50 +94,7 @@ func (a Builder) ServicesCollection(
 			if len(ios.Objects) == 0 {
 				return nil
 			}
-
-			typedServiceInfos := ios.Objects
-
-			bestByNamespace := make(map[string]model.ServiceInfo)
-
-			// check if a is a better ServiceInfo than b
-			// better meaning both:
-			//     a is older than b
-			//     b is not a Kubernetes Service
-			isBetter := func(a, b model.ServiceInfo) bool {
-				return a.CreationTime.Before(b.CreationTime) && b.Source.Kind != kind.Service
-			}
-			var canonical *model.ServiceInfo
-			for _, tsi := range typedServiceInfos {
-				tsiNamespace := tsi.GetNamespace()
-				if tsi.Source.Kind == kind.Service {
-					// A Kubernetes Service is always used, and canonical
-					bestByNamespace[tsiNamespace] = tsi.ServiceInfo
-					canonical = &tsi.ServiceInfo
-					continue
-				}
-				currentBest, found := bestByNamespace[tsiNamespace]
-				if !found || isBetter(tsi.ServiceInfo, currentBest) {
-					bestByNamespace[tsiNamespace] = tsi.ServiceInfo
-				} else {
-					// if we are not the best for our namespace, then we don't need to worry about being canonical
-					continue
-				}
-				// namespace visibility should not take canonical
-				if tsi.Service.GetVisibility() == workloadapi.Service_NAMESPACE {
-					continue
-				}
-				if canonical == nil || isBetter(tsi.ServiceInfo, *canonical) {
-					canonical = &tsi.ServiceInfo
-				}
-			}
-
-			// make a copy and then set canonical
-			if canonical != nil {
-				bestByNamespace[canonical.GetNamespace()] = setCanonical(canonical)
-			}
-
-			// convert map into slice and return
-			return maps.Values(bestByNamespace)
+			return selectWorkloadServices(ios.Objects)
 		}, append(
 			opts.WithName("WorkloadServices"),
 			krt.WithMetadata(krt.Metadata{
@@ -146,6 +103,53 @@ func (a Builder) ServicesCollection(
 		)...,
 	)
 	return WorkloadServices
+}
+
+// selectWorkloadServices resolves the set of services sharing a hostname down to one winner per
+// namespace and marks the single canonical service.
+func selectWorkloadServices(typedServiceInfos []TypedServiceInfo) []model.ServiceInfo {
+	bestByNamespace := make(map[string]model.ServiceInfo)
+
+	// check if a is a better ServiceInfo than b
+	// better meaning both:
+	//     a is older than b
+	//     b is not a Kubernetes Service
+	isBetter := func(a, b model.ServiceInfo) bool {
+		return a.CreationTime.Before(b.CreationTime) && b.Source.Kind != kind.Service
+	}
+	// Pick the winner for each namespace: a Kubernetes Service always wins, else the oldest.
+	for _, tsi := range typedServiceInfos {
+		tsiNamespace := tsi.GetNamespace()
+		if tsi.Source.Kind == kind.Service {
+			bestByNamespace[tsiNamespace] = tsi.ServiceInfo
+			continue
+		}
+		currentBest, found := bestByNamespace[tsiNamespace]
+		if !found || isBetter(tsi.ServiceInfo, currentBest) {
+			bestByNamespace[tsiNamespace] = tsi.ServiceInfo
+		}
+	}
+
+	// select and mark Canonical from bestByNamespace
+	var canonical *model.ServiceInfo
+	for ns := range bestByNamespace {
+		si := bestByNamespace[ns]
+		switch {
+		case si.Source.Kind == kind.Service:
+			canonical = &si
+		case si.Service.GetVisibility() == workloadapi.Service_NAMESPACE:
+			continue
+		default:
+			if canonical == nil || isBetter(si, *canonical) {
+				canonical = &si
+			}
+		}
+	}
+	if canonical != nil {
+		bestByNamespace[canonical.GetNamespace()] = setCanonical(canonical)
+	}
+
+	return maps.Values(bestByNamespace)
 }
 
 func GlobalNestedWorkloadServicesCollection(

--- a/pilot/pkg/serviceregistry/ambient/services.go
+++ b/pilot/pkg/serviceregistry/ambient/services.go
@@ -670,6 +670,12 @@ func serviceEntriesInfo(
 
 	vis := krt.FetchOne(ctx, visibility.AsCollection())
 	services := constructServiceEntries(ctx, s, w, nsAnnotations, networkGetter)
+	// A ServiceEntry host with NAMESPACE visibility must not bind to a waypoint in another
+	// namespace: that would expose the namespace-scoped service to the waypoint's namespace, a leak
+	// the data plane can't currently contain. Only use-waypoint-namespace (on the ServiceEntry or
+	// inherited from its namespace) can resolve a waypoint outside the ServiceEntry's namespace, so
+	// a differing namespace is exactly that case. Detect it here; fail the binding per host below.
+	crossNamespaceWaypoint := w != nil && w.Namespace != s.Namespace
 	result := make([]model.ServiceInfo, 0, len(services))
 	for _, e := range services {
 		// Resolve visibility per host from the precompiled serviceEntryVisibility.
@@ -681,14 +687,24 @@ func serviceEntriesInfo(
 			continue
 		}
 		e.Visibility = *hostVisibility
-		e.IngressUseWaypoint = waypoint.IngressUseWaypoint
+		// Fail (never silently retarget to a same-named colocated waypoint) a cross-namespace
+		// waypoint binding for a namespace-scoped host: drop the binding for this host and surface
+		// the reason via status.
+		hostWaypoint := waypoint
+		if *hostVisibility == workloadapi.Service_NAMESPACE && crossNamespaceWaypoint {
+			log.Debugf("ServiceEntry %s/%s host %s has NAMESPACE visibility; refusing cross-namespace waypoint %s",
+				s.Namespace, s.Name, e.Hostname, w.ResourceName())
+			e.Waypoint = nil
+			hostWaypoint = model.WaypointBindingStatus{Error: ReportWaypointCrossNamespaceForbidden(w.ResourceName())}
+		}
+		e.IngressUseWaypoint = hostWaypoint.IngressUseWaypoint
 		e.WeightedWaypoints = weighted
 		result = append(result, precomputeService(model.ServiceInfo{
 			Service:            e,
 			PortNames:          portNames,
 			LabelSelector:      sel,
 			Source:             MakeSource(s),
-			Waypoint:           waypoint,
+			Waypoint:           hostWaypoint,
 			DNSConnectStrategy: model.GetDNSConnectStrategy(s.Annotations),
 			CreationTime:       s.CreationTimestamp.Time,
 		}))

--- a/pilot/pkg/serviceregistry/ambient/services_test.go
+++ b/pilot/pkg/serviceregistry/ambient/services_test.go
@@ -17,6 +17,7 @@ package ambient
 import (
 	"net/netip"
 	"testing"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,6 +33,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/mesh/meshwatcher"
+	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/kube/krt/krttest"
 	"istio.io/istio/pkg/ptr"
@@ -1381,6 +1383,95 @@ func TestServiceEntryServices(t *testing.T) {
 			if tt.waypointErr != nil {
 				assert.Equal(t, len(wrapper), 1)
 				assert.Equal(t, wrapper[0].Waypoint.Error, tt.waypointErr)
+			}
+		})
+	}
+}
+
+func TestSelectWorkloadServices(t *testing.T) {
+	const host = "shared.example.com"
+	older := time.Unix(100, 0)
+	newer := time.Unix(200, 0)
+
+	si := func(ns, name string, k kind.Kind, vis workloadapi.Service_Visibility, created time.Time) TypedServiceInfo {
+		return TypedServiceInfo{ServiceInfo: model.ServiceInfo{
+			Service: &workloadapi.Service{
+				Name:       name,
+				Namespace:  ns,
+				Hostname:   host,
+				Visibility: vis,
+			},
+			Source:       model.TypedObject{Kind: k},
+			CreationTime: created,
+		}}
+	}
+
+	// run returns the winning service name per namespace and the name of the single canonical
+	// service ("" if none).
+	run := func(t *testing.T, inputs []TypedServiceInfo) (map[string]string, string) {
+		winners := map[string]string{}
+		canonical := ""
+		for _, s := range selectWorkloadServices(inputs) {
+			winners[s.Service.Namespace] = s.Service.Name
+			if s.Service.Canonical {
+				if canonical != "" {
+					t.Fatalf("more than one canonical service: %s and %s", canonical, s.Service.Name)
+				}
+				canonical = s.Service.Name
+			}
+		}
+		return winners, canonical
+	}
+
+	cases := []struct {
+		name          string
+		inputs        []TypedServiceInfo
+		wantWinners   map[string]string
+		wantCanonical string
+	}{
+		{
+			// Same namespace, same hostname: the older SE owns the slot. Because the owner is
+			// NAMESPACE-scoped, nothing is canonical (out-of-namespace clients see no service).
+			name: "same namespace: older NAMESPACE beats newer PUBLIC, nothing canonical",
+			inputs: []TypedServiceInfo{
+				si("ns", "pub", kind.ServiceEntry, workloadapi.Service_PUBLIC, newer),
+				si("ns", "nslocal", kind.ServiceEntry, workloadapi.Service_NAMESPACE, older),
+			},
+			wantWinners:   map[string]string{"ns": "nslocal"},
+			wantCanonical: "",
+		},
+		{
+			// A Kubernetes Service must be canonical over an older ServiceEntry that camps its
+			// hostname -- age must not let the SE capture it.
+			name: "kube Service is canonical over an older camping PUBLIC ServiceEntry",
+			inputs: []TypedServiceInfo{
+				si("team-a", "svc", kind.Service, workloadapi.Service_PUBLIC, newer),
+				si("team-b", "camp", kind.ServiceEntry, workloadapi.Service_PUBLIC, older),
+			},
+			wantWinners:   map[string]string{"team-a": "svc", "team-b": "camp"},
+			wantCanonical: "svc",
+		},
+		{
+			// Cross namespace: the PUBLIC SE is canonical; the NAMESPACE SE owns only its namespace.
+			name: "cross namespace: PUBLIC is canonical, NAMESPACE is not",
+			inputs: []TypedServiceInfo{
+				si("team-a", "nslocal", kind.ServiceEntry, workloadapi.Service_NAMESPACE, older),
+				si("team-b", "pub", kind.ServiceEntry, workloadapi.Service_PUBLIC, newer),
+			},
+			wantWinners:   map[string]string{"team-a": "nslocal", "team-b": "pub"},
+			wantCanonical: "pub",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Order-independence: same result for the inputs and their reverse.
+			reverse := slices.Clone(tc.inputs)
+			slices.Reverse(reverse)
+			for _, order := range [][]TypedServiceInfo{tc.inputs, reverse} {
+				winners, canonical := run(t, order)
+				assert.Equal(t, winners, tc.wantWinners)
+				assert.Equal(t, canonical, tc.wantCanonical)
 			}
 		})
 	}

--- a/pilot/pkg/serviceregistry/ambient/services_test.go
+++ b/pilot/pkg/serviceregistry/ambient/services_test.go
@@ -951,6 +951,248 @@ func TestServiceEntryServices(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "ServiceEntry visibility NAMESPACE via namespaceSelector",
+			inputs: []any{
+				ns,
+				meshwatcher.MeshConfigResource{MeshConfig: &meshConfig.MeshConfig{
+					ServiceEntryVisibility: &meshConfig.ServiceEntryVisibility{
+						DefaultVisibility: meshConfig.ServiceEntryVisibility_PUBLIC,
+						Policies: []*meshConfig.ServiceEntryVisibility_Policy{{
+							Visibility: meshConfig.ServiceEntryVisibility_NAMESPACE,
+							MatchingRules: []*meshConfig.ServiceEntryVisibility_MatchRule{{
+								Matcher: &meshConfig.ServiceEntryVisibility_MatchRule_NamespaceSelector{
+									NamespaceSelector: &meshConfig.LabelSelector{
+										MatchLabels: map[string]string{v1.LabelMetadataName: "ns"},
+									},
+								},
+							}},
+						}},
+					},
+				}},
+			},
+			se: &networkingclient.ServiceEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vis-namespace-se",
+					Namespace: "ns",
+				},
+				Spec: networking.ServiceEntry{
+					Addresses:  []string{"1.2.3.4/32"},
+					Hosts:      []string{"nslocal.example.com"},
+					Ports:      []*networking.ServicePort{{Number: 80, Name: "http", Protocol: "HTTP"}},
+					Resolution: networking.ServiceEntry_DNS,
+				},
+			},
+			result: []*workloadapi.Service{
+				{
+					Name:      "vis-namespace-se",
+					Namespace: "ns",
+					Hostname:  "nslocal.example.com",
+					Addresses: []*workloadapi.NetworkAddress{{
+						Network: testNW,
+						Address: netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice(),
+					}},
+					Ports: []*workloadapi.Port{{
+						ServicePort: 80,
+						TargetPort:  80,
+						AppProtocol: workloadapi.AppProtocol_HTTP11,
+					}},
+					Visibility: workloadapi.Service_NAMESPACE,
+				},
+			},
+		},
+		{
+			name: "ServiceEntry visibility NONE is dropped",
+			inputs: []any{
+				ns,
+				meshwatcher.MeshConfigResource{MeshConfig: &meshConfig.MeshConfig{
+					ServiceEntryVisibility: &meshConfig.ServiceEntryVisibility{
+						DefaultVisibility: meshConfig.ServiceEntryVisibility_NONE,
+					},
+				}},
+			},
+			se: &networkingclient.ServiceEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vis-none-se",
+					Namespace: "ns",
+				},
+				Spec: networking.ServiceEntry{
+					Addresses:  []string{"1.2.3.4/32"},
+					Hosts:      []string{"dropped.example.com"},
+					Ports:      []*networking.ServicePort{{Number: 80, Name: "http", Protocol: "HTTP"}},
+					Resolution: networking.ServiceEntry_DNS,
+				},
+			},
+			result: []*workloadapi.Service{},
+		},
+		{
+			name: "ServiceEntry falls back to defaultVisibility NAMESPACE when no policy matches",
+			inputs: []any{
+				ns,
+				meshwatcher.MeshConfigResource{MeshConfig: &meshConfig.MeshConfig{
+					ServiceEntryVisibility: &meshConfig.ServiceEntryVisibility{
+						DefaultVisibility: meshConfig.ServiceEntryVisibility_NAMESPACE,
+						Policies: []*meshConfig.ServiceEntryVisibility_Policy{{
+							Visibility: meshConfig.ServiceEntryVisibility_PUBLIC,
+							MatchingRules: []*meshConfig.ServiceEntryVisibility_MatchRule{{
+								Matcher: &meshConfig.ServiceEntryVisibility_MatchRule_NamespaceSelector{
+									NamespaceSelector: &meshConfig.LabelSelector{
+										// Selects a different namespace, so this policy does not match.
+										MatchLabels: map[string]string{v1.LabelMetadataName: "other"},
+									},
+								},
+							}},
+						}},
+					},
+				}},
+			},
+			se: &networkingclient.ServiceEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vis-default-ns-se",
+					Namespace: "ns",
+				},
+				Spec: networking.ServiceEntry{
+					Addresses:  []string{"1.2.3.4/32"},
+					Hosts:      []string{"defaultns.example.com"},
+					Ports:      []*networking.ServicePort{{Number: 80, Name: "http", Protocol: "HTTP"}},
+					Resolution: networking.ServiceEntry_DNS,
+				},
+			},
+			result: []*workloadapi.Service{
+				{
+					Name:      "vis-default-ns-se",
+					Namespace: "ns",
+					Hostname:  "defaultns.example.com",
+					Addresses: []*workloadapi.NetworkAddress{{
+						Network: testNW,
+						Address: netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice(),
+					}},
+					Ports: []*workloadapi.Port{{
+						ServicePort: 80,
+						TargetPort:  80,
+						AppProtocol: workloadapi.AppProtocol_HTTP11,
+					}},
+					Visibility: workloadapi.Service_NAMESPACE,
+				},
+			},
+		},
+		{
+			// Two policies both match the SE's namespace. First-match-wins means the earlier
+			// NAMESPACE policy applies; if ordering were broken (last-wins/most-restrictive),
+			// the later NONE policy would instead drop the service and this test would fail.
+			name: "ServiceEntry visibility uses the first matching policy in order",
+			inputs: []any{
+				ns,
+				meshwatcher.MeshConfigResource{MeshConfig: &meshConfig.MeshConfig{
+					ServiceEntryVisibility: &meshConfig.ServiceEntryVisibility{
+						DefaultVisibility: meshConfig.ServiceEntryVisibility_PUBLIC,
+						Policies: []*meshConfig.ServiceEntryVisibility_Policy{
+							{
+								Visibility: meshConfig.ServiceEntryVisibility_NAMESPACE,
+								MatchingRules: []*meshConfig.ServiceEntryVisibility_MatchRule{{
+									Matcher: &meshConfig.ServiceEntryVisibility_MatchRule_NamespaceSelector{
+										NamespaceSelector: &meshConfig.LabelSelector{
+											MatchLabels: map[string]string{v1.LabelMetadataName: "ns"},
+										},
+									},
+								}},
+							},
+							{
+								Visibility: meshConfig.ServiceEntryVisibility_NONE,
+								MatchingRules: []*meshConfig.ServiceEntryVisibility_MatchRule{{
+									Matcher: &meshConfig.ServiceEntryVisibility_MatchRule_NamespaceSelector{
+										NamespaceSelector: &meshConfig.LabelSelector{
+											MatchLabels: map[string]string{v1.LabelMetadataName: "ns"},
+										},
+									},
+								}},
+							},
+						},
+					},
+				}},
+			},
+			se: &networkingclient.ServiceEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vis-ordering-se",
+					Namespace: "ns",
+				},
+				Spec: networking.ServiceEntry{
+					Addresses:  []string{"1.2.3.4/32"},
+					Hosts:      []string{"ordered.example.com"},
+					Ports:      []*networking.ServicePort{{Number: 80, Name: "http", Protocol: "HTTP"}},
+					Resolution: networking.ServiceEntry_DNS,
+				},
+			},
+			result: []*workloadapi.Service{
+				{
+					Name:      "vis-ordering-se",
+					Namespace: "ns",
+					Hostname:  "ordered.example.com",
+					Addresses: []*workloadapi.NetworkAddress{{
+						Network: testNW,
+						Address: netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice(),
+					}},
+					Ports: []*workloadapi.Port{{
+						ServicePort: 80,
+						TargetPort:  80,
+						AppProtocol: workloadapi.AppProtocol_HTTP11,
+					}},
+					Visibility: workloadapi.Service_NAMESPACE,
+				},
+			},
+		},
+		{
+			// An empty namespaceSelector matches every namespace. Redundant with
+			// defaultVisibility in practice, but it is expressible, so confirm it always
+			// matches: the NAMESPACE policy applies rather than falling through to the
+			// PUBLIC default.
+			name: "ServiceEntry visibility empty namespaceSelector matches all namespaces",
+			inputs: []any{
+				ns,
+				meshwatcher.MeshConfigResource{MeshConfig: &meshConfig.MeshConfig{
+					ServiceEntryVisibility: &meshConfig.ServiceEntryVisibility{
+						DefaultVisibility: meshConfig.ServiceEntryVisibility_PUBLIC,
+						Policies: []*meshConfig.ServiceEntryVisibility_Policy{{
+							Visibility: meshConfig.ServiceEntryVisibility_NAMESPACE,
+							MatchingRules: []*meshConfig.ServiceEntryVisibility_MatchRule{{
+								Matcher: &meshConfig.ServiceEntryVisibility_MatchRule_NamespaceSelector{
+									NamespaceSelector: &meshConfig.LabelSelector{},
+								},
+							}},
+						}},
+					},
+				}},
+			},
+			se: &networkingclient.ServiceEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vis-empty-selector-se",
+					Namespace: "ns",
+				},
+				Spec: networking.ServiceEntry{
+					Addresses:  []string{"1.2.3.4/32"},
+					Hosts:      []string{"emptysel.example.com"},
+					Ports:      []*networking.ServicePort{{Number: 80, Name: "http", Protocol: "HTTP"}},
+					Resolution: networking.ServiceEntry_DNS,
+				},
+			},
+			result: []*workloadapi.Service{
+				{
+					Name:      "vis-empty-selector-se",
+					Namespace: "ns",
+					Hostname:  "emptysel.example.com",
+					Addresses: []*workloadapi.NetworkAddress{{
+						Network: testNW,
+						Address: netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice(),
+					}},
+					Ports: []*workloadapi.Port{{
+						ServicePort: 80,
+						TargetPort:  80,
+						AppProtocol: workloadapi.AppProtocol_HTTP11,
+					}},
+					Visibility: workloadapi.Service_NAMESPACE,
+				},
+			},
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
@@ -959,6 +1201,7 @@ func TestServiceEntryServices(t *testing.T) {
 			builder := a.serviceEntryServiceBuilder(
 				krttest.GetMockCollection[Waypoint](mock),
 				krttest.GetMockCollection[*v1.Namespace](mock),
+				krttest.GetMockSingleton[MeshConfig](mock),
 			)
 			wrapper := builder(krt.TestingDummyContext{}, tt.se)
 			res := slices.Map(wrapper, func(e TypedServiceInfo) *workloadapi.Service {

--- a/pilot/pkg/serviceregistry/ambient/services_test.go
+++ b/pilot/pkg/serviceregistry/ambient/services_test.go
@@ -1198,10 +1198,16 @@ func TestServiceEntryServices(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := krttest.NewMock(t, tt.inputs)
 			a := newAmbientUnitTest(t)
+			// Build a synchronous, precompiled visibility singleton from the mock mesh config.
+			// (A reactive NewSingleton is not computed synchronously under TestingDummyContext.)
+			var sev *meshConfig.ServiceEntryVisibility
+			if mc := krttest.GetMockSingleton[MeshConfig](mock).Get(); mc != nil {
+				sev = mc.GetServiceEntryVisibility()
+			}
 			builder := a.serviceEntryServiceBuilder(
 				krttest.GetMockCollection[Waypoint](mock),
 				krttest.GetMockCollection[*v1.Namespace](mock),
-				krttest.GetMockSingleton[MeshConfig](mock),
+				krt.NewStatic(ptr.Of(compileServiceEntryVisibility(sev)), true),
 			)
 			wrapper := builder(krt.TestingDummyContext{}, tt.se)
 			res := slices.Map(wrapper, func(e TypedServiceInfo) *workloadapi.Service {

--- a/pilot/pkg/serviceregistry/ambient/services_test.go
+++ b/pilot/pkg/serviceregistry/ambient/services_test.go
@@ -1371,7 +1371,7 @@ func TestServiceEntryServices(t *testing.T) {
 			builder := a.serviceEntryServiceBuilder(
 				krttest.GetMockCollection[Waypoint](mock),
 				krttest.GetMockCollection[*v1.Namespace](mock),
-				krt.NewStatic(ptr.Of(compileServiceEntryVisibility(sev)), true),
+				krt.NewStatic(model.CompileServiceEntryVisibility(sev), true),
 			)
 			wrapper := builder(krt.TestingDummyContext{}, tt.se)
 			res := slices.Map(wrapper, func(e TypedServiceInfo) *workloadapi.Service {

--- a/pilot/pkg/serviceregistry/ambient/services_test.go
+++ b/pilot/pkg/serviceregistry/ambient/services_test.go
@@ -1370,10 +1370,11 @@ func TestServiceEntryServices(t *testing.T) {
 			if mc := krttest.GetMockSingleton[MeshConfig](mock).Get(); mc != nil {
 				sev = mc.GetServiceEntryVisibility()
 			}
+			matcher, _ := model.CompileServiceEntryVisibility(sev)
 			builder := a.serviceEntryServiceBuilder(
 				krttest.GetMockCollection[Waypoint](mock),
 				krttest.GetMockCollection[*v1.Namespace](mock),
-				krt.NewStatic(model.CompileServiceEntryVisibility(sev), true),
+				krt.NewStatic(matcher, true),
 			)
 			wrapper := builder(krt.TestingDummyContext{}, tt.se)
 			res := slices.Map(wrapper, func(e TypedServiceInfo) *workloadapi.Service {

--- a/pilot/pkg/serviceregistry/ambient/services_test.go
+++ b/pilot/pkg/serviceregistry/ambient/services_test.go
@@ -74,11 +74,40 @@ func TestServiceEntryServices(t *testing.T) {
 		},
 	}
 
+	// A waypoint in a different namespace than the ServiceEntry ("ns"), reachable via
+	// use-waypoint-namespace. Its allowedRoutes permit attachment from "ns", so the binding is
+	// attempted and reaches the NAMESPACE-visibility guard rather than being denied earlier.
+	crossNsWaypointAddr := &workloadapi.GatewayAddress{
+		Destination: &workloadapi.GatewayAddress_Hostname{
+			Hostname: &workloadapi.NamespacedHostname{
+				Namespace: "other",
+				Hostname:  "hostname.other.example",
+			},
+		},
+		HboneMtlsPort: 15008,
+	}
+	crossNsWaypoint := Waypoint{
+		Named: krt.Named{
+			Name:      "waypoint",
+			Namespace: "other",
+		},
+		TrafficType: constants.AllTraffic,
+		Address:     crossNsWaypointAddr,
+		AllowedRoutes: WaypointSelector{
+			FromNamespaces: gatewayv1.NamespacesFromSelector,
+			Selector:       labels.ValidatedSetSelector(map[string]string{v1.LabelMetadataName: "ns"}),
+		},
+	}
+
 	cases := []struct {
 		name   string
 		inputs []any
 		se     *networkingclient.ServiceEntry
 		result []*workloadapi.Service
+		// waypointErr, when set, asserts the (single) resulting service's
+		// WaypointBindingStatus.Error -- the status surfaced when a binding is refused. The
+		// service builder result otherwise only carries the *workloadapi.Service, which drops it.
+		waypointErr *model.StatusMessage
 	}{
 		{
 			name:   "DNS service entry with address",
@@ -1193,6 +1222,141 @@ func TestServiceEntryServices(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "NAMESPACE visibility refuses cross-namespace waypoint binding",
+			inputs: []any{
+				ns,
+				crossNsWaypoint,
+				meshwatcher.MeshConfigResource{MeshConfig: &meshConfig.MeshConfig{
+					ServiceEntryVisibility: &meshConfig.ServiceEntryVisibility{
+						DefaultVisibility: meshConfig.ServiceEntryVisibility_NAMESPACE,
+					},
+				}},
+			},
+			se: &networkingclient.ServiceEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ns-crossns-wp",
+					Namespace: "ns",
+					Labels: map[string]string{
+						label.IoIstioUseWaypoint.Name:          "waypoint",
+						label.IoIstioUseWaypointNamespace.Name: "other",
+					},
+				},
+				Spec: networking.ServiceEntry{
+					Addresses:  []string{"1.2.3.4"},
+					Hosts:      []string{"a.example.com"},
+					Ports:      []*networking.ServicePort{{Number: 80, Name: "http", Protocol: "HTTP"}},
+					Resolution: networking.ServiceEntry_STATIC,
+				},
+			},
+			result: []*workloadapi.Service{
+				{
+					Name:      "ns-crossns-wp",
+					Namespace: "ns",
+					Hostname:  "a.example.com",
+					Addresses: []*workloadapi.NetworkAddress{{
+						Network: testNW,
+						Address: netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice(),
+					}},
+					Ports: []*workloadapi.Port{{
+						ServicePort: 80,
+						TargetPort:  80,
+						AppProtocol: workloadapi.AppProtocol_HTTP11,
+					}},
+					Visibility: workloadapi.Service_NAMESPACE,
+					// Waypoint intentionally nil: the cross-namespace binding is refused, and it is
+					// NOT retargeted to a same-named colocated waypoint.
+				},
+			},
+			waypointErr: ReportWaypointCrossNamespaceForbidden("other/waypoint"),
+		},
+		{
+			name: "NAMESPACE visibility keeps same-namespace waypoint binding",
+			inputs: []any{
+				ns,
+				waypoint,
+				meshwatcher.MeshConfigResource{MeshConfig: &meshConfig.MeshConfig{
+					ServiceEntryVisibility: &meshConfig.ServiceEntryVisibility{
+						DefaultVisibility: meshConfig.ServiceEntryVisibility_NAMESPACE,
+					},
+				}},
+			},
+			se: &networkingclient.ServiceEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ns-samens-wp",
+					Namespace: "ns",
+					Labels: map[string]string{
+						label.IoIstioUseWaypoint.Name:          "waypoint",
+						label.IoIstioUseWaypointNamespace.Name: "ns",
+					},
+				},
+				Spec: networking.ServiceEntry{
+					Addresses:  []string{"1.2.3.4"},
+					Hosts:      []string{"a.example.com"},
+					Ports:      []*networking.ServicePort{{Number: 80, Name: "http", Protocol: "HTTP"}},
+					Resolution: networking.ServiceEntry_STATIC,
+				},
+			},
+			result: []*workloadapi.Service{
+				{
+					Name:      "ns-samens-wp",
+					Namespace: "ns",
+					Hostname:  "a.example.com",
+					Addresses: []*workloadapi.NetworkAddress{{
+						Network: testNW,
+						Address: netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice(),
+					}},
+					Waypoint: waypointAddr,
+					Ports: []*workloadapi.Port{{
+						ServicePort: 80,
+						TargetPort:  80,
+						AppProtocol: workloadapi.AppProtocol_HTTP11,
+					}},
+					Visibility: workloadapi.Service_NAMESPACE,
+				},
+			},
+		},
+		{
+			name: "PUBLIC visibility keeps cross-namespace waypoint binding",
+			inputs: []any{
+				ns,
+				crossNsWaypoint,
+			},
+			se: &networkingclient.ServiceEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "public-crossns-wp",
+					Namespace: "ns",
+					Labels: map[string]string{
+						label.IoIstioUseWaypoint.Name:          "waypoint",
+						label.IoIstioUseWaypointNamespace.Name: "other",
+					},
+				},
+				Spec: networking.ServiceEntry{
+					Addresses:  []string{"1.2.3.4"},
+					Hosts:      []string{"a.example.com"},
+					Ports:      []*networking.ServicePort{{Number: 80, Name: "http", Protocol: "HTTP"}},
+					Resolution: networking.ServiceEntry_STATIC,
+				},
+			},
+			result: []*workloadapi.Service{
+				{
+					Name:      "public-crossns-wp",
+					Namespace: "ns",
+					Hostname:  "a.example.com",
+					Addresses: []*workloadapi.NetworkAddress{{
+						Network: testNW,
+						Address: netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice(),
+					}},
+					Waypoint: crossNsWaypointAddr,
+					Ports: []*workloadapi.Port{{
+						ServicePort: 80,
+						TargetPort:  80,
+						AppProtocol: workloadapi.AppProtocol_HTTP11,
+					}},
+					// Visibility PUBLIC (zero value): cross-namespace binding is allowed.
+				},
+			},
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1214,6 +1378,10 @@ func TestServiceEntryServices(t *testing.T) {
 				return e.Service
 			})
 			assert.Equal(t, res, tt.result)
+			if tt.waypointErr != nil {
+				assert.Equal(t, len(wrapper), 1)
+				assert.Equal(t, wrapper[0].Waypoint.Error, tt.waypointErr)
+			}
 		})
 	}
 }

--- a/pilot/pkg/serviceregistry/ambient/status.go
+++ b/pilot/pkg/serviceregistry/ambient/status.go
@@ -54,3 +54,11 @@ func ReportWaypointCanarySameAsPrimary(waypoint string) *model.StatusMessage {
 		Message: fmt.Sprintf("canary waypoint %q must differ from the primary waypoint", waypoint),
 	}
 }
+
+func ReportWaypointCrossNamespaceForbidden(waypoint string) *model.StatusMessage {
+	return &model.StatusMessage{
+		Reason: "CrossNamespaceWaypointForbidden",
+		Message: fmt.Sprintf("cannot bind to waypoint %q in another namespace: cross-namespace waypoint binding is "+
+			"not permitted for a ServiceEntry with NAMESPACE visibility", waypoint),
+	}
+}

--- a/pilot/pkg/serviceregistry/ambient/waypoints.go
+++ b/pilot/pkg/serviceregistry/ambient/waypoints.go
@@ -148,8 +148,9 @@ func fetchWaypointForTarget(
 	return nil, nil
 }
 
+// SAFETY: if fetching waypoints for a ServiceEntry visibility must be taken into account. For Kubernetes services a nil visibility singleton is expected
 func fetchWaypointForService(ctx krt.HandlerContext, Waypoints krt.Collection[Waypoint],
-	Namespaces krt.Collection[*v1.Namespace], o metav1.ObjectMeta,
+	Namespaces krt.Collection[*v1.Namespace], ServiceEntryVisibility krt.Singleton[model.ServiceEntryVisibilityMatcher], o metav1.ObjectMeta,
 ) (*Waypoint, *model.StatusMessage) {
 	// This is a waypoint, so it cannot have a waypoint
 	if o.Labels[label.GatewayManaged.Name] == constants.ManagedGatewayMeshControllerLabel {
@@ -163,13 +164,25 @@ func fetchWaypointForService(ctx krt.HandlerContext, Waypoints krt.Collection[Wa
 	if err != nil || w == nil {
 		return nil, err
 	}
-	if w.TrafficType == constants.ServiceTraffic || w.TrafficType == constants.AllTraffic {
-		return w, nil
+	if w.TrafficType != constants.ServiceTraffic && w.TrafficType != constants.AllTraffic {
+		// Waypoint does not support Service traffic
+		log.Debugf("Unable to add service waypoint %s/%s; traffic type %s not supported for %s/%s",
+			w.Namespace, w.Name, w.TrafficType, o.Namespace, o.Name)
+		return nil, ReportWaypointUnsupportedTrafficType(w.ResourceName(), constants.ServiceTraffic)
 	}
-	// Waypoint does not support Service traffic
-	log.Debugf("Unable to add service waypoint %s/%s; traffic type %s not supported for %s/%s",
-		w.Namespace, w.Name, w.TrafficType, o.Namespace, o.Name)
-	return nil, ReportWaypointUnsupportedTrafficType(w.ResourceName(), constants.ServiceTraffic)
+	// A NAMESPACE-visibility ServiceEntry must not bind to a waypoint in another namespace: that would
+	// expose it to the waypoint's namespace. Refuse here so every consumer is covered.
+	// ServiceEntryVisibility is nil for consumers it doesn't govern (e.g. Kubernetes Services).
+	if ServiceEntryVisibility != nil && w.Namespace != o.Namespace {
+		var nsLabels map[string]string
+		if ns := krt.FetchOne(ctx, Namespaces, krt.FilterKey(o.Namespace)); ns != nil {
+			nsLabels = (*ns).Labels
+		}
+		if krt.FetchOne(ctx, ServiceEntryVisibility.AsCollection()).VisibilityFor(nsLabels) == model.ServiceVisibilityNamespace {
+			return nil, ReportWaypointCrossNamespaceForbidden(w.ResourceName())
+		}
+	}
+	return w, nil
 }
 
 func fetchWaypointForWorkload(ctx krt.HandlerContext, Waypoints krt.Collection[Waypoint],

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -517,14 +517,9 @@ func services(
 	canonicalServiceForMeshExternal bool,
 	opts krt.OptionsBuilder,
 ) (krt.Collection[ServiceWithInstances], krt.Index[string, ServiceWithInstances], krt.Index[string, ServiceWithInstances]) {
-	// Precompile the serviceEntryVisibility matcher once as a singleton rather than per ServiceEntry.
-	serviceEntryVisibility := krt.NewSingleton[model.ServiceEntryVisibilityMatcher](func(ctx krt.HandlerContext) *model.ServiceEntryVisibilityMatcher {
-		mc := krt.FetchOne(ctx, meshConfig)
-		if mc == nil {
-			return model.CompileServiceEntryVisibility(nil)
-		}
-		return model.CompileServiceEntryVisibility(mc.MeshConfig.GetServiceEntryVisibility())
-	}, opts.WithName("ServiceEntryVisibility")...)
+	// Precompile the serviceEntryVisibility matcher once (shared with the ambient path) rather than
+	// per ServiceEntry.
+	serviceEntryVisibility := model.ServiceEntryVisibilityCollection(meshConfig, opts)
 
 	collection := krt.NewManyCollection(serviceEntries, func(ctx krt.HandlerContext, cfg config.Config) []ServiceWithInstances {
 		se := cfg.Spec.(*networking.ServiceEntry)

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -517,15 +517,35 @@ func services(
 	canonicalServiceForMeshExternal bool,
 	opts krt.OptionsBuilder,
 ) (krt.Collection[ServiceWithInstances], krt.Index[string, ServiceWithInstances], krt.Index[string, ServiceWithInstances]) {
+	// Precompile the serviceEntryVisibility matcher once as a singleton rather than per ServiceEntry.
+	serviceEntryVisibility := krt.NewSingleton[model.ServiceEntryVisibilityMatcher](func(ctx krt.HandlerContext) *model.ServiceEntryVisibilityMatcher {
+		mc := krt.FetchOne(ctx, meshConfig)
+		if mc == nil {
+			return model.CompileServiceEntryVisibility(nil)
+		}
+		return model.CompileServiceEntryVisibility(mc.MeshConfig.GetServiceEntryVisibility())
+	}, opts.WithName("ServiceEntryVisibility")...)
+
 	collection := krt.NewManyCollection(serviceEntries, func(ctx krt.HandlerContext, cfg config.Config) []ServiceWithInstances {
 		se := cfg.Spec.(*networking.ServiceEntry)
 		namespace := krt.FetchOne(ctx, namespaces, krt.FilterKey(cfg.Namespace))
 		var namespaceAnnotations map[string]string
+		var namespaceLabels map[string]string
 		if namespace != nil {
 			namespaceAnnotations = (*namespace).Annotations
+			namespaceLabels = (*namespace).Labels
 		}
 
 		services := convertServices(cfg, namespaceAnnotations, canonicalServiceForMeshExternal)
+		// Resolve the ServiceEntry's visibility from the precompiled serviceEntryVisibility matcher so
+		// classic (sidecar) exportTo can be capped by it (see PushContext.serviceExportTo). The default
+		// (feature unset) resolves to Public, leaving services at their zero value.
+		if vis := krt.FetchOne(ctx, serviceEntryVisibility.AsCollection()); vis != nil {
+			resolved := vis.VisibilityFor(namespaceLabels)
+			for _, svc := range services {
+				svc.Attributes.Visibility = resolved
+			}
+		}
 		if se.WorkloadSelector == nil {
 			// No selector: endpoints from SE directly
 			return slices.Map(services, func(ss *model.Service) ServiceWithInstances {

--- a/pkg/config/mesh/labelselector.go
+++ b/pkg/config/mesh/labelselector.go
@@ -1,0 +1,67 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mesh
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+
+	meshconfig "istio.io/api/mesh/v1alpha1"
+)
+
+// LabelSelectorAsSelector converts a mesh API LabelSelector to a labels.Selector.
+// A nil selector matches nothing; an empty selector matches everything.
+func LabelSelectorAsSelector(ps *meshconfig.LabelSelector) (labels.Selector, error) {
+	if ps == nil {
+		return labels.Nothing(), nil
+	}
+	if len(ps.MatchLabels)+len(ps.MatchExpressions) == 0 {
+		return labels.Everything(), nil
+	}
+	requirements := make([]labels.Requirement, 0, len(ps.MatchLabels)+len(ps.MatchExpressions))
+	for k, v := range ps.MatchLabels {
+		r, err := labels.NewRequirement(k, selection.Equals, []string{v})
+		if err != nil {
+			return nil, err
+		}
+		requirements = append(requirements, *r)
+	}
+	for _, expr := range ps.MatchExpressions {
+		var op selection.Operator
+		switch metav1.LabelSelectorOperator(expr.Operator) {
+		case metav1.LabelSelectorOpIn:
+			op = selection.In
+		case metav1.LabelSelectorOpNotIn:
+			op = selection.NotIn
+		case metav1.LabelSelectorOpExists:
+			op = selection.Exists
+		case metav1.LabelSelectorOpDoesNotExist:
+			op = selection.DoesNotExist
+		default:
+			return nil, fmt.Errorf("%q is not a valid label selector operator", expr.Operator)
+		}
+		r, err := labels.NewRequirement(expr.Key, op, append([]string(nil), expr.Values...))
+		if err != nil {
+			return nil, err
+		}
+		requirements = append(requirements, *r)
+	}
+	selector := labels.NewSelector()
+	selector = selector.Add(requirements...)
+	return selector, nil
+}

--- a/pkg/config/mesh/labelselector/labelselector.go
+++ b/pkg/config/mesh/labelselector/labelselector.go
@@ -12,7 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package mesh
+// Package labelselector converts the mesh API LabelSelector to a k8s labels.Selector. It is a
+// separate package from pkg/config/mesh so that importing the converter pulls in
+// k8s.io/apimachinery/pkg/labels only where it is needed: lean binaries like pilot-agent import
+// pkg/config/mesh but must not gain the apimachinery dependency (enforced by tests/binary
+// TestDependencies).
+package labelselector
 
 import (
 	"fmt"

--- a/pkg/kube/namespace/filter.go
+++ b/pkg/kube/namespace/filter.go
@@ -23,6 +23,7 @@ import (
 
 	meshapi "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pkg/config/mesh"
+	"istio.io/istio/pkg/config/mesh/labelselector"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/kclient"
@@ -196,7 +197,7 @@ func (d *discoveryNamespacesFilter) selectorsChanged(
 
 		// convert LabelSelectors to Selectors
 		for _, selector := range discoverySelectors {
-			ls, err := mesh.LabelSelectorAsSelector(selector)
+			ls, err := labelselector.LabelSelectorAsSelector(selector)
 			if err != nil {
 				log.Errorf("error initializing discovery namespaces filter, invalid discovery selector: %v", err)
 				return nil, nil

--- a/pkg/kube/namespace/filter.go
+++ b/pkg/kube/namespace/filter.go
@@ -15,13 +15,11 @@
 package namespace
 
 import (
-	"fmt"
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 
 	meshapi "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pkg/config/mesh"
@@ -182,46 +180,6 @@ func extractObjectNamespace(obj any) (string, bool) {
 	return object.GetNamespace(), true
 }
 
-func LabelSelectorAsSelector(ps *meshapi.LabelSelector) (labels.Selector, error) {
-	if ps == nil {
-		return labels.Nothing(), nil
-	}
-	if len(ps.MatchLabels)+len(ps.MatchExpressions) == 0 {
-		return labels.Everything(), nil
-	}
-	requirements := make([]labels.Requirement, 0, len(ps.MatchLabels)+len(ps.MatchExpressions))
-	for k, v := range ps.MatchLabels {
-		r, err := labels.NewRequirement(k, selection.Equals, []string{v})
-		if err != nil {
-			return nil, err
-		}
-		requirements = append(requirements, *r)
-	}
-	for _, expr := range ps.MatchExpressions {
-		var op selection.Operator
-		switch metav1.LabelSelectorOperator(expr.Operator) {
-		case metav1.LabelSelectorOpIn:
-			op = selection.In
-		case metav1.LabelSelectorOpNotIn:
-			op = selection.NotIn
-		case metav1.LabelSelectorOpExists:
-			op = selection.Exists
-		case metav1.LabelSelectorOpDoesNotExist:
-			op = selection.DoesNotExist
-		default:
-			return nil, fmt.Errorf("%q is not a valid label selector operator", expr.Operator)
-		}
-		r, err := labels.NewRequirement(expr.Key, op, append([]string(nil), expr.Values...))
-		if err != nil {
-			return nil, err
-		}
-		requirements = append(requirements, *r)
-	}
-	selector := labels.NewSelector()
-	selector = selector.Add(requirements...)
-	return selector, nil
-}
-
 // SelectorsChanged initializes the discovery filter state with the discovery selectors and selected namespaces
 func (d *discoveryNamespacesFilter) selectorsChanged(
 	discoverySelectors []*meshapi.LabelSelector,
@@ -238,7 +196,7 @@ func (d *discoveryNamespacesFilter) selectorsChanged(
 
 		// convert LabelSelectors to Selectors
 		for _, selector := range discoverySelectors {
-			ls, err := LabelSelectorAsSelector(selector)
+			ls, err := mesh.LabelSelectorAsSelector(selector)
 			if err != nil {
 				log.Errorf("error initializing discovery namespaces filter, invalid discovery selector: %v", err)
 				return nil, nil

--- a/pkg/workloadapi/workload.pb.go
+++ b/pkg/workloadapi/workload.pb.go
@@ -356,6 +356,56 @@ func (TunnelProtocol) EnumDescriptor() ([]byte, []int) {
 	return file_workloadapi_workload_proto_rawDescGZIP(), []int{5}
 }
 
+// Visibility controls which clients can resolve and send traffic to a service.
+type Service_Visibility int32
+
+const (
+	// Visible to every client the control plane serves. This is the default,
+	// and matches the behavior before this field was introduced.
+	Service_PUBLIC Service_Visibility = 0
+	// Visible only to clients in the same namespace as the service.
+	Service_NAMESPACE Service_Visibility = 1
+)
+
+// Enum value maps for Service_Visibility.
+var (
+	Service_Visibility_name = map[int32]string{
+		0: "PUBLIC",
+		1: "NAMESPACE",
+	}
+	Service_Visibility_value = map[string]int32{
+		"PUBLIC":    0,
+		"NAMESPACE": 1,
+	}
+)
+
+func (x Service_Visibility) Enum() *Service_Visibility {
+	p := new(Service_Visibility)
+	*p = x
+	return p
+}
+
+func (x Service_Visibility) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (Service_Visibility) Descriptor() protoreflect.EnumDescriptor {
+	return file_workloadapi_workload_proto_enumTypes[6].Descriptor()
+}
+
+func (Service_Visibility) Type() protoreflect.EnumType {
+	return &file_workloadapi_workload_proto_enumTypes[6]
+}
+
+func (x Service_Visibility) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use Service_Visibility.Descriptor instead.
+func (Service_Visibility) EnumDescriptor() ([]byte, []int) {
+	return file_workloadapi_workload_proto_rawDescGZIP(), []int{1, 0}
+}
+
 type LoadBalancing_Scope int32
 
 const (
@@ -407,11 +457,11 @@ func (x LoadBalancing_Scope) String() string {
 }
 
 func (LoadBalancing_Scope) Descriptor() protoreflect.EnumDescriptor {
-	return file_workloadapi_workload_proto_enumTypes[6].Descriptor()
+	return file_workloadapi_workload_proto_enumTypes[7].Descriptor()
 }
 
 func (LoadBalancing_Scope) Type() protoreflect.EnumType {
-	return &file_workloadapi_workload_proto_enumTypes[6]
+	return &file_workloadapi_workload_proto_enumTypes[7]
 }
 
 func (x LoadBalancing_Scope) Number() protoreflect.EnumNumber {
@@ -472,11 +522,11 @@ func (x LoadBalancing_Mode) String() string {
 }
 
 func (LoadBalancing_Mode) Descriptor() protoreflect.EnumDescriptor {
-	return file_workloadapi_workload_proto_enumTypes[7].Descriptor()
+	return file_workloadapi_workload_proto_enumTypes[8].Descriptor()
 }
 
 func (LoadBalancing_Mode) Type() protoreflect.EnumType {
-	return &file_workloadapi_workload_proto_enumTypes[7]
+	return &file_workloadapi_workload_proto_enumTypes[8]
 }
 
 func (x LoadBalancing_Mode) Number() protoreflect.EnumNumber {
@@ -520,11 +570,11 @@ func (x LoadBalancing_HealthPolicy) String() string {
 }
 
 func (LoadBalancing_HealthPolicy) Descriptor() protoreflect.EnumDescriptor {
-	return file_workloadapi_workload_proto_enumTypes[8].Descriptor()
+	return file_workloadapi_workload_proto_enumTypes[9].Descriptor()
 }
 
 func (LoadBalancing_HealthPolicy) Type() protoreflect.EnumType {
-	return &file_workloadapi_workload_proto_enumTypes[8]
+	return &file_workloadapi_workload_proto_enumTypes[9]
 }
 
 func (x LoadBalancing_HealthPolicy) Number() protoreflect.EnumNumber {
@@ -572,11 +622,11 @@ func (x ApplicationTunnel_Protocol) String() string {
 }
 
 func (ApplicationTunnel_Protocol) Descriptor() protoreflect.EnumDescriptor {
-	return file_workloadapi_workload_proto_enumTypes[9].Descriptor()
+	return file_workloadapi_workload_proto_enumTypes[10].Descriptor()
 }
 
 func (ApplicationTunnel_Protocol) Type() protoreflect.EnumType {
-	return &file_workloadapi_workload_proto_enumTypes[9]
+	return &file_workloadapi_workload_proto_enumTypes[10]
 }
 
 func (x ApplicationTunnel_Protocol) Number() protoreflect.EnumNumber {
@@ -746,8 +796,12 @@ type Service struct {
 	// set, `waypoint` remains populated with the primary waypoint so that dataplanes which do
 	// not understand this field continue to send all traffic to the primary.
 	WeightedWaypoints []*WeightedWaypoint `protobuf:"bytes,13,rep,name=weighted_waypoints,json=weightedWaypoints,proto3" json:"weighted_waypoints,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// visibility controls which clients this service is resolvable by. When
+	// unset it defaults to PUBLIC. Services that a mesh administrator has scoped
+	// to no visibility at all are simply not sent, so they do not appear here.
+	Visibility    Service_Visibility `protobuf:"varint,14,opt,name=visibility,proto3,enum=istio.workload.Service_Visibility" json:"visibility,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Service) Reset() {
@@ -869,6 +923,13 @@ func (x *Service) GetWeightedWaypoints() []*WeightedWaypoint {
 		return x.WeightedWaypoints
 	}
 	return nil
+}
+
+func (x *Service) GetVisibility() Service_Visibility {
+	if x != nil {
+		return x.Visibility
+	}
+	return Service_PUBLIC
 }
 
 type LoadBalancing struct {
@@ -1810,7 +1871,7 @@ const file_workloadapi_workload_proto_rawDesc = "" +
 	"\aAddress\x126\n" +
 	"\bworkload\x18\x01 \x01(\v2\x18.istio.workload.WorkloadH\x00R\bworkload\x123\n" +
 	"\aservice\x18\x02 \x01(\v2\x17.istio.workload.ServiceH\x00R\aserviceB\x06\n" +
-	"\x04type\"\x88\x05\n" +
+	"\x04type\"\xf5\x05\n" +
 	"\aService\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1c\n" +
 	"\tnamespace\x18\x02 \x01(\tR\tnamespace\x12\x1a\n" +
@@ -1828,7 +1889,15 @@ const file_workloadapi_workload_proto_rawDesc = "" +
 	"extensions\x12\x1c\n" +
 	"\tcanonical\x18\v \x01(\bR\tcanonical\x120\n" +
 	"\x14ingress_use_waypoint\x18\f \x01(\bR\x12ingressUseWaypoint\x12O\n" +
-	"\x12weighted_waypoints\x18\r \x03(\v2 .istio.workload.WeightedWaypointR\x11weightedWaypoints\"\xcd\x03\n" +
+	"\x12weighted_waypoints\x18\r \x03(\v2 .istio.workload.WeightedWaypointR\x11weightedWaypoints\x12B\n" +
+	"\n" +
+	"visibility\x18\x0e \x01(\x0e2\".istio.workload.Service.VisibilityR\n" +
+	"visibility\"'\n" +
+	"\n" +
+	"Visibility\x12\n" +
+	"\n" +
+	"\x06PUBLIC\x10\x00\x12\r\n" +
+	"\tNAMESPACE\x10\x01\"\xcd\x03\n" +
 	"\rLoadBalancing\x12R\n" +
 	"\x12routing_preference\x18\x01 \x03(\x0e2#.istio.workload.LoadBalancing.ScopeR\x11routingPreference\x126\n" +
 	"\x04mode\x18\x02 \x01(\x0e2\".istio.workload.LoadBalancing.ModeR\x04mode\x12O\n" +
@@ -1965,7 +2034,7 @@ func file_workloadapi_workload_proto_rawDescGZIP() []byte {
 	return file_workloadapi_workload_proto_rawDescData
 }
 
-var file_workloadapi_workload_proto_enumTypes = make([]protoimpl.EnumInfo, 10)
+var file_workloadapi_workload_proto_enumTypes = make([]protoimpl.EnumInfo, 11)
 var file_workloadapi_workload_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
 var file_workloadapi_workload_proto_goTypes = []any{
 	(IPFamilies)(0),                 // 0: istio.workload.IPFamilies
@@ -1974,64 +2043,66 @@ var file_workloadapi_workload_proto_goTypes = []any{
 	(WorkloadType)(0),               // 3: istio.workload.WorkloadType
 	(AppProtocol)(0),                // 4: istio.workload.AppProtocol
 	(TunnelProtocol)(0),             // 5: istio.workload.TunnelProtocol
-	(LoadBalancing_Scope)(0),        // 6: istio.workload.LoadBalancing.Scope
-	(LoadBalancing_Mode)(0),         // 7: istio.workload.LoadBalancing.Mode
-	(LoadBalancing_HealthPolicy)(0), // 8: istio.workload.LoadBalancing.HealthPolicy
-	(ApplicationTunnel_Protocol)(0), // 9: istio.workload.ApplicationTunnel.Protocol
-	(*Address)(nil),                 // 10: istio.workload.Address
-	(*Service)(nil),                 // 11: istio.workload.Service
-	(*LoadBalancing)(nil),           // 12: istio.workload.LoadBalancing
-	(*Workload)(nil),                // 13: istio.workload.Workload
-	(*Locality)(nil),                // 14: istio.workload.Locality
-	(*PortList)(nil),                // 15: istio.workload.PortList
-	(*Port)(nil),                    // 16: istio.workload.Port
-	(*ApplicationTunnel)(nil),       // 17: istio.workload.ApplicationTunnel
-	(*GatewayAddress)(nil),          // 18: istio.workload.GatewayAddress
-	(*WeightedWaypoint)(nil),        // 19: istio.workload.WeightedWaypoint
-	(*NetworkAddress)(nil),          // 20: istio.workload.NetworkAddress
-	(*NamespacedHostname)(nil),      // 21: istio.workload.NamespacedHostname
-	(*Extension)(nil),               // 22: istio.workload.Extension
-	nil,                             // 23: istio.workload.Workload.ServicesEntry
-	(*wrapperspb.UInt32Value)(nil),  // 24: google.protobuf.UInt32Value
-	(*anypb.Any)(nil),               // 25: google.protobuf.Any
+	(Service_Visibility)(0),         // 6: istio.workload.Service.Visibility
+	(LoadBalancing_Scope)(0),        // 7: istio.workload.LoadBalancing.Scope
+	(LoadBalancing_Mode)(0),         // 8: istio.workload.LoadBalancing.Mode
+	(LoadBalancing_HealthPolicy)(0), // 9: istio.workload.LoadBalancing.HealthPolicy
+	(ApplicationTunnel_Protocol)(0), // 10: istio.workload.ApplicationTunnel.Protocol
+	(*Address)(nil),                 // 11: istio.workload.Address
+	(*Service)(nil),                 // 12: istio.workload.Service
+	(*LoadBalancing)(nil),           // 13: istio.workload.LoadBalancing
+	(*Workload)(nil),                // 14: istio.workload.Workload
+	(*Locality)(nil),                // 15: istio.workload.Locality
+	(*PortList)(nil),                // 16: istio.workload.PortList
+	(*Port)(nil),                    // 17: istio.workload.Port
+	(*ApplicationTunnel)(nil),       // 18: istio.workload.ApplicationTunnel
+	(*GatewayAddress)(nil),          // 19: istio.workload.GatewayAddress
+	(*WeightedWaypoint)(nil),        // 20: istio.workload.WeightedWaypoint
+	(*NetworkAddress)(nil),          // 21: istio.workload.NetworkAddress
+	(*NamespacedHostname)(nil),      // 22: istio.workload.NamespacedHostname
+	(*Extension)(nil),               // 23: istio.workload.Extension
+	nil,                             // 24: istio.workload.Workload.ServicesEntry
+	(*wrapperspb.UInt32Value)(nil),  // 25: google.protobuf.UInt32Value
+	(*anypb.Any)(nil),               // 26: google.protobuf.Any
 }
 var file_workloadapi_workload_proto_depIdxs = []int32{
-	13, // 0: istio.workload.Address.workload:type_name -> istio.workload.Workload
-	11, // 1: istio.workload.Address.service:type_name -> istio.workload.Service
-	20, // 2: istio.workload.Service.addresses:type_name -> istio.workload.NetworkAddress
-	16, // 3: istio.workload.Service.ports:type_name -> istio.workload.Port
-	18, // 4: istio.workload.Service.waypoint:type_name -> istio.workload.GatewayAddress
-	12, // 5: istio.workload.Service.load_balancing:type_name -> istio.workload.LoadBalancing
+	14, // 0: istio.workload.Address.workload:type_name -> istio.workload.Workload
+	12, // 1: istio.workload.Address.service:type_name -> istio.workload.Service
+	21, // 2: istio.workload.Service.addresses:type_name -> istio.workload.NetworkAddress
+	17, // 3: istio.workload.Service.ports:type_name -> istio.workload.Port
+	19, // 4: istio.workload.Service.waypoint:type_name -> istio.workload.GatewayAddress
+	13, // 5: istio.workload.Service.load_balancing:type_name -> istio.workload.LoadBalancing
 	0,  // 6: istio.workload.Service.ip_families:type_name -> istio.workload.IPFamilies
-	22, // 7: istio.workload.Service.extensions:type_name -> istio.workload.Extension
-	19, // 8: istio.workload.Service.weighted_waypoints:type_name -> istio.workload.WeightedWaypoint
-	6,  // 9: istio.workload.LoadBalancing.routing_preference:type_name -> istio.workload.LoadBalancing.Scope
-	7,  // 10: istio.workload.LoadBalancing.mode:type_name -> istio.workload.LoadBalancing.Mode
-	8,  // 11: istio.workload.LoadBalancing.health_policy:type_name -> istio.workload.LoadBalancing.HealthPolicy
-	5,  // 12: istio.workload.Workload.tunnel_protocol:type_name -> istio.workload.TunnelProtocol
-	18, // 13: istio.workload.Workload.waypoint:type_name -> istio.workload.GatewayAddress
-	18, // 14: istio.workload.Workload.network_gateway:type_name -> istio.workload.GatewayAddress
-	3,  // 15: istio.workload.Workload.workload_type:type_name -> istio.workload.WorkloadType
-	17, // 16: istio.workload.Workload.application_tunnel:type_name -> istio.workload.ApplicationTunnel
-	23, // 17: istio.workload.Workload.services:type_name -> istio.workload.Workload.ServicesEntry
-	2,  // 18: istio.workload.Workload.status:type_name -> istio.workload.WorkloadStatus
-	14, // 19: istio.workload.Workload.locality:type_name -> istio.workload.Locality
-	1,  // 20: istio.workload.Workload.network_mode:type_name -> istio.workload.NetworkMode
-	22, // 21: istio.workload.Workload.extensions:type_name -> istio.workload.Extension
-	24, // 22: istio.workload.Workload.capacity:type_name -> google.protobuf.UInt32Value
-	16, // 23: istio.workload.PortList.ports:type_name -> istio.workload.Port
-	4,  // 24: istio.workload.Port.app_protocol:type_name -> istio.workload.AppProtocol
-	9,  // 25: istio.workload.ApplicationTunnel.protocol:type_name -> istio.workload.ApplicationTunnel.Protocol
-	21, // 26: istio.workload.GatewayAddress.hostname:type_name -> istio.workload.NamespacedHostname
-	20, // 27: istio.workload.GatewayAddress.address:type_name -> istio.workload.NetworkAddress
-	18, // 28: istio.workload.WeightedWaypoint.destination:type_name -> istio.workload.GatewayAddress
-	25, // 29: istio.workload.Extension.config:type_name -> google.protobuf.Any
-	15, // 30: istio.workload.Workload.ServicesEntry.value:type_name -> istio.workload.PortList
-	31, // [31:31] is the sub-list for method output_type
-	31, // [31:31] is the sub-list for method input_type
-	31, // [31:31] is the sub-list for extension type_name
-	31, // [31:31] is the sub-list for extension extendee
-	0,  // [0:31] is the sub-list for field type_name
+	23, // 7: istio.workload.Service.extensions:type_name -> istio.workload.Extension
+	20, // 8: istio.workload.Service.weighted_waypoints:type_name -> istio.workload.WeightedWaypoint
+	6,  // 9: istio.workload.Service.visibility:type_name -> istio.workload.Service.Visibility
+	7,  // 10: istio.workload.LoadBalancing.routing_preference:type_name -> istio.workload.LoadBalancing.Scope
+	8,  // 11: istio.workload.LoadBalancing.mode:type_name -> istio.workload.LoadBalancing.Mode
+	9,  // 12: istio.workload.LoadBalancing.health_policy:type_name -> istio.workload.LoadBalancing.HealthPolicy
+	5,  // 13: istio.workload.Workload.tunnel_protocol:type_name -> istio.workload.TunnelProtocol
+	19, // 14: istio.workload.Workload.waypoint:type_name -> istio.workload.GatewayAddress
+	19, // 15: istio.workload.Workload.network_gateway:type_name -> istio.workload.GatewayAddress
+	3,  // 16: istio.workload.Workload.workload_type:type_name -> istio.workload.WorkloadType
+	18, // 17: istio.workload.Workload.application_tunnel:type_name -> istio.workload.ApplicationTunnel
+	24, // 18: istio.workload.Workload.services:type_name -> istio.workload.Workload.ServicesEntry
+	2,  // 19: istio.workload.Workload.status:type_name -> istio.workload.WorkloadStatus
+	15, // 20: istio.workload.Workload.locality:type_name -> istio.workload.Locality
+	1,  // 21: istio.workload.Workload.network_mode:type_name -> istio.workload.NetworkMode
+	23, // 22: istio.workload.Workload.extensions:type_name -> istio.workload.Extension
+	25, // 23: istio.workload.Workload.capacity:type_name -> google.protobuf.UInt32Value
+	17, // 24: istio.workload.PortList.ports:type_name -> istio.workload.Port
+	4,  // 25: istio.workload.Port.app_protocol:type_name -> istio.workload.AppProtocol
+	10, // 26: istio.workload.ApplicationTunnel.protocol:type_name -> istio.workload.ApplicationTunnel.Protocol
+	22, // 27: istio.workload.GatewayAddress.hostname:type_name -> istio.workload.NamespacedHostname
+	21, // 28: istio.workload.GatewayAddress.address:type_name -> istio.workload.NetworkAddress
+	19, // 29: istio.workload.WeightedWaypoint.destination:type_name -> istio.workload.GatewayAddress
+	26, // 30: istio.workload.Extension.config:type_name -> google.protobuf.Any
+	16, // 31: istio.workload.Workload.ServicesEntry.value:type_name -> istio.workload.PortList
+	32, // [32:32] is the sub-list for method output_type
+	32, // [32:32] is the sub-list for method input_type
+	32, // [32:32] is the sub-list for extension type_name
+	32, // [32:32] is the sub-list for extension extendee
+	0,  // [0:32] is the sub-list for field type_name
 }
 
 func init() { file_workloadapi_workload_proto_init() }
@@ -2053,7 +2124,7 @@ func file_workloadapi_workload_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_workloadapi_workload_proto_rawDesc), len(file_workloadapi_workload_proto_rawDesc)),
-			NumEnums:      10,
+			NumEnums:      11,
 			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/pkg/workloadapi/workload.proto
+++ b/pkg/workloadapi/workload.proto
@@ -109,6 +109,19 @@ message Service {
   // set, `waypoint` remains populated with the primary waypoint so that dataplanes which do
   // not understand this field continue to send all traffic to the primary.
   repeated WeightedWaypoint weighted_waypoints = 13;
+  // Visibility controls which clients can resolve and send traffic to a service.
+  enum Visibility {
+    // Visible to every client the control plane serves. This is the default,
+    // and matches the behavior before this field was introduced.
+    PUBLIC = 0;
+    // Visible only to clients in the same namespace as the service.
+    NAMESPACE = 1;
+  }
+
+  // visibility controls which clients this service is resolvable by. When
+  // unset it defaults to PUBLIC. Services that a mesh administrator has scoped
+  // to no visibility at all are simply not sent, so they do not appear here.
+  Visibility visibility = 14;
 }
 
 enum IPFamilies {

--- a/pkg/workloadapi/workload_vtproto.pb.go
+++ b/pkg/workloadapi/workload_vtproto.pb.go
@@ -205,6 +205,9 @@ func (this *Service) EqualVT(that *Service) bool {
 			}
 		}
 	}
+	if this.Visibility != that.Visibility {
+		return false
+	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
@@ -782,6 +785,11 @@ func (m *Service) MarshalToSizedBufferVTStrict(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Visibility != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Visibility))
+		i--
+		dAtA[i] = 0x70
 	}
 	if len(m.WeightedWaypoints) > 0 {
 		for iNdEx := len(m.WeightedWaypoints) - 1; iNdEx >= 0; iNdEx-- {
@@ -1836,6 +1844,9 @@ func (m *Service) SizeVT() (n int) {
 			l = e.SizeVT()
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
+	}
+	if m.Visibility != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.Visibility))
 	}
 	n += len(m.unknownFields)
 	return n

--- a/releasenotes/notes/60870-serviceentry-visibility.yaml
+++ b/releasenotes/notes/60870-serviceentry-visibility.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 60870
+releaseNotes:
+- |
+  **Added** `meshConfig.serviceEntryVisibility`, letting a mesh administrator control the visibility of
+  `ServiceEntry` resources. Ambient (ztunnel and waypoints) enforces visibility by default;
+  classic sidecars additionally honor it when `applyToSidecars` is set. The feature is
+  inert unless configured, so existing meshes are unaffected by default.

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -2704,6 +2704,7 @@ func TestServiceEntryVisibility(t *testing.T) {
 		// explicitly labeled se-visibility=public.
 		i.PatchMeshConfigOrFail(t, `
 serviceEntryVisibility:
+  applyToSidecars: true
   defaultVisibility: NAMESPACE
   policies:
   - visibility: PUBLIC
@@ -2713,9 +2714,11 @@ serviceEntryVisibility:
           se-visibility: public`)
 
 		const (
-			shadowHost   = "visibility-shadow.internal"
-			localBackend = "shadowlocal"  // backs the namespace-local ServiceEntry
-			pubBackend   = "shadowpublic" // backs the public ServiceEntry
+			shadowHost    = "visibility-shadow.internal"
+			localOnlyHost = "visibility-local-only.internal"
+			localBackend  = "shadowlocal"  // backs the namespace-local ServiceEntry
+			pubBackend    = "shadowpublic" // backs the public ServiceEntry
+			sidecarClient = "seclient"     // sidecar-injected client exercising applyToSidecars
 		)
 
 		// Two ambient namespaces, both discovered by istiod (they lack the test-exclude label the
@@ -2736,13 +2739,35 @@ serviceEntryVisibility:
 			},
 		})
 
-		// Distinct backends so a shadow surfaces as the wrong responder, not merely a failure.
-		deployment.New(t).
+		// Distinct backends so a shadow surfaces as the wrong responder, not merely a failure. The
+		// sidecar client lives in the public namespace -- cross-namespace to the namespace-local
+		// ServiceEntry -- with DNS capture on so it resolves auto-allocated ServiceEntry addresses
+		// (PILOT_ENABLE_IP_AUTOALLOCATE is on by default). A sidecar-injected pod in an ambient
+		// namespace opts out of ztunnel capture (DataplaneModeNone) and uses its injected proxy, so it
+		// exercises the applyToSidecars exportTo ceiling rather than the ztunnel path.
+		echos := deployment.New(t).
 			WithConfig(echo.Config{Service: localBackend, Namespace: localNs, Ports: ports.All()}).
 			WithConfig(echo.Config{Service: pubBackend, Namespace: pubNs, Ports: ports.All()}).
+			WithConfig(echo.Config{
+				Service:        sidecarClient,
+				Namespace:      pubNs,
+				Ports:          ports.All(),
+				ServiceAccount: true,
+				Subsets: []echo.SubsetConfig{{
+					Replicas: 1,
+					Labels: map[string]string{
+						"sidecar.istio.io/inject":       "true",
+						label.IoIstioDataplaneMode.Name: constants.DataplaneModeNone,
+					},
+					Annotations: map[string]string{
+						"proxy.istio.io/config": `{"proxyMetadata":{"ISTIO_META_DNS_CAPTURE":"true"}}`,
+					},
+				}},
+			}).
 			BuildOrFail(t)
+		sidecar := match.ServiceName(echo.NamespacedName{Name: sidecarClient, Namespace: pubNs}).GetMatches(echos)
 
-		se := func(name, app string) string {
+		seHost := func(name, host, app string) string {
 			return fmt.Sprintf(`apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
@@ -2759,13 +2784,17 @@ spec:
   resolution: STATIC
   workloadSelector:
     labels:
-      app: %s`, name, shadowHost, app)
+      app: %s`, name, host, app)
 		}
 
 		// Create the namespace-local ServiceEntry FIRST so it is the older entry: absent the
 		// canonical guard it would win canonical selection and shadow the public one.
-		t.ConfigIstio().YAML(localNs.Name(), se("shadow-local", localBackend)).ApplyOrFail(t)
-		t.ConfigIstio().YAML(pubNs.Name(), se("shadow-public", pubBackend)).ApplyOrFail(t)
+		t.ConfigIstio().YAML(localNs.Name(), seHost("shadow-local", shadowHost, localBackend)).ApplyOrFail(t)
+		t.ConfigIstio().YAML(pubNs.Name(), seHost("shadow-public", shadowHost, pubBackend)).ApplyOrFail(t)
+		// A namespace-local ServiceEntry with no public sibling, used only for the sidecar negative
+		// case below: it is NAMESPACE-visible and lives in localNs, so it must be unreachable from a
+		// client outside localNs.
+		t.ConfigIstio().YAML(localNs.Name(), seHost("local-only", localOnlyHost, localBackend)).ApplyOrFail(t)
 
 		// A cross-namespace ambient client: the namespace-local ServiceEntry is invisible to it and
 		// must not shadow the public one, so the shared host must resolve to the PUBLIC backend.
@@ -2780,6 +2809,31 @@ spec:
 				// never the namespace-local one (which would indicate shadowing / wrong canonical).
 				check.BodyContains("Hostname="+pubBackend),
 			),
+		})
+
+		// The sidecar client is cross-namespace to the namespace-local ServiceEntry. With
+		// applyToSidecars, that SE's exportTo is capped to its own namespace, so it is absent from the
+		// sidecar's config: the shared host resolves only to the PUBLIC backend (no shadowing), exactly
+		// as for the ambient client above.
+		sidecar[0].CallOrFail(t, echo.CallOptions{
+			Address: shadowHost,
+			Port:    echo.Port{Name: "http", ServicePort: 80},
+			Scheme:  scheme.HTTP,
+			HTTP:    echo.HTTP{Path: "/visibility"},
+			Check: check.And(
+				check.OK(),
+				check.BodyContains("Hostname="+pubBackend),
+			),
+		})
+		// The namespace-local-only ServiceEntry has no public sibling, so the ceiling removes it from
+		// the cross-namespace sidecar entirely: the host is neither routable nor resolvable, and the
+		// call fails. This distinguishes the positive case above from one that passes for unrelated
+		// reasons.
+		sidecar[0].CallOrFail(t, echo.CallOptions{
+			Address: localOnlyHost,
+			Port:    echo.Port{Name: "http", ServicePort: 80},
+			Scheme:  scheme.HTTP,
+			Check:   check.Error(),
 		})
 	})
 }

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -53,6 +53,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo/common/ports"
 	"istio.io/istio/pkg/test/framework/components/echo/config"
 	"istio.io/istio/pkg/test/framework/components/echo/config/param"
+	"istio.io/istio/pkg/test/framework/components/echo/deployment"
 	"istio.io/istio/pkg/test/framework/components/echo/echotest"
 	"istio.io/istio/pkg/test/framework/components/echo/match"
 	"istio.io/istio/pkg/test/framework/components/echo/util/traffic"
@@ -2688,6 +2689,99 @@ spec:
 				})
 			}
 		})
+}
+
+// TestServiceEntryVisibility exercises MeshConfig.serviceEntryVisibility end-to-end in ambient:
+// with a safe-by-default NAMESPACE default and a policy promoting se-visibility=public namespaces
+// to PUBLIC, a namespace-local ServiceEntry must be completely invisible to an out-of-namespace
+// client and must not shadow a PUBLIC ServiceEntry that shares its hostname -- even when the
+// namespace-local one is created first (older, so it would win canonical selection if istiod's
+// guard were missing). This single test covers visibility filtering, the canonical guard, and
+// non-shadowing at once.
+func TestServiceEntryVisibility(t *testing.T) {
+	framework.NewTest(t).Run(func(t framework.TestContext) {
+		// Safe-by-default posture: every ServiceEntry is namespace-local unless its namespace is
+		// explicitly labeled se-visibility=public.
+		i.PatchMeshConfigOrFail(t, `
+serviceEntryVisibility:
+  defaultVisibility: NAMESPACE
+  policies:
+  - visibility: PUBLIC
+    matchingRules:
+    - namespaceSelector:
+        matchLabels:
+          se-visibility: public`)
+
+		const (
+			shadowHost   = "visibility-shadow.internal"
+			localBackend = "shadowlocal"  // backs the namespace-local ServiceEntry
+			pubBackend   = "shadowpublic" // backs the public ServiceEntry
+		)
+
+		// Two ambient namespaces, both discovered by istiod (they lack the test-exclude label the
+		// discoverySelectors in tests/integration/iop-ambient-test-defaults.yaml filter on -- note
+		// apps.ExternalNamespace carries that label and is deliberately NOT discovered, so a
+		// ServiceEntry there never reaches WDS). Only the public namespace is labeled
+		// se-visibility=public, so the policy promotes just its ServiceEntries to PUBLIC; the other
+		// stays namespace-local by the NAMESPACE default.
+		localNs := namespace.NewOrFail(t, namespace.Config{
+			Prefix: "vis-local",
+			Labels: map[string]string{"istio.io/dataplane-mode": "ambient"},
+		})
+		pubNs := namespace.NewOrFail(t, namespace.Config{
+			Prefix: "vis-public",
+			Labels: map[string]string{
+				"istio.io/dataplane-mode": "ambient",
+				"se-visibility":           "public",
+			},
+		})
+
+		// Distinct backends so a shadow surfaces as the wrong responder, not merely a failure.
+		deployment.New(t).
+			WithConfig(echo.Config{Service: localBackend, Namespace: localNs, Ports: ports.All()}).
+			WithConfig(echo.Config{Service: pubBackend, Namespace: pubNs, Ports: ports.All()}).
+			BuildOrFail(t)
+
+		se := func(name, app string) string {
+			return fmt.Sprintf(`apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: %s
+spec:
+  hosts:
+  - %s
+  ports:
+  - name: http
+    number: 80
+    protocol: HTTP
+    targetPort: 8080
+  location: MESH_INTERNAL
+  resolution: STATIC
+  workloadSelector:
+    labels:
+      app: %s`, name, shadowHost, app)
+		}
+
+		// Create the namespace-local ServiceEntry FIRST so it is the older entry: absent the
+		// canonical guard it would win canonical selection and shadow the public one.
+		t.ConfigIstio().YAML(localNs.Name(), se("shadow-local", localBackend)).ApplyOrFail(t)
+		t.ConfigIstio().YAML(pubNs.Name(), se("shadow-public", pubBackend)).ApplyOrFail(t)
+
+		// A cross-namespace ambient client: the namespace-local ServiceEntry is invisible to it and
+		// must not shadow the public one, so the shared host must resolve to the PUBLIC backend.
+		apps.Captured[0].CallOrFail(t, echo.CallOptions{
+			Address: shadowHost,
+			Port:    echo.Port{Name: "http", ServicePort: 80},
+			Scheme:  scheme.HTTP,
+			HTTP:    echo.HTTP{Path: "/visibility"},
+			Check: check.And(
+				check.OK(),
+				// The echo response identifies the responding pod; it must be the public backend,
+				// never the namespace-local one (which would indicate shadowing / wrong canonical).
+				check.BodyContains("Hostname="+pubBackend),
+			),
+		})
+	})
 }
 
 // Run runs the given reachability test cases with the context.


### PR DESCRIPTION
**Please provide a description of this PR:**

This is the control plane implementation of the [Safer ServiceEntry](https://docs.google.com/document/d/17CLPeo1Jzi283GBAutqhXLTa1LZxDili5EIhllmbPn0/edit?usp=sharing) proposal.

This includes control plane changes for the ambient as well as sidecar data plane modes. Status is derived from code in the ambient indexes even when applyToSidecars is on.

The current implementation uses the new visibility to calculate a ceiling for sidecar visibility. This is to say `exportTo: *` when combined with `visibility: NAMESPACE` will reduce the export to being namespace scoped. The converse is that `exportTo: beep` with `visibility: PUBLIC` will not be visible in all namespaces, but rather only to `beep` as requested. It's genuinely unclear if this is the best solution however since folks may use `exportTo` in order to control the sizes of proxy configuration being generated, it seemed counter productive to eliminate that scoping when applyToSidecars is enabled.

https://github.com/istio/ztunnel/pull/1976 contains dataplane code.