### PR TITLE
fix: consider mergeable ServiceEntries sharing hostname+namespace in exact-host path

### DIFF
--- a/pilot/pkg/config/kube/gatewaycommon/context.go
+++ b/pilot/pkg/config/kube/gatewaycommon/context.go
@@ -80,8 +80,8 @@ func (gc GatewayContext) ResolveGatewayInstances(
 	foundUnusable := false
 	log.Debugf("Resolving gateway instances for %v in namespace %s", gwsvcs, namespace)
 	for _, g := range gwsvcs {
-		svc, f := gc.ps.ServiceIndex.HostnameAndNamespace[host.Name(g)][namespace]
-		if !f {
+		svcs := gc.ps.ServiceIndex.HostnameAndNamespace[host.Name(g)][namespace]
+		if len(svcs) == 0 {
 			otherNamespaces := []string{}
 			for ns := range gc.ps.ServiceIndex.HostnameAndNamespace[host.Name(g)] {
 				otherNamespaces = append(otherNamespaces, `"`+ns+`"`) // Wrap in quotes for output
@@ -96,6 +96,7 @@ func (gc GatewayContext) ResolveGatewayInstances(
 			foundUnusable = true
 			continue
 		}
+		svc := svcs[0]
 		svcKey := svc.Key()
 		for port := range ports {
 			instances := gc.ps.ServiceEndpointsByPort(svc, port, nil)
@@ -160,7 +161,10 @@ func (gc GatewayContext) ResolveGatewayInstances(
 }
 
 func (gc GatewayContext) GetService(hostname, namespace string) *model.Service {
-	return gc.ps.ServiceIndex.HostnameAndNamespace[host.Name(hostname)][namespace]
+	if svcs := gc.ps.ServiceIndex.HostnameAndNamespace[host.Name(hostname)][namespace]; len(svcs) > 0 {
+		return svcs[0]
+	}
+	return nil
 }
 
 // InstancesEmpty returns true if there are no instances in any port.

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -71,8 +71,9 @@ type serviceIndex struct {
 	// by an exportTo explicitly specifying this namespace or because they are private to the namespace.
 	exportedToNamespace map[string][]*Service
 
-	// HostnameAndNamespace has all services, indexed by hostname then namespace.
-	HostnameAndNamespace map[host.Name]map[string]*Service `json:"-"`
+	// HostnameAndNamespace has all services, indexed by hostname then namespace. Index 0 is the first
+	// Service (the oldest); later entries share the same hostname+namespace.
+	HostnameAndNamespace map[host.Name]map[string][]*Service `json:"-"`
 
 	// instancesByPort contains a map of service key and instances by port. It is stored here
 	// to avoid recomputations during push. This caches instanceByPort calls with empty labels.
@@ -85,7 +86,7 @@ func newServiceIndex() serviceIndex {
 		count:                0,
 		public:               []*Service{},
 		exportedToNamespace:  map[string][]*Service{},
-		HostnameAndNamespace: map[host.Name]map[string]*Service{},
+		HostnameAndNamespace: map[host.Name]map[string][]*Service{},
 		instancesByPort:      map[string]map[int][]*IstioEndpoint{},
 	}
 }
@@ -1063,8 +1064,10 @@ func (ps *PushContext) ServiceForHostname(proxy *Proxy, hostname host.Name) *Ser
 
 	// SidecarScope shouldn't be null here. If it is, we can't disambiguate the hostname to use for a namespace,
 	// so the selection must be undefined.
-	for _, service := range ps.ServiceIndex.HostnameAndNamespace[hostname] {
-		return service
+	for _, services := range ps.ServiceIndex.HostnameAndNamespace[hostname] {
+		if len(services) > 0 {
+			return services[0]
+		}
 	}
 
 	// No service found
@@ -1577,20 +1580,21 @@ func (ps *PushContext) initServiceRegistry(env *Environment, configsUpdate sets.
 
 		hostMap, f := ps.ServiceIndex.HostnameAndNamespace[s.Hostname]
 		if !f {
-			hostMap = map[string]*Service{}
+			hostMap = map[string][]*Service{}
 			ps.ServiceIndex.HostnameAndNamespace[s.Hostname] = hostMap
 		}
-		// In some scenarios, there may be multiple Services defined for the same hostname due to ServiceEntry allowing
-		// arbitrary hostnames. In these cases, we want to pick the first Service, which is the oldest. This ensures
-		// newly created Services cannot take ownership unexpectedly.
-		// However, the Service is from Kubernetes it should take precedence over ones not. This prevents someone from
-		// "domain squatting" on the hostname before a Kubernetes Service is created.
-		if existing := hostMap[s.Attributes.Namespace]; existing != nil &&
-			!(existing.Attributes.ServiceRegistry != provider.Kubernetes && s.Attributes.ServiceRegistry == provider.Kubernetes) {
-			log.Debugf("Service %s/%s from registry %s ignored by %s/%s/%s", s.Attributes.Namespace, s.Hostname, s.Attributes.ServiceRegistry,
-				existing.Attributes.ServiceRegistry, existing.Attributes.Namespace, existing.Hostname)
+		// Multiple Services may share a hostname+namespace (ServiceEntry allows arbitrary hostnames). Keep all of
+		// them; index 0 is the first Service, the oldest, unless a Kubernetes Service exists, which takes
+		// precedence to prevent "domain squatting".
+		existingList := hostMap[s.Attributes.Namespace]
+		if len(existingList) == 0 {
+			hostMap[s.Attributes.Namespace] = []*Service{s}
+		} else if winner := existingList[0]; winner.Attributes.ServiceRegistry != provider.Kubernetes &&
+			s.Attributes.ServiceRegistry == provider.Kubernetes {
+			// Kubernetes Service preempts a non-Kubernetes winner; move it to index 0.
+			hostMap[s.Attributes.Namespace] = append([]*Service{s}, existingList...)
 		} else {
-			hostMap[s.Attributes.Namespace] = s
+			hostMap[s.Attributes.Namespace] = append(existingList, s)
 		}
 
 		ns := s.Attributes.Namespace
@@ -2176,12 +2180,12 @@ func (ps *PushContext) TrafficExtensions(proxy *Proxy) map[extensions.TrafficExt
 		servicesInfo := ps.ServicesForWaypoint(WaypointKeyForProxy(proxy))
 		for _, si := range servicesInfo {
 			s := si.Service
-			svc, exist := ps.ServiceIndex.HostnameAndNamespace[host.Name(s.Hostname)][s.Namespace]
-			if !exist {
+			svcs := ps.ServiceIndex.HostnameAndNamespace[host.Name(s.Hostname)][s.Namespace]
+			if len(svcs) == 0 {
 				log.Warnf("cannot find waypoint service in serviceindex, namespace/hostname: %s/%s", s.Namespace, s.Hostname)
 				continue
 			}
-			listenerInfo = listenerInfo.WithService(svc)
+			listenerInfo = listenerInfo.WithService(svcs[0])
 		}
 	}
 	return ps.TrafficExtensionsByListenerInfo(proxy, listenerInfo, FilterChainTypeAny)

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -2368,9 +2368,9 @@ func TestSidecarScope(t *testing.T) {
 	ps := NewPushContext()
 	env := &Environment{Watcher: meshwatcher.NewTestWatcher(&meshconfig.MeshConfig{RootNamespace: "istio-system"})}
 	ps.Mesh = env.Mesh()
-	ps.ServiceIndex.HostnameAndNamespace["svc1.default.cluster.local"] = map[string]*Service{"default": nil}
-	ps.ServiceIndex.HostnameAndNamespace["svc2.nosidecar.cluster.local"] = map[string]*Service{"nosidecar": nil}
-	ps.ServiceIndex.HostnameAndNamespace["svc3.istio-system.cluster.local"] = map[string]*Service{"istio-system": nil}
+	ps.ServiceIndex.HostnameAndNamespace["svc1.default.cluster.local"] = map[string][]*Service{"default": nil}
+	ps.ServiceIndex.HostnameAndNamespace["svc2.nosidecar.cluster.local"] = map[string][]*Service{"nosidecar": nil}
+	ps.ServiceIndex.HostnameAndNamespace["svc3.istio-system.cluster.local"] = map[string][]*Service{"istio-system": nil}
 
 	configStore := NewFakeStore()
 	sidecarWithWorkloadSelector := &networking.Sidecar{
@@ -4045,7 +4045,7 @@ func TestServiceWithExportTo(t *testing.T) {
 	}
 	ps.initDefaultExportMaps()
 	ps.initServiceRegistry(env, nil)
-	assert.Equal(t, ps.ServiceIndex.HostnameAndNamespace[svc4.Hostname][svc4.Attributes.Namespace].Attributes.ServiceRegistry, provider.Kubernetes)
+	assert.Equal(t, ps.ServiceIndex.HostnameAndNamespace[svc4.Hostname][svc4.Attributes.Namespace][0].Attributes.ServiceRegistry, provider.Kubernetes)
 	cases := []struct {
 		proxyNs   string
 		wantHosts []string

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -395,9 +395,9 @@ func (sc *SidecarScope) collectImportedServices(ps *PushContext, configNamespace
 			for h, ports := range virtualServiceDestinationsFilteredBySourceNamespace(v, configNamespace) {
 				byNamespace := ps.ServiceIndex.HostnameAndNamespace[host.Name(h)]
 				// Default to this hostname in our config namespace
-				if s, ok := byNamespace[configNamespace]; ok {
+				if s, ok := byNamespace[configNamespace]; ok && len(s) > 0 {
 					// This won't overwrite hostnames that have already been found eg because they were requested in hosts
-					if matchedSvc := serviceMatchingPort(s, ilw, ports); matchedSvc != nil {
+					if matchedSvc := serviceMatchingPort(s[0], ilw, ports); matchedSvc != nil {
 						sc.appendSidecarServices(servicesAdded, matchedSvc)
 					}
 				} else {
@@ -415,8 +415,10 @@ func (sc *SidecarScope) collectImportedServices(ps *PushContext, configNamespace
 						pickNamespace = pickBestVisibleNamespace
 					}
 					if ns := pickNamespace(ps, byNamespace, configNamespace); ns != "" {
-						if matchedSvc := serviceMatchingPort(byNamespace[ns], ilw, ports); matchedSvc != nil {
-							sc.appendSidecarServices(servicesAdded, matchedSvc)
+						if svcs := byNamespace[ns]; len(svcs) > 0 {
+							if matchedSvc := serviceMatchingPort(svcs[0], ilw, ports); matchedSvc != nil {
+								sc.appendSidecarServices(servicesAdded, matchedSvc)
+							}
 						}
 					}
 				}
@@ -570,15 +572,14 @@ func (ps *PushContext) servicesForExactHosts(configNamespace string,
 			if !ok {
 				continue
 			}
-			svc, ok := byNamespace[ns]
-			if !ok {
-				continue
+			// Include all Services for this hostname+namespace so their ports merge, matching the scan path.
+			for _, svc := range byNamespace[ns] {
+				// HostnameAndNamespace ignores exportTo, so reapply visibility.
+				if !ps.IsServiceVisible(svc, configNamespace) {
+					continue
+				}
+				candidates = append(candidates, svc)
 			}
-			// HostnameAndNamespace contains all services regardless of exportTo, so visibility is reapplied.
-			if !ps.IsServiceVisible(svc, configNamespace) {
-				continue
-			}
-			candidates = append(candidates, svc)
 		}
 	}
 	// Sort for deterministic output, matching servicesExportedToNamespace (built from creation-ordered services).
@@ -1133,10 +1134,10 @@ func canMergeServices(s1, s2 *Service) bool {
 // Pick the Service namespace visible to the configNamespace namespace.
 // If it does not exist, return an empty string,
 // If there are more than one, pick the first alphabetically.
-func pickFirstVisibleNamespace(ps *PushContext, byNamespace map[string]*Service, configNamespace string) string {
+func pickFirstVisibleNamespace(ps *PushContext, byNamespace map[string][]*Service, configNamespace string) string {
 	nss := make([]string, 0, len(byNamespace))
-	for ns := range byNamespace {
-		if ps.IsServiceVisible(byNamespace[ns], configNamespace) {
+	for ns, svcs := range byNamespace {
+		if len(svcs) > 0 && ps.IsServiceVisible(svcs[0], configNamespace) {
 			nss = append(nss, ns)
 		}
 	}
@@ -1154,9 +1155,13 @@ func pickFirstVisibleNamespace(ps *PushContext, byNamespace map[string]*Service,
 // 2. contains the oldest non-Kubernetes service which is visible to configNamespace
 // This does not consider whether a svc is in the configNamespace,
 // the calling logic has already attempted a direct lookup of byNamespace[configNamespace]
-func pickBestVisibleNamespace(ps *PushContext, byNamespace map[string]*Service, configNamespace string) string {
+func pickBestVisibleNamespace(ps *PushContext, byNamespace map[string][]*Service, configNamespace string) string {
 	var currentBestService *Service
-	for _, svc := range byNamespace {
+	for _, svcs := range byNamespace {
+		if len(svcs) == 0 {
+			continue
+		}
+		svc := svcs[0]
 		if ps.IsServiceVisible(svc, configNamespace) {
 			// if we have a visible kube service, use it
 			if svc.Attributes.ServiceRegistry == provider.Kubernetes {

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -2932,6 +2932,8 @@ func TestSelectServicesExactParity(t *testing.T) {
 		svc("foo", "b", port8000),                              // same hostname, different namespace
 		svc("priv", "b", port8000, visibility.Private),         // private to b
 		svc("shared", "c", port8000, visibility.Instance("a")), // exported to a only
+		svc("multiport", "a", port8000),                        // mergeable duplicate of below
+		svc("multiport", "a", port9000),                        // both must be returned
 	}
 
 	tests := []struct {
@@ -2983,6 +2985,13 @@ func TestSelectServicesExactParity(t *testing.T) {
 				"c": {allHosts: []host.Name{"shared"}, exactHosts: sets.New[host.Name]("shared")},
 			},
 		},
+		{
+			name:     "mergeable partial-port duplicates on same hostname+namespace",
+			configNS: "a",
+			listenerHosts: map[string]hostClassification{
+				"a": {allHosts: []host.Name{"multiport"}, exactHosts: sets.New[host.Name]("multiport")},
+			},
+		},
 	}
 
 	// Build a PushContext with the service index populated as initServiceRegistry would.
@@ -2991,10 +3000,10 @@ func TestSelectServicesExactParity(t *testing.T) {
 	for _, s := range svcs {
 		hostMap, ok := ps.ServiceIndex.HostnameAndNamespace[s.Hostname]
 		if !ok {
-			hostMap = map[string]*Service{}
+			hostMap = map[string][]*Service{}
 			ps.ServiceIndex.HostnameAndNamespace[s.Hostname] = hostMap
 		}
-		hostMap[s.Attributes.Namespace] = s
+		hostMap[s.Attributes.Namespace] = append(hostMap[s.Attributes.Namespace], s)
 		if s.Attributes.ExportTo.IsEmpty() || s.Attributes.ExportTo.Contains(visibility.Public) {
 			ps.ServiceIndex.public = append(ps.ServiceIndex.public, s)
 		} else {
@@ -3008,14 +3017,23 @@ func TestSelectServicesExactParity(t *testing.T) {
 		}
 	}
 
-	// byHostname gives a total order over a selection result. selectServices dedups to a single service per
-	// hostname, so hostname is a unique key. We compare order-insensitively because cluster order is not
-	// functionally significant to Envoy (CDS is state-of-the-world) and both paths are independently
-	// deterministic across pushes; the meaningful invariant is identical membership and trimmed content.
-	byHostname := func(svcs []*Service) []*Service {
+	// Sort order-insensitively; a hostname may repeat (mergeable duplicates), so tie-break on namespace then port.
+	firstPort := func(s *Service) int {
+		if len(s.Ports) > 0 {
+			return s.Ports[0].Port
+		}
+		return 0
+	}
+	sortServices := func(svcs []*Service) []*Service {
 		out := slices.Clone(svcs)
 		slices.SortFunc(out, func(a, b *Service) int {
-			return strings.Compare(string(a.Hostname), string(b.Hostname))
+			if r := strings.Compare(string(a.Hostname), string(b.Hostname)); r != 0 {
+				return r
+			}
+			if r := strings.Compare(a.Attributes.Namespace, b.Attributes.Namespace); r != 0 {
+				return r
+			}
+			return firstPort(a) - firstPort(b)
 		})
 		return out
 	}
@@ -3023,8 +3041,8 @@ func TestSelectServicesExactParity(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ilw := &IstioEgressListenerWrapper{}
-			fast := byHostname(ilw.selectServices(ps.servicesForExactHosts(tt.configNS, tt.listenerHosts), tt.configNS, tt.listenerHosts))
-			scan := byHostname(ilw.selectServices(ps.servicesExportedToNamespace(tt.configNS), tt.configNS, tt.listenerHosts))
+			fast := sortServices(ilw.selectServices(ps.servicesForExactHosts(tt.configNS, tt.listenerHosts), tt.configNS, tt.listenerHosts))
+			scan := sortServices(ilw.selectServices(ps.servicesExportedToNamespace(tt.configNS), tt.configNS, tt.listenerHosts))
 			if !reflect.DeepEqual(fast, scan) {
 				fastJSON, _ := json.MarshalIndent(fast, "", "  ")
 				scanJSON, _ := json.MarshalIndent(scan, "", "  ")
@@ -3054,7 +3072,7 @@ func BenchmarkSelectServicesExact(b *testing.B) {
 				Ports:      port8000,
 				Attributes: ServiceAttributes{Name: string(hostname), Namespace: "ns", ServiceRegistry: provider.Kubernetes},
 			}
-			ps.ServiceIndex.HostnameAndNamespace[hostname] = map[string]*Service{"ns": s}
+			ps.ServiceIndex.HostnameAndNamespace[hostname] = map[string][]*Service{"ns": {s}}
 			ps.ServiceIndex.public = append(ps.ServiceIndex.public, s)
 		}
 

--- a/pilot/pkg/model/telemetry_logging.go
+++ b/pilot/pkg/model/telemetry_logging.go
@@ -551,7 +551,8 @@ func LookupCluster(push *PushContext, service string, port int) (hostname string
 	// TODO(yangminzhu): Verify the service and its cluster is supported, e.g. resolution type is not OriginalDst.
 	if parts := strings.Split(service, "/"); len(parts) == 2 {
 		namespace, name := parts[0], parts[1]
-		if svc := push.ServiceIndex.HostnameAndNamespace[host.Name(name)][namespace]; svc != nil {
+		if svcs := push.ServiceIndex.HostnameAndNamespace[host.Name(name)][namespace]; len(svcs) > 0 {
+			svc := svcs[0]
 			hostname = string(svc.Hostname)
 			cluster = BuildSubsetKey(TrafficDirectionOutbound, "", svc.Hostname, port)
 			return hostname, cluster, err
@@ -564,10 +565,12 @@ func LookupCluster(push *PushContext, service string, port int) (hostname string
 		}
 		// If namespace is omitted, return successfully if there is only one such host name in the service index.
 		if len(namespaces) == 1 {
-			svc := namespaceToServices[namespaces[0]]
-			hostname = string(svc.Hostname)
-			cluster = BuildSubsetKey(TrafficDirectionOutbound, "", svc.Hostname, port)
-			return hostname, cluster, err
+			if svcs := namespaceToServices[namespaces[0]]; len(svcs) > 0 {
+				svc := svcs[0]
+				hostname = string(svc.Hostname)
+				cluster = BuildSubsetKey(TrafficDirectionOutbound, "", svc.Hostname, port)
+				return hostname, cluster, err
+			}
 		} else if len(namespaces) > 1 {
 			err = fmt.Errorf("found %s in multiple namespaces %v, specify the namespace explicitly in "+
 				"the format of <Namespace>/<Hostname>", service, namespaces)

--- a/pilot/pkg/model/telemetry_logging_test.go
+++ b/pilot/pkg/model/telemetry_logging_test.go
@@ -1417,8 +1417,8 @@ func TestTelemetryAccessLog(t *testing.T) {
 	defaultFormatJSON, _ := protomarshal.ToJSON(EnvoyJSONLogFormatIstio)
 
 	ctx := NewPushContext()
-	ctx.ServiceIndex.HostnameAndNamespace["otel-collector.foo.svc.cluster.local"] = map[string]*Service{
-		"foo": {
+	ctx.ServiceIndex.HostnameAndNamespace["otel-collector.foo.svc.cluster.local"] = map[string][]*Service{
+		"foo": {{
 			Hostname:       "otel-collector.foo.svc.cluster.local",
 			DefaultAddress: "172.217.0.0/16",
 			Ports: PortList{
@@ -1439,7 +1439,7 @@ func TestTelemetryAccessLog(t *testing.T) {
 				Namespace:       "foo",
 				ServiceRegistry: provider.Kubernetes,
 			},
-		},
+		}},
 	}
 
 	for _, tc := range []struct {

--- a/pilot/pkg/networking/core/gateway.go
+++ b/pilot/pkg/networking/core/gateway.go
@@ -358,8 +358,8 @@ func buildNameToServiceMapForHTTPRoutes(node *model.Proxy, push *model.PushConte
 
 		var service *model.Service
 		// First, we obtain the service which has the same namespace as virtualService
-		s, exist := push.ServiceIndex.HostnameAndNamespace[hostname][virtualService.Namespace]
-		if exist {
+		if svcs := push.ServiceIndex.HostnameAndNamespace[hostname][virtualService.Namespace]; len(svcs) > 0 {
+			s := svcs[0]
 			// We should check whether the selected service is visible to the proxy node.
 			if push.IsServiceVisible(s, node.ConfigNamespace) {
 				service = s

--- a/pilot/pkg/networking/core/gateway_test.go
+++ b/pilot/pkg/networking/core/gateway_test.go
@@ -4642,11 +4642,11 @@ func TestBuildGatewayListenersFilters(t *testing.T) {
 				Configs:    tt.configs,
 				MeshConfig: mc,
 			})
-			cg.PushContext().ServiceIndex.HostnameAndNamespace = map[host.Name]map[string]*pilot_model.Service{
+			cg.PushContext().ServiceIndex.HostnameAndNamespace = map[host.Name]map[string][]*pilot_model.Service{
 				"example.local": {
-					"foo": &pilot_model.Service{
+					"foo": {{
 						Hostname: "example.local",
-					},
+					}},
 				},
 			}
 			proxy := cg.SetupProxy(&proxyGateway)
@@ -4932,11 +4932,11 @@ func TestListenerTransportSocketConnectTimeoutForGateway(t *testing.T) {
 				Configs:    tt.configs,
 				MeshConfig: mesh.DefaultMeshConfig(),
 			})
-			cg.PushContext().ServiceIndex.HostnameAndNamespace = map[host.Name]map[string]*pilot_model.Service{
+			cg.PushContext().ServiceIndex.HostnameAndNamespace = map[host.Name]map[string][]*pilot_model.Service{
 				"example.local": {
-					"foo": &pilot_model.Service{
+					"foo": {{
 						Hostname: "example.local",
-					},
+					}},
 				},
 			}
 			proxy := cg.SetupProxy(&proxyGateway)
@@ -5064,9 +5064,9 @@ func TestGatewayExternalSDSProvider(t *testing.T) {
 				Configs:    []config.Config{gatewayConfig, vsConfig},
 				MeshConfig: mc,
 			})
-			cg.PushContext().ServiceIndex.HostnameAndNamespace = map[host.Name]map[string]*pilot_model.Service{
+			cg.PushContext().ServiceIndex.HostnameAndNamespace = map[host.Name]map[string][]*pilot_model.Service{
 				host.Name(tt.providerService): {
-					"sds-ns": {
+					"sds-ns": {{
 						Hostname: host.Name(tt.providerService),
 						Ports: []*pilot_model.Port{
 							{
@@ -5075,7 +5075,7 @@ func TestGatewayExternalSDSProvider(t *testing.T) {
 								Protocol: protocol.GRPC,
 							},
 						},
-					},
+					}},
 				},
 			}
 

--- a/pilot/pkg/networking/core/listener_test.go
+++ b/pilot/pkg/networking/core/listener_test.go
@@ -3675,9 +3675,9 @@ func TestBuildListenerTLSContext(t *testing.T) {
 						},
 					},
 				}
-				pc.ServiceIndex.HostnameAndNamespace = map[host.Name]map[string]*model.Service{
+				pc.ServiceIndex.HostnameAndNamespace = map[host.Name]map[string][]*model.Service{
 					"sds-provider-service": {
-						"": &model.Service{
+						"": {{
 							Hostname: "sds-provider-service",
 							Ports: []*model.Port{
 								{
@@ -3686,7 +3686,7 @@ func TestBuildListenerTLSContext(t *testing.T) {
 									Protocol: protocol.GRPC,
 								},
 							},
-						},
+						}},
 					},
 				}
 				return pc
@@ -3723,9 +3723,9 @@ func TestBuildListenerTLSContext(t *testing.T) {
 						},
 					},
 				}
-				pc.ServiceIndex.HostnameAndNamespace = map[host.Name]map[string]*model.Service{
+				pc.ServiceIndex.HostnameAndNamespace = map[host.Name]map[string][]*model.Service{
 					"sds-provider-service": {
-						"": &model.Service{
+						"": {{
 							Hostname: "sds-provider-service",
 							Ports: []*model.Port{
 								{
@@ -3734,7 +3734,7 @@ func TestBuildListenerTLSContext(t *testing.T) {
 									Protocol: protocol.GRPC,
 								},
 							},
-						},
+						}},
 					},
 				}
 				return pc

--- a/pilot/pkg/networking/core/waypoint.go
+++ b/pilot/pkg/networking/core/waypoint.go
@@ -69,10 +69,11 @@ func findWaypointResources(node *model.Proxy, push *model.PushContext) ([]model.
 	waypointServices := &waypointServices{}
 	for _, s := range serviceInfos {
 		hostName := host.Name(s.Service.Hostname)
-		svc, ok := push.ServiceIndex.HostnameAndNamespace[hostName][s.Service.Namespace]
-		if !ok {
+		svcs := push.ServiceIndex.HostnameAndNamespace[hostName][s.Service.Namespace]
+		if len(svcs) == 0 {
 			continue
 		}
+		svc := svcs[0]
 		// Exclude MESH_INTERNAL services with DYNAMIC_DNS resolution from waypoint.
 		if svc.Resolution == model.DynamicDNS && !svc.MeshExternal {
 			log.Warnf("DYNAMIC_DNS is supported only for MESH_EXTERNAL services; skipping waypoint service %s/%s", svc.Attributes.Namespace, svc.Hostname)

--- a/pilot/pkg/security/authn/policy_applier_test.go
+++ b/pilot/pkg/security/authn/policy_applier_test.go
@@ -955,10 +955,10 @@ func TestJwtFilter(t *testing.T) {
 
 	defer push.JwtKeyResolver.Close()
 
-	push.ServiceIndex.HostnameAndNamespace[host.Name("jwt-token-issuer.mesh")] = map[string]*model.Service{}
-	push.ServiceIndex.HostnameAndNamespace[host.Name("jwt-token-issuer.mesh")]["mesh"] = &model.Service{
+	push.ServiceIndex.HostnameAndNamespace[host.Name("jwt-token-issuer.mesh")] = map[string][]*model.Service{}
+	push.ServiceIndex.HostnameAndNamespace[host.Name("jwt-token-issuer.mesh")]["mesh"] = []*model.Service{{
 		Hostname: "jwt-token-issuer.mesh.svc.cluster.local",
-	}
+	}}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			istiotest.SetForTest(t, &features.JwksFetchMode, c.jwksFetchMode)

--- a/pilot/pkg/security/authz/builder/builder_test.go
+++ b/pilot/pkg/security/authz/builder/builder_test.go
@@ -450,11 +450,11 @@ func push(t *testing.T, input string, mc *meshconfig.MeshConfig) *model.PushCont
 		AuthzPolicies: yamlPolicy(t, basePath+input),
 		Mesh:          mc,
 	}
-	p.ServiceIndex.HostnameAndNamespace = map[host.Name]map[string]*model.Service{
+	p.ServiceIndex.HostnameAndNamespace = map[host.Name]map[string][]*model.Service{
 		"my-custom-ext-authz.foo.svc.cluster.local": {
-			"foo": &model.Service{
+			"foo": {{
 				Hostname: "my-custom-ext-authz.foo.svc.cluster.local",
-			},
+			}},
 		},
 	}
 	return p

--- a/pilot/pkg/security/model/authentication_test.go
+++ b/pilot/pkg/security/model/authentication_test.go
@@ -766,9 +766,9 @@ func TestConstructSdsSecretConfigForCredential(t *testing.T) {
 						},
 					},
 				}
-				pc.ServiceIndex.HostnameAndNamespace = map[host.Name]map[string]*model.Service{
+				pc.ServiceIndex.HostnameAndNamespace = map[host.Name]map[string][]*model.Service{
 					"sds-provider-service": {
-						"": &model.Service{
+						"": {{
 							Hostname: "sds-provider-service",
 							Ports: []*model.Port{
 								{
@@ -777,7 +777,7 @@ func TestConstructSdsSecretConfigForCredential(t *testing.T) {
 									Protocol: protocol.GRPC,
 								},
 							},
-						},
+						}},
 					},
 				}
 				return pc
@@ -824,7 +824,7 @@ func TestConstructSdsSecretConfigForCredential(t *testing.T) {
 					},
 				}
 				// ServiceIndex is empty, so LookupCluster will fail
-				pc.ServiceIndex.HostnameAndNamespace = map[host.Name]map[string]*model.Service{}
+				pc.ServiceIndex.HostnameAndNamespace = map[host.Name]map[string][]*model.Service{}
 				return pc
 			}(),
 			expected: nil,


### PR DESCRIPTION
**Please provide a description of this PR:**
* Store all services sharing hostname + namespace in `HostnameAndNamespace` cache.
* All existing caller sites for `HostnameAndNamespace` now look for `[0]` indexed Services to preserve existing behavior.
* Add all services in the `servicesForExactHosts` path so mergeable service entries are all considered, which if not done can lead to missing ports for example.
* Add a parity test that checks shared hostname + namespace case.