### PR TITLE
add authority to external SDS provider

### DIFF
--- a/pilot/pkg/security/model/authentication.go
+++ b/pilot/pkg/security/model/authentication.go
@@ -91,18 +91,18 @@ func ConstructSdsSecretConfigForCredential(name string, credentialSocketExist bo
 		if credentialSocketExist {
 			// Preserve full name (including sds:// prefix) for backward compatibility —
 			// existing UDS-based SDS agents expect the complete credentialName as the resource name.
-			return ConstructSdsSecretConfigForCredentialSocket(name, security.SDSExternalClusterName)
+			return ConstructSdsSecretConfigForCredentialSocket(name, security.SDSExternalClusterName, "")
 		}
 		if push != nil {
 			for _, provider := range push.Mesh.ExtensionProviders {
 				if provider.GetSds() != nil {
-					_, cluster, err := model.LookupCluster(push, provider.GetSds().Service, int(provider.GetSds().Port))
+					hostName, cluster, err := model.LookupCluster(push, provider.GetSds().Service, int(provider.GetSds().Port))
 					if err != nil {
 						model.IncLookupClusterFailures("externalSds")
 						log.Errorf("could not find cluster for external sds provider %q: %v", provider.GetSds(), err)
 						return nil
 					}
-					return ConstructSdsSecretConfigForCredentialSocket(resourceName, cluster)
+					return ConstructSdsSecretConfigForCredentialSocket(resourceName, cluster, hostName)
 				}
 			}
 		}
@@ -117,7 +117,7 @@ func ConstructSdsSecretConfigForCredential(name string, credentialSocketExist bo
 }
 
 // ConstructSdsSecretConfigForCredentialSocket constructs SDS Secret Configuration based on CredentialNameSocketPath
-func ConstructSdsSecretConfigForCredentialSocket(name string, clusterName string) *tls.SdsSecretConfig {
+func ConstructSdsSecretConfigForCredentialSocket(name string, clusterName string, hostName string) *tls.SdsSecretConfig {
 	return &tls.SdsSecretConfig{
 		Name: name,
 		SdsConfig: &core.ConfigSource{
@@ -129,7 +129,10 @@ func ConstructSdsSecretConfigForCredentialSocket(name string, clusterName string
 					GrpcServices: []*core.GrpcService{
 						{
 							TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
-								EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: clusterName},
+								EnvoyGrpc: &core.GrpcService_EnvoyGrpc{
+									ClusterName: clusterName,
+									Authority:   hostName,
+								},
 							},
 						},
 					},

--- a/pilot/pkg/security/model/authentication_test.go
+++ b/pilot/pkg/security/model/authentication_test.go
@@ -793,7 +793,10 @@ func TestConstructSdsSecretConfigForCredential(t *testing.T) {
 							GrpcServices: []*core.GrpcService{
 								{
 									TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
-										EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: "outbound|8080||sds-provider-service"},
+										EnvoyGrpc: &core.GrpcService_EnvoyGrpc{
+											ClusterName: "outbound|8080||sds-provider-service",
+											Authority:   "sds-provider-service",
+										},
 									},
 								},
 							},

--- a/releasenotes/notes/external-sds-authority.yaml
+++ b/releasenotes/notes/external-sds-authority.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+releaseNotes:
+- |
+  **Fixed** external SDS providers configured through `extensionProviders` to use the configured service hostname
+  as the gRPC authority.


### PR DESCRIPTION
Without this the SDS request fails with invalid authority

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions