### PR TITLE
nds: add support for true Delta NDS

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
@@ -131,6 +131,10 @@ spec:
         ]
     - name: ISTIO_META_APP_CONTAINERS
       value: "{{ $containers | join "," }}"
+    {{- if .EnableDeltaNds }}
+    - name: ISTIO_META_DELTA_NDS
+      value: "true"
+    {{- end }}
     - name: ISTIO_META_CLUSTER_ID
       value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
     - name: ISTIO_META_NODE_NAME

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -308,6 +308,10 @@ spec:
       value: "fips140=only"
     {{- end }}
     {{- end }}
+    {{- if .EnableDeltaNds }}
+    - name: ISTIO_META_DELTA_NDS
+      value: "true"
+    {{- end }}
     - name: ISTIO_META_CLUSTER_ID
       value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
     - name: ISTIO_META_NODE_NAME

--- a/operator/pkg/helm/testdata/output/istiod-waypoint-workload-socket.golden.yaml
+++ b/operator/pkg/helm/testdata/output/istiod-waypoint-workload-socket.golden.yaml
@@ -478,6 +478,10 @@ data:
               value: "fips140=only"
             {{- end }}
             {{- end }}
+            {{- if .EnableDeltaNds }}
+            - name: ISTIO_META_DELTA_NDS
+              value: "true"
+            {{- end }}
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
             - name: ISTIO_META_NODE_NAME
@@ -1211,6 +1215,10 @@ data:
                 ]
             - name: ISTIO_META_APP_CONTAINERS
               value: "{{ $containers | join "," }}"
+            {{- if .EnableDeltaNds }}
+            - name: ISTIO_META_DELTA_NDS
+              value: "true"
+            {{- end }}
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
             - name: ISTIO_META_NODE_NAME

--- a/pilot/pkg/features/experimental.go
+++ b/pilot/pkg/features/experimental.go
@@ -239,4 +239,13 @@ var (
 			"This value should be a comma-separated list of resources names."+
 			"Items on this list can be prefixed with a '*.' meaning a whole group should be included regardless of the ignore list.",
 	).Get()
+
+	// EnableDeltaNds controls whether istiod injects the DELTA_NDS capability into a proxy's
+	// metadata at injection/bootstrap templating time. When enabled, injected agents advertise
+	// NodeMetadata.DeltaNDS, which makes istiod generate NDS incrementally for them (see
+	// pilot/pkg/xds/nds.go). The actual delta decision is driven by the per-proxy capability,
+	// so this flag only gates whether new proxies opt in.
+	EnableDeltaNds = env.Register("PILOT_ENABLE_DELTA_NDS", false,
+		"If true, injected proxies will advertise the DELTA_NDS capability and receive "+
+			"incremental NDS updates.").Get()
 )

--- a/pilot/pkg/features/xds.go
+++ b/pilot/pkg/features/xds.go
@@ -74,4 +74,13 @@ var (
 
 	EnableXDSCacheMetrics = env.Register("PILOT_XDS_CACHE_STATS", false,
 		"If true, Pilot will collect metrics for XDS cache efficiency.").Get()
+
+	// EnableDeltaNds controls whether istiod injects the DELTA_NDS capability into a proxy's
+	// metadata at injection/bootstrap templating time. When enabled, injected agents advertise
+	// NodeMetadata.DeltaNDS, which makes istiod generate NDS incrementally for them (see
+	// pilot/pkg/xds/nds.go). The actual delta decision is driven by the per-proxy capability,
+	// so this flag only gates whether new proxies opt in.
+	EnableDeltaNds = env.Register("PILOT_ENABLE_DELTA_NDS", false,
+		"If true, injected proxies will advertise the DELTA_NDS capability and receive "+
+			"incremental NDS updates.").Get()
 )

--- a/pilot/pkg/features/xds.go
+++ b/pilot/pkg/features/xds.go
@@ -74,13 +74,4 @@ var (
 
 	EnableXDSCacheMetrics = env.Register("PILOT_XDS_CACHE_STATS", false,
 		"If true, Pilot will collect metrics for XDS cache efficiency.").Get()
-
-	// EnableDeltaNds controls whether istiod injects the DELTA_NDS capability into a proxy's
-	// metadata at injection/bootstrap templating time. When enabled, injected agents advertise
-	// NodeMetadata.DeltaNDS, which makes istiod generate NDS incrementally for them (see
-	// pilot/pkg/xds/nds.go). The actual delta decision is driven by the per-proxy capability,
-	// so this flag only gates whether new proxies opt in.
-	EnableDeltaNds = env.Register("PILOT_ENABLE_DELTA_NDS", false,
-		"If true, injected proxies will advertise the DELTA_NDS capability and receive "+
-			"incremental NDS updates.").Get()
 )

--- a/pilot/pkg/networking/core/configgen.go
+++ b/pilot/pkg/networking/core/configgen.go
@@ -21,7 +21,6 @@ import (
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
-	dnsProto "istio.io/istio/pkg/dns/proto"
 )
 
 // ConfigGenerator represents the interfaces to be implemented by code that generates xDS responses
