### PR TITLE
cap envoyfilter proxyversion match length

### DIFF
--- a/pilot/pkg/model/envoyfilter.go
+++ b/pilot/pkg/model/envoyfilter.go
@@ -75,6 +75,11 @@ func (efw *EnvoyFilterWrapper) GetSelector() *v1beta1.WorkloadSelector {
 	return nil
 }
 
+// maxProxyVersionLen bounds the proxyVersion match expression length. Version strings are short;
+// very long patterns are expensive to compile and are treated as a non-match rather than compiled.
+// Kept in sync with the same const in pkg/config/validation/envoyfilter, which warns on it.
+const maxProxyVersionLen = 1024
+
 // EnvoyFilterConfigPatchWrapper is a wrapper over the EnvoyFilter ConfigPatch api object
 // fields are ordered such that this struct is aligned
 type EnvoyFilterConfigPatchWrapper struct {
@@ -91,6 +96,10 @@ type EnvoyFilterConfigPatchWrapper struct {
 	Name             string
 	Namespace        string
 	FullName         string
+	// ProxyVersionNoMatch is set when the proxyVersion match expression could not be safely compiled
+	// (e.g. it exceeds maxProxyVersionLen). When true the patch matches no proxy (fail closed) rather
+	// than matching every version, which is what a nil ProxyVersionRegex would otherwise do.
+	ProxyVersionNoMatch bool
 }
 
 // wellKnownVersions defines a mapping of well known regex matches to prefix matches
@@ -180,6 +189,10 @@ func convertToEnvoyFilterWrapper(local *config.Config) *EnvoyFilterWrapper {
 			// we can workaround the performance impact of regex
 			if prefix, f := wellKnownVersions[cp.Match.Proxy.ProxyVersion]; f {
 				cpw.ProxyPrefixMatch = prefix
+			} else if len(cp.Match.Proxy.ProxyVersion) > maxProxyVersionLen {
+				// Don't compile pathologically long patterns; the compile is expensive enough to be a
+				// DoS vector against istiod. Fail closed so the patch matches no proxy.
+				cpw.ProxyVersionNoMatch = true
 			} else {
 				// pre-compile the regex for proxy version if it exists
 				// ignore the error because validation catches invalid regular expressions.
@@ -210,6 +223,11 @@ func convertToEnvoyFilterWrapper(local *config.Config) *EnvoyFilterWrapper {
 func proxyMatch(proxy *Proxy, cp *EnvoyFilterConfigPatchWrapper) bool {
 	if cp.Match.Proxy == nil {
 		return true
+	}
+
+	if cp.ProxyVersionNoMatch {
+		// the proxyVersion match could not be safely compiled, so we can't evaluate it; fail closed
+		return false
 	}
 
 	if cp.ProxyPrefixMatch != "" {

--- a/pilot/pkg/model/envoyfilter_test.go
+++ b/pilot/pkg/model/envoyfilter_test.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"google.golang.org/protobuf/types/known/structpb"
@@ -95,6 +96,28 @@ func TestEnvoyFilterMatch(t *testing.T) {
 				"1.19.0":       false,
 				"1.19-dev.foo": false,
 				"foobar":       true,
+			},
+		},
+		{
+			// an over-length pattern is never compiled; the patch must match nothing (fail closed),
+			// not fall through to matching every version.
+			"proxy version too long",
+			&networking.EnvoyFilter{
+				ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
+					{
+						Patch: &networking.EnvoyFilter_Patch{},
+						Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
+							Proxy: &networking.EnvoyFilter_ProxyMatch{ProxyVersion: strings.Repeat("a{100}", 200)},
+						},
+					},
+				},
+			},
+			"",
+			map[string]bool{
+				"1.19":   false,
+				"1.19.0": false,
+				"foobar": false,
+				"":       false,
 			},
 		},
 	}

--- a/pkg/config/validation/envoyfilter/envoyfilter.go
+++ b/pkg/config/validation/envoyfilter/envoyfilter.go
@@ -40,6 +40,7 @@ type (
 
 // maxProxyVersionLen bounds the proxyVersion match expression. Version strings are short
 // (e.g. `1\.30.*`); very long patterns are expensive to compile and serve no legitimate use.
+// Kept in sync with the same const in pilot/pkg/model, which does the actual guarding.
 const maxProxyVersionLen = 1024
 
 // ValidateEnvoyFilter checks envoy filter config supplied by user
@@ -99,10 +100,11 @@ func validateEnvoyFilter(cfg config.Config, errs Validation) (Warning, error) {
 		// ensure that the supplied regex for proxy version compiles
 		if cp.Match != nil && cp.Match.Proxy != nil && cp.Match.Proxy.ProxyVersion != "" {
 			if len(cp.Match.Proxy.ProxyVersion) > maxProxyVersionLen {
-				errs = validation.AppendValidation(errs, fmt.Errorf("Envoy filter: proxyVersion exceeds max length %d", maxProxyVersionLen)) // nolint: stylecheck
-				continue
-			}
-			if _, err := regexp.Compile(cp.Match.Proxy.ProxyVersion); err != nil {
+				// Don't compile pathologically long patterns; warn instead of rejecting so existing
+				// filters keep admitting. istiod ignores the version match at translation time.
+				errs = validation.AppendValidation(errs, validation.WrapWarning(
+					fmt.Errorf("Envoy filter: proxyVersion match exceeds %d characters and will be ignored", maxProxyVersionLen))) // nolint: stylecheck
+			} else if _, err := regexp.Compile(cp.Match.Proxy.ProxyVersion); err != nil {
 				errs = validation.AppendValidation(errs, fmt.Errorf("Envoy filter: invalid regex for proxy version, [%v]", err)) // nolint: stylecheck
 				continue
 			}

--- a/pkg/config/validation/envoyfilter/envoyfilter.go
+++ b/pkg/config/validation/envoyfilter/envoyfilter.go
@@ -99,7 +99,7 @@ func validateEnvoyFilter(cfg config.Config, errs Validation) (Warning, error) {
 		// ensure that the supplied regex for proxy version compiles
 		if cp.Match != nil && cp.Match.Proxy != nil && cp.Match.Proxy.ProxyVersion != "" {
 			if len(cp.Match.Proxy.ProxyVersion) > maxProxyVersionLen {
-				errs = validation.AppendValidation(errs, fmt.Errorf("Envoy filter: proxy version match must be at most %d characters", maxProxyVersionLen)) // nolint: stylecheck
+				errs = validation.AppendValidation(errs, fmt.Errorf("Envoy filter: proxyVersion exceeds max length %d", maxProxyVersionLen)) // nolint: stylecheck
 				continue
 			}
 			if _, err := regexp.Compile(cp.Match.Proxy.ProxyVersion); err != nil {

--- a/pkg/config/validation/envoyfilter/envoyfilter.go
+++ b/pkg/config/validation/envoyfilter/envoyfilter.go
@@ -38,6 +38,10 @@ type (
 	Validation = validation.Validation
 )
 
+// maxProxyVersionLen bounds the proxyVersion match expression. Version strings are short
+// (e.g. `1\.30.*`); very long patterns are expensive to compile and serve no legitimate use.
+const maxProxyVersionLen = 1024
+
 // ValidateEnvoyFilter checks envoy filter config supplied by user
 var ValidateEnvoyFilter = validation.RegisterValidateFunc("ValidateEnvoyFilter",
 	func(cfg config.Config) (Warning, error) {
@@ -94,6 +98,10 @@ func validateEnvoyFilter(cfg config.Config, errs Validation) (Warning, error) {
 
 		// ensure that the supplied regex for proxy version compiles
 		if cp.Match != nil && cp.Match.Proxy != nil && cp.Match.Proxy.ProxyVersion != "" {
+			if len(cp.Match.Proxy.ProxyVersion) > maxProxyVersionLen {
+				errs = validation.AppendValidation(errs, fmt.Errorf("Envoy filter: proxy version match must be at most %d characters", maxProxyVersionLen)) // nolint: stylecheck
+				continue
+			}
 			if _, err := regexp.Compile(cp.Match.Proxy.ProxyVersion); err != nil {
 				errs = validation.AppendValidation(errs, fmt.Errorf("Envoy filter: invalid regex for proxy version, [%v]", err)) // nolint: stylecheck
 				continue

--- a/pkg/config/validation/envoyfilter/envoyfilter_test.go
+++ b/pkg/config/validation/envoyfilter/envoyfilter_test.go
@@ -148,7 +148,7 @@ func TestValidateEnvoyFilter(t *testing.T) {
 					},
 				},
 			},
-		}, error: "Envoy filter: proxy version match must be at most 1024 characters"},
+		}, error: "Envoy filter: proxyVersion exceeds max length 1024"},
 		{name: "listener with invalid match", in: &networking.EnvoyFilter{
 			ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
 				{

--- a/pkg/config/validation/envoyfilter/envoyfilter_test.go
+++ b/pkg/config/validation/envoyfilter/envoyfilter_test.go
@@ -134,6 +134,21 @@ func TestValidateEnvoyFilter(t *testing.T) {
 				},
 			},
 		}, error: ""},
+		{name: "match with proxy version regex too long", in: &networking.EnvoyFilter{
+			ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
+				{
+					ApplyTo: networking.EnvoyFilter_LISTENER,
+					Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
+						Proxy: &networking.EnvoyFilter_ProxyMatch{
+							ProxyVersion: strings.Repeat("a{100}", 200),
+						},
+					},
+					Patch: &networking.EnvoyFilter_Patch{
+						Operation: networking.EnvoyFilter_Patch_REMOVE,
+					},
+				},
+			},
+		}, error: "Envoy filter: proxy version match must be at most 1024 characters"},
 		{name: "listener with invalid match", in: &networking.EnvoyFilter{
 			ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
 				{

--- a/pkg/config/validation/envoyfilter/envoyfilter_test.go
+++ b/pkg/config/validation/envoyfilter/envoyfilter_test.go
@@ -148,7 +148,7 @@ func TestValidateEnvoyFilter(t *testing.T) {
 					},
 				},
 			},
-		}, error: "Envoy filter: proxyVersion exceeds max length 1024"},
+		}, warning: "Envoy filter: proxyVersion match exceeds 1024 characters and will be ignored"},
 		{name: "listener with invalid match", in: &networking.EnvoyFilter{
 			ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
 				{

--- a/releasenotes/notes/envoyfilter-proxyversion-length.yaml
+++ b/releasenotes/notes/envoyfilter-proxyversion-length.yaml
@@ -1,0 +1,15 @@
+apiVersion: release-notes/v2
+
+kind: security-fix
+
+area: security
+
+issue: []
+
+releaseNotes:
+- |
+  **Fixed** an `EnvoyFilter` validation gap where an uncapped `proxyVersion` match expression
+  could drive excessive istiod memory and CPU during regex compilation. The match expression
+  is now limited to 1024 characters.
+
+  **Credit**: This issue was reported by Artem Cherezov (https://github.com/cherez0ff).


### PR DESCRIPTION
**Please provide a description of this PR:**

envoyfilter proxyversion match had no length bound; large patterns are slow to compile in istiod. cap at 1024 chars.