### PR TITLE
fix(agentgateway): validate BackendTLS CA

### DIFF
--- a/pilot/pkg/config/kube/agentgateway/policy_collection.go
+++ b/pilot/pkg/config/kube/agentgateway/policy_collection.go
@@ -342,7 +342,7 @@ func getBackendTLSCACert(
 		if !ok || caCert == "" {
 			conds[string(gatewayv1.BackendTLSPolicyConditionResolvedRefs)].error = &ConfigError{
 				Reason:  string(gatewayv1.BackendTLSPolicyReasonInvalidCACertificateRef),
-				Message: "ConfigMap missing or empty ca.crt key",
+				Message: "ConfigMap missing ca.crt key or empty ca.crt key",
 			}
 			return nil, fmt.Errorf("ConfigMap %v missing or empty ca.crt key", nn)
 		}

--- a/pilot/pkg/config/kube/agentgateway/policy_collection.go
+++ b/pilot/pkg/config/kube/agentgateway/policy_collection.go
@@ -339,12 +339,12 @@ func getBackendTLSCACert(
 		}
 		cm := ptr.Flatten(cfgmap)
 		caCert, ok := cm.Data["ca.crt"]
-		if !ok {
+		if !ok || caCert == "" {
 			conds[string(gatewayv1.BackendTLSPolicyConditionResolvedRefs)].error = &ConfigError{
 				Reason:  string(gatewayv1.BackendTLSPolicyReasonInvalidCACertificateRef),
-				Message: "ConfigMap missing ca.crt key",
+				Message: "ConfigMap missing or empty ca.crt key",
 			}
-			return nil, fmt.Errorf("ConfigMap %v missing ca.crt key", nn)
+			return nil, fmt.Errorf("ConfigMap %v missing or empty ca.crt key", nn)
 		}
 		if sb.Len() > 0 {
 			sb.WriteString("\n")

--- a/pilot/pkg/config/kube/agentgateway/policy_collection_test.go
+++ b/pilot/pkg/config/kube/agentgateway/policy_collection_test.go
@@ -1,0 +1,130 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentgateway
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/kube/krt/krttest"
+	"istio.io/istio/pkg/ptr"
+	"istio.io/istio/pkg/test"
+)
+
+func TestBackendTLSPolicyRejectsEmptyCACertificate(t *testing.T) {
+	const (
+		namespace   = "default"
+		policyName  = "backend-tls"
+		backendName = "backend"
+		gatewayName = "gateway"
+		generation  = int64(7)
+	)
+	opts := krttest.Options(t)
+	policy := &gatewayv1.BackendTLSPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       policyName,
+			Namespace:  namespace,
+			Generation: generation,
+		},
+		Spec: gatewayv1.BackendTLSPolicySpec{
+			TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{{
+				LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+					Group: "",
+					Kind:  "Service",
+					Name:  backendName,
+				},
+				SectionName: ptr.Of(gatewayv1.SectionName("https")),
+			}},
+			Validation: gatewayv1.BackendTLSPolicyValidation{
+				CACertificateRefs: []gatewayv1.LocalObjectReference{{
+					Group: "",
+					Kind:  "ConfigMap",
+					Name:  "backend-ca",
+				}},
+				Hostname: "backend.example.com",
+			},
+		},
+	}
+	ancestor := &AncestorBackend{
+		Gateway: types.NamespacedName{Namespace: namespace, Name: gatewayName},
+		Backend: types.NamespacedName{Namespace: namespace, Name: backendName},
+		Source: TypedResource{
+			Kind: gvk.HTTPRoute,
+			Name: types.NamespacedName{Namespace: namespace, Name: "route"},
+		},
+	}
+
+	statuses, _ := BackendTLSPolicyCollection(BackendTLSPolicyInputs{
+		BackendTLSPolicies: krt.NewStaticCollection(nil, []*gatewayv1.BackendTLSPolicy{policy}, opts.WithName("Policies")...),
+		ConfigMaps: krt.NewStaticCollection(nil, []*corev1.ConfigMap{{
+			ObjectMeta: metav1.ObjectMeta{Name: "backend-ca", Namespace: namespace},
+			Data:       map[string]string{"ca.crt": ""},
+		}}, opts.WithName("ConfigMaps")...),
+		Secrets: krt.NewStaticCollection[*corev1.Secret](nil, nil, opts.WithName("Secrets")...),
+		Services: krt.NewStaticCollection(nil, []*corev1.Service{{
+			ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: namespace},
+			Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{
+				Name: "https",
+				Port: 443,
+			}}},
+		}}, opts.WithName("Services")...),
+		Gateways:         krt.NewStaticCollection[*gatewayv1.Gateway](nil, nil, opts.WithName("Gateways")...),
+		AncestorBackends: krt.NewStaticCollection(nil, []*AncestorBackend{ancestor}, opts.WithName("Ancestors")...),
+		ControllerName:   "istio.io/agentgateway-controller",
+		DomainSuffix:     "cluster.local",
+	}, opts)
+	statuses.WaitUntilSynced(test.NewStop(t))
+
+	got := statuses.GetKey(namespace + "/" + policyName)
+	if got == nil {
+		t.Fatal("expected BackendTLSPolicy status")
+	}
+	if len(got.Status.Ancestors) != 1 {
+		t.Fatalf("got %d ancestors, want 1", len(got.Status.Ancestors))
+	}
+	conditions := got.Status.Ancestors[0].Conditions
+	assertPolicyCondition(t, conditions, string(gatewayv1.PolicyConditionAccepted), metav1.ConditionFalse,
+		string(gatewayv1.BackendTLSPolicyReasonNoValidCACertificate), generation)
+	assertPolicyCondition(t, conditions, string(gatewayv1.BackendTLSPolicyConditionResolvedRefs), metav1.ConditionFalse,
+		string(gatewayv1.BackendTLSPolicyReasonInvalidCACertificateRef), generation)
+}
+
+func assertPolicyCondition(
+	t *testing.T,
+	conditions []metav1.Condition,
+	conditionType string,
+	status metav1.ConditionStatus,
+	reason string,
+	generation int64,
+) {
+	t.Helper()
+	for _, condition := range conditions {
+		if condition.Type != conditionType {
+			continue
+		}
+		if condition.Status != status || condition.Reason != reason || condition.ObservedGeneration != generation {
+			t.Fatalf("condition %q = %#v, want status=%q reason=%q observedGeneration=%d",
+				conditionType, condition, status, reason, generation)
+		}
+		return
+	}
+	t.Fatalf("condition %q not found in %#v", conditionType, conditions)
+}

