### PR TITLE
agw: fix missing service config on canary waypoints

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -18,6 +18,6 @@
     "name": "AGENTGATEWAY_IMAGE",
     "repoName": "agentgateway",
     "file": "",
-    "lastStableSHA": "v1.4.0"
+    "lastStableSHA": "v1.4.1"
   }
 ]

--- a/pilot/pkg/config/kube/agentgateway/gateway_collection.go
+++ b/pilot/pkg/config/kube/agentgateway/gateway_collection.go
@@ -561,10 +561,10 @@ func InternalGatewayName(gwNamespace, gwName, lName string) string {
 type RouteParents struct {
 	gatewayIndex krt.Index[AgwParentKey, *GatewayListener]
 
-	// waypointBindings maps services to their AGW waypoint gateways.
-	// When a route references a Service as parentRef, this collection is used to
-	// resolve the service to its waypoint gateway, enabling route attachment.
-	waypointBindings krt.Collection[WaypointServiceBinding]
+	// waypointBindingsByService maps services to their AGW waypoint gateways.
+	// When a route references a Service as parentRef, this index is used to
+	// resolve the service to its waypoint gateways, enabling route attachment.
+	waypointBindingsByService krt.Index[types.NamespacedName, WaypointServiceBinding]
 }
 
 func (p RouteParents) fetch(ctx krt.HandlerContext, pk AgwParentKey) []*AgwParentInfo {
@@ -577,30 +577,28 @@ func (p RouteParents) fetch(ctx krt.HandlerContext, pk AgwParentKey) []*AgwParen
 	})
 }
 
