### PR TITLE
CNI restore hostnet filter

### DIFF
--- a/cni/pkg/nodeagent/informers.go
+++ b/cni/pkg/nodeagent/informers.go
@@ -138,7 +138,7 @@ func (s *InformerHandlers) GetPodIfAmbientEnabled(podName, podNamespace string) 
 	if pod == nil {
 		return nil, fmt.Errorf("failed to find pod %v", ns)
 	}
-	if s.enablementSelector.Matches(pod.Labels, pod.Annotations, ns.Labels) {
+	if s.enablementSelector.Matches(pod, ns.Labels) {
 		return pod, nil
 	}
 	return nil, nil
@@ -289,7 +289,7 @@ func (s *InformerHandlers) reconcilePod(input any) error {
 		oldPod := event.Old.(*corev1.Pod)
 		isEnrolled := util.PodFullyEnrolled(currentPod)
 		isPartiallyEnrolled := util.PodPartiallyEnrolled(currentPod)
-		matchesSelector := s.enablementSelector.Matches(currentPod.Labels, currentPod.Annotations, ns.Labels)
+		matchesSelector := s.enablementSelector.Matches(currentPod, ns.Labels)
 		namespaceExcluded := s.isNamespaceExcluded(currentPod.Namespace)
 		shouldBeEnabled := matchesSelector && !namespaceExcluded
 		isTerminated := kube.CheckPodTerminal(currentPod)
@@ -401,7 +401,7 @@ func (s *InformerHandlers) reconcilePod(input any) error {
 		// pod information from the triggering event.
 		if util.PodFullyEnrolled(latestEventPod) ||
 			util.PodPartiallyEnrolled(latestEventPod) ||
-			s.enablementSelector.Matches(latestEventPod.Labels, latestEventPod.Annotations, ns.Labels) {
+			s.enablementSelector.Matches(latestEventPod, ns.Labels) {
 			log.Debugf("pod is deleted and was or should be captured, removing from ztunnel")
 			if err := s.dataplane.RemovePodFromMesh(s.ctx, latestEventPod, true); err != nil {
 				log.Warnf("Unable to send pod to ztunnel for removal. Will retry. RemovePodFrmMesh returned: %v", err)

--- a/cni/pkg/nodeagent/informers_test.go
+++ b/cni/pkg/nodeagent/informers_test.go
@@ -356,6 +356,53 @@ func TestInformerExistingPodNotAddedIfNoIPInAnyStatusField(t *testing.T) {
 	fs.AssertExpectations(t)
 }
 
+func TestInformerExistingHostNetworkPodNotAddedWhenNsLabeled(t *testing.T) {
+	setupLogging()
+	NodeName = "testnode"
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Host network pods have no netns of their own to capture, so they must never be
+	// enrolled, even in an ambient-labeled namespace. Note the pod has a valid IP:
+	// hostNetwork is the only thing keeping it out of the mesh.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: corev1.PodSpec{
+			NodeName:    NodeName,
+			HostNetwork: true,
+		},
+		Status: corev1.PodStatus{
+			PodIP: "11.1.1.12",
+		},
+	}
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
+
+	client := kube.NewFakeClient(ns, pod)
+
+	fs := &fakeServer{}
+
+	_, mt := populateClientAndWaitForInformer(ctx, t, client, fs, 2, 1)
+
+	// label the namespace
+	labelsPatch := []byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":"%s"}}}`,
+		label.IoIstioDataplaneMode.Name, constants.DataplaneModeAmbient))
+	_, err := client.Kube().CoreV1().Namespaces().Patch(ctx, ns.Name,
+		types.MergePatchType, labelsPatch, metav1.PatchOptions{})
+	assert.NoError(t, err)
+
+	// wait for all update events to settle
+	// total 3: 1. init ns reconcile 2. ns label reconcile 3. pod reconcile
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.Exactly(3))
+
+	assertPodNotAnnotated(t, client, pod)
+
+	// Assert no dataplane calls (e.g. AddPodToMesh) were made
+	fs.AssertExpectations(t)
+}
+
 func TestInformerExistingPodRemovedWhenNsUnlabeled(t *testing.T) {
 	setupLogging()
 	NodeName = "testnode"
@@ -984,6 +1031,48 @@ func TestInformerAmbientEnabledReturnsNoPodIfNotEnabled(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, disabledPod, nil)
+}
+
+func TestInformerAmbientEnabledReturnsNoPodIfHostNetwork(t *testing.T) {
+	setupLogging()
+	NodeName = "testnode"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// GetPodIfAmbientEnabled feeds the CNI-event enrollment path, whose netns
+	// resolution can fall back to guessing via /proc scans. Host network pods must be
+	// rejected here so that fallback is never entered for them.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+			UID:       "1234",
+		},
+		Spec: corev1.PodSpec{
+			NodeName:    NodeName,
+			HostNetwork: true,
+		},
+		Status: corev1.PodStatus{
+			PodIP: "11.1.1.12",
+		},
+	}
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test",
+			Labels: map[string]string{label.IoIstioDataplaneMode.Name: constants.DataplaneModeAmbient},
+		},
+	}
+
+	client := kube.NewFakeClient(ns, pod)
+	fs := &fakeServer{}
+
+	handlers, _ := populateClientAndWaitForInformer(ctx, t, client, fs, 2, 1)
+
+	hostNetworkPod, err := handlers.GetPodIfAmbientEnabled(pod.Name, ns.Name)
+
+	assert.NoError(t, err)
+	assert.Equal(t, hostNetworkPod, nil)
 }
 
 func TestInformerAmbientEnabledReturnsErrorIfBogusNS(t *testing.T) {

--- a/cni/pkg/plugin/plugin.go
+++ b/cni/pkg/plugin/plugin.go
@@ -431,7 +431,7 @@ func isAmbientPod(client kubernetes.Interface, podName, podNamespace string, sel
 		return false, fmt.Errorf("failed to get pod or namespace info: podErr=%v, nsErr=%v", podErr, nsErr)
 	}
 
-	return compiledSelectors.Matches(pod.Labels, pod.Annotations, ns.Labels), nil
+	return compiledSelectors.Matches(pod, ns.Labels), nil
 }
 
 // isCNIPod reports whether the CNI args look like our own istio-cni node agent pod.

