### PR TITLE
agw conformance: support gateway api client cert tls

### DIFF
--- a/pilot/pkg/config/kube/agentgateway/agentgateway_controller.go
+++ b/pilot/pkg/config/kube/agentgateway/agentgateway_controller.go
@@ -877,6 +877,9 @@ func (c *Controller) getProtocolAndTLSConfig(obj *GatewayListener) (api.Protocol
 		}
 		if len(obj.TLSInfo.CaCert) > 0 {
 			tlsConfig.Root = obj.TLSInfo.CaCert
+			if obj.TLSInfo.AllowInsecureFallback {
+				tlsConfig.MtlsMode = api.TLSConfig_ALLOW_INSECURE_FALLBACK
+			}
 		}
 	}
 

--- a/pilot/pkg/config/kube/agentgateway/gateway_collection.go
+++ b/pilot/pkg/config/kube/agentgateway/gateway_collection.go
@@ -42,9 +42,10 @@ import (
 // Used by agentgateway controller
 // TLSInfo contains the TLS certificate and key for a gateway listener.
 type TLSInfo struct {
-	Cert   []byte
-	CaCert []byte
-	Key    []byte `json:"-"`
+	Cert                  []byte
+	CaCert                []byte
+	Key                   []byte `json:"-"`
+	AllowInsecureFallback bool
 }
 
 type portProtocol struct {
@@ -107,7 +108,8 @@ func (g GatewayListener) Equals(other GatewayListener) bool {
 	if g.TLSInfo != nil {
 		if !bytes.Equal(g.TLSInfo.Cert, other.TLSInfo.Cert) ||
 			!bytes.Equal(g.TLSInfo.Key, other.TLSInfo.Key) ||
-			!bytes.Equal(g.TLSInfo.CaCert, other.TLSInfo.CaCert) {
+			!bytes.Equal(g.TLSInfo.CaCert, other.TLSInfo.CaCert) ||
+			g.TLSInfo.AllowInsecureFallback != other.TLSInfo.AllowInsecureFallback {
 			return false
 		}
 	}
@@ -161,7 +163,8 @@ func (g ListenerSet) Equals(other ListenerSet) bool {
 	if g.TLSInfo != nil {
 		if !bytes.Equal(g.TLSInfo.Cert, other.TLSInfo.Cert) ||
 			!bytes.Equal(g.TLSInfo.Key, other.TLSInfo.Key) ||
-			!bytes.Equal(g.TLSInfo.CaCert, other.TLSInfo.CaCert) {
+			!bytes.Equal(g.TLSInfo.CaCert, other.TLSInfo.CaCert) ||
+			g.TLSInfo.AllowInsecureFallback != other.TLSInfo.AllowInsecureFallback {
 			return false
 		}
 	}
@@ -447,7 +450,7 @@ func GatewayCollection(
 		if len(gatewayServices) == 0 && err != nil {
 			// Short circuit if its a hard failure
 			log.Errorf("failed to translate gwv1", "name", obj.GetName(), "namespace", obj.GetNamespace(), "err", err.message)
-			reportGatewayStatus(context, obj, status, classInfo, gatewayServices, servers, 0, err.error, 0)
+			reportGatewayStatus(context, obj, status, classInfo, gatewayServices, servers, 0, err.error, nil, 0)
 			return status, nil
 		}
 		var gatewayErr *ConfigError
@@ -537,7 +540,11 @@ func GatewayCollection(
 		}
 		validateListenerConflicts(result)
 		// TODO(jaellio): include unique listener sets in status after validating listener conflicts
-		reportGatewayStatus(context, obj, status, classInfo, gatewayServices, servers, len(listenerSets), gatewayErr, validListeners)
+		var backendTLSErr *ConfigError
+		if obj.Spec.TLS != nil {
+			backendTLSErr = resolveGatewayBackendTLS(ctx, secrets, grants, obj.Spec.TLS.Backend, obj)
+		}
+		reportGatewayStatus(context, obj, status, classInfo, gatewayServices, servers, len(listenerSets), gatewayErr, backendTLSErr, validListeners)
 		return status, result
 	}, opts.WithName("KubernetesGateway")...)
 

--- a/pilot/pkg/config/kube/agentgateway/gateway_status.go
+++ b/pilot/pkg/config/kube/agentgateway/gateway_status.go
@@ -88,6 +88,7 @@ func reportGatewayStatus(
 	servers []*istio.Server,
 	listenerSetCount int,
 	gatewayErr *ConfigError,
+	backendTLSErr *ConfigError,
 	validListeners int,
 ) {
 	// TODO: we lose address if servers is empty due to an error
@@ -108,6 +109,15 @@ func reportGatewayStatus(
 			reason:  string(gatewayv1.GatewayReasonProgrammed),
 			message: "Resource programmed",
 		},
+		string(gatewayv1.GatewayConditionResolvedRefs): {
+			reason:  string(gatewayv1.GatewayReasonResolvedRefs),
+			message: "All references resolved",
+		},
+		string(gatewayv1.GatewayConditionInsecureFrontendValidationMode): {
+			status:  metav1.ConditionFalse,
+			reason:  "AllowInsecureFallbackNotConfigured",
+			message: "AllowInsecureFallback mode is disabled for frontend validation",
+		},
 	}
 	if gatewayErr != nil {
 		gatewayConditions[string(gatewayv1.GatewayConditionAccepted)].error = gatewayErr
@@ -124,6 +134,31 @@ func reportGatewayStatus(
 		} else {
 			accepted.reason = string(gatewayv1.GatewayReasonListenersNotValid)
 			accepted.message = "One or more of the Gateway's listeners are invalid"
+		}
+	}
+	// Surface backend client certificate (spec.tls.backend.clientCertificateRef) validation errors
+	// on the Gateway ResolvedRefs condition.
+	if backendTLSErr != nil {
+		gatewayConditions[string(gatewayv1.GatewayConditionResolvedRefs)].error = backendTLSErr
+	}
+
+	if obj.Spec.TLS != nil && obj.Spec.TLS.Frontend != nil {
+		frontend := obj.Spec.TLS.Frontend
+		hasInsecure := frontend.Default.Validation != nil && frontend.Default.Validation.Mode == gatewayv1.AllowInsecureFallback
+		if !hasInsecure {
+			for _, perPort := range frontend.PerPort {
+				if perPort.TLS.Validation != nil && perPort.TLS.Validation.Mode == gatewayv1.AllowInsecureFallback {
+					hasInsecure = true
+					break
+				}
+			}
+		}
+		if hasInsecure {
+			gatewayConditions[string(gatewayv1.GatewayConditionInsecureFrontendValidationMode)] = &Condition{
+				status:  metav1.ConditionTrue,
+				reason:  string(gatewayv1.GatewayReasonConfigurationChanged),
+				message: "Gateway is operating in AllowInsecureFallback mode for frontend validation",
+			}
 		}
 	}
 

--- a/pilot/pkg/config/kube/agentgateway/listener.go
+++ b/pilot/pkg/config/kube/agentgateway/listener.go
@@ -116,6 +116,15 @@ func buildListener(
 		listenerConditions[string(gatewayv1.GatewayConditionProgrammed)].Error = &gatewaycommon.ListenerStatusConfigError{
 			Reason: string(gatewayv1.GatewayReasonInvalid), Message: "Bad TLS configuration",
 		}
+		// Frontend client certificate validation (CA) failures additionally mark the listener
+		// as not Accepted with the NoValidCACertificate reason. A reference-grant failure only
+		// applies to a CA reference (not the server certificate), identified by the message prefix.
+		if err.Reason == InvalidCACertificateRef || err.Reason == InvalidCACertificateKind ||
+			(err.Reason == InvalidListenerRefNotPermitted && strings.HasPrefix(err.Message, "caCertificateRef")) {
+			listenerConditions[string(gatewayv1.ListenerConditionAccepted)].Error = &gatewaycommon.ListenerStatusConfigError{
+				Reason: string(gatewayv1.ListenerReasonNoValidCACertificate), Message: err.Message,
+			}
+		}
 		ok = false
 	}
 	if portErr != nil {
@@ -328,7 +337,7 @@ func buildTLS(
 		// If we are going to send a cert, validate we can access it
 		sameNamespace := tlsRes.Source.Namespace == namespace
 		objectKind := schematypes.GvkFromObject(gw)
-		if !sameNamespace && !AgwSecretAllowed(grants, ctx, objectKind, tlsRes.Source, namespace) {
+		if !sameNamespace && !AgwSecretAllowed(grants, ctx, objectKind, gvk.Secret, tlsRes.Source, namespace) {
 			return dummyTLS, &ConfigError{
 				Reason: InvalidListenerRefNotPermitted,
 				Message: fmt.Sprintf(
@@ -339,10 +348,9 @@ func buildTLS(
 		}
 
 		if gatewayTLS != nil && gatewayTLS.Validation != nil && len(gatewayTLS.Validation.CACertificateRefs) > 0 {
-			// TODO: add 'Mode'
 			if len(gatewayTLS.Validation.CACertificateRefs) > 1 {
 				return dummyTLS, &ConfigError{
-					Reason:  InvalidTLS,
+					Reason:  InvalidCACertificateRef,
 					Message: "only one caCertificateRef is supported",
 				}
 			}
@@ -352,8 +360,13 @@ func buildTLS(
 				return dummyTLS, err
 			}
 			sameNamespace := cred.Source.Namespace == namespace
-			isSecret := cred.Kind == gvk.Secret.Kind
-			if isSecret && !sameNamespace && !AgwSecretAllowed(grants, ctx, schematypes.GvkFromObject(gw), cred.Source, namespace) {
+			// CA certificate references may be Secrets or ConfigMaps; enforce a ReferenceGrant for
+			// cross-namespace references of either kind.
+			caCertToKind := gvk.Secret
+			if cred.Kind == gvk.ConfigMap.Kind {
+				caCertToKind = gvk.ConfigMap
+			}
+			if !sameNamespace && !AgwSecretAllowed(grants, ctx, schematypes.GvkFromObject(gw), caCertToKind, cred.Source, namespace) {
 				return dummyTLS, &ConfigError{
 					Reason: InvalidListenerRefNotPermitted,
 					Message: fmt.Sprintf(
@@ -363,6 +376,9 @@ func buildTLS(
 				}
 			}
 			tlsRes.Info.CaCert = cred.Info.CaCert
+			// AllowInsecureFallback permits clients to connect without presenting a valid client
+			// certificate; otherwise (AllowValidOnly, the default) mTLS is strictly enforced.
+			tlsRes.Info.AllowInsecureFallback = gatewayTLS.Validation.Mode == gatewayv1.AllowInsecureFallback
 		}
 		return &tlsRes.Info, nil
 	case gatewayv1.TLSModePassthrough:
@@ -370,6 +386,41 @@ func buildTLS(
 		return nil, nil
 	}
 	return nil, nil
+}
+
+// resolveGatewayBackendTLS validates the Gateway's spec.tls.backend.clientCertificateRef, which is
+// the client certificate the Gateway presents when originating mTLS to a backend. It returns a
+// ConfigError to surface on the Gateway ResolvedRefs condition; the certificate itself is wired into
+// backend TLS policies separately (see BackendTLSPolicyCollection).
+func resolveGatewayBackendTLS(
+	ctx krt.HandlerContext,
+	secrets krt.Collection[*corev1.Secret],
+	grants gatewaycommon.ReferenceGrants,
+	backendTLS *gatewayv1.GatewayBackendTLS,
+	gw controllers.Object,
+) *ConfigError {
+	if backendTLS == nil || backendTLS.ClientCertificateRef == nil {
+		return nil
+	}
+	tlsRes, err := buildSecretReference(ctx, *backendTLS.ClientCertificateRef, gw, secrets)
+	if err != nil {
+		return &ConfigError{
+			Reason:  string(gatewayv1.GatewayReasonInvalidClientCertificateRef),
+			Message: err.Message,
+		}
+	}
+	namespace := gw.GetNamespace()
+	if tlsRes.Source.Namespace != namespace &&
+		!AgwSecretAllowed(grants, ctx, schematypes.GvkFromObject(gw), gvk.Secret, tlsRes.Source, namespace) {
+		return &ConfigError{
+			Reason: string(gatewayv1.GatewayReasonRefNotPermitted),
+			Message: fmt.Sprintf(
+				"clientCertificateRef %v/%v not accessible to a Gateway in namespace %q (missing a ReferenceGrant?)",
+				backendTLS.ClientCertificateRef.Name, tlsRes.Source.Namespace, namespace,
+			),
+		}
+	}
+	return nil
 }
 
 func buildCaCertificateReference(
@@ -395,14 +446,14 @@ func buildCaCertificateReference(
 		cm := ptr.Flatten(krt.FetchOne(ctx, configMaps, krt.FilterObjectName(res.Source)))
 		if cm == nil {
 			return nil, &ConfigError{
-				Reason:  InvalidTLS,
+				Reason:  InvalidCACertificateRef,
 				Message: fmt.Sprintf("invalid CA certificate reference, configmap %v not found", res.Source),
 			}
 		}
 		certInfo, err := kubecreds.ExtractRootFromString(cm.Data)
 		if err != nil {
 			return nil, &ConfigError{
-				Reason:  InvalidTLS,
+				Reason:  InvalidCACertificateRef,
 				Message: fmt.Sprintf("invalid CA certificate reference %v, %v", plainObjectReferenceString(ref), err),
 			}
 		}
@@ -412,21 +463,21 @@ func buildCaCertificateReference(
 		scrt := ptr.Flatten(krt.FetchOne(ctx, secrets, krt.FilterObjectName(res.Source)))
 		if scrt == nil {
 			return nil, &ConfigError{
-				Reason:  InvalidTLS,
+				Reason:  InvalidCACertificateRef,
 				Message: fmt.Sprintf("invalid CA certificate reference, secret %v not found", res.Source),
 			}
 		}
 		certInfo, err := kubecreds.ExtractRoot(scrt.Data)
 		if err != nil {
 			return nil, &ConfigError{
-				Reason:  InvalidTLS,
+				Reason:  InvalidCACertificateRef,
 				Message: fmt.Sprintf("invalid CA certificate reference %v, %v", plainObjectReferenceString(ref), err),
 			}
 		}
 		res.Info.CaCert = certInfo.Cert
 	default:
 		return nil, &ConfigError{
-			Reason:  InvalidTLS,
+			Reason:  InvalidCACertificateKind,
 			Message: fmt.Sprintf("invalid CA certificate reference %v, only secret and configmap are allowed", plainObjectReferenceString(ref)),
 		}
 	}

--- a/pilot/pkg/config/kube/agentgateway/references_collection.go
+++ b/pilot/pkg/config/kube/agentgateway/references_collection.go
@@ -20,7 +20,6 @@ import (
 
 	"istio.io/istio/pilot/pkg/config/kube/gatewaycommon"
 	"istio.io/istio/pkg/config"
-	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/kube/krt"
 )
 
@@ -28,11 +27,12 @@ func AgwSecretAllowed(
 	refs gatewaycommon.ReferenceGrants,
 	ctx krt.HandlerContext,
 	kind config.GroupVersionKind,
+	toKind config.GroupVersionKind,
 	resourceName types.NamespacedName,
 	namespace string,
 ) bool {
 	from := gatewaycommon.Reference{Kind: kind, Namespace: gateway.Namespace(namespace)}
-	to := gatewaycommon.Reference{Kind: gvk.Secret, Namespace: gateway.Namespace(resourceName.Namespace)}
+	to := gatewaycommon.Reference{Kind: toKind, Namespace: gateway.Namespace(resourceName.Namespace)}
 	pair := gatewaycommon.ReferencePair{From: from, To: to}
 	grants := krt.FetchOrList(ctx, refs.Collection, krt.FilterIndex(refs.Index, pair))
 	for _, g := range grants {

--- a/pilot/pkg/config/kube/agentgateway/types.go
+++ b/pilot/pkg/config/kube/agentgateway/types.go
@@ -98,6 +98,10 @@ const (
 	InvalidFilter ConfigErrorReason = "InvalidFilter"
 	// InvalidTLS indicates an issue with TLS settings
 	InvalidTLS ConfigErrorReason = ConfigErrorReason(gatewayv1.ListenerReasonInvalidCertificateRef)
+	// InvalidCACertificateRef indicates an issue with a CA certificate reference
+	InvalidCACertificateRef ConfigErrorReason = ConfigErrorReason(gatewayv1.ListenerReasonInvalidCACertificateRef)
+	// InvalidCACertificateKind indicates an issue with the kind of a CA certificate reference
+	InvalidCACertificateKind ConfigErrorReason = ConfigErrorReason(gatewayv1.ListenerReasonInvalidCACertificateKind)
 	// InvalidListenerRefNotPermitted indicates a listener reference was not permitted
 	InvalidListenerRefNotPermitted ConfigErrorReason = ConfigErrorReason(gatewayv1.ListenerReasonRefNotPermitted)
 	// InvalidConfiguration indicates a generic error for all other invalid configurations

--- a/releasenotes/notes/agentgateway-gwapi-client-certificate-tls.yaml
+++ b/releasenotes/notes/agentgateway-gwapi-client-certificate-tls.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+  - |
+    **Added** support for Gateway API client certificate TLS configuration when using `agentgateway`. Gateways now honor
+    frontend client certificate validation (`spec.tls.frontend`, including `AllowInsecureFallback` mode) and backend client
+    certificates (`spec.tls.backend.clientCertificateRef`), and report the corresponding `ResolvedRefs` and
+    `InsecureFrontendValidationMode` conditions in status.

--- a/tests/integration/pilot/agentgateway/gateway_conformance_test.go
+++ b/tests/integration/pilot/agentgateway/gateway_conformance_test.go
@@ -66,14 +66,6 @@ var skippedTests = map[string]string{
 	// The following tests were added in v1.5.0
 	"BackendTLSPolicyObservedGenerationBump": "TODO",
 
-	"GatewayBackendClientCertificateFeature":                     "TODO",
-	"GatewayFrontendInvalidDefaultClientCertificateValidation":   "TODO",
-	"GatewayInvalidTLSBackendConfiguration":                      "TODO",
-	"GatewayTLSBackendClientCertificate":                         "TODO",
-	"GatewayFrontendClientCertificateValidationInsecureFallback": "TODO",
-	"GatewayFrontendClientCertificateValidation":                 "TODO",
-	"GatewayInvalidFrontendClientCertificateValidation":          "TODO",
-
 	"HTTPRouteHTTPSListenerDetectMisdirectedRequests": "TODO",
 
 	// The following tests were modified between v1.4.0 && v1.5.0
@@ -116,6 +108,9 @@ func TestGatewayConformanceAgentgateway(t *testing.T) {
 
 			supportedFeatures := gateway.SupportedFeatures.Clone().
 				Delete(features.MeshClusterIPMatchingFeature) // https://github.com/istio/istio/issues/44702
+			// Backend client certificate support (spec.tls.backend.clientCertificateRef) is implemented
+			// for agentgateway even though it is disabled in the shared gateway.SupportedFeatures.
+			supportedFeatures.Insert(features.GatewayBackendClientCertificateFeature)
 			if ctx.Settings().GatewayConformanceStandardOnly {
 				for f := range supportedFeatures {
 					if f.Channel != features.FeatureChannelStandard {


### PR DESCRIPTION
**Please provide a description of this PR:**

When a Gateway on `agentgateway` is configured with Gateway API client certificate TLS, the control plane should translate it and set the right status. Today most of it is dropped.

**Frontend (`spec.tls.frontend`):**
- `buildTLS` reads the CA cert but ignores the validation `Mode`, so `AllowInsecureFallback` never reaches the dataplane.
- CA failures report the generic `InvalidCertificateRef` reason instead of `InvalidCACertificateRef`/`InvalidCACertificateKind` on `ResolvedRefs` and `NoValidCACertificate` on `Accepted`.
- Cross-namespace ConfigMap CA refs skip the `ReferenceGrant` check.

**Backend (`spec.tls.backend.clientCertificateRef`):**
- The client cert ref is never validated, so the Gateway never sets its `ResolvedRefs` condition.

We wire all of these through, mirroring `agentgateway`'s own controller and Istio's built-in gateway. This un-skips the 6 client-cert conformance tests in gateway_conformance_test.go.