### PR TITLE
add metric exposing the the istio-cni server requests received

### DIFF
--- a/cni/pkg/nodeagent/cni-watcher.go
+++ b/cni/pkg/nodeagent/cni-watcher.go
@@ -17,11 +17,13 @@ package nodeagent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/netip"
+	"strconv"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -29,7 +31,16 @@ import (
 	pconstants "istio.io/istio/cni/pkg/constants"
 	"istio.io/istio/cni/pkg/pluginlistener"
 	istiolog "istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/monitoring"
 	"istio.io/istio/pkg/sleep"
+)
+
+var (
+	responseCodeLabel   = monitoring.CreateLabel("response_code")
+	pluginRequestsTotal = monitoring.NewSum(
+		"istio_cni_plugin_requests_total",
+		"The total number of CNI plugin requests handled by the node agent.",
+	)
 )
 
 // Just a composite of the CNI plugin add event struct + some extracted "args"
@@ -118,30 +129,37 @@ func (s *CniPluginServer) Start() error {
 }
 
 func (s *CniPluginServer) handleAddEvent(w http.ResponseWriter, req *http.Request) {
+	code, err := s.processAddRequest(req)
+	pluginRequestsTotal.With(responseCodeLabel.Value(strconv.Itoa(code))).Increment()
+	if err != nil {
+		http.Error(w, err.Error(), code)
+		return
+	}
+	w.WriteHeader(code)
+}
+
+func (s *CniPluginServer) processAddRequest(req *http.Request) (int, error) {
 	if req.Body == nil {
 		log.Error("empty request body")
-		http.Error(w, "empty request body", http.StatusBadRequest)
-		return
+		return http.StatusBadRequest, errors.New("empty request body")
 	}
 	defer req.Body.Close()
 	data, err := io.ReadAll(req.Body)
 	if err != nil {
 		log.Errorf("failed to read event report from cni plugin: %v", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+		return http.StatusInternalServerError, err
 	}
 	msg, err := processAddEvent(data)
 	if err != nil {
 		log.Errorf("failed to process CNI event payload: %v", err)
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
+		return http.StatusBadRequest, err
 	}
 
 	if err := s.ReconcileCNIAddEvent(req.Context(), msg); err != nil {
 		log.WithLabels("ns", msg.PodNamespace, "name", msg.PodName).Errorf("failed to handle add event: %v", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+		return http.StatusInternalServerError, err
 	}
+	return http.StatusOK, nil
 }
 
 func processAddEvent(body []byte) (CNIPluginAddEvent, error) {

--- a/cni/pkg/nodeagent/cni-watcher_test.go
+++ b/cni/pkg/nodeagent/cni-watcher_test.go
@@ -15,10 +15,13 @@
 package nodeagent
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"net/netip"
 	"strings"
 	"testing"
@@ -29,9 +32,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"istio.io/api/label"
+	pconstants "istio.io/istio/cni/pkg/constants"
 	"istio.io/istio/cni/pkg/util"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/monitoring/monitortest"
 	"istio.io/istio/pkg/test/util/assert"
 )
 
@@ -113,6 +118,7 @@ func TestCNIPluginServer(t *testing.T) {
 	}
 
 	setupLogging()
+	mt := monitortest.New(t)
 	NodeName = "testnode"
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -161,18 +167,34 @@ func TestCNIPluginServer(t *testing.T) {
 
 	payload, _ := json.Marshal(valid)
 
-	// serialize our fake plugin event
-	addEvent, err := processAddEvent(payload)
-	assert.Equal(t, err, nil)
-
-	// Push it thru the handler
-	pluginServer.ReconcileCNIAddEvent(ctx, addEvent)
+	// Push it thru the plugin event handler
+	rec := httptest.NewRecorder()
+	pluginServer.handleAddEvent(rec, httptest.NewRequest(http.MethodPost, pconstants.CNIAddEventPath, bytes.NewReader(payload)).WithContext(ctx))
+	assert.Equal(t, rec.Code, http.StatusOK)
+	mt.Assert(pluginRequestsTotal.Name(), map[string]string{"response_code": "200"}, monitortest.Exactly(1))
 
 	waitForMockCalls()
 
 	assertPodAnnotated(t, client, pod)
 	// Assert expected calls actually made
 	fs.AssertExpectations(t)
+
+	// An unparseable payload should get a 400
+	rec = httptest.NewRecorder()
+	pluginServer.handleAddEvent(rec, httptest.NewRequest(http.MethodPost, pconstants.CNIAddEventPath, strings.NewReader("notjson")).WithContext(ctx))
+	assert.Equal(t, rec.Code, http.StatusBadRequest)
+	mt.Assert(pluginRequestsTotal.Name(), map[string]string{"response_code": "400"}, monitortest.Exactly(1))
+
+	// An event for a pod we can't find should get a 500
+	payload, _ = json.Marshal(CNIPluginAddEvent{
+		Netns:        "/var/netns/foo",
+		PodName:      "pod-nonexistent",
+		PodNamespace: "funkyns",
+	})
+	rec = httptest.NewRecorder()
+	pluginServer.handleAddEvent(rec, httptest.NewRequest(http.MethodPost, pconstants.CNIAddEventPath, bytes.NewReader(payload)).WithContext(ctx))
+	assert.Equal(t, rec.Code, http.StatusInternalServerError)
+	mt.Assert(pluginRequestsTotal.Name(), map[string]string{"response_code": "500"}, monitortest.Exactly(1))
 }
 
 func TestGetPodWithRetry(t *testing.T) {

--- a/releasenotes/notes/cni-plugin-request-metric.yaml
+++ b/releasenotes/notes/cni-plugin-request-metric.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+
+issue:
+  - https://github.com/istio/istio/pull/60878
+
+releaseNotes:
+  - |
+    **Added** a new metric, `istio_cni_plugin_requests_total`, to the istio-cni node agent. It counts CNI plugin
+    add-event requests handled by the node agent, labeled by `response_code`.


### PR DESCRIPTION
**Please provide a description of this PR:**

Add a metric for  `istio-cni-node` exposing the number of requests handled by the UDS server which the plugin binary connects to, `istio_cni_plugin_requests_total`. This metric includes 1 label, the `response_code` we served.