@@ -42,8 +41,8 @@ type ConfigGenerator interface {
 	// BuildHTTPRoutes returns the list of HTTP routes for the given proxy. This is the RDS output
 	BuildHTTPRoutes(node *model.Proxy, req *model.PushRequest, routeNames []string) ([]*discovery.Resource, model.XdsLogDetails)
 
-	// BuildNameTable returns list of hostnames and the associated IPs
-	BuildNameTable(node *model.Proxy, push *model.PushContext) *dnsProto.NameTable
+	// BuildNameTable returns the full name table as a single xDS resource. This is the NDS SotW output.
+	BuildNameTable(node *model.Proxy, push *model.PushContext) ([]*discovery.Resource, model.XdsLogDetails)
 
 	// BuildDeltaNameTable generates per-host NDS resource deltas for a proxy
 	BuildDeltaNameTable(proxy *model.Proxy, updates *model.PushRequest,

--- a/pilot/pkg/networking/core/configgen.go
+++ b/pilot/pkg/networking/core/configgen.go
@@ -45,6 +45,12 @@ type ConfigGenerator interface {
 	// BuildNameTable returns list of hostnames and the associated IPs
 	BuildNameTable(node *model.Proxy, push *model.PushContext) *dnsProto.NameTable
 
+	// BuildDeltaNameTable generates the per-host NDS resource deltas for a proxy. It mirrors
+	// BuildDeltaClusters: it handles the delta gate and falls back to a full build when needed,
+	// returning (resources, removed, logDetails, usedDelta).
+	BuildDeltaNameTable(proxy *model.Proxy, updates *model.PushRequest,
+		watched *model.WatchedResource) ([]*discovery.Resource, []string, model.XdsLogDetails, bool)
+
 	// BuildExtensionConfiguration returns the list of extension configuration for the given proxy and list of names. This is the ECDS output.
 	BuildExtensionConfiguration(node *model.Proxy, push *model.PushContext, extensionConfigNames []string,
 		pullSecrets map[string][]byte) []*core.TypedExtensionConfig

--- a/pilot/pkg/networking/core/configgen.go
+++ b/pilot/pkg/networking/core/configgen.go
@@ -45,9 +45,7 @@ type ConfigGenerator interface {
 	// BuildNameTable returns list of hostnames and the associated IPs
 	BuildNameTable(node *model.Proxy, push *model.PushContext) *dnsProto.NameTable
 
-	// BuildDeltaNameTable generates the per-host NDS resource deltas for a proxy. It mirrors
-	// BuildDeltaClusters: it handles the delta gate and falls back to a full build when needed,
-	// returning (resources, removed, logDetails, usedDelta).
+	// BuildDeltaNameTable generates per-host NDS resource deltas for a proxy
 	BuildDeltaNameTable(proxy *model.Proxy, updates *model.PushRequest,
 		watched *model.WatchedResource) ([]*discovery.Resource, []string, model.XdsLogDetails, bool)
 

--- a/pilot/pkg/networking/core/name_table.go
+++ b/pilot/pkg/networking/core/name_table.go
@@ -87,10 +87,10 @@ func (configgen *ConfigGeneratorImpl) BuildDeltaNameTable(proxy *model.Proxy, up
 		}
 		service := proxy.SidecarScope.GetService(hostname)
 
-		wasHeadless := prevService != nil && prevService.Attributes.ServiceRegistry == provider.Kubernetes &&
-			prevService.Resolution == model.Passthrough
-
-		if wasHeadless {
+		// we need to check if the previous service was headless to cleanup per-pod hostnames,
+		// we also need to check current service because DNSName kind updates
+		// don't trigger a SidecarScope recomputation.
+		if isHeadless(prevService) || isHeadless(service) {
 			headlessServiceChanged.Insert(key.Name)
 		}
 
@@ -136,6 +136,18 @@ func shouldUseNdsDelta(updates *model.PushRequest) bool {
 		}
 	}
 	return true
+}
+
+// isHeadless reports whether a service publishes per-pod headless DNS records
+// (<pod>.<subdomain>.<ns>.svc.<domain>). Only Kubernetes headless (Passthrough) services do.
+// provider.Mock is accepted so the in-memory registry used in tests, which stamps Mock, exercises
+// the same path as a real Kubernetes headless service.
+func isHeadless(svc *model.Service) bool {
+	if svc == nil || svc.Resolution != model.Passthrough {
+		return false
+	}
+	// we also include provider.Mock because MemRegistry.AddService hardcodes it
+	return svc.Attributes.ServiceRegistry == provider.Kubernetes || svc.Attributes.ServiceRegistry == provider.Mock
 }
 
 // ownedByAny reports whether name is owned by any of the given service hostnames: either name

--- a/pilot/pkg/networking/core/name_table.go
+++ b/pilot/pkg/networking/core/name_table.go
@@ -21,7 +21,9 @@ import (
 
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/serviceregistry/provider"
 	"istio.io/istio/pilot/pkg/util/protoconv"
+	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/schema/kind"
 	dnsProto "istio.io/istio/pkg/dns/proto"
 	dnsServer "istio.io/istio/pkg/dns/server"
@@ -73,18 +75,53 @@ func (configgen *ConfigGeneratorImpl) BuildDeltaNameTable(proxy *model.Proxy, up
 		return toPerHostResources(nt.GetTable()), nil, model.DefaultXdsLogDetails, false
 	}
 
-	// True delta: build only the changed hostnames' records.
-	config.Hostnames = ndsChangedHostnames(updates.ConfigsUpdated)
-	newTable := dnsServer.BuildNameTable(config).GetTable()
+	headlessServiceChanged := sets.New[string]()
+	deletedResources := sets.New[string]()
+	var changed []*model.Service
+	seen := sets.New[host.Name]()
+	for key := range updates.ConfigsUpdated {
+		hostname := host.Name(key.Name)
+		var prevService *model.Service
+		if proxy.PrevSidecarScope != nil {
+			prevService = proxy.PrevSidecarScope.GetService(hostname)
+		}
+		service := proxy.SidecarScope.GetService(hostname)
 
-	res := toPerHostResources(newTable)
+		wasHeadless := prevService != nil && prevService.Attributes.ServiceRegistry == provider.Kubernetes &&
+			prevService.Resolution == model.Passthrough
+
+		if wasHeadless {
+			headlessServiceChanged.Insert(key.Name)
+		}
+
+		if service == nil {
+			deletedResources.Insert(key.Name)
+			continue
+		}
+
+		// Multiple ConfigKeys (e.g. a ServiceEntry and a DNSName) can resolve to the same service;
+		// dedup so BuildNameTableForServices doesn't process a hostname (and merge its IPs) twice.
+		if seen.InsertContains(hostname) {
+			continue
+		}
+		changed = append(changed, service)
+	}
+
+	// True delta: build only the changed services' records.
+	newTable := dnsServer.BuildNameTableForServices(config, changed).GetTable()
+
 	var removed []string
 	for name := range watched.ResourceNames {
-		if _, stillPresent := newTable[name]; !stillPresent && ownedByAny(name, config.Hostnames) {
+		if deletedResources.Contains(name) {
+			removed = append(removed, name)
+			continue
+		}
+		// check changed headless services for per-pod headless records that are no longer present in the new table
+		if _, stillPresent := newTable[name]; !stillPresent && ownedByAny(name, headlessServiceChanged) {
 			removed = append(removed, name)
 		}
 	}
-	return res, removed, model.XdsLogDetails{Incremental: true}, true
+	return toPerHostResources(newTable), removed, model.XdsLogDetails{Incremental: true}, true
 }
 
 // shouldUseNdsDelta reports whether the push can be handled incrementally: not forced and
@@ -99,16 +136,6 @@ func shouldUseNdsDelta(updates *model.PushRequest) bool {
 		}
 	}
 	return true
-}
-
-func ndsChangedHostnames(cfgs sets.Set[model.ConfigKey]) sets.String {
-	hosts := sets.NewWithLength[string](len(cfgs))
-	for k := range cfgs {
-		if deltaAwareNdsConfigs.Contains(k.Kind) {
-			hosts.Insert(k.Name)
-		}
-	}
-	return hosts
 }
 
 // ownedByAny reports whether name is owned by any of the given service hostnames: either name

--- a/pilot/pkg/networking/core/name_table.go
+++ b/pilot/pkg/networking/core/name_table.go
@@ -35,13 +35,18 @@ var deltaAwareNdsConfigs = sets.New(
 
 // BuildNameTable produces a table of hostnames and their associated IPs that can then
 // be used by the agent to resolve DNS. This logic is always active. However, local DNS resolution
-// will only be effective if DNS capture is enabled in the proxy
-func (configgen *ConfigGeneratorImpl) BuildNameTable(node *model.Proxy, push *model.PushContext) *dnsProto.NameTable {
-	return dnsServer.BuildNameTable(dnsServer.Config{
+// will only be effective if DNS capture is enabled in the proxy. This is the NDS SotW output:
+// the whole table wrapped in a single xDS resource.
+func (configgen *ConfigGeneratorImpl) BuildNameTable(node *model.Proxy, push *model.PushContext) ([]*discovery.Resource, model.XdsLogDetails) {
+	nt := dnsServer.BuildNameTable(dnsServer.Config{
 		Node:                        node,
 		Push:                        push,
 		MulticlusterHeadlessEnabled: features.MulticlusterHeadlessEnabled,
 	})
+	if nt == nil {
+		return nil, model.DefaultXdsLogDetails
+	}
+	return []*discovery.Resource{{Resource: protoconv.MessageToAny(nt)}}, model.DefaultXdsLogDetails
 }
 
 // BuildDeltaNameTable generates the per-host NDS resource deltas for a proxy.
@@ -51,30 +56,31 @@ func (configgen *ConfigGeneratorImpl) BuildDeltaNameTable(proxy *model.Proxy, up
 ) ([]*discovery.Resource, []string, model.XdsLogDetails, bool) {
 	// this agent does not support or is requesting to not receive true Delta NDS.
 	if !bool(proxy.Metadata.DeltaNDS) {
-		nt := configgen.BuildNameTable(proxy, updates.Push)
-		return []*discovery.Resource{{Resource: protoconv.MessageToAny(nt)}}, nil, model.DefaultXdsLogDetails, false
+		resources, logs := configgen.BuildNameTable(proxy, updates.Push)
+		return resources, nil, logs, false
+	}
+
+	config := dnsServer.Config{
+		Node:                        proxy,
+		Push:                        updates.Push,
+		MulticlusterHeadlessEnabled: features.MulticlusterHeadlessEnabled,
 	}
 
 	// at least one config kind has changed that doesn't support delta, we need to rebuild the whole table and send
 	// each table entry
 	if !shouldUseNdsDelta(updates) {
-		nt := configgen.BuildNameTable(proxy, updates.Push)
+		nt := dnsServer.BuildNameTable(config)
 		return toPerHostResources(nt.GetTable()), nil, model.DefaultXdsLogDetails, false
 	}
 
 	// True delta: build only the changed hostnames' records.
-	changedHosts := ndsChangedHostnames(updates.ConfigsUpdated)
-	newTable := dnsServer.BuildNameTable(dnsServer.Config{
-		Node:                        proxy,
-		Push:                        updates.Push,
-		MulticlusterHeadlessEnabled: features.MulticlusterHeadlessEnabled,
-		Hostnames:                   changedHosts,
-	}).GetTable()
+	config.Hostnames = ndsChangedHostnames(updates.ConfigsUpdated)
+	newTable := dnsServer.BuildNameTable(config).GetTable()
 
 	res := toPerHostResources(newTable)
 	var removed []string
 	for name := range watched.ResourceNames {
-		if _, stillPresent := newTable[name]; !stillPresent && ownedByAny(name, changedHosts) {
+		if _, stillPresent := newTable[name]; !stillPresent && ownedByAny(name, config.Hostnames) {
 			removed = append(removed, name)
 		}
 	}
@@ -127,10 +133,13 @@ func isOwnedBy(name, h string) bool {
 }
 
 // toPerHostResources decomposes a NameTable map into one discovery.Resource per hostname.
+// Each resource carries the hostname in discovery.Resource.Name and the resolution attributes
+// in the single-valued NameTable.NameInfo field (rather than a single-entry table map), avoiding
+// duplicating the hostname and allocating a one-entry map per resource.
 func toPerHostResources(table map[string]*dnsProto.NameTable_NameInfo) []*discovery.Resource {
 	res := make([]*discovery.Resource, 0, len(table))
 	for name, ni := range table {
-		nt := &dnsProto.NameTable{Table: map[string]*dnsProto.NameTable_NameInfo{name: ni}}
+		nt := &dnsProto.NameTable{NameInfo: ni}
 		res = append(res, &discovery.Resource{
 			Name:     name,
 			Resource: protoconv.MessageToAny(nt),

--- a/pilot/pkg/networking/core/name_table.go
+++ b/pilot/pkg/networking/core/name_table.go
@@ -28,9 +28,6 @@ import (
 	"istio.io/istio/pkg/util/sets"
 )
 
-// deltaAwareNdsConfigs are the config kinds that carry a service hostname as ConfigKey.Name,
-// allowing NDS to compute per-host deltas. Any other kind may change service visibility for the
-// proxy, so we fall back to a full build.
 var deltaAwareNdsConfigs = sets.New(
 	kind.ServiceEntry,
 	kind.DNSName,
@@ -47,22 +44,20 @@ func (configgen *ConfigGeneratorImpl) BuildNameTable(node *model.Proxy, push *mo
 	})
 }
 
-// BuildDeltaNameTable generates the per-host NDS resource deltas for a proxy. It mirrors
-// BuildDeltaClusters: handles the delta gate and falls back to a full build when needed,
-// returning (resources, removed, logDetails, usedDelta).
+// BuildDeltaNameTable generates the per-host NDS resource deltas for a proxy.
+// It handles the delta gate and falls back to a full build when needed.
 func (configgen *ConfigGeneratorImpl) BuildDeltaNameTable(proxy *model.Proxy, updates *model.PushRequest,
 	watched *model.WatchedResource,
 ) ([]*discovery.Resource, []string, model.XdsLogDetails, bool) {
-	// this agent does not support or is requesting to not receive
-	// true Delta NDS.
+	// this agent does not support or is requesting to not receive true Delta NDS.
 	if !bool(proxy.Metadata.DeltaNDS) {
 		nt := configgen.BuildNameTable(proxy, updates.Push)
 		return []*discovery.Resource{{Resource: protoconv.MessageToAny(nt)}}, nil, model.DefaultXdsLogDetails, false
 	}
 
+	// at least one config kind has changed that doesn't support delta, we need to rebuild the whole table and send
+	// each table entry
 	if !shouldUseNdsDelta(updates) {
-		// at least one config kind has changed that doesn't support delta, we need to rebuild the whole table and send
-		// each table entry
 		nt := configgen.BuildNameTable(proxy, updates.Push)
 		return toPerHostResources(nt.GetTable()), nil, model.DefaultXdsLogDetails, false
 	}
@@ -87,7 +82,7 @@ func (configgen *ConfigGeneratorImpl) BuildDeltaNameTable(proxy *model.Proxy, up
 }
 
 // shouldUseNdsDelta reports whether the push can be handled incrementally: not forced and
-// containing only delta-aware, service-scoped kinds. Mirrors CDS's shouldUseDelta.
+// containing only delta-aware, service-scoped kinds.
 func shouldUseNdsDelta(updates *model.PushRequest) bool {
 	if updates == nil || updates.Forced {
 		return false
@@ -100,8 +95,6 @@ func shouldUseNdsDelta(updates *model.PushRequest) bool {
 	return true
 }
 
-// ndsChangedHostnames collects the service FQDNs from the push's ConfigsUpdated. For
-// ServiceEntry and DNSName keys, ConfigKey.Name is the service hostname.
 func ndsChangedHostnames(cfgs sets.Set[model.ConfigKey]) sets.String {
 	hosts := sets.NewWithLength[string](len(cfgs))
 	for k := range cfgs {

--- a/pilot/pkg/networking/core/name_table.go
+++ b/pilot/pkg/networking/core/name_table.go
@@ -15,10 +15,25 @@
 package core
 
 import (
+	"strings"
+
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/util/protoconv"
+	"istio.io/istio/pkg/config/schema/kind"
 	dnsProto "istio.io/istio/pkg/dns/proto"
 	dnsServer "istio.io/istio/pkg/dns/server"
+	"istio.io/istio/pkg/util/sets"
+)
+
+// deltaAwareNdsConfigs are the config kinds that carry a service hostname as ConfigKey.Name,
+// allowing NDS to compute per-host deltas. Any other kind may change service visibility for the
+// proxy, so we fall back to a full build.
+var deltaAwareNdsConfigs = sets.New(
+	kind.ServiceEntry,
+	kind.DNSName,
 )
 
 // BuildNameTable produces a table of hostnames and their associated IPs that can then
@@ -30,4 +45,103 @@ func (configgen *ConfigGeneratorImpl) BuildNameTable(node *model.Proxy, push *mo
 		Push:                        push,
 		MulticlusterHeadlessEnabled: features.MulticlusterHeadlessEnabled,
 	})
+}
+
+// BuildDeltaNameTable generates the per-host NDS resource deltas for a proxy. It mirrors
+// BuildDeltaClusters: handles the delta gate and falls back to a full build when needed,
+// returning (resources, removed, logDetails, usedDelta).
+func (configgen *ConfigGeneratorImpl) BuildDeltaNameTable(proxy *model.Proxy, updates *model.PushRequest,
+	watched *model.WatchedResource,
+) ([]*discovery.Resource, []string, model.XdsLogDetails, bool) {
+	// this agent does not support or is requesting to not receive
+	// true Delta NDS.
+	if !bool(proxy.Metadata.DeltaNDS) {
+		nt := configgen.BuildNameTable(proxy, updates.Push)
+		return []*discovery.Resource{{Resource: protoconv.MessageToAny(nt)}}, nil, model.DefaultXdsLogDetails, false
+	}
+
+	if !shouldUseNdsDelta(updates) {
+		// at least one config kind has changed that doesn't support delta, we need to rebuild the whole table and send
+		// each table entry
+		nt := configgen.BuildNameTable(proxy, updates.Push)
+		return toPerHostResources(nt.GetTable()), nil, model.DefaultXdsLogDetails, false
+	}
+
+	// True delta: build only the changed hostnames' records.
+	changedHosts := ndsChangedHostnames(updates.ConfigsUpdated)
+	newTable := dnsServer.BuildNameTable(dnsServer.Config{
+		Node:                        proxy,
+		Push:                        updates.Push,
+		MulticlusterHeadlessEnabled: features.MulticlusterHeadlessEnabled,
+		Hostnames:                   changedHosts,
+	}).GetTable()
+
+	res := toPerHostResources(newTable)
+	var removed []string
+	for name := range watched.ResourceNames {
+		if _, stillPresent := newTable[name]; !stillPresent && ownedByAny(name, changedHosts) {
+			removed = append(removed, name)
+		}
+	}
+	return res, removed, model.XdsLogDetails{Incremental: true}, true
+}
+
+// shouldUseNdsDelta reports whether the push can be handled incrementally: not forced and
+// containing only delta-aware, service-scoped kinds. Mirrors CDS's shouldUseDelta.
+func shouldUseNdsDelta(updates *model.PushRequest) bool {
+	if updates == nil || updates.Forced {
+		return false
+	}
+	for k := range updates.ConfigsUpdated {
+		if !deltaAwareNdsConfigs.Contains(k.Kind) {
+			return false
+		}
+	}
+	return true
+}
+
+// ndsChangedHostnames collects the service FQDNs from the push's ConfigsUpdated. For
+// ServiceEntry and DNSName keys, ConfigKey.Name is the service hostname.
+func ndsChangedHostnames(cfgs sets.Set[model.ConfigKey]) sets.String {
+	hosts := sets.NewWithLength[string](len(cfgs))
+	for k := range cfgs {
+		if deltaAwareNdsConfigs.Contains(k.Kind) {
+			hosts.Insert(k.Name)
+		}
+	}
+	return hosts
+}
+
+// ownedByAny reports whether name is owned by any of the given service hostnames: either name
+// equals a hostname, or it is a single-label prefix of one (the per-pod headless records,
+// e.g. mysql-0.mysql.default.svc.cluster.local owned by mysql.default.svc.cluster.local).
+func ownedByAny(name string, hosts sets.String) bool {
+	for h := range hosts {
+		if isOwnedBy(name, h) {
+			return true
+		}
+	}
+	return false
+}
+
+// isOwnedBy reports whether name is owned by service hostname h.
+func isOwnedBy(name, h string) bool {
+	if name == h {
+		return true
+	}
+	label, ok := strings.CutSuffix(name, "."+h)
+	return ok && label != "" && !strings.Contains(label, ".")
+}
+
+// toPerHostResources decomposes a NameTable map into one discovery.Resource per hostname.
+func toPerHostResources(table map[string]*dnsProto.NameTable_NameInfo) []*discovery.Resource {
+	res := make([]*discovery.Resource, 0, len(table))
+	for name, ni := range table {
+		nt := &dnsProto.NameTable{Table: map[string]*dnsProto.NameTable_NameInfo{name: ni}}
+		res = append(res, &discovery.Resource{
+			Name:     name,
+			Resource: protoconv.MessageToAny(nt),
+		})
+	}
+	return res
 }

--- a/pilot/pkg/networking/core/name_table_delta_test.go
+++ b/pilot/pkg/networking/core/name_table_delta_test.go
@@ -62,7 +62,7 @@ func headlessK8sService(hostname string) *model.Service {
 	}
 }
 
-func podEndpoints(ip string, svc *model.Service, hostname, subdomain string) map[int][]*model.IstioEndpoint {
+func podEndpoints(ip string, svc *model.Service, hostname string) map[int][]*model.IstioEndpoint {
 	instances := make(map[int][]*model.IstioEndpoint)
 	for _, port := range svc.Ports {
 		instances[port.Port] = []*model.IstioEndpoint{{
@@ -71,7 +71,7 @@ func podEndpoints(ip string, svc *model.Service, hostname, subdomain string) map
 			EndpointPort:    uint32(port.Port),
 			HealthStatus:    model.Healthy,
 			HostName:        hostname,
-			SubDomain:       subdomain,
+			SubDomain:       "headless-svc",
 		}}
 	}
 	return instances
@@ -164,10 +164,10 @@ func TestBuildDeltaNameTableServiceEntryNotOwnedAsPerPod(t *testing.T) {
 func TestBuildDeltaNameTableHeadlessDeletion(t *testing.T) {
 	svc := headlessK8sService("headless-svc.testns.svc.cluster.local")
 	prev := pushWith([]*model.Service{svc}, map[*model.Service]map[int][]*model.IstioEndpoint{
-		svc: podEndpoints("1.2.3.1", svc, "pod1", "headless-svc"),
+		svc: podEndpoints("1.2.3.1", svc, "pod1"),
 	})
 	// pod2 lived in a prior push too; both per-pod records are being watched.
-	prev.AddServiceInstances(svc, podEndpoints("1.2.3.2", svc, "pod2", "headless-svc"))
+	prev.AddServiceInstances(svc, podEndpoints("1.2.3.2", svc, "pod2"))
 
 	// New push no longer has the headless service.
 	next := pushWith([]*model.Service{externalService("other.example.com", "10.0.0.9")}, nil)
@@ -201,16 +201,16 @@ func TestBuildDeltaNameTableHeadlessScaleDown(t *testing.T) {
 	svc := headlessK8sService("headless-svc.testns.svc.cluster.local")
 
 	prev := pushWith([]*model.Service{svc}, map[*model.Service]map[int][]*model.IstioEndpoint{
-		svc: podEndpoints("1.2.3.1", svc, "pod1", "headless-svc"),
+		svc: podEndpoints("1.2.3.1", svc, "pod1"),
 	})
-	prev.AddServiceInstances(svc, podEndpoints("1.2.3.2", svc, "pod2", "headless-svc"))
-	prev.AddServiceInstances(svc, podEndpoints("1.2.3.3", svc, "pod3", "headless-svc"))
+	prev.AddServiceInstances(svc, podEndpoints("1.2.3.2", svc, "pod2"))
+	prev.AddServiceInstances(svc, podEndpoints("1.2.3.3", svc, "pod3"))
 
 	// pod3 is scaled down; the service is still headless.
 	next := pushWith([]*model.Service{svc}, map[*model.Service]map[int][]*model.IstioEndpoint{
-		svc: podEndpoints("1.2.3.1", svc, "pod1", "headless-svc"),
+		svc: podEndpoints("1.2.3.1", svc, "pod1"),
 	})
-	next.AddServiceInstances(svc, podEndpoints("1.2.3.2", svc, "pod2", "headless-svc"))
+	next.AddServiceInstances(svc, podEndpoints("1.2.3.2", svc, "pod2"))
 	proxy := deltaProxy(prev, next)
 
 	cg := &ConfigGeneratorImpl{}

--- a/pilot/pkg/networking/core/name_table_delta_test.go
+++ b/pilot/pkg/networking/core/name_table_delta_test.go
@@ -1,0 +1,250 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"sort"
+	"testing"
+
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/serviceregistry/provider"
+	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/config/host"
+	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/config/schema/kind"
+	"istio.io/istio/pkg/util/sets"
+)
+
+const testDNSDomain = "testns.svc.cluster.local"
+
+// externalService builds a ClientSideLB ServiceEntry-style service with a single VIP.
+func externalService(hostname, vip string) *model.Service {
+	return &model.Service{
+		Hostname:       host.Name(hostname),
+		DefaultAddress: vip,
+		Ports:          model.PortList{{Name: "http", Port: 80, Protocol: protocol.HTTP}},
+		Resolution:     model.ClientSideLB,
+		Attributes: model.ServiceAttributes{
+			Name:            hostname,
+			Namespace:       "testns",
+			ServiceRegistry: provider.External,
+		},
+	}
+}
+
+// headlessService builds a Kubernetes headless (Passthrough) service.
+func headlessK8sService(hostname string) *model.Service {
+	return &model.Service{
+		Hostname:       host.Name(hostname),
+		DefaultAddress: constants.UnspecifiedIP,
+		Ports:          model.PortList{{Name: "tcp", Port: 9000, Protocol: protocol.TCP}},
+		Resolution:     model.Passthrough,
+		Attributes: model.ServiceAttributes{
+			Name:            hostname,
+			Namespace:       "testns",
+			ServiceRegistry: provider.Kubernetes,
+		},
+	}
+}
+
+func podEndpoints(ip string, svc *model.Service, hostname, subdomain string) map[int][]*model.IstioEndpoint {
+	instances := make(map[int][]*model.IstioEndpoint)
+	for _, port := range svc.Ports {
+		instances[port.Port] = []*model.IstioEndpoint{{
+			Addresses:       []string{ip},
+			ServicePortName: port.Name,
+			EndpointPort:    uint32(port.Port),
+			HealthStatus:    model.Healthy,
+			HostName:        hostname,
+			SubDomain:       subdomain,
+		}}
+	}
+	return instances
+}
+
+// pushWith builds a push context containing the given services and their (optional) endpoints.
+func pushWith(services []*model.Service, instances map[*model.Service]map[int][]*model.IstioEndpoint) *model.PushContext {
+	push := model.NewPushContext()
+	push.Mesh = &meshconfig.MeshConfig{RootNamespace: "istio-system"}
+	push.AddPublicServices(services)
+	for svc, inst := range instances {
+		push.AddServiceInstances(svc, inst)
+	}
+	return push
+}
+
+// deltaProxy builds a delta-NDS-capable sidecar proxy whose SidecarScope is derived from newPush
+// and whose PrevSidecarScope is derived from prevPush (mirroring the real SetSidecarScope flow).
+func deltaProxy(prevPush, newPush *model.PushContext) *model.Proxy {
+	proxy := &model.Proxy{
+		IPAddresses: []string{"1.1.1.1"},
+		Metadata:    &model.NodeMetadata{DeltaNDS: model.StringBool(true)},
+		Type:        model.SidecarProxy,
+		DNSDomain:   testDNSDomain,
+	}
+	proxy.SetSidecarScope(prevPush)
+	proxy.SetSidecarScope(newPush)
+	return proxy
+}
+
+func serviceEntryUpdate(hostnames ...string) *model.PushRequest {
+	cfgs := sets.New[model.ConfigKey]()
+	for _, h := range hostnames {
+		cfgs.Insert(model.ConfigKey{Kind: kind.ServiceEntry, Name: h, Namespace: "testns"})
+	}
+	return &model.PushRequest{ConfigsUpdated: cfgs}
+}
+
+func watched(names ...string) *model.WatchedResource {
+	return &model.WatchedResource{ResourceNames: sets.New(names...)}
+}
+
+func resourceNames(res []*discovery.Resource) []string {
+	names := make([]string, 0, len(res))
+	for _, r := range res {
+		names = append(names, r.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func sorted(s []string) []string {
+	out := append([]string(nil), s...)
+	sort.Strings(out)
+	return out
+}
+
+// TestBuildDeltaNameTableServiceEntryNotOwnedAsPerPod verifies that changing a ServiceEntry
+// hostname does not cause an unrelated watched hostname that happens to be a single-label prefix
+// of it (e.g. x.foo.bar.com vs foo.bar.com) to be treated as a per-pod record and deleted.
+// Only Kubernetes headless services own per-pod records.
+func TestBuildDeltaNameTableServiceEntryNotOwnedAsPerPod(t *testing.T) {
+	parent := externalService("foo.bar.com", "10.0.0.1")
+	// x.foo.bar.com looks like a per-pod record of foo.bar.com under isOwnedBy, but it is a
+	// distinct, unchanged ServiceEntry.
+	child := externalService("x.foo.bar.com", "10.0.0.2")
+
+	prev := pushWith([]*model.Service{parent, child}, nil)
+	next := pushWith([]*model.Service{parent, child}, nil)
+	proxy := deltaProxy(prev, next)
+
+	cg := &ConfigGeneratorImpl{}
+	// Only the parent ServiceEntry changed.
+	res, removed, _, delta := cg.BuildDeltaNameTable(proxy, withPush(serviceEntryUpdate("foo.bar.com"), next),
+		watched("foo.bar.com", "x.foo.bar.com"))
+
+	if !delta {
+		t.Fatalf("expected a true delta build")
+	}
+	if len(removed) != 0 {
+		t.Errorf("no resource should be removed when a sibling ServiceEntry changes, got removed=%v", removed)
+	}
+	if got := resourceNames(res); !slicesEqual(got, []string{"foo.bar.com"}) {
+		t.Errorf("expected only foo.bar.com to be rebuilt, got %v", got)
+	}
+}
+
+// TestBuildDeltaNameTableHeadlessDeletion verifies that deleting a Kubernetes headless service
+// removes both its own record and all of its per-pod records from the watched set.
+func TestBuildDeltaNameTableHeadlessDeletion(t *testing.T) {
+	svc := headlessK8sService("headless-svc.testns.svc.cluster.local")
+	prev := pushWith([]*model.Service{svc}, map[*model.Service]map[int][]*model.IstioEndpoint{
+		svc: podEndpoints("1.2.3.1", svc, "pod1", "headless-svc"),
+	})
+	// pod2 lived in a prior push too; both per-pod records are being watched.
+	prev.AddServiceInstances(svc, podEndpoints("1.2.3.2", svc, "pod2", "headless-svc"))
+
+	// New push no longer has the headless service.
+	next := pushWith([]*model.Service{externalService("other.example.com", "10.0.0.9")}, nil)
+	proxy := deltaProxy(prev, next)
+
+	cg := &ConfigGeneratorImpl{}
+	_, removed, _, delta := cg.BuildDeltaNameTable(proxy,
+		withPush(serviceEntryUpdate("headless-svc.testns.svc.cluster.local"), next),
+		watched(
+			"headless-svc.testns.svc.cluster.local",
+			"pod1.headless-svc.testns.svc.cluster.local",
+			"pod2.headless-svc.testns.svc.cluster.local",
+		))
+
+	if !delta {
+		t.Fatalf("expected a true delta build")
+	}
+	want := []string{
+		"headless-svc.testns.svc.cluster.local",
+		"pod1.headless-svc.testns.svc.cluster.local",
+		"pod2.headless-svc.testns.svc.cluster.local",
+	}
+	if got := sorted(removed); !slicesEqual(got, want) {
+		t.Errorf("expected the service and all per-pod records removed\n got: %v\nwant: %v", got, want)
+	}
+}
+
+// TestBuildDeltaNameTableHeadlessScaleDown verifies that when a still-headless service loses a pod,
+// the removed pod's per-pod record is cleaned up from the watched set.
+func TestBuildDeltaNameTableHeadlessScaleDown(t *testing.T) {
+	svc := headlessK8sService("headless-svc.testns.svc.cluster.local")
+
+	prev := pushWith([]*model.Service{svc}, map[*model.Service]map[int][]*model.IstioEndpoint{
+		svc: podEndpoints("1.2.3.1", svc, "pod1", "headless-svc"),
+	})
+	prev.AddServiceInstances(svc, podEndpoints("1.2.3.2", svc, "pod2", "headless-svc"))
+	prev.AddServiceInstances(svc, podEndpoints("1.2.3.3", svc, "pod3", "headless-svc"))
+
+	// pod3 is scaled down; the service is still headless.
+	next := pushWith([]*model.Service{svc}, map[*model.Service]map[int][]*model.IstioEndpoint{
+		svc: podEndpoints("1.2.3.1", svc, "pod1", "headless-svc"),
+	})
+	next.AddServiceInstances(svc, podEndpoints("1.2.3.2", svc, "pod2", "headless-svc"))
+	proxy := deltaProxy(prev, next)
+
+	cg := &ConfigGeneratorImpl{}
+	_, removed, _, delta := cg.BuildDeltaNameTable(proxy,
+		withPush(serviceEntryUpdate("headless-svc.testns.svc.cluster.local"), next),
+		watched(
+			"headless-svc.testns.svc.cluster.local",
+			"pod1.headless-svc.testns.svc.cluster.local",
+			"pod2.headless-svc.testns.svc.cluster.local",
+			"pod3.headless-svc.testns.svc.cluster.local",
+		))
+
+	if !delta {
+		t.Fatalf("expected a true delta build")
+	}
+	want := []string{"pod3.headless-svc.testns.svc.cluster.local"}
+	if got := sorted(removed); !slicesEqual(got, want) {
+		t.Errorf("expected only the scaled-down pod record removed\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func withPush(pr *model.PushRequest, push *model.PushContext) *model.PushRequest {
+	pr.Push = push
+	return pr
+}

--- a/pilot/pkg/xds/nds.go
+++ b/pilot/pkg/xds/nds.go
@@ -15,12 +15,9 @@
 package xds
 
 import (
-	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core"
-	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/util/sets"
 )
@@ -94,12 +91,8 @@ func (n NdsGenerator) Generate(proxy *model.Proxy, _ *model.WatchedResource, req
 	if !needsPush {
 		return nil, model.DefaultXdsLogDetails, nil
 	}
-	nt := n.ConfigGenerator.BuildNameTable(proxy, req.Push)
-	if nt == nil {
-		return nil, model.DefaultXdsLogDetails, nil
-	}
-	resources := model.Resources{&discovery.Resource{Resource: protoconv.MessageToAny(nt)}}
-	return resources, model.DefaultXdsLogDetails, nil
+	resources, logs := n.ConfigGenerator.BuildNameTable(proxy, req.Push)
+	return resources, logs, nil
 }
 
 func (n NdsGenerator) GenerateDeltas(proxy *model.Proxy, req *model.PushRequest,

--- a/pilot/pkg/xds/nds.go
+++ b/pilot/pkg/xds/nds.go
@@ -67,9 +67,7 @@ var skippedNdsConfigs = func() sets.Set[kind.Kind] {
 	return s
 }()
 
-// ndsNeedsPush returns a (possibly filtered) PushRequest and whether NDS needs to be pushed.
-// ConfigsUpdated is filtered to only NDS-relevant kinds so that BuildDeltaNameTable sees a
-// clean set when deciding whether to use true delta. This mirrors cdsNeedsPush.
+// ndsNeedsPush returns a filtered PushRequest (including only NDS-relevant kinds) and whether NDS needs to be pushed.
 func ndsNeedsPush(req *model.PushRequest, proxy *model.Proxy) (*model.PushRequest, bool) {
 	if res, ok := xdsNeedsPush(req, proxy); ok {
 		return req, res
@@ -104,8 +102,6 @@ func (n NdsGenerator) Generate(proxy *model.Proxy, _ *model.WatchedResource, req
 	return resources, model.DefaultXdsLogDetails, nil
 }
 
-// GenerateDeltas generates incremental NDS resources. See BuildDeltaNameTable for the full
-// delta logic, including the capability check and fallback paths.
 func (n NdsGenerator) GenerateDeltas(proxy *model.Proxy, req *model.PushRequest,
 	w *model.WatchedResource,
 ) (model.Resources, model.DeletedResources, model.XdsLogDetails, bool, error) {

--- a/pilot/pkg/xds/nds.go
+++ b/pilot/pkg/xds/nds.go
@@ -37,6 +37,8 @@ type NdsGenerator struct {
 
 var _ model.XdsResourceGenerator = &NdsGenerator{}
 
+var _ model.XdsDeltaResourceGenerator = &NdsGenerator{}
+
 // Map of all configs that do not impact NDS
 var skippedNdsConfigs = func() sets.Set[kind.Kind] {
 	s := sets.New(
@@ -65,20 +67,33 @@ var skippedNdsConfigs = func() sets.Set[kind.Kind] {
 	return s
 }()
 
-func ndsNeedsPush(req *model.PushRequest, proxy *model.Proxy) bool {
+// ndsNeedsPush returns a (possibly filtered) PushRequest and whether NDS needs to be pushed.
+// ConfigsUpdated is filtered to only NDS-relevant kinds so that BuildDeltaNameTable sees a
+// clean set when deciding whether to use true delta. This mirrors cdsNeedsPush.
+func ndsNeedsPush(req *model.PushRequest, proxy *model.Proxy) (*model.PushRequest, bool) {
 	if res, ok := xdsNeedsPush(req, proxy); ok {
-		return res
+		return req, res
 	}
+	relevantUpdates := make(sets.Set[model.ConfigKey])
+	filtered := false
 	for config := range req.ConfigsUpdated {
-		if _, f := skippedNdsConfigs[config.Kind]; !f {
-			return true
+		if !skippedNdsConfigs.Contains(config.Kind) {
+			relevantUpdates.Insert(config)
+		} else {
+			filtered = true
 		}
 	}
-	return false
+	if filtered {
+		newReq := *req
+		newReq.ConfigsUpdated = relevantUpdates
+		req = &newReq
+	}
+	return req, len(req.ConfigsUpdated) > 0
 }
 
 func (n NdsGenerator) Generate(proxy *model.Proxy, _ *model.WatchedResource, req *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
-	if !ndsNeedsPush(req, proxy) {
+	req, needsPush := ndsNeedsPush(req, proxy)
+	if !needsPush {
 		return nil, model.DefaultXdsLogDetails, nil
 	}
 	nt := n.ConfigGenerator.BuildNameTable(proxy, req.Push)
@@ -87,4 +102,17 @@ func (n NdsGenerator) Generate(proxy *model.Proxy, _ *model.WatchedResource, req
 	}
 	resources := model.Resources{&discovery.Resource{Resource: protoconv.MessageToAny(nt)}}
 	return resources, model.DefaultXdsLogDetails, nil
+}
+
+// GenerateDeltas generates incremental NDS resources. See BuildDeltaNameTable for the full
+// delta logic, including the capability check and fallback paths.
+func (n NdsGenerator) GenerateDeltas(proxy *model.Proxy, req *model.PushRequest,
+	w *model.WatchedResource,
+) (model.Resources, model.DeletedResources, model.XdsLogDetails, bool, error) {
+	req, needsPush := ndsNeedsPush(req, proxy)
+	if !needsPush {
+		return nil, nil, model.DefaultXdsLogDetails, false, nil
+	}
+	res, removed, log, usedDelta := n.ConfigGenerator.BuildDeltaNameTable(proxy, req, w)
+	return res, removed, log, usedDelta, nil
 }

--- a/pilot/pkg/xds/nds_test.go
+++ b/pilot/pkg/xds/nds_test.go
@@ -128,9 +128,8 @@ func ndsTableFromDeltaResponse(t *testing.T, resp *discovery.DeltaDiscoveryRespo
 		if err := r.Resource.UnmarshalTo(&entry); err != nil {
 			t.Fatalf("failed to unmarshal NDS resource %q: %v", r.Name, err)
 		}
-		for k, v := range entry.Table {
-			nt.Table[k] = v
-		}
+		// Per-host delta resources carry the hostname in Resource.Name and the attributes in NameInfo.
+		nt.Table[r.Name] = entry.GetNameInfo()
 	}
 	for _, name := range resp.RemovedResources {
 		delete(nt.Table, name)
@@ -207,6 +206,28 @@ func addHeadlessPod(s *xds.FakeDiscoveryServer, svcName, ns, podName, ip string)
 func removeAllHeadlessPods(s *xds.FakeDiscoveryServer, svcName, ns string) {
 	h := host.Name(fmt.Sprintf("%s.%s.svc.cluster.local", svcName, ns))
 	s.MemRegistry.SetEndpoints(string(h), ns, nil)
+	s.Discovery.ConfigUpdate(&model.PushRequest{
+		ConfigsUpdated: sets.New(model.ConfigKey{Kind: kind.DNSName, Name: string(h), Namespace: ns}),
+	})
+}
+
+// setHeadlessPods replaces the full endpoint set of a headless service with one endpoint per
+// entry in pods (podName->ip) and fires a DNSName push. Used to model headless scale up/down,
+// where the service record and surviving pods stay but a departed pod's per-pod record must go.
+func setHeadlessPods(s *xds.FakeDiscoveryServer, svcName, ns string, pods map[string]string) {
+	h := host.Name(fmt.Sprintf("%s.%s.svc.cluster.local", svcName, ns))
+	eps := make([]*model.IstioEndpoint, 0, len(pods))
+	for podName, ip := range pods {
+		eps = append(eps, &model.IstioEndpoint{
+			Addresses:       []string{ip},
+			ServicePortName: "http",
+			EndpointPort:    80,
+			HostName:        podName,
+			SubDomain:       svcName,
+			HealthStatus:    model.Healthy,
+		})
+	}
+	s.MemRegistry.SetEndpoints(string(h), ns, eps)
 	s.Discovery.ConfigUpdate(&model.PushRequest{
 		ConfigsUpdated: sets.New(model.ConfigKey{Kind: kind.DNSName, Name: string(h), Namespace: ns}),
 	})
@@ -365,6 +386,37 @@ func TestNDSDelta(t *testing.T) {
 		} {
 			if !removed.Contains(expected) {
 				t.Errorf("expected %q in RemovedResources after scale-to-zero, got: %v", expected, resp.RemovedResources)
+			}
+		}
+	})
+
+	t.Run("headless scale-down removes only the departed pod's per-pod entry", func(t *testing.T) {
+		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+		addHeadlessService(s, "svc-h", ns)
+		setHeadlessPods(s, "svc-h", ns, map[string]string{"pod-0": "10.1.0.1", "pod-1": "10.1.0.2", "pod-2": "10.1.0.3"})
+		s.EnsureSynced(t)
+
+		ads := connectDeltaNDS(t, s)
+		ads.RequestResponseAck(&discovery.DeltaDiscoveryRequest{})
+
+		// Scale down by one: pod-2 leaves; the service record and pod-0/pod-1 remain. This is the
+		// key removal case — the push only names the service hostname, yet the generator must
+		// derive that pod-2's per-pod record is gone (via owned(H) vs w.ResourceNames).
+		setHeadlessPods(s, "svc-h", ns, map[string]string{"pod-0": "10.1.0.1", "pod-1": "10.1.0.2"})
+		resp := ads.ExpectResponse()
+
+		pod2 := perPodHostname("pod-2", "svc-h", ns)
+		if !slices.Contains(resp.RemovedResources, pod2) {
+			t.Errorf("expected departed pod %q in RemovedResources, got %v", pod2, resp.RemovedResources)
+		}
+		// Neither the surviving pods nor the service record may be removed.
+		for _, keep := range []string{
+			perPodHostname("pod-0", "svc-h", ns),
+			perPodHostname("pod-1", "svc-h", ns),
+			fmt.Sprintf("svc-h.%s.svc.cluster.local", ns),
+		} {
+			if slices.Contains(resp.RemovedResources, keep) {
+				t.Errorf("%q survived a partial scale-down and must not be removed", keep)
 			}
 		}
 	})

--- a/pilot/pkg/xds/nds_test.go
+++ b/pilot/pkg/xds/nds_test.go
@@ -14,6 +14,8 @@
 package xds_test
 
 import (
+	"fmt"
+	"maps"
 	"reflect"
 	"testing"
 	"time"
@@ -26,10 +28,15 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/util/protoconv"
+	pkgxds "istio.io/istio/pilot/pkg/xds"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pilot/test/xds"
 	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/config/host"
+	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/config/schema/kind"
 	dnsProto "istio.io/istio/pkg/dns/proto"
+	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/util/sets"
 )
@@ -109,6 +116,286 @@ func TestNDS(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ndsTableFromDeltaResponse merges a set of per-host delta resources into a single NameTable,
+// applying removals. This mirrors what the agent accumulates client-side.
+func ndsTableFromDeltaResponse(t *testing.T, resp *discovery.DeltaDiscoveryResponse) *dnsProto.NameTable {
+	t.Helper()
+	nt := &dnsProto.NameTable{Table: map[string]*dnsProto.NameTable_NameInfo{}}
+	for _, r := range resp.Resources {
+		var entry dnsProto.NameTable
+		if err := r.Resource.UnmarshalTo(&entry); err != nil {
+			t.Fatalf("failed to unmarshal NDS resource %q: %v", r.Name, err)
+		}
+		for k, v := range entry.Table {
+			nt.Table[k] = v
+		}
+	}
+	for _, name := range resp.RemovedResources {
+		delete(nt.Table, name)
+	}
+	return nt
+}
+
+// connectDeltaNDS sets up a delta ADS connection subscribed to NDS with DeltaNDS capability set.
+func connectDeltaNDS(t *testing.T, s *xds.FakeDiscoveryServer) *pkgxds.DeltaAdsTest {
+	t.Helper()
+	ads := s.ConnectDeltaADS().WithType(v3.NameTableType).WithMetadata(model.NodeMetadata{
+		DNSCapture: true,
+		DeltaNDS:   true,
+	})
+	return ads
+}
+
+// addClusterIPService registers a ClusterIP service in the mem registry and fires a push.
+func addClusterIPService(s *xds.FakeDiscoveryServer, name, ns, ip string) {
+	h := host.Name(fmt.Sprintf("%s.%s.svc.cluster.local", name, ns))
+	s.MemRegistry.AddService(&model.Service{
+		Hostname:       h,
+		DefaultAddress: ip,
+		Ports:          []*model.Port{{Name: "http", Port: 80, Protocol: protocol.HTTP}},
+		Attributes: model.ServiceAttributes{
+			Namespace: ns,
+			Name:      name,
+		},
+	})
+}
+
+// removeService signals a service deletion push for the given hostname.
+func removeService(s *xds.FakeDiscoveryServer, name, ns string) {
+	h := host.Name(fmt.Sprintf("%s.%s.svc.cluster.local", name, ns))
+	s.MemRegistry.RemoveService(h)
+}
+
+// addHeadlessService registers a headless (Passthrough) service and fires a push.
+func addHeadlessService(s *xds.FakeDiscoveryServer, name, ns string) {
+	h := host.Name(fmt.Sprintf("%s.%s.svc.cluster.local", name, ns))
+	s.MemRegistry.AddService(&model.Service{
+		Hostname:       h,
+		DefaultAddress: constants.UnspecifiedIP,
+		Resolution:     model.Passthrough,
+		Ports:          []*model.Port{{Name: "http", Port: 80, Protocol: protocol.HTTP}},
+		Attributes:     model.ServiceAttributes{Namespace: ns, Name: name},
+	})
+}
+
+// addHeadlessPod adds a pod endpoint to a headless service and fires a push. The pod gets a
+// per-pod DNS entry <podName>.<svcName>.<ns>.svc.cluster.local.
+func addHeadlessPod(s *xds.FakeDiscoveryServer, svcName, ns, podName, ip string) {
+	h := host.Name(fmt.Sprintf("%s.%s.svc.cluster.local", svcName, ns))
+	s.MemRegistry.AddInstance(&model.ServiceInstance{
+		Service: &model.Service{Hostname: h},
+		Endpoint: &model.IstioEndpoint{
+			Addresses:       []string{ip},
+			ServicePortName: "http",
+			EndpointPort:    80,
+			HostName:        podName,
+			SubDomain:       svcName,
+			HealthStatus:    model.Healthy,
+		},
+		ServicePort: &model.Port{Name: "http", Port: 80, Protocol: protocol.HTTP},
+	})
+	s.Discovery.ConfigUpdate(&model.PushRequest{
+		ConfigsUpdated: sets.New(model.ConfigKey{Kind: kind.DNSName, Name: string(h), Namespace: ns}),
+	})
+}
+
+// removeAllHeadlessPods clears all endpoints from a headless service. With no endpoints the
+// service record itself also disappears from the name table, so RemovedResources will contain
+// the service hostname plus all per-pod hostnames that were previously tracked.
+func removeAllHeadlessPods(s *xds.FakeDiscoveryServer, svcName, ns string) {
+	h := host.Name(fmt.Sprintf("%s.%s.svc.cluster.local", svcName, ns))
+	s.MemRegistry.SetEndpoints(string(h), ns, nil)
+	s.Discovery.ConfigUpdate(&model.PushRequest{
+		ConfigsUpdated: sets.New(model.ConfigKey{Kind: kind.DNSName, Name: string(h), Namespace: ns}),
+	})
+}
+
+// perPodHostname returns the expected per-pod DNS name for a headless service pod.
+func perPodHostname(podName, svcName, ns string) string {
+	return fmt.Sprintf("%s.%s.%s.svc.cluster.local", podName, svcName, ns)
+}
+
+func TestNDSDelta(t *testing.T) {
+	const ns = "default"
+
+	t.Run("initial full push returns per-host resources including headless per-pod entries", func(t *testing.T) {
+		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+		addClusterIPService(s, "svc-a", ns, "10.0.0.1")
+		addHeadlessService(s, "svc-h", ns)
+		addHeadlessPod(s, "svc-h", ns, "pod-0", "10.1.0.1")
+		addHeadlessPod(s, "svc-h", ns, "pod-1", "10.1.0.2")
+		s.EnsureSynced(t)
+
+		ads := connectDeltaNDS(t, s)
+		resp := ads.RequestResponseAck(&discovery.DeltaDiscoveryRequest{})
+
+		if len(resp.Resources) == 0 {
+			t.Fatal("expected per-host resources, got none")
+		}
+		if resp.Resources[0].Name == "" {
+			t.Fatal("expected named per-host resources, got unnamed full-table resource")
+		}
+		table := ndsTableFromDeltaResponse(t, resp)
+		expectedHosts := []string{
+			fmt.Sprintf("svc-a.%s.svc.cluster.local", ns),
+			fmt.Sprintf("svc-h.%s.svc.cluster.local", ns),
+			perPodHostname("pod-0", "svc-h", ns),
+			perPodHostname("pod-1", "svc-h", ns),
+		}
+		if len(expectedHosts) != len(table.Table) {
+			t.Errorf("expected %d entries in push table, got: %d", len(expectedHosts), len(table.Table))
+		}
+		for _, expected := range expectedHosts {
+			if _, ok := table.Table[expected]; !ok {
+				t.Errorf("expected %q in initial push table, got: %v", expected, maps.Keys(table.Table))
+			}
+		}
+	})
+
+	t.Run("incapable agent receives unnamed full-table resource", func(t *testing.T) {
+		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+		addClusterIPService(s, "svc-a", ns, "10.0.0.1")
+		s.EnsureSynced(t)
+
+		// No DeltaNDS metadata — old agent.
+		ads := s.ConnectDeltaADS().WithType(v3.NameTableType).WithMetadata(model.NodeMetadata{DNSCapture: true})
+		resp := ads.RequestResponseAck(&discovery.DeltaDiscoveryRequest{})
+
+		if len(resp.Resources) != 1 {
+			t.Fatalf("expected 1 resource, got %d", len(resp.Resources))
+		}
+		if resp.Resources[0].Name != "" {
+			t.Errorf("expected unnamed full-table resource, got Name=%q", resp.Resources[0].Name)
+		}
+	})
+
+	t.Run("service add sends only the new hostname", func(t *testing.T) {
+		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+		addClusterIPService(s, "svc-a", ns, "10.0.0.1")
+		addHeadlessService(s, "svc-h", ns)
+		addHeadlessPod(s, "svc-h", ns, "pod-0", "10.1.0.1")
+		s.EnsureSynced(t)
+
+		ads := connectDeltaNDS(t, s)
+		ads.RequestResponseAck(&discovery.DeltaDiscoveryRequest{}) // consume initial push
+
+		// Adding a new ClusterIP service should only send that service's hostname.
+		addClusterIPService(s, "svc-b", ns, "10.0.0.2")
+		resp := ads.ExpectResponse()
+		hB := fmt.Sprintf("svc-b.%s.svc.cluster.local", ns)
+		if len(resp.Resources) != 1 || resp.Resources[0].Name != hB {
+			t.Errorf("expected only %q in delta, got resources: %v", hB, slices.Map(resp.Resources, func(r *discovery.Resource) string { return r.Name }))
+		}
+
+		// Adding a pod to the headless service should send the service record and the new per-pod entry.
+		addHeadlessPod(s, "svc-h", ns, "pod-1", "10.1.0.2")
+		resp = ads.ExpectResponse()
+		addedNames := sets.New(slices.Map(resp.Resources, func(r *discovery.Resource) string { return r.Name })...)
+		if !addedNames.Contains(perPodHostname("pod-1", "svc-h", ns)) {
+			t.Errorf("expected per-pod hostname %q in delta, got: %v", perPodHostname("pod-1", "svc-h", ns), addedNames)
+		}
+		// svc-a and svc-b must not appear (they were not changed).
+		for _, unchanged := range []string{
+			fmt.Sprintf("svc-a.%s.svc.cluster.local", ns),
+			fmt.Sprintf("svc-b.%s.svc.cluster.local", ns),
+		} {
+			if addedNames.Contains(unchanged) {
+				t.Errorf("%q should not be in an incremental push for svc-h pod", unchanged)
+			}
+		}
+	})
+
+	t.Run("service IP change sends updated entry", func(t *testing.T) {
+		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+		addClusterIPService(s, "svc-a", ns, "10.0.0.1")
+		s.EnsureSynced(t)
+
+		ads := connectDeltaNDS(t, s)
+		ads.RequestResponseAck(&discovery.DeltaDiscoveryRequest{})
+
+		addClusterIPService(s, "svc-a", ns, "10.0.0.99")
+		resp := ads.ExpectResponse()
+
+		table := ndsTableFromDeltaResponse(t, resp)
+		if len(resp.Resources) != 1 {
+			t.Fatalf("expected 1 resource, got %d", len(resp.Resources))
+		}
+		h := fmt.Sprintf("svc-a.%s.svc.cluster.local", ns)
+		if found, ok := table.Table[h]; ok {
+			if len(found.Ips) == 0 || found.Ips[0] != "10.0.0.99" {
+				t.Errorf("expected IP 10.0.0.99, got %v", found.Ips)
+			}
+		} else {
+			t.Errorf("expected %q in delta resources, got %v", h, table.Table)
+		}
+	})
+
+	t.Run("service delete sends RemovedResources including headless per-pod entries", func(t *testing.T) {
+		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+		addClusterIPService(s, "svc-a", ns, "10.0.0.1")
+		addClusterIPService(s, "svc-b", ns, "10.0.0.2")
+		addHeadlessService(s, "svc-h", ns)
+		addHeadlessPod(s, "svc-h", ns, "pod-0", "10.1.0.1")
+		addHeadlessPod(s, "svc-h", ns, "pod-1", "10.1.0.2")
+		s.EnsureSynced(t)
+
+		ads := connectDeltaNDS(t, s)
+		ads.RequestResponseAck(&discovery.DeltaDiscoveryRequest{})
+
+		// ClusterIP service delete: only its hostname should be removed.
+		removeService(s, "svc-a", ns)
+		resp := ads.ExpectResponse()
+		hA := fmt.Sprintf("svc-a.%s.svc.cluster.local", ns)
+		if !slices.Contains(resp.RemovedResources, hA) {
+			t.Errorf("expected %q in RemovedResources, got %v", hA, resp.RemovedResources)
+		}
+
+		// Headless scale-to-zero: removing all pods removes all per-pod entries AND the
+		// service record itself (no endpoints → no addresses → no table entry).
+		removeAllHeadlessPods(s, "svc-h", ns)
+		resp = ads.ExpectResponse()
+
+		removed := sets.New(resp.RemovedResources...)
+		for _, expected := range []string{
+			fmt.Sprintf("svc-h.%s.svc.cluster.local", ns),
+			perPodHostname("pod-0", "svc-h", ns),
+			perPodHostname("pod-1", "svc-h", ns),
+		} {
+			if !removed.Contains(expected) {
+				t.Errorf("expected %q in RemovedResources after scale-to-zero, got: %v", expected, resp.RemovedResources)
+			}
+		}
+	})
+
+	t.Run("non-delta-aware push sends full per-host set with server-computed removals", func(t *testing.T) {
+		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+		addClusterIPService(s, "svc-a", ns, "10.0.0.1")
+		addClusterIPService(s, "svc-b", ns, "10.0.0.2")
+		s.EnsureSynced(t)
+
+		ads := connectDeltaNDS(t, s)
+		ads.RequestResponseAck(&discovery.DeltaDiscoveryRequest{})
+
+		s.Discovery.ConfigUpdate(&model.PushRequest{
+			ConfigsUpdated: sets.New(model.ConfigKey{Kind: kind.MeshConfig}),
+			Forced:         true,
+		})
+		resp := ads.ExpectResponse()
+
+		// All resources should be named per-host (not the unnamed full-table format).
+		for _, r := range resp.Resources {
+			if r.Name == "" {
+				t.Error("non-delta push to capable agent should still produce named per-host resources")
+			}
+		}
+
+		table := ndsTableFromDeltaResponse(t, resp)
+		if len(table.Table) != 2 {
+			t.Errorf("expected 2 entries in table, got %d", len(table.Table))
+		}
+	})
 }
 
 func TestGenerate(t *testing.T) {

--- a/pilot/pkg/xds/nds_test.go
+++ b/pilot/pkg/xds/nds_test.go
@@ -15,7 +15,6 @@ package xds_test
 
 import (
 	"fmt"
-	"maps"
 	"reflect"
 	"testing"
 	"time"
@@ -36,6 +35,7 @@ import (
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/kind"
 	dnsProto "istio.io/istio/pkg/dns/proto"
+	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/util/sets"
@@ -147,8 +147,15 @@ func connectDeltaNDS(t *testing.T, s *xds.FakeDiscoveryServer) *pkgxds.DeltaAdsT
 	return ads
 }
 
+// The delta NDS tests all run in a single namespace against a single headless service, so these
+// are fixed constants rather than helper parameters (avoids unparam churn on the helpers below).
+const (
+	ns          = "default"
+	headlessSvc = "svc-h"
+)
+
 // addClusterIPService registers a ClusterIP service in the mem registry and fires a push.
-func addClusterIPService(s *xds.FakeDiscoveryServer, name, ns, ip string) {
+func addClusterIPService(s *xds.FakeDiscoveryServer, name, ip string) {
 	h := host.Name(fmt.Sprintf("%s.%s.svc.cluster.local", name, ns))
 	s.MemRegistry.AddService(&model.Service{
 		Hostname:       h,
@@ -162,27 +169,27 @@ func addClusterIPService(s *xds.FakeDiscoveryServer, name, ns, ip string) {
 }
 
 // removeService signals a service deletion push for the given hostname.
-func removeService(s *xds.FakeDiscoveryServer, name, ns string) {
+func removeService(s *xds.FakeDiscoveryServer, name string) {
 	h := host.Name(fmt.Sprintf("%s.%s.svc.cluster.local", name, ns))
 	s.MemRegistry.RemoveService(h)
 }
 
-// addHeadlessService registers a headless (Passthrough) service and fires a push.
-func addHeadlessService(s *xds.FakeDiscoveryServer, name, ns string) {
-	h := host.Name(fmt.Sprintf("%s.%s.svc.cluster.local", name, ns))
+// addHeadlessService registers the headless (Passthrough) service and fires a push.
+func addHeadlessService(s *xds.FakeDiscoveryServer) {
+	h := host.Name(fmt.Sprintf("%s.%s.svc.cluster.local", headlessSvc, ns))
 	s.MemRegistry.AddService(&model.Service{
 		Hostname:       h,
 		DefaultAddress: constants.UnspecifiedIP,
 		Resolution:     model.Passthrough,
 		Ports:          []*model.Port{{Name: "http", Port: 80, Protocol: protocol.HTTP}},
-		Attributes:     model.ServiceAttributes{Namespace: ns, Name: name},
+		Attributes:     model.ServiceAttributes{Namespace: ns, Name: headlessSvc},
 	})
 }
 
-// addHeadlessPod adds a pod endpoint to a headless service and fires a push. The pod gets a
-// per-pod DNS entry <podName>.<svcName>.<ns>.svc.cluster.local.
-func addHeadlessPod(s *xds.FakeDiscoveryServer, svcName, ns, podName, ip string) {
-	h := host.Name(fmt.Sprintf("%s.%s.svc.cluster.local", svcName, ns))
+// addHeadlessPod adds a pod endpoint to the headless service and fires a push. The pod gets a
+// per-pod DNS entry <podName>.<headlessSvc>.<ns>.svc.cluster.local.
+func addHeadlessPod(s *xds.FakeDiscoveryServer, podName, ip string) {
+	h := host.Name(fmt.Sprintf("%s.%s.svc.cluster.local", headlessSvc, ns))
 	s.MemRegistry.AddInstance(&model.ServiceInstance{
 		Service: &model.Service{Hostname: h},
 		Endpoint: &model.IstioEndpoint{
@@ -190,7 +197,7 @@ func addHeadlessPod(s *xds.FakeDiscoveryServer, svcName, ns, podName, ip string)
 			ServicePortName: "http",
 			EndpointPort:    80,
 			HostName:        podName,
-			SubDomain:       svcName,
+			SubDomain:       headlessSvc,
 			HealthStatus:    model.Healthy,
 		},
 		ServicePort: &model.Port{Name: "http", Port: 80, Protocol: protocol.HTTP},
@@ -200,22 +207,22 @@ func addHeadlessPod(s *xds.FakeDiscoveryServer, svcName, ns, podName, ip string)
 	})
 }
 
-// removeAllHeadlessPods clears all endpoints from a headless service. With no endpoints the
+// removeAllHeadlessPods clears all endpoints from the headless service. With no endpoints the
 // service record itself also disappears from the name table, so RemovedResources will contain
 // the service hostname plus all per-pod hostnames that were previously tracked.
-func removeAllHeadlessPods(s *xds.FakeDiscoveryServer, svcName, ns string) {
-	h := host.Name(fmt.Sprintf("%s.%s.svc.cluster.local", svcName, ns))
+func removeAllHeadlessPods(s *xds.FakeDiscoveryServer) {
+	h := host.Name(fmt.Sprintf("%s.%s.svc.cluster.local", headlessSvc, ns))
 	s.MemRegistry.SetEndpoints(string(h), ns, nil)
 	s.Discovery.ConfigUpdate(&model.PushRequest{
 		ConfigsUpdated: sets.New(model.ConfigKey{Kind: kind.DNSName, Name: string(h), Namespace: ns}),
 	})
 }
 
-// setHeadlessPods replaces the full endpoint set of a headless service with one endpoint per
+// setHeadlessPods replaces the full endpoint set of the headless service with one endpoint per
 // entry in pods (podName->ip) and fires a DNSName push. Used to model headless scale up/down,
 // where the service record and surviving pods stay but a departed pod's per-pod record must go.
-func setHeadlessPods(s *xds.FakeDiscoveryServer, svcName, ns string, pods map[string]string) {
-	h := host.Name(fmt.Sprintf("%s.%s.svc.cluster.local", svcName, ns))
+func setHeadlessPods(s *xds.FakeDiscoveryServer, pods map[string]string) {
+	h := host.Name(fmt.Sprintf("%s.%s.svc.cluster.local", headlessSvc, ns))
 	eps := make([]*model.IstioEndpoint, 0, len(pods))
 	for podName, ip := range pods {
 		eps = append(eps, &model.IstioEndpoint{
@@ -223,7 +230,7 @@ func setHeadlessPods(s *xds.FakeDiscoveryServer, svcName, ns string, pods map[st
 			ServicePortName: "http",
 			EndpointPort:    80,
 			HostName:        podName,
-			SubDomain:       svcName,
+			SubDomain:       headlessSvc,
 			HealthStatus:    model.Healthy,
 		})
 	}
@@ -234,19 +241,17 @@ func setHeadlessPods(s *xds.FakeDiscoveryServer, svcName, ns string, pods map[st
 }
 
 // perPodHostname returns the expected per-pod DNS name for a headless service pod.
-func perPodHostname(podName, svcName, ns string) string {
-	return fmt.Sprintf("%s.%s.%s.svc.cluster.local", podName, svcName, ns)
+func perPodHostname(podName string) string {
+	return fmt.Sprintf("%s.%s.%s.svc.cluster.local", podName, headlessSvc, ns)
 }
 
 func TestNDSDelta(t *testing.T) {
-	const ns = "default"
-
 	t.Run("initial full push returns per-host resources including headless per-pod entries", func(t *testing.T) {
 		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
-		addClusterIPService(s, "svc-a", ns, "10.0.0.1")
-		addHeadlessService(s, "svc-h", ns)
-		addHeadlessPod(s, "svc-h", ns, "pod-0", "10.1.0.1")
-		addHeadlessPod(s, "svc-h", ns, "pod-1", "10.1.0.2")
+		addClusterIPService(s, "svc-a", "10.0.0.1")
+		addHeadlessService(s)
+		addHeadlessPod(s, "pod-0", "10.1.0.1")
+		addHeadlessPod(s, "pod-1", "10.1.0.2")
 		s.EnsureSynced(t)
 
 		ads := connectDeltaNDS(t, s)
@@ -262,8 +267,8 @@ func TestNDSDelta(t *testing.T) {
 		expectedHosts := []string{
 			fmt.Sprintf("svc-a.%s.svc.cluster.local", ns),
 			fmt.Sprintf("svc-h.%s.svc.cluster.local", ns),
-			perPodHostname("pod-0", "svc-h", ns),
-			perPodHostname("pod-1", "svc-h", ns),
+			perPodHostname("pod-0"),
+			perPodHostname("pod-1"),
 		}
 		if len(expectedHosts) != len(table.Table) {
 			t.Errorf("expected %d entries in push table, got: %d", len(expectedHosts), len(table.Table))
@@ -277,7 +282,7 @@ func TestNDSDelta(t *testing.T) {
 
 	t.Run("incapable agent receives unnamed full-table resource", func(t *testing.T) {
 		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
-		addClusterIPService(s, "svc-a", ns, "10.0.0.1")
+		addClusterIPService(s, "svc-a", "10.0.0.1")
 		s.EnsureSynced(t)
 
 		// No DeltaNDS metadata — old agent.
@@ -294,16 +299,16 @@ func TestNDSDelta(t *testing.T) {
 
 	t.Run("service add sends only the new hostname", func(t *testing.T) {
 		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
-		addClusterIPService(s, "svc-a", ns, "10.0.0.1")
-		addHeadlessService(s, "svc-h", ns)
-		addHeadlessPod(s, "svc-h", ns, "pod-0", "10.1.0.1")
+		addClusterIPService(s, "svc-a", "10.0.0.1")
+		addHeadlessService(s)
+		addHeadlessPod(s, "pod-0", "10.1.0.1")
 		s.EnsureSynced(t)
 
 		ads := connectDeltaNDS(t, s)
 		ads.RequestResponseAck(&discovery.DeltaDiscoveryRequest{}) // consume initial push
 
 		// Adding a new ClusterIP service should only send that service's hostname.
-		addClusterIPService(s, "svc-b", ns, "10.0.0.2")
+		addClusterIPService(s, "svc-b", "10.0.0.2")
 		resp := ads.ExpectResponse()
 		hB := fmt.Sprintf("svc-b.%s.svc.cluster.local", ns)
 		if len(resp.Resources) != 1 || resp.Resources[0].Name != hB {
@@ -311,11 +316,11 @@ func TestNDSDelta(t *testing.T) {
 		}
 
 		// Adding a pod to the headless service should send the service record and the new per-pod entry.
-		addHeadlessPod(s, "svc-h", ns, "pod-1", "10.1.0.2")
+		addHeadlessPod(s, "pod-1", "10.1.0.2")
 		resp = ads.ExpectResponse()
 		addedNames := sets.New(slices.Map(resp.Resources, func(r *discovery.Resource) string { return r.Name })...)
-		if !addedNames.Contains(perPodHostname("pod-1", "svc-h", ns)) {
-			t.Errorf("expected per-pod hostname %q in delta, got: %v", perPodHostname("pod-1", "svc-h", ns), addedNames)
+		if !addedNames.Contains(perPodHostname("pod-1")) {
+			t.Errorf("expected per-pod hostname %q in delta, got: %v", perPodHostname("pod-1"), addedNames)
 		}
 		// svc-a and svc-b must not appear (they were not changed).
 		for _, unchanged := range []string{
@@ -330,13 +335,13 @@ func TestNDSDelta(t *testing.T) {
 
 	t.Run("service IP change sends updated entry", func(t *testing.T) {
 		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
-		addClusterIPService(s, "svc-a", ns, "10.0.0.1")
+		addClusterIPService(s, "svc-a", "10.0.0.1")
 		s.EnsureSynced(t)
 
 		ads := connectDeltaNDS(t, s)
 		ads.RequestResponseAck(&discovery.DeltaDiscoveryRequest{})
 
-		addClusterIPService(s, "svc-a", ns, "10.0.0.99")
+		addClusterIPService(s, "svc-a", "10.0.0.99")
 		resp := ads.ExpectResponse()
 
 		table := ndsTableFromDeltaResponse(t, resp)
@@ -355,18 +360,18 @@ func TestNDSDelta(t *testing.T) {
 
 	t.Run("service delete sends RemovedResources including headless per-pod entries", func(t *testing.T) {
 		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
-		addClusterIPService(s, "svc-a", ns, "10.0.0.1")
-		addClusterIPService(s, "svc-b", ns, "10.0.0.2")
-		addHeadlessService(s, "svc-h", ns)
-		addHeadlessPod(s, "svc-h", ns, "pod-0", "10.1.0.1")
-		addHeadlessPod(s, "svc-h", ns, "pod-1", "10.1.0.2")
+		addClusterIPService(s, "svc-a", "10.0.0.1")
+		addClusterIPService(s, "svc-b", "10.0.0.2")
+		addHeadlessService(s)
+		addHeadlessPod(s, "pod-0", "10.1.0.1")
+		addHeadlessPod(s, "pod-1", "10.1.0.2")
 		s.EnsureSynced(t)
 
 		ads := connectDeltaNDS(t, s)
 		ads.RequestResponseAck(&discovery.DeltaDiscoveryRequest{})
 
 		// ClusterIP service delete: only its hostname should be removed.
-		removeService(s, "svc-a", ns)
+		removeService(s, "svc-a")
 		resp := ads.ExpectResponse()
 		hA := fmt.Sprintf("svc-a.%s.svc.cluster.local", ns)
 		if !slices.Contains(resp.RemovedResources, hA) {
@@ -375,14 +380,14 @@ func TestNDSDelta(t *testing.T) {
 
 		// Headless scale-to-zero: removing all pods removes all per-pod entries AND the
 		// service record itself (no endpoints → no addresses → no table entry).
-		removeAllHeadlessPods(s, "svc-h", ns)
+		removeAllHeadlessPods(s)
 		resp = ads.ExpectResponse()
 
 		removed := sets.New(resp.RemovedResources...)
 		for _, expected := range []string{
 			fmt.Sprintf("svc-h.%s.svc.cluster.local", ns),
-			perPodHostname("pod-0", "svc-h", ns),
-			perPodHostname("pod-1", "svc-h", ns),
+			perPodHostname("pod-0"),
+			perPodHostname("pod-1"),
 		} {
 			if !removed.Contains(expected) {
 				t.Errorf("expected %q in RemovedResources after scale-to-zero, got: %v", expected, resp.RemovedResources)
@@ -392,8 +397,8 @@ func TestNDSDelta(t *testing.T) {
 
 	t.Run("headless scale-down removes only the departed pod's per-pod entry", func(t *testing.T) {
 		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
-		addHeadlessService(s, "svc-h", ns)
-		setHeadlessPods(s, "svc-h", ns, map[string]string{"pod-0": "10.1.0.1", "pod-1": "10.1.0.2", "pod-2": "10.1.0.3"})
+		addHeadlessService(s)
+		setHeadlessPods(s, map[string]string{"pod-0": "10.1.0.1", "pod-1": "10.1.0.2", "pod-2": "10.1.0.3"})
 		s.EnsureSynced(t)
 
 		ads := connectDeltaNDS(t, s)
@@ -402,17 +407,17 @@ func TestNDSDelta(t *testing.T) {
 		// Scale down by one: pod-2 leaves; the service record and pod-0/pod-1 remain. This is the
 		// key removal case — the push only names the service hostname, yet the generator must
 		// derive that pod-2's per-pod record is gone (via owned(H) vs w.ResourceNames).
-		setHeadlessPods(s, "svc-h", ns, map[string]string{"pod-0": "10.1.0.1", "pod-1": "10.1.0.2"})
+		setHeadlessPods(s, map[string]string{"pod-0": "10.1.0.1", "pod-1": "10.1.0.2"})
 		resp := ads.ExpectResponse()
 
-		pod2 := perPodHostname("pod-2", "svc-h", ns)
+		pod2 := perPodHostname("pod-2")
 		if !slices.Contains(resp.RemovedResources, pod2) {
 			t.Errorf("expected departed pod %q in RemovedResources, got %v", pod2, resp.RemovedResources)
 		}
 		// Neither the surviving pods nor the service record may be removed.
 		for _, keep := range []string{
-			perPodHostname("pod-0", "svc-h", ns),
-			perPodHostname("pod-1", "svc-h", ns),
+			perPodHostname("pod-0"),
+			perPodHostname("pod-1"),
 			fmt.Sprintf("svc-h.%s.svc.cluster.local", ns),
 		} {
 			if slices.Contains(resp.RemovedResources, keep) {
@@ -423,8 +428,8 @@ func TestNDSDelta(t *testing.T) {
 
 	t.Run("non-delta-aware push sends full per-host set with server-computed removals", func(t *testing.T) {
 		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
-		addClusterIPService(s, "svc-a", ns, "10.0.0.1")
-		addClusterIPService(s, "svc-b", ns, "10.0.0.2")
+		addClusterIPService(s, "svc-a", "10.0.0.1")
+		addClusterIPService(s, "svc-b", "10.0.0.2")
 		s.EnsureSynced(t)
 
 		ads := connectDeltaNDS(t, s)

--- a/pkg/bootstrap/config_test.go
+++ b/pkg/bootstrap/config_test.go
@@ -117,6 +117,14 @@ func TestGetNodeMetaData(t *testing.T) {
 	g.Expect(node.Metadata.Labels[model.LocalityLabel]).To(Equal("region/zone/subzone"))
 }
 
+func TestGetNodeMetaDataDeltaNDS(t *testing.T) {
+	t.Setenv(IstioMetaPrefix+"DELTA_NDS", "true")
+	node, err := GetNodeMetaData(MetadataOptions{ID: "test", Envs: os.Environ()})
+	g := NewWithT(t)
+	g.Expect(err).Should(BeNil())
+	g.Expect(node.Metadata.DeltaNDS).To(Equal(model.StringBool(true)))
+}
+
 func TestGetNodeMetaDataSecureMetricsPorts(t *testing.T) {
 	node, err := GetNodeMetaData(MetadataOptions{
 		ID:                           "test",

--- a/pkg/dns/client/dns.go
+++ b/pkg/dns/client/dns.go
@@ -287,8 +287,14 @@ func (h *LocalDNSServer) removeHostEntries(table *LookupTable, hostname string, 
 	if ni == nil {
 		return
 	}
-	for ah := range h.altHostsFor(hostname, ni) {
+	altHosts := h.altHostsFor(hostname, ni)
+	for ah := range altHosts {
+		ah = strings.ToLower(ah)
 		delete(table.hosts, ah)
+		// buildDNSAnswers may have added a search-namespace-expanded CNAME entry for this alt host
+		if expandedHost, ok := expandedSearchHost(ah, altHosts, h.searchNamespaces); ok {
+			delete(table.hosts, expandedHost)
+		}
 	}
 }
 
@@ -711,28 +717,40 @@ func (table *LookupTable) buildDNSAnswers(altHosts map[string]struct{}, ipv4 []n
 			rec.name6 = aaaa(h, ipv6)
 		}
 		table.hosts[h] = rec
-		if len(searchNamespaces) > 0 && !strings.HasSuffix(h, searchNamespaces[0]+".") {
+		if expandedHost, ok := expandedSearchHost(h, altHosts, searchNamespaces); ok {
 			// NOTE: Right now, rather than storing one expanded host for each one of the search namespace
 			// entries, we are going to store just the first one (assuming that most clients will
 			// do sequential dns resolution, starting with the first search namespace)
-
-			// host h already ends with a .
-			// search namespace might not. So we append one in the end if needed
-			expandedHost := strings.ToLower(h + searchNamespaces[0])
-			if !strings.HasSuffix(searchNamespaces[0], ".") {
-				expandedHost += "."
-			}
-			// make sure this is not a proper hostname
-			// if host is productpage, and search namespace is ns1.svc.cluster.local
-			// then the expanded host productpage.ns1.svc.cluster.local is a valid hostname
-			// that is likely to be already present in the altHosts
-			if _, exists := altHosts[expandedHost]; !exists {
-				rec := table.hosts[expandedHost]
-				rec.cname = cname(expandedHost, h)
-				table.hosts[expandedHost] = rec
-			}
+			rec := table.hosts[expandedHost]
+			rec.cname = cname(expandedHost, h)
+			table.hosts[expandedHost] = rec
 		}
 	}
+}
+
+// expandedSearchHost returns the search-namespace-expanded hostname
+// CNAME for alt host h (e.g. "www.google.com." -> "www.google.com.ns1.svc.cluster.local.").
+// ok is false when no expansion applies: there are no search namespaces, h already ends with the
+// first search namespace, or the expanded name is itself one of altHosts and is therefore a real
+// host rather than a CNAME alias.
+func expandedSearchHost(h string, altHosts map[string]struct{}, searchNamespaces []string) (string, bool) {
+	if len(searchNamespaces) == 0 || strings.HasSuffix(h, searchNamespaces[0]+".") {
+		return "", false
+	}
+	// host h already ends with a .
+	// search namespace might not. So we append one in the end if needed
+	expandedHost := strings.ToLower(h + searchNamespaces[0])
+	if !strings.HasSuffix(searchNamespaces[0], ".") {
+		expandedHost += "."
+	}
+	// make sure this is not a proper hostname
+	// if host is productpage, and search namespace is ns1.svc.cluster.local
+	// then the expanded host productpage.ns1.svc.cluster.local is a valid hostname
+	// that is likely to be already present in the altHosts
+	if _, exists := altHosts[expandedHost]; exists {
+		return "", false
+	}
+	return expandedHost, true
 }
 
 // Borrowed from https://github.com/coredns/coredns/blob/master/plugin/hosts/hosts.go

--- a/pkg/dns/client/dns.go
+++ b/pkg/dns/client/dns.go
@@ -17,7 +17,6 @@ package client
 import (
 	"context"
 	"fmt"
-	"maps"
 	"net"
 	"net/netip"
 	"os"
@@ -33,6 +32,7 @@ import (
 	"istio.io/istio/pkg/config/host"
 	dnsProto "istio.io/istio/pkg/dns/proto"
 	istiolog "istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/slices"
 	netutil "istio.io/istio/pkg/util/net"
 	"istio.io/istio/pkg/util/sets"

--- a/pkg/dns/client/dns.go
+++ b/pkg/dns/client/dns.go
@@ -235,6 +235,9 @@ func (h *LocalDNSServer) Rebuild(table map[string]*dnsProto.NameTable_NameInfo) 
 func (h *LocalDNSServer) UpdateLookupTable(added map[string]*dnsProto.NameTable_NameInfo, removed []string) {
 	prevNT := h.nameTable.Load().(*dnsProto.NameTable)
 	base := h.lookupTable.Load().(*LookupTable)
+	// We cannot modify the existing lookup table in place, as it may be concurrently read by DNS queries.
+	// Instead, we create a new table and atomically replace the old one.
+	// This can be more costly than modifying in place but it allows us to avoid blocking DNS queries while we update the table.
 	newTable := &LookupTable{
 		allHosts: base.allHosts.Copy(),
 		name4:    maps.Clone(base.name4),

--- a/pkg/dns/client/dns.go
+++ b/pkg/dns/client/dns.go
@@ -17,6 +17,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net"
 	"net/netip"
 	"os"
@@ -213,17 +214,82 @@ func (h *LocalDNSServer) StartDNS() {
 	}
 }
 
-func (h *LocalDNSServer) UpdateLookupTable(nt *dnsProto.NameTable) {
-	lookupTable := &LookupTable{
+// Rebuild builds a fresh lookup table from added and atomically replaces the current one.
+// Used when the full set of DNS entries is known (initial load, reconnect after stream reset).
+func (h *LocalDNSServer) Rebuild(added map[string]*dnsProto.NameTable_NameInfo) {
+	newTable := &LookupTable{
 		allHosts: sets.String{},
 		name4:    map[string][]dns.RR{},
 		name6:    map[string][]dns.RR{},
 		cname:    map[string][]dns.RR{},
 	}
-	h.BuildAlternateHosts(nt, lookupTable.buildDNSAnswers)
-	h.lookupTable.Store(lookupTable)
-	h.nameTable.Store(nt)
-	log.Debugf("updated lookup table with %d hosts", len(lookupTable.allHosts))
+	for hostname, ni := range added {
+		h.addHostEntries(newTable, hostname, ni)
+	}
+	h.lookupTable.Store(newTable)
+	h.nameTable.Store(added)
+	log.Debugf("rebuilt lookup table with %d hosts", len(newTable.allHosts))
+}
+
+// UpdateLookupTable incrementally updates the lookup table for a set of added/modified and removed NDS hostnames.
+func (h *LocalDNSServer) UpdateLookupTable(added map[string]*dnsProto.NameTable_NameInfo, removed []string) {
+	prevNT := h.nameTable.Load().(*dnsProto.NameTable)
+	base := h.lookupTable.Load().(*LookupTable)
+	newTable := &LookupTable{
+		allHosts: base.allHosts.Copy(),
+		name4:    maps.Clone(base.name4),
+		name6:    maps.Clone(base.name6),
+		cname:    maps.Clone(base.cname),
+	}
+	updatedNT := &dnsProto.NameTable{Table: maps.Clone(prevNT.GetTable())}
+	for _, hostname := range removed {
+		h.removeHostEntries(newTable, hostname, prevNT.GetTable()[hostname])
+		delete(updatedNT.Table, hostname)
+	}
+	for hostname, ni := range added {
+		h.removeHostEntries(newTable, hostname, prevNT.GetTable()[hostname])
+		h.addHostEntries(newTable, hostname, ni)
+		updatedNT.Table[hostname] = ni
+	}
+	h.lookupTable.Store(newTable)
+	h.nameTable.Store(updatedNT)
+
+	log.Debugf("applied delta to lookup table +%d -%d, total %d hosts", len(added), len(removed), len(newTable.allHosts))
+}
+
+// altHostsFor returns the set of DNS keys a hostname contributes, derived from its NameInfo.
+func (h *LocalDNSServer) altHostsFor(hostname string, ni *dnsProto.NameTable_NameInfo) sets.String {
+	if ni.Registry == string(provider.Kubernetes) {
+		return generateAltHosts(hostname, ni, h.proxyNamespace, h.proxyDomain, h.proxyDomainParts)
+	}
+	fqdn := hostname
+	if !strings.HasSuffix(fqdn, ".") {
+		fqdn += "."
+	}
+	return sets.New(fqdn)
+}
+
+// addHostEntries computes the DNS alt-hosts for a single NDS hostname and inserts them into table.
+func (h *LocalDNSServer) addHostEntries(table *LookupTable, hostname string, ni *dnsProto.NameTable_NameInfo) {
+	ipv4, ipv6 := netutil.ParseIPsSplitToV4V6(ni.Ips)
+	if len(ipv4) == 0 && len(ipv6) == 0 {
+		return
+	}
+	table.buildDNSAnswers(h.altHostsFor(hostname, ni), ipv4, ipv6, h.searchNamespaces)
+}
+
+// removeHostEntries deletes all DNS keys that hostname contributed, re-deriving them from ni
+// (the NameInfo the hostname had before this delta).
+func (h *LocalDNSServer) removeHostEntries(table *LookupTable, hostname string, ni *dnsProto.NameTable_NameInfo) {
+	if ni == nil {
+		return
+	}
+	for ah := range h.altHostsFor(hostname, ni) {
+		table.allHosts.Delete(ah)
+		delete(table.name4, ah)
+		delete(table.name6, ah)
+		delete(table.cname, ah)
+	}
 }
 
 // BuildAlternateHosts builds alternate hosts for Kubernetes services in the name table and

--- a/pkg/dns/client/dns.go
+++ b/pkg/dns/client/dns.go
@@ -227,7 +227,7 @@ func (h *LocalDNSServer) Rebuild(added map[string]*dnsProto.NameTable_NameInfo) 
 		h.addHostEntries(newTable, hostname, ni)
 	}
 	h.lookupTable.Store(newTable)
-	h.nameTable.Store(added)
+	h.nameTable.Store(&dnsProto.NameTable{Table: added})
 	log.Debugf("rebuilt lookup table with %d hosts", len(newTable.allHosts))
 }
 

--- a/pkg/dns/client/dns.go
+++ b/pkg/dns/client/dns.go
@@ -43,10 +43,10 @@ var log = istiolog.RegisterScope("dns", "Istio DNS proxy")
 // LocalDNSServer holds configurations for the DNS downstreamUDPServer in Istio Agent
 type LocalDNSServer struct {
 	// Holds the pointer to the DNS lookup table
-	lookupTable atomic.Value
+	lookupTable atomic.Pointer[LookupTable]
 
 	// nameTable holds the original NameTable, for debugging
-	nameTable atomic.Value
+	nameTable atomic.Pointer[dnsProto.NameTable]
 
 	dnsProxies []*dnsProxy
 
@@ -66,21 +66,27 @@ type LocalDNSServer struct {
 
 // LookupTable is borrowed from https://github.com/coredns/coredns/blob/master/plugin/hosts/hostsfile.go
 type LookupTable struct {
-	// This table will be first looked up to see if the host is something that we got a Nametable entry for
-	// (i.e. came from istiod's service registry). If it is, then we will be able to confidently return
-	// NXDOMAIN errors for AAAA records for such hosts when only A records exist (or vice versa). If the
-	// host does not exist in this map, then we will return nil, causing the caller to query the upstream
-	// DNS server to resolve the host. Without this map, we would end up making unnecessary upstream DNS queries
-	// for hosts that will never resolve (e.g., AAAA for svc1.ns1.svc.cluster.local.svc.cluster.local.)
-	allHosts sets.String
+	// hosts is keyed by a FQDN matching a DNS query (like example.com.) and holds the pre-created
+	// DNS RR records for that host.
+	//
+	// The presence of a key is first looked up to see if the host is something that we got a
+	// Nametable entry for (i.e. came from istiod's service registry). If it is, then we will be
+	// able to confidently return NXDOMAIN errors for AAAA records for such hosts when only A
+	// records exist (or vice versa). If the host does not exist in this map, then we will return
+	// nil, causing the caller to query the upstream DNS server to resolve the host. Without this
+	// map, we would end up making unnecessary upstream DNS queries for hosts that will never
+	// resolve (e.g., AAAA for svc1.ns1.svc.cluster.local.svc.cluster.local.)
+	hosts map[string]hostRecords
+}
 
-	// The key is a FQDN matching a DNS query (like example.com.), the value is pre-created DNS RR records
-	// of A or AAAA type as appropriate.
-	name4 map[string][]dns.RR
-	name6 map[string][]dns.RR
-	// The cname records here (comprised of different variants of the hosts above,
+// hostRecords holds the pre-created DNS RR records for a single host key.
+type hostRecords struct {
+	// name4 and name6 are the A and AAAA records for the host, as appropriate.
+	name4 []dns.RR
+	name6 []dns.RR
+	// cname holds CNAME records (comprised of different variants of the hosts,
 	// expanded by the search namespaces) pointing to the actual host.
-	cname map[string][]dns.RR
+	cname []dns.RR
 }
 
 const (
@@ -218,31 +224,25 @@ func (h *LocalDNSServer) StartDNS() {
 // Used when the full set of DNS entries is known (initial load, reconnect after stream reset).
 func (h *LocalDNSServer) Rebuild(table map[string]*dnsProto.NameTable_NameInfo) {
 	newTable := &LookupTable{
-		allHosts: sets.String{},
-		name4:    map[string][]dns.RR{},
-		name6:    map[string][]dns.RR{},
-		cname:    map[string][]dns.RR{},
+		hosts: map[string]hostRecords{},
 	}
 	for hostname, ni := range table {
 		h.addHostEntries(newTable, hostname, ni)
 	}
 	h.lookupTable.Store(newTable)
 	h.nameTable.Store(&dnsProto.NameTable{Table: table})
-	log.Debugf("rebuilt lookup table with %d hosts", len(newTable.allHosts))
+	log.Debugf("rebuilt lookup table with %d hosts", len(newTable.hosts))
 }
 
 // UpdateLookupTable incrementally updates the lookup table for a set of added/modified and removed NDS hostnames.
 func (h *LocalDNSServer) UpdateLookupTable(added map[string]*dnsProto.NameTable_NameInfo, removed []string) {
-	prevNT := h.nameTable.Load().(*dnsProto.NameTable)
-	base := h.lookupTable.Load().(*LookupTable)
+	prevNT := h.nameTable.Load()
+	base := h.lookupTable.Load()
 	// We cannot modify the existing lookup table in place, as it may be concurrently read by DNS queries.
 	// Instead, we create a new table and atomically replace the old one.
 	// This can be more costly than modifying in place but it allows us to avoid blocking DNS queries while we update the table.
 	newTable := &LookupTable{
-		allHosts: base.allHosts.Copy(),
-		name4:    maps.Clone(base.name4),
-		name6:    maps.Clone(base.name6),
-		cname:    maps.Clone(base.cname),
+		hosts: maps.Clone(base.hosts),
 	}
 	updatedNT := &dnsProto.NameTable{Table: maps.Clone(prevNT.GetTable())}
 	for _, hostname := range removed {
@@ -257,7 +257,7 @@ func (h *LocalDNSServer) UpdateLookupTable(added map[string]*dnsProto.NameTable_
 	h.lookupTable.Store(newTable)
 	h.nameTable.Store(updatedNT)
 
-	log.Debugf("applied delta to lookup table +%d -%d, total %d hosts", len(added), len(removed), len(newTable.allHosts))
+	log.Debugf("applied delta to lookup table +%d -%d, total %d hosts", len(added), len(removed), len(newTable.hosts))
 }
 
 // altHostsFor returns the set of DNS keys a hostname contributes, derived from its NameInfo.
@@ -288,10 +288,7 @@ func (h *LocalDNSServer) removeHostEntries(table *LookupTable, hostname string, 
 		return
 	}
 	for ah := range h.altHostsFor(hostname, ni) {
-		table.allHosts.Delete(ah)
-		delete(table.name4, ah)
-		delete(table.name6, ah)
-		delete(table.cname, ah)
+		delete(table.hosts, ah)
 	}
 }
 
@@ -354,9 +351,9 @@ func (h *LocalDNSServer) ServeDNS(proxy *dnsProxy, w dns.ResponseWriter, req *dn
 		return
 	}
 
-	lp := h.lookupTable.Load()
+	lookupTable := h.lookupTable.Load()
 	hostname := strings.ToLower(req.Question[0].Name)
-	if lp == nil {
+	if lookupTable == nil {
 		if h.respondBeforeSync {
 			response = h.upstream(proxy, req, hostname)
 			response.Truncate(size(proxy.protocol, req))
@@ -370,7 +367,6 @@ func (h *LocalDNSServer) ServeDNS(proxy *dnsProxy, w dns.ResponseWriter, req *dn
 		}
 		return
 	}
-	lookupTable := lp.(*LookupTable)
 	var answers []dns.RR
 
 	// This name will always end in a dot.
@@ -411,11 +407,7 @@ func (h *LocalDNSServer) IsReady() bool {
 }
 
 func (h *LocalDNSServer) NameTable() *dnsProto.NameTable {
-	lt := h.nameTable.Load()
-	if lt == nil {
-		return nil
-	}
-	return lt.(*dnsProto.NameTable)
+	return h.nameTable.Load()
 }
 
 // Inspired by https://github.com/coredns/coredns/blob/master/plugin/loadbalance/loadbalance.go
@@ -611,8 +603,8 @@ func generateAltHosts(hostname string, nameinfo *dnsProto.NameTable_NameInfo, pr
 func (table *LookupTable) lookupHost(qtype uint16, hostname string) ([]dns.RR, bool) {
 	question := string(host.Name(hostname))
 	wildcard := false
-	// First check if host exists in all hosts.
-	hostFound := table.allHosts.Contains(hostname)
+	// First check if the host exists in the lookup table.
+	rec, hostFound := table.hosts[hostname]
 	// If it is not found, check if a wildcard host exists for it.
 	// For example for "*.example.com", with the question "svc.svcns.example.com",
 	// we check if we have entries for "*.svcns.example.com", "*.example.com" etc.
@@ -620,7 +612,7 @@ func (table *LookupTable) lookupHost(qtype uint16, hostname string) ([]dns.RR, b
 		labels := dns.SplitDomainName(hostname)
 		for idx := range labels {
 			qhost := "*." + strings.Join(labels[idx+1:], ".") + "."
-			if hostFound = table.allHosts.Contains(qhost); hostFound {
+			if rec, hostFound = table.hosts[qhost]; hostFound {
 				wildcard = true
 				hostname = qhost
 				break
@@ -639,20 +631,24 @@ func (table *LookupTable) lookupHost(qtype uint16, hostname string) ([]dns.RR, b
 
 	// Odds are, the first query will always be an expanded hostname
 	// (productpage.ns1.svc.cluster.local.ns1.svc.cluster.local)
-	// So lookup the cname table first
-	for _, cn := range table.cname[hostname] {
+	// So lookup the cname records first
+	for _, cn := range rec.cname {
 		// this was a cname match
 		copied := dns.Copy(cn).(*dns.CNAME)
 		copied.Header().Name = question
 		cnAnswers = append(cnAnswers, copied)
 		hostname = copied.Target
 	}
+	// If we followed a CNAME, the A/AAAA records live under the target host.
+	if len(cnAnswers) > 0 {
+		rec = table.hosts[hostname]
+	}
 
 	switch qtype {
 	case dns.TypeA:
-		ipAnswers = table.name4[hostname]
+		ipAnswers = rec.name4
 	case dns.TypeAAAA:
-		ipAnswers = table.name6[hostname]
+		ipAnswers = rec.name6
 	default:
 		// TODO: handle PTR records for reverse dns lookups
 		return nil, false
@@ -707,13 +703,14 @@ func (table *LookupTable) lookupHost(qtype uint16, hostname string) ([]dns.RR, b
 func (table *LookupTable) buildDNSAnswers(altHosts map[string]struct{}, ipv4 []netip.Addr, ipv6 []netip.Addr, searchNamespaces []string) {
 	for h := range altHosts {
 		h = strings.ToLower(h)
-		table.allHosts.Insert(h)
+		rec := table.hosts[h]
 		if len(ipv4) > 0 {
-			table.name4[h] = a(h, ipv4)
+			rec.name4 = a(h, ipv4)
 		}
 		if len(ipv6) > 0 {
-			table.name6[h] = aaaa(h, ipv6)
+			rec.name6 = aaaa(h, ipv6)
 		}
+		table.hosts[h] = rec
 		if len(searchNamespaces) > 0 && !strings.HasSuffix(h, searchNamespaces[0]+".") {
 			// NOTE: Right now, rather than storing one expanded host for each one of the search namespace
 			// entries, we are going to store just the first one (assuming that most clients will
@@ -730,8 +727,9 @@ func (table *LookupTable) buildDNSAnswers(altHosts map[string]struct{}, ipv4 []n
 			// then the expanded host productpage.ns1.svc.cluster.local is a valid hostname
 			// that is likely to be already present in the altHosts
 			if _, exists := altHosts[expandedHost]; !exists {
-				table.cname[expandedHost] = cname(expandedHost, h)
-				table.allHosts.Insert(expandedHost)
+				rec := table.hosts[expandedHost]
+				rec.cname = cname(expandedHost, h)
+				table.hosts[expandedHost] = rec
 			}
 		}
 	}

--- a/pkg/dns/client/dns.go
+++ b/pkg/dns/client/dns.go
@@ -214,20 +214,20 @@ func (h *LocalDNSServer) StartDNS() {
 	}
 }
 
-// Rebuild builds a fresh lookup table from added and atomically replaces the current one.
+// Rebuild builds a fresh lookup table from table and atomically replaces the current one.
 // Used when the full set of DNS entries is known (initial load, reconnect after stream reset).
-func (h *LocalDNSServer) Rebuild(added map[string]*dnsProto.NameTable_NameInfo) {
+func (h *LocalDNSServer) Rebuild(table map[string]*dnsProto.NameTable_NameInfo) {
 	newTable := &LookupTable{
 		allHosts: sets.String{},
 		name4:    map[string][]dns.RR{},
 		name6:    map[string][]dns.RR{},
 		cname:    map[string][]dns.RR{},
 	}
-	for hostname, ni := range added {
+	for hostname, ni := range table {
 		h.addHostEntries(newTable, hostname, ni)
 	}
 	h.lookupTable.Store(newTable)
-	h.nameTable.Store(&dnsProto.NameTable{Table: added})
+	h.nameTable.Store(&dnsProto.NameTable{Table: table})
 	log.Debugf("rebuilt lookup table with %d hosts", len(newTable.allHosts))
 }
 

--- a/pkg/dns/client/dns_test.go
+++ b/pkg/dns/client/dns_test.go
@@ -811,6 +811,39 @@ func TestRebuildPurgesStaleEntries(t *testing.T) {
 	}
 }
 
+// TestUpdateLookupTableNonKubernetes exercises the non-Kubernetes (ServiceEntry/External)
+// registry branch of the incremental delta path: such hosts contribute only their exact FQDN
+// (no short-name alt hosts), and add/remove must touch exactly that key.
+func TestUpdateLookupTableNonKubernetes(t *testing.T) {
+	h := newTestDNSServer(t)
+	h.Rebuild(map[string]*dnsProto.NameTable_NameInfo{
+		"www.example.com": {Ips: []string{"1.2.3.4"}, Registry: "External"},
+	})
+	if !resolves(h, "www.example.com") {
+		t.Fatal("expected external host to resolve after Rebuild")
+	}
+
+	// Incremental add of a second external host must not disturb the first.
+	h.UpdateLookupTable(map[string]*dnsProto.NameTable_NameInfo{
+		"api.example.com": {Ips: []string{"5.6.7.8"}, Registry: "External"},
+	}, nil)
+	if !resolves(h, "api.example.com") {
+		t.Error("expected api.example.com to resolve after incremental add")
+	}
+	if !resolves(h, "www.example.com") {
+		t.Error("www.example.com should survive an incremental add")
+	}
+
+	// Incremental removal must delete exactly the FQDN the host contributed, leaving the other.
+	h.UpdateLookupTable(nil, []string{"www.example.com"})
+	if resolves(h, "www.example.com") {
+		t.Error("www.example.com should no longer resolve after removal")
+	}
+	if !resolves(h, "api.example.com") {
+		t.Error("api.example.com should still resolve after removing www.example.com")
+	}
+}
+
 func TestDNSTimeoutBehavior(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/dns/client/dns_test.go
+++ b/pkg/dns/client/dns_test.go
@@ -606,7 +606,7 @@ func initDNS(t test.Failer, forwardToUpstreamParallel bool) *LocalDNSServer {
 
 func fillTable(server *LocalDNSServer) {
 	server.searchNamespaces = []string{"ns1.svc.cluster.local", "svc.cluster.local", "cluster.local"}
-	server.UpdateLookupTable(&dnsProto.NameTable{
+	server.Rebuild((&dnsProto.NameTable{
 		Table: map[string]*dnsProto.NameTable_NameInfo{
 			"www.google.com": {
 				Ips:      []string{"1.1.1.1"},
@@ -668,7 +668,7 @@ func fillTable(server *LocalDNSServer) {
 				Registry: "External",
 			},
 		},
-	})
+	}).GetTable())
 }
 
 // reflect.DeepEqual doesn't seem to work well for dns.RR

--- a/pkg/dns/client/dns_test.go
+++ b/pkg/dns/client/dns_test.go
@@ -696,7 +696,7 @@ func resolves(h *LocalDNSServer, hostname string) bool {
 	if lp == nil {
 		return false
 	}
-	_, found := lp.(*LookupTable).lookupHost(dns.TypeA, hostname+".")
+	_, found := lp.lookupHost(dns.TypeA, hostname+".")
 	return found
 }
 
@@ -757,7 +757,7 @@ func TestUpdateLookupTableIncremental(t *testing.T) {
 		h.UpdateLookupTable(map[string]*dnsProto.NameTable_NameInfo{
 			"svc-a.ns1.svc.cluster.local": {Ips: []string{"10.0.0.99"}, Registry: "Kubernetes", Namespace: "ns1", Shortname: "svc-a"},
 		}, nil)
-		lp := h.lookupTable.Load().(*LookupTable)
+		lp := h.lookupTable.Load()
 		rrs, _ := lp.lookupHost(dns.TypeA, "svc-a.ns1.svc.cluster.local.")
 		if len(rrs) == 0 || rrs[0].(*dns.A).A.String() != "10.0.0.99" {
 			t.Errorf("expected svc-a to resolve to 10.0.0.99, got %v", rrs)

--- a/pkg/dns/client/dns_test.go
+++ b/pkg/dns/client/dns_test.go
@@ -681,6 +681,136 @@ func equalsDNSrecords(got []dns.RR, want []dns.RR) bool {
 	return reflect.DeepEqual(got, want)
 }
 
+func newTestDNSServer(t *testing.T) *LocalDNSServer {
+	t.Helper()
+	h, err := NewLocalDNSServer("ns1", "ns1.svc.cluster.local", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	h.searchNamespaces = []string{"ns1.svc.cluster.local", "svc.cluster.local", "cluster.local"}
+	return h
+}
+
+func resolves(h *LocalDNSServer, hostname string) bool {
+	lp := h.lookupTable.Load()
+	if lp == nil {
+		return false
+	}
+	_, found := lp.(*LookupTable).lookupHost(dns.TypeA, hostname+".")
+	return found
+}
+
+func TestRebuild(t *testing.T) {
+	h := newTestDNSServer(t)
+
+	h.Rebuild(map[string]*dnsProto.NameTable_NameInfo{
+		"svc-a.ns1.svc.cluster.local": {Ips: []string{"10.0.0.1"}, Registry: "Kubernetes", Namespace: "ns1", Shortname: "svc-a"},
+		"svc-b.ns1.svc.cluster.local": {Ips: []string{"10.0.0.2"}, Registry: "Kubernetes", Namespace: "ns1", Shortname: "svc-b"},
+	})
+
+	if !resolves(h, "svc-a.ns1.svc.cluster.local") {
+		t.Error("expected svc-a to resolve after Rebuild")
+	}
+	if !resolves(h, "svc-b.ns1.svc.cluster.local") {
+		t.Error("expected svc-b to resolve after Rebuild")
+	}
+
+	// NameTable() must reflect the rebuilt state.
+	nt := h.NameTable()
+	if nt == nil || len(nt.Table) != 2 {
+		t.Errorf("expected NameTable with 2 entries, got %v", nt)
+	}
+
+	// Second Rebuild replaces the first — svc-a must disappear.
+	h.Rebuild(map[string]*dnsProto.NameTable_NameInfo{
+		"svc-c.ns1.svc.cluster.local": {Ips: []string{"10.0.0.3"}, Registry: "Kubernetes", Namespace: "ns1", Shortname: "svc-c"},
+	})
+	if resolves(h, "svc-a.ns1.svc.cluster.local") {
+		t.Error("svc-a should have been purged by the second Rebuild")
+	}
+	if !resolves(h, "svc-c.ns1.svc.cluster.local") {
+		t.Error("expected svc-c to resolve after second Rebuild")
+	}
+}
+
+func TestUpdateLookupTableIncremental(t *testing.T) {
+	h := newTestDNSServer(t)
+	h.Rebuild(map[string]*dnsProto.NameTable_NameInfo{
+		"svc-a.ns1.svc.cluster.local": {Ips: []string{"10.0.0.1"}, Registry: "Kubernetes", Namespace: "ns1", Shortname: "svc-a"},
+		"svc-b.ns1.svc.cluster.local": {Ips: []string{"10.0.0.2"}, Registry: "Kubernetes", Namespace: "ns1", Shortname: "svc-b"},
+	})
+
+	t.Run("add new entry", func(t *testing.T) {
+		h.UpdateLookupTable(map[string]*dnsProto.NameTable_NameInfo{
+			"svc-c.ns1.svc.cluster.local": {Ips: []string{"10.0.0.3"}, Registry: "Kubernetes", Namespace: "ns1", Shortname: "svc-c"},
+		}, nil)
+		if !resolves(h, "svc-c.ns1.svc.cluster.local") {
+			t.Error("expected svc-c to resolve after incremental add")
+		}
+		// Existing entries must be preserved.
+		if !resolves(h, "svc-a.ns1.svc.cluster.local") {
+			t.Error("svc-a should still resolve after adding svc-c")
+		}
+	})
+
+	t.Run("update existing entry IP", func(t *testing.T) {
+		h.UpdateLookupTable(map[string]*dnsProto.NameTable_NameInfo{
+			"svc-a.ns1.svc.cluster.local": {Ips: []string{"10.0.0.99"}, Registry: "Kubernetes", Namespace: "ns1", Shortname: "svc-a"},
+		}, nil)
+		lp := h.lookupTable.Load().(*LookupTable)
+		rrs, _ := lp.lookupHost(dns.TypeA, "svc-a.ns1.svc.cluster.local.")
+		if len(rrs) == 0 || rrs[0].(*dns.A).A.String() != "10.0.0.99" {
+			t.Errorf("expected svc-a to resolve to 10.0.0.99, got %v", rrs)
+		}
+	})
+
+	t.Run("remove entry", func(t *testing.T) {
+		h.UpdateLookupTable(nil, []string{"svc-b.ns1.svc.cluster.local"})
+		if resolves(h, "svc-b.ns1.svc.cluster.local") {
+			t.Error("svc-b should no longer resolve after removal")
+		}
+		if !resolves(h, "svc-a.ns1.svc.cluster.local") {
+			t.Error("svc-a should still resolve after removing svc-b")
+		}
+	})
+
+	t.Run("NameTable stays in sync", func(t *testing.T) {
+		nt := h.NameTable()
+		if nt == nil {
+			t.Fatal("NameTable() returned nil")
+		}
+		// svc-b was removed, svc-c was added, svc-a was updated.
+		if _, ok := nt.Table["svc-b.ns1.svc.cluster.local"]; ok {
+			t.Error("NameTable still contains removed svc-b")
+		}
+		if _, ok := nt.Table["svc-c.ns1.svc.cluster.local"]; !ok {
+			t.Error("NameTable missing added svc-c")
+		}
+		if ni := nt.Table["svc-a.ns1.svc.cluster.local"]; ni == nil || len(ni.Ips) == 0 || ni.Ips[0] != "10.0.0.99" {
+			t.Errorf("NameTable has wrong IP for svc-a: %v", ni)
+		}
+	})
+}
+
+func TestRebuildPurgesStaleEntries(t *testing.T) {
+	h := newTestDNSServer(t)
+	h.Rebuild(map[string]*dnsProto.NameTable_NameInfo{
+		"svc-a.ns1.svc.cluster.local": {Ips: []string{"10.0.0.1"}, Registry: "Kubernetes", Namespace: "ns1", Shortname: "svc-a"},
+	})
+	// Add incrementally.
+	h.UpdateLookupTable(map[string]*dnsProto.NameTable_NameInfo{
+		"svc-b.ns1.svc.cluster.local": {Ips: []string{"10.0.0.2"}, Registry: "Kubernetes", Namespace: "ns1", Shortname: "svc-b"},
+	}, nil)
+
+	// Simulate reconnect: Rebuild with only svc-a. svc-b (stale from prior connection) must vanish.
+	h.Rebuild(map[string]*dnsProto.NameTable_NameInfo{
+		"svc-a.ns1.svc.cluster.local": {Ips: []string{"10.0.0.1"}, Registry: "Kubernetes", Namespace: "ns1", Shortname: "svc-a"},
+	})
+	if resolves(h, "svc-b.ns1.svc.cluster.local") {
+		t.Error("Rebuild must purge svc-b from the previous connection")
+	}
+}
+
 func TestDNSTimeoutBehavior(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/dns/client/dns_test.go
+++ b/pkg/dns/client/dns_test.go
@@ -834,10 +834,20 @@ func TestUpdateLookupTableNonKubernetes(t *testing.T) {
 		t.Error("www.example.com should survive an incremental add")
 	}
 
+	// The add path also stores a search-namespace-expanded CNAME entry
+	// (www.example.com.ns1.svc.cluster.local -> www.example.com); sanity check it exists.
+	if !resolves(h, "www.example.com.ns1.svc.cluster.local") {
+		t.Fatal("expected search-namespace-expanded CNAME entry for www.example.com")
+	}
+
 	// Incremental removal must delete exactly the FQDN the host contributed, leaving the other.
 	h.UpdateLookupTable(nil, []string{"www.example.com"})
 	if resolves(h, "www.example.com") {
 		t.Error("www.example.com should no longer resolve after removal")
+	}
+	// Removal must also purge the expanded CNAME entry, otherwise it leaks on every delta.
+	if resolves(h, "www.example.com.ns1.svc.cluster.local") {
+		t.Error("expanded CNAME entry for www.example.com should be purged after removal")
 	}
 	if !resolves(h, "api.example.com") {
 		t.Error("api.example.com should still resolve after removing www.example.com")

--- a/pkg/dns/proto/nds.pb.go
+++ b/pkg/dns/proto/nds.pb.go
@@ -40,7 +40,10 @@ const (
 type NameTable struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Map of hostname to resolution attributes.
-	Table         map[string]*NameTable_NameInfo `protobuf:"bytes,1,rep,name=table,proto3" json:"table,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Table map[string]*NameTable_NameInfo `protobuf:"bytes,1,rep,name=table,proto3" json:"table,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// Resolution attributes for a single hostname, the hostname itself is carried by discovery.Resource.Name.
+	// Used to send incremental updates to the NameTable. Sent by istiod to istio agents via xds.
+	NameInfo      *NameTable_NameInfo `protobuf:"bytes,2,opt,name=name_info,json=nameInfo,proto3" json:"name_info,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -78,6 +81,13 @@ func (*NameTable) Descriptor() ([]byte, []int) {
 func (x *NameTable) GetTable() map[string]*NameTable_NameInfo {
 	if x != nil {
 		return x.Table
+	}
+	return nil
+}
+
+func (x *NameTable) GetNameInfo() *NameTable_NameInfo {
+	if x != nil {
+		return x.NameInfo
 	}
 	return nil
 }
@@ -170,9 +180,10 @@ var File_dns_proto_nds_proto protoreflect.FileDescriptor
 
 const file_dns_proto_nds_proto_rawDesc = "" +
 	"\n" +
-	"\x13dns/proto/nds.proto\x12\x17istio.networking.nds.v1\"\xcf\x02\n" +
+	"\x13dns/proto/nds.proto\x12\x17istio.networking.nds.v1\"\x99\x03\n" +
 	"\tNameTable\x12C\n" +
-	"\x05table\x18\x01 \x03(\v2-.istio.networking.nds.v1.NameTable.TableEntryR\x05table\x1a\x95\x01\n" +
+	"\x05table\x18\x01 \x03(\v2-.istio.networking.nds.v1.NameTable.TableEntryR\x05table\x12H\n" +
+	"\tname_info\x18\x02 \x01(\v2+.istio.networking.nds.v1.NameTable.NameInfoR\bnameInfo\x1a\x95\x01\n" +
 	"\bNameInfo\x12\x10\n" +
 	"\x03ips\x18\x01 \x03(\tR\x03ips\x12\x1a\n" +
 	"\bregistry\x18\x02 \x01(\tR\bregistry\x12\x1c\n" +
@@ -204,12 +215,13 @@ var file_dns_proto_nds_proto_goTypes = []any{
 }
 var file_dns_proto_nds_proto_depIdxs = []int32{
 	2, // 0: istio.networking.nds.v1.NameTable.table:type_name -> istio.networking.nds.v1.NameTable.TableEntry
-	1, // 1: istio.networking.nds.v1.NameTable.TableEntry.value:type_name -> istio.networking.nds.v1.NameTable.NameInfo
-	2, // [2:2] is the sub-list for method output_type
-	2, // [2:2] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	1, // 1: istio.networking.nds.v1.NameTable.name_info:type_name -> istio.networking.nds.v1.NameTable.NameInfo
+	1, // 2: istio.networking.nds.v1.NameTable.TableEntry.value:type_name -> istio.networking.nds.v1.NameTable.NameInfo
+	3, // [3:3] is the sub-list for method output_type
+	3, // [3:3] is the sub-list for method input_type
+	3, // [3:3] is the sub-list for extension type_name
+	3, // [3:3] is the sub-list for extension extendee
+	0, // [0:3] is the sub-list for field type_name
 }
 
 func init() { file_dns_proto_nds_proto_init() }

--- a/pkg/dns/proto/nds.proto
+++ b/pkg/dns/proto/nds.proto
@@ -40,5 +40,8 @@ message NameTable {
 
     // Map of hostname to resolution attributes.
     map<string, NameInfo> table = 1;
+    // Resolution attributes for a single hostname, the hostname itself is carried by discovery.Resource.Name.
+    // Used to send incremental updates to the NameTable. Sent by istiod to istio agents via xds.
+    NameInfo name_info = 2;
 }
 

--- a/pkg/dns/server/name_table.go
+++ b/pkg/dns/server/name_table.go
@@ -36,12 +36,8 @@ type Config struct {
 	// same-network endpoints in any cluster.
 	MulticlusterHeadlessEnabled bool
 
-	// Hostnames, if non-nil, restricts the table to services whose hostname is in the set
-	// (plus the per-pod records those services own). A nil set builds the full proxy-scoped
-	// table. This is used to build incremental (delta) NDS updates without rebuilding and
-	// re-serializing the whole table: each service only contributes records under its own
-	// hostname, and the sole cross-service interaction is same-hostname merging, so filtering
-	// by hostname yields the same entries the full build would produce for those hostnames.
+	// Hostnames, if non-nil, restricts the table generation to services whose hostname is in the set
+	// (plus the per-pod records those services own). This is used to build incremental NDS updates.
 	Hostnames sets.String
 }
 
@@ -55,7 +51,6 @@ func BuildNameTable(cfg Config) *dnsProto.NameTable {
 	for _, el := range cfg.Node.SidecarScope.EgressListeners {
 		for _, svc := range el.Services() {
 			if cfg.Hostnames != nil && !cfg.Hostnames.Contains(svc.Hostname.String()) {
-				// Delta build: skip services whose hostname didn't change.
 				continue
 			}
 			var addressList []string

--- a/pkg/dns/server/name_table.go
+++ b/pkg/dns/server/name_table.go
@@ -24,6 +24,7 @@ import (
 	"istio.io/istio/pkg/config/constants"
 	dnsProto "istio.io/istio/pkg/dns/proto"
 	netutil "istio.io/istio/pkg/util/net"
+	"istio.io/istio/pkg/util/sets"
 )
 
 // Config for building the name table.
@@ -34,6 +35,14 @@ type Config struct {
 	// MulticlusterHeadlessEnabled if true, the DNS name table for a headless service will resolve to
 	// same-network endpoints in any cluster.
 	MulticlusterHeadlessEnabled bool
+
+	// Hostnames, if non-nil, restricts the table to services whose hostname is in the set
+	// (plus the per-pod records those services own). A nil set builds the full proxy-scoped
+	// table. This is used to build incremental (delta) NDS updates without rebuilding and
+	// re-serializing the whole table: each service only contributes records under its own
+	// hostname, and the sole cross-service interaction is same-hostname merging, so filtering
+	// by hostname yields the same entries the full build would produce for those hostnames.
+	Hostnames sets.String
 }
 
 // BuildNameTable produces a table of hostnames and their associated IPs that can then
@@ -45,6 +54,10 @@ func BuildNameTable(cfg Config) *dnsProto.NameTable {
 	}
 	for _, el := range cfg.Node.SidecarScope.EgressListeners {
 		for _, svc := range el.Services() {
+			if cfg.Hostnames != nil && !cfg.Hostnames.Contains(svc.Hostname.String()) {
+				// Delta build: skip services whose hostname didn't change.
+				continue
+			}
 			var addressList []string
 			hostName := svc.Hostname
 			headless := false

--- a/pkg/dns/server/name_table.go
+++ b/pkg/dns/server/name_table.go
@@ -24,7 +24,6 @@ import (
 	"istio.io/istio/pkg/config/constants"
 	dnsProto "istio.io/istio/pkg/dns/proto"
 	netutil "istio.io/istio/pkg/util/net"
-	"istio.io/istio/pkg/util/sets"
 )
 
 // Config for building the name table.
@@ -35,156 +34,169 @@ type Config struct {
 	// MulticlusterHeadlessEnabled if true, the DNS name table for a headless service will resolve to
 	// same-network endpoints in any cluster.
 	MulticlusterHeadlessEnabled bool
-
-	// Hostnames, if non-nil, restricts the table generation to services whose hostname is in the set
-	// (plus the per-pod records those services own). This is used to build incremental NDS updates.
-	Hostnames sets.String
 }
 
 // BuildNameTable produces a table of hostnames and their associated IPs that can then
 // be used by the agent to resolve DNS. This logic is always active. However, local DNS resolution
-// will only be effective if DNS capture is enabled in the proxy
+// will only be effective if DNS capture is enabled in the proxy. This builds the full table for all
+// services visible to the proxy's sidecar scope.
 func BuildNameTable(cfg Config) *dnsProto.NameTable {
 	out := &dnsProto.NameTable{
 		Table: make(map[string]*dnsProto.NameTable_NameInfo),
 	}
 	for _, el := range cfg.Node.SidecarScope.EgressListeners {
 		for _, svc := range el.Services() {
-			if cfg.Hostnames != nil && !cfg.Hostnames.Contains(svc.Hostname.String()) {
-				continue
-			}
-			var addressList []string
-			hostName := svc.Hostname
-			headless := false
-			for _, svcAddress := range svc.GetAllAddressesForProxy(cfg.Node) {
-				if svcAddress == constants.UnspecifiedIP {
-					headless = true
-					break
+			addServiceToTable(out, cfg, svc)
+		}
+	}
+	return out
+}
+
+// BuildNameTableForServices produces a name table restricted to the given services, avoiding the
+// walk over the sidecar scope's egress listeners. Used by the incremental NDS path, where the
+// changed services have already been resolved. Callers must pass at most one service per hostname.
+func BuildNameTableForServices(cfg Config, services []*model.Service) *dnsProto.NameTable {
+	out := &dnsProto.NameTable{
+		Table: make(map[string]*dnsProto.NameTable_NameInfo, len(services)),
+	}
+	for _, svc := range services {
+		addServiceToTable(out, cfg, svc)
+	}
+	return out
+}
+
+// addServiceToTable adds the DNS entries a single service contributes (its own record plus, for
+// Kubernetes headless services, one record per endpoint pod) into out.
+func addServiceToTable(out *dnsProto.NameTable, cfg Config, svc *model.Service) {
+	var addressList []string
+	hostName := svc.Hostname
+	headless := false
+	for _, svcAddress := range svc.GetAllAddressesForProxy(cfg.Node) {
+		if svcAddress == constants.UnspecifiedIP {
+			headless = true
+			break
+		}
+		// Filter out things we cannot parse as IP. Generally this means CIDRs, as anything else
+		// should be caught in validation.
+		if !netutil.IsValidIPAddress(svcAddress) {
+			continue
+		}
+		addressList = append(addressList, svcAddress)
+	}
+	if headless {
+		// The IP will be unspecified here if its headless service or if the auto
+		// IP allocation logic for service entry was unable to allocate an IP.
+		if svc.Resolution == model.Passthrough && len(svc.Ports) > 0 {
+			localAddresses := make(map[string][]string)
+			remoteAddresses := make(map[string][]string)
+			hostMetadata := make(map[string]types.NamespacedName)
+			for _, instance := range cfg.Push.ServiceEndpointsByPort(svc, svc.Ports[0].Port, nil) {
+				// addresses may be empty or invalid here
+				isValidInstance := true
+				for _, addr := range instance.Addresses {
+					if !netutil.IsValidIPAddress(addr) {
+						isValidInstance = false
+						break
+					}
 				}
-				// Filter out things we cannot parse as IP. Generally this means CIDRs, as anything else
-				// should be caught in validation.
-				if !netutil.IsValidIPAddress(svcAddress) {
+				if len(instance.Addresses) == 0 || !isValidInstance ||
+					(!svc.Attributes.PublishNotReadyAddresses && instance.HealthStatus != model.Healthy) {
 					continue
 				}
-				addressList = append(addressList, svcAddress)
-			}
-			if headless {
-				// The IP will be unspecified here if its headless service or if the auto
-				// IP allocation logic for service entry was unable to allocate an IP.
-				if svc.Resolution == model.Passthrough && len(svc.Ports) > 0 {
-					localAddresses := make(map[string][]string)
-					remoteAddresses := make(map[string][]string)
-					hostMetadata := make(map[string]types.NamespacedName)
-					for _, instance := range cfg.Push.ServiceEndpointsByPort(svc, svc.Ports[0].Port, nil) {
-						// addresses may be empty or invalid here
-						isValidInstance := true
-						for _, addr := range instance.Addresses {
-							if !netutil.IsValidIPAddress(addr) {
-								isValidInstance = false
-								break
-							}
-						}
-						if len(instance.Addresses) == 0 || !isValidInstance ||
-							(!svc.Attributes.PublishNotReadyAddresses && instance.HealthStatus != model.Healthy) {
-							continue
-						}
-						// TODO(stevenctl): headless across-networks https://github.com/istio/istio/issues/38327
-						sameNetwork := cfg.Node.InNetwork(instance.Network)
-						sameCluster := cfg.Node.InCluster(instance.Locality.ClusterID)
-						// For all k8s headless services, populate the dns table with the endpoint IPs as k8s does.
-						// And for each individual pod, populate the dns table with the endpoint IP with a manufactured host name.
-						if instance.SubDomain != "" && sameNetwork {
-							// Follow k8s pods dns naming convention of "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>"
-							// i.e. "mysql-0.mysql.default.svc.cluster.local".
-							parts := strings.SplitN(hostName.String(), ".", 2)
-							if len(parts) != 2 {
-								continue
-							}
-							shortName := instance.HostName + "." + instance.SubDomain
-							host := shortName + "." + parts[1] // Add cluster domain.
-							hostMetadata[host] = types.NamespacedName{Name: shortName, Namespace: svc.Attributes.Namespace}
-							if sameCluster {
-								localAddresses[host] = append(localAddresses[host], instance.Addresses...)
-							} else {
-								remoteAddresses[host] = append(remoteAddresses[host], instance.Addresses...)
-							}
-						}
-						skipForMulticluster := !cfg.MulticlusterHeadlessEnabled && !sameCluster
-						if skipForMulticluster || !sameNetwork {
-							// We take only cluster-local endpoints. While this seems contradictory to
-							// our logic other parts of the code, where cross-cluster is the default.
-							// However, this only impacts the DNS response. If we were to send all
-							// endpoints, cross network routing would break, as we do passthrough LB and
-							// don't go through the network gateway. While we could, hypothetically, send
-							// "network-local" endpoints, this would still make enabling DNS give vastly
-							// different load balancing than without, so its probably best to filter.
-							// This ends up matching the behavior of Kubernetes DNS.
-							continue
-						}
-						addressList = append(addressList, instance.Addresses...)
+				// TODO(stevenctl): headless across-networks https://github.com/istio/istio/issues/38327
+				sameNetwork := cfg.Node.InNetwork(instance.Network)
+				sameCluster := cfg.Node.InCluster(instance.Locality.ClusterID)
+				// For all k8s headless services, populate the dns table with the endpoint IPs as k8s does.
+				// And for each individual pod, populate the dns table with the endpoint IP with a manufactured host name.
+				if instance.SubDomain != "" && sameNetwork {
+					// Follow k8s pods dns naming convention of "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>"
+					// i.e. "mysql-0.mysql.default.svc.cluster.local".
+					parts := strings.SplitN(hostName.String(), ".", 2)
+					if len(parts) != 2 {
+						continue
 					}
-					// Write local cluster entries first
-					for host, ips := range localAddresses {
-						meta := hostMetadata[host]
-						out.Table[host] = &dnsProto.NameTable_NameInfo{
-							Ips:       ips,
-							Registry:  string(svc.Attributes.ServiceRegistry),
-							Namespace: meta.Namespace,
-							Shortname: meta.Name,
-						}
-					}
-					// Write remote cluster entries only if local doesn't exist
-					for host, ips := range remoteAddresses {
-						if _, exists := localAddresses[host]; !exists {
-							meta := hostMetadata[host]
-							out.Table[host] = &dnsProto.NameTable_NameInfo{
-								Ips:       ips,
-								Registry:  string(svc.Attributes.ServiceRegistry),
-								Namespace: meta.Namespace,
-								Shortname: meta.Name,
-							}
-						}
+					shortName := instance.HostName + "." + instance.SubDomain
+					host := shortName + "." + parts[1] // Add cluster domain.
+					hostMetadata[host] = types.NamespacedName{Name: shortName, Namespace: svc.Attributes.Namespace}
+					if sameCluster {
+						localAddresses[host] = append(localAddresses[host], instance.Addresses...)
+					} else {
+						remoteAddresses[host] = append(remoteAddresses[host], instance.Addresses...)
 					}
 				}
-			}
-			if len(addressList) == 0 {
-				// could not reliably determine the addresses of endpoints of headless service
-				// or this is not a k8s service
-				continue
-			}
-
-			if ni, f := out.Table[hostName.String()]; !f {
-				nameInfo := &dnsProto.NameTable_NameInfo{
-					Ips:      addressList,
-					Registry: string(svc.Attributes.ServiceRegistry),
+				skipForMulticluster := !cfg.MulticlusterHeadlessEnabled && !sameCluster
+				if skipForMulticluster || !sameNetwork {
+					// We take only cluster-local endpoints. While this seems contradictory to
+					// our logic other parts of the code, where cross-cluster is the default.
+					// However, this only impacts the DNS response. If we were to send all
+					// endpoints, cross network routing would break, as we do passthrough LB and
+					// don't go through the network gateway. While we could, hypothetically, send
+					// "network-local" endpoints, this would still make enabling DNS give vastly
+					// different load balancing than without, so its probably best to filter.
+					// This ends up matching the behavior of Kubernetes DNS.
+					continue
 				}
-				if svc.Attributes.ServiceRegistry == provider.Kubernetes &&
-					!strings.HasSuffix(hostName.String(), "."+constants.DefaultClusterSetLocalDomain) {
-					// The agent will take care of resolving a, a.ns, a.ns.svc, etc.
-					// No need to provide a DNS entry for each variant.
-					//
-					// NOTE: This is not done for Kubernetes Multi-Cluster Services (MCS) hosts, in order
-					// to avoid conflicting with the entries for the regular (cluster.local) service.
-					nameInfo.Namespace = svc.Attributes.Namespace
-					nameInfo.Shortname = svc.Attributes.Name
+				addressList = append(addressList, instance.Addresses...)
+			}
+			// Write local cluster entries first
+			for host, ips := range localAddresses {
+				meta := hostMetadata[host]
+				out.Table[host] = &dnsProto.NameTable_NameInfo{
+					Ips:       ips,
+					Registry:  string(svc.Attributes.ServiceRegistry),
+					Namespace: meta.Namespace,
+					Shortname: meta.Name,
 				}
-				out.Table[hostName.String()] = nameInfo
-			} else if provider.ID(ni.Registry) != provider.Kubernetes {
-				// 2 possible cases:
-				// 1. If the SE has multiple addresses(vips) specified, merge the ips
-				// 2. If the previous SE is a decorator of the k8s service, give precedence to the k8s service
-				if svc.Attributes.ServiceRegistry == provider.Kubernetes {
-					ni.Ips = addressList
-					ni.Registry = string(provider.Kubernetes)
-					if !strings.HasSuffix(hostName.String(), "."+constants.DefaultClusterSetLocalDomain) {
-						ni.Namespace = svc.Attributes.Namespace
-						ni.Shortname = svc.Attributes.Name
+			}
+			// Write remote cluster entries only if local doesn't exist
+			for host, ips := range remoteAddresses {
+				if _, exists := localAddresses[host]; !exists {
+					meta := hostMetadata[host]
+					out.Table[host] = &dnsProto.NameTable_NameInfo{
+						Ips:       ips,
+						Registry:  string(svc.Attributes.ServiceRegistry),
+						Namespace: meta.Namespace,
+						Shortname: meta.Name,
 					}
-				} else {
-					ni.Ips = append(ni.Ips, addressList...)
 				}
 			}
 		}
 	}
-	return out
+	if len(addressList) == 0 {
+		// could not reliably determine the addresses of endpoints of headless service
+		// or this is not a k8s service
+		return
+	}
+
+	if ni, f := out.Table[hostName.String()]; !f {
+		nameInfo := &dnsProto.NameTable_NameInfo{
+			Ips:      addressList,
+			Registry: string(svc.Attributes.ServiceRegistry),
+		}
+		if svc.Attributes.ServiceRegistry == provider.Kubernetes &&
+			!strings.HasSuffix(hostName.String(), "."+constants.DefaultClusterSetLocalDomain) {
+			// The agent will take care of resolving a, a.ns, a.ns.svc, etc.
+			// No need to provide a DNS entry for each variant.
+			//
+			// NOTE: This is not done for Kubernetes Multi-Cluster Services (MCS) hosts, in order
+			// to avoid conflicting with the entries for the regular (cluster.local) service.
+			nameInfo.Namespace = svc.Attributes.Namespace
+			nameInfo.Shortname = svc.Attributes.Name
+		}
+		out.Table[hostName.String()] = nameInfo
+	} else if provider.ID(ni.Registry) != provider.Kubernetes {
+		// 2 possible cases:
+		// 1. If the SE has multiple addresses(vips) specified, merge the ips
+		// 2. If the previous SE is a decorator of the k8s service, give precedence to the k8s service
+		if svc.Attributes.ServiceRegistry == provider.Kubernetes {
+			ni.Ips = addressList
+			ni.Registry = string(provider.Kubernetes)
+			if !strings.HasSuffix(hostName.String(), "."+constants.DefaultClusterSetLocalDomain) {
+				ni.Namespace = svc.Attributes.Namespace
+				ni.Shortname = svc.Attributes.Name
+			}
+		} else {
+			ni.Ips = append(ni.Ips, addressList...)
+		}
+	}
 }

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -162,7 +162,6 @@ func initXdsProxy(ia *Agent) (*XdsProxy, error) {
 	}
 
 	if ia.localDNSServer != nil {
-		// SotW path: istiod sends the full NameTable as a single resource on every push.
 		proxy.handlers[model.NameTableType] = func(resp *anypb.Any) error {
 			var nt dnsProto.NameTable
 			if err := resp.UnmarshalTo(&nt); err != nil {
@@ -171,7 +170,6 @@ func initXdsProxy(ia *Agent) (*XdsProxy, error) {
 			ia.localDNSServer.Rebuild(nt.GetTable())
 			return nil
 		}
-		// Delta path: each resource is a single-entry NameTable keyed by hostname.
 		proxy.deltaHandlers[model.NameTableType] = &ndsDeltaHandler{dnsServer: ia.localDNSServer}
 	}
 	if ia.cfg.EnableDynamicProxyConfig && ia.secretCache != nil {

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -624,7 +624,7 @@ func (h *ndsDeltaHandler) OnStreamStart() {
 func (h *ndsDeltaHandler) Handle(resources []*discovery.Resource, removed []string) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	if resources[0].Name == "" {
+	if len(resources) > 0 && resources[0].Name == "" {
 		// Full-table resource from old/incapable istiod: single resource contains the whole table.
 		var nt dnsProto.NameTable
 		if err := resources[0].Resource.UnmarshalTo(&nt); err != nil {

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -17,7 +17,6 @@ package istioagent
 import (
 	"context"
 	"fmt"
-	"maps"
 	"math"
 	"net"
 	"sync"
@@ -639,7 +638,7 @@ func (h *ndsDeltaHandler) Handle(resources []*discovery.Resource, removed []stri
 		if err := r.Resource.UnmarshalTo(&nt); err != nil {
 			return err
 		}
-		maps.Copy(added, nt.GetTable())
+		added[r.Name] = nt.NameInfo
 	}
 
 	if h.needsRebuild {

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -17,6 +17,7 @@ package istioagent
 import (
 	"context"
 	"fmt"
+	"maps"
 	"math"
 	"net"
 	"sync"
@@ -68,6 +69,11 @@ var connectionNumber = atomic.NewUint32(0)
 // resource.
 type ResponseHandler func(resp *anypb.Any) error
 
+// DeltaResponseHandler handles a delta XDS response in the agent. Unlike ResponseHandler it
+// receives all resources and removed names in the response, allowing multi-resource and
+// removal-aware processing.
+type DeltaResponseHandler func(resources []*discovery.Resource, removed []string) error
+
 // XdsProxy proxies all XDS requests from envoy to istiod, in addition to allowing
 // subsystems inside the agent to also communicate with either istiod/envoy (eg dns, sds, etc).
 // The goal here is to consolidate all xds related connections to istiod/envoy into a
@@ -84,11 +90,18 @@ type XdsProxy struct {
 	optsMutex            sync.RWMutex
 	dialOptions          []grpc.DialOption
 	handlers             map[string]ResponseHandler
-	healthChecker        *health.WorkloadHealthChecker
-	xdsHeaders           map[string]string
-	xdsUdsPath           string
-	proxyAddresses       []string
-	ia                   *Agent
+	deltaHandlers        map[string]DeltaResponseHandler
+
+	// ndsAccumulator holds the per-hostname DNS entries accumulated from incremental NDS
+	// updates. It is reset at the start of each new upstream delta stream so reconnects
+	// produce a clean slate. Protected by ndsAccumulatorMu.
+	ndsAccumulator   map[string]*dnsProto.NameTable_NameInfo
+	ndsAccumulatorMu sync.Mutex
+	healthChecker    *health.WorkloadHealthChecker
+	xdsHeaders       map[string]string
+	xdsUdsPath       string
+	proxyAddresses   []string
+	ia               *Agent
 
 	// connected stores the active gRPC stream. The proxy will only have 1 connection at a time
 	connected                 *ProxyConnection
@@ -138,6 +151,7 @@ func initXdsProxy(ia *Agent) (*XdsProxy, error) {
 		istiodSAN:             ia.cfg.IstiodSAN,
 		clusterID:             ia.secOpts.ClusterID,
 		handlers:              map[string]ResponseHandler{},
+		deltaHandlers:         map[string]DeltaResponseHandler{},
 		stopChan:              make(chan struct{}),
 		healthChecker:         health.NewWorkloadHealthChecker(ia.proxyConfig.ReadinessProbe, envoyProbe, ia.cfg.ProxyIPAddresses, ia.cfg.IsIPv6),
 		xdsHeaders:            ia.cfg.XDSHeaders,
@@ -149,13 +163,36 @@ func initXdsProxy(ia *Agent) (*XdsProxy, error) {
 	}
 
 	if ia.localDNSServer != nil {
-		proxy.handlers[model.NameTableType] = func(resp *anypb.Any) error {
-			var nt dnsProto.NameTable
-			if err := resp.UnmarshalTo(&nt); err != nil {
-				log.Errorf("failed to unmarshal name table: %v", err)
-				return err
+		// Delta path: each resource is a single-entry NameTable keyed by hostname. An empty
+		// Name signals the old full-table format (old istiod or incapable path), which resets
+		// the accumulator. Named resources are merged/removed incrementally.
+		proxy.deltaHandlers[model.NameTableType] = func(resources []*discovery.Resource, removed []string) error {
+			proxy.ndsAccumulatorMu.Lock()
+			defer proxy.ndsAccumulatorMu.Unlock()
+			for _, r := range resources {
+				if r.Name == "" {
+					// Full-table resource from an old or incapable istiod: reset accumulator.
+					var nt dnsProto.NameTable
+					if err := r.Resource.UnmarshalTo(&nt); err != nil {
+						return err
+					}
+					proxy.ndsAccumulator = nt.GetTable()
+				} else {
+					var nt dnsProto.NameTable
+					if err := r.Resource.UnmarshalTo(&nt); err != nil {
+						return err
+					}
+					for name, ni := range nt.GetTable() {
+						proxy.ndsAccumulator[name] = ni
+					}
+				}
 			}
-			ia.localDNSServer.UpdateLookupTable(&nt)
+			for _, name := range removed {
+				delete(proxy.ndsAccumulator, name)
+			}
+			// Pass a snapshot copy so UpdateLookupTable's stored pointer is independent of our
+			// live accumulator map (UpdateLookupTable stores nt via nameTable.Store(nt)).
+			ia.localDNSServer.UpdateLookupTable(&dnsProto.NameTable{Table: maps.Clone(proxy.ndsAccumulator)})
 			return nil
 		}
 	}
@@ -419,7 +456,7 @@ func (p *XdsProxy) handleUpstreamRequest(con *ProxyConnection) {
 			con.sendRequest(req)
 			if !initialRequestsSent.Load() && req.TypeUrl == model.ListenerType {
 				// fire off an initial NDS request
-				if _, f := p.handlers[model.NameTableType]; f {
+				if _, f := p.deltaHandlers[model.NameTableType]; f {
 					con.sendRequest(&discovery.DiscoveryRequest{
 						TypeUrl: model.NameTableType,
 					})
@@ -588,6 +625,14 @@ func (p *XdsProxy) close() {
 	if p.downstreamListener != nil {
 		_ = p.downstreamListener.Close()
 	}
+}
+
+// resetNDSAccumulator clears the NDS hostname accumulator at the start of each new upstream
+// delta stream so that stale entries from a previous connection do not survive reconnects.
+func (p *XdsProxy) resetNDSAccumulator() {
+	p.ndsAccumulatorMu.Lock()
+	p.ndsAccumulator = make(map[string]*dnsProto.NameTable_NameInfo)
+	p.ndsAccumulatorMu.Unlock()
 }
 
 func (p *XdsProxy) initDownstreamServer() error {

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -38,6 +38,7 @@ import (
 	istiogrpc "istio.io/istio/pilot/pkg/grpc"
 	"istio.io/istio/pkg/channels"
 	"istio.io/istio/pkg/config/constants"
+	dnsClient "istio.io/istio/pkg/dns/client"
 	dnsProto "istio.io/istio/pkg/dns/proto"
 	"istio.io/istio/pkg/istio-agent/health"
 	"istio.io/istio/pkg/istio-agent/metrics"
@@ -69,10 +70,14 @@ var connectionNumber = atomic.NewUint32(0)
 // resource.
 type ResponseHandler func(resp *anypb.Any) error
 
-// DeltaResponseHandler handles a delta XDS response in the agent. Unlike ResponseHandler it
-// receives all resources and removed names in the response, allowing multi-resource and
-// removal-aware processing.
-type DeltaResponseHandler func(resources []*discovery.Resource, removed []string) error
+// DeltaHandler handles delta XDS responses for a specific type URL.
+type DeltaHandler interface {
+	// Handle processes the resources and removed names from a delta response.
+	Handle(resources []*discovery.Resource, removed []string) error
+	// OnStreamStart is called when a new upstream delta stream is established.
+	// Implementations should use this to reset any stream-scoped state.
+	OnStreamStart()
+}
 
 // XdsProxy proxies all XDS requests from envoy to istiod, in addition to allowing
 // subsystems inside the agent to also communicate with either istiod/envoy (eg dns, sds, etc).
@@ -90,18 +95,12 @@ type XdsProxy struct {
 	optsMutex            sync.RWMutex
 	dialOptions          []grpc.DialOption
 	handlers             map[string]ResponseHandler
-	deltaHandlers        map[string]DeltaResponseHandler
-
-	// ndsAccumulator holds the per-hostname DNS entries accumulated from incremental NDS
-	// updates. It is reset at the start of each new upstream delta stream so reconnects
-	// produce a clean slate. Protected by ndsAccumulatorMu.
-	ndsAccumulator   map[string]*dnsProto.NameTable_NameInfo
-	ndsAccumulatorMu sync.Mutex
-	healthChecker    *health.WorkloadHealthChecker
-	xdsHeaders       map[string]string
-	xdsUdsPath       string
-	proxyAddresses   []string
-	ia               *Agent
+	deltaHandlers        map[string]DeltaHandler
+	healthChecker        *health.WorkloadHealthChecker
+	xdsHeaders           map[string]string
+	xdsUdsPath           string
+	proxyAddresses       []string
+	ia                   *Agent
 
 	// connected stores the active gRPC stream. The proxy will only have 1 connection at a time
 	connected                 *ProxyConnection
@@ -151,7 +150,7 @@ func initXdsProxy(ia *Agent) (*XdsProxy, error) {
 		istiodSAN:             ia.cfg.IstiodSAN,
 		clusterID:             ia.secOpts.ClusterID,
 		handlers:              map[string]ResponseHandler{},
-		deltaHandlers:         map[string]DeltaResponseHandler{},
+		deltaHandlers:         map[string]DeltaHandler{},
 		stopChan:              make(chan struct{}),
 		healthChecker:         health.NewWorkloadHealthChecker(ia.proxyConfig.ReadinessProbe, envoyProbe, ia.cfg.ProxyIPAddresses, ia.cfg.IsIPv6),
 		xdsHeaders:            ia.cfg.XDSHeaders,
@@ -163,38 +162,17 @@ func initXdsProxy(ia *Agent) (*XdsProxy, error) {
 	}
 
 	if ia.localDNSServer != nil {
-		// Delta path: each resource is a single-entry NameTable keyed by hostname. An empty
-		// Name signals the old full-table format (old istiod or incapable path), which resets
-		// the accumulator. Named resources are merged/removed incrementally.
-		proxy.deltaHandlers[model.NameTableType] = func(resources []*discovery.Resource, removed []string) error {
-			proxy.ndsAccumulatorMu.Lock()
-			defer proxy.ndsAccumulatorMu.Unlock()
-			for _, r := range resources {
-				if r.Name == "" {
-					// Full-table resource from an old or incapable istiod: reset accumulator.
-					var nt dnsProto.NameTable
-					if err := r.Resource.UnmarshalTo(&nt); err != nil {
-						return err
-					}
-					proxy.ndsAccumulator = nt.GetTable()
-				} else {
-					var nt dnsProto.NameTable
-					if err := r.Resource.UnmarshalTo(&nt); err != nil {
-						return err
-					}
-					for name, ni := range nt.GetTable() {
-						proxy.ndsAccumulator[name] = ni
-					}
-				}
+		// SotW path: istiod sends the full NameTable as a single resource on every push.
+		proxy.handlers[model.NameTableType] = func(resp *anypb.Any) error {
+			var nt dnsProto.NameTable
+			if err := resp.UnmarshalTo(&nt); err != nil {
+				return err
 			}
-			for _, name := range removed {
-				delete(proxy.ndsAccumulator, name)
-			}
-			// Pass a snapshot copy so UpdateLookupTable's stored pointer is independent of our
-			// live accumulator map (UpdateLookupTable stores nt via nameTable.Store(nt)).
-			ia.localDNSServer.UpdateLookupTable(&dnsProto.NameTable{Table: maps.Clone(proxy.ndsAccumulator)})
+			ia.localDNSServer.Rebuild(nt.GetTable())
 			return nil
 		}
+		// Delta path: each resource is a single-entry NameTable keyed by hostname.
+		proxy.deltaHandlers[model.NameTableType] = &ndsDeltaHandler{dnsServer: ia.localDNSServer}
 	}
 	if ia.cfg.EnableDynamicProxyConfig && ia.secretCache != nil {
 		proxy.handlers[model.ProxyConfigType] = func(resp *anypb.Any) error {
@@ -456,7 +434,7 @@ func (p *XdsProxy) handleUpstreamRequest(con *ProxyConnection) {
 			con.sendRequest(req)
 			if !initialRequestsSent.Load() && req.TypeUrl == model.ListenerType {
 				// fire off an initial NDS request
-				if _, f := p.deltaHandlers[model.NameTableType]; f {
+				if _, f := p.handlers[model.NameTableType]; f {
 					con.sendRequest(&discovery.DiscoveryRequest{
 						TypeUrl: model.NameTableType,
 					})
@@ -627,12 +605,52 @@ func (p *XdsProxy) close() {
 	}
 }
 
-// resetNDSAccumulator clears the NDS hostname accumulator at the start of each new upstream
-// delta stream so that stale entries from a previous connection do not survive reconnects.
-func (p *XdsProxy) resetNDSAccumulator() {
-	p.ndsAccumulatorMu.Lock()
-	p.ndsAccumulator = make(map[string]*dnsProto.NameTable_NameInfo)
-	p.ndsAccumulatorMu.Unlock()
+// ndsDeltaHandler implements DeltaHandler for the Name Discovery Service. It handles both the
+// full-table format (unnamed single resource from old/incapable istiod) and the per-hostname
+// incremental format. Stream-scoped state (needsRebuild) is reset via OnStreamStart so that
+// stale entries from a previous connection are purged on the first response.
+type ndsDeltaHandler struct {
+	dnsServer    *dnsClient.LocalDNSServer
+	needsRebuild bool
+	mu           sync.Mutex
+}
+
+func (h *ndsDeltaHandler) OnStreamStart() {
+	h.mu.Lock()
+	h.needsRebuild = true
+	h.mu.Unlock()
+}
+
+func (h *ndsDeltaHandler) Handle(resources []*discovery.Resource, removed []string) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if resources[0].Name == "" {
+		// Full-table resource from old/incapable istiod: single resource contains the whole table.
+		var nt dnsProto.NameTable
+		if err := resources[0].Resource.UnmarshalTo(&nt); err != nil {
+			return err
+		}
+		h.dnsServer.Rebuild(nt.GetTable())
+		h.needsRebuild = false
+		return nil
+	}
+
+	added := make(map[string]*dnsProto.NameTable_NameInfo, len(resources))
+	for _, r := range resources {
+		var nt dnsProto.NameTable
+		if err := r.Resource.UnmarshalTo(&nt); err != nil {
+			return err
+		}
+		maps.Copy(added, nt.GetTable())
+	}
+
+	if h.needsRebuild {
+		h.dnsServer.Rebuild(added)
+		h.needsRebuild = false
+	} else {
+		h.dnsServer.UpdateLookupTable(added, removed)
+	}
+	return nil
 }
 
 func (p *XdsProxy) initDownstreamServer() error {

--- a/pkg/istio-agent/xds_proxy_delta.go
+++ b/pkg/istio-agent/xds_proxy_delta.go
@@ -145,7 +145,7 @@ func (p *XdsProxy) handleUpstreamDeltaRequest(con *ProxyConnection) {
 			con.sendDeltaRequest(req)
 			if !initialRequestsSent.Load() && req.TypeUrl == model.ListenerType {
 				// fire off an initial NDS request
-				if _, f := p.handlers[model.NameTableType]; f {
+				if _, f := p.deltaHandlers[model.NameTableType]; f {
 					con.sendDeltaRequest(&discovery.DeltaDiscoveryRequest{
 						TypeUrl: model.NameTableType,
 					})
@@ -204,6 +204,7 @@ func (p *XdsProxy) handleUpstreamDeltaRequest(con *ProxyConnection) {
 }
 
 func (p *XdsProxy) handleUpstreamDeltaResponse(con *ProxyConnection) {
+	p.resetNDSAccumulator()
 	forwardEnvoyCh := make(chan *discovery.DeltaDiscoveryResponse, 1)
 	for {
 		select {
@@ -217,6 +218,22 @@ func (p *XdsProxy) handleUpstreamDeltaResponse(con *ProxyConnection) {
 				"removes", len(resp.RemovedResources),
 			).Debugf("upstream response")
 			metrics.XdsProxyResponses.Increment()
+			if h, f := p.deltaHandlers[resp.TypeUrl]; f {
+				err := h(resp.Resources, resp.RemovedResources)
+				var errorResp *google_rpc.Status
+				if err != nil {
+					errorResp = &google_rpc.Status{
+						Code:    int32(codes.Internal),
+						Message: err.Error(),
+					}
+				}
+				con.sendDeltaRequest(&discovery.DeltaDiscoveryRequest{
+					TypeUrl:       resp.TypeUrl,
+					ResponseNonce: resp.Nonce,
+					ErrorDetail:   errorResp,
+				})
+				continue
+			}
 			if h, f := p.handlers[resp.TypeUrl]; f {
 				if len(resp.Resources) == 0 {
 					// Empty response, nothing to do

--- a/pkg/istio-agent/xds_proxy_delta.go
+++ b/pkg/istio-agent/xds_proxy_delta.go
@@ -220,6 +220,7 @@ func (p *XdsProxy) handleUpstreamDeltaResponse(con *ProxyConnection) {
 				"removes", len(resp.RemovedResources),
 			).Debugf("upstream response")
 			metrics.XdsProxyResponses.Increment()
+			// first check if we have a true delta handler for this TypeUrl
 			if h, f := p.deltaHandlers[resp.TypeUrl]; f {
 				err := h.Handle(resp.Resources, resp.RemovedResources)
 				var errorResp *google_rpc.Status
@@ -236,6 +237,7 @@ func (p *XdsProxy) handleUpstreamDeltaResponse(con *ProxyConnection) {
 				})
 				continue
 			}
+			// fall back to stow handlers
 			if h, f := p.handlers[resp.TypeUrl]; f {
 				if len(resp.Resources) == 0 {
 					// Empty response, nothing to do

--- a/pkg/istio-agent/xds_proxy_delta.go
+++ b/pkg/istio-agent/xds_proxy_delta.go
@@ -204,7 +204,9 @@ func (p *XdsProxy) handleUpstreamDeltaRequest(con *ProxyConnection) {
 }
 
 func (p *XdsProxy) handleUpstreamDeltaResponse(con *ProxyConnection) {
-	p.resetNDSAccumulator()
+	for _, h := range p.deltaHandlers {
+		h.OnStreamStart()
+	}
 	forwardEnvoyCh := make(chan *discovery.DeltaDiscoveryResponse, 1)
 	for {
 		select {
@@ -219,7 +221,7 @@ func (p *XdsProxy) handleUpstreamDeltaResponse(con *ProxyConnection) {
 			).Debugf("upstream response")
 			metrics.XdsProxyResponses.Increment()
 			if h, f := p.deltaHandlers[resp.TypeUrl]; f {
-				err := h(resp.Resources, resp.RemovedResources)
+				err := h.Handle(resp.Resources, resp.RemovedResources)
 				var errorResp *google_rpc.Status
 				if err != nil {
 					errorResp = &google_rpc.Status{

--- a/pkg/istio-agent/xds_proxy_test.go
+++ b/pkg/istio-agent/xds_proxy_test.go
@@ -40,6 +40,8 @@ import (
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
+	dnsClient "istio.io/istio/pkg/dns/client"
+	dnsProto "istio.io/istio/pkg/dns/proto"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/model/status"
 	"istio.io/istio/pilot/pkg/util/protoconv"
@@ -611,4 +613,134 @@ func setupDownstreamConnectionUDS(t test.Failer, path string) *grpc.ClientConn {
 
 func setupDownstreamConnection(t *testing.T, proxy *XdsProxy) *grpc.ClientConn {
 	return setupDownstreamConnectionUDS(t, proxy.xdsUdsPath)
+}
+
+func TestNDSDeltaHandler(t *testing.T) {
+	makeResource := func(name string, ips ...string) *discovery.Resource {
+		ni := &dnsProto.NameTable_NameInfo{Ips: ips, Registry: "Kubernetes"}
+		table := map[string]*dnsProto.NameTable_NameInfo{}
+		if name == "" {
+			// unnamed = full-table resource (old istiod format)
+			table["svc-a.default.svc.cluster.local"] = ni
+		} else {
+			table[name] = ni
+		}
+		nt := &dnsProto.NameTable{Table: table}
+		return &discovery.Resource{Name: name, Resource: protoconv.MessageToAny(nt)}
+	}
+
+	newDNSServer := func(t *testing.T) *dnsClient.LocalDNSServer {
+		t.Helper()
+		srv, err := dnsClient.NewLocalDNSServer("default", "default.svc.cluster.local", "localhost:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		return srv
+	}
+
+	t.Run("OnStreamStart marks rebuild needed; first Handle calls Rebuild", func(t *testing.T) {
+		srv := newDNSServer(t)
+		h := &ndsDeltaHandler{dnsServer: srv}
+
+		h.OnStreamStart()
+		if err := h.Handle([]*discovery.Resource{
+			makeResource("svc-a.default.svc.cluster.local", "10.0.0.1"),
+		}, nil); err != nil {
+			t.Fatal(err)
+		}
+		if srv.NameTable() == nil || srv.NameTable().Table["svc-a.default.svc.cluster.local"] == nil {
+			t.Error("expected svc-a after first Handle post-OnStreamStart")
+		}
+	})
+
+	t.Run("subsequent Handle calls are incremental", func(t *testing.T) {
+		srv := newDNSServer(t)
+		h := &ndsDeltaHandler{dnsServer: srv}
+
+		h.OnStreamStart()
+		_ = h.Handle([]*discovery.Resource{makeResource("svc-a.default.svc.cluster.local", "10.0.0.1")}, nil)
+
+		// Second call should be incremental (no rebuild needed flag), adding svc-b without losing svc-a.
+		_ = h.Handle([]*discovery.Resource{makeResource("svc-b.default.svc.cluster.local", "10.0.0.2")}, nil)
+
+		nt := srv.NameTable()
+		if nt.Table["svc-a.default.svc.cluster.local"] == nil {
+			t.Error("svc-a should survive an incremental push")
+		}
+		if nt.Table["svc-b.default.svc.cluster.local"] == nil {
+			t.Error("svc-b should be present after incremental push")
+		}
+	})
+
+	t.Run("removals are applied incrementally", func(t *testing.T) {
+		srv := newDNSServer(t)
+		h := &ndsDeltaHandler{dnsServer: srv}
+
+		h.OnStreamStart()
+		_ = h.Handle([]*discovery.Resource{
+			makeResource("svc-a.default.svc.cluster.local", "10.0.0.1"),
+			makeResource("svc-b.default.svc.cluster.local", "10.0.0.2"),
+		}, nil)
+		_ = h.Handle(nil, []string{"svc-a.default.svc.cluster.local"})
+
+		nt := srv.NameTable()
+		if nt.Table["svc-a.default.svc.cluster.local"] != nil {
+			t.Error("svc-a should have been removed")
+		}
+		if nt.Table["svc-b.default.svc.cluster.local"] == nil {
+			t.Error("svc-b should still be present after removing svc-a")
+		}
+	})
+
+	t.Run("unnamed resource triggers Rebuild (old istiod compat)", func(t *testing.T) {
+		srv := newDNSServer(t)
+		h := &ndsDeltaHandler{dnsServer: srv}
+
+		// Seed svc-a via a normal incremental push.
+		h.OnStreamStart()
+		_ = h.Handle([]*discovery.Resource{makeResource("svc-a.default.svc.cluster.local", "10.0.0.1")}, nil)
+
+		// Unnamed resource = full table from old istiod containing only svc-b; must replace svc-a.
+		unnamedResource := func() *discovery.Resource {
+			nt := &dnsProto.NameTable{Table: map[string]*dnsProto.NameTable_NameInfo{
+				"svc-b.default.svc.cluster.local": {Ips: []string{"10.0.0.2"}, Registry: "Kubernetes"},
+			}}
+			return &discovery.Resource{Name: "", Resource: protoconv.MessageToAny(nt)}
+		}
+		_ = h.Handle([]*discovery.Resource{unnamedResource()}, nil)
+
+		nt := srv.NameTable()
+		if nt.Table["svc-a.default.svc.cluster.local"] != nil {
+			t.Error("svc-a should be gone after full-table replace from unnamed resource")
+		}
+		if nt.Table["svc-b.default.svc.cluster.local"] == nil {
+			t.Error("svc-b from the unnamed full-table resource should be present")
+		}
+	})
+
+	t.Run("OnStreamStart followed by reconnect rebuild purges stale entries", func(t *testing.T) {
+		srv := newDNSServer(t)
+		h := &ndsDeltaHandler{dnsServer: srv}
+
+		// First stream: load svc-a and svc-b.
+		h.OnStreamStart()
+		_ = h.Handle([]*discovery.Resource{
+			makeResource("svc-a.default.svc.cluster.local", "10.0.0.1"),
+			makeResource("svc-b.default.svc.cluster.local", "10.0.0.2"),
+		}, nil)
+
+		// Reconnect: svc-b is gone from istiod (deleted between streams).
+		h.OnStreamStart()
+		_ = h.Handle([]*discovery.Resource{
+			makeResource("svc-a.default.svc.cluster.local", "10.0.0.1"),
+		}, nil)
+
+		nt := srv.NameTable()
+		if nt.Table["svc-b.default.svc.cluster.local"] != nil {
+			t.Error("svc-b was deleted between reconnects and must not survive OnStreamStart + Rebuild")
+		}
+		if nt.Table["svc-a.default.svc.cluster.local"] == nil {
+			t.Error("svc-a should still be present after reconnect")
+		}
+	})
 }

--- a/pkg/istio-agent/xds_proxy_test.go
+++ b/pkg/istio-agent/xds_proxy_test.go
@@ -40,8 +40,6 @@ import (
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
-	dnsClient "istio.io/istio/pkg/dns/client"
-	dnsProto "istio.io/istio/pkg/dns/proto"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/model/status"
 	"istio.io/istio/pilot/pkg/util/protoconv"
@@ -51,6 +49,8 @@ import (
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/gvk"
+	dnsClient "istio.io/istio/pkg/dns/client"
+	dnsProto "istio.io/istio/pkg/dns/proto"
 	"istio.io/istio/pkg/envoy"
 	"istio.io/istio/pkg/security"
 	"istio.io/istio/pkg/test"
@@ -618,14 +618,16 @@ func setupDownstreamConnection(t *testing.T, proxy *XdsProxy) *grpc.ClientConn {
 func TestNDSDeltaHandler(t *testing.T) {
 	makeResource := func(name string, ips ...string) *discovery.Resource {
 		ni := &dnsProto.NameTable_NameInfo{Ips: ips, Registry: "Kubernetes"}
-		table := map[string]*dnsProto.NameTable_NameInfo{}
+		var nt *dnsProto.NameTable
 		if name == "" {
 			// unnamed = full-table resource (old istiod format)
-			table["svc-a.default.svc.cluster.local"] = ni
+			nt = &dnsProto.NameTable{Table: map[string]*dnsProto.NameTable_NameInfo{
+				"svc-a.default.svc.cluster.local": ni,
+			}}
 		} else {
-			table[name] = ni
+			// named per-host resource carries attributes in the single-valued NameInfo field.
+			nt = &dnsProto.NameTable{NameInfo: ni}
 		}
-		nt := &dnsProto.NameTable{Table: table}
 		return &discovery.Resource{Name: name, Resource: protoconv.MessageToAny(nt)}
 	}
 

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -117,6 +117,9 @@ type SidecarTemplateData struct {
 	ProxyGID                 int64
 	InboundTrafficPolicyMode string
 	CompliancePolicy         string
+	// EnableDeltaNds advertises the DELTA_NDS capability on the injected proxy so istiod
+	// generates NDS incrementally for it. Driven by the istiod feature flag EnableDeltaNds.
+	EnableDeltaNds bool
 }
 
 type (
@@ -493,6 +496,7 @@ func RunTemplate(params InjectionParameters) (mergedPod *corev1.Pod, templatePod
 		ProxyGID:                 proxyGID,
 		InboundTrafficPolicyMode: InboundTrafficPolicyMode(meshConfig),
 		CompliancePolicy:         common_features.CompliancePolicy,
+		EnableDeltaNds:           features.EnableDeltaNds,
 	}
 	if params.valuesConfig.asMap == nil {
 		return nil, nil, fmt.Errorf("failed to parse values.yaml; check Istiod logs for errors")

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -117,9 +117,7 @@ type SidecarTemplateData struct {
 	ProxyGID                 int64
 	InboundTrafficPolicyMode string
 	CompliancePolicy         string
-	// EnableDeltaNds advertises the DELTA_NDS capability on the injected proxy so istiod
-	// generates NDS incrementally for it. Driven by the istiod feature flag EnableDeltaNds.
-	EnableDeltaNds bool
+	EnableDeltaNds           bool
 }
 
 type (

--- a/pkg/model/proxy.go
+++ b/pkg/model/proxy.go
@@ -296,6 +296,12 @@ type NodeMetadata struct {
 	// This depends on DNSCapture.
 	DNSAutoAllocate StringBool `json:"DNS_AUTO_ALLOCATE,omitempty"`
 
+	// DeltaNDS indicates that the agent binary understands incremental (delta) NDS: it can
+	// consume a NameTable decomposed into one resource per DNS name and apply removals. This
+	// is a true binary capability advertised programmatically by the agent (not an operator
+	// settable ISTIO_META_* value), so istiod only decomposes NDS for proxies that set it.
+	DeltaNDS StringBool `json:"DELTA_NDS,omitempty"`
+
 	// DNSProxyAddr is the host:port where istio-agent listens for DNS (DNS_PROXY_ADDR). Populated from bootstrap
 	// so Pilot can point Envoy dynamic forward proxy at the same address.
 	DNSProxyAddr string `json:"DNS_PROXY_ADDR,omitempty"`

--- a/pkg/model/proxy.go
+++ b/pkg/model/proxy.go
@@ -297,9 +297,7 @@ type NodeMetadata struct {
 	DNSAutoAllocate StringBool `json:"DNS_AUTO_ALLOCATE,omitempty"`
 
 	// DeltaNDS indicates that the agent binary understands incremental (delta) NDS: it can
-	// consume a NameTable decomposed into one resource per DNS name and apply removals. This
-	// is a true binary capability advertised programmatically by the agent (not an operator
-	// settable ISTIO_META_* value), so istiod only decomposes NDS for proxies that set it.
+	// consume a NameTable decomposed into one resource per DNS name and apply removals.
 	DeltaNDS StringBool `json:"DELTA_NDS,omitempty"`
 
 	// DNSProxyAddr is the host:port where istio-agent listens for DNS (DNS_PROXY_ADDR). Populated from bootstrap

--- a/releasenotes/notes/delta-nds.yaml
+++ b/releasenotes/notes/delta-nds.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+releaseNotes:
+  - |
+    **Added** a new incremental Name Discovery Service (NDS) implementation which allows Istiod
+    to push only the added, modified, and removed name table entries
+    instead of always rebuilding and pushing the entire name table.
+    This feature is disabled by default and can be enabled with the `PILOT_ENABLE_DELTA_NDS` environment variable.

--- a/tests/integration/pilot/delta_nds_test.go
+++ b/tests/integration/pilot/delta_nds_test.go
@@ -1,0 +1,156 @@
+//go:build integ
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pilot
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"istio.io/istio/pkg/test/echo/common/scheme"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/check"
+	"istio.io/istio/pkg/test/framework/components/echo/deployment"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/istio/pkg/util/sets"
+)
+
+// TestDeltaNDS exercises the incremental (delta) Name Discovery Service end-to-end. It deploys an
+// echo workload whose agent advertises the DELTA_NDS capability (via ISTIO_META_DELTA_NDS) and has
+// DNS capture enabled, then drives the delta flows that the unit tests cover in isolation:
+//   - initial name table delivery (a host resolves),
+//   - incremental add (a second host added after sync resolves, WITHOUT losing the first — proving
+//     the agent accumulates deltas rather than replacing the table),
+//   - incremental removal (deleting a host stops its resolution while the other survives).
+func TestDeltaNDS(t *testing.T) {
+	framework.
+		NewTest(t).
+		Run(func(t framework.TestContext) {
+			ns := namespace.NewOrFail(t, namespace.Config{
+				Prefix: "delta-nds",
+				Inject: true,
+			})
+
+			// The agent only advertises the DELTA_NDS capability (and captures DNS) when these
+			// env vars are present at injection time, so apply the ProxyConfig before deploying.
+			proxyCfg := `apiVersion: networking.istio.io/v1beta1
+kind: ProxyConfig
+metadata:
+  name: enable-delta-nds
+spec:
+  selector:
+    matchLabels:
+      app: delta
+  environmentVariables:
+    ISTIO_META_DNS_CAPTURE: "true"
+    ISTIO_META_DELTA_NDS: "true"
+`
+			t.ConfigIstio().YAML(ns.Name(), proxyCfg).ApplyOrFail(t)
+
+			client := deployment.New(t, t.AllClusters().Configs()...).
+				WithConfig(echo.Config{Namespace: ns, Service: "delta"}).
+				BuildOrFail(t)[0]
+
+			// A STATIC ServiceEntry publishes its `addresses` as the resolved IPs for `host` in the
+			// NDS name table, so a captured DNS query for `host` returns exactly those addresses.
+			makeSE := func(name, host, addr string) string {
+				return fmt.Sprintf(`apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: %s
+spec:
+  hosts:
+  - "%s"
+  addresses:
+  - "%s"
+  resolution: STATIC
+  endpoints:
+  - address: "10.0.0.1"
+  ports:
+  - number: 80
+    name: http
+    protocol: HTTP
+`, name, host, addr)
+			}
+
+			const (
+				hostA = "fake-a.delta.local"
+				hostB = "fake-b.delta.local"
+				ipA   = "240.0.0.1"
+				ipB   = "240.0.0.2"
+			)
+
+			resolvesTo := func(host string, want ...string) {
+				t.Helper()
+				retry.UntilSuccessOrFail(t, func() error {
+					_, err := client.Call(echo.CallOptions{
+						Scheme:  scheme.DNS,
+						Count:   1,
+						Address: host + "?&protocol=udp",
+						Check: func(result echo.CallResult, _ error) error {
+							if len(result.Responses) == 0 {
+								return fmt.Errorf("no DNS responses for %s", host)
+							}
+							for _, r := range result.Responses {
+								if got := sets.New(r.Body()...); !got.Equals(sets.New(want...)) {
+									return fmt.Errorf("dns %s: wanted %v, got %v", host, want, r.Body())
+								}
+							}
+							return nil
+						},
+					})
+					return err
+				}, retry.Timeout(60*time.Second))
+			}
+
+			doesNotResolve := func(host string) {
+				t.Helper()
+				retry.UntilSuccessOrFail(t, func() error {
+					// With the host absent from the name table the agent forwards upstream, which
+					// NXDOMAINs for this fake .local name, so the call errors.
+					_, err := client.Call(echo.CallOptions{
+						Scheme:  scheme.DNS,
+						Count:   1,
+						Address: host + "?&protocol=udp",
+						Check:   check.Error(),
+					})
+					return err
+				}, retry.Timeout(60*time.Second))
+			}
+
+			// Phase 1: initial name table delivery — hostA resolves once NDS is synced.
+			seA := t.ConfigIstio().YAML(ns.Name(), makeSE("fake-a", hostA, ipA))
+			seA.ApplyOrFail(t)
+			resolvesTo(hostA, ipA)
+
+			// Phase 2: incremental add — hostB (added after the initial sync) resolves, and hostA
+			// must still resolve. If deltas replaced the table instead of accumulating, hostA would
+			// vanish here.
+			seB := t.ConfigIstio().YAML(ns.Name(), makeSE("fake-b", hostB, ipB))
+			seB.ApplyOrFail(t)
+			resolvesTo(hostB, ipB)
+			resolvesTo(hostA, ipA)
+
+			// Phase 3: incremental removal — deleting hostB stops its resolution (delivered as a
+			// RemovedResources delta) while hostA survives.
+			seB.DeleteOrFail(t)
+			doesNotResolve(hostB)
+			resolvesTo(hostA, ipA)
+		})
+}


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR adds support for **true** Delta NDS.
Currently NDS always builds an entire NameTable with all the hostnames a proxy needs and is rebuilt entirely on every Service change or Headless Service endpoint churn, this can be pretty expensive. Headless Service endpoint churn is the most impactful of all, pure-http service currently are handled quite well because we separate a `kind.DNSName`, but this kind also currently generates a full table rebuild.

Instead of sending a single *unnamed* `NameTable` resource with `table` containing the entire host table, I added a `name_info` field allowing a `NameTable` to only contain information for a single hostname. When Delta NDS is enabled we now generate a `NameTable` resource for each added/modified resource, populating only the `Nametable.name_info` field with the hostname resolving info, and we also populate `removed_resources`. This allows the agent to perform incremental modifications to the lookup table.

There were multiple ways this could be implemented, I chose using the same `NameTable` resource with a new field to balance performance, amount of changes and backwards-compatibility. Other discarded options:
- Using `NameTable.table` we would be unnecessarily allocating a new 1-entry map for each resource.
- Using a new `NameInfo` top-level proto message, this requires also defining new TypeURLs, new Generators, conversions between `NameTable.NameInfo` and top-level `NameInfo`. This would mean a significant amount of changes and could actually prove less backwards compatible, because agents requesting a new TypeURL against an nonsupporting Istiod would just fail.

This feature is mainly guarded by `ISTIO_META_DELTA_NDS` on agents, this makes new agent set `NodeMetadata.DeltaNDS` which can be read by Istiod to ensure that the connected agent supports and wants **true** Delta NDS. This makes changes backwards compatible.

An Istiod flag `PILOT_ENABLE_DELTA_NDS` which enables automatic templating of `ISTIO_META_DELTA_NDS` is also added as to provide a way to enable this feature by default eventually and supporting disabling this feature by compatibility profiles.

Closes https://github.com/istio/istio/issues/60919