### PR TITLE
Fix CODEOWNERS for the environments team merging with UX

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,14 +3,14 @@
 /.gitignore                                                      @istio/wg-test-and-release-maintainers
 /Makefile.core.mk                                                @istio/wg-test-and-release-maintainers
 /bin/                                                            @istio/wg-test-and-release-maintainers
-/cmd/istiod/                                                     @istio/wg-environments-maintainers
+/cmd/istiod/                                                     @istio/wg-user-experience-maintainers
 /cni/                                                            @istio/wg-networking-maintainers
 /common/                                                         @istio/wg-test-and-release-maintainers
-/install/                                                        @istio/wg-environments-maintainers
+/install/                                                        @istio/wg-user-experiences-maintainers
 /istioctl/                                                       @istio/wg-user-experience-maintainers @istio/wg-networking-maintainers
 Makefile*                                                        @istio/wg-test-and-release-maintainers
-/manifests/                                                      @istio/wg-environments-maintainers
-/operator/                                                       @istio/wg-environments-maintainers
+/manifests/                                                      @istio/wg-user-experience-maintainers
+/operator/                                                       @istio/wg-user-experience-maintainers
 /pilot/                                                          @istio/wg-networking-maintainers
 /pilot/pkg/security/                                             @istio/wg-security-maintainers
 /pilot/pkg/config/                                               @istio/wg-networking-maintainers
@@ -33,20 +33,20 @@ Makefile*                                                        @istio/wg-test-
 /pkg/kube/                                                       @istio/wg-networking-maintainers
 /pkg/mcp/                                                        @istio/wg-networking-maintainers
 /pkg/queue/                                                      @istio/wg-networking-maintainers
-/pkg/security/                                                   @istio/wg-security-maintainers @istio/wg-environments-maintainers
+/pkg/security/                                                   @istio/wg-security-maintainers @istio/wg-user-experience-maintainers
 /pkg/spiffe/                                                     @istio/wg-security-maintainers
 /pkg/test/                                                       @istio/wg-test-and-release-maintainers
 /pkg/fuzz/                                                       @istio/wg-test-and-release-maintainers
 /pkg/tracing/                                                    @istio/wg-policies-and-telemetry-maintainers
 /pkg/wasm/                                                       @istio/wg-policies-and-telemetry-maintainers
-/pkg/webhooks/                                                   @istio/wg-environments-maintainers
+/pkg/webhooks/                                                   @istio/wg-user-experience-maintainers
 /pkg/workloadapi/                                                @istio/wg-networking-maintainers
 /prow/                                                           @istio/wg-test-and-release-maintainers
 /release/                                                        @istio/wg-test-and-release-maintainers
 /releasenotes/                                                   @istio/wg-test-and-release-maintainers
 /releasenotes/notes
 /samples/                                                        @istio/wg-docs-maintainers-english
-/samples/addons                                                  @istio/wg-policies-and-telemetry-maintainers @istio/wg-environments-maintainers
+/samples/addons                                                  @istio/wg-policies-and-telemetry-maintainers @istio/wg-user-experience-maintainers
 /samples/ambient-argo                                            @istio/wg-user-experience-maintainers @istio/wg-networking-maintainers
 /samples/multicluster                                            @istio/wg-networking-maintainers
 /security/                                                       @istio/wg-security-maintainers
@@ -63,6 +63,6 @@ Makefile*                                                        @istio/wg-test-
 /tools/packaging/common/envoy_bootstrap.json                     @istio/wg-networking-maintainers
 /tools/istio-iptables/                                           @istio/wg-networking-maintainers
 architecture/ambient                                             @istio/wg-networking-maintainers-pilot @istio/wg-networking-maintainers-ztunnel
-architecture/environments                                        @istio/wg-environments-maintainers
+architecture/environments                                        @istio/wg-user-experience-maintainers
 architecture/networking                                          @istio/wg-networking-maintainers
 architecture/security                                            @istio/wg-security-maintainers


### PR DESCRIPTION
**Please provide a description of this PR:**

Environments team was merged with UX, this fixes CODEOWNERS so the correct team is tagged for PR reviews.

This fixes an issue where PRs like https://github.com/istio/istio/pull/60899 would not be assigned the correct team for review.