### PR TITLE
security: renew expired self-signed CA cert on startup

### DIFF
--- a/releasenotes/notes/renew-expired-self-signed-ca.yaml
+++ b/releasenotes/notes/renew-expired-self-signed-ca.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+releaseNotes:
+- |
+  **Fixed** istiod failing to start when the self-signed CA certificate in `istio-ca-secret` has expired,
+  which can happen when the deployment is scaled to zero for longer than the certificate TTL.
+  The expired certificate is now automatically renewed using the existing private key.

--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -19,6 +19,7 @@ import (
 	"crypto/elliptic"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -162,18 +163,15 @@ func NewSelfSignedIstioCAOptions(ctx context.Context,
 		b := backoff.NewExponentialBackOff(backoff.DefaultOption())
 		if retryErr := b.RetryWithContext(ctx, func() error {
 			loadErr = loadSelfSignedCaSecret(client, namespace, name, rootCertFile, caOpts)
-			if loadErr == nil || apierror.IsNotFound(loadErr) {
+			if loadErr == nil || apierror.IsNotFound(loadErr) || isCertExpired(loadErr) {
 				return nil // stop retrying
 			}
 			return loadErr
 		}); retryErr != nil {
 			return nil, retryErr
 		}
-		if loadErr == nil {
+		if loadErr == nil || isCertExpired(loadErr) {
 			break
-		}
-		if !apierror.IsNotFound(loadErr) {
-			return nil, loadErr
 		}
 	}
 
@@ -187,6 +185,11 @@ func NewSelfSignedIstioCAOptions(ctx context.Context,
 			}
 			return err
 		}); err != nil {
+			return nil, err
+		}
+	} else if isCertExpired(loadErr) {
+		pkiCaLog.Infof("Expired CA cert in secret %s, will renew", caCertName)
+		if err := renewSelfSignedCaSecret(client, namespace, caCertName, rootCertFile, caCertTTL, org, dualUse, caRSAKeySize, caOpts); err != nil {
 			return nil, err
 		}
 	}
@@ -532,9 +535,54 @@ func loadSelfSignedCaSecret(client corev1.CoreV1Interface, namespace string, caC
 			rootCerts,
 			nil,
 		); err != nil {
-			return fmt.Errorf("failed to create CA KeyCertBundle (%v)", err)
+			return fmt.Errorf("failed to create CA KeyCertBundle: %w", err)
 		}
 		pkiCaLog.Infof("Using existing public key: %v", string(rootCerts))
 	}
 	return err
+}
+
+func isCertExpired(err error) bool {
+	var certInvalidErr x509.CertificateInvalidError
+	return errors.As(err, &certInvalidErr) && certInvalidErr.Reason == x509.Expired
+}
+
+func renewSelfSignedCaSecret(client corev1.CoreV1Interface, namespace, caCertName, rootCertFile string,
+	caCertTTL time.Duration, org string, dualUse bool, caRSAKeySize int, caOpts *IstioCAOptions,
+) error {
+	caSecret, err := client.Secrets(namespace).Get(context.TODO(), caCertName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get CA secret for renewal: %w", err)
+	}
+
+	options := util.CertOptions{
+		TTL:           caCertTTL,
+		SignerPrivPem: caSecret.Data[CAPrivateKeyFile],
+		Org:           org,
+		IsCA:          true,
+		IsSelfSigned:  true,
+		RSAKeySize:    caRSAKeySize,
+		IsDualUse:     dualUse,
+	}
+	pemCert, pemKey, err := util.GenRootCertFromExistingKey(options)
+	if err != nil {
+		return fmt.Errorf("unable to generate CA cert from existing key for renewal: %w", err)
+	}
+
+	rootCerts, err := util.AppendRootCerts(pemCert, rootCertFile)
+	if err != nil {
+		return fmt.Errorf("failed to append root certificates: %w", err)
+	}
+	if caOpts.KeyCertBundle, err = util.NewVerifiedKeyCertBundleFromPem(pemCert, pemKey, nil, rootCerts, nil); err != nil {
+		return fmt.Errorf("failed to create CA KeyCertBundle: %w", err)
+	}
+
+	caSecret.Data[CACertFile] = pemCert
+	caSecret.Data[CAPrivateKeyFile] = pemKey
+	caSecret.Data[RootCertFile] = pemCert
+	if _, err = client.Secrets(namespace).Update(context.TODO(), caSecret, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("failed to update CA secret after renewal: %w", err)
+	}
+	pkiCaLog.Infof("Renewed expired self-signed CA cert in secret %s/%s", namespace, caCertName)
+	return nil
 }

