### PR TITLE
GWAPI: Remove InsecureFrontendValidationMode condition instead of reporting it as false

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -1854,11 +1854,6 @@ func reportGatewayStatus(
 			reason:  string(k8s.GatewayReasonResolvedRefs),
 			message: "All references resolved",
 		},
-		string(k8s.GatewayConditionInsecureFrontendValidationMode): {
-			status:  metav1.ConditionFalse,
-			reason:  "AllowInsecureFallbackNotConfigured",
-			message: "AllowInsecureFallback mode is disabled for frontend validation",
-		},
 	}
 	if gatewayErr != nil {
 		gatewayConditions[string(k8s.GatewayConditionAccepted)].error = gatewayErr
@@ -1902,6 +1897,8 @@ func reportGatewayStatus(
 				reason:  string(k8s.GatewayReasonConfigurationChanged),
 				message: "Gateway is operating in AllowInsecureFallback mode for frontend validation",
 			}
+		} else {
+			gs.Conditions = kstatus.RemoveCondition(gs.Conditions, string(k8s.GatewayConditionInsecureFrontendValidationMode))
 		}
 	}
 

--- a/pilot/pkg/config/kube/gateway/testdata/backend-tls-client-cert.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/backend-tls-client-cert.status.yaml.golden
@@ -28,11 +28,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed
     status: "True"
@@ -89,11 +84,6 @@ status:
     reason: Accepted
     status: "True"
     type: Accepted
-  - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
   - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed
@@ -152,11 +142,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed
     status: "True"
@@ -213,11 +198,6 @@ status:
     reason: Accepted
     status: "True"
     type: Accepted
-  - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
   - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed

--- a/pilot/pkg/config/kube/gateway/testdata/backend-tls-policy.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/backend-tls-policy.status.yaml.golden
@@ -392,11 +392,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed
     status: "True"

--- a/pilot/pkg/config/kube/gateway/testdata/delegated.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/delegated.status.yaml.golden
@@ -28,11 +28,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed
     status: "True"

--- a/pilot/pkg/config/kube/gateway/testdata/east-west-ambient.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/east-west-ambient.status.yaml.golden
@@ -12,11 +12,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: 'Failed to assign to any requested addresses: hostname "eastwestgateway.istio-system.svc.domain.suffix"
       not found'
     reason: AddressNotUsable
@@ -66,11 +61,6 @@ status:
     reason: Accepted
     status: "True"
     type: Accepted
-  - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
   - lastTransitionTime: fake
     message: 'Failed to assign to any requested addresses: hostname "invalid.istio-system.svc.domain.suffix"
       not found'
@@ -122,11 +112,6 @@ status:
     reason: Accepted
     status: "True"
     type: Accepted
-  - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
   - lastTransitionTime: fake
     message: 'Failed to assign to any requested addresses: hostname "with-tls-passthrough.istio-system.svc.domain.suffix"
       not found'

--- a/pilot/pkg/config/kube/gateway/testdata/eastwest-labelport.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/eastwest-labelport.status.yaml.golden
@@ -12,11 +12,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: 'Failed to assign to any requested addresses: hostname "eastwestgateway-istio.istio-system.svc.domain.suffix"
       not found'
     reason: AddressNotUsable

--- a/pilot/pkg/config/kube/gateway/testdata/eastwest-tlsoption.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/eastwest-tlsoption.status.yaml.golden
@@ -12,11 +12,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: 'Failed to assign to any requested addresses: hostname "eastwestgateway-istio.istio-system.svc.domain.suffix"
       not found'
     reason: AddressNotUsable

--- a/pilot/pkg/config/kube/gateway/testdata/eastwest.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/eastwest.status.yaml.golden
@@ -12,11 +12,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: 'Failed to assign to any requested addresses: hostname "eastwestgateway-istio.istio-system.svc.domain.suffix"
       not found'
     reason: AddressNotUsable

