### PR TITLE
krt: fix multiple collections registration leaks

### DIFF
--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -42,7 +42,8 @@ type dependencyState[I any] struct {
 	// collectionDependencies specifies the set of collections we depend on from within the transformation functions (via Fetch).
 	// These are keyed by the internal uid() function on collections.
 	// Note this does not include `parent`, which is the *primary* dependency declared outside of transformation functions.
-	collectionDependencies sets.Set[collectionUID]
+	collectionDependencies       sets.Set[collectionUID]
+	collectionDependencyHandlers map[collectionUID]HandlerRegistration
 	// Stores a map of I -> secondary dependencies (added via Fetch)
 	objectDependencies  map[Key[I]][]*dependency
 	indexedDependencies map[indexedDependency]sets.Set[Key[I]]
@@ -608,6 +609,7 @@ func newManyCollection[I, O any](
 		parent:         c,
 		dependencyState: dependencyState[I]{
 			collectionDependencies:       sets.New[collectionUID](),
+			collectionDependencyHandlers: map[collectionUID]HandlerRegistration{},
 			objectDependencies:           map[Key[I]][]*dependency{},
 			indexedDependencies:          map[indexedDependency]sets.Set[Key[I]]{},
 			indexedDependenciesExtractor: map[extractorKey]func(o any) []string{},
@@ -656,7 +658,7 @@ func (h *manyCollection[I, O]) runQueue() {
 		return
 	}
 	// Now register to our primary collection. On any event, we will enqueue the update.
-	syncer := c.RegisterBatch(func(o []Event[I]) {
+	parentReg := c.RegisterBatch(func(o []Event[I]) {
 		if h.onPrimaryInputEventHandler != nil {
 			h.onPrimaryInputEventHandler(o)
 		}
@@ -666,9 +668,22 @@ func (h *manyCollection[I, O]) runQueue() {
 		})
 	}, true)
 	// Wait for everything initial state to be enqueued
-	if !syncer.WaitUntilSynced(h.stop) {
+	if !parentReg.WaitUntilSynced(h.stop) {
+		parentReg.UnregisterHandler()
 		return
 	}
+
+	defer func() {
+		// This collection has been stopped, ensure we cleanup all handler registrations we made on
+		// other collections.
+		parentReg.UnregisterHandler()
+		h.mu.Lock()
+		for _, reg := range h.dependencyState.collectionDependencyHandlers {
+			reg.UnregisterHandler()
+		}
+		h.mu.Unlock()
+	}()
+
 	h.queue.Run(h.stop)
 }
 
@@ -814,7 +829,7 @@ func (i *collectionDependencyTracker[I, O]) name() string {
 func (i *collectionDependencyTracker[I, O]) registerDependency(
 	d *dependency,
 	syncer Syncer,
-	register func(f erasedEventHandler) Syncer,
+	register func(f erasedEventHandler) HandlerRegistration,
 ) {
 	i.d = append(i.d, d)
 
@@ -824,13 +839,22 @@ func (i *collectionDependencyTracker[I, O]) registerDependency(
 	// For any new collections we depend on, start watching them if its the first time we have watched them.
 	if !existed {
 		i.log.WithLabels("collection", d.collectionName).Debugf("register new dependency")
-		syncer.WaitUntilSynced(i.stop)
-		register(func(o []Event[any]) {
+		if !syncer.WaitUntilSynced(i.stop) {
+			return
+		}
+		h := register(func(o []Event[any]) {
 			i.queue.Push(func() error {
 				i.onSecondaryDependencyEvent(d.id, o)
 				return nil
 			})
-		}).WaitUntilSynced(i.stop)
+		})
+		i.mu.Lock()
+		if h.WaitUntilSynced(i.stop) {
+			i.dependencyState.collectionDependencyHandlers[d.id] = h
+		} else {
+			h.UnregisterHandler()
+		}
+		i.mu.Unlock()
 	}
 }
 

--- a/pkg/kube/krt/collection_leak_test.go
+++ b/pkg/kube/krt/collection_leak_test.go
@@ -1,0 +1,271 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package krt_test
+
+import (
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/kclient"
+	"istio.io/istio/pkg/kube/kclient/clienttest"
+	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/slices"
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/assert"
+	"istio.io/istio/tests/util/leak"
+)
+
+// leakSources holds a set of long-lived source collections used by the leak
+// tests below. These collections outlive the derived collections under test, so
+// any handler registration a derived collection leaves behind on them (after it
+// is stopped) shows up as a leaked goroutine.
+type leakSources struct {
+	opts        krt.OptionsBuilder
+	stop        <-chan struct{}
+	pods        krt.Collection[SimplePod]
+	services    krt.Collection[SimpleService]
+	rawServices krt.Collection[*corev1.Service]
+}
+
+// setupLeakSources builds long-lived pod and service collections seeded with a
+// single matching pod/service, and returns them along with the shared options
+// and stop channel.
+func setupLeakSources(t *testing.T) leakSources {
+	stop := test.NewStop(t)
+	opts := testOptions(t)
+	c := kube.NewFakeClient()
+
+	kpc := kclient.New[*corev1.Pod](c)
+	pc := clienttest.Wrap(t, kpc)
+	pods := krt.WrapClient(kpc, opts.WithName("Pods")...)
+
+	ksc := kclient.New[*corev1.Service](c)
+	sc := clienttest.Wrap(t, ksc)
+	services := krt.WrapClient(ksc, opts.WithName("Services")...)
+	c.RunAndWait(stop)
+
+	SimplePods := SimplePodCollection(pods, opts)
+	SimpleServices := SimpleServiceCollection(services, opts)
+	assert.Equal(t, SimplePods.WaitUntilSynced(stop), true)
+	assert.Equal(t, SimpleServices.WaitUntilSynced(stop), true)
+
+	pc.Create(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "ns", Labels: map[string]string{"app": "foo"}},
+		Status:     corev1.PodStatus{PodIP: "1.2.3.4"},
+	})
+	sc.Create(&corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "ns"},
+		Spec:       corev1.ServiceSpec{Selector: map[string]string{"app": "foo"}},
+	})
+
+	return leakSources{opts: opts, stop: stop, pods: SimplePods, services: SimpleServices, rawServices: services}
+}
+
+// TestCollectionDependencyLeak verifies that stopping a derived NewManyCollection
+// (via its own stop channel), while the collections it depends on remain alive,
+// does not leak the handler registrations (and their goroutines) it created on
+// those collections -- both the primary parent subscription and any Fetch
+// dependency subscriptions.
+func TestCollectionDependencyLeak(t *testing.T) {
+	s := setupLeakSources(t)
+	leak.Check(t)
+
+	const iterations = 20
+	for i := 0; i < iterations; i++ {
+		derivedStop := make(chan struct{})
+		endpoints := krt.NewManyCollection(
+			s.services,
+			func(ctx krt.HandlerContext, svc SimpleService) []SimpleEndpoint {
+				matched := krt.Fetch(ctx, s.pods, krt.FilterLabel(svc.Selector))
+				return slices.Map(matched, func(pod SimplePod) SimpleEndpoint {
+					return SimpleEndpoint{Pod: pod.Name, Service: svc.Name, Namespace: svc.Namespace, IP: pod.IP}
+				})
+			},
+			s.opts.With(krt.WithName("Endpoints"), krt.WithStop(derivedStop))...,
+		)
+		assert.Equal(t, endpoints.WaitUntilSynced(s.stop), true)
+		assert.EventuallyEqual(t, func() int { return len(endpoints.List()) }, 1)
+		close(derivedStop)
+	}
+}
+
+// TestMergeJoinCollectionLeak verifies that stopping a JoinWithMergeCollection
+// does not leak the handler registrations it created on its (still-alive) source
+// collections.
+func TestMergeJoinCollectionLeak(t *testing.T) {
+	s := setupLeakSources(t)
+	leak.Check(t)
+
+	merge := func(ts []SimplePod) *SimplePod { return &ts[0] }
+
+	const iterations = 20
+	for i := 0; i < iterations; i++ {
+		derivedStop := make(chan struct{})
+		merged := krt.JoinWithMergeCollection(
+			[]krt.Collection[SimplePod]{s.pods},
+			merge,
+			s.opts.With(krt.WithName("MergedPods"), krt.WithStop(derivedStop))...,
+		)
+		assert.Equal(t, merged.WaitUntilSynced(s.stop), true)
+		assert.EventuallyEqual(t, func() int { return len(merged.List()) }, 1)
+		close(derivedStop)
+	}
+}
+
+// TestNestedJoinWithMergeCollectionLeak verifies that stopping a
+// NestedJoinWithMergeCollection does not leak the handler registrations it created
+// on the (still-alive) container collection or its sub-collections.
+func TestNestedJoinWithMergeCollectionLeak(t *testing.T) {
+	s := setupLeakSources(t)
+
+	// A long-lived container collection holding a single sub-collection.
+	multi := krt.NewStaticCollection(
+		nil,
+		[]krt.Collection[SimplePod]{s.pods},
+		s.opts.WithName("MultiPods")...,
+	)
+	assert.Equal(t, multi.WaitUntilSynced(s.stop), true)
+
+	leak.Check(t)
+
+	merge := func(ts []SimplePod) *SimplePod { return &ts[0] }
+
+	const iterations = 20
+	for i := 0; i < iterations; i++ {
+		derivedStop := make(chan struct{})
+		merged := krt.NestedJoinWithMergeCollection(
+			multi,
+			merge,
+			s.opts.With(krt.WithName("NestedMergedPods"), krt.WithStop(derivedStop))...,
+		)
+		assert.Equal(t, merged.WaitUntilSynced(s.stop), true)
+		assert.EventuallyEqual(t, func() int { return len(merged.List()) }, 1)
+		close(derivedStop)
+	}
+}
+
+// TestJoinCollectionLeak guards JoinCollection in checked mode (>=2 sub-collections).
+// Checked joins subscribe to every sub-collection at construction and rely on their
+// own dedicated stop-cleanup goroutine (separate from the manyCollection teardown
+// path) to unregister them; this ensures that cleanup keeps working.
+func TestJoinCollectionLeak(t *testing.T) {
+	stop := test.NewStop(t)
+	opts := testOptions(t)
+
+	c1 := krt.NewStaticCollection(nil, []Named{{Namespace: "ns", Name: "a"}}, opts.WithName("Join1")...)
+	c2 := krt.NewStaticCollection(nil, []Named{{Namespace: "ns", Name: "b"}}, opts.WithName("Join2")...)
+	assert.Equal(t, c1.WaitUntilSynced(stop), true)
+	assert.Equal(t, c2.WaitUntilSynced(stop), true)
+
+	leak.Check(t)
+
+	const iterations = 20
+	for i := 0; i < iterations; i++ {
+		derivedStop := make(chan struct{})
+		joined := krt.JoinCollection(
+			[]krt.Collection[Named]{c1, c2},
+			opts.With(krt.WithName("Joined"), krt.WithStop(derivedStop))...,
+		)
+		assert.Equal(t, joined.WaitUntilSynced(stop), true)
+		assert.EventuallyEqual(t, func() int { return len(joined.List()) }, 2)
+		close(derivedStop)
+	}
+}
+
+// TestJoinCollectionUncheckedLeak guards JoinCollection in unchecked mode. Unchecked
+// joins currently hold no construction-time subscription (handlers register lazily and
+// are caller-owned), so stopping one should leak nothing. This guards against a future
+// change that adds construction-time subscriptions to the unchecked path without
+// wiring up teardown.
+func TestJoinCollectionUncheckedLeak(t *testing.T) {
+	stop := test.NewStop(t)
+	opts := testOptions(t)
+
+	c1 := krt.NewStaticCollection(nil, []Named{{Namespace: "ns", Name: "a"}}, opts.WithName("UJoin1")...)
+	c2 := krt.NewStaticCollection(nil, []Named{{Namespace: "ns", Name: "b"}}, opts.WithName("UJoin2")...)
+	assert.Equal(t, c1.WaitUntilSynced(stop), true)
+	assert.Equal(t, c2.WaitUntilSynced(stop), true)
+
+	leak.Check(t)
+
+	const iterations = 20
+	for i := 0; i < iterations; i++ {
+		derivedStop := make(chan struct{})
+		joined := krt.JoinCollection(
+			[]krt.Collection[Named]{c1, c2},
+			opts.With(krt.WithName("UJoined"), krt.WithStop(derivedStop), krt.WithJoinUnchecked())...,
+		)
+		assert.Equal(t, joined.WaitUntilSynced(stop), true)
+		assert.EventuallyEqual(t, func() int { return len(joined.List()) }, 2)
+		close(derivedStop)
+	}
+}
+
+// TestSingletonCollectionLeak guards NewSingleton, which is implemented on top of a
+// manyCollection (over an internal dummy collection) that Fetches other collections.
+// This ensures the singleton wrapper does not leak the Fetch subscription it makes on a
+// still-alive dependency when it is stopped.
+func TestSingletonCollectionLeak(t *testing.T) {
+	s := setupLeakSources(t)
+	leak.Check(t)
+
+	const iterations = 20
+	for i := 0; i < iterations; i++ {
+		derivedStop := make(chan struct{})
+		single := krt.NewSingleton(
+			func(ctx krt.HandlerContext) *Named {
+				pods := krt.Fetch(ctx, s.pods)
+				return &Named{Namespace: "ns", Name: fmt.Sprintf("count-%d", len(pods))}
+			},
+			s.opts.With(krt.WithName("Singleton"), krt.WithStop(derivedStop))...,
+		)
+		assert.Equal(t, single.AsCollection().WaitUntilSynced(s.stop), true)
+		assert.EventuallyEqual(t, func() *Named { return single.Get() }, &Named{Namespace: "ns", Name: "count-1"})
+		close(derivedStop)
+	}
+}
+
+// TestStatusCollectionLeak guards NewStatusCollection, another public constructor built
+// on manyCollection. It subscribes to its parent input and Fetches a dependency; stopping
+// it must unregister both from the still-alive inputs.
+func TestStatusCollectionLeak(t *testing.T) {
+	s := setupLeakSources(t)
+	leak.Check(t)
+
+	const iterations = 20
+	for i := 0; i < iterations; i++ {
+		derivedStop := make(chan struct{})
+		_, primary := krt.NewStatusCollection(
+			s.rawServices,
+			func(ctx krt.HandlerContext, svc *corev1.Service) (*string, *Named) {
+				pods := krt.Fetch(ctx, s.pods, krt.FilterLabel(svc.Spec.Selector))
+				if len(pods) == 0 {
+					st := "empty"
+					return &st, nil
+				}
+				st := "ok"
+				return &st, &Named{Namespace: svc.Namespace, Name: svc.Name}
+			},
+			s.opts.With(krt.WithName("Status"), krt.WithStop(derivedStop))...,
+		)
+		assert.Equal(t, primary.WaitUntilSynced(s.stop), true)
+		assert.EventuallyEqual(t, func() int { return len(primary.List()) }, 1)
+		close(derivedStop)
+	}
+}

--- a/pkg/kube/krt/fetch.go
+++ b/pkg/kube/krt/fetch.go
@@ -84,7 +84,7 @@ func fetch[T any](ctx HandlerContext, cc Collection[T], allowMissingContext bool
 	if ctx != nil {
 		h := ctx.(registerDependency)
 		// Important: register before we List(), so we cannot miss any events
-		h.registerDependency(d, c, func(f erasedEventHandler) Syncer {
+		h.registerDependency(d, c, func(f erasedEventHandler) HandlerRegistration {
 			ff := func(o []Event[T]) {
 				f(slices.Map(o, castEvent[T, any]))
 			}

--- a/pkg/kube/krt/internal.go
+++ b/pkg/kube/krt/internal.go
@@ -110,7 +110,7 @@ type erasedEventHandler = func(o []Event[any])
 // This is called from Fetch to Collections, generally.
 type registerDependency interface {
 	// Registers a dependency, returning true if it is finalized
-	registerDependency(*dependency, Syncer, func(f erasedEventHandler) Syncer)
+	registerDependency(*dependency, Syncer, func(f erasedEventHandler) HandlerRegistration)
 	name() string
 }
 

--- a/pkg/kube/krt/mergejoin.go
+++ b/pkg/kube/krt/mergejoin.go
@@ -377,6 +377,13 @@ func (j *mergejoin[T]) runQueue() {
 			})
 		}, true))
 	}
+	// These registrations were made on collections that may outlive us. Once we are stopped,
+	// unregister them.
+	defer func() {
+		for _, reg := range regs {
+			reg.UnregisterHandler()
+		}
+	}()
 
 	syncers = slices.Map(regs, func(r HandlerRegistration) cache.InformerSynced {
 		return r.HasSynced

--- a/pkg/kube/krt/nestedjoinmerge.go
+++ b/pkg/kube/krt/nestedjoinmerge.go
@@ -142,6 +142,11 @@ func NestedJoinWithMergeCollection[T any](collections Collection[Collection[T]],
 }
 
 func (j *nestedjoinmerge[T]) runQueue(initialCollections []Collection[T], subscriptionFunc func([]Event[T]), reg HandlerRegistration) {
+	// We subscribed to the container collection (reg) and to each sub-collection (j.regs); all of
+	// these may outlive us. Once we are stopped, unregister them (and their goroutines) so we don't
+	// leak them.
+	defer j.unregisterAll(reg)
+
 	// Wait for the container of collections to be synced before we start processing events.
 	if !j.collections.WaitUntilSynced(j.stop) {
 		return
@@ -166,6 +171,21 @@ func (j *nestedjoinmerge[T]) runQueue(initialCollections []Collection[T], subscr
 		return
 	}
 	j.queue.Run(j.stop)
+}
+
+// unregisterAll unregisters the container collection subscription along with all currently tracked
+// sub-collection subscriptions. It is safe to call once the collection has stopped; after
+// unregistering the container subscription no new sub-collection subscriptions can be added.
+func (j *nestedjoinmerge[T]) unregisterAll(containerReg HandlerRegistration) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	// Unregister the container subscription first so no further sub-collection subscriptions are added.
+	containerReg.UnregisterHandler()
+	for uid, reg := range j.regs {
+		reg.UnregisterHandler()
+		// we need to delete the entry to play nice with handleCollectionDelete
+		delete(j.regs, uid)
+	}
 }
 
 func (j *nestedjoinmerge[T]) handleCollectionUpdate(e Event[Collection[T]]) {

--- a/pkg/kube/krt/testing.go
+++ b/pkg/kube/krt/testing.go
@@ -19,7 +19,7 @@ type TestingDummyContext struct{}
 func (t TestingDummyContext) _internalHandler() {
 }
 
-func (t TestingDummyContext) registerDependency(d *dependency, s Syncer, f func(f erasedEventHandler) Syncer) {
+func (t TestingDummyContext) registerDependency(d *dependency, s Syncer, f func(f erasedEventHandler) HandlerRegistration) {
 }
 
 func (t TestingDummyContext) name() string {

--- a/releasenotes/notes/krt-collection-teardown-leaks.yaml
+++ b/releasenotes/notes/krt-collection-teardown-leaks.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 60033
+releaseNotes:
+  - |
+    **Fixed** goroutine and memory leaks in istiod in ambient multi-cluster mode when remote
+    clusters are removed or updated. The internal collections built for each remote cluster did
+    not release the event handlers they had registered on their inputs when torn down, causing
+    goroutines and memory to accumulate over time as clusters were removed or reconfigured.


### PR DESCRIPTION
**Please provide a description of this PR:**
This is  a fix one (maybe the worse) of the issues found by [h0tbird](https://github.com/h0tbird) in https://github.com/istio/istio/issues/60033#issuecomment-5220248356

I think this leaks happen because KRT wasn't first intended to dinamically create and destroy collections which we now do in Ambient Multi Cluster.
This PR fixes:
- `NewCollection/NewManyCollection`: created a parent subscription and a new subscription to each dependency collection, but never unregistered those subscriptions when the collection was stopped, thus leaking the goroutines associated with the subscription.

- `JoinWithMergeCollection`: created a subscription for each sub-collection but never unregistered them when collection was stopped.
- `NestedJoinWithMergeCollection`: created a suscription on the container collection and on each dynamic sub-collection, only cleared sub-collection subscriptions on a delete event, but didn't make any cleanup when the collection was stopped.

I checked other collections and none other has this kind of leaks, but I added a couple more of collections to the test, so that we prevent further leaks.

Partially fixes https://github.com/istio/istio/issues/60033

Most of the credit goes to [h0tbird](https://github.com/h0tbird) which actually found the issues