### PR TITLE
xds: scope ConfigMap and Secret pushes to only affected proxies

### DIFF
--- a/pilot/pkg/model/credentials/resource.go
+++ b/pilot/pkg/model/credentials/resource.go
@@ -30,7 +30,7 @@ const (
 	// KubernetesGatewaySecretType is the name of a SDS secret stored in Kubernetes, used by the gateway-api. Secrets here
 	// take the form kubernetes-gateway://namespace/name. They are pulled from the config cluster.
 	KubernetesGatewaySecretType    = "kubernetes-gateway"
-	kubernetesGatewaySecretTypeURI = KubernetesGatewaySecretType + "://"
+	KubernetesGatewaySecretTypeURI = KubernetesGatewaySecretType + "://"
 	// BuiltinGatewaySecretType is the name of a SDS secret that uses the workloads own mTLS certificate
 	BuiltinGatewaySecretType    = "builtin"
 	BuiltinGatewaySecretTypeURI = BuiltinGatewaySecretType + "://"
@@ -86,7 +86,7 @@ func ToResourceName(name string) string {
 	// If they explicitly defined the type, keep it
 	if strings.HasPrefix(name, KubernetesConfigMapTypeURI) ||
 		strings.HasPrefix(name, KubernetesSecretTypeURI) ||
-		strings.HasPrefix(name, kubernetesGatewaySecretTypeURI) {
+		strings.HasPrefix(name, KubernetesGatewaySecretTypeURI) {
 		return name
 	}
 	// Otherwise, to kubernetes://
@@ -143,7 +143,7 @@ func ParseResourceName(resourceName string, proxyNamespace string, proxyCluster 
 			ResourceName: resourceName,
 			Cluster:      configCluster,
 		}, nil
-	} else if after, ok := strings.CutPrefix(resourceName, kubernetesGatewaySecretTypeURI); ok {
+	} else if after, ok := strings.CutPrefix(resourceName, KubernetesGatewaySecretTypeURI); ok {
 		// Valid formats:
 		// * kubernetes-gateway://secret-namespace/secret-name
 		// Namespace is required. The secret is read from the config cluster; this is the primary difference from KubernetesSecretType.

--- a/pilot/pkg/xds/proxy_dependencies.go
+++ b/pilot/pkg/xds/proxy_dependencies.go
@@ -15,8 +15,11 @@
 package xds
 
 import (
+	"strings"
+
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/model/credentials"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/schema/kind"
@@ -84,6 +87,20 @@ func proxyDependentOnConfig(proxy *model.Proxy, config model.ConfigKey, push *mo
 	if features.ScopedAddressPushes && config.Kind == kind.Address {
 		return proxy.GetWatchedResource(v3.AddressType) != nil
 	}
+	// Secret/ConfigMap updates only matter to proxies that subscribe to the specific resource via SDS.
+	if config.Kind == kind.Secret {
+		// Proxies using WasmPlugin/TrafficExtension might use image pull credentials outside of SDS subscriptions,
+		// so for those proxies, we need to preserve the old behavior of pushing at every change.
+		// TODO: build a reverse index (secret -> TrafficExtension resource names) in PushContext so we
+		// can precisely match instead of pushing on each Secret change
+		if proxy.GetWatchedResource(v3.ExtensionConfigurationType) != nil {
+			return true
+		}
+		return proxyReferencesSecret(proxy, config)
+	}
+	if config.Kind == kind.ConfigMap {
+		return proxyReferencesConfigMap(proxy, config)
+	}
 	// Detailed config dependencies check.
 	switch proxy.Type {
 	case model.SidecarProxy:
@@ -114,6 +131,47 @@ func proxyDependentOnConfig(proxy *model.Proxy, config model.ConfigKey, push *mo
 		return true
 	}
 	return false
+}
+
+// proxyReferencesSecret checks whether the proxy's SDS subscriptions include the given secret.
+func proxyReferencesSecret(proxy *model.Proxy, config model.ConfigKey) bool {
+	sds := proxy.GetWatchedResource(v3.SecretType)
+	if sds == nil || sds.ResourceNames.Len() == 0 {
+		return false
+	}
+	secretName := config.Name
+	secretNS := config.Namespace
+	proxyNS := proxy.GetNamespace()
+
+	// Build candidate names: the secret itself and its -cacert counterpart.
+	names := []string{secretName}
+	if stripped := strings.TrimSuffix(secretName, credentials.SdsCaSuffix); stripped != secretName {
+		names = append(names, stripped)
+	} else {
+		names = append(names, secretName+credentials.SdsCaSuffix)
+	}
+
+	for _, name := range names {
+		if proxyNS == secretNS && sds.ResourceNames.Contains(credentials.KubernetesSecretTypeURI+name) {
+			return true
+		}
+		if sds.ResourceNames.Contains(credentials.KubernetesSecretTypeURI + secretNS + "/" + name) {
+			return true
+		}
+		if sds.ResourceNames.Contains(credentials.KubernetesGatewaySecretTypeURI + secretNS + "/" + name) {
+			return true
+		}
+	}
+	return false
+}
+
+// proxyReferencesConfigMap checks whether the proxy's SDS subscriptions include the given configmap.
+func proxyReferencesConfigMap(proxy *model.Proxy, config model.ConfigKey) bool {
+	sds := proxy.GetWatchedResource(v3.SecretType)
+	if sds == nil {
+		return false
+	}
+	return sds.ResourceNames.Contains(credentials.KubernetesConfigMapTypeURI + config.Namespace + "/" + config.Name)
 }
 
 // DefaultProxyNeedsPush check if a proxy needs push for this push event and returns a new PushRequest in the case

--- a/pilot/pkg/xds/proxy_dependencies_test.go
+++ b/pilot/pkg/xds/proxy_dependencies_test.go
@@ -679,3 +679,130 @@ func TestWaypointNeedsPush(t *testing.T) {
 		assert.Equal(t, waypointNeedsPush(addressUpdate(), waypoint), true)
 	})
 }
+
+func TestScopedSecretPushes(t *testing.T) {
+	const (
+		nsName     = "ns1"
+		nsOther    = "ns2"
+		nsRoot     = "rootns"
+		secretName = "my-tls-secret"
+	)
+
+	type Case struct {
+		name    string
+		proxy   *model.Proxy
+		configs sets.Set[model.ConfigKey]
+		want    bool
+	}
+
+	makeProxy := func(proxyType model.NodeType, ns string, sdsResources []string, watchECDS bool) *model.Proxy {
+		p := &model.Proxy{
+			Type:             proxyType,
+			ConfigNamespace:  ns,
+			Metadata:         &model.NodeMetadata{Namespace: ns},
+			SidecarScope:     &model.SidecarScope{Name: "default", Namespace: ns},
+			WatchedResources: map[string]*model.WatchedResource{},
+		}
+		if len(sdsResources) > 0 {
+			p.NewWatchedResource(v3.SecretType, sdsResources)
+		}
+		if watchECDS {
+			p.NewWatchedResource(v3.ExtensionConfigurationType, nil)
+		}
+		return p
+	}
+
+	push := &model.PushContext{}
+	push.Mesh = &mesh.MeshConfig{RootNamespace: nsRoot}
+
+	cases := []Case{
+		{
+			name:    "secret update, sidecar with matching kubernetes:// subscription",
+			proxy:   makeProxy(model.SidecarProxy, nsName, []string{"kubernetes://my-tls-secret"}, false),
+			configs: sets.New(model.ConfigKey{Kind: kind.Secret, Name: secretName, Namespace: nsName}),
+			want:    true,
+		},
+		{
+			name:    "secret update, sidecar with no SDS subscription",
+			proxy:   makeProxy(model.SidecarProxy, nsName, nil, false),
+			configs: sets.New(model.ConfigKey{Kind: kind.Secret, Name: secretName, Namespace: nsName}),
+			want:    false,
+		},
+		{
+			name:    "secret update, sidecar with unrelated SDS subscription",
+			proxy:   makeProxy(model.SidecarProxy, nsName, []string{"kubernetes://other-secret"}, false),
+			configs: sets.New(model.ConfigKey{Kind: kind.Secret, Name: secretName, Namespace: nsName}),
+			want:    false,
+		},
+		{
+			name:    "secret update, sidecar subscribes to -cacert variant",
+			proxy:   makeProxy(model.SidecarProxy, nsName, []string{"kubernetes://my-tls-secret-cacert"}, false),
+			configs: sets.New(model.ConfigKey{Kind: kind.Secret, Name: secretName, Namespace: nsName}),
+			want:    true,
+		},
+		{
+			name:    "cacert secret update, sidecar subscribes to base secret",
+			proxy:   makeProxy(model.SidecarProxy, nsName, []string{"kubernetes://my-tls-secret"}, false),
+			configs: sets.New(model.ConfigKey{Kind: kind.Secret, Name: secretName + "-cacert", Namespace: nsName}),
+			want:    true,
+		},
+		{
+			name:    "secret update, proxy in different namespace with implicit kubernetes:// name",
+			proxy:   makeProxy(model.SidecarProxy, nsOther, []string{"kubernetes://my-tls-secret"}, false),
+			configs: sets.New(model.ConfigKey{Kind: kind.Secret, Name: secretName, Namespace: nsName}),
+			want:    false,
+		},
+		{
+			name:    "secret update, proxy with explicit kubernetes://ns/name subscription",
+			proxy:   makeProxy(model.SidecarProxy, nsOther, []string{"kubernetes://ns1/my-tls-secret"}, false),
+			configs: sets.New(model.ConfigKey{Kind: kind.Secret, Name: secretName, Namespace: nsName}),
+			want:    true,
+		},
+		{
+			name:    "secret update, gateway with kubernetes-gateway:// subscription",
+			proxy:   makeProxy(model.Router, nsName, []string{"kubernetes-gateway://ns1/my-tls-secret"}, false),
+			configs: sets.New(model.ConfigKey{Kind: kind.Secret, Name: secretName, Namespace: nsName}),
+			want:    true,
+		},
+		{
+			name:    "secret update, gateway with non-matching kubernetes-gateway:// subscription",
+			proxy:   makeProxy(model.Router, nsName, []string{"kubernetes-gateway://ns1/other-secret"}, false),
+			configs: sets.New(model.ConfigKey{Kind: kind.Secret, Name: secretName, Namespace: nsName}),
+			want:    false,
+		},
+		{
+			name:    "secret update, proxy watches ECDS (conservative push)",
+			proxy:   makeProxy(model.SidecarProxy, nsName, nil, true),
+			configs: sets.New(model.ConfigKey{Kind: kind.Secret, Name: secretName, Namespace: nsName}),
+			want:    true,
+		},
+		{
+			name:    "configmap update, proxy with matching configmap:// subscription",
+			proxy:   makeProxy(model.SidecarProxy, nsName, []string{"configmap://ns1/my-ca-cert"}, false),
+			configs: sets.New(model.ConfigKey{Kind: kind.ConfigMap, Name: "my-ca-cert", Namespace: nsName}),
+			want:    true,
+		},
+		{
+			name:    "configmap update, proxy with no subscription",
+			proxy:   makeProxy(model.SidecarProxy, nsName, nil, false),
+			configs: sets.New(model.ConfigKey{Kind: kind.ConfigMap, Name: "my-ca-cert", Namespace: nsName}),
+			want:    false,
+		},
+		{
+			name:    "configmap update, proxy with non-matching subscription",
+			proxy:   makeProxy(model.SidecarProxy, nsName, []string{"configmap://ns1/other-cm"}, false),
+			configs: sets.New(model.ConfigKey{Kind: kind.ConfigMap, Name: "my-ca-cert", Namespace: nsName}),
+			want:    false,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, got := DefaultProxyNeedsPush(tt.proxy, &model.PushRequest{
+				ConfigsUpdated: tt.configs,
+				Push:           push,
+			})
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}

--- a/pilot/pkg/xds/sds_test.go
+++ b/pilot/pkg/xds/sds_test.go
@@ -15,6 +15,7 @@
 package xds_test
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -31,6 +32,7 @@ import (
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	credentials "istio.io/istio/pilot/pkg/credentials/kube"
 	"istio.io/istio/pilot/pkg/model"
+	pilotxds "istio.io/istio/pilot/pkg/xds"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pilot/test/xds"
 	"istio.io/istio/pilot/test/xdstest"
@@ -40,6 +42,7 @@ import (
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/util/assert"
+	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/util/sets"
 	xdsserver "istio.io/istio/pkg/xds"
 )
@@ -547,5 +550,120 @@ func TestPrivateKeyProviderProxyConfig(t *testing.T) {
 		if scrt.GetTlsCertificate().GetPrivateKeyProvider() != nil {
 			t.Fatal("expect no private key provider in secret")
 		}
+	}
+}
+
+func TestScopedSecretPushNoStaleConfig(t *testing.T) {
+	const ns = "istio-system"
+	oldCert := readFile(filepath.Join(certDir, "dns/root-cert.pem"))
+	newCert := readFile(filepath.Join(certDir, "mountedcerts-client/root-cert.pem"))
+
+	type Case struct {
+		name         string
+		configKind   kind.Kind
+		makeObject   func(name, cert string) runtime.Object
+		resourceName func(name string) string
+		update       func(cc *fake.Clientset, obj runtime.Object) error
+	}
+
+	cases := []Case{
+		{
+			name:       "secret",
+			configKind: kind.Secret,
+			makeObject: func(name, cert string) runtime.Object {
+				return makeSecret(name, map[string]string{credentials.GenericScrtCaCert: cert})
+			},
+			resourceName: func(name string) string { return "kubernetes://" + name + "-cacert" },
+			update: func(cc *fake.Clientset, obj runtime.Object) error {
+				_, err := cc.CoreV1().Secrets(ns).Update(context.Background(), obj.(*corev1.Secret), metav1.UpdateOptions{})
+				return err
+			},
+		},
+		{
+			name:       "configmap",
+			configKind: kind.ConfigMap,
+			makeObject: func(name, cert string) runtime.Object {
+				return &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+					Data:       map[string]string{credentials.GenericScrtCaCert: cert},
+				}
+			},
+			resourceName: func(name string) string { return "configmap://" + ns + "/" + name },
+			update: func(cc *fake.Clientset, obj runtime.Object) error {
+				_, err := cc.CoreV1().ConfigMaps(ns).Update(context.Background(), obj.(*corev1.ConfigMap), metav1.UpdateOptions{})
+				return err
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			const (
+				rotatedName = "rotated"
+				otherName   = "other"
+			)
+			rotatedObj := tt.makeObject(rotatedName, oldCert)
+			otherObj := tt.makeObject(otherName, oldCert)
+
+			s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
+				KubernetesObjects:          []runtime.Object{rotatedObj, otherObj},
+				DisableSecretAuthorization: true,
+			})
+
+			makeProxy := func(sdsResource string, watchECDS bool) *model.Proxy {
+				p := &model.Proxy{
+					Type:             model.SidecarProxy,
+					ConfigNamespace:  ns,
+					VerifiedIdentity: &spiffe.Identity{Namespace: ns},
+					Metadata:         &model.NodeMetadata{ClusterID: constants.DefaultClusterName, Namespace: ns},
+					WatchedResources: map[string]*model.WatchedResource{},
+				}
+				p.NewWatchedResource(v3.SecretType, []string{sdsResource})
+				if watchECDS {
+					p.NewWatchedResource(v3.ExtensionConfigurationType, nil)
+				}
+				return p
+			}
+			proxyRotated := makeProxy(tt.resourceName(rotatedName), false)
+			proxyOther := makeProxy(tt.resourceName(otherName), false)
+			proxyWasm := makeProxy(tt.resourceName(otherName), true)
+
+			gen := s.Discovery.Generators[v3.SecretType]
+			getCaCert := func(p *model.Proxy, name string) string {
+				t.Helper()
+				wr := p.GetWatchedResource(v3.SecretType)
+				res, _, err := gen.Generate(p, wr, &model.PushRequest{Forced: true, Start: time.Now(), Push: s.PushContext()})
+				assert.NoError(t, err)
+				raw := xdstest.ExtractTLSSecrets(t, xdsserver.ResourcesToAny(res))
+				scrt, ok := raw[tt.resourceName(name)]
+				if !ok {
+					t.Fatalf("expected resource %v in response, got %v", tt.resourceName(name), raw)
+				}
+				return string(scrt.GetValidationContext().GetTrustedCa().GetInlineBytes())
+			}
+
+			assert.Equal(t, getCaCert(proxyRotated, rotatedName), oldCert)
+
+			cc := s.KubeClient().Kube().(*fake.Clientset)
+			before := s.Discovery.CommittedUpdates.Load()
+			assert.NoError(t, tt.update(cc, tt.makeObject(rotatedName, newCert)))
+			retry.UntilOrFail(t, func() bool {
+				return s.Discovery.CommittedUpdates.Load() > before
+			}, retry.Timeout(10*time.Second), retry.Delay(time.Millisecond*10))
+
+			changeKey := model.ConfigKey{Kind: tt.configKind, Name: rotatedName, Namespace: ns}
+			req := &model.PushRequest{ConfigsUpdated: sets.New(changeKey), Push: s.PushContext()}
+			_, needsPush := pilotxds.DefaultProxyNeedsPush(proxyRotated, req)
+			assert.Equal(t, needsPush, true)
+			_, needsPush = pilotxds.DefaultProxyNeedsPush(proxyOther, req)
+			assert.Equal(t, needsPush, false)
+			if tt.configKind == kind.Secret {
+				_, needsPush = pilotxds.DefaultProxyNeedsPush(proxyWasm, req)
+				assert.Equal(t, needsPush, true)
+			}
+
+			assert.Equal(t, getCaCert(proxyRotated, rotatedName), newCert)
+			assert.Equal(t, getCaCert(proxyOther, otherName), oldCert)
+		})
 	}
 }

--- a/pilot/test/xds/fake.go
+++ b/pilot/test/xds/fake.go
@@ -180,6 +180,12 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	}
 	mc := multicluster.NewFakeController()
 	creds := kubesecrets.NewMulticluster(opts.DefaultClusterName, mc)
+	creds.AddSecretHandler(func(k kind.Kind, name string, namespace string) {
+		s.ConfigUpdate(&model.PushRequest{
+			ConfigsUpdated: sets.New(model.ConfigKey{Kind: k, Name: name, Namespace: namespace}),
+			Reason:         model.NewReasonStats(model.SecretTrigger),
+		})
+	})
 
 	configController := memory.NewController(memory.MakeSkipValidation(collections.PilotGatewayAPI()))
 	clientBuilder := opts.KubeClientBuilder

--- a/releasenotes/notes/scoped-secret-pushes.yaml
+++ b/releasenotes/notes/scoped-secret-pushes.yaml
@@ -1,0 +1,13 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+issue:
+  - 60893
+
+releaseNotes:
+  - |
+    **Improved** xDS push efficiency by scoping Secret and ConfigMap updates to only the proxies that
+    subscribe to the changed resource via SDS. Previously, any Secret change triggered a push to every
+    proxy in the mesh, causing unnecessary CPU and network overhead in clusters with frequent secret
+    churn.


### PR DESCRIPTION
**Please provide a description of this PR:**
Previously, we'd push out new config to all proxies when any ConfigMap or Secret was updated. This is incredibly wasteful in clusters with a lot of churn, often from automation like credential rotation.

This patch makes sure that we only push new config to those proxies affected by the changed Secret or ConfigMap. There's one exception and that is proxies running WasmPlugin/TrafficExtension and using a secret to pull the relevant container images. Because these Secrets are not pulled directly by Envoy through xDS, we retain the previous behavior for those proxies.