### PR TITLE
Fix: Recompute a pod's proxy when its ServiceEntry membership changes

### DIFF
--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -83,6 +83,8 @@ type Inputs struct {
 	ServiceEntries  krt.Collection[config.Config]
 	// TODO: this should be a joined collection with multi cluster workloads
 	ExternalWorkloads krt.StaticCollection[*model.WorkloadInstance]
+	// ExternalWorkloadsByIP attributes a service instance event back to the workload kind that produced it.
+	ExternalWorkloadsByIP krt.Index[string, *model.WorkloadInstance]
 }
 
 type Outputs struct {
@@ -222,6 +224,9 @@ func newController(
 		s.inputs.Namespaces = multiclusterController.ConfigCluster().Namespaces()
 		s.inputs.ServiceEntries = store.KrtCollection(gvk.ServiceEntry)
 		s.inputs.ExternalWorkloads = krt.NewStaticCollection[*model.WorkloadInstance](nil, nil, s.opts.WithName("inputs/ExternalWorkloads")...)
+		s.inputs.ExternalWorkloadsByIP = krt.NewIndex(s.inputs.ExternalWorkloads, "ip", func(wi *model.WorkloadInstance) []string {
+			return []string{wi.Endpoint.FirstAddressOrNil()}
+		})
 	}
 
 	s.buildCollections()
@@ -232,6 +237,8 @@ func newController(
 			s.handlers,
 			s.outputs.ServiceInstancesByNamespaceHost.RegisterBatch(s.pushServiceEndpointUpdates, false),
 			s.outputs.Services.RegisterBatch(s.pushServiceUpdates, false),
+			s.outputs.ServiceInstancesByIP.AsCollection(s.opts.WithName("outputs/ServiceInstancesByIPCollection")...).
+				RegisterBatch(s.pushPodProxyUpdates, false),
 		)
 	}
 	// Register EDS/XDS push handlers for WLEs
@@ -350,6 +357,34 @@ func (s *Controller) pushWorkloadUpdates(events []krt.Event[*model.WorkloadInsta
 			e.Event == controllers.EventUpdate && !(*e.Old).Endpoint.Labels.Equals((*e.New).Endpoint.Labels) {
 			s.XdsUpdater.ProxyUpdate(s.Cluster(), (*e.New).Endpoint.FirstAddressOrNil())
 		}
+	}
+}
+
+// pushPodProxyUpdates forces a pod's own proxy to recompute when this registry's instances for
+// that pod change.
+//
+// A proxy snapshots model.Proxy.ServiceTargets when its xDS stream is established and reuses it for
+// every later push. A pod only becomes an endpoint here once it is Ready, which is after that
+// snapshot, and the incremental endpoint update that follows does not refresh it.
+//
+// Triggering off the derived instance collection rather than the pod event is what makes this
+// reliable: krt updates a collection's indexes before dispatching handlers, so GetProxyServiceTargets,
+// which reads this same index, observes the new state. It also collapses a workload's per-port
+// instances into one event per IP.
+func (s *Controller) pushPodProxyUpdates(events []krt.Event[krt.IndexObject[string, *model.ServiceInstance]]) {
+	for _, e := range events {
+		ip := e.Latest().Key
+		if ip == "" {
+			continue
+		}
+		// Only pods. ExternalWorkloads also carries WorkloadEntry-derived instances from non-config
+		// clusters, whose proxies connect elsewhere and are pushed by pushWorkloadUpdates.
+		if !slices.ContainsFunc(s.inputs.ExternalWorkloadsByIP.Lookup(ip), func(wi *model.WorkloadInstance) bool {
+			return wi.Kind == model.PodKind
+		}) {
+			continue
+		}
+		s.XdsUpdater.ProxyUpdate(s.Cluster(), ip)
 	}
 }
 

