### PR TITLE
test: speed up leader election and multicluster secret controller tests

### DIFF
--- a/pilot/pkg/leaderelection/leaderelection_test.go
+++ b/pilot/pkg/leaderelection/leaderelection_test.go
@@ -36,6 +36,12 @@ import (
 
 const testLock = "test-lock"
 
+// testTTL is deliberately short to keep the tests fast: RenewDeadline (ttl/2) bounds how
+// long it takes a leader to detect a lost lease, and RetryPeriod (ttl/4) bounds how often
+// candidates attempt to (re-)acquire the lock. It should still be large enough that a
+// healthy leader does not spuriously lose the lease on a slow CI machine.
+const testTTL = 200 * time.Millisecond
+
 func createElection(t *testing.T,
 	name string, revision string,
 	watcher revisions.DefaultWatcher,
@@ -77,7 +83,7 @@ func createElectionMulticluster(t *testing.T,
 		remote:         remote,
 		defaultWatcher: watcher,
 		perRevision:    perRevision,
-		ttl:            time.Second,
+		ttl:            testTTL,
 		cycle:          atomic.NewInt32(0),
 		enabled:        true,
 	}
@@ -92,7 +98,7 @@ func createElectionMulticluster(t *testing.T,
 
 	retry.UntilOrFail(t, func() bool {
 		return l.isLeader() == expectLeader
-	}, retry.Converge(5), retry.Delay(time.Millisecond*100), retry.Timeout(time.Second*10))
+	}, retry.Converge(5), retry.Delay(time.Millisecond*10), retry.Timeout(time.Second*10))
 	return l, stop
 }
 
@@ -194,7 +200,7 @@ func TestRunCycleGoroutineLeak(t *testing.T) {
 		// Wait until pod1's election loop actually starts a new cycle, i.e. its previous
 		// LeaderElector exited after losing the lock and its stop watcher was orphaned.
 		retry.UntilOrFail(t, func() bool { return l.cycle.Load() > prev },
-			retry.Delay(time.Millisecond*50), retry.Timeout(time.Second*30))
+			retry.Delay(time.Millisecond*10), retry.Timeout(time.Second*30))
 		// pod2 releases the lock; pod1 re-acquires it, completing the cycle.
 		close(stop2)
 		retry.UntilOrFail(t, func() bool { return l.isLeader() },
@@ -207,7 +213,7 @@ func TestRunCycleGoroutineLeak(t *testing.T) {
 			return fmt.Errorf("%d stop watcher goroutines still alive after %d election cycles, expected 1", n, cycles)
 		}
 		return nil
-	}, retry.Delay(time.Millisecond*100), retry.Timeout(time.Second*5))
+	}, retry.Delay(time.Millisecond*10), retry.Timeout(time.Second*5))
 	close(stop)
 }
 
@@ -397,7 +403,7 @@ func TestLeaderElectionDisabled(t *testing.T) {
 		client:         client,
 		revision:       "",
 		defaultWatcher: watcher,
-		ttl:            time.Second,
+		ttl:            testTTL,
 		cycle:          atomic.NewInt32(0),
 	}
 	gotLeader := atomic.NewBool(false)
@@ -411,7 +417,7 @@ func TestLeaderElectionDisabled(t *testing.T) {
 	})
 
 	// Need to retry until Run() starts to execute in the goroutine.
-	retry.UntilOrFail(t, gotLeader.Load, retry.Converge(5), retry.Delay(time.Millisecond*100), retry.Timeout(time.Second*10))
+	retry.UntilOrFail(t, gotLeader.Load, retry.Converge(5), retry.Delay(time.Millisecond*10), retry.Timeout(time.Second*10))
 	if !l.isLeader() {
 		t.Errorf("isLeader()=false, want true")
 	}

--- a/pkg/kube/multicluster/secretcontroller_test.go
+++ b/pkg/kube/multicluster/secretcontroller_test.go
@@ -1040,18 +1040,19 @@ func TestKRTClustersCollection(t *testing.T) {
 	}
 
 	steps := []struct {
-		name           string
-		add            *v1.Secret
-		update         *v1.Secret
-		delete         *v1.Secret
-		want           []result
-		afterTestDelay time.Duration // sleep after assertion to verify no panic/segfault
+		name   string
+		add    *v1.Secret
+		update *v1.Secret
+		delete *v1.Secret
+		want   []result
 	}{
 		{
-			name:           "Create secret s0 with bad kubeconfig for cluster c0, client builder returns error so cluster is never stored",
-			add:            secret0Bad,
-			want:           []result{{"config", 1}},
-			afterTestDelay: features.RemoteClusterTimeout + 500*time.Millisecond,
+			// The client builder fails before a Cluster is ever constructed, so no sync-timeout
+			// timer is armed for it. The timer-fires-after-failure path is covered by
+			// TestKRTClustersCollectionSyncTimeoutEviction.
+			name: "Create secret s0 with bad kubeconfig for cluster c0, client builder returns error so cluster is never stored",
+			add:  secret0Bad,
+			want: []result{{"config", 1}},
 		},
 		{
 			name:   "Update secret s0 and add good kubeconfig for cluster c0, which will add remote cluster c0",
@@ -1184,10 +1185,6 @@ func TestKRTClustersCollection(t *testing.T) {
 					return result(e)
 				})
 			}, step.want)
-			if step.afterTestDelay > 0 {
-				// Wait past the timeout to confirm no segfaults or panics
-				time.Sleep(step.afterTestDelay)
-			}
 		})
 	}
 }
