### PR TITLE
fix: clean up namespace controller handlers

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
@@ -125,6 +125,12 @@ func NewNamespaceController(kubeClient kube.Client, caBundleWatcher *keycertbund
 
 // Run starts the NamespaceController until a value is sent to stopCh.
 func (nc *NamespaceController) Run(stopCh <-chan struct{}) {
+	handlers := []controllers.Shutdowner{nc.configmaps, nc.namespaces}
+	if nc.crlConfigmaps != nil {
+		handlers = append(handlers, nc.crlConfigmaps)
+	}
+	defer controllers.ShutdownAll(handlers...)
+
 	if !kube.WaitForCacheSync("namespace controller", stopCh, nc.namespaces.HasSynced, nc.configmaps.HasSynced) {
 		nc.queue.ShutDownEarly()
 		return
@@ -132,7 +138,6 @@ func (nc *NamespaceController) Run(stopCh <-chan struct{}) {
 
 	go nc.startCaBundleWatcher(stopCh)
 	nc.queue.Run(stopCh)
-	controllers.ShutdownAll(nc.configmaps, nc.namespaces)
 }
 
 // startCaBundleWatcher listens for updates to the CA bundle and update cm in each namespace

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
@@ -26,16 +26,62 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/keycertbundle"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/mesh/meshwatcher"
 	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/inject"
 	"istio.io/istio/pkg/kube/kclient"
 	filter "istio.io/istio/pkg/kube/namespace"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/retry"
 )
+
+type shutdownTrackingClient[T controllers.Object] struct {
+	kclient.Client[T]
+	shutdownCalled bool
+}
+
+func (c *shutdownTrackingClient[T]) ShutdownHandlers() {
+	c.shutdownCalled = true
+	c.Client.ShutdownHandlers()
+}
+
+func (c *shutdownTrackingClient[T]) HasSynced() bool {
+	return false
+}
+
+func TestNamespaceControllerRunCleansUpHandlersBeforeCacheSync(t *testing.T) {
+	test.SetForTest(t, &features.EnableCACRL, true)
+	client := kube.NewFakeClient()
+	t.Cleanup(client.Shutdown)
+	clientStop := test.NewStop(t)
+
+	nc := NewNamespaceController(client, keycertbundle.NewWatcher())
+	namespaces := &shutdownTrackingClient[*v1.Namespace]{Client: nc.namespaces}
+	configmaps := &shutdownTrackingClient[*v1.ConfigMap]{Client: nc.configmaps}
+	crlConfigmaps := &shutdownTrackingClient[*v1.ConfigMap]{Client: nc.crlConfigmaps}
+	nc.namespaces = namespaces
+	nc.configmaps = configmaps
+	nc.crlConfigmaps = crlConfigmaps
+	client.RunAndWait(clientStop)
+
+	stop := make(chan struct{})
+	close(stop)
+	nc.Run(stop)
+
+	if !namespaces.shutdownCalled {
+		t.Error("namespace handlers were not shut down")
+	}
+	if !configmaps.shutdownCalled {
+		t.Error("configmap handlers were not shut down")
+	}
+	if !crlConfigmaps.shutdownCalled {
+		t.Error("CRL configmap handlers were not shut down")
+	}
+}
 
 func TestNamespaceController(t *testing.T) {
 	client := kube.NewFakeClient()

--- a/releasenotes/notes/60909.yaml
+++ b/releasenotes/notes/60909.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 60909
+releaseNotes:
+  - |
+    **Fixed** a memory leak in istiod where namespace controller informer handlers
+    accumulated across leader election cycles.


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes #60909.

Namespace controller instances register handlers on process-wide shared informers. When leadership was lost before cache synchronization completed, the early return skipped handler cleanup. The CRL ConfigMap handler was also omitted from cleanup after a normal run.

This change:

- defers informer handler cleanup before waiting for cache synchronization
- includes the optional CRL ConfigMap handler in cleanup
- adds a regression test for cancellation before cache synchronization
- adds a release note for the istiod memory leak

**Testing:**

- `go test ./pilot/pkg/serviceregistry/kube/controller -count=1`
- `go test -race ./pilot/pkg/serviceregistry/kube/controller -run "^TestNamespaceControllerRunCleansUpHandlersBeforeCacheSync$" -count=1`


**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any user-facing changes.