### PR TITLE
build: support SELinux-enforcing systems with CONTAINER_SELINUX=1

### DIFF
--- a/Makefile.overrides.mk
+++ b/Makefile.overrides.mk
@@ -21,8 +21,12 @@
 BUILD_WITH_CONTAINER ?= 1
 # Container options for the build container. Can be customized for different container runtimes.
 # Example for podman on macOS: CONTAINER_OPTIONS="--mount type=bind,source=/tmp,destination=/tmp --net=host --security-opt label=disable"
-# Note: --security-opt label=disable disables SELinux labeling (safer than --privileged)
-CONTAINER_OPTIONS ?= --mount type=bind,source=/tmp,destination=/tmp --net=host
+# Set CONTAINER_SELINUX=1 on SELinux-enforcing systems to add :z labels to bind mounts.
+ifeq ($(CONTAINER_SELINUX),1)
+  CONTAINER_OPTIONS ?= --tmpfs /tmp:exec --net=host
+else
+  CONTAINER_OPTIONS ?= --mount type=bind,source=/tmp,destination=/tmp --net=host
+endif
 
 export COMMONFILES_POSTPROCESS = tools/commonfiles-postprocess.sh
 

--- a/common/scripts/run.sh
+++ b/common/scripts/run.sh
@@ -39,6 +39,8 @@ read -ra DOCKER_RUN_OPTIONS <<< "${DOCKER_RUN_OPTIONS:-}"
 [[ -t 0 ]] && DOCKER_RUN_OPTIONS+=("-it")
 [[ ${UID} -ne 0 ]] && DOCKER_RUN_OPTIONS+=(-u "${UID}:${DOCKER_GID}")
 
+[[ "${CONTAINER_SELINUX:-0}" == "1" ]] && _SELINUX_BIND_RW=":z" || _SELINUX_BIND_RW=""
+
 # $CONTAINER_OPTIONS becomes an empty arg when quoted, so SC2086 is disabled for the
 # following command only
 # shellcheck disable=SC2086
@@ -48,13 +50,13 @@ read -ra DOCKER_RUN_OPTIONS <<< "${DOCKER_RUN_OPTIONS:-}"
     --init \
     --sig-proxy=true \
     --cap-add=SYS_ADMIN \
-    ${DOCKER_SOCKET_MOUNT:--v /var/run/docker.sock:/var/run/docker.sock} \
+    ${DOCKER_SOCKET_MOUNT:--v /var/run/docker.sock:/var/run/docker.sock${_SELINUX_BIND_RW}} \
     -e DOCKER_HOST=${DOCKER_SOCKET_HOST:-unix:///var/run/docker.sock} \
     $CONTAINER_OPTIONS \
     --env-file <(env | grep -v ${ENV_BLOCKLIST}) \
     -e IN_BUILD_CONTAINER=1 \
     -e TZ="${TIMEZONE:-$TZ}" \
-    --mount "type=bind,source=${MOUNT_SOURCE},destination=/work" \
+    -v "${MOUNT_SOURCE}:/work${_SELINUX_BIND_RW}" \
     --mount "type=volume,source=go,destination=/go" \
     --mount "type=volume,source=gocache,destination=/gocache" \
     --mount "type=volume,source=cache,destination=/home/.cache" \

--- a/common/scripts/setup_env.sh
+++ b/common/scripts/setup_env.sh
@@ -97,6 +97,16 @@ IMG="${IMG:-${TOOLS_REGISTRY_PROVIDER}/${PROJECT_ID}/${IMAGE_NAME}:${IMAGE_VERSI
 
 CONTAINER_CLI="${CONTAINER_CLI:-docker}"
 
+# SELinux: when CONTAINER_SELINUX=1, bind mounts get :z (shared label) so the
+# container process can access host paths under SELinux enforcement.
+if [[ "${CONTAINER_SELINUX:-0}" == "1" ]]; then
+  _SELINUX_BIND_RO=":ro,z"
+  _SELINUX_BIND_RW=":z"
+else
+  _SELINUX_BIND_RO=":ro"
+  _SELINUX_BIND_RW=""
+fi
+
 # Try to use the latest cached image we have. Use at your own risk, may have incompatibly-old versions
 if [[ "${LATEST_CACHED_IMAGE:-}" != "" ]]; then
   prefix="$(<<<"$IMAGE_VERSION" cut -d- -f1)"
@@ -124,22 +134,22 @@ container_kubeconfig=''
 
 # docker conditional host mount (needed for make docker push)
 if [[ -d "${HOME}/.docker" ]]; then
-  CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${HOME}/.docker,destination=/config/.docker,readonly "
+  CONDITIONAL_HOST_MOUNTS+="-v ${HOME}/.docker:/config/.docker${_SELINUX_BIND_RO} "
 fi
 
 # gcloud conditional host mount (needed for docker push with the gcloud auth configure-docker)
 if [[ -d "${HOME}/.config/gcloud" ]]; then
-  CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${HOME}/.config/gcloud,destination=/config/.config/gcloud,readonly "
+  CONDITIONAL_HOST_MOUNTS+="-v ${HOME}/.config/gcloud:/config/.config/gcloud${_SELINUX_BIND_RO} "
 fi
 
 # gitconfig conditional host mount (needed for git commands inside container)
 if [[ -f "${HOME}/.gitconfig" ]]; then
-  CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${HOME}/.gitconfig,destination=/home/.gitconfig,readonly "
+  CONDITIONAL_HOST_MOUNTS+="-v ${HOME}/.gitconfig:/home/.gitconfig${_SELINUX_BIND_RO} "
 fi
 
 # .netrc conditional host mount (needed for git commands inside container)
 if [[ -f "${HOME}/.netrc" ]]; then
-  CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${HOME}/.netrc,destination=/home/.netrc,readonly "
+  CONDITIONAL_HOST_MOUNTS+="-v ${HOME}/.netrc:/home/.netrc${_SELINUX_BIND_RO} "
 fi
 
 # echo ${CONDITIONAL_HOST_MOUNTS}
@@ -155,7 +165,7 @@ add_KUBECONFIG_if_exists () {
 
     kubeconfig_random="$(od -vAn -N4 -tx /dev/random | tr -d '[:space:]' | cut -c1-8)"
     container_kubeconfig+="/config/${kubeconfig_random}:"
-    CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${local_config},destination=/config/${kubeconfig_random} "
+    CONDITIONAL_HOST_MOUNTS+="-v ${local_config}:/config/${kubeconfig_random}${_SELINUX_BIND_RW} "
   fi
 }
 
@@ -231,6 +241,7 @@ VARS=(
       CONDITIONAL_HOST_MOUNTS
       ENV_BLOCKLIST
       CONTAINER_CLI
+      CONTAINER_SELINUX
       DOCKER_GID
       IMG
       IMAGE_NAME


### PR DESCRIPTION
**Please provide a description of this PR:**
When CONTAINER_SELINUX=1 is set, all bind mounts get the :z shared SELinux label, allowing containerized builds and tests to work on SELinux-enforcing systems (Fedora, RHEL, CentOS) without disabling SELinux enforcement. The /tmp mount uses --tmpfs with exec to avoid relabeling a system directory.






Depends on: https://github.com/istio/common-files/pull/1293.