### PR TITLE
Sidecar injects missing XFCC header over hbone

### DIFF
--- a/pilot/pkg/networking/core/listener_builder.go
+++ b/pilot/pkg/networking/core/listener_builder.go
@@ -476,6 +476,13 @@ func (lb *ListenerBuilder) buildHTTPConnectionManager(httpOpts *httpListenerOpts
 		// Metadata exchange filter needs to be added before any other HTTP filters are added. This is done to
 		// ensure that mx filter comes before HTTP RBAC filter. This is related to https://github.com/istio/istio/issues/41066
 		filters = appendMxFilter(httpOpts, filters)
+		if fccd := httpOpts.connectionManager.GetForwardClientCertDetails(); lb.node.Type == model.SidecarProxy &&
+			httpOpts.hbone && httpOpts.class == istionetworking.ListenerClassSidecarInbound &&
+			(fccd == hcm.HttpConnectionManager_APPEND_FORWARD || fccd == hcm.HttpConnectionManager_SANITIZE_SET) {
+			// synthensize XFCC if permitted
+			// See: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+			filters = append(filters, xdsfilters.SidecarXFCCClientIdentityFilter(fccd == hcm.HttpConnectionManager_SANITIZE_SET))
+		}
 		// TODO: how to deal with ext-authz? It will be in the ordering twice
 		filters = append(filters, lb.authzCustomBuilder.BuildHTTP(httpOpts.class)...)
 		filters = extension.PopAppendHTTPTrafficExtension(filters, trafficExtensions, extensions.TrafficExtension_AUTHN)

--- a/pilot/pkg/networking/core/listener_builder_test.go
+++ b/pilot/pkg/networking/core/listener_builder_test.go
@@ -24,6 +24,7 @@ import (
 	matcher "github.com/cncf/xds/go/xds/type/matcher/v3"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	header_mutationv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/header_mutation/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -35,6 +36,7 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
+	istionetworking "istio.io/istio/pilot/pkg/networking"
 	"istio.io/istio/pilot/pkg/networking/core/listenertest"
 	"istio.io/istio/pilot/pkg/networking/plugin/authz"
 	"istio.io/istio/pilot/pkg/networking/util"
@@ -1508,6 +1510,161 @@ func TestPreserveHeader(t *testing.T) {
 			assert.NoError(t, tt.isExpected(lb.buildHTTPConnectionManager(tt.opts)))
 		})
 	}
