### PR TITLE
security: fix waypoint remote JWKS clusters for service targetRefs

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -874,8 +874,8 @@ func virtualServiceDestinationsFilteredBySourceNamespace(v *networking.VirtualSe
 	return out
 }
 
-func (ps *PushContext) ExtraWaypointServices(proxy *Proxy, patches *MergedEnvoyFilterWrapper) (sets.Set[NamespacedHostname], sets.String) {
-	return ps.extraServicesForProxy(proxy, patches)
+func (ps *PushContext) ExtraWaypointServices(proxy *Proxy, patches *MergedEnvoyFilterWrapper, services []*Service) (sets.Set[NamespacedHostname], sets.String) {
+	return ps.extraServicesForProxy(proxy, patches, services)
 }
 
 // GatewayServices returns the set of services which are referred from the proxy gateways.
@@ -883,7 +883,7 @@ func (ps *PushContext) GatewayServices(proxy *Proxy, patches *MergedEnvoyFilterW
 	svcs := proxy.SidecarScope.services
 
 	// host set.
-	namespacedHostsFromGateways, hostsFromGateways := ps.extraServicesForProxy(proxy, patches)
+	namespacedHostsFromGateways, hostsFromGateways := ps.extraServicesForProxy(proxy, patches, nil)
 	// MergedGateway will be nil when there are no configs in the
 	// system during initial installation.
 	if proxy.MergedGateway != nil {
@@ -932,7 +932,7 @@ func (ps *PushContext) ServiceAttachedToGateway(hostname string, namespace strin
 		}
 	}
 	patches := ps.EnvoyFilters(proxy)
-	namespaced, hosts := ps.extraServicesForProxy(proxy, patches)
+	namespaced, hosts := ps.extraServicesForProxy(proxy, patches, nil)
 	return hosts.Contains(hostname) || namespaced.Contains(NamespacedHostname{Hostname: host.Name(hostname), Namespace: namespace})
 }
 
@@ -971,7 +971,7 @@ const addHostsFromMeshConfigProvidersHandled = 15
 // 1. MeshConfig.ExtensionProviders
 // 2. RequestAuthentication.JwtRules.JwksUri
 // 3. EnvoyFilters with explicitly annotated references
-func (ps *PushContext) extraServicesForProxy(proxy *Proxy, patches *MergedEnvoyFilterWrapper) (sets.Set[NamespacedHostname], sets.String) {
+func (ps *PushContext) extraServicesForProxy(proxy *Proxy, patches *MergedEnvoyFilterWrapper, services []*Service) (sets.Set[NamespacedHostname], sets.String) {
 	hosts := sets.String{}
 	namespaceScoped := sets.New[NamespacedHostname]()
 	addService := func(s string) {
@@ -1019,7 +1019,7 @@ func (ps *PushContext) extraServicesForProxy(proxy *Proxy, patches *MergedEnvoyF
 	}
 	// add services from RequestAuthentication.JwtRules.JwksUri
 	if features.JwksFetchMode != jwt.Istiod {
-		forWorkload := PolicyMatcherForProxy(proxy)
+		forWorkload := PolicyMatcherForProxy(proxy).WithServices(services)
 		jwtPolicies := ps.AuthnPolicies.GetJwtPoliciesForWorkload(forWorkload)
 		for _, cfg := range jwtPolicies {
 			rules := cfg.Spec.(*v1beta1.RequestAuthentication).JwtRules

--- a/pilot/pkg/networking/core/cluster.go
+++ b/pilot/pkg/networking/core/cluster.go
@@ -351,7 +351,7 @@ func (configgen *ConfigGeneratorImpl) buildClusters(proxy *model.Proxy, req *mod
 		_, wps := findWaypointResources(proxy, req.Push)
 		// Waypoint proxies do not need outbound clusters in most cases, unless we have a route pointing to something
 		outboundPatcher := clusterPatcher{efw: envoyFilterPatches, pctx: networking.EnvoyFilter_SIDECAR_OUTBOUND}
-		extraNamespacedHosts, extraHosts := req.Push.ExtraWaypointServices(proxy, envoyFilterPatches)
+		extraNamespacedHosts, extraHosts := req.Push.ExtraWaypointServices(proxy, envoyFilterPatches, wps.orderedServices)
 		outboundServices := filterWaypointOutboundServices(
 			req.Push.ServicesAttachedToMesh(), wps.services, extraNamespacedHosts, extraHosts, services)
 		// For E/W gateways that also expose non-HBONE ports via the Gateway API (e.g., TLS passthrough

--- a/pilot/pkg/xds/waypoint_test.go
+++ b/pilot/pkg/xds/waypoint_test.go
@@ -39,6 +39,7 @@ import (
 	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/mesh"
+	"istio.io/istio/pkg/jwt"
 	"istio.io/istio/pkg/kube/kclient/clienttest"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test"
@@ -413,6 +414,41 @@ spec:
 	notApp := xdstest.ExtractHTTPConnectionManager(t,
 		xdstest.ExtractFilterChain(model.BuildSubsetKey(model.TrafficDirectionInboundVIP, "http", "not-app.com", 80), l))
 	assert.Equal(t, sets.New(slices.Map(notApp.HttpFilters, (*hcm.HttpFilter).GetName)...).Contains("envoy.filters.http.jwt_authn"), false)
+}
+
+func TestWaypointRequestAuthRemoteJWKSCluster(t *testing.T) {
+	test.SetForTest(t, &features.JwksFetchMode, jwt.Envoy)
+	requestAuthn := `apiVersion: security.istio.io/v1
+kind: RequestAuthentication
+metadata:
+  name: jwt-on-waypoint
+  namespace: default
+spec:
+  targetRefs:
+  - group: networking.istio.io
+    kind: ServiceEntry
+    name: app
+  jwtRules:
+  - issuer: example.ietf.org
+    jwksUri: http://jwks.example.com/jwks`
+	jwksServiceEntry := `apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: jwks
+  namespace: default
+spec:
+  hosts: [jwks.example.com]
+  ports:
+  - number: 80
+    name: http
+    protocol: HTTP
+  resolution: DNS`
+	d, proxy := setupWaypointTest(t,
+		waypointGateway, waypointSvc, waypointInstance,
+		appServiceEntry, jwksServiceEntry, requestAuthn)
+
+	clusters := xdstest.ExtractClusters(d.Clusters(proxy))
+	assert.Equal(t, clusters["outbound|80||jwks.example.com"] != nil, true)
 }
 
 func TestCrossNamespaceWaypointRequestAuth(t *testing.T) {

--- a/releasenotes/notes/waypoint-targetref-remote-jwks.yaml
+++ b/releasenotes/notes/waypoint-targetref-remote-jwks.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+
+releaseNotes:
+  - |
+    **Fixed** waypoint proxies failing to receive remote JWKS clusters when a `RequestAuthentication` policy uses a service `targetRef`.


### PR DESCRIPTION
**Please provide a description of this PR:**
### Reproduction

Remote JWKS fetching is enabled with:

```text
PILOT_JWT_ENABLE_REMOTE_JWKS=envoy
```
A waypoint manages the protected service:

```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: waypoint
  namespace: application
spec:
  gatewayClassName: istio-waypoint
  listeners:
    - name: mesh
      port: 15008
      protocol: HBONE
---
apiVersion: v1
kind: Service
metadata:
  name: protected-api
  namespace: application
  labels:
    istio.io/use-waypoint: waypoint
spec:
  selector:
    app: protected-api
  ports:
    - name: http
      port: 80
      targetPort: 8080
```

A RequestAuthentication policy is attached to the service through targetRefs and uses an in-mesh service as its remote JWKS provider:

```yaml
apiVersion: security.istio.io/v1
kind: RequestAuthentication
metadata:
  name: protected-api-jwt
  namespace: application
spec:
  targetRefs:
    - group: ""
      kind: Service
      name: protected-api
  jwtRules:
    - issuer: https://issuer.example.test
      jwksUri: http://jwks-provider.security.svc.cluster.local/.well-known/jwks.json
---
apiVersion: v1
kind: Service
metadata:
  name: jwks-provider
  namespace: security
spec:
  selector:
    app: jwks-provider
  ports:
    - name: http
      port: 80
      targetPort: 8080
```

The same issue can be reproduced when the protected target or JWKS provider is registered using a ServiceEntry.

### Expected result
The waypoint receives the remote JWKS cluster: `outbound|80||jwks-provider.security.svc.cluster.local` and Envoy can fetch the configured JWKS document.

### Actual result
The JWT authentication filter references the remote JWKS cluster, but the cluster is absent from the waypoint's CDS configuration. Envoy reports:

```text
fetch: fetch pubkey failed: cluster = outbound|80||jwks-provider.security.svc.cluster.local is not configured
```