### PR TITLE
Enable Gateway API features that pass conformance tests

### DIFF
--- a/tests/integration/ambient/gateway_conformance_test.go
+++ b/tests/integration/ambient/gateway_conformance_test.go
@@ -67,10 +67,6 @@ var conformanceNamespaces = []string{
 
 var skippedTests = map[string]string{
 	// The following tests were added in v1.5.0
-
-	"GatewayBackendClientCertificateFeature":                     "TODO",
-	"GatewayFrontendClientCertificateValidationInsecureFallback": "TODO",
-
 	"HTTPRouteHTTPSListenerDetectMisdirectedRequests": "TODO",
 
 	// Fixed upstream, waiting for new gateway api release to pick up fix

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -64,9 +64,6 @@ var conformanceNamespaces = []string{
 
 var skippedTests = map[string]string{
 	// The following tests were added in v1.5.0
-	"GatewayBackendClientCertificateFeature": "TODO",
-	"GatewayInvalidTLSBackendConfiguration":  "TODO",
-
 	"HTTPRouteHTTPSListenerDetectMisdirectedRequests": "TODO",
 
 	// Fixed upstream, waiting for new gateway api release to pick up fix


### PR DESCRIPTION
**Please provide a description of this PR:**

GatewayFrontendClientCertificateValidationInsecureFallback was recently implemented, but I overlooked that we have a separate conformance test entry for Ambient, so I didn't enable it in ambient

Both GatewayBackendClientCertificateFeature and
GatewayInvalidTLSBackendConfiguration features do pass Gateway API conformance tests in both regular pilot mode and ambient mode.

I suspect that we just forgot to enable those tests after fixing issues.

Fixes #60018.

NOTE: There are other Gateway API tests that #60018 used to track, but those were transferred into different open issue once we bumped gateway api version to 1.6, so they are tracked somewhere else now.