### PR TITLE
fix: TestAutoregistrationLifecycle/fast_reconnect/same_instance is flaky

### DIFF
--- a/pilot/pkg/autoregistration/controller_test.go
+++ b/pilot/pkg/autoregistration/controller_test.go
@@ -249,10 +249,7 @@ func TestAutoregistrationLifecycle(t *testing.T) {
 		c2.OnDisconnect(p2conn1) // cleanup for future tests
 	})
 	t.Run("fast reconnect", func(t *testing.T) {
-		initGracePeriod := features.WorkloadEntryCleanupGracePeriod
-		features.WorkloadEntryCleanupGracePeriod = 2 * time.Second
-		defer func() { features.WorkloadEntryCleanupGracePeriod = initGracePeriod }()
-
+		test.SetForTest(t, &features.WorkloadEntryCleanupGracePeriod, 2 * time.Second)
 		t.Run("same instance", func(t *testing.T) {
 			// disconnect, make sure entry is still there with disconnect meta
 			c1.OnDisconnect(p1conn1)

--- a/pilot/pkg/autoregistration/controller_test.go
+++ b/pilot/pkg/autoregistration/controller_test.go
@@ -249,6 +249,10 @@ func TestAutoregistrationLifecycle(t *testing.T) {
 		c2.OnDisconnect(p2conn1) // cleanup for future tests
 	})
 	t.Run("fast reconnect", func(t *testing.T) {
+		initGracePeriod := features.WorkloadEntryCleanupGracePeriod
+		features.WorkloadEntryCleanupGracePeriod = 2 * time.Second
+		defer func() { features.WorkloadEntryCleanupGracePeriod = initGracePeriod }()
+
 		t.Run("same instance", func(t *testing.T) {
 			// disconnect, make sure entry is still there with disconnect meta
 			c1.OnDisconnect(p1conn1)


### PR DESCRIPTION
**Please provide a description of this PR:**