+}
+
+const sidecarXFCCFilterName = "istio.sidecar.xfcc_client_identity"
+
+func TestSidecarXFCCClientIdentityFilter(t *testing.T) {
+	cg := NewConfigGenTest(t, TestOptions{})
+	push := cg.PushContext()
+
+	cases := []struct {
+		name       string
+		proxy      *model.Proxy
+		opts       *httpListenerOpts
+		isExpected func(*hcm.HttpConnectionManager) error
+	}{
+		{
+			name: "hbone + APPEND_FORWARD",
+			opts: &httpListenerOpts{
+				hbone: true,
+				class: istionetworking.ListenerClassSidecarInbound,
+				connectionManager: &hcm.HttpConnectionManager{
+					ForwardClientCertDetails: hcm.HttpConnectionManager_APPEND_FORWARD,
+				},
+			},
+			isExpected: expectXFCCAction(core.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD),
+		},
+		{
+			name: "hbone + SANITIZE_SET",
+			opts: &httpListenerOpts{
+				hbone: true,
+				class: istionetworking.ListenerClassSidecarInbound,
+				connectionManager: &hcm.HttpConnectionManager{
+					ForwardClientCertDetails: hcm.HttpConnectionManager_SANITIZE_SET,
+				},
+			},
+			isExpected: expectXFCCAction(core.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD),
+		},
+		{
+			name: "hbone + SANITIZE",
+			opts: &httpListenerOpts{
+				hbone: true,
+				class: istionetworking.ListenerClassSidecarInbound,
+				connectionManager: &hcm.HttpConnectionManager{
+					ForwardClientCertDetails: hcm.HttpConnectionManager_SANITIZE,
+				},
+			},
+			isExpected: expectNoXFCC(),
+		},
+		{
+			name: "hbone + FORWARD_ONLY",
+			opts: &httpListenerOpts{
+				hbone: true,
+				class: istionetworking.ListenerClassSidecarInbound,
+				connectionManager: &hcm.HttpConnectionManager{
+					ForwardClientCertDetails: hcm.HttpConnectionManager_FORWARD_ONLY,
+				},
+			},
+			isExpected: expectNoXFCC(),
+		},
+		{
+			name: "non-hbone + APPEND_FORWARD",
+			opts: &httpListenerOpts{
+				hbone: false,
+				class: istionetworking.ListenerClassSidecarInbound,
+				connectionManager: &hcm.HttpConnectionManager{
+					ForwardClientCertDetails: hcm.HttpConnectionManager_APPEND_FORWARD,
+				},
+			},
+			isExpected: expectNoXFCC(),
+		},
+		{
+			name: "hbone + APPEND_FORWARD + outbound",
+			opts: &httpListenerOpts{
+				hbone: true,
+				class: istionetworking.ListenerClassSidecarOutbound,
+				connectionManager: &hcm.HttpConnectionManager{
+					ForwardClientCertDetails: hcm.HttpConnectionManager_APPEND_FORWARD,
+				},
+			},
+			isExpected: expectNoXFCC(),
+		},
+		{
+			name:  "hbone + APPEND_FORWARD + Router",
+			proxy: &model.Proxy{Type: model.Router},
+			opts: &httpListenerOpts{
+				hbone: true,
+				class: istionetworking.ListenerClassSidecarInbound,
+				connectionManager: &hcm.HttpConnectionManager{
+					ForwardClientCertDetails: hcm.HttpConnectionManager_APPEND_FORWARD,
+				},
+			},
+			isExpected: expectNoXFCC(),
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			proxy := cg.SetupProxy(tt.proxy)
+			lb := &ListenerBuilder{
+				push:               push,
+				node:               proxy,
+				authzCustomBuilder: &authz.Builder{},
+				authzBuilder:       &authz.Builder{},
+			}
+			assert.NoError(t, tt.isExpected(lb.buildHTTPConnectionManager(tt.opts)))
+		})
+	}
+}
+
+// expectNoXFCC returns a check that fails if the XFCC synthesis filter is present.
+func expectNoXFCC() func(*hcm.HttpConnectionManager) error {
+	return func(connMgr *hcm.HttpConnectionManager) error {
+		if findXFCCFilter(connMgr) != nil {
+			return fmt.Errorf("did not expect %q filter, but it was added", sidecarXFCCFilterName)
+		}
+		return nil
+	}
+}
+
+// expectXFCCAction returns a check that fails unless the XFCC synthesis filter is
+// present and its request header mutation uses the given append action.
+func expectXFCCAction(want core.HeaderValueOption_HeaderAppendAction) func(*hcm.HttpConnectionManager) error {
+	return func(connMgr *hcm.HttpConnectionManager) error {
+		filter := findXFCCFilter(connMgr)
+		if filter == nil {
+			return fmt.Errorf("expected %q filter, but it was not added", sidecarXFCCFilterName)
+		}
+		hm := &header_mutationv3.HeaderMutation{}
+		if err := filter.GetTypedConfig().UnmarshalTo(hm); err != nil {
+			return fmt.Errorf("failed to unmarshal %q typed config: %v", sidecarXFCCFilterName, err)
+		}
+		muts := hm.GetMutations().GetRequestMutations()
+		if len(muts) != 1 {
+			return fmt.Errorf("expected exactly 1 request mutation, got %d", len(muts))
+		}
+		opt := muts[0].GetAppend()
+		if opt == nil {
+			return fmt.Errorf("expected an append mutation on the XFCC header")
+		}
+		if got := opt.GetHeader().GetKey(); got != "x-forwarded-client-cert" {
+			return fmt.Errorf("expected header key x-forwarded-client-cert, got %q", got)
+		}
+		if got := opt.GetAppendAction(); got != want {
+			return fmt.Errorf("expected append action %v, got %v", want, got)
+		}
+		return nil
+	}
+}
+
+func findXFCCFilter(connMgr *hcm.HttpConnectionManager) *hcm.HttpFilter {
+	for _, f := range connMgr.GetHttpFilters() {
+		if f.GetName() == sidecarXFCCFilterName {
+			return f
+		}
+	}
+	return nil
 }
 
 func TestVirtualOutboundListenerAllowAnyDynamicDNS(t *testing.T) {

--- a/pilot/pkg/xds/filters/filters.go
+++ b/pilot/pkg/xds/filters/filters.go
@@ -522,6 +522,38 @@ var (
 			}),
 		},
 	}