--- a/pilot/pkg/serviceregistry/serviceentry/controller_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller_test.go
@@ -1210,21 +1210,24 @@ func TestWorkloadInstanceFullPush(t *testing.T) {
 		expectServiceInstances(t, sd, selectorDNS, 0, instances)
 		expectEvents(t, events,
 			Event{Type: "eds", ID: "selector.com", Namespace: selectorDNS.Namespace, EndpointCount: len(instances)},
-			Event{Type: "xds", ID: "selector.com"})
+			Event{Type: "xds", ID: "selector.com"},
+			Event{Type: "proxy", ID: "4.4.4.4"})
 	})
 
 	t.Run("full push for another new workload instance", func(t *testing.T) {
 		callInstanceHandlers([]*model.WorkloadInstance{fi2}, sd, model.EventAdd, t)
 		expectEvents(t, events,
 			Event{Type: "eds", ID: "selector.com", Namespace: selectorDNS.Namespace, EndpointCount: 6},
-			Event{Type: "xds", ID: "selector.com"})
+			Event{Type: "xds", ID: "selector.com"},
+			Event{Type: "proxy", ID: "2.2.2.2"})
 	})
 
 	t.Run("full push for new instance with multiple addresses", func(t *testing.T) {
 		callInstanceHandlers([]*model.WorkloadInstance{fiwithmulAddrs}, sd, model.EventAdd, t)
 		expectEvents(t, events,
 			Event{Type: "eds", ID: "selector.com", Namespace: selectorDNS.Namespace, EndpointCount: 8},
-			Event{Type: "xds", ID: "selector.com"})
+			Event{Type: "xds", ID: "selector.com"},
+			Event{Type: "proxy", ID: "3.3.3.3"})
 	})
 
 	t.Run("full push on delete workload instance", func(t *testing.T) {
@@ -1359,7 +1362,9 @@ func TestServiceDiscoveryWorkloadInstance(t *testing.T) {
 		}
 		expectProxyInstances(t, sd, instances, []string{"2.2.2.2"})
 		expectServiceInstances(t, sd, selector, 0, instances)
-		expectEvents(t, events, Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 2})
+		expectEvents(t, events,
+			Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 2},
+			Event{Type: "proxy", ID: "2.2.2.2"})
 	})
 
 	t.Run("another workload instance", func(t *testing.T) {
@@ -1378,7 +1383,9 @@ func TestServiceDiscoveryWorkloadInstance(t *testing.T) {
 			makeInstanceWithServiceAccount(selector, "some-other-name", []string{"3.3.3.3"}, 445,
 				selector.Spec.(*networking.ServiceEntry).Ports[1], map[string]string{"app": "wle"}, "default"))
 		expectServiceInstances(t, sd, selector, 0, instances)
-		expectEvents(t, events, Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 4})
+		expectEvents(t, events,
+			Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 4},
+			Event{Type: "proxy", ID: "3.3.3.3"})
 	})
 
 	t.Run("add workload instance with multiple addresses", func(t *testing.T) {
@@ -1402,7 +1409,9 @@ func TestServiceDiscoveryWorkloadInstance(t *testing.T) {
 		expectProxyInstances(t, sd, instances[2:4], []string{"3.3.3.3"})
 		expectProxyInstances(t, sd, instances[4:], []string{"4.4.4.4", "2001:1::1"})
 		expectServiceInstances(t, sd, selector, 0, instances)
-		expectEvents(t, events, Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 6})
+		expectEvents(t, events,
+			Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 6},
+			Event{Type: "proxy", ID: "4.4.4.4"})
 	})
 
 	t.Run("delete workload instance", func(t *testing.T) {
@@ -1486,6 +1495,7 @@ func TestServiceDiscoveryWorkloadInstance(t *testing.T) {
 		expectEvents(t, events,
 			Event{Type: "eds", ID: "dns.selector.com", Namespace: dnsSelector.Namespace, EndpointCount: 2},
 			Event{Type: "xds", ID: "dns.selector.com"},
+			Event{Type: "proxy", ID: "2.2.2.2"},
 		)
 	})
 }
@@ -1679,10 +1689,103 @@ func TestServiceDiscoveryWorkloadInstanceChangeLabel(t *testing.T) {
 				}
 
 				expectServiceInstances(t, sd, selector, 0, totalInstances)
+				// The instance's own proxy is forced to recompute: which services it backs just changed.
 				expectEvents(t, events,
-					Event{Type: "eds", ID: selector.Spec.(*networking.ServiceEntry).Hosts[0], Namespace: selector.Namespace, EndpointCount: len(totalInstances)})
+					Event{Type: "eds", ID: selector.Spec.(*networking.ServiceEntry).Hosts[0], Namespace: selector.Namespace, EndpointCount: len(totalInstances)},
+					Event{Type: "proxy", ID: instance.address})
 			}
 		})
