### PR TITLE
test(cni): speed up TestSleepCheckInstall

### DIFF
--- a/cni/pkg/install/install_test.go
+++ b/cni/pkg/install/install_test.go
@@ -274,6 +274,7 @@ func TestSleepCheckInstall(t *testing.T) {
 			// indefinitely for a file modification.
 			errChan := make(chan error, 1)
 			runAndWaitForReady := func() {
+				t.Helper()
 				go func() {
 					errChan <- in.sleepWatchInstall(ctx, sets.String{})
 				}()

--- a/cni/pkg/install/install_test.go
+++ b/cni/pkg/install/install_test.go
@@ -26,6 +26,7 @@ import (
 	testutils "istio.io/istio/pilot/test/util"
 	"istio.io/istio/pkg/file"
 	"istio.io/istio/pkg/test/util/assert"
+	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/util/sets"
 )
 
@@ -269,41 +270,27 @@ func TestSleepCheckInstall(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			// Listen for isReady to be set to true
-			ticker := time.NewTicker(500 * time.Millisecond)
-			defer ticker.Stop()
-			readyChan := make(chan bool)
-			go func(ctx context.Context, tick <-chan time.Time) {
-				for {
+			// sleepWatchInstall should detect a valid configuration, become ready, and wait
+			// indefinitely for a file modification.
+			errChan := make(chan error, 1)
+			runAndWaitForReady := func() {
+				go func() {
+					errChan <- in.sleepWatchInstall(ctx, sets.String{})
+				}()
+
+				retry.UntilOrFail(t, func() bool {
 					select {
-					case <-ctx.Done():
-						return
-					case <-tick:
-						if isReady.Load().(bool) {
-							readyChan <- true
+					case err := <-errChan:
+						if err == nil {
+							t.Fatal("invalid configuration detected")
 						}
+						t.Fatal(err)
+					default:
 					}
-				}
-			}(ctx, ticker.C)
-
-			// Listen to sleepWatchInstall return value
-			// Should detect a valid configuration and wait indefinitely for a file modification
-			errChan := make(chan error)
-			go func(ctx context.Context) {
-				errChan <- in.sleepWatchInstall(ctx, sets.String{})
-			}(ctx)
-
-			select {
-			case <-readyChan:
-				assert.Equal(t, isReady.Load(), true)
-			case err := <-errChan:
-				if err == nil {
-					t.Fatal("invalid configuration detected")
-				}
-				t.Fatal(err)
-			case <-time.After(5 * time.Second):
-				t.Fatal("timed out waiting for isReady to be set to true")
+					return isReady.Load().(bool)
+				}, retry.Timeout(5*time.Second), retry.Message("waiting for isReady to be set to true"))
 			}
+			runAndWaitForReady()
 
 			// Change SA token
 			if len(c.saNewFilename) > 0 {
@@ -328,10 +315,7 @@ func TestSleepCheckInstall(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				// Run sleepWatchInstall
-				go func(ctx context.Context, in *Installer) {
-					errChan <- in.sleepWatchInstall(ctx, sets.String{})
-				}(ctx, in)
+				runAndWaitForReady()
 			}
 
 			// Remove Istio CNI's config


### PR DESCRIPTION
**Please provide a description of this PR:**

Speed up `TestSleepCheckInstall` by replacing its 500ms readiness ticker and dedicated goroutine with the shared `retry.UntilOrFail` helper.

A small `runAndWaitForReady` helper now starts `sleepWatchInstall` and waits for readiness for both watcher launches. Its buffered result channel also decouples watcher completion from test scheduling, while preserving early error detection and the existing five-second failure bound.

In a local run, the test body completed in 0.06s instead of 1.51s. This is a test-only change; CNI runtime behavior is unchanged.

Contributes to #37555.

Tested with:

```console
go test ./cni/pkg/install -run '^TestSleepCheckInstall$' -count=1000
go test -race ./cni/pkg/install -run '^TestSleepCheckInstall$' -count=500
go test -race ./cni/pkg/install -run '^TestSleepCheckInstall$/^standalone_CNI_plugin$' -count=200
go test -race ./cni/pkg/install
go vet ./cni/pkg/install
```