### PR TITLE
ambient: do not report status for foreign waypoints

### DIFF
--- a/pilot/pkg/config/kube/gateway/controller.go
+++ b/pilot/pkg/config/kube/gateway/controller.go
@@ -312,6 +312,8 @@ func NewController(
 		DomainSuffix:    c.domainSuffix,
 		Services:        inputs.Services,
 		Namespaces:      inputs.Namespaces,
+		GatewayClasses:  inputs.GatewayClasses,
+		Gateways:        inputs.Gateways,
 		ServiceEntries:  inputs.ServiceEntries,
 		InferencePools:  inputs.InferencePools,
 		internalContext: c.gatewayContext,

--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -569,6 +569,57 @@ func waypointConfigured(labels map[string]string) bool {
 	return false
 }
 
+func waypointManagedByAnotherController(ctx RouteContext, parentRef parentReference) bool {
+	var labels map[string]string
+	switch parentRef.Kind {
+	case gvk.Service:
+		svc := ptr.Flatten(krt.FetchOne(ctx.Krt, ctx.Services, krt.FilterKey(parentRef.Namespace+"/"+parentRef.Name)))
+		if svc == nil {
+			return false
+		}
+		labels = svc.Labels
+	case gvk.ServiceEntry:
+		svc := ptr.Flatten(krt.FetchOne(ctx.Krt, ctx.ServiceEntries, krt.FilterKey(parentRef.Namespace+"/"+parentRef.Name)))
+		if svc == nil {
+			return false
+		}
+		labels = svc.Labels
+	default:
+		return false
+	}
+
+	waypointName, found := labels[label.IoIstioUseWaypoint.Name]
+	if !found {
+		ns := ptr.Flatten(krt.FetchOne(ctx.Krt, ctx.Namespaces, krt.FilterKey(parentRef.Namespace)))
+		if ns == nil {
+			return false
+		}
+		labels = ns.Labels
+		waypointName, found = labels[label.IoIstioUseWaypoint.Name]
+	}
+	if !found || waypointName == "" || strings.EqualFold(waypointName, "none") {
+		return false
+	}
+	if ctx.Gateways == nil || ctx.GatewayClasses == nil {
+		return false
+	}
+
+	waypointNamespace := parentRef.Namespace
+	if namespace := labels[label.IoIstioUseWaypointNamespace.Name]; namespace != "" {
+		waypointNamespace = namespace
+	}
+	waypoint := ptr.Flatten(krt.FetchOne(ctx.Krt, ctx.Gateways, krt.FilterKey(waypointNamespace+"/"+waypointName)))
+	if waypoint == nil {
+		return false
+	}
+	class := ptr.Flatten(krt.FetchOne(ctx.Krt, ctx.GatewayClasses, krt.FilterKey(string(waypoint.Spec.GatewayClassName))))
+	if class == nil {
+		return false
+	}
+	return class.Spec.ControllerName != constants.ManagedGatewayMeshController &&
+		class.Spec.ControllerName != k8s.GatewayController(features.ManagedGatewayController)
+}
+
 func referenceAllowed(
 	ctx RouteContext,
 	parent *parentInfo,
@@ -738,6 +789,9 @@ func extractParentReferenceInfo(ctx RouteContext, parents RouteParents, obj cont
 		}
 		gk := ir
 		if ir.Kind == gvk.Service || ir.Kind == gvk.ServiceEntry {
+			if waypointManagedByAnotherController(ctx, pk) {
+				continue
+			}
 			gk = meshParentKey
 		}
 		currentParents := parents.fetch(ctx.Krt, gk)

--- a/pilot/pkg/config/kube/gateway/conversion_test.go
+++ b/pilot/pkg/config/kube/gateway/conversion_test.go
@@ -715,6 +715,7 @@ func TestConvertResources(t *testing.T) {
 		{name: "weighted"},
 		{name: "zero"},
 		{name: "mesh"},
+		{name: "foreign-waypoint"},
 		{
 			name: "invalid",
 			validationIgnorer: crdvalidation.NewValidationIgnorer(

--- a/pilot/pkg/config/kube/gateway/route_collections.go
+++ b/pilot/pkg/config/kube/gateway/route_collections.go
@@ -701,6 +701,8 @@ type RouteContextInputs struct {
 	DomainSuffix    string
 	Services        krt.Collection[*corev1.Service]
 	Namespaces      krt.Collection[*corev1.Namespace]
+	GatewayClasses  krt.Collection[*gatewayv1.GatewayClass]
+	Gateways        krt.Collection[*gatewayv1.Gateway]
 	ServiceEntries  krt.Collection[*networkingclient.ServiceEntry]
 	InferencePools  krt.Collection[*inferencev1.InferencePool]
 	internalContext krt.RecomputeProtected[*atomic.Pointer[gatewaycommon.GatewayContext]]

--- a/pilot/pkg/config/kube/gateway/testdata/foreign-waypoint.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/foreign-waypoint.status.yaml.golden
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mcp
+  namespace: default
+spec: null
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: fake
+      message: Route was valid
+      observedGeneration: 1
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    controllerName: example.com/waypoint-controller
+    parentRef:
+      group: networking.istio.io
+      kind: ServiceEntry
+      name: mcp
+---

--- a/pilot/pkg/config/kube/gateway/testdata/foreign-waypoint.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/foreign-waypoint.yaml
@@ -1,0 +1,79 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: example
+spec:
+  controllerName: example.com/waypoint-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-waypoint
+  namespace: default
+spec:
+  gatewayClassName: example
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+---
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: mcp
+  namespace: default
+  labels:
+    istio.io/use-waypoint: example-waypoint
+spec:
+  hosts:
+  - mcp.example.com
+  resolution: STATIC
+  ports:
+  - name: http
+    number: 80
+    protocol: HTTP
+  endpoints:
+  - address: 0.0.0.1
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mcp
+  namespace: default
+spec:
+  parentRefs:
+  - group: networking.istio.io
+    kind: ServiceEntry
+    name: mcp
+  rules:
+  - backendRefs:
+    - group: example.com
+      kind: Backend
+      name: mcp
+status:
+  parents:
+  - parentRef:
+      group: networking.istio.io
+      kind: ServiceEntry
+      name: mcp
+    controllerName: example.com/waypoint-controller
+    conditions:
+    - lastTransitionTime: 2026-07-16T20:06:43Z
+      message: Route was valid
+      observedGeneration: 1
+      reason: Accepted
+      status: "True"
+      type: Accepted
+  # Stale status written by older Istio versions; the Istio controller should remove it.
+  - parentRef:
+      group: networking.istio.io
+      kind: ServiceEntry
+      name: mcp
+    controllerName: istio.io/gateway-controller
+    conditions:
+    - lastTransitionTime: 2026-07-16T20:06:43Z
+      message: 'referencing unsupported backendRef: group "example.com" kind "Backend"'
+      observedGeneration: 1
+      reason: InvalidKind
+      status: "False"
+      type: ResolvedRefs


### PR DESCRIPTION
If a HTTPRoute is attached to a Service that is *not* owned by us, we should not report a status on it. Otherwise, we may report its invalid (even when it is valid, to the controller actually managing it) which can break tooling that expects objects to achieve a 'ready' status.
