### PR TITLE
Fix echo response MIME header ordering

### DIFF
--- a/pkg/test/echo/server/endpoint/http.go
+++ b/pkg/test/echo/server/endpoint/http.go
@@ -309,6 +309,7 @@ func (h *httpHandler) echo(w http.ResponseWriter, r *http.Request, id uuid.UUID)
 	if err := setHeaderResponseFromHeaders(r, w); err != nil {
 		writeError(&body, "response headers error: "+err.Error())
 	}
+	setSafeResponseHeaders(w.Header())
 
 	// If the request has form ?codes=code[:chance][,code[:chance]]* return those codes, rather than 200
 	// For example, ?codes=500:1,200:1 returns 500 1/2 times and 200 1/2 times
@@ -320,7 +321,6 @@ func (h *httpHandler) echo(w http.ResponseWriter, r *http.Request, id uuid.UUID)
 
 	h.addResponsePayload(r, &body)
 
-	w.Header().Set("Content-Type", "application/text")
 	if _, err := w.Write(body.Bytes()); err != nil {
 		epLog.Warn(err)
 	}
@@ -412,6 +412,20 @@ func (h *httpHandler) addResponsePayload(r *http.Request, body *bytes.Buffer) {
 	if hostname, err := os.Hostname(); err == nil {
 		echo.HostnameField.Write(body, hostname)
 	}
+}
+
+// setSafeResponseHeaders prevents caller-supplied response headers from
+// causing the echo payload to be interpreted as executable content. Delete
+// every case variant first because setHeaderResponseFromHeaders intentionally
+// preserves non-canonical names.
+func setSafeResponseHeaders(headers http.Header) {
+	for key := range headers {
+		if strings.EqualFold(key, "Content-Type") || strings.EqualFold(key, "X-Content-Type-Options") {
+			delete(headers, key)
+		}
+	}
+	headers.Set("Content-Type", "text/plain; charset=utf-8")
+	headers.Set("X-Content-Type-Options", "nosniff")
 }
 
 func delayResponse(request *http.Request) error {

--- a/pkg/test/echo/server/endpoint/http_test.go
+++ b/pkg/test/echo/server/endpoint/http_test.go
@@ -1,0 +1,54 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoint
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestEchoForcesPlainTextContentType(t *testing.T) {
+	query := url.Values{
+		"headers": {"content-type:text/html,CoNtEnT-TyPe:application/xhtml+xml,X-CoNtEnT-TyPe-OpTiOnS:unsafe,X-Test-Header:retained"},
+		"codes":   {"200"},
+	}.Encode()
+	request := httptest.NewRequest(http.MethodGet, "http://example.test/?"+query, nil)
+	response := httptest.NewRecorder()
+
+	(&httpHandler{}).echo(response, request, uuid.New())
+
+	if got, want := response.Header().Get("Content-Type"), "text/plain; charset=utf-8"; got != want {
+		t.Fatalf("Content-Type = %q, want %q", got, want)
+	}
+	if got, want := response.Header().Get("X-Content-Type-Options"), "nosniff"; got != want {
+		t.Fatalf("X-Content-Type-Options = %q, want %q", got, want)
+	}
+	if got, want := response.Header().Get("X-Test-Header"), "retained"; got != want {
+		t.Fatalf("X-Test-Header = %q, want %q", got, want)
+	}
+	for key := range response.Header() {
+		if strings.EqualFold(key, "Content-Type") && key != "Content-Type" {
+			t.Fatalf("response retained non-canonical Content-Type header %q", key)
+		}
+		if strings.EqualFold(key, "X-Content-Type-Options") && key != "X-Content-Type-Options" {
+			t.Fatalf("response retained non-canonical X-Content-Type-Options header %q", key)
+		}
+	}
+}


### PR DESCRIPTION
**Please provide a description of this PR:**

The HTTP echo handler applies request-selected `?headers=` values and then calls `WriteHeader` while choosing the response status. Its later `Content-Type` assignment is too late to affect the committed response, so a caller-supplied `Content-Type` can cause the plain-text echo payload to be interpreted as active HTML.

Make the echo handler authoritative over its final MIME headers before the status is committed:

- remove every case variant of caller-supplied `Content-Type` and `X-Content-Type-Options`;
- set `Content-Type: text/plain; charset=utf-8` and `X-Content-Type-Options: nosniff` before `setResponseFromCodes` calls `WriteHeader`;
- preserve non-MIME response headers requested through `?headers=`.

Add a regression test covering canonical, lower-case, and mixed-case MIME overrides while confirming an unrelated diagnostic header remains intact.

Validation:

- `go test -count=1 ./pkg/test/echo/server/endpoint`