--- a/pilot/pkg/config/kube/gateway/testdata/empty-backend-refs.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/empty-backend-refs.status.yaml.golden
@@ -28,11 +28,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed
     status: "True"

--- a/pilot/pkg/config/kube/gateway/testdata/frontend-tls-invalid.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/frontend-tls-invalid.status.yaml.golden
@@ -28,11 +28,6 @@ status:
     status: "False"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:443
     reason: Programmed
     status: "True"
@@ -90,11 +85,6 @@ status:
     reason: ListenersNotValid
     status: "True"
     type: Accepted
-  - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
   - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:443
       and istio-ingressgateway.istio-system.svc.domain.suffix:80

--- a/pilot/pkg/config/kube/gateway/testdata/gateway-invalid-parameters-ref.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/gateway-invalid-parameters-ref.status.yaml.golden
@@ -29,11 +29,6 @@ status:
     status: "False"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed
     status: "True"
@@ -90,11 +85,6 @@ status:
     status: "False"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed
     status: "True"
@@ -150,11 +140,6 @@ status:
     reason: Accepted
     status: "True"
     type: Accepted
-  - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
   - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed

--- a/pilot/pkg/config/kube/gateway/testdata/grpc.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/grpc.status.yaml.golden
@@ -28,11 +28,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed
     status: "True"

--- a/pilot/pkg/config/kube/gateway/testdata/http-grpc-same-host.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/http-grpc-same-host.status.yaml.golden
@@ -28,11 +28,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed
     status: "True"

--- a/pilot/pkg/config/kube/gateway/testdata/http.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/http.status.yaml.golden
@@ -60,11 +60,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed
     status: "True"

--- a/pilot/pkg/config/kube/gateway/testdata/invalid.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/invalid.status.yaml.golden
@@ -25,11 +25,6 @@ status:
     status: "False"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Failed to assign to any requested addresses
     reason: UnsupportedAddress
     status: "False"
@@ -56,11 +51,6 @@ status:
     reason: Accepted
     status: "True"
     type: Accepted
-  - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
   - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed
@@ -118,11 +108,6 @@ status:
     status: "False"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:34000
     reason: Programmed
     status: "True"
@@ -176,11 +161,6 @@ status:
     reason: ListenersNotValid
     status: "False"
     type: Accepted
-  - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
   - lastTransitionTime: fake
     message: 'Failed to assign to any requested addresses: port 34002 not found for
       hostname "istio-ingressgateway.istio-system.svc.domain.suffix"'
@@ -240,11 +220,6 @@ status:
     status: "False"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:34001
     reason: Programmed
     status: "True"
@@ -302,11 +277,6 @@ status:
     status: "False"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:34000
     reason: Programmed
     status: "True"
@@ -362,11 +332,6 @@ status:
     reason: ListenersNotValid
     status: "False"
     type: Accepted
-  - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
   - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:34000
     reason: Programmed
@@ -426,11 +391,6 @@ status:
     status: "False"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:34000
     reason: Programmed
     status: "True"
@@ -489,11 +449,6 @@ status:
     status: "False"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:34000
     reason: Programmed
     status: "True"
@@ -549,11 +504,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: 'Failed to assign to any requested addresses: hostname "fake-service.com"
       not found'
     reason: AddressNotUsable
@@ -608,11 +558,6 @@ status:
     status: "False"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: 'Failed to assign to any requested addresses: hostname "protocol-lower-case-istio.istio-system.svc.domain.suffix"
       not found'
     reason: AddressNotUsable
@@ -662,11 +607,6 @@ status:
     reason: Accepted
     status: "True"
     type: Accepted
