### PR TITLE
fix: don't wipe endpoint shards when a superseded registry closes

### DIFF
--- a/pilot/pkg/model/endpointshards.go
+++ b/pilot/pkg/model/endpointshards.go
@@ -238,6 +238,28 @@ func (e *EndpointIndex) DeleteShard(shardKey ShardKey) {
 	e.cache.ClearAll()
 }
 
+// PruneShard removes shardKey from every (service, namespace) entry not present in keep. A
+// registry calls this after completing a full resync (e.g. following a credential rotation) to
+// clean up shard entries for services that no longer exist in the source: such a service never
+// generates a delete event of its own, since a full resync only lists what currently exists -
+// there's nothing left to diff a fresh list against.
+func (e *EndpointIndex) PruneShard(shardKey ShardKey, keep map[string]sets.String) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for svc, shardsByNamespace := range e.shardsBySvc {
+		for ns := range shardsByNamespace {
+			if keep[svc].Contains(ns) {
+				continue
+			}
+			e.deleteServiceInner(shardKey, svc, ns, false)
+		}
+	}
+	if e.cache == nil {
+		return
+	}
+	e.cache.ClearAll()
+}
+
 // must be called with lock
 func (e *EndpointIndex) deleteServiceInner(shard ShardKey, serviceName, namespace string, preserveKeys bool) {
 	if e.shardsBySvc[serviceName] == nil ||

--- a/pilot/pkg/model/endpointshards.go
+++ b/pilot/pkg/model/endpointshards.go
@@ -254,10 +254,6 @@ func (e *EndpointIndex) PruneShard(shardKey ShardKey, keep map[string]sets.Strin
 			e.deleteServiceInner(shardKey, svc, ns, false)
 		}
 	}
-	if e.cache == nil {
-		return
-	}
-	e.cache.ClearAll()
 }
 
 // must be called with lock

--- a/pilot/pkg/model/fake_endpointshards.go
+++ b/pilot/pkg/model/fake_endpointshards.go
@@ -68,3 +68,7 @@ func (f *FakeEndpointIndexUpdater) ProxyUpdate(_ cluster.ID, _ string) {}
 func (f *FakeEndpointIndexUpdater) RemoveShard(shardKey ShardKey) {
 	f.Index.DeleteShard(shardKey)
 }
+
+func (f *FakeEndpointIndexUpdater) PruneShard(shardKey ShardKey, keep map[string]sets.String) {
+	f.Index.PruneShard(shardKey, keep)
+}

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -351,6 +351,13 @@ type XDSUpdater interface {
 
 	// RemoveShard removes all endpoints for the given shard key
 	RemoveShard(shardKey ShardKey)
+
+	// PruneShard removes the given shard key from every (hostname, namespace) pair not present
+	// in keep. Called after a registry completes a full resync (e.g. following a credential
+	// rotation) to clean up shard entries for services that no longer exist in the source -
+	// such a service never generates a delete event of its own, since a full resync only lists
+	// what currently exists.
+	PruneShard(shardKey ShardKey, keep map[string]sets.String)
 }
 
 // PushRequest defines a request to push to proxies