--- a/pilot/pkg/config/kube/agentgateway/policy_collection_test.go
+++ b/pilot/pkg/config/kube/agentgateway/policy_collection_test.go
@@ -29,7 +29,7 @@ import (
 	"istio.io/istio/pkg/test"
 )
 
-func TestBackendTLSPolicyRejectsEmptyCACertificate(t *testing.T) {
+func TestBackendTLSPolicyRejectsMissingOrEmptyCACertificate(t *testing.T) {
 	const (
 		namespace   = "default"
 		policyName  = "backend-tls"
@@ -37,74 +37,91 @@ func TestBackendTLSPolicyRejectsEmptyCACertificate(t *testing.T) {
 		gatewayName = "gateway"
 		generation  = int64(7)
 	)
-	opts := krttest.Options(t)
-	policy := &gatewayv1.BackendTLSPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       policyName,
-			Namespace:  namespace,
-			Generation: generation,
+	testCases := []struct {
+		name string
+		data map[string]string
+	}{
+		{
+			name: "missing ca.crt",
+			data: map[string]string{},
 		},
-		Spec: gatewayv1.BackendTLSPolicySpec{
-			TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{{
-				LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
-					Group: "",
-					Kind:  "Service",
-					Name:  backendName,
+		{
+			name: "empty ca.crt",
+			data: map[string]string{"ca.crt": ""},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := krttest.Options(t)
+			policy := &gatewayv1.BackendTLSPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       policyName,
+					Namespace:  namespace,
+					Generation: generation,
 				},
-				SectionName: ptr.Of(gatewayv1.SectionName("https")),
-			}},
-			Validation: gatewayv1.BackendTLSPolicyValidation{
-				CACertificateRefs: []gatewayv1.LocalObjectReference{{
-					Group: "",
-					Kind:  "ConfigMap",
-					Name:  "backend-ca",
-				}},
-				Hostname: "backend.example.com",
-			},
-		},
-	}
-	ancestor := &AncestorBackend{
-		Gateway: types.NamespacedName{Namespace: namespace, Name: gatewayName},
-		Backend: types.NamespacedName{Namespace: namespace, Name: backendName},
-		Source: TypedResource{
-			Kind: gvk.HTTPRoute,
-			Name: types.NamespacedName{Namespace: namespace, Name: "route"},
-		},
-	}
+				Spec: gatewayv1.BackendTLSPolicySpec{
+					TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{{
+						LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+							Group: "",
+							Kind:  "Service",
+							Name:  backendName,
+						},
+						SectionName: ptr.Of(gatewayv1.SectionName("https")),
+					}},
+					Validation: gatewayv1.BackendTLSPolicyValidation{
+						CACertificateRefs: []gatewayv1.LocalObjectReference{{
+							Group: "",
+							Kind:  "ConfigMap",
+							Name:  "backend-ca",
+						}},
+						Hostname: "backend.example.com",
+					},
+				},
+			}
+			ancestor := &AncestorBackend{
+				Gateway: types.NamespacedName{Namespace: namespace, Name: gatewayName},
+				Backend: types.NamespacedName{Namespace: namespace, Name: backendName},
+				Source: TypedResource{
+					Kind: gvk.HTTPRoute,
+					Name: types.NamespacedName{Namespace: namespace, Name: "route"},
+				},
+			}
 
-	statuses, _ := BackendTLSPolicyCollection(BackendTLSPolicyInputs{
-		BackendTLSPolicies: krt.NewStaticCollection(nil, []*gatewayv1.BackendTLSPolicy{policy}, opts.WithName("Policies")...),
-		ConfigMaps: krt.NewStaticCollection(nil, []*corev1.ConfigMap{{
-			ObjectMeta: metav1.ObjectMeta{Name: "backend-ca", Namespace: namespace},
-			Data:       map[string]string{"ca.crt": ""},
-		}}, opts.WithName("ConfigMaps")...),
-		Secrets: krt.NewStaticCollection[*corev1.Secret](nil, nil, opts.WithName("Secrets")...),
-		Services: krt.NewStaticCollection(nil, []*corev1.Service{{
-			ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: namespace},
-			Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{
-				Name: "https",
-				Port: 443,
-			}}},
-		}}, opts.WithName("Services")...),
-		Gateways:         krt.NewStaticCollection[*gatewayv1.Gateway](nil, nil, opts.WithName("Gateways")...),
-		AncestorBackends: krt.NewStaticCollection(nil, []*AncestorBackend{ancestor}, opts.WithName("Ancestors")...),
-		ControllerName:   "istio.io/agentgateway-controller",
-		DomainSuffix:     "cluster.local",
-	}, opts)
-	statuses.WaitUntilSynced(test.NewStop(t))
+			statuses, _ := BackendTLSPolicyCollection(BackendTLSPolicyInputs{
+				BackendTLSPolicies: krt.NewStaticCollection(nil, []*gatewayv1.BackendTLSPolicy{policy}, opts.WithName("Policies")...),
+				ConfigMaps: krt.NewStaticCollection(nil, []*corev1.ConfigMap{{
+					ObjectMeta: metav1.ObjectMeta{Name: "backend-ca", Namespace: namespace},
+					Data:       tc.data,
+				}}, opts.WithName("ConfigMaps")...),
+				Secrets: krt.NewStaticCollection[*corev1.Secret](nil, nil, opts.WithName("Secrets")...),
+				Services: krt.NewStaticCollection(nil, []*corev1.Service{{
+					ObjectMeta: metav1.ObjectMeta{Name: backendName, Namespace: namespace},
+					Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{
+						Name: "https",
+						Port: 443,
+					}}},
+				}}, opts.WithName("Services")...),
+				Gateways:         krt.NewStaticCollection[*gatewayv1.Gateway](nil, nil, opts.WithName("Gateways")...),
+				AncestorBackends: krt.NewStaticCollection(nil, []*AncestorBackend{ancestor}, opts.WithName("Ancestors")...),
+				ControllerName:   "istio.io/agentgateway-controller",
+				DomainSuffix:     "cluster.local",
+			}, opts)
+			statuses.WaitUntilSynced(test.NewStop(t))
 
