### PR TITLE
ambient: fix misleading status message for DENY policies with only L7 attributes (issue 61126)

### DIFF
--- a/pilot/pkg/serviceregistry/ambient/authorization.go
+++ b/pilot/pkg/serviceregistry/ambient/authorization.go
@@ -25,6 +25,7 @@ import (
 	securityclient "istio.io/client-go/pkg/apis/security/v1"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/maps"
@@ -431,12 +432,10 @@ func convertAuthorizationPolicy(rootns string, obj *securityclient.Authorization
 		}
 	}
 	action := security.Action_ALLOW
-	boilerplate := httpAllowRuleBoilerplate
 	switch pol.Action {
 	case v1beta1.AuthorizationPolicy_ALLOW:
 	case v1beta1.AuthorizationPolicy_DENY:
 		action = security.Action_DENY
-		boilerplate = httpDenyRuleBoilerplate
 	default:
 		return nil, &model.StatusMessage{
 			Reason:  "UnsupportedValue",
@@ -466,6 +465,17 @@ func convertAuthorizationPolicy(rootns string, obj *securityclient.Authorization
 	}
 	if len(rulesWithL7) > 0 {
 		// this is an accepted with warning condition
+		var boilerplate string
+		switch {
+		case action == security.Action_DENY && !hasEffectiveRules(opol.Groups):
+			// After omitting L7 fields, no group can match (empty matches are
+			// skipped by ztunnel), so the DENY is a no-op.
+			boilerplate = httpDenyNoEffectBoilerplate
+		case action == security.Action_DENY:
+			boilerplate = httpDenyMixedBoilerplate
+		default:
+			boilerplate = httpAllowRuleBoilerplate
+		}
 
 		warnings := slices.Join(", ", sets.SortedList(rulesWithL7)...)
 
@@ -482,7 +492,9 @@ const (
 	httpRuleFmt string = "ztunnel does not support HTTP attributes (found: %s). " +
 		"In ambient mode you must use a waypoint proxy to enforce HTTP rules. %s"
 
-	httpDenyRuleBoilerplate string = "DENY policy with HTTP attributes is enforced without the HTTP rules. " +
+	httpDenyNoEffectBoilerplate string = "After omitting unsupported HTTP attributes, this DENY policy has no enforceable rules at ztunnel and will have no effect. " +
+		"Deploy a waypoint proxy and use a targetRef to enforce this policy."
+	httpDenyMixedBoilerplate string = "DENY policy with HTTP attributes is enforced without the HTTP rules. " +
 		"This will be more restrictive than requested."
 	httpAllowRuleBoilerplate string = "Within an ALLOW policy, rules matching HTTP attributes are omitted. " +
 		"This will be more restrictive than requested."
@@ -528,6 +540,45 @@ func httpSources(s *v1beta1.Source) []string {
 	}
 
 	return foundUnsupportedSources
+}
+
+// isMatchEmpty reports whether a Match has no fields populated.
+// An empty match sent to ztunnel is skipped (match-none), not match-all.
+func isMatchEmpty(m *security.Match) bool {
+	return m == nil || protoconv.Equals(m, &security.Match{})
+}
+
+// hasEffectiveRules reports whether the policy has at least one group that will
+// fire at ztunnel. Groups with only empty matches are skipped by ztunnel and
+// will never trigger.
+func hasEffectiveRules(groups []*security.Group) bool {
+	for _, g := range groups {
+		if g == nil {
+			continue
+		}
+		// Empty Authz rule → Group with no clauses → match-all at ztunnel.
+		if len(g.Rules) == 0 {
+			return true
+		}
+		groupEffective := true
+		for _, clause := range g.Rules {
+			hasNonEmpty := false
+			for _, m := range clause.GetMatches() {
+				if !isMatchEmpty(m) {
+					hasNonEmpty = true
+					break
+				}
+			}
+			if !hasNonEmpty {
+				groupEffective = false
+				break
+			}
+		}
+		if groupEffective {
+			return true
+		}
+	}
+	return false
 }
 
 func handleRule(action security.Action, rule *v1beta1.Rule, ruleNamespace string) ([]*security.Rules, []string) {
@@ -598,7 +649,7 @@ func handleRule(action security.Action, rule *v1beta1.Rule, ruleNamespace string
 	}
 	if action == security.Action_ALLOW && l7RuleFound {
 		// L7 policies never match for ALLOW
-		// For DENY they will always match, so it is more restrictive
+		// For DENY, empty matches are still emitted; ztunnel skips them (no-op).
 		rules = nil
 	}
 	// we will sort later, don't spend effort sorting now

--- a/pilot/pkg/serviceregistry/ambient/authorization.go
+++ b/pilot/pkg/serviceregistry/ambient/authorization.go
@@ -492,8 +492,8 @@ const (
 	httpRuleFmt string = "ztunnel does not support HTTP attributes (found: %s). " +
 		"In ambient mode you must use a waypoint proxy to enforce HTTP rules. %s"
 
-	httpDenyNoEffectBoilerplate string = "After omitting unsupported HTTP attributes, this DENY policy has no enforceable rules at ztunnel and will have no effect. " +
-		"Deploy a waypoint proxy and use a targetRef to enforce this policy."
+	httpDenyNoEffectBoilerplate string = "After omitting unsupported HTTP attributes, this DENY policy has no enforceable rules at ztunnel " +
+		"and will have no effect. Deploy a waypoint proxy and use a targetRef to enforce this policy."
 	httpDenyMixedBoilerplate string = "DENY policy with HTTP attributes is enforced without the HTTP rules. " +
 		"This will be more restrictive than requested."
 	httpAllowRuleBoilerplate string = "Within an ALLOW policy, rules matching HTTP attributes are omitted. " +

--- a/pilot/pkg/serviceregistry/ambient/authorization_test.go
+++ b/pilot/pkg/serviceregistry/ambient/authorization_test.go
@@ -51,9 +51,11 @@ const (
 
 func TestConvertAuthorizationPolicyStatus(t *testing.T) {
 	testCases := []struct {
-		name                string
-		inputAuthzPol       *securityclient.AuthorizationPolicy
-		expectStatusMessage *model.StatusMessage
+		name                 string
+		inputAuthzPol        *securityclient.AuthorizationPolicy
+		expectStatusMessage  *model.StatusMessage
+		checkEffectiveRules  bool
+		expectEffectiveRules bool
 	}{
 		{
 			name: "no status - targetRef is not for ztunnel",
@@ -208,12 +210,248 @@ func TestConvertAuthorizationPolicyStatus(t *testing.T) {
 					"This will be more restrictive than requested.",
 			},
 		},
+		{
+			name: "DENY policy with only L4 attributes - no status warning",
+			inputAuthzPol: &securityclient.AuthorizationPolicy{
+				Spec: v1beta1.AuthorizationPolicy{
+					Action: v1beta1.AuthorizationPolicy_DENY,
+					Rules: []*v1beta1.Rule{
+						{
+							From: []*v1beta1.Rule_From{
+								{
+									Source: &v1beta1.Source{
+										Principals: []string{
+											"cluster.local/ns/foo/sa/bar",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectStatusMessage: nil,
+		},
+		{
+			name: "DENY policy with only L7 attributes results in no effect at ztunnel",
+			inputAuthzPol: &securityclient.AuthorizationPolicy{
+				Spec: v1beta1.AuthorizationPolicy{
+					Action: v1beta1.AuthorizationPolicy_DENY,
+					Rules: []*v1beta1.Rule{
+						{
+							From: []*v1beta1.Rule_From{
+								{
+									Source: &v1beta1.Source{
+										NotRequestPrincipals: []string{
+											"example.com/sub-1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectStatusMessage: &model.StatusMessage{
+				Reason: "UnsupportedValue",
+				Message: "ztunnel does not support HTTP attributes (found: notRequestPrincipals). " +
+					"In ambient mode you must use a waypoint proxy to enforce HTTP rules. " +
+					"After omitting unsupported HTTP attributes, this DENY policy has no enforceable rules at ztunnel and will have no effect. " +
+					"Deploy a waypoint proxy and use a targetRef to enforce this policy.",
+			},
+			checkEffectiveRules:  true,
+			expectEffectiveRules: false,
+		},
+		{
+			name: "DENY policy with mixed L4 and L7 attributes is enforced without HTTP rules",
+			inputAuthzPol: &securityclient.AuthorizationPolicy{
+				Spec: v1beta1.AuthorizationPolicy{
+					Action: v1beta1.AuthorizationPolicy_DENY,
+					Rules: []*v1beta1.Rule{
+						{
+							From: []*v1beta1.Rule_From{
+								{
+									Source: &v1beta1.Source{
+										Principals: []string{
+											"cluster.local/ns/foo/sa/bar",
+										},
+										NotRequestPrincipals: []string{
+											"example.com/sub-1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectStatusMessage: &model.StatusMessage{
+				Reason: "UnsupportedValue",
+				Message: "ztunnel does not support HTTP attributes (found: notRequestPrincipals). " +
+					"In ambient mode you must use a waypoint proxy to enforce HTTP rules. " +
+					"DENY policy with HTTP attributes is enforced without the HTTP rules. " +
+					"This will be more restrictive than requested.",
+			},
+			checkEffectiveRules:  true,
+			expectEffectiveRules: true,
+		},
+		{
+			name: "DENY policy with L7-only and separate L4 rule is still enforced",
+			inputAuthzPol: &securityclient.AuthorizationPolicy{
+				Spec: v1beta1.AuthorizationPolicy{
+					Action: v1beta1.AuthorizationPolicy_DENY,
+					Rules: []*v1beta1.Rule{
+						{
+							From: []*v1beta1.Rule_From{
+								{
+									Source: &v1beta1.Source{
+										NotRequestPrincipals: []string{
+											"example.com/sub-1",
+										},
+									},
+								},
+							},
+						},
+						{
+							From: []*v1beta1.Rule_From{
+								{
+									Source: &v1beta1.Source{
+										Principals: []string{
+											"cluster.local/ns/foo/sa/bar",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectStatusMessage: &model.StatusMessage{
+				Reason: "UnsupportedValue",
+				Message: "ztunnel does not support HTTP attributes (found: notRequestPrincipals). " +
+					"In ambient mode you must use a waypoint proxy to enforce HTTP rules. " +
+					"DENY policy with HTTP attributes is enforced without the HTTP rules. " +
+					"This will be more restrictive than requested.",
+			},
+			checkEffectiveRules:  true,
+			expectEffectiveRules: true,
+		},
+		{
+			name: "DENY policy with empty catch-all rule and L7-only rule is still enforced",
+			inputAuthzPol: &securityclient.AuthorizationPolicy{
+				Spec: v1beta1.AuthorizationPolicy{
+					Action: v1beta1.AuthorizationPolicy_DENY,
+					Rules: []*v1beta1.Rule{
+						{},
+						{
+							From: []*v1beta1.Rule_From{
+								{
+									Source: &v1beta1.Source{
+										NotRequestPrincipals: []string{
+											"example.com/sub-1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectStatusMessage: &model.StatusMessage{
+				Reason: "UnsupportedValue",
+				Message: "ztunnel does not support HTTP attributes (found: notRequestPrincipals). " +
+					"In ambient mode you must use a waypoint proxy to enforce HTTP rules. " +
+					"DENY policy with HTTP attributes is enforced without the HTTP rules. " +
+					"This will be more restrictive than requested.",
+			},
+			checkEffectiveRules:  true,
+			expectEffectiveRules: true,
+		},
+		{
+			name: "DENY policy with L4 From and L7 When is a no-op due to AND empty clause",
+			inputAuthzPol: &securityclient.AuthorizationPolicy{
+				Spec: v1beta1.AuthorizationPolicy{
+					Action: v1beta1.AuthorizationPolicy_DENY,
+					Rules: []*v1beta1.Rule{
+						{
+							From: []*v1beta1.Rule_From{
+								{
+									Source: &v1beta1.Source{
+										Principals: []string{
+											"cluster.local/ns/foo/sa/bar",
+										},
+									},
+								},
+							},
+							When: []*v1beta1.Condition{
+								{
+									Key:    "request.headers[x-token]",
+									Values: []string{"secret"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectStatusMessage: &model.StatusMessage{
+				Reason: "UnsupportedValue",
+				Message: "ztunnel does not support HTTP attributes (found: request.headers[x-token]). " +
+					"In ambient mode you must use a waypoint proxy to enforce HTTP rules. " +
+					"After omitting unsupported HTTP attributes, this DENY policy has no enforceable rules at ztunnel and will have no effect. " +
+					"Deploy a waypoint proxy and use a targetRef to enforce this policy.",
+			},
+			checkEffectiveRules:  true,
+			expectEffectiveRules: false,
+		},
+		{
+			name: "DENY policy with L4 From and L7-only To methods is a no-op due to AND empty clause",
+			inputAuthzPol: &securityclient.AuthorizationPolicy{
+				Spec: v1beta1.AuthorizationPolicy{
+					Action: v1beta1.AuthorizationPolicy_DENY,
+					Rules: []*v1beta1.Rule{
+						{
+							From: []*v1beta1.Rule_From{
+								{
+									Source: &v1beta1.Source{
+										Principals: []string{
+											"cluster.local/ns/foo/sa/bar",
+										},
+									},
+								},
+							},
+							To: []*v1beta1.Rule_To{
+								{
+									Operation: &v1beta1.Operation{
+										Methods: []string{"GET"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectStatusMessage: &model.StatusMessage{
+				Reason: "UnsupportedValue",
+				Message: "ztunnel does not support HTTP attributes (found: methods). " +
+					"In ambient mode you must use a waypoint proxy to enforce HTTP rules. " +
+					"After omitting unsupported HTTP attributes, this DENY policy has no enforceable rules at ztunnel and will have no effect. " +
+					"Deploy a waypoint proxy and use a targetRef to enforce this policy.",
+			},
+			checkEffectiveRules:  true,
+			expectEffectiveRules: false,
+		},
 	}
 
-	for _, test := range testCases {
-		t.Run(test.name, func(t *testing.T) {
-			_, outStatusMessage := convertAuthorizationPolicy(rootns, test.inputAuthzPol)
-			assert.Equal(t, test.expectStatusMessage, outStatusMessage)
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			outPol, outStatusMessage := convertAuthorizationPolicy(rootns, tt.inputAuthzPol)
+			assert.Equal(t, tt.expectStatusMessage, outStatusMessage)
+			if tt.checkEffectiveRules {
+				if outPol == nil {
+					t.Fatal("expected non-nil authorization policy when checking effective rules")
+				}
+				assert.Equal(t, tt.expectEffectiveRules, hasEffectiveRules(outPol.Groups))
+			}
 		})
 	}
 }

--- a/releasenotes/notes/61126.yaml
+++ b/releasenotes/notes/61126.yaml
@@ -1,0 +1,12 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+issue:
+  - 61126
+
+releaseNotes:
+  - |
+    **Fixed** an incorrect status message for DENY AuthorizationPolicies with
+    only HTTP attributes in ambient mode. These policies are not enforced by
+    ztunnel (empty matches are skipped), so the status now reports that they
+    have no effect and recommends deploying a waypoint proxy with a targetRef.


### PR DESCRIPTION
**Please provide a description of this PR:**
When a DENY AuthorizationPolicy only has L7 attributes (for example, notRequestPrincipals, HTTP methods, etc.), istiod reported the same status message as the mixed L4+L7 case: "DENY policy with HTTP attribute is enforced without the HTTP rules. This will be more restrictive than requested."

That message is wrong. A DENY with only L7 attributes produces empty match groups that ztunnel skips silently, making the policy a no-op and allowing traffic instead of denying it. The mixed case (L4+L7) is genuinely enforced (more restrictively), so it warrants a different message.

A new message and the condition check is going to be displayed when only L7 attributes are present in a DENY:

```
httpDenyNoEffectBoilerplate string = "After omitting unsupported HTTP attributes, this DENY policy has no enforceable rules at ztunnel and will have no effect. " +
		"Deploy a waypoint proxy and use a targetRef to enforce this policy."
```

Fixes #61126