--- a/pilot/pkg/model/virtualservice_controller_test.go
+++ b/pilot/pkg/model/virtualservice_controller_test.go
@@ -800,6 +800,7 @@ func (f *fakeXDSUpdater) EDSCacheUpdate(ShardKey, string, string, []*IstioEndpoi
 func (f *fakeXDSUpdater) SvcUpdate(ShardKey, string, string, Event)                 {}
 func (f *fakeXDSUpdater) ProxyUpdate(cluster.ID, string)                            {}
 func (f *fakeXDSUpdater) RemoveShard(ShardKey)                                      {}
+func (f *fakeXDSUpdater) PruneShard(ShardKey, map[string]sets.String)               {}
 
 func setupControllerWithXDS(t *testing.T, xds XDSUpdater, objs ...config.Config) (*VirtualServiceController, *FakeStore) {
 	stop := test.NewStop(t)

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -143,31 +143,34 @@ func (c *Controller) DeleteRegistry(clusterID cluster.ID, providerID provider.ID
 // DeleteRegistryIfCurrent deletes the registry for registry's cluster/provider, but only if it is
 // still the instance registered - i.e. it was not already replaced by a concurrent UpdateRegistry
 // swap. This avoids removing a registry that was already atomically replaced by a newer one.
-func (c *Controller) DeleteRegistryIfCurrent(registry serviceregistry.Instance) {
-	c.deleteRegistry(registry.Cluster(), registry.Provider(), registry)
+// Returns true if registry was deleted, false if it had already been superseded.
+func (c *Controller) DeleteRegistryIfCurrent(registry serviceregistry.Instance) bool {
+	return c.deleteRegistry(registry.Cluster(), registry.Provider(), registry)
 }
 
 // deleteRegistry removes the registry for clusterID/providerID. If expect is non-nil, the
-// deletion only happens if the currently registered instance is identical to expect.
-func (c *Controller) deleteRegistry(clusterID cluster.ID, providerID provider.ID, expect serviceregistry.Instance) {
+// deletion only happens if the currently registered instance is identical to expect. Returns
+// true if a registry was deleted.
+func (c *Controller) deleteRegistry(clusterID cluster.ID, providerID provider.ID, expect serviceregistry.Instance) bool {
 	c.storeLock.Lock()
 	defer c.storeLock.Unlock()
 	if len(c.registries) == 0 {
 		log.Warnf("Registry list is empty, nothing to delete")
-		return
+		return false
 	}
 	index, ok := c.getRegistryIndex(clusterID, providerID)
 	if !ok {
 		log.Warnf("Registry %s/%s is not found in the registries list, nothing to delete", providerID, clusterID)
-		return
+		return false
 	}
 	if expect != nil && c.registries[index].Instance != expect {
 		log.Infof("%s registry for cluster %s was already replaced, skipping delete.", providerID, clusterID)
-		return
+		return false
 	}
 	c.registries[index] = nil
 	c.registries = append(c.registries[:index], c.registries[index+1:]...)
 	log.Infof("%s registry for the cluster %s has been deleted.", providerID, clusterID)
+	return true
 }
 
 // UpdateRegistry atomically replaces an existing registry with a new one, used

--- a/pilot/pkg/serviceregistry/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex_test.go
@@ -3288,6 +3288,7 @@ func (p *pushRequestRecorder) SvcUpdate(model.ShardKey, string, string, model.Ev
 func (p *pushRequestRecorder) ConfigUpdate(req *model.PushRequest)                   { p.req = req }
 func (p *pushRequestRecorder) ProxyUpdate(cluster.ID, string)                        {}
 func (p *pushRequestRecorder) RemoveShard(model.ShardKey)                            {}
+func (p *pushRequestRecorder) PruneShard(model.ShardKey, map[string]sets.String)     {}
 
 func TestPushXdsAddressWaypointRefs(t *testing.T) {
 	waypoint := &workloadapi.GatewayAddress{

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -392,11 +392,15 @@ func (c *Controller) Network(endpointIP string, labels labels.Instance) network.
 	return ""
 }
 
-func (c *Controller) Cleanup() error {
+// Cleanup releases resources held by the controller. removeShard must be false if this
+// controller has already been superseded by a newer registry for the same cluster (e.g. a
+// credential-rotation swap) - the old and new registries share a ShardKey, so removing it here
+// would wipe out endpoints the new registry already populated (istio.io/istio#61043).
+func (c *Controller) Cleanup(removeShard bool) error {
 	if err := queue.WaitForClose(c.queue, 30*time.Second); err != nil {
 		log.Warnf("queue for removed kube registry %q may not be done processing: %v", c.Cluster(), err)
 	}
-	if c.opts.XDSUpdater != nil {
+	if removeShard && c.opts.XDSUpdater != nil {
 		c.opts.XDSUpdater.RemoveShard(model.ShardKeyFromRegistry(c))
 	}
 

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -41,6 +41,7 @@ import (
 	kubelib "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/kube/multicluster"
+	"istio.io/istio/pkg/util/sets"
 	"istio.io/istio/pkg/webhooks"
 )
 
@@ -96,6 +97,21 @@ func (k *kubeController) Close() {
 	if k.opts.XDSUpdater != nil {
 		k.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{Reason: model.NewReasonStats(model.ClusterUpdate), Forced: true})
 	}
+}
+
+// liveServiceHosts returns the hostname/namespace pairs registry currently knows about, for use
+// as the "keep" set passed to XDSUpdater.PruneShard once registry's initial sync completes.
+func liveServiceHosts(registry *Controller) map[string]sets.String {
+	svcs := registry.Services()
+	keep := make(map[string]sets.String, len(svcs))
+	for _, svc := range svcs {
+		hostname := string(svc.Hostname)
+		if keep[hostname] == nil {
+			keep[hostname] = sets.New[string]()
+		}
+		keep[hostname].Insert(svc.Attributes.Namespace)
+	}
+	return keep
 }
 
 // Multicluster structure holds the remote kube Controllers and multicluster specific attributes.
@@ -254,6 +270,15 @@ func (m *Multicluster) initializeCluster(cluster *multicluster.Cluster, kubeCont
 		kubeController.syncedFn = func() {
 			log.Infof("cluster %s synced, replacing registry", cluster.ID)
 			m.opts.MeshServiceController.UpdateRegistry(kubeRegistry, clusterStopCh)
+			// The old registry (being replaced) may have written shard entries for services
+			// that no longer exist in the remote cluster - e.g. deleted in the same window the
+			// old registry's watch stopped observing changes. Those services never appear in
+			// kubeRegistry's own sync, so nothing else would ever clean up their stale shard
+			// entries. Prune anything under this shard key that kubeRegistry didn't just
+			// reaffirm.
+			if kubeRegistry.opts.XDSUpdater != nil {
+				kubeRegistry.opts.XDSUpdater.PruneShard(model.ShardKeyFromRegistry(kubeRegistry), liveServiceHosts(kubeRegistry))
+			}
 		}
 		go kubeRegistry.Run(clusterStopCh)
 	} else {

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -84,12 +84,13 @@ func (k *kubeController) Close() {
 	clusterID := k.Controller.clusterID
 	k.MeshServiceController.UnRegisterHandlersForCluster(clusterID)
 	// DeleteRegistryIfCurrent avoids deleting a registry that HasSynced's UpdateRegistry call
-	// above already swapped in to replace this one.
-	k.MeshServiceController.DeleteRegistryIfCurrent(k.Controller)
+	// above already swapped in to replace this one. If it was already superseded, our EDS shard
+	// key now belongs to that new registry, so Cleanup must not remove it.
+	current := k.MeshServiceController.DeleteRegistryIfCurrent(k.Controller)
 	if k.workloadEntryController != nil {
 		k.MeshServiceController.DeleteRegistry(clusterID, provider.External)
 	}
-	if err := k.Controller.Cleanup(); err != nil {
+	if err := k.Controller.Cleanup(current); err != nil {
 		log.Warnf("failed cleaning up services in %s: %v", clusterID, err)
 	}
 	if k.opts.XDSUpdater != nil {

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
@@ -17,6 +17,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -326,6 +327,116 @@ func Test_KubeSecretController_CredentialRotation(t *testing.T) {
 		assertShardPopulated(fmt.Sprintf("after credential rotation %d", generation))
 		originalRegistry = registryForCluster(mockserviceController, remoteClusterID)
 	}
+
+	assert.NoError(t, deleteMultiClusterSecret(clientset, "test-secret-1"))
+	verifyControllers(t, mc, 1, "delete remote controller")
+}
+
+// Test_KubeSecretController_CredentialRotation_StaleServiceAfterRotation validates a potential gap
+// when a service is removed from the remote cluster in the same window as a credential rotation,
+// its stale endpoint shard is never cleaned up.
+//
+// The old registry keeps running - and could observe the deletion itself - right up until the
+// new registry syncs. But credential rotation is exactly the scenario where the old registry's
+// watch connection can go bad (that's the reason for rotating), so it may never see the delete.
+// The new registry's initial sync only lists what currently exists in the remote cluster, so a
+// service that's already gone by then never generates any event to diff against - there's
+// nothing to tell the shard index the old entry is now stale. kubeController.Close() no longer
+// blindly wipes the shard for this exact reason (see the fix above), so that stale entry is
+// never cleaned up.
+func Test_KubeSecretController_CredentialRotation_StaleServiceAfterRotation(t *testing.T) {
+	const (
+		vanishingSvcName = "vanishing-svc"
+		vanishingSvcNS   = "app-ns"
+		vanishingSvcIP   = "10.10.0.2"
+	)
+	vanishingHostname := vanishingSvcName + "." + vanishingSvcNS + ".svc." + DomainSuffix
+
+	clusterID := cluster.ID("cluster-1")
+	remoteClusterID := cluster.ID("test-remote-cluster-1")
+	shardKey := model.ShardKey{Cluster: remoteClusterID, Provider: provider.Kubernetes}
+
+	endpointIndex := model.NewEndpointIndex(model.DisabledCache{})
+	xdsUpdater := model.NewEndpointIndexUpdater(endpointIndex)
+
+	mockserviceController := newMockserviceController(clusterID)
+	clientset := kube.NewFakeClient()
+	stop := test.NewStop(t)
+	s := server.New()
+	mcc := initController(clientset, testSecretNameSpace, stop)
+
+	// vanishing-svc is only ever seeded into the first generation of the remote client (the
+	// initial Add) - simulating a service that existed when the cluster was first added, but
+	// was deleted from the remote cluster before the credential rotation below, in the same
+	// window the old registry's watch stopped observing changes.
+	var generation atomic.Int32
+	mcc.ClientBuilder = func(kubeConfig []byte, c cluster.ID, configOverrides ...func(*rest.Config)) (kube.Client, error) {
+		remoteClient := kube.NewFakeClient()
+		if generation.Add(1) == 1 {
+			seedStableRemoteService(t, remoteClient, vanishingSvcName, vanishingSvcNS, vanishingSvcIP)
+		}
+		return remoteClient, nil
+	}
+	mc := NewMulticluster("pilot-abc-123", Options{
+		ClusterID:             clusterID,
+		DomainSuffix:          DomainSuffix,
+		MeshWatcher:           meshwatcher.NewTestWatcher(&meshconfig.MeshConfig{}),
+		MeshNetworksWatcher:   meshwatcher.NewFixedNetworksWatcher(nil),
+		MeshServiceController: mockserviceController,
+		XDSUpdater:            xdsUpdater,
+	}, nil, nil, "default", false, nil, s, mcc)
+	assert.NoError(t, mcc.Run(stop))
+	go mockserviceController.Run(stop)
+	clientset.RunAndWait(stop)
+	kube.WaitForCacheSync("test", stop, mcc.HasSynced)
+	_ = s.Start(stop)
+
+	verifyControllers(t, mc, 1, "create local controller")
+	assert.NoError(t, createMultiClusterSecret(clientset, "test-secret-1", string(remoteClusterID)))
+	verifyControllers(t, mc, 2, "create remote controller")
+
+	retry.UntilSuccessOrFail(t, func() error {
+		shards, ok := endpointIndex.ShardsForService(vanishingHostname, vanishingSvcNS)
+		if !ok {
+			return fmt.Errorf("expected endpoint shard for %s to be populated before rotation", vanishingHostname)
+		}
+		shards.RLock()
+		defer shards.RUnlock()
+		if len(shards.Shards[shardKey]) == 0 {
+			return fmt.Errorf("expected endpoint shard for %s to be populated before rotation", vanishingHostname)
+		}
+		return nil
+	}, retry.Timeout(time.Second*5), retry.Delay(time.Millisecond*10))
+
+	originalRegistry := registryForCluster(mockserviceController, remoteClusterID)
+
+	// Rotate credentials. The remote cluster's fixture no longer includes vanishing-svc,
+	// simulating that it was deleted before this rotation - the new registry's fresh sync
+	// never lists it, so nothing ever generates a delete for the shard entry the old registry
+	// wrote.
+	assert.NoError(t, updateMultiClusterSecret(clientset, "test-secret-1", string(remoteClusterID), 1))
+	retry.UntilSuccessOrFail(t, func() error {
+		current := registryForCluster(mockserviceController, remoteClusterID)
+		if current == nil || current == originalRegistry {
+			return fmt.Errorf("registry for %s not swapped after credential rotation", remoteClusterID)
+		}
+		return nil
+	}, retry.Timeout(time.Second*5), retry.Delay(time.Millisecond*10))
+
+	// The deleted service's endpoint shard must eventually be cleaned up - it must not serve
+	// stale endpoints for a service that no longer exists in the remote cluster.
+	retry.UntilSuccessOrFail(t, func() error {
+		shards, ok := endpointIndex.ShardsForService(vanishingHostname, vanishingSvcNS)
+		if !ok {
+			return nil
+		}
+		shards.RLock()
+		defer shards.RUnlock()
+		if len(shards.Shards[shardKey]) == 0 {
+			return nil
+		}
+		return fmt.Errorf("stale endpoint shard %v for deleted service %s still present after rotation", shardKey, vanishingHostname)
+	}, retry.Timeout(time.Second*2), retry.Delay(time.Millisecond*10))
 
 	assert.NoError(t, deleteMultiClusterSecret(clientset, "test-secret-1"))
 	verifyControllers(t, mc, 1, "delete remote controller")

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
@@ -289,7 +289,12 @@ func Test_KubeSecretController_CredentialRotation(t *testing.T) {
 		t.Helper()
 		retry.UntilSuccessOrFail(t, func() error {
 			shards, ok := endpointIndex.ShardsForService(hostname, remoteSvcNS)
-			if !ok || len(shards.Shards[shardKey]) == 0 {
+			if !ok {
+				return fmt.Errorf("endpoint shard %v for %s missing %s", shardKey, hostname, when)
+			}
+			shards.RLock()
+			defer shards.RUnlock()
+			if len(shards.Shards[shardKey]) == 0 {
 				return fmt.Errorf("endpoint shard %v for %s missing %s", shardKey, hostname, when)
 			}
 			return nil

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
@@ -51,9 +51,9 @@ const (
 	DomainSuffix        = "fake_domain"
 )
 
-func newMockserviceController(configCluster cluster.ID) *aggregate.Controller {
+func newMockserviceController() *aggregate.Controller {
 	return aggregate.NewController(aggregate.Options{
-		ConfigClusterID: configCluster,
+		ConfigClusterID: "cluster-1",
 	})
 }
 
@@ -115,10 +115,10 @@ func verifyControllers(t *testing.T, m *Multicluster, expectedControllerCount in
 	}, expectedControllerCount, retry.Message(timeoutName), retry.Delay(time.Millisecond*10), retry.Timeout(time.Second*5))
 }
 
-func initController(client kube.CLIClient, ns string, stop <-chan struct{}) *multicluster.Controller {
+func initController(client kube.CLIClient, stop <-chan struct{}) *multicluster.Controller {
 	sc := multicluster.NewController(multicluster.ControllerOptions{
 		Client:          client,
-		SystemNamespace: ns,
+		SystemNamespace: testSecretNameSpace,
 		ClusterID:       "cluster-1",
 		MeshConfig:      meshwatcher.NewTestWatcher(nil),
 		Debugger:        krt.GlobalDebugHandler,
@@ -132,11 +132,11 @@ func initController(client kube.CLIClient, ns string, stop <-chan struct{}) *mul
 
 func Test_KubeSecretController(t *testing.T) {
 	clusterID := cluster.ID("cluster-1")
-	mockserviceController := newMockserviceController(clusterID)
+	mockserviceController := newMockserviceController()
 	clientset := kube.NewFakeClient()
 	stop := test.NewStop(t)
 	s := server.New()
-	mcc := initController(clientset, testSecretNameSpace, stop)
+	mcc := initController(clientset, stop)
 	mc := NewMulticluster("pilot-abc-123", Options{
 		ClusterID:    clusterID,
 		DomainSuffix: DomainSuffix,
@@ -249,11 +249,11 @@ func Test_KubeSecretController_CredentialRotation(t *testing.T) {
 	endpointIndex := model.NewEndpointIndex(model.DisabledCache{})
 	xdsUpdater := model.NewEndpointIndexUpdater(endpointIndex)
 
-	mockserviceController := newMockserviceController(clusterID)
+	mockserviceController := newMockserviceController()
 	clientset := kube.NewFakeClient()
 	stop := test.NewStop(t)
 	s := server.New()
-	mcc := initController(clientset, testSecretNameSpace, stop)
+	mcc := initController(clientset, stop)
 	mcc.ClientBuilder = func(kubeConfig []byte, c cluster.ID, configOverrides ...func(*rest.Config)) (kube.Client, error) {
 		remoteClient := kube.NewFakeClient()
 		seedStableRemoteService(t, remoteClient, remoteSvcName, remoteSvcNS, remoteSvcIP)
@@ -359,11 +359,11 @@ func Test_KubeSecretController_CredentialRotation_StaleServiceAfterRotation(t *t
 	endpointIndex := model.NewEndpointIndex(model.DisabledCache{})
 	xdsUpdater := model.NewEndpointIndexUpdater(endpointIndex)
 
-	mockserviceController := newMockserviceController(clusterID)
+	mockserviceController := newMockserviceController()
 	clientset := kube.NewFakeClient()
 	stop := test.NewStop(t)
 	s := server.New()
-	mcc := initController(clientset, testSecretNameSpace, stop)
+	mcc := initController(clientset, stop)
 
 	// vanishing-svc is only ever seeded into the first generation of the remote client (the
 	// initial Add) - simulating a service that existed when the cluster was first added, but
@@ -446,12 +446,12 @@ func Test_KubeSecretController_ExternalIstiod_MultipleClusters(t *testing.T) {
 	test.SetForTest(t, &features.ExternalIstiod, true)
 	test.SetForTest(t, &features.InjectionWebhookConfigName, "")
 	clusterID := cluster.ID("cluster-1")
-	mockserviceController := newMockserviceController(clusterID)
+	mockserviceController := newMockserviceController()
 	clientset := kube.NewFakeClient()
 	stop := test.NewStop(t)
 	s := server.New()
 	certWatcher := keycertbundle.NewWatcher()
-	mcc := initController(clientset, testSecretNameSpace, stop)
+	mcc := initController(clientset, stop)
 	mc := NewMulticluster("pilot-abc-123", Options{
 		ClusterID:             clusterID,
 		DomainSuffix:          DomainSuffix,

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
@@ -21,18 +21,22 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/keycertbundle"
+	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/server"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
+	"istio.io/istio/pilot/pkg/serviceregistry/provider"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/mesh/meshwatcher"
 	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/kclient/clienttest"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/kube/multicluster"
 	"istio.io/istio/pkg/test"
@@ -185,26 +189,82 @@ func Test_KubeSecretController(t *testing.T) {
 	})
 }
 
+// seedStableRemoteService creates a Service + EndpointSlice with a fixed IP on the given
+// client. It is called from the ClientBuilder for every generation of a remote cluster's
+// client (both the initial Add and every subsequent Update from a secret rotation), so the
+// remote content is byte-for-byte identical across rotations - simulating a service whose
+// endpoints do not change ("no pod churn") across a credential rotation.
+func seedStableRemoteService(t *testing.T, client kube.Client, name, namespace, ip string) {
+	t.Helper()
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: v1.ServiceSpec{
+			ClusterIP:  ip,
+			ClusterIPs: []string{ip},
+			Ports:      []v1.ServicePort{{Name: "http", Port: 80, Protocol: v1.ProtocolTCP}},
+		},
+	}
+	clienttest.NewWriter[*v1.Service](t, client).Create(svc)
+
+	portName := "http"
+	var portNum int32 = 80
+	endpointIP := ip[:len(ip)-1] + "5" // distinct from the service ClusterIP
+	slice := &discovery.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{discovery.LabelServiceName: name},
+		},
+		AddressType: discovery.AddressTypeIPv4,
+		Endpoints: []discovery.Endpoint{{
+			Addresses: []string{endpointIP},
+		}},
+		Ports: []discovery.EndpointPort{{Name: &portName, Port: &portNum}},
+	}
+	clienttest.NewWriter[*discovery.EndpointSlice](t, client).Create(slice)
+}
+
 // Test_KubeSecretController_CredentialRotation verifies that when a remote cluster's secret is
 // updated with new kubeconfig bytes, the aggregate controller ends up with exactly one registry
 // for that cluster at all times - the make-before-break swap in kubeController.HasSynced must
 // complete before the old kubeController.Close() removes its registry, otherwise there would be
 // a window where the cluster has no registered registry, or the swap would delete the
 // newly-registered one out from under it.
+//
+// It also verifies that endpoint shards for services with stable (unchanged) endpoints in the
+// remote cluster survive every rotation - see https://github.com/istio/istio/issues/61043.
 func Test_KubeSecretController_CredentialRotation(t *testing.T) {
+	const (
+		remoteSvcName = "stable-svc"
+		remoteSvcNS   = "app-ns"
+		remoteSvcIP   = "10.10.0.1"
+	)
+	hostname := remoteSvcName + "." + remoteSvcNS + ".svc." + DomainSuffix
+
 	clusterID := cluster.ID("cluster-1")
 	remoteClusterID := cluster.ID("test-remote-cluster-1")
+	shardKey := model.ShardKey{Cluster: remoteClusterID, Provider: provider.Kubernetes}
+
+	endpointIndex := model.NewEndpointIndex(model.DisabledCache{})
+	xdsUpdater := model.NewEndpointIndexUpdater(endpointIndex)
+
 	mockserviceController := newMockserviceController(clusterID)
 	clientset := kube.NewFakeClient()
 	stop := test.NewStop(t)
 	s := server.New()
 	mcc := initController(clientset, testSecretNameSpace, stop)
+	mcc.ClientBuilder = func(kubeConfig []byte, c cluster.ID, configOverrides ...func(*rest.Config)) (kube.Client, error) {
+		remoteClient := kube.NewFakeClient()
+		seedStableRemoteService(t, remoteClient, remoteSvcName, remoteSvcNS, remoteSvcIP)
+		return remoteClient, nil
+	}
 	mc := NewMulticluster("pilot-abc-123", Options{
 		ClusterID:             clusterID,
 		DomainSuffix:          DomainSuffix,
 		MeshWatcher:           meshwatcher.NewTestWatcher(&meshconfig.MeshConfig{}),
 		MeshNetworksWatcher:   meshwatcher.NewFixedNetworksWatcher(nil),
 		MeshServiceController: mockserviceController,
+		XDSUpdater:            xdsUpdater,
 	}, nil, nil, "default", false, nil, s, mcc)
 	assert.NoError(t, mcc.Run(stop))
 	go mockserviceController.Run(stop)
@@ -225,9 +285,23 @@ func Test_KubeSecretController_CredentialRotation(t *testing.T) {
 	}, retry.Timeout(time.Second*5))
 	originalRegistry := registryForCluster(mockserviceController, remoteClusterID)
 
+	assertShardPopulated := func(when string) {
+		t.Helper()
+		retry.UntilSuccessOrFail(t, func() error {
+			shards, ok := endpointIndex.ShardsForService(hostname, remoteSvcNS)
+			if !ok || len(shards.Shards[shardKey]) == 0 {
+				return fmt.Errorf("endpoint shard %v for %s missing %s", shardKey, hostname, when)
+			}
+			return nil
+		}, retry.Timeout(time.Second*5), retry.Delay(time.Millisecond*10))
+	}
+	assertShardPopulated("after add")
+
 	// Rotate the credentials a few times. After each rotation, the aggregate controller must have
 	// exactly one registry for the cluster, and it must be a different instance than before -
-	// never zero (a push/lookup gap) and never the stale one (a silently-dropped swap).
+	// never zero (a push/lookup gap) and never the stale one (a silently-dropped swap). The
+	// remote cluster's content is unchanged across rotations (no pod churn), so its endpoint
+	// shard must also survive every rotation.
 	for generation := 1; generation <= 3; generation++ {
 		assert.NoError(t, updateMultiClusterSecret(clientset, "test-secret-1", string(remoteClusterID), generation))
 
@@ -244,6 +318,7 @@ func Test_KubeSecretController_CredentialRotation(t *testing.T) {
 
 		// The controller count must stay stable across the swap - no transient duplicate, no gap.
 		verifyControllers(t, mc, 2, fmt.Sprintf("controller count after credential rotation %d", generation))
+		assertShardPopulated(fmt.Sprintf("after credential rotation %d", generation))
 		originalRegistry = registryForCluster(mockserviceController, remoteClusterID)
 	}
 

--- a/pilot/pkg/serviceregistry/util/xdsfake/updater.go
+++ b/pilot/pkg/serviceregistry/util/xdsfake/updater.go
@@ -24,6 +24,7 @@ import (
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/util/sets"
 )
 
 // NewFakeXDS creates a XdsUpdater reporting events via a channel.
@@ -169,6 +170,16 @@ func (fx *Updater) RemoveShard(shardKey model.ShardKey) {
 	}
 	if fx.Delegate != nil {
 		fx.Delegate.RemoveShard(shardKey)
+	}
+}
+
+func (fx *Updater) PruneShard(shardKey model.ShardKey, keep map[string]sets.String) {
+	select {
+	case fx.Events <- Event{Type: "pruneShard", ID: shardKey.String()}:
+	default:
+	}
+	if fx.Delegate != nil {
+		fx.Delegate.PruneShard(shardKey, keep)
 	}
 }
 

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -86,6 +86,10 @@ func (s *DiscoveryServer) RemoveShard(shardKey model.ShardKey) {
 	s.Env.EndpointIndex.DeleteShard(shardKey)
 }
 
+func (s *DiscoveryServer) PruneShard(shardKey model.ShardKey, keep map[string]sets.String) {
+	s.Env.EndpointIndex.PruneShard(shardKey, keep)
+}
+
 // EdsGenerator implements the new Generate method for EDS, using the in-memory, optimized endpoint
 // storage in DiscoveryServer.
 type EdsGenerator struct {

--- a/releasenotes/notes/61043.yaml
+++ b/releasenotes/notes/61043.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 61043
+releaseNotes:
+  - |
+    **Fixed** an issue in multicluster deployments where rotating a remote cluster's
+    `istio-remote-secret` could permanently wipe endpoint shards for services with
+    stable endpoints in that cluster, making them unreachable across clusters until
+    istiod was restarted.


### PR DESCRIPTION
**Please provide a description of this PR:**

After rotating a remote cluster's `istio-remote-secret`, endpoint shards for services with
stable (unchanged) endpoints in that cluster were permanently wiped, making them unreachable
cross-cluster until istiod was restarted.

`kubeController.Close()` calls `Controller.Cleanup()`, which unconditionally removes the
controller's EDS shard via `XDSUpdater.RemoveShard(shardKey)`. During a credential-rotation
swap, the new registry is atomically swapped into the aggregate controller before the old one
is closed, but the old and new registries for the same cluster share the same `ShardKey`
(`Cluster` + `Provider`, not a per-instance identity). So the old registry's `Close()` removed
the shard the new registry had just populated during its own sync - and since the remote
content hadn't changed, nothing re-triggered an EDS update to repopulate it.

`DeleteRegistryIfCurrent` now reports whether it actually removed the registry (vs. finding it
already superseded by a newer one), and `Cleanup()` only removes the EDS shard when that's
true - i.e. when the registry is genuinely gone, not replaced.

Skipping the shard removal for a superseded registry protects live data, but opens a narrower
gap: a service deleted from the remote cluster in that same rotation window never generates a
delete event for either registry to process (the old registry's watch may already be going bad
- that's the reason for rotating - and the new registry's fresh sync only lists what currently
exists, so a gone service produces no event to diff against). To handle this, `EndpointIndex`
gets a new `PruneShard(shardKey, keep)` that removes shard entries not present in `keep`,
called once the new registry's swap completes with the set of services it just synced. Wired
through the `XDSUpdater` interface alongside `RemoveShard`.

Test coverage:
- `Test_KubeSecretController_CredentialRotation` seeds a remote cluster with a stable service
  and asserts its endpoint shard survives every credential rotation.
- `Test_KubeSecretController_CredentialRotation_StaleServiceAfterRotation` seeds a service that
  only exists in the cluster's first generation and asserts its shard is pruned after rotation.

Fixes #61043

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [x] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
