### PR TITLE
fix: mark webhooks ready only after server ready

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -367,7 +367,10 @@ func NewServer(args *PilotArgs, initFuncs ...func(*Server)) (*Server, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error initializing sidecar injector: %v", err)
 		}
-		s.readinessFlags.sidecarInjectorReady.Store(true)
+		// Mark webhook ready now here only if it runs on the shared main server.
+		if s.httpsServer == nil {
+			s.readinessFlags.sidecarInjectorReady.Store(true)
+		}
 		s.webhookInfo.mu.Lock()
 		s.webhookInfo.wh = wh
 		s.webhookInfo.mu.Unlock()
@@ -515,6 +518,9 @@ func (s *Server) Start(stop <-chan struct{}) error {
 		if err != nil {
 			return err
 		}
+		// Mark webhooks ready only after the dedicated server has started accepting connections.
+		s.readinessFlags.sidecarInjectorReady.Store(true)
+		s.readinessFlags.configValidationReady.Store(true)
 		go func() {
 			log.Infof("starting webhook service at %s", httpsListener.Addr())
 			if err := s.httpsServer.ServeTLS(httpsListener, "", ""); network.IsUnexpectedListenerError(err) {

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -872,6 +872,68 @@ func TestIstiodReadinessHandler(t *testing.T) {
 	}
 }
 
+// Webhook readiness must track when the server hosting the handlers is serving:
+// immediately for the shared main HTTP server, only after Start() for a dedicated
+// HTTPS server (istio/istio#61049).
+func TestWebhookReadiness(t *testing.T) {
+	cases := []struct {
+		name          string
+		httpsAddr     string
+		readyAfterNew bool // expected webhook readiness immediately after NewServer
+	}{
+		{
+			// istio defaults this to :15017.
+			name:          "dedicated HTTPS server",
+			httpsAddr:     ":45017",
+			readyAfterNew: false,
+		},
+		{
+			name:          "shared main HTTP server",
+			httpsAddr:     "",
+			readyAfterNew: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			configDir := t.TempDir()
+			args := NewPilotArgs(func(p *PilotArgs) {
+				p.Namespace = "istio-system"
+				p.ServerOptions = DiscoveryServerOptions{
+					HTTPAddr:       ":0",
+					HTTPSAddr:      c.httpsAddr,
+					MonitoringAddr: ":0",
+					GRPCAddr:       ":0",
+				}
+				p.RegistryOptions = RegistryOptions{
+					KubeConfig: "config",
+					FileDir:    configDir,
+				}
+				p.ShutdownDuration = 1 * time.Millisecond
+			})
+
+			g := NewWithT(t)
+			s, err := NewServer(args, func(s *Server) {
+				s.kubeClient = kube.NewFakeClient()
+			})
+			g.Expect(err).To(Succeed())
+
+			g.Expect(s.readinessFlags.configValidationReady.Load()).To(Equal(c.readyAfterNew))
+			g.Expect(s.readinessFlags.sidecarInjectorReady.Load()).To(Equal(c.readyAfterNew))
+
+			stop := make(chan struct{})
+			g.Expect(s.Start(stop)).To(Succeed())
+			defer func() {
+				close(stop)
+				s.WaitUntilCompletion()
+			}()
+
+			g.Expect(s.readinessFlags.configValidationReady.Load()).To(BeTrue())
+			g.Expect(s.readinessFlags.sidecarInjectorReady.Load()).To(BeTrue())
+		})
+	}
+}
+
 func TestInitOIDC(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pilot/pkg/bootstrap/validation.go
+++ b/pilot/pkg/bootstrap/validation.go
@@ -39,7 +39,10 @@ func (s *Server) initConfigValidation(args *PilotArgs) error {
 		return err
 	}
 
-	s.readinessFlags.configValidationReady.Store(true)
+	// Mark webhook ready now here only if it runs on the shared main server.
+	if s.httpsServer == nil {
+		s.readinessFlags.configValidationReady.Store(true)
+	}
 
 	if features.ValidationWebhookConfigName != "" && s.kubeClient != nil {
 		s.addStartFunc("validation controller", func(stop <-chan struct{}) error {

--- a/releasenotes/notes/61049.yaml
+++ b/releasenotes/notes/61049.yaml
@@ -1,0 +1,13 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 61049
+releaseNotes:
+  - |
+    **Fixed** a race condition on istiod startup where the readiness probe could
+    report ready before the dedicated injection and validation webhook server
+    (`--httpsAddr`, default `:15017`) was accepting connections, causing
+    intermittent `failed calling webhook` timeouts when creating resources
+    immediately after istiod became ready. This does not affect deployments
+    where webhooks share the main HTTP server (empty `--httpsAddr`).


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix when injection and validation webhooks are marked as ready only after the service starts accepting connections. This does not affect deployments where webhooks share the main HTTP server (empty `--httpsAddr`) as it was getting marked in the right place already.

Fixes #61049 