-  - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
   - lastTransitionTime: fake
     message: 'Failed to assign to any requested addresses: port 8080 not found for
       hostname "istio-ingressgateway.istio-system.svc.domain.suffix" (hint: the service
@@ -724,11 +664,6 @@ status:
     status: "False"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: 'Failed to assign to any requested addresses: hostname "udp-protocol-istio.istio-system.svc.domain.suffix"
       not found'
     reason: AddressNotUsable
@@ -778,11 +713,6 @@ status:
     reason: ListenersNotValid
     status: "False"
     type: Accepted
-  - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
   - lastTransitionTime: fake
     message: 'Failed to assign to any requested addresses: hostname "unknown-protocol-istio.istio-system.svc.domain.suffix"
       not found'

--- a/pilot/pkg/config/kube/gateway/testdata/isolation.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/isolation.status.yaml.golden
@@ -12,11 +12,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: 'Failed to assign to any requested addresses: hostname "isolation-istio.gateway-conformance-infra.svc.domain.suffix"
       not found'
     reason: AddressNotUsable

--- a/pilot/pkg/config/kube/gateway/testdata/listenerset-cross-namespace.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/listenerset-cross-namespace.status.yaml.golden
@@ -253,11 +253,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:443
       and istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed

--- a/pilot/pkg/config/kube/gateway/testdata/listenerset-empty-listeners.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/listenerset-empty-listeners.status.yaml.golden
@@ -77,11 +77,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed
     status: "True"

--- a/pilot/pkg/config/kube/gateway/testdata/listenerset-hostname-conflict.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/listenerset-hostname-conflict.status.yaml.golden
@@ -297,11 +297,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed
     status: "True"

--- a/pilot/pkg/config/kube/gateway/testdata/listenerset-https-missing-tls.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/listenerset-https-missing-tls.status.yaml.golden
@@ -76,11 +76,6 @@ status:
     status: "False"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:443
     reason: Programmed
     status: "True"

--- a/pilot/pkg/config/kube/gateway/testdata/listenerset-invalid.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/listenerset-invalid.status.yaml.golden
@@ -131,11 +131,6 @@ status:
     status: "False"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Failed to assign to any requested addresses
     reason: UnsupportedAddress
     status: "False"
@@ -163,11 +158,6 @@ status:
     reason: Accepted
     status: "True"
     type: Accepted
-  - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
   - lastTransitionTime: fake
     message: 'Assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80,
       but failed to assign to all requested addresses: port 12345 not found for hostname
@@ -227,11 +217,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed
     status: "True"
@@ -288,11 +273,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed
     status: "True"
@@ -345,11 +325,6 @@ status:
     reason: Accepted
     status: "True"
     type: Accepted
-  - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
   - lastTransitionTime: fake
     message: 'Failed to assign to any requested addresses: port 15008 not found for
       hostname "istio-ingressgateway.istio-system.svc.domain.suffix"'

--- a/pilot/pkg/config/kube/gateway/testdata/listenerset-overlapping-port.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/listenerset-overlapping-port.status.yaml.golden
@@ -77,11 +77,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:443
     reason: Programmed
     status: "True"

--- a/pilot/pkg/config/kube/gateway/testdata/listenerset-protocol-conflict.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/listenerset-protocol-conflict.status.yaml.golden
@@ -289,11 +289,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed
     status: "True"

--- a/pilot/pkg/config/kube/gateway/testdata/listenerset-same-name-different-ns.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/listenerset-same-name-different-ns.status.yaml.golden
@@ -125,11 +125,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed
     status: "True"

--- a/pilot/pkg/config/kube/gateway/testdata/listenerset.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/listenerset.status.yaml.golden
@@ -202,11 +202,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:443
       and istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed

--- a/pilot/pkg/config/kube/gateway/testdata/mcs.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/mcs.status.yaml.golden
@@ -15,11 +15,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:34000
     reason: Programmed
     status: "True"

--- a/pilot/pkg/config/kube/gateway/testdata/mesh.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/mesh.status.yaml.golden
@@ -28,11 +28,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed
     status: "True"

--- a/pilot/pkg/config/kube/gateway/testdata/multi-gateway.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/multi-gateway.status.yaml.golden
@@ -28,11 +28,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: 'Assigned to service(s) example.com:34000, example.com:80, istio-ingressgateway.istio-system.svc.domain.suffix:34000,
       and istio-ingressgateway.istio-system.svc.domain.suffix:80, but failed to assign
       to all requested addresses: hostname "istio-ingressgateway.not-default.svc.domain.suffix"

--- a/pilot/pkg/config/kube/gateway/testdata/redirect-only.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/redirect-only.status.yaml.golden
@@ -28,11 +28,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:443
       and istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed

--- a/pilot/pkg/config/kube/gateway/testdata/reference-grant-multiple-to.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/reference-grant-multiple-to.status.yaml.golden
@@ -25,11 +25,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: 'Failed to assign to any requested addresses: hostname "istio-ingressgateway.bookinfo-ingress.svc.domain.suffix"
       not found'
     reason: AddressNotUsable

--- a/pilot/pkg/config/kube/gateway/testdata/reference-policy-inferencepool.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/reference-policy-inferencepool.status.yaml.golden
@@ -23,11 +23,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed
     status: "True"

--- a/pilot/pkg/config/kube/gateway/testdata/reference-policy-service.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/reference-policy-service.status.yaml.golden
@@ -15,11 +15,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed
     status: "True"

--- a/pilot/pkg/config/kube/gateway/testdata/reference-policy-tcp.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/reference-policy-tcp.status.yaml.golden
@@ -15,11 +15,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:34000
       and istio-ingressgateway.istio-system.svc.domain.suffix:34001
     reason: Programmed

--- a/pilot/pkg/config/kube/gateway/testdata/reference-policy-tls.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/reference-policy-tls.status.yaml.golden
@@ -28,11 +28,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:443
     reason: Programmed
     status: "True"

--- a/pilot/pkg/config/kube/gateway/testdata/route-binding.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/route-binding.status.yaml.golden
@@ -28,11 +28,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed
     status: "True"

--- a/pilot/pkg/config/kube/gateway/testdata/route-precedence.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/route-precedence.status.yaml.golden
@@ -28,11 +28,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed
     status: "True"

--- a/pilot/pkg/config/kube/gateway/testdata/serviceentry.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/serviceentry.status.yaml.golden
@@ -12,11 +12,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: 'Failed to assign to any requested addresses: hostname "gateway-istio.istio-system.svc.domain.suffix"
       not found'
     reason: AddressNotUsable

--- a/pilot/pkg/config/kube/gateway/testdata/status.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/status.status.yaml.golden
@@ -28,11 +28,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed
     status: "True"

--- a/pilot/pkg/config/kube/gateway/testdata/tcp.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/tcp.status.yaml.golden
@@ -28,11 +28,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:34000
     reason: Programmed
     status: "True"
@@ -86,11 +81,6 @@ status:
     reason: Accepted
     status: "True"
     type: Accepted
-  - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
   - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:34000
     reason: Programmed

--- a/pilot/pkg/config/kube/gateway/testdata/tls-terminate.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/tls-terminate.status.yaml.golden
@@ -28,11 +28,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: 'Assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:443,
       but failed to assign to all requested addresses: port 9443 not found for hostname
       "istio-ingressgateway.istio-system.svc.domain.suffix"'

--- a/pilot/pkg/config/kube/gateway/testdata/tls.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/tls.status.yaml.golden
@@ -28,11 +28,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:34000
     reason: Programmed
     status: "True"
@@ -311,11 +306,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:34000
     reason: Programmed
     status: "True"
@@ -369,11 +359,6 @@ status:
     reason: Accepted
     status: "True"
     type: Accepted
-  - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
   - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:34000
     reason: Programmed
@@ -429,11 +414,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:34000
     reason: Programmed
     status: "True"
@@ -487,11 +467,6 @@ status:
     reason: Accepted
     status: "True"
     type: Accepted
-  - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
   - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:34000
     reason: Programmed

--- a/pilot/pkg/config/kube/gateway/testdata/valid-invalid-parent-ref.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/valid-invalid-parent-ref.status.yaml.golden
@@ -28,11 +28,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed
     status: "True"

--- a/pilot/pkg/config/kube/gateway/testdata/waypoint.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/waypoint.status.yaml.golden
@@ -12,11 +12,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: 'Failed to assign to any requested addresses: hostname "invalid.ns.svc.domain.suffix"
       not found'
     reason: AddressNotUsable
@@ -70,11 +65,6 @@ status:
     reason: Accepted
     status: "True"
     type: Accepted
-  - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
   - lastTransitionTime: fake
     message: 'Failed to assign to any requested addresses: hostname "namespace.ns.svc.domain.suffix"
       not found'

--- a/pilot/pkg/config/kube/gateway/testdata/weighted.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/weighted.status.yaml.golden
@@ -28,11 +28,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:34000
       and istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed

--- a/pilot/pkg/config/kube/gateway/testdata/zero.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/zero.status.yaml.golden
@@ -28,11 +28,6 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: AllowInsecureFallback mode is disabled for frontend validation
-    reason: AllowInsecureFallbackNotConfigured
-    status: "False"
-    type: InsecureFrontendValidationMode
-  - lastTransitionTime: fake
     message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:34000
       and istio-ingressgateway.istio-system.svc.domain.suffix:80
     reason: Programmed

--- a/pilot/pkg/model/kstatus/helper.go
+++ b/pilot/pkg/model/kstatus/helper.go
@@ -46,6 +46,16 @@ func GetCondition(conditions []metav1.Condition, condition string) metav1.Condit
 	return EmptyCondition
 }
 
