### PR TITLE
Restrict xds api generator to control-plane identities

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -103,6 +103,11 @@ var (
 	EnableDebugEndpointAuth = env.Register("ENABLE_DEBUG_ENDPOINT_AUTH", true,
 		"Enforce namespace-based authorization on debug endpoints. Non-system namespaces restricted to config_dump/ndsz/edsz for same-namespace proxies only.").Get()
 
+	EnableXDSAPIGeneratorAuth = env.Register("ENABLE_XDS_API_GENERATOR_AUTH", true,
+		"If enabled, the XDS 'api' generator (MCP-over-xDS config serving) is restricted to callers with a verified "+
+			"control-plane (root namespace) identity. Prevents an unauthenticated client on the plaintext xDS port, or a "+
+			"workload in an unrelated namespace on the mTLS port, from reading cluster-wide Istio config.").Get()
+
 	DebugEndpointAuthAllowedNamespaces = func() sets.String {
 		v := env.Register(
 			"DEBUG_ENDPOINT_AUTH_ALLOWED_NAMESPACES",

--- a/pilot/pkg/networking/apigen/apigen.go
+++ b/pilot/pkg/networking/apigen/apigen.go
@@ -18,12 +18,16 @@ import (
 	"strings"
 
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
 	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/log"
 )
@@ -60,6 +64,10 @@ func NewGenerator(store model.ConfigStore) *APIGenerator {
 //
 // Names are based on the current resource naming in istiod stores.
 func (g *APIGenerator) Generate(proxy *model.Proxy, w *model.WatchedResource, req *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
+	if err := authorize(proxy, req); err != nil {
+		return nil, model.DefaultXdsLogDetails, err
+	}
+
 	resp := model.Resources{}
 
 	// Note: this is the style used by MCP and its config. Pilot is using 'Group/Version/Kind' as the
@@ -130,4 +138,23 @@ func (g *APIGenerator) Generate(proxy *model.Proxy, w *model.WatchedResource, re
 	}
 
 	return resp, model.DefaultXdsLogDetails, nil
+}
+
+// authorize protects the api generator from unauthorized access. It serves cluster-wide
+// config, so only callers with a verified control-plane (root namespace) identity are allowed.
+func authorize(proxy *model.Proxy, req *model.PushRequest) error {
+	if !features.EnableXDSAPIGeneratorAuth {
+		return nil
+	}
+	systemNamespace := constants.IstioSystemNamespace
+	if req != nil && req.Push != nil && req.Push.Mesh != nil && req.Push.Mesh.GetRootNamespace() != "" {
+		systemNamespace = req.Push.Mesh.GetRootNamespace()
+	}
+	if proxy == nil || proxy.VerifiedIdentity == nil {
+		return grpcstatus.Error(codes.Unauthenticated, "the api generator requires an authenticated control-plane identity")
+	}
+	if proxy.VerifiedIdentity.Namespace != systemNamespace {
+		return grpcstatus.Error(codes.PermissionDenied, "the api generator is restricted to the control-plane (root) namespace")
+	}
+	return nil
 }

--- a/pilot/pkg/networking/apigen/apigen.go
+++ b/pilot/pkg/networking/apigen/apigen.go
@@ -44,11 +44,15 @@ import (
 type APIGenerator struct {
 	// ConfigStore interface for listing istio api resources.
 	store model.ConfigStore
+	// requireAuth restricts the generator to verified control-plane identities.
+	// Captured at construction to avoid reading the feature flag per-request.
+	requireAuth bool
 }
 
 func NewGenerator(store model.ConfigStore) *APIGenerator {
 	return &APIGenerator{
-		store: store,
+		store:       store,
+		requireAuth: features.EnableXDSAPIGeneratorAuth,
 	}
 }
 
@@ -64,7 +68,7 @@ func NewGenerator(store model.ConfigStore) *APIGenerator {
 //
 // Names are based on the current resource naming in istiod stores.
 func (g *APIGenerator) Generate(proxy *model.Proxy, w *model.WatchedResource, req *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {
-	if err := authorize(proxy, req); err != nil {
+	if err := g.authorize(proxy, req); err != nil {
 		return nil, model.DefaultXdsLogDetails, err
 	}
 
@@ -142,8 +146,8 @@ func (g *APIGenerator) Generate(proxy *model.Proxy, w *model.WatchedResource, re
 
 // authorize protects the api generator from unauthorized access. It serves cluster-wide
 // config, so only callers with a verified control-plane (root namespace) identity are allowed.
-func authorize(proxy *model.Proxy, req *model.PushRequest) error {
-	if !features.EnableXDSAPIGeneratorAuth {
+func (g *APIGenerator) authorize(proxy *model.Proxy, req *model.PushRequest) error {
+	if !g.requireAuth {
 		return nil
 	}
 	systemNamespace := constants.IstioSystemNamespace

--- a/pilot/pkg/networking/apigen/apigen_test.go
+++ b/pilot/pkg/networking/apigen/apigen_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 	"time"
 
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+
 	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
@@ -140,6 +142,25 @@ func TestAPIGenRequiresControlPlaneIdentity(t *testing.T) {
 		_, _, err := newGen().Generate(proxy, w, nil)
 		assert.NoError(t, err)
 	})
+}
+
+// TestAPIGenADSRejectsUnauthenticated exercises the control-plane-identity gate over a full
+// ADS stream rather than calling authorize directly: a client that selects GENERATOR=api with
+// no verified identity (as on the plaintext xDS port 15010) must be rejected. This covers the
+// real path (generator selection in pushXds -> Generate -> authorize -> stream error) that the
+// unit test above stubs out.
+func TestAPIGenADSRejectsUnauthenticated(t *testing.T) {
+	test.SetForTest(t, &features.EnableXDSAPIGeneratorAuth, true)
+	ds := initDS(t)
+
+	// The buffcon ADS connection has no verified identity, matching an unauthenticated caller.
+	ads := ds.ConnectADS().
+		WithType(gvk.ServiceEntry.String()).
+		WithMetadata(model.NodeMetadata{Generator: "api"})
+	ads.Request(t, &discovery.DiscoveryRequest{TypeUrl: gvk.ServiceEntry.String()})
+	if err := ads.ExpectError(t); err == nil {
+		t.Fatal("expected api generator to reject an ADS connection without a verified identity")
+	}
 }
 
 // Test using resolving DNS over GRPC. This uses XDS protocol, and Listener resources

--- a/pilot/pkg/networking/apigen/apigen_test.go
+++ b/pilot/pkg/networking/apigen/apigen_test.go
@@ -19,10 +19,16 @@ import (
 	"time"
 
 	"istio.io/istio/pilot/pkg/config/memory"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/apigen"
 	"istio.io/istio/pilot/test/xds"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/spiffe"
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/assert"
 )
 
 // Creates an in-process discovery server, using the same code as Istiod, but
@@ -60,6 +66,9 @@ func initDSwithMulAddresses(t *testing.T) *xds.FakeDiscoveryServer {
 // Test using resolving DNS over GRPC. This uses XDS protocol, and Listener resources
 // to represent the names. The protocol is based on GRPC resolution of XDS resources.
 func TestAPIGen(t *testing.T) {
+	// This test exercises the config-serving mechanics over an in-process connection that has no
+	// verified identity; disable the control-plane-identity gate so it targets the generator itself.
+	test.SetForTest(t, &features.EnableXDSAPIGeneratorAuth, false)
 	ds := initDS(t)
 
 	// Verify we can receive the DNS cluster IPs using XDS
@@ -92,9 +101,47 @@ func TestAPIGen(t *testing.T) {
 	})
 }
 
+// TestAPIGenRequiresControlPlaneIdentity verifies that the api generator only serves callers
+// with a verified control-plane (root namespace) identity. Without this, an unauthenticated
+// client on the plaintext xDS port (15010) or a workload in any namespace on the mTLS port can
+// select GENERATOR=api and read cluster-wide Istio config across all namespaces.
+func TestAPIGenRequiresControlPlaneIdentity(t *testing.T) {
+	gen := apigen.NewGenerator(memory.NewController(memory.Make(collections.Pilot)))
+	w := &model.WatchedResource{TypeUrl: gvk.AuthorizationPolicy.String()}
+
+	t.Run("unauthenticated rejected", func(t *testing.T) {
+		test.SetForTest(t, &features.EnableXDSAPIGeneratorAuth, true)
+		proxy := &model.Proxy{VerifiedIdentity: nil} // simulates plaintext port 15010
+		_, _, err := gen.Generate(proxy, w, nil)
+		assert.Error(t, err)
+	})
+
+	t.Run("non-system namespace rejected", func(t *testing.T) {
+		test.SetForTest(t, &features.EnableXDSAPIGeneratorAuth, true)
+		proxy := &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "attacker"}}
+		_, _, err := gen.Generate(proxy, w, nil)
+		assert.Error(t, err)
+	})
+
+	t.Run("control-plane identity allowed", func(t *testing.T) {
+		test.SetForTest(t, &features.EnableXDSAPIGeneratorAuth, true)
+		proxy := &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: constants.IstioSystemNamespace}}
+		_, _, err := gen.Generate(proxy, w, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("gate disabled allows unauthenticated", func(t *testing.T) {
+		test.SetForTest(t, &features.EnableXDSAPIGeneratorAuth, false)
+		proxy := &model.Proxy{VerifiedIdentity: nil}
+		_, _, err := gen.Generate(proxy, w, nil)
+		assert.NoError(t, err)
+	})
+}
+
 // Test using resolving DNS over GRPC. This uses XDS protocol, and Listener resources
 // to represent the names. The protocol is based on GRPC resolution of XDS resources.
 func TestAPIGenWithMulAddresses(t *testing.T) {
+	test.SetForTest(t, &features.EnableXDSAPIGeneratorAuth, false)
 	ds := initDSwithMulAddresses(t)
 
 	// Verify we can receive the DNS cluster IPs using XDS

--- a/pilot/pkg/networking/apigen/apigen_test.go
+++ b/pilot/pkg/networking/apigen/apigen_test.go
@@ -106,34 +106,38 @@ func TestAPIGen(t *testing.T) {
 // client on the plaintext xDS port (15010) or a workload in any namespace on the mTLS port can
 // select GENERATOR=api and read cluster-wide Istio config across all namespaces.
 func TestAPIGenRequiresControlPlaneIdentity(t *testing.T) {
-	gen := apigen.NewGenerator(memory.NewController(memory.Make(collections.Pilot)))
+	// The generator captures the feature flag at construction, so each subtest builds its
+	// own generator after setting the flag.
+	newGen := func() *apigen.APIGenerator {
+		return apigen.NewGenerator(memory.NewController(memory.Make(collections.Pilot)))
+	}
 	w := &model.WatchedResource{TypeUrl: gvk.AuthorizationPolicy.String()}
 
 	t.Run("unauthenticated rejected", func(t *testing.T) {
 		test.SetForTest(t, &features.EnableXDSAPIGeneratorAuth, true)
 		proxy := &model.Proxy{VerifiedIdentity: nil} // simulates plaintext port 15010
-		_, _, err := gen.Generate(proxy, w, nil)
+		_, _, err := newGen().Generate(proxy, w, nil)
 		assert.Error(t, err)
 	})
 
 	t.Run("non-system namespace rejected", func(t *testing.T) {
 		test.SetForTest(t, &features.EnableXDSAPIGeneratorAuth, true)
 		proxy := &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: "attacker"}}
-		_, _, err := gen.Generate(proxy, w, nil)
+		_, _, err := newGen().Generate(proxy, w, nil)
 		assert.Error(t, err)
 	})
 
 	t.Run("control-plane identity allowed", func(t *testing.T) {
 		test.SetForTest(t, &features.EnableXDSAPIGeneratorAuth, true)
 		proxy := &model.Proxy{VerifiedIdentity: &spiffe.Identity{Namespace: constants.IstioSystemNamespace}}
-		_, _, err := gen.Generate(proxy, w, nil)
+		_, _, err := newGen().Generate(proxy, w, nil)
 		assert.NoError(t, err)
 	})
 
 	t.Run("gate disabled allows unauthenticated", func(t *testing.T) {
 		test.SetForTest(t, &features.EnableXDSAPIGeneratorAuth, false)
 		proxy := &model.Proxy{VerifiedIdentity: nil}
-		_, _, err := gen.Generate(proxy, w, nil)
+		_, _, err := newGen().Generate(proxy, w, nil)
 		assert.NoError(t, err)
 	})
 }

--- a/releasenotes/notes/xds-api-generator-auth.yaml
+++ b/releasenotes/notes/xds-api-generator-auth.yaml
@@ -1,0 +1,21 @@
+apiVersion: release-notes/v2
+
+kind: security-fix
+
+area: security
+
+# no public issue for security vulnerability
+issue: []
+
+releaseNotes:
+- |
+  **Fixed** the XDS `api` generator (MCP config serving) to require a verified control-plane identity.
+  Previously any client that could reach istiod's XDS port could read Istio config across all namespaces.
+  Disable with ENABLE_XDS_API_GENERATOR_AUTH=false if needed for compatibility.
+
+upgradeNotes:
+- title: The XDS api generator now requires a control-plane identity
+  content: |
+    Custom MCP consumers connecting to istiod's api generator from non-system namespaces are now rejected.
+    Standard sidecar, gateway, and ztunnel traffic is unaffected.
+    To restore previous behavior, set ENABLE_XDS_API_GENERATOR_AUTH=false.


### PR DESCRIPTION
The api generator served cluster-wide config to any client on the xds port. Require a verified control-plane (root namespace) identity, gated by ENABLE_XDS_API_GENERATOR_AUTH.