### PR TITLE
fix SSRF in the Wasm module

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -386,6 +386,35 @@ var (
 		return blockedCIDRs
 	}()
 
+	// BlockedCIDRsInWasmFetch is additive to the always-on link-local block applied to Wasm
+	// module fetches (see pkg/wasm/ssrf.go); it lets operators also block private ranges or
+	// specific in-cluster addresses (e.g. the Kubernetes API server or kubelet) if their
+	// environment does not need to fetch Wasm modules from internal registries/servers.
+	BlockedCIDRsInWasmFetch = func() []*net.IPNet {
+		v := env.Register(
+			"BLOCKED_CIDRS_IN_WASM_FETCH",
+			"",
+			"Comma separated list of CIDR ranges that are blocked when fetching Wasm modules (e.g., 10.0.0.0/8,192.168.1.0/24).").Get()
+		if v == "" {
+			return nil
+		}
+		cidrs := strings.Split(v, ",")
+		var blockedCIDRs []*net.IPNet
+		for _, cidr := range cidrs {
+			cidr = strings.TrimSpace(cidr)
+			if cidr == "" {
+				continue
+			}
+			_, ipNet, err := net.ParseCIDR(cidr)
+			if err != nil {
+				log.Warnf("Failed to parse CIDR range %q: %v", cidr, err)
+				continue
+			}
+			blockedCIDRs = append(blockedCIDRs, ipNet)
+		}
+		return blockedCIDRs
+	}()
+
 	// GatewayTransportSocketConnectTimeout specifies the timeout for transport socket (e.g., TLS
 	// handshake) connections on gateway listeners. This protects against slow or incomplete TLS
 	// handshakes consuming resources. Set to 0s to disable the timeout entirely.

