### PR TITLE
Wait for PushContext before processing gateway deployments

### DIFF
--- a/pilot/pkg/config/kube/gatewaycommon/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gatewaycommon/deploymentcontroller.go
@@ -17,7 +17,6 @@ package gatewaycommon
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -304,6 +303,7 @@ func (d *DeploymentController) Run(stop <-chan struct{}) {
 		d.gatewayClasses.HasSynced,
 		d.tagWatcher.HasSynced,
 		d.env.Watcher.AsCollection().HasSynced,
+		d.env.PushContextReady,
 	)
 	d.queue.Run(stop)
 	controllers.ShutdownAll(
@@ -363,8 +363,6 @@ func (d *DeploymentController) Reconcile(req types.NamespacedName) error {
 	return d.configureIstioGateway(log, *gw, ci)
 }
 
-var errPushContext = errors.New("PushContext not initialized")
-
 func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gateway.Gateway, gi ClassInfo) error {
 	// If user explicitly sets addresses, we are assuming they are pointing to an existing deployment.
 	// We will not manage it in this case
@@ -375,10 +373,6 @@ func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gat
 	if !IsManaged(&gw.Spec) {
 		log.Debug("skip disabled gateway")
 		return nil
-	}
-	if !d.env.PushContext().InitDone.Load() {
-		log.Debug("skip PushContext not initialized")
-		return errPushContext
 	}
 	existingControllerVersion, overwriteControllerVersion, shouldHandle := ManagedGatewayControllerVersion(gw)
 	if !shouldHandle {

--- a/pilot/pkg/config/kube/gatewaycommon/deploymentcontroller_test.go
+++ b/pilot/pkg/config/kube/gatewaycommon/deploymentcontroller_test.go
@@ -1548,3 +1548,61 @@ metadata:
 		})
 	}
 }
+
+// TestDeploymentControllerWaitsForPushContext verifies that the deployment
+// controller's queue does not start processing until PushContext is ready.
+func TestDeploymentControllerWaitsForPushContext(t *testing.T) {
+	c := kube.NewFakeClient(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+	})
+	tw := revisions.NewTagWatcher(c, "default", "istio-system")
+
+	// Create an environment where PushContext is NOT initialized to simulate
+	// a startup race (i.e., informers sync before PushContext is ready)
+	env := model.NewEnvironment()
+	env.Watcher = meshwatcher.NewTestWatcher(mesh.DefaultMeshConfig())
+
+	d := NewDeploymentController(c, "", env, testInjectionConfig(t, ""), func(fn func()) {}, tw, "", "")
+
+	reconciles := atomic.NewInt32(0)
+	d.patcher = func(g schema.GroupVersionResource, name string, namespace string, data []byte, subresources ...string) error {
+		if g == gvr.Service {
+			reconciles.Inc()
+		}
+		return nil
+	}
+
+	stop := test.NewStop(t)
+	gws := clienttest.Wrap(t, d.gateways)
+
+	go tw.Run(stop)
+	// d.Run() enters WaitForCacheSync, which blocks because PushContextReady()
+	// returns false. queue.Run() is therefore not called yet.
+	go d.Run(stop)
+	// RunAndWait starts the fake client's reflectors and returns once all
+	// informer caches are synced. After this returns, d.Run() is still blocked
+	// on PushContextReady(), so no queue processing has started.
+	c.RunAndWait(stop)
+
+	// Create a Gateway while PushContext is not ready. The informer event handler
+	// enqueues the work item into the queue's internal buffer, but queue.Run()
+	// has not been called, so no reconciliation can occur.
+	gws.Create(&k8s.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "default"},
+		Spec: k8s.GatewaySpec{
+			GatewayClassName: k8s.ObjectName(features.GatewayAPIDefaultGatewayClass),
+		},
+	})
+
+	// Since queue.Run() has not been called, reconciliation will not happen.
+	assert.Equal(t, reconciles.Load(), int32(0))
+
+	// Mark PushContext as ready. WaitForCacheSync in d.Run() will now detect all
+	// conditions satisfied, return, and call queue.Run(). The queued Gateway will
+	// then be processed, invoking the reconciliation method.
+	env.PushContext().InitDone.Store(true)
+
+	assert.EventuallyEqual(t, func() bool { return reconciles.Load() >= 1 }, true,
+		retry.Timeout(time.Second*5),
+		retry.Message("expected reconciliation after PushContext became ready, but none occurred"))
+}

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -189,6 +189,12 @@ func (e *Environment) PushContext() *PushContext {
 	return e.pushContext
 }
 
+// PushContextReady reports whether the current PushContext has completed
+// initialization. Suitable for use with WaitForCacheSync.
+func (e *Environment) PushContextReady() bool {
+	return e.PushContext().InitDone.Load()
+}
+
 // GetDiscoveryAddress parses the DiscoveryAddress specified via MeshConfig.
 func (e *Environment) GetDiscoveryAddress() (host.Name, string, error) {
 	proxyConfig := mesh.DefaultProxyConfig()

--- a/releasenotes/notes/61095.yaml
+++ b/releasenotes/notes/61095.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 61095
+releaseNotes:
+- |
+  **Fixed** an issue where gateway proxy Deployments could permanently fail to be created during istiod startup.


### PR DESCRIPTION
**Please provide a description of this PR:**

The gateway deployment controller's `Run()` waits for informer caches to sync via `WaitForCacheSync`, then immediately starts processing the queue. PushContext initializes asynchronously in a separate goroutine. If the deployment controller's informer caches sync before PushContext finishes initializing, the controller starts processing Gateways and every reconciliation fails with `PushContext not initialized`. With `WithMaxAttempts(5)` and exponential backoff starting at 5ms, all retries are exhausted in ~56ms. The queue calls `Forget(key)`, permanently dropping the Gateway. The proxy Deployment and Service are never created.

Add `Environment.PushContextReady` and include it in the deployment controller's `WaitForCacheSync` so the queue does not start processing until PushContext is ready.

fixes #61095