### PR TITLE
krt: avoid false assertion for concurrent JoinWithMerge updates

### DIFF
--- a/pkg/kube/krt/assert_test.go
+++ b/pkg/kube/krt/assert_test.go
@@ -14,7 +14,11 @@
 
 package krt
 
-import "testing"
+import (
+	"testing"
+
+	"istio.io/istio/pkg/kube/controllers"
+)
 
 // TestAssertState logs the state of KRT test assertions. In the future we may wish to make this fail if tests are being run without strict assertions
 func TestAssertState(t *testing.T) {
@@ -23,4 +27,29 @@ func TestAssertState(t *testing.T) {
 		state = "enabled"
 	}
 	t.Logf("krt test assertions are %s.", state)
+}
+
+func TestAssertMergeJoinRefreshesStaleEventAsAdd(t *testing.T) {
+	const key = "key"
+	source := NewStaticCollection[string](nil, []string{key}, WithStop(t.Context().Done()))
+	joined := &mergejoin[string]{
+		collectionName: "test",
+		collections:    collections[string]{source},
+		log:            log.WithLabels("owner", "test"),
+		outputs:        map[Key[string]]string{},
+		merge:          func(values []string) *string { return &values[0] },
+	}
+
+	// Model an event that became stale in the queue: the source contains the
+	// object now, while the joined output does not contain it yet.
+	old := key
+	current := key
+	events := joined.refreshEventsLocked([]Event[string]{
+		{Event: controllers.EventUpdate, Old: &old, New: &current},
+	})
+
+	if len(events) != 1 || events[0].Event != controllers.EventAdd || events[0].Old != nil ||
+		events[0].New == nil || *events[0].New != current {
+		t.Fatalf("expected stale event to become an add, got %+v", events)
+	}
 }

--- a/pkg/kube/krt/mergejoin.go
+++ b/pkg/kube/krt/mergejoin.go
@@ -304,20 +304,9 @@ func (j *mergejoin[T]) refreshEventsLocked(items []Event[T]) []Event[T] {
 		}
 		existing, ok := j.outputs[iKey]
 		if !ok {
-			switch ev.Event {
-			case controllers.EventAdd:
-				items[idx] = Event[T]{Event: controllers.EventAdd, New: iObj}
-			default:
-				// Not finding the key in our cache for update or delete events is probably a bug
-				msg := fmt.Sprintf("POTENTIAL BUG: key %s not found in cache for event %s", iKey, ev.Event)
-				if EnableAssertions {
-					msg += fmt.Sprintf(" in %s(%T)", j.collectionName, j)
-					panic(msg)
-				}
-				j.log.Debug(msg)
-				// Convert the update into an add since that's what it is to us
-				items[idx] = Event[T]{Event: controllers.EventAdd, New: iObj}
-			}
+			// The source state may have changed since this event was enqueued. The merged
+			// object exists now, so this is an add from the joined collection's perspective.
+			items[idx] = Event[T]{Event: controllers.EventAdd, New: iObj}
 			continue
 		}
 

--- a/pkg/kube/krt/mergejoin_test.go
+++ b/pkg/kube/krt/mergejoin_test.go
@@ -15,6 +15,7 @@ package krt_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -27,6 +28,51 @@ import (
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test/util/assert"
 )
+
+func TestJoinWithMergeConcurrent(t *testing.T) {
+	opts := testOptions(t)
+	c1 := krt.NewStaticCollection[SimplePod](nil, nil, opts.WithName("c1")...)
+	c2 := krt.NewStaticCollection[SimplePod](nil, nil, opts.WithName("c2")...)
+	joined := krt.JoinWithMergeCollection(
+		[]krt.Collection[SimplePod]{c1, c2},
+		func(pods []SimplePod) *SimplePod {
+			switch len(pods) {
+			case 1:
+				return &pods[0]
+			case 2:
+				return &pods[1]
+			default:
+				return nil
+			}
+		},
+		opts.WithName("Join")...,
+	)
+	assert.EventuallyEqual(t, func() bool { return joined.WaitUntilSynced(opts.Stop()) }, true)
+
+	key := "c1/a"
+	val1 := SimplePod{Named: Named{"c1", "a"}, IP: "1.1.1.1"}
+	val2 := SimplePod{Named: Named{"c1", "a"}, IP: "1.1.1.2"}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for range 100 {
+			c1.UpdateObject(val1)
+			c1.DeleteObject(key)
+			c1.UpdateObject(val1)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range 100 {
+			c2.UpdateObject(val2)
+			c2.DeleteObject(key)
+			c2.UpdateObject(val2)
+		}
+	}()
+	wg.Wait()
+	assert.EventuallyEqual(t, func() *SimplePod { return joined.GetKey(key) }, &val2)
+}
 
 func TestJoinWithMergeSimpleCollection(t *testing.T) {
 	opts := testOptions(t)


### PR DESCRIPTION
**Please provide a description of this PR:**

`JoinWithMerge` recalculates merged state after dequeuing source events. Concurrent source updates can therefore make an update or delete event observe a merged object while the joined collection does not yet have that key in its output cache. This is an expected stale-event transition, so handle it as an add from the joined collection's perspective instead of raising an assertion.

Adds a deterministic regression test for the stale-event transition and a stress test covering concurrent updates and deletes across two source collections.

Fixes #58861.

Tests:

```console
go test -tags=assert ./pkg/kube/krt -run '^(TestAssertMergeJoinRefreshesStaleEventAsAdd|TestJoinWithMergeConcurrent)$' -count=1000
go test -tags=assert -race ./pkg/kube/krt -run '^(TestAssertMergeJoinRefreshesStaleEventAsAdd|TestJoinWithMergeConcurrent)$' -count=500
go test ./pkg/kube/krt -count=1
go test -tags=assert ./pkg/kube/krt -count=1
go test -tags=assert -race ./pkg/kube/krt -count=1
go vet -tags=assert ./pkg/kube/krt
```