### PR TITLE
k3s support in the nftables kubelet UID detection 

### DIFF
--- a/cni/pkg/nftables/kubeletuid_linux.go
+++ b/cni/pkg/nftables/kubeletuid_linux.go
@@ -25,6 +25,8 @@ import (
 // getKubeletUIDFromPath finds the kubelet or kubelite process UID by inspecting the proc filesystem path.
 // In standard Kubernetes distributions, it looks for the "kubelet" process.
 // On some platforms like MicroK8s, where multiple k8s components are consolidated, it looks for the "kubelite" process.
+// On k3s, the kubelet is embedded directly in the "k3s" binary (invoked as "k3s server" or
+// "k3s agent"), rather than running as its own process, so it is handled as a special case below.
 func getKubeletUIDFromPath(procPath string) (string, error) {
 	fs, err := procfs.NewFS(procPath)
 	if err != nil {
@@ -37,7 +39,7 @@ func getKubeletUIDFromPath(procPath string) (string, error) {
 	}
 
 	// List of process names to search for, in order of preference
-	processNames := []string{"kubelet", "kubelite"}
+	processNames := []string{"kubelet", "kubelite", "k3s"}
 
 	for _, proc := range procs {
 		comm, err := proc.Comm()
@@ -47,8 +49,20 @@ func getKubeletUIDFromPath(procPath string) (string, error) {
 		}
 
 		for _, targetName := range processNames {
-			if comm == targetName {
-				// Lets check the command line to ensure it's really the target process
+			if comm != targetName {
+				continue
+			}
+
+			var processFound bool
+			if targetName == "k3s" {
+				// k3s embeds kubelet directly in the "k3s" binary itself (invoked as
+				// "k3s server" or "k3s agent"), rather than running it as its own
+				// process. Unlike standalone kubelet or MicroK8s's kubelite, there is
+				// no reliable substring to look for in argv under a default install —
+				// the comm match on "k3s" is distinctive enough on its own, so no
+				// further cmdline verification is done here.
+				processFound = true
+			} else {
 				cmdline, err := proc.CmdLine()
 				if err != nil {
 					continue
@@ -59,30 +73,29 @@ func getKubeletUIDFromPath(procPath string) (string, error) {
 				// This works for both:
 				//   - Standard kubelet: /usr/bin/kubelet [args...]
 				//   - MicroK8s kubelite: /snap/microk8s/.../kubelite --kubelet-args-file=...
-				processFound := false
 				for _, arg := range cmdline {
 					if strings.Contains(strings.ToLower(arg), "kubelet") {
 						processFound = true
 						break
 					}
 				}
-				if !processFound {
-					continue
-				}
-
-				// Get process status with UIDs
-				status, err := proc.NewStatus()
-				if err != nil {
-					continue
-				}
-
-				realUID := status.UIDs[0]
-				realUIDStr := strconv.FormatUint(realUID, 10)
-
-				return realUIDStr, nil
 			}
+			if !processFound {
+				continue
+			}
+
+			// Get process status with UIDs
+			status, err := proc.NewStatus()
+			if err != nil {
+				continue
+			}
+
+			realUID := status.UIDs[0]
+			realUIDStr := strconv.FormatUint(realUID, 10)
+
+			return realUIDStr, nil
 		}
 	}
 
-	return "", fmt.Errorf("kubelet or kubelite process not found in %s", procPath)
+	return "", fmt.Errorf("kubelet, kubelite, or k3s process not found in %s", procPath)
 }

--- a/cni/pkg/nftables/kubeletuid_linux.go
+++ b/cni/pkg/nftables/kubeletuid_linux.go
@@ -22,11 +22,31 @@ import (
 	"github.com/prometheus/procfs"
 )
 
-// getKubeletUIDFromPath finds the kubelet or kubelite process UID by inspecting the proc filesystem path.
-// In standard Kubernetes distributions, it looks for the "kubelet" process.
-// On some platforms like MicroK8s, where multiple k8s components are consolidated, it looks for the "kubelite" process.
-// On k3s, the kubelet is embedded directly in the "k3s" binary (invoked as "k3s server" or
-// "k3s agent"), rather than running as its own process, so it is handled as a special case below.
+// kubeletProcess describes how to identify a kubelet-hosting process by name.
+type kubeletProcess struct {
+	// name is the value expected in /proc/<pid>/comm.
+	name string
+
+	// requireKubeletInCmdline, when true, requires that at least one cmdline argument
+	// contains the substring "kubelet" before the process is accepted. Set to false for
+	// platforms (e.g. k3s) where kubelet is embedded directly in the binary and argv do
+	// not include any kubelet name.
+	requireKubeletInCmdline bool
+}
+
+// kubeletProcesses lists platforms whose kubelet-hosting process we can identify,
+// in order of preference.
+var kubeletProcesses = []kubeletProcess{
+	// Standard Kubernetes: /usr/bin/kubelet [args...]
+	{"kubelet", true},
+	// MicroK8s consolidates k8s components; kubelite path contains "kubelet".
+	{"kubelite", true},
+	// k3s embeds kubelet directly in the k3s binary (k3s server / k3s agent).
+	// No kubelet substring appears in argv under a default install.
+	{"k3s", false},
+}
+
+// getKubeletUIDFromPath finds the UID of the kubelet-hosting process by inspecting procPath.
 func getKubeletUIDFromPath(procPath string) (string, error) {
 	fs, err := procfs.NewFS(procPath)
 	if err != nil {
@@ -38,9 +58,6 @@ func getKubeletUIDFromPath(procPath string) (string, error) {
 		return "", fmt.Errorf("failed to read processes from %s: %v", procPath, err)
 	}
 
-	// List of process names to search for, in order of preference
-	processNames := []string{"kubelet", "kubelite", "k3s"}
-
 	for _, proc := range procs {
 		comm, err := proc.Comm()
 		if err != nil {
@@ -48,54 +65,36 @@ func getKubeletUIDFromPath(procPath string) (string, error) {
 			continue
 		}
 
-		for _, targetName := range processNames {
-			if comm != targetName {
+		for _, kp := range kubeletProcesses {
+			if comm != kp.name {
 				continue
 			}
 
-			var processFound bool
-			if targetName == "k3s" {
-				// k3s embeds kubelet directly in the "k3s" binary itself (invoked as
-				// "k3s server" or "k3s agent"), rather than running it as its own
-				// process. Unlike standalone kubelet or MicroK8s's kubelite, there is
-				// no reliable substring to look for in argv under a default install —
-				// the comm match on "k3s" is distinctive enough on its own, so no
-				// further cmdline verification is done here.
-				processFound = true
-			} else {
+			if kp.requireKubeletInCmdline {
 				cmdline, err := proc.CmdLine()
 				if err != nil {
 					continue
 				}
-
-				// Verify that this process is actually related to kubelet by checking
-				// if "kubelet" appears in any of the command line arguments.
-				// This works for both:
-				//   - Standard kubelet: /usr/bin/kubelet [args...]
-				//   - MicroK8s kubelite: /snap/microk8s/.../kubelite --kubelet-args-file=...
+				found := false
 				for _, arg := range cmdline {
 					if strings.Contains(strings.ToLower(arg), "kubelet") {
-						processFound = true
+						found = true
 						break
 					}
 				}
-			}
-			if !processFound {
-				continue
+				if !found {
+					continue
+				}
 			}
 
-			// Get process status with UIDs
 			status, err := proc.NewStatus()
 			if err != nil {
 				continue
 			}
 
-			realUID := status.UIDs[0]
-			realUIDStr := strconv.FormatUint(realUID, 10)
-
-			return realUIDStr, nil
+			return strconv.FormatUint(status.UIDs[0], 10), nil
 		}
 	}
 
-	return "", fmt.Errorf("kubelet, kubelite, or k3s process not found in %s", procPath)
+	return "", fmt.Errorf("no kubelet process found in %s", procPath)
 }

--- a/cni/pkg/nftables/kubeletuid_linux_test.go
+++ b/cni/pkg/nftables/kubeletuid_linux_test.go
@@ -1,0 +1,130 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nftables
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// fakeProc describes a single synthetic /proc/<pid> entry to write to a fake procfs root.
+type fakeProc struct {
+	pid     int
+	comm    string
+	cmdline []string
+	uid     uint64
+}
+
+// writeFakeProc creates the subset of /proc/<pid>/* files that getKubeletUIDFromPath reads.
+func writeFakeProc(t *testing.T, procRoot string, p fakeProc) {
+	t.Helper()
+
+	pidDir := filepath.Join(procRoot, strconv.Itoa(p.pid))
+	if err := os.MkdirAll(pidDir, 0o755); err != nil {
+		t.Fatalf("failed to create fake proc dir: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(pidDir, "comm"), []byte(p.comm+"\n"), 0o644); err != nil {
+		t.Fatalf("failed to write comm: %v", err)
+	}
+
+	cmdline := strings.Join(p.cmdline, "\x00")
+	if len(p.cmdline) > 0 {
+		cmdline += "\x00"
+	}
+	if err := os.WriteFile(filepath.Join(pidDir, "cmdline"), []byte(cmdline), 0o644); err != nil {
+		t.Fatalf("failed to write cmdline: %v", err)
+	}
+
+	status := fmt.Sprintf("Uid:\t%d\t%d\t%d\t%d\n", p.uid, p.uid, p.uid, p.uid)
+	if err := os.WriteFile(filepath.Join(pidDir, "status"), []byte(status), 0o644); err != nil {
+		t.Fatalf("failed to write status: %v", err)
+	}
+}
+
+func TestGetKubeletUIDFromPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		procs   []fakeProc
+		wantUID string
+		wantErr bool
+	}{
+		{
+			name: "kubelet",
+			procs: []fakeProc{
+				{pid: 100, comm: "kubelet", cmdline: []string{"/usr/bin/kubelet", "--config=/var/lib/kubelet/config.yaml"}, uid: 1001},
+			},
+			wantUID: "1001",
+		},
+		{
+			name: "kubelite",
+			procs: []fakeProc{
+				{pid: 100, comm: "kubelite", cmdline: []string{"/snap/microk8s/current/bin/kubelite", "--kubelet"}, uid: 1002},
+			},
+			wantUID: "1002",
+		},
+		{
+			name: "k3s",
+			procs: []fakeProc{
+				// A default k3s invocation has no "kubelet" substring anywhere in argv.
+				{pid: 100, comm: "k3s", cmdline: []string{"k3s", "server"}, uid: 1003},
+			},
+			wantUID: "1003",
+		},
+		{
+			name: "no_match",
+			procs: []fakeProc{
+				{pid: 100, comm: "bash", cmdline: []string{"/bin/bash"}, uid: 1000},
+			},
+			wantErr: true,
+		},
+		{
+			name: "multiple_processes",
+			procs: []fakeProc{
+				{pid: 50, comm: "sshd", cmdline: []string{"/usr/sbin/sshd", "-D"}, uid: 0},
+				{pid: 75, comm: "bash", cmdline: []string{"/bin/bash"}, uid: 1000},
+				{pid: 100, comm: "kubelet", cmdline: []string{"/usr/bin/kubelet"}, uid: 1004},
+			},
+			wantUID: "1004",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			procRoot := t.TempDir()
+			for _, p := range tt.procs {
+				writeFakeProc(t, procRoot, p)
+			}
+
+			uid, err := getKubeletUIDFromPath(procRoot)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got uid %q", uid)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if uid != tt.wantUID {
+				t.Fatalf("got uid %q, want %q", uid, tt.wantUID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes #61078 

Adds "k3s" to the processNames list. 

For that target name only, skips the existing "kubelet"-substring cmdline check rather than trying to replicate it. A default k3s invocation (k3s server / k3s agent) has nothing kubelet-flavored in argv — that substring only shows up if the operator explicitly passed --kubelet-arg=..., which most installs don't — so there's no reliable positive signal to check for in argv the way there is for standalone kubelet or MicroK8s's kubelite. The comm == "k3s" match is treated as sufficient on its own.



**Please check any characteristics that apply to this pull request.**

- [ X ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.