### PR TITLE
conformance: pass route creation timestmap to agw dataplane

### DIFF
--- a/pilot/pkg/config/kube/agentgateway/routes.go
+++ b/pilot/pkg/config/kube/agentgateway/routes.go
@@ -27,6 +27,7 @@ import (
 
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/slices"
@@ -47,6 +48,18 @@ func InternalRouteRuleKey(routeNamespace, routeName, ruleName string) string {
 		return fmt.Sprintf("%s/%s", routeNamespace, routeName)
 	}
 	return fmt.Sprintf("%s/%s.%s", routeNamespace, routeName, ruleName)
+}
+
+// internalL4RouteRuleKey returns the data-plane key for a TCPRoute/TLSRoute rule, prefixed with the
+// route's creation timestamp (fixed-width Unix seconds). The data plane sorts L4 routes by key and
+// picks the first, so this makes the oldest route win conflict resolution on a shared listener.
+func internalL4RouteRuleKey(obj controllers.Object, pos int) string {
+	key := InternalRouteRuleKey(obj.GetNamespace(), obj.GetName(), strconv.Itoa(pos))
+	created := obj.GetCreationTimestamp()
+	if created.IsZero() {
+		return key
+	}
+	return fmt.Sprintf("%010d/%s", created.Unix(), key)
 }
 
 // RouteName constructs the RouteName for a route rule, including the rule name if specified
@@ -307,10 +320,9 @@ func ConvertGRPCRouteToAgw(ctx RouteContext, r gatewayv1.GRPCRouteRule,
 func ConvertTCPRouteToAgw(ctx RouteContext, r gatewayv1.TCPRouteRule,
 	obj *gatewayv1.TCPRoute, pos int,
 ) (*api.TCPRoute, *Condition) {
-	routeRuleKey := strconv.Itoa(pos)
 	res := &api.TCPRoute{
 		// unique for route rule
-		Key:         InternalRouteRuleKey(obj.Namespace, obj.Name, routeRuleKey),
+		Key:         internalL4RouteRuleKey(obj, pos),
 		Name:        RouteName(gvk.TCPRoute.Kind, obj.Namespace, obj.Name, r.Name),
 		ListenerKey: "",
 	}
@@ -331,10 +343,9 @@ func ConvertTCPRouteToAgw(ctx RouteContext, r gatewayv1.TCPRouteRule,
 func ConvertTLSRouteToAgw(ctx RouteContext, r gatewayv1.TLSRouteRule,
 	obj *gatewayv1.TLSRoute, pos int,
 ) (*api.TCPRoute, *Condition) {
-	routeRuleKey := strconv.Itoa(pos)
 	res := &api.TCPRoute{
 		// unique for route rule
-		Key:         InternalRouteRuleKey(obj.Namespace, obj.Name, routeRuleKey),
+		Key:         internalL4RouteRuleKey(obj, pos),
 		Name:        RouteName(gvk.TLSRoute.Kind, obj.Namespace, obj.Name, r.Name),
 		ListenerKey: "",
 	}

--- a/releasenotes/notes/agw-l4-route-conflict-resolution.yaml
+++ b/releasenotes/notes/agw-l4-route-conflict-resolution.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed**: when multiple `TCPRoute`s or `TLSRoute`s attach to the same `agentgateway` Gateway
+    listener, the oldest route (by creation timestamp, then namespace/name) is now consistently
+    selected, following the Gateway API conflict-resolution rules. Previously the route bound to the
+    listener was not deterministic, so traffic could reach the wrong backend.

--- a/tests/integration/pilot/agentgateway/gateway_conformance_test.go
+++ b/tests/integration/pilot/agentgateway/gateway_conformance_test.go
@@ -83,8 +83,6 @@ var skippedTests = map[string]string{
 	"GatewayInvalidParametersRef":        "TODO",
 	"GatewayListenerUnsupportedProtocol": "TODO",
 	"TCPRouteWeightedRouting":            "TODO: flaky in dual-stack and multicluster environments",
-
-	"TCPRouteMultipleRoutesAttachment": "TODO: agentgateway does not yet support TCPRoute traffic",
 }
 
 func TestGatewayConformanceAgentgateway(t *testing.T) {


### PR DESCRIPTION
**Please provide a description of this PR:**

Pass the route creation timestamp so agentgateway can pick the oldest TCPRoute/TLSRoute.

Fixes `TCPRouteMultipleRoutesAttachment` conformance test