### PR TITLE
fix: validate bug report filter field count

### DIFF
--- a/releasenotes/notes/bug-report-filter-validation.yaml
+++ b/releasenotes/notes/bug-report-filter-validation.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+  - |
+    **Fixed** `istioctl bug-report` crashing when an include or exclude filter has too many fields.

--- a/tools/bug-report/pkg/config/config.go
+++ b/tools/bug-report/pkg/config/config.go
@@ -250,7 +250,11 @@ func parseToIncludeTypeMap(s string) (map[string]string, error) {
 func (s *SelectionSpec) UnmarshalJSON(b []byte) error {
 	ft := []ResourceType{Namespace, Deployment, Pod, Label, Annotation, Container}
 	str := strings.TrimPrefix(strings.TrimSuffix(string(b), `"`), `"`)
-	for i, f := range strings.Split(str, "/") {
+	parts := strings.Split(str, "/")
+	if len(parts) > len(ft) {
+		return fmt.Errorf("bad selection spec %q: expected at most %d slash-separated fields", str, len(ft))
+	}
+	for i, f := range parts {
 		var err error
 		switch ft[i] {
 		case Namespace:

--- a/tools/bug-report/pkg/config/config_test.go
+++ b/tools/bug-report/pkg/config/config_test.go
@@ -144,6 +144,13 @@ func TestUnmarshalSelectionSpec(t *testing.T) {
 	assert.Equal(t, got, want)
 }
 
+func TestUnmarshalSelectionSpecTooManyFields(t *testing.T) {
+	got := &SelectionSpec{}
+	err := got.UnmarshalJSON([]byte("ns/deployment/pod/label=value/annotation=value/container/extra"))
+
+	assert.Error(t, err)
+}
+
 func TestMarshalSelectionSpec(t *testing.T) {
 	spec := &SelectionSpec{
 		Namespaces:  []string{"ns1", "ns2"},


### PR DESCRIPTION
A `bug-report` filter with more than six slash-separated fields panics. This validates the count and returns an error instead, all good.

Repro:
`istioctl bug-report --include 'ns/deploy/pod/l=v/a=v/container/extra'`

FYI, tiny input-validation fix, no drama.

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

- [ ] Does not have any user-facing changes.