### PR TITLE
AuthorizationPolicy targetRefs support referencing classic Istio Gateways

### DIFF
--- a/pilot/pkg/model/authorization.go
+++ b/pilot/pkg/model/authorization.go
@@ -81,7 +81,12 @@ type AuthorizationPoliciesResult struct {
 	Audit  []AuthorizationPolicy
 }
 
-// ListAuthorizationPolicies returns authorization policies applied to the workload in the given namespace.
+// ListAuthorizationPolicies returns authorization policies applied to the workload in the given
+// namespace. It scans the root namespace, the workload namespace, and any service namespaces via
+// the full ShouldAttachPolicy path; it additionally scans the namespaces of selectionOpts.Gateways
+// (classic networking.istio.io Gateways) but there attaches ONLY classic-Gateway targetRef matches,
+// never selector / no-targetRef fallbacks, so a tenant's selector policy cannot leak onto a shared
+// gateway proxy in a different namespace.
 func (policy *AuthorizationPolicies) ListAuthorizationPolicies(selectionOpts WorkloadPolicyMatcher) AuthorizationPoliciesResult {
 	configs := AuthorizationPoliciesResult{}
 	if policy == nil {
@@ -100,7 +105,8 @@ func (policy *AuthorizationPolicies) ListAuthorizationPolicies(selectionOpts Wor
 		lookupInNamespaces = append(lookupInNamespaces, svc.Namespace)
 	}
 
-	for _, ns := range slices.FilterDuplicates(lookupInNamespaces) {
+	baseNamespaces := slices.FilterDuplicates(lookupInNamespaces)
+	for _, ns := range baseNamespaces {
 		for _, config := range policy.NamespaceToPolicies[ns] {
 			spec := config.Spec
 
@@ -110,21 +116,47 @@ func (policy *AuthorizationPolicies) ListAuthorizationPolicies(selectionOpts Wor
 		}
 	}
 
+	// In the shared-ingress topology a classic Gateway (and its targetRef policy) can live in a
+	// namespace that is neither the root nor the proxy config namespace. Scan those extra gateway
+	// namespaces too, but attach ONLY policies matching a classic-Gateway targetRef for one of
+	// selectionOpts.Gateways. The ordinary selector / no-targetRef fallback is deliberately NOT
+	// applied here, so a tenant's selector policy cannot leak onto the shared proxy.
+	seen := sets.New(baseNamespaces...)
+	var extraNamespaces []string
+	for _, gw := range selectionOpts.Gateways {
+		if !seen.Contains(gw.Namespace) {
+			seen.Insert(gw.Namespace)
+			extraNamespaces = append(extraNamespaces, gw.Namespace)
+		}
+	}
+	for _, ns := range extraNamespaces {
+		for _, config := range policy.NamespaceToPolicies[ns] {
+			if selectionOpts.attachesToClassicGateway(config.NamespacedName(), config.Spec) {
+				configs = updateAuthorizationPoliciesResult(configs, config)
+			}
+		}
+	}
+
 	return configs
 }
 
 // GatewaysTargetedByTargetRef returns the set of classic networking.istio.io Gateways that at
-// least one in-scope AuthorizationPolicy attaches to via a targetRef. Scope mirrors
-// ListAuthorizationPolicies: only the root namespace and the given proxy config namespace are
-// scanned, under the classic-Gateway same-namespace rule. Callers use this to activate
-// per-Gateway authz scoping ONLY for Gateways that are actually targeted, so untargeted
-// Gateways keep the shared proxy-wide builder (byte-identical output).
-func (policy *AuthorizationPolicies) GatewaysTargetedByTargetRef(configNamespace string) sets.Set[types.NamespacedName] {
+// least one in-scope AuthorizationPolicy attaches to via a targetRef. Scope: the root namespace,
+// the given proxy config namespace, and the namespaces of the classic Gateways bound to the proxy
+// (gatewayNamespaces), all under the classic-Gateway same-namespace rule. The gateway namespaces
+// are needed for the shared-ingress topology, where a selector-less Gateway in a tenant namespace
+// binds to a proxy in a different namespace and its targetRef policy lives alongside it. Callers
+// use this to activate per-Gateway authz scoping ONLY for Gateways that are actually targeted, so
+// untargeted Gateways keep the shared proxy-wide builder (byte-identical output).
+func (policy *AuthorizationPolicies) GatewaysTargetedByTargetRef(
+	configNamespace string,
+	gatewayNamespaces ...string,
+) sets.Set[types.NamespacedName] {
 	result := sets.New[types.NamespacedName]()
 	if policy == nil {
 		return result
 	}
-	for _, ns := range slices.FilterDuplicates([]string{policy.RootNamespace, configNamespace}) {
+	for _, ns := range slices.FilterDuplicates(append([]string{policy.RootNamespace, configNamespace}, gatewayNamespaces...)) {
 		for _, cfg := range policy.NamespaceToPolicies[ns] {
 			for _, ref := range GetTargetRefs(cfg.Spec) {
 				if !matchesGroupKind(ref, gvk.Gateway) {

--- a/pilot/pkg/model/authorization.go
+++ b/pilot/pkg/model/authorization.go
@@ -20,6 +20,7 @@ import (
 	authpb "istio.io/api/security/v1beta1"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/slices"
+	"istio.io/istio/pkg/util/sets"
 )
 
 type AuthorizationPolicy struct {
@@ -110,6 +111,34 @@ func (policy *AuthorizationPolicies) ListAuthorizationPolicies(selectionOpts Wor
 	}
 
 	return configs
+}
+
+// GatewaysTargetedByTargetRef returns the set of classic networking.istio.io Gateways that at
+// least one in-scope AuthorizationPolicy attaches to via a targetRef. Scope mirrors
+// ListAuthorizationPolicies: only the root namespace and the given proxy config namespace are
+// scanned, under the classic-Gateway same-namespace rule. Callers use this to activate
+// per-Gateway authz scoping ONLY for Gateways that are actually targeted, so untargeted
+// Gateways keep the shared proxy-wide builder (byte-identical output).
+func (policy *AuthorizationPolicies) GatewaysTargetedByTargetRef(configNamespace string) sets.Set[types.NamespacedName] {
+	result := sets.New[types.NamespacedName]()
+	if policy == nil {
+		return result
+	}
+	for _, ns := range slices.FilterDuplicates([]string{policy.RootNamespace, configNamespace}) {
+		for _, cfg := range policy.NamespaceToPolicies[ns] {
+			for _, ref := range GetTargetRefs(cfg.Spec) {
+				if !matchesGroupKind(ref, gvk.Gateway) {
+					continue
+				}
+				// Same-namespace rule: policyNamespace == gatewayNamespace, so cfg.Namespace is
+				// the gateway namespace; a targetRef namespace, if set, must equal it.
+				if ref.GetNamespace() == "" || ref.GetNamespace() == cfg.Namespace {
+					result.Insert(types.NamespacedName{Namespace: cfg.Namespace, Name: ref.GetName()})
+				}
+			}
+		}
+	}
+	return result
 }
 
 func updateAuthorizationPoliciesResult(configs AuthorizationPoliciesResult, config AuthorizationPolicy) AuthorizationPoliciesResult {

--- a/pilot/pkg/model/authorization_test.go
+++ b/pilot/pkg/model/authorization_test.go
@@ -19,6 +19,8 @@ import (
 	"reflect"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	"istio.io/api/label"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	authpb "istio.io/api/security/v1beta1"
@@ -481,6 +483,74 @@ func TestAuthorizationPolicies_ListAuthorizationPolicies(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGatewaysTargetedByTargetRef_CrossNamespace(t *testing.T) {
+	classicGWTargetRef := &authpb.AuthorizationPolicy{
+		Action: authpb.AuthorizationPolicy_ALLOW,
+		TargetRef: &selectorpb.PolicyTargetReference{
+			Group: gvk.Gateway.Group, // networking.istio.io
+			Kind:  gvk.Gateway.Kind,  // Gateway (classic, not KubernetesGateway)
+			Name:  "gateway",
+		},
+	}
+	authzPolicies := createFakeAuthorizationPolicies([]config.Config{
+		newConfig("policy", "tenant-a", classicGWTargetRef),
+	})
+
+	// Passing tenant-a (the namespace of a classic Gateway bound to the proxy) widens the scan so the
+	// cross-namespace targetRef in tenant-a is seen even though the proxy config namespace is not-default.
+	got := authzPolicies.GatewaysTargetedByTargetRef("not-default", "tenant-a")
+	tenantGW := types.NamespacedName{Namespace: "tenant-a", Name: "gateway"}
+	if !got.Contains(tenantGW) {
+		t.Fatalf("expected cross-namespace gateway %v in targeted set for proxy ns not-default, got %v",
+			tenantGW, got.UnsortedList())
+	}
+}
+
+func TestListAuthorizationPolicies_CrossNamespaceGateway(t *testing.T) {
+	proxyLabels := labels.Instance{"app": "istio-ingressgateway"}
+	tenantGateways := []types.NamespacedName{{Namespace: "tenant-a", Name: "gateway"}}
+
+	classicGWTargetRef := &authpb.AuthorizationPolicy{
+		Action: authpb.AuthorizationPolicy_ALLOW,
+		TargetRef: &selectorpb.PolicyTargetReference{
+			Group: gvk.Gateway.Group,
+			Kind:  gvk.Gateway.Kind,
+			Name:  "gateway",
+		},
+	}
+	selectorSpec := &authpb.AuthorizationPolicy{
+		Action:   authpb.AuthorizationPolicy_ALLOW,
+		Selector: &selectorpb.WorkloadSelector{MatchLabels: proxyLabels},
+	}
+
+	t.Run("targetRef attaches cross-namespace", func(t *testing.T) {
+		authzPolicies := createFakeAuthorizationPolicies([]config.Config{
+			newConfig("policy", "tenant-a", classicGWTargetRef),
+		})
+		opts := PolicyMatcherFor("not-default", proxyLabels, false).
+			WithGateways(tenantGateways).
+			WithRootNamespace("istio-config")
+		got := authzPolicies.ListAuthorizationPolicies(opts)
+		want := []AuthorizationPolicy{{Name: "policy", Namespace: "tenant-a", Spec: classicGWTargetRef}}
+		if !reflect.DeepEqual(want, got.Allow) {
+			t.Fatalf("want:%v\n but got: %v\n", want, got.Allow)
+		}
+	})
+
+	t.Run("selector does not leak cross-namespace", func(t *testing.T) {
+		authzPolicies := createFakeAuthorizationPolicies([]config.Config{
+			newConfig("selleak", "tenant-a", selectorSpec),
+		})
+		opts := PolicyMatcherFor("not-default", proxyLabels, false).
+			WithGateways(tenantGateways).
+			WithRootNamespace("istio-config")
+		got := authzPolicies.ListAuthorizationPolicies(opts)
+		if len(got.Allow) != 0 {
+			t.Fatalf("selector policy in gateway namespace must not attach to the shared proxy, got %v", got.Allow)
+		}
+	})
 }
 
 func createFakeAuthorizationPolicies(configs []config.Config) *AuthorizationPolicies {

--- a/pilot/pkg/model/policyattachment.go
+++ b/pilot/pkg/model/policyattachment.go
@@ -144,6 +144,26 @@ func GetTargetRefs(p TargetablePolicy) []*v1beta1.PolicyTargetReference {
 	return targetRefs
 }
 
+// attachesToClassicGateway reports whether policy attaches to one of p.Gateways via a classic
+// networking.istio.io Gateway targetRef, under the same-namespace rule: the policy must be in the
+// gateway's namespace and any targetRef namespace, if set, must equal it. It no-ops when p.Gateways
+// is empty. This is the ONLY classic-Gateway attachment path and never falls back to selectors.
+func (p WorkloadPolicyMatcher) attachesToClassicGateway(policyName types.NamespacedName, policy TargetablePolicy) bool {
+	for _, targetRef := range GetTargetRefs(policy) {
+		if !matchesGroupKind(targetRef, gvk.Gateway) {
+			continue
+		}
+		for _, gw := range p.Gateways {
+			if targetRef.GetName() == gw.Name &&
+				policyName.Namespace == gw.Namespace &&
+				(targetRef.GetNamespace() == "" || targetRef.GetNamespace() == gw.Namespace) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (p WorkloadPolicyMatcher) ShouldAttachPolicy(kind config.GroupVersionKind,
 	policyName types.NamespacedName,
 	policy TargetablePolicy,
@@ -155,18 +175,9 @@ func (p WorkloadPolicyMatcher) ShouldAttachPolicy(kind config.GroupVersionKind,
 	// p.Gateways rather than the label. This runs independently of isGatewayAPI because a single
 	// workload can be both a Gateway API gateway (label present => isGatewayAPI==true) and an
 	// instance of a classic Gateway; gating it on !isGatewayAPI would silently drop classic-Gateway
-	// targetRefs for such mixed workloads. The loop no-ops when p.Gateways is empty.
-	for _, targetRef := range targetRefs {
-		if !matchesGroupKind(targetRef, gvk.Gateway) {
-			continue
-		}
-		for _, gw := range p.Gateways {
-			if targetRef.GetName() == gw.Name &&
-				policyName.Namespace == gw.Namespace &&
-				(targetRef.GetNamespace() == "" || targetRef.GetNamespace() == gw.Namespace) {
-				return true
-			}
-		}
+	// targetRefs for such mixed workloads. The check no-ops when p.Gateways is empty.
+	if p.attachesToClassicGateway(policyName, policy) {
+		return true
 	}
 
 	// non-gateway: use selector

--- a/pilot/pkg/model/policyattachment.go
+++ b/pilot/pkg/model/policyattachment.go
@@ -44,11 +44,8 @@ type WorkloadPolicyMatcher struct {
 	WorkloadLabels    labels.Instance
 	IsWaypoint        bool
 	Services          []ServiceInfoForPolicyMatcher
-	// Gateways are the classic networking.istio.io Gateways this workload is an instance of.
-	// Unlike Gateway API gateways, they are not identified by a workload label, so targetRef
-	// attachment matches against this list instead.
-	Gateways      []types.NamespacedName
-	RootNamespace string
+	Gateways          []types.NamespacedName
+	RootNamespace     string
 }
 
 type ServiceInfoForPolicyMatcher struct {

--- a/pilot/pkg/model/policyattachment.go
+++ b/pilot/pkg/model/policyattachment.go
@@ -44,7 +44,11 @@ type WorkloadPolicyMatcher struct {
 	WorkloadLabels    labels.Instance
 	IsWaypoint        bool
 	Services          []ServiceInfoForPolicyMatcher
-	RootNamespace     string
+	// Gateways are the classic networking.istio.io Gateways this workload is an instance of.
+	// Unlike Gateway API gateways, they are not identified by a workload label, so targetRef
+	// attachment matches against this list instead.
+	Gateways      []types.NamespacedName
+	RootNamespace string
 }
 
 type ServiceInfoForPolicyMatcher struct {
@@ -84,6 +88,26 @@ func (p WorkloadPolicyMatcher) WithService(service *Service) WorkloadPolicyMatch
 		Namespace: service.Attributes.Namespace,
 		Registry:  service.Attributes.ServiceRegistry,
 	})
+	return p
+}
+
+// WithGateway adds a classic networking.istio.io Gateway to the selection criteria, so
+// targetRef-based policies can attach to it. The zero NamespacedName is ignored.
+func (p WorkloadPolicyMatcher) WithGateway(nn types.NamespacedName) WorkloadPolicyMatcher {
+	if nn == (types.NamespacedName{}) {
+		return p
+	}
+
+	p.Gateways = append(p.Gateways, nn)
+	return p
+}
+
+// WithGateways adds multiple classic networking.istio.io Gateways to the selection criteria.
+// Like WithServices, it is nil-slice safe.
+func (p WorkloadPolicyMatcher) WithGateways(nns []types.NamespacedName) WorkloadPolicyMatcher {
+	for _, nn := range nns {
+		p = p.WithGateway(nn)
+	}
 	return p
 }
 
@@ -129,6 +153,20 @@ func (p WorkloadPolicyMatcher) ShouldAttachPolicy(kind config.GroupVersionKind,
 
 	// non-gateway: use selector
 	if !isGatewayAPI {
+		// A classic Gateway proxy has no gateway-name label, so it lands here rather than in the
+		// Gateway API branch below; a targetRef may still select it.
+		for _, targetRef := range targetRefs {
+			if !matchesGroupKind(targetRef, gvk.Gateway) {
+				continue
+			}
+			for _, gw := range p.Gateways {
+				if targetRef.GetName() == gw.Name &&
+					policyName.Namespace == gw.Namespace &&
+					(targetRef.GetNamespace() == "" || targetRef.GetNamespace() == gw.Namespace) {
+					return true
+				}
+			}
+		}
 		// if targetRef is specified, ignore the policy altogether
 		if len(targetRefs) > 0 {
 			return false

--- a/pilot/pkg/model/policyattachment.go
+++ b/pilot/pkg/model/policyattachment.go
@@ -145,9 +145,7 @@ func GetTargetRefs(p TargetablePolicy) []*v1beta1.PolicyTargetReference {
 }
 
 // attachesToClassicGateway reports whether policy attaches to one of p.Gateways via a classic
-// networking.istio.io Gateway targetRef, under the same-namespace rule: the policy must be in the
-// gateway's namespace and any targetRef namespace, if set, must equal it. It no-ops when p.Gateways
-// is empty. This is the ONLY classic-Gateway attachment path and never falls back to selectors.
+// networking.istio.io Gateway targetRef. Gateway must be in the same namespace as the policy
 func (p WorkloadPolicyMatcher) attachesToClassicGateway(policyName types.NamespacedName, policy TargetablePolicy) bool {
 	for _, targetRef := range GetTargetRefs(policy) {
 		if !matchesGroupKind(targetRef, gvk.Gateway) {
@@ -171,11 +169,9 @@ func (p WorkloadPolicyMatcher) ShouldAttachPolicy(kind config.GroupVersionKind,
 	gatewayName, isGatewayAPI := workloadGatewayName(p.WorkloadLabels)
 	targetRefs := GetTargetRefs(policy)
 
-	// Classic networking.istio.io Gateways carry no gateway-name label, so they are matched via
-	// p.Gateways rather than the label. This runs independently of isGatewayAPI because a single
-	// workload can be both a Gateway API gateway (label present => isGatewayAPI==true) and an
-	// instance of a classic Gateway; gating it on !isGatewayAPI would silently drop classic-Gateway
-	// targetRefs for such mixed workloads. The check no-ops when p.Gateways is empty.
+	// This runs independently of isGatewayAPI because a single
+	// workload can be both a Gateway API gateway and an
+	// instance of a classic Gateway
 	if p.attachesToClassicGateway(policyName, policy) {
 		return true
 	}

--- a/pilot/pkg/model/policyattachment.go
+++ b/pilot/pkg/model/policyattachment.go
@@ -151,22 +151,26 @@ func (p WorkloadPolicyMatcher) ShouldAttachPolicy(kind config.GroupVersionKind,
 	gatewayName, isGatewayAPI := workloadGatewayName(p.WorkloadLabels)
 	targetRefs := GetTargetRefs(policy)
 
-	// non-gateway: use selector
-	if !isGatewayAPI {
-		// A classic Gateway proxy has no gateway-name label, so it lands here rather than in the
-		// Gateway API branch below; a targetRef may still select it.
-		for _, targetRef := range targetRefs {
-			if !matchesGroupKind(targetRef, gvk.Gateway) {
-				continue
-			}
-			for _, gw := range p.Gateways {
-				if targetRef.GetName() == gw.Name &&
-					policyName.Namespace == gw.Namespace &&
-					(targetRef.GetNamespace() == "" || targetRef.GetNamespace() == gw.Namespace) {
-					return true
-				}
+	// Classic networking.istio.io Gateways carry no gateway-name label, so they are matched via
+	// p.Gateways rather than the label. This runs independently of isGatewayAPI because a single
+	// workload can be both a Gateway API gateway (label present => isGatewayAPI==true) and an
+	// instance of a classic Gateway; gating it on !isGatewayAPI would silently drop classic-Gateway
+	// targetRefs for such mixed workloads. The loop no-ops when p.Gateways is empty.
+	for _, targetRef := range targetRefs {
+		if !matchesGroupKind(targetRef, gvk.Gateway) {
+			continue
+		}
+		for _, gw := range p.Gateways {
+			if targetRef.GetName() == gw.Name &&
+				policyName.Namespace == gw.Namespace &&
+				(targetRef.GetNamespace() == "" || targetRef.GetNamespace() == gw.Namespace) {
+				return true
 			}
 		}
+	}
+
+	// non-gateway: use selector
+	if !isGatewayAPI {
 		// if targetRef is specified, ignore the policy altogether
 		if len(targetRefs) > 0 {
 			return false

--- a/pilot/pkg/model/policyattachment_test.go
+++ b/pilot/pkg/model/policyattachment_test.go
@@ -595,6 +595,106 @@ func TestShouldAttachPolicy_ClassicGatewayZeroImpact(t *testing.T) {
 	}
 }
 
+// TestShouldAttachPolicy_MixedGatewayAPIAndClassic covers a workload that is BOTH a Gateway API
+// gateway (it carries the gateway.networking.k8s.io/gateway-name label, so isGatewayAPI==true) AND an
+// instance of a classic networking.istio.io Gateway (p.Gateways is non-empty). A classic-Gateway
+// targetRef must attach to such a mixed workload; the classic-Gateway match runs independently of
+// isGatewayAPI rather than only inside the `if !isGatewayAPI` branch. The remaining cases guard the
+// surrounding behavior: a Gateway-API targetRef must still attach, and a classic targetRef must NOT
+// attach when the workload is not an instance of any classic Gateway (empty p.Gateways).
+func TestShouldAttachPolicy_MixedGatewayAPIAndClassic(t *testing.T) {
+	const k8sGatewayName = "some-k8s-gw"
+
+	classicGatewayTargetRef := &v1beta1.PolicyTargetReference{
+		Group: gvk.Gateway.Group,
+		Kind:  gvk.Gateway.Kind,
+		Name:  "gw-a",
+	}
+	k8sGatewayTargetRef := &v1beta1.PolicyTargetReference{
+		Group: gvk.KubernetesGateway.Group,
+		Kind:  gvk.KubernetesGateway.Kind,
+		Name:  k8sGatewayName,
+	}
+
+	// A workload that is simultaneously a Gateway API gateway (label present => isGatewayAPI==true)
+	// and an instance of the classic Gateway gw-a (Gateways non-empty).
+	mixedWorkload := WorkloadPolicyMatcher{
+		WorkloadNamespace: "ns1",
+		WorkloadLabels: labels.Instance{
+			label.IoK8sNetworkingGatewayGatewayName.Name: k8sGatewayName,
+		},
+		IsWaypoint: false,
+		Gateways:   []types.NamespacedName{{Name: "gw-a", Namespace: "ns1"}},
+	}
+	// A pure Gateway API workload: it carries the gateway-name label but is not an instance of any
+	// classic Gateway (empty Gateways).
+	pureK8sGatewayWorkload := WorkloadPolicyMatcher{
+		WorkloadNamespace: "ns1",
+		WorkloadLabels: labels.Instance{
+			label.IoK8sNetworkingGatewayGatewayName.Name: k8sGatewayName,
+		},
+		IsWaypoint: false,
+	}
+
+	tests := []struct {
+		name      string
+		selection WorkloadPolicyMatcher
+		policy    TargetablePolicy
+		expected  bool
+	}{
+		{
+			// The classic-Gateway targetRef attaches even though the workload is also a Gateway API
+			// gateway, because the workload is an instance of the targeted classic Gateway.
+			name:      "mixed workload attaches classic Gateway targetRef",
+			selection: mixedWorkload,
+			policy: &mockPolicyTargetGetter{
+				targetRefs: []*v1beta1.PolicyTargetReference{classicGatewayTargetRef},
+			},
+			expected: true,
+		},
+		{
+			// Guard: a Gateway-API (KubernetesGateway) targetRef must still attach to the mixed workload
+			// via its gateway-name label, exactly as before.
+			name:      "mixed workload still attaches Gateway-API targetRef",
+			selection: mixedWorkload,
+			policy: &mockPolicyTargetGetter{
+				targetRefs: []*v1beta1.PolicyTargetReference{k8sGatewayTargetRef},
+			},
+			expected: true,
+		},
+		{
+			// Guard: a pure Gateway-API workload still attaches a matching Gateway-API targetRef.
+			name:      "pure Gateway-API workload attaches Gateway-API targetRef",
+			selection: pureK8sGatewayWorkload,
+			policy: &mockPolicyTargetGetter{
+				targetRefs: []*v1beta1.PolicyTargetReference{k8sGatewayTargetRef},
+			},
+			expected: true,
+		},
+		{
+			// Guard: a classic-Gateway targetRef must NOT attach to a Gateway-API workload that is not an
+			// instance of any classic Gateway (empty Gateways); the match keys off the Gateways list.
+			name:      "pure Gateway-API workload does not attach classic Gateway targetRef",
+			selection: pureK8sGatewayWorkload,
+			policy: &mockPolicyTargetGetter{
+				targetRefs: []*v1beta1.PolicyTargetReference{classicGatewayTargetRef},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			test.SetForTest(t, &features.EnableSelectorBasedK8sGatewayPolicy, true)
+			nsName := types.NamespacedName{Name: "policy1", Namespace: "ns1"}
+			got := tt.selection.ShouldAttachPolicy(mockKind, nsName, tt.policy)
+			if got != tt.expected {
+				t.Errorf("Expected %v, but got %v", tt.expected, got)
+			}
+		})
+	}
+}
+
 // TestWithGateways verifies the plural WithGateways helper appends every non-zero NamespacedName to
 // the matcher's Gateways slice (mirroring WithServices), is nil-slice safe, and skips zero values
 // (delegating to the Change-2 WithGateway, which no-ops on the zero NamespacedName).

--- a/pilot/pkg/model/policyattachment_test.go
+++ b/pilot/pkg/model/policyattachment_test.go
@@ -396,6 +396,243 @@ func TestPolicyMatcher(t *testing.T) {
 	}
 }
 
+// TestShouldAttachPolicy_ClassicGateway verifies targetRef-based attachment to a classic
+// networking.istio.io Gateway. A classic Gateway proxy is NOT a Gateway API workload (it lacks the
+// gateway.networking.k8s.io/gateway-name label), so it is matched via the WorkloadPolicyMatcher.Gateways
+// list rather than via a workload label.
+func TestShouldAttachPolicy_ClassicGateway(t *testing.T) {
+	classicGatewayTargetRef := &v1beta1.PolicyTargetReference{
+		Group: gvk.Gateway.Group, // networking.istio.io
+		Kind:  gvk.Gateway.Kind,  // Gateway
+		Name:  "gw-a",
+	}
+	classicGatewayTargetRefWrongName := &v1beta1.PolicyTargetReference{
+		Group: gvk.Gateway.Group,
+		Kind:  gvk.Gateway.Kind,
+		Name:  "gw-b",
+	}
+	classicGatewayTargetRefExplicitOtherNS := &v1beta1.PolicyTargetReference{
+		Group:     gvk.Gateway.Group,
+		Kind:      gvk.Gateway.Kind,
+		Name:      "gw-a",
+		Namespace: "ns2",
+	}
+	classicGatewayTargetRefExplicitSameNS := &v1beta1.PolicyTargetReference{
+		Group:     gvk.Gateway.Group,
+		Kind:      gvk.Gateway.Kind,
+		Name:      "gw-a",
+		Namespace: "ns1",
+	}
+	// A classic ingress gateway workload: no gateway-name label, so it is not a Gateway API workload.
+	classicGateway := WorkloadPolicyMatcher{
+		WorkloadNamespace: "ns1",
+		WorkloadLabels: labels.Instance{
+			"app": "istio-ingressgateway",
+		},
+		IsWaypoint: false,
+		Gateways:   []types.NamespacedName{{Name: "gw-a", Namespace: "ns1"}},
+	}
+	classicGatewayNoGateways := WorkloadPolicyMatcher{
+		WorkloadNamespace: "ns1",
+		WorkloadLabels: labels.Instance{
+			"app": "istio-ingressgateway",
+		},
+		IsWaypoint: false,
+	}
+
+	tests := []struct {
+		name                   string
+		selection              WorkloadPolicyMatcher
+		policy                 TargetablePolicy
+		enableSelectorPolicies bool
+		policyNamespacedName   *types.NamespacedName
+		expected               bool
+	}{
+		{
+			name:      "classic gateway matching targetRef (legacy singular)",
+			selection: classicGateway,
+			policy: &mockPolicyTargetGetter{
+				targetRef: classicGatewayTargetRef,
+			},
+			policyNamespacedName: &types.NamespacedName{Namespace: "ns1", Name: "policy1"},
+			expected:             true,
+		},
+		{
+			name:      "classic gateway matching targetRefs (plural)",
+			selection: classicGateway,
+			policy: &mockPolicyTargetGetter{
+				targetRefs: []*v1beta1.PolicyTargetReference{classicGatewayTargetRef},
+			},
+			policyNamespacedName: &types.NamespacedName{Namespace: "ns1", Name: "policy1"},
+			expected:             true,
+		},
+		{
+			name:      "classic gateway targetRef with explicit matching namespace",
+			selection: classicGateway,
+			policy: &mockPolicyTargetGetter{
+				targetRefs: []*v1beta1.PolicyTargetReference{classicGatewayTargetRefExplicitSameNS},
+			},
+			policyNamespacedName: &types.NamespacedName{Namespace: "ns1", Name: "policy1"},
+			expected:             true,
+		},
+		{
+			name:      "classic gateway targetRef wrong name",
+			selection: classicGateway,
+			policy: &mockPolicyTargetGetter{
+				targetRefs: []*v1beta1.PolicyTargetReference{classicGatewayTargetRefWrongName},
+			},
+			policyNamespacedName: &types.NamespacedName{Namespace: "ns1", Name: "policy1"},
+			expected:             false,
+		},
+		{
+			name:      "classic gateway targetRef policy in different namespace",
+			selection: classicGateway,
+			policy: &mockPolicyTargetGetter{
+				targetRefs: []*v1beta1.PolicyTargetReference{classicGatewayTargetRef},
+			},
+			policyNamespacedName: &types.NamespacedName{Namespace: "ns2", Name: "policy1"},
+			expected:             false,
+		},
+		{
+			name:      "classic gateway targetRef with explicit different namespace",
+			selection: classicGateway,
+			policy: &mockPolicyTargetGetter{
+				targetRefs: []*v1beta1.PolicyTargetReference{classicGatewayTargetRefExplicitOtherNS},
+			},
+			policyNamespacedName: &types.NamespacedName{Namespace: "ns1", Name: "policy1"},
+			expected:             false,
+		},
+		{
+			name:      "classic gateway targetRef but empty Gateways",
+			selection: classicGatewayNoGateways,
+			policy: &mockPolicyTargetGetter{
+				targetRefs: []*v1beta1.PolicyTargetReference{classicGatewayTargetRef},
+			},
+			policyNamespacedName: &types.NamespacedName{Namespace: "ns1", Name: "policy1"},
+			expected:             false,
+		},
+		{
+			name:      "classic gateway with KubernetesGateway-kind targetRef does not match classic Gateway",
+			selection: classicGateway,
+			policy: &mockPolicyTargetGetter{
+				targetRefs: []*v1beta1.PolicyTargetReference{{
+					Group: gvk.KubernetesGateway.Group,
+					Kind:  gvk.KubernetesGateway.Kind,
+					Name:  "gw-a",
+				}},
+			},
+			policyNamespacedName: &types.NamespacedName{Namespace: "ns1", Name: "policy1"},
+			expected:             false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			test.SetForTest(t, &features.EnableSelectorBasedK8sGatewayPolicy, tt.enableSelectorPolicies)
+			nsName := types.NamespacedName{Name: "policy1", Namespace: "default"}
+			if tt.policyNamespacedName != nil {
+				nsName = *tt.policyNamespacedName
+			}
+			got := tt.selection.ShouldAttachPolicy(mockKind, nsName, tt.policy)
+			if got != tt.expected {
+				t.Errorf("Expected %v, but got %v", tt.expected, got)
+			}
+		})
+	}
+}
+
+// TestShouldAttachPolicy_ClassicGatewayZeroImpact asserts the zero-impact invariant: adding the
+// Gateways field must not change the behavior of no-targetRef selector policies (they still fall
+// through to selector matching), and a non-Gateway-kind targetRef on a non-GatewayAPI proxy is still
+// ignored (returns false), regardless of whether Gateways is populated.
+func TestShouldAttachPolicy_ClassicGatewayZeroImpact(t *testing.T) {
+	test.SetForTest(t, &features.EnableSelectorBasedK8sGatewayPolicy, true)
+	nsName := types.NamespacedName{Name: "policy1", Namespace: "ns1"}
+
+	baseLabels := labels.Instance{"app": "istio-ingressgateway"}
+	withoutGateways := WorkloadPolicyMatcher{
+		WorkloadNamespace: "ns1",
+		WorkloadLabels:    baseLabels,
+	}
+	withGateways := WorkloadPolicyMatcher{
+		WorkloadNamespace: "ns1",
+		WorkloadLabels:    baseLabels,
+		Gateways:          []types.NamespacedName{{Name: "gw-a", Namespace: "ns1"}},
+	}
+
+	// A selector-only policy that matches the workload labels.
+	selectorPolicy := &mockPolicyTargetGetter{
+		selector: &v1beta1.WorkloadSelector{MatchLabels: labels.Instance{"app": "istio-ingressgateway"}},
+	}
+	if got := withoutGateways.ShouldAttachPolicy(mockKind, nsName, selectorPolicy); !got {
+		t.Fatalf("selector policy without Gateways: expected true, got %v", got)
+	}
+	if got := withGateways.ShouldAttachPolicy(mockKind, nsName, selectorPolicy); !got {
+		t.Fatalf("selector policy with Gateways: expected true, got %v", got)
+	}
+
+	// A no-targetRef, no-selector policy is selected on a non-gateway workload; result must be identical.
+	emptyPolicy := &mockPolicyTargetGetter{}
+	if a, b := withoutGateways.ShouldAttachPolicy(mockKind, nsName, emptyPolicy),
+		withGateways.ShouldAttachPolicy(mockKind, nsName, emptyPolicy); a != b {
+		t.Fatalf("empty policy behavior changed by Gateways field: without=%v with=%v", a, b)
+	}
+
+	// A non-Gateway-kind targetRef (e.g. a Service) on a non-GatewayAPI proxy is still ignored today,
+	// whether or not Gateways is populated.
+	nonGatewayTargetRefPolicy := &mockPolicyTargetGetter{
+		targetRefs: []*v1beta1.PolicyTargetReference{{
+			Group: gvk.Service.Group,
+			Kind:  gvk.Service.Kind,
+			Name:  "gw-a",
+		}},
+	}
+	if got := withoutGateways.ShouldAttachPolicy(mockKind, nsName, nonGatewayTargetRefPolicy); got {
+		t.Fatalf("non-Gateway targetRef without Gateways: expected false, got %v", got)
+	}
+	if got := withGateways.ShouldAttachPolicy(mockKind, nsName, nonGatewayTargetRefPolicy); got {
+		t.Fatalf("non-Gateway targetRef with Gateways: expected false, got %v", got)
+	}
+}
+
+// TestWithGateways verifies the plural WithGateways helper appends every non-zero NamespacedName to
+// the matcher's Gateways slice (mirroring WithServices), is nil-slice safe, and skips zero values
+// (delegating to the Change-2 WithGateway, which no-ops on the zero NamespacedName).
+func TestWithGateways(t *testing.T) {
+	base := WorkloadPolicyMatcher{WorkloadNamespace: "ns1"}
+
+	// nil slice: no change, no panic.
+	if got := base.WithGateways(nil); len(got.Gateways) != 0 {
+		t.Fatalf("WithGateways(nil): expected 0 gateways, got %v", got.Gateways)
+	}
+
+	// empty slice: no change.
+	if got := base.WithGateways([]types.NamespacedName{}); len(got.Gateways) != 0 {
+		t.Fatalf("WithGateways([]): expected 0 gateways, got %v", got.Gateways)
+	}
+
+	// multiple gateways are all appended, order preserved.
+	gws := []types.NamespacedName{{Name: "gw-a", Namespace: "ns1"}, {Name: "gw-b", Namespace: "ns2"}}
+	got := base.WithGateways(gws)
+	if len(got.Gateways) != 2 {
+		t.Fatalf("WithGateways: expected 2 gateways, got %v", got.Gateways)
+	}
+	if got.Gateways[0] != gws[0] || got.Gateways[1] != gws[1] {
+		t.Fatalf("WithGateways: expected %v, got %v", gws, got.Gateways)
+	}
+
+	// zero NamespacedName is skipped (WithGateway no-ops on the zero value).
+	gotZero := base.WithGateways([]types.NamespacedName{{}, {Name: "gw-a", Namespace: "ns1"}})
+	if len(gotZero.Gateways) != 1 || gotZero.Gateways[0] != (types.NamespacedName{Name: "gw-a", Namespace: "ns1"}) {
+		t.Fatalf("WithGateways: expected only non-zero gw-a, got %v", gotZero.Gateways)
+	}
+
+	// receiver is not mutated (value semantics, like WithService/WithServices).
+	if len(base.Gateways) != 0 {
+		t.Fatalf("WithGateways mutated receiver: %v", base.Gateways)
+	}
+}
+
 type mockPolicyTargetGetter struct {
 	targetRef  *v1beta1.PolicyTargetReference
 	targetRefs []*v1beta1.PolicyTargetReference

--- a/pilot/pkg/networking/core/gateway.go
+++ b/pilot/pkg/networking/core/gateway.go
@@ -30,6 +30,7 @@ import (
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/hashicorp/go-multierror"
 	"google.golang.org/protobuf/types/known/anypb"
+	"k8s.io/apimachinery/pkg/types"
 
 	extensions "istio.io/api/extensions/v1alpha1"
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -714,8 +715,27 @@ func (configgen *ConfigGeneratorImpl) createGatewayHTTPFilterChainOpts(node *mod
 			statPrefix:                server.Name,
 			http3Only:                 http3Enabled,
 			class:                     istionetworking.ListenerClassGateway,
+			gatewayName:               gatewayNameForServer(node, server),
 		},
 	}
+}
+
+// gatewayNameForServer returns the classic Gateway that owns the given server, which
+// MergedGateway records as a "namespace/name" string. The zero value is returned when the
+// server has no known owner, leaving authz scoping a no-op.
+func gatewayNameForServer(node *model.Proxy, server *networking.Server) types.NamespacedName {
+	if node.MergedGateway == nil {
+		return types.NamespacedName{}
+	}
+	name, ok := node.MergedGateway.GatewayNameForServer[server]
+	if !ok {
+		return types.NamespacedName{}
+	}
+	ns, n, found := strings.Cut(name, "/")
+	if !found {
+		return types.NamespacedName{}
+	}
+	return types.NamespacedName{Namespace: ns, Name: n}
 }
 
 func buildGatewayConnectionManager(proxyConfig *meshconfig.ProxyConfig, node *model.Proxy, http3SupportEnabled bool,

--- a/pilot/pkg/networking/core/gateway.go
+++ b/pilot/pkg/networking/core/gateway.go
@@ -731,6 +731,12 @@ func gatewayNameForServer(node *model.Proxy, server *networking.Server) types.Na
 	if !ok {
 		return types.NamespacedName{}
 	}
+	return parseGatewayName(name)
+}
+
+// parseGatewayName parses a "namespace/name" classic Gateway identifier into a NamespacedName.
+// The zero value is returned for an empty or malformed name, leaving authz scoping a no-op.
+func parseGatewayName(name string) types.NamespacedName {
 	ns, n, found := strings.Cut(name, "/")
 	if !found {
 		return types.NamespacedName{}
@@ -835,6 +841,13 @@ func (lb *ListenerBuilder) createGatewayTCPFilterChainOpts(
 	server *networking.Server, listenerPort uint32,
 	gatewayName string, tlsHostsByPort map[uint32]map[string]string,
 ) []*filterChainOpts {
+	// Scope authz to the owning classic Gateway while this server's network filters are built.
+	// buildCompleteNetworkFilters reads authzGatewayName, so every network-filter chain below MUST be
+	// materialized synchronously within this call, before the defer clears the field; a lazily/deferred
+	// build would silently fall back to the proxy-wide builder and widen authz (fail-open).
+	lb.authzGatewayName = parseGatewayName(gatewayName)
+	defer func() { lb.authzGatewayName = types.NamespacedName{} }()
+
 	// We have a TCP/TLS server. This could be TLS termination (user specifies server.TLS with simple/mutual)
 	// or opaque TCP (server.TLS is nil). or it could be a TLS passthrough with SNI based routing.
 

--- a/pilot/pkg/networking/core/gateway.go
+++ b/pilot/pkg/networking/core/gateway.go
@@ -841,13 +841,6 @@ func (lb *ListenerBuilder) createGatewayTCPFilterChainOpts(
 	server *networking.Server, listenerPort uint32,
 	gatewayName string, tlsHostsByPort map[uint32]map[string]string,
 ) []*filterChainOpts {
-	// Scope authz to the owning classic Gateway while this server's network filters are built.
-	// buildCompleteNetworkFilters reads authzGatewayName, so every network-filter chain below MUST be
-	// materialized synchronously within this call, before the defer clears the field; a lazily/deferred
-	// build would silently fall back to the proxy-wide builder and widen authz (fail-open).
-	lb.authzGatewayName = parseGatewayName(gatewayName)
-	defer func() { lb.authzGatewayName = types.NamespacedName{} }()
-
 	// We have a TCP/TLS server. This could be TLS termination (user specifies server.TLS with simple/mutual)
 	// or opaque TCP (server.TLS is nil). or it could be a TLS passthrough with SNI based routing.
 
@@ -894,6 +887,9 @@ func (lb *ListenerBuilder) buildGatewayNetworkFiltersFromTCPRoutes(server *netwo
 		Port:     int(server.Port.Number),
 		Protocol: protocol.Parse(server.Port.Protocol),
 	}
+	// Scope authz to the owning classic Gateway. buildCompleteNetworkFilters selects the per-gateway
+	// authz builder for this identity; the zero value falls back to the proxy-wide builder.
+	authzGateway := parseGatewayName(gatewayName)
 
 	gatewayServerHosts := sets.NewWithLength[host.Name](len(server.Hosts))
 	for _, hostname := range server.Hosts {
@@ -926,7 +922,7 @@ func (lb *ListenerBuilder) buildGatewayNetworkFiltersFromTCPRoutes(server *netwo
 					continue
 				}
 				includeMx := server.GetTls().GetMode() == networking.ServerTLSSettings_ISTIO_MUTUAL
-				return lb.buildOutboundNetworkFilters(tcp.Route, port, v.Meta, includeMx)
+				return lb.buildOutboundNetworkFilters(tcp.Route, port, v.Meta, includeMx, authzGateway)
 			}
 		}
 
@@ -940,7 +936,7 @@ func (lb *ListenerBuilder) buildGatewayNetworkFiltersFromTCPRoutes(server *netwo
 			for _, tls := range vsvc.Tls {
 				for _, match := range tls.Match {
 					if l4SingleMatch(convertTLSMatchToL4Match(match), server, gatewayName) {
-						return lb.buildOutboundNetworkFilters(tls.Route, port, v.Meta, includeMx)
+						return lb.buildOutboundNetworkFilters(tls.Route, port, v.Meta, includeMx, authzGateway)
 					}
 				}
 			}
@@ -960,6 +956,9 @@ func (lb *ListenerBuilder) buildGatewayNetworkFiltersFromTLSRoutes(server *netwo
 		Port:     int(server.Port.Number),
 		Protocol: protocol.Parse(server.Port.Protocol),
 	}
+	// Scope authz to the owning classic Gateway. buildCompleteNetworkFilters selects the per-gateway
+	// authz builder for this identity; the zero value falls back to the proxy-wide builder.
+	authzGateway := parseGatewayName(gatewayName)
 
 	gatewayServerHosts := sets.NewWithLength[host.Name](len(server.Hosts))
 	for _, hostname := range server.Hosts {
@@ -1013,7 +1012,7 @@ func (lb *ListenerBuilder) buildGatewayNetworkFiltersFromTLSRoutes(server *netwo
 						filterChains = append(filterChains, &filterChainOpts{
 							sniHosts:       match.SniHosts,
 							tlsContext:     nil, // NO TLS context because this is passthrough
-							networkFilters: lb.buildOutboundNetworkFilters(tls.Route, port, v.Meta, false),
+							networkFilters: lb.buildOutboundNetworkFilters(tls.Route, port, v.Meta, false, authzGateway),
 						})
 					}
 				}
@@ -1071,7 +1070,7 @@ func builtAutoPassthroughFilterChains(push *model.PushContext, proxy *model.Prox
 				applicationProtocols: allIstioMtlsALPNs,
 				tlsContext:           nil, // NO TLS context because this is passthrough
 				networkFilters: lb.buildOutboundNetworkFiltersWithSingleDestination(
-					statPrefix, clusterName, "", port, destinationRule, tunnelingconfig.Skip, false, nil),
+					statPrefix, clusterName, "", port, destinationRule, tunnelingconfig.Skip, false, nil, types.NamespacedName{}),
 			})
 
 			// Do the same, but for each subset
@@ -1087,7 +1086,7 @@ func builtAutoPassthroughFilterChains(push *model.PushContext, proxy *model.Prox
 					applicationProtocols: allIstioMtlsALPNs,
 					tlsContext:           nil, // NO TLS context because this is passthrough
 					networkFilters: lb.buildOutboundNetworkFiltersWithSingleDestination(
-						subsetStatPrefix, subsetClusterName, subset.Name, port, destinationRule, tunnelingconfig.Skip, false, nil),
+						subsetStatPrefix, subsetClusterName, subset.Name, port, destinationRule, tunnelingconfig.Skip, false, nil, types.NamespacedName{}),
 				})
 			}
 		}

--- a/pilot/pkg/networking/core/gateway_test.go
+++ b/pilot/pkg/networking/core/gateway_test.go
@@ -37,6 +37,7 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 	security "istio.io/api/security/v1beta1"
 	telemetry "istio.io/api/telemetry/v1alpha1"
+	apitypev1beta1 "istio.io/api/type/v1beta1"
 	"istio.io/istio/pilot/pkg/features"
 	pilot_model "istio.io/istio/pilot/pkg/model"
 	istionetworking "istio.io/istio/pilot/pkg/networking"
@@ -5239,5 +5240,176 @@ func TestGatewayListenerConnectionSettings(t *testing.T) {
 			hcmFilter := xdstest.ExtractHTTPConnectionManager(t, l.GetFilterChains()[0])
 			tc.verifyHCM(t, hcmFilter)
 		})
+	}
+}
+
+// buildGatewayListenersForAuthzTest builds the gateway listeners for proxyGateway (ConfigNamespace
+// "not-default") given a set of Gateway/AuthorizationPolicy/etc. configs, using the same wiring as
+// TestBuildGatewayListenersFilters.
+func buildGatewayListenersForAuthzTest(t *testing.T, configs []config.Config) []*listener.Listener {
+	t.Helper()
+	cg := NewConfigGenTest(t, TestOptions{Configs: configs})
+	proxy := cg.SetupProxy(&proxyGateway)
+	metadata := proxyGatewayMetadata
+	proxy.Metadata = &metadata
+	lb := NewListenerBuilder(proxy, cg.PushContext())
+	return cg.ConfigGen.buildGatewayListeners(lb).gatewayListeners
+}
+
+// httpFilterNamesForListener aggregates the HTTP filter names across all of a listener's filter
+// chains (HTTPS gateways typically produce a single HCM filter chain per listener).
+func httpFilterNamesForListener(t *testing.T, l *listener.Listener) []string {
+	t.Helper()
+	if l == nil {
+		t.Fatalf("listener not found")
+	}
+	var httpFilters []string
+	for _, fc := range l.GetFilterChains() {
+		_, hf := xdstest.ExtractFilterNames(t, fc)
+		httpFilters = append(httpFilters, hf...)
+	}
+	return httpFilters
+}
+
+// classicGatewayTargetRef returns a targetRef pointing at a classic networking.istio.io Gateway.
+func classicGatewayTargetRef(gwName string) *apitypev1beta1.PolicyTargetReference {
+	return &apitypev1beta1.PolicyTargetReference{
+		Group: gvk.Gateway.Group, // networking.istio.io
+		Kind:  gvk.Gateway.Kind,  // Gateway
+		Name:  gwName,
+	}
+}
+
+func httpsGatewayConfig(name string, port uint32, hostName string) config.Config {
+	return config.Config{
+		Meta: config.Meta{Name: name, Namespace: "not-default", GroupVersionKind: gvk.Gateway},
+		Spec: &networking.Gateway{
+			Servers: []*networking.Server{
+				{
+					Port:  &networking.Port{Name: "https", Number: port, Protocol: "HTTPS"},
+					Hosts: []string{hostName},
+					Tls:   &networking.ServerTLSSettings{CredentialName: "test", Mode: networking.ServerTLSSettings_SIMPLE},
+				},
+			},
+		},
+	}
+}
+
+// TestBuildGatewayListenersAuthzTargetRefScoping is the "money" test: an AuthorizationPolicy whose
+// targetRef points at classic Gateway gw-a must produce the Envoy RBAC HTTP filter ONLY on gw-a's
+// HTTPS filter chain, and must NOT appear on the co-resident gw-b's HTTPS filter chain.
+func TestBuildGatewayListenersAuthzTargetRefScoping(t *testing.T) {
+	configs := []config.Config{
+		httpsGatewayConfig("gw-a", 443, "a.example.com"),
+		httpsGatewayConfig("gw-b", 8443, "b.example.com"),
+		{
+			Meta: config.Meta{Name: "authz-gw-a", Namespace: "not-default", GroupVersionKind: gvk.AuthorizationPolicy},
+			Spec: &security.AuthorizationPolicy{
+				Action:     security.AuthorizationPolicy_ALLOW,
+				TargetRefs: []*apitypev1beta1.PolicyTargetReference{classicGatewayTargetRef("gw-a")},
+				Rules: []*security.Rule{{
+					From: []*security.Rule_From{{
+						Source: &security.Source{Principals: []string{"cluster.local/ns/default/sa/client"}},
+					}},
+				}},
+			},
+		},
+	}
+
+	listeners := buildGatewayListenersForAuthzTest(t, configs)
+
+	gwAFilters := httpFilterNamesForListener(t, xdstest.ExtractListener("0.0.0.0_443", listeners))
+	gwBFilters := httpFilterNamesForListener(t, xdstest.ExtractListener("0.0.0.0_8443", listeners))
+
+	if !slices.Contains(gwAFilters, wellknown.HTTPRoleBasedAccessControl) {
+		t.Errorf("expected RBAC http filter %q on gw-a's HTTPS chain, got %v",
+			wellknown.HTTPRoleBasedAccessControl, gwAFilters)
+	}
+	if slices.Contains(gwBFilters, wellknown.HTTPRoleBasedAccessControl) {
+		t.Errorf("did NOT expect RBAC http filter %q on gw-b's HTTPS chain (policy targets gw-a only), got %v",
+			wellknown.HTTPRoleBasedAccessControl, gwBFilters)
+	}
+
+	// gw-b is not targeted, so its HTTPS chain must be byte-identical to the no-policy baseline.
+	baseline := buildGatewayListenersForAuthzTest(t, []config.Config{httpsGatewayConfig("gw-b", 8443, "b.example.com")})
+	baselineB := xdstest.ExtractListener("0.0.0.0_8443", baseline)
+	if diff := cmp.Diff(baselineB, xdstest.ExtractListener("0.0.0.0_8443", listeners), protocmp.Transform()); diff != "" {
+		t.Errorf("gw-b HTTPS listener changed by an unrelated targetRef policy (-baseline +got):\n%s", diff)
+	}
+}
+
+// TestBuildGatewayListenersAuthzNoTargetRefByteIdentical asserts the byte-identical/no-op invariant:
+// when NO classic-Gateway-targetRef policy is present, the per-gateway scoping path must leave the
+// HTTPS chain identical to today. A proxy-wide (selector-less) AuthorizationPolicy must still be
+// enforced on the HTTPS chain (RBAC present); with no policy at all, RBAC must be absent.
+func TestBuildGatewayListenersAuthzNoTargetRefByteIdentical(t *testing.T) {
+	gw := httpsGatewayConfig("gw", 443, "a.example.com")
+
+	// No authz policy: RBAC absent.
+	noPolicy := buildGatewayListenersForAuthzTest(t, []config.Config{gw})
+	if got := httpFilterNamesForListener(t, xdstest.ExtractListener("0.0.0.0_443", noPolicy)); slices.Contains(got, wellknown.HTTPRoleBasedAccessControl) {
+		t.Errorf("did not expect RBAC http filter with no authz policy, got %v", got)
+	}
+
+	// Proxy-wide (no targetRef) policy: RBAC present — enforcement is not weakened by scoping.
+	proxyWide := buildGatewayListenersForAuthzTest(t, []config.Config{
+		gw,
+		{
+			Meta: config.Meta{Name: "authz-proxywide", Namespace: "not-default", GroupVersionKind: gvk.AuthorizationPolicy},
+			Spec: &security.AuthorizationPolicy{Action: security.AuthorizationPolicy_ALLOW},
+		},
+	})
+	if got := httpFilterNamesForListener(t, xdstest.ExtractListener("0.0.0.0_443", proxyWide)); !slices.Contains(got, wellknown.HTTPRoleBasedAccessControl) {
+		t.Errorf("expected RBAC http filter for a proxy-wide (no-targetRef) policy, got %v", got)
+	}
+}
+
+// TestBuildGatewayListenersAuthzPlaintextHTTPUnaffected asserts plaintext HTTP chains (server == nil,
+// unknown provenance) are never scoped: a classic-Gateway-targetRef policy must NOT attach to a
+// plaintext HTTP chain (byte-identical to today, where such a policy would not attach), while a
+// proxy-wide policy continues to attach exactly as before.
+func TestBuildGatewayListenersAuthzPlaintextHTTPUnaffected(t *testing.T) {
+	httpGw := config.Config{
+		Meta: config.Meta{Name: "gw-http", Namespace: "not-default", GroupVersionKind: gvk.Gateway},
+		Spec: &networking.Gateway{
+			Servers: []*networking.Server{{
+				Port:  &networking.Port{Name: "http", Number: 80, Protocol: "HTTP"},
+				Hosts: []string{"a.example.com"},
+			}},
+		},
+	}
+
+	// A targetRef policy pointing at the plaintext HTTP gateway must NOT add RBAC to its HTTP chain.
+	targeted := buildGatewayListenersForAuthzTest(t, []config.Config{
+		httpGw,
+		{
+			Meta: config.Meta{Name: "authz-http", Namespace: "not-default", GroupVersionKind: gvk.AuthorizationPolicy},
+			Spec: &security.AuthorizationPolicy{
+				Action:     security.AuthorizationPolicy_ALLOW,
+				TargetRefs: []*apitypev1beta1.PolicyTargetReference{classicGatewayTargetRef("gw-http")},
+			},
+		},
+	})
+	if got := httpFilterNamesForListener(t, xdstest.ExtractListener("0.0.0.0_80", targeted)); slices.Contains(got, wellknown.HTTPRoleBasedAccessControl) {
+		t.Errorf("plaintext HTTP chain must not be scoped by a targetRef policy, got %v", got)
+	}
+
+	// The plaintext HTTP chain must be byte-identical to the no-policy baseline.
+	baseline := buildGatewayListenersForAuthzTest(t, []config.Config{httpGw})
+	if diff := cmp.Diff(xdstest.ExtractListener("0.0.0.0_80", baseline),
+		xdstest.ExtractListener("0.0.0.0_80", targeted), protocmp.Transform()); diff != "" {
+		t.Errorf("plaintext HTTP listener changed by a targetRef policy (-baseline +got):\n%s", diff)
+	}
+
+	// A proxy-wide policy still attaches to the plaintext HTTP chain, exactly as today.
+	proxyWide := buildGatewayListenersForAuthzTest(t, []config.Config{
+		httpGw,
+		{
+			Meta: config.Meta{Name: "authz-proxywide", Namespace: "not-default", GroupVersionKind: gvk.AuthorizationPolicy},
+			Spec: &security.AuthorizationPolicy{Action: security.AuthorizationPolicy_ALLOW},
+		},
+	})
+	if got := httpFilterNamesForListener(t, xdstest.ExtractListener("0.0.0.0_80", proxyWide)); !slices.Contains(got, wellknown.HTTPRoleBasedAccessControl) {
+		t.Errorf("expected RBAC http filter on plaintext HTTP chain for a proxy-wide policy, got %v", got)
 	}
 }

--- a/pilot/pkg/networking/core/gateway_test.go
+++ b/pilot/pkg/networking/core/gateway_test.go
@@ -5330,6 +5330,32 @@ func buildGatewayListenerBuilderForAuthzTest(t *testing.T, configs []config.Conf
 	return cg.ConfigGen.buildGatewayListeners(lb)
 }
 
+// buildGatewayListenerBuilderForAuthzCustomTest is like buildGatewayListenerBuilderForAuthzTest but
+// registers the "extauthz" extension provider (and its backing service in the ServiceIndex) so a CUSTOM
+// AuthorizationPolicy resolves to a real ext_authz HTTP filter instead of falling back to deny rules.
+func buildGatewayListenerBuilderForAuthzCustomTest(t *testing.T, configs []config.Config) *ListenerBuilder {
+	t.Helper()
+	mc := mesh.DefaultMeshConfig()
+	mc.ExtensionProviders = append(mc.ExtensionProviders, &meshconfig.MeshConfig_ExtensionProvider{
+		Name: "extauthz",
+		Provider: &meshconfig.MeshConfig_ExtensionProvider_EnvoyExtAuthzGrpc{
+			EnvoyExtAuthzGrpc: &meshconfig.MeshConfig_ExtensionProvider_EnvoyExternalAuthorizationGrpcProvider{
+				Service: "foo/example.local",
+				Port:    1234,
+			},
+		},
+	})
+	cg := NewConfigGenTest(t, TestOptions{Configs: configs, MeshConfig: mc})
+	cg.PushContext().ServiceIndex.HostnameAndNamespace = map[host.Name]map[string]*pilot_model.Service{
+		"example.local": {"foo": &pilot_model.Service{Hostname: "example.local"}},
+	}
+	proxy := cg.SetupProxy(&proxyGateway)
+	metadata := proxyGatewayMetadata
+	proxy.Metadata = &metadata
+	lb := NewListenerBuilder(proxy, cg.PushContext())
+	return cg.ConfigGen.buildGatewayListeners(lb)
+}
+
 // httpFilterNamesForListener aggregates the HTTP filter names across all of a listener's filter
 // chains (HTTPS gateways typically produce a single HCM filter chain per listener).
 func httpFilterNamesForListener(t *testing.T, l *listener.Listener) []string {
@@ -5449,6 +5475,25 @@ func classicGatewayTargetRefAuthz(name, gwName string) config.Config {
 	}
 }
 
+// classicGatewayTargetRefCustomAuthz returns a CUSTOM AuthorizationPolicy (ext_authz via the
+// "extauthz" provider) targeting a classic networking.istio.io Gateway, co-located in the proxy's
+// config namespace ("not-default").
+func classicGatewayTargetRefCustomAuthz(name, gwName string) config.Config {
+	return config.Config{
+		Meta: config.Meta{Name: name, Namespace: "not-default", GroupVersionKind: gvk.AuthorizationPolicy},
+		Spec: &security.AuthorizationPolicy{
+			Action:       security.AuthorizationPolicy_CUSTOM,
+			ActionDetail: &security.AuthorizationPolicy_Provider{Provider: &security.AuthorizationPolicy_ExtensionProvider{Name: "extauthz"}},
+			TargetRefs:   []*apitypev1beta1.PolicyTargetReference{classicGatewayTargetRef(gwName)},
+			Rules: []*security.Rule{{
+				From: []*security.Rule_From{{
+					Source: &security.Source{Principals: []string{"cluster.local/ns/default/sa/client"}},
+				}},
+			}},
+		},
+	}
+}
+
 // classicGatewayTargetRef returns a targetRef pointing at a classic networking.istio.io Gateway.
 func classicGatewayTargetRef(gwName string) *apitypev1beta1.PolicyTargetReference {
 	return &apitypev1beta1.PolicyTargetReference{
@@ -5459,8 +5504,14 @@ func classicGatewayTargetRef(gwName string) *apitypev1beta1.PolicyTargetReferenc
 }
 
 func httpsGatewayConfig(name string, port uint32, hostName string) config.Config {
+	return httpsGatewayConfigNS(name, "not-default", port, hostName)
+}
+
+// httpsGatewayConfigNS is httpsGatewayConfig parameterized by namespace. The Gateway is selector-less,
+// so with PILOT_SCOPE_GATEWAY_TO_NAMESPACE=false (default) it binds to the proxy regardless of namespace.
+func httpsGatewayConfigNS(name, ns string, port uint32, hostName string) config.Config {
 	return config.Config{
-		Meta: config.Meta{Name: name, Namespace: "not-default", GroupVersionKind: gvk.Gateway},
+		Meta: config.Meta{Name: name, Namespace: ns, GroupVersionKind: gvk.Gateway},
 		Spec: &networking.Gateway{
 			Servers: []*networking.Server{
 				{
@@ -5469,6 +5520,22 @@ func httpsGatewayConfig(name string, port uint32, hostName string) config.Config
 					Tls:   &networking.ServerTLSSettings{CredentialName: "test", Mode: networking.ServerTLSSettings_SIMPLE},
 				},
 			},
+		},
+	}
+}
+
+// classicGatewayTargetRefAuthzNS is classicGatewayTargetRefAuthz parameterized by namespace.
+func classicGatewayTargetRefAuthzNS(name, ns, gwName string) config.Config {
+	return config.Config{
+		Meta: config.Meta{Name: name, Namespace: ns, GroupVersionKind: gvk.AuthorizationPolicy},
+		Spec: &security.AuthorizationPolicy{
+			Action:     security.AuthorizationPolicy_ALLOW,
+			TargetRefs: []*apitypev1beta1.PolicyTargetReference{classicGatewayTargetRef(gwName)},
+			Rules: []*security.Rule{{
+				From: []*security.Rule_From{{
+					Source: &security.Source{Principals: []string{"cluster.local/ns/default/sa/client"}},
+				}},
+			}},
 		},
 	}
 }
@@ -5735,6 +5802,36 @@ func TestBuildGatewayListenersAuthzActivationGateHTTPS(t *testing.T) {
 	}
 }
 
+// TestBuildGatewayListenersAuthzActivationGateCustom asserts the activation gate is action-agnostic: a
+// CUSTOM (ext_authz) classic-Gateway-targetRef policy activates per-gateway scoping exactly like an ALLOW
+// one. It targets gw-a and asserts (1) the per-gateway authz builders exist for gw-a only, and (2) the
+// ext_authz HTTP filter is emitted only on gw-a's HTTPS chain, never on the co-resident untargeted gw-b.
+func TestBuildGatewayListenersAuthzActivationGateCustom(t *testing.T) {
+	gwA := types.NamespacedName{Namespace: "not-default", Name: "gw-a"}
+
+	lb := buildGatewayListenerBuilderForAuthzCustomTest(t, []config.Config{
+		httpsGatewayConfig("gw-a", 443, "a.example.com"),
+		httpsGatewayConfig("gw-b", 8443, "b.example.com"),
+		classicGatewayTargetRefCustomAuthz("authz-gw-a", "gw-a"),
+	})
+
+	if got := perGatewayAuthzBuilderKeys(lb); !got.Equals(sets.New(gwA)) {
+		t.Errorf("activation gate (CUSTOM): expected per-gateway authz builders for exactly %v, got %v",
+			sets.New(gwA).UnsortedList(), got.UnsortedList())
+	}
+
+	gwAFilters := httpFilterNamesForListener(t, xdstest.ExtractListener("0.0.0.0_443", lb.gatewayListeners))
+	gwBFilters := httpFilterNamesForListener(t, xdstest.ExtractListener("0.0.0.0_8443", lb.gatewayListeners))
+	if !slices.Contains(gwAFilters, wellknown.HTTPExternalAuthorization) {
+		t.Errorf("expected ext_authz http filter %q on gw-a's HTTPS chain, got %v",
+			wellknown.HTTPExternalAuthorization, gwAFilters)
+	}
+	if slices.Contains(gwBFilters, wellknown.HTTPExternalAuthorization) {
+		t.Errorf("did NOT expect ext_authz http filter %q on gw-b's HTTPS chain (CUSTOM policy targets gw-a only), got %v",
+			wellknown.HTTPExternalAuthorization, gwBFilters)
+	}
+}
+
 // TestBuildGatewayListenersAuthzActivationGateTCP is the network-filter (opaque-TCP) analog of the HTTPS
 // activation-gate test: buildCompleteNetworkFilters (networkfilter.go) diverges to a per-gateway authz
 // builder only when the chain's owning classic Gateway is in lb.authzTargetedGateways, so the untargeted
@@ -5758,5 +5855,64 @@ func TestBuildGatewayListenersAuthzActivationGateTCP(t *testing.T) {
 	if got := perGatewayAuthzBuilderKeys(noPolicy); got.Len() != 0 {
 		t.Errorf("activation gate (TCP): expected NO per-gateway authz builders with no targetRef policy, got %v",
 			got.UnsortedList())
+	}
+}
+
+// TestBuildGatewayListenersAuthzTargetRefScopingCrossNamespace is the shared-ingress topology: the classic
+// Gateway and its targetRef AuthorizationPolicy both live in a tenant namespace (tenant-a) while the proxy
+// stays in not-default. The RBAC HTTP filter must still be emitted on the gateway's HTTPS chain.
+func TestBuildGatewayListenersAuthzTargetRefScopingCrossNamespace(t *testing.T) {
+	configs := []config.Config{
+		httpsGatewayConfigNS("gateway", "tenant-a", 443, "a.example.com"),
+		classicGatewayTargetRefAuthzNS("authz", "tenant-a", "gateway"),
+	}
+
+	listeners := buildGatewayListenersForAuthzTest(t, configs)
+
+	got := httpFilterNamesForListener(t, xdstest.ExtractListener("0.0.0.0_443", listeners))
+	if !slices.Contains(got, wellknown.HTTPRoleBasedAccessControl) {
+		t.Errorf("expected RBAC http filter %q on cross-namespace gateway's HTTPS chain, got %v",
+			wellknown.HTTPRoleBasedAccessControl, got)
+	}
+}
+
+// TestBuildGatewayListenersAuthzActivationGateCrossNamespace asserts the activation gate fires for a
+// cross-namespace classic-Gateway targetRef: the tenant-a gateway must get a per-gateway authz builder.
+func TestBuildGatewayListenersAuthzActivationGateCrossNamespace(t *testing.T) {
+	lb := buildGatewayListenerBuilderForAuthzTest(t, []config.Config{
+		httpsGatewayConfigNS("gateway", "tenant-a", 443, "a.example.com"),
+		classicGatewayTargetRefAuthzNS("authz", "tenant-a", "gateway"),
+	})
+	want := sets.New(types.NamespacedName{Namespace: "tenant-a", Name: "gateway"})
+	if got := perGatewayAuthzBuilderKeys(lb); !got.Equals(want) {
+		t.Errorf("activation gate (cross-namespace): expected per-gateway authz builders for exactly %v, got %v",
+			want.UnsortedList(), got.UnsortedList())
+	}
+}
+
+// TestBuildGatewayListenersAuthzCrossNamespaceNoLeak is the anti-leak guard: a selector policy in the tenant
+// namespace (no targetRef) selecting the proxy's labels must NOT attach to the shared proxy's HTTPS chain.
+func TestBuildGatewayListenersAuthzCrossNamespaceNoLeak(t *testing.T) {
+	configs := []config.Config{
+		httpsGatewayConfigNS("gateway", "tenant-a", 443, "a.example.com"),
+		{
+			Meta: config.Meta{Name: "selleak", Namespace: "tenant-a", GroupVersionKind: gvk.AuthorizationPolicy},
+			Spec: &security.AuthorizationPolicy{
+				Action:   security.AuthorizationPolicy_ALLOW,
+				Selector: &apitypev1beta1.WorkloadSelector{MatchLabels: map[string]string{"istio": "ingressgateway"}},
+				Rules: []*security.Rule{{
+					From: []*security.Rule_From{{
+						Source: &security.Source{Principals: []string{"cluster.local/ns/default/sa/client"}},
+					}},
+				}},
+			},
+		},
+	}
+
+	listeners := buildGatewayListenersForAuthzTest(t, configs)
+
+	got := httpFilterNamesForListener(t, xdstest.ExtractListener("0.0.0.0_443", listeners))
+	if slices.Contains(got, wellknown.HTTPRoleBasedAccessControl) {
+		t.Errorf("selector policy in tenant namespace must not leak onto the shared proxy's HTTPS chain, got %v", got)
 	}
 }

--- a/pilot/pkg/networking/core/gateway_test.go
+++ b/pilot/pkg/networking/core/gateway_test.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/durationpb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
+	"k8s.io/apimachinery/pkg/types"
 
 	extensions "istio.io/api/extensions/v1alpha1"
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -4341,6 +4342,67 @@ func TestBuildGatewayListenersFilters(t *testing.T) {
 			},
 		},
 		{
+			// An AuthorizationPolicy whose targetRef points at a classic networking.istio.io Gateway
+			// scopes the RBAC *network* filter onto that gateway's TCP filter chain. The gateway and
+			// policy are co-located in the proxy's config namespace ("not-default") so the policy is in
+			// the authz lookup set and ShouldAttachPolicy's classic-Gateway branch
+			// (policy.Namespace == gateway.Namespace) matches.
+			name: "TCP RBAC scoped to targeted classic Gateway",
+			configs: []config.Config{
+				{
+					Meta: config.Meta{Name: "gw-tcp-a", Namespace: "not-default", GroupVersionKind: gvk.Gateway},
+					Spec: &networking.Gateway{
+						Servers: []*networking.Server{
+							{
+								Port:  &networking.Port{Name: "tcp", Number: 100, Protocol: "TCP"},
+								Hosts: []string{"www-a.example.com"},
+							},
+						},
+					},
+				},
+				{
+					Meta: config.Meta{Name: uuid.NewString(), Namespace: uuid.NewString(), GroupVersionKind: gvk.VirtualService},
+					Spec: &networking.VirtualService{
+						Gateways: []string{"not-default/gw-tcp-a"},
+						Hosts:    []string{"www-a.example.com"},
+						Tcp: []*networking.TCPRoute{
+							{
+								Route: []*networking.RouteDestination{
+									{
+										Destination: &networking.Destination{
+											Host: "http.com",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Meta: config.Meta{Name: "authz-gw-tcp-a", Namespace: "not-default", GroupVersionKind: gvk.AuthorizationPolicy},
+					Spec: &security.AuthorizationPolicy{
+						Action:     security.AuthorizationPolicy_ALLOW,
+						TargetRefs: []*apitypev1beta1.PolicyTargetReference{classicGatewayTargetRef("gw-tcp-a")},
+						Rules: []*security.Rule{{
+							From: []*security.Rule_From{{
+								Source: &security.Source{Principals: []string{"cluster.local/ns/default/sa/client"}},
+							}},
+						}},
+					},
+				},
+			},
+			expectedListener: listenertest.ListenerTest{
+				FilterChains: []listenertest.FilterChainTest{
+					{
+						NetworkFilters: []string{
+							wellknown.RoleBasedAccessControl,
+							wellknown.TCPProxy,
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "mTLS, RBAC, WASM, TrafficExtension, and Stats",
 			configs: []config.Config{
 				{
@@ -5248,12 +5310,24 @@ func TestGatewayListenerConnectionSettings(t *testing.T) {
 // TestBuildGatewayListenersFilters.
 func buildGatewayListenersForAuthzTest(t *testing.T, configs []config.Config) []*listener.Listener {
 	t.Helper()
+	return buildGatewayListenerBuilderForAuthzTest(t, configs).gatewayListeners
+}
+
+// buildGatewayListenerBuilderForAuthzTest is like buildGatewayListenersForAuthzTest but returns the
+// mutated *ListenerBuilder itself, so a test can inspect the per-classic-Gateway authz builder caches
+// (authzGatewayBuilders / authzCustomGatewayBuilders) that are populated as a side effect of building
+// the gateway listeners. A per-gateway builder is cached only when a chain diverges from the shared
+// proxy-wide authz builder, so the cache's key set is the observable for the activation gate: it must
+// contain exactly the classic Gateways actually targeted by an in-scope classic-Gateway-targetRef
+// AuthorizationPolicy, and nothing else.
+func buildGatewayListenerBuilderForAuthzTest(t *testing.T, configs []config.Config) *ListenerBuilder {
+	t.Helper()
 	cg := NewConfigGenTest(t, TestOptions{Configs: configs})
 	proxy := cg.SetupProxy(&proxyGateway)
 	metadata := proxyGatewayMetadata
 	proxy.Metadata = &metadata
 	lb := NewListenerBuilder(proxy, cg.PushContext())
-	return cg.ConfigGen.buildGatewayListeners(lb).gatewayListeners
+	return cg.ConfigGen.buildGatewayListeners(lb)
 }
 
 // httpFilterNamesForListener aggregates the HTTP filter names across all of a listener's filter
@@ -5269,6 +5343,110 @@ func httpFilterNamesForListener(t *testing.T, l *listener.Listener) []string {
 		httpFilters = append(httpFilters, hf...)
 	}
 	return httpFilters
+}
+
+// networkFilterNamesForListener aggregates the network (L4) filter names across all of a listener's
+// filter chains. TCP/passthrough gateways route through the network-filter path (not HCM), so RBAC
+// scoping there must be asserted on these names rather than the HTTP filter names.
+func networkFilterNamesForListener(t *testing.T, l *listener.Listener) []string {
+	t.Helper()
+	if l == nil {
+		t.Fatalf("listener not found")
+	}
+	var networkFilters []string
+	for _, fc := range l.GetFilterChains() {
+		nf, _ := xdstest.ExtractFilterNames(t, fc)
+		networkFilters = append(networkFilters, nf...)
+	}
+	return networkFilters
+}
+
+// tcpGatewayConfigs returns a classic opaque-TCP Gateway plus a VirtualService with a TCP route bound
+// to it, on the proxy's config namespace ("not-default") so a co-located targetRef policy can attach.
+func tcpGatewayConfigs(name string, port uint32, hostName string) []config.Config {
+	return []config.Config{
+		{
+			Meta: config.Meta{Name: name, Namespace: "not-default", GroupVersionKind: gvk.Gateway},
+			Spec: &networking.Gateway{
+				Servers: []*networking.Server{
+					{
+						Port:  &networking.Port{Name: "tcp", Number: port, Protocol: "TCP"},
+						Hosts: []string{hostName},
+					},
+				},
+			},
+		},
+		{
+			Meta: config.Meta{Name: uuid.NewString(), Namespace: uuid.NewString(), GroupVersionKind: gvk.VirtualService},
+			Spec: &networking.VirtualService{
+				Gateways: []string{"not-default/" + name},
+				Hosts:    []string{hostName},
+				Tcp: []*networking.TCPRoute{
+					{
+						Match: []*networking.L4MatchAttributes{{Port: port}},
+						Route: []*networking.RouteDestination{
+							{Destination: &networking.Destination{Host: "foo.com"}},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// passthroughGatewayConfigs returns a classic TLS-passthrough Gateway plus a VirtualService with a TLS
+// route bound to it, on the proxy's config namespace ("not-default"). Passthrough servers route
+// through the network-filter path via buildGatewayNetworkFiltersFromTLSRoutes.
+func passthroughGatewayConfigs(name string, port uint32, hostName string) []config.Config {
+	return []config.Config{
+		{
+			Meta: config.Meta{Name: name, Namespace: "not-default", GroupVersionKind: gvk.Gateway},
+			Spec: &networking.Gateway{
+				Servers: []*networking.Server{
+					{
+						Port:  &networking.Port{Name: "tls", Number: port, Protocol: "TLS"},
+						Hosts: []string{hostName},
+						Tls:   &networking.ServerTLSSettings{Mode: networking.ServerTLSSettings_PASSTHROUGH},
+					},
+				},
+			},
+		},
+		{
+			Meta: config.Meta{Name: uuid.NewString(), Namespace: uuid.NewString(), GroupVersionKind: gvk.VirtualService},
+			Spec: &networking.VirtualService{
+				Gateways: []string{"not-default/" + name},
+				Hosts:    []string{hostName},
+				Tls: []*networking.TLSRoute{
+					{
+						Match: []*networking.TLSMatchAttributes{
+							{Port: port, SniHosts: []string{hostName}},
+						},
+						Route: []*networking.RouteDestination{
+							{Destination: &networking.Destination{Host: "foo.com"}},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// classicGatewayTargetRefAuthz returns an ALLOW AuthorizationPolicy (with a real rule so the RBAC
+// filter is actually emitted) targeting a classic networking.istio.io Gateway, co-located in the
+// proxy's config namespace ("not-default").
+func classicGatewayTargetRefAuthz(name, gwName string) config.Config {
+	return config.Config{
+		Meta: config.Meta{Name: name, Namespace: "not-default", GroupVersionKind: gvk.AuthorizationPolicy},
+		Spec: &security.AuthorizationPolicy{
+			Action:     security.AuthorizationPolicy_ALLOW,
+			TargetRefs: []*apitypev1beta1.PolicyTargetReference{classicGatewayTargetRef(gwName)},
+			Rules: []*security.Rule{{
+				From: []*security.Rule_From{{
+					Source: &security.Source{Principals: []string{"cluster.local/ns/default/sa/client"}},
+				}},
+			}},
+		},
+	}
 }
 
 // classicGatewayTargetRef returns a targetRef pointing at a classic networking.istio.io Gateway.
@@ -5295,9 +5473,9 @@ func httpsGatewayConfig(name string, port uint32, hostName string) config.Config
 	}
 }
 
-// TestBuildGatewayListenersAuthzTargetRefScoping is the "money" test: an AuthorizationPolicy whose
-// targetRef points at classic Gateway gw-a must produce the Envoy RBAC HTTP filter ONLY on gw-a's
-// HTTPS filter chain, and must NOT appear on the co-resident gw-b's HTTPS filter chain.
+// TestBuildGatewayListenersAuthzTargetRefScoping is the core HTTPS scoping test: an
+// AuthorizationPolicy whose targetRef points at classic Gateway gw-a must produce the Envoy RBAC HTTP
+// filter ONLY on gw-a's HTTPS filter chain, and must NOT appear on the co-resident gw-b's HTTPS chain.
 func TestBuildGatewayListenersAuthzTargetRefScoping(t *testing.T) {
 	configs := []config.Config{
 		httpsGatewayConfig("gw-a", 443, "a.example.com"),
@@ -5411,5 +5589,174 @@ func TestBuildGatewayListenersAuthzPlaintextHTTPUnaffected(t *testing.T) {
 	})
 	if got := httpFilterNamesForListener(t, xdstest.ExtractListener("0.0.0.0_80", proxyWide)); !slices.Contains(got, wellknown.HTTPRoleBasedAccessControl) {
 		t.Errorf("expected RBAC http filter on plaintext HTTP chain for a proxy-wide policy, got %v", got)
+	}
+}
+
+// TestBuildGatewayListenersAuthzTargetRefScopingTCP is the network-filter analog of the HTTPS
+// scoping test: an AuthorizationPolicy whose targetRef points at classic opaque-TCP Gateway gw-tcp-a
+// must produce the Envoy RBAC *network* filter ONLY on gw-tcp-a's TCP filter chain, and must NOT
+// appear on the co-resident gw-tcp-b's TCP filter chain. The TCP/passthrough path scopes authz via
+// the per-gateway builder selected in buildCompleteNetworkFilters (networkfilter.go) from the
+// transient lb.authzGatewayName armed in createGatewayTCPFilterChainOpts.
+func TestBuildGatewayListenersAuthzTargetRefScopingTCP(t *testing.T) {
+	configs := append(tcpGatewayConfigs("gw-tcp-a", 100, "www-a.example.com"),
+		tcpGatewayConfigs("gw-tcp-b", 101, "www-b.example.com")...)
+	configs = append(configs, classicGatewayTargetRefAuthz("authz-gw-tcp-a", "gw-tcp-a"))
+
+	listeners := buildGatewayListenersForAuthzTest(t, configs)
+
+	gwAFilters := networkFilterNamesForListener(t, xdstest.ExtractListener("0.0.0.0_100", listeners))
+	gwBFilters := networkFilterNamesForListener(t, xdstest.ExtractListener("0.0.0.0_101", listeners))
+
+	if !slices.Contains(gwAFilters, wellknown.RoleBasedAccessControl) {
+		t.Errorf("expected RBAC network filter %q on gw-tcp-a's TCP chain, got %v",
+			wellknown.RoleBasedAccessControl, gwAFilters)
+	}
+	if slices.Contains(gwBFilters, wellknown.RoleBasedAccessControl) {
+		t.Errorf("did NOT expect RBAC network filter %q on gw-tcp-b's TCP chain (policy targets gw-tcp-a only), got %v",
+			wellknown.RoleBasedAccessControl, gwBFilters)
+	}
+
+	// gw-tcp-b is not targeted, so its TCP listener must be byte-identical to the no-policy baseline.
+	baseline := buildGatewayListenersForAuthzTest(t, tcpGatewayConfigs("gw-tcp-b", 101, "www-b.example.com"))
+	baselineB := xdstest.ExtractListener("0.0.0.0_101", baseline)
+	if diff := cmp.Diff(baselineB, xdstest.ExtractListener("0.0.0.0_101", listeners), protocmp.Transform()); diff != "" {
+		t.Errorf("gw-tcp-b TCP listener changed by an unrelated targetRef policy (-baseline +got):\n%s", diff)
+	}
+}
+
+// TestBuildGatewayListenersAuthzTargetRefScopingPassthrough is the TLS-passthrough analog: an
+// AuthorizationPolicy targeting classic passthrough Gateway gw-tls-a must produce the RBAC network
+// filter ONLY on gw-tls-a's passthrough filter chain, not on the co-resident gw-tls-b. Passthrough
+// servers route through buildGatewayNetworkFiltersFromTLSRoutes, which shares the same network
+// authz path as opaque TCP, so both are scoped by the per-gateway builder in buildCompleteNetworkFilters.
+func TestBuildGatewayListenersAuthzTargetRefScopingPassthrough(t *testing.T) {
+	configs := append(passthroughGatewayConfigs("gw-tls-a", 9443, "www-a.example.com"),
+		passthroughGatewayConfigs("gw-tls-b", 9444, "www-b.example.com")...)
+	configs = append(configs, classicGatewayTargetRefAuthz("authz-gw-tls-a", "gw-tls-a"))
+
+	listeners := buildGatewayListenersForAuthzTest(t, configs)
+
+	gwAFilters := networkFilterNamesForListener(t, xdstest.ExtractListener("0.0.0.0_9443", listeners))
+	gwBFilters := networkFilterNamesForListener(t, xdstest.ExtractListener("0.0.0.0_9444", listeners))
+
+	if !slices.Contains(gwAFilters, wellknown.RoleBasedAccessControl) {
+		t.Errorf("expected RBAC network filter %q on gw-tls-a's passthrough chain, got %v",
+			wellknown.RoleBasedAccessControl, gwAFilters)
+	}
+	if slices.Contains(gwBFilters, wellknown.RoleBasedAccessControl) {
+		t.Errorf("did NOT expect RBAC network filter %q on gw-tls-b's passthrough chain (policy targets gw-tls-a only), got %v",
+			wellknown.RoleBasedAccessControl, gwBFilters)
+	}
+
+	// gw-tls-b is not targeted, so its passthrough listener must be byte-identical to the baseline.
+	baseline := buildGatewayListenersForAuthzTest(t, passthroughGatewayConfigs("gw-tls-b", 9444, "www-b.example.com"))
+	baselineB := xdstest.ExtractListener("0.0.0.0_9444", baseline)
+	if diff := cmp.Diff(baselineB, xdstest.ExtractListener("0.0.0.0_9444", listeners), protocmp.Transform()); diff != "" {
+		t.Errorf("gw-tls-b passthrough listener changed by an unrelated targetRef policy (-baseline +got):\n%s", diff)
+	}
+}
+
+// TestBuildGatewayListenersAuthzTCPNoPolicyBaseline is the zero-impact guard for the network path:
+// with NO classic-Gateway-targetRef policy present, a TCP gateway's network-filter stack must be
+// exactly [TCPProxy] (no RBAC), and a proxy-wide (no-targetRef) policy must still be enforced (RBAC
+// present) — the existing "TCP RBAC and Stats" table case covers the proxy-wide-with-stats variant.
+func TestBuildGatewayListenersAuthzTCPNoPolicyBaseline(t *testing.T) {
+	// No authz policy: RBAC network filter absent.
+	noPolicy := buildGatewayListenersForAuthzTest(t, tcpGatewayConfigs("gw-tcp", 100, "www.example.com"))
+	if got := networkFilterNamesForListener(t, xdstest.ExtractListener("0.0.0.0_100", noPolicy)); slices.Contains(got, wellknown.RoleBasedAccessControl) {
+		t.Errorf("did not expect RBAC network filter with no authz policy, got %v", got)
+	}
+
+	// Proxy-wide (no targetRef) policy: RBAC network filter present — enforcement not weakened.
+	proxyWide := buildGatewayListenersForAuthzTest(t, append(tcpGatewayConfigs("gw-tcp", 100, "www.example.com"),
+		config.Config{
+			Meta: config.Meta{Name: "authz-proxywide", Namespace: "not-default", GroupVersionKind: gvk.AuthorizationPolicy},
+			Spec: &security.AuthorizationPolicy{Action: security.AuthorizationPolicy_ALLOW},
+		}))
+	if got := networkFilterNamesForListener(t, xdstest.ExtractListener("0.0.0.0_100", proxyWide)); !slices.Contains(got, wellknown.RoleBasedAccessControl) {
+		t.Errorf("expected RBAC network filter for a proxy-wide (no-targetRef) policy, got %v", got)
+	}
+}
+
+// perGatewayAuthzBuilderKeys returns the union of the classic-Gateway keys across both per-gateway
+// authz builder caches on the ListenerBuilder. A key is present iff a chain owned by that classic
+// Gateway diverged from the shared proxy-wide authz builder and constructed a dedicated per-gateway
+// builder (authz.NewBuilderForGateways). This set is the observable for the authz activation gate.
+func perGatewayAuthzBuilderKeys(lb *ListenerBuilder) sets.Set[types.NamespacedName] {
+	keys := sets.New[types.NamespacedName]()
+	for k := range lb.authzGatewayBuilders {
+		keys.Insert(k)
+	}
+	for k := range lb.authzCustomGatewayBuilders {
+		keys.Insert(k)
+	}
+	return keys
+}
+
+// TestBuildGatewayListenersAuthzActivationGateHTTPS asserts the authz activation gate for the HCM
+// (HTTPS) path: istiod must construct a per-classic-Gateway authz builder ONLY for gateways actually
+// targeted by an in-scope classic-Gateway-targetRef AuthorizationPolicy, reusing the shared proxy-wide
+// builder for every other gateway.
+//
+// The gate is xDS-invisible: an untargeted gateway's per-gateway builder would resolve to the same
+// policy set as the proxy-wide builder, so filter output is byte-identical either way. It can only be
+// observed through the per-gateway builder caches -- constructing one is a NewBuilderForGateways scan +
+// allocation that an untargeted gateway does not need.
+//
+// The gate is a precomputed "targeted gateways" set on the ListenerBuilder (authzTargetedGateways),
+// populated in NewListenerBuilder from AuthorizationPolicies.GatewaysTargetedByTargetRef over
+// {RootNamespace, node.ConfigNamespace} for policies whose targetRefs include a classic Gateway
+// (group networking.istio.io, kind Gateway) under the same-namespace rule; authzBuildersForChain and
+// buildCompleteNetworkFilters diverge from the proxy-wide path only for gateways in that set.
+func TestBuildGatewayListenersAuthzActivationGateHTTPS(t *testing.T) {
+	gwA := types.NamespacedName{Namespace: "not-default", Name: "gw-a"}
+
+	// Case 1: gw-a targeted, gw-b co-resident but untargeted. Only gw-a may get a per-gateway builder.
+	targeted := buildGatewayListenerBuilderForAuthzTest(t, []config.Config{
+		httpsGatewayConfig("gw-a", 443, "a.example.com"),
+		httpsGatewayConfig("gw-b", 8443, "b.example.com"),
+		classicGatewayTargetRefAuthz("authz-gw-a", "gw-a"),
+	})
+	if got := perGatewayAuthzBuilderKeys(targeted); !got.Equals(sets.New(gwA)) {
+		t.Errorf("activation gate (HTTPS): expected per-gateway authz builders for exactly %v, got %v",
+			sets.New(gwA).UnsortedList(), got.UnsortedList())
+	}
+
+	// Case 2: no classic-Gateway-targetRef policy at all. No per-gateway builder may be constructed;
+	// both gateways must reuse the shared proxy-wide builder.
+	noPolicy := buildGatewayListenerBuilderForAuthzTest(t, []config.Config{
+		httpsGatewayConfig("gw-a", 443, "a.example.com"),
+		httpsGatewayConfig("gw-b", 8443, "b.example.com"),
+	})
+	if got := perGatewayAuthzBuilderKeys(noPolicy); got.Len() != 0 {
+		t.Errorf("activation gate (HTTPS): expected NO per-gateway authz builders with no targetRef policy, got %v",
+			got.UnsortedList())
+	}
+}
+
+// TestBuildGatewayListenersAuthzActivationGateTCP is the network-filter (opaque-TCP) analog of the HTTPS
+// activation-gate test: buildCompleteNetworkFilters (networkfilter.go) diverges to a per-gateway authz
+// builder only when the chain's owning classic Gateway is in lb.authzTargetedGateways, so the untargeted
+// gw-tcp-b -- and both gateways in the no-policy case -- reuse the shared proxy-wide builder. Same gate as
+// the HTTPS case.
+func TestBuildGatewayListenersAuthzActivationGateTCP(t *testing.T) {
+	gwA := types.NamespacedName{Namespace: "not-default", Name: "gw-tcp-a"}
+
+	configs := append(tcpGatewayConfigs("gw-tcp-a", 100, "www-a.example.com"),
+		tcpGatewayConfigs("gw-tcp-b", 101, "www-b.example.com")...)
+	configs = append(configs, classicGatewayTargetRefAuthz("authz-gw-tcp-a", "gw-tcp-a"))
+	targeted := buildGatewayListenerBuilderForAuthzTest(t, configs)
+	if got := perGatewayAuthzBuilderKeys(targeted); !got.Equals(sets.New(gwA)) {
+		t.Errorf("activation gate (TCP): expected per-gateway authz builders for exactly %v, got %v",
+			sets.New(gwA).UnsortedList(), got.UnsortedList())
+	}
+
+	noPolicy := buildGatewayListenerBuilderForAuthzTest(t, append(
+		tcpGatewayConfigs("gw-tcp-a", 100, "www-a.example.com"),
+		tcpGatewayConfigs("gw-tcp-b", 101, "www-b.example.com")...))
+	if got := perGatewayAuthzBuilderKeys(noPolicy); got.Len() != 0 {
+		t.Errorf("activation gate (TCP): expected NO per-gateway authz builders with no targetRef policy, got %v",
+			got.UnsortedList())
 	}
 }

--- a/pilot/pkg/networking/core/gateway_test.go
+++ b/pilot/pkg/networking/core/gateway_test.go
@@ -5664,7 +5664,7 @@ func TestBuildGatewayListenersAuthzPlaintextHTTPUnaffected(t *testing.T) {
 // must produce the Envoy RBAC *network* filter ONLY on gw-tcp-a's TCP filter chain, and must NOT
 // appear on the co-resident gw-tcp-b's TCP filter chain. The TCP/passthrough path scopes authz via
 // the per-gateway builder selected in buildCompleteNetworkFilters (networkfilter.go) from the
-// transient lb.authzGatewayName armed in createGatewayTCPFilterChainOpts.
+// authzGateway identity threaded down from buildGatewayNetworkFiltersFrom{TCP,TLS}Routes.
 func TestBuildGatewayListenersAuthzTargetRefScopingTCP(t *testing.T) {
 	configs := append(tcpGatewayConfigs("gw-tcp-a", 100, "www-a.example.com"),
 		tcpGatewayConfigs("gw-tcp-b", 101, "www-b.example.com")...)

--- a/pilot/pkg/networking/core/listener.go
+++ b/pilot/pkg/networking/core/listener.go
@@ -32,6 +32,7 @@ import (
 	auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"google.golang.org/protobuf/types/known/durationpb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
+	"k8s.io/apimachinery/pkg/types"
 
 	extensions "istio.io/api/extensions/v1alpha1"
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -1060,6 +1061,11 @@ type httpListenerOpts struct {
 	// allow service attached policy for to-service chains
 	// currently only used for waypoints
 	policySvc *model.Service
+
+	// gatewayName identifies the classic Gateway that owns this filter chain, when known
+	// (chains built from a specific *networking.Server: HTTPS/QUIC/TCP). When set, authz is
+	// scoped to policies targeting this gateway. Plaintext HTTP chains leave it zero.
+	gatewayName types.NamespacedName
 }
 
 // filterChainOpts describes a filter chain: a set of filters with the same TLS context

--- a/pilot/pkg/networking/core/listener_builder.go
+++ b/pilot/pkg/networking/core/listener_builder.go
@@ -46,6 +46,7 @@ import (
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/proto"
+	"istio.io/istio/pkg/util/sets"
 	"istio.io/istio/pkg/wellknown"
 )
 
@@ -81,6 +82,16 @@ type ListenerBuilder struct {
 	// keyed by the owning Gateway, so the many filter chains of one gateway share a builder.
 	authzGatewayBuilders       map[types.NamespacedName]*authz.Builder
 	authzCustomGatewayBuilders map[types.NamespacedName]*authz.Builder
+
+	// authzGatewayName is transient scratch state, set only while a classic-Gateway TCP or TLS
+	// chain's network filters are built, so buildCompleteNetworkFilters can scope authz to the
+	// owning Gateway. The zero value means "use the proxy-wide builders".
+	authzGatewayName types.NamespacedName
+
+	// authzTargetedGateways is the set of classic Gateways targeted by an in-scope
+	// classic-Gateway-targetRef AuthorizationPolicy. Per-gateway authz scoping activates only for
+	// Gateways in this set; every other chain reuses the shared proxy-wide builders. Computed once.
+	authzTargetedGateways sets.Set[types.NamespacedName]
 }
 
 // enabledInspector captures if for a given listener, listener filter inspectors are added
@@ -98,6 +109,9 @@ func NewListenerBuilder(node *model.Proxy, push *model.PushContext) *ListenerBui
 	builder.authnBuilder = authn.NewBuilder(push, node)
 	builder.authzBuilder = authz.NewBuilder(authz.Local, push, node, node.Type == model.Waypoint)
 	builder.authzCustomBuilder = authz.NewBuilder(authz.Custom, push, node, node.Type == model.Waypoint)
+	if node.Type == model.Router {
+		builder.authzTargetedGateways = push.AuthzPolicies.GatewaysTargetedByTargetRef(node.ConfigNamespace)
+	}
 	return builder
 }
 
@@ -570,10 +584,12 @@ func (lb *ListenerBuilder) buildHTTPConnectionManager(httpOpts *httpListenerOpts
 }
 
 // authzBuildersForChain returns the (Local, Custom) authz builders for an HTTP filter chain:
-// per-gateway builders for a classic Gateway chain with a known owner, and the shared proxy-wide
-// builders for every other chain (which keeps their output byte-identical).
+// per-gateway builders for a classic Gateway TARGETED by a targetRef AuthorizationPolicy, and the
+// shared proxy-wide builders for every other chain. Reusing the shared builders for every untargeted
+// chain keeps their output byte-identical to the pre-scoping behavior.
 func (lb *ListenerBuilder) authzBuildersForChain(httpOpts *httpListenerOpts) (local, custom *authz.Builder) {
-	if httpOpts.class != istionetworking.ListenerClassGateway || httpOpts.gatewayName == (types.NamespacedName{}) {
+	if httpOpts.class != istionetworking.ListenerClassGateway ||
+		!lb.authzTargetedGateways.Contains(httpOpts.gatewayName) {
 		return lb.authzBuilder, lb.authzCustomBuilder
 	}
 	return lb.gatewayAuthzBuilder(authz.Local, httpOpts.gatewayName),

--- a/pilot/pkg/networking/core/listener_builder.go
+++ b/pilot/pkg/networking/core/listener_builder.go
@@ -76,6 +76,11 @@ type ListenerBuilder struct {
 	authzBuilder *authz.Builder
 	// authzCustomBuilder provides access to CUSTOM authz configuration for the given proxy.
 	authzCustomBuilder *authz.Builder
+
+	// authzGatewayBuilders and its CUSTOM counterpart cache per-classic-Gateway authz builders
+	// keyed by the owning Gateway, so the many filter chains of one gateway share a builder.
+	authzGatewayBuilders       map[types.NamespacedName]*authz.Builder
+	authzCustomGatewayBuilders map[types.NamespacedName]*authz.Builder
 }
 
 // enabledInspector captures if for a given listener, listener filter inspectors are added
@@ -476,12 +481,13 @@ func (lb *ListenerBuilder) buildHTTPConnectionManager(httpOpts *httpListenerOpts
 		// Metadata exchange filter needs to be added before any other HTTP filters are added. This is done to
 		// ensure that mx filter comes before HTTP RBAC filter. This is related to https://github.com/istio/istio/issues/41066
 		filters = appendMxFilter(httpOpts, filters)
+		authzBuilder, authzCustomBuilder := lb.authzBuildersForChain(httpOpts)
 		// TODO: how to deal with ext-authz? It will be in the ordering twice
-		filters = append(filters, lb.authzCustomBuilder.BuildHTTP(httpOpts.class)...)
+		filters = append(filters, authzCustomBuilder.BuildHTTP(httpOpts.class)...)
 		filters = extension.PopAppendHTTPTrafficExtension(filters, trafficExtensions, extensions.TrafficExtension_AUTHN)
 		filters = append(filters, lb.authnBuilder.BuildHTTP(httpOpts.class)...)
 		filters = extension.PopAppendHTTPTrafficExtension(filters, trafficExtensions, extensions.TrafficExtension_AUTHZ)
-		filters = append(filters, lb.authzBuilder.BuildHTTP(httpOpts.class)...)
+		filters = append(filters, authzBuilder.BuildHTTP(httpOpts.class)...)
 		// TODO: these feel like the wrong place to insert, but this retains backwards compatibility with the original implementation
 		filters = extension.PopAppendHTTPTrafficExtension(filters, trafficExtensions, extensions.TrafficExtension_STATS)
 		filters = extension.PopAppendHTTPTrafficExtension(filters, trafficExtensions, extensions.TrafficExtension_UNSPECIFIED)
@@ -561,6 +567,35 @@ func (lb *ListenerBuilder) buildHTTPConnectionManager(httpOpts *httpListenerOpts
 	}
 	connectionManager.Proxy_100Continue = features.Enable100ContinueHeaders
 	return connectionManager
+}
+
+// authzBuildersForChain returns the (Local, Custom) authz builders for an HTTP filter chain:
+// per-gateway builders for a classic Gateway chain with a known owner, and the shared proxy-wide
+// builders for every other chain (which keeps their output byte-identical).
+func (lb *ListenerBuilder) authzBuildersForChain(httpOpts *httpListenerOpts) (local, custom *authz.Builder) {
+	if httpOpts.class != istionetworking.ListenerClassGateway || httpOpts.gatewayName == (types.NamespacedName{}) {
+		return lb.authzBuilder, lb.authzCustomBuilder
+	}
+	return lb.gatewayAuthzBuilder(authz.Local, httpOpts.gatewayName),
+		lb.gatewayAuthzBuilder(authz.Custom, httpOpts.gatewayName)
+}
+
+// gatewayAuthzBuilder returns the cached per-gateway authz builder, building it on first use.
+func (lb *ListenerBuilder) gatewayAuthzBuilder(actionType authz.ActionType, gatewayName types.NamespacedName) *authz.Builder {
+	useFilterState := lb.node.Type == model.Waypoint
+	cache := &lb.authzGatewayBuilders
+	if actionType == authz.Custom {
+		cache = &lb.authzCustomGatewayBuilders
+	}
+	if *cache == nil {
+		*cache = map[types.NamespacedName]*authz.Builder{}
+	}
+	if b, ok := (*cache)[gatewayName]; ok {
+		return b
+	}
+	b := authz.NewBuilderForGateways(actionType, lb.push, lb.node, useFilterState, []types.NamespacedName{gatewayName})
+	(*cache)[gatewayName] = b
+	return b
 }
 
 func appendMxFilter(httpOpts *httpListenerOpts, filters []*hcm.HttpFilter) []*hcm.HttpFilter {

--- a/pilot/pkg/networking/core/listener_builder.go
+++ b/pilot/pkg/networking/core/listener_builder.go
@@ -83,11 +83,6 @@ type ListenerBuilder struct {
 	authzGatewayBuilders       map[types.NamespacedName]*authz.Builder
 	authzCustomGatewayBuilders map[types.NamespacedName]*authz.Builder
 
-	// authzGatewayName is transient scratch state, set only while a classic-Gateway TCP or TLS
-	// chain's network filters are built, so buildCompleteNetworkFilters can scope authz to the
-	// owning Gateway. The zero value means "use the proxy-wide builders".
-	authzGatewayName types.NamespacedName
-
 	// authzTargetedGateways is the set of classic Gateways targeted by an in-scope
 	// classic-Gateway-targetRef AuthorizationPolicy. Per-gateway authz scoping activates only for
 	// Gateways in this set; every other chain reuses the shared proxy-wide builders. Computed once.

--- a/pilot/pkg/networking/core/listener_builder.go
+++ b/pilot/pkg/networking/core/listener_builder.go
@@ -110,9 +110,28 @@ func NewListenerBuilder(node *model.Proxy, push *model.PushContext) *ListenerBui
 	builder.authzBuilder = authz.NewBuilder(authz.Local, push, node, node.Type == model.Waypoint)
 	builder.authzCustomBuilder = authz.NewBuilder(authz.Custom, push, node, node.Type == model.Waypoint)
 	if node.Type == model.Router {
-		builder.authzTargetedGateways = push.AuthzPolicies.GatewaysTargetedByTargetRef(node.ConfigNamespace)
+		builder.authzTargetedGateways = push.AuthzPolicies.GatewaysTargetedByTargetRef(
+			node.ConfigNamespace, boundGatewayNamespaces(node)...)
 	}
 	return builder
+}
+
+// boundGatewayNamespaces returns the distinct namespaces of the classic Gateways bound to the proxy,
+// derived from the merged gateway's "namespace/name" identifiers. It is nil-safe and skips malformed
+// names. These namespaces are where cross-namespace classic-Gateway targetRef policies may live.
+func boundGatewayNamespaces(node *model.Proxy) []string {
+	if node.MergedGateway == nil {
+		return nil
+	}
+	namespaces := sets.New[string]()
+	for _, name := range node.MergedGateway.GetGatewayNames() {
+		nn := parseGatewayName(name)
+		if nn == (types.NamespacedName{}) {
+			continue
+		}
+		namespaces.Insert(nn.Namespace)
+	}
+	return namespaces.UnsortedList()
 }
 
 func maxConnectionsToAcceptPerSocketEvent() *wrappers.UInt32Value {

--- a/pilot/pkg/networking/core/listener_inbound.go
+++ b/pilot/pkg/networking/core/listener_inbound.go
@@ -902,5 +902,6 @@ func (lb *ListenerBuilder) buildInboundNetworkFilters(fcc inboundChainConfig) []
 	}
 	tcpFilter := setAccessLogAndBuildTCPFilter(lb.push, lb.node, tcpProxy, istionetworking.ListenerClassSidecarInbound, fcc.policyService)
 	networkFilterstack := buildNetworkFiltersStack(fcc.port.Protocol, tcpFilter, statPrefix, fcc.clusterName)
-	return lb.buildCompleteNetworkFilters(istionetworking.ListenerClassSidecarInbound, fcc.port.Port, networkFilterstack, true, fcc.policyService)
+	return lb.buildCompleteNetworkFilters(istionetworking.ListenerClassSidecarInbound, fcc.port.Port, networkFilterstack, true,
+		networkFilterOptions{policySvc: fcc.policyService})
 }

--- a/pilot/pkg/networking/core/listener_waypoint.go
+++ b/pilot/pkg/networking/core/listener_waypoint.go
@@ -1042,7 +1042,8 @@ func (lb *ListenerBuilder) buildWaypointNetworkFilters(svc *model.Service, fcc i
 		// Add SNI DFP before the TCP proxy so it can use SNI to resolve DNS
 		networkFilterstack = append([]*listener.Filter{sniDFPFilter}, networkFilterstack...)
 	}
-	return lb.buildCompleteNetworkFilters(istionetworking.ListenerClassSidecarInbound, fcc.port.Port, networkFilterstack, true, fcc.policyService)
+	return lb.buildCompleteNetworkFilters(istionetworking.ListenerClassSidecarInbound, fcc.port.Port, networkFilterstack, true,
+		networkFilterOptions{policySvc: fcc.policyService})
 }
 
 var meshGateways = sets.New(constants.IstioMeshGateway)

--- a/pilot/pkg/networking/core/networkfilter.go
+++ b/pilot/pkg/networking/core/networkfilter.go
@@ -209,7 +209,11 @@ func (lb *ListenerBuilder) buildCompleteNetworkFilters(
 ) []*listener.Filter {
 	authzCustomBuilder := lb.authzCustomBuilder
 	authzBuilder := lb.authzBuilder
-	if policySvc != nil {
+	switch {
+	case class == istionetworking.ListenerClassGateway && lb.authzTargetedGateways.Contains(lb.authzGatewayName):
+		authzBuilder = lb.gatewayAuthzBuilder(authz.Local, lb.authzGatewayName)
+		authzCustomBuilder = lb.gatewayAuthzBuilder(authz.Custom, lb.authzGatewayName)
+	case policySvc != nil:
 		useFilterState := lb.node.Type == model.Waypoint
 		authzBuilder = authz.NewBuilderForService(authz.Local, lb.push, lb.node, useFilterState, policySvc)
 		authzCustomBuilder = authz.NewBuilderForService(authz.Custom, lb.push, lb.node, useFilterState, policySvc)

--- a/pilot/pkg/networking/core/networkfilter.go
+++ b/pilot/pkg/networking/core/networkfilter.go
@@ -35,6 +35,7 @@ import (
 	anypb "google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
+	"k8s.io/apimachinery/pkg/types"
 
 	extensions "istio.io/api/extensions/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
@@ -170,11 +171,20 @@ func buildAllowAnyDynamicDNSHTTPForwardProxyFilter(meta *model.NodeMetadata) *hc
 	}
 }
 
+// networkFilterOptions carries the per-filter-chain context that selects which authz builder a
+// network filter stack uses. authzGateway scopes authz to the owning classic Gateway (its zero
+// value means "use the proxy-wide builders"); policySvc scopes authz and telemetry to a specific
+// service. In practice a chain belongs to a gateway or a service, not both.
+type networkFilterOptions struct {
+	policySvc    *model.Service
+	authzGateway types.NamespacedName
+}
+
 // buildOutboundNetworkFiltersWithSingleDestination takes a single cluster name
 // and builds a stack of network filters.
 func (lb *ListenerBuilder) buildOutboundNetworkFiltersWithSingleDestination(
 	statPrefix, clusterName, subsetName string, port *model.Port, destinationRule *networking.DestinationRule, applyTunnelingConfig tunnelingconfig.ApplyFunc,
-	includeMx bool, service *model.Service,
+	includeMx bool, service *model.Service, authzGateway types.NamespacedName,
 ) []*listener.Filter {
 	idleTimeout := destinationRule.GetTrafficPolicy().GetConnectionPool().GetTcp().GetIdleTimeout()
 	if idleTimeout == nil {
@@ -195,9 +205,11 @@ func (lb *ListenerBuilder) buildOutboundNetworkFiltersWithSingleDestination(
 
 	// Only pass service for DYNAMIC_DNS wildcard services that need SNI DFP filtering
 	if service != nil && service.Hostname.IsWildCarded() && service.Resolution == model.DynamicDNS {
-		return lb.buildCompleteNetworkFilters(class, port.Port, networkFilterStack, includeMx, service)
+		return lb.buildCompleteNetworkFilters(class, port.Port, networkFilterStack, includeMx,
+			networkFilterOptions{policySvc: service, authzGateway: authzGateway})
 	}
-	return lb.buildCompleteNetworkFilters(class, port.Port, networkFilterStack, includeMx, nil)
+	return lb.buildCompleteNetworkFilters(class, port.Port, networkFilterStack, includeMx,
+		networkFilterOptions{authzGateway: authzGateway})
 }
 
 func (lb *ListenerBuilder) buildCompleteNetworkFilters(
@@ -205,14 +217,15 @@ func (lb *ListenerBuilder) buildCompleteNetworkFilters(
 	port int,
 	networkFilterStack []*listener.Filter,
 	includeMx bool,
-	policySvc *model.Service,
+	opts networkFilterOptions,
 ) []*listener.Filter {
+	policySvc := opts.policySvc
 	authzCustomBuilder := lb.authzCustomBuilder
 	authzBuilder := lb.authzBuilder
 	switch {
-	case class == istionetworking.ListenerClassGateway && lb.authzTargetedGateways.Contains(lb.authzGatewayName):
-		authzBuilder = lb.gatewayAuthzBuilder(authz.Local, lb.authzGatewayName)
-		authzCustomBuilder = lb.gatewayAuthzBuilder(authz.Custom, lb.authzGatewayName)
+	case class == istionetworking.ListenerClassGateway && lb.authzTargetedGateways.Contains(opts.authzGateway):
+		authzBuilder = lb.gatewayAuthzBuilder(authz.Local, opts.authzGateway)
+		authzCustomBuilder = lb.gatewayAuthzBuilder(authz.Custom, opts.authzGateway)
 	case policySvc != nil:
 		useFilterState := lb.node.Type == model.Waypoint
 		authzBuilder = authz.NewBuilderForService(authz.Local, lb.push, lb.node, useFilterState, policySvc)
@@ -262,7 +275,7 @@ func (lb *ListenerBuilder) buildCompleteNetworkFilters(
 // destination routes and builds a stack of network filters.
 func (lb *ListenerBuilder) buildOutboundNetworkFiltersWithWeightedClusters(routes []*networking.RouteDestination,
 	port *model.Port, configMeta config.Meta, destinationRule *networking.DestinationRule,
-	includeMx bool,
+	includeMx bool, authzGateway types.NamespacedName,
 ) []*listener.Filter {
 	statPrefix := configMeta.Name + "." + configMeta.Namespace
 	clusterSpecifier := &tcp.TcpProxy_WeightedClusters{
@@ -303,7 +316,8 @@ func (lb *ListenerBuilder) buildOutboundNetworkFiltersWithWeightedClusters(route
 	tcpFilter := setAccessLogAndBuildTCPFilter(lb.push, lb.node, tcpProxy, class, nil)
 	networkFilterStack := buildNetworkFiltersStack(port.Protocol, tcpFilter, statPrefix, clusterName)
 
-	return lb.buildCompleteNetworkFilters(class, port.Port, networkFilterStack, includeMx, nil)
+	return lb.buildCompleteNetworkFilters(class, port.Port, networkFilterStack, includeMx,
+		networkFilterOptions{authzGateway: authzGateway})
 }
 
 func maybeSetHashPolicy(destinationRule *networking.DestinationRule, tcpProxy *tcp.TcpProxy, subsetName string) {
@@ -368,7 +382,7 @@ func buildNetworkFiltersStack(p protocol.Instance, tcpFilter *listener.Filter, s
 // filter).
 func (lb *ListenerBuilder) buildOutboundNetworkFilters(
 	routes []*networking.RouteDestination,
-	port *model.Port, configMeta config.Meta, includeMx bool,
+	port *model.Port, configMeta config.Meta, includeMx bool, authzGateway types.NamespacedName,
 ) []*listener.Filter {
 	push, node := lb.push, lb.node
 	service := push.ServiceForHostname(node, host.Name(routes[0].Destination.Host))
@@ -386,9 +400,9 @@ func (lb *ListenerBuilder) buildOutboundNetworkFilters(
 		}
 
 		return lb.buildOutboundNetworkFiltersWithSingleDestination(
-			statPrefix, clusterName, routes[0].Destination.Subset, port, destinationRule, tunnelingconfig.Apply, includeMx, nil)
+			statPrefix, clusterName, routes[0].Destination.Subset, port, destinationRule, tunnelingconfig.Apply, includeMx, nil, authzGateway)
 	}
-	return lb.buildOutboundNetworkFiltersWithWeightedClusters(routes, port, configMeta, destinationRule, includeMx)
+	return lb.buildOutboundNetworkFiltersWithWeightedClusters(routes, port, configMeta, destinationRule, includeMx, authzGateway)
 }
 
 // buildMongoFilter builds an outbound Envoy MongoProxy filter.

--- a/pilot/pkg/networking/core/networkfilter_test.go
+++ b/pilot/pkg/networking/core/networkfilter_test.go
@@ -28,6 +28,7 @@ import (
 	cares "github.com/envoyproxy/go-control-plane/envoy/extensions/network/dns_resolver/cares/v3"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"k8s.io/apimachinery/pkg/types"
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/api/security/v1beta1"
@@ -309,7 +310,7 @@ func TestOutboundNetworkFilterIdleTimeout(t *testing.T) {
 			})
 			lb := ListenerBuilder{node: proxy, push: cg.PushContext()}
 			filters := lb.buildOutboundNetworkFilters(tt.routes, &model.Port{Port: 443},
-				config.Meta{Name: "routing-config-for-example-com", Namespace: "not-default"}, false)
+				config.Meta{Name: "routing-config-for-example-com", Namespace: "not-default"}, false, types.NamespacedName{})
 
 			tcpProxy := xdstest.ExtractTCPProxy(t, &listener.FilterChain{Filters: filters})
 			if !reflect.DeepEqual(tcpProxy.IdleTimeout, tt.expected) {
@@ -517,7 +518,7 @@ func TestBuildOutboundNetworkFiltersTunnelingConfig(t *testing.T) {
 			proxy := cg.SetupProxy(&model.Proxy{ConfigNamespace: ns})
 			lb := ListenerBuilder{node: proxy, push: cg.PushContext()}
 			filters := lb.buildOutboundNetworkFilters(tt.routeDestinations,
-				&model.Port{Port: 443}, config.Meta{Name: "routing-config-for-example-com", Namespace: ns}, false)
+				&model.Port{Port: 443}, config.Meta{Name: "routing-config-for-example-com", Namespace: ns}, false, types.NamespacedName{})
 
 			tcpProxy := xdstest.ExtractTCPProxy(t, &listener.FilterChain{Filters: filters})
 			if tt.expectedTunnelingConfig == nil {
@@ -640,7 +641,7 @@ func TestOutboundNetworkFilterStatPrefix(t *testing.T) {
 			lb := ListenerBuilder{node: cg.SetupProxy(nil), push: cg.PushContext()}
 			listeners := lb.buildOutboundNetworkFilters(
 				tt.routes,
-				&model.Port{Port: 9999}, config.Meta{Name: "test.com", Namespace: "ns"}, false)
+				&model.Port{Port: 9999}, config.Meta{Name: "test.com", Namespace: "ns"}, false, types.NamespacedName{})
 			tcp := &tcp.TcpProxy{}
 			listeners[0].GetTypedConfig().UnmarshalTo(tcp)
 			if tcp.StatPrefix != tt.expectedStatPrefix {
@@ -835,7 +836,7 @@ func TestOutboundNetworkFilterWithSourceIPHashing(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			lb := ListenerBuilder{node: proxy, push: cg.PushContext()}
-			listeners := lb.buildOutboundNetworkFilters(tt.routes, &model.Port{Port: 9999}, tt.configMeta, false)
+			listeners := lb.buildOutboundNetworkFilters(tt.routes, &model.Port{Port: 9999}, tt.configMeta, false, types.NamespacedName{})
 			tcp := &tcp.TcpProxy{}
 			listeners[0].GetTypedConfig().UnmarshalTo(tcp)
 			hasSourceIP := len(tcp.HashPolicy) == 1 && tcp.HashPolicy[0].GetSourceIp() != nil

--- a/pilot/pkg/networking/core/tls.go
+++ b/pilot/pkg/networking/core/tls.go
@@ -18,6 +18,8 @@ import (
 	"sort"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	"istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core/tunnelingconfig"
@@ -158,7 +160,7 @@ func buildSidecarOutboundTLSFilterChainOpts(node *model.Proxy, push *model.PushC
 							metadata:         util.BuildConfigInfoMetadata(cfg.Meta),
 							sniHosts:         match.SniHosts,
 							destinationCIDRs: destinationCIDRs,
-							networkFilters:   lb.buildOutboundNetworkFilters(tls.Route, listenPort, cfg.Meta, false),
+							networkFilters:   lb.buildOutboundNetworkFilters(tls.Route, listenPort, cfg.Meta, false, types.NamespacedName{}),
 						})
 						hasTLSMatch = true
 					}
@@ -225,7 +227,7 @@ func buildSidecarOutboundTLSFilterChainOpts(node *model.Proxy, push *model.PushC
 			sniHosts:         sniHosts,
 			destinationCIDRs: destinationCIDRs,
 			networkFilters: lb.buildOutboundNetworkFiltersWithSingleDestination(statPrefix, clusterName, "",
-				listenPort, destinationRule, tunnelingconfig.Apply, false, service),
+				listenPort, destinationRule, tunnelingconfig.Apply, false, service, types.NamespacedName{}),
 		})
 	}
 
@@ -260,7 +262,7 @@ TcpLoop:
 				out = append(out, &filterChainOpts{
 					metadata:         util.BuildConfigInfoMetadata(cfg.Meta),
 					destinationCIDRs: destinationCIDRs,
-					networkFilters:   lb.buildOutboundNetworkFilters(tcp.Route, listenPort, cfg.Meta, false),
+					networkFilters:   lb.buildOutboundNetworkFilters(tcp.Route, listenPort, cfg.Meta, false, types.NamespacedName{}),
 				})
 				defaultRouteAdded = true
 				break TcpLoop
@@ -284,7 +286,7 @@ TcpLoop:
 						out = append(out, &filterChainOpts{
 							metadata:         util.BuildConfigInfoMetadata(cfg.Meta),
 							destinationCIDRs: destinationCIDRs,
-							networkFilters:   lb.buildOutboundNetworkFilters(tcp.Route, listenPort, cfg.Meta, false),
+							networkFilters:   lb.buildOutboundNetworkFilters(tcp.Route, listenPort, cfg.Meta, false, types.NamespacedName{}),
 						})
 						defaultRouteAdded = true
 						break TcpLoop
@@ -296,7 +298,7 @@ TcpLoop:
 			if len(virtualServiceDestinationSubnets) > 0 {
 				out = append(out, &filterChainOpts{
 					destinationCIDRs: virtualServiceDestinationSubnets,
-					networkFilters:   lb.buildOutboundNetworkFilters(tcp.Route, listenPort, cfg.Meta, false),
+					networkFilters:   lb.buildOutboundNetworkFilters(tcp.Route, listenPort, cfg.Meta, false, types.NamespacedName{}),
 				})
 
 				// If at this point there is a filter chain generated with the same CIDR match as the
@@ -335,7 +337,7 @@ TcpLoop:
 		out = append(out, &filterChainOpts{
 			destinationCIDRs: destinationCIDRs,
 			networkFilters: lb.buildOutboundNetworkFiltersWithSingleDestination(statPrefix, clusterName, "",
-				listenPort, destinationRule, tunnelingconfig.Apply, false, service),
+				listenPort, destinationRule, tunnelingconfig.Apply, false, service, types.NamespacedName{}),
 		})
 	}
 

--- a/pilot/pkg/networking/plugin/authz/authorization.go
+++ b/pilot/pkg/networking/plugin/authz/authorization.go
@@ -17,6 +17,7 @@ package authz
 import (
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"k8s.io/apimachinery/pkg/types"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking"
@@ -47,12 +48,18 @@ func NewBuilder(actionType ActionType, push *model.PushContext, proxy *model.Pro
 }
 
 func NewBuilderForService(actionType ActionType, push *model.PushContext, proxy *model.Proxy, useFilterState bool, svc *model.Service) *Builder {
-	return newBuilder(actionType, push, proxy, useFilterState, svc, false)
+	return newBuilder(actionType, push, proxy, useFilterState, svc, nil, false)
+}
+
+// NewBuilderForGateways creates a builder scoped to the given classic networking.istio.io Gateways,
+// so targetRef-based AuthorizationPolicies attach only to those gateways' filter chains.
+func NewBuilderForGateways(actionType ActionType, push *model.PushContext, proxy *model.Proxy, useFilterState bool, gateways []types.NamespacedName) *Builder {
+	return newBuilder(actionType, push, proxy, useFilterState, nil, gateways, false)
 }
 
 // NewWaypointTerminationBuilder creates a builder for use on the waypoints HBONE termination layer
 func NewWaypointTerminationBuilder(actionType ActionType, push *model.PushContext, proxy *model.Proxy) *Builder {
-	return newBuilder(actionType, push, proxy, false, nil, true)
+	return newBuilder(actionType, push, proxy, false, nil, nil, true)
 }
 
 func newBuilder(
@@ -61,6 +68,7 @@ func newBuilder(
 	proxy *model.Proxy,
 	useFilterState bool,
 	svc *model.Service,
+	gateways []types.NamespacedName,
 	alwaysTreatAsNonWaypoint bool,
 ) *Builder {
 	tdBundle := trustdomain.NewBundle(push.Mesh.TrustDomain, push.Mesh.TrustDomainAliases)
@@ -68,7 +76,10 @@ func newBuilder(
 		IsCustomBuilder: actionType == Custom,
 		UseFilterState:  useFilterState,
 	}
-	selectionOpts := model.PolicyMatcherForProxy(proxy).WithService(svc).WithRootNamespace(push.AuthzPolicies.RootNamespace)
+	selectionOpts := model.PolicyMatcherForProxy(proxy).
+		WithService(svc).
+		WithGateways(gateways).
+		WithRootNamespace(push.AuthzPolicies.RootNamespace)
 	if alwaysTreatAsNonWaypoint {
 		// The intention here is to apply authz rules to the waypoint, but using the standard workload selector policy semantics,
 		// rather than the per-service rules.

--- a/pilot/pkg/networking/plugin/authz/authorization_test.go
+++ b/pilot/pkg/networking/plugin/authz/authorization_test.go
@@ -130,6 +130,33 @@ func TestNewBuilderForGateways_NotAttached(t *testing.T) {
 	}
 }
 
+// TestNewBuilderForGateways_CrossNamespace verifies that a policy targeting a classic Gateway attaches even
+// when the policy/gateway live in a namespace different from the proxy's config namespace (the shared-ingress
+// topology).
+func TestNewBuilderForGateways_CrossNamespace(t *testing.T) {
+	push := pushWith(classicGatewayTargetRefPolicy("policy", "tenant-a", "gateway"))
+	proxy := classicGatewayProxy("not-default")
+
+	b := NewBuilderForGateways(Local, push, proxy, false, []types.NamespacedName{{Name: "gateway", Namespace: "tenant-a"}})
+	got := b.BuildHTTP(networking.ListenerClassGateway)
+	if len(got) == 0 {
+		t.Fatalf("expected cross-namespace policy targeting tenant-a/gateway to attach, got %d filters", len(got))
+	}
+}
+
+// TestNewBuilderForGateways_CrossNamespaceNoLeak is the anti-leak guard: a selector policy in the gateway's
+// namespace matching the shared proxy's labels must NOT attach, even when that gateway is passed in.
+func TestNewBuilderForGateways_CrossNamespaceNoLeak(t *testing.T) {
+	push := pushWith(selectorPolicy("selleak", "tenant-a", map[string]string{"app": "istio-ingressgateway"}))
+	proxy := classicGatewayProxy("not-default")
+
+	b := NewBuilderForGateways(Local, push, proxy, false, []types.NamespacedName{{Name: "gateway", Namespace: "tenant-a"}})
+	got := b.BuildHTTP(networking.ListenerClassGateway)
+	if len(got) != 0 {
+		t.Fatalf("selector policy in gateway namespace must not attach to the shared proxy, got %d filters", len(got))
+	}
+}
+
 // TestNewBuilderForService_SelectorRegression is a regression guard: NewBuilderForService with a nil service
 // still attaches a selector-based policy to a matching sidecar workload, exactly as before this change.
 func TestNewBuilderForService_SelectorRegression(t *testing.T) {

--- a/pilot/pkg/networking/plugin/authz/authorization_test.go
+++ b/pilot/pkg/networking/plugin/authz/authorization_test.go
@@ -1,0 +1,148 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authz
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	authpb "istio.io/api/security/v1beta1"
+	apitypev1beta1 "istio.io/api/type/v1beta1"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking"
+	"istio.io/istio/pkg/config/schema/gvk"
+)
+
+const testNS = "ns-x"
+
+// classicGatewayTargetRefPolicy builds an ALLOW AuthorizationPolicy whose (single) targetRef points at a
+// classic networking.istio.io Gateway named gwName.
+func classicGatewayTargetRefPolicy(name, ns, gwName string) model.AuthorizationPolicy {
+	return model.AuthorizationPolicy{
+		Name:      name,
+		Namespace: ns,
+		Spec: &authpb.AuthorizationPolicy{
+			Action: authpb.AuthorizationPolicy_ALLOW,
+			TargetRefs: []*apitypev1beta1.PolicyTargetReference{{
+				Group: gvk.Gateway.Group, // networking.istio.io
+				Kind:  gvk.Gateway.Kind,  // Gateway
+				Name:  gwName,
+			}},
+			Rules: []*authpb.Rule{{
+				From: []*authpb.Rule_From{{
+					Source: &authpb.Source{Principals: []string{"cluster.local/ns/default/sa/client"}},
+				}},
+			}},
+		},
+	}
+}
+
+// selectorPolicy builds an ALLOW AuthorizationPolicy selected by workload labels (no targetRef).
+func selectorPolicy(name, ns string, matchLabels map[string]string) model.AuthorizationPolicy {
+	return model.AuthorizationPolicy{
+		Name:      name,
+		Namespace: ns,
+		Spec: &authpb.AuthorizationPolicy{
+			Action:   authpb.AuthorizationPolicy_ALLOW,
+			Selector: &apitypev1beta1.WorkloadSelector{MatchLabels: matchLabels},
+			Rules: []*authpb.Rule{{
+				From: []*authpb.Rule_From{{
+					Source: &authpb.Source{Principals: []string{"cluster.local/ns/default/sa/client"}},
+				}},
+			}},
+		},
+	}
+}
+
+func pushWith(policies ...model.AuthorizationPolicy) *model.PushContext {
+	byNS := map[string][]model.AuthorizationPolicy{}
+	for _, p := range policies {
+		byNS[p.Namespace] = append(byNS[p.Namespace], p)
+	}
+	return &model.PushContext{
+		Mesh: &meshconfig.MeshConfig{RootNamespace: "istio-system"},
+		AuthzPolicies: &model.AuthorizationPolicies{
+			NamespaceToPolicies: byNS,
+			RootNamespace:       "istio-system",
+		},
+	}
+}
+
+// classicGatewayProxy is a classic ingress gateway: a Router with no gateway.networking.k8s.io/gateway-name
+// label, so it is NOT a Gateway API workload and is matched only via WorkloadPolicyMatcher.Gateways.
+func classicGatewayProxy(ns string) *model.Proxy {
+	return &model.Proxy{
+		Type:            model.Router,
+		ConfigNamespace: ns,
+		Labels:          map[string]string{"app": "istio-ingressgateway"},
+	}
+}
+
+// TestNewBuilderForGateways_Attached verifies that a policy targeting a classic Gateway attaches (produces
+// a non-nil HTTP RBAC filter) only when the matching Gateway is passed to NewBuilderForGateways.
+func TestNewBuilderForGateways_Attached(t *testing.T) {
+	push := pushWith(classicGatewayTargetRefPolicy("policy1", testNS, "gw-a"))
+	proxy := classicGatewayProxy(testNS)
+
+	b := NewBuilderForGateways(Local, push, proxy, false, []types.NamespacedName{{Name: "gw-a", Namespace: testNS}})
+	got := b.BuildHTTP(networking.ListenerClassGateway)
+	if len(got) == 0 {
+		t.Fatalf("expected policy targeting gw-a to attach (non-nil HTTP filter), got %d filters", len(got))
+	}
+}
+
+// TestNewBuilderForGateways_NotAttached verifies the policy does NOT attach when a different gateway (or no
+// gateway) is supplied — the scoping must be exact.
+func TestNewBuilderForGateways_NotAttached(t *testing.T) {
+	cases := []struct {
+		name     string
+		gateways []types.NamespacedName
+	}{
+		{name: "wrong gateway name", gateways: []types.NamespacedName{{Name: "gw-b", Namespace: testNS}}},
+		{name: "nil gateways", gateways: nil},
+		{name: "wrong namespace", gateways: []types.NamespacedName{{Name: "gw-a", Namespace: "other-ns"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			push := pushWith(classicGatewayTargetRefPolicy("policy1", testNS, "gw-a"))
+			proxy := classicGatewayProxy(testNS)
+
+			b := NewBuilderForGateways(Local, push, proxy, false, tc.gateways)
+			got := b.BuildHTTP(networking.ListenerClassGateway)
+			if len(got) != 0 {
+				t.Fatalf("expected policy NOT to attach for %q, got %d filters", tc.name, len(got))
+			}
+		})
+	}
+}
+
+// TestNewBuilderForService_SelectorRegression is a regression guard: NewBuilderForService with a nil service
+// still attaches a selector-based policy to a matching sidecar workload, exactly as before this change.
+func TestNewBuilderForService_SelectorRegression(t *testing.T) {
+	push := pushWith(selectorPolicy("policy1", testNS, map[string]string{"app": "my-app"}))
+	proxy := &model.Proxy{
+		Type:            model.SidecarProxy,
+		ConfigNamespace: testNS,
+		Labels:          map[string]string{"app": "my-app"},
+	}
+
+	b := NewBuilderForService(Local, push, proxy, false, nil)
+	got := b.BuildHTTP(networking.ListenerClassSidecarInbound)
+	if len(got) == 0 {
+		t.Fatalf("selector-based policy should attach to matching workload via NewBuilderForService(nil svc), got %d filters", len(got))
+	}
+}

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1341,8 +1341,12 @@ func IsNegativeDuration(in time.Duration) error {
 }
 
 func validatePolicyTargetReferences(targetRefs []*type_beta.PolicyTargetReference) (v Validation) {
+	return validatePolicyTargetReferencesForKinds(targetRefs, allowedTargetRefs)
+}
+
+func validatePolicyTargetReferencesForKinds(targetRefs []*type_beta.PolicyTargetReference, allowed []config.GroupVersionKind) (v Validation) {
 	for _, r := range targetRefs {
-		v = AppendValidation(v, validatePolicyTargetReference(r))
+		v = AppendValidation(v, validatePolicyTargetReferenceForKinds(r, allowed))
 	}
 	return v
 }
@@ -1355,7 +1359,15 @@ var allowedTargetRefs = []config.GroupVersionKind{
 	gvk.GatewayClass,
 }
 
+// authorizationPolicyTargetRefs extends allowedTargetRefs with the classic
+// networking.istio.io Gateway, which is accepted only for AuthorizationPolicy.
+var authorizationPolicyTargetRefs = append(slices.Clone(allowedTargetRefs), gvk.Gateway)
+
 func validatePolicyTargetReference(targetRef *type_beta.PolicyTargetReference) (v Validation) {
+	return validatePolicyTargetReferenceForKinds(targetRef, allowedTargetRefs)
+}
+
+func validatePolicyTargetReferenceForKinds(targetRef *type_beta.PolicyTargetReference, allowed []config.GroupVersionKind) (v Validation) {
 	if targetRef == nil {
 		return v
 	}
@@ -1371,13 +1383,13 @@ func validatePolicyTargetReference(targetRef *type_beta.PolicyTargetReference) (
 	if canoncalGroup == "" {
 		canoncalGroup = "core"
 	}
-	allowed := slices.FindFunc(allowedTargetRefs, func(gvk config.GroupVersionKind) bool {
+	found := slices.FindFunc(allowed, func(gvk config.GroupVersionKind) bool {
 		return gvk.Kind == targetRef.Kind && gvk.CanonicalGroup() == canoncalGroup
 	}) != nil
 
-	if !allowed {
+	if !found {
 		v = appendErrorf(v, "targetRef must be to one of %v but was %s/%s",
-			allowedTargetRefs, targetRef.Group, targetRef.Kind)
+			allowed, targetRef.Group, targetRef.Kind)
 	}
 	return v
 }
@@ -1437,8 +1449,8 @@ var ValidateAuthorizationPolicy = RegisterValidateFunc("ValidateAuthorizationPol
 		var warnings Warning
 		selectorTypeValidation := validateOneOfSelectorType(in.GetSelector(), in.GetTargetRef(), in.GetTargetRefs())
 		workloadSelectorValidation := validateWorkloadSelector(in.GetSelector())
-		targetRefValidation := validatePolicyTargetReference(in.GetTargetRef())
-		targetRefsValidation := validatePolicyTargetReferences(in.GetTargetRefs())
+		targetRefValidation := validatePolicyTargetReferenceForKinds(in.GetTargetRef(), authorizationPolicyTargetRefs)
+		targetRefsValidation := validatePolicyTargetReferencesForKinds(in.GetTargetRefs(), authorizationPolicyTargetRefs)
 		errs = appendErrors(errs, selectorTypeValidation, workloadSelectorValidation, targetRefValidation, targetRefsValidation)
 		warnings = appendErrors(warnings, workloadSelectorValidation.Warning)
 

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1379,12 +1379,12 @@ func validatePolicyTargetReferenceForKinds(targetRef *type_beta.PolicyTargetRefe
 		v = appendErrorf(v, "targetRef namespace must not be set; cross namespace referencing is not supported")
 	}
 
-	canoncalGroup := targetRef.Group
-	if canoncalGroup == "" {
-		canoncalGroup = "core"
+	canonicalGroup := targetRef.Group
+	if canonicalGroup == "" {
+		canonicalGroup = "core"
 	}
 	found := slices.FindFunc(allowed, func(gvk config.GroupVersionKind) bool {
-		return gvk.Kind == targetRef.Kind && gvk.CanonicalGroup() == canoncalGroup
+		return gvk.Kind == targetRef.Kind && gvk.CanonicalGroup() == canonicalGroup
 	}) != nil
 
 	if !found {

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -5077,6 +5077,103 @@ func TestValidateAuthorizationPolicy(t *testing.T) {
 			Warning: false,
 		},
 		{
+			name: "target-ref-good-classic-gateway",
+			in: &security_beta.AuthorizationPolicy{
+				Action: security_beta.AuthorizationPolicy_DENY,
+				TargetRef: &api.PolicyTargetReference{
+					Group: gvk.Gateway.Group,
+					Kind:  gvk.Gateway.Kind,
+					Name:  "foo",
+				},
+				Rules: []*security_beta.Rule{
+					{
+						From: []*security_beta.Rule_From{
+							{
+								Source: &security_beta.Source{
+									Principals: []string{"temp"},
+								},
+							},
+						},
+						To: []*security_beta.Rule_To{
+							{
+								Operation: &security_beta.Operation{
+									Ports:   []string{"8080"},
+									Methods: []string{"GET", "DELETE"},
+								},
+							},
+						},
+					},
+				},
+			},
+			valid:   true,
+			Warning: false,
+		},
+		{
+			name: "target-refs-good-classic-gateway",
+			in: &security_beta.AuthorizationPolicy{
+				Action: security_beta.AuthorizationPolicy_DENY,
+				TargetRefs: []*api.PolicyTargetReference{{
+					Group: gvk.Gateway.Group,
+					Kind:  gvk.Gateway.Kind,
+					Name:  "foo",
+				}},
+				Rules: []*security_beta.Rule{
+					{
+						From: []*security_beta.Rule_From{
+							{
+								Source: &security_beta.Source{
+									Principals: []string{"temp"},
+								},
+							},
+						},
+						To: []*security_beta.Rule_To{
+							{
+								Operation: &security_beta.Operation{
+									Ports:   []string{"8080"},
+									Methods: []string{"GET", "DELETE"},
+								},
+							},
+						},
+					},
+				},
+			},
+			valid:   true,
+			Warning: false,
+		},
+		{
+			name: "target-ref-classic-gateway-non-empty-namespace",
+			in: &security_beta.AuthorizationPolicy{
+				Action: security_beta.AuthorizationPolicy_DENY,
+				TargetRef: &api.PolicyTargetReference{
+					Group:     gvk.Gateway.Group,
+					Kind:      gvk.Gateway.Kind,
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Rules: []*security_beta.Rule{
+					{
+						From: []*security_beta.Rule_From{
+							{
+								Source: &security_beta.Source{
+									Principals: []string{"temp"},
+								},
+							},
+						},
+						To: []*security_beta.Rule_To{
+							{
+								Operation: &security_beta.Operation{
+									Ports:   []string{"8080"},
+									Methods: []string{"GET", "DELETE"},
+								},
+							},
+						},
+					},
+				},
+			},
+			valid:   false,
+			Warning: false,
+		},
+		{
 			name: "target-ref-non-empty-namespace",
 			in: &security_beta.AuthorizationPolicy{
 				Action: security_beta.AuthorizationPolicy_DENY,
@@ -7269,6 +7366,25 @@ func TestValidateRequestAuthentication(t *testing.T) {
 			valid: false,
 		},
 		{
+			// classic networking.istio.io/Gateway is only allowed for AuthorizationPolicy, not RequestAuthentication.
+			name:       "bad targetRef - classic gateway not allowed",
+			configName: "foo",
+			in: &security_beta.RequestAuthentication{
+				TargetRef: &api.PolicyTargetReference{
+					Group: gvk.Gateway.Group,
+					Kind:  gvk.Gateway.Kind,
+					Name:  "foo",
+				},
+				JwtRules: []*security_beta.JWTRule{
+					{
+						Issuer:  "foo.com",
+						JwksUri: "https://foo.com/cert",
+					},
+				},
+			},
+			valid: false,
+		},
+		{
 			name:       "targetRef and selector cannot both be set",
 			configName: "foo",
 			in: &security_beta.RequestAuthentication{
@@ -8014,6 +8130,30 @@ func TestValidateTelemetry(t *testing.T) {
 				allowedTargetRefs, gvk.KubernetesGateway.Group, "wrong-kind"), "",
 		},
 		{
+			// classic networking.istio.io/Gateway is only allowed for AuthorizationPolicy, not Telemetry.
+			"bad targetRef - classic gateway not allowed",
+			&telemetry.Telemetry{
+				Tracing: []*telemetry.Tracing{{
+					CustomTags: map[string]*telemetry.Tracing_CustomTag{
+						"clusterID": {
+							Type: &telemetry.Tracing_CustomTag_Environment{
+								Environment: &telemetry.Tracing_Environment{
+									Name: "FOO",
+								},
+							},
+						},
+					},
+				}},
+				TargetRef: &api.PolicyTargetReference{
+					Group: gvk.Gateway.Group,
+					Kind:  gvk.Gateway.Kind,
+					Name:  "foo",
+				},
+			},
+			fmt.Sprintf("targetRef must be to one of %v but was %s/%s",
+				allowedTargetRefs, gvk.Gateway.Group, gvk.Gateway.Kind), "",
+		},
+		{
 			"targetRef and selector cannot both be set",
 			&telemetry.Telemetry{
 				Tracing: []*telemetry.Tracing{{
@@ -8304,6 +8444,20 @@ func TestValidateWasmPlugin(t *testing.T) {
 			},
 			fmt.Sprintf("targetRef must be to one of %v but was %s/%s",
 				allowedTargetRefs, gvk.KubernetesGateway.Group, "wrong-kind"), "",
+		},
+		{
+			// classic networking.istio.io/Gateway is only allowed for AuthorizationPolicy, not WasmPlugin.
+			"target-ref-classic-gateway-not-allowed",
+			&extensions.WasmPlugin{
+				Url: "http://test.com/test",
+				TargetRef: &api.PolicyTargetReference{
+					Group: gvk.Gateway.Group,
+					Kind:  gvk.Gateway.Kind,
+					Name:  "foo",
+				},
+			},
+			fmt.Sprintf("targetRef must be to one of %v but was %s/%s",
+				allowedTargetRefs, gvk.Gateway.Group, gvk.Gateway.Kind), "",
 		},
 		{
 			"target-ref-and-selector-cannot-both-be-set",

--- a/releasenotes/notes/authz-classic-gateway-targetref.yaml
+++ b/releasenotes/notes/authz-classic-gateway-targetref.yaml
@@ -7,4 +7,10 @@ issue:
 
 releaseNotes:
 - |
-  **Added** the ability for `AuthorizationPolicy` resources to target classic `networking.istio.io/Gateway` resources via `targetRefs`. This allows policies to be scoped to the exact gateway chains they cover instead of landing on every chain of the proxy. This applies to HTTPS and TLS passthrough chains. There is no behavior change to plain HTTP gateways.
+  **Added** the ability for `AuthorizationPolicy` resources to target classic `networking.istio.io/Gateway` resources via `targetRefs`. This allows policies to be scoped to the exact gateway chains they cover instead of landing on every chain of the proxy. This applies to the following types of chains:
+      - HTTPS
+      - Opaque TCP
+      - TCP with TLS termination
+      - TLS passthrough
+      - QUIC/HTTP3
+  There is no behavior change to plain HTTP gateways.

--- a/releasenotes/notes/authz-classic-gateway-targetref.yaml
+++ b/releasenotes/notes/authz-classic-gateway-targetref.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+
+issue:
+  - 38610
+
+releaseNotes:
+- |
+  **Added** the ability for `AuthorizationPolicy` resources to target classic `networking.istio.io/Gateway` resources via `targetRefs`. This allows policies to be scoped to the exact gateway chains they cover instead of landing on every chain of the proxy. This applies to HTTPS and TLS passthrough chains. There is no behavior change to plain HTTP gateways.


### PR DESCRIPTION
**Please provide a description of this PR:**
Today when authorization policies are created they attach indiscriminately to all Gateway driven filter chains causing a large amount of config bloat. This is because AuthorizationPolicy attaches purely on workload selector but does not filter down any further than that. The capability to scope an AuthorizationPolicy to a `gateway.networking.k8s.io/Gateway`via `targetRefs` is already supported. This PR expands upon that to allow `targetRefs` to reference classic Istio `networking.istio.io/Gateway`.

We are already tracking the mapping of servers --> Istio Gateways, this is used to derive the relevant server hosts that the Authz policy should attach to.

Note the following capabilities/limitations/edge cases considered

- referenced Gateways must exist in the same namespace as the Authorization Policy
- This works for Gateways selecting shared ingress workloads as well as Gateway API driven workloads
- No change to plaintext HTTP servers

Prior issues https://github.com/istio/istio/issues/38610