### PR TITLE
fix: NDS name table to include headless endpoints from all service ports

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -2649,6 +2649,27 @@ func (ps *PushContext) ServiceEndpoints(svcKey string) map[int][]*IstioEndpoint 
 	return nil
 }
 
+// ServiceEndpointsUnique returns deduplicated endpoints across all ports of a service.
+// When Kubernetes splits EndpointSlices by port subset, the same pod may be indexed
+// under multiple ports. This method deduplicates by address (unique per pod via K8s IPAM).
+func (ps *PushContext) ServiceEndpointsUnique(svc *Service) []*IstioEndpoint {
+	allPorts := ps.ServiceEndpoints(svc.Key())
+	if len(allPorts) == 0 {
+		return nil
+	}
+	seen := sets.New[string]()
+	var out []*IstioEndpoint
+	for _, endpoints := range allPorts {
+		for _, ep := range endpoints {
+			if seen.InsertContains(ep.FirstAddressOrNil()) {
+				continue
+			}
+			out = append(out, ep)
+		}
+	}
+	return out
+}
+
 // initKubernetesGateways initializes Kubernetes gateway-api objects
 func (ps *PushContext) initKubernetesGateways(env *Environment) {
 	if env.GatewayAPIController != nil {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -2649,27 +2649,6 @@ func (ps *PushContext) ServiceEndpoints(svcKey string) map[int][]*IstioEndpoint 
 	return nil
 }
 
-// ServiceEndpointsUnique returns deduplicated endpoints across all ports of a service.
-// When Kubernetes splits EndpointSlices by port subset, the same pod may be indexed
-// under multiple ports. This method deduplicates by address (unique per pod via K8s IPAM).
-func (ps *PushContext) ServiceEndpointsUnique(svc *Service) []*IstioEndpoint {
-	allPorts := ps.ServiceEndpoints(svc.Key())
-	if len(allPorts) == 0 {
-		return nil
-	}
-	seen := sets.New[string]()
-	var out []*IstioEndpoint
-	for _, endpoints := range allPorts {
-		for _, ep := range endpoints {
-			if seen.InsertContains(ep.FirstAddressOrNil()) {
-				continue
-			}
-			out = append(out, ep)
-		}
-	}
-	return out
-}
-
 // initKubernetesGateways initializes Kubernetes gateway-api objects
 func (ps *PushContext) initKubernetesGateways(env *Environment) {
 	if env.GatewayAPIController != nil {

--- a/pkg/dns/server/name_table.go
+++ b/pkg/dns/server/name_table.go
@@ -67,7 +67,7 @@ func BuildNameTable(cfg Config) *dnsProto.NameTable {
 					localAddresses := make(map[string][]string)
 					remoteAddresses := make(map[string][]string)
 					hostMetadata := make(map[string]types.NamespacedName)
-					for _, instance := range cfg.Push.ServiceEndpointsByPort(svc, svc.Ports[0].Port, nil) {
+					for _, instance := range cfg.Push.ServiceEndpointsUnique(svc) {
 						// addresses may be empty or invalid here
 						isValidInstance := true
 						for _, addr := range instance.Addresses {

--- a/pkg/dns/server/name_table.go
+++ b/pkg/dns/server/name_table.go
@@ -69,13 +69,10 @@ func BuildNameTable(cfg Config) *dnsProto.NameTable {
 					remoteAddresses := make(map[string][]string)
 					hostMetadata := make(map[string]types.NamespacedName)
 					// Iterate all ports to collect endpoints from every EndpointSlice.
-					// Dedup by address since pod IPs are unique per cluster (K8s IPAM guarantee).
+					// Dedup by address since pod IPs are unique (IPAM guarantee).
 					seen := sets.New[string]()
 					for _, endpoints := range cfg.Push.ServiceEndpoints(svc.Key()) {
 						for _, instance := range endpoints {
-							if seen.InsertContains(instance.FirstAddressOrNil()) {
-								continue
-							}
 							isValidInstance := true
 							for _, addr := range instance.Addresses {
 								if !netutil.IsValidIPAddress(addr) {
@@ -85,6 +82,9 @@ func BuildNameTable(cfg Config) *dnsProto.NameTable {
 							}
 							if len(instance.Addresses) == 0 || !isValidInstance ||
 								(!svc.Attributes.PublishNotReadyAddresses && instance.HealthStatus != model.Healthy) {
+								continue
+							}
+							if seen.InsertContains(instance.FirstAddressOrNil()) {
 								continue
 							}
 							// TODO(stevenctl): headless across-networks https://github.com/istio/istio/issues/38327

--- a/pkg/dns/server/name_table.go
+++ b/pkg/dns/server/name_table.go
@@ -24,6 +24,7 @@ import (
 	"istio.io/istio/pkg/config/constants"
 	dnsProto "istio.io/istio/pkg/dns/proto"
 	netutil "istio.io/istio/pkg/util/net"
+	"istio.io/istio/pkg/util/sets"
 )
 
 // Config for building the name table.
@@ -67,53 +68,60 @@ func BuildNameTable(cfg Config) *dnsProto.NameTable {
 					localAddresses := make(map[string][]string)
 					remoteAddresses := make(map[string][]string)
 					hostMetadata := make(map[string]types.NamespacedName)
-					for _, instance := range cfg.Push.ServiceEndpointsUnique(svc) {
-						// addresses may be empty or invalid here
-						isValidInstance := true
-						for _, addr := range instance.Addresses {
-							if !netutil.IsValidIPAddress(addr) {
-								isValidInstance = false
-								break
-							}
-						}
-						if len(instance.Addresses) == 0 || !isValidInstance ||
-							(!svc.Attributes.PublishNotReadyAddresses && instance.HealthStatus != model.Healthy) {
-							continue
-						}
-						// TODO(stevenctl): headless across-networks https://github.com/istio/istio/issues/38327
-						sameNetwork := cfg.Node.InNetwork(instance.Network)
-						sameCluster := cfg.Node.InCluster(instance.Locality.ClusterID)
-						// For all k8s headless services, populate the dns table with the endpoint IPs as k8s does.
-						// And for each individual pod, populate the dns table with the endpoint IP with a manufactured host name.
-						if instance.SubDomain != "" && sameNetwork {
-							// Follow k8s pods dns naming convention of "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>"
-							// i.e. "mysql-0.mysql.default.svc.cluster.local".
-							parts := strings.SplitN(hostName.String(), ".", 2)
-							if len(parts) != 2 {
+					// Iterate all ports to collect endpoints from every EndpointSlice.
+					// Dedup by address since pod IPs are unique per cluster (K8s IPAM guarantee).
+					seen := sets.New[string]()
+					for _, endpoints := range cfg.Push.ServiceEndpoints(svc.Key()) {
+						for _, instance := range endpoints {
+							if seen.InsertContains(instance.FirstAddressOrNil()) {
 								continue
 							}
-							shortName := instance.HostName + "." + instance.SubDomain
-							host := shortName + "." + parts[1] // Add cluster domain.
-							hostMetadata[host] = types.NamespacedName{Name: shortName, Namespace: svc.Attributes.Namespace}
-							if sameCluster {
-								localAddresses[host] = append(localAddresses[host], instance.Addresses...)
-							} else {
-								remoteAddresses[host] = append(remoteAddresses[host], instance.Addresses...)
+							isValidInstance := true
+							for _, addr := range instance.Addresses {
+								if !netutil.IsValidIPAddress(addr) {
+									isValidInstance = false
+									break
+								}
 							}
+							if len(instance.Addresses) == 0 || !isValidInstance ||
+								(!svc.Attributes.PublishNotReadyAddresses && instance.HealthStatus != model.Healthy) {
+								continue
+							}
+							// TODO(stevenctl): headless across-networks https://github.com/istio/istio/issues/38327
+							sameNetwork := cfg.Node.InNetwork(instance.Network)
+							sameCluster := cfg.Node.InCluster(instance.Locality.ClusterID)
+							// For all k8s headless services, populate the dns table with the endpoint IPs as k8s does.
+							// And for each individual pod, populate the dns table with the endpoint IP with a manufactured host name.
+							if instance.SubDomain != "" && sameNetwork {
+								// Follow k8s pods dns naming convention of "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>"
+								// i.e. "mysql-0.mysql.default.svc.cluster.local".
+								parts := strings.SplitN(hostName.String(), ".", 2)
+								if len(parts) != 2 {
+									continue
+								}
+								shortName := instance.HostName + "." + instance.SubDomain
+								host := shortName + "." + parts[1] // Add cluster domain.
+								hostMetadata[host] = types.NamespacedName{Name: shortName, Namespace: svc.Attributes.Namespace}
+								if sameCluster {
+									localAddresses[host] = append(localAddresses[host], instance.Addresses...)
+								} else {
+									remoteAddresses[host] = append(remoteAddresses[host], instance.Addresses...)
+								}
+							}
+							skipForMulticluster := !cfg.MulticlusterHeadlessEnabled && !sameCluster
+							if skipForMulticluster || !sameNetwork {
+								// We take only cluster-local endpoints. While this seems contradictory to
+								// our logic other parts of the code, where cross-cluster is the default.
+								// However, this only impacts the DNS response. If we were to send all
+								// endpoints, cross network routing would break, as we do passthrough LB and
+								// don't go through the network gateway. While we could, hypothetically, send
+								// "network-local" endpoints, this would still make enabling DNS give vastly
+								// different load balancing than without, so its probably best to filter.
+								// This ends up matching the behavior of Kubernetes DNS.
+								continue
+							}
+							addressList = append(addressList, instance.Addresses...)
 						}
-						skipForMulticluster := !cfg.MulticlusterHeadlessEnabled && !sameCluster
-						if skipForMulticluster || !sameNetwork {
-							// We take only cluster-local endpoints. While this seems contradictory to
-							// our logic other parts of the code, where cross-cluster is the default.
-							// However, this only impacts the DNS response. If we were to send all
-							// endpoints, cross network routing would break, as we do passthrough LB and
-							// don't go through the network gateway. While we could, hypothetically, send
-							// "network-local" endpoints, this would still make enabling DNS give vastly
-							// different load balancing than without, so its probably best to filter.
-							// This ends up matching the behavior of Kubernetes DNS.
-							continue
-						}
-						addressList = append(addressList, instance.Addresses...)
 					}
 					// Write local cluster entries first
 					for host, ips := range localAddresses {

--- a/pkg/dns/server/name_table_test.go
+++ b/pkg/dns/server/name_table_test.go
@@ -794,25 +794,22 @@ func TestMultiPortHeadlessServiceSplitEndpointSlices(t *testing.T) {
 	push.AddServiceInstances(multiPortHeadlessService, brokerInstances)
 
 	cases := []struct {
-		name                       string
-		proxy                      *model.Proxy
-		enableMultiClusterHeadless bool
-		expectBrokerDNS            bool
-		expectControllerDNS        bool
+		name                string
+		proxy               *model.Proxy
+		expectBrokerDNS     bool
+		expectControllerDNS bool
 	}{
 		{
-			name:                       "local cluster sees both controller and broker",
-			proxy:                      controllerProxy,
-			enableMultiClusterHeadless: true,
-			expectBrokerDNS:            true,
-			expectControllerDNS:        true,
+			name:                "local cluster sees both controller and broker",
+			proxy:               controllerProxy,
+			expectBrokerDNS:     true,
+			expectControllerDNS: true,
 		},
 		{
-			name:                       "remote cluster sees both controller and broker",
-			proxy:                      remoteProxy,
-			enableMultiClusterHeadless: true,
-			expectBrokerDNS:            true,
-			expectControllerDNS:        true,
+			name:                "remote cluster sees both controller and broker",
+			proxy:               remoteProxy,
+			expectBrokerDNS:     true,
+			expectControllerDNS: true,
 		},
 	}
 
@@ -824,7 +821,7 @@ func TestMultiPortHeadlessServiceSplitEndpointSlices(t *testing.T) {
 			nt := dnsServer.BuildNameTable(dnsServer.Config{
 				Node:                        tt.proxy,
 				Push:                        push,
-				MulticlusterHeadlessEnabled: tt.enableMultiClusterHeadless,
+				MulticlusterHeadlessEnabled: true,
 			})
 
 			brokerEntry := "kafka-0.kafka-brokers.kafka.svc.cluster.local"

--- a/pkg/dns/server/name_table_test.go
+++ b/pkg/dns/server/name_table_test.go
@@ -696,6 +696,164 @@ func makeInstances(proxy *model.Proxy, svc *model.Service, servicePort int, targ
 	return ret
 }
 
+func TestMultiPortHeadlessServiceSplitEndpointSlices(t *testing.T) {
+	mesh := &meshconfig.MeshConfig{RootNamespace: "istio-system"}
+
+	multiPortHeadlessService := &model.Service{
+		Hostname:       host.Name("kafka-brokers.kafka.svc.cluster.local"),
+		DefaultAddress: constants.UnspecifiedIP,
+		Ports: model.PortList{
+			{Name: "tcp-ctrlplane", Port: 9090, Protocol: protocol.TCP},
+			{Name: "tcp-replication", Port: 9091, Protocol: protocol.TCP},
+			{Name: "tcp-kafkaagent", Port: 8443, Protocol: protocol.TCP},
+			{Name: "tcp-clientstls", Port: 9093, Protocol: protocol.TCP},
+		},
+		Resolution: model.Passthrough,
+		Attributes: model.ServiceAttributes{
+			Name:            "kafka-brokers",
+			Namespace:       "kafka",
+			ServiceRegistry: provider.Kubernetes,
+		},
+	}
+
+	controllerProxy := &model.Proxy{
+		IPAddresses: []string{"10.0.1.1"},
+		Metadata:    &model.NodeMetadata{ClusterID: "cluster1"},
+		Type:        model.SidecarProxy,
+		DNSDomain:   "kafka.svc.cluster.local",
+	}
+	brokerProxy := &model.Proxy{
+		IPAddresses: []string{"10.0.2.1"},
+		Metadata:    &model.NodeMetadata{ClusterID: "cluster1"},
+		Type:        model.SidecarProxy,
+		DNSDomain:   "kafka.svc.cluster.local",
+	}
+	remoteProxy := &model.Proxy{
+		IPAddresses: []string{"10.1.0.1"},
+		Metadata:    &model.NodeMetadata{ClusterID: "cluster2"},
+		Type:        model.SidecarProxy,
+		DNSDomain:   "kafka.svc.cluster.local",
+	}
+
+	push := model.NewPushContext()
+	push.Mesh = mesh
+	push.AddPublicServices([]*model.Service{multiPortHeadlessService})
+
+	controllerInstances := map[int][]*model.IstioEndpoint{
+		9090: {{
+			Addresses:       controllerProxy.IPAddresses,
+			ServicePortName: "tcp-ctrlplane",
+			EndpointPort:    9090,
+			HostName:        "controller-0",
+			SubDomain:       "kafka-brokers",
+			HealthStatus:    model.Healthy,
+			Locality:        model.Locality{ClusterID: "cluster1"},
+		}},
+		8443: {{
+			Addresses:       controllerProxy.IPAddresses,
+			ServicePortName: "tcp-kafkaagent",
+			EndpointPort:    8443,
+			HostName:        "controller-0",
+			SubDomain:       "kafka-brokers",
+			HealthStatus:    model.Healthy,
+			Locality:        model.Locality{ClusterID: "cluster1"},
+		}},
+	}
+	push.AddServiceInstances(multiPortHeadlessService, controllerInstances)
+
+	// Broker has no endpoints on port 9090 (Ports[0]).
+	brokerInstances := map[int][]*model.IstioEndpoint{
+		9091: {{
+			Addresses:       brokerProxy.IPAddresses,
+			ServicePortName: "tcp-replication",
+			EndpointPort:    9091,
+			HostName:        "kafka-0",
+			SubDomain:       "kafka-brokers",
+			HealthStatus:    model.Healthy,
+			Locality:        model.Locality{ClusterID: "cluster1"},
+		}},
+		9093: {{
+			Addresses:       brokerProxy.IPAddresses,
+			ServicePortName: "tcp-clientstls",
+			EndpointPort:    9093,
+			HostName:        "kafka-0",
+			SubDomain:       "kafka-brokers",
+			HealthStatus:    model.Healthy,
+			Locality:        model.Locality{ClusterID: "cluster1"},
+		}},
+		8443: {{
+			Addresses:       brokerProxy.IPAddresses,
+			ServicePortName: "tcp-kafkaagent",
+			EndpointPort:    8443,
+			HostName:        "kafka-0",
+			SubDomain:       "kafka-brokers",
+			HealthStatus:    model.Healthy,
+			Locality:        model.Locality{ClusterID: "cluster1"},
+		}},
+	}
+	push.AddServiceInstances(multiPortHeadlessService, brokerInstances)
+
+	cases := []struct {
+		name                       string
+		proxy                      *model.Proxy
+		enableMultiClusterHeadless bool
+		expectBrokerDNS            bool
+		expectControllerDNS        bool
+	}{
+		{
+			name:                       "local cluster sees both controller and broker",
+			proxy:                      controllerProxy,
+			enableMultiClusterHeadless: true,
+			expectBrokerDNS:            true,
+			expectControllerDNS:        true,
+		},
+		{
+			name:                       "remote cluster sees both controller and broker",
+			proxy:                      remoteProxy,
+			enableMultiClusterHeadless: true,
+			expectBrokerDNS:            true,
+			expectControllerDNS:        true,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.proxy.SetSidecarScope(push)
+			tt.proxy.DiscoverIPMode()
+
+			nt := dnsServer.BuildNameTable(dnsServer.Config{
+				Node:                        tt.proxy,
+				Push:                        push,
+				MulticlusterHeadlessEnabled: tt.enableMultiClusterHeadless,
+			})
+
+			brokerEntry := "kafka-0.kafka-brokers.kafka.svc.cluster.local"
+			controllerEntry := "controller-0.kafka-brokers.kafka.svc.cluster.local"
+
+			if tt.expectBrokerDNS {
+				if _, found := nt.Table[brokerEntry]; !found {
+					t.Errorf("expected broker DNS entry %q but it was missing from name table (keys: %v)",
+						brokerEntry, nameTableKeys(nt))
+				}
+			}
+			if tt.expectControllerDNS {
+				if _, found := nt.Table[controllerEntry]; !found {
+					t.Errorf("expected controller DNS entry %q but it was missing from name table (keys: %v)",
+						controllerEntry, nameTableKeys(nt))
+				}
+			}
+		})
+	}
+}
+
+func nameTableKeys(nt *dnsProto.NameTable) []string {
+	keys := make([]string, 0, len(nt.Table))
+	for k := range nt.Table {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
 func TestPodNameTableLocalRemoteAddresses(t *testing.T) {
 	mesh := &meshconfig.MeshConfig{RootNamespace: "istio-system"}
 

--- a/releasenotes/notes/61038.yaml
+++ b/releasenotes/notes/61038.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - https://github.com/istio/istio/issues/61038
+releaseNotes:
+  - |
+    **Fixed** NDS name table generation for headless services to include endpoints from all service ports,
+    not just the first port. Previously, when Kubernetes split EndpointSlices by port subset (e.g., heterogeneous
+    `targetPort` names across pod pools), only pods present in the first-port slice were included in the DNS
+    name table, causing `NXDOMAIN` for other pods' per-pod hostnames on remote clusters.


### PR DESCRIPTION
**Please provide a description of this PR:**
Assumption was that enumerating the first port will give us all the endpoints. Should enumerate all ports and get all unique endpoints.
Fixes: #61038 