### PR TITLE
reduce wds full push on ztunnel reconnect

### DIFF
--- a/pilot/pkg/config/kube/agentgateway/service.go
+++ b/pilot/pkg/config/kube/agentgateway/service.go
@@ -21,7 +21,6 @@ import (
 	inferencev1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 
 	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/kube/krt"
@@ -68,12 +67,8 @@ func precomputeServicePtr(w *model.ServiceInfo) *model.ServiceInfo {
 }
 
 func precomputeService(w model.ServiceInfo) model.ServiceInfo {
-	addr := serviceToAddress(w.Service)
-	w.MarshaledAddress = protoconv.MessageToAny(addr)
-	w.AsAddress = model.AddressInfo{
-		Address:   addr,
-		Marshaled: w.MarshaledAddress,
-	}
+	w.AsAddress = model.NewAddressInfo(serviceToAddress(w.Service))
+	w.MarshaledAddress = w.AsAddress.Marshaled
 	return w
 }
 

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -31,6 +31,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cespare/xxhash/v2"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/protobuf/proto"
@@ -1148,6 +1149,23 @@ var _ AmbientIndexes = NoopAmbientIndexes{}
 type AddressInfo struct {
 	*workloadapi.Address
 	Marshaled *anypb.Any
+	// Version is a content-based hash of Marshaled, sent as the resource version over WDS.
+	// Clients echo it back in InitialResourceVersions on reconnect, letting the server skip
+	// resources the client already has; hashing the content keeps versions consistent across
+	// istiod replicas. Empty when no pre-marshaled form exists, in which case the resource is
+	// never skipped.
+	Version string
+}
+
+// NewAddressInfo builds an AddressInfo from an Address, pre-marshaling it and computing the
+// content-based Version.
+func NewAddressInfo(addr *workloadapi.Address) AddressInfo {
+	marshaled := protoconv.MessageToAny(addr)
+	return AddressInfo{
+		Address:   addr,
+		Marshaled: marshaled,
+		Version:   strconv.FormatUint(xxhash.Sum64(marshaled.Value), 16),
+	}
 }
 
 func (i AddressInfo) Equals(other AddressInfo) bool {

--- a/pilot/pkg/serviceregistry/ambient/services.go
+++ b/pilot/pkg/serviceregistry/ambient/services.go
@@ -33,7 +33,6 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/serviceentry"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
-	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/host"
@@ -759,12 +758,8 @@ func precomputeServicePtr(w *model.ServiceInfo) *model.ServiceInfo {
 }
 
 func precomputeService(w model.ServiceInfo) model.ServiceInfo {
-	addr := serviceToAddress(w.Service)
-	w.MarshaledAddress = protoconv.MessageToAny(addr)
-	w.AsAddress = model.AddressInfo{
-		Address:   addr,
-		Marshaled: w.MarshaledAddress,
-	}
+	w.AsAddress = model.NewAddressInfo(serviceToAddress(w.Service))
+	w.MarshaledAddress = w.AsAddress.Marshaled
 	return w
 }
 

--- a/pilot/pkg/serviceregistry/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/ambient/workloads.go
@@ -36,7 +36,6 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
 	labelutil "istio.io/istio/pilot/pkg/serviceregistry/util/label"
-	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/constants"
 	cfgkube "istio.io/istio/pkg/config/kube"
@@ -1520,12 +1519,8 @@ func precomputeWorkloadPtr(w *model.WorkloadInfo) *model.WorkloadInfo {
 }
 
 func precomputeWorkload(w model.WorkloadInfo) model.WorkloadInfo {
-	addr := workloadToAddress(w.Workload)
-	w.MarshaledAddress = protoconv.MessageToAny(addr)
-	w.AsAddress = model.AddressInfo{
-		Address:   addr,
-		Marshaled: w.MarshaledAddress,
-	}
+	w.AsAddress = model.NewAddressInfo(workloadToAddress(w.Workload))
+	w.MarshaledAddress = w.AsAddress.Marshaled
 	return w
 }
 

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -297,6 +297,9 @@ func (s *DiscoveryServer) processDeltaRequest(req *discovery.DeltaDiscoveryReque
 			// Record sub/unsub, but drop synthetic wildcard info
 			Subscribed:   subs,
 			Unsubscribed: sets.New(req.ResourceNamesUnsubscribe...).Delete("*"),
+			// On reconnect, the versions of resources the client retained. Generators with
+			// content-based versions use this to skip re-sending unchanged resources.
+			InitialResourceVersions: req.InitialResourceVersions,
 		},
 		Forced: true,
 	}

--- a/pilot/pkg/xds/workload.go
+++ b/pilot/pkg/xds/workload.go
@@ -66,7 +66,7 @@ func (e WorkloadGenerator) GenerateDeltas(
 	have := sets.New[string]()
 	resources := make(model.Resources, 0, len(addrs))
 	for _, addr := range addrs {
-		resources = appendAddress(addr, w.TypeUrl, nil, have, resources)
+		resources = appendAddress(addr, w.TypeUrl, nil, have, req.Delta.InitialResourceVersions, resources)
 	}
 
 	if isReq {
@@ -85,14 +85,30 @@ func (e WorkloadGenerator) GenerateDeltas(
 	return resources, removed.UnsortedList(), model.XdsLogDetails{}, true, nil
 }
 
-func appendAddress(addr model.AddressInfo, requestedType string, aliases []string, have sets.Set[string], resources model.Resources) model.Resources {
+func appendAddress(
+	addr model.AddressInfo,
+	requestedType string,
+	aliases []string,
+	have sets.Set[string],
+	retained map[string]string,
+	resources model.Resources,
+) model.Resources {
 	n := addr.ResourceName()
 	have.Insert(n)
+	// On reconnect, the client reports the versions of resources it retained. If the content is
+	// unchanged, it does not need to be re-sent. Note this must come after the `have` insertion,
+	// as a skipped resource is still one the client (correctly) holds; it must not be removed.
+	if addr.Version != "" && addr.Version == retained[n] {
+		return resources
+	}
 	switch requestedType {
 	case v3.WorkloadType:
 		if addr.GetWorkload() != nil {
 			resources = append(resources, &discovery.Resource{
-				Name:     n,
+				Name: n,
+				// The Version hashes the Address wrapper rather than the Workload sent here; since
+				// the wrapping is 1:1 it still changes exactly when the content changes.
+				Version:  addr.Version,
 				Aliases:  aliases,
 				Resource: protoconv.MessageToAny(addr.GetWorkload()), // TODO: pre-marshal
 			})
@@ -105,6 +121,7 @@ func appendAddress(addr model.AddressInfo, requestedType string, aliases []strin
 
 		resources = append(resources, &discovery.Resource{
 			Name:     n,
+			Version:  addr.Version,
 			Aliases:  aliases,
 			Resource: proto,
 		})
@@ -163,7 +180,7 @@ func (e WorkloadGenerator) generateDeltasOndemand(
 	for _, addr := range addrs {
 		aliases := addr.Aliases()
 		removed.DeleteAll(aliases...)
-		resources = appendAddress(addr, w.TypeUrl, aliases, have, resources)
+		resources = appendAddress(addr, w.TypeUrl, aliases, have, req.Delta.InitialResourceVersions, resources)
 	}
 
 	proxy.Lock()

--- a/pilot/pkg/xds/workload_test.go
+++ b/pilot/pkg/xds/workload_test.go
@@ -171,6 +171,101 @@ func TestWorkloadReconnect(t *testing.T) {
 		})
 		expect(ads.ExpectResponse(), "Kubernetes//Pod/default/pod", "Kubernetes//Pod/default/pod2")
 	})
+	t.Run("ondemand-versioned", func(t *testing.T) {
+		expect := buildExpect(t)
+		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
+			KubernetesObjects: []runtime.Object{mkPod("pod", "sa", "127.0.0.1", "not-node")},
+		})
+		ads := s.ConnectDeltaADS().WithType(v3.AddressType).WithMetadata(model.NodeMetadata{NodeName: "node"})
+		ads.Request(&discovery.DeltaDiscoveryRequest{
+			ResourceNamesSubscribe:   []string{"*"},
+			ResourceNamesUnsubscribe: []string{"*"},
+		})
+		ads.ExpectEmptyResponse()
+
+		// Subscribe to the pod and record the version the server assigns.
+		resp := ads.RequestResponseAck(&discovery.DeltaDiscoveryRequest{
+			ResourceNamesSubscribe: []string{"/127.0.0.1"},
+		})
+		expect(resp, "Kubernetes//Pod/default/pod")
+		podVersion := resp.Resources[0].Version
+		if podVersion == "" {
+			t.Fatal("resource sent without a version")
+		}
+		ads.Cleanup()
+
+		// Reconnect claiming the retained version. The content is unchanged, so it is not re-sent.
+		ads = s.ConnectDeltaADS().WithType(v3.AddressType).WithMetadata(model.NodeMetadata{NodeName: "node"})
+		ads.Request(&discovery.DeltaDiscoveryRequest{
+			ResourceNamesSubscribe:   []string{"*"},
+			ResourceNamesUnsubscribe: []string{"*"},
+			InitialResourceVersions: map[string]string{
+				"Kubernetes//Pod/default/pod": podVersion,
+			},
+		})
+		ads.ExpectEmptyResponse()
+		ads.Cleanup()
+
+		// Reconnect claiming a stale version. The pod must be re-sent.
+		ads = s.ConnectDeltaADS().WithType(v3.AddressType).WithMetadata(model.NodeMetadata{NodeName: "node"})
+		ads.Request(&discovery.DeltaDiscoveryRequest{
+			ResourceNamesSubscribe:   []string{"*"},
+			ResourceNamesUnsubscribe: []string{"*"},
+			InitialResourceVersions: map[string]string{
+				"Kubernetes//Pod/default/pod": "stale",
+			},
+		})
+		expect(ads.ExpectResponse(), "Kubernetes//Pod/default/pod")
+	})
+	t.Run("wildcard-versioned", func(t *testing.T) {
+		expectAddedAndRemoved := buildExpectAddedAndRemoved(t)
+		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
+			KubernetesObjects: []runtime.Object{
+				mkPod("pod", "sa", "127.0.0.1", "not-node"),
+				mkPod("pod2", "sa", "127.0.0.2", "node"),
+			},
+		})
+		ads := s.ConnectDeltaADS().WithType(v3.AddressType).WithMetadata(model.NodeMetadata{NodeName: "node"})
+
+		// Subscribe to everything and record the versions the server assigns.
+		resp := ads.RequestResponseAck(&discovery.DeltaDiscoveryRequest{})
+		retained := map[string]string{}
+		for _, r := range resp.Resources {
+			if r.Version == "" {
+				t.Fatalf("resource %v sent without a version", r.Name)
+			}
+			retained[r.Name] = r.Version
+		}
+		assert.Equal(t, len(retained), 2)
+		ads.Cleanup()
+
+		// While disconnected, delete pod2 and create pod3.
+		deletePod(s, "pod2")
+		assert.EventuallyEqual(t, func() int {
+			return len(s.AmbientIndex.All())
+		}, 1)
+		createPod(s, "pod3", "sa", "127.0.0.3", "node")
+		assert.EventuallyEqual(t, func() int {
+			return len(s.AmbientIndex.All())
+		}, 2)
+
+		// Reconnect with the retained versions: the unchanged pod is skipped, pod3 is sent, and
+		// pod2 is removed.
+		ads = s.ConnectDeltaADS().WithType(v3.AddressType).WithMetadata(model.NodeMetadata{NodeName: "node"})
+		ads.Request(&discovery.DeltaDiscoveryRequest{InitialResourceVersions: retained})
+		resp = ads.ExpectResponse()
+		expectAddedAndRemoved(resp, []string{"Kubernetes//Pod/default/pod3"}, []string{"Kubernetes//Pod/default/pod2"})
+		pod3Version := resp.Resources[0].Version
+		ads.Cleanup()
+
+		// Reconnect claiming a stale version for the pod: it must be re-sent.
+		ads = s.ConnectDeltaADS().WithType(v3.AddressType).WithMetadata(model.NodeMetadata{NodeName: "node"})
+		ads.Request(&discovery.DeltaDiscoveryRequest{InitialResourceVersions: map[string]string{
+			"Kubernetes//Pod/default/pod":  "stale",
+			"Kubernetes//Pod/default/pod3": pod3Version,
+		}})
+		expectAddedAndRemoved(ads.ExpectResponse(), []string{"Kubernetes//Pod/default/pod"}, nil)
+	})
 }
 
 func TestWorkload(t *testing.T) {

--- a/pkg/xds/server.go
+++ b/pkg/xds/server.go
@@ -36,6 +36,11 @@ type ResourceDelta struct {
 	Subscribed sets.String
 	// Unsubscribed indicates the client no longer requires these resources
 	Unsubscribed sets.String
+	// InitialResourceVersions, sent by a client on stream (re)establishment, maps the resources
+	// the client already retains to their versions. Generators that assign content-based versions
+	// (WDS) use it to skip re-sending resources the client already has. Every name in it is also
+	// present in Subscribed.
+	InitialResourceVersions map[string]string
 }
 
 var emptyResourceDelta = ResourceDelta{}

--- a/releasenotes/notes/wds-reconnect-version-skip.yaml
+++ b/releasenotes/notes/wds-reconnect-version-skip.yaml
@@ -1,0 +1,30 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+issue:
+  - https://github.com/istio/ztunnel/issues/1966
+
+releaseNotes:
+  - |
+    **Fixed** a bug where a ztunnel reconnect (such as the periodic connection recycle
+    from `keepaliveMaxServerConnectionAge`) triggered a full workload (WDS) push. Istiod now
+    assigns each WDS resource a content-based version and, when a reconnecting client
+    reports the versions it already holds via `initial_resource_versions`, re-sends only
+    resources that changed while the client was disconnected. Older ztunnel versions that
+    do not report versions continue to receive the full set.
+
+upgradeNotes:
+  - title: WDS reconnect requests are larger in big ambient meshes
+    content: |
+      On reconnect, ztunnel reports the name and version of every workload (WDS) resource it
+      holds. This request can exceed istiod's default 4MiB gRPC receive limit, leaving ztunnel
+      in a reconnect loop with `ResourceExhausted: grpc: received message larger than max`
+      errors. Meshes could already hit the limit at roughly 55,000 workloads, since resource
+      names were reported before this change; the added versions grow the request by about a
+      third, lowering the trigger point to roughly 40,000 workloads (sooner with long resource
+      names or many services). If your mesh is near this scale, raise
+      `ISTIO_GPRC_MAXRECVMSGSIZE` on istiod — budget roughly 1MiB per 10,000 workloads and
+      services; for example, `--set pilot.env.ISTIO_GPRC_MAXRECVMSGSIZE=33554432` (32MiB)
+      covers meshes well past 300,000 resources — and watch istiod logs for the error above
+      after upgrading.


### PR DESCRIPTION
**Please provide a description of this PR:**

fixes: https://github.com/istio/ztunnel/issues/1966

Based on similar work in [Agentgateway](https://github.com/agentgateway/agentgateway/pull/2497).

This, alongside https://github.com/istio/ztunnel/pull/1996, reduce the stall/freeze observed in  https://github.com/istio/ztunnel/issues/1966 by changing the reconnect event from a full push, to a delta push. This is done by computing a stable version hash which istiod sends with the resources. ztunnel stores this in it's list of "retained" resources. When ztunnel reconnects it sends the name+version of it's retained resources to istiod. Istiod then replies with only the changes which occurred while ztunnel was not connected.

## Benchmarking

Both profiles are real customer shapes at ~69k workloads: clusterA has fewer, larger
services (one 2,700-endpoint service; ΣEi²≈8.1M), clusterB many smaller ones (one
1,600-endpoint service; ΣEi²≈2.9M).

| arm | profile | reconnects | max p100 (ms) |
| --- | --- | ---: | ---: |
| baseline | clusterA | 5 | 391 |
| patched | clusterA | 5 | 12 |
| baseline | clusterB | 6 | 309 |
| patched | clusterB | 5 | 12 |