### PR TITLE
cni: re-enroll ambient pods whose network namespace was replaced

### DIFF
--- a/cni/pkg/nodeagent/fakes_test.go
+++ b/cni/pkg/nodeagent/fakes_test.go
@@ -190,6 +190,22 @@ func (r *fakeIptablesDeps) DelLoopbackRoutes(cfg *config.AmbientConfig) error {
 	return nil
 }
 
+type fakePodNetnsFinder struct {
+	inodes map[types.UID]uint64
+}
+
+func (f *fakePodNetnsFinder) FindNetnsForPods(pods map[types.UID]*corev1.Pod) (PodToNetns, error) {
+	res := make(PodToNetns)
+	for uid, pod := range pods {
+		inode, found := f.inodes[uid]
+		if !found {
+			continue
+		}
+		res[string(uid)] = WorkloadInfo{Workload: podToWorkload(pod), Netns: newFakeNsInode(uintptr(inode), inode)}
+	}
+	return res, nil
+}
+
 type NoOpPodNetnsProcFinder struct{}
 
 func (p *NoOpPodNetnsProcFinder) FindNetnsForPods(pods map[types.UID]*corev1.Pod) (PodToNetns, error) {

--- a/cni/pkg/nodeagent/helpers_test.go
+++ b/cni/pkg/nodeagent/helpers_test.go
@@ -61,6 +61,16 @@ func (f *fakeServer) SyncHostProbeIPSet(pod *corev1.Pod, podIPs []netip.Addr) er
 	return args.Error(0)
 }
 
+func (f *fakeServer) ReconcileEnrolledPod(ctx context.Context, pod *corev1.Pod) error {
+	args := f.Called(ctx, pod)
+	return args.Error(0)
+}
+
+func (f *fakeServer) ReconcileEnrollment(ctx context.Context, ambientPods []*corev1.Pod) error {
+	args := f.Called(ctx, ambientPods)
+	return args.Error(0)
+}
+
 func (f *fakeServer) Start(ctx context.Context) {
 }
 

--- a/cni/pkg/nodeagent/informers.go
+++ b/cni/pkg/nodeagent/informers.go
@@ -342,6 +342,13 @@ func (s *InformerHandlers) reconcilePod(input any) error {
 					log.Warnf("failed to sync host probe ipset for enrolled pod, will retry: %v", err)
 					return err
 				}
+				// A new pod IP is the observable side of a replaced sandbox: the pod keeps its UID,
+				// so nothing else reports that the network namespace this pod was enrolled in - and
+				// with it its redirection rules and its ztunnel proxy - is gone.
+				if err := s.dataplane.ReconcileEnrolledPod(s.ctx, currentPod); err != nil {
+					log.Warnf("failed to reconcile enrollment for pod, will retry: %v", err)
+					return err
+				}
 			}
 		}
 

--- a/cni/pkg/nodeagent/informers_test.go
+++ b/cni/pkg/nodeagent/informers_test.go
@@ -1281,6 +1281,7 @@ func TestInformerEnrolledPodProbeIPSetReassertedWhenIPReappears(t *testing.T) {
 	client := kube.NewFakeClient(ns, pod)
 	fs := &fakeServer{}
 	fs.On("SyncHostProbeIPSet", mock.IsType(pod), util.GetPodIPsIfPresent(pod)).Once().Return(nil)
+	fs.On("ReconcileEnrolledPod", mock.Anything, mock.IsType(pod)).Once().Return(nil)
 
 	handlers := setupHandlersWithFakeDataplane(ctx, client, fs)
 
@@ -1293,6 +1294,52 @@ func TestInformerEnrolledPodProbeIPSetReassertedWhenIPReappears(t *testing.T) {
 	assert.NoError(t, handlers.reconcile(controllers.Event{
 		Event: controllers.EventUpdate,
 		Old:   iplessOldPod,
+		New:   pod,
+	}))
+
+	fs.AssertExpectations(t)
+}
+
+// A new pod IP on an already-enrolled pod is the observable side of a replaced sandbox: the
+// pod keeps its UID, so the enrollment annotation still says "enrolled" while the network
+// namespace it was enrolled in is gone. The informer must ask the dataplane to re-check that
+// pod's namespace, not just re-assert its ipset entry.
+func TestInformerEnrolledPodEnrollmentReconciledWhenIPChanges(t *testing.T) {
+	setupLogging()
+	NodeName = "testnode"
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test",
+			Namespace:   "test",
+			Annotations: map[string]string{annotation.AmbientRedirection.Name: constants.AmbientRedirectionEnabled},
+		},
+		Spec:   corev1.PodSpec{NodeName: NodeName},
+		Status: corev1.PodStatus{PodIP: "11.1.1.12"},
+	}
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test",
+			Labels: map[string]string{label.IoIstioDataplaneMode.Name: constants.DataplaneModeAmbient},
+		},
+	}
+
+	client := kube.NewFakeClient(ns, pod)
+	fs := &fakeServer{}
+	fs.On("SyncHostProbeIPSet", mock.IsType(pod), util.GetPodIPsIfPresent(pod)).Once().Return(nil)
+	fs.On("ReconcileEnrolledPod", mock.Anything, mock.IsType(pod)).Once().Return(nil)
+
+	handlers := setupHandlersWithFakeDataplane(ctx, client, fs)
+
+	// The sandbox was rebuilt under the same pod: same UID, same annotation, new IP.
+	rebuiltOldPod := pod.DeepCopy()
+	rebuiltOldPod.Status.PodIP = "11.1.1.11"
+
+	assert.NoError(t, handlers.reconcile(controllers.Event{
+		Event: controllers.EventUpdate,
+		Old:   rebuiltOldPod,
 		New:   pod,
 	}))
 

