### PR TITLE
tests: increase binary size for ztunnel and envoy in TestBinarySizes

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -11,7 +11,7 @@
     "name": "ZTUNNEL_REPO_SHA",
     "repoName": "ztunnel",
     "file": "",
-    "lastStableSHA": "2bf66d52822fb98037153dd4ce9ae049ec94ef48"
+    "lastStableSHA": "3276243f2c23ec825efbaea5637d004e09e86163"
   },
   {
     "_comment": "",

--- a/istio.deps
+++ b/istio.deps
@@ -11,7 +11,7 @@
     "name": "ZTUNNEL_REPO_SHA",
     "repoName": "ztunnel",
     "file": "",
-    "lastStableSHA": "3276243f2c23ec825efbaea5637d004e09e86163"
+    "lastStableSHA": "2bf66d52822fb98037153dd4ce9ae049ec94ef48"
   },
   {
     "_comment": "",

--- a/tests/binary/binaries_test.go
+++ b/tests/binary/binaries_test.go
@@ -112,7 +112,7 @@ func TestBinarySizes(t *testing.T) {
 		"bug-report":      {60, 80},
 		"client":          {15, 30},
 		"server":          {15, 32},
-		"envoy":           {60, 167},
+		"envoy":           {60, 168},
 		"ztunnel":         {12, 19},
 	}
 

--- a/tests/binary/binaries_test.go
+++ b/tests/binary/binaries_test.go
@@ -113,7 +113,7 @@ func TestBinarySizes(t *testing.T) {
 		"client":          {15, 30},
 		"server":          {15, 32},
 		"envoy":           {60, 167},
-		"ztunnel":         {12, 17},
+		"ztunnel":         {12, 19},
 	}
 
 	runBinariesTest(t, func(t *testing.T, name string) {


### PR DESCRIPTION
**Please provide a description of this PR:**

The automated [ztunnel](https://github.com/istio/istio/pull/61017) and [proxy](https://github.com/istio/istio/pull/60970) updates caused failure of TestBinarySizes/ztunnel.