### PR TITLE
Introduce topology config that combines single and multi-network clusters

### DIFF
--- a/prow/config/topology/ambient-multicluster-large.json
+++ b/prow/config/topology/ambient-multicluster-large.json
@@ -1,0 +1,20 @@
+[
+  {
+    "clusterName": "primary-1",
+    "podSubnet": "10.10.0.0/16",
+    "svcSubnet": "10.255.10.0/24",
+    "network": "network-1"
+  },
+  {
+    "clusterName": "primary-2",
+    "podSubnet": "10.30.0.0/16",
+    "svcSubnet": "10.255.30.0/24",
+    "network": "network-1"
+  },
+  {
+    "clusterName": "cross-network-primary-1",
+    "podSubnet": "10.40.0.0/16",
+    "svcSubnet": "10.255.40.0/24",
+    "network": "network-2"
+  }
+]


### PR DESCRIPTION
**Please provide a description of this PR:**

In this setup we have two clusters on the same network (network-1) and an additional cluster on another network (network-2).

The intention is in preparation of getting ambient single-network multi-cluster to a prudction ready state we want to start running tests for that setup on CI.

Long-term, rather than introducing another test suite for ambient single-network multi-network, I want to have a test that combient multi-network with single-network deployments together.

The motivation for that is it reduces the number of test suites we need to run and save CI resources (e.g., running two test suites for single and multi-network multi-cluster vs running a single test suite covering both), but also it covers interoperability between multiple types of the ambient multi-cluster deployments.

That's also seems to be the path we took for sidecar as well.

On that note, why not just re-use once of the existing configs? The existing multi-cluster configs either don't include clusters on the same network (like the currently use multicluster config for ambient) or include setups that are not supported for ambient (i.e., remote primary deployment model currently not supported for ambient).

Why not just update the existing ambient multi-cluster topology config?

That's the long term plan, but I'd like to give the test suite some time to run in non-blocking mode before we go that way. I naturally run the test suite with this configuration multiple times locally without detecting flakes, but that does not mean that we wouldn't find those on CI.

NOTE: beside this PR, I will have another PR that configures the test suite to run as well, but it's in a different repository; I also will go through the test suite to make sure that all the tests we currently have actually execrcise both single and milti-network data paths.

Part of #61067
Related to #61066