### PR TITLE
Support suffix string matching in VirtualService HTTP match conditions

### DIFF
--- a/istioctl/pkg/describe/describe.go
+++ b/istioctl/pkg/describe/describe.go
@@ -455,6 +455,8 @@ func renderStringMatch(sm *v1alpha3.StringMatch) string {
 		return x.Exact
 	case *v1alpha3.StringMatch_Prefix:
 		return x.Prefix + "*"
+	case *v1alpha3.StringMatch_Suffix:
+		return "*" + x.Suffix
 	}
 
 	return sm.String()

--- a/istioctl/pkg/describe/describe_test.go
+++ b/istioctl/pkg/describe/describe_test.go
@@ -1203,3 +1203,21 @@ func TestGetIstioVirtualServicePathForSvcFromRoute(t *testing.T) {
 		})
 	}
 }
+
+func TestRenderStringMatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       *networking.StringMatch
+		expected string
+	}{
+		{name: "nil", in: nil, expected: ""},
+		{name: "exact", in: &networking.StringMatch{MatchType: &networking.StringMatch_Exact{Exact: "foo"}}, expected: "foo"},
+		{name: "prefix", in: &networking.StringMatch{MatchType: &networking.StringMatch_Prefix{Prefix: "foo"}}, expected: "foo*"},
+		{name: "suffix", in: &networking.StringMatch{MatchType: &networking.StringMatch_Suffix{Suffix: ".example.com"}}, expected: "*.example.com"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, renderStringMatch(test.in), test.expected)
+		})
+	}
+}