-	got := statuses.GetKey(namespace + "/" + policyName)
-	if got == nil {
-		t.Fatal("expected BackendTLSPolicy status")
+			got := statuses.GetKey(namespace + "/" + policyName)
+			if got == nil {
+				t.Fatal("expected BackendTLSPolicy status")
+			}
+			if len(got.Status.Ancestors) != 1 {
+				t.Fatalf("got %d ancestors, want 1", len(got.Status.Ancestors))
+			}
+			conditions := got.Status.Ancestors[0].Conditions
+			assertPolicyCondition(t, conditions, string(gatewayv1.PolicyConditionAccepted), metav1.ConditionFalse,
+				string(gatewayv1.BackendTLSPolicyReasonNoValidCACertificate), generation)
+			assertPolicyCondition(t, conditions, string(gatewayv1.BackendTLSPolicyConditionResolvedRefs), metav1.ConditionFalse,
+				string(gatewayv1.BackendTLSPolicyReasonInvalidCACertificateRef), generation)
+		})
 	}
-	if len(got.Status.Ancestors) != 1 {
-		t.Fatalf("got %d ancestors, want 1", len(got.Status.Ancestors))
-	}
-	conditions := got.Status.Ancestors[0].Conditions
-	assertPolicyCondition(t, conditions, string(gatewayv1.PolicyConditionAccepted), metav1.ConditionFalse,
-		string(gatewayv1.BackendTLSPolicyReasonNoValidCACertificate), generation)
-	assertPolicyCondition(t, conditions, string(gatewayv1.BackendTLSPolicyConditionResolvedRefs), metav1.ConditionFalse,
-		string(gatewayv1.BackendTLSPolicyReasonInvalidCACertificateRef), generation)
 }
 
 func assertPolicyCondition(

--- a/tests/integration/pilot/agentgateway/gateway_conformance_test.go
+++ b/tests/integration/pilot/agentgateway/gateway_conformance_test.go
@@ -63,12 +63,6 @@ var conformanceNamespaces = []string{
 }
 
 var skippedTests = map[string]string{
-	// The following tests were added in v1.5.0
-	"BackendTLSPolicyObservedGenerationBump": "TODO",
-
-	// The following tests were modified between v1.4.0 && v1.5.0
-	"BackendTLSPolicy": "TODO",
-
 	// The following tests were added in v1.6.0
 	"GatewayInvalidParametersRef":        "TODO",
 	"GatewayListenerUnsupportedProtocol": "TODO",


### PR DESCRIPTION
Reject empty ca.crt values and enable the related Gateway API conformance tests.

Refs #60795

**Please provide a description of this PR:**

The updated Gateway API conformance test sets `ca.crt` to an empty value. Agentgateway previously checked only whether the key existed, causing the `BackendTLSPolicy` to remain accepted.

This change rejects missing or empty `ca.crt` values, adds regression coverage, and enables the `BackendTLSPolicy` and `BackendTLSPolicyObservedGenerationBump` conformance tests.

Part of #60795