### PR TITLE
feat: wire globalDownstreamConnectionLimit from ConnectionSettings

### DIFF
--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -364,19 +364,26 @@ func getNodeMetadataOptions(node *model.Node, policy string) []option.Instance {
 		option.RuntimeFlags(extractRuntimeFlags(node.Metadata.ProxyConfig, policy)),
 		option.EnvoyStatusPort(node.Metadata.EnvoyStatusPort),
 		option.EnvoyPrometheusPort(node.Metadata.EnvoyPrometheusPort))
-	// Default value of max connections is the maximum integer value.
+	// Resolve the global downstream connection limit. Precedence (highest to lowest):
+	// 1. ProxyConfig.ConnectionSettings.GlobalDownstreamConnectionLimit (new API)
+	// 2. ISTIO_META_GLOBAL_DOWNSTREAM_MAX_CONNECTIONS proxy metadata
+	// 3. overload.global_downstream_max_connections runtime flag (deprecated)
+	// 4. math.MaxInt32 (effectively unlimited)
 	globalDownstreamMaxConnections := math.MaxInt32
-	// If proxy metadata is set, use it to set the global downstream max connections.
-	// If not set, use the default value of max connections.
-	// TODO: Consider moving this to proxy config A
-	metadataExists := false
-	if node.Metadata.ProxyConfig.ProxyMetadata != nil {
-		if maxConnections, err := strconv.Atoi(node.Metadata.ProxyConfig.ProxyMetadata[GlobalDownstreamMaxConnections]); err == nil {
-			globalDownstreamMaxConnections = maxConnections
-			metadataExists = true
+	resolved := false
+	if cs := node.Metadata.ProxyConfig.ConnectionSettings; cs != nil {
+		if v := cs.GetGlobalDownstreamConnectionLimit(); v != nil && v.GetValue() > 0 {
+			globalDownstreamMaxConnections = int(v.GetValue())
+			resolved = true
 		}
 	}
-	if !metadataExists {
+	if !resolved && node.Metadata.ProxyConfig.ProxyMetadata != nil {
+		if maxConnections, err := strconv.Atoi(node.Metadata.ProxyConfig.ProxyMetadata[GlobalDownstreamMaxConnections]); err == nil {
+			globalDownstreamMaxConnections = maxConnections
+			resolved = true
+		}
+	}
+	if !resolved {
 		// If the runtime flag overload.global_downstream_max_connections is set, honor it
 		// for backwards compatibility. This will be removed in a future release.
 		globalDownstreamMaxConnectionsRuntime := globalDownstreamMaxConnectionsRuntimeFlag(node.Metadata.ProxyConfig)

--- a/pkg/bootstrap/config_test.go
+++ b/pkg/bootstrap/config_test.go
@@ -15,12 +15,15 @@
 package bootstrap
 
 import (
+	"math"
 	"os"
 	"reflect"
 	"regexp"
 	"testing"
 
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	. "github.com/onsi/gomega"
+	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 	"k8s.io/kubectl/pkg/util/fieldpath"
 
 	"istio.io/api/mesh/v1alpha1"
@@ -393,6 +396,114 @@ func TestZoneAwareRoutingTemplateParam(t *testing.T) {
 			got, _ := params["enable_self_discovery"].(bool)
 			if got != tc.want {
 				t.Errorf("enable_self_discovery = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGlobalDownstreamConnectionLimitPrecedence(t *testing.T) {
+	tests := []struct {
+		name     string
+		node     *model.Node
+		expected int
+	}{
+		{
+			name: "connection_settings takes precedence over metadata",
+			node: &model.Node{
+				Metadata: &model.BootstrapNodeMetadata{
+					NodeMetadata: model.NodeMetadata{
+						ProxyConfig: &model.NodeMetaProxyConfig{
+							ConnectionSettings: &v1alpha1.ProxyConfig_ConnectionSettings{
+								GlobalDownstreamConnectionLimit: &wrappers.Int32Value{Value: 25000},
+							},
+							ProxyMetadata: map[string]string{
+								GlobalDownstreamMaxConnections: "10000",
+							},
+						},
+					},
+				},
+				Locality: &core.Locality{},
+			},
+			expected: 25000,
+		},
+		{
+			name: "connection_settings takes precedence over runtime",
+			node: &model.Node{
+				Metadata: &model.BootstrapNodeMetadata{
+					NodeMetadata: model.NodeMetadata{
+						ProxyConfig: &model.NodeMetaProxyConfig{
+							ConnectionSettings: &v1alpha1.ProxyConfig_ConnectionSettings{
+								GlobalDownstreamConnectionLimit: &wrappers.Int32Value{Value: 30000},
+							},
+							RuntimeValues: map[string]string{
+								"overload.global_downstream_max_connections": "5000",
+							},
+						},
+					},
+				},
+				Locality: &core.Locality{},
+			},
+			expected: 30000,
+		},
+		{
+			name: "metadata used when connection_settings not set",
+			node: &model.Node{
+				Metadata: &model.BootstrapNodeMetadata{
+					NodeMetadata: model.NodeMetadata{
+						ProxyConfig: &model.NodeMetaProxyConfig{
+							ProxyMetadata: map[string]string{
+								GlobalDownstreamMaxConnections: "10000",
+							},
+						},
+					},
+				},
+				Locality: &core.Locality{},
+			},
+			expected: 10000,
+		},
+		{
+			name: "runtime used when nothing else set",
+			node: &model.Node{
+				Metadata: &model.BootstrapNodeMetadata{
+					NodeMetadata: model.NodeMetadata{
+						ProxyConfig: &model.NodeMetaProxyConfig{
+							RuntimeValues: map[string]string{
+								"overload.global_downstream_max_connections": "5000",
+							},
+						},
+					},
+				},
+				Locality: &core.Locality{},
+			},
+			expected: 5000,
+		},
+		{
+			name: "default when nothing set",
+			node: &model.Node{
+				Metadata: &model.BootstrapNodeMetadata{
+					NodeMetadata: model.NodeMetadata{
+						ProxyConfig: &model.NodeMetaProxyConfig{},
+					},
+				},
+				Locality: &core.Locality{},
+			},
+			expected: math.MaxInt32,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := getNodeMetadataOptions(tt.node, "")
+			params, err := option.NewTemplateParams(opts...)
+			if err != nil {
+				t.Fatalf("NewTemplateParams failed: %v", err)
+			}
+			got, ok := params["global_downstream_max_connections"]
+			if !ok {
+				t.Fatal("global_downstream_max_connections not found in template params")
+			}
+			if got != tt.expected {
+				t.Errorf("global_downstream_max_connections = %v, want %v", got, tt.expected)
 			}
 		})
 	}

--- a/pkg/bootstrap/instance_test.go
+++ b/pkg/bootstrap/instance_test.go
@@ -248,6 +248,18 @@ func TestGolden(t *testing.T) {
 			},
 		},
 		{
+			// connection_settings.global_downstream_connection_limit set via ProxyConfig.
+			base: "global_downstream_connection_settings",
+		},
+		{
+			// Both connection_settings.global_downstream_connection_limit and
+			// ISTIO_META_GLOBAL_DOWNSTREAM_MAX_CONNECTIONS set; connection_settings wins.
+			base: "global_downstream_connection_settings_with_meta",
+			envVars: map[string]string{
+				GlobalDownstreamMaxConnections: "10000",
+			},
+		},
+		{
 			base: "stats_compression",
 		},
 		{

--- a/pkg/bootstrap/testdata/global_downstream_connection_settings.proxycfg
+++ b/pkg/bootstrap/testdata/global_downstream_connection_settings.proxycfg
@@ -1,0 +1,15 @@
+config_path:               "/etc/istio/proxy"
+binary_path:               "/usr/local/bin/envoy"
+service_cluster:           "istio-proxy"
+drain_duration:            {seconds: 2}
+discovery_address:         "istio-pilot:15010"
+proxy_admin_port:          15000
+control_plane_auth_policy: NONE
+connection_settings: {
+  global_downstream_connection_limit: { value: 15000 }
+}
+
+#
+# Test case: connection_settings.global_downstream_connection_limit set
+# This should be honored in the bootstrap config
+

--- a/pkg/bootstrap/testdata/global_downstream_connection_settings_golden.json
+++ b/pkg/bootstrap/testdata/global_downstream_connection_settings_golden.json
@@ -1,0 +1,527 @@
+{
+  "application_log_config": {
+    "log_format": {
+      "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
+    }
+  },
+  "node": {
+    "id": "sidecar~1.2.3.4~foo~bar",
+    "cluster": "istio-proxy",
+    "locality": {
+    },
+    "metadata": {"ENVOY_PROMETHEUS_PORT":15090,"ENVOY_STATUS_PORT":15021,"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","ISTIO_VERSION":"binary-1.0","METADATA_DISCOVERY":"false","OUTLIER_LOG_PATH":"/dev/stdout","PILOT_SAN":["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"],"PROXY_CONFIG":{"binaryPath":"/usr/local/bin/envoy","configPath":"/tmp/bootstrap/global_downstream_connection_settings","connectionSettings":{"globalDownstreamConnectionLimit":15000},"customConfigFile":"envoy_bootstrap.json","discoveryAddress":"istio-pilot:15010","drainDuration":"2s","proxyAdminPort":15000,"serviceCluster":"istio-proxy","statusPort":15020},"WORKLOAD_IDENTITY_SOCKET_FILE":"test.sock"}
+  },
+  "layered_runtime": {
+    "layers": [
+      {
+        "name": "global config",
+        "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.coalesce_lb_rebuilds_on_batch_update":false,"envoy.reloadable_features.fixed_heap_use_allocated":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"re2.max_program_size.error_level":"32768"}
+      },
+      {
+        "name": "admin",
+        "admin_layer": {}
+      }
+    ]
+  },
+  "bootstrap_extensions": [
+    {
+      "name": "envoy.bootstrap.internal_listener",
+      "typed_config": {
+        "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
+        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
+        "value": {
+          "buffer_size_kb": 64
+        }
+      }
+    }
+  ],
+  "stats_config": {
+    "use_all_default_tags": false,
+    "stats_tags": [
+      {
+        "tag_name": "cluster_name",
+        "regex": "^cluster(\\.(.+);)"
+      },
+      {
+        "tag_name": "http_conn_manager_prefix",
+        "regex": "^http\\.(((?:[_.[:digit:]\\w]*|[_\\[\\]aAbBcCdDeEfF[:digit:]\\w\\:]*));\\.)"
+      },
+      {
+        "tag_name": "thread_name",
+        "regex": "^server(\\.(.+))\\.watchdog"
+      },
+      {
+        "tag_name": "tcp_prefix",
+        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
+        "tag_name": "response_code"
+      },
+      {
+        "tag_name": "response_code_class",
+        "regex": "_rq(_(\\dxx))$"
+      },
+      {
+        "tag_name": "http_conn_manager_listener_prefix",
+        "regex": "^listener(?=\\.).*?\\.http\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
+      },
+      {
+        "tag_name": "listener_address",
+        "regex": "^listener\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
+      },
+      {
+        "tag_name": "mongo_prefix",
+        "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
+      },
+      {
+        "regex": "(cache\\.(.+?)\\.)",
+        "tag_name": "cache"
+      },
+      {
+        "regex": "(component\\.(.+?)\\.)",
+        "tag_name": "component"
+      },
+      {
+        "regex": "(tag\\.(.+?);\\.)",
+        "tag_name": "tag"
+      },
+      {
+        "regex": "(wasm_filter\\.(.+?)\\.)",
+        "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "rbac(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
+      }
+    ],
+    "stats_matcher": {
+      "inclusion_list": {
+        "patterns": [
+          {
+          "prefix": "reporter="
+          },
+          {
+          "prefix": "cluster_manager"
+          },
+          {
+          "prefix": "listener_manager"
+          },
+          {
+          "prefix": "server"
+          },
+          {
+          "prefix": "cluster.xds-grpc"
+          },
+          {
+          "prefix": "wasm"
+          },
+          {
+          "suffix": "rbac.allowed"
+          },
+          {
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
+          },
+          {
+          "safe_regex": {"regex":"vhost\\..*\\.route\\..*"}
+          },
+          {
+          "prefix": "component"
+          },
+          {
+          "prefix": "istio"
+          }
+        ]
+      }
+    }
+  },
+  "admin": {
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
+    "profile_path": "/var/lib/istio/data/envoy.prof",
+    "address": {
+      "socket_address": {
+        "address": "127.0.0.1",
+        "port_value": 15000
+      }
+    }
+  },
+  "dynamic_resources": {
+    "lds_config": {
+      "ads": {},
+      "initial_fetch_timeout": "0s",
+      "resource_api_version": "V3"
+    },
+    "cds_config": {
+      "ads": {},
+      "initial_fetch_timeout": "0s",
+      "resource_api_version": "V3"
+    },
+    "ads_config": {
+      "api_type": "DELTA_GRPC",
+      "set_node_on_first_message_only": true,
+      "transport_api_version": "V3",
+      "grpc_services": [
+        {
+          "envoy_grpc": {
+            "cluster_name": "xds-grpc"
+          }
+        }
+      ]
+    }
+  },
+  "static_resources": {
+    "clusters": [
+      {
+        "name": "prometheus_stats",
+        "alt_stat_name": "prometheus_stats;",
+        "type": "STATIC",
+        "connect_timeout": "0.250s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "prometheus_stats",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {
+                    "protocol": "TCP",
+                    "address": "127.0.0.1",
+                    "port_value": 15000
+                  }
+                }
+              }
+            }]
+          }]
+        }
+      },
+      {
+        "name": "agent",
+        "alt_stat_name": "agent;",
+        "type": "STATIC",
+        "connect_timeout": "0.250s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "agent",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {
+                    "protocol": "TCP",
+                    "address": "127.0.0.1",
+                    "port_value": 15020
+                  }
+                }
+              }
+            }]
+          }]
+        }
+      },
+      {
+        "name": "sds-grpc",
+        "alt_stat_name": "sds-grpc;",
+        "type": "STATIC",
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+           "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+           "explicit_http_config": {
+            "http2_protocol_options": {}
+           }
+          }
+        },
+        "connect_timeout": "1s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "sds-grpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "pipe": {
+                    "path": "./var/run/secrets/workload-spiffe-uds/test.sock"
+                  }
+                }
+              }
+            }]
+          }]
+        }
+      },
+      {
+        "name": "xds-grpc",
+        "alt_stat_name": "xds-grpc;",
+        "type" : "STATIC",
+        "connect_timeout": "1s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "xds-grpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "pipe": {
+                    "path": "/tmp/XDS"
+                  }
+                }
+              }
+            }]
+          }]
+        },
+        "circuit_breakers": {
+          "thresholds": [
+            {
+              "priority": "DEFAULT",
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 100000
+            },
+            {
+              "priority": "HIGH",
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 100000
+            }
+          ]
+        },
+        "upstream_connection_options": {
+          "tcp_keepalive": {
+            "keepalive_time": 300
+          }
+        },
+        "max_requests_per_connection": 1,
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+           "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+           "explicit_http_config": {
+            "http2_protocol_options": {}
+           }
+          }
+        }
+      }
+      
+      
+      
+    ],
+    "listeners":[
+      {
+        "name": "0.0.0.0_15090",
+        
+        "address": {
+          "socket_address": {
+            "protocol": "TCP",
+            "address": "0.0.0.0",
+            
+            "port_value": 15090
+          }
+        },
+        "ignore_global_conn_limit": true,
+        "bypass_overload_manager": true,
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "codec_type": "AUTO",
+                  "stat_prefix": "stats",
+                  "route_config": {
+                    "virtual_hosts": [
+                      {
+                        "name": "backend",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/stats/prometheus"
+                            },
+                            "route": {
+                              "cluster": "prometheus_stats"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": [
+                  {
+                    "name": "envoy.filters.http.compressor.brotli",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor",
+                      "compressor_library": {
+                        "name": "stats_brotli",
+                        "typed_config": {
+                          "@type": "type.googleapis.com/envoy.extensions.compression.brotli.compressor.v3.Brotli"
+                        }
+                      },
+                      "response_direction_config": {
+                        "common_config": {
+                          "content_type": [
+                            "text/plain",
+                            "application/vnd.google.protobuf",
+                            "application/openmetrics-text",
+                            "application/openmetrics-protobuf"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.compressor.zstd",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor",
+                      "compressor_library": {
+                        "name": "stats_zstd",
+                        "typed_config": {
+                          "@type": "type.googleapis.com/envoy.extensions.compression.zstd.compressor.v3.Zstd"
+                        }
+                      },
+                      "response_direction_config": {
+                        "common_config": {
+                          "content_type": [
+                            "text/plain",
+                            "application/vnd.google.protobuf",
+                            "application/openmetrics-text",
+                            "application/openmetrics-protobuf"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.compressor.gzip",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor",
+                      "compressor_library": {
+                        "name": "stats_gzip",
+                        "typed_config": {
+                          "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
+                        }
+                      },
+                      "response_direction_config": {
+                        "common_config": {
+                          "content_type": [
+                            "text/plain",
+                            "application/vnd.google.protobuf",
+                            "application/openmetrics-text",
+                            "application/openmetrics-protobuf"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                    }
+                  }
+                ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "0.0.0.0_15021",
+        "address": {
+           "socket_address": {
+             "protocol": "TCP",
+             "address": "0.0.0.0",
+             "port_value": 15021
+           }
+        },
+        "ignore_global_conn_limit": true,
+        "bypass_overload_manager": true,
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "codec_type": "AUTO",
+                  "stat_prefix": "agent",
+                  "route_config": {
+                    "virtual_hosts": [
+                      {
+                        "name": "backend",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/healthz/ready"
+                            },
+                            "route": {
+                              "cluster": "agent"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": [{
+                    "name": "envoy.filters.http.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                    }
+                  }]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "overload_manager": {
+    "resource_monitors": [
+      {
+        "name": "envoy.resource_monitors.global_downstream_max_connections",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig",
+          "max_active_downstream_connections": 15000
+        }
+      }
+    ]
+  }
+  
+  
+  ,
+  "cluster_manager": {
+    "outlier_detection": {
+      "event_log_path": "/dev/stdout"
+    },
+    "enable_deferred_cluster_creation": true
+  }
+  ,
+  "deferred_stat_options": {
+    "enable_deferred_creation_stats": true
+  }
+}

--- a/pkg/bootstrap/testdata/global_downstream_connection_settings_with_meta.proxycfg
+++ b/pkg/bootstrap/testdata/global_downstream_connection_settings_with_meta.proxycfg
@@ -1,0 +1,16 @@
+config_path:               "/etc/istio/proxy"
+binary_path:               "/usr/local/bin/envoy"
+service_cluster:           "istio-proxy"
+drain_duration:            {seconds: 2}
+discovery_address:         "istio-pilot:15010"
+proxy_admin_port:          15000
+control_plane_auth_policy: NONE
+connection_settings: {
+  global_downstream_connection_limit: { value: 25000 }
+}
+
+#
+# Test case: Both connection_settings.global_downstream_connection_limit and
+# ISTIO_META_GLOBAL_DOWNSTREAM_MAX_CONNECTIONS set.
+# connection_settings should take precedence.
+

--- a/pkg/bootstrap/testdata/global_downstream_connection_settings_with_meta_golden.json
+++ b/pkg/bootstrap/testdata/global_downstream_connection_settings_with_meta_golden.json
@@ -1,0 +1,527 @@
+{
+  "application_log_config": {
+    "log_format": {
+      "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
+    }
+  },
+  "node": {
+    "id": "sidecar~1.2.3.4~foo~bar",
+    "cluster": "istio-proxy",
+    "locality": {
+    },
+    "metadata": {"ENVOY_PROMETHEUS_PORT":15090,"ENVOY_STATUS_PORT":15021,"GLOBAL_DOWNSTREAM_MAX_CONNECTIONS":"10000","INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","ISTIO_VERSION":"binary-1.0","METADATA_DISCOVERY":"false","OUTLIER_LOG_PATH":"/dev/stdout","PILOT_SAN":["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"],"PROXY_CONFIG":{"binaryPath":"/usr/local/bin/envoy","configPath":"/tmp/bootstrap/global_downstream_connection_settings_with_meta","connectionSettings":{"globalDownstreamConnectionLimit":25000},"customConfigFile":"envoy_bootstrap.json","discoveryAddress":"istio-pilot:15010","drainDuration":"2s","proxyAdminPort":15000,"proxyMetadata":{"ISTIO_META_GLOBAL_DOWNSTREAM_MAX_CONNECTIONS":"10000"},"serviceCluster":"istio-proxy","statusPort":15020},"WORKLOAD_IDENTITY_SOCKET_FILE":"test.sock"}
+  },
+  "layered_runtime": {
+    "layers": [
+      {
+        "name": "global config",
+        "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.coalesce_lb_rebuilds_on_batch_update":false,"envoy.reloadable_features.fixed_heap_use_allocated":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"re2.max_program_size.error_level":"32768"}
+      },
+      {
+        "name": "admin",
+        "admin_layer": {}
+      }
+    ]
+  },
+  "bootstrap_extensions": [
+    {
+      "name": "envoy.bootstrap.internal_listener",
+      "typed_config": {
+        "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
+        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
+        "value": {
+          "buffer_size_kb": 64
+        }
+      }
+    }
+  ],
+  "stats_config": {
+    "use_all_default_tags": false,
+    "stats_tags": [
+      {
+        "tag_name": "cluster_name",
+        "regex": "^cluster(\\.(.+);)"
+      },
+      {
+        "tag_name": "http_conn_manager_prefix",
+        "regex": "^http\\.(((?:[_.[:digit:]\\w]*|[_\\[\\]aAbBcCdDeEfF[:digit:]\\w\\:]*));\\.)"
+      },
+      {
+        "tag_name": "thread_name",
+        "regex": "^server(\\.(.+))\\.watchdog"
+      },
+      {
+        "tag_name": "tcp_prefix",
+        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
+        "tag_name": "response_code"
+      },
+      {
+        "tag_name": "response_code_class",
+        "regex": "_rq(_(\\dxx))$"
+      },
+      {
+        "tag_name": "http_conn_manager_listener_prefix",
+        "regex": "^listener(?=\\.).*?\\.http\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
+      },
+      {
+        "tag_name": "listener_address",
+        "regex": "^listener\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
+      },
+      {
+        "tag_name": "mongo_prefix",
+        "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
+      },
+      {
+        "regex": "(cache\\.(.+?)\\.)",
+        "tag_name": "cache"
+      },
+      {
+        "regex": "(component\\.(.+?)\\.)",
+        "tag_name": "component"
+      },
+      {
+        "regex": "(tag\\.(.+?);\\.)",
+        "tag_name": "tag"
+      },
+      {
+        "regex": "(wasm_filter\\.(.+?)\\.)",
+        "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "rbac(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
+      }
+    ],
+    "stats_matcher": {
+      "inclusion_list": {
+        "patterns": [
+          {
+          "prefix": "reporter="
+          },
+          {
+          "prefix": "cluster_manager"
+          },
+          {
+          "prefix": "listener_manager"
+          },
+          {
+          "prefix": "server"
+          },
+          {
+          "prefix": "cluster.xds-grpc"
+          },
+          {
+          "prefix": "wasm"
+          },
+          {
+          "suffix": "rbac.allowed"
+          },
+          {
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
+          },
+          {
+          "safe_regex": {"regex":"vhost\\..*\\.route\\..*"}
+          },
+          {
+          "prefix": "component"
+          },
+          {
+          "prefix": "istio"
+          }
+        ]
+      }
+    }
+  },
+  "admin": {
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
+    "profile_path": "/var/lib/istio/data/envoy.prof",
+    "address": {
+      "socket_address": {
+        "address": "127.0.0.1",
+        "port_value": 15000
+      }
+    }
+  },
+  "dynamic_resources": {
+    "lds_config": {
+      "ads": {},
+      "initial_fetch_timeout": "0s",
+      "resource_api_version": "V3"
+    },
+    "cds_config": {
+      "ads": {},
+      "initial_fetch_timeout": "0s",
+      "resource_api_version": "V3"
+    },
+    "ads_config": {
+      "api_type": "DELTA_GRPC",
+      "set_node_on_first_message_only": true,
+      "transport_api_version": "V3",
+      "grpc_services": [
+        {
+          "envoy_grpc": {
+            "cluster_name": "xds-grpc"
+          }
+        }
+      ]
+    }
+  },
+  "static_resources": {
+    "clusters": [
+      {
+        "name": "prometheus_stats",
+        "alt_stat_name": "prometheus_stats;",
+        "type": "STATIC",
+        "connect_timeout": "0.250s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "prometheus_stats",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {
+                    "protocol": "TCP",
+                    "address": "127.0.0.1",
+                    "port_value": 15000
+                  }
+                }
+              }
+            }]
+          }]
+        }
+      },
+      {
+        "name": "agent",
+        "alt_stat_name": "agent;",
+        "type": "STATIC",
+        "connect_timeout": "0.250s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "agent",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {
+                    "protocol": "TCP",
+                    "address": "127.0.0.1",
+                    "port_value": 15020
+                  }
+                }
+              }
+            }]
+          }]
+        }
+      },
+      {
+        "name": "sds-grpc",
+        "alt_stat_name": "sds-grpc;",
+        "type": "STATIC",
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+           "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+           "explicit_http_config": {
+            "http2_protocol_options": {}
+           }
+          }
+        },
+        "connect_timeout": "1s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "sds-grpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "pipe": {
+                    "path": "./var/run/secrets/workload-spiffe-uds/test.sock"
+                  }
+                }
+              }
+            }]
+          }]
+        }
+      },
+      {
+        "name": "xds-grpc",
+        "alt_stat_name": "xds-grpc;",
+        "type" : "STATIC",
+        "connect_timeout": "1s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "xds-grpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "pipe": {
+                    "path": "/tmp/XDS"
+                  }
+                }
+              }
+            }]
+          }]
+        },
+        "circuit_breakers": {
+          "thresholds": [
+            {
+              "priority": "DEFAULT",
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 100000
+            },
+            {
+              "priority": "HIGH",
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 100000
+            }
+          ]
+        },
+        "upstream_connection_options": {
+          "tcp_keepalive": {
+            "keepalive_time": 300
+          }
+        },
+        "max_requests_per_connection": 1,
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+           "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+           "explicit_http_config": {
+            "http2_protocol_options": {}
+           }
+          }
+        }
+      }
+      
+      
+      
+    ],
+    "listeners":[
+      {
+        "name": "0.0.0.0_15090",
+        
+        "address": {
+          "socket_address": {
+            "protocol": "TCP",
+            "address": "0.0.0.0",
+            
+            "port_value": 15090
+          }
+        },
+        "ignore_global_conn_limit": true,
+        "bypass_overload_manager": true,
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "codec_type": "AUTO",
+                  "stat_prefix": "stats",
+                  "route_config": {
+                    "virtual_hosts": [
+                      {
+                        "name": "backend",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/stats/prometheus"
+                            },
+                            "route": {
+                              "cluster": "prometheus_stats"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": [
+                  {
+                    "name": "envoy.filters.http.compressor.brotli",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor",
+                      "compressor_library": {
+                        "name": "stats_brotli",
+                        "typed_config": {
+                          "@type": "type.googleapis.com/envoy.extensions.compression.brotli.compressor.v3.Brotli"
+                        }
+                      },
+                      "response_direction_config": {
+                        "common_config": {
+                          "content_type": [
+                            "text/plain",
+                            "application/vnd.google.protobuf",
+                            "application/openmetrics-text",
+                            "application/openmetrics-protobuf"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.compressor.zstd",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor",
+                      "compressor_library": {
+                        "name": "stats_zstd",
+                        "typed_config": {
+                          "@type": "type.googleapis.com/envoy.extensions.compression.zstd.compressor.v3.Zstd"
+                        }
+                      },
+                      "response_direction_config": {
+                        "common_config": {
+                          "content_type": [
+                            "text/plain",
+                            "application/vnd.google.protobuf",
+                            "application/openmetrics-text",
+                            "application/openmetrics-protobuf"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.compressor.gzip",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor",
+                      "compressor_library": {
+                        "name": "stats_gzip",
+                        "typed_config": {
+                          "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
+                        }
+                      },
+                      "response_direction_config": {
+                        "common_config": {
+                          "content_type": [
+                            "text/plain",
+                            "application/vnd.google.protobuf",
+                            "application/openmetrics-text",
+                            "application/openmetrics-protobuf"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                    }
+                  }
+                ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "0.0.0.0_15021",
+        "address": {
+           "socket_address": {
+             "protocol": "TCP",
+             "address": "0.0.0.0",
+             "port_value": 15021
+           }
+        },
+        "ignore_global_conn_limit": true,
+        "bypass_overload_manager": true,
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "codec_type": "AUTO",
+                  "stat_prefix": "agent",
+                  "route_config": {
+                    "virtual_hosts": [
+                      {
+                        "name": "backend",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/healthz/ready"
+                            },
+                            "route": {
+                              "cluster": "agent"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": [{
+                    "name": "envoy.filters.http.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                    }
+                  }]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "overload_manager": {
+    "resource_monitors": [
+      {
+        "name": "envoy.resource_monitors.global_downstream_max_connections",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig",
+          "max_active_downstream_connections": 25000
+        }
+      }
+    ]
+  }
+  
+  
+  ,
+  "cluster_manager": {
+    "outlier_detection": {
+      "event_log_path": "/dev/stdout"
+    },
+    "enable_deferred_cluster_creation": true
+  }
+  ,
+  "deferred_stat_options": {
+    "enable_deferred_creation_stats": true
+  }
+}

--- a/pkg/config/validation/agent/validation.go
+++ b/pkg/config/validation/agent/validation.go
@@ -1143,7 +1143,7 @@ func validateConnectionSettings(cs *meshconfig.ProxyConfig_ConnectionSettings) e
 	if v := cs.GetHttp2InitialConnectionWindowSize(); v != nil && v.GetValue() < 65535 {
 		errs = multierror.Append(errs, errors.New("http2_initial_connection_window_size must be at least 65535"))
 	}
-	// TODO: ListenerConnectionLimit and GlobalDownstreamConnectionLimit are validated here but wired in later PR (listener limits).
+	// TODO: ListenerConnectionLimit is validated here but wired in a later PR (listener limits).
 	if v := cs.GetListenerConnectionLimit(); v != nil && v.GetValue() <= 0 {
 		errs = multierror.Append(errs, errors.New("listener_connection_limit must be positive"))
 	}

--- a/releasenotes/notes/global-downstream-connection-limit.yaml
+++ b/releasenotes/notes/global-downstream-connection-limit.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 57973
+releaseNotes:
+  - |
+    **Added** support for `globalDownstreamConnectionLimit` in `ProxyConfig.connectionSettings`,
+    providing a first-class API field for configuring the global downstream connection limit.
+    This takes precedence over the existing `ISTIO_META_GLOBAL_DOWNSTREAM_MAX_CONNECTIONS` metadata
+    and the deprecated `overload.global_downstream_max_connections` runtime flag.


### PR DESCRIPTION
Add ProxyConfig.ConnectionSettings.GlobalDownstreamConnectionLimit as a first-class API field for configuring the Envoy global downstream connection limit in the bootstrap overload manager.

Precedence (highest to lowest):
1. ConnectionSettings.GlobalDownstreamConnectionLimit (new API)
2. ISTIO_META_GLOBAL_DOWNSTREAM_MAX_CONNECTIONS proxy metadata
3. overload.global_downstream_max_connections runtime flag (deprecated)
4. math.MaxInt32 (effectively unlimited)

Related to istio/api#3707 and #57973.

Followup PR to: #60785 + #60576