--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -418,20 +418,20 @@ func stringMatchConflict(root, leaf *networking.StringMatch) bool {
 	}
 	// If root regex match is specified, delegate should not have other matches.
 	if root.GetRegex() != "" {
-		if leaf.GetRegex() != "" || leaf.GetPrefix() != "" || leaf.GetExact() != "" {
+		if leaf.GetRegex() != "" || leaf.GetPrefix() != "" || leaf.GetExact() != "" || leaf.GetSuffix() != "" {
 			return true
 		}
 	}
 	// If delegate regex match is specified, root should not have other matches.
 	if leaf.GetRegex() != "" {
-		if root.GetRegex() != "" || root.GetPrefix() != "" || root.GetExact() != "" {
+		if root.GetRegex() != "" || root.GetPrefix() != "" || root.GetExact() != "" || root.GetSuffix() != "" {
 			return true
 		}
 	}
 	// root is exact match
 	if exact := root.GetExact(); exact != "" {
-		// leaf is prefix match, conflict
-		if leaf.GetPrefix() != "" {
+		// leaf is prefix or suffix match, conflict
+		if leaf.GetPrefix() != "" || leaf.GetSuffix() != "" {
 			return true
 		}
 		// both exact, but not equal
@@ -442,6 +442,10 @@ func stringMatchConflict(root, leaf *networking.StringMatch) bool {
 	}
 	// root is prefix match
 	if prefix := root.GetPrefix(); prefix != "" {
+		// leaf is suffix match, conflict
+		if leaf.GetSuffix() != "" {
+			return true
+		}
 		// leaf is prefix match
 		if leaf.GetPrefix() != "" {
 			// leaf(`/a`) is not subset of root(`/a/b`)
@@ -451,6 +455,23 @@ func stringMatchConflict(root, leaf *networking.StringMatch) bool {
 		if leaf.GetExact() != "" {
 			// leaf(`/a`) is not subset of root(`/a/b`)
 			return !strings.HasPrefix(leaf.GetExact(), prefix)
+		}
+	}
+	// root is suffix match
+	if suffix := root.GetSuffix(); suffix != "" {
+		// leaf is prefix match, conflict
+		if leaf.GetPrefix() != "" {
+			return true
+		}
+		// leaf is suffix match
+		if leaf.GetSuffix() != "" {
+			// leaf(`.com`) is not subset of root(`.example.com`)
+			return !strings.HasSuffix(leaf.GetSuffix(), suffix)
+		}
+		// leaf is exact match
+		if leaf.GetExact() != "" {
+			// leaf(`a.com`) is not subset of root(`.example.com`)
+			return !strings.HasSuffix(leaf.GetExact(), suffix)
 		}
 	}
 

--- a/pilot/pkg/model/virtualservice_test.go
+++ b/pilot/pkg/model/virtualservice_test.go
@@ -549,6 +549,68 @@ func TestMergeHTTPMatchRequests(t *testing.T) {
 			expected: nil,
 		},
 		{
+			name: "authority suffix match",
+			root: []*networking.HTTPMatchRequest{
+				{
+					Authority: &networking.StringMatch{
+						MatchType: &networking.StringMatch_Suffix{Suffix: ".example.com"},
+					},
+				},
+			},
+			delegate: []*networking.HTTPMatchRequest{
+				{
+					Authority: &networking.StringMatch{
+						MatchType: &networking.StringMatch_Exact{Exact: "foo.example.com"},
+					},
+				},
+			},
+			expected: []*networking.HTTPMatchRequest{
+				{
+					Authority: &networking.StringMatch{
+						MatchType: &networking.StringMatch_Exact{Exact: "foo.example.com"},
+					},
+				},
+			},
+		},
+		{
+			name: "authority suffix inherited from root",
+			root: []*networking.HTTPMatchRequest{
+				{
+					Authority: &networking.StringMatch{
+						MatchType: &networking.StringMatch_Suffix{Suffix: ".example.com"},
+					},
+				},
+			},
+			delegate: []*networking.HTTPMatchRequest{
+				{},
+			},
+			expected: []*networking.HTTPMatchRequest{
+				{
+					Authority: &networking.StringMatch{
+						MatchType: &networking.StringMatch_Suffix{Suffix: ".example.com"},
+					},
+				},
+			},
+		},
+		{
+			name: "authority suffix conflict",
+			root: []*networking.HTTPMatchRequest{
+				{
+					Authority: &networking.StringMatch{
+						MatchType: &networking.StringMatch_Suffix{Suffix: ".example.com"},
+					},
+				},
+			},
+			delegate: []*networking.HTTPMatchRequest{
+				{
+					Authority: &networking.StringMatch{
+						MatchType: &networking.StringMatch_Exact{Exact: "example.org"},
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
 			name: "multi url match",
 			root: []*networking.HTTPMatchRequest{
 				{
@@ -1003,6 +1065,114 @@ func TestHasConflict(t *testing.T) {
 					MatchType: &networking.StringMatch_Exact{Exact: "/productpage/v2"},
 				},
 			},
+			expected: false,
+		},
+		{
+			name: "match authority suffix",
+			root: &networking.HTTPMatchRequest{
+				Authority: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Suffix{Suffix: ".example.com"},
+				},
+			},
+			leaf: &networking.HTTPMatchRequest{
+				Authority: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Suffix{Suffix: "a.example.com"},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "mismatch authority suffix",
+			root: &networking.HTTPMatchRequest{
+				Authority: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Suffix{Suffix: "a.example.com"},
+				},
+			},
+			leaf: &networking.HTTPMatchRequest{
+				Authority: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Suffix{Suffix: ".example.com"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "suffix authority in root and exact match in delegate",
+			root: &networking.HTTPMatchRequest{
+				Authority: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Suffix{Suffix: ".example.com"},
+				},
+			},
+			leaf: &networking.HTTPMatchRequest{
+				Authority: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Exact{Exact: "foo.example.com"},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "suffix authority in root and conflicting exact match in delegate",
+			root: &networking.HTTPMatchRequest{
+				Authority: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Suffix{Suffix: ".example.com"},
+				},
+			},
+			leaf: &networking.HTTPMatchRequest{
+				Authority: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Exact{Exact: "example.org"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "suffix authority in root and prefix match in delegate",
+			root: &networking.HTTPMatchRequest{
+				Authority: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Suffix{Suffix: ".example.com"},
+				},
+			},
+			leaf: &networking.HTTPMatchRequest{
+				Authority: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Prefix{Prefix: "foo"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "exact authority in root and suffix match in delegate",
+			root: &networking.HTTPMatchRequest{
+				Authority: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Exact{Exact: "foo.example.com"},
+				},
+			},
+			leaf: &networking.HTTPMatchRequest{
+				Authority: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Suffix{Suffix: ".example.com"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "regex authority in root and suffix match in delegate",
+			root: &networking.HTTPMatchRequest{
+				Authority: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Regex{Regex: ".*example.com"},
+				},
+			},
+			leaf: &networking.HTTPMatchRequest{
+				Authority: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Suffix{Suffix: ".example.com"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "suffix authority in root and delegate does not have authority",
+			root: &networking.HTTPMatchRequest{
+				Authority: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Suffix{Suffix: ".example.com"},
+				},
+			},
+			leaf:     &networking.HTTPMatchRequest{},
 			expected: false,
 		},
 		{

--- a/pilot/pkg/networking/core/route/route.go
+++ b/pilot/pkg/networking/core/route/route.go
@@ -1108,6 +1108,15 @@ func TranslateRouteMatch(vs config.Config, in *networking.HTTPMatchRequest) *rou
 					Regex: m.Regex,
 				},
 			}
+		case *networking.StringMatch_Suffix:
+			// Envoy's RouteMatch has no native suffix path matcher, so suffix URI matches are
+			// rejected by validation. Lower to a safe regex anyway so an unvalidated config
+			// cannot fall through to the catch-all prefix "/" match initialized above.
+			out.PathSpecifier = &route.RouteMatch_SafeRegex{
+				SafeRegex: &matcher.RegexMatcher{
+					Regex: ".*" + regexp.QuoteMeta(m.Suffix) + "$",
+				},
+			}
 		}
 	}
 

--- a/pilot/pkg/networking/core/route/route_internal_test.go
+++ b/pilot/pkg/networking/core/route/route_internal_test.go
@@ -33,6 +33,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	authzmatcher "istio.io/istio/pilot/pkg/security/authz/matcher"
 	authz "istio.io/istio/pilot/pkg/security/authz/model"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/util/sets"
@@ -173,6 +174,7 @@ func TestTranslateCORSPolicyForwardNotMatchingPreflights(t *testing.T) {
 			{MatchType: &networking.StringMatch_Exact{Exact: "exact"}},
 			{MatchType: &networking.StringMatch_Prefix{Prefix: "prefix"}},
 			{MatchType: &networking.StringMatch_Regex{Regex: "regex"}},
+			{MatchType: &networking.StringMatch_Suffix{Suffix: "suffix"}},
 		},
 		UnmatchedPreflights: networking.CorsPolicy_IGNORE,
 	}
@@ -188,6 +190,7 @@ func TestTranslateCORSPolicyForwardNotMatchingPreflights(t *testing.T) {
 					},
 				},
 			},
+			{MatchPattern: &matcher.StringMatcher_Suffix{Suffix: "suffix"}},
 		},
 		FilterEnabled: &core.RuntimeFractionalPercent{
 			DefaultValue: &xdstype.FractionalPercent{
@@ -208,6 +211,7 @@ func TestTranslateCORSPolicy(t *testing.T) {
 			{MatchType: &networking.StringMatch_Exact{Exact: "exact"}},
 			{MatchType: &networking.StringMatch_Prefix{Prefix: "prefix"}},
 			{MatchType: &networking.StringMatch_Regex{Regex: "regex"}},
+			{MatchType: &networking.StringMatch_Suffix{Suffix: "suffix"}},
 		},
 	}
 	expectedCorsPolicy := &cors.CorsPolicy{
@@ -221,6 +225,7 @@ func TestTranslateCORSPolicy(t *testing.T) {
 					},
 				},
 			},
+			{MatchPattern: &matcher.StringMatcher_Suffix{Suffix: "suffix"}},
 		},
 		ForwardNotMatchingPreflights: wrapperspb.Bool(true),
 		FilterEnabled: &core.RuntimeFractionalPercent{
@@ -232,6 +237,20 @@ func TestTranslateCORSPolicy(t *testing.T) {
 	}
 	if got := TranslateCORSPolicy(node, corsPolicy); !reflect.DeepEqual(got, expectedCorsPolicy) {
 		t.Errorf("TranslateCORSPolicy() = \n%v, want \n%v", got, expectedCorsPolicy)
+	}
+}
+
+func TestTranslateRouteMatchURISuffix(t *testing.T) {
+	// uri suffix matches are rejected by validation, but if one slips through it must
+	// be lowered to a regex rather than fall through to the default catch-all prefix "/".
+	out := TranslateRouteMatch(config.Config{}, &networking.HTTPMatchRequest{
+		Uri: &networking.StringMatch{MatchType: &networking.StringMatch_Suffix{Suffix: ".php"}},
+	})
+	if got, want := out.GetSafeRegex().GetRegex(), `.*\.php$`; got != want {
+		t.Errorf("expected safe regex %q, got %q", want, got)
+	}
+	if IsCatchAllRoute(&route.Route{Match: out}) {
+		t.Errorf("suffix uri match should not produce a catch-all route")
 	}
 }
 
@@ -475,6 +494,11 @@ func TestTranslateMetadataMatch(t *testing.T) {
 			name: "@request.auth.claims.prefix",
 			in:   &networking.StringMatch{MatchType: &networking.StringMatch_Prefix{Prefix: "prefix"}},
 			want: authz.MetadataMatcherForJWTClaims([]string{"prefix"}, authzmatcher.StringMatcher("prefix*")),
+		},
+		{
+			name: "@request.auth.claims.suffix",
+			in:   &networking.StringMatch{MatchType: &networking.StringMatch_Suffix{Suffix: "suffix"}},
+			want: authz.MetadataMatcherForJWTClaims([]string{"suffix"}, authzmatcher.StringMatcher("*suffix")),
 		},
 		{
 			name: "@request.auth.claims.regex",

--- a/pilot/pkg/networking/core/route/route_test.go
+++ b/pilot/pkg/networking/core/route/route_test.go
@@ -355,6 +355,31 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetStringMatch().GetSafeRegex().GetRegex()).To(Equal("Bearer .+?\\..+?\\..+?"))
 	})
 
+	t.Run("for virtual service with suffix matching on header", func(t *testing.T) {
+		g := NewWithT(t)
+		cg := core.NewConfigGenTest(t, core.TestOptions{})
+
+		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithSuffixMatchingOnHeader,
+			8080, gatewayNames, routeOpts)
+		xdstest.ValidateRoutes(t, routes)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
+		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetStringMatch().GetSuffix()).To(Equal(".bar.com"))
+	})
+
+	t.Run("for virtual service with suffix matching on authority", func(t *testing.T) {
+		g := NewWithT(t)
+		cg := core.NewConfigGenTest(t, core.TestOptions{})
+
+		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithSuffixMatchingOnAuthority,
+			8080, gatewayNames, routeOpts)
+		xdstest.ValidateRoutes(t, routes)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
+		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetName()).To(Equal(":authority"))
+		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetStringMatch().GetSuffix()).To(Equal(".example.com"))
+	})
+
 	t.Run("for virtual service with regex matching on without_header", func(t *testing.T) {
 		g := NewWithT(t)
 		cg := core.NewConfigGenTest(t, core.TestOptions{})
@@ -365,6 +390,20 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(len(routes)).To(Equal(1))
 		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetStringMatch().GetSafeRegex().GetRegex()).To(Equal("BAR .+?\\..+?\\..+?"))
+		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetInvertMatch()).To(Equal(true))
+		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetTreatMissingHeaderAsEmpty()).To(Equal(true))
+	})
+
+	t.Run("for virtual service with suffix matching on without_header", func(t *testing.T) {
+		g := NewWithT(t)
+		cg := core.NewConfigGenTest(t, core.TestOptions{})
+
+		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithSuffixMatchingOnWithoutHeader,
+			8080, gatewayNames, routeOpts)
+		xdstest.ValidateRoutes(t, routes)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
+		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetStringMatch().GetSuffix()).To(Equal(".jwt"))
 		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetInvertMatch()).To(Equal(true))
 		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetTreatMissingHeaderAsEmpty()).To(Equal(true))
 	})
