### PR TITLE
ambient: propagate locality label to E/W gateway workloads

### DIFF
--- a/pilot/pkg/model/network.go
+++ b/pilot/pkg/model/network.go
@@ -33,6 +33,7 @@ import (
 	"istio.io/istio/pkg/util/istiomultierror"
 	netutil "istio.io/istio/pkg/util/net"
 	"istio.io/istio/pkg/util/sets"
+	"istio.io/istio/pkg/workloadapi"
 )
 
 // NetworkGateway is the gateway of a network
@@ -49,6 +50,9 @@ type NetworkGateway struct {
 	HBONEPort uint32
 	// ServiceAccount the gateway runs as
 	ServiceAccount types.NamespacedName
+	// Locality of the gateway, read from topology.istio.io/locality (or the legacy
+	// istio-locality label) on the gateway. Nil if no locality label is set.
+	Locality *workloadapi.Locality
 }
 
 type NetworkGatewaysWatcher interface {

--- a/pilot/pkg/serviceregistry/ambient/networks.go
+++ b/pilot/pkg/serviceregistry/ambient/networks.go
@@ -25,6 +25,7 @@ import (
 	"istio.io/api/label"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
+	labelutil "istio.io/istio/pilot/pkg/serviceregistry/util/label"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
@@ -32,8 +33,10 @@ import (
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/kube/multicluster"
 	"istio.io/istio/pkg/log"
+	pm "istio.io/istio/pkg/model"
 	"istio.io/istio/pkg/network"
 	"istio.io/istio/pkg/ptr"
+	"istio.io/istio/pkg/workloadapi"
 )
 
 type NetworkGateway struct {
@@ -257,6 +260,30 @@ func k8sGatewayToNetworkGatewaysWithCluster(
 	return networkGateways
 }
 
+// localityFromLabels returns the locality encoded in the topology.istio.io/locality label (or the
+// legacy istio-locality label), if set. Returns nil if neither label is present.
+func localityFromLabels(labels map[string]string) *workloadapi.Locality {
+	localityLabel := pm.SanitizeLocalityLabel(pm.GetLocalityLabel(labels))
+	if localityLabel == "" {
+		return nil
+	}
+	region, zone, subzone := labelutil.SplitLocalityLabel(localityLabel)
+	if region == "" && zone == "" && subzone == "" {
+		return nil
+	}
+	return &workloadapi.Locality{
+		Region:  region,
+		Zone:    zone,
+		Subzone: subzone,
+	}
+}
+
+// gatewayLocality returns the locality advertised by the gateway via the topology.istio.io/locality
+// label (or the legacy istio-locality label), if set. Returns nil if the gateway has no locality label.
+func gatewayLocality(gw *gatewayv1.Gateway) *workloadapi.Locality {
+	return localityFromLabels(gw.GetLabels())
+}
+
 func remoteK8sGatewayToNetworkGateways(clusterID cluster.ID, gw *gatewayv1.Gateway) []NetworkGateway {
 	netLabel := gw.GetLabels()[label.TopologyNetwork.Name]
 	if netLabel == "" {
@@ -275,6 +302,7 @@ func remoteK8sGatewayToNetworkGateways(clusterID cluster.ID, gw *gatewayv1.Gatew
 			Namespace: gw.Namespace,
 			Name:      kube.GatewaySA(gw),
 		},
+		Locality: gatewayLocality(gw),
 	}
 	gateways := []NetworkGateway{}
 	source := config.NamespacedName(gw)
@@ -318,6 +346,7 @@ func localK8sGatewayToNetworkGateways(clusterID cluster.ID, gw *gatewayv1.Gatewa
 			Namespace: gw.Namespace,
 			Name:      kube.GatewaySA(gw),
 		},
+		Locality: gatewayLocality(gw),
 	}
 	gateways := []NetworkGateway{}
 	source := config.NamespacedName(gw)

--- a/pilot/pkg/serviceregistry/ambient/networks_test.go
+++ b/pilot/pkg/serviceregistry/ambient/networks_test.go
@@ -1,0 +1,81 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ambient
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"istio.io/api/label"
+	"istio.io/istio/pkg/test/util/assert"
+	"istio.io/istio/pkg/workloadapi"
+)
+
+func TestGatewayLocality(t *testing.T) {
+	cases := []struct {
+		name   string
+		labels map[string]string
+		want   *workloadapi.Locality
+	}{
+		{
+			name:   "no locality label",
+			labels: map[string]string{"topology.istio.io/network": "network-1"},
+			want:   nil,
+		},
+		{
+			name: "topology.istio.io/locality label, all three levels",
+			labels: map[string]string{
+				label.TopologyLocality.Name: "region1.zone1.subzone1",
+			},
+			want: &workloadapi.Locality{Region: "region1", Zone: "zone1", Subzone: "subzone1"},
+		},
+		{
+			name: "topology.istio.io/locality label, region only",
+			labels: map[string]string{
+				label.TopologyLocality.Name: "region1",
+			},
+			want: &workloadapi.Locality{Region: "region1"},
+		},
+		{
+			name: "legacy istio-locality label",
+			labels: map[string]string{
+				"istio-locality": "region1.zone1",
+			},
+			want: &workloadapi.Locality{Region: "region1", Zone: "zone1"},
+		},
+		{
+			name: "topology.istio.io/locality takes precedence over legacy label",
+			labels: map[string]string{
+				label.TopologyLocality.Name: "region1.zone1",
+				"istio-locality":            "region2.zone2",
+			},
+			want: &workloadapi.Locality{Region: "region1", Zone: "zone1"},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			gw := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "eastwestgateway",
+					Namespace: testNS,
+					Labels:    tt.labels,
+				},
+			}
+			assert.Equal(t, gatewayLocality(gw), tt.want)
+		})
+	}
+}