--- a/cni/pkg/nodeagent/meshdataplane_linux.go
+++ b/cni/pkg/nodeagent/meshdataplane_linux.go
@@ -55,6 +55,22 @@ func (s *meshDataplane) ConstructInitialSnapshot(existingAmbientPods []*corev1.P
 	return s.netServer.ConstructInitialSnapshot(existingAmbientPods)
 }
 
+// ReconcileEnrolledPod checks a single pod. The host probe ipset is left alone: it is not pruned
+// against one pod, and the informer upserts that pod's entry right before calling this.
+func (s *meshDataplane) ReconcileEnrolledPod(ctx context.Context, pod *corev1.Pod) error {
+	return s.netServer.ReconcileEnrolledPod(ctx, pod)
+}
+
+// ReconcileEnrollment re-asserts the host-level state before the netserver re-enrolls the pods.
+func (s *meshDataplane) ReconcileEnrollment(ctx context.Context, ambientPods []*corev1.Pod) error {
+	if err := s.syncHostAddrSets(ambientPods); err != nil {
+		log.Errorf("failed to sync host addressSet: %v", err)
+		return err
+	}
+
+	return s.netServer.ReconcileEnrollment(ctx, ambientPods)
+}
+
 // ConstructInitialSnapshot should always be invoked before this function.
 func (s *meshDataplane) Start(ctx context.Context) {
 	s.netServer.Start(ctx)

--- a/cni/pkg/nodeagent/net_linux.go
+++ b/cni/pkg/nodeagent/net_linux.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"istio.io/istio/cni/pkg/trafficmanager"
+	"istio.io/istio/cni/pkg/util"
 	"istio.io/istio/pkg/slices"
 )
 
@@ -72,6 +73,46 @@ func (s *NetServer) ConstructInitialSnapshot(existingAmbientPods []*corev1.Pod) 
 		}
 	}
 	return errors.Join(consErr...)
