### PR TITLE
[release-1.31] Allow ZAR to be disabled in Envoy, with routing_enabled of 0%

### DIFF
--- a/pilot/pkg/networking/core/cluster_traffic_policy_test.go
+++ b/pilot/pkg/networking/core/cluster_traffic_policy_test.go
@@ -397,4 +397,23 @@ func TestApplyZoneAwareLoadBalancer(t *testing.T) {
 			t.Error("expected ZoneAwareLbConfig set even with nil LoadAssignment")
 		}
 	})
+
+	t.Run("disabled sets routing_enabled 0% and leaves priorities untouched", func(t *testing.T) {
+		c := newCluster()
+		za := &networking.ZoneAwareLoadBalancerSetting{Enabled: wrappers.Bool(false)}
+		loadbalancer.ZoneAwareLBSettings{Setting: za}.ApplyToCluster(c, nil, proxyLocality, nil, false, "test-proxy", true)
+		zaCfg := c.CommonLbConfig.GetZoneAwareLbConfig()
+		if zaCfg == nil {
+			t.Fatal("expected ZoneAwareLbConfig to be set even when disabled")
+		}
+		if zaCfg.GetRoutingEnabled() == nil || zaCfg.GetRoutingEnabled().GetValue() != 0 {
+			t.Errorf("RoutingEnabled = %v, want 0", zaCfg.GetRoutingEnabled())
+		}
+		// Priorities should be untouched (all 0 from newCluster).
+		for i, ep := range c.LoadAssignment.Endpoints {
+			if ep.Priority != 0 {
+				t.Errorf("endpoint[%d] priority = %d, want 0 (priorities untouched when disabled)", i, ep.Priority)
+			}
+		}
+	})
 }

--- a/pilot/pkg/networking/core/loadbalancer/loadbalancer.go
+++ b/pilot/pkg/networking/core/loadbalancer/loadbalancer.go
@@ -79,6 +79,13 @@ type LBSettings interface {
 	)
 }
 