--- a/pilot/pkg/serviceregistry/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/ambient/workloads.go
@@ -1341,6 +1341,12 @@ func constructServices(p *v1.Pod, services []model.ServiceInfo) map[string]*work
 }
 
 func getPodLocality(ctx krt.HandlerContext, Nodes krt.Collection[Node], pod *v1.Pod) *workloadapi.Locality {
+	// Prefer an explicit locality label on the pod itself (topology.istio.io/locality, falling back to
+	// the legacy istio-locality label) over the locality derived from the node it's scheduled on.
+	if loc := localityFromLabels(pod.Labels); loc != nil {
+		return loc
+	}
+
 	// NodeName is set by the scheduler after the pod is created
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#late-initialization
 	node := krt.FetchOne(ctx, Nodes, krt.FilterKey(pod.Spec.NodeName))
@@ -1420,6 +1426,7 @@ func convertGateway(mesh *MeshConfig) func(gw NetworkGateway) model.WorkloadInfo
 			Namespace:      gw.ServiceAccount.Namespace,
 			Network:        gw.Network.String(),
 			TrustDomain:    pickTrustDomain(mesh),
+			Locality:       gw.Locality,
 		}
 
 		if ip, err := netip.ParseAddr(gw.Addr); err == nil {

--- a/pilot/pkg/serviceregistry/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/ambient/workloads_test.go
@@ -410,6 +410,50 @@ func TestPodWorkloads(t *testing.T) {
 			},
 		},
 		{
+			name: "pod locality label takes precedence over node locality",
+			inputs: []any{
+				Node{
+					Name: "node",
+					Locality: &workloadapi.Locality{
+						Region: "node-region",
+						Zone:   "node-zone",
+					},
+				},
+			},
+			pod: &v1.Pod{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "ns",
+					Labels:    map[string]string{label.TopologyLocality.Name: "pod-region.pod-zone.pod-subzone"},
+				},
+				Spec: v1.PodSpec{NodeName: "node"},
+				Status: v1.PodStatus{
+					Phase: v1.PodPending,
+					PodIP: "1.2.3.4",
+				},
+			},
+			result: &workloadapi.Workload{
+				Uid:               "cluster0//Pod/ns/name",
+				Name:              "name",
+				Namespace:         "ns",
+				Node:              "node",
+				Addresses:         [][]byte{netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice()},
+				Network:           testNW,
+				CanonicalName:     "name",
+				CanonicalRevision: "latest",
+				WorkloadType:      workloadapi.WorkloadType_POD,
+				WorkloadName:      "name",
+				Status:            workloadapi.WorkloadStatus_UNHEALTHY,
+				ClusterId:         testC,
+				Locality: &workloadapi.Locality{
+					Region:  "pod-region",
+					Zone:    "pod-zone",
+					Subzone: "pod-subzone",
+				},
+			},
+		},
+		{
 			name: "pod with authz",
 			inputs: []any{
 				model.WorkloadAuthorization{

--- a/releasenotes/notes/60889.yaml
+++ b/releasenotes/notes/60889.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+- 60889
+releaseNotes:
+- |
+    **Added** support for setting locality (region/zone/subzone) on an ambient east-west gateway via the
+    `topology.istio.io/locality` label (or the legacy `istio-locality` label). The locality is now propagated
+    to remote ztunnels, enabling full locality-aware load balancing across networks in ambient mesh.


### PR DESCRIPTION
**Please provide a description of this PR:**

Allow setting topology.istio.io/locality on an ambient east-west Gateway and propagate it to remote ztunnels via the NetworkGateway workload, enabling locality aware load balancing across networks. Also fixes ambient pod locality to prefer the pod's own label over the node's, matching the sidecar path.

Fixes #60889