--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -180,6 +180,7 @@ func NewSelfSignedIstioCAOptions(ctx context.Context,
 		b := backoff.NewExponentialBackOff(backoff.DefaultOption())
 		if err := b.RetryWithContext(ctx, func() error {
 			err := createSelfSignedCaSecret(client, namespace, caCertName, rootCertFile, caCertTTL, org, dualUse, caRSAKeySize, caOpts)
+			// another replica created certificate
 			if apierror.IsAlreadyExists(err) {
 				return loadSelfSignedCaSecret(client, namespace, caCertName, rootCertFile, caOpts)
 			}
@@ -189,7 +190,15 @@ func NewSelfSignedIstioCAOptions(ctx context.Context,
 		}
 	} else if isCertExpired(loadErr) {
 		pkiCaLog.Infof("Expired CA cert in secret %s, will renew", caCertName)
-		if err := renewSelfSignedCaSecret(client, namespace, caCertName, rootCertFile, caCertTTL, org, dualUse, caRSAKeySize, caOpts); err != nil {
+		b := backoff.NewExponentialBackOff(backoff.DefaultOption())
+		if err := b.RetryWithContext(ctx, func() error {
+			err := renewSelfSignedCaSecret(client, namespace, caCertName, rootCertFile, caCertTTL, org, dualUse, caRSAKeySize, caOpts)
+			// another replica rotated certificate
+			if apierror.IsConflict(err) {
+				return loadSelfSignedCaSecret(client, namespace, caCertName, rootCertFile, caOpts)
+			}
+			return err
+		}); err != nil {
 			return nil, err
 		}
 	}
@@ -555,6 +564,15 @@ func renewSelfSignedCaSecret(client corev1.CoreV1Interface, namespace, caCertNam
 		return fmt.Errorf("failed to get CA secret for renewal: %w", err)
 	}
 
+	cert, err := util.ParsePemEncodedCertificate(caSecret.Data[CACertFile])
+	if err != nil {
+		return fmt.Errorf("failed to parse CA cert for renewal: %w", err)
+	}
+	if time.Now().Before(cert.NotAfter) {
+		pkiCaLog.Info("CA cert already renewed by another replica")
+		return loadSelfSignedCaSecret(client, namespace, caCertName, rootCertFile, caOpts)
+	}
+
 	options := util.CertOptions{
 		TTL:           caCertTTL,
 		SignerPrivPem: caSecret.Data[CAPrivateKeyFile],
@@ -569,19 +587,18 @@ func renewSelfSignedCaSecret(client corev1.CoreV1Interface, namespace, caCertNam
 		return fmt.Errorf("unable to generate CA cert from existing key for renewal: %w", err)
 	}
 
+	caSecret.Data[CACertFile] = pemCert
+	caSecret.Data[RootCertFile] = pemCert
+	if _, err = client.Secrets(namespace).Update(context.TODO(), caSecret, metav1.UpdateOptions{}); err != nil {
+		return err
+	}
+
 	rootCerts, err := util.AppendRootCerts(pemCert, rootCertFile)
 	if err != nil {
 		return fmt.Errorf("failed to append root certificates: %w", err)
 	}
 	if caOpts.KeyCertBundle, err = util.NewVerifiedKeyCertBundleFromPem(pemCert, pemKey, nil, rootCerts, nil); err != nil {
 		return fmt.Errorf("failed to create CA KeyCertBundle: %w", err)
-	}
-
-	caSecret.Data[CACertFile] = pemCert
-	caSecret.Data[CAPrivateKeyFile] = pemKey
-	caSecret.Data[RootCertFile] = pemCert
-	if _, err = client.Secrets(namespace).Update(context.TODO(), caSecret, metav1.UpdateOptions{}); err != nil {
-		return fmt.Errorf("failed to update CA secret after renewal: %w", err)
 	}
 	pkiCaLog.Infof("Renewed expired self-signed CA cert in secret %s/%s", namespace, caCertName)
 	return nil

--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -181,7 +181,11 @@ func NewSelfSignedIstioCAOptions(ctx context.Context,
 		pkiCaLog.Infof("CASecret %s not found, will create one", caCertName)
 		b := backoff.NewExponentialBackOff(backoff.DefaultOption())
 		if err := b.RetryWithContext(ctx, func() error {
-			return createSelfSignedCaSecret(client, namespace, caCertName, rootCertFile, caCertTTL, org, dualUse, caRSAKeySize, caOpts)
+			err := createSelfSignedCaSecret(client, namespace, caCertName, rootCertFile, caCertTTL, org, dualUse, caRSAKeySize, caOpts)
+			if apierror.IsAlreadyExists(err) {
+				return loadSelfSignedCaSecret(client, namespace, caCertName, rootCertFile, caOpts)
+			}
+			return err
 		}); err != nil {
 			return nil, err
 		}

--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -128,8 +128,8 @@ func NewSelfSignedIstioCAOptions(ctx context.Context,
 	rootCertGracePeriodPercentile int, caCertTTL, rootCertCheckInverval, defaultCertTTL,
 	maxCertTTL time.Duration, org string, useCacertsSecretName, dualUse bool, namespace string, client corev1.CoreV1Interface,
 	rootCertFile string, enableJitter bool, caRSAKeySize int,
-) (caOpts *IstioCAOptions, err error) {
-	caOpts = &IstioCAOptions{
+) (*IstioCAOptions, error) {
+	caOpts := &IstioCAOptions{
 		CAType:         selfSignedCA,
 		DefaultCertTTL: defaultCertTTL,
 		MaxCertTTL:     maxCertTTL,
@@ -148,97 +148,48 @@ func NewSelfSignedIstioCAOptions(ctx context.Context,
 		},
 	}
 
-	// always use ``istio-ca-secret` in priority, otherwise fall back to `cacerts`
+	// Try to load an existing CA secret, checking istio-ca-secret first, then cacerts if enabled.
+	// If neither is found, create a new self-signed CA secret using the last candidate name.
+	candidates := []string{CASecret}
+	if useCacertsSecretName {
+		candidates = append(candidates, CACertsSecret)
+	}
+
 	var caCertName string
-	b := backoff.NewExponentialBackOff(backoff.DefaultOption())
-	err = b.RetryWithContext(ctx, func() error {
-		caCertName = CASecret
-		// 1. fetch `istio-ca-secret` in priority
-		err := loadSelfSignedCaSecret(client, namespace, caCertName, rootCertFile, caOpts)
-		if err == nil {
-			return nil
-		} else if apierror.IsNotFound(err) {
-			// 2. if `istio-ca-secret` not exist and use cacerts enabled, fallback to fetch `cacerts`
-			if useCacertsSecretName {
-				caCertName = CACertsSecret
-				err := loadSelfSignedCaSecret(client, namespace, caCertName, rootCertFile, caOpts)
-				if err == nil {
-					return nil
-				} else if apierror.IsNotFound(err) { // if neither `istio-ca-secret` nor `cacerts` exists, we create a `cacerts`
-					// continue to create `cacerts`
-				} else {
-					return err
-				}
+	var loadErr error
+	for _, name := range candidates {
+		caCertName = name
+		b := backoff.NewExponentialBackOff(backoff.DefaultOption())
+		if retryErr := b.RetryWithContext(ctx, func() error {
+			loadErr = loadSelfSignedCaSecret(client, namespace, name, rootCertFile, caOpts)
+			if loadErr == nil || apierror.IsNotFound(loadErr) {
+				return nil // stop retrying
 			}
-
-			// 3. if use cacerts disabled, create `istio-ca-secret`, otherwise create `cacerts`.
-			pkiCaLog.Infof("CASecret %s not found, will create one", caCertName)
-			options := util.CertOptions{
-				TTL:          caCertTTL,
-				Org:          org,
-				IsCA:         true,
-				IsSelfSigned: true,
-				RSAKeySize:   caRSAKeySize,
-				IsDualUse:    dualUse,
-			}
-			pemCert, pemKey, ckErr := util.GenCertKeyFromOptions(options)
-			if ckErr != nil {
-				pkiCaLog.Warnf("unable to generate CA cert and key for self-signed CA (%v)", ckErr)
-				return fmt.Errorf("unable to generate CA cert and key for self-signed CA (%v)", ckErr)
-			}
-
-			rootCerts, err := util.AppendRootCerts(pemCert, rootCertFile)
-			if err != nil {
-				pkiCaLog.Warnf("failed to append root certificates (%v)", err)
-				return fmt.Errorf("failed to append root certificates (%v)", err)
-			}
-			if caOpts.KeyCertBundle, err = util.NewVerifiedKeyCertBundleFromPem(
-				pemCert,
-				pemKey,
-				nil,
-				rootCerts,
-				nil,
-			); err != nil {
-				pkiCaLog.Warnf("failed to create CA KeyCertBundle (%v)", err)
-				return fmt.Errorf("failed to create CA KeyCertBundle (%v)", err)
-			}
-			// Write the key/cert back to secret, so they will be persistent when CA restarts.
-			secret := BuildSecret(caCertName, namespace, nil, nil, pemCert, pemCert, pemKey, istioCASecretType)
-			_, err = client.Secrets(namespace).Create(context.TODO(), secret, metav1.CreateOptions{})
-			if err != nil {
-				pkiCaLog.Warnf("Failed to create secret %s (%v)", caCertName, err)
-				return err
-			}
-			pkiCaLog.Infof("Using self-generated public key: %v", string(rootCerts))
-			return nil
+			return loadErr
+		}); retryErr != nil {
+			return nil, retryErr
 		}
-		return err
-	})
+		if loadErr == nil {
+			break
+		}
+		if !apierror.IsNotFound(loadErr) {
+			return nil, loadErr
+		}
+	}
+
+	if apierror.IsNotFound(loadErr) {
+		pkiCaLog.Infof("CASecret %s not found, will create one", caCertName)
+		b := backoff.NewExponentialBackOff(backoff.DefaultOption())
+		if err := b.RetryWithContext(ctx, func() error {
+			return createSelfSignedCaSecret(client, namespace, caCertName, rootCertFile, caCertTTL, org, dualUse, caRSAKeySize, caOpts)
+		}); err != nil {
+			return nil, err
+		}
+	}
+
 	pkiCaLog.Infof("Set secret name for self-signed CA cert rotator to %s", caCertName)
 	caOpts.RotatorConfig.secretName = caCertName
-	return caOpts, err
-}
-
-func loadSelfSignedCaSecret(client corev1.CoreV1Interface, namespace string, caCertName string, rootCertFile string, caOpts *IstioCAOptions) error {
-	caSecret, err := client.Secrets(namespace).Get(context.TODO(), caCertName, metav1.GetOptions{})
-	if err == nil {
-		pkiCaLog.Infof("Load signing key and cert from existing secret %s/%s", caSecret.Namespace, caSecret.Name)
-		rootCerts, err := util.AppendRootCerts(caSecret.Data[CACertFile], rootCertFile)
-		if err != nil {
-			return fmt.Errorf("failed to append root certificates (%v)", err)
-		}
-		if caOpts.KeyCertBundle, err = util.NewVerifiedKeyCertBundleFromPem(
-			caSecret.Data[CACertFile],
-			caSecret.Data[CAPrivateKeyFile],
-			nil,
-			rootCerts,
-			nil,
-		); err != nil {
-			return fmt.Errorf("failed to create CA KeyCertBundle (%v)", err)
-		}
-		pkiCaLog.Infof("Using existing public key: %v", string(rootCerts))
-	}
-	return err
+	return caOpts, nil
 }
 
 // NewSelfSignedDebugIstioCAOptions returns a new IstioCAOptions instance using self-signed certificate produced by in-memory CA,
@@ -528,4 +479,58 @@ func (ca *IstioCA) signWithCertChain(csrPEM []byte, subjectIDs []string, request
 		cert = append(cert, chainPem...)
 	}
 	return cert, nil
+}
+
+func createSelfSignedCaSecret(client corev1.CoreV1Interface, namespace, caCertName, rootCertFile string,
+	caCertTTL time.Duration, org string, dualUse bool, caRSAKeySize int, caOpts *IstioCAOptions,
+) error {
+	options := util.CertOptions{
+		TTL:          caCertTTL,
+		Org:          org,
+		IsCA:         true,
+		IsSelfSigned: true,
+		RSAKeySize:   caRSAKeySize,
+		IsDualUse:    dualUse,
+	}
+	pemCert, pemKey, ckErr := util.GenCertKeyFromOptions(options)
+	if ckErr != nil {
+		return fmt.Errorf("unable to generate CA cert and key for self-signed CA (%v)", ckErr)
+	}
+
+	rootCerts, err := util.AppendRootCerts(pemCert, rootCertFile)
+	if err != nil {
+		return fmt.Errorf("failed to append root certificates (%v)", err)
+	}
+	if caOpts.KeyCertBundle, err = util.NewVerifiedKeyCertBundleFromPem(pemCert, pemKey, nil, rootCerts, nil); err != nil {
+		return fmt.Errorf("failed to create CA KeyCertBundle (%v)", err)
+	}
+
+	secret := BuildSecret(caCertName, namespace, nil, nil, pemCert, pemCert, pemKey, istioCASecretType)
+	if _, err = client.Secrets(namespace).Create(context.TODO(), secret, metav1.CreateOptions{}); err != nil {
+		return err
+	}
+	pkiCaLog.Infof("Using self-generated public key: %v", string(rootCerts))
+	return nil
+}
+
+func loadSelfSignedCaSecret(client corev1.CoreV1Interface, namespace string, caCertName string, rootCertFile string, caOpts *IstioCAOptions) error {
+	caSecret, err := client.Secrets(namespace).Get(context.TODO(), caCertName, metav1.GetOptions{})
+	if err == nil {
+		pkiCaLog.Infof("Load signing key and cert from existing secret %s/%s", caSecret.Namespace, caSecret.Name)
+		rootCerts, err := util.AppendRootCerts(caSecret.Data[CACertFile], rootCertFile)
+		if err != nil {
+			return fmt.Errorf("failed to append root certificates (%v)", err)
+		}
+		if caOpts.KeyCertBundle, err = util.NewVerifiedKeyCertBundleFromPem(
+			caSecret.Data[CACertFile],
+			caSecret.Data[CAPrivateKeyFile],
+			nil,
+			rootCerts,
+			nil,
+		); err != nil {
+			return fmt.Errorf("failed to create CA KeyCertBundle (%v)", err)
+		}
+		pkiCaLog.Infof("Using existing public key: %v", string(rootCerts))
+	}
+	return err
 }

--- a/security/pkg/pki/ca/ca_test.go
+++ b/security/pkg/pki/ca/ca_test.go
@@ -44,6 +44,9 @@ var (
 	testRootCertCheckInverval = time.Hour
 	testRSAKeySize            = 2048
 
+	signingCertPem = []byte(cert1Pem)
+	signingKeyPem  = []byte(key1Pem)
+
 	cert1Pem = `
 -----BEGIN CERTIFICATE-----
 MIIC3jCCAcagAwIBAgIJAMwyWk0iqlOoMA0GCSqGSIb3DQEBCwUAMBwxGjAYBgNV
@@ -214,9 +217,6 @@ func TestCreateSelfSignedIstioCAWithoutSecretAndUseCacertsEnabled(t *testing.T) 
 func TestCreateSelfSignedIstioCAWithSecret(t *testing.T) {
 	rootCertPem := cert1Pem
 	// Use the same signing cert and root cert for self-signed CA.
-	signingCertPem := []byte(cert1Pem)
-	signingKeyPem := []byte(key1Pem)
-
 	client := fake.NewClientset()
 	initSecret := BuildSecret(CASecret, testCaNamespace, nil, nil, nil, signingCertPem, signingKeyPem, istioCASecretType)
 	_, err := client.CoreV1().Secrets(testCaNamespace).Create(context.TODO(), initSecret, metav1.CreateOptions{})
@@ -261,9 +261,6 @@ func TestCreateSelfSignedIstioCAWithSecret(t *testing.T) {
 }
 
 func TestCreateSelfSignedIstioCAWithExistingSecretAndUseCacertsEnabled(t *testing.T) {
-	signingCertPem := []byte(cert1Pem)
-	signingKeyPem := []byte(key1Pem)
-
 	client := fake.NewClientset()
 	initSecret := BuildSecret(CASecret, testCaNamespace, nil, nil, nil, signingCertPem, signingKeyPem, istioCASecretType)
 	if _, err := client.CoreV1().Secrets(testCaNamespace).Create(context.TODO(), initSecret, metav1.CreateOptions{}); err != nil {
@@ -963,12 +960,10 @@ func TestGenKeyCert(t *testing.T) {
 
 // TestBuildSecret verifies that BuildSecret returns expected secret.
 func TestBuildSecret(t *testing.T) {
-	CertPem := []byte(cert1Pem)
-	KeyPem := []byte(key1Pem)
 	namespace := "default"
 	secretType := "secret-type"
 
-	caSecret := BuildSecret(CASecret, namespace, nil, nil, nil, CertPem, KeyPem, v1.SecretType(secretType))
+	caSecret := BuildSecret(CASecret, namespace, nil, nil, nil, signingCertPem, signingKeyPem, v1.SecretType(secretType))
 	if caSecret.ObjectMeta.Annotations != nil {
 		t.Fatalf("Annotation should be nil but got %v", caSecret)
 	}
@@ -981,13 +976,13 @@ func TestBuildSecret(t *testing.T) {
 	if caSecret.Data[PrivateKeyFile] != nil {
 		t.Fatalf("Private key should be nil but got %v", caSecret.Data[PrivateKeyFile])
 	}
-	if !bytes.Equal(caSecret.Data[CACertFile], CertPem) {
-		t.Fatalf("CA cert does not match, want %v got %v", CertPem, caSecret.Data[CACertFile])
+	if !bytes.Equal(caSecret.Data[CACertFile], signingCertPem) {
+		t.Fatalf("CA cert does not match, want %v got %v", signingCertPem, caSecret.Data[CACertFile])
 	}
-	if !bytes.Equal(caSecret.Data[CAPrivateKeyFile], KeyPem) {
-		t.Fatalf("CA cert does not match, want %v got %v", KeyPem, caSecret.Data[CAPrivateKeyFile])
+	if !bytes.Equal(caSecret.Data[CAPrivateKeyFile], signingKeyPem) {
+		t.Fatalf("CA cert does not match, want %v got %v", signingKeyPem, caSecret.Data[CAPrivateKeyFile])
 	}
-	serverSecret := BuildSecret(CACertsSecret, namespace, CertPem, KeyPem, nil, nil, nil, v1.SecretType(secretType))
+	serverSecret := BuildSecret(CACertsSecret, namespace, signingCertPem, signingKeyPem, nil, nil, nil, v1.SecretType(secretType))
 	if serverSecret.ObjectMeta.Annotations != nil {
 		t.Fatalf("Annotation should be nil but got %v", serverSecret)
 	}
@@ -1000,11 +995,11 @@ func TestBuildSecret(t *testing.T) {
 	if serverSecret.Data[CAPrivateKeyFile] != nil {
 		t.Fatalf("CA private key should be nil but got %v", serverSecret.Data[CAPrivateKeyFile])
 	}
-	if !bytes.Equal(serverSecret.Data[CertChainFile], CertPem) {
-		t.Fatalf("Cert chain does not match, want %v got %v", CertPem, serverSecret.Data[CertChainFile])
+	if !bytes.Equal(serverSecret.Data[CertChainFile], signingCertPem) {
+		t.Fatalf("Cert chain does not match, want %v got %v", signingCertPem, serverSecret.Data[CertChainFile])
 	}
-	if !bytes.Equal(serverSecret.Data[PrivateKeyFile], KeyPem) {
-		t.Fatalf("Private key does not match, want %v got %v", KeyPem, serverSecret.Data[PrivateKeyFile])
+	if !bytes.Equal(serverSecret.Data[PrivateKeyFile], signingKeyPem) {
+		t.Fatalf("Private key does not match, want %v got %v", signingKeyPem, serverSecret.Data[PrivateKeyFile])
 	}
 }
 

--- a/security/pkg/pki/ca/ca_test.go
+++ b/security/pkg/pki/ca/ca_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"os"
 	"reflect"
 	"sync"
@@ -28,7 +29,10 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
 
 	caerror "istio.io/istio/security/pkg/pki/error"
 	"istio.io/istio/security/pkg/pki/util"
@@ -352,6 +356,108 @@ func TestSelfSignedIstioCARotatesExpiredCert(t *testing.T) {
 	}
 	if updatedCert.NotAfter.Before(time.Now()) {
 		t.Error("Cert in K8s secret should not be expired after renewal")
+	}
+}
+
+func TestConcurrentRenewSelfSignedIstioCA(t *testing.T) {
+	expiredCert, expiredKey, err := util.GenCertKeyFromOptions(util.CertOptions{
+		TTL:          time.Second,
+		Org:          testOrg,
+		IsCA:         true,
+		IsSelfSigned: true,
+		RSAKeySize:   testRSAKeySize,
+		NotBefore:    time.Now().Add(-10 * time.Second),
+	})
+	if err != nil {
+		t.Fatalf("Failed to generate expired cert: %v", err)
+	}
+
+	client := fake.NewClientset()
+	initSecret := BuildSecret(CASecret, testCaNamespace, nil, nil, nil, expiredCert, expiredKey, istioCASecretType)
+	created, err := client.CoreV1().Secrets(testCaNamespace).Create(context.TODO(), initSecret, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create secret: %v", err)
+	}
+
+	// Simulate optimistic concurrency control: reject updates with stale resourceVersion.
+	var versionMu sync.Mutex
+	currentVersion := created.ResourceVersion
+	client.PrependReactor("update", "secrets", func(action ktesting.Action) (bool, runtime.Object, error) {
+		updateAction := action.(ktesting.UpdateAction)
+		secret := updateAction.GetObject().(*v1.Secret).DeepCopy()
+		versionMu.Lock()
+		defer versionMu.Unlock()
+		if secret.ResourceVersion != currentVersion {
+			return true, nil, apierror.NewConflict(
+				schema.GroupResource{Resource: "secrets"}, secret.Name, fmt.Errorf("resourceVersion mismatch"))
+		}
+		currentVersion = fmt.Sprintf("%s+1", secret.ResourceVersion)
+		secret.ResourceVersion = currentVersion
+		// Persist the update through the tracker so subsequent Get calls return it.
+		if err := client.Tracker().Update(
+			schema.GroupVersionResource{Version: "v1", Resource: "secrets"}, secret, secret.Namespace); err != nil {
+			return true, nil, err
+		}
+		return true, secret, nil
+	})
+
+	parallel := 10
+	wg := sync.WaitGroup{}
+	wg.Add(parallel)
+	rootCertCh := make(chan []byte, parallel)
+	privateKeyCh := make(chan []byte, parallel)
+
+	for i := 0; i < parallel; i++ {
+		go func() {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			defer cancel()
+			caOpts, err := NewSelfSignedIstioCAOptions(ctx, 0,
+				testCaCertTTL, testDefaultCertTTL, testRootCertCheckInverval, testMaxCertTTL, testOrg, false, false,
+				testCaNamespace, client.CoreV1(), testRootCertFile, false, testRSAKeySize)
+			if err != nil {
+				t.Errorf("NewSelfSignedIstioCAOptions got unexpected error: %v", err)
+				return
+			}
+			cert, privateKey, _, rootCert := caOpts.KeyCertBundle.GetAllPem()
+			if !bytes.Equal(cert, rootCert) {
+				t.Error("Root cert and cert do not match")
+			}
+			rootCertCh <- rootCert
+			privateKeyCh <- privateKey
+		}()
+	}
+	wg.Wait()
+
+	caSecret, err := client.CoreV1().Secrets(testCaNamespace).Get(context.TODO(), CASecret, metav1.GetOptions{})
+	if err != nil || caSecret == nil {
+		t.Fatalf("Failed getting CA secret: %v", err)
+	}
+
+	updatedCert, err := util.ParsePemEncodedCertificate(caSecret.Data[CACertFile])
+	if err != nil {
+		t.Fatalf("Failed to parse cert from secret: %v", err)
+	}
+	if updatedCert.NotAfter.Before(time.Now()) {
+		t.Fatal("Cert in K8s secret should not be expired after renewal")
+	}
+
+	rootCert := caSecret.Data[CACertFile]
+	privateKey := caSecret.Data[CAPrivateKeyFile]
+
+	for {
+		select {
+		case current := <-rootCertCh:
+			if !bytes.Equal(rootCert, current) {
+				t.Error("Root cert does not match")
+			}
+		case current := <-privateKeyCh:
+			if !bytes.Equal(privateKey, current) {
+				t.Error("Private key does not match")
+			}
+		default:
+			return
+		}
 	}
 }
 

--- a/security/pkg/pki/ca/ca_test.go
+++ b/security/pkg/pki/ca/ca_test.go
@@ -296,6 +296,65 @@ func TestCreateSelfSignedIstioCAWithExistingSecretAndUseCacertsEnabled(t *testin
 	}
 }
 
+func TestSelfSignedIstioCARotatesExpiredCert(t *testing.T) {
+	expiredCert, expiredKey, err := util.GenCertKeyFromOptions(util.CertOptions{
+		TTL:          time.Second,
+		Org:          testOrg,
+		IsCA:         true,
+		IsSelfSigned: true,
+		RSAKeySize:   testRSAKeySize,
+		NotBefore:    time.Now().Add(-10 * time.Second),
+	})
+	if err != nil {
+		t.Fatalf("Failed to generate expired cert: %v", err)
+	}
+
+	client := fake.NewClientset()
+	initSecret := BuildSecret(CASecret, testCaNamespace, nil, nil, nil, expiredCert, expiredKey, istioCASecretType)
+	if _, err := client.CoreV1().Secrets(testCaNamespace).Create(context.TODO(), initSecret, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create secret: %v", err)
+	}
+
+	caopts, err := NewSelfSignedIstioCAOptions(context.Background(),
+		0, testCaCertTTL, testRootCertCheckInverval, testDefaultCertTTL, testMaxCertTTL,
+		testOrg, false, false, testCaNamespace, client.CoreV1(),
+		testRootCertFile, false, testRSAKeySize)
+	if err != nil {
+		t.Fatalf("Failed to create a self-signed CA Options: %v", err)
+	}
+
+	ca, err := NewIstioCA(caopts)
+	if err != nil {
+		t.Fatalf("Failed to create a self-signed CA: %v", err)
+	}
+
+	signingCert, _, _, rootCertBytes := ca.GetCAKeyCertBundle().GetAll()
+
+	if signingCert.NotAfter.Before(time.Now()) {
+		t.Error("Renewed signing cert should not be expired")
+	}
+
+	rootCert, err := util.ParsePemEncodedCertificate(rootCertBytes)
+	if err != nil {
+		t.Fatalf("Failed to parse root cert: %v", err)
+	}
+	if rootCert.NotAfter.Before(time.Now()) {
+		t.Error("Renewed root cert should not be expired")
+	}
+
+	caSecret, err := client.CoreV1().Secrets(testCaNamespace).Get(context.TODO(), CASecret, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get secret: %v", err)
+	}
+	updatedCert, err := util.ParsePemEncodedCertificate(caSecret.Data[CACertFile])
+	if err != nil {
+		t.Fatalf("Failed to parse cert from secret: %v", err)
+	}
+	if updatedCert.NotAfter.Before(time.Now()) {
+		t.Error("Cert in K8s secret should not be expired after renewal")
+	}
+}
+
 func TestCreateSelfSignedIstioCAReadSigningCertOnly(t *testing.T) {
 	client := fake.NewClientset()
 

--- a/security/pkg/pki/ca/ca_test.go
+++ b/security/pkg/pki/ca/ca_test.go
@@ -35,6 +35,15 @@ import (
 )
 
 var (
+	testCaCertTTL             = time.Hour
+	testDefaultCertTTL        = 30 * time.Minute
+	testMaxCertTTL            = time.Hour
+	testOrg                   = "test.ca.Org"
+	testCaNamespace           = "default"
+	testRootCertFile          = ""
+	testRootCertCheckInverval = time.Hour
+	testRSAKeySize            = 2048
+
 	cert1Pem = `
 -----BEGIN CERTIFICATE-----
 MIIC3jCCAcagAwIBAgIJAMwyWk0iqlOoMA0GCSqGSIb3DQEBCwUAMBwxGjAYBgNV
@@ -89,20 +98,12 @@ iOmuuOfQWnMfcVk8I0YDL5+G9Pg=
 // TODO (myidpt): Test Istio CA can load plugin key/certs from secret.
 
 func TestCreateSelfSignedIstioCAWithoutSecret(t *testing.T) {
-	caCertTTL := time.Hour
-	defaultCertTTL := 30 * time.Minute
-	maxCertTTL := time.Hour
-	org := "test.ca.Org"
-	const caNamespace = "default"
 	client := fake.NewClientset()
-	rootCertFile := ""
-	rootCertCheckInverval := time.Hour
-	rsaKeySize := 2048
 
 	caopts, err := NewSelfSignedIstioCAOptions(context.Background(),
-		0, caCertTTL, rootCertCheckInverval, defaultCertTTL,
-		maxCertTTL, org, false, false, caNamespace, client.CoreV1(),
-		rootCertFile, false, rsaKeySize)
+		0, testCaCertTTL, testRootCertCheckInverval, testDefaultCertTTL,
+		testMaxCertTTL, testOrg, false, false, testCaNamespace, client.CoreV1(),
+		testRootCertFile, false, testRSAKeySize)
 	if err != nil {
 		t.Fatalf("Failed to create a self-signed CA Options: %v", err)
 	}
@@ -125,12 +126,12 @@ func TestCreateSelfSignedIstioCAWithoutSecret(t *testing.T) {
 		t.Error("CA root cert does not match signing cert")
 	}
 
-	if ttl := rootCert.NotAfter.Sub(rootCert.NotBefore); ttl != caCertTTL {
-		t.Errorf("Unexpected CA certificate TTL (expecting %v, actual %v)", caCertTTL, ttl)
+	if ttl := rootCert.NotAfter.Sub(rootCert.NotBefore); ttl != testCaCertTTL {
+		t.Errorf("Unexpected CA certificate TTL (expecting %v, actual %v)", testCaCertTTL, ttl)
 	}
 
-	if certOrg := rootCert.Issuer.Organization[0]; certOrg != org {
-		t.Errorf("Unexpected CA certificate organization (expecting %v, actual %v)", org, certOrg)
+	if certOrg := rootCert.Issuer.Organization[0]; certOrg != testOrg {
+		t.Errorf("Unexpected CA certificate organization (expecting %v, actual %v)", testOrg, certOrg)
 	}
 
 	if len(certChainBytes) != 0 {
@@ -138,7 +139,7 @@ func TestCreateSelfSignedIstioCAWithoutSecret(t *testing.T) {
 	}
 
 	// Check the signing cert stored in K8s secret.
-	caSecret, err := client.CoreV1().Secrets("default").Get(context.TODO(), CASecret, metav1.GetOptions{})
+	caSecret, err := client.CoreV1().Secrets(testCaNamespace).Get(context.TODO(), CASecret, metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Failed to get secret (error: %s)", err)
 	}
@@ -154,20 +155,12 @@ func TestCreateSelfSignedIstioCAWithoutSecret(t *testing.T) {
 }
 
 func TestCreateSelfSignedIstioCAWithoutSecretAndUseCacertsEnabled(t *testing.T) {
-	caCertTTL := time.Hour
-	defaultCertTTL := 30 * time.Minute
-	maxCertTTL := time.Hour
-	org := "test.ca.Org"
-	const caNamespace = "default"
 	client := fake.NewClientset()
-	rootCertFile := ""
-	rootCertCheckInverval := time.Hour
-	rsaKeySize := 2048
 
 	caopts, err := NewSelfSignedIstioCAOptions(context.Background(),
-		0, caCertTTL, rootCertCheckInverval, defaultCertTTL,
-		maxCertTTL, org, true, false, caNamespace, client.CoreV1(),
-		rootCertFile, false, rsaKeySize)
+		0, testCaCertTTL, testRootCertCheckInverval, testDefaultCertTTL,
+		testMaxCertTTL, testOrg, true, false, testCaNamespace, client.CoreV1(),
+		testRootCertFile, false, testRSAKeySize)
 	if err != nil {
 		t.Fatalf("Failed to create a self-signed CA Options: %v", err)
 	}
@@ -190,12 +183,12 @@ func TestCreateSelfSignedIstioCAWithoutSecretAndUseCacertsEnabled(t *testing.T) 
 		t.Error("CA root cert does not match signing cert")
 	}
 
-	if ttl := rootCert.NotAfter.Sub(rootCert.NotBefore); ttl != caCertTTL {
-		t.Errorf("Unexpected CA certificate TTL (expecting %v, actual %v)", caCertTTL, ttl)
+	if ttl := rootCert.NotAfter.Sub(rootCert.NotBefore); ttl != testCaCertTTL {
+		t.Errorf("Unexpected CA certificate TTL (expecting %v, actual %v)", testCaCertTTL, ttl)
 	}
 
-	if certOrg := rootCert.Issuer.Organization[0]; certOrg != org {
-		t.Errorf("Unexpected CA certificate organization (expecting %v, actual %v)", org, certOrg)
+	if certOrg := rootCert.Issuer.Organization[0]; certOrg != testOrg {
+		t.Errorf("Unexpected CA certificate organization (expecting %v, actual %v)", testOrg, certOrg)
 	}
 
 	if len(certChainBytes) != 0 {
@@ -203,7 +196,7 @@ func TestCreateSelfSignedIstioCAWithoutSecretAndUseCacertsEnabled(t *testing.T) 
 	}
 
 	// Check the signing cert stored in K8s secret.
-	caSecret, err := client.CoreV1().Secrets("default").Get(context.TODO(), CACertsSecret, metav1.GetOptions{})
+	caSecret, err := client.CoreV1().Secrets(testCaNamespace).Get(context.TODO(), CACertsSecret, metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Failed to get secret (error: %s)", err)
 	}
@@ -225,25 +218,16 @@ func TestCreateSelfSignedIstioCAWithSecret(t *testing.T) {
 	signingKeyPem := []byte(key1Pem)
 
 	client := fake.NewClientset()
-	initSecret := BuildSecret(CASecret, "default", nil, nil, nil, signingCertPem, signingKeyPem, istioCASecretType)
-	_, err := client.CoreV1().Secrets("default").Create(context.TODO(), initSecret, metav1.CreateOptions{})
+	initSecret := BuildSecret(CASecret, testCaNamespace, nil, nil, nil, signingCertPem, signingKeyPem, istioCASecretType)
+	_, err := client.CoreV1().Secrets(testCaNamespace).Create(context.TODO(), initSecret, metav1.CreateOptions{})
 	if err != nil {
 		t.Errorf("Failed to create secret (error: %s)", err)
 	}
 
-	caCertTTL := time.Hour
-	defaultCertTTL := 30 * time.Minute
-	maxCertTTL := time.Hour
-	org := "test.ca.Org"
-	caNamespace := "default"
-	const rootCertFile = ""
-	rootCertCheckInverval := time.Hour
-	rsaKeySize := 2048
-
 	caopts, err := NewSelfSignedIstioCAOptions(context.Background(),
-		0, caCertTTL, rootCertCheckInverval, defaultCertTTL, maxCertTTL,
-		org, false, false, caNamespace, client.CoreV1(),
-		rootCertFile, false, rsaKeySize)
+		0, testCaCertTTL, testRootCertCheckInverval, testDefaultCertTTL, testMaxCertTTL,
+		testOrg, false, false, testCaNamespace, client.CoreV1(),
+		testRootCertFile, false, testRSAKeySize)
 	if err != nil {
 		t.Fatalf("Failed to create a self-signed CA Options: %v", err)
 	}
@@ -277,28 +261,19 @@ func TestCreateSelfSignedIstioCAWithSecret(t *testing.T) {
 }
 
 func TestCreateSelfSignedIstioCAWithExistingSecretAndUseCacertsEnabled(t *testing.T) {
-	caCertTTL := time.Hour
-	defaultCertTTL := 30 * time.Minute
-	maxCertTTL := time.Hour
-	org := "test.ca.Org"
-	caNamespace := "default"
-	const rootCertFile = ""
-	rootCertCheckInverval := time.Hour
-	rsaKeySize := 2048
-
 	signingCertPem := []byte(cert1Pem)
 	signingKeyPem := []byte(key1Pem)
 
 	client := fake.NewClientset()
-	initSecret := BuildSecret(CASecret, caNamespace, nil, nil, nil, signingCertPem, signingKeyPem, istioCASecretType)
-	if _, err := client.CoreV1().Secrets(caNamespace).Create(context.TODO(), initSecret, metav1.CreateOptions{}); err != nil {
+	initSecret := BuildSecret(CASecret, testCaNamespace, nil, nil, nil, signingCertPem, signingKeyPem, istioCASecretType)
+	if _, err := client.CoreV1().Secrets(testCaNamespace).Create(context.TODO(), initSecret, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create secret: %v", err)
 	}
 
 	caopts, err := NewSelfSignedIstioCAOptions(context.Background(),
-		0, caCertTTL, rootCertCheckInverval, defaultCertTTL, maxCertTTL,
-		org, true, false, caNamespace, client.CoreV1(),
-		rootCertFile, false, rsaKeySize)
+		0, testCaCertTTL, testRootCertCheckInverval, testDefaultCertTTL, testMaxCertTTL,
+		testOrg, true, false, testCaNamespace, client.CoreV1(),
+		testRootCertFile, false, testRSAKeySize)
 	if err != nil {
 		t.Fatalf("Failed to create a self-signed CA Options: %v", err)
 	}
@@ -318,36 +293,27 @@ func TestCreateSelfSignedIstioCAWithExistingSecretAndUseCacertsEnabled(t *testin
 	}
 
 	// cacerts should NOT have been created since istio-ca-secret was loaded successfully.
-	_, err = client.CoreV1().Secrets(caNamespace).Get(context.TODO(), CACertsSecret, metav1.GetOptions{})
+	_, err = client.CoreV1().Secrets(testCaNamespace).Get(context.TODO(), CACertsSecret, metav1.GetOptions{})
 	if !apierror.IsNotFound(err) {
 		t.Errorf("expected NotFound error for cacerts secret, got: %v", err)
 	}
 }
 
 func TestCreateSelfSignedIstioCAReadSigningCertOnly(t *testing.T) {
-	caCertTTL := time.Hour
-	defaultCertTTL := 30 * time.Minute
-	maxCertTTL := time.Hour
-	org := "test.ca.Org"
-	caNamespace := "default"
-	const rootCertFile = ""
-	rootCertCheckInverval := time.Hour
-	rsaKeySize := 2048
-
 	client := fake.NewClientset()
 
 	// succeed creating a self-signed cert
 	ctx0, cancel0 := context.WithTimeout(context.Background(), time.Millisecond*50)
 	defer cancel0()
 	_, err := NewSelfSignedIstioCAOptions(ctx0, 0,
-		caCertTTL, defaultCertTTL, rootCertCheckInverval, maxCertTTL, org, false, false,
-		caNamespace, client.CoreV1(), rootCertFile, false, rsaKeySize)
+		testCaCertTTL, testDefaultCertTTL, testRootCertCheckInverval, testMaxCertTTL, testOrg, false, false,
+		testCaNamespace, client.CoreV1(), testRootCertFile, false, testRSAKeySize)
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
 	// Using existing CASecret.
-	secret, err := client.CoreV1().Secrets("default").Get(context.TODO(), CASecret, metav1.GetOptions{})
+	secret, err := client.CoreV1().Secrets(testCaNamespace).Get(context.TODO(), CASecret, metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Got unexpected error %v", err)
 	}
@@ -355,8 +321,8 @@ func TestCreateSelfSignedIstioCAReadSigningCertOnly(t *testing.T) {
 
 	ctx1 := t.Context()
 	caopts, err := NewSelfSignedIstioCAOptions(ctx1, 0,
-		caCertTTL, defaultCertTTL, rootCertCheckInverval, maxCertTTL, org, false, false,
-		caNamespace, client.CoreV1(), rootCertFile, false, rsaKeySize)
+		testCaCertTTL, testDefaultCertTTL, testRootCertCheckInverval, testMaxCertTTL, testOrg, false, false,
+		testCaNamespace, client.CoreV1(), testRootCertFile, false, testRSAKeySize)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -384,15 +350,6 @@ func TestCreateSelfSignedIstioCAReadSigningCertOnly(t *testing.T) {
 }
 
 func TestConcurrentCreateSelfSignedIstioCA(t *testing.T) {
-	caCertTTL := time.Hour
-	defaultCertTTL := 30 * time.Minute
-	maxCertTTL := time.Hour
-	org := "test.ca.Org"
-	caNamespace := "default"
-	const rootCertFile = ""
-	rootCertCheckInverval := time.Hour
-	rsaKeySize := 2048
-
 	client := fake.NewClientset()
 
 	parallel := 10
@@ -408,8 +365,8 @@ func TestConcurrentCreateSelfSignedIstioCA(t *testing.T) {
 			ctx0, cancel0 := context.WithTimeout(context.Background(), 20*time.Second)
 			defer cancel0()
 			caOpts, err := NewSelfSignedIstioCAOptions(ctx0, 0,
-				caCertTTL, defaultCertTTL, rootCertCheckInverval, maxCertTTL, org, false, false,
-				caNamespace, client.CoreV1(), rootCertFile, false, rsaKeySize)
+				testCaCertTTL, testDefaultCertTTL, testRootCertCheckInverval, testMaxCertTTL, testOrg, false, false,
+				testCaNamespace, client.CoreV1(), testRootCertFile, false, testRSAKeySize)
 			if err != nil {
 				t.Errorf("NewSelfSignedIstioCAOptions got unexpected error: %v", err)
 			}
@@ -426,7 +383,7 @@ func TestConcurrentCreateSelfSignedIstioCA(t *testing.T) {
 		}()
 	}
 	wg.Wait()
-	caSecret, err := client.CoreV1().Secrets(caNamespace).Get(context.TODO(), CASecret, metav1.GetOptions{})
+	caSecret, err := client.CoreV1().Secrets(testCaNamespace).Get(context.TODO(), CASecret, metav1.GetOptions{})
 	if err != nil || caSecret == nil {
 		t.Errorf("failed getting ca secret %v", err)
 	}

--- a/security/pkg/pki/ca/ca_test.go
+++ b/security/pkg/pki/ca/ca_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	apierror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -272,6 +273,54 @@ func TestCreateSelfSignedIstioCAWithSecret(t *testing.T) {
 
 	if len(certChainBytesFromCA) != 0 {
 		t.Errorf("Cert chain should be empty")
+	}
+}
+
+func TestCreateSelfSignedIstioCAWithExistingSecretAndUseCacertsEnabled(t *testing.T) {
+	caCertTTL := time.Hour
+	defaultCertTTL := 30 * time.Minute
+	maxCertTTL := time.Hour
+	org := "test.ca.Org"
+	caNamespace := "default"
+	const rootCertFile = ""
+	rootCertCheckInverval := time.Hour
+	rsaKeySize := 2048
+
+	signingCertPem := []byte(cert1Pem)
+	signingKeyPem := []byte(key1Pem)
+
+	client := fake.NewClientset()
+	initSecret := BuildSecret(CASecret, caNamespace, nil, nil, nil, signingCertPem, signingKeyPem, istioCASecretType)
+	if _, err := client.CoreV1().Secrets(caNamespace).Create(context.TODO(), initSecret, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create secret: %v", err)
+	}
+
+	caopts, err := NewSelfSignedIstioCAOptions(context.Background(),
+		0, caCertTTL, rootCertCheckInverval, defaultCertTTL, maxCertTTL,
+		org, true, false, caNamespace, client.CoreV1(),
+		rootCertFile, false, rsaKeySize)
+	if err != nil {
+		t.Fatalf("Failed to create a self-signed CA Options: %v", err)
+	}
+
+	ca, err := NewIstioCA(caopts)
+	if err != nil {
+		t.Fatalf("Failed to create a self-signed CA: %v", err)
+	}
+
+	signingCertFromCA, _, _, _ := ca.GetCAKeyCertBundle().GetAll()
+	signingCert, err := util.ParsePemEncodedCertificate(signingCertPem)
+	if err != nil {
+		t.Fatalf("Failed to parse cert: %v", err)
+	}
+	if !signingCert.Equal(signingCertFromCA) {
+		t.Error("Signing cert does not match the existing istio-ca-secret")
+	}
+
+	// cacerts should NOT have been created since istio-ca-secret was loaded successfully.
+	_, err = client.CoreV1().Secrets(caNamespace).Get(context.TODO(), CACertsSecret, metav1.GetOptions{})
+	if !apierror.IsNotFound(err) {
+		t.Errorf("expected NotFound error for cacerts secret, got: %v", err)
 	}
 }
 

--- a/security/pkg/pki/util/keycertbundle.go
+++ b/security/pkg/pki/util/keycertbundle.go
@@ -348,7 +348,7 @@ func Verify(certBytes, privKeyBytes, certChainBytes, rootCertBytes, crl []byte) 
 	if len(chains) == 0 || err != nil {
 		return fmt.Errorf(
 			"cannot verify the cert with the provided root chain and cert "+
-				"pool with error: %v", err)
+				"pool with error: %w", err)
 	}
 
 	// Verify that the key can be correctly parsed.


### PR DESCRIPTION
**Please provide a description of this PR:**

When istiod is scaled to zero while using a self-signed CA, the CA certificate in the istio-ca-secret may expire before the deployment is scaled back up. On restart, istiod fails to load the expired certificate and retries indefinitely, preventing recovery.

This change detects the expired certificate error by wrapping the x509 verification error with `%w` instead of `%v`, making it unwrappable through the error chain. When an expired istio-ca-secret is detected, istiod regenerates the certificate using the existing private key and updates the Kubernetes secret. Concurrent replicas are handled safely: the renewal checks if another replica already renewed the cert before attempting an update, and on a resourceVersion conflict, falls back to loading the already-renewed secret.

The renewal updates both `ca-cert.pem` and `root-cert.pem` in the secret, since for self-signed CAs Istio uses the same certificate (and TTL) for both. Previously, the existing self-signed CA cert rotator only rotated `ca-cert.pem`, leaving `root-cert.pem` expired permanently after rotation.

The implementation of `NewSelfSignedIstioCAOptions` was refactored from nested if conditions into a clean loop over candidate secret names with extracted helper functions (`loadSelfSignedCaSecret`, `createSelfSignedCaSecret`, `renewSelfSignedCaSecret`), making the flow easier to read and extend. Tests were refactored to use shared package-level variables for common defaults, reducing code duplication across test cases.