### PR TITLE
chore(go): bump Go version to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module istio.io/istio
 
-go 1.26.0
+go 1.26.5
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0


### PR DESCRIPTION
## Summary

Bumps the minimum Go version from 1.26.0 to 1.26.5 to resolve three HIGH-severity stdlib CVEs affecting binaries built with Go 1.26.0–1.26.3.

## CVEs fixed

| CVE | Package | Description | Fixed in |
|-----|---------|-------------|----------|
| CVE-2026-27145 | `crypto/x509` | `VerifyHostname` has quadratic cost with large DNS SAN lists, exploitable on unauthenticated TLS connections | Go 1.26.4 |
| CVE-2026-42504 | `mime` | Denial of service via crafted MIME input | Go 1.26.4 |
| CVE-2026-39822 | `os` | `os.Root` follows symlinks, enabling path traversal | Go 1.26.5 |

## Notes

- Only `go.mod` changes — no dependency additions or removals.
- Go 1.26.5 covers all three CVEs (supersedes 1.26.4).
- The four `istio.io/istio` CVEs appearing in vulnerability scans of the proxyv2 image (CVE-2019-14993, CVE-2021-39155, CVE-2021-39156, CVE-2022-23635) are false positives caused by trivy misinterpreting the Go pseudo-version `v0.0.0-...` against semver-tagged fix versions — they are not addressed here.