### PR TITLE
Only skip TestPodIP when source and destination are on different networks

### DIFF
--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -285,9 +285,9 @@ func TestPodIP(t *testing.T) {
 									t.Skip("not supported yet")
 								}
 
-								if t.Settings().AmbientMultiNetwork && srcWl.Cluster() != dstWl.Cluster() {
+								if t.Settings().AmbientMultiNetwork && srcWl.Cluster().NetworkName() != dstWl.Cluster().NetworkName() {
 									// TODO: Enable when we support multi-network workload addressing
-									t.Skip("not supported yet")
+									t.Skip("direct workload to workload communication is not supported in multi-network deployments")
 								}
 								for _, opt := range basicCalls {
 									opt := opt.DeepCopy()


### PR DESCRIPTION
**Please provide a description of this PR:**

Currently, TestPodIP test is skipped if the source and destination workloads are in different clusters. It makes sense if the only form of multi-cluster deployment we support in ambient is multi-network.

In single-network multi-cluster deployments, direct communication between workloads using workload IPs is possible and should be supported because all pods on the same network are directly reachable.

I want to start running CI tests against single-network multi-cluster and for that reason I'm adjusting this test to avoid skipping it unnecessarily when source and destination workloads are on the same network.

Part of #61067
Related to #61066