### PR TITLE
block cloud metadata by default and validate jwks body in jwks resolver

### DIFF
--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -274,6 +274,11 @@ func (r *JwksResolver) GetPublicKey(issuer string, jwksURI string, timeout time.
 		resp, err = r.getRemoteContentWithRetry(jwksURI, networkFetchRetryCountOnMainFlow, timeout)
 		if err != nil {
 			log.Errorf("Failed to fetch public key from jwks URI %q: %v", jwksURI, err)
+		} else if err = validateJWKSFormat(resp); err != nil {
+			// Reject a response that is not a JWKS so an SSRF-controlled jwksURI cannot get an
+			// arbitrary fetched body embedded verbatim as an inline JWKS and read back via config_dump.
+			log.Errorf("Content fetched from jwks URI %q is not a valid JWKS: %v", jwksURI, err)
+			resp = nil
 		}
 		pubKey = string(resp)
 	}
@@ -606,11 +611,46 @@ func (r *JwksResolver) Close() {
 // for why this is done at the dial level rather than by inspecting the jwksURI upfront.
 var blockedCIDRDialContext = security.BlockedIPDialContext(&net.Dialer{}, jwksBlockedIP)
 
+// jwksBlockedIP blocks link-local addresses (which include cloud instance metadata endpoints such
+// as 169.254.169.254) and well-known cloud metadata addresses outside the link-local range, neither
+// of which has a legitimate use as a JWKS host, plus any operator-configured ranges from
+// BlockedCIDRsInJWKURIs. This mirrors the always-on default applied to Wasm module fetches
+// (pkg/wasm/ssrf.go). Private (RFC1918/ULA) and loopback ranges are not blocked by default since
+// in-cluster OIDC providers (e.g. Keycloak) legitimately live in private space; operators can add
+// them via BLOCKED_CIDRS_IN_JWKS_URIS.
 func jwksBlockedIP(ip net.IP) error {
+	if security.IsLinkLocal(ip) {
+		return fmt.Errorf("connection blocked: resolved IP %s is link-local", ip.String())
+	}
+	if security.IsKnownCloudMetadataAddress(ip) {
+		return fmt.Errorf("connection blocked: resolved IP %s is a known cloud metadata address", ip.String())
+	}
 	for _, cidr := range features.BlockedCIDRsInJWKURIs {
 		if cidr.Contains(ip) {
 			return fmt.Errorf("connection blocked: resolved IP %s is in blocked CIDR range %s", ip.String(), cidr.String())
 		}
+	}
+	return nil
+}
+
+// validateJWKSFormat reports an error if body does not look like a JWKS: a JSON object with a
+// "keys" array (RFC 7517). It is deliberately loose - it does not validate individual keys - and
+// exists to stop an arbitrary fetched response (e.g. from an SSRF-controlled jwksURI pointed at an
+// internal endpoint) from being embedded verbatim into a proxy's config as an inline JWKS and read
+// back through config_dump.
+func validateJWKSFormat(body []byte) error {
+	var doc struct {
+		Keys *json.RawMessage `json:"keys"`
+	}
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return fmt.Errorf("not valid JSON: %w", err)
+	}
+	if doc.Keys == nil {
+		return fmt.Errorf("missing \"keys\" field")
+	}
+	var keys []json.RawMessage
+	if err := json.Unmarshal(*doc.Keys, &keys); err != nil {
+		return fmt.Errorf("\"keys\" is not an array: %w", err)
 	}
 	return nil
 }

--- a/pilot/pkg/model/jwks_resolver_test.go
+++ b/pilot/pkg/model/jwks_resolver_test.go
@@ -16,13 +16,16 @@ package model
 
 import (
 	"fmt"
+	"net"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model/test"
 	"istio.io/istio/pkg/monitoring/monitortest"
+	pkgtest "istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/retry"
 )
 
@@ -834,4 +837,61 @@ func TestBuildLocalJwksFailsClosed(t *testing.T) {
 	if strings.Contains(jwksStr, `"d":`) || strings.Contains(jwksStr, `"p":`) || strings.Contains(jwksStr, `"q":`) {
 		t.Errorf("BuildLocalJwks() contains private key fields - security vulnerability! JWKS: %s", jwksStr)
 	}
+}
+
+func TestValidateJWKSFormat(t *testing.T) {
+	cases := []struct {
+		name    string
+		body    string
+		wantErr bool
+	}{
+		{"valid jwks", `{"keys":[{"kty":"RSA","e":"AQAB","n":"abc"}]}`, false},
+		{"valid empty keys", `{"keys":[]}`, false},
+		{"not json", `<html>not a jwks</html>`, true},
+		{"mesh config json (ssrf debug body)", `{"proxyListenPort":15001,"defaultConfig":{}}`, true},
+		{"missing keys field", `{"foo":"bar"}`, true},
+		{"keys not an array", `{"keys":"nope"}`, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateJWKSFormat([]byte(tc.body))
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validateJWKSFormat(%q) err=%v, wantErr=%v", tc.body, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestJwksBlockedIP(t *testing.T) {
+	// default behavior: link-local and known cloud metadata are blocked; loopback, private, and
+	// public are allowed (private/loopback are opt-in via BLOCKED_CIDRS_IN_JWKS_URIS).
+	cases := []struct {
+		name    string
+		ip      string
+		blocked bool
+	}{
+		{"link-local metadata", "169.254.169.254", true},
+		{"link-local v6", "fe80::1", true},
+		{"alibaba metadata cgnat", "100.100.100.200", true},
+		{"aws imds v6", "fd00:ec2::254", true},
+		{"loopback allowed by default", "127.0.0.1", false},
+		{"private allowed by default", "10.0.0.1", false},
+		{"public allowed", "8.8.8.8", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := jwksBlockedIP(net.ParseIP(tc.ip)); (err != nil) != tc.blocked {
+				t.Errorf("jwksBlockedIP(%s) err=%v, blocked=%v", tc.ip, err, tc.blocked)
+			}
+		})
+	}
+
+	// operator-configured CIDR is additive to the always-on defaults.
+	t.Run("configured cidr", func(t *testing.T) {
+		_, cidr, _ := net.ParseCIDR("192.168.0.0/16")
+		pkgtest.SetForTest(t, &features.BlockedCIDRsInJWKURIs, []*net.IPNet{cidr})
+		if err := jwksBlockedIP(net.ParseIP("192.168.1.5")); err == nil {
+			t.Errorf("jwksBlockedIP(192.168.1.5) should be blocked by configured CIDR")
+		}
+	})
 }

--- a/releasenotes/notes/jwks-ssrf-default-block.yaml
+++ b/releasenotes/notes/jwks-ssrf-default-block.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+releaseNotes:
+  - |
+    **Fixed** an SSRF gap in istiod's `RequestAuthentication` `jwksUri` fetching. istiod now
+    blocks link-local and known cloud metadata addresses (such as `169.254.169.254`) at the dial
+    level by default and rejects fetched responses that are not a valid JWKS. Private and loopback
+    ranges remain reachable and can be blocked with `BLOCKED_CIDRS_IN_JWKS_URIS`.


### PR DESCRIPTION
mirrors #61112 on the jwks path: always-on link-local and the cloud metadata block in the jwks resolver reusing the shared security helpers, plus reject a fetched body that isn't a valid jwks so an internal response can't be embedded as inline_string and read back via config_dump. private/loopback stay opt-in via `BLOCKED_CIDRS_IN_JWKS_URIS` incomplete-fix/insecure-default follow-up to CVE-2026-41413, no new CVE.
