### PR TITLE
ztunnel: inject CPU limit/request env vars for CPU-aware worker defaults

### DIFF
--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -168,6 +168,22 @@ spec:
             resourceFieldRef:
               resource: limits.cpu
               divisor: "1"
+        {{- if .Values.resources }}
+        {{- if (.Values.resources.limits).cpu }}
+        - name: ZTUNNEL_RESOURCE_CPU_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+              divisor: "1"
+        {{- end }}
+        {{- if (.Values.resources.requests).cpu }}
+        - name: ZTUNNEL_RESOURCE_CPU_REQUEST
+          valueFrom:
+            resourceFieldRef:
+              resource: requests.cpu
+              divisor: "1"
+        {{- end }}
+        {{- end }}
         {{- with .Values.env }}
         {{- range $key, $val := . }}
         - name: {{ $key }}

--- a/manifests/charts/ztunnel/values.yaml
+++ b/manifests/charts/ztunnel/values.yaml
@@ -57,6 +57,7 @@ _internal_defaults_do_not_set:
   # Pod resource configuration
   resources:
     requests:
+      # When above 2 cores, requests.cpu also sets ztunnel's minimum worker-thread count.
       cpu: 200m
       # Ztunnel memory scales with the size of the cluster and traffic load
       # While there are many factors, this is enough for ~200k pod cluster or 100k concurrently open connections.

--- a/operator/pkg/helm/testdata/output/ztunnel-dns-config.golden.yaml
+++ b/operator/pkg/helm/testdata/output/ztunnel-dns-config.golden.yaml
@@ -140,6 +140,11 @@ spec:
             resourceFieldRef:
               resource: limits.cpu
               divisor: "1"
+        - name: ZTUNNEL_RESOURCE_CPU_REQUEST
+          valueFrom:
+            resourceFieldRef:
+              resource: requests.cpu
+              divisor: "1"
         volumeMounts:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert

--- a/operator/pkg/render/manifest.go
+++ b/operator/pkg/render/manifest.go
@@ -216,6 +216,19 @@ func applyComponentValuesToHelmValues(comp component.Component, spec apis.Gatewa
 			_ = merged.SetPath(fmt.Sprintf("spec.values.%s.replicaCount", root), int64(spec.Kubernetes.ReplicaCount))
 		}
 	}
+	// Translate k8s.resources CPU into Helm values so chart guard conditions (e.g.
+	// ztunnel's ZTUNNEL_RESOURCE_CPU_* env vars) see operator-set resources. Without
+	// this, k8s.resources only patches the container post-render and is invisible at
+	// template time, so the guards would never fire on the istioctl/operator path.
+	if spec.Kubernetes != nil && spec.Kubernetes.Resources != nil {
+		merged = merged.DeepClone()
+		if cpu := spec.Kubernetes.Resources.Limits.Cpu(); !cpu.IsZero() {
+			_ = merged.SetPath(fmt.Sprintf("spec.values.%s.resources.limits.cpu", root), cpu.String())
+		}
+		if cpu := spec.Kubernetes.Resources.Requests.Cpu(); !cpu.IsZero() {
+			_ = merged.SetPath(fmt.Sprintf("spec.values.%s.resources.requests.cpu", root), cpu.String())
+		}
+	}
 	// No changes needed, skip early to avoid copy
 	if !comp.FlattenValues && spec.Hub == "" && spec.Tag == nil && spec.Label == nil {
 		return merged

--- a/releasenotes/notes/60899.yaml
+++ b/releasenotes/notes/60899.yaml
@@ -1,0 +1,12 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+
+issue: []
+
+releaseNotes:
+  - |
+    **Added** `ZTUNNEL_RESOURCE_CPU_LIMIT` and `ZTUNNEL_RESOURCE_CPU_REQUEST`
+    environment variables to the ztunnel DaemonSet, populated from the
+    configured `resources.limits.cpu` / `resources.requests.cpu` when set.
+    ztunnel uses these to derive CPU-aware worker-thread counts.


### PR DESCRIPTION
companion PR to: https://github.com/istio/ztunnel/pull/1993

Add `ZTUNNEL_RESOURCE_CPU_LIMIT` and `ZTUNNEL_RESOURCE_CPU_REQUEST` to the ztunnel daemonset, populated from the downward API only when `resources.limits.cpu` / `resources.requests.cpu` are configured. Their presence signals an explicit operator limit/request, which ztunnel uses to derive CPU-aware worker-thread defaults.

Also translate `k8s.resources` CPU into Helm values in the operator render path, so the new env var guards fire for istioctl/IstioOperator installs (where resources are otherwise applied only as a post-render overlay).

The existing unconditional `ZTUNNEL_CPU_LIMIT` block is left in place.

**note**: I noticed while working on this that the `data-snapshot.tar.gz` is pretty significantly out of date and seems to only be updated manually. Not doing that here but just registering it as the istioctl render path isn't technically covered with this out of date snapshot.