### PR TITLE
Fix NamespaceController leaking informer handlers on early shutdown

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
@@ -125,6 +125,17 @@ func NewNamespaceController(kubeClient kube.Client, caBundleWatcher *keycertbund
 
 // Run starts the NamespaceController until a value is sent to stopCh.
 func (nc *NamespaceController) Run(stopCh <-chan struct{}) {
+	// The informers are shared and keep running after this controller stops, so the event
+	// handlers registered in NewNamespaceController must be removed on every exit path.
+	// Otherwise, each leader election cycle leaks them.
+	defer func() {
+		shutdowners := []controllers.Shutdowner{nc.configmaps, nc.namespaces}
+		if nc.crlConfigmaps != nil {
+			shutdowners = append(shutdowners, nc.crlConfigmaps)
+		}
+		controllers.ShutdownAll(shutdowners...)
+	}()
+
 	if !kube.WaitForCacheSync("namespace controller", stopCh, nc.namespaces.HasSynced, nc.configmaps.HasSynced) {
 		nc.queue.ShutDownEarly()
 		return
@@ -132,7 +143,6 @@ func (nc *NamespaceController) Run(stopCh <-chan struct{}) {
 
 	go nc.startCaBundleWatcher(stopCh)
 	nc.queue.Run(stopCh)
-	controllers.ShutdownAll(nc.configmaps, nc.namespaces)
 }
 
 // startCaBundleWatcher listens for updates to the CA bundle and update cm in each namespace

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
@@ -32,8 +32,10 @@ import (
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/inject"
 	"istio.io/istio/pkg/kube/kclient"
+	"istio.io/istio/pkg/kube/kclient/clienttest"
 	filter "istio.io/istio/pkg/kube/namespace"
 	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/test/util/retry"
 )
 
@@ -133,6 +135,47 @@ func TestNamespaceControllerForCrlConfigMap(t *testing.T) {
 		createConfigMap(t, client.Kube(), "not-root-cm", namespace, "key")
 		expectConfigMapNotExist(t, nc.crlConfigmaps, namespace)
 	}
+}
+
+// TestNamespaceControllerHandlerCleanup verifies that the event handlers registered in
+// NewNamespaceController are removed when Run exits, including when it exits before the
+// informer caches have synced (e.g. leadership is lost right after it was acquired).
+// The underlying informers are shared and keep running after the controller stops, so
+// leftover handlers would leak on every leader election cycle.
+func TestNamespaceControllerHandlerCleanup(t *testing.T) {
+	client := kube.NewFakeClient()
+	t.Cleanup(client.Shutdown)
+	watcher := keycertbundle.NewWatcher()
+	nc := NewNamespaceController(client, watcher)
+
+	// Register probe handlers on the controller's clients. ShutdownAll removes all handlers
+	// on a client, so if cleanup runs these probes are removed together with the handlers
+	// registered by NewNamespaceController.
+	leakTracker := assert.NewTracker[string](t)
+	nc.namespaces.AddEventHandler(clienttest.TrackerHandler(leakTracker))
+	nc.configmaps.AddEventHandler(clienttest.TrackerHandler(leakTracker))
+	nc.crlConfigmaps.AddEventHandler(clienttest.TrackerHandler(leakTracker))
+
+	// Interrupt WaitForCacheSync: the stop channel is closed before the informers ever start.
+	stop := make(chan struct{})
+	close(stop)
+	nc.Run(stop)
+
+	// The informers are shared and outlive the controller; start them now, as the real server
+	// does with the process-wide stop channel.
+	client.RunAndWait(test.NewStop(t))
+
+	// A handler registered after Run has returned still receives events and serves as a
+	// synchronization point for event delivery.
+	liveTracker := assert.NewTracker[string](t)
+	nc.namespaces.AddEventHandler(clienttest.TrackerHandler(liveTracker))
+
+	createConfigMap(t, client.Kube(), "some-config", "probe", "k")
+	createNamespace(t, client.Kube(), "probe", nil)
+	liveTracker.WaitUnordered("add/probe")
+
+	// All handlers registered before Run must be gone.
+	leakTracker.Empty()
 }
 
 func TestNamespaceControllerWithDiscoverySelectors(t *testing.T) {

--- a/releasenotes/notes/namespace-controller-handler-leak.yaml
+++ b/releasenotes/notes/namespace-controller-handler-leak.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+issue:
+- 60909
+releaseNotes:
+- |
+  **Fixed** an issue where the namespace controller leaked informer event handlers on every
+  leader election cycle: handlers were not removed when the controller was stopped while
+  waiting for its caches to sync, and the CRL ConfigMap handler was never removed at all.


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes #60909

`NewNamespaceController` registers event handlers on shared informers that outlive the controller (they run with the process-wide stop channel, and a new controller is created on every leader election cycle). `Run` removed them only on the happy path:

- when `WaitForCacheSync` was interrupted, the early return skipped `controllers.ShutdownAll`, leaking all handlers of that cycle;
- `nc.crlConfigmaps` was never part of `ShutdownAll`, leaking its handler even on graceful shutdown.

Move the cleanup into a `defer` covering every exit path, and include the CRL ConfigMap client. Add a regression test that stops the controller during cache sync and asserts its handlers no longer receive events.