### PR TITLE
[release-1.31] Downgrade go-control-plane to v1.39

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,8 +20,8 @@ require (
 	github.com/coreos/go-oidc/v3 v3.18.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/docker/cli v29.5.2+incompatible
-	github.com/envoyproxy/go-control-plane/contrib v1.36.1-0.20260717024754-ce40001c657f
-	github.com/envoyproxy/go-control-plane/envoy v1.37.1-0.20260717024754-ce40001c657f
+	github.com/envoyproxy/go-control-plane/contrib v1.36.1-0.20260713214202-ca8ce173c36f
+	github.com/envoyproxy/go-control-plane/envoy v1.37.1-0.20260713214202-ca8ce173c36f
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/fatih/color v1.19.0
 	github.com/felixge/fgprof v0.9.5

--- a/go.sum
+++ b/go.sum
@@ -135,10 +135,10 @@ github.com/emicklei/go-restful/v3 v3.13.0 h1:C4Bl2xDndpU6nJ4bc1jXd+uTmYPVUwkD6bF
 github.com/emicklei/go-restful/v3 v3.13.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/go-control-plane v0.14.0 h1:hbG2kr4RuFj222B6+7T83thSPqLjwBIfQawTkC++2HA=
 github.com/envoyproxy/go-control-plane v0.14.0/go.mod h1:NcS5X47pLl/hfqxU70yPwL9ZMkUlwlKxtAohpi2wBEU=
-github.com/envoyproxy/go-control-plane/contrib v1.36.1-0.20260717024754-ce40001c657f h1:xf+9tlpUv6xBuUTOSc0iu7XaP8892q+yiAuoC06jxCQ=
-github.com/envoyproxy/go-control-plane/contrib v1.36.1-0.20260717024754-ce40001c657f/go.mod h1:TZSYc7TXD0XedCMEmlxNrlgV3NwgJAdJwWxUSWKJ2SU=
-github.com/envoyproxy/go-control-plane/envoy v1.37.1-0.20260717024754-ce40001c657f h1:aoxxTBuCXQwIiJW5st8m8W2BJ3wkl1yFpdGL9guK1AE=
-github.com/envoyproxy/go-control-plane/envoy v1.37.1-0.20260717024754-ce40001c657f/go.mod h1:5e4ylfTZO723MEEFsCpSW4ZEBWR8mwkEyXfwJBTCZ9c=
+github.com/envoyproxy/go-control-plane/contrib v1.36.1-0.20260713214202-ca8ce173c36f h1:a4wgSYb7fOhCRA+Fm//N70TcxDOit20VlwVooHeCyes=
+github.com/envoyproxy/go-control-plane/contrib v1.36.1-0.20260713214202-ca8ce173c36f/go.mod h1:TZSYc7TXD0XedCMEmlxNrlgV3NwgJAdJwWxUSWKJ2SU=
+github.com/envoyproxy/go-control-plane/envoy v1.37.1-0.20260713214202-ca8ce173c36f h1:x76c29Vq6dZ9lwQQ3xDs/9Yrcz60A0Jf3E3y3drBXm8=
+github.com/envoyproxy/go-control-plane/envoy v1.37.1-0.20260713214202-ca8ce173c36f/go.mod h1:5e4ylfTZO723MEEFsCpSW4ZEBWR8mwkEyXfwJBTCZ9c=
 github.com/envoyproxy/go-control-plane/ratelimit v0.1.0 h1:/G9QYbddjL25KvtKTv3an9lx6VBE2cnb8wp1vEGNYGI=
 github.com/envoyproxy/go-control-plane/ratelimit v0.1.0/go.mod h1:Wk+tMFAFbCXaJPzVVHnPgRKdUdwW/KdbRt94AzgRee4=
 github.com/envoyproxy/protoc-gen-validate v1.3.3 h1:MVQghNeW+LZcmXe7SY1V36Z+WFMDjpqGAGacLe2T0ds=

--- a/pkg/config/xds/filter_types.gen.go
+++ b/pkg/config/xds/filter_types.gen.go
@@ -391,7 +391,6 @@ import (
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/tcp/generic/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/tcp/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/wasm/v3"
-	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/watchdog/backtrace_action/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/watchdog/profile_action/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/service/accesslog/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"


### PR DESCRIPTION
This change refers to step 6 in https://github.com/istio/istio/issues/60658.

The go-control-plane dependency on the release-1.31 branch was pointing to commit [ce40001c657f](https://github.com/envoyproxy/go-control-plane/commit/ce40001c657f), which mirrors Envoy commit [1a7ac335ed8c](https://github.com/envoyproxy/envoy/commit/1a7ac335ed8c) - a commit that landed after the release/v1.39 Envoy branch was cut. This means the Istio release branch was using Envoy API definitions not present on the release branch.

This change downgrades go-control-plane/envoy and go-control-plane/contrib to [ca8ce173c36f](https://github.com/envoyproxy/go-control-plane/commit/ca8ce173c36f).