### PR TITLE
agw conformance: enable legacy mtls transport for agentgateway gateway

### DIFF
--- a/pilot/pkg/config/kube/agentgateway/agentgateway_controller.go
+++ b/pilot/pkg/config/kube/agentgateway/agentgateway_controller.go
@@ -504,6 +504,11 @@ func (c *Controller) buildAddressCollections(opts krt.OptionsBuilder) krt.Collec
 		Networks:     Networks,
 		Flags: ambient.FeatureFlags{
 			EnableK8SServiceSelectWorkloadEntries: true,
+			// Mark sidecar-meshed workloads (security.istio.io/tlsMode=istio) as
+			// LEGACY_ISTIO_MTLS in the WDS stream we serve to agentgateway. The
+			// agentgateway data plane uses this to reach such backends via
+			// istio-mutual mTLS instead of plaintext.
+			EnableMtlsTransportProtocol: true,
 		},
 	}
 	// Dummy empty mesh config

--- a/releasenotes/notes/agw-mesh-backend-mtls.yaml
+++ b/releasenotes/notes/agw-mesh-backend-mtls.yaml
@@ -1,0 +1,14 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed**: an `agentgateway` Gateway now connects to sidecar-injected (mesh) backends using
+    Istio mutual TLS instead of plaintext. Previously, raw TCP routed to a mesh backend (via
+    `TCPRoute`, or a `TLSRoute` in Terminate mode) could hang for server-first protocols — where
+    the backend speaks first, such as SMTP or MySQL — and backends enforcing `STRICT` mutual TLS
+    were unreachable.
+securityNotes:
+  - |
+    Traffic from an `agentgateway` Gateway to sidecar-injected mesh backends is now encrypted with
+    Istio mutual TLS, where previously it was sent in plaintext.

--- a/tests/integration/pilot/agentgateway/gateway_conformance_test.go
+++ b/tests/integration/pilot/agentgateway/gateway_conformance_test.go
@@ -79,22 +79,12 @@ var skippedTests = map[string]string{
 	// The following tests were modified between v1.4.0 && v1.5.0
 	"BackendTLSPolicy": "TODO",
 
-	// The following tests were added in v1.5.0
-	"TLSRouteTerminateSimpleSameNamespace":  "TODO",
-	"TLSRouteMixedTerminationSameNamespace": "TODO",
-
 	// The following tests were added in v1.6.0
 	"GatewayInvalidParametersRef":        "TODO",
 	"GatewayListenerUnsupportedProtocol": "TODO",
 	"TCPRouteWeightedRouting":            "TODO: flaky in dual-stack and multicluster environments",
 
-	// agentgateway does not yet route TCPRoute data-plane traffic, so the
-	// traffic-based TCPRoute conformance tests fail. The status/validation-only
-	// TCPRouteInvalid* tests still run and pass, so they are not skipped.
-	"TCPRouteMultipleRoutesAttachment":    "TODO: agentgateway does not yet support TCPRoute traffic",
-	"TCPRouteParentRefAttachAll":          "TODO: agentgateway does not yet support TCPRoute traffic",
-	"TCPRouteParentRefPortAndSectionName": "TODO: agentgateway does not yet support TCPRoute traffic",
-	"TCPRouteReferenceGrant":              "TODO: agentgateway does not yet support TCPRoute traffic",
+	"TCPRouteMultipleRoutesAttachment": "TODO: agentgateway does not yet support TCPRoute traffic",
 }
 
 func TestGatewayConformanceAgentgateway(t *testing.T) {


### PR DESCRIPTION
**Please provide a description of this PR:**

An `agentgateway` Gateway talked to sidecar-injected (mesh) backends in **plaintext**. The backend sidecar sniffs inbound protocols and waits for the client to speak first, so server-first protocols (like the conformance TCP echo over `TCPRoute`/`TLSRoute` Terminate) deadlocked, and `STRICT` mTLS backends were unreachable.

We set `EnableMtlsTransportProtocol: true` on the agentgateway controller's WDS builder, so workloads labeled `security.istio.io/tlsMode=istio` are marked `LEGACY_ISTIO_MTLS` and the data plane reaches them over istio-mutual mTLS instead of plaintext. Un-skips the fixed conformance tests (`TLSRouteTerminate*`, `TLSRouteMixedTermination*`, and the traffic-based `TCPRouteParentRef*` / `TCPRouteReferenceGrant`).

Uses only the endpoint `tlsMode` label, not istiod's full auto-mTLS precedence (DestinationRule -> PeerAuthentication -> label). So a backend that explicitly disabled mTLS (PeerAuthentication/ DestinationRule `DISABLE`, or per-port) would still get mTLS. This default probably makes sense for now, but we should add support for these explicit overrides in the future.