+func uint32ToUint64Value(v *wrappers.UInt32Value) *wrappers.UInt64Value {
+	if v == nil {
+		return nil
+	}
+	return &wrappers.UInt64Value{Value: uint64(v.GetValue())}
+}
+
 // wrapEndpoints adapts a single WrappedLocalityLbEndpoints to the slice form expected by the
 // package-level Apply* helpers, preserving the nil case.
 func wrapEndpoints(w *WrappedLocalityLbEndpoints) []*WrappedLocalityLbEndpoints {
@@ -214,7 +221,7 @@ func (z ZoneAwareLBSettings) ApplyToCluster(
 		c.CommonLbConfig.LocalityConfigSpecifier = &cluster.Cluster_CommonLbConfig_ZoneAwareLbConfig_{
 			ZoneAwareLbConfig: &cluster.Cluster_CommonLbConfig_ZoneAwareLbConfig{
 				RoutingEnabled: &xdstype.Percent{Value: 0},
-				MinClusterSize: z.Setting.GetMinClusterSize(),
+				MinClusterSize: uint32ToUint64Value(z.Setting.GetMinClusterSize()),
 			},
 		}
 		return
@@ -222,13 +229,9 @@ func (z ZoneAwareLBSettings) ApplyToCluster(
 	if !enableSelfDiscovery {
 		log.Warnf("Zone-aware load balancing is enabled for cluster %s, but proxy self-discovery is not enabled on %s", c.Name, proxyID)
 	}
-	var minClusterSize *wrappers.UInt64Value
-	if v := z.Setting.GetMinClusterSize(); v != nil {
-		minClusterSize = &wrappers.UInt64Value{Value: uint64(v.GetValue())}
-	}
 	c.CommonLbConfig.LocalityConfigSpecifier = &cluster.Cluster_CommonLbConfig_ZoneAwareLbConfig_{
 		ZoneAwareLbConfig: &cluster.Cluster_CommonLbConfig_ZoneAwareLbConfig{
-			MinClusterSize: minClusterSize,
+			MinClusterSize: uint32ToUint64Value(z.Setting.GetMinClusterSize()),
 		},
 	}
 	if c.LoadAssignment != nil {

--- a/pilot/pkg/networking/core/loadbalancer/loadbalancer.go
+++ b/pilot/pkg/networking/core/loadbalancer/loadbalancer.go
@@ -23,6 +23,7 @@ import (
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	xdstype "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
 	"istio.io/api/label"
@@ -154,14 +155,26 @@ type ZoneAwareLBSettings struct {
 
 var _ LBSettings = ZoneAwareLBSettings{}
 
-// ForceFailover always returns true: similar to TrafficDistributionPreferSameZone, zone-aware
-// routing requires that we always enable failovers, since we need to always separate endpoints
-// in different regions.
-func (z ZoneAwareLBSettings) ForceFailover() bool { return true }
+// routingEnabled reports whether ZAR is enabled. When `enabled` is unset, ZAR is on
+// by default (consistent with localityLbSetting). When false, ApplyToCluster emits
+// routing_enabled: 0% to suppress Envoy's intrinsic zone-aware routing.
+func (z ZoneAwareLBSettings) routingEnabled() bool {
+	enabled := z.Setting.GetEnabled()
+	return enabled == nil || enabled.GetValue()
+}
 
+// ForceFailover returns true when routing is enabled, false when explicitly disabled.
+func (z ZoneAwareLBSettings) ForceFailover() bool {
+	return z.routingEnabled()
+}
+
+// IsZoneAware reports the config type, regardless of `enabled`.
 func (z ZoneAwareLBSettings) IsZoneAware() bool { return true }
 
 func (z ZoneAwareLBSettings) FailoverPriorityLabels() []string {
+	if !z.routingEnabled() {
+		return nil
+	}
 	return z.Setting.GetFailoverPriority()
 }
 
@@ -172,6 +185,10 @@ func (z ZoneAwareLBSettings) ApplyToLoadAssignment(
 	proxyLabels map[string]string,
 	_ bool,
 ) {
+	if !z.routingEnabled() {
+		// Skip regional failover partitioning to avoid corrupting EDS priorities.
+		return
+	}
 	ApplyZoneAwareLoadBalancer(loadAssignment, wrappedLocalityLbEndpoints, locality, proxyLabels, z.Setting)
 }
 
@@ -193,6 +210,15 @@ func (z ZoneAwareLBSettings) ApplyToCluster(
 		)
 		return
 	}
+	if !z.routingEnabled() {
+		c.CommonLbConfig.LocalityConfigSpecifier = &cluster.Cluster_CommonLbConfig_ZoneAwareLbConfig_{
+			ZoneAwareLbConfig: &cluster.Cluster_CommonLbConfig_ZoneAwareLbConfig{
+				RoutingEnabled: &xdstype.Percent{Value: 0},
+				MinClusterSize: z.Setting.GetMinClusterSize(),
+			},
+		}
+		return
+	}
 	if !enableSelfDiscovery {
 		log.Warnf("Zone-aware load balancing is enabled for cluster %s, but proxy self-discovery is not enabled on %s", c.Name, proxyID)
 	}
@@ -211,8 +237,12 @@ func (z ZoneAwareLBSettings) ApplyToCluster(
 }
 
 // GetEffectiveLbSetting resolves which load-balancing locality semantics apply for a
-// given DR / service / mesh combination. It returns nil when locality load balancing is
-// effectively disabled.
+// given DR / service / mesh combination. It returns nil when no setting applies.
+//
+// Resolution order is DR > service traffic distribution > mesh; within DR and mesh,
+// zone_aware_lb_setting takes precedence over locality_lb_setting. When ZAR is explicitly
+// disabled (enabled: false), it still wins at its level so ApplyToCluster emits
+// routing_enabled: 0% to suppress Envoy's intrinsic zone-aware routing.
 func GetEffectiveLbSetting(
 	meshLocality *v1alpha3.LocalityLoadBalancerSetting,
 	meshZoneAware *v1alpha3.ZoneAwareLoadBalancerSetting,
@@ -220,9 +250,6 @@ func GetEffectiveLbSetting(
 	service *model.Service,
 ) LBSettings {
 	if zaLbSetting := drSettings.GetZoneAwareLbSetting(); zaLbSetting != nil {
-		if zaLbSetting.GetEnabled() != nil && !zaLbSetting.GetEnabled().Value {
-			return nil
-		}
 		return ZoneAwareLBSettings{Setting: zaLbSetting}
 	}
 	if localityLbSetting := drSettings.GetLocalityLbSetting(); localityLbSetting != nil {
@@ -266,9 +293,6 @@ func GetEffectiveLbSetting(
 		}
 	}
 	if meshZoneAware != nil {
-		if meshZoneAware.GetEnabled() != nil && !meshZoneAware.GetEnabled().Value {
-			return nil
-		}
 		return ZoneAwareLBSettings{Setting: meshZoneAware}
 	}
 	if meshLocality != nil {

--- a/pilot/pkg/networking/core/loadbalancer/loadbalancer_test.go
+++ b/pilot/pkg/networking/core/loadbalancer/loadbalancer_test.go
@@ -1226,6 +1226,8 @@ func TestGetEffectiveLbSetting(t *testing.T) {
 		expectedLocality  *networking.LocalityLoadBalancerSetting
 		expectedZoneAware *networking.ZoneAwareLoadBalancerSetting
 		expectedForce     bool
+
+		expectedRoutingEnabled bool
 	}{
 		{
 			name: "all disabled",
@@ -1287,12 +1289,16 @@ func TestGetEffectiveLbSetting(t *testing.T) {
 			meshZoneAware:     &networking.ZoneAwareLoadBalancerSetting{},
 			expectedZoneAware: &networking.ZoneAwareLoadBalancerSetting{},
 			expectedForce:     true,
+
+			expectedRoutingEnabled: true,
 		},
 		{
 			name:              "dr zone-aware only",
 			dr:                drZA(&networking.ZoneAwareLoadBalancerSetting{Failover: zaFailover}),
 			expectedZoneAware: &networking.ZoneAwareLoadBalancerSetting{Failover: zaFailover},
 			expectedForce:     true,
+
+			expectedRoutingEnabled: true,
 		},
 		{
 			name:              "dr zone-aware wins over mesh zone-aware",
@@ -1300,6 +1306,8 @@ func TestGetEffectiveLbSetting(t *testing.T) {
 			dr:                drZA(&networking.ZoneAwareLoadBalancerSetting{Failover: zaFailover}),
 			expectedZoneAware: &networking.ZoneAwareLoadBalancerSetting{Failover: zaFailover},
 			expectedForce:     true,
+
+			expectedRoutingEnabled: true,
 		},
 		{
 			name:              "dr zone-aware wins over mesh locality",
@@ -1307,6 +1315,8 @@ func TestGetEffectiveLbSetting(t *testing.T) {
 			dr:                drZA(&networking.ZoneAwareLoadBalancerSetting{}),
 			expectedZoneAware: &networking.ZoneAwareLoadBalancerSetting{},
 			expectedForce:     true,
+
+			expectedRoutingEnabled: true,
 		},
 		{
 			name:             "dr locality wins over mesh zone-aware",
@@ -1320,15 +1330,31 @@ func TestGetEffectiveLbSetting(t *testing.T) {
 			meshZoneAware:     &networking.ZoneAwareLoadBalancerSetting{Failover: zaFailover},
 			expectedZoneAware: &networking.ZoneAwareLoadBalancerSetting{Failover: zaFailover},
 			expectedForce:     true,
+
+			expectedRoutingEnabled: true,
 		},
 		{
 			name:          "mesh zone-aware disabled",
 			meshZoneAware: &networking.ZoneAwareLoadBalancerSetting{Enabled: &wrappers.BoolValue{Value: false}},
+
+			expectedZoneAware:      &networking.ZoneAwareLoadBalancerSetting{Enabled: &wrappers.BoolValue{Value: false}},
+			expectedRoutingEnabled: false,
+		},
+		{
+			name:              "mesh zone-aware disabled wins over mesh locality enabled",
+			meshLocality:      &networking.LocalityLoadBalancerSetting{Enabled: &wrappers.BoolValue{Value: true}},
+			meshZoneAware:     &networking.ZoneAwareLoadBalancerSetting{Enabled: &wrappers.BoolValue{Value: false}},
+			expectedZoneAware: &networking.ZoneAwareLoadBalancerSetting{Enabled: &wrappers.BoolValue{Value: false}},
+
+			expectedRoutingEnabled: false,
 		},
 		{
 			name:         "dr zone-aware disabled overrides mesh locality enabled",
 			meshLocality: &networking.LocalityLoadBalancerSetting{Enabled: &wrappers.BoolValue{Value: true}},
 			dr:           drZA(&networking.ZoneAwareLoadBalancerSetting{Enabled: &wrappers.BoolValue{Value: false}}),
+
+			expectedZoneAware:      &networking.ZoneAwareLoadBalancerSetting{Enabled: &wrappers.BoolValue{Value: false}},
+			expectedRoutingEnabled: false,
 		},
 		{
 			name:          "dr zone-aware enabled overrides mesh zone-aware disabled",
@@ -1338,6 +1364,8 @@ func TestGetEffectiveLbSetting(t *testing.T) {
 				Enabled: &wrappers.BoolValue{Value: true},
 			},
 			expectedForce: true,
+
+			expectedRoutingEnabled: true,
 		},
 		{
 			name:             "service traffic distribution wins over mesh zone-aware",
@@ -1352,6 +1380,8 @@ func TestGetEffectiveLbSetting(t *testing.T) {
 			svc:               preferSameZoneService,
 			expectedZoneAware: &networking.ZoneAwareLoadBalancerSetting{},
 			expectedForce:     true,
+
+			expectedRoutingEnabled: true,
 		},
 		{
 			name:             "dr locality wins over service traffic distribution",
@@ -1367,12 +1397,15 @@ func TestGetEffectiveLbSetting(t *testing.T) {
 				gotLocality  *networking.LocalityLoadBalancerSetting
 				gotZoneAware *networking.ZoneAwareLoadBalancerSetting
 				gotForce     bool
+
+				gotRoutingEnabled bool
 			)
 			switch s := got.(type) {
 			case LocalityLBSettings:
 				gotLocality, gotForce = s.Setting, s.ForceFailover()
 			case ZoneAwareLBSettings:
 				gotZoneAware, gotForce = s.Setting, s.ForceFailover()
+				gotRoutingEnabled = s.routingEnabled()
 			}
 			if !reflect.DeepEqual(tt.expectedLocality, gotLocality) {
 				t.Fatalf("locality: expected %v, got %v", tt.expectedLocality, gotLocality)
@@ -1382,6 +1415,9 @@ func TestGetEffectiveLbSetting(t *testing.T) {
 			}
 			if tt.expectedForce != gotForce {
 				t.Fatalf("forceFailover: expected %v, got %v", tt.expectedForce, gotForce)
+			}
+			if tt.expectedZoneAware != nil && tt.expectedRoutingEnabled != gotRoutingEnabled {
+				t.Fatalf("routingEnabled: expected %v, got %v", tt.expectedRoutingEnabled, gotRoutingEnabled)
 			}
 		})
 	}

--- a/releasenotes/notes/zone-aware-disable.yaml
+++ b/releasenotes/notes/zone-aware-disable.yaml
@@ -1,0 +1,12 @@
+apiVersion: release-notes/v2
+kind: enhancement
+area: traffic-management
+
+releaseNotes:
+  - |
+    **Improved** `zoneAwareLbSetting.enabled: false` to explicitly disable Envoy's intrinsic
+    zone-aware routing by emitting `routing_enabled: 0%`. Previously, `enabled: false` was
+    a no-op: Istio emitted no `ZoneAwareLbConfig`, causing Envoy to fall back to its default
+    `routing_enabled: 100%`, which engaged zone-aware routing automatically whenever a
+    self-discovery local cluster was present. This made gradual rollout unsafe, as pods in a
+    mixed state (some with self-discovery, some without) would unevenly distribute traffic.

--- a/releasenotes/notes/zone-aware-disable.yaml
+++ b/releasenotes/notes/zone-aware-disable.yaml
@@ -1,10 +1,10 @@
 apiVersion: release-notes/v2
-kind: enhancement
+kind: bug-fix
 area: traffic-management
 
 releaseNotes:
   - |
-    **Improved** `zoneAwareLbSetting.enabled: false` to explicitly disable Envoy's intrinsic
+    **Fixed** `zoneAwareLbSetting.enabled: false` to explicitly disable Envoy's intrinsic
     zone-aware routing by emitting `routing_enabled: 0%`. Previously, `enabled: false` was
     a no-op: Istio emitted no `ZoneAwareLbConfig`, causing Envoy to fall back to its default
     `routing_enabled: 100%`, which engaged zone-aware routing automatically whenever a

--- a/tests/integration/pilot/zone_aware_lb_test.go
+++ b/tests/integration/pilot/zone_aware_lb_test.go
@@ -106,11 +106,15 @@ spec:
       baseEjectionTime: 10m
       maxEjectionPercent: 100
 {{ end }}
-{{ if not .DisableZoneAware }}
+{{ if not .SkipZoneAware }}
     loadBalancer:
       zoneAwareLbSetting:
+{{ if .DisableZoneAware }}
+        enabled: false
+{{ else }}
         enabled: true
         minClusterSize: {{ .MinClusterSize }}
+{{ end }}
 {{ end }}
 {{ range $i, $we := .LocalClusterWorkloads }}
 ---
@@ -158,6 +162,7 @@ type zoneAwareInput struct {
 	WithOutlierDetection     bool
 	MinClusterSize           int
 	DisableZoneAware         bool
+	SkipZoneAware            bool
 }
 
 func TestZoneAwareLoadBalancer(t *testing.T) {
@@ -203,6 +208,7 @@ func TestZoneAwareLoadBalancer(t *testing.T) {
 				withOutlierDetection  bool
 				minClusterSize        int
 				disableZoneAware      bool
+				skipZoneAware         bool
 				expected              map[string]int
 			}{
 				{
@@ -295,16 +301,33 @@ func TestZoneAwareLoadBalancer(t *testing.T) {
 				},
 				{
 					// Same topology as CrossRegionEndpointIgnoredWhileSameRegionHealthy, but with
-					// no loadBalancer DR block (default locality LB, no outlier detection).
-					// Without zone-aware region-bucketing, both endpoints are at equal priority
-					// and traffic splits evenly across the same-region and cross-region endpoints.
-					name:                  "ZoneAwareDisabledCrossRegionEndpointNotIgnored",
+					// zone_aware_lb_setting explicitly disabled. No regional bucketing is applied,
+					// so both endpoints are at equal priority and traffic splits evenly across
+					// the same-region and cross-region endpoints.
+					name:                  "ZoneAwareDisabledCrossRegionEndpointEqualPriority",
 					localClusterWorkloads: oneLocalClusterEndpoint,
 					destinationWorkloads: []weEntry{
 						{Address: destB.Address(), Locality: localLocality},
 						{Address: destC.Address(), Locality: remoteRegionLocality},
 					},
 					disableZoneAware: true,
+					expected: map[string]int{
+						destB.Config().Service: sendCount / 2,
+						destC.Config().Service: sendCount / 2,
+					},
+				},
+				{
+					// No DR loadBalancer block; falls back to mesh default locality_lb_setting
+					// (enabled: true). Without outlier detection, applyLocalityFailover is skipped,
+					// so both same-region and cross-region endpoints stay at priority 0 and traffic
+					// splits evenly.
+					name:                  "MeshDefaultLocalityLBCrossRegionEndpointEqualPriority",
+					localClusterWorkloads: oneLocalClusterEndpoint,
+					destinationWorkloads: []weEntry{
+						{Address: destB.Address(), Locality: localLocality},
+						{Address: destC.Address(), Locality: remoteRegionLocality},
+					},
+					skipZoneAware: true,
 					expected: map[string]int{
 						destB.Config().Service: sendCount / 2,
 						destC.Config().Service: sendCount / 2,
@@ -362,20 +385,22 @@ func TestZoneAwareLoadBalancer(t *testing.T) {
 						WithOutlierDetection:     tc.withOutlierDetection,
 						MinClusterSize:           minClusterSize,
 						DisableZoneAware:         tc.disableZoneAware,
+						SkipZoneAware:            tc.skipZoneAware,
 					}
 					t.ConfigIstio().
 						Eval(apps.Namespace.Name(), input, zoneAwareConfig).
 						ApplyOrFail(t)
 
-					// For cases where zone-aware is enabled, verify the proxy's Envoy config
+					// For cases where zone-aware is explicitly enabled/disabled, verify the proxy's Envoy config
 					// is actually using zone-aware LB (not just locality LB defaults):
 					//   1. local_cluster is present as a static cluster
 					//   2. local_cluster has exactly the expected endpoint count (CLA populated via EDS)
 					//   3. the remote-host cluster uses zone_aware_lb_config, not locality_weighted
-					// For disabled cases, wait for EDS to converge on the destination cluster
+					//   4. routing_percentage is 100% when enabled, 0% when disabled
+					// For the unset case, wait for EDS to converge on the destination cluster
 					// before sending traffic so the distribution assertion is meaningful.
-					if !tc.disableZoneAware {
-						assertZoneAwareConfig(t, caller, input.RemoteHost, len(tc.localClusterWorkloads), tc.destinationWorkloads)
+					if !tc.skipZoneAware {
+						assertZoneAwareConfig(t, caller, input.RemoteHost, len(tc.localClusterWorkloads), tc.destinationWorkloads, tc.disableZoneAware)
 					} else {
 						waitForDestinationEndpoints(t, caller, input.RemoteHost, len(tc.destinationWorkloads))
 					}
@@ -424,11 +449,12 @@ func assertZoneAwareConfig(
 	remoteHost string,
 	expectedLocalClusterHosts int,
 	destinationWorkloads []weEntry,
+	disabled bool,
 ) {
 	t.Helper()
 	sidecar := caller.WorkloadsOrFail(t)[0].Sidecar()
 	remoteClusterName := fmt.Sprintf("outbound|80||%s", remoteHost)
-	expectedDestinationHosts := expectedDestinationHostPriorities(destinationWorkloads)
+	expectedDestinationHosts := expectedDestinationHostPriorities(destinationWorkloads, disabled)
 
 	// First: assert cluster definitions are correct.
 	sidecar.WaitForConfigOrFail(t, func(cd *admin.ConfigDump) (bool, error) {
@@ -463,6 +489,20 @@ func assertZoneAwareConfig(
 		default:
 			return false, fmt.Errorf("cluster %q has unexpected LocalityConfigSpecifier %T — expected ZoneAwareLbConfig",
 				remoteClusterName, remote.GetCommonLbConfig().GetLocalityConfigSpecifier())
+		}
+
+		// Assert routing_enabled: 0% when disabled, unset when enabled (Envoy defaults to 100%).
+		zaCfg := remote.GetCommonLbConfig().GetZoneAwareLbConfig()
+		if disabled {
+			if zaCfg.GetRoutingEnabled() == nil || zaCfg.GetRoutingEnabled().GetValue() != 0 {
+				return false, fmt.Errorf("cluster %q routing_enabled = %v, want 0",
+					remoteClusterName, zaCfg.GetRoutingEnabled())
+			}
+		} else {
+			if zaCfg.GetRoutingEnabled() != nil {
+				return false, fmt.Errorf("cluster %q routing_enabled = %v, want nil (unset; Envoy defaults to 100%%)",
+					remoteClusterName, zaCfg.GetRoutingEnabled())
+			}
 		}
 		return true, nil
 	}, retry.Delay(time.Second), retry.Timeout(30*time.Second))
@@ -536,12 +576,12 @@ func waitForDestinationEndpoints(
 	}, retry.Delay(time.Second), retry.Timeout(30*time.Second))
 }
 
-func expectedDestinationHostPriorities(workloads []weEntry) map[string]uint32 {
+func expectedDestinationHostPriorities(workloads []weEntry, disabled bool) map[string]uint32 {
 	raw := make(map[string]int, len(workloads))
 	seenRawPriority := map[int]bool{}
 	for _, we := range workloads {
 		priority := 0
-		if localityRegion(we.Locality) != localityRegion(localLocality) {
+		if !disabled && localityRegion(we.Locality) != localityRegion(localLocality) {
 			priority = 1
 		}
 		raw[we.Address] = priority


### PR DESCRIPTION
The automated cherry-pick needed to be rebased and fixed after changes made in https://github.com/istio/istio/pull/61252.