--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -32,7 +32,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -40,6 +39,7 @@ import (
 
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/monitoring"
+	"istio.io/istio/pkg/security"
 )
 
 const (
@@ -602,32 +602,17 @@ func (r *JwksResolver) Close() {
 }
 
 // blockedCIDRDialContext is a custom dialContext that blocks connections to IP addresses
-// in CIDR ranges using the dialer's Control callback, which receives the resolved
-// IP address for each connection attempt.
-func blockedCIDRDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
-	dialer := &net.Dialer{}
+// in CIDR ranges configured via BlockedCIDRsInJWKURIs. See security.BlockedIPDialContext
+// for why this is done at the dial level rather than by inspecting the jwksURI upfront.
+var blockedCIDRDialContext = security.BlockedIPDialContext(&net.Dialer{}, jwksBlockedIP)
 
-	if len(features.BlockedCIDRsInJWKURIs) > 0 {
-		dialer.Control = func(network, address string, c syscall.RawConn) error {
-			host, _, err := net.SplitHostPort(address)
-			if err != nil {
-				return err
-			}
-			ip := net.ParseIP(host)
-			if ip == nil {
-				return fmt.Errorf("unable to parse IP from resolved address %s", address)
-			}
-			for _, cidr := range features.BlockedCIDRsInJWKURIs {
-				if cidr.Contains(ip) {
-					return fmt.Errorf("connection to %s (resolved IP %s) blocked: IP is in blocked CIDR range %s",
-						addr, ip.String(), cidr.String())
-				}
-			}
-			return nil
+func jwksBlockedIP(ip net.IP) error {
+	for _, cidr := range features.BlockedCIDRsInJWKURIs {
+		if cidr.Contains(ip) {
+			return fmt.Errorf("connection blocked: resolved IP %s is in blocked CIDR range %s", ip.String(), cidr.String())
 		}
 	}
-
-	return dialer.DialContext(ctx, network, addr)
+	return nil
 }
 
 // Compare two JWKS responses, returning true if there is a difference and false otherwise

--- a/pkg/security/dial.go
+++ b/pkg/security/dial.go
@@ -1,0 +1,88 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package security
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"syscall"
+)
+
+// BlockedIPDialContext returns a DialContext (suitable for http.Transport.DialContext) that
+// rejects a connection when isBlocked returns a non-nil error for the address's resolved IP.
+//
+// The check is implemented via the dialer's Control callback, which fires after DNS resolution
+// but before the socket connects. This means the block applies uniformly to the original request
+// and to every redirect hop a client follows, and cannot be bypassed by redirecting to a hostname
+// that resolves to a blocked address (a check against the pre-fetch URL or Location header string
+// alone cannot catch this).
+//
+// dialer is copied and only its Control field is overridden, so callers keep their own
+// Timeout/KeepAlive/etc settings.
+func BlockedIPDialContext(dialer *net.Dialer, isBlocked func(net.IP) error) func(ctx context.Context, network, addr string) (net.Conn, error) {
+	d := *dialer
+	d.Control = func(network, address string, c syscall.RawConn) error {
+		host, _, err := net.SplitHostPort(address)
+		if err != nil {
+			return err
+		}
+		ip := net.ParseIP(host)
+		if ip == nil {
+			return fmt.Errorf("unable to parse IP from resolved address %s", address)
+		}
+		return isBlocked(ip)
+	}
+	return d.DialContext
+}
+
+// IsLinkLocal reports whether ip is in a link-local range (169.254.0.0/16, fe80::/10). This
+// includes cloud provider instance metadata endpoints (e.g. 169.254.169.254) and has no
+// legitimate use as a remote fetch target.
+func IsLinkLocal(ip net.IP) bool {
+	return ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()
+}
+
+// knownCloudMetadataRanges are cloud provider instance metadata addresses that fall outside
+// the link-local range and so aren't caught by IsLinkLocal: Alibaba Cloud's metadata service
+// lives in RFC 6598 carrier-grade-NAT space (not private, loopback, or link-local by any
+// net.IP predicate), and AWS's IPv6 IMDS endpoint lives in ULA space reserved by AWS
+// specifically for this. Each is reserved by its provider for this one purpose and has no
+// other legitimate use, unlike the general private/ULA ranges these otherwise sit in.
+var knownCloudMetadataRanges = func() []*net.IPNet {
+	var nets []*net.IPNet
+	for _, cidr := range []string{
+		"100.100.100.200/32", // Alibaba Cloud metadata service
+		"fd00:ec2::/32",      // AWS IMDS IPv6 endpoint
+	} {
+		_, n, err := net.ParseCIDR(cidr)
+		if err != nil {
+			panic(err) // static list; only fails on a programming error
+		}
+		nets = append(nets, n)
+	}
+	return nets
+}()
+
+// IsKnownCloudMetadataAddress reports whether ip is a well-known cloud provider instance
+// metadata address not otherwise covered by IsLinkLocal.
+func IsKnownCloudMetadataAddress(ip net.IP) bool {
+	for _, n := range knownCloudMetadataRanges {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/security/dial_test.go
+++ b/pkg/security/dial_test.go
@@ -1,0 +1,112 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package security
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIsLinkLocal(t *testing.T) {
+	cases := []struct {
+		ip      string
+		blocked bool
+	}{
+		{"169.254.169.254", true}, // cloud metadata endpoint
+		{"169.254.0.1", true},
+		{"fe80::1", true},
+		{"10.0.0.1", false},
+		{"172.16.0.1", false},
+		{"192.168.1.1", false},
+		{"127.0.0.1", false},
+		{"8.8.8.8", false},
+	}
+	for _, c := range cases {
+		t.Run(c.ip, func(t *testing.T) {
+			ip := net.ParseIP(c.ip)
+			if ip == nil {
+				t.Fatalf("failed to parse test IP %s", c.ip)
+			}
+			if got := IsLinkLocal(ip); got != c.blocked {
+				t.Errorf("IsLinkLocal(%s) = %v, want %v", c.ip, got, c.blocked)
+			}
+		})
+	}
+}
+
+func TestIsKnownCloudMetadataAddress(t *testing.T) {
+	cases := []struct {
+		ip      string
+		blocked bool
+	}{
+		{"100.100.100.200", true},  // Alibaba Cloud metadata (RFC 6598 CGNAT space)
+		{"100.100.100.199", false}, // just outside the /32
+		{"fd00:ec2::230", true},    // AWS IMDS IPv6 endpoint
+		{"fd00:ec2::1", true},      // still within fd00:ec2::/32
+		{"fd12:3456::1", false},    // ULA space, but not AWS's reserved prefix
+		{"10.0.0.1", false},
+		{"169.254.169.254", false}, // link-local, covered by IsLinkLocal instead
+	}
+	for _, c := range cases {
+		t.Run(c.ip, func(t *testing.T) {
+			ip := net.ParseIP(c.ip)
+			if ip == nil {
+				t.Fatalf("failed to parse test IP %s", c.ip)
+			}
+			if got := IsKnownCloudMetadataAddress(ip); got != c.blocked {
+				t.Errorf("IsKnownCloudMetadataAddress(%s) = %v, want %v", c.ip, got, c.blocked)
+			}
+		})
+	}
+}
+
+func TestBlockedIPDialContext(t *testing.T) {
+	blockLoopback := func(ip net.IP) error {
+		if ip.IsLoopback() {
+			return errors.New("blocked: loopback")
+		}
+		return nil
+	}
+
+	t.Run("blocks matching predicate", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		defer ts.Close()
+
+		dialCtx := BlockedIPDialContext(&net.Dialer{}, blockLoopback)
+		client := &http.Client{Transport: &http.Transport{DialContext: dialCtx}}
+
+		_, err := client.Get(ts.URL)
+		if err == nil {
+			t.Fatal("expected request to a blocked address to fail, got nil error")
+		}
+	})
+
+	t.Run("allows non-matching predicate", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		defer ts.Close()
+
+		dialCtx := BlockedIPDialContext(&net.Dialer{}, func(ip net.IP) error { return nil })
+		client := &http.Client{Transport: &http.Transport{DialContext: dialCtx}}
+
+		resp, err := client.Get(ts.URL)
+		if err != nil {
+			t.Fatalf("expected request to succeed, got error: %v", err)
+		}
+		resp.Body.Close()
+	})
+}

--- a/pkg/wasm/httpfetcher.go
+++ b/pkg/wasm/httpfetcher.go
@@ -51,17 +51,24 @@ func NewHTTPFetcher(requestTimeout time.Duration, requestMaxRetry int) *HTTPFetc
 	if requestTimeout == 0 {
 		requestTimeout = 5 * time.Second
 	}
-	transport := http.DefaultTransport.(*http.Transport).Clone()
+	dialContext := wasmDialContext()
+
+	secureTransport := http.DefaultTransport.(*http.Transport).Clone()
+	secureTransport.DialContext = dialContext
+
+	insecureTransport := http.DefaultTransport.(*http.Transport).Clone()
+	insecureTransport.DialContext = dialContext
 	// nolint: gosec
 	// This is only when a user explicitly sets a flag to enable insecure mode
-	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	insecureTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	return &HTTPFetcher{
 		client: &http.Client{
-			Timeout: requestTimeout,
+			Timeout:   requestTimeout,
+			Transport: secureTransport,
 		},
 		insecureClient: &http.Client{
 			Timeout:   requestTimeout,
-			Transport: transport,
+			Transport: insecureTransport,
 		},
 		initialBackoff:  time.Millisecond * 500,
 		requestMaxRetry: requestMaxRetry,

--- a/pkg/wasm/imagefetcher.go
+++ b/pkg/wasm/imagefetcher.go
@@ -166,18 +166,22 @@ func NewImageFetcher(ctx context.Context, opt ImageFetcherOption) *ImageFetcher 
 		fetchOpts = append(fetchOpts, remote.WithAuthFromKeychain(&wasmKeyChain{data: opt.PullSecret}))
 	}
 
-	var transport http.RoundTripper
+	// Always clone rather than mutating the shared package-level remote.DefaultTransport.
+	t := remote.DefaultTransport.(*http.Transport).Clone()
 	if opt.Insecure {
-		t := remote.DefaultTransport.(*http.Transport).Clone()
 		// nolint: gosec
 		// This is only when a user explicitly sets a flag to enable insecure mode
 		t.TLSClientConfig = &tls.Config{
 			InsecureSkipVerify: opt.Insecure,
 		}
-		transport = t
-	} else {
-		transport = remote.DefaultTransport
 	}
+	// Block SSRF at the dial level: go-containerregistry's own CheckRedirect only rejects
+	// redirects to an IP-literal in a private/loopback/link-local range, and explicitly allows
+	// redirects to a hostname that resolves to one (e.g. metadata.google.internal). Checking the
+	// resolved IP at dial time closes that gap for every request this fetcher makes, including
+	// the bearer token fetch and any redirect hop, regardless of what the Location header names.
+	t.DialContext = wasmDialContext()
+	var transport http.RoundTripper = t
 
 	// wrap transport with SSRF protection for CVE-pending bearer realm vulnerability
 	fetchOpts = append(fetchOpts, remote.WithTransport(&ssrfProtectionTransport{inner: transport}))

--- a/pkg/wasm/ssrf.go
+++ b/pkg/wasm/ssrf.go
@@ -1,0 +1,62 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wasm
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pkg/security"
+)
+
+// wasmBlockedIP always blocks link-local addresses (which includes cloud instance metadata
+// endpoints such as 169.254.169.254, and never has a legitimate use as a Wasm module host) and
+// a small list of well-known cloud metadata addresses that fall outside the link-local range
+// (e.g. Alibaba Cloud's and AWS's IPv6 metadata services), plus any additional
+// operator-configured ranges from BlockedCIDRsInWasmFetch.
+//
+// Private (RFC1918/ULA) and loopback ranges are intentionally NOT blocked by default: unlike
+// cloud metadata endpoints, they are commonly used to legitimately host Wasm modules from an
+// in-cluster registry or HTTP server. Operators who don't need that can lock it down further
+// via BLOCKED_CIDRS_IN_WASM_FETCH.
+func wasmBlockedIP(ip net.IP) error {
+	if security.IsLinkLocal(ip) {
+		return fmt.Errorf("connection blocked: resolved IP %s is link-local", ip.String())
+	}
+	if security.IsKnownCloudMetadataAddress(ip) {
+		return fmt.Errorf("connection blocked: resolved IP %s is a known cloud metadata address", ip.String())
+	}
+	for _, cidr := range features.BlockedCIDRsInWasmFetch {
+		if cidr.Contains(ip) {
+			return fmt.Errorf("connection blocked: resolved IP %s is in blocked CIDR range %s", ip.String(), cidr.String())
+		}
+	}
+	return nil
+}
+
+// wasmDialContext returns a DialContext that applies wasmBlockedIP to every connection made
+// while fetching a Wasm module, including redirect hops (see security.BlockedIPDialContext).
+// Timeout/KeepAlive match http.DefaultTransport's and go-containerregistry's
+// remote.DefaultTransport's dialer settings, so this does not change existing dial behavior
+// beyond adding the IP check.
+func wasmDialContext() func(ctx context.Context, network, addr string) (net.Conn, error) {
+	return security.BlockedIPDialContext(&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}, wasmBlockedIP)
+}

