### PR TITLE
key listener conflicts by owner kind

### DIFF
--- a/pilot/pkg/config/kube/gatewaycommon/listener_conflict.go
+++ b/pilot/pkg/config/kube/gatewaycommon/listener_conflict.go
@@ -37,6 +37,20 @@ type listenerOwner struct {
 	name      string
 }
 
+const (
+	ownerKindGateway     = "Gateway"
+	ownerKindListenerSet = "ListenerSet"
+)
+
+// ConflictOwner keys recorded conflicts by the owner's kind as well as its namespace and name.
+// Kind is part of the key on purpose: a Gateway and a ListenerSet may legally share a namespace
+// and name, and keying by namespace/name alone made such a pair read each other's conflict
+// entries, marking winning listeners as conflicted.
+type ConflictOwner struct {
+	Kind string
+	types.NamespacedName
+}
+
 // EligibleListenerSetsForConflict filters attached ListenerSets to those allowed on the Gateway.
 // Ineligible sets are excluded so they cannot mark allowed listeners as conflicted.
 func EligibleListenerSetsForConflict(
@@ -59,12 +73,12 @@ func EligibleListenerSetsForConflict(
 func ComputeGatewayListenerConflicts(
 	parent *gatewayv1.Gateway,
 	eligible []*gatewayv1.ListenerSet,
-) map[types.NamespacedName]map[gatewayv1.SectionName]gatewayv1.ListenerConditionReason {
+) map[ConflictOwner]map[gatewayv1.SectionName]gatewayv1.ListenerConditionReason {
 	if parent == nil {
 		return nil
 	}
 	ordered := orderedMergedListeners(parent, eligible)
-	conflicts := map[types.NamespacedName]map[gatewayv1.SectionName]gatewayv1.ListenerConditionReason{}
+	conflicts := map[ConflictOwner]map[gatewayv1.SectionName]gatewayv1.ListenerConditionReason{}
 	accepted := make([]gatewayv1.Listener, 0, len(ordered))
 	for _, entry := range ordered {
 		if prior, ok := firstConflictingPrior(entry.listener, accepted); ok {
@@ -89,16 +103,16 @@ func firstConflictingPrior(listener gatewayv1.Listener, accepted []gatewayv1.Lis
 
 // recordListenerConflict records a conflict reason for a Gateway or ListenerSet listener.
 func recordListenerConflict(
-	conflicts map[types.NamespacedName]map[gatewayv1.SectionName]gatewayv1.ListenerConditionReason,
+	conflicts map[ConflictOwner]map[gatewayv1.SectionName]gatewayv1.ListenerConditionReason,
 	owner listenerOwner,
 	name gatewayv1.SectionName,
 	reason gatewayv1.ListenerConditionReason,
 ) {
-	nsn := types.NamespacedName{Namespace: owner.namespace, Name: owner.name}
-	if conflicts[nsn] == nil {
-		conflicts[nsn] = map[gatewayv1.SectionName]gatewayv1.ListenerConditionReason{}
+	key := ConflictOwner{Kind: owner.kind, NamespacedName: types.NamespacedName{Namespace: owner.namespace, Name: owner.name}}
+	if conflicts[key] == nil {
+		conflicts[key] = map[gatewayv1.SectionName]gatewayv1.ListenerConditionReason{}
 	}
-	conflicts[nsn][name] = reason
+	conflicts[key][name] = reason
 }
 
 // orderedMergedListeners returns Gateway listeners followed by ListenerSet listeners in merge precedence order.
@@ -114,7 +128,7 @@ func orderedMergedListeners(parent *gatewayv1.Gateway, attached []*gatewayv1.Lis
 		out = append(out, mergedListener{
 			listener: l,
 			owner: listenerOwner{
-				kind:      "Gateway",
+				kind:      ownerKindGateway,
 				namespace: parent.Namespace,
 				name:      parent.Name,
 			},
@@ -135,7 +149,7 @@ func orderedMergedListeners(parent *gatewayv1.Gateway, attached []*gatewayv1.Lis
 
 	for _, set := range sets {
 		owner := listenerOwner{
-			kind:      "ListenerSet",
+			kind:      ownerKindListenerSet,
 			namespace: set.Namespace,
 			name:      set.Name,
 		}

--- a/pilot/pkg/config/kube/gatewaycommon/listener_conflict_collection.go
+++ b/pilot/pkg/config/kube/gatewaycommon/listener_conflict_collection.go
@@ -27,7 +27,7 @@ import (
 // GatewayListenerConflicts holds listener conflict results for one Gateway.
 type GatewayListenerConflicts struct {
 	Gateway   types.NamespacedName
-	Conflicts map[types.NamespacedName]map[gatewayv1.SectionName]gatewayv1.ListenerConditionReason
+	Conflicts map[ConflictOwner]map[gatewayv1.SectionName]gatewayv1.ListenerConditionReason
 }
 
 func (g GatewayListenerConflicts) ResourceName() string {
@@ -60,7 +60,7 @@ func (g GatewayListenerConflicts) ConflictsForGateway(gw *gatewayv1.Gateway) map
 	if gw == nil || g.Conflicts == nil {
 		return nil
 	}
-	return g.Conflicts[types.NamespacedName{Namespace: gw.Namespace, Name: gw.Name}]
+	return g.Conflicts[ConflictOwner{Kind: ownerKindGateway, NamespacedName: types.NamespacedName{Namespace: gw.Namespace, Name: gw.Name}}]
 }
 
 // ConflictsFor returns conflict reasons for listeners on the given ListenerSet.
@@ -68,7 +68,7 @@ func (g GatewayListenerConflicts) ConflictsFor(ls *gatewayv1.ListenerSet) map[ga
 	if ls == nil || g.Conflicts == nil {
 		return nil
 	}
-	return g.Conflicts[types.NamespacedName{Namespace: ls.Namespace, Name: ls.Name}]
+	return g.Conflicts[ConflictOwner{Kind: ownerKindListenerSet, NamespacedName: types.NamespacedName{Namespace: ls.Namespace, Name: ls.Name}}]
 }
 
 // GatewayListenerConflictCollection computes listener conflicts once per Gateway.
@@ -88,11 +88,11 @@ func GatewayListenerConflictCollection(
 		gwNN := config.NamespacedName(gw)
 		class := fetchClass(ctx, gw.Spec.GatewayClassName)
 		if class == nil {
-			return &GatewayListenerConflicts{Gateway: gwNN, Conflicts: map[types.NamespacedName]map[gatewayv1.SectionName]gatewayv1.ListenerConditionReason{}}
+			return &GatewayListenerConflicts{Gateway: gwNN, Conflicts: map[ConflictOwner]map[gatewayv1.SectionName]gatewayv1.ListenerConditionReason{}}
 		}
 		classInfo, ok := ClassInfos[class.Controller]
 		if !ok || !classInfo.SupportsListenerSet {
-			return &GatewayListenerConflicts{Gateway: gwNN, Conflicts: map[types.NamespacedName]map[gatewayv1.SectionName]gatewayv1.ListenerConditionReason{}}
+			return &GatewayListenerConflicts{Gateway: gwNN, Conflicts: map[ConflictOwner]map[gatewayv1.SectionName]gatewayv1.ListenerConditionReason{}}
 		}
 
 		attached := listenerSetsByGateway.Fetch(ctx, gwNN)

--- a/pilot/pkg/config/kube/gatewaycommon/listener_conflict_test.go
+++ b/pilot/pkg/config/kube/gatewaycommon/listener_conflict_test.go
@@ -576,3 +576,39 @@ func TestListenerSetParentKey(t *testing.T) {
 		t.Fatalf("got %q/%q", ns, name)
 	}
 }
+
+// TestConflictsKeyedByOwnerKind proves a Gateway and a ListenerSet sharing a namespace and name do
+// not read each other's conflict entries. The conflicts map was previously keyed by namespace/name
+// alone; with a same-named pair, a conflict recorded for the losing ListenerSet listener was also
+// returned for the Gateway, marking the winning listener conflicted and taking both objects dark.
+func TestConflictsKeyedByOwnerKind(t *testing.T) {
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared", Namespace: "infra"},
+		Spec: gatewayv1.GatewaySpec{
+			Listeners: []gatewayv1.Listener{
+				{Name: "http", Port: 80, Protocol: gatewayv1.HTTPProtocolType, Hostname: hostname("app.example.com")},
+			},
+		},
+	}
+	// Same namespace AND name as the Gateway, and a listener that loses to the Gateway's.
+	ls := &gatewayv1.ListenerSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared", Namespace: "infra", CreationTimestamp: metav1.NewTime(time.Now())},
+		Spec: gatewayv1.ListenerSetSpec{
+			Listeners: []gatewayv1.ListenerEntry{
+				{Name: "http", Port: 80, Protocol: gatewayv1.HTTPProtocolType, Hostname: hostname("app.example.com")},
+			},
+		},
+	}
+
+	result := GatewayListenerConflicts{Conflicts: ComputeGatewayListenerConflicts(gw, []*gatewayv1.ListenerSet{ls})}
+
+	// The ListenerSet listener loses to the Gateway's own listener: conflict expected.
+	if got := result.ConflictsFor(ls)["http"]; got != gatewayv1.ListenerReasonHostnameConflict {
+		t.Fatalf("ListenerSet listener should lose to the Gateway listener: got %q", got)
+	}
+	// The Gateway's listener WON. It must not inherit the ListenerSet's conflict through the
+	// shared namespace/name key.
+	if got := result.ConflictsForGateway(gw); len(got) != 0 {
+		t.Fatalf("winning Gateway listener must not be marked conflicted by a same-named ListenerSet: %+v", got)
+	}
+}

--- a/releasenotes/notes/listenerset-conflict-owner-kind.yaml
+++ b/releasenotes/notes/listenerset-conflict-owner-kind.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue: []
+releaseNotes:
+  - |
+    **Fixed** listener conflict tracking treating a `Gateway` and a `ListenerSet` with the same
+    namespace and name as the same object, which caused a conflict recorded for one to mark the
+    other's winning listener as `Conflicted` and stop it from being programmed.


### PR DESCRIPTION
the listener conflicts map is keyed by `namespace/name` with the owner `kind` discarded. 
`Gateway` and `ListenerSet` may legally share a namespace and name, a conflict recorded for one is returned for the other, so the winning listener is reported `Conflicted` and `not programmed`. legal naming choice takes both dark. 
this PR fixes the issue by keying the map by owner kind as well. Added a regression test with a same-named pair.