### PR TITLE
fix panic in RemovePodFromMesh

### DIFF
--- a/cni/pkg/nodeagent/net_windows.go
+++ b/cni/pkg/nodeagent/net_windows.go
@@ -215,8 +215,9 @@ func (p *podNetnsCache) Take(uid string) NamespaceCloser {
 	defer p.mu.Unlock()
 	if ns, ok := p.currentPodCache[uid]; ok {
 		delete(p.currentPodCache, uid)
-		// already in cache
-		return ns.NetnsCloser().(NamespaceCloser)
+		// already in cache. NetnsCloser() may be nil if we never found a netns for this pod.
+		nc, _ := ns.NetnsCloser().(NamespaceCloser)
+		return nc
 	}
 
 	return nil


### PR DESCRIPTION
**Please provide a description of this PR:**

```console
2026-07-23T16:53:26.760919Z	info	cni-agent	ztunnel acked	conn_uuid=14c6a964-2555-421f-9ac7-e6330cba64af
panic: interface conversion: interface is nil, not nodeagent.NamespaceCloser

goroutine 78 [running]:
istio.io/istio/cni/pkg/nodeagent.(*podNetnsCache).Take(0xc00065dbf0, {0xc00097d680, 0x24})
	istio.io/istio/cni/pkg/nodeagent/net_windows.go:219 +0x19e
istio.io/istio/cni/pkg/nodeagent.(*NetServer).RemovePodFromMesh(0xc0005194c0, {0x7ff77c99c890, 0xc000610fa0}, 0xc00088aa08, 0x1)
	istio.io/istio/cni/pkg/nodeagent/net_windows.go:188 +0x365
istio.io/istio/cni/pkg/nodeagent.(*meshDataplane).RemovePodFromMesh(0xc0003875a0, {0x7ff77c99c890, 0xc000610fa0}, 0xc00088aa08, 0x1)
	istio.io/istio/cni/pkg/nodeagent/meshdataplane_windows.go:103 +0x148
istio.io/istio/cni/pkg/nodeagent.(*InformerHandlers).reconcilePod(0xc000538320, {0x7ff77c237c60?, 0xc000ab66f0?})
	istio.io/istio/cni/pkg/nodeagent/informers.go:360 +0x788
istio.io/istio/cni/pkg/nodeagent.(*InformerHandlers).reconcile(0xc000538320, {0x7ff77c237c60, 0xc000ab66f0})
	istio.io/istio/cni/pkg/nodeagent/informers.go:205 +0x336
istio.io/istio/cni/pkg/nodeagent.setupHandlers.WithGenericReconciler.func3.1({0x7ff77c237c60?, 0xc000ab66f0?})
	istio.io/istio/pkg/kube/controllers/queue.go:77 +0x22
istio.io/istio/pkg/kube/controllers.Queue.processNextItem({{0x7ff77c9b2ee0, 0xc000387a60}, 0xc00051a770, {0x7ff77c50996f, 0x7}, 0x7fffffffffffffff, 0xc00056d110, 0xc000526cb0, 0xc00026eb60})
	istio.io/istio/pkg/kube/controllers/queue.go:182 +0x183
istio.io/istio/pkg/kube/controllers.Queue.Run.func1()
	istio.io/istio/pkg/kube/controllers/queue.go:131 +0x45
created by istio.io/istio/pkg/kube/controllers.Queue.Run in goroutine 46
	istio.io/istio/pkg/kube/controllers/queue.go:129 +0x171
```