### PR TITLE
Reduce PeerAuthentication scanning by indexing on namespace

### DIFF
--- a/pilot/pkg/config/kube/agentgateway/agentgateway_controller.go
+++ b/pilot/pkg/config/kube/agentgateway/agentgateway_controller.go
@@ -540,7 +540,7 @@ func (c *Controller) buildAddressCollections(opts krt.OptionsBuilder) krt.Collec
 		meshConfig,
 		// Authz/Authn are not use for agentgateway, ignore
 		krt.NewStaticCollection[model.WorkloadAuthorization](nil, nil),
-		krt.NewStaticCollection[*securityclient.PeerAuthentication](nil, nil),
+		krt.NewNamespaceIndex(krt.NewStaticCollection[*securityclient.PeerAuthentication](nil, nil)),
 		waypoints,
 		services,
 		inputs.WorkloadEntries,

--- a/pilot/pkg/serviceregistry/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex.go
@@ -337,12 +337,13 @@ func New(options Options) Index {
 	}, opts.WithName("NamespacesInfo")...)
 
 	NodeLocality := NodesCollection(Nodes, opts.WithName("NodeLocality")...)
+	PeerAuthsByNs := krt.NewNamespaceIndex(PeerAuths)
 	Workloads := builder.WorkloadsCollection(
 		Pods,
 		NodeLocality,
 		a.meshConfig,
 		AuthorizationPolicies,
-		PeerAuths,
+		PeerAuthsByNs,
 		Waypoints,
 		WorkloadServices,
 		WorkloadEntries,

--- a/pilot/pkg/serviceregistry/ambient/multicluster.go
+++ b/pilot/pkg/serviceregistry/ambient/multicluster.go
@@ -262,6 +262,7 @@ func (a *index) buildGlobalCollections(
 	GlobalNodeLocality := GlobalNodesCollection(localCluster, LocalNodeLocality, a.mcController, opts)
 	GlobalNodeLocalityByCluster := multicluster.NestedCollectionIndexByCluster(GlobalNodeLocality)
 
+	localPeerAuthsByNs := krt.NewNamespaceIndex(localPeerAuths)
 	GlobalWorkloads := MergedGlobalWorkloadsCollection(
 		localCluster,
 		LocalWaypoints,
@@ -273,7 +274,7 @@ func (a *index) buildGlobalCollections(
 		GlobalNodeLocalityByCluster,
 		options.MeshConfig,
 		AuthorizationPolicies,
-		localPeerAuths,
+		localPeerAuthsByNs,
 		GlobalWaypoints,
 		WaypointsByCluster,
 		LocalWorkloadServices,

--- a/pilot/pkg/serviceregistry/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/ambient/workloads.go
@@ -63,7 +63,7 @@ func (a Builder) WorkloadsCollection(
 	nodes krt.Collection[Node],
 	meshConfig krt.Singleton[MeshConfig],
 	authorizationPolicies krt.Collection[model.WorkloadAuthorization],
-	peerAuths krt.Collection[*securityclient.PeerAuthentication],
+	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
 	workloadServices krt.Collection[model.ServiceInfo],
 	workloadEntries krt.Collection[*networkingclient.WorkloadEntry],
@@ -80,7 +80,7 @@ func (a Builder) WorkloadsCollection(
 		a.podWorkloadBuilder(
 			meshConfig,
 			authorizationPolicies,
-			peerAuths,
+			peerAuthsByNs,
 			waypoints,
 			workloadServices,
 			WorkloadServicesNamespaceIndex,
@@ -93,14 +93,14 @@ func (a Builder) WorkloadsCollection(
 	// Workloads coming from workloadEntries. These are 1:1 with WorkloadEntry.
 	WorkloadEntryWorkloads := krt.NewCollection(
 		workloadEntries,
-		a.workloadEntryWorkloadBuilder(meshConfig, authorizationPolicies, peerAuths, waypoints, workloadServices, WorkloadServicesNamespaceIndex, namespaces),
+		a.workloadEntryWorkloadBuilder(meshConfig, authorizationPolicies, peerAuthsByNs, waypoints, workloadServices, WorkloadServicesNamespaceIndex, namespaces),
 		opts.WithName("WorkloadEntryWorkloads")...,
 	)
 	// Workloads coming from serviceEntries. These are inlined workloadEntries (under `spec.endpoints`); these serviceEntries will
 	// also be generating `workloadapi.Service` definitions in the `ServicesCollection` logic.
 	ServiceEntryWorkloads := krt.NewManyCollection(
 		serviceEntries,
-		a.serviceEntryWorkloadBuilder(meshConfig, authorizationPolicies, peerAuths, waypoints, namespaces, workloadServices),
+		a.serviceEntryWorkloadBuilder(meshConfig, authorizationPolicies, peerAuthsByNs, waypoints, namespaces, workloadServices),
 		opts.WithName("ServiceEntryWorkloads")...,
 	)
 	// Workloads coming from endpointSlices. These are for *manually added* endpoints. Typically, Kubernetes will insert each pod
@@ -144,7 +144,7 @@ func MergedGlobalWorkloadsCollection(
 	nodesByCluster krt.Index[cluster.ID, krt.Collection[krt.ObjectWithCluster[Node]]],
 	meshConfig krt.Singleton[MeshConfig],
 	localAuthorizationPolicies krt.Collection[model.WorkloadAuthorization],
-	localPeerAuths krt.Collection[*securityclient.PeerAuthentication],
+	localPeerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	globalWaypoints krt.Collection[krt.Collection[Waypoint]],
 	waypointsByCluster krt.Index[cluster.ID, krt.Collection[Waypoint]],
 	localWorkloadServices krt.Collection[model.ServiceInfo],
@@ -164,7 +164,7 @@ func MergedGlobalWorkloadsCollection(
 			meshConfig,
 			globalNetworks.FetchLocalNetworkID,
 			localAuthorizationPolicies,
-			localPeerAuths,
+			localPeerAuthsByNs,
 			localWaypoints,
 			localWorkloadServices,
 			LocalWorkloadServicesNamespaceIndex,
@@ -191,7 +191,7 @@ func MergedGlobalWorkloadsCollection(
 			meshConfig,
 			globalNetworks.FetchLocalNetworkID,
 			localAuthorizationPolicies,
-			localPeerAuths,
+			localPeerAuthsByNs,
 			localWaypoints,
 			localWorkloadServices,
 			LocalWorkloadServicesNamespaceIndex,
@@ -216,7 +216,7 @@ func MergedGlobalWorkloadsCollection(
 		serviceEntryWorkloadBuilder(
 			meshConfig,
 			localAuthorizationPolicies,
-			localPeerAuths,
+			localPeerAuthsByNs,
 			localWaypoints,
 			localCluster.Namespaces(),
 			localWorkloadServices,
@@ -336,7 +336,7 @@ func MergedGlobalWorkloadsCollection(
 					meshConfig,
 					globalNetworks.FetchLocalNetworkID,
 					localAuthorizationPolicies,
-					localPeerAuths,
+					localPeerAuthsByNs,
 					waypoints,
 					globalWorkloadServices,
 					WorkloadServicesNamespaceIndex,
@@ -384,7 +384,7 @@ func MergedGlobalWorkloadsCollection(
 					meshConfig,
 					globalNetworks.FetchLocalNetworkID,
 					localAuthorizationPolicies,
-					localPeerAuths,
+					localPeerAuthsByNs,
 					waypoints,
 					globalWorkloadServices,
 					WorkloadServicesNamespaceIndex,
@@ -429,7 +429,7 @@ func MergedGlobalWorkloadsCollection(
 				serviceEntryWorkloadBuilder(
 					meshConfig,
 					localAuthorizationPolicies,
-					localPeerAuths,
+					localPeerAuthsByNs,
 					waypoints,
 					namespaces,
 					globalWorkloadServices,
@@ -527,7 +527,7 @@ func workloadEntryWorkloadBuilder(
 	meshConfig krt.Singleton[MeshConfig],
 	localNetworkGetter func(krt.HandlerContext) network.ID,
 	authorizationPolicies krt.Collection[model.WorkloadAuthorization],
-	peerAuths krt.Collection[*securityclient.PeerAuthentication],
+	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
 	workloadServices krt.Collection[model.ServiceInfo],
 	workloadServicesNamespaceIndex krt.Index[string, model.ServiceInfo],
@@ -542,7 +542,7 @@ func workloadEntryWorkloadBuilder(
 		// WLE can put labels in multiple places; normalize this
 		wle = serviceentry.ConvertClientWorkloadEntry(wle)
 		meshCfg := krt.FetchOne(ctx, meshConfig.AsCollection())
-		policies := buildWorkloadPolicies(ctx, authorizationPolicies, peerAuths, meshCfg, wle.Labels, wle.Namespace)
+		policies := buildWorkloadPolicies(ctx, authorizationPolicies, peerAuthsByNs, meshCfg, wle.Labels, wle.Namespace)
 
 		appTunnel, targetWaypoint, waypointErr := computeWaypoint(ctx, waypoints, namespaces, wle.ObjectMeta)
 
@@ -616,7 +616,7 @@ func workloadEntryWorkloadBuilder(
 func (a Builder) workloadEntryWorkloadBuilder(
 	meshConfig krt.Singleton[MeshConfig],
 	authorizationPolicies krt.Collection[model.WorkloadAuthorization],
-	peerAuths krt.Collection[*securityclient.PeerAuthentication],
+	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
 	workloadServices krt.Collection[model.ServiceInfo],
 	workloadServicesNamespaceIndex krt.Index[string, model.ServiceInfo],
@@ -626,7 +626,7 @@ func (a Builder) workloadEntryWorkloadBuilder(
 		meshConfig,
 		a.Networks.FetchLocalNetworkID,
 		authorizationPolicies,
-		peerAuths,
+		peerAuthsByNs,
 		waypoints,
 		workloadServices,
 		workloadServicesNamespaceIndex,
@@ -669,7 +669,7 @@ func podWorkloadBuilder(
 	meshConfig krt.Singleton[MeshConfig],
 	localNetworkGetter func(krt.HandlerContext) network.ID,
 	authorizationPolicies krt.Collection[model.WorkloadAuthorization],
-	peerAuths krt.Collection[*securityclient.PeerAuthentication],
+	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
 	workloadServices krt.Collection[model.ServiceInfo],
 	workloadServicesNamespaceIndex krt.Index[string, model.ServiceInfo],
@@ -706,7 +706,7 @@ func podWorkloadBuilder(
 			return nil
 		}
 		meshCfg := krt.FetchOne(ctx, meshConfig.AsCollection())
-		policies := buildWorkloadPolicies(ctx, authorizationPolicies, peerAuths, meshCfg, p.Labels, p.Namespace)
+		policies := buildWorkloadPolicies(ctx, authorizationPolicies, peerAuthsByNs, meshCfg, p.Labels, p.Namespace)
 		fo := []krt.FetchOption{krt.FilterIndex(workloadServicesNamespaceIndex, p.Namespace), krt.FilterSelectsNonEmpty(p.GetLabels())}
 		if !features.EnableServiceEntrySelectPods {
 			fo = append(fo, krt.FilterGeneric(func(a any) bool {
@@ -774,7 +774,7 @@ func podWorkloadBuilder(
 func (a Builder) podWorkloadBuilder(
 	meshConfig krt.Singleton[MeshConfig],
 	authorizationPolicies krt.Collection[model.WorkloadAuthorization],
-	peerAuths krt.Collection[*securityclient.PeerAuthentication],
+	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
 	workloadServices krt.Collection[model.ServiceInfo],
 	workloadServicesNamespaceIndex krt.Index[string, model.ServiceInfo],
@@ -786,7 +786,7 @@ func (a Builder) podWorkloadBuilder(
 		meshConfig,
 		a.Networks.FetchLocalNetworkID,
 		authorizationPolicies,
-		peerAuths,
+		peerAuthsByNs,
 		waypoints,
 		workloadServices,
 		workloadServicesNamespaceIndex,
@@ -870,7 +870,7 @@ func matchingServicesWithoutSelectors(
 func buildWorkloadPolicies(
 	ctx krt.HandlerContext,
 	authorizationPolicies krt.Collection[model.WorkloadAuthorization],
-	peerAuths krt.Collection[*securityclient.PeerAuthentication],
+	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	meshCfg *MeshConfig,
 	workloadLabels map[string]string,
 	workloadNamespace string,
@@ -895,7 +895,7 @@ func buildWorkloadPolicies(
 		return t.ResourceName()
 	}))
 	// We could do a non-FilterGeneric but krt currently blows up if we depend on the same collection twice
-	auths := fetchPeerAuthentications(ctx, peerAuths, meshCfg, workloadNamespace, workloadLabels)
+	auths := fetchPeerAuthentications(ctx, peerAuthsByNs, meshCfg, workloadNamespace, workloadLabels)
 	policies = append(policies, convertedSelectorPeerAuthentications(meshCfg.GetRootNamespace(), auths)...)
 	return policies
 }
@@ -903,7 +903,7 @@ func buildWorkloadPolicies(
 func serviceEntryWorkloadBuilder(
 	meshConfig krt.Singleton[MeshConfig],
 	authorizationPolicies krt.Collection[model.WorkloadAuthorization],
-	peerAuths krt.Collection[*securityclient.PeerAuthentication],
+	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
 	namespaces krt.Collection[*v1.Namespace],
 	workloadServices krt.Collection[model.ServiceInfo],
@@ -961,7 +961,7 @@ func serviceEntryWorkloadBuilder(
 				services = []model.ServiceInfo{allServices[i]}
 			}
 
-			policies := buildWorkloadPolicies(ctx, authorizationPolicies, peerAuths, meshCfg, se.Labels, se.Namespace)
+			policies := buildWorkloadPolicies(ctx, authorizationPolicies, peerAuthsByNs, meshCfg, se.Labels, se.Namespace)
 
 			var appTunnel *workloadapi.ApplicationTunnel
 			var targetWaypoint *Waypoint
@@ -1025,7 +1025,7 @@ func serviceEntryWorkloadBuilder(
 func (a Builder) serviceEntryWorkloadBuilder(
 	meshConfig krt.Singleton[MeshConfig],
 	authorizationPolicies krt.Collection[model.WorkloadAuthorization],
-	peerAuths krt.Collection[*securityclient.PeerAuthentication],
+	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
 	namespaces krt.Collection[*v1.Namespace],
 	workloadServices krt.Collection[model.ServiceInfo],
@@ -1033,7 +1033,7 @@ func (a Builder) serviceEntryWorkloadBuilder(
 	return serviceEntryWorkloadBuilder(
 		meshConfig,
 		authorizationPolicies,
-		peerAuths,
+		peerAuthsByNs,
 		waypoints,
 		namespaces,
 		workloadServices,
@@ -1221,25 +1221,28 @@ func pickTrustDomain(mesh *MeshConfig) string {
 
 func fetchPeerAuthentications(
 	ctx krt.HandlerContext,
-	peerAuths krt.Collection[*securityclient.PeerAuthentication],
+	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	meshCfg *MeshConfig,
 	ns string,
 	matchLabels map[string]string,
 ) []*securityclient.PeerAuthentication {
-	return krt.Fetch(ctx, peerAuths, krt.FilterGeneric(func(a any) bool {
-		pol := a.(*securityclient.PeerAuthentication)
-		if pol.Namespace == meshCfg.GetRootNamespace() && pol.Spec.Selector == nil {
-			return true
-		}
-		if pol.Namespace != ns {
-			return false
-		}
-		sel := pol.Spec.Selector
+	// Policies in the workload's own namespace apply if they have no selector or their selector matches.
+	auths := peerAuthsByNs.Fetch(ctx, ns, krt.FilterGeneric(func(a any) bool {
+		sel := a.(*securityclient.PeerAuthentication).Spec.Selector
 		if sel == nil {
 			return true // No selector matches everything
 		}
 		return labels.Instance(sel.MatchLabels).SubsetOf(matchLabels)
 	}))
+	// Mesh-wide policies live in the root namespace and must not have a selector. When the workload is
+	// itself in the root namespace, these are already covered by the fetch above.
+	if rootNamespace := meshCfg.GetRootNamespace(); ns != rootNamespace {
+		rootAuths := peerAuthsByNs.Fetch(ctx, rootNamespace, krt.FilterGeneric(func(a any) bool {
+			return a.(*securityclient.PeerAuthentication).Spec.Selector == nil
+		}))
+		auths = append(auths, rootAuths...)
+	}
+	return auths
 }
 
 func constructServicesFromWorkloadEntry(p *networkingv1alpha3.WorkloadEntry, services []model.ServiceInfo) map[string]*workloadapi.PortList {

--- a/pilot/pkg/serviceregistry/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/ambient/workloads_test.go
@@ -838,7 +838,7 @@ func TestPodWorkloads(t *testing.T) {
 			builder := a.podWorkloadBuilder(
 				GetMeshConfig(mock),
 				krttest.GetMockCollection[model.WorkloadAuthorization](mock),
-				krttest.GetMockCollection[*securityclient.PeerAuthentication](mock),
+				krt.NewNamespaceIndex(krttest.GetMockCollection[*securityclient.PeerAuthentication](mock)),
 				krttest.GetMockCollection[Waypoint](mock),
 				WorkloadServices,
 				WorkloadServicesNamespaceIndex,
@@ -1446,7 +1446,7 @@ func TestWorkloadEntryWorkloads(t *testing.T) {
 			builder := a.workloadEntryWorkloadBuilder(
 				GetMeshConfig(mock),
 				krttest.GetMockCollection[model.WorkloadAuthorization](mock),
-				krttest.GetMockCollection[*securityclient.PeerAuthentication](mock),
+				krt.NewNamespaceIndex(krttest.GetMockCollection[*securityclient.PeerAuthentication](mock)),
 				krttest.GetMockCollection[Waypoint](mock),
 				WorkloadServices,
 				WorkloadServicesNamespaceIndex,
@@ -1693,7 +1693,7 @@ func TestWorkloadEntryConditions(t *testing.T) {
 			builder := a.workloadEntryWorkloadBuilder(
 				GetMeshConfig(mock),
 				krttest.GetMockCollection[model.WorkloadAuthorization](mock),
-				krttest.GetMockCollection[*securityclient.PeerAuthentication](mock),
+				krt.NewNamespaceIndex(krttest.GetMockCollection[*securityclient.PeerAuthentication](mock)),
 				krttest.GetMockCollection[Waypoint](mock),
 				WorkloadServices,
 				WorkloadServicesNamespaceIndex,
@@ -1938,7 +1938,7 @@ func TestServiceEntryWorkloads(t *testing.T) {
 			builder := a.serviceEntryWorkloadBuilder(
 				GetMeshConfig(mock),
 				krttest.GetMockCollection[model.WorkloadAuthorization](mock),
-				krttest.GetMockCollection[*securityclient.PeerAuthentication](mock),
+				krt.NewNamespaceIndex(krttest.GetMockCollection[*securityclient.PeerAuthentication](mock)),
 				krttest.GetMockCollection[Waypoint](mock),
 				krttest.GetMockCollection[*v1.Namespace](mock),
 				krttest.GetMockCollection[model.ServiceInfo](mock),

--- a/releasenotes/notes/peerauth-by-ns.yaml
+++ b/releasenotes/notes/peerauth-by-ns.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Improved** performance when fetching PeerAuthentications for a given workload.


### PR DESCRIPTION
Index PeerAuthentications by namespace and fetch only the workload's namespace and the root namespace, instead of scanning every PeerAuthentication for each workload.

**Please provide a description of this PR:**
fixes https://github.com/istio/istio/issues/61254