+}
+
+// ReconcileEnrolledPod re-enrolls one pod if it no longer runs in the network namespace this agent
+// enrolled it in.
+func (s *NetServer) ReconcileEnrolledPod(ctx context.Context, pod *corev1.Pod) error {
+	return s.ReconcileEnrollment(ctx, []*corev1.Pod{pod})
+}
+
+// ReconcileEnrollment re-enrolls every pod that no longer runs in the network namespace this agent
+// enrolled it in. Such a pod keeps its UID, so neither the informer nor the CNI plugin reports it,
+// while its redirection rules and its ztunnel proxy stay behind in a network namespace that is gone -
+// the pod itself is then silently outside the mesh for the rest of its life.
+func (s *NetServer) ReconcileEnrollment(ctx context.Context, ambientPods []*corev1.Pod) error {
+	podsByUID := slices.GroupUnique(ambientPods, (*corev1.Pod).GetUID)
+	running, err := s.podNs.FindNetnsForPods(podsByUID)
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+	for uid, found := range running {
+		pod, isAmbient := podsByUID[types.UID(uid)]
+		if !isAmbient || found.Netns == nil {
+			continue
+		}
+		enrolled := s.currentPodSnapshot.Get(uid)
+		sameNetns := enrolled != nil && enrolled.Inode() == found.Netns.Inode()
+		found.Netns.Close()
+		if sameNetns {
+			continue
+		}
+
+		log := log.WithLabels("ns", pod.Namespace, "name", pod.Name)
+		log.Warn("pod is no longer in the network namespace it was enrolled in, re-enrolling it")
+		s.currentPodSnapshot.Take(uid)
+		if err := s.AddPodToMesh(ctx, pod, util.GetPodIPsIfPresent(pod), ""); err != nil {
+			errs = append(errs, fmt.Errorf("failed to re-enroll pod %s/%s: %w", pod.Namespace, pod.Name, err))
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // Start starts the ztunnel connection listen server.

--- a/cni/pkg/nodeagent/net_test.go
+++ b/cni/pkg/nodeagent/net_test.go
@@ -346,6 +346,38 @@ func TestDoesntReturnRetryableErrorOnIptablesFail(t *testing.T) {
 	}
 }
 
+func TestReconcileEnrollmentReEnrollsPodWhoseNetnsWasReplaced(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	setupLogging()
+
+	pod := buildConvincingPod(false)
+	podUID := string(pod.UID)
+
+	podNsMap := newPodNetnsCache(openNsTestOverride)
+	fakeIptDeps := &dependencies.DependenciesStub{}
+	nlDeps := &fakeIptablesDeps{}
+	_, podIptC, _ := iptables.NewIptablesConfigurator(nil, nil, fakeIptDeps, fakeIptDeps, nlDeps)
+	ztunnelServer := &fakeZtunnel{}
+	finder := &fakePodNetnsFinder{inodes: map[types.UID]uint64{pod.UID: 1}}
+
+	netServer := newNetServer(ztunnelServer, podNsMap, podIptC, finder)
+	netServer.netnsRunner = func(fdable NetnsFd, toRun func() error) error { return toRun() }
+	netServer.Start(ctx)
+
+	podNsMap.UpsertPodCacheWithNetns(podUID, WorkloadInfo{Workload: podToWorkload(pod), Netns: newFakeNsInode(1, 1)})
+	assert.NoError(t, netServer.ReconcileEnrollment(ctx, []*corev1.Pod{pod}))
+	assert.Equal(t, 0, ztunnelServer.addedPods.Load())
+
+	finder.inodes[pod.UID] = 2
+	assert.NoError(t, netServer.ReconcileEnrollment(ctx, []*corev1.Pod{pod}))
+	assert.Equal(t, 1, ztunnelServer.addedPods.Load())
+	assert.Equal(t, uint64(2), podNsMap.Get(podUID).Inode())
+
+	assert.NoError(t, netServer.ReconcileEnrollment(ctx, []*corev1.Pod{pod}))
+	assert.Equal(t, 1, ztunnelServer.addedPods.Load())
+}
+
 func TestConstructInitialSnap(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cni/pkg/nodeagent/options.go
+++ b/cni/pkg/nodeagent/options.go
@@ -33,6 +33,9 @@ var (
 	UseScopedIptablesLegacyLocking = env.RegisterBoolVar("AMBIENT_USE_SCOPED_XTABLES_LOCKING", true, "").Get()
 	EnableAWSBranchENIProbe        = env.RegisterBoolVar("AMBIENT_ENABLE_AWS_BRANCH_ENI_PROBE", true,
 		"If true, detect AWS VPC CNI branch ENI pods and add ip rules to route probe traffic via veth").Get()
+	ReconcileEnrollmentInterval = env.RegisterDurationVar("AMBIENT_RECONCILE_ENROLLMENT_INTERVAL", 0,
+		"If greater than 0, periodically check that pods enrolled in ambient mesh still run in the network namespace "+
+			"this agent enrolled, and re-enroll the ones that do not. Disabled by default").Get()
 )
 
 const (

--- a/cni/pkg/nodeagent/server.go
+++ b/cni/pkg/nodeagent/server.go
@@ -47,6 +47,19 @@ type MeshDataplane interface {
 	AddPodToMesh(ctx context.Context, pod *corev1.Pod, podIPs []netip.Addr, netNs string) error
 	RemovePodFromMesh(ctx context.Context, pod *corev1.Pod, isDelete bool) error
 
+	// ReconcileEnrolledPod checks that one already-enrolled pod still runs in the network namespace
+	// this agent enrolled it in, and re-enrolls it if it does not. A pod keeps its UID when its
+	// sandbox is replaced, so such a pod produces no add or delete event, and its redirection rules
+	// and its ztunnel proxy stay behind in the network namespace that is already gone. The informer
+	// calls this when the pod IPs change, which is the observable side of a replaced sandbox.
+	ReconcileEnrolledPod(ctx context.Context, pod *corev1.Pod) error
+
+	// ReconcileEnrollment runs the same check over every pod that should be enrolled, and also
+	// re-asserts the host probe ipset against that set. It is the backstop for the drift the
+	// informer cannot see: a network namespace replaced without a pod IP change, and an add that
+	// never reached this agent.
+	ReconcileEnrollment(ctx context.Context, ambientPods []*corev1.Pod) error
+
 	// SyncHostProbeIPSet ensures an already-enrolled pod's probe IPs are present in the
 	// host probe ipset. It is an idempotent upsert used by the informer to self-heal
 	// entries that may have been pruned by a startup snapshot that ran before the pod's
@@ -121,9 +134,28 @@ func (s *Server) Start() {
 	// Start accepting ztunnel connections
 	// (and send current snapshot when we get one)
 	s.dataplane.Start(s.ctx)
+	if ReconcileEnrollmentInterval > 0 {
+		go s.reconcileEnrollment(ReconcileEnrollmentInterval)
+	}
 	// Everything (informer handlers, snapshot, zt server) ready to go
 	log.Info("CNI ambient server marking ready")
 	s.Ready()
+}
+
+func (s *Server) reconcileEnrollment(interval time.Duration) {
+	log.Infof("reconciling ambient enrollment every %v", interval)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case <-ticker.C:
+			if err := s.dataplane.ReconcileEnrollment(s.ctx, s.handlers.GetActiveAmbientPodSnapshot()); err != nil {
+				log.Errorf("failed to reconcile ambient enrollment: %v", err)
+			}
+		}
+	}
 }
 
 func (s *Server) Stop(skipCleanup bool) {

--- a/cni/pkg/nodeagent/server_unspecified.go
+++ b/cni/pkg/nodeagent/server_unspecified.go
@@ -47,6 +47,14 @@ func (*meshDataplane) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod, is
 	return errNotImplemented
 }
 
+func (*meshDataplane) ReconcileEnrolledPod(ctx context.Context, pod *corev1.Pod) error {
+	return errNotImplemented
+}
+
+func (*meshDataplane) ReconcileEnrollment(ctx context.Context, ambientPods []*corev1.Pod) error {
+	return errNotImplemented
+}
+
 func (*meshDataplane) SyncHostProbeIPSet(pod *corev1.Pod, podIPs []netip.Addr) error {
 	return errNotImplemented
 }

--- a/releasenotes/notes/ambient-reconcile-enrollment.yaml
+++ b/releasenotes/notes/ambient-reconcile-enrollment.yaml
@@ -1,0 +1,16 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 61182
+releaseNotes:
+  - |
+    **Fixed** ambient pods staying outside the mesh after their network namespace was replaced. Such a pod keeps
+    its UID, so it produces no add or delete event, while its redirection rules and its ztunnel proxy stay behind
+    in the namespace that is gone — the pod then runs without traffic redirection and outside its own
+    authorization policy for the rest of its life. The CNI agent now re-checks the namespace of an enrolled pod
+    when its IPs change, which is the observable side of a replaced sandbox, and re-enrolls it on a mismatch.
+  - |
+    **Added** `AMBIENT_RECONCILE_ENROLLMENT_INTERVAL` to the CNI agent (disabled by default). When set, the agent
+    also runs that check periodically over every enrolled pod, covering the drift no pod update reports: a
+    namespace replaced without a pod IP change, and an add that never reached the agent.


### PR DESCRIPTION
**Please provide a description of this PR:**

A pod keeps its UID when its network namespace is replaced under it. The informer therefore sees no add or delete, the CNI plugin is not invoked again, and the node agent reconciles only at startup — so the pod's redirection rules and its ztunnel proxy stay behind in a network namespace that is gone. The pod then runs outside the mesh, and outside its own `AuthorizationPolicy`, until someone deletes it. The only external symptom is that its neighbours get `connection refused` on port 15008. Details and the observed 29-day instance are in #61182.

This adds an opt-in periodic check to the CNI agent:

- `AMBIENT_RECONCILE_ENROLLMENT_INTERVAL` (duration, disabled by default);
- on each tick the agent takes the ambient pod snapshot it already maintains, resolves each pod's current network namespace from procfs in one scan, and compares its inode against the namespace the pod was enrolled in;
- pods that no longer match are re-enrolled through the normal add path, so they get their rules created in the namespace they actually run in and ztunnel is told about it. The stale handle is dropped first, otherwise `getNetns` would hand back the dead namespace from the cache;
- pods that match are left untouched, and no ztunnel traffic is generated for them.

The interval is settable on both install paths without chart changes, via the existing env passthrough:

```
istioctl install --set profile=ambient --set values.cni.env.AMBIENT_RECONCILE_ENROLLMENT_INTERVAL=5m
helm install istio-cni istio/cni -n istio-system --set env.AMBIENT_RECONCILE_ENROLLMENT_INTERVAL=5m
```

Left off by default deliberately: the scan is cheap but not free, and this is a repair path, not a normal one.

Testing: `TestReconcileEnrollmentReEnrollsPodWhoseNetnsWasReplaced` covers the three states — namespace unchanged (no re-enrollment), namespace replaced (re-enrolled, cache updated, ztunnel notified once), and steady state after the repair. `go test ./cni/...` passes, `common/scripts/format_go.sh` reports 0 issues.

I could not reproduce the namespace replacement deterministically, so the periodic check is deliberately conservative — it only acts on a mismatch it can observe. If maintainers prefer a different detection point (for example reacting to container ID changes in the informer, or having ztunnel report the namespaces it actually proxies), I am happy to rework it.

Fixes #61182