@@ -446,6 +485,18 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(len(routes)).To(Equal(1))
 		g.Expect(routes[0].GetMatch().GetQueryParameters()[0].GetStringMatch().GetPrefix()).To(Equal("foo-"))
+	})
+
+	t.Run("for virtual service with suffix matching on query parameter", func(t *testing.T) {
+		g := NewWithT(t)
+		cg := core.NewConfigGenTest(t, core.TestOptions{})
+
+		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithSuffixMatchingOnQueryParameter,
+			8080, gatewayNames, routeOpts)
+		xdstest.ValidateRoutes(t, routes)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
+		g.Expect(routes[0].GetMatch().GetQueryParameters()[0].GetStringMatch().GetSuffix()).To(Equal("-bar"))
 	})
 
 	t.Run("for virtual service with regex matching on query parameter", func(t *testing.T) {
@@ -2684,6 +2735,68 @@ var virtualServiceWithRegexMatchingOnHeader = config.Config{
 	},
 }
 
+var virtualServiceWithSuffixMatchingOnHeader = config.Config{
+	Meta: config.Meta{
+		GroupVersionKind: gvk.VirtualService,
+		Name:             "acme",
+	},
+	Spec: &networking.VirtualService{
+		Hosts:    []string{},
+		Gateways: []string{"some-gateway"},
+		Http: []*networking.HTTPRoute{
+			{
+				Match: []*networking.HTTPMatchRequest{
+					{
+						Name: "referer",
+						Headers: map[string]*networking.StringMatch{
+							"Referer": {
+								MatchType: &networking.StringMatch_Suffix{
+									Suffix: ".bar.com",
+								},
+							},
+						},
+					},
+				},
+				Redirect: &networking.HTTPRedirect{
+					Uri:          "example.org",
+					Authority:    "some-authority.default.svc.cluster.local",
+					RedirectCode: 308,
+				},
+			},
+		},
+	},
+}
+
+var virtualServiceWithSuffixMatchingOnAuthority = config.Config{
+	Meta: config.Meta{
+		GroupVersionKind: gvk.VirtualService,
+		Name:             "acme",
+	},
+	Spec: &networking.VirtualService{
+		Hosts:    []string{},
+		Gateways: []string{"some-gateway"},
+		Http: []*networking.HTTPRoute{
+			{
+				Match: []*networking.HTTPMatchRequest{
+					{
+						Name: "authority",
+						Authority: &networking.StringMatch{
+							MatchType: &networking.StringMatch_Suffix{
+								Suffix: ".example.com",
+							},
+						},
+					},
+				},
+				Redirect: &networking.HTTPRedirect{
+					Uri:          "example.org",
+					Authority:    "some-authority.default.svc.cluster.local",
+					RedirectCode: 308,
+				},
+			},
+		},
+	},
+}
+
 func createVirtualServiceWithRegexMatchingForAllCasesOnHeader() []*config.Config {
 	ret := []*config.Config{}
 	regex := "*"
@@ -2739,6 +2852,38 @@ var virtualServiceWithRegexMatchingOnWithoutHeader = config.Config{
 							"FOO-HEADER": {
 								MatchType: &networking.StringMatch_Regex{
 									Regex: "BAR .+?\\..+?\\..+?",
+								},
+							},
+						},
+					},
+				},
+				Redirect: &networking.HTTPRedirect{
+					Uri:          "example.org",
+					Authority:    "some-authority.default.svc.cluster.local",
+					RedirectCode: 308,
+				},
+			},
+		},
+	},
+}
+
+var virtualServiceWithSuffixMatchingOnWithoutHeader = config.Config{
+	Meta: config.Meta{
+		GroupVersionKind: gvk.VirtualService,
+		Name:             "acme",
+	},
+	Spec: &networking.VirtualService{
+		Hosts:    []string{},
+		Gateways: []string{"some-gateway"},
+		Http: []*networking.HTTPRoute{
+			{
+				Match: []*networking.HTTPMatchRequest{
+					{
+						Name: "without-test",
+						WithoutHeaders: map[string]*networking.StringMatch{
+							"FOO-HEADER": {
+								MatchType: &networking.StringMatch_Suffix{
+									Suffix: ".jwt",
 								},
 							},
 						},
@@ -2887,6 +3032,38 @@ var virtualServiceWithPrefixMatchingOnQueryParameter = config.Config{
 							"token": {
 								MatchType: &networking.StringMatch_Prefix{
 									Prefix: "foo-",
+								},
+							},
+						},
+					},
+				},
+				Redirect: &networking.HTTPRedirect{
+					Uri:          "example.org",
+					Authority:    "some-authority.default.svc.cluster.local",
+					RedirectCode: 308,
+				},
+			},
+		},
+	},
+}
+
+var virtualServiceWithSuffixMatchingOnQueryParameter = config.Config{
+	Meta: config.Meta{
+		GroupVersionKind: gvk.VirtualService,
+		Name:             "acme",
+	},
+	Spec: &networking.VirtualService{
+		Hosts:    []string{},
+		Gateways: []string{"some-gateway"},
+		Http: []*networking.HTTPRoute{
+			{
+				Match: []*networking.HTTPMatchRequest{
+					{
+						Name: "auth",
+						QueryParams: map[string]*networking.StringMatch{
+							"token": {
+								MatchType: &networking.StringMatch_Suffix{
+									Suffix: "-bar",
 								},
 							},
 						},

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -619,6 +619,8 @@ func ConvertToEnvoyMatch(in *networking.StringMatch) *matcher.StringMatcher {
 				},
 			},
 		}
+	case *networking.StringMatch_Suffix:
+		return &matcher.StringMatcher{MatchPattern: &matcher.StringMatcher_Suffix{Suffix: m.Suffix}}
 	}
 	return nil
 }

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -27,6 +27,7 @@ import (
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	cookiev3 "github.com/envoyproxy/go-control-plane/envoy/extensions/http/stateful_session/cookie/v3"
 	httpv3 "github.com/envoyproxy/go-control-plane/envoy/type/http/v3"
+	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
 	structpb "google.golang.org/protobuf/types/known/structpb"
@@ -2064,6 +2065,51 @@ func TestSelectDNSLookupFamily(t *testing.T) {
 			if got := SelectDNSLookupFamily(tc.ips); got != tc.want {
 				t.Errorf("SelectDNSLookupFamily(%v) = %v, want %v", tc.ips, got, tc.want)
 			}
+		})
+	}
+}
+
+func TestConvertToEnvoyMatch(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *networking.StringMatch
+		want *matcher.StringMatcher
+	}{
+		{
+			name: "exact",
+			in:   &networking.StringMatch{MatchType: &networking.StringMatch_Exact{Exact: "foo"}},
+			want: &matcher.StringMatcher{MatchPattern: &matcher.StringMatcher_Exact{Exact: "foo"}},
+		},
+		{
+			name: "prefix",
+			in:   &networking.StringMatch{MatchType: &networking.StringMatch_Prefix{Prefix: "foo"}},
+			want: &matcher.StringMatcher{MatchPattern: &matcher.StringMatcher_Prefix{Prefix: "foo"}},
+		},
+		{
+			name: "suffix",
+			in:   &networking.StringMatch{MatchType: &networking.StringMatch_Suffix{Suffix: "foo"}},
+			want: &matcher.StringMatcher{MatchPattern: &matcher.StringMatcher_Suffix{Suffix: "foo"}},
+		},
+		{
+			name: "regex",
+			in:   &networking.StringMatch{MatchType: &networking.StringMatch_Regex{Regex: "foo.*"}},
+			want: &matcher.StringMatcher{
+				MatchPattern: &matcher.StringMatcher_SafeRegex{
+					SafeRegex: &matcher.RegexMatcher{
+						Regex: "foo.*",
+					},
+				},
+			},
+		},
+		{
+			name: "unset",
+			in:   &networking.StringMatch{},
+			want: nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, ConvertToEnvoyMatch(tc.in), tc.want)
 		})
 	}
 }

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -70,6 +70,7 @@ const (
 
 	matchExact  = "exact:"
 	matchPrefix = "prefix:"
+	matchSuffix = "suffix:"
 )
 
 // https://greenbytes.de/tech/webdav/rfc7230.html#header.fields