--- a/pkg/wasm/ssrf_test.go
+++ b/pkg/wasm/ssrf_test.go
@@ -1,0 +1,118 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wasm
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"istio.io/istio/pilot/pkg/features"
+)
+
+func TestWasmBlockedIP(t *testing.T) {
+	cases := []struct {
+		ip      string
+		blocked bool
+	}{
+		{"169.254.169.254", true}, // cloud metadata endpoint
+		{"fe80::1", true},
+		{"100.100.100.200", true}, // Alibaba Cloud metadata endpoint
+		{"fd00:ec2::230", true},   // AWS IMDS IPv6 endpoint
+		{"10.0.0.1", false},       // legitimately used for in-cluster Wasm module hosting
+		{"127.0.0.1", false},      // not blocked by default so unit tests using httptest keep working
+		{"8.8.8.8", false},
+	}
+	for _, c := range cases {
+		t.Run(c.ip, func(t *testing.T) {
+			ip := net.ParseIP(c.ip)
+			if ip == nil {
+				t.Fatalf("failed to parse test IP %s", c.ip)
+			}
+			err := wasmBlockedIP(ip)
+			if c.blocked && err == nil {
+				t.Errorf("wasmBlockedIP(%s) = nil, want blocked", c.ip)
+			}
+			if !c.blocked && err != nil {
+				t.Errorf("wasmBlockedIP(%s) = %v, want allowed", c.ip, err)
+			}
+		})
+	}
+}
+
+func TestWasmBlockedIPHonorsConfiguredCIDRs(t *testing.T) {
+	_, cidr, err := net.ParseCIDR("10.0.0.0/8")
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := features.BlockedCIDRsInWasmFetch
+	features.BlockedCIDRsInWasmFetch = []*net.IPNet{cidr}
+	defer func() { features.BlockedCIDRsInWasmFetch = orig }()
+
+	if err := wasmBlockedIP(net.ParseIP("10.1.2.3")); err == nil {
+		t.Error("expected 10.1.2.3 to be blocked once configured, got nil error")
+	}
+	if err := wasmBlockedIP(net.ParseIP("192.168.1.1")); err != nil {
+		t.Errorf("expected 192.168.1.1 to remain allowed, got %v", err)
+	}
+}
+
+// TestWasmFetchBlocksRedirectToBlockedHost proves the dial-level block also applies to a
+// redirect target, not just the original request URL -- the exact gap left open by
+// go-containerregistry's own checkRedirectSSRF (which only inspects IP-literal redirect
+// targets) and by header/URL string checks in general. It uses the operator-configurable
+// BlockedCIDRsInWasmFetch list (rather than a real link-local address) as the test vehicle,
+// since real link-local addresses aren't reliably bindable in a test sandbox.
+//
+// The redirector and the redirect target are bound to distinct loopback addresses
+// (127.0.0.1 and 127.0.0.2) so only the target -- not the redirector itself -- is blocked;
+// this isolates "the redirect hop was blocked" from "the initial request was blocked".
+func TestWasmFetchBlocksRedirectToBlockedHost(t *testing.T) {
+	targetLis, err := net.Listen("tcp", "127.0.0.2:0")
+	if err != nil {
+		t.Skipf("could not bind to 127.0.0.2, skipping: %v", err)
+	}
+
+	_, cidr, err := net.ParseCIDR("127.0.0.2/32")
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := features.BlockedCIDRsInWasmFetch
+	features.BlockedCIDRsInWasmFetch = []*net.IPNet{cidr}
+	defer func() { features.BlockedCIDRsInWasmFetch = orig }()
+
+	blocked := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("should never be reached"))
+	}))
+	blocked.Listener.Close()
+	blocked.Listener = targetLis
+	blocked.Start()
+	defer blocked.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, blocked.URL, http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	fetcher := NewHTTPFetcher(DefaultHTTPRequestTimeout, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := fetcher.Fetch(ctx, redirector.URL, false); err == nil {
+		t.Fatal("expected fetch following a redirect to a blocked host to fail, got nil error")
+	}
+}

