### PR TITLE
swap the cluster synchronously

### DIFF
--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -137,8 +137,6 @@ func (c *Controller) AddRegistryAndRun(registry serviceregistry.Instance, stop <
 
 // DeleteRegistry deletes specified registry from the aggregated controller
 func (c *Controller) DeleteRegistry(clusterID cluster.ID, providerID provider.ID) {
-	c.storeLock.Lock()
-	defer c.storeLock.Unlock()
 	c.deleteRegistry(clusterID, providerID, nil)
 }
 
@@ -146,15 +144,14 @@ func (c *Controller) DeleteRegistry(clusterID cluster.ID, providerID provider.ID
 // still the instance registered - i.e. it was not already replaced by a concurrent UpdateRegistry
 // swap. This avoids removing a registry that was already atomically replaced by a newer one.
 func (c *Controller) DeleteRegistryIfCurrent(registry serviceregistry.Instance) {
-	c.storeLock.Lock()
-	defer c.storeLock.Unlock()
 	c.deleteRegistry(registry.Cluster(), registry.Provider(), registry)
 }
 
 // deleteRegistry removes the registry for clusterID/providerID. If expect is non-nil, the
 // deletion only happens if the currently registered instance is identical to expect.
-// Must be called with storeLock held.
 func (c *Controller) deleteRegistry(clusterID cluster.ID, providerID provider.ID, expect serviceregistry.Instance) {
+	c.storeLock.Lock()
+	defer c.storeLock.Unlock()
 	if len(c.registries) == 0 {
 		log.Warnf("Registry list is empty, nothing to delete")
 		return

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -139,7 +139,22 @@ func (c *Controller) AddRegistryAndRun(registry serviceregistry.Instance, stop <
 func (c *Controller) DeleteRegistry(clusterID cluster.ID, providerID provider.ID) {
 	c.storeLock.Lock()
 	defer c.storeLock.Unlock()
+	c.deleteRegistry(clusterID, providerID, nil)
+}
 
+// DeleteRegistryIfCurrent deletes the registry for registry's cluster/provider, but only if it is
+// still the instance registered - i.e. it was not already replaced by a concurrent UpdateRegistry
+// swap. This avoids removing a registry that was already atomically replaced by a newer one.
+func (c *Controller) DeleteRegistryIfCurrent(registry serviceregistry.Instance) {
+	c.storeLock.Lock()
+	defer c.storeLock.Unlock()
+	c.deleteRegistry(registry.Cluster(), registry.Provider(), registry)
+}
+
+// deleteRegistry removes the registry for clusterID/providerID. If expect is non-nil, the
+// deletion only happens if the currently registered instance is identical to expect.
+// Must be called with storeLock held.
+func (c *Controller) deleteRegistry(clusterID cluster.ID, providerID provider.ID, expect serviceregistry.Instance) {
 	if len(c.registries) == 0 {
 		log.Warnf("Registry list is empty, nothing to delete")
 		return
@@ -147,6 +162,10 @@ func (c *Controller) DeleteRegistry(clusterID cluster.ID, providerID provider.ID
 	index, ok := c.getRegistryIndex(clusterID, providerID)
 	if !ok {
 		log.Warnf("Registry %s/%s is not found in the registries list, nothing to delete", providerID, clusterID)
+		return
+	}
+	if expect != nil && c.registries[index].Instance != expect {
+		log.Infof("%s registry for cluster %s was already replaced, skipping delete.", providerID, clusterID)
 		return
 	}
 	c.registries[index] = nil

--- a/pilot/pkg/serviceregistry/aggregate/controller_test.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller_test.go
@@ -651,6 +651,75 @@ func TestReplaceRegistryReloadsGateways(t *testing.T) {
 	}, retry.Timeout(time.Second))
 }
 
+// TestReplaceRegistrySyncsNewServices verifies that services added to the new registry
+// after UpdateRegistry swaps it in are visible via the aggregate controller's Services()/
+// GetService() - i.e. the swapped-in registry is actually queried, not just notified.
+func TestReplaceRegistrySyncsNewServices(t *testing.T) {
+	stop := make(chan struct{})
+	defer close(stop)
+	ctrl := NewController(Options{})
+
+	oldSD := memory.NewServiceDiscovery()
+	oldSD.AddService(&model.Service{Hostname: "old.example.com", Attributes: model.ServiceAttributes{}})
+	oldRegistry := &RunnableRegistry{
+		Instance: serviceregistry.Simple{ClusterID: "cluster1", ProviderID: "test", DiscoveryController: oldSD},
+		running:  atomic.NewBool(false),
+	}
+	ctrl.AddRegistryAndRun(oldRegistry, stop)
+	go ctrl.Run(stop)
+	expectRunningOrFail(t, ctrl, true)
+
+	if svc := ctrl.GetService("old.example.com"); svc == nil {
+		t.Fatal("expected old service to be visible before swap")
+	}
+
+	// Caller starts and syncs the new registry - with its own, different set of services -
+	// before UpdateRegistry swaps it in.
+	newSD := memory.NewServiceDiscovery()
+	newSD.AddService(&model.Service{Hostname: "new.example.com", Attributes: model.ServiceAttributes{}})
+	newRegistry := &RunnableRegistry{
+		Instance: serviceregistry.Simple{ClusterID: "cluster1", ProviderID: "test", DiscoveryController: newSD},
+		running:  atomic.NewBool(false),
+	}
+	go newRegistry.Run(stop)
+	retry.UntilSuccessOrFail(t, func() error {
+		if !newRegistry.running.Load() {
+			return fmt.Errorf("new registry should be running before swap")
+		}
+		return nil
+	}, retry.Timeout(time.Second))
+	ctrl.UpdateRegistry(newRegistry, stop)
+
+	// The swapped-in registry's pre-existing service must be visible immediately.
+	if svc := ctrl.GetService("new.example.com"); svc == nil {
+		t.Fatal("expected new service to be visible immediately after swap")
+	}
+	if svc := ctrl.GetService("old.example.com"); svc != nil {
+		t.Fatal("expected old registry's service to no longer be visible after swap")
+	}
+
+	// A service added to the new registry after the swap must also be synced - this only
+	// works if appendHandlers actually wired the swapped-in registry's handlers.
+	newSD.AddService(&model.Service{Hostname: "post-swap.example.com", Attributes: model.ServiceAttributes{}})
+	retry.UntilSuccessOrFail(t, func() error {
+		if svc := ctrl.GetService("post-swap.example.com"); svc == nil {
+			return fmt.Errorf("expected service added after swap to be synced")
+		}
+		return nil
+	}, retry.Timeout(time.Second))
+
+	names := map[host.Name]bool{}
+	for _, svc := range ctrl.Services() {
+		names[svc.Hostname] = true
+	}
+	if !names["new.example.com"] || !names["post-swap.example.com"] {
+		t.Fatalf("expected Services() to include new and post-swap services, got %v", names)
+	}
+	if names["old.example.com"] {
+		t.Fatalf("expected Services() to no longer include old registry's service, got %v", names)
+	}
+}
+
 func TestMergeServiceWithSameTrustDomain(t *testing.T) {
 	svc1 := mock.MakeService(mock.ServiceArgs{
 		Hostname:        "test.default.svc.cluster.local",

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -55,29 +55,26 @@ type kubeController struct {
 	workloadEntryController *serviceentry.Controller
 	stop                    chan struct{}
 
-	// action records whether this controller was constructed for a cluster Add or Update.
-	// HasSynced uses it to decide whether it must swap itself into the aggregate controller
-	// before returning true, since the multicluster framework closes the previous controller
-	// for this cluster as soon as HasSynced reports synced.
-	action multicluster.ACTION
-	// registerOnce ensures the update-path swap into the aggregate controller happens exactly once.
-	registerOnce sync.Once
+	// syncedFn, if set, is invoked exactly once, the first time HasSynced observes the
+	// underlying registry has synced. initializeCluster uses this to swap the registry into
+	// the aggregate controller on the update path, without kubeController needing to know why.
+	syncedFn   func()
+	syncedOnce sync.Once
 }
 
 // HasSynced reports whether the underlying kube registry has completed its initial sync.
-// For cluster updates (credential rotation), the first time the registry syncs this also swaps
-// it into the aggregate controller: the multicluster framework calls Close() on the previous
-// controller for this cluster as soon as HasSynced returns true, so the swap must happen here,
-// synchronously, to avoid a window where the aggregate controller has no registry for the cluster.
+// The first time it does, syncedFn (if set) is invoked before returning true. This lets
+// initializeCluster hook cluster-update logic - such as swapping the new registry into the
+// aggregate controller - directly into sync completion: the multicluster framework calls Close()
+// on the previous controller for this cluster as soon as HasSynced returns true, so any such
+// swap must happen here, synchronously, to avoid a window where the aggregate controller has no
+// registry for the cluster.
 func (k *kubeController) HasSynced() bool {
 	if !k.Controller.HasSynced() {
 		return false
 	}
-	if k.action == multicluster.Update {
-		k.registerOnce.Do(func() {
-			log.Infof("cluster %s synced, replacing registry", k.Controller.clusterID)
-			k.MeshServiceController.UpdateRegistry(k.Controller, k.stop)
-		})
+	if k.syncedFn != nil {
+		k.syncedOnce.Do(k.syncedFn)
 	}
 	return true
 }
@@ -195,7 +192,6 @@ func NewMulticluster(
 			MeshServiceController: opts.MeshServiceController,
 			Controller:            kubeRegistry,
 			stop:                  stop,
-			action:                cluster.Action,
 		}
 		mc.initializeCluster(cluster, kubeController, kubeRegistry, options, configCluster, stop)
 		return kubeController
@@ -251,9 +247,13 @@ func (m *Multicluster) initializeCluster(cluster *multicluster.Cluster, kubeCont
 	// run after WorkloadHandler is added
 	if cluster.Action == multicluster.Update {
 		// Start the new registry here. The old registry keeps serving until the new one syncs;
-		// kubeController.HasSynced swaps the new registry into the aggregate controller as soon as
-		// that happens, which is also the signal the multicluster framework uses to close the old
-		// kubeController, so the swap is guaranteed to complete before the old registry is removed.
+		// syncedFn swaps the new registry into the aggregate controller as soon as that happens,
+		// which is also the signal the multicluster framework uses to close the old kubeController,
+		// so the swap is guaranteed to complete before the old registry is removed.
+		kubeController.syncedFn = func() {
+			log.Infof("cluster %s synced, replacing registry", cluster.ID)
+			m.opts.MeshServiceController.UpdateRegistry(kubeRegistry, clusterStopCh)
+		}
 		go kubeRegistry.Run(clusterStopCh)
 	} else {
 		// For adds, register immediately

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -17,6 +17,7 @@ package controller
 import (
 	"context"
 	"strings"
+	"sync"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,13 +54,41 @@ type kubeController struct {
 	*Controller
 	workloadEntryController *serviceentry.Controller
 	stop                    chan struct{}
+
+	// action records whether this controller was constructed for a cluster Add or Update.
+	// HasSynced uses it to decide whether it must swap itself into the aggregate controller
+	// before returning true, since the multicluster framework closes the previous controller
+	// for this cluster as soon as HasSynced reports synced.
+	action multicluster.ACTION
+	// registerOnce ensures the update-path swap into the aggregate controller happens exactly once.
+	registerOnce sync.Once
+}
+
+// HasSynced reports whether the underlying kube registry has completed its initial sync.
+// For cluster updates (credential rotation), the first time the registry syncs this also swaps
+// it into the aggregate controller: the multicluster framework calls Close() on the previous
+// controller for this cluster as soon as HasSynced returns true, so the swap must happen here,
+// synchronously, to avoid a window where the aggregate controller has no registry for the cluster.
+func (k *kubeController) HasSynced() bool {
+	if !k.Controller.HasSynced() {
+		return false
+	}
+	if k.action == multicluster.Update {
+		k.registerOnce.Do(func() {
+			log.Infof("cluster %s synced, replacing registry", k.Controller.clusterID)
+			k.MeshServiceController.UpdateRegistry(k.Controller, k.stop)
+		})
+	}
+	return true
 }
 
 func (k *kubeController) Close() {
 	close(k.stop)
 	clusterID := k.Controller.clusterID
 	k.MeshServiceController.UnRegisterHandlersForCluster(clusterID)
-	k.MeshServiceController.DeleteRegistry(clusterID, provider.Kubernetes)
+	// DeleteRegistryIfCurrent avoids deleting a registry that HasSynced's UpdateRegistry call
+	// above already swapped in to replace this one.
+	k.MeshServiceController.DeleteRegistryIfCurrent(k.Controller)
 	if k.workloadEntryController != nil {
 		k.MeshServiceController.DeleteRegistry(clusterID, provider.External)
 	}
@@ -166,6 +195,7 @@ func NewMulticluster(
 			MeshServiceController: opts.MeshServiceController,
 			Controller:            kubeRegistry,
 			stop:                  stop,
+			action:                cluster.Action,
 		}
 		mc.initializeCluster(cluster, kubeController, kubeRegistry, options, configCluster, stop)
 		return kubeController
@@ -220,15 +250,11 @@ func (m *Multicluster) initializeCluster(cluster *multicluster.Cluster, kubeCont
 
 	// run after WorkloadHandler is added
 	if cluster.Action == multicluster.Update {
-		// Start the new registry here. The registry is swapped in only after it syncs,
-		// so the old registry keeps serving until then.
+		// Start the new registry here. The old registry keeps serving until the new one syncs;
+		// kubeController.HasSynced swaps the new registry into the aggregate controller as soon as
+		// that happens, which is also the signal the multicluster framework uses to close the old
+		// kubeController, so the swap is guaranteed to complete before the old registry is removed.
 		go kubeRegistry.Run(clusterStopCh)
-		go func() {
-			// Wait for the new cluster to sync
-			<-cluster.SyncedCh
-			log.Infof("cluster %s synced, replacing registry", cluster.ID)
-			m.opts.MeshServiceController.UpdateRegistry(kubeRegistry, clusterStopCh)
-		}()
 	} else {
 		// For adds, register immediately
 		m.opts.MeshServiceController.AddRegistryAndRun(kubeRegistry, clusterStopCh)

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
@@ -16,6 +16,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -27,6 +28,7 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/keycertbundle"
 	"istio.io/istio/pilot/pkg/server"
+	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/mesh/meshwatcher"
@@ -75,6 +77,30 @@ func deleteMultiClusterSecret(k8s kube.Client, sname string) error {
 	return k8s.Kube().CoreV1().Secrets(testSecretNameSpace).Delete(
 		context.TODO(),
 		sname, metav1.DeleteOptions{GracePeriodSeconds: &immediate})
+}
+
+// updateMultiClusterSecret rewrites the secret's kubeconfig bytes for cname, simulating
+// credential rotation. The bytes must differ from the original so the sha256 check in
+// addRemoteConfig doesn't treat this as a no-op.
+func updateMultiClusterSecret(k8s kube.Client, sname, cname string, generation int) error {
+	secret, err := k8s.Kube().CoreV1().Secrets(testSecretNameSpace).Get(context.TODO(), sname, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	secret.Data[cname] = []byte(fmt.Sprintf("Test-%d", generation))
+	_, err = k8s.Kube().CoreV1().Secrets(testSecretNameSpace).Update(context.TODO(), secret, metav1.UpdateOptions{})
+	return err
+}
+
+// registryForCluster finds the registered serviceregistry.Instance for a given cluster/provider,
+// or nil if none is registered.
+func registryForCluster(mockserviceController *aggregate.Controller, clusterID cluster.ID) serviceregistry.Instance {
+	for _, r := range mockserviceController.GetRegistries() {
+		if r.Cluster() == clusterID {
+			return r
+		}
+	}
+	return nil
 }
 
 func verifyControllers(t *testing.T, m *Multicluster, expectedControllerCount int, timeoutName string) {
@@ -157,6 +183,72 @@ func Test_KubeSecretController(t *testing.T) {
 		// Test - Verify that the remote controller has been removed.
 		verifyControllers(t, mc, 1, "delete remote controller")
 	})
+}
+
+// Test_KubeSecretController_CredentialRotation verifies that when a remote cluster's secret is
+// updated with new kubeconfig bytes, the aggregate controller ends up with exactly one registry
+// for that cluster at all times - the make-before-break swap in kubeController.HasSynced must
+// complete before the old kubeController.Close() removes its registry, otherwise there would be
+// a window where the cluster has no registered registry, or the swap would delete the
+// newly-registered one out from under it.
+func Test_KubeSecretController_CredentialRotation(t *testing.T) {
+	clusterID := cluster.ID("cluster-1")
+	remoteClusterID := cluster.ID("test-remote-cluster-1")
+	mockserviceController := newMockserviceController(clusterID)
+	clientset := kube.NewFakeClient()
+	stop := test.NewStop(t)
+	s := server.New()
+	mcc := initController(clientset, testSecretNameSpace, stop)
+	mc := NewMulticluster("pilot-abc-123", Options{
+		ClusterID:             clusterID,
+		DomainSuffix:          DomainSuffix,
+		MeshWatcher:           meshwatcher.NewTestWatcher(&meshconfig.MeshConfig{}),
+		MeshNetworksWatcher:   meshwatcher.NewFixedNetworksWatcher(nil),
+		MeshServiceController: mockserviceController,
+	}, nil, nil, "default", false, nil, s, mcc)
+	assert.NoError(t, mcc.Run(stop))
+	go mockserviceController.Run(stop)
+	clientset.RunAndWait(stop)
+	kube.WaitForCacheSync("test", stop, mcc.HasSynced)
+	_ = s.Start(stop)
+
+	verifyControllers(t, mc, 1, "create local controller")
+
+	assert.NoError(t, createMultiClusterSecret(clientset, "test-secret-1", string(remoteClusterID)))
+	verifyControllers(t, mc, 2, "create remote controller")
+
+	retry.UntilSuccessOrFail(t, func() error {
+		if registryForCluster(mockserviceController, remoteClusterID) == nil {
+			return fmt.Errorf("expected a registry for %s after add", remoteClusterID)
+		}
+		return nil
+	}, retry.Timeout(time.Second*5))
+	originalRegistry := registryForCluster(mockserviceController, remoteClusterID)
+
+	// Rotate the credentials a few times. After each rotation, the aggregate controller must have
+	// exactly one registry for the cluster, and it must be a different instance than before -
+	// never zero (a push/lookup gap) and never the stale one (a silently-dropped swap).
+	for generation := 1; generation <= 3; generation++ {
+		assert.NoError(t, updateMultiClusterSecret(clientset, "test-secret-1", string(remoteClusterID), generation))
+
+		retry.UntilSuccessOrFail(t, func() error {
+			current := registryForCluster(mockserviceController, remoteClusterID)
+			if current == nil {
+				return fmt.Errorf("registry for %s missing after credential rotation %d", remoteClusterID, generation)
+			}
+			if current == originalRegistry {
+				return fmt.Errorf("registry for %s was not swapped after credential rotation %d", remoteClusterID, generation)
+			}
+			return nil
+		}, retry.Timeout(time.Second*5), retry.Delay(time.Millisecond*10))
+
+		// The controller count must stay stable across the swap - no transient duplicate, no gap.
+		verifyControllers(t, mc, 2, fmt.Sprintf("controller count after credential rotation %d", generation))
+		originalRegistry = registryForCluster(mockserviceController, remoteClusterID)
+	}
+
+	assert.NoError(t, deleteMultiClusterSecret(clientset, "test-secret-1"))
+	verifyControllers(t, mc, 1, "delete remote controller")
 }
 
 func Test_KubeSecretController_ExternalIstiod_MultipleClusters(t *testing.T) {


### PR DESCRIPTION
While reviewing the PR https://github.com/istio/istio/pull/60927 - I noticed in the current code there is chance of aggregate controller might not have the updated cluster for very brief period of time
The old registry could be torn down from the aggregate controller before the new one was swapped in, leaving a window with no egistry for that cluster. It is kind of race condition

The multicluster framework calls `Close() `on the old per-cluster controller as soon as `HasSynced()` on the new one returns true — but pilot's own UpdateRegistry swap was previously
  gated on a separate signal (`cluster.SyncedCh`) that fires later. This may lead to the old registry was deleted before the new one was registered.

Please note there may not be any noticeable functional loss.

This PR fixes that situation