@@ -1866,14 +1867,37 @@ var ValidateVirtualService = RegisterValidateFunc("ValidateVirtualService",
 		return errs.Unwrap()
 	})
 
-func assignExactOrPrefix(exact, prefix string) string {
-	if exact != "" {
+// assignStringMatch encodes the exact, prefix or suffix value of a StringMatch into a
+// single tagged string used by the overlapping-match analysis, e.g. "prefix:/debug".
+func assignStringMatch(sm *networking.StringMatch) string {
+	if exact := sm.GetExact(); exact != "" {
 		return matchExact + exact
 	}
-	if prefix != "" {
+	if prefix := sm.GetPrefix(); prefix != "" {
 		return matchPrefix + prefix
 	}
+	if suffix := sm.GetSuffix(); suffix != "" {
+		return matchSuffix + suffix
+	}
 	return ""
+}
+
+// coveredStringMatch returns true if the encoded string match vA is covered by vB,
+// i.e. vB matches a superset of what vA matches. An empty vB covers anything.
+func coveredStringMatch(vA, vB string) bool {
+	if vA == vB {
+		return true
+	}
+	if suffixB, ok := strings.CutPrefix(vB, matchSuffix); ok {
+		// vB is a suffix match: it only covers a suffix match ending with vB's suffix.
+		suffixA, ok := strings.CutPrefix(vA, matchSuffix)
+		return ok && strings.HasSuffix(suffixA, suffixB)
+	}
+	if strings.HasPrefix(vA, matchSuffix) {
+		// vA is a suffix match while vB is not: only an unconstrained vB covers it.
+		return vB == ""
+	}
+	return strings.HasPrefix(vA, vB)
 }
 
 func isSniHost(context *networking.VirtualService) bool {
@@ -1909,44 +1933,31 @@ func genMatchHTTPRoutes(route *networking.HTTPRoute, match *networking.HTTPMatch
 	tmpPrefix := match.Uri.GetPrefix()
 	if tmpPrefix != "" {
 		// set Method
-		methodExact := match.Method.GetExact()
-		methodPrefix := match.Method.GetPrefix()
-		methodMatch := assignExactOrPrefix(methodExact, methodPrefix)
+		methodMatch := assignStringMatch(match.Method)
 		// if no method information, it should be GET by default
 		if methodMatch == "" {
 			methodMatch = matchExact + "GET"
 		}
 
 		// set Authority
-		authorityExact := match.Authority.GetExact()
-		authorityPrefix := match.Authority.GetPrefix()
-		authorityMatch := assignExactOrPrefix(authorityExact, authorityPrefix)
+		authorityMatch := assignStringMatch(match.Authority)
 
 		// set Headers
 		headerMap := make(map[string]string)
 		for hkey, hvalue := range match.Headers {
-			hvalueExact := hvalue.GetExact()
-			hvaluePrefix := hvalue.GetPrefix()
-			hvalueMatch := assignExactOrPrefix(hvalueExact, hvaluePrefix)
-			headerMap[hkey] = hvalueMatch
+			headerMap[hkey] = assignStringMatch(hvalue)
 		}
 
 		// set QueryParams
 		QPMap := make(map[string]string)
 		for qpkey, qpvalue := range match.QueryParams {
-			qpvalueExact := qpvalue.GetExact()
-			qpvaluePrefix := qpvalue.GetPrefix()
-			qpvalueMatch := assignExactOrPrefix(qpvalueExact, qpvaluePrefix)
-			QPMap[qpkey] = qpvalueMatch
+			QPMap[qpkey] = assignStringMatch(qpvalue)
 		}
 
 		// set WithoutHeaders
 		noHeaderMap := make(map[string]string)
 		for nhkey, nhvalue := range match.WithoutHeaders {
-			nhvalueExact := nhvalue.GetExact()
-			nhvaluePrefix := nhvalue.GetPrefix()
-			nhvalueMatch := assignExactOrPrefix(nhvalueExact, nhvaluePrefix)
-			noHeaderMap[nhkey] = nhvalueMatch
+			noHeaderMap[nhkey] = assignStringMatch(nhvalue)
 		}
 
 		matchHTTPRoutes = &OverlappingMatchValidationForHTTPRoute{
@@ -1975,17 +1986,13 @@ func coveredValidation(vA, vB *OverlappingMatchValidationForHTTPRoute) bool {
 		}
 
 		// check the match method
-		if vA.MatchMethod != vB.MatchMethod {
-			if !strings.HasPrefix(vA.MatchMethod, vB.MatchMethod) {
-				return false
-			}
+		if !coveredStringMatch(vA.MatchMethod, vB.MatchMethod) {
+			return false
 		}
 
 		// check the match authority
-		if vA.MatchAuthority != vB.MatchAuthority {
-			if !strings.HasPrefix(vA.MatchAuthority, vB.MatchAuthority) {
-				return false
-			}
+		if !coveredStringMatch(vA.MatchAuthority, vB.MatchAuthority) {
+			return false
 		}
 
 		// check the match Headers
@@ -1998,10 +2005,8 @@ func coveredValidation(vA, vB *OverlappingMatchValidationForHTTPRoute) bool {
 			vBhdValue, ok := vB.MatchHeaders[hdKey]
 			if !ok {
 				return false
-			} else if hdValue != vBhdValue {
-				if !strings.HasPrefix(hdValue, vBhdValue) {
-					return false
-				}
+			} else if !coveredStringMatch(hdValue, vBhdValue) {
+				return false
 			}
 		}
 
@@ -2015,10 +2020,8 @@ func coveredValidation(vA, vB *OverlappingMatchValidationForHTTPRoute) bool {
 			vBqpValue, ok := vB.MatchQueryParams[qpKey]
 			if !ok {
 				return false
-			} else if qpValue != vBqpValue {
-				if !strings.HasPrefix(qpValue, vBqpValue) {
-					return false
-				}
+			} else if !coveredStringMatch(qpValue, vBqpValue) {
+				return false
 			}
 		}
 
@@ -2032,10 +2035,8 @@ func coveredValidation(vA, vB *OverlappingMatchValidationForHTTPRoute) bool {
 			vBnhValue, ok := vB.MatchNonHeaders[nhKey]
 			if !ok {
 				return false
-			} else if nhValue != vBnhValue {
-				if !strings.HasPrefix(nhValue, vBnhValue) {
-					return false
-				}
+			} else if !coveredStringMatch(nhValue, vBnhValue) {
+				return false
 			}
 		}
 	} else {
@@ -2330,6 +2331,10 @@ func validateStringMatch(sm *networking.StringMatch, where string) error {
 		if sm.GetPrefix() == "" {
 			return fmt.Errorf("%q: prefix string match should not be empty", where)
 		}
+	case *networking.StringMatch_Suffix:
+		if sm.GetSuffix() == "" {
+			return fmt.Errorf("%q: suffix string match should not be empty", where)
+		}
 	case *networking.StringMatch_Regex:
 		return validateStringMatchRegexp(sm, where)
 	}
@@ -2509,6 +2514,8 @@ func validateAllowOrigins(origin *networking.StringMatch) error {
 		match = origin.GetPrefix()
 	case *networking.StringMatch_Regex:
 		match = origin.GetRegex()
+	case *networking.StringMatch_Suffix:
+		match = origin.GetSuffix()
 	}
 	if match == "" {
 		return fmt.Errorf("'%v' is not a valid match type for CORS allow origins", match)

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -1156,6 +1156,7 @@ func TestValidateCORSPolicy(t *testing.T) {
 				{MatchType: &networking.StringMatch_Exact{Exact: ""}},
 				{MatchType: &networking.StringMatch_Prefix{Prefix: ""}},
 				{MatchType: &networking.StringMatch_Regex{Regex: ""}},
+				{MatchType: &networking.StringMatch_Suffix{Suffix: ""}},
 			},
 			AllowMethods:  []string{"GET", "POST"},
 			AllowHeaders:  []string{"header1", "header2"},
@@ -1167,6 +1168,7 @@ func TestValidateCORSPolicy(t *testing.T) {
 				{MatchType: &networking.StringMatch_Exact{Exact: "exact"}},
 				{MatchType: &networking.StringMatch_Prefix{Prefix: "prefix"}},
 				{MatchType: &networking.StringMatch_Regex{Regex: "regex"}},
+				{MatchType: &networking.StringMatch_Suffix{Suffix: "suffix"}},
 			},
 			AllowMethods:  []string{"GET", "POST"},
 			AllowHeaders:  []string{"header1", "header2"},
@@ -2162,6 +2164,42 @@ func TestValidateHTTPRoute(t *testing.T) {
 				},
 			}},
 		}, valid: false},
+		{name: "empty suffix header match", route: &networking.HTTPRoute{
+			Route: []*networking.HTTPRouteDestination{{
+				Destination: &networking.Destination{Host: "foo.bar"},
+			}},
+			Match: []*networking.HTTPMatchRequest{{
+				Headers: map[string]*networking.StringMatch{
+					"emptysuffix": {MatchType: &networking.StringMatch_Suffix{Suffix: ""}},
+				},
+			}},
+		}, valid: false},
+		{name: "suffix header match", route: &networking.HTTPRoute{
+			Route: []*networking.HTTPRouteDestination{{
+				Destination: &networking.Destination{Host: "foo.bar"},
+			}},
+			Match: []*networking.HTTPMatchRequest{{
+				Headers: map[string]*networking.StringMatch{
+					"referer": {MatchType: &networking.StringMatch_Suffix{Suffix: ".example.com"}},
+				},
+			}},
+		}, valid: true},
+		{name: "suffix authority match", route: &networking.HTTPRoute{
+			Route: []*networking.HTTPRouteDestination{{
+				Destination: &networking.Destination{Host: "foo.bar"},
+			}},
+			Match: []*networking.HTTPMatchRequest{{
+				Authority: &networking.StringMatch{MatchType: &networking.StringMatch_Suffix{Suffix: ".example.com"}},
+			}},
+		}, valid: true},
+		{name: "uri suffix match", route: &networking.HTTPRoute{
+			Route: []*networking.HTTPRouteDestination{{
+				Destination: &networking.Destination{Host: "foo.bar"},
+			}},
+			Match: []*networking.HTTPMatchRequest{{
+				Uri: &networking.StringMatch{MatchType: &networking.StringMatch_Suffix{Suffix: ".php"}},
+			}},
+		}, valid: false},
 		{name: "nil match", route: &networking.HTTPRoute{
 			Route: []*networking.HTTPRouteDestination{{
 				Destination: &networking.Destination{Host: "foo.bar"},
@@ -2372,6 +2410,54 @@ func TestValidateVirtualService(t *testing.T) {
 				}},
 			}},
 		}, valid: true},
+		{name: "overlapping suffix header match", in: &networking.VirtualService{
+			Hosts: []string{"foo.bar"},
+			Http: []*networking.HTTPRoute{{
+				Match: []*networking.HTTPMatchRequest{{
+					Uri: &networking.StringMatch{MatchType: &networking.StringMatch_Prefix{Prefix: "/a"}},
+					Headers: map[string]*networking.StringMatch{
+						"foo": {MatchType: &networking.StringMatch_Suffix{Suffix: "foo.example.com"}},
+					},
+				}},
+				Route: []*networking.HTTPRouteDestination{{
+					Destination: &networking.Destination{Host: "foo.baz"},
+				}},
+			}, {
+				Match: []*networking.HTTPMatchRequest{{
+					Uri: &networking.StringMatch{MatchType: &networking.StringMatch_Prefix{Prefix: "/a/b"}},
+					Headers: map[string]*networking.StringMatch{
+						"foo": {MatchType: &networking.StringMatch_Suffix{Suffix: ".example.com"}},
+					},
+				}},
+				Route: []*networking.HTTPRouteDestination{{
+					Destination: &networking.Destination{Host: "foo.baz"},
+				}},
+			}},
+		}, valid: true, warning: true},
+		{name: "disjoint suffix header match", in: &networking.VirtualService{
+			Hosts: []string{"foo.bar"},
+			Http: []*networking.HTTPRoute{{
+				Match: []*networking.HTTPMatchRequest{{
+					Uri: &networking.StringMatch{MatchType: &networking.StringMatch_Prefix{Prefix: "/a"}},
+					Headers: map[string]*networking.StringMatch{
+						"foo": {MatchType: &networking.StringMatch_Suffix{Suffix: "x.com"}},
+					},
+				}},
+				Route: []*networking.HTTPRouteDestination{{
+					Destination: &networking.Destination{Host: "foo.baz"},
+				}},
+			}, {
+				Match: []*networking.HTTPMatchRequest{{
+					Uri: &networking.StringMatch{MatchType: &networking.StringMatch_Prefix{Prefix: "/a/b"}},
+					Headers: map[string]*networking.StringMatch{
+						"foo": {MatchType: &networking.StringMatch_Suffix{Suffix: "x"}},
+					},
+				}},
+				Route: []*networking.HTTPRouteDestination{{
+					Destination: &networking.Destination{Host: "foo.baz"},
+				}},
+			}},
+		}, valid: true, warning: false},
 		{name: "allow sni based domains", in: &networking.VirtualService{
 			Hosts:    []string{"outbound_.15010_._.istiod.istio-system.svc.cluster.local"},
 			Gateways: []string{"ns1/gateway"},

--- a/pkg/config/validation/virtualservice.go
+++ b/pkg/config/validation/virtualservice.go
@@ -154,6 +154,11 @@ func validateHTTPRouteMatchRequest(http *networking.HTTPRoute) (errs error) {
 				}
 			}
 
+			// Envoy's RouteMatch does not support suffix path matching:
+			// https://github.com/envoyproxy/envoy/blob/v1.29.2/api/envoy/config/route/v3/route_components.proto#L541
+			if _, ok := match.GetUri().GetMatchType().(*networking.StringMatch_Suffix); ok {
+				errs = appendErrors(errs, fmt.Errorf(`"uri": suffix match type is not supported`))
+			}
 			// uri allows empty prefix match:
 			// https://github.com/envoyproxy/envoy/blob/v1.29.2/api/envoy/config/route/v3/route_components.proto#L560
 			// whereas scheme/method/authority does not:

--- a/pkg/config/validation/virtualservice_test.go
+++ b/pkg/config/validation/virtualservice_test.go
@@ -236,6 +236,36 @@ func TestValidateRootHTTPRoute(t *testing.T) {
 			}, valid: false,
 		},
 		{
+			name: "suffix header match", route: &networking.HTTPRoute{
+				Delegate: &networking.Delegate{
+					Name:      "test",
+					Namespace: "test",
+				},
+				Match: []*networking.HTTPMatchRequest{{
+					Headers: map[string]*networking.StringMatch{
+						"header": {
+							MatchType: &networking.StringMatch_Suffix{Suffix: "test"},
+						},
+					},
+				}},
+			}, valid: true,
+		},
+		{
+			name: "empty suffix header match (delegate)", route: &networking.HTTPRoute{
+				Delegate: &networking.Delegate{
+					Name:      "test",
+					Namespace: "test",
+				},
+				Match: []*networking.HTTPMatchRequest{{
+					Headers: map[string]*networking.StringMatch{
+						"header": {
+							MatchType: &networking.StringMatch_Suffix{Suffix: ""},
+						},
+					},
+				}},
+			}, valid: false,
+		},
+		{
 			name: "exact header match", route: &networking.HTTPRoute{
 				Delegate: &networking.Delegate{
 					Name:      "test",
@@ -348,6 +378,17 @@ func TestValidateRootHTTPRoute(t *testing.T) {
 				},
 			}},
 		}, valid: true},
+		{name: "suffix uri match", route: &networking.HTTPRoute{
+			Delegate: &networking.Delegate{
+				Name:      "test",
+				Namespace: "test",
+			},
+			Match: []*networking.HTTPMatchRequest{{
+				Uri: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Suffix{Suffix: "test"},
+				},
+			}},
+		}, valid: false},
 		{
 			name: "prefix queryParams match", route: &networking.HTTPRoute{
 				Delegate: &networking.Delegate{
@@ -503,6 +544,28 @@ func TestValidateDelegateHTTPRoute(t *testing.T) {
 				Destination: &networking.Destination{Host: "foo.baz"},
 			}},
 		}, valid: true},
+		{name: "suffix header match", route: &networking.HTTPRoute{
+			Route: []*networking.HTTPRouteDestination{{
+				Destination: &networking.Destination{Host: "foo.baz"},
+			}},
+			Match: []*networking.HTTPMatchRequest{{
+				Headers: map[string]*networking.StringMatch{
+					"header": {
+						MatchType: &networking.StringMatch_Suffix{Suffix: "test"},
+					},
+				},
+			}},
+		}, valid: true},
+		{name: "suffix uri match", route: &networking.HTTPRoute{
+			Route: []*networking.HTTPRouteDestination{{
+				Destination: &networking.Destination{Host: "foo.baz"},
+			}},
+			Match: []*networking.HTTPMatchRequest{{
+				Uri: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Suffix{Suffix: "test"},
+				},
+			}},
+		}, valid: false},
 		{name: "no destination", route: &networking.HTTPRoute{
 			Route: []*networking.HTTPRouteDestination{{
 				Destination: nil,

--- a/releasenotes/notes/61292.yaml
+++ b/releasenotes/notes/61292.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 61292
+releaseNotes:
+  - |
+    **Added** support for `suffix` string matching in `VirtualService` HTTP match conditions
+    (`headers`, `withoutHeaders`, `authority`, `scheme`, `method`, `queryParams`) and CORS `allowOrigins`.
+    Suffix matching is not supported for `uri`.

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -749,6 +749,67 @@ spec:
 		},
 	})
 	t.RunTraffic(TrafficTestCase{
+		name: "authority suffix match",
+		config: `
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: default
+spec:
+  hosts:
+    - b
+  http:
+  - match:
+    - authority:
+        suffix: .svc.cluster.local
+    route:
+    - destination:
+        host: b
+  - route:
+    - destination:
+        host: b
+    fault:
+      abort:
+        percentage:
+          value: 100
+        httpStatus: 418
+`,
+		children: []TrafficCall{
+			{
+				name: "matches suffix",
+				call: t.Apps.A[0].CallOrFail,
+				opts: echo.CallOptions{
+					To: t.Apps.B,
+					Port: echo.Port{
+						Name: "http",
+					},
+					HTTP: echo.HTTP{
+						Path:    "/foo",
+						Headers: HostHeader(t.Apps.B.Config().ClusterLocalFQDN()),
+					},
+					Count: 1,
+					Check: check.OK(),
+				},
+			},
+			{
+				name: "does not match suffix",
+				call: t.Apps.A[0].CallOrFail,
+				opts: echo.CallOptions{
+					To: t.Apps.B,
+					Port: echo.Port{
+						Name: "http",
+					},
+					HTTP: echo.HTTP{
+						Path:    "/foo",
+						Headers: HostHeader("b"),
+					},
+					Count: 1,
+					Check: check.Status(http.StatusTeapot),
+				},
+			},
+		},
+	})
+	t.RunTraffic(TrafficTestCase{
 		name: "rewrite uri",
 		config: `
 apiVersion: networking.istio.io/v1
@@ -1181,6 +1242,90 @@ spec:
 								Path: "/foo",
 								Headers: headers.New().
 									With("end-user", "not-jason").
+									Build(),
+							},
+							Count: 1,
+							Check: check.Status(http.StatusForbidden),
+						}
+					}(),
+				},
+				{
+					name: "do not have end-user header",
+					opts: func() echo.CallOptions {
+						return echo.CallOptions{
+							Port: echo.Port{
+								Name: "http",
+							},
+							HTTP: echo.HTTP{
+								Path: "/foo",
+							},
+							Count: 1,
+							Check: check.Status(http.StatusForbidden),
+						}
+					}(),
+				},
+			},
+			workloadAgnostic: true,
+		})
+
+		// access is denied when the request header `end-user` does not end with "son".
+		t.RunTraffic(TrafficTestCase{
+			name: "without headers suffix",
+			config: `
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: vs
+spec:
+  hosts:
+  - {{ .dstSvc }}
+  http:
+  - match:
+    - withoutHeaders:
+        end-user:
+          suffix: son
+    route:
+    - destination:
+        host: {{ .dstSvc }}
+    fault:
+      abort:
+        percentage:
+          value: 100
+        httpStatus: 403
+  - route:
+    - destination:
+        host: {{ .dstSvc }}
+`,
+			children: []TrafficCall{
+				{
+					name: "end-user ends with son",
+					opts: func() echo.CallOptions {
+						return echo.CallOptions{
+							Port: echo.Port{
+								Name: "http",
+							},
+							HTTP: echo.HTTP{
+								Path: "/foo",
+								Headers: headers.New().
+									With("end-user", "jason").
+									Build(),
+							},
+							Count: 1,
+							Check: check.Status(http.StatusOK),
+						}
+					}(),
+				},
+				{
+					name: "end-user does not end with son",
+					opts: func() echo.CallOptions {
+						return echo.CallOptions{
+							Port: echo.Port{
+								Name: "http",
+							},
+							HTTP: echo.HTTP{
+								Path: "/foo",
+								Headers: headers.New().
+									With("end-user", "mike").
 									Build(),
 							},
 							Count: 1,


### PR DESCRIPTION
**Please provide a description of this PR:**

Adds support for the new StringMatch "suffix" match type in headers, withoutHeaders, authority, scheme, method, queryParams and CORS allowOrigins, translated to Envoy's native StringMatcher "suffix" match.

Suffix matching is rejected for uri, since Envoy's RouteMatch has no suffix path matcher; the translation layer still defensively lowers a uri suffix match to a safe regex so an unvalidated config can never fall through to the catch-all prefix "/" match.

Fixes: https://github.com/istio/istio/issues/61292

**This PR must be merged only after https://github.com/istio/api/pull/3759 was merged!**