+	}
+}
+
+// A pod reaches this registry only after its proxy connected and snapshotted ServiceTargets from an
+// empty membership. Nothing else recomputes that snapshot, so the registry must push the pod's own
+// proxy once the pod starts backing a ServiceEntry.
+func TestPodEndpointForcesOwnProxyPush(t *testing.T) {
+	store, sd, events := initServiceDiscovery(t)
+
+	createConfigs([]*config.Config{selector}, store, t)
+	expectEvents(t, events,
+		Event{Type: "service", ID: "selector.com", Namespace: selector.Namespace},
+		Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace},
+		Event{Type: "xds", ID: "selector.com"})
+
+	pod := &model.WorkloadInstance{
+		Name:      "pod-1",
+		Namespace: selector.Namespace,
+		Kind:      model.PodKind,
+		Endpoint: &model.IstioEndpoint{
+			Addresses: []string{"2.2.2.2"},
+			Labels:    map[string]string{"app": "wle"},
+		},
+	}
+	proxy := &model.Proxy{IPAddresses: []string{"2.2.2.2"}, Metadata: &model.NodeMetadata{}}
+
+	// The state a proxy connecting before its pod is Ready would snapshot.
+	if targets := sd.GetProxyServiceTargets(proxy); len(targets) != 0 {
+		t.Fatalf("expected no service targets before the pod is registered, got %v", targets)
+	}
+
+	callInstanceHandlers([]*model.WorkloadInstance{pod}, sd, model.EventAdd, t)
+
+	// The push must be requested for this pod's own proxy...
+	expectEvents(t, events,
+		Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 2},
+		Event{Type: "proxy", ID: "2.2.2.2"})
+
+	// ...and by then re-resolving must yield the hostname, since that is what the push
+	// regenerates config from.
+	targets := sd.GetProxyServiceTargets(proxy)
+	if len(targets) != 2 {
+		t.Fatalf("expected 2 service targets after the pod is registered, got %d: %v", len(targets), targets)
+	}
+	for _, target := range targets {
+		if got := string(target.Service.Hostname); got != "selector.com" {
+			t.Fatalf("expected target hostname selector.com, got %q", got)
+		}
+	}
+}
+
+// The push is scoped to pods, and a WorkloadEntry from a non-config cluster lands in
+// ExternalWorkloads alongside them. model.PodKind is the zero value of workloadKind, so without the
+// explicit Kind check the scoping would hold only by accident.
+func TestWorkloadEntryEndpointDoesNotDoublePushProxy(t *testing.T) {
+	store, sd, events := initServiceDiscovery(t)
+
+	createConfigs([]*config.Config{selector}, store, t)
+	expectEvents(t, events,
+		Event{Type: "service", ID: "selector.com", Namespace: selector.Namespace},
+		Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace},
+		Event{Type: "xds", ID: "selector.com"})
+
+	// Same shape as a pod-derived instance, but explicitly a WorkloadEntry.
+	wle := &model.WorkloadInstance{
+		Name:      "vm-1",
+		Namespace: selector.Namespace,
+		Kind:      model.WorkloadEntryKind,
+		Endpoint: &model.IstioEndpoint{
+			Addresses: []string{"2.2.2.2"},
+			Labels:    map[string]string{"app": "wle"},
+		},
+	}
+	callInstanceHandlers([]*model.WorkloadInstance{wle}, sd, model.EventAdd, t)
+
+	// Membership must still resolve; only the extra push is suppressed.
+	proxy := &model.Proxy{IPAddresses: []string{"2.2.2.2"}, Metadata: &model.NodeMetadata{}}
+	retry.UntilSuccessOrFail(t, func() error {
+		if got := len(sd.GetProxyServiceTargets(proxy)); got != 2 {
+			return fmt.Errorf("expected 2 service targets for the WorkloadEntry, got %d", got)
+		}
+		return nil
+	}, retry.Timeout(5*time.Second))
+
+	// The eds event proves the instance landed; no "proxy" event may accompany it. The match returns
+	// as soon as the wanted set empties, so assert on the event that arrives last.
+	expectEvents(t, events, Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 2})
+	select {
+	case e := <-events.Events:
+		t.Fatalf("expected no further events for a WorkloadEntry-derived instance, got %q/%v", e.Type, e.ID)
+	case <-time.After(2 * time.Second):
 	}
 }
 

--- a/releasenotes/notes/61157.yaml
+++ b/releasenotes/notes/61157.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 61157
+releaseNotes:
+  - |
+    **Fixed** an issue where a pod selected by a `ServiceEntry` `workloadSelector` could start up
+    missing that service from its sidecar's inbound configuration. Traffic to the port was not
+    handled as the protocol declared in the `ServiceEntry`, and port-level `PeerAuthentication`
+    was not applied. The pod did not recover on its own; only restarting istiod repaired it.


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes #61157

A proxy resolves which services it backs when its xDS stream is established. A pod only becomes an endpoint of the ServiceEntry registry once it is Ready, which is after that, and the incremental endpoint update that follows never refreshes it. The sidecar is then permanently missing the inbound filter chain, port-level `PeerAuthentication` and inbound clusters for that service's port.

The registry already pushes a workload's own proxy when a WorkloadEntry starts backing a ServiceEntry; pods don't get the equivalent push. This adds it, triggered off the derived `ServiceInstancesByIP` index rather than the pod event so `GetProxyServiceTargets` is guaranteed to observe the new state, and scoped to `PodKind` so cross-cluster WorkloadEntries keep their existing push.

Dropping the `PodKind` filter fails `TestServiceDiscoveryWorkloadUpdate` and several others, so the scoping is covered.