@@ -1197,7 +1194,7 @@ func TestKRTClustersCollection(t *testing.T) {
 // the Clusters() collection after RemoteClusterTimeout fires, and that no panic
 // occurs after the timeout.
 func TestKRTClustersCollectionSyncTimeoutEviction(t *testing.T) {
-	test.SetForTest(t, &features.RemoteClusterTimeout, 500*time.Millisecond)
+	test.SetForTest(t, &features.RemoteClusterTimeout, 100*time.Millisecond)
 
 	client := kube.NewFakeClient()
 	stopCh := test.NewStop(t)
@@ -1231,14 +1228,14 @@ func TestKRTClustersCollectionSyncTimeoutEviction(t *testing.T) {
 		return len(c.Clusters().List())
 	}, 0)
 
-	// Wait for RemoteClusterTimeout to fire, then wait a bit more to confirm no panic/segfault
-	time.Sleep(features.RemoteClusterTimeout + 500*time.Millisecond)
+	// Wait for RemoteClusterTimeout to fire and mark the cluster as timed out, rather than
+	// sleeping past the timeout.
+	assert.EventuallyEqual(t, func() bool {
+		cl := c.cs.GetByID("c0")
+		return cl != nil && cl.SyncDidTimeout()
+	}, true)
 
-	// The cluster should still not be in the Clusters() collection after timeout
+	// The cluster should still not be in the Clusters() collection after the timeout fired,
+	// and processing the timeout must not panic.
 	assert.Equal(t, len(c.Clusters().List()), 0)
-
-	// Verify the cluster timed out via the ClusterStore
-	cl := c.cs.GetByID("c0")
-	assert.Equal(t, cl != nil, true)
-	assert.Equal(t, cl.SyncDidTimeout(), true)
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

Part of #37555 (slow unit tests). Both slow-test inventories on the issue are outdated, so I re-derived the worst offenders by timing candidate packages at current HEAD and fixed the top four (skipping `TestSleepCheckInstall`, already covered by #60923). All changes are test-only.

### Root causes

**`pilot/pkg/leaderelection`** — every test elects with `ttl: time.Second`, from which the elector derives `RenewDeadline = ttl/2` (how long until a leader notices a lost lease) and `RetryPeriod = ttl/4` (how often candidates attempt to acquire). Tests that exercise losing/stealing/re-acquiring the lock (`TestRunCycleGoroutineLeak` does 3 full cycles, `TestLeaderElectionNoPermission` one loss + re-acquire) spend 250–500ms of pure wall clock per transition, plus 50–100ms poll delays on every wait.

**`pkg/kube/multicluster`**:
- `TestKRTClustersCollection` slept `features.RemoteClusterTimeout + 500ms` (**1.5s**) after its bad-kubeconfig step to catch delayed panics from the remote-cluster sync-timeout timer. In the current (post-#59211) code, `ClientBuilder` fails before a `Cluster` is constructed, so the `time.AfterFunc` timer (armed only in `Cluster.Run`) never exists for that step, and the secret queue does not retry — the sleep guards a path that cannot execute.
- `TestKRTClustersCollectionSyncTimeoutEviction` slept `RemoteClusterTimeout + 500ms` (**1s**) blind instead of waiting for the timer's observable effect.

### Fix

- `leaderelection_test.go`: introduce `testTTL = 200ms` and drop wait-poll `retry.Delay`s to 10ms (the retry default; delays only apply between failed checks, so this purely cuts wait latency). This follows the precedent of #42920, merged against this same issue, which lowered the equivalent knobs in the `k8sleaderelection` tests to 40ms/20ms/10ms — 200ms (renew 100ms / retry 50ms) keeps 5x more headroom against spurious lease loss on a slow CI machine. If reviewers want more margin, bumping `testTTL` to 400ms still preserves most of the win.
- `secretcontroller_test.go`: remove the dead `afterTestDelay` sleep from `TestKRTClustersCollection` (comment points at the eviction test for the timer-fires-after-failure coverage). In `TestKRTClustersCollectionSyncTimeoutEviction`, wait event-driven for `SyncDidTimeout()` instead of sleeping past the timeout, and lower `RemoteClusterTimeout` to 100ms — safe in this test because its only cluster uses an erroring fake client and is *supposed* to never sync, and both pre-timeout assertions (`GetByID != nil`, empty `Clusters().List()`) hold identically before and after the timer fires.

### Measured results (same machine, before → after)

With `-race` (as CI runs):

| Test | Before | After |
|---|---|---|
| TestRunCycleGoroutineLeak | 3.67s | 0.76s |
| TestKRTClustersCollection | 2.72s | 1.78s |
| TestPerRevisionElection | 2.13s | 1.14s |
| TestLeaderElectionNoPermission | 1.38s | 0.41s |
| TestKRTClustersCollectionSyncTimeoutEviction | 1.16s | 0.26s |
| TestPrioritizedLeaderElection | 0.41s | 0.09s |

Without `-race`: TestRunCycleGoroutineLeak 3.30s → 0.69s, TestKRTClustersCollection 1.70s → 0.22s, TestLeaderElectionNoPermission 1.38s → 0.33s, TestKRTClustersCollectionSyncTimeoutEviction 1.04s → 0.15s.

Flake check: `go test -race -count=5` on both packages passed with 0 failures; `golangci-lint` clean on both packages.