### PR TITLE
configure push hub in release-commit

### DIFF
--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -29,6 +29,7 @@ setup_gcloud_credentials
 # Old prow image does not set this, so needed explicitly here as this is not called through make
 export GO111MODULE=on
 
+DOCKER_PUSH_HUB=${DOCKER_PUSH_HUB:-gcr.io/istio-testing}
 DOCKER_HUB=${DOCKER_HUB:-registry.istio.io/testing}
 HELM_HUB=${HELM_HUB:-gcr.io/istio-testing/charts}
 GCS_BUCKET=${GCS_BUCKET:-istio-build/dev}
@@ -115,5 +116,5 @@ if [[ -z "${DRY_RUN:-}" ]]; then
     release-builder publish --release "${WORK_DIR}/out" \
       --gcsbucket "${GCS_BUCKET}" --gcsaliases "${TAG},${NEXT_VERSION}-dev,latest" \
       --s3bucket "${R2_BUCKET}" --s3aliases "${TAG},${NEXT_VERSION}-dev,latest" --s3-base-endpoint "${ENDPOINT}" \
-      --dockerhub "gcr.io/istio-testing" --helmhub "${HELM_HUB}" --dockertags "${TAG},${VERSION},${NEXT_VERSION}-dev,latest"
+      --dockerhub "${DOCKER_PUSH_HUB}" --helmhub "${HELM_HUB}" --dockertags "${TAG},${VERSION},${NEXT_VERSION}-dev,latest"
 fi


### PR DESCRIPTION
**Please provide a description of this PR:**

Like https://github.com/istio/istio/pull/61015 but I think this is better because it allows us to change the push target by changing the push target via an env variable rather than having to time a merge.