### PR TITLE
anchor service account subject parsing in oidc ca authenticator

### DIFF
--- a/releasenotes/notes/oidc-service-account-subject.yaml
+++ b/releasenotes/notes/oidc-service-account-subject.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: security-fix
+area: security
+releaseNotes:
+  - |
+    **Fixed** the OIDC (`JWT_RULE`) CA authenticator to require the token subject to be exactly
+    `system:serviceaccount:<namespace>:<serviceaccount>`. A subject that only shared the
+    `system:serviceaccount` prefix was previously mapped to an unrelated namespace and service
+    account, and a subject with too few segments panicked the istiod handler.

--- a/security/pkg/server/ca/authenticate/oidc.go
+++ b/security/pkg/server/ca/authenticate/oidc.go
@@ -101,10 +101,14 @@ func (j *JwtAuthenticator) authenticate(ctx context.Context, bearerToken string)
 	if err := idToken.Claims(&sa); err != nil {
 		return nil, fmt.Errorf("failed to extract claims from ID token: %v", err)
 	}
-	if !strings.HasPrefix(sa.Sub, "system:serviceaccount") {
+	// sub must be exactly "system:serviceaccount:<namespace>:<serviceaccount>". Anchoring the
+	// prefix and pinning the segment count keeps a token whose sub merely begins with
+	// "system:serviceaccount" (e.g. "system:serviceaccountx:kube-system:istiod") from being
+	// mapped to an unrelated namespace/service account, and avoids indexing a shorter sub.
+	parts := strings.Split(sa.Sub, ":")
+	if len(parts) != 4 || parts[0] != "system" || parts[1] != "serviceaccount" {
 		return nil, fmt.Errorf("invalid sub %v", sa.Sub)
 	}
-	parts := strings.Split(sa.Sub, ":")
 	ns := parts[2]
 	ksa := parts[3]
 	if !checkAudience(sa.Aud, j.audiences) {

--- a/security/pkg/server/ca/authenticate/oidc_test.go
+++ b/security/pkg/server/ca/authenticate/oidc_test.go
@@ -175,6 +175,19 @@ func TestOIDCAuthenticate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to generate JWT: %v", err)
 	}
+	// Create a JWT token whose subject only shares the "system:serviceaccount" prefix but is not
+	// the canonical "system:serviceaccount:<ns>:<sa>" form. It must not be mapped to bar/foo.
+	claimsUnanchoredSubject := `{"iss": "` + server.URL + `", "aud": ["baz.svc.id.goog"], "sub": "system:serviceaccountx:bar:foo", "exp": ` + expStr + `}`
+	tokenUnanchoredSubject, err := generateJWT(&key, []byte(claimsUnanchoredSubject))
+	if err != nil {
+		t.Fatalf("failed to generate JWT: %v", err)
+	}
+	// Create a JWT token whose subject has too few segments to index a namespace/service account.
+	claimsShortSubject := `{"iss": "` + server.URL + `", "aud": ["baz.svc.id.goog"], "sub": "system:serviceaccounts", "exp": ` + expStr + `}`
+	tokenShortSubject, err := generateJWT(&key, []byte(claimsShortSubject))
+	if err != nil {
+		t.Fatalf("failed to generate JWT: %v", err)
+	}
 
 	tests := map[string]struct {
 		token      string
@@ -199,6 +212,14 @@ func TestOIDCAuthenticate(t *testing.T) {
 		},
 		"Token with invalid subject": {
 			token:     tokenInvalidSubject,
+			expectErr: true,
+		},
+		"Token with unanchored subject prefix": {
+			token:     tokenUnanchoredSubject,
+			expectErr: true,
+		},
+		"Token with short subject": {
+			token:     tokenShortSubject,
 			expectErr: true,
 		},
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**

The OIDC (`JWT_RULE`) CA authenticator maps the JWT `sub` to a namespace/service account without pinning the format:
- `sub` is matched with an unanchored `HasPrefix`, so `system:serviceaccountx:kube-system:istiod` is accepted and mapped to `kube-system/istiod`
- `strings.Split` then reads `parts[2]`/`parts[3]` with no length check, so a short subject like `system:serviceaccounts` panics the handler
- `security/pkg/k8s/tokenreview/k8sauthn.go` already parses the same string with a `len == 4` guard; this brings the OIDC path in line

Requires exactly `system:serviceaccount:<ns>:<sa>` and rejects anything else. Added the two subject cases to `TestOIDCAuthenticate`.