### PR TITLE
perf: use trie instead of map for HostnameAndNamespace cache

### DIFF
--- a/pilot/pkg/config/kube/gatewaycommon/context.go
+++ b/pilot/pkg/config/kube/gatewaycommon/context.go
@@ -80,10 +80,11 @@ func (gc GatewayContext) ResolveGatewayInstances(
 	foundUnusable := false
 	log.Debugf("Resolving gateway instances for %v in namespace %s", gwsvcs, namespace)
 	for _, g := range gwsvcs {
-		svc, f := gc.ps.ServiceIndex.HostnameAndNamespace[host.Name(g)][namespace]
+		byNamespace := gc.ps.ServicesByHostname(host.Name(g))
+		svc, f := byNamespace[namespace]
 		if !f {
 			otherNamespaces := []string{}
-			for ns := range gc.ps.ServiceIndex.HostnameAndNamespace[host.Name(g)] {
+			for ns := range byNamespace {
 				otherNamespaces = append(otherNamespaces, `"`+ns+`"`) // Wrap in quotes for output
 			}
 			if len(otherNamespaces) > 0 {
@@ -160,7 +161,7 @@ func (gc GatewayContext) ResolveGatewayInstances(
 }
 
 func (gc GatewayContext) GetService(hostname, namespace string) *model.Service {
-	return gc.ps.ServiceIndex.HostnameAndNamespace[host.Name(hostname)][namespace]
+	return gc.ps.ServiceByHostnameAndNamespace(host.Name(hostname), namespace)
 }
 
 // InstancesEmpty returns true if there are no instances in any port.

--- a/pilot/pkg/model/hosttrie.go
+++ b/pilot/pkg/model/hosttrie.go
@@ -1,0 +1,206 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"strings"
+
+	"istio.io/istio/pilot/pkg/serviceregistry/provider"
+	"istio.io/istio/pkg/config/host"
+)
+
+// hostTrie resolves a Sidecar egress host ("namespace/dnsName") to its candidate services without scanning the
+// whole mesh. It is hostname-first: services are indexed by reversed DNS labels ("a.foo.com" under com -> foo ->
+// a) and each terminal node carries a byNamespace map, so the namespace is the leaf key rather than the top key.
+// This lets an exact FQDN resolve to a single node (also reachable in O(1) via byHostname), a leading-label
+// wildcard ("*.foo.com") resolve to the subtree at its suffix node, and the match-all "*" resolve to the whole
+// trie; the requested namespace (concrete or the wildcard "*") is applied at each node. Because the namespace
+// lives at the leaf, a service is stored exactly once (no per-namespace duplication) and a node keeps every
+// service terminating there, so unlike HostnameAndNamespace the candidate set is not lossy.
+type hostTrie struct {
+	root *hostTrieNode
+	// byHostname maps a full hostname to its terminal node for O(1) exact and enumerate-namespaces lookups,
+	// avoiding a label walk. The wildcard paths descend root.children instead.
+	byHostname map[host.Name]*hostTrieNode
+	// order records each service's index in the creation-time-sorted build slice so callers can restore that
+	// deterministic order after a map-based dedup (map iteration and collect() walk order are random).
+	order map[*Service]int
+}
+
+type hostTrieNode struct {
+	children map[string]*hostTrieNode
+	// byNamespace holds the services terminating at this hostname, keyed by their namespace.
+	byNamespace map[string][]*Service
+}
+
+// newHostTrie builds the trie over the primary hostnames of services, once per PushContext.
+// services must be creation-time sorted; their index in that slice is recorded in order.
+func newHostTrie(services []*Service) *hostTrie {
+	t := &hostTrie{
+		root:       &hostTrieNode{},
+		byHostname: make(map[host.Name]*hostTrieNode, len(services)),
+		order:      make(map[*Service]int, len(services)),
+	}
+	for i, svc := range services {
+		t.order[svc] = i
+		t.insert(svc)
+	}
+	return t
+}
+
+// insert walks the reversed DNS labels of svc's hostname, then files svc under its namespace at the terminal node.
+func (t *hostTrie) insert(svc *Service) {
+	node := t.root
+	labels := strings.Split(string(svc.Hostname), ".")
+	for i := len(labels) - 1; i >= 0; i-- {
+		child, ok := node.children[labels[i]]
+		if !ok {
+			if node.children == nil {
+				node.children = make(map[string]*hostTrieNode)
+			}
+			child = &hostTrieNode{}
+			node.children[labels[i]] = child
+		}
+		node = child
+	}
+	if node.byNamespace == nil {
+		node.byNamespace = make(map[string][]*Service)
+	}
+	ns := svc.Attributes.Namespace
+	node.byNamespace[ns] = append(node.byNamespace[ns], svc)
+	t.byHostname[svc.Hostname] = node
+}
+
+// servicesFor returns the unfiltered candidate services for "namespace/h"; callers reapply visibility. h is the
+// match-all "*" (whole trie), a leading-label wildcard "*.foo.com" (its suffix subtree), or an exact FQDN (the
+// services at that node). namespace is a concrete namespace or the wildcard "*" (all namespaces at each node).
+func (t *hostTrie) servicesFor(namespace string, h host.Name) []*Service {
+	if t == nil {
+		return nil
+	}
+	if h == wildcardService {
+		var out []*Service
+		t.root.collect(namespace, &out)
+		return out
+	}
+	if h.IsWildCarded() {
+		// Strip the leading "*." to obtain the suffix, e.g. "*.foo.com" -> "foo.com".
+		suffix := strings.TrimPrefix(strings.TrimPrefix(string(h), "*"), ".")
+		node := t.root.find(suffix)
+		if node == nil {
+			return nil
+		}
+		var out []*Service
+		node.collect(namespace, &out)
+		return out
+	}
+	node, ok := t.byHostname[h]
+	if !ok {
+		return nil
+	}
+	// Exact host in a concrete namespace: return the stored slice directly (no copy, no allocation).
+	if namespace != wildcardNamespace {
+		return node.byNamespace[namespace]
+	}
+	var out []*Service
+	node.appendServices(namespace, &out)
+	return out
+}
+
+// canonicalServiceFor returns the single service that owns the exact hostname h in namespace, or nil if none.
+// The trie retains every service terminating at a (hostname, namespace); this collapses them to the one canonical
+// service, matching what HostnameAndNamespace stores (see canonicalService for the precedence rule). Callers that
+// need every service (e.g. sidecar egress host selection) use servicesFor instead.
+func (t *hostTrie) canonicalServiceFor(namespace string, h host.Name) *Service {
+	if t == nil {
+		return nil
+	}
+	node, ok := t.byHostname[h]
+	if !ok {
+		return nil
+	}
+	return canonicalService(node.byNamespace[namespace])
+}
+
+// canonicalServicesByNamespace returns the canonical service (see canonicalService) for the exact hostname h in
+// each namespace where it exists, mirroring HostnameAndNamespace[h]. It returns nil when h is absent.
+func (t *hostTrie) canonicalServicesByNamespace(h host.Name) map[string]*Service {
+	if t == nil {
+		return nil
+	}
+	node, ok := t.byHostname[h]
+	if !ok {
+		return nil
+	}
+	out := make(map[string]*Service, len(node.byNamespace))
+	for ns, svcs := range node.byNamespace {
+		if svc := canonicalService(svcs); svc != nil {
+			out[ns] = svc
+		}
+	}
+	return out
+}
+
+// canonicalService picks the one service that owns a (hostname, namespace) from all services terminating there,
+// reproducing the precedence PushContext.initServiceRegistry applies when populating HostnameAndNamespace: the
+// oldest service wins, except a Kubernetes service takes precedence over a non-Kubernetes one (to prevent domain
+// squatting on a hostname before a Kubernetes Service is created). services is in creation-time (build) order.
+func canonicalService(services []*Service) *Service {
+	var canonical *Service
+	for _, s := range services {
+		if canonical == nil ||
+			(canonical.Attributes.ServiceRegistry != provider.Kubernetes && s.Attributes.ServiceRegistry == provider.Kubernetes) {
+			canonical = s
+		}
+	}
+	return canonical
+}
+
+// find walks the reversed labels of name from this node and returns the terminal node, or nil if absent. An
+// empty name returns the receiver (whose subtree is every service under it).
+func (n *hostTrieNode) find(name string) *hostTrieNode {
+	if name == "" {
+		return n
+	}
+	node := n
+	labels := strings.Split(name, ".")
+	for i := len(labels) - 1; i >= 0; i-- {
+		child, ok := node.children[labels[i]]
+		if !ok {
+			return nil
+		}
+		node = child
+	}
+	return node
+}
+
+// collect appends the services at this node and all of its descendants that match namespace to out.
+func (n *hostTrieNode) collect(namespace string, out *[]*Service) {
+	n.appendServices(namespace, out)
+	for _, child := range n.children {
+		child.collect(namespace, out)
+	}
+}
+
+// appendServices appends this node's services for namespace (or all namespaces when namespace is the wildcard).
+func (n *hostTrieNode) appendServices(namespace string, out *[]*Service) {
+	if namespace == wildcardNamespace {
+		for _, svcs := range n.byNamespace {
+			*out = append(*out, svcs...)
+		}
+		return
+	}
+	*out = append(*out, n.byNamespace[namespace]...)
+}

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -71,8 +71,20 @@ type serviceIndex struct {
 	// by an exportTo explicitly specifying this namespace or because they are private to the namespace.
 	exportedToNamespace map[string][]*Service
 
-	// HostnameAndNamespace has all services, indexed by hostname then namespace.
+	// HostnameAndNamespace has all services, indexed by hostname then namespace, keeping one canonical service
+	// per (hostname, namespace).
+	//
+	// TODO: delete this map once the hostTrie has been proven out by BenchmarkSelectServices* and the trie-backed
+	// accessors (ServiceByHostnameAndNamespace/ServicesByHostname) have replaced it everywhere. Production always
+	// builds the trie from the same services (initServiceRegistry), so the map is only read by tests that populate
+	// it directly and never build the trie; removing it means migrating those tests to build the trie and dropping
+	// the servicesForExactHostsMap comparison in BenchmarkSelectServicesExact.
 	HostnameAndNamespace map[host.Name]map[string]*Service `json:"-"`
+
+	// hostTrie indexes all services by reversed DNS labels then namespace, retaining every service per
+	// (hostname, namespace). It resolves Sidecar egress hosts (exact and wildcard) without a full-mesh scan and
+	// backs the canonical-service accessors.
+	hostTrie *hostTrie
 
 	// instancesByPort contains a map of service key and instances by port. It is stored here
 	// to avoid recomputations during push. This caches instanceByPort calls with empty labels.
@@ -1070,12 +1082,39 @@ func (ps *PushContext) ServiceForHostname(proxy *Proxy, hostname host.Name) *Ser
 
 	// SidecarScope shouldn't be null here. If it is, we can't disambiguate the hostname to use for a namespace,
 	// so the selection must be undefined.
-	for _, service := range ps.ServiceIndex.HostnameAndNamespace[hostname] {
+	for _, service := range ps.ServicesByHostname(hostname) {
 		return service
 	}
 
 	// No service found
 	return nil
+}
+
+// ServiceByHostnameAndNamespace returns the single canonical service for the exact hostname in namespace, or nil
+// if none exists. This is the trie-backed replacement for the ServiceIndex.HostnameAndNamespace[hostname][namespace]
+// lookup and returns the same service (see canonicalService for the precedence rule). Sidecar egress host
+// selection, which needs every matching service rather than the canonical one, uses servicesImportedToNamespace.
+func (ps *PushContext) ServiceByHostnameAndNamespace(hostname host.Name, namespace string) *Service {
+	if trie := ps.ServiceIndex.hostTrie; trie != nil {
+		if svc := trie.canonicalServiceFor(namespace, hostname); svc != nil {
+			return svc
+		}
+	}
+	// TODO: drop this fallback with HostnameAndNamespace. Production builds the trie from the same services as the
+	// map, so the fallback is only reached by tests that populate HostnameAndNamespace directly (bypassing the trie).
+	return ps.ServiceIndex.HostnameAndNamespace[hostname][namespace]
+}
+
+// ServicesByHostname returns the canonical service for the exact hostname in each namespace where it exists,
+// mirroring ServiceIndex.HostnameAndNamespace[hostname]. The returned map is freshly allocated and safe to read.
+func (ps *PushContext) ServicesByHostname(hostname host.Name) map[string]*Service {
+	if trie := ps.ServiceIndex.hostTrie; trie != nil {
+		if svcs := trie.canonicalServicesByNamespace(hostname); len(svcs) > 0 {
+			return svcs
+		}
+	}
+	// TODO: drop this fallback with HostnameAndNamespace (see ServiceByHostnameAndNamespace).
+	return ps.ServiceIndex.HostnameAndNamespace[hostname]
 }
 
 // serviceExportTo returns the effective exportTo set for a service: the declared exportTo (or the
@@ -1582,6 +1621,8 @@ func (ps *PushContext) initServiceRegistry(env *Environment, configsUpdate sets.
 		}
 		ps.addServiceAccounts(s, accounts)
 
+		// TODO: this HostnameAndNamespace bookkeeping is now redundant with the hostTrie built below (the trie's
+		// canonicalService applies the same precedence); remove it once the trie is proven out (see the field doc).
 		hostMap, f := ps.ServiceIndex.HostnameAndNamespace[s.Hostname]
 		if !f {
 			hostMap = map[string]*Service{}
@@ -1635,6 +1676,9 @@ func (ps *PushContext) initServiceRegistry(env *Environment, configsUpdate sets.
 			ps.ServiceIndex.exportedToNamespace[key] = append(exportedServices, s)
 		}
 	}
+
+	// Build the (namespace, reversed-label) trie over all services for wildcard egress host resolution.
+	ps.ServiceIndex.hostTrie = newHostTrie(allServices)
 }
 
 func (ps *PushContext) addServiceAccounts(s *Service, accounts sets.String) {
@@ -2183,8 +2227,8 @@ func (ps *PushContext) TrafficExtensions(proxy *Proxy) map[extensions.TrafficExt
 		servicesInfo := ps.ServicesForWaypoint(WaypointKeyForProxy(proxy))
 		for _, si := range servicesInfo {
 			s := si.Service
-			svc, exist := ps.ServiceIndex.HostnameAndNamespace[host.Name(s.Hostname)][s.Namespace]
-			if !exist {
+			svc := ps.ServiceByHostnameAndNamespace(host.Name(s.Hostname), s.Namespace)
+			if svc == nil {
 				log.Warnf("cannot find waypoint service in serviceindex, namespace/hostname: %s/%s", s.Namespace, s.Hostname)
 				continue
 			}

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1621,26 +1621,6 @@ func (ps *PushContext) initServiceRegistry(env *Environment, configsUpdate sets.
 		}
 		ps.addServiceAccounts(s, accounts)
 
-		// TODO: this HostnameAndNamespace bookkeeping is now redundant with the hostTrie built below (the trie's
-		// canonicalService applies the same precedence); remove it once the trie is proven out (see the field doc).
-		hostMap, f := ps.ServiceIndex.HostnameAndNamespace[s.Hostname]
-		if !f {
-			hostMap = map[string]*Service{}
-			ps.ServiceIndex.HostnameAndNamespace[s.Hostname] = hostMap
-		}
-		// In some scenarios, there may be multiple Services defined for the same hostname due to ServiceEntry allowing
-		// arbitrary hostnames. In these cases, we want to pick the first Service, which is the oldest. This ensures
-		// newly created Services cannot take ownership unexpectedly.
-		// However, the Service is from Kubernetes it should take precedence over ones not. This prevents someone from
-		// "domain squatting" on the hostname before a Kubernetes Service is created.
-		if existing := hostMap[s.Attributes.Namespace]; existing != nil &&
-			!(existing.Attributes.ServiceRegistry != provider.Kubernetes && s.Attributes.ServiceRegistry == provider.Kubernetes) {
-			log.Debugf("Service %s/%s from registry %s ignored by %s/%s/%s", s.Attributes.Namespace, s.Hostname, s.Attributes.ServiceRegistry,
-				existing.Attributes.ServiceRegistry, existing.Attributes.Namespace, existing.Hostname)
-		} else {
-			hostMap[s.Attributes.Namespace] = s
-		}
-
 		ns := s.Attributes.Namespace
 		exportToSet := ps.serviceExportTo(s)
 
@@ -1677,8 +1657,36 @@ func (ps *PushContext) initServiceRegistry(env *Environment, configsUpdate sets.
 		}
 	}
 
-	// Build the (namespace, reversed-label) trie over all services for wildcard egress host resolution.
+	// Build the hostname indexes over all services: the legacy HostnameAndNamespace map (one canonical service per
+	// (hostname, namespace)) and the reversed-label trie used for wildcard egress host resolution.
+	ps.ServiceIndex.HostnameAndNamespace = buildHostnameAndNamespaceIndex(allServices)
 	ps.ServiceIndex.hostTrie = newHostTrie(allServices)
+}
+
+// buildHostnameAndNamespaceIndex indexes services by hostname then namespace, keeping one canonical service per
+// (hostname, namespace). services must be creation-time sorted; precedence matches canonicalService (oldest wins,
+// except a Kubernetes service beats a non-Kubernetes one to prevent domain squatting before a Kubernetes Service
+// exists).
+//
+// TODO: delete this together with the HostnameAndNamespace map once the hostTrie is proven out. newHostTrie indexes
+// the same services and canonicalService applies identical precedence, so this map is redundant.
+func buildHostnameAndNamespaceIndex(services []*Service) map[host.Name]map[string]*Service {
+	index := make(map[host.Name]map[string]*Service, len(services))
+	for _, s := range services {
+		hostMap, f := index[s.Hostname]
+		if !f {
+			hostMap = map[string]*Service{}
+			index[s.Hostname] = hostMap
+		}
+		if existing := hostMap[s.Attributes.Namespace]; existing != nil &&
+			!(existing.Attributes.ServiceRegistry != provider.Kubernetes && s.Attributes.ServiceRegistry == provider.Kubernetes) {
+			log.Debugf("Service %s/%s from registry %s ignored by %s/%s/%s", s.Attributes.Namespace, s.Hostname, s.Attributes.ServiceRegistry,
+				existing.Attributes.ServiceRegistry, existing.Attributes.Namespace, existing.Hostname)
+			continue
+		}
+		hostMap[s.Attributes.Namespace] = s
+	}
+	return index
 }
 
 func (ps *PushContext) addServiceAccounts(s *Service, accounts sets.String) {

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -2351,7 +2351,7 @@ func TestInitPushContext(t *testing.T) {
 		cmp.AllowUnexported(PushContext{}, exportToDefaults{}, serviceIndex{}, virtualServiceIndex{},
 			destinationRuleIndex{}, gatewayIndex{}, consolidatedDestRules{}, IstioEgressListenerWrapper{}, SidecarScope{},
 			AuthenticationPolicies{}, NetworkManager{}, sidecarIndex{}, Telemetries{}, ProxyConfigs{}, ConsolidatedDestRule{},
-			ClusterLocalHosts{}),
+			ClusterLocalHosts{}, hostTrie{}, hostTrieNode{}),
 		// These are not feasible/worth comparing
 		cmpopts.IgnoreTypes(sync.RWMutex{}, localServiceDiscovery{}, FakeStore{}, atomic.Bool{}, sync.Mutex{}, func() {}),
 		cmpopts.IgnoreUnexported(IstioEndpoint{}),

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -393,7 +393,7 @@ func (sc *SidecarScope) collectImportedServices(ps *PushContext, configNamespace
 			}.HashCode())
 			v := vs.Spec.(*networking.VirtualService)
 			for h, ports := range virtualServiceDestinationsFilteredBySourceNamespace(v, configNamespace) {
-				byNamespace := ps.ServiceIndex.HostnameAndNamespace[host.Name(h)]
+				byNamespace := ps.ServicesByHostname(host.Name(h))
 				// Default to this hostname in our config namespace
 				if s, ok := byNamespace[configNamespace]; ok {
 					// This won't overwrite hostnames that have already been found eg because they were requested in hosts
@@ -495,8 +495,8 @@ func convertIstioListenerToWrapper(ps *PushContext, configNamespace string,
 	}
 
 	hostsByNamespace := make(map[string]hostClassification)
+	includesAllMesh := false
 
-	allExactHosts := true
 	for _, h := range istioListener.Hosts {
 		if strings.Count(h, "/") != 1 {
 			log.Errorf("Illegal host in sidecar resource: %s, host must be of form namespace/dnsName", h)
@@ -530,11 +530,10 @@ func convertIstioListenerToWrapper(ps *PushContext, configNamespace string,
 		// exact hosts are saved separately for map lookup
 		if !hName.IsWildCarded() {
 			hc.exactHosts.Insert(hName)
-		} else {
-			allExactHosts = false
 		}
-		if ns == wildcardNamespace {
-			allExactHosts = false
+
+		if ns == wildcardNamespace && hName == wildcardService {
+			includesAllMesh = true
 		}
 
 		// allHosts contains the exact hosts and wildcard hosts,
@@ -544,45 +543,116 @@ func convertIstioListenerToWrapper(ps *PushContext, configNamespace string,
 	}
 
 	out.virtualServices = SelectVirtualServices(ps.virtualServiceIndex, configNamespace, hostsByNamespace)
-	var svces []*Service
-	if allExactHosts {
-		svces = ps.servicesForExactHosts(configNamespace, hostsByNamespace)
-	} else {
-		svces = ps.servicesExportedToNamespace(configNamespace)
-	}
+	svces := ps.servicesImportedToNamespace(configNamespace, hostsByNamespace, includesAllMesh)
 	out.services = out.selectServices(svces, configNamespace, hostsByNamespace)
 	out.mostSpecificWildcardVsIndex = computeWildcardHostVirtualServiceIndex(out.virtualServices, out.services)
 
 	return out
 }
 
-// servicesForExactHosts resolves the candidate services for an egress listener whose hosts are all exact
-// (non-wildcard) and explicitly namespaced, via direct lookups in ps.ServiceIndex.HostnameAndNamespace instead
-// of scanning every service visible to configNamespace. It is a fast-path replacement for
-// servicesExportedToNamespace; the returned list is fed to selectServices, exactly like the scan-based path.
-func (ps *PushContext) servicesForExactHosts(configNamespace string,
-	hostsByNamespace map[string]hostClassification,
-) []*Service {
-	var candidates []*Service
-	for ns, hc := range hostsByNamespace {
-		for hName := range hc.exactHosts {
-			byNamespace, ok := ps.ServiceIndex.HostnameAndNamespace[hName]
-			if !ok {
-				continue
-			}
-			svc, ok := byNamespace[ns]
-			if !ok {
-				continue
-			}
-			// HostnameAndNamespace contains all services regardless of exportTo, so visibility is reapplied.
-			if !ps.IsServiceVisible(svc, configNamespace) {
-				continue
-			}
-			candidates = append(candidates, svc)
+// dedupEgressHosts drops egress hosts whose trie fanout another host in the same namespace group already covers,
+// so each subtree is walked at most once. Within a namespace the visibility filter is identical, so coverage is
+// pure suffix nesting: "*" subsumes everything, and "*.b.c" subsumes the narrower "*.a.b.c". Trie subtrees never
+// partially overlap, so the survivors are disjoint and collect() stays O(mesh) regardless of the host count. This
+// only prunes redundant traversal — the caller's seen-set still dedups services — and runs in O(hosts). Exact
+// hosts are kept as-is: each is an O(1) byHostname lookup, not worth pruning.
+func dedupEgressHosts(allHosts []host.Name) []host.Name {
+	matchAll := false
+	wildcardSuffixes := sets.New[string]()
+	for _, h := range allHosts {
+		if h == wildcardService {
+			matchAll = true
+			break
+		}
+		if h.IsWildCarded() {
+			wildcardSuffixes.Insert(wildcardSuffix(h))
 		}
 	}
-	// Sort for deterministic output, matching servicesExportedToNamespace (built from creation-ordered services).
-	return SortServicesByCreationTime(candidates)
+	// "*" collects the whole (namespace-filtered) trie, so on its own it covers every other listed host.
+	if matchAll {
+		return []host.Name{wildcardService}
+	}
+	if wildcardSuffixes.Len() == 0 {
+		return allHosts // no wildcards: nothing can subsume anything, so there is nothing to drop.
+	}
+	out := make([]host.Name, 0, len(allHosts))
+	for _, h := range allHosts {
+		// Drop a wildcard whose suffix sits under a broader wildcard's suffix; that broader wildcard's collect()
+		// already visits this one's entire subtree.
+		if h.IsWildCarded() && coveredByBroaderWildcard(wildcardSuffix(h), wildcardSuffixes) {
+			continue
+		}
+		out = append(out, h)
+	}
+	return out
+}
+
+// wildcardSuffix strips the leading "*." from a leading-label wildcard host, e.g. "*.foo.com" -> "foo.com".
+func wildcardSuffix(h host.Name) string {
+	return strings.TrimPrefix(strings.TrimPrefix(string(h), "*"), ".")
+}
+
+// coveredByBroaderWildcard reports whether a strict suffix of s is itself a selected wildcard suffix, i.e. some
+// "*.<shorter-suffix>" already covers "*.s".
+func coveredByBroaderWildcard(s string, suffixes sets.Set[string]) bool {
+	for i := strings.IndexByte(s, '.'); i >= 0; i = strings.IndexByte(s, '.') {
+		s = s[i+1:]
+		if suffixes.Contains(s) {
+			return true
+		}
+	}
+	return false
+}
+
+// servicesImportedToNamespace resolves the candidate services for an egress listener's hosts without
+// scanning every service visible to configNamespace. Each host ("namespace/dnsName", exact or wildcard) is
+// resolved through the hostname-first hostTrie: an exact host hits an O(1) byHostname lookup, a wildcard host
+// walks the reversed-label subtree, and the namespace is applied at the leaf. The result is fed to
+// selectServices exactly like the legacy scan, which reapplies visibility, exclusions and the
+// single-namespace-per-hostname dedup. Falls back to the full scan when the trie is unavailable.
+func (ps *PushContext) servicesImportedToNamespace(configNamespace string,
+	hostsByNamespace map[string]hostClassification, includesAllMesh bool,
+) []*Service {
+	trie := ps.ServiceIndex.hostTrie
+	if trie == nil {
+		return ps.servicesExportedToNamespace(configNamespace)
+	}
+	// The default "*/*" host imports the entire visible mesh, which is exactly servicesExportedToNamespace, and it
+	// dominates any other listed host. Walking the whole trie for it only adds overhead over the flat scan (see
+	// BenchmarkSelectServicesMatchAll), so short-circuit to the scan.
+	if includesAllMesh {
+		return ps.servicesExportedToNamespace(configNamespace)
+	}
+	return ps.servicesImportedViaTrie(configNamespace, hostsByNamespace, trie)
+}
+
+// servicesImportedViaTrie resolves the listener's hosts through the hostTrie: each host is an O(1) byHostname
+// lookup (exact) or a reversed-label subtree walk (wildcard) via servicesFor, visibility is reapplied (the trie
+// holds all services regardless of exportTo), and the result is restored to the trie's build order (creation-time
+// sorted) so it matches servicesExportedToNamespace deterministically — a map-based dedup and the trie's collect()
+// walk both scramble order.
+func (ps *PushContext) servicesImportedViaTrie(configNamespace string,
+	hostsByNamespace map[string]hostClassification, trie *hostTrie,
+) []*Service {
+	seen := sets.New[*Service]()
+	var candidates []*Service
+	add := func(svc *Service) {
+		if svc == nil || seen.InsertContains(svc) {
+			return
+		}
+		if !ps.IsServiceVisible(svc, configNamespace) {
+			return
+		}
+		candidates = append(candidates, svc)
+	}
+	for ns, hc := range hostsByNamespace {
+		for _, hName := range dedupEgressHosts(hc.allHosts) {
+			for _, svc := range trie.servicesFor(ns, hName) {
+				add(svc)
+			}
+		}
+	}
+	return slices.SortBy(candidates, func(s *Service) int { return trie.order[s] })
 }
 
 // GetEgressListenerForRDS returns the egress listener corresponding to

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -2909,10 +2909,11 @@ func TestCreateSidecarScope(t *testing.T) {
 	}
 }
 
-// TestSelectServicesExactParity asserts that the exact-host fast path (servicesForExactHosts, used when every
-// imported host is non-wildcarded) returns exactly what the legacy full-scan path (servicesExportedToNamespace)
-// returns once both are run through selectServices. This guards against the two paths diverging.
-func TestSelectServicesExactParity(t *testing.T) {
+// TestServicesImportedToNamespaceParity asserts that servicesImportedToNamespace (exact hosts via the
+// HostnameAndNamespace map lookup, wildcard hosts via the two-level trie) returns exactly what the legacy
+// full-scan path (servicesExportedToNamespace) returns once both are run through selectServices. This
+// guards against the two paths diverging.
+func TestServicesImportedToNamespaceParity(t *testing.T) {
 	svc := func(hostname, ns string, ports PortList, exportTo ...visibility.Instance) *Service {
 		s := &Service{
 			Hostname:   host.Name(hostname),
@@ -2932,6 +2933,12 @@ func TestSelectServicesExactParity(t *testing.T) {
 		svc("foo", "b", port8000),                              // same hostname, different namespace
 		svc("priv", "b", port8000, visibility.Private),         // private to b
 		svc("shared", "c", port8000, visibility.Instance("a")), // exported to a only
+		// Hierarchical hostnames so wildcards can nest: "*.mesh.example.com" subsumes "*.svc.mesh.example.com".
+		svc("mesh.example.com", "a", port8000),
+		svc("a.mesh.example.com", "a", port8000),
+		svc("b.svc.mesh.example.com", "a", port8000),
+		svc("c.svc.mesh.example.com", "a", port8000),
+		svc("a.mesh.example.com", "d", port8000), // caught by "*/a.mesh.example.com" but not "a/*.mesh.example.com"
 	}
 
 	tests := []struct {
@@ -2983,6 +2990,65 @@ func TestSelectServicesExactParity(t *testing.T) {
 				"c": {allHosts: []host.Name{"shared"}, exactHosts: sets.New[host.Name]("shared")},
 			},
 		},
+		{
+			name:     "exact host in wildcard namespace",
+			configNS: "a",
+			listenerHosts: map[string]hostClassification{
+				"*": {allHosts: []host.Name{"foo"}, exactHosts: sets.New[host.Name]("foo")},
+			},
+		},
+		{
+			name:     "match-all host in a namespace",
+			configNS: "a",
+			listenerHosts: map[string]hostClassification{
+				"a": {allHosts: []host.Name{"*"}, exactHosts: sets.New[host.Name]()},
+			},
+		},
+		{
+			name:     "whole mesh",
+			configNS: "a",
+			listenerHosts: map[string]hostClassification{
+				"*": {allHosts: []host.Name{"*"}, exactHosts: sets.New[host.Name]()},
+			},
+		},
+		{
+			name:     "nested wildcards: broader suffix subsumes narrower",
+			configNS: "a",
+			listenerHosts: map[string]hostClassification{
+				"a": {
+					allHosts:   []host.Name{"*.mesh.example.com", "*.svc.mesh.example.com"},
+					exactHosts: sets.New[host.Name](),
+				},
+			},
+		},
+		{
+			name:     "wildcard subsumes exact host under it",
+			configNS: "a",
+			listenerHosts: map[string]hostClassification{
+				"a": {
+					allHosts:   []host.Name{"*.mesh.example.com", "a.mesh.example.com"},
+					exactHosts: sets.New[host.Name]("a.mesh.example.com"),
+				},
+			},
+		},
+		{
+			name:     "match-all subsumes wildcard and exact",
+			configNS: "a",
+			listenerHosts: map[string]hostClassification{
+				"a": {
+					allHosts:   []host.Name{"*", "*.mesh.example.com", "foo"},
+					exactHosts: sets.New[host.Name]("foo"),
+				},
+			},
+		},
+		{
+			name:     "wildcard-namespace exact and concrete-namespace wildcard do not cross-collapse",
+			configNS: "a",
+			listenerHosts: map[string]hostClassification{
+				"*": {allHosts: []host.Name{"a.mesh.example.com"}, exactHosts: sets.New[host.Name]("a.mesh.example.com")},
+				"a": {allHosts: []host.Name{"*.mesh.example.com"}, exactHosts: sets.New[host.Name]()},
+			},
+		},
 	}
 
 	// Build a PushContext with the service index populated as initServiceRegistry would.
@@ -3007,6 +3073,7 @@ func TestSelectServicesExactParity(t *testing.T) {
 			}
 		}
 	}
+	ps.ServiceIndex.hostTrie = newHostTrie(svcs)
 
 	// byHostname gives a total order over a selection result. selectServices dedups to a single service per
 	// hostname, so hostname is a unique key. We compare order-insensitively because cluster order is not
@@ -3023,64 +3090,280 @@ func TestSelectServicesExactParity(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ilw := &IstioEgressListenerWrapper{}
-			fast := byHostname(ilw.selectServices(ps.servicesForExactHosts(tt.configNS, tt.listenerHosts), tt.configNS, tt.listenerHosts))
+			hc, ok := tt.listenerHosts[wildcardNamespace]
+			includesAllMesh := ok && slices.Contains(hc.allHosts, wildcardService)
+			fast := byHostname(ilw.selectServices(ps.servicesImportedToNamespace(tt.configNS, tt.listenerHosts, includesAllMesh), tt.configNS, tt.listenerHosts))
 			scan := byHostname(ilw.selectServices(ps.servicesExportedToNamespace(tt.configNS), tt.configNS, tt.listenerHosts))
 			if !reflect.DeepEqual(fast, scan) {
 				fastJSON, _ := json.MarshalIndent(fast, "", "  ")
 				scanJSON, _ := json.MarshalIndent(scan, "", "  ")
-				t.Errorf("fast path and scan path diverged.\nfast: %s\nscan: %s", string(fastJSON), string(scanJSON))
+				t.Errorf("import path and scan path diverged.\nimport: %s\nscan: %s", string(fastJSON), string(scanJSON))
 			}
 		})
 	}
 }
 
-// BenchmarkSelectServicesExact compares the exact-host fast path (servicesForExactHosts, O(H) index lookups +
-// O(H log H) sort) against the legacy full-scan path (servicesExportedToNamespace, O(M) scan + allocation),
-// each followed by the shared selectServices call, on identical input. H (hosts imported by the listener) is held at 10% of M
-// (services visible to the namespace), modeling a sidecar that imports a constant fraction of the mesh. Run with:
+// TestDedupEgressHosts asserts dedupEgressHosts drops only the hosts whose trie fanout a retained host already
+// covers: match-all "*" collapses the list to itself, a broader wildcard subsumes narrower ones, and exact hosts
+// (and disjoint wildcards) are always retained.
+func TestDedupEgressHosts(t *testing.T) {
+	tests := []struct {
+		name  string
+		hosts []host.Name
+		want  []host.Name
+	}{
+		{
+			name:  "no wildcards keeps every exact host",
+			hosts: []host.Name{"foo.com", "bar.com"},
+			want:  []host.Name{"foo.com", "bar.com"},
+		},
+		{
+			name:  "disjoint wildcards both kept",
+			hosts: []host.Name{"*.foo.com", "*.bar.com"},
+			want:  []host.Name{"*.foo.com", "*.bar.com"},
+		},
+		{
+			name:  "broader wildcard subsumes narrower",
+			hosts: []host.Name{"*.foo.com", "*.svc.foo.com"},
+			want:  []host.Name{"*.foo.com"},
+		},
+		{
+			name:  "chain collapses to the broadest wildcard",
+			hosts: []host.Name{"*.a.b.foo.com", "*.b.foo.com", "*.foo.com"},
+			want:  []host.Name{"*.foo.com"},
+		},
+		{
+			name:  "wildcard keeps an exact host sitting under it",
+			hosts: []host.Name{"*.foo.com", "a.foo.com"},
+			want:  []host.Name{"*.foo.com", "a.foo.com"},
+		},
+		{
+			name:  "match-all collapses everything",
+			hosts: []host.Name{"*.foo.com", "bar.com", "*"},
+			want:  []host.Name{"*"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dedupEgressHosts(tt.hosts)
+			if !sets.New(got...).Equals(sets.New(tt.want...)) {
+				t.Errorf("dedupEgressHosts(%v) = %v, want %v", tt.hosts, got, tt.want)
+			}
+		})
+	}
+}
+
+// benchServiceMesh populates ps with M public services named "endpoint.svc-i.ns.svc.cluster.local", built
+// exactly as initServiceRegistry would (HostnameAndNamespace + public + trie), for the benchmarks below.
+func benchServiceMesh(meshServices int) *PushContext {
+	ps := NewPushContext()
+	ps.exportToDefaults.service = sets.New(visibility.Public)
+	for i := 0; i < meshServices; i++ {
+		hostname := host.Name("endpoint.svc-" + strconv.Itoa(i) + ".ns.svc.cluster.local")
+		s := &Service{
+			Hostname:   hostname,
+			Ports:      port8000,
+			Attributes: ServiceAttributes{Name: string(hostname), Namespace: "ns", ServiceRegistry: provider.Kubernetes},
+		}
+		ps.ServiceIndex.HostnameAndNamespace[hostname] = map[string]*Service{"ns": s}
+		ps.ServiceIndex.public = append(ps.ServiceIndex.public, s)
+	}
+	ps.ServiceIndex.hostTrie = newHostTrie(ps.ServiceIndex.public)
+	return ps
+}
+
+// servicesForExactHostsMap is the previous exact-host resolution path (before the hostTrie): direct
+// ps.ServiceIndex.HostnameAndNamespace[host][namespace] lookups. It is kept here only to benchmark the trie's
+// exact path against the plain map it replaced; it handles all-exact, explicitly-namespaced hosts.
+//
+// TODO: delete this together with the HostnameAndNamespace map (and its "map" subtest in BenchmarkSelectServicesExact)
+// once the trie is proven out.
+func servicesForExactHostsMap(ps *PushContext, configNamespace string,
+	hostsByNamespace map[string]hostClassification,
+) []*Service {
+	var candidates []*Service
+	for ns, hc := range hostsByNamespace {
+		for hName := range hc.exactHosts {
+			byNamespace, ok := ps.ServiceIndex.HostnameAndNamespace[hName]
+			if !ok {
+				continue
+			}
+			svc, ok := byNamespace[ns]
+			if !ok {
+				continue
+			}
+			if !ps.IsServiceVisible(svc, configNamespace) {
+				continue
+			}
+			candidates = append(candidates, svc)
+		}
+	}
+	return SortServicesByCreationTime(candidates)
+}
+
+// benchSelectServices runs the trie path (servicesImportedToNamespace) and the legacy full-scan path
+// (servicesExportedToNamespace) over hostsByNamespace, each followed by the shared selectServices call. When
+// includeMap is set it also runs the pre-trie exact path (servicesForExactHostsMap), for the all-exact case.
+func benchSelectServices(b *testing.B, ps *PushContext, hostsByNamespace map[string]hostClassification, includeMap bool) {
+	ilw := &IstioEgressListenerWrapper{}
+	hc, ok := hostsByNamespace[wildcardNamespace]
+	includesAllMesh := ok && slices.Contains(hc.allHosts, wildcardService)
+	b.Run("trie", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			ilw.selectServices(ps.servicesImportedToNamespace("ns", hostsByNamespace, includesAllMesh), "ns", hostsByNamespace)
+		}
+	})
+	if includeMap {
+		b.Run("map", func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				ilw.selectServices(servicesForExactHostsMap(ps, "ns", hostsByNamespace), "ns", hostsByNamespace)
+			}
+		})
+	}
+	b.Run("scan", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			ilw.selectServices(ps.servicesExportedToNamespace("ns"), "ns", hostsByNamespace)
+		}
+	})
+}
+
+// benchMeshSizes is the set of mesh sizes M the benchmarks sweep, each importing H=10% of the mesh.
+var benchMeshSizes = []int{1000, 10000, 100000}
+
+// BenchmarkSelectServicesExact sweeps M=1000/10000/100000 with the listener importing H=10% of the mesh as exact,
+// explicitly-namespaced hosts. It compares trie (current, O(H) byHostname lookups), map (pre-trie
+// HostnameAndNamespace lookups), and scan (legacy O(M) full scan). trie and map grow with H, not M; the trie edges
+// out the map by sorting on a precomputed build-order index instead of re-running SortServicesByCreationTime.
+//
+// trie and map are both faster than the scan (each entry is the speedup over the scan):
 //
 //	go test ./pilot/pkg/model/ -run '^$' -bench BenchmarkSelectServicesExact -benchmem
+//
+//	           trie vs scan   map vs scan
+//	M=1000     ~4x            ~4x
+//	M=10000    ~22x           ~16x
+//	M=100000   ~288x          ~158x
 func BenchmarkSelectServicesExact(b *testing.B) {
-	for _, meshServices := range []int{1000, 10000, 100000} {
-		importedHosts := meshServices / 10 // H: 10% of the mesh
-		ps := NewPushContext()
-		ps.exportToDefaults.service = sets.New(visibility.Public)
-		// Populate the indexes exactly as initServiceRegistry would: every service goes into
-		// HostnameAndNamespace (used by the fast path) and, being public, into public (used by the scan path).
-		for i := 0; i < meshServices; i++ {
-			hostname := host.Name("svc-" + strconv.Itoa(i) + ".ns.svc.cluster.local")
-			s := &Service{
-				Hostname:   hostname,
-				Ports:      port8000,
-				Attributes: ServiceAttributes{Name: string(hostname), Namespace: "ns", ServiceRegistry: provider.Kubernetes},
-			}
-			ps.ServiceIndex.HostnameAndNamespace[hostname] = map[string]*Service{"ns": s}
-			ps.ServiceIndex.public = append(ps.ServiceIndex.public, s)
-		}
-
-		// Listener imports the first H services as exact, explicitly-namespaced hosts.
+	for _, meshServices := range benchMeshSizes {
+		importedHosts := meshServices / 10 // H: 10% of the mesh, all exact
+		ps := benchServiceMesh(meshServices)
 		exact := sets.New[host.Name]()
 		all := make([]host.Name, 0, importedHosts)
 		for i := 0; i < importedHosts; i++ {
-			h := host.Name("svc-" + strconv.Itoa(i) + ".ns.svc.cluster.local")
+			h := host.Name("endpoint.svc-" + strconv.Itoa(i) + ".ns.svc.cluster.local")
 			exact.Insert(h)
 			all = append(all, h)
 		}
 		hostsByNamespace := map[string]hostClassification{"ns": {exactHosts: exact, allHosts: all}}
-
-		suffix := "M=" + strconv.Itoa(meshServices) + "/H=" + strconv.Itoa(importedHosts)
-		ilw := &IstioEgressListenerWrapper{}
-		b.Run("fast/"+suffix, func(b *testing.B) {
-			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
-				ilw.selectServices(ps.servicesForExactHosts("ns", hostsByNamespace), "ns", hostsByNamespace)
-			}
+		b.Run("M="+strconv.Itoa(meshServices), func(b *testing.B) {
+			benchSelectServices(b, ps, hostsByNamespace, true)
 		})
-		b.Run("scan/"+suffix, func(b *testing.B) {
-			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
-				ilw.selectServices(ps.servicesExportedToNamespace("ns"), "ns", hostsByNamespace)
-			}
+	}
+}
+
+// BenchmarkSelectServicesWildcardAndExact sweeps M=1000/10000/100000 with the listener importing H=10%: half (5%)
+// exact hosts and half (5%) wildcard dnsName hosts, each matching one service. Wildcards make each host a trie
+// walk, so the trie is slower than the all-exact case but still well ahead of the O(M) scan.
+//
+// trie is faster than the scan (each entry is the speedup over the scan):
+//
+//	go test ./pilot/pkg/model/ -run '^$' -bench BenchmarkSelectServicesWildcardAndExact -benchmem
+//
+//	           trie vs scan
+//	M=1000     ~7x
+//	M=10000    ~21x
+//	M=100000   ~29x
+func BenchmarkSelectServicesWildcardAndExact(b *testing.B) {
+	for _, meshServices := range benchMeshSizes {
+		exactHosts := meshServices / 20    // 5% of the mesh, exact
+		wildcardHosts := meshServices / 20 // 5% of the mesh, wildcard dnsName
+		ps := benchServiceMesh(meshServices)
+		exact := sets.New[host.Name]()
+		all := make([]host.Name, 0, exactHosts+wildcardHosts)
+		for i := 0; i < exactHosts; i++ {
+			h := host.Name("endpoint.svc-" + strconv.Itoa(i) + ".ns.svc.cluster.local")
+			exact.Insert(h)
+			all = append(all, h)
+		}
+		// Wildcard hosts cover a disjoint range of services; each "*.svc-i.ns..." matches one service.
+		for i := exactHosts; i < exactHosts+wildcardHosts; i++ {
+			all = append(all, host.Name("*.svc-"+strconv.Itoa(i)+".ns.svc.cluster.local"))
+		}
+		hostsByNamespace := map[string]hostClassification{"ns": {exactHosts: exact, allHosts: all}}
+		b.Run("M="+strconv.Itoa(meshServices), func(b *testing.B) {
+			benchSelectServices(b, ps, hostsByNamespace, false)
+		})
+	}
+}
+
+// BenchmarkSelectServicesWildcard sweeps M=1000/10000/100000 with the listener importing H=10% of the mesh as
+// wildcard dnsName hosts, each matching one service. Every host is a trie walk with no byHostname fast path, yet
+// it stays ahead of the O(M) scan across the sweep.
+//
+// trie is faster than the scan (each entry is the speedup over the scan):
+//
+//	go test ./pilot/pkg/model/ -run '^$' -bench BenchmarkSelectServicesWildcard -benchmem
+//
+//	           trie vs scan
+//	M=1000     ~7x
+//	M=10000    ~16x
+//	M=100000   ~19x
+func BenchmarkSelectServicesWildcard(b *testing.B) {
+	for _, meshServices := range benchMeshSizes {
+		importedHosts := meshServices / 10 // H: 10% of the mesh, all wildcard dnsName
+		ps := benchServiceMesh(meshServices)
+		all := make([]host.Name, 0, importedHosts)
+		for i := 0; i < importedHosts; i++ {
+			all = append(all, host.Name("*.svc-"+strconv.Itoa(i)+".ns.svc.cluster.local"))
+		}
+		hostsByNamespace := map[string]hostClassification{"ns": {exactHosts: sets.New[host.Name](), allHosts: all}}
+		b.Run("M="+strconv.Itoa(meshServices), func(b *testing.B) {
+			benchSelectServices(b, ps, hostsByNamespace, false)
+		})
+	}
+}
+
+// BenchmarkSelectServicesMatchAll sweeps M=1000/10000/100000 for a single match-all "*/*" host importing the whole
+// mesh. This is the trie's worst case: "*" walks every node of the reversed-label tree and sorts all M services,
+// the same work as the scan's flat O(M) pass but with tree-walk overhead and no fanout to prune, so the scan wins.
+// That gap is exactly why servicesImportedToNamespace short-circuits "*/*" to the scan; this benchmark documents it
+// by calling servicesImportedViaTrie directly for the "trie" subtest (the short-circuit would otherwise route it
+// straight to the scan and both subtests would measure the same thing).
+//
+// scan is faster than the trie; both are O(M) here, so this is a constant-factor overhead that plateaus (does not
+// grow with M) — each entry is the scan's speedup over the trie:
+//
+//	go test ./pilot/pkg/model/ -run '^$' -bench BenchmarkSelectServicesMatchAll -benchmem
+//
+//	           scan vs trie
+//	M=1000     ~7x
+//	M=10000    ~9x
+//	M=100000   ~9x
+func BenchmarkSelectServicesMatchAll(b *testing.B) {
+	ilw := &IstioEgressListenerWrapper{}
+	for _, meshServices := range benchMeshSizes {
+		ps := benchServiceMesh(meshServices)
+		trie := ps.ServiceIndex.hostTrie
+		// A single "*/*" host: namespace "*" and dnsName "*", matching every service in the mesh.
+		hostsByNamespace := map[string]hostClassification{
+			wildcardNamespace: {exactHosts: sets.New[host.Name](), allHosts: []host.Name{wildcardService}},
+		}
+		b.Run("M="+strconv.Itoa(meshServices), func(b *testing.B) {
+			b.Run("trie", func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					ilw.selectServices(ps.servicesImportedViaTrie("ns", hostsByNamespace, trie), "ns", hostsByNamespace)
+				}
+			})
+			b.Run("scan", func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					ilw.selectServices(ps.servicesExportedToNamespace("ns"), "ns", hostsByNamespace)
+				}
+			})
 		})
 	}
 }

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -3165,9 +3165,9 @@ func benchServiceMesh(meshServices int) *PushContext {
 			Ports:      port8000,
 			Attributes: ServiceAttributes{Name: string(hostname), Namespace: "ns", ServiceRegistry: provider.Kubernetes},
 		}
-		ps.ServiceIndex.HostnameAndNamespace[hostname] = map[string]*Service{"ns": s}
 		ps.ServiceIndex.public = append(ps.ServiceIndex.public, s)
 	}
+	ps.ServiceIndex.HostnameAndNamespace = buildHostnameAndNamespaceIndex(ps.ServiceIndex.public)
 	ps.ServiceIndex.hostTrie = newHostTrie(ps.ServiceIndex.public)
 	return ps
 }
@@ -3362,6 +3362,41 @@ func BenchmarkSelectServicesMatchAll(b *testing.B) {
 				b.ReportAllocs()
 				for i := 0; i < b.N; i++ {
 					ilw.selectServices(ps.servicesExportedToNamespace("ns"), "ns", hostsByNamespace)
+				}
+			})
+		})
+	}
+}
+
+// BenchmarkBuildServiceIndex measures the one-time cost of building each hostname index over the mesh's services,
+// sweeping M=1000/10000/100000. It answers the review question of whether the trie's build cost (newHostTrie) is
+// comparable to the map it replaces (buildHostnameAndNamespaceIndex); both are built once per PushContext and
+// amortized across every lookup that PushContext serves.
+//
+// Both build in O(M); the trie is a ~4.5x constant-factor heavier build (it allocates a node per DNS label rather
+// than one entry per hostname), which stays flat as M grows and is repaid by the lookup speedups (up to ~288x at
+// M=100000, see BenchmarkSelectServicesExact):
+//
+//	go test ./pilot/pkg/model/ -run '^$' -bench BenchmarkBuildServiceIndex -benchmem
+//
+//	           trie build   map build   trie/map
+//	M=1000     ~355µs       ~78µs       ~4.5x
+//	M=10000    ~3.6ms       ~0.78ms     ~4.6x
+//	M=100000   ~44ms        ~9.9ms      ~4.5x
+func BenchmarkBuildServiceIndex(b *testing.B) {
+	for _, meshServices := range benchMeshSizes {
+		svcs := benchServiceMesh(meshServices).ServiceIndex.public
+		b.Run("M="+strconv.Itoa(meshServices), func(b *testing.B) {
+			b.Run("trie", func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					_ = newHostTrie(svcs)
+				}
+			})
+			b.Run("map", func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					_ = buildHostnameAndNamespaceIndex(svcs)
 				}
 			})
 		})

