### PR TITLE
fix setCanonical function && regression testing

### DIFF
--- a/pilot/pkg/serviceregistry/ambient/services.go
+++ b/pilot/pkg/serviceregistry/ambient/services.go
@@ -145,7 +145,7 @@ func selectWorkloadServices(typedServiceInfos []TypedServiceInfo) []model.Servic
 		}
 	}
 	if canonical != nil {
-		bestByNamespace[canonical.GetNamespace()] = setCanonical(canonical)
+		bestByNamespace[canonical.GetNamespace()] = setCanonical(*canonical)
 	}
 
 	return maps.Values(bestByNamespace)
@@ -764,22 +764,13 @@ func precomputeService(w model.ServiceInfo) model.ServiceInfo {
 	return w
 }
 
-// setCanonical sets the canonical field in a WDS service without mangling the ServiceInfo
-func setCanonical(se *model.ServiceInfo) model.ServiceInfo {
-	wdsSvc := protomarshal.ShallowClone(se.Service)
-	wdsSvc.Canonical = true
-	return precomputeService(model.ServiceInfo{
-		Service:            wdsSvc,
-		LabelSelector:      se.LabelSelector,
-		PortNames:          se.PortNames,
-		Source:             se.Source,
-		Scope:              se.Scope,
-		Waypoint:           se.Waypoint,
-		MarshaledAddress:   se.MarshaledAddress,
-		AsAddress:          se.AsAddress,
-		DNSConnectStrategy: se.DNSConnectStrategy,
-		CreationTime:       se.CreationTime,
-	})
+// setCanonical sets the canonical field in a WDS service without mangling the ServiceInfo.
+// The ServiceInfo is passed by value so every field is carried over to the returned copy; only
+// the cloned Service proto and the precomputed address fields differ from the input.
+func setCanonical(se model.ServiceInfo) model.ServiceInfo {
+	se.Service = protomarshal.ShallowClone(se.Service)
+	se.Service.Canonical = true
+	return precomputeService(se)
 }
 
 // ingressUseWaypointFromLabels returns whether the ingress-use-waypoint label is

--- a/pilot/pkg/serviceregistry/ambient/services_test.go
+++ b/pilot/pkg/serviceregistry/ambient/services_test.go
@@ -16,6 +16,7 @@ package ambient
 
 import (
 	"net/netip"
+	"reflect"
 	"testing"
 	"time"
 
@@ -1476,6 +1477,43 @@ func TestSelectWorkloadServices(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Test_setCanonical asserts setCanonical propagates every ServiceInfo field to the canonical
+// copy. The reflection check keeps the fixture fully populated as fields are added; without it a
+// new field would default to zero and the equality below would pass without covering it. The
+// input is a fixed point of setCanonical: Canonical is already true and the marshaled address is
+// precomputed, so output must equal input exactly.
+func Test_setCanonical(t *testing.T) {
+	svc := &workloadapi.Service{
+		Name:      "name",
+		Namespace: "ns",
+		Hostname:  "host.example.com",
+		Canonical: true,
+	}
+	ai := model.NewAddressInfo(serviceToAddress(svc))
+	se := model.ServiceInfo{
+		Service:              svc,
+		LabelSelector:        model.LabelSelector{Labels: map[string]string{"app": "a"}},
+		PortNames:            map[int32]model.ServicePortName{80: {PortName: "http"}},
+		Source:               model.TypedObject{Kind: kind.ServiceEntry},
+		Scope:                model.Local,
+		Waypoint:             model.WaypointBindingStatus{ResourceName: "ns/waypoint"},
+		MarshaledAddress:     ai.Marshaled,
+		AsAddress:            ai,
+		DNSConnectStrategy:   model.DNSConnectStrategyRaceFirstTCPConnect,
+		CreationTime:         time.Now(),
+		VisibilityConfigured: true,
+	}
+	rv := reflect.ValueOf(se)
+	rt := rv.Type()
+	for i := range rv.NumField() {
+		if rv.Field(i).IsZero() {
+			t.Errorf("field %q must be non-zero so this test covers it", rt.Field(i).Name)
+		}
+	}
+	seCopy := setCanonical(se)
+	assert.Equal(t, &se, &seCopy)
 }
 
 func TestServiceServices(t *testing.T) {


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix setCanonical to make adding fields to model.ServiceInfo less problematic.

Add a regression test for the same.