### PR TITLE
Adjust TestEastWestGatewayTLSRoute to skip when clusters are on the same network

### DIFF
--- a/tests/integration/ambient/multicluster_test.go
+++ b/tests/integration/ambient/multicluster_test.go
@@ -28,6 +28,8 @@ import (
 
 	"istio.io/api/label"
 	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/maps"
+	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/ambient"
@@ -50,7 +52,7 @@ type workload struct {
 	serviceLabels map[string]string
 }
 
-func TestMultinetworkFailover(t *testing.T) {
+func TestMulticlusterFailover(t *testing.T) {
 	const brokenService1 = "broken1"
 	const brokenService2 = "broken2"
 	const clientService = "client"
@@ -169,11 +171,11 @@ func TestMultinetworkFailover(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
 		t.NewSubTest("without-waypoint").Run(func(t framework.TestContext) {
 			if !t.Settings().Ambient || !t.Settings().AmbientMultiNetwork {
-				t.Skip("this test is ambient multi-network specific")
+				t.Skip("this test is ambient multi-cluster specific")
 			}
 
 			if len(t.Clusters()) < 2 {
-				t.Fatal("ambient multi-network failover test requires at least 2 clusters")
+				t.Fatal("ambient multi-cluster failover test requires at least 2 clusters")
 			}
 
 			allClusters := t.Clusters()
@@ -207,11 +209,11 @@ func TestMultinetworkFailover(t *testing.T) {
 		})
 		t.NewSubTest("with-waypoints").Run(func(t framework.TestContext) {
 			if !t.Settings().Ambient || !t.Settings().AmbientMultiNetwork {
-				t.Skip("this test is ambient multi-network specific")
+				t.Skip("this test is ambient multi-cluster specific")
 			}
 
 			if len(t.Clusters()) < 2 {
-				t.Fatal("ambient multi-network failover test requires at least 2 clusters")
+				t.Fatal("ambient multi-cluster failover test requires at least 2 clusters")
 			}
 
 			allClusters := t.Clusters()
@@ -401,18 +403,24 @@ func scaleDeploymentOrFail(t framework.TestContext, c cluster.Cluster, namespace
 func TestEastWestGatewayTLSRoute(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
 		if !t.Settings().Ambient || !t.Settings().AmbientMultiNetwork {
-			t.Skip("this test is ambient multi-network specific")
+			t.Skip("this test is ambient multi-cluster specific")
 		}
-		if len(t.Clusters()) < 2 {
-			t.Fatal("east-west gateway TLSRoute test requires at least 2 clusters")
+		allClusters := slices.Group(t.Clusters(), func(c cluster.Cluster) string {
+			return c.NetworkName()
+		})
+		networks := maps.Keys(allClusters)
+		if len(networks) < 2 {
+			t.Skip("east-west gateway TLSRoute test requires at least 2 clusters on different networks")
 		}
+
+		// gwCluster hosts the E/W gateway + backend; remoteCluster is the client.
+		gwNetwork := networks[0]
+		gwCluster := allClusters[gwNetwork][0]
+
+		remoteNetwork := networks[1]
+		remoteCluster := allClusters[remoteNetwork][0]
 
 		crd.DeployGatewayAPIOrSkip(t)
-
-		allClusters := t.Clusters()
-		// gwCluster hosts the E/W gateway + backend; remoteCluster is the client.
-		gwCluster := allClusters[0]
-		remoteCluster := allClusters[1]
 
 		nsConfig := namespace.NewOrFail(t, namespace.Config{
 			Prefix: "ew-tlsroute",


### PR DESCRIPTION
**Please provide a description of this PR:**

The intention of this test is to verify that we can configure a TLS passthrough on an ambient E/W gateway to allow connecting to a remote network API server through a gateway instead of assuming direct connectivity.

Deploying E/W gateway only makes sense in multi-network setup, so when clusters are on the same network this test does not make sense and we should skip it.

Until now we've only been running ambient multi-cluster tests on deployment with just two clusters and both of them are on different networks, so the fact that the test didn't verify that clusters are on different networks didn't matter at all.

I want to start running CI multi-cluster tests on a mixed deployment of clusters where some clusters belong to the same network and some are on a different network to cover single-network multi-cluster and compatibility between single-network and multi-network multi-cluster by tests.

This PR adjusts the test to skip if all clusters are on the same network and if there are more than two clusters, it will actually find and pick clusters from different networks to use them for testing.

NOTE: The other test in this file might also need to be adjusted to explicitly cover both failover options (within the same network and between networks), but I will do that in a separate PR and the test itself will work just fine on the mixed deployment, but just wouldn't provide the level of coverage I want.

NOTE: I also did some minor renaming - hystorically ambient multi-cluster tests only covered multi-network, so error messages, command line flags, feature flags and test names are all kind of confusing as they use multi-cluster and multi-network interchangibly. We can't easily change all of those flags, but we should start being more precise where we can going forward.

Part of #61067
Related to #61066