### PR TITLE
Monitor istio_ca processing of CA/CRL updates

### DIFF
--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -36,6 +36,7 @@ import (
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/env"
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/monitoring"
 	"istio.io/istio/pkg/security"
 	"istio.io/istio/pkg/util/sets"
 	"istio.io/istio/security/pkg/cmd"
@@ -136,6 +137,11 @@ var (
 	// TODO: Likely to be removed and added to mesh config
 	k8sSigner = env.Register("K8S_SIGNER", "",
 		"Kubernetes CA Signer type. Valid from Kubernetes 1.18").Get()
+
+	cacertsInvalid = monitoring.NewGauge(
+		"istiod_cacerts_invalid",
+		"Whether the current cacerts are invalid",
+	)
 )
 
 // initCAServer create a CA Server. The CA API uses cert with the max workload cert TTL.
@@ -338,6 +344,7 @@ func handleEvent(s *Server) {
 	fileBundle, err := detectSigningCABundleAndCRL()
 	if err != nil {
 		log.Errorf("unable to determine signing file format %v", err)
+		cacertsInvalid.Record(1)
 		return
 	}
 
@@ -345,6 +352,7 @@ func handleEvent(s *Server) {
 	newCABundle, err = os.ReadFile(fileBundle.RootCertFile)
 	if err != nil {
 		log.Errorf("failed reading root-cert.pem: %v", err)
+		cacertsInvalid.Record(1)
 		return
 	}
 
@@ -354,6 +362,7 @@ func handleEvent(s *Server) {
 	if !bytes.Equal(currentCABundle, newCABundle) {
 		if !features.MultiRootMesh {
 			log.Warn("Multi root is disabled, updating new ROOT-CA not supported")
+			cacertsInvalid.Record(1)
 			return
 		}
 
@@ -363,6 +372,7 @@ func handleEvent(s *Server) {
 			log.Info("Updating new ROOT-CA")
 		} else {
 			log.Warn("Updating new ROOT-CA not supported")
+			cacertsInvalid.Record(1)
 			return
 		}
 	}
@@ -396,6 +406,7 @@ func handleEvent(s *Server) {
 	)
 	if err != nil {
 		log.Errorf("Failed to update new Plug-in CA certs: %v", err)
+		cacertsInvalid.Record(1)
 		return
 	}
 	if len(s.CA.GetCAKeyCertBundle().GetRootCertPem()) != 0 {
@@ -414,11 +425,13 @@ func handleEvent(s *Server) {
 		return
 	}
 
+	cacertsInvalid.Record(0)
 	log.Info("Istiod has detected the newly added intermediate CA and updated its key and certs accordingly")
 }
 
 // handleCACertsFileWatch handles the events on cacerts files
 func (s *Server) handleCACertsFileWatch() {
+	cacertsInvalid.Record(0)
 	var timerC <-chan time.Time
 	for {
 		select {

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -37,6 +38,7 @@ import (
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/filewatcher"
 	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/monitoring"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/test/util/retry"
@@ -400,6 +402,19 @@ func TestReloadIstiodCABundle(t *testing.T) {
 	g.Expect(kc.KeyPem).To(Equal(testcerts.ServerKey))
 }
 
+type metricRecording struct {
+	mu    sync.Mutex
+	tags  []monitoring.LabelValue
+	value float64
+}
+
+func (m *metricRecording) OnRecord(name string, tags []monitoring.LabelValue, value float64) {
+	m.mu.Lock()
+	m.tags = tags
+	m.value = value
+	m.mu.Unlock()
+}
+
 func TestReloadcacerts(t *testing.T) {
 	var err error
 
@@ -452,6 +467,9 @@ func TestReloadcacerts(t *testing.T) {
 		_ = s.cacertsWatcher.Close()
 	}()
 
+	recording := &metricRecording{value: -1}
+	monitoring.RegisterRecordHook(cacertsInvalid.Name(), recording)
+
 	// start server
 	if err := s.server.Start(stop); err != nil {
 		t.Fatalf("Could not invoke startFuncs: %v", err)
@@ -468,6 +486,27 @@ func TestReloadcacerts(t *testing.T) {
 		return len(s.CA.GetCAKeyCertBundle().GetCertChainPem()) > 0
 	}, "10s", "100ms").Should(BeTrue())
 
+	g.Eventually(func() bool {
+		recording.mu.Lock()
+		defer recording.mu.Unlock()
+		return len(recording.tags) == 0 && recording.value == 0
+	}, "1s", "100ms").Should(BeTrue())
+
+	// remove the root-cert  which will cause an error
+	if err := os.Rename(filepath.Join(cacertsDir, "root-cert.pem"), filepath.Join(cacertsDir, "root-cert.pem.tmp")); err != nil {
+		t.Fatal(err)
+	}
+
+	g.Eventually(func() bool {
+		recording.mu.Lock()
+		defer recording.mu.Unlock()
+		return len(recording.tags) == 0 && recording.value == 1
+	}, "1s", "100ms").Should(BeTrue())
+
+	if err := os.Rename(filepath.Join(cacertsDir, "root-cert.pem.tmp"), filepath.Join(cacertsDir, "root-cert.pem")); err != nil {
+		t.Fatal(err)
+	}
+
 	// update cert chain of cert bundle to alt version
 	certChainAlt, err := readSampleCertFromFile("cert-chain-alt.pem")
 	if err != nil {
@@ -482,6 +521,12 @@ func TestReloadcacerts(t *testing.T) {
 		currentCertChain := s.CA.GetCAKeyCertBundle().GetCertChainPem()
 		return bytes.Equal(currentCertChain, certChainAlt)
 	}, "10s", "100ms").Should(BeTrue())
+
+	g.Eventually(func() bool {
+		recording.mu.Lock()
+		defer recording.mu.Unlock()
+		return len(recording.tags) == 0 && recording.value == 0
+	}, "1s", "100ms").Should(BeTrue())
 }
 
 func TestNewServer(t *testing.T) {

--- a/releasenotes/notes/61075.yaml
+++ b/releasenotes/notes/61075.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - https://github.com/istio/istio/issues/61075
+releaseNotes:
+  - |
+    **Added** a metric, `istiod_cacerts_invalid`, to track failures when processing updates from the secret.


### PR DESCRIPTION
Track whether the changes in the cacerts secret failed.

Other than the log lines that are produced at the time of processing, there is no way for someone to know if the contents of the current cacerts are valid.

fixes #61075 

**Please provide a description of this PR:**