### PR TITLE
Allow an empty pem to clear the existing CRL pem

### DIFF
--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -41,6 +41,7 @@ import (
 	"istio.io/istio/security/pkg/cmd"
 	"istio.io/istio/security/pkg/pki/ca"
 	"istio.io/istio/security/pkg/pki/ra"
+	pkiutil "istio.io/istio/security/pkg/pki/util"
 	caserver "istio.io/istio/security/pkg/server/ca"
 	"istio.io/istio/security/pkg/server/ca/authenticate"
 	"istio.io/istio/security/pkg/util"
@@ -368,12 +369,7 @@ func handleEvent(s *Server) {
 
 	if features.EnableCACRL {
 		currentCRLData := s.CA.GetCAKeyCertBundle().GetCRLPem()
-		crlData, crlReadErr := os.ReadFile(fileBundle.CRLFile)
-		if os.IsNotExist(crlReadErr) {
-			// no file is the same as no data
-			crlData = []byte{}
-			crlReadErr = nil
-		}
+		crlData, crlReadErr := pkiutil.ReadCRLBytesFromFile(fileBundle.CRLFile)
 		if crlReadErr != nil {
 			// handleEvent can be triggered either for key-cert bundle update or
 			// for crl file update. So, even if there is an error in reading crl file,
@@ -547,15 +543,13 @@ func (s *Server) createIstioCA(opts *caOptions) (*ca.IstioCA, error) {
 		if features.EnableCACRL {
 			// CRL is only supported for Plugged CA.
 			// If CRL file is present, read and notify it for initial replication
-			log.Debugf("CRL file %s found, notifying it for initial replication", fileBundle.CRLFile)
-			crlBytes, crlErr := os.ReadFile(fileBundle.CRLFile)
-			if os.IsNotExist(crlErr) {
-				crlBytes = []byte{}
-			} else if crlErr != nil {
+			crlBytes, crlErr := pkiutil.ReadCRLBytesFromFile(fileBundle.CRLFile)
+			if crlErr != nil {
 				log.Errorf("failed to read CRL file %s: %v", fileBundle.CRLFile, crlErr)
 				return nil, crlErr
 			}
 
+			log.Debugf("CRL file %s found, notifying it for initial replication", fileBundle.CRLFile)
 			s.istiodCertBundleWatcher.SetAndNotifyCACRL(crlBytes)
 		}
 

--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -255,11 +255,10 @@ func detectSigningCABundleAndCRL() (ca.SigningCAFileBundle, error) {
 	}
 
 	if features.EnableCACRL {
-		// load crl file if it exists
 		crlFilePath := path.Join(LocalCertDir.Get(), ca.CACRLFile)
+		signingCAFileBundle.CRLFile = crlFilePath
 		if _, err := os.Stat(crlFilePath); err == nil {
 			log.Info("Detected CRL file")
-			signingCAFileBundle.CRLFile = crlFilePath
 		}
 	}
 
@@ -368,21 +367,21 @@ func handleEvent(s *Server) {
 	}
 
 	if features.EnableCACRL {
-		// check if crl file is updated
-		if len(fileBundle.CRLFile) > 0 {
-			currentCRLData := s.CA.GetCAKeyCertBundle().GetCRLPem()
-			crlData, crlReadErr := os.ReadFile(fileBundle.CRLFile)
-			if crlReadErr != nil {
-				// handleEvent can be triggered either for key-cert bundle update or
-				// for crl file update. So, even if there is an error in reading crl file,
-				// we should log error and continue with key-cert bundle update.
-				log.Errorf("failed reading crl file: %v", crlReadErr)
-			}
-
-			if !bytes.Equal(currentCRLData, crlData) {
-				log.Infof("Updating CRL data")
-				updateCRL = true
-			}
+		currentCRLData := s.CA.GetCAKeyCertBundle().GetCRLPem()
+		crlData, crlReadErr := os.ReadFile(fileBundle.CRLFile)
+		if os.IsNotExist(crlReadErr) {
+			// no file is the same as no data
+			crlData = []byte{}
+			crlReadErr = nil
+		}
+		if crlReadErr != nil {
+			// handleEvent can be triggered either for key-cert bundle update or
+			// for crl file update. So, even if there is an error in reading crl file,
+			// we should log error and continue with key-cert bundle update.
+			log.Errorf("failed reading crl file: %v", crlReadErr)
+		} else if !bytes.Equal(currentCRLData, crlData) {
+			log.Infof("Updating CRL data")
+			updateCRL = true
 		}
 	}
 
@@ -548,16 +547,16 @@ func (s *Server) createIstioCA(opts *caOptions) (*ca.IstioCA, error) {
 		if features.EnableCACRL {
 			// CRL is only supported for Plugged CA.
 			// If CRL file is present, read and notify it for initial replication
-			if len(fileBundle.CRLFile) > 0 {
-				log.Debugf("CRL file %s found, notifying it for initial replication", fileBundle.CRLFile)
-				crlBytes, crlErr := os.ReadFile(fileBundle.CRLFile)
-				if crlErr != nil {
-					log.Errorf("failed to read CRL file %s: %v", fileBundle.CRLFile, crlErr)
-					return nil, crlErr
-				}
-
-				s.istiodCertBundleWatcher.SetAndNotifyCACRL(crlBytes)
+			log.Debugf("CRL file %s found, notifying it for initial replication", fileBundle.CRLFile)
+			crlBytes, crlErr := os.ReadFile(fileBundle.CRLFile)
+			if os.IsNotExist(crlErr) {
+				crlBytes = []byte{}
+			} else if crlErr != nil {
+				log.Errorf("failed to read CRL file %s: %v", fileBundle.CRLFile, crlErr)
+				return nil, crlErr
 			}
+
+			s.istiodCertBundleWatcher.SetAndNotifyCACRL(crlBytes)
 		}
 
 		s.initCACertsAndCRLWatcher()

--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -260,6 +260,8 @@ func detectSigningCABundleAndCRL() (ca.SigningCAFileBundle, error) {
 		signingCAFileBundle.CRLFile = crlFilePath
 		if _, err := os.Stat(crlFilePath); err == nil {
 			log.Info("Detected CRL file")
+		} else if os.IsNotExist(err) {
+			log.Warn("No CRL file found")
 		}
 	}
 
@@ -370,7 +372,7 @@ func handleEvent(s *Server) {
 	if features.EnableCACRL {
 		currentCRLData := s.CA.GetCAKeyCertBundle().GetCRLPem()
 		crlData, crlReadErr := pkiutil.ReadCRLBytesFromFile(fileBundle.CRLFile)
-		if crlReadErr != nil {
+		if crlReadErr != nil && !os.IsNotExist(crlReadErr) {
 			// handleEvent can be triggered either for key-cert bundle update or
 			// for crl file update. So, even if there is an error in reading crl file,
 			// we should log error and continue with key-cert bundle update.
@@ -544,12 +546,16 @@ func (s *Server) createIstioCA(opts *caOptions) (*ca.IstioCA, error) {
 			// CRL is only supported for Plugged CA.
 			// If CRL file is present, read and notify it for initial replication
 			crlBytes, crlErr := pkiutil.ReadCRLBytesFromFile(fileBundle.CRLFile)
-			if crlErr != nil {
+			if os.IsNotExist(crlErr) {
+				log.Debugf("CRL file %q not found", fileBundle.CRLFile)
+			} else if crlErr != nil {
 				log.Errorf("failed to read CRL file %s: %v", fileBundle.CRLFile, crlErr)
 				return nil, crlErr
+			} else if len(crlBytes) == 0 {
+				log.Debugf("CRL file %s is empty, notifying it for initial replication", fileBundle.CRLFile)
+			} else {
+				log.Debugf("CRL file %s found, notifying it for initial replication", fileBundle.CRLFile)
 			}
-
-			log.Debugf("CRL file %s found, notifying it for initial replication", fileBundle.CRLFile)
 			s.istiodCertBundleWatcher.SetAndNotifyCACRL(crlBytes)
 		}
 

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -38,6 +38,7 @@ import (
 	"istio.io/istio/pkg/filewatcher"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/testcerts"
@@ -482,6 +483,117 @@ func TestReloadcacerts(t *testing.T) {
 		currentCertChain := s.CA.GetCAKeyCertBundle().GetCertChainPem()
 		return bytes.Equal(currentCertChain, certChainAlt)
 	}, "10s", "100ms").Should(BeTrue())
+}
+
+func TestClearCRL(t *testing.T) {
+	crlTestDir := filepath.Join(env.IstioSrc, "security/pkg/pki/testdata/crl")
+
+	cacertsDir := filepath.Join(t.TempDir(), "etc", "cacerts")
+	if err := os.MkdirAll(cacertsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%v) failed: %v", cacertsDir, err)
+	}
+	test.SetEnvForTest(t, "ROOT_CA_DIR", cacertsDir)
+	test.SetForTest(t, &features.EnableCACRL, true)
+
+	readTestFile := func(name string) []byte {
+		data, err := os.ReadFile(filepath.Join(crlTestDir, name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		return data
+	}
+	validCRL := readTestFile("ca-crl.pem")
+
+	// Seed a complete plugged-in signing bundle from the CRL testdata.
+	for _, f := range []string{"ca-cert.pem", "ca-key.pem", "cert-chain.pem", "root-cert.pem"} {
+		if err := os.WriteFile(filepath.Join(cacertsDir, f), readTestFile(f), 0o644); err != nil {
+			t.Fatalf("WriteFile(%v) failed: %v", f, err)
+		}
+	}
+
+	stop := make(chan struct{})
+	s := &Server{
+		istiodCertBundleWatcher: keycertbundle.NewWatcher(),
+		server:                  server.New(),
+	}
+
+	defer func() {
+		close(stop)
+		_ = s.cacertsWatcher.Close()
+		s.WaitUntilCompletion()
+	}()
+
+	// start server
+	if err := s.server.Start(stop); err != nil {
+		t.Fatalf("Could not invoke startFuncs: %v", err)
+	}
+
+	// create server CA for load cacerts files
+	if err := s.maybeCreateCA(&caOptions{}); err != nil {
+		t.Fatalf("Could not create CA: %v", err)
+	}
+
+	// validate that the cacerts files are loaded
+	g := NewWithT(t)
+	g.Eventually(func() bool {
+		return len(s.CA.GetCAKeyCertBundle().GetCertChainPem()) > 0
+	}, "10s", "100ms").Should(BeTrue())
+
+	g.Expect(s.CA.GetCAKeyCertBundle().GetCRLPem()).Should(BeEmpty())
+	g.Expect(s.istiodCertBundleWatcher.GetCRL()).Should(BeEmpty())
+
+	crlPath := filepath.Join(cacertsDir, "ca-crl.pem")
+	for _, tt := range []struct {
+		name   string
+		action func(t *testing.T)
+	}{
+		{
+			"crl deleted",
+			func(t *testing.T) {
+				if err := os.Remove(crlPath); err != nil {
+					t.Fatal(err)
+				}
+				// deletes are not watched so create a file
+				if err := os.WriteFile(filepath.Join(cacertsDir, "trigger"), []byte{}, 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			"empty crl",
+			func(t *testing.T) {
+				if err := os.WriteFile(crlPath, []byte{}, 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := os.WriteFile(crlPath, validCRL, 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			g.Eventually(func() bool {
+				currentCRL := s.CA.GetCAKeyCertBundle().GetCRLPem()
+				return bytes.Equal(currentCRL, validCRL)
+			}, "10s", "100ms").Should(BeTrue())
+			g.Eventually(func() bool {
+				currentCRL := s.istiodCertBundleWatcher.GetCRL()
+				return bytes.Equal(currentCRL, validCRL)
+			}, "10s", "100ms").Should(BeTrue())
+
+			tt.action(t)
+
+			g.Eventually(func() bool {
+				currentCRL := s.CA.GetCAKeyCertBundle().GetCRLPem()
+				return currentCRL != nil && len(currentCRL) == 0
+			}, "10s", "100ms").Should(BeTrue())
+			g.Eventually(func() bool {
+				currentCRL := s.istiodCertBundleWatcher.GetCRL()
+				return currentCRL != nil && len(currentCRL) == 0
+			}, "10s", "100ms").Should(BeTrue())
+		})
+	}
 }
 
 func TestNewServer(t *testing.T) {

--- a/pilot/pkg/keycertbundle/watcher.go
+++ b/pilot/pkg/keycertbundle/watcher.go
@@ -89,9 +89,8 @@ func (w *Watcher) SetAndNotifyCACRL(crl []byte) {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
 
-	if len(crl) != 0 {
-		w.bundle.CRL = crl
-	}
+	// an empty crl clears a previously set CRL
+	w.bundle.CRL = crl
 
 	for _, ch := range w.watchers {
 		select {

--- a/pilot/pkg/keycertbundle/watcher_test.go
+++ b/pilot/pkg/keycertbundle/watcher_test.go
@@ -82,6 +82,23 @@ func TestWatcher(t *testing.T) {
 	}
 }
 
+// TestSetAndNotifyCACRLClear verifies that an empty CRL clears a previously set
+// CRL, so that emptying ca-crl.pem removes the revocation from the propagated
+// istio-ca-crl ConfigMap.
+func TestSetAndNotifyCACRLClear(t *testing.T) {
+	watcher := NewWatcher()
+
+	watcher.SetAndNotifyCACRL([]byte("crl"))
+	if got := watcher.GetCRL(); !bytes.Equal(got, []byte("crl")) {
+		t.Errorf("expected CRL to be set, got %q", got)
+	}
+
+	watcher.SetAndNotifyCACRL([]byte{})
+	if got := watcher.GetCRL(); len(got) != 0 {
+		t.Errorf("expected CRL to be cleared, got %q", got)
+	}
+}
+
 func TestWatcherFromFile(t *testing.T) {
 	watcher := NewWatcher()
 

--- a/releasenotes/notes/61073.yaml
+++ b/releasenotes/notes/61073.yaml
@@ -5,4 +5,4 @@ issue:
   - https://github.com/istio/istio/issues/61073
 releaseNotes:
 - |
-  **Fixed** the ability to clear the Certificate Revocation List (CRL) by specifying the empty string as the ca-crl.pem.
+  **Fixed** the ability to clear the Certificate Revocation List (CRL) by either specifying the empty string as the ca-crl.pem or removing it.

--- a/releasenotes/notes/61073.yaml
+++ b/releasenotes/notes/61073.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+issue:
+  - https://github.com/istio/istio/issues/61073
+releaseNotes:
+- |
+  **Added** the ability to clear the Certificate Revocation List (CRL) by specifying the empty string as the ca-crl.pem.

--- a/releasenotes/notes/61073.yaml
+++ b/releasenotes/notes/61073.yaml
@@ -5,4 +5,4 @@ issue:
   - https://github.com/istio/istio/issues/61073
 releaseNotes:
 - |
-  **Added** the ability to clear the Certificate Revocation List (CRL) by specifying the empty string as the ca-crl.pem.
+  **Fixed** the ability to clear the Certificate Revocation List (CRL) by specifying the empty string as the ca-crl.pem.

--- a/security/pkg/pki/util/keycertbundle.go
+++ b/security/pkg/pki/util/keycertbundle.go
@@ -197,7 +197,7 @@ func (b *KeyCertBundle) setAllFromPem(certBytes, privKeyBytes, certChainBytes, r
 	b.rootCertBytes = copyBytes(rootCertBytes)
 
 	// CRL is optional and used with plugged in CA, if not provided, it will be nil
-	if len(crlBytes) != 0 {
+	if crlBytes != nil {
 		b.crlBytes = copyBytes(crlBytes)
 	}
 

--- a/security/pkg/pki/util/keycertbundle.go
+++ b/security/pkg/pki/util/keycertbundle.go
@@ -291,13 +291,18 @@ func (b *KeyCertBundle) UpdateVerifiedKeyCertBundleFromFile(
 }
 
 // gerCRLBytesFromFile reads the CRL file and returns the content if it exists.
+// if the crlFile does not exist, it is treated as an empty file.
 // Providing CRL file is optional, if not provided, it returns nil without an error.
 func gerCRLBytesFromFile(crlFile string) ([]byte, error) {
 	if crlFile == "" {
 		return nil, nil
 	}
 
-	return os.ReadFile(crlFile)
+	bytes, err := os.ReadFile(crlFile)
+	if os.IsNotExist(err) {
+		return []byte{}, nil
+	}
+	return bytes, err
 }
 
 // ExtractRootCertExpiryTimestamp returns the expiration of the first root cert

--- a/security/pkg/pki/util/keycertbundle.go
+++ b/security/pkg/pki/util/keycertbundle.go
@@ -102,7 +102,7 @@ func NewVerifiedKeyCertBundleFromFile(
 	}
 
 	// Read CRL file if provided
-	crlBytes, crlErr := gerCRLBytesFromFile(crlFile)
+	crlBytes, crlErr := ReadCRLBytesFromFile(crlFile)
 	if crlErr != nil {
 		return nil, crlErr
 	}
@@ -277,7 +277,7 @@ func (b *KeyCertBundle) UpdateVerifiedKeyCertBundleFromFile(
 	}
 
 	// Read CRL file if provided
-	crlBytes, crlErr := gerCRLBytesFromFile(crlFile)
+	crlBytes, crlErr := ReadCRLBytesFromFile(crlFile)
 	if crlErr != nil {
 		return crlErr
 	}
@@ -290,10 +290,10 @@ func (b *KeyCertBundle) UpdateVerifiedKeyCertBundleFromFile(
 	return nil
 }
 
-// gerCRLBytesFromFile reads the CRL file and returns the content if it exists.
-// if the crlFile does not exist, it is treated as an empty file.
+// ReadCRLBytesFromFile reads the CRL file and returns the content if it exists.
+// If the crlFile does not exist, it is treated as an empty file.
 // Providing CRL file is optional, if not provided, it returns nil without an error.
-func gerCRLBytesFromFile(crlFile string) ([]byte, error) {
+func ReadCRLBytesFromFile(crlFile string) ([]byte, error) {
 	if crlFile == "" {
 		return nil, nil
 	}

--- a/security/pkg/pki/util/keycertbundle.go
+++ b/security/pkg/pki/util/keycertbundle.go
@@ -103,7 +103,7 @@ func NewVerifiedKeyCertBundleFromFile(
 
 	// Read CRL file if provided
 	crlBytes, crlErr := ReadCRLBytesFromFile(crlFile)
-	if crlErr != nil {
+	if crlErr != nil && !os.IsNotExist(crlErr) {
 		return nil, crlErr
 	}
 
@@ -278,7 +278,7 @@ func (b *KeyCertBundle) UpdateVerifiedKeyCertBundleFromFile(
 
 	// Read CRL file if provided
 	crlBytes, crlErr := ReadCRLBytesFromFile(crlFile)
-	if crlErr != nil {
+	if crlErr != nil && !os.IsNotExist(crlErr) {
 		return crlErr
 	}
 
@@ -300,7 +300,7 @@ func ReadCRLBytesFromFile(crlFile string) ([]byte, error) {
 
 	bytes, err := os.ReadFile(crlFile)
 	if os.IsNotExist(err) {
-		return []byte{}, nil
+		return []byte{}, err
 	}
 	return bytes, err
 }

--- a/security/pkg/pki/util/keycertbundle.go
+++ b/security/pkg/pki/util/keycertbundle.go
@@ -189,6 +189,7 @@ func (b *KeyCertBundle) VerifyAndSetAll(certBytes, privKeyBytes, certChainBytes,
 }
 
 // Setting all values together avoids inconsistency.
+// if crlBytes is nil, no CRL update will be performed.
 func (b *KeyCertBundle) setAllFromPem(certBytes, privKeyBytes, certChainBytes, rootCertBytes, crlBytes []byte) {
 	b.mutex.Lock()
 	b.certBytes = copyBytes(certBytes)

--- a/security/pkg/pki/util/keycertbundle_test.go
+++ b/security/pkg/pki/util/keycertbundle_test.go
@@ -347,7 +347,7 @@ func TestNewVerifiedKeyCertBundleFromFile(t *testing.T) {
 	}
 }
 
-// The test of NewVerifiedKeyCertBundleFromPem, VerifyAndSetAll can be covered by this test.
+// The test of NewVerifiedKeyCertBundleFromPem can be covered by this test.
 func TestNewVerifiedKeyCertBundleFromFileWithCrl(t *testing.T) {
 	testCases := map[string]struct {
 		caCertFile    string
@@ -388,6 +388,35 @@ func TestNewVerifiedKeyCertBundleFromFileWithCrl(t *testing.T) {
 				t.Errorf("%s: Expected error %s but succeeded", id, tc.expectedErr)
 			}
 		})
+	}
+}
+
+func TestVerifyAndSetAll(t *testing.T) {
+	b, err := NewVerifiedKeyCertBundleFromFile(crlCertFile, crlKeyFile, []string{crlCertChainFile}, crlRootCertFile, crlFile)
+	if err != nil {
+		t.Fatalf("Unexpected err: %v", err)
+	}
+
+	if len(b.GetCRLPem()) == 0 {
+		t.Fatalf("expected CRL to be set")
+	}
+
+	cert, key, certChain, root := b.GetAllPem()
+
+	// preserve the existing CRL.
+	if err := b.VerifyAndSetAll(cert, key, certChain, root, nil); err != nil {
+		t.Fatalf("nil CRL failed: %v", err)
+	}
+	if len(b.GetCRLPem()) == 0 {
+		t.Fatalf("CRL not preserved")
+	}
+
+	// clear the CRL
+	if err := b.VerifyAndSetAll(cert, key, certChain, root, []byte{}); err != nil {
+		t.Fatalf("empty CRL failed: %v", err)
+	}
+	if len(b.GetCRLPem()) != 0 {
+		t.Fatalf("CRL not cleared, got %q", b.GetCRLPem())
 	}
 }
 

--- a/security/pkg/pki/util/keycertbundle_test.go
+++ b/security/pkg/pki/util/keycertbundle_test.go
@@ -373,6 +373,14 @@ func TestNewVerifiedKeyCertBundleFromFileWithCrl(t *testing.T) {
 			crlFile:       badCrlFile,
 			expectedErr:   "missing CRL signed by certificates",
 		},
+		"crl does not exist": {
+			caCertFile:    crlCertFile,
+			caKeyFile:     crlKeyFile,
+			certChainFile: []string{crlCertChainFile},
+			rootCertFile:  crlRootCertFile,
+			crlFile:       "notfound",
+			expectedErr:   "",
+		},
 	}
 	for id, tc := range testCases {
 		t.Run(id, func(t *testing.T) {

--- a/tests/integration/ambient/crl/crl_test.go
+++ b/tests/integration/ambient/crl/crl_test.go
@@ -106,7 +106,8 @@ func TestZtunnelCrlInbound(t *testing.T) {
 // resetCrlState resets a cluster's CRL to empty state, waits for ConfigMap propagation, then restarts all ztunnel instances.
 func resetCrlState(t framework.TestContext, cl cluster.Cluster) {
 	t.Helper()
-	certBundle.ResetCRL(t, cl)
+	certBundle.RemoveCRL(t, cl)
+	certBundle.WaitForCRLPropagation(t, cl)
 	restartZtunnelPodAndWait(t, cl)
 	t.Logf("CRL reset complete on %s", cl.Name())
 }

--- a/tests/integration/security/crl/crl_test.go
+++ b/tests/integration/security/crl/crl_test.go
@@ -54,7 +54,6 @@ func TestPluggedInCACRL(t *testing.T) {
 			// Revoke the intermediate certificate in each primary cluster where istiod runs and watches the cacerts secret
 			for _, c := range t.AllClusters().Primaries() {
 				certBundle.RevokeOwnIntermediate(t, c)
-
 				// wait for the CRL ConfigMap to be updated
 				util.WaitForCRLUpdate(
 					t,
@@ -71,6 +70,27 @@ func TestPluggedInCACRL(t *testing.T) {
 			// after CRL update, the call should fail
 			opts.Check = check.Error()
 			t.Logf("testing mTLS call after CRL update, expecting failure")
+			retry.UntilSuccessOrFail(t, func() error {
+				client.CallOrFail(t, opts)
+				return nil
+			})
+
+			// removing CRL
+			for _, c := range t.AllClusters().Primaries() {
+				certBundle.RemoveCRL(t, c)
+				// wait for the CRL ConfigMap to be updated
+				util.WaitForCRLUpdate(
+					t,
+					[]string{
+						clientNS.Name(),
+						serverNS.Name(),
+					},
+					certBundle.Bundle(c),
+					client,
+					server,
+				)
+			}
+			opts.Check = nil
 			retry.UntilSuccessOrFail(t, func() error {
 				client.CallOrFail(t, opts)
 				return nil

--- a/tests/integration/security/crl/util/cert.go
+++ b/tests/integration/security/crl/util/cert.go
@@ -272,6 +272,14 @@ func (rb *RootBundle) ResetCRL(t framework.TestContext, c cluster.Cluster) {
 	}, retry.Timeout(waitTimeout))
 }
 
+func (rb *RootBundle) RemoveCRL(t framework.TestContext, c cluster.Cluster) {
+	t.Helper()
+	b := rb.bundles[c.Name()]
+	t.Logf("removing CRLs on %s", c.Name())
+	b.crlPEM = []byte{}
+	rb.updateCRLInSecret(t, b)
+}
+
 func (rb *RootBundle) newBundle(c cluster.Cluster, iaSerial *big.Int) (*IABundle, error) {
 	iaCert, iaKey, iaCertPEM, iaKeyPEM, err := generateIntermediateCA(
 		rb.rootCert, rb.rootKey, "Intermediate CA "+c.Name(), iaSerial,


### PR DESCRIPTION
**Please provide a description of this PR:**

An empty pem ("") for the ca-crl.pem will clear the existing CRL.




fixes #61073 