+
+	// SidecarXFCCClientIdentityFilter synthesizes an x-forwarded-client-cert header
+	// on the main_internal HCM, populated from the ztunnel-provided source
+	// workload identity kept in filter state. mTLS is terminated on the outer
+	// CONNECT listener, so Envoy's native XFCC handling on main_internal has no peer
+	// cert and cannot populate the header.
+	SidecarXFCCClientIdentityFilter = func(overwrite bool) *hcm.HttpFilter {
+		action := core.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD
+		if overwrite {
+			action = core.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD
+		}
+		return &hcm.HttpFilter{
+			Name: "istio.sidecar.xfcc_client_identity",
+			ConfigType: &hcm.HttpFilter_TypedConfig{
+				TypedConfig: protoconv.MessageToAny(&header_mutationv3.HeaderMutation{
+					Mutations: &header_mutationv3.Mutations{
+						RequestMutations: []*mutation_rulesv3.HeaderMutation{{
+							Action: &mutation_rulesv3.HeaderMutation_Append{
+								Append: &core.HeaderValueOption{
+									Header: &core.HeaderValue{
+										Key:   "x-forwarded-client-cert",
+										Value: `By=%FILTER_STATE(io.istio.local_principal:PLAIN)%;URI=%FILTER_STATE(io.istio.peer_principal:PLAIN)%`,
+									},
+									AppendAction: action,
+								},
+							},
+						}},
+					},
+				}),
+			},
+		}
+	}
 )
 
 // Router is used a bunch, so its worth precomputing even though we have a few options.

--- a/releasenotes/notes/sidecar-xfcc.yaml
+++ b/releasenotes/notes/sidecar-xfcc.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+  - |
+    **Added** synthesis of `x-forwarded-client-cert` on sidecars when coming over hbone.

--- a/tests/integration/ambient/xfcc_client_identity_test.go
+++ b/tests/integration/ambient/xfcc_client_identity_test.go
@@ -97,6 +97,46 @@ func TestWaypointXFCCClientIdentity(t *testing.T) {
 	})
 }
 
+// TestSidecarXFCCClientIdentity verifies that when a sidecar synthesizes an
+// x-forwarded-client-cert header populated from the ztunnel-provided source workload
+// SPIFFE identity.
+func TestSidecarXFCCClientIdentity(t *testing.T) {
+	framework.NewTest(t).Run(func(t framework.TestContext) {
+		runTestContext(t, func(t framework.TestContext, src echo.Instance, dst echo.Target, opt echo.CallOptions) {
+			if !dst.Config().HasSidecar() {
+				t.Skip("dst has no sidecar")
+			}
+
+			if opt.Scheme != scheme.HTTP {
+				t.Skip("not http")
+			}
+
+			expectXFCC := src.Config().HasProxyCapabilities()
+			expectedURI := "spiffe://" + src.Config().SpiffeIdentity()
+
+			opt.Count = 5
+			opt.Check = check.And(
+				check.OK(),
+				check.Each(func(r echot.Response) error {
+					xfcc := firstXFCC(r)
+					if expectXFCC {
+						if xfcc == "" {
+							return fmt.Errorf("no X-Forwarded-Client-Cert header in response: %v", r.RequestHeaders)
+						}
+						if !containsXFCCField(xfcc, "URI", expectedURI) {
+							return fmt.Errorf("XFCC missing URI=%s; got %q", expectedURI, xfcc)
+						}
+					} else if xfcc != "" {
+						return fmt.Errorf("X-Forwarded-Client-Cert header in response: %v", r.RequestHeaders)
+					}
+					return nil
+				}),
+			)
+			src.CallOrFail(t, opt)
+		})
+	})
+}
+
 func firstXFCC(r echot.Response) string {
 	if v := r.RequestHeaders.Get("X-Forwarded-Client-Cert"); v != "" {
 		return v


### PR DESCRIPTION
**Please provide a description of this PR:**

When ztunnel connects to a sidecar destination, sidecar can synthesize an XFCC header similar to how the waypoint now does it.