### PR TITLE
test: speed up TestGetCNIConfigFilepath

### DIFF
--- a/cni/pkg/install/cniconfig_test.go
+++ b/cni/pkg/install/cniconfig_test.go
@@ -255,11 +255,9 @@ func TestGetCNIConfigFilepath(t *testing.T) {
 				if len(c.delayedConfName) > 0 {
 					// Delayed case
 					t.Fatalf("did not expect to retrieve a CNI config file %s", result)
-				} else if result != expectedFilepath {
-					if len(expectedFilepath) > 0 {
-						t.Fatalf("expected %s, got %s", expectedFilepath, result)
-					}
-					t.Fatalf("did not expect to retrieve a CNI config file %s", result)
+				}
+				if result != expectedFilepath {
+					t.Fatalf("expected %s, got %s", expectedFilepath, result)
 				}
 				// Successful test for non-delayed cases
 				return
@@ -278,11 +276,8 @@ func TestGetCNIConfigFilepath(t *testing.T) {
 						t.Fatal(err)
 					}
 					t.Logf("delayed write to %v", filepath.Join(tempDir, c.delayedConfName))
-				} else if len(c.expectedConfName) > 0 {
-					t.Fatalf("timed out waiting for expected %s", expectedFilepath)
 				} else {
-					// Successful test for test cases where CNI config file is never created
-					return
+					t.Fatalf("timed out waiting for expected %s", expectedFilepath)
 				}
 			}
 

--- a/cni/pkg/install/cniconfig_test.go
+++ b/cni/pkg/install/cniconfig_test.go
@@ -125,6 +125,7 @@ func TestGetCNIConfigFilepath(t *testing.T) {
 		specifiedConfName string
 		delayedConfName   string
 		expectedConfName  string
+		expectedError     error
 		existingConfFiles []string
 	}{
 		{
@@ -142,6 +143,7 @@ func TestGetCNIConfigFilepath(t *testing.T) {
 		{
 			name:             "unspecified CNI config file never created",
 			chainedCNIPlugin: true,
+			expectedError:    context.Canceled,
 		},
 		{
 			name:              "specified existing CNI config file",
@@ -175,6 +177,7 @@ func TestGetCNIConfigFilepath(t *testing.T) {
 			name:              "specified CNI config file never created",
 			chainedCNIPlugin:  true,
 			specifiedConfName: "never-created.conf",
+			expectedError:     context.Canceled,
 			existingConfFiles: []string{"bridge.conf", "list.conflist"},
 		},
 		{
@@ -222,6 +225,15 @@ func TestGetCNIConfigFilepath(t *testing.T) {
 					t.Fatalf("expected %s, got %s", expectedFilepath, result)
 				}
 				// Successful test case
+				return
+			}
+
+			if c.expectedError != nil {
+				ctx, cancel := context.WithCancel(t.Context())
+				cancel()
+				result, err := getCNIConfigFilepath(ctx, c.specifiedConfName, tempDir, c.chainedCNIPlugin)
+				assert.Equal(t, result, "")
+				assert.Equal(t, err, c.expectedError)
 				return
 			}
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Part of #37555 (slow unit tests). This change is test-only.

### Root cause

`TestGetCNIConfigFilepath` uses 250ms waits for four test cases. Two cases
exercise delayed CNI config creation, while the other two only verify behavior
when a config file is never created.

The never-created cases therefore spend 500ms waiting before succeeding.
Lowering these timeouts is unsafe: they were previously increased in #29278
after rare test flakes.

### Fix

Mark the never-created cases as expecting `context.Canceled` and invoke
`getCNIConfigFilepath` synchronously with an already-canceled context.

This directly verifies the function's cancellation behavior without waiting.
The existing 250ms waits for delayed filesystem events remain unchanged.

Coverage is preserved: the never-created cases previously asserted that the
function keeps blocking, and now assert that it returns `("", context.Canceled)`.
The "does not return before the file appears" property is still covered by the
two delayed cases, which retain their waits.

### Measured results

With `-race`, across 100 runs on the same machine:

| Metric | Before | After |
| --- | --- | --- |
| Minimum | 1.07s | 0.62s |
| Average | 1.142s | 0.685s |
| Maximum | 1.26s | 0.82s |
| Runs below 1s | 0/100 | 100/100 |

Before was measured at upstream commit `95c1677839`; after was measured at
commit `1e1b58b2a6`.

Test command:

```bash
go test -race -json ./cni/pkg/install -run '^TestGetCNIConfigFilepath$' -count=100
```

The optimized test completed 100 race-enabled runs with no failures.