### PR TITLE
[release-1.28] Wait for PushContext before processing gateway deployments

### DIFF
--- a/pilot/pkg/config/kube/gateway/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller.go
@@ -17,7 +17,6 @@ package gateway
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -413,6 +412,7 @@ func (d *DeploymentController) Run(stop <-chan struct{}) {
 		d.gatewayClasses.HasSynced,
 		d.tagWatcher.HasSynced,
 		d.env.Watcher.AsCollection().HasSynced,
+		d.env.PushContextReady,
 	)
 	d.queue.Run(stop)
 	controllers.ShutdownAll(
@@ -467,8 +467,6 @@ func (d *DeploymentController) Reconcile(req types.NamespacedName) error {
 	return d.configureIstioGateway(log, *gw, ci)
 }
 
-var errPushContext = errors.New("PushContext not initialized")
-
 func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gateway.Gateway, gi classInfo) error {
 	// If user explicitly sets addresses, we are assuming they are pointing to an existing deployment.
 	// We will not manage it in this case
@@ -479,10 +477,6 @@ func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gat
 	if !IsManaged(&gw.Spec) {
 		log.Debug("skip disabled gateway")
 		return nil
-	}
-	if !d.env.PushContext().InitDone.Load() {
-		log.Debug("skip PushContext not initialized")
-		return errPushContext
 	}
 	existingControllerVersion, overwriteControllerVersion, shouldHandle := ManagedGatewayControllerVersion(gw)
 	if !shouldHandle {

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
@@ -1378,3 +1378,61 @@ metadata:
 		})
 	}
 }
+
+// TestDeploymentControllerWaitsForPushContext verifies that the deployment
+// controller's queue does not start processing until PushContext is ready.
+func TestDeploymentControllerWaitsForPushContext(t *testing.T) {
+	c := kube.NewFakeClient(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+	})
+	tw := revisions.NewTagWatcher(c, "default", "istio-system")
+
+	// Create an environment where PushContext is NOT initialized to simulate
+	// a startup race (i.e., informers sync before PushContext is ready)
+	env := model.NewEnvironment()
+	env.Watcher = meshwatcher.NewTestWatcher(mesh.DefaultMeshConfig())
+
+	d := NewDeploymentController(c, "", env, testInjectionConfig(t, ""), func(fn func()) {}, tw, "", "")
+
+	reconciles := atomic.NewInt32(0)
+	d.patcher = func(g schema.GroupVersionResource, name string, namespace string, data []byte, subresources ...string) error {
+		if g == gvr.Service {
+			reconciles.Inc()
+		}
+		return nil
+	}
+
+	stop := test.NewStop(t)
+	gws := clienttest.Wrap(t, d.gateways)
+
+	go tw.Run(stop)
+	// d.Run() enters WaitForCacheSync, which blocks because PushContextReady()
+	// returns false. queue.Run() is therefore not called yet.
+	go d.Run(stop)
+	// RunAndWait starts the fake client's reflectors and returns once all
+	// informer caches are synced. After this returns, d.Run() is still blocked
+	// on PushContextReady(), so no queue processing has started.
+	c.RunAndWait(stop)
+
+	// Create a Gateway while PushContext is not ready. The informer event handler
+	// enqueues the work item into the queue's internal buffer, but queue.Run()
+	// has not been called, so no reconciliation can occur.
+	gws.Create(&k8sbeta.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "default"},
+		Spec: k8sbeta.GatewaySpec{
+			GatewayClassName: k8sbeta.ObjectName(features.GatewayAPIDefaultGatewayClass),
+		},
+	})
+
+	// Since queue.Run() has not been called, reconciliation will not happen.
+	assert.Equal(t, reconciles.Load(), int32(0))
+
+	// Mark PushContext as ready. WaitForCacheSync in d.Run() will now detect all
+	// conditions satisfied, return, and call queue.Run(). The queued Gateway will
+	// then be processed, invoking the reconciliation method.
+	env.PushContext().InitDone.Store(true)
+
+	assert.EventuallyEqual(t, func() bool { return reconciles.Load() >= 1 }, true,
+		retry.Timeout(time.Second*5),
+		retry.Message("expected reconciliation after PushContext became ready, but none occurred"))
+}

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -178,6 +178,12 @@ func (e *Environment) PushContext() *PushContext {
 	return e.pushContext
 }
 
+// PushContextReady reports whether the current PushContext has completed
+// initialization. Suitable for use with WaitForCacheSync.
+func (e *Environment) PushContextReady() bool {
+	return e.PushContext().InitDone.Load()
+}
+
 // GetDiscoveryAddress parses the DiscoveryAddress specified via MeshConfig.
 func (e *Environment) GetDiscoveryAddress() (host.Name, string, error) {
 	proxyConfig := mesh.DefaultProxyConfig()

--- a/releasenotes/notes/61095.yaml
+++ b/releasenotes/notes/61095.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 61095
+releaseNotes:
+- |
+  **Fixed** an issue where gateway proxy Deployments could permanently fail to be created during istiod startup.


### PR DESCRIPTION
Manual cherry-pick of #61094 from release-1.29 (#61143). Updated the test to use v1beta1 Gateway types since release-1.28 has not yet migrated to v1 (see #58110).

fixes #61136