--- a/releasenotes/notes/wasm-ssrf-redirect-dial-context.yaml
+++ b/releasenotes/notes/wasm-ssrf-redirect-dial-context.yaml
@@ -1,0 +1,14 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+releaseNotes:
+  - |
+    **Fixed** SSRF protection gaps in Wasm module fetching (`pkg/wasm`). The HTTP fetcher
+    previously had no restriction on destination IP at all, and the OCI image fetcher's SSRF
+    protection only inspected `401` bearer-realm responses, not `3xx` redirects on the actual
+    manifest/blob fetch. Both fetchers now block connections to link-local addresses (which
+    includes cloud instance metadata endpoints such as `169.254.169.254`) at the dial level,
+    so the block applies to the original request and to every redirect hop, regardless of
+    whether the redirect target is an IP literal or a hostname that resolves to one. A new
+    `BLOCKED_CIDRS_IN_WASM_FETCH` environment variable lets operators additionally block
+    private ranges or specific in-cluster addresses if desired.


### PR DESCRIPTION

**Please provide a description of this PR:**

Fixes two SSRF vulnerabilities in the Wasm module fetch path:

1. pkg/wasm/httpfetcher.go: NewHTTPFetcher built both HTTP clients with no destination restriction at all — no DialContext, no IP filtering. A WasmPlugin.spec.url could point directly at a cloud metadata endpoint, the Kubernetes API, or the kubelet, and istiod would fetch it with no resistance.
2. pkg/wasm/imagefetcher.go: existing SSRF protection (ssrfProtectionTransport) only inspects 401 responses' WWW-Authenticate header — it never validates 3xx redirects on the actual manifest/blob fetch. go-containerregistry's own redirect check blocks IP-literal targets but still allows a redirect to a hostname that resolves to a blocked address (e.g. metadata.google.internal), leaving a real gap.