--- a/pilot/pkg/model/telemetry_logging.go
+++ b/pilot/pkg/model/telemetry_logging.go
@@ -551,13 +551,13 @@ func LookupCluster(push *PushContext, service string, port int) (hostname string
 	// TODO(yangminzhu): Verify the service and its cluster is supported, e.g. resolution type is not OriginalDst.
 	if parts := strings.Split(service, "/"); len(parts) == 2 {
 		namespace, name := parts[0], parts[1]
-		if svc := push.ServiceIndex.HostnameAndNamespace[host.Name(name)][namespace]; svc != nil {
+		if svc := push.ServiceByHostnameAndNamespace(host.Name(name), namespace); svc != nil {
 			hostname = string(svc.Hostname)
 			cluster = BuildSubsetKey(TrafficDirectionOutbound, "", svc.Hostname, port)
 			return hostname, cluster, err
 		}
 	} else {
-		namespaceToServices := push.ServiceIndex.HostnameAndNamespace[host.Name(service)]
+		namespaceToServices := push.ServicesByHostname(host.Name(service))
 		var namespaces []string
 		for k := range namespaceToServices {
 			namespaces = append(namespaces, k)

--- a/pilot/pkg/networking/core/gateway.go
+++ b/pilot/pkg/networking/core/gateway.go
@@ -358,8 +358,8 @@ func buildNameToServiceMapForHTTPRoutes(node *model.Proxy, push *model.PushConte
 
 		var service *model.Service
 		// First, we obtain the service which has the same namespace as virtualService
-		s, exist := push.ServiceIndex.HostnameAndNamespace[hostname][virtualService.Namespace]
-		if exist {
+		s := push.ServiceByHostnameAndNamespace(hostname, virtualService.Namespace)
+		if s != nil {
 			// We should check whether the selected service is visible to the proxy node.
 			if push.IsServiceVisible(s, node.ConfigNamespace) {
 				service = s

--- a/pilot/pkg/networking/core/waypoint.go
+++ b/pilot/pkg/networking/core/waypoint.go
@@ -69,8 +69,8 @@ func findWaypointResources(node *model.Proxy, push *model.PushContext) ([]model.
 	waypointServices := &waypointServices{}
 	for _, s := range serviceInfos {
 		hostName := host.Name(s.Service.Hostname)
-		svc, ok := push.ServiceIndex.HostnameAndNamespace[hostName][s.Service.Namespace]
-		if !ok {
+		svc := push.ServiceByHostnameAndNamespace(hostName, s.Service.Namespace)
+		if svc == nil {
 			continue
 		}
 		// Exclude MESH_INTERNAL services with DYNAMIC_DNS resolution from waypoint.


### PR DESCRIPTION
## Change

* Replace existing `ServiceIndex.HostnameAndNamespace` map with a trie for efficient`(hostname, namespace)` lookups in `O(L)` where `L` corresponds to number of `.` separated tokens in the hostname. It can be considered constant time for all reasonable usecases.
* Today lookup is `O(1)`, but it is unusable in the Sidecar egress host resolution hot path if all the hosts in the listener are not fully qualified. If all are fully qualified hostnames, #60473 offers the efficient path as an option. With this change all cases become `O(L)`.

## Perf

Speedup over the full-mesh scan, sweeping mesh size M with the listener importing H=10% of the mesh.

All fully qualified hosts, explicitly-namespaced hosts (`trie` is the new path, `map` the pre-trie lookup it replaces):

|          | trie vs scan | map vs scan |
|----------|--------------|-------------|
| M=1000   | ~4x          | ~4x         |
| M=10000  | ~22x         | ~16x        |
| M=100000 | ~288x        | ~158x       |

The trie is faster than the plain map path for all fully qualified hosts as well, because it doesn't need the per call `SortServicesByCreationTime`, it comes pre-sorted during build time, unlike a map.

Mixed (5% fully qualified + 5% wildcard):

|          | trie vs scan |
|----------|--------------|
| M=1000   | ~7x          |
| M=10000  | ~21x         |
| M=100000 | ~29x         |

Wildcard (all H as `*.suffix`, each matching one service):

|          | trie vs scan |
|----------|--------------|
| M=1000   | ~7x          |
| M=10000  | ~16x         |
| M=100000 | ~19x         |


Match-all `*/*` (the default egress) imports the whole mesh: the trie's worst case, walking every node for the same `O(M)` work as the scan but with tree-walk overhead. Scan outperforms trie but linearly, with a constant factor that doesn't scale exponentially:

|          | scan vs trie |
|----------|--------------|
| M=1000   | ~7x          |
| M=10000  | ~9x          |
| M=100000 | ~9x          |

Hence, presence of all mesh `*/*` in the hosts list uses the existing logic to avoid unnecessary penalty of walking the trie.

## Assumption
This assumes egress `hosts` grammar will remain unchanged, most importantly its current design intentionally does not, and should not, support generic regex host matching. Quoting the [documentation](https://istio.io/latest/docs/reference/config/networking/sidecar/#IstioEgressListener-hosts):
>The dnsName should be specified using FQDN format, optionally including a wildcard character in the left-most component (e.g., prod/*.example.com).

Code refs: https://github.com/istio/istio/blob/d497f4d9b126a9d1321efa13b21739ec9979c518/pkg/config/validation/agent/validation.go#L1017
https://github.com/istio/istio/blob/d497f4d9b126a9d1321efa13b21739ec9979c518/pkg/config/validation/agent/validation.go#L741