--- a/cni/pkg/util/enablement_selector.go
+++ b/cni/pkg/util/enablement_selector.go
@@ -17,6 +17,7 @@ package util
 import (
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
@@ -73,12 +74,19 @@ func NewCompiledEnablementSelectors(selectors []EnablementSelector) (*CompiledEn
 	}, nil
 }
 
-func (c *CompiledEnablementSelectors) Matches(podLabels, podAnnotations, namespaceLabels map[string]string) bool {
-	if podHasSidecar(podAnnotations) {
+// Matches reports whether the pod should be enrolled into ambient. Host-network pods
+// can never be captured (we cannot insert redirection rules into a netns they do not own),
+// so they are always excluded regardless of labels; otherwise the configured enablement
+// selectors decide.
+func (c *CompiledEnablementSelectors) Matches(pod *corev1.Pod, namespaceLabels map[string]string) bool {
+	if pod.Spec.HostNetwork {
+		return false
+	}
+	if podHasSidecar(pod.Annotations) {
 		// Ztunnel and sidecar for a single pod is currently not supported; opt out.
 		return false
 	}
-	podls := labels.Set(podLabels)
+	podls := labels.Set(pod.Labels)
 	namespacels := labels.Set(namespaceLabels)
 	for i, podSelector := range c.podSelectors {
 		if podSelector.Matches(podls) && c.namespaceSelectors[i].Matches(namespacels) {

--- a/cni/pkg/util/podutil.go
+++ b/cni/pkg/util/podutil.go
@@ -66,7 +66,7 @@ func SplitExcludeNamespaces(s string) []string {
 //
 // That is, have we annotated it after successfully setting up iptables rules AND sending it to a node proxy instance.
 //
-// If you just want to know if the pod _should be_ configured for traffic redirection, see PodRedirectionEnabled
+// If you just want to know if the pod _should be_ configured for traffic redirection, see CompiledEnablementSelectors.Matches
 func PodFullyEnrolled(pod *corev1.Pod) bool {
 	if pod != nil {
 		return pod.GetAnnotations()[annotation.AmbientRedirection.Name] == constants.AmbientRedirectionEnabled
@@ -82,7 +82,7 @@ func PodFullyEnrolled(pod *corev1.Pod) bool {
 //
 // Pods like this still need to undergo the removal process (to potentially undo the redirection).
 //
-// If you just want to know if the pod _should be_ configured for traffic redirection, see PodRedirectionEnabled
+// If you just want to know if the pod _should be_ configured for traffic redirection, see CompiledEnablementSelectors.Matches
 func PodPartiallyEnrolled(pod *corev1.Pod) bool {
 	if pod != nil {
 		return pod.GetAnnotations()[annotation.AmbientRedirection.Name] == constants.AmbientRedirectionPending

--- a/cni/pkg/util/podutil_test.go
+++ b/cni/pkg/util/podutil_test.go
@@ -242,7 +242,7 @@ func TestPodRedirectionEnabled(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := defaultAmbientSelector.Matches(tt.args.pod.Labels, tt.args.pod.Annotations, tt.args.namespace.Labels); got != tt.want {
+			if got := defaultAmbientSelector.Matches(tt.args.pod, tt.args.namespace.Labels); got != tt.want {
 				t.Errorf("PodRedirectionEnabled() = %v, want %v", got, tt.want)
 			}
 		})

--- a/cni/pkg/util/podutil_test.go
+++ b/cni/pkg/util/podutil_test.go
@@ -114,7 +114,7 @@ func TestGetPodIPsIfNoPodIPPresent(t *testing.T) {
 	assert.Equal(t, len(podIPs), 0)
 }
 
-func TestPodRedirectionEnabled(t *testing.T) {
+func TestEnablementSelectorMatches(t *testing.T) {
 	var (
 		ambientEnabledLabel     = map[string]string{label.IoIstioDataplaneMode.Name: constants.DataplaneModeAmbient}
 		ambientDisabledLabel    = map[string]string{label.IoIstioDataplaneMode.Name: constants.DataplaneModeNone}
@@ -280,7 +280,7 @@ func TestPodRedirectionEnabled(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := defaultAmbientSelector.Matches(tt.args.pod, tt.args.namespace.Labels); got != tt.want {
-				t.Errorf("PodRedirectionEnabled() = %v, want %v", got, tt.want)
+				t.Errorf("Matches() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/cni/pkg/util/podutil_test.go
+++ b/cni/pkg/util/podutil_test.go
@@ -172,6 +172,27 @@ func TestPodRedirectionEnabled(t *testing.T) {
 				Annotations: sidecarStatusAnnotation,
 			},
 		}
+
+		hostNetworkPod = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test",
+			},
+			Spec: corev1.PodSpec{
+				HostNetwork: true,
+			},
+		}
+
+		hostNetworkPodWithAmbientEnabledLabel = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test",
+				Labels:    ambientEnabledLabel,
+			},
+			Spec: corev1.PodSpec{
+				HostNetwork: true,
+			},
+		}
 	)
 
 	type args struct {
@@ -236,6 +257,22 @@ func TestPodRedirectionEnabled(t *testing.T) {
 			args: args{
 				namespace: unlabelledNamespace,
 				pod:       podWithSidecarAndAmbientEnabledLabel,
+			},
+			want: false,
+		},
+		{
+			name: "hostNetwork pod in ambient-enabled namespace",
+			args: args{
+				namespace: namespaceWithAmbientEnabledLabel,
+				pod:       hostNetworkPod,
+			},
+			want: false,
+		},
+		{
+			name: "hostNetwork pod with ambient mode label",
+			args: args{
+				namespace: unlabelledNamespace,
+				pod:       hostNetworkPodWithAmbientEnabledLabel,
 			},
 			want: false,
 		},

--- a/releasenotes/notes/61168.yaml
+++ b/releasenotes/notes/61168.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 61168
+releaseNotes:
+  - |
+    **Fixed** an issue where `istio-cni` considered `hostNetwork` pods eligible for ambient
+    enrollment.


### PR DESCRIPTION
**Please provide a description of this PR:**

When introducing the ability to customize ambient enablement labels, #56048 removed a filter which prevented enrolling pods which have `hostNetwork: true`. This PR adds a filter for hostNetwork pods, without otherwise altering the custom enablement selection.