### PR TITLE
Run TestAuthorizationServiceAttached and TestDestinationRules in multi-cluster mode

### DIFF
--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -1087,6 +1087,7 @@ spec:
 
 func TestAuthorizationServiceAttached(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
+		maybeSetupMultiCluster(t)
 		applyDrainingWorkaround(t)
 		src := apps.Captured
 		authzDst := apps.ServiceAddressedWaypoint
@@ -1901,6 +1902,7 @@ spec:
 		},
 	}
 	framework.NewTest(t).Run(func(t framework.TestContext) {
+		maybeSetupMultiCluster(t)
 		for _, tt := range cases {
 			t.NewSubTest(tt.name).Run(func(t framework.TestContext) {
 				for _, src := range apps.All {
@@ -3065,20 +3067,17 @@ func runAllTests(t framework.TestContext, f func(t framework.TestContext, src ec
 	runTestContextForCalls(t, allCalls, f)
 }
 
-func runTestContextForCalls(
-	t framework.TestContext,
-	callOptions []echo.CallOptions,
-	f func(t framework.TestContext, src echo.Instance, dst echo.Target, opt echo.CallOptions),
-) {
-	svcs := apps.All
+func maybeSetupMultiCluster(t framework.TestContext) {
 	if t.Settings().AmbientMultiNetwork {
 		// all meshed services need to be labeled as global for the reachability tests.
 		for _, app := range apps.Mesh {
 			if app.Config().IsAmbient() {
-				// don't label sidecar services until https://github.com/istio/istio/issues/57877 is resolved.
+				// don't label sidecar services until https://github.com/istio/istio/issues/57877 is
+				// resolved.
 				labelServiceGlobal(t, app.ServiceName(), app.Config().Cluster)
 			}
 		}
+
 		for name := range apps.WaypointProxies {
 			labelServiceGlobal(t, name, t.Clusters()...)
 		}
@@ -3105,7 +3104,15 @@ func runTestContextForCalls(
 		// to account for this issue.
 		time.Sleep(2 * features.DebounceAfter)
 	}
-	for _, src := range svcs {
+}
+
+func runTestContextForCalls(
+	t framework.TestContext,
+	callOptions []echo.CallOptions,
+	f func(t framework.TestContext, src echo.Instance, dst echo.Target, opt echo.CallOptions),
+) {
+	maybeSetupMultiCluster(t)
+	for _, src := range apps.All {
 		t.NewSubTestf("from %v %v", src.Config().Cluster.Name(), src.Config().Service).Run(func(t framework.TestContext) {
 			for _, dst := range getAllInstancesByServiceName() {
 				t.NewSubTestf("to all %v", dst.Config().Service).Run(func(t framework.TestContext) {

--- a/tests/integration/ambient/multicluster_test.go
+++ b/tests/integration/ambient/multicluster_test.go
@@ -28,6 +28,8 @@ import (
 
 	"istio.io/api/label"
 	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/maps"
+	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/ambient"
@@ -50,7 +52,7 @@ type workload struct {
 	serviceLabels map[string]string
 }
 
-func TestMultinetworkFailover(t *testing.T) {
+func TestMulticlusterFailover(t *testing.T) {
 	const brokenService1 = "broken1"
 	const brokenService2 = "broken2"
 	const clientService = "client"
@@ -169,11 +171,11 @@ func TestMultinetworkFailover(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
 		t.NewSubTest("without-waypoint").Run(func(t framework.TestContext) {
 			if !t.Settings().Ambient || !t.Settings().AmbientMultiNetwork {
-				t.Skip("this test is ambient multi-network specific")
+				t.Skip("this test is ambient multi-cluster specific")
 			}
 
 			if len(t.Clusters()) < 2 {
-				t.Fatal("ambient multi-network failover test requires at least 2 clusters")
+				t.Fatal("ambient multi-cluster failover test requires at least 2 clusters")
 			}
 
 			allClusters := t.Clusters()
@@ -207,11 +209,11 @@ func TestMultinetworkFailover(t *testing.T) {
 		})
 		t.NewSubTest("with-waypoints").Run(func(t framework.TestContext) {
 			if !t.Settings().Ambient || !t.Settings().AmbientMultiNetwork {
-				t.Skip("this test is ambient multi-network specific")
+				t.Skip("this test is ambient multi-cluster specific")
 			}
 
 			if len(t.Clusters()) < 2 {
-				t.Fatal("ambient multi-network failover test requires at least 2 clusters")
+				t.Fatal("ambient multi-cluster failover test requires at least 2 clusters")
 			}
 
 			allClusters := t.Clusters()
@@ -401,18 +403,24 @@ func scaleDeploymentOrFail(t framework.TestContext, c cluster.Cluster, namespace
 func TestEastWestGatewayTLSRoute(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
 		if !t.Settings().Ambient || !t.Settings().AmbientMultiNetwork {
-			t.Skip("this test is ambient multi-network specific")
+			t.Skip("this test is ambient multi-cluster specific")
 		}
-		if len(t.Clusters()) < 2 {
-			t.Fatal("east-west gateway TLSRoute test requires at least 2 clusters")
+		allClusters := slices.Group(t.Clusters(), func(c cluster.Cluster) string {
+			return c.NetworkName()
+		})
+		networks := maps.Keys(allClusters)
+		if len(networks) < 2 {
+			t.Skip("east-west gateway TLSRoute test requires at least 2 clusters on different networks")
 		}
+
+		// gwCluster hosts the E/W gateway + backend; remoteCluster is the client.
+		gwNetwork := networks[0]
+		gwCluster := allClusters[gwNetwork][0]
+
+		remoteNetwork := networks[1]
+		remoteCluster := allClusters[remoteNetwork][0]
 
 		crd.DeployGatewayAPIOrSkip(t)
-
-		allClusters := t.Clusters()
-		// gwCluster hosts the E/W gateway + backend; remoteCluster is the client.
-		gwCluster := allClusters[0]
-		remoteCluster := allClusters[1]
 
 		nsConfig := namespace.NewOrFail(t, namespace.Config{
 			Prefix: "ew-tlsroute",


### PR DESCRIPTION
**Please provide a description of this PR:**

Most of the tests in baseline_test.go properly mark services and waypoints as global when tests are running in multi-cluster deployments. That's the case because most tests directly or indirectly rely on `runTestContextForCalls` that labels services and waypoints as global.

TestAuthorizationServiceAttached and TestDestinationRules are two tests that I noticed that don't do that and don't otherwise mark involved services as global.

This PR does a small refactoring to make it easier to label involved services and waypoints as global in multi-cluster deployments and updates `TestAuthorizationServiceAttached` and `TestDestinationRules` to use that to label involved services as global.

NOTE: It's not directly related to #61067, but I noticed this potential gap while working on adjusting Istio tests for single-network Ambient multi-cluster.

NOTE: There are some other tests that don't properly setup multi-cluster as well, but I need to take a deeper look at them before changing that - there are tests for which multi-cluster setup just does not make terribly a lot of sense (i.e., TestPodIP checks reachability using workload IP directly, so global label on the service does not do anything there).