### PR TITLE
Update to networking.istio.io/v1 where possible in tests.

### DIFF
--- a/pilot/pkg/config/kube/crd/conversion_test.go
+++ b/pilot/pkg/config/kube/crd/conversion_test.go
@@ -133,15 +133,15 @@ func TestParseInputs(t *testing.T) {
 	if varr, others, err := ParseInputs("---\n"); err != nil || len(varr) != 0 || len(others) != 0 {
 		t.Errorf(`ParseInput("---") => got %v, %v, %v`, varr, others, err)
 	}
-	if _, _, err := ParseInputs("apiVersion: networking.istio.io/v1alpha3\nkind: VirtualService\nspec:\n  destination: x"); err == nil {
+	if _, _, err := ParseInputs("apiVersion: networking.istio.io/v1\nkind: VirtualService\nspec:\n  destination: x"); err == nil {
 		t.Error("ParseInput(bad spec) => got no error")
 	}
-	if _, _, err := ParseInputs("apiVersion: networking.istio.io/v1alpha3\nkind: VirtualService\nspec:\n  destination:\n    service:"); err == nil {
+	if _, _, err := ParseInputs("apiVersion: networking.istio.io/v1\nkind: VirtualService\nspec:\n  destination:\n    service:"); err == nil {
 		t.Error("ParseInput(invalid spec) => got no error")
 	}
 
 	// nolint: lll
-	validInput := `{"apiVersion": "networking.istio.io/v1alpha3", "kind":"VirtualService", "spec":{"hosts":["foo"],"http":[{"route":[{"destination":{"host":"bar"},"weight":100}]}]}}`
+	validInput := `{"apiVersion": "networking.istio.io/v1", "kind":"VirtualService", "spec":{"hosts":["foo"],"http":[{"route":[{"destination":{"host":"bar"},"weight":100}]}]}}`
 	varr, _, err := ParseInputs(validInput)
 	if err != nil || len(varr) == 0 {
 		t.Errorf("ParseInputs(correct input) => got %v, %v", varr, err)

--- a/pkg/config/validation/testdata/crds/serviceentry-invalid.yaml
+++ b/pkg/config/validation/testdata/crds/serviceentry-invalid.yaml
@@ -12,7 +12,7 @@ metadata:
 spec: {}
 ---
 #_err: "TODO"
-#apiVersion: networking.istio.io/v1alpha3
+#apiVersion: networking.istio.io/v1
 #kind: ServiceEntry
 #metadata:
 #  name: bad-selector-key
@@ -24,7 +24,7 @@ spec: {}
 #      "*": val
 #---
 _err: "wildcard is not supported in selector"
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: bad-selector-value
@@ -35,7 +35,7 @@ spec:
       "val": "*"
 ---
 _err: "only one of WorkloadSelector or Endpoints can be set"
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: selector-and-endpoints
@@ -46,7 +46,7 @@ spec:
     - address: "1.2.3.4"
 ---
 _err: "hostname cannot be wildcard"
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: bad-host-wildcard
@@ -54,7 +54,7 @@ spec:
   hosts: ["*"]
 #---
 #_err: "TODO"
-#apiVersion: networking.istio.io/v1alpha3
+#apiVersion: networking.istio.io/v1
 #kind: ServiceEntry
 #metadata:
 #  name: bad-host-wildcard-suffix
@@ -62,7 +62,7 @@ spec:
 #  hosts: ["foo*"]
 #---
 #_err: "TODO"
-#apiVersion: networking.istio.io/v1alpha3
+#apiVersion: networking.istio.io/v1
 #kind: ServiceEntry
 #metadata:
 #  name: bad-cidr
@@ -71,7 +71,7 @@ spec:
 #  addresses: [1.2.3.4/99]
 ---
 _err: "CIDR addresses are allowed only for NONE/STATIC resolution types"
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: bad-cidr-resolution
@@ -81,7 +81,7 @@ spec:
   resolution: DNS
 ---
 _err: "Duplicate value"
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: duplicate-ports-name
@@ -94,7 +94,7 @@ spec:
       number: 12
 ---
 _err: "port number cannot be duplicated"
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: duplicate-ports-number
@@ -107,7 +107,7 @@ spec:
       number: 1
 ---
 _err: "port must be between 1-65535"
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: bad-port
@@ -118,7 +118,7 @@ spec:
       number: 99999
 ---
 _err: "port must be between 1-65535"
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: bad-port-target
@@ -130,7 +130,7 @@ spec:
       targetPort: 99999
 ---
 _err: "NONE mode cannot set endpoints"
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: none-with-endpoints
@@ -141,7 +141,7 @@ spec:
   resolution: NONE
 ---
 _err: "DNS_ROUND_ROBIN mode cannot have multiple endpoints"
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: dns-rr-with-multiple-endpoints

--- a/pkg/config/validation/testdata/crds/serviceentry-valid.yaml
+++ b/pkg/config/validation/testdata/crds/serviceentry-valid.yaml
@@ -35,7 +35,7 @@ spec:
   resolution: DNS
 ---
 # Weird case but we allow it
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: empty-selector
@@ -44,7 +44,7 @@ spec:
   hosts: ["example.com"]
 ---
 # Weird case but we allow it
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: partial-wildcard
@@ -52,7 +52,7 @@ spec:
   hosts: ["*x"]
 ---
 # Weird case but we allow it
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: none-cidr

--- a/pkg/config/validation/testdata/crds/workloadentry-invalid.yaml
+++ b/pkg/config/validation/testdata/crds/workloadentry-invalid.yaml
@@ -1,18 +1,18 @@
 _err: 'spec: Required value'
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: WorkloadEntry
 metadata:
   name: no-spec
 ---
 _err: Address is required
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: WorkloadEntry
 metadata:
   name: missing-address
 spec: {}
 ---
 _err: UDS may not be a dir
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: WorkloadEntry
 metadata:
   name: bad-uds-dir
@@ -20,7 +20,7 @@ spec:
   address: unix:///dir/
 ---
 _err: UDS must be an absolute path or abstract socket
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: WorkloadEntry
 metadata:
   name: bad-uds-relative
@@ -28,7 +28,7 @@ spec:
   address: unix://relative
 ---
 _err: UDS may not include ports
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: WorkloadEntry
 metadata:
   name: uds-with-ports
@@ -38,7 +38,7 @@ spec:
     "http": 80
 ---
 _err: port must be between 1-65535
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: WorkloadEntry
 metadata:
   name: high-port
@@ -48,7 +48,7 @@ spec:
     "http": 99999
 ---
 _err: 'spec.ports: Invalid value'
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: WorkloadEntry
 metadata:
   name: bad-port-name

--- a/pkg/config/validation/testdata/crds/workloadentry-valid.yaml
+++ b/pkg/config/validation/testdata/crds/workloadentry-valid.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: WorkloadEntry
 metadata:
   name: full
@@ -13,28 +13,28 @@ spec:
   weight: 2
   locality: foo/bar/baz
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: WorkloadEntry
 metadata:
   name: missing-address-network-set
 spec:
   network: net
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: WorkloadEntry
 metadata:
   name: uds-abstract
 spec:
   address: unix://@foo
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: WorkloadEntry
 metadata:
   name: uds-path
 spec:
   address: unix:///foo/bar
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: WorkloadEntry
 metadata:
   name: fqdn

--- a/pkg/config/validation/testdata/crds/workloadgroup-invalid.yaml
+++ b/pkg/config/validation/testdata/crds/workloadgroup-invalid.yaml
@@ -5,7 +5,7 @@ metadata:
   name: no-spec
 ---
 _err: port must be between 1-65535
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: WorkloadGroup
 metadata:
   name: tcp-probe-invalid
@@ -18,7 +18,7 @@ spec:
     network: net
 ---
 _err: 'spec.probe.httpGet.httpHeaders[0].name in body should match'
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: WorkloadGroup
 metadata:
   name: http-probe-invalid

--- a/pkg/config/validation/testdata/crds/workloadgroup-valid.yaml
+++ b/pkg/config/validation/testdata/crds/workloadgroup-valid.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: WorkloadGroup
 metadata:
   name: full
@@ -32,7 +32,7 @@ spec:
     weight: 2
     locality: foo/bar/baz
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: WorkloadGroup
 metadata:
   name: tcp-probe

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -2953,7 +2953,7 @@ func TestIngressTLS(t *testing.T) {
 		t.ConfigIstio().Eval(apps.Namespace.Name(), map[string]any{
 			"Destination": apps.Captured.Config().Service,
 			"Port":        ports.HTTPS.ServicePort,
-		}, `apiVersion: networking.istio.io/v1alpha3
+		}, `apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: gateway
@@ -2967,7 +2967,7 @@ spec:
       protocol: HTTP
     hosts: ["*"]
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: route
@@ -2983,7 +2983,7 @@ spec:
         port:
           number: {{.Port}}
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: "{{.Destination}}"

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -2967,7 +2967,7 @@ func TestIngressTLS(t *testing.T) {
 		t.ConfigIstio().Eval(apps.Namespace.Name(), map[string]any{
 			"Destination": apps.Captured.Config().Service,
 			"Port":        ports.HTTPS.ServicePort,
-		}, `apiVersion: networking.istio.io/v1alpha3
+		}, `apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: gateway
@@ -2981,7 +2981,7 @@ spec:
       protocol: HTTP
     hosts: ["*"]
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: route
@@ -2997,7 +2997,7 @@ spec:
         port:
           number: {{.Port}}
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: "{{.Destination}}"

--- a/tests/integration/ambient/waypoint_canary_test.go
+++ b/tests/integration/ambient/waypoint_canary_test.go
@@ -185,7 +185,7 @@ func TestWeightedWaypointIngressTrafficShift(t *testing.T) {
 		// Ingress gateway routing to Captured.
 		t.ConfigIstio().Eval(ns, map[string]string{
 			"Destination": apps.Captured.ServiceName(),
-		}, `apiVersion: networking.istio.io/v1alpha3
+		}, `apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: canary-ingress
@@ -199,7 +199,7 @@ spec:
       protocol: HTTP
     hosts: ["*"]
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: canary-ingress-route

--- a/tests/integration/ambient/waypoint_canary_test.go
+++ b/tests/integration/ambient/waypoint_canary_test.go
@@ -189,7 +189,7 @@ func TestWeightedWaypointIngressTrafficShift(t *testing.T) {
 		// Ingress gateway routing to Captured.
 		t.ConfigIstio().Eval(ns, map[string]string{
 			"Destination": apps.Captured.ServiceName(),
-		}, `apiVersion: networking.istio.io/v1alpha3
+		}, `apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: canary-ingress
@@ -203,7 +203,7 @@ spec:
       protocol: HTTP
     hosts: ["*"]
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: canary-ingress-route

--- a/tests/integration/ambient/waypoint_test.go
+++ b/tests/integration/ambient/waypoint_test.go
@@ -968,7 +968,7 @@ spec:
       protocol: HTTP
     hosts: ["*"]
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: route
@@ -1011,7 +1011,7 @@ spec:
 			}
 			t.ConfigIstio().Eval(apps.Namespace.Name(), map[string]string{
 				"Destination": apps.ServiceAddressedWaypoint.ServiceName(),
-			}, `apiVersion: networking.istio.io/v1alpha3
+			}, `apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: gateway
@@ -1025,7 +1025,7 @@ spec:
       protocol: HTTP
     hosts: ["*"]
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: route

--- a/tests/integration/ambient/waypoint_test.go
+++ b/tests/integration/ambient/waypoint_test.go
@@ -974,7 +974,7 @@ spec:
       protocol: HTTP
     hosts: ["*"]
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: route
@@ -1017,7 +1017,7 @@ spec:
 			}
 			t.ConfigIstio().Eval(apps.Namespace.Name(), map[string]string{
 				"Destination": apps.ServiceAddressedWaypoint.ServiceName(),
-			}, `apiVersion: networking.istio.io/v1alpha3
+			}, `apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: gateway
@@ -1031,7 +1031,7 @@ spec:
       protocol: HTTP
     hosts: ["*"]
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: route


### PR DESCRIPTION
**Please provide a description of this PR:**

I had a look in the [documentation](https://istio.io/latest/docs/reference/config/networking/) where `v1` is used for `WorkloadGroup`, `WorkloadEntry` and `ServiceEntry`