-// fetchServiceParent resolves a Service parentRef to the waypoint gateway that fronts it.
-// If the service has a use-waypoint label pointing to an AGW waypoint gateway, the route
-// is attached to that waypoint gateway's listeners.
+// fetchServiceParent resolves a Service parentRef to the waypoint gateways that front it.
+// If the service has a use-waypoint or use-waypoint-canary label pointing to an AGW waypoint
+// gateway, the route is attached to that waypoint gateway's listeners. A service split between a
+// primary and a canary waypoint resolves to both.
 func (p RouteParents) fetchServiceParent(ctx krt.HandlerContext, pk AgwParentKey) []*AgwParentInfo {
-	if p.waypointBindings == nil {
+	if p.waypointBindingsByService == nil {
 		return nil
 	}
 
-	// Look up the waypoint binding for this service
-	svcKey := pk.Namespace + "/" + pk.Name
-	binding := krt.FetchOne(ctx, p.waypointBindings, krt.FilterKey(svcKey))
-	if binding == nil {
-		return nil
+	svcKey := types.NamespacedName{Namespace: pk.Namespace, Name: pk.Name}
+	var parents []*AgwParentInfo
+	for _, binding := range p.waypointBindingsByService.Fetch(ctx, svcKey) {
+		wpKey := AgwParentKey{
+			Kind:      gvk.KubernetesGateway.Kubernetes(),
+			Name:      binding.WaypointGateway.Name,
+			Namespace: binding.WaypointGateway.Namespace,
+		}
+		parents = append(parents, slices.Map(p.gatewayIndex.Fetch(ctx, wpKey), func(gw *GatewayListener) *AgwParentInfo {
+			return &gw.ParentInfo
+		})...)
 	}
-
-	// Found a waypoint binding, look up the waypoint's listeners
-	wpKey := AgwParentKey{
-		Kind:      gvk.KubernetesGateway.Kubernetes(),
-		Name:      binding.WaypointGateway.Name,
-		Namespace: binding.WaypointGateway.Namespace,
-	}
-	return slices.Map(p.gatewayIndex.Fetch(ctx, wpKey), func(gw *GatewayListener) *AgwParentInfo {
-		return &gw.ParentInfo
-	})
+	return parents
 }
 
 func BuildRouteParents(
@@ -610,11 +608,14 @@ func BuildRouteParents(
 	idx := krt.NewIndex(gateways, "parent", func(o *GatewayListener) []AgwParentKey {
 		return []AgwParentKey{o.ParentObject}
 	})
-	return RouteParents{
-		gatewayIndex: idx,
-		// waypointBindings maps services to their AGW waypoint gateways
-		waypointBindings: waypointBindings,
+	p := RouteParents{gatewayIndex: idx}
+	if waypointBindings != nil {
+		p.waypointBindingsByService = krt.NewIndex(waypointBindings, "waypoint-by-service",
+			func(b WaypointServiceBinding) []types.NamespacedName {
+				return []types.NamespacedName{b.ServiceKey}
+			})
 	}
+	return p
 }
 
 // AgwRoute is a wrapper type that contains the route on the gateway, as well as the status for the route.

--- a/pilot/pkg/config/kube/agentgateway/waypoint_collections.go
+++ b/pilot/pkg/config/kube/agentgateway/waypoint_collections.go
@@ -35,8 +35,10 @@ type WaypointServiceBinding struct {
 	WaypointGateway types.NamespacedName
 }
 
+// ResourceName keys on both the service and the gateway: a service can be fronted by two AGW
+// waypoints at once, a primary and a canary.
 func (w WaypointServiceBinding) ResourceName() string {
-	return w.ServiceKey.String()
+	return w.ServiceKey.String() + "/" + w.WaypointGateway.String()
 }
 
 func (w WaypointServiceBinding) Equals(other WaypointServiceBinding) bool {
@@ -46,6 +48,15 @@ func (w WaypointServiceBinding) Equals(other WaypointServiceBinding) bool {
 // BuildWaypointServiceBindings creates a collection mapping services to their AGW waypoint gateways.
 // For each k8s Service with a use-waypoint label (or inheriting from namespace) pointing to an
 // agentgateway-waypoint class Gateway, a WaypointServiceBinding is created.
+//
+// A service may also name a canary waypoint, which ztunnel splits connections to alongside the
+// primary. Primary and canary are independent: either, both, or neither may be an AGW waypoint, and
+// a binding is emitted for each one that is. This mirrors how the ambient index gives both weighted
+// waypoints ownership of the service.
+//
+// A binding only needs the Gateway to exist, so config reaches a waypoint before its pods are ready.
+// The ambient index additionally requires the canary to allow attachment and to accept service
+// traffic; a canary failing those gets config here that it never receives traffic for.
 func BuildWaypointServiceBindings(
 	services krt.Collection[*corev1.Service],
 	namespaces krt.Collection[*corev1.Namespace],
@@ -53,29 +64,41 @@ func BuildWaypointServiceBindings(
 	gatewayClasses krt.Collection[gatewaycommon.GatewayClass],
 	opts krt.OptionsBuilder,
 ) krt.Collection[WaypointServiceBinding] {
-	return krt.NewCollection(services, func(ctx krt.HandlerContext, svc *corev1.Service) *WaypointServiceBinding {
+	return krt.NewManyCollection(services, func(ctx krt.HandlerContext, svc *corev1.Service) []WaypointServiceBinding {
 		// check if the service or its namespace has the use-waypoint label
-		wpRef := resolveUseWaypoint(ctx, svc.ObjectMeta, namespaces)
-		if wpRef == nil {
+		primary := resolveUseWaypoint(ctx, svc.ObjectMeta, namespaces)
+		if primary == nil {
+			return nil
+		}
+		// The primary must exist for the service to be fronted at all, whatever class it is.
+		primaryGw := ptr.Flatten(krt.FetchOne(ctx, gateways, krt.FilterKey(primary.ResourceName())))
+		if primaryGw == nil {
 			return nil
 		}
 
-		// Check if the referenced gateway exists. Ignore otherwise
-		gw := ptr.Flatten(krt.FetchOne(ctx, gateways, krt.FilterKey(wpRef.ResourceName())))
-		if gw == nil {
-			return nil
+		fronting := []*gatewayv1.Gateway{primaryGw}
+		// A canary with an unparseable weight is ignored by the ambient index too, so it fronts
+		// nothing and needs no config.
+		if canary, _, validWeight := ambient.ResolveUseWaypointCanary(ctx, namespaces, svc.ObjectMeta); canary != nil && validWeight &&
+			canary.ResourceName() != primary.ResourceName() {
+			if gw := ptr.Flatten(krt.FetchOne(ctx, gateways, krt.FilterKey(canary.ResourceName()))); gw != nil {
+				fronting = append(fronting, gw)
+			}
 		}
 
-		// Check that the gateway has an AGW waypoint class. Ignore otherwise
-		class := gatewaycommon.FetchAgentgatewayClass(ctx, gatewayClasses, gw.Spec.GatewayClassName)
-		if class == nil || class.Controller != constants.ManagedAgentgatewayWaypointController {
-			return nil
+		bindings := make([]WaypointServiceBinding, 0, len(fronting))
+		for _, gw := range fronting {
+			// Keep only the gateways that are ours to configure.
+			class := gatewaycommon.FetchAgentgatewayClass(ctx, gatewayClasses, gw.Spec.GatewayClassName)
+			if class == nil || class.Controller != constants.ManagedAgentgatewayWaypointController {
+				continue
+			}
+			bindings = append(bindings, WaypointServiceBinding{
+				ServiceKey:      types.NamespacedName{Namespace: svc.Namespace, Name: svc.Name},
+				WaypointGateway: types.NamespacedName{Namespace: gw.Namespace, Name: gw.Name},
+			})
 		}
-
-		return &WaypointServiceBinding{
-			ServiceKey:      types.NamespacedName{Namespace: svc.Namespace, Name: svc.Name},
-			WaypointGateway: types.NamespacedName{Namespace: wpRef.Namespace, Name: wpRef.Name},
-		}
+		return bindings
 	}, opts.WithName("WaypointServiceBindings")...)
 }
 

--- a/pilot/pkg/config/kube/agentgateway/waypoint_test.go
+++ b/pilot/pkg/config/kube/agentgateway/waypoint_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"istio.io/api/annotation"
 	"istio.io/api/label"
 	"istio.io/istio/pilot/pkg/config/kube/gatewaycommon"
 	"istio.io/istio/pilot/pkg/features"
@@ -252,13 +253,29 @@ func testService(labels map[string]string) *corev1.Service {
 	return &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "svc1", Labels: labels}}
 }
 
+func testServiceAnnotated(labels, annotations map[string]string) *corev1.Service {
+	svc := testService(labels)
+	svc.Annotations = annotations
+	return svc
+}
+
 func testNamespace(labels map[string]string) *corev1.Namespace {
 	return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns1", Labels: labels}}
 }
 
+func testNamespaceAnnotated(labels, annotations map[string]string) *corev1.Namespace {
+	ns := testNamespace(labels)
+	ns.Annotations = annotations
+	return ns
+}
+
 func testGateway(name, class string) *gatewayv1.Gateway {
+	return testGatewayIn("ns1", name, class)
+}
+
+func testGatewayIn(namespace, name, class string) *gatewayv1.Gateway {
 	return &gatewayv1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: name},
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
 		Spec:       gatewayv1.GatewaySpec{GatewayClassName: gatewayv1.ObjectName(class)},
 	}
 }
@@ -270,6 +287,16 @@ func staticCol[T any](opts krt.OptionsBuilder, name string, items ...T) krt.Coll
 func TestBuildWaypointServiceBindings(t *testing.T) {
 	useWaypoint := func(wp string) map[string]string {
 		return map[string]string{label.IoIstioUseWaypoint.Name: wp}
+	}
+	useWaypointWithCanary := func(wp, canary string) map[string]string {
+		return map[string]string{label.IoIstioUseWaypoint.Name: wp, label.IoIstioUseWaypointCanary.Name: canary}
+	}
+	canaryWeight := func(w string) map[string]string {
+		return map[string]string{annotation.IoIstioUseWaypointCanaryWeight.Name: w}
+	}
+	svcKey := types.NamespacedName{Namespace: "ns1", Name: "svc1"}
+	bindingTo := func(gw string) WaypointServiceBinding {
+		return WaypointServiceBinding{ServiceKey: svcKey, WaypointGateway: types.NamespacedName{Namespace: "ns1", Name: gw}}
 	}
 	tests := []struct {
 		name       string
@@ -326,6 +353,132 @@ func TestBuildWaypointServiceBindings(t *testing.T) {
 			gateways:   []*gatewayv1.Gateway{testGateway("wp", constants.AgentgatewayWaypointClassName)},
 			want:       nil,
 		},
+		{
+			name:       "agw primary and agw canary both bind",
+			services:   []*corev1.Service{testServiceAnnotated(useWaypointWithCanary("wp", "wpc"), canaryWeight("50"))},
+			namespaces: []*corev1.Namespace{testNamespace(nil)},
+			gateways: []*gatewayv1.Gateway{
+				testGateway("wp", constants.AgentgatewayWaypointClassName),
+				testGateway("wpc", constants.AgentgatewayWaypointClassName),
+			},
+			want: []WaypointServiceBinding{bindingTo("wp"), bindingTo("wpc")},
+		},
+		{
+			// The mixed pairing: an Envoy waypoint fronts the service, connections shift to an AGW
+			// canary. Only the canary is ours, and it still needs the service's config.
+			name:       "envoy primary with agw canary binds only the canary",
+			services:   []*corev1.Service{testServiceAnnotated(useWaypointWithCanary("wp", "wpc"), canaryWeight("50"))},
+			namespaces: []*corev1.Namespace{testNamespace(nil)},
+			gateways: []*gatewayv1.Gateway{
+				testGateway("wp", constants.WaypointGatewayClassName),
+				testGateway("wpc", constants.AgentgatewayWaypointClassName),
+			},
+			want: []WaypointServiceBinding{bindingTo("wpc")},
+		},
+		{
+			name:       "agw primary with envoy canary binds only the primary",
+			services:   []*corev1.Service{testServiceAnnotated(useWaypointWithCanary("wp", "wpc"), canaryWeight("50"))},
+			namespaces: []*corev1.Namespace{testNamespace(nil)},
+			gateways: []*gatewayv1.Gateway{
+				testGateway("wp", constants.AgentgatewayWaypointClassName),
+				testGateway("wpc", constants.WaypointGatewayClassName),
+			},
+			want: []WaypointServiceBinding{bindingTo("wp")},
+		},
+		{
+			name:       "canary at weight 0 still binds",
+			services:   []*corev1.Service{testServiceAnnotated(useWaypointWithCanary("wp", "wpc"), canaryWeight("0"))},
+			namespaces: []*corev1.Namespace{testNamespace(nil)},
+			gateways: []*gatewayv1.Gateway{
+				testGateway("wp", constants.AgentgatewayWaypointClassName),
+				testGateway("wpc", constants.AgentgatewayWaypointClassName),
+			},
+			want: []WaypointServiceBinding{bindingTo("wp"), bindingTo("wpc")},
+		},
+		{
+			name:       "canary with invalid weight is ignored",
+			services:   []*corev1.Service{testServiceAnnotated(useWaypointWithCanary("wp", "wpc"), canaryWeight("nonsense"))},
+			namespaces: []*corev1.Namespace{testNamespace(nil)},
+			gateways: []*gatewayv1.Gateway{
+				testGateway("wp", constants.AgentgatewayWaypointClassName),
+				testGateway("wpc", constants.AgentgatewayWaypointClassName),
+			},
+			want: []WaypointServiceBinding{bindingTo("wp")},
+		},
+		{
+			name:       "canary equal to the primary binds once",
+			services:   []*corev1.Service{testServiceAnnotated(useWaypointWithCanary("wp", "wp"), canaryWeight("50"))},
+			namespaces: []*corev1.Namespace{testNamespace(nil)},
+			gateways:   []*gatewayv1.Gateway{testGateway("wp", constants.AgentgatewayWaypointClassName)},
+			want:       []WaypointServiceBinding{bindingTo("wp")},
+		},
+		{
+			name: "canary without a primary produces no binding",
+			services: []*corev1.Service{testServiceAnnotated(
+				map[string]string{label.IoIstioUseWaypointCanary.Name: "wpc"}, canaryWeight("50"))},
+			namespaces: []*corev1.Namespace{testNamespace(nil)},
+			gateways:   []*gatewayv1.Gateway{testGateway("wpc", constants.AgentgatewayWaypointClassName)},
+			want:       nil,
+		},
+		{
+			name:       "canary none is ignored",
+			services:   []*corev1.Service{testService(useWaypointWithCanary("wp", "none"))},
+			namespaces: []*corev1.Namespace{testNamespace(nil)},
+			gateways: []*gatewayv1.Gateway{
+				testGateway("wp", constants.AgentgatewayWaypointClassName),
+				testGateway("none", constants.AgentgatewayWaypointClassName),
+			},
+			want: []WaypointServiceBinding{bindingTo("wp")},
+		},
+		{
+			name:     "namespace canary inherited alongside namespace primary",
+			services: []*corev1.Service{testService(nil)},
+			namespaces: []*corev1.Namespace{
+				testNamespaceAnnotated(useWaypointWithCanary("wp", "wpc"), canaryWeight("50")),
+			},
+			gateways: []*gatewayv1.Gateway{
+				testGateway("wp", constants.AgentgatewayWaypointClassName),
+				testGateway("wpc", constants.AgentgatewayWaypointClassName),
+			},
+			want: []WaypointServiceBinding{bindingTo("wp"), bindingTo("wpc")},
+		},
+		{
+			// The service declares its own primary, so it does not inherit the namespace's canary.
+			name:     "namespace canary ignored when the service sets its own primary",
+			services: []*corev1.Service{testService(useWaypoint("wp"))},
+			namespaces: []*corev1.Namespace{
+				testNamespaceAnnotated(useWaypointWithCanary("wp", "wpc"), canaryWeight("50")),
+			},
+			gateways: []*gatewayv1.Gateway{
+				testGateway("wp", constants.AgentgatewayWaypointClassName),
+				testGateway("wpc", constants.AgentgatewayWaypointClassName),
+			},
+			want: []WaypointServiceBinding{bindingTo("wp")},
+		},
+		{
+			name: "canary in another namespace binds there",
+			services: []*corev1.Service{testServiceAnnotated(map[string]string{
+				label.IoIstioUseWaypoint.Name:                "wp",
+				label.IoIstioUseWaypointCanary.Name:          "wpc",
+				label.IoIstioUseWaypointCanaryNamespace.Name: "ns2",
+			}, canaryWeight("50"))},
+			namespaces: []*corev1.Namespace{testNamespace(nil)},
+			gateways: []*gatewayv1.Gateway{
+				testGateway("wp", constants.AgentgatewayWaypointClassName),
+				testGatewayIn("ns2", "wpc", constants.AgentgatewayWaypointClassName),
+			},
+			want: []WaypointServiceBinding{
+				bindingTo("wp"),
+				{ServiceKey: svcKey, WaypointGateway: types.NamespacedName{Namespace: "ns2", Name: "wpc"}},
+			},
+		},
+		{
+			name:       "canary gateway missing produces only the primary binding",
+			services:   []*corev1.Service{testServiceAnnotated(useWaypointWithCanary("wp", "wpc"), canaryWeight("50"))},
+			namespaces: []*corev1.Namespace{testNamespace(nil)},
+			gateways:   []*gatewayv1.Gateway{testGateway("wp", constants.AgentgatewayWaypointClassName)},
+			want:       []WaypointServiceBinding{bindingTo("wp")},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -355,6 +508,15 @@ func TestExtractWaypointGatewayRefs(t *testing.T) {
 		WaypointServiceBinding{
 			ServiceKey:      types.NamespacedName{Namespace: "ns2", Name: "svc2"},
 			WaypointGateway: types.NamespacedName{Namespace: "ns2", Name: "wp2"},
+		},
+		// svc3 is split between a primary and a canary waypoint.
+		WaypointServiceBinding{
+			ServiceKey:      types.NamespacedName{Namespace: "ns1", Name: "svc3"},
+			WaypointGateway: types.NamespacedName{Namespace: "ns1", Name: "wp1"},
+		},
+		WaypointServiceBinding{
+			ServiceKey:      types.NamespacedName{Namespace: "ns1", Name: "svc3"},
+			WaypointGateway: types.NamespacedName{Namespace: "ns1", Name: "wp3"},
 		},
 	)
 	bindings.WaitUntilSynced(test.NewStop(t))
@@ -387,6 +549,12 @@ func TestExtractWaypointGatewayRefs(t *testing.T) {
 			defaultNS: "ns1",
 			refs:      []gatewayv1.ParentReference{serviceRef("ns2", "svc2")},
 			want:      []types.NamespacedName{{Namespace: "ns2", Name: "wp2"}},
+		},
+		{
+			name:      "service ref resolves to both primary and canary waypoints",
+			defaultNS: "ns1",
+			refs:      []gatewayv1.ParentReference{serviceRef("", "svc3")},
+			want:      []types.NamespacedName{{Namespace: "ns1", Name: "wp1"}, {Namespace: "ns1", Name: "wp3"}},
 		},
 		{
 			name:      "gateway kind ref is ignored",
@@ -422,33 +590,49 @@ func TestExtractWaypointGatewayRefs(t *testing.T) {
 
 func TestRouteParentsFetchServiceParent(t *testing.T) {
 	opts := krttest.Options(t)
-	wpParentInfo := AgwParentInfo{
-		ParentGateway:          types.NamespacedName{Namespace: "ns1", Name: "wp"},
-		ParentGatewayClassName: constants.AgentgatewayWaypointClassName,
-		Protocol:               hboneProtocol,
-		Port:                   15008,
+	waypointListener := func(name string) *GatewayListener {
+		gw := types.NamespacedName{Namespace: "ns1", Name: name}
+		return &GatewayListener{
+			Name:          "ns1/" + name,
+			ParentGateway: gw,
+			ParentObject:  AgwParentKey{Kind: gvk.KubernetesGateway.Kubernetes(), Namespace: "ns1", Name: name},
+			ParentInfo: AgwParentInfo{
+				ParentGateway:          gw,
+				ParentGatewayClassName: constants.AgentgatewayWaypointClassName,
+				Protocol:               hboneProtocol,
+				Port:                   15008,
+			},
+			Valid: true,
+		}
 	}
 	wpKey := AgwParentKey{Kind: gvk.KubernetesGateway.Kubernetes(), Namespace: "ns1", Name: "wp"}
-	gateways := staticCol(opts, "Gateways", &GatewayListener{
-		Name:          "ns1/wp",
-		ParentGateway: types.NamespacedName{Namespace: "ns1", Name: "wp"},
-		ParentObject:  wpKey,
-		ParentInfo:    wpParentInfo,
-		Valid:         true,
-	})
+	gateways := staticCol(opts, "Gateways", waypointListener("wp"), waypointListener("wpc"))
 	gateways.WaitUntilSynced(test.NewStop(t))
-	bindings := staticCol(opts, "Bindings", WaypointServiceBinding{
-		ServiceKey:      types.NamespacedName{Namespace: "ns1", Name: "svc1"},
-		WaypointGateway: types.NamespacedName{Namespace: "ns1", Name: "wp"},
-	})
+	binding := func(svc, gw string) WaypointServiceBinding {
+		return WaypointServiceBinding{
+			ServiceKey:      types.NamespacedName{Namespace: "ns1", Name: svc},
+			WaypointGateway: types.NamespacedName{Namespace: "ns1", Name: gw},
+		}
+	}
+	// svc1 is fronted by one waypoint, svc2 is split between a primary and a canary waypoint.
+	bindings := staticCol(opts, "Bindings", binding("svc1", "wp"), binding("svc2", "wp"), binding("svc2", "wpc"))
 	bindings.WaitUntilSynced(test.NewStop(t))
 	parents := BuildRouteParents(gateways, bindings)
+
+	gatewayNames := func(got []*AgwParentInfo) []string {
+		return slices.Sort(slices.Map(got, func(p *AgwParentInfo) string { return p.ParentGateway.String() }))
+	}
 
 	t.Run("service parent resolves to waypoint listeners", func(t *testing.T) {
 		svcKey := AgwParentKey{Kind: gvk.Service.Kubernetes(), Namespace: "ns1", Name: "svc1"}
 		got := parents.fetch(krt.TestingDummyContext{}, svcKey)
-		assert.Equal(t, len(got), 1)
-		assert.Equal(t, got[0].ParentGateway, types.NamespacedName{Namespace: "ns1", Name: "wp"})
+		assert.Equal(t, gatewayNames(got), []string{"ns1/wp"})
+	})
+
+	t.Run("service parent resolves to both primary and canary waypoints", func(t *testing.T) {
+		svcKey := AgwParentKey{Kind: gvk.Service.Kubernetes(), Namespace: "ns1", Name: "svc2"}
+		got := parents.fetch(krt.TestingDummyContext{}, svcKey)
+		assert.Equal(t, gatewayNames(got), []string{"ns1/wp", "ns1/wpc"})
 	})
 
 	t.Run("service parent without binding resolves to nothing", func(t *testing.T) {
@@ -459,8 +643,7 @@ func TestRouteParentsFetchServiceParent(t *testing.T) {
 
 	t.Run("gateway parent resolves via gateway index", func(t *testing.T) {
 		got := parents.fetch(krt.TestingDummyContext{}, wpKey)
-		assert.Equal(t, len(got), 1)
-		assert.Equal(t, got[0].ParentGateway, types.NamespacedName{Namespace: "ns1", Name: "wp"})
+		assert.Equal(t, gatewayNames(got), []string{"ns1/wp"})
 	})
 }
 

--- a/pilot/pkg/serviceregistry/ambient/waypoints.go
+++ b/pilot/pkg/serviceregistry/ambient/waypoints.go
@@ -271,6 +271,29 @@ func getCanaryWeight(meta metav1.ObjectMeta, nsMeta *metav1.ObjectMeta) (weight 
 	return uint32(n), true
 }
 
+// ResolveUseWaypointCanary returns the canary waypoint declared for o and its weight, or nil if o
+// declares no canary. The canary is inherited from the same level as the primary: the namespace's
+// canary attributes are consulted only when o sets no use-waypoint of its own. valid is false when
+// the declared weight is not a percentage, in which case the canary must be ignored.
+func ResolveUseWaypointCanary(
+	ctx krt.HandlerContext,
+	namespaces krt.Collection[*v1.Namespace],
+	o metav1.ObjectMeta,
+) (named *krt.Named, weight uint32, valid bool) {
+	var nsMeta *metav1.ObjectMeta
+	if objPrimary, _ := GetUseWaypoint(o, o.Namespace); objPrimary == nil {
+		if ns := ptr.OrEmpty(krt.FetchOne(ctx, namespaces, krt.FilterKey(o.Namespace))); ns != nil {
+			nsMeta = &ns.ObjectMeta
+		}
+	}
+	named = getUseWaypointCanary(o, nsMeta, o.Namespace)
+	if named == nil {
+		return nil, 0, true
+	}
+	weight, valid = getCanaryWeight(o, nsMeta)
+	return named, weight, valid
+}
+
 // resolveCanaryWaypoint applies the primary waypoint attachment and traffic-type checks.
 func resolveCanaryWaypoint(
 	ctx krt.HandlerContext,
@@ -305,16 +328,7 @@ func buildWeightedWaypoints(
 	if primary == nil || status.Error != nil {
 		return nil
 	}
-	// The canary is inherited from the same level as the primary: consult the namespace's canary
-	// attributes only when the primary itself was inherited from the namespace (the object sets no
-	// use-waypoint of its own).
-	var nsMeta *metav1.ObjectMeta
-	if objPrimary, _ := GetUseWaypoint(o, o.Namespace); objPrimary == nil {
-		if ns := ptr.OrEmpty(krt.FetchOne(ctx, namespaces, krt.FilterKey(o.Namespace))); ns != nil {
-			nsMeta = &ns.ObjectMeta
-		}
-	}
-	named := getUseWaypointCanary(o, nsMeta, o.Namespace)
+	named, weight, ok := ResolveUseWaypointCanary(ctx, namespaces, o)
 	if named == nil {
 		return nil
 	}
@@ -322,7 +336,6 @@ func buildWeightedWaypoints(
 		status.Error = ReportWaypointCanarySameAsPrimary(named.ResourceName())
 		return nil
 	}
-	weight, ok := getCanaryWeight(o, nsMeta)
 	if !ok {
 		status.Error = ReportWaypointCanaryInvalidWeight(named.ResourceName())
 		return nil

--- a/releasenotes/notes/agw-canary-waypoint-service-bindings.yaml
+++ b/releasenotes/notes/agw-canary-waypoint-service-bindings.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - https://github.com/istio/istio/issues/61036
+releaseNotes:
+- |
+  **Fixed** an issue where an agentgateway waypoint that a service referenced only as its canary,
+  via the `istio.io/use-waypoint-canary` label, was not programmed with the routes and policies
+  attached to that service. Connections shifted to the canary waypoint were rejected, because the
+  waypoint had no configuration for the service it was fronting.

--- a/tests/integration/ambient/agentgateway/waypoint_canary_test.go
+++ b/tests/integration/ambient/agentgateway/waypoint_canary_test.go
@@ -64,12 +64,6 @@ func TestWeightedWaypointCanaryToAgentgateway(t *testing.T) {
 	framework.
 		NewTest(t).
 		Run(func(t framework.TestContext) {
-			// A waypoint only accepts traffic for a service that names it in the singular waypoint
-			// field, so a canary waypoint answers 404 "route not found" for everything until
-			// agentgateway/agentgateway#2716 - which is in no release yet; v1.4.0 predates it.
-			// Drop this skip once AGENTGATEWAY_IMAGE in istio.deps names a later release.
-			t.Skip("needs an agentgateway release after v1.4.0 (agentgateway/agentgateway#2716)")
-
 			if !t.Settings().Agentgateway {
 				t.Skip("Only run agentgateway tests when explicitly enabled")
 			}

--- a/tests/integration/ambient/agentgateway/waypoint_canary_test.go
+++ b/tests/integration/ambient/agentgateway/waypoint_canary_test.go
@@ -1,0 +1,317 @@
+//go:build integ
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentgateway
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"istio.io/api/annotation"
+	"istio.io/api/label"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/crd"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/scopes"
+	"istio.io/istio/pkg/test/util/retry"
+)
+
+const canaryPrimaryWaypointName = "istio-waypoint-primary"
+
+// acceptAny lets a call succeed regardless of HTTP status; the test classifies the responses itself
+// rather than failing on a non-2xx.
+var acceptAny = func(echo.CallResult, error) error { return nil }
+
+// TestWeightedWaypointCanaryToAgentgateway shifts connections from an istio (Envoy) waypoint to an
+// agentgateway waypoint using the weighted canary labels. Both waypoints front the same service
+// under one control plane, so this covers the canary across waypoint implementations: the weighted
+// set is resolved by name regardless of GatewayClass, and ztunnel samples one of the two waypoints
+// per connection.
+//
+// The waypoints are told apart by service-account identity, the same way the istio-only canary
+// tests do it. Each waypoint originates HBONE to the backend under its own SA, so an ALLOW policy
+// admitting a single SA - enforced at the destination ztunnel, which sees the forwarding waypoint
+// as the source principal - isolates the traffic that waypoint served. Only 200s count as served:
+// denials of the other waypoint and warming 503s never do, so an assertion cannot pass on failed
+// traffic.
+//
+// This also covers config propagation to the canary: agentgateway answers 404 for a service it has
+// no route for, so the canary serving traffic at all means the Service-attached route reached a
+// waypoint that only the canary label points at.
+func TestWeightedWaypointCanaryToAgentgateway(t *testing.T) {
+	framework.
+		NewTest(t).
+		Run(func(t framework.TestContext) {
+			// A waypoint only accepts traffic for a service that names it in the singular waypoint
+			// field, so a canary waypoint answers 404 "route not found" for everything until
+			// agentgateway/agentgateway#2716 - which is in no release yet; v1.4.0 predates it.
+			// Drop this skip once AGENTGATEWAY_IMAGE in istio.deps names a later release.
+			t.Skip("needs an agentgateway release after v1.4.0 (agentgateway/agentgateway#2716)")
+
+			if !t.Settings().Agentgateway {
+				t.Skip("Only run agentgateway tests when explicitly enabled")
+			}
+			crd.DeployGatewayAPIOrSkip(t)
+			testNs, client, server := setupSmallTrafficTest(t)
+
+			newCanaryWaypoint(t, testNs, canaryPrimaryWaypointName, constants.WaypointGatewayClassName)
+			newCanaryWaypoint(t, testNs, agentgatewayWaypointName, constants.AgentgatewayWaypointClassName)
+
+			// agentgateway has no implicit passthrough: a waypoint fronting a service it has no route
+			// for answers 404. The route attaches to the Service, so it must reach both waypoints -
+			// which is what makes a successful response proof that the serving waypoint was
+			// programmed with the service, not just reachable.
+			t.ConfigIstio().YAML(testNs.Name(), fmt.Sprintf(`
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: canary-httproute
+  namespace: %s
+spec:
+  parentRefs:
+    - name: %s
+      kind: Service
+      group: ""
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: %s
+          port: 80
+`, testNs.Name(), server.ServiceName(), server.ServiceName())).ApplyOrFail(t)
+
+			// ztunnel samples a waypoint per connection, so re-sample on every request.
+			call := func() (echo.CallResult, error) {
+				return client.Call(echo.CallOptions{
+					To:                      server,
+					Address:                 fmt.Sprintf("%s.%s.svc.cluster.local", server.ServiceName(), server.NamespaceName()),
+					Port:                    server.PortForName("http"),
+					Count:                   40,
+					NewConnectionPerRequest: true,
+					Check:                   acceptAny,
+				})
+			}
+
+			// Bind both waypoints once and only move the weight from there. Clearing the labels
+			// between weights would tear the binding down and rebuild it each time, which istiod
+			// reports by dropping and re-adding the service's WaypointBound condition - a shift is
+			// then measured against a binding that is still settling.
+			bindWeightedWaypoints(t, server, agentgatewayWaypointName)
+
+			for _, tc := range []struct {
+				name            string
+				weight          int
+				canary, primary func(served, total int) error
+			}{
+				{"weight-0-all-istio-waypoint", 0, wantNone, wantAll},
+				{"weight-25-mostly-istio-waypoint", 25, wantMinority, wantMajority},
+				{"weight-75-mostly-agentgateway-waypoint", 75, wantMajority, wantMinority},
+				{"weight-100-all-agentgateway-waypoint", 100, wantAll, wantNone},
+			} {
+				t.NewSubTest(tc.name).Run(func(t framework.TestContext) {
+					setCanaryWeight(t, server, tc.weight)
+					servedThrough(t, server, agentgatewayWaypointName, call, tc.canary)
+					servedThrough(t, server, canaryPrimaryWaypointName, call, tc.primary)
+				})
+			}
+		})
+}
+
+// newCanaryWaypoint provisions a service waypoint of the given GatewayClass and waits until ready.
+func newCanaryWaypoint(t framework.TestContext, ns namespace.Instance, name, class string) {
+	t.ConfigIstio().YAML(ns.Name(), fmt.Sprintf(`
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: %s
+  namespace: %s
+  labels:
+    istio.io/waypoint-for: service
+  annotations:
+    networking.istio.io/service-type: ClusterIP
+spec:
+  gatewayClassName: %s
+  listeners:
+  - allowedRoutes:
+      namespaces:
+        from: All
+    name: mesh
+    port: 15008
+    protocol: HBONE
+`, name, ns.Name(), class)).ApplyOrFail(t)
+
+	retry.UntilSuccessOrFail(t, func() error {
+		return checkWaypointIsReady(t, ns.Name(), name)
+	}, retry.Timeout(2*time.Minute))
+}
+
+// bindWeightedWaypoints labels the server service with the primary and canary waypoints at weight 0
+// and waits for the binding to be accepted. The labels stay put for the rest of the test so the
+// binding is established once; only the weight moves after this. Cleanup clears all three.
+func bindWeightedWaypoints(t framework.TestContext, server echo.Instance, canary string) {
+	set := fmt.Sprintf(`{"metadata":{"labels":{"%s":%q,"%s":%q},"annotations":{"%s":"0"}}}`,
+		label.IoIstioUseWaypoint.Name, canaryPrimaryWaypointName,
+		label.IoIstioUseWaypointCanary.Name, canary,
+		annotation.IoIstioUseWaypointCanaryWeight.Name)
+	if err := patchServerService(t, server, set); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		reset := fmt.Sprintf(`{"metadata":{"labels":{"%s":null,"%s":null},"annotations":{"%s":null}}}`,
+			label.IoIstioUseWaypoint.Name, label.IoIstioUseWaypointCanary.Name,
+			annotation.IoIstioUseWaypointCanaryWeight.Name)
+		if err := patchServerService(t, server, reset); err != nil {
+			scopes.Framework.Errorf("failed clearing weighted waypoint for %s: %v", server.ServiceName(), err)
+		}
+	})
+
+	// An unresolvable canary is reported on the binding status and falls back to the primary, so
+	// confirm the binding was accepted before measuring any split.
+	retry.UntilSuccessOrFail(t, func() error {
+		svc, err := t.Clusters().Default().Kube().CoreV1().Services(server.NamespaceName()).Get(
+			context.TODO(), server.ServiceName(), metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		for _, cond := range svc.Status.Conditions {
+			if cond.Type == string(model.WaypointBound) {
+				if cond.Status == metav1.ConditionTrue {
+					return nil
+				}
+				return fmt.Errorf("waypoint binding not accepted: %s", cond.Message)
+			}
+		}
+		return fmt.Errorf("waypoint condition not found on service (conditions: %v)", svc.Status.Conditions)
+	}, retry.Timeout(1*time.Minute))
+}
+
+// setCanaryWeight moves the canary weight on the already-bound service.
+func setCanaryWeight(t framework.TestContext, server echo.Instance, weight int) {
+	patch := fmt.Sprintf(`{"metadata":{"annotations":{"%s":%q}}}`,
+		annotation.IoIstioUseWaypointCanaryWeight.Name, strconv.Itoa(weight))
+	if err := patchServerService(t, server, patch); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// servedThrough admits only waypoint's SA with an ALLOW policy (enforced at the destination ztunnel)
+// and retries call until the count of successful (200) responses - the requests that waypoint served
+// - satisfies want.
+func servedThrough(
+	t framework.TestContext,
+	server echo.Instance,
+	waypoint string,
+	call func() (echo.CallResult, error),
+	want func(served, total int) error,
+) {
+	ns := server.NamespaceName()
+	cfg := t.ConfigIstio().YAML(ns, fmt.Sprintf(`
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-only-waypoint
+spec:
+  selector:
+    matchLabels:
+      app: %s
+  action: ALLOW
+  rules:
+  - from:
+    - source:
+        principals: ["cluster.local/ns/%s/sa/%s"]
+`, server.ServiceName(), ns, waypoint))
+	cfg.ApplyOrFail(t)
+	defer func() {
+		if err := cfg.Delete(); err != nil {
+			scopes.Framework.Errorf("failed deleting allow-only-waypoint policy: %v", err)
+		}
+	}()
+
+	retry.UntilSuccessOrFail(t, func() error {
+		res, err := call()
+		if err != nil {
+			return err
+		}
+		served, total := 0, len(res.Responses)
+		for _, r := range res.Responses {
+			if r.Code == "200" {
+				served++
+			}
+		}
+		return want(served, total)
+	}, retry.Timeout(90*time.Second), retry.Delay(time.Second))
+}
+
+// wantAll: the admitted waypoint served every request (it fronts the service and got all traffic).
+func wantAll(served, total int) error {
+	if total == 0 || served != total {
+		return fmt.Errorf("want all served, got %d/%d", served, total)
+	}
+	return nil
+}
+
+// wantNone: the admitted waypoint served nothing (it received no traffic at this weight).
+func wantNone(served, total int) error {
+	if total == 0 {
+		return fmt.Errorf("no responses")
+	}
+	if served != 0 {
+		return fmt.Errorf("want none served, got %d/%d", served, total)
+	}
+	return nil
+}
+
+// wantMinority: the admitted waypoint served part of the traffic, but less than half - it is the
+// lower-weighted side of the split. Checking which side holds the majority, rather than just that
+// both served something, is what catches the weights landing on the wrong waypoint.
+//
+// The margin is wide enough not to flake: at 40 connections and a 25/75 split, landing 20 or more
+// on the 25% side is about a 3.5 sigma event.
+func wantMinority(served, total int) error {
+	if served == 0 || served*2 >= total {
+		return fmt.Errorf("want a minority share, got %d/%d", served, total)
+	}
+	return nil
+}
+
+// wantMajority: the admitted waypoint served more than half the traffic - the higher-weighted side.
+func wantMajority(served, total int) error {
+	if total == 0 || served*2 <= total {
+		return fmt.Errorf("want a majority share, got %d/%d", served, total)
+	}
+	return nil
+}
+
+func patchServerService(t framework.TestContext, server echo.Instance, patch string) error {
+	for _, c := range t.Clusters() {
+		if _, err := c.Kube().CoreV1().Services(server.NamespaceName()).Patch(
+			context.TODO(), server.ServiceName(), types.MergePatchType, []byte(patch), metav1.PatchOptions{}); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
**Please provide a description of this PR:**

## Problem

An agentgateway waypoint that a service names only as its canary (`istio.io/use-waypoint-canary`) receives no service-scoped configuration. ztunnel shifts the configured share of connections to it, but the waypoint has no route for the service and rejects them.

## Cause

`BuildWaypointServiceBindings` resolves only `istio.io/use-waypoint` and then requires that Gateway to be of an agentgateway waypoint class. When the primary is an Envoy waypoint and only the canary is agentgateway, no `WaypointServiceBinding` is emitted at all, so `RouteParents.fetchServiceParent` resolves a Service parentRef to zero parents, and `extractWaypointGatewayRefs` finds no gateway for service-scoped policies.

This is the agentgateway-controller equivalent of an ambient index change in #60805. There, `serviceOwningWaypoints` was extended to walk `WeightedWaypoints` so both weighted waypoints own the service. The agentgateway controller keeps its own notion of which services a waypoint fronts, and it was not updated.

## Fix

- `BuildWaypointServiceBindings` emits a binding for the canary as well as the primary, keeping each one that resolves to an agentgateway waypoint class. Canary resolution matches the ambient index: the namespace's canary is inherited only when the service sets no primary of its own, and the canary is ignored when it equals the primary or when the weight is not a valid percentage.
- `WaypointServiceBinding.ResourceName` keys on service plus gateway, so one service can hold two bindings.
- `RouteParents.fetchServiceParent` uses a by-service index and returns every waypoint fronting the service.

A binding requires only that the Gateway exists, so config reaches a waypoint before its pods are ready. The ambient index additionally requires the canary to allow attachment and to accept service traffic; a canary failing those gets config here that it never receives traffic for, which is harmless but noted in a comment.

## Tests

Unit tests in `waypoint_test.go` cover both-agentgateway, Envoy-primary with agentgateway-canary, agentgateway-primary with Envoy-canary, weight 0, invalid weight, canary equal to the primary, canary without a primary, namespace inheritance, cross-namespace canary, and a missing canary Gateway.

`TestWeightedWaypointCanaryToAgentgateway` covers weights 0/25/75/100 end to end, telling the two waypoints apart by the service account identity the destination ztunnel sees as the source principal.

Fixes https://github.com/istio/istio/issues/61036