### PR TITLE
Move back from nftables to nftables-slim and unpin the version

### DIFF
--- a/docker/iptables.yaml
+++ b/docker/iptables.yaml
@@ -12,7 +12,7 @@ contents:
     - libnfnetlink
     - libmnl
     - libgcc
-    - nftables=1.1.1-r40
+    - nftables-slim
 archs:
   - x86_64
   - aarch64

--- a/releasenotes/notes/58492.yaml
+++ b/releasenotes/notes/58492.yaml
@@ -1,0 +1,13 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 58492 
+releaseNotes:
+- |
+  **Upgraded** version of nftables used by Istio images. The version has been pinned to 1.1.1 to
+  avoid a bug that causes older versions of nftables on k8s node to crash after Istio uses a newer
+  version of nftables packaged with the images on the same node.
+  Major Linux distributions have been informed of the nftables issue and released a fix for it, so
+  we are removing the pinning in Istio. Users are advised to update nftables package on their
+  nodes to the latest version to make sure that the version of with the fix is used on the node.

--- a/releasenotes/notes/58492.yaml
+++ b/releasenotes/notes/58492.yaml
@@ -10,4 +10,4 @@ releaseNotes:
   version of nftables packaged with the images on the same node.
   Major Linux distributions have been informed of the nftables issue and released a fix for it, so
   we are removing the pinning in Istio. Users are advised to update nftables package on their
-  nodes to the latest version to make sure that the version of with the fix is used on the node.
+  nodes to the latest version to make sure that the version with the fix is used on the node.

--- a/releasenotes/notes/58492.yaml
+++ b/releasenotes/notes/58492.yaml
@@ -5,8 +5,8 @@ issue:
 - 58492 
 releaseNotes:
 - |
-**Upgraded** version of `nftables` used by Istio distroless images. The `nftables` version was previously pinned to 1.1.1 to avoid a bug that could cause older versions of `nftables` on K8s nodes to crash after Istio used a newer version packaged in its images on the same node.
+  **Upgraded** version of `nftables` used by Istio distroless images. The `nftables` version was previously pinned to 1.1.1 to avoid a bug that could cause older versions of `nftables` on K8s nodes to crash after Istio used a newer version packaged in its images on the same node.
 
-Major Linux distributions have been informed of the issue and have released fixes. As a result, Istio is removing the `nftables` version pinning. Users are advised to update the `nftables` package on their nodes to the latest available version to ensure that the fixed version is installed.
+  Major Linux distributions have been informed of the issue and have released fixes. As a result, Istio is removing the `nftables` version pinning. Users are advised to update the `nftables` package on their nodes to the latest available version to ensure that the fixed version is installed.
 
-If you continue to experience `nftables` crashes on your nodes, downgrade to an older version of Istio and contact your node OS provider to request that the fix be backported to your OS version.
+  If you continue to experience `nftables` crashes on your nodes, downgrade to an older version of Istio and contact your node OS provider to request that the fix be backported to your OS version.

--- a/releasenotes/notes/58492.yaml
+++ b/releasenotes/notes/58492.yaml
@@ -5,12 +5,8 @@ issue:
 - 58492 
 releaseNotes:
 - |
-  **Upgraded** version of nftables used by Istio images. The version has been pinned to 1.1.1 to
-  avoid a bug that causes older versions of nftables on k8s node to crash after Istio uses a newer
-  version of nftables packaged with the images on the same node.
-  Major Linux distributions have been informed of the nftables issue and released a fix for it, so
-  we are removing the pinning in Istio. Users are advised to update nftables package on their
-  nodes to the latest version to make sure that the version with the fix is used on the node.
-  If you're still experiencing issues with node nftables crashing please downgrade to an older
-  version of Istio and contact the provider of the node OS for your deployment and ask them to
-  backport the fix.
+**Upgraded** version of `nftables` used by Istio distroless images. The `nftables` version was previously pinned to 1.1.1 to avoid a bug that could cause older versions of `nftables` on K8s nodes to crash after Istio used a newer version packaged in its images on the same node.
+
+Major Linux distributions have been informed of the issue and have released fixes. As a result, Istio is removing the `nftables` version pinning. Users are advised to update the `nftables` package on their nodes to the latest available version to ensure that the fixed version is installed.
+
+If you continue to experience `nftables` crashes on your nodes, downgrade to an older version of Istio and contact your node OS provider to request that the fix be backported to your OS version.

--- a/releasenotes/notes/58492.yaml
+++ b/releasenotes/notes/58492.yaml
@@ -11,3 +11,6 @@ releaseNotes:
   Major Linux distributions have been informed of the nftables issue and released a fix for it, so
   we are removing the pinning in Istio. Users are advised to update nftables package on their
   nodes to the latest version to make sure that the version with the fix is used on the node.
+  If you're still experiencing issues with node nftables crashing please downgrade to an older
+  version of Istio and contact the provider of the node OS for your deployment and ask them to
+  backport the fix.

--- a/tools/build-base-images.sh
+++ b/tools/build-base-images.sh
@@ -77,15 +77,7 @@ unexpectedFiles="$(
     grep -v '^usr/bin/nft' | \
     grep -v '^usr/share/doc/nftables/examples/.*.nft' | \
     grep -v '^etc/apk/commit_hooks.d/ldconfig-commit.sh$' | \
-    grep -v '.*\.so[0-9\.]*' | \
-    # TODO: Remove the following test files when getting a nftables-slim=1.1.1 package from packages.wolfi.dev/os
-    grep -v '^usr/bin/clear' | \
-    grep -v '^usr/bin/infocmp' | \
-    grep -v '^usr/bin/tabs' | \
-    grep -v '^usr/bin/tic' | \
-    grep -v '^usr/bin/toe' | \
-    grep -v '^usr/bin/tput' | \
-    grep -v '^usr/bin/tset' || true
+    grep -v '.*\.so[0-9\.]*' || true
 )"
 expectedFiles=(
   "usr/bin/xtables-legacy-multi"


### PR DESCRIPTION
**Please provide a description of this PR:**

This is basically undoing #58544. That PR was merged because we wanted to pin version of nftables we use to an old one explicitly to avoid #58492.

Since the issue in #58492 was detected and triaged, many major Linux distributions backported a patch that fixes nftables crash, so we don't need to pin nftables version used by Istio anymore.

NOTE: There is still a chance that users don't update their k8s host images and can hit this issue, but we don't have control over how often users update - the best we can do is make sure that the fix is available and they can update.

NOTE: #58544 both pinned the version used and switched from nftables-slim to plain nftables at the same time, the switch to plain nftables was done because there was no nftables-slim version we could pin to - using nftables-slim is still desirable.

Fixes #58492






+cc @dhawton @sridhargaddam @yxun @xnox @keithmattix @jaellio 