+func RemoveCondition(conditions []metav1.Condition, condition string) []metav1.Condition {
+	idx := slices.IndexFunc(conditions, func(c metav1.Condition) bool {
+		return c.Type == condition
+	})
+	if idx == -1 {
+		return conditions
+	}
+	return append(conditions[:idx], conditions[idx+1:]...)
+}
+
 // UpdateConditionIfChanged updates a condition if it has been changed.
 func UpdateConditionIfChanged(conditions []metav1.Condition, condition metav1.Condition) []metav1.Condition {
 	ret := slices.Clone(conditions)

--- a/pilot/pkg/model/kstatus/helper_test.go
+++ b/pilot/pkg/model/kstatus/helper_test.go
@@ -162,6 +162,84 @@ func TestGetCondition(t *testing.T) {
 	}
 }
 
+func TestRemoveCondition(t *testing.T) {
+	time := metav1.Now()
+	accepted := metav1.Condition{
+		Type:               string(k8s.GatewayConditionAccepted),
+		Reason:             string(k8s.GatewayReasonAccepted),
+		Status:             StatusTrue,
+		Message:            "Resource accepted",
+		LastTransitionTime: time,
+	}
+	programmed := metav1.Condition{
+		Type:               string(k8s.GatewayConditionProgrammed),
+		Reason:             string(k8s.GatewayReasonProgrammed),
+		Status:             StatusTrue,
+		Message:            "Resource programmed",
+		LastTransitionTime: time,
+	}
+	resolvedRefs := metav1.Condition{
+		Type:               string(k8s.GatewayConditionResolvedRefs),
+		Reason:             string(k8s.GatewayReasonResolvedRefs),
+		Status:             StatusTrue,
+		Message:            "All references resolved",
+		LastTransitionTime: time,
+	}
+	insecureMode := metav1.Condition{
+		Type:               string(k8s.GatewayConditionInsecureFrontendValidationMode),
+		Reason:             string(k8s.GatewayReasonConfigurationChanged),
+		Status:             StatusTrue,
+		Message:            "Gateway is operating in AllowInsecureFallback mode for frontend validation",
+		LastTransitionTime: time,
+	}
+	secureMode := metav1.Condition{
+		Type:               string(k8s.GatewayConditionInsecureFrontendValidationMode),
+		Reason:             "SomeReason",
+		Status:             StatusFalse,
+		Message:            "AllowInsecureFallback mode is not configured",
+		LastTransitionTime: time,
+	}
+	tests := []struct {
+		name       string
+		conditions []metav1.Condition
+		condition  string
+		want       []metav1.Condition
+	}{
+		{
+			name:       "condition not present",
+			conditions: []metav1.Condition{accepted, programmed, resolvedRefs},
+			condition:  string(k8s.GatewayConditionInsecureFrontendValidationMode),
+			want:       []metav1.Condition{accepted, programmed, resolvedRefs},
+		},
+		{
+			name:       "conditions list is empty",
+			conditions: []metav1.Condition{},
+			condition:  string(k8s.GatewayConditionInsecureFrontendValidationMode),
+			want:       []metav1.Condition{},
+		},
+		{
+			name:       "condition present with status true",
+			conditions: []metav1.Condition{accepted, programmed, resolvedRefs, insecureMode},
+			condition:  string(k8s.GatewayConditionInsecureFrontendValidationMode),
+			want:       []metav1.Condition{accepted, programmed, resolvedRefs},
+		},
+		{
+			name:       "condition present with status false",
+			conditions: []metav1.Condition{accepted, programmed, resolvedRefs, secureMode},
+			condition:  string(k8s.GatewayConditionInsecureFrontendValidationMode),
+			want:       []metav1.Condition{accepted, programmed, resolvedRefs},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := RemoveCondition(test.conditions, test.condition); !reflect.DeepEqual(got, test.want) {
+				t.Errorf("RemoveCondition got %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
 func TestCreateCondition(t *testing.T) {
 	transitionTime := metav1.Now()
 	tests := []struct {

--- a/tests/integration/pilot/gateway_test.go
+++ b/tests/integration/pilot/gateway_test.go
@@ -60,6 +60,7 @@ func TestGateway(t *testing.T) {
 			t.NewSubTest("managed-owner").Run(ManagedOwnerGatewayTest)
 			t.NewSubTest("status").Run(StatusGatewayTest)
 			t.NewSubTest("managed-short-name").Run(ManagedGatewayShortNameTest)
+			t.NewSubTest("insecure-frontend-validation-mode").Run(InsecureFrontendValidationModeTest)
 		})
 }
 
@@ -952,6 +953,129 @@ func StatusGatewayTest(t framework.TestContext) {
 	client.Update(context.Background(), gwc, metav1.UpdateOptions{})
 	// It should be added back
 	retry.UntilSuccessOrFail(t, check)
+}
+
+// InsecureFrontendValidationModeTest verifies that the Gateway API InsecureFrontendValidationMode condition gets removed from the gateway.
+// Normally for the conditions we report their status as either False or True, but the conditions remain in place.
+// InsecureFrontendValidationMode condition is somewhat unusual in the sense that Gateway API spec explicitly says that it must be removed
+// from the status as opposed to setting it to False.
+//
+// Ideally Gateway API conformance tests should check that, but they don't and given that I got it wrong before, it makes sense to cover it
+// with a test.
+func InsecureFrontendValidationModeTest(t framework.TestContext) {
+	gatewayName := "gateway"
+	gatewayNamespace := apps.Namespace.Name()
+	cluster := t.Clusters().Default()
+
+	i := istio.DefaultConfigOrFail(t, t)
+	ca := file.AsStringOrFail(t, filepath.Join(env.IstioSrc, "tests/testdata/certs/default/root-cert.pem"))
+	t.ConfigIstio().Eval(gatewayNamespace, ca, `
+apiVersion: v1
+kind: ConfigMap
+data:
+  ca.crt: |
+{{. | indent 4}}
+metadata:
+  name: root-cert`)
+	ingressutil.CreateIngressKubeSecretInNamespace(t, "tls", ingressutil.TLS, ingressutil.IngressCredentialA,
+		false, gatewayNamespace, cluster)
+	templateArgs := map[string]string{
+		"gatewayClass": i.GatewayClassName,
+		"gatewayName":  gatewayName,
+	}
+	t.ConfigIstio().Eval(gatewayNamespace, templateArgs,
+		`apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{.gatewayName}}
+spec:
+  gatewayClassName: {{.gatewayClass}}
+  tls:
+    frontend:
+      default:
+        validation:
+          mode: AllowInsecureFallback
+          caCertificateRefs:
+          - group: ""
+            kind: ConfigMap
+            name: root-cert
+  allowedListeners:
+    namespaces:
+      from: All
+  listeners:
+  - name: default
+    hostname: "server.example.com"
+    port: 443
+    protocol: HTTPS
+    tls:
+      certificateRefs:
+      - group: ""
+        kind: Secret
+        name: tls
+      mode: Terminate
+`).ApplyOrFail(t)
+	client := cluster.GatewayAPI().GatewayV1().Gateways(gatewayNamespace)
+	retry.UntilSuccessOrFail(t, func() error {
+		gw, err := client.Get(context.Background(), gatewayName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to get gateway %s/%s: %v", gatewayNamespace, gatewayName, err)
+		}
+		if cond := kstatus.GetCondition(gw.Status.Conditions, string(k8sv1.GatewayConditionProgrammed)); cond == kstatus.EmptyCondition {
+			return fmt.Errorf("gateway has not been programmed yet: %+v", gw.Status.Conditions)
+		}
+		cond := kstatus.GetCondition(gw.Status.Conditions, string(k8sv1.GatewayConditionInsecureFrontendValidationMode))
+		if cond == kstatus.EmptyCondition {
+			return fmt.Errorf("gateway missing InsecureFrontendValidationMode condition: %+v", gw.Status.Conditions)
+		}
+		if cond.Status != metav1.ConditionTrue {
+			return fmt.Errorf("gateway InsecureFrontendValidationMode condition is not true: %+v", cond)
+		}
+		return nil
+	})
+	t.ConfigIstio().Eval(gatewayNamespace, templateArgs,
+		`apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{.gatewayName}}
+spec:
+  gatewayClassName: {{.gatewayClass}}
+  tls:
+    frontend:
+      default:
+        validation:
+          caCertificateRefs:
+          - group: ""
+            kind: ConfigMap
+            name: root-cert
+  allowedListeners:
+    namespaces:
+      from: All
+  listeners:
+  - name: default
+    hostname: "server.example.com"
+    port: 443
+    protocol: HTTPS
+    tls:
+      certificateRefs:
+      - group: ""
+        kind: Secret
+        name: tls
+      mode: Terminate
+`).ApplyOrFail(t)
+	retry.UntilSuccessOrFail(t, func() error {
+		gw, err := client.Get(context.Background(), gatewayName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to get gateway %s/%s: %v", gatewayNamespace, gatewayName, err)
+		}
+		if cond := kstatus.GetCondition(gw.Status.Conditions, string(k8sv1.GatewayConditionProgrammed)); cond == kstatus.EmptyCondition {
+			return fmt.Errorf("gateway has not been programmed yet: %+v", gw.Status.Conditions)
+		}
+		cond := kstatus.GetCondition(gw.Status.Conditions, string(k8sv1.GatewayConditionInsecureFrontendValidationMode))
+		if cond != kstatus.EmptyCondition {
+			return fmt.Errorf("gateway has InsecureFrontendValidationMode condition: %+v", cond)
+		}
+		return nil
+	})
 }
 
 // Verify that the envoy readiness probes are reachable at


### PR DESCRIPTION
**Please provide a description of this PR:**

It's somewhat unusual condition and GWAPI explicitly calls out in https://gateway-api.sigs.k8s.io/geps/gep-91/ that the condition is removed as soon as the FrontendValidationModeType changed back to AllowValidOnly.

So it's not correct to report it as false all the time, even if conformance tests don't cover it.

To that extent I fixed the logic to delete the condition when it's false instead of reporting it and added an integration test that verifies that the condition will be deleted after it has been set.

+cc @rikatz 