### PR TITLE
ambient: make ambient index sync when remote clusters sync

### DIFF
--- a/pilot/pkg/serviceregistry/ambient/ambientindex_multicluster_test.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex_multicluster_test.go
@@ -1059,12 +1059,19 @@ func TestMulticlusterAmbientIndex_ClusterLifecycleNoLeak(t *testing.T) {
 		// on the Clusters collection directly: capture the current cluster's stop channel and wait for
 		// an event carrying a remote-cluster-2 with a *different* stop (the swap surfaces as a delete of
 		// the not-yet-ready cluster followed by an add once it syncs, not necessarily a single update).
+		var oldStop <-chan struct{}
+		for _, c := range clusters.List() {
+			if c.ID == "remote-cluster-2" {
+				oldStop = c.GetStop()
+			}
+		}
 		s.AddSecret("s2", "remote-cluster-2")
 		select {
 		case <-swapped:
 		case <-time.After(30 * time.Second):
 			t.Fatal("timed out waiting for remote-cluster-2 swap event")
 		}
+		<-oldStop
 
 		// Remove so the subtest ends back at the single warm-up cluster, matching the leak.Check baseline.
 		s.DeleteSecret("s2")

--- a/pilot/pkg/serviceregistry/ambient/ambientindex_multicluster_test.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex_multicluster_test.go
@@ -31,6 +31,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/kclient/clienttest"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/kube/multicluster"
@@ -1020,6 +1021,7 @@ func TestMulticlusterAmbientIndex_ClusterLifecycleNoLeak(t *testing.T) {
 
 		s.AddSecret("s2", "remote-cluster-2")
 		waitRemoteClusters(t, 2)
+
 		s.DeleteSecret("s2")
 		waitRemoteClusters(t, 1)
 	})
@@ -1030,10 +1032,7 @@ func TestMulticlusterAmbientIndex_ClusterLifecycleNoLeak(t *testing.T) {
 		swapped := make(chan struct{}, 1)
 		reg := clusters.RegisterBatch(func(events []krt.Event[*multicluster.Cluster]) {
 			for _, e := range events {
-				if e.New == nil {
-					continue
-				}
-				if c := *e.New; c.ID == "remote-cluster-2" {
+				if e.Event == controllers.EventUpdate && e.Latest().ID == "remote-cluster-2" {
 					select {
 					case swapped <- struct{}{}:
 					default:
@@ -1045,11 +1044,6 @@ func TestMulticlusterAmbientIndex_ClusterLifecycleNoLeak(t *testing.T) {
 		reg.WaitUntilSynced(test.NewStop(t))
 
 		s.AddSecret("s2", "remote-cluster-2")
-		select {
-		case <-swapped:
-		case <-time.After(30 * time.Second):
-			t.Fatal("timed out waiting for remote-cluster-2 swap event")
-		}
 		waitRemoteClusters(t, 2)
 
 		// Update the cluster: re-adding the secret with a fresh kubeconfig swaps in a new Cluster (new

--- a/pilot/pkg/serviceregistry/ambient/ambientindex_multicluster_test.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex_multicluster_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -987,31 +988,86 @@ func (a *ambientTestServer) AddSecret(secretName, clusterID string) {
 // add/remove cycles run in a subtest wrapped in leak.Check.
 func TestMulticlusterAmbientIndex_ClusterLifecycleNoLeak(t *testing.T) {
 	test.SetForTest(t, &features.EnableAmbientMultiNetwork, true)
-	s := newAmbientTestServer(t, testC, testNW, "")
+	// Build the index WITHOUT starting the config cluster client. This lets us create the warmup
+	// remote-cluster secret up front and have it processed as part of the very first sync, so that
+	// waiting on HasSynced deterministically means "all global collections are wired up".
+	s := newAmbientTestServerWithFlags(t, testC, testNW, FeatureFlags{
+		DefaultAllowFromWaypoint:              features.DefaultAllowFromWaypoint,
+		EnableK8SServiceSelectWorkloadEntries: features.EnableK8SServiceSelectWorkloadEntries,
+	}, "", false /* runClient */)
 	clusters := s.mcController.Clusters()
+	cl := s.mcController.ConfigCluster().Client
 
-	waitRemoteClusters := func(n int) {
+	waitRemoteClusters := func(t *testing.T, n int) {
 		t.Helper()
 		assert.EventuallyEqual(t, func() int { return len(clusters.List()) }, n)
 	}
 
-	// Warm-up cycle: long-lived global collections lazily register a few dependency handlers the
-	// first time they process a remote cluster. Do one add/remove up front so those one-time
-	// registrations exist before leak.Check snapshots the baseline (they are fixed, not per-cycle).
-	s.AddSecret("s1", "remote-cluster")
-	waitRemoteClusters(1)
-	s.DeleteSecret("s1")
-	waitRemoteClusters(0)
+	// Warm-up: create a remote cluster BEFORE running the client. Global collections lazily wire up
+	// per-cluster dependency handlers the first time they see a remote cluster; doing this as part of
+	// the initial sync (gated by HasSynced) guarantees they are all created before leak.Check snapshots
+	// its baseline. We intentionally do NOT remove this cluster: teardown is async, and leaving the
+	// cluster in place keeps us in a stable, fully-initialized steady state. The subtests exercise
+	// add/remove of a *second* cluster and must return to this baseline.
+	s.AddSecret("s1", "remote-cluster-1")
+	t.Cleanup(cl.Shutdown)
+	cl.RunAndWait(test.NewStop(t))
+	assert.EventuallyEqual(t, s.HasSynced, true)
+	waitRemoteClusters(t, 1)
 
 	t.Run("add-remove-cluster", func(t *testing.T) {
 		leak.Check(t)
 
-		const iterations = 5
-		for i := 0; i < iterations; i++ {
-			s.AddSecret("s1", "remote-cluster")
-			waitRemoteClusters(1)
-			s.DeleteSecret("s1")
-			waitRemoteClusters(0)
+		s.AddSecret("s2", "remote-cluster-2")
+		waitRemoteClusters(t, 2)
+		s.DeleteSecret("s2")
+		waitRemoteClusters(t, 1)
+	})
+
+	t.Run("update-then-remove-cluster", func(t *testing.T) {
+		leak.Check(t)
+
+		swapped := make(chan struct{}, 1)
+		reg := clusters.RegisterBatch(func(events []krt.Event[*multicluster.Cluster]) {
+			for _, e := range events {
+				if e.New == nil {
+					continue
+				}
+				if c := *e.New; c.ID == "remote-cluster-2" {
+					select {
+					case swapped <- struct{}{}:
+					default:
+					}
+				}
+			}
+		}, false)
+		defer reg.UnregisterHandler()
+		reg.WaitUntilSynced(test.NewStop(t))
+
+		s.AddSecret("s2", "remote-cluster-2")
+		select {
+		case <-swapped:
+		case <-time.After(30 * time.Second):
+			t.Fatal("timed out waiting for remote-cluster-2 swap event")
 		}
+		waitRemoteClusters(t, 2)
+
+		// Update the cluster: re-adding the secret with a fresh kubeconfig swaps in a new Cluster (new
+		// stop + collections), tearing down the old one. This is the teardown path we verify doesn't
+		// leak. The cluster count stays at 2 across the update, so waitRemoteClusters would return
+		// immediately without the swap having propagated into the collection. Instead, observe the swap
+		// on the Clusters collection directly: capture the current cluster's stop channel and wait for
+		// an event carrying a remote-cluster-2 with a *different* stop (the swap surfaces as a delete of
+		// the not-yet-ready cluster followed by an add once it syncs, not necessarily a single update).
+		s.AddSecret("s2", "remote-cluster-2")
+		select {
+		case <-swapped:
+		case <-time.After(30 * time.Second):
+			t.Fatal("timed out waiting for remote-cluster-2 swap event")
+		}
+
+		// Remove so the subtest ends back at the single warm-up cluster, matching the leak.Check baseline.
+		s.DeleteSecret("s2")
+		waitRemoteClusters(t, 1)
 	})
 }

--- a/pilot/pkg/serviceregistry/ambient/ambientindex_serviceentry_test.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex_serviceentry_test.go
@@ -522,7 +522,7 @@ func TestAmbientIndex_ServiceEntry_DisableK8SServiceSelectWorkloadEntries(t *tes
 			s := newAmbientTestServerWithFlags(t, testC, testNW, FeatureFlags{
 				DefaultAllowFromWaypoint:              features.DefaultAllowFromWaypoint,
 				EnableK8SServiceSelectWorkloadEntries: false,
-			}, "")
+			}, "", true)
 
 			s.addPods(t, "140.140.0.10", "pod1", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
 			s.assertEvent(t, s.podXdsName("pod1"))

--- a/pilot/pkg/serviceregistry/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex_test.go
@@ -1629,7 +1629,7 @@ func TestDefaultAllowWaypointPolicy(t *testing.T) {
 			s := newAmbientTestServerWithFlags(t, testC, testNW, FeatureFlags{
 				DefaultAllowFromWaypoint:              true,
 				EnableK8SServiceSelectWorkloadEntries: features.EnableK8SServiceSelectWorkloadEntries,
-			}, "")
+			}, "", true)
 			setupPolicyTest(t, s)
 
 			t.Run("policy with service accounts", func(t *testing.T) {
@@ -2354,7 +2354,7 @@ func newAmbientTestServer(t *testing.T, clusterID cluster.ID, networkID network.
 	return newAmbientTestServerWithFlags(t, clusterID, networkID, FeatureFlags{
 		DefaultAllowFromWaypoint:              features.DefaultAllowFromWaypoint,
 		EnableK8SServiceSelectWorkloadEntries: features.EnableK8SServiceSelectWorkloadEntries,
-	}, revision)
+	}, revision, true)
 }
 
 func newAmbientTestServerFromOptions(t *testing.T, networkID network.ID, options Options, runClient bool) *ambientTestServer {
@@ -2458,7 +2458,14 @@ func newAmbientTestServerFromOptions(t *testing.T, networkID network.ID, options
 	return a
 }
 
-func newAmbientTestServerWithFlags(t *testing.T, clusterID cluster.ID, networkID network.ID, flags FeatureFlags, revision string) *ambientTestServer {
+func newAmbientTestServerWithFlags(
+	t *testing.T,
+	clusterID cluster.ID,
+	networkID network.ID,
+	flags FeatureFlags,
+	revision string,
+	runClient bool,
+) *ambientTestServer {
 	up := xdsfake.NewFakeXDS()
 	up.SplitEvents = true
 	cl := kubeclient.NewFakeClient()
@@ -2520,7 +2527,7 @@ func newAmbientTestServerWithFlags(t *testing.T, clusterID cluster.ID, networkID
 		}
 	}
 
-	return newAmbientTestServerFromOptions(t, networkID, o, true)
+	return newAmbientTestServerFromOptions(t, networkID, o, runClient)
 }
 
 func dumpOnFailure(t *testing.T, debugger *krt.DebugHandler) {

--- a/pilot/pkg/serviceregistry/ambient/ambientindex_workloadentry_test.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex_workloadentry_test.go
@@ -449,7 +449,7 @@ func TestAmbientIndex_WorkloadEntries_DisableK8SServiceSelectWorkloadEntries(t *
 			s := newAmbientTestServerWithFlags(t, testC, testNW, FeatureFlags{
 				DefaultAllowFromWaypoint:              features.DefaultAllowFromWaypoint,
 				EnableK8SServiceSelectWorkloadEntries: false,
-			}, "")
+			}, "", true)
 
 			s.addWorkloadEntries(t, "127.0.0.1", "name1", "sa1", map[string]string{"app": "a"})
 			s.assertEvent(t, s.wleXdsName("name1"))

--- a/pkg/kube/multicluster/cluster.go
+++ b/pkg/kube/multicluster/cluster.go
@@ -435,3 +435,29 @@ func (c *Cluster) WaitUntilSynced(stop <-chan struct{}) bool {
 
 	return true
 }
+
+// WaitUntilInitiallySynced waits for the cluster to be fully synced
+// compared to WaitUntilSynced, this method does not return when cluster initial sync has timed out,
+// it will only return when the cluster is closed, has synced or the stop channel is closed.
+func (c *Cluster) WaitUntilInitiallySynced(stop <-chan struct{}) bool {
+	if c.Closed() {
+		return true
+	}
+	if c.initialSync.Load() {
+		return true
+	}
+
+	// First wait to confirm all of the collections are assigned
+	// and then check if they are synced.
+	kube.WaitForCacheSync(fmt.Sprintf("cluster[%s] synced", c.ID), stop, func() bool {
+		if c.Closed() {
+			return true
+		}
+		if c.initialSync.Load() {
+			return true
+		}
+		return false
+	})
+
+	return true
+}

--- a/pkg/kube/multicluster/clusterstore.go
+++ b/pkg/kube/multicluster/clusterstore.go
@@ -101,7 +101,7 @@ func (c *ClusterStore) Swap(secretKey string, clusterID cluster.ID, value *Clust
 	if exists && c.clustersAwaitingSync.Contains(clusterID) {
 		c.clustersAwaitingSync.Delete(clusterID)
 	}
-	// If the previous cluster is currently serviceable, keep serving it via AllReady until the new
+	// If the previous cluster is currently ready, keep serving it via AllReady until the new
 	// (not-yet-synced) cluster syncs. This preserves make-before-break at the collection level:
 	// otherwise AllReady would drop the cluster (emitting a spurious delete followed by an add once
 	// the new cluster syncs) instead of a single update.
@@ -258,7 +258,8 @@ func (c *ClusterStore) HasSynced() bool {
 
 // clusterReady reports whether a cluster is currently usable: it is still open
 // and it's synced. Used to decide whether the previous cluster can keep serving
-// during an in-flight update.
+// during an in-flight update and allow performing an atomic swap of clusters without
+// dropping the cluster from the collection.
 func clusterReady(cl *Cluster) bool {
 	return cl != nil && !cl.Closed() && cl.HasSynced() && !cl.SyncDidTimeout()
 }

--- a/pkg/kube/multicluster/clusterstore.go
+++ b/pkg/kube/multicluster/clusterstore.go
@@ -170,8 +170,17 @@ func (c *ClusterStore) AllReady() map[string]map[cluster.ID]*Cluster {
 	out := make(map[string]map[cluster.ID]*Cluster)
 	for secret, clusters := range c.remoteClusters {
 		for cid, cl := range clusters {
-			if cl.Closed() || cl.SyncDidTimeout() {
-				log.Warnf("remote cluster %s is closed or timed out, omitting it from the clusters collection", cl.ID)
+			if cl.Closed() {
+				log.Warnf("remote cluster %s is closed, omitting it from the clusters collection", cl.ID)
+				continue
+			}
+			// If the cluster has timed out, we don't want to serve it, but we also don't want to drop it entirely.
+			// Instead, we wait for it to sync (or fail) and then recompute the collection.
+			if cl.SyncDidTimeout() {
+				log.Warnf("remote cluster %s is timed out, omitting it from the clusters collection", cl.ID)
+				c.triggerRecomputeOnSync(cl)
+				// we should also clear the previous cluster if it exists, since the new cluster is not usable and we don't want to keep serving it.
+				c.clearPreviousCluster(cid)
 				continue
 			}
 			if !cl.HasSynced() {

--- a/pkg/kube/multicluster/clusterstore.go
+++ b/pkg/kube/multicluster/clusterstore.go
@@ -30,7 +30,11 @@ type ClusterStore struct {
 	remoteClusters       map[string]map[cluster.ID]*Cluster
 	clusters             sets.String
 	clustersAwaitingSync sets.Set[cluster.ID]
-	casMu                sync.Mutex
+	// previousClusters holds, per cluster ID, the previous synced cluster during an in-flight
+	// update (make-before-break). AllReady keeps serving it until the new cluster has synced,
+	// so the cluster is not momentarily dropped from the collection. Guarded by casMu.
+	previousClusters map[cluster.ID]*Cluster
+	casMu            sync.Mutex
 	*krt.RecomputeTrigger
 }
 
@@ -58,6 +62,7 @@ func NewClustersStore() *ClusterStore {
 		clusters:             sets.New[string](),
 		RecomputeTrigger:     krt.NewRecomputeTrigger(false),
 		clustersAwaitingSync: sets.New[cluster.ID](),
+		previousClusters:     make(map[cluster.ID]*Cluster),
 	}
 }
 
@@ -96,6 +101,13 @@ func (c *ClusterStore) Swap(secretKey string, clusterID cluster.ID, value *Clust
 	if exists && c.clustersAwaitingSync.Contains(clusterID) {
 		c.clustersAwaitingSync.Delete(clusterID)
 	}
+	// If the previous cluster is currently serviceable, keep serving it via AllReady until the new
+	// (not-yet-synced) cluster syncs. This preserves make-before-break at the collection level:
+	// otherwise AllReady would drop the cluster (emitting a spurious delete followed by an add once
+	// the new cluster syncs) instead of a single update.
+	if clusterServable(prev) {
+		c.previousClusters[clusterID] = prev
+	}
 	c.TriggerRecomputation()
 
 	return &PendingClusterSwap{
@@ -114,6 +126,7 @@ func (c *ClusterStore) Delete(secretKey string, clusterID cluster.ID) {
 	if c.clustersAwaitingSync.Contains(clusterID) {
 		c.clustersAwaitingSync.Delete(clusterID)
 	}
+	delete(c.previousClusters, clusterID)
 	if len(c.remoteClusters[secretKey]) == 0 {
 		delete(c.remoteClusters, secretKey)
 	}
@@ -163,9 +176,21 @@ func (c *ClusterStore) AllReady() map[string]map[cluster.ID]*Cluster {
 			}
 			if !cl.HasSynced() {
 				log.Debugf("remote cluster %s registered informers have not been synced up yet. Skipping and will recompute on sync", cl.ID)
+				// During an in-flight update, keep serving the previous synced cluster until the new
+				// one syncs, so it is not momentarily dropped from the collection (make-before-break).
+				if prev := c.getPreviousCluster(cid); clusterServable(prev) {
+					log.Debugf("serving previous synced cluster %s while its update syncs", cid)
+					outCluster := *prev
+					if _, ok := out[secret]; !ok {
+						out[secret] = make(map[cluster.ID]*Cluster)
+					}
+					out[secret][cid] = &outCluster
+				}
 				c.triggerRecomputeOnSync(cl)
 				continue
 			}
+			// The new cluster has synced; stop tracking the previous cluster we were serving.
+			c.clearPreviousCluster(cid)
 			outCluster := *cl
 			if _, ok := out[secret]; !ok {
 				out[secret] = make(map[cluster.ID]*Cluster)
@@ -229,6 +254,27 @@ func (c *ClusterStore) HasSynced() bool {
 	}
 
 	return true
+}
+
+// clusterServable reports whether a cluster is currently usable: synced and neither
+// closed nor timed out. Used to decide whether the previous cluster can keep serving
+// during an in-flight update.
+func clusterServable(cl *Cluster) bool {
+	return cl != nil && !cl.Closed() && !cl.SyncDidTimeout() && cl.HasSynced()
+}
+
+// getPreviousCluster returns the previous cluster tracked for an in-flight update, if any.
+func (c *ClusterStore) getPreviousCluster(id cluster.ID) *Cluster {
+	c.casMu.Lock()
+	defer c.casMu.Unlock()
+	return c.previousClusters[id]
+}
+
+// clearPreviousCluster stops tracking the previous cluster for the given cluster ID.
+func (c *ClusterStore) clearPreviousCluster(id cluster.ID) {
+	c.casMu.Lock()
+	defer c.casMu.Unlock()
+	delete(c.previousClusters, id)
 }
 
 // triggerRecomputeOnSync sets up a goroutine to wait for the cluster to be synced,

--- a/pkg/kube/multicluster/clusterstore.go
+++ b/pkg/kube/multicluster/clusterstore.go
@@ -277,7 +277,7 @@ func (c *ClusterStore) clearPreviousCluster(id cluster.ID) {
 	delete(c.previousClusters, id)
 }
 
-// triggerRecomputeOnSync sets up a goroutine to wait for the cluster to be synced,
+// triggerRecomputeOnSync sets up a goroutine to wait for the cluster to be fully synced,
 // and then triggers a recompute when it is. Callers must pass the cluster directly
 // rather than its ID: AllReady holds the store RLock when calling this, and looking
 // the cluster up here would attempt a recursive RLock that can deadlock against a
@@ -294,13 +294,13 @@ func (c *ClusterStore) triggerRecomputeOnSync(cl *Cluster) {
 	}
 
 	go func() {
-		// Wait until the cluster is synced. If it's deleted from the store before
+		// Wait until the cluster is fully synced. If it's deleted from the store before
 		// it's fully synced, this will return because of the stop.
 		// Double check to make sure this cluster is still in the store
-		// and that it wasn't closed/timed out (we don't want to send an event for bad clusters).
+		// and that it wasn't closed (we don't want to send an event for bad clusters).
 		// The GetByID call below runs without holding the caller's RLock, so it does not
 		// reintroduce the recursive-lock hazard.
-		if cl.WaitUntilSynced(cl.stop) && !cl.Closed() && !cl.SyncDidTimeout() && c.GetByID(id) != nil {
+		if cl.WaitUntilInitiallySynced(cl.stop) && !cl.Closed() && c.GetByID(id) != nil {
 			// Let dependent krt collections know that this cluster is ready to use
 			c.TriggerRecomputation()
 			// And clean up our tracking set

--- a/pkg/kube/multicluster/clusterstore.go
+++ b/pkg/kube/multicluster/clusterstore.go
@@ -301,13 +301,12 @@ func (c *ClusterStore) triggerRecomputeOnSync(cl *Cluster) {
 		// The GetByID call below runs without holding the caller's RLock, so it does not
 		// reintroduce the recursive-lock hazard.
 		if cl.WaitUntilInitiallySynced(cl.stop) && !cl.Closed() && c.GetByID(id) != nil {
+			log.Debugf("remote cluster %s informers synced, triggering recompute", id)
 			// Let dependent krt collections know that this cluster is ready to use
 			c.TriggerRecomputation()
-			// And clean up our tracking set
-			c.casMu.Lock()
-			c.clustersAwaitingSync.Delete(id)
-			c.casMu.Unlock()
-			log.Debugf("remote cluster %s informers synced, triggering recompute", id)
 		}
+		c.casMu.Lock()
+		c.clustersAwaitingSync.Delete(id)
+		c.casMu.Unlock()
 	}()
 }

--- a/pkg/kube/multicluster/clusterstore.go
+++ b/pkg/kube/multicluster/clusterstore.go
@@ -105,7 +105,7 @@ func (c *ClusterStore) Swap(secretKey string, clusterID cluster.ID, value *Clust
 	// (not-yet-synced) cluster syncs. This preserves make-before-break at the collection level:
 	// otherwise AllReady would drop the cluster (emitting a spurious delete followed by an add once
 	// the new cluster syncs) instead of a single update.
-	if clusterServable(prev) {
+	if clusterReady(prev) {
 		c.previousClusters[clusterID] = prev
 	}
 	c.TriggerRecomputation()
@@ -178,7 +178,7 @@ func (c *ClusterStore) AllReady() map[string]map[cluster.ID]*Cluster {
 				log.Debugf("remote cluster %s registered informers have not been synced up yet. Skipping and will recompute on sync", cl.ID)
 				// During an in-flight update, keep serving the previous synced cluster until the new
 				// one syncs, so it is not momentarily dropped from the collection (make-before-break).
-				if prev := c.getPreviousCluster(cid); clusterServable(prev) {
+				if prev := c.getPreviousCluster(cid); clusterReady(prev) {
 					log.Debugf("serving previous synced cluster %s while its update syncs", cid)
 					outCluster := *prev
 					if _, ok := out[secret]; !ok {
@@ -256,10 +256,10 @@ func (c *ClusterStore) HasSynced() bool {
 	return true
 }
 
-// clusterServable reports whether a cluster is currently usable: it is still open
+// clusterReady reports whether a cluster is currently usable: it is still open
 // and it's synced. Used to decide whether the previous cluster can keep serving
 // during an in-flight update.
-func clusterServable(cl *Cluster) bool {
+func clusterReady(cl *Cluster) bool {
 	return cl != nil && !cl.Closed() && cl.HasSynced() && !cl.SyncDidTimeout()
 }
 

--- a/pkg/kube/multicluster/clusterstore.go
+++ b/pkg/kube/multicluster/clusterstore.go
@@ -256,11 +256,11 @@ func (c *ClusterStore) HasSynced() bool {
 	return true
 }
 
-// clusterServable reports whether a cluster is currently usable: synced and neither
-// closed nor timed out. Used to decide whether the previous cluster can keep serving
+// clusterServable reports whether a cluster is currently usable: it is still open
+// and it's synced. Used to decide whether the previous cluster can keep serving
 // during an in-flight update.
 func clusterServable(cl *Cluster) bool {
-	return cl != nil && !cl.Closed() && !cl.SyncDidTimeout() && cl.HasSynced()
+	return cl != nil && !cl.Closed() && cl.HasSynced()
 }
 
 // getPreviousCluster returns the previous cluster tracked for an in-flight update, if any.

--- a/pkg/kube/multicluster/clusterstore.go
+++ b/pkg/kube/multicluster/clusterstore.go
@@ -260,7 +260,7 @@ func (c *ClusterStore) HasSynced() bool {
 // and it's synced. Used to decide whether the previous cluster can keep serving
 // during an in-flight update.
 func clusterServable(cl *Cluster) bool {
-	return cl != nil && !cl.Closed() && cl.HasSynced()
+	return cl != nil && !cl.Closed() && cl.HasSynced() && !cl.SyncDidTimeout()
 }
 
 // getPreviousCluster returns the previous cluster tracked for an in-flight update, if any.

--- a/pkg/kube/multicluster/clusterstore_test.go
+++ b/pkg/kube/multicluster/clusterstore_test.go
@@ -1,0 +1,108 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicluster
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	uberatomic "go.uber.org/atomic"
+
+	"istio.io/istio/pkg/cluster"
+	"istio.io/istio/pkg/test/util/assert"
+)
+
+func testStoreCluster(id cluster.ID, seed string) *Cluster {
+	return &Cluster{
+		ID:                       id,
+		kubeConfigSha:            sha256.Sum256([]byte(seed)),
+		stop:                     make(chan struct{}),
+		initialSync:              uberatomic.NewBool(false),
+		initialSyncTimeout:       uberatomic.NewBool(false),
+		remoteClusterCollections: uberatomic.NewPointer[remoteClusterCollections](nil),
+	}
+}
+
+// TestClusterStoreSwapServesPreviousUntilSynced verifies that while an update is in flight
+// (the new cluster has not synced yet), AllReady keeps returning the previous synced cluster
+// instead of dropping the cluster ID from the collection. Once the new cluster syncs, AllReady
+// switches to it. This is what turns the update into a single Update event downstream rather
+// than a Delete followed by an Add.
+func TestClusterStoreSwapServesPreviousUntilSynced(t *testing.T) {
+	store := NewClustersStore()
+	secret := "istio-system/s0"
+	id := cluster.ID("c0")
+
+	// Initial cluster, synced.
+	old := testStoreCluster(id, "kubeconfig-old")
+	store.Swap(secret, id, old)
+	old.initialSync.Store(true)
+
+	ready := store.AllReady()
+	if got := ready[secret][id]; got == nil || got.kubeConfigSha != old.kubeConfigSha {
+		t.Fatalf("expected old cluster to be ready, got %v", got)
+	}
+
+	// Update: new cluster for the same ID, not synced yet.
+	newCluster := testStoreCluster(id, "kubeconfig-new")
+	store.Swap(secret, id, newCluster)
+
+	// While the new cluster is syncing, AllReady must still serve the previous (old) cluster.
+	ready = store.AllReady()
+	got := ready[secret][id]
+	if got == nil {
+		t.Fatalf("cluster %s was dropped during in-flight update; expected the previous cluster to keep serving", id)
+	}
+	assert.Equal(t, got.kubeConfigSha, old.kubeConfigSha)
+
+	// New cluster finishes syncing.
+	newCluster.initialSync.Store(true)
+
+	ready = store.AllReady()
+	got = ready[secret][id]
+	if got == nil {
+		t.Fatalf("expected the new cluster to be ready after syncing")
+	}
+	assert.Equal(t, got.kubeConfigSha, newCluster.kubeConfigSha)
+
+	// The previous-cluster tracking must be cleared once the new cluster is serving.
+	assert.Equal(t, store.getPreviousCluster(id), nil)
+}
+
+// TestClusterStoreSwapWithoutSyncedPreviousDrops verifies that if the previous cluster is not
+// itself serviceable (e.g. it never synced), AllReady does not attempt to serve it and the
+// cluster is skipped until the new cluster syncs, matching the pre-existing behavior.
+func TestClusterStoreSwapWithoutSyncedPreviousDrops(t *testing.T) {
+	store := NewClustersStore()
+	secret := "istio-system/s0"
+	id := cluster.ID("c0")
+
+	// Initial cluster that never synced.
+	old := testStoreCluster(id, "kubeconfig-old")
+	store.Swap(secret, id, old)
+
+	// Update before the old cluster ever synced.
+	newCluster := testStoreCluster(id, "kubeconfig-new")
+	store.Swap(secret, id, newCluster)
+
+	ready := store.AllReady()
+	if _, ok := ready[secret]; ok {
+		if got := ready[secret][id]; got != nil {
+			t.Fatalf("did not expect a cluster to be served when neither old nor new is synced, got %v", got)
+		}
+	}
+	// Nothing should be tracked as a serviceable previous cluster.
+	assert.Equal(t, store.getPreviousCluster(id), nil)
+}

--- a/pkg/kube/multicluster/clusterstore_test.go
+++ b/pkg/kube/multicluster/clusterstore_test.go
@@ -24,9 +24,11 @@ import (
 	"istio.io/istio/pkg/test/util/assert"
 )
 
-func testStoreCluster(id cluster.ID, seed string) *Cluster {
+const testClusterID cluster.ID = "c0"
+
+func testStoreCluster(seed string) *Cluster {
 	return &Cluster{
-		ID:                       id,
+		ID:                       testClusterID,
 		kubeConfigSha:            sha256.Sum256([]byte(seed)),
 		stop:                     make(chan struct{}),
 		initialSync:              uberatomic.NewBool(false),
@@ -43,10 +45,10 @@ func testStoreCluster(id cluster.ID, seed string) *Cluster {
 func TestClusterStoreSwapServesPreviousUntilSynced(t *testing.T) {
 	store := NewClustersStore()
 	secret := "istio-system/s0"
-	id := cluster.ID("c0")
+	id := testClusterID
 
 	// Initial cluster, synced.
-	old := testStoreCluster(id, "kubeconfig-old")
+	old := testStoreCluster("kubeconfig-old")
 	store.Swap(secret, id, old)
 	old.initialSync.Store(true)
 
@@ -56,7 +58,7 @@ func TestClusterStoreSwapServesPreviousUntilSynced(t *testing.T) {
 	}
 
 	// Update: new cluster for the same ID, not synced yet.
-	newCluster := testStoreCluster(id, "kubeconfig-new")
+	newCluster := testStoreCluster("kubeconfig-new")
 	store.Swap(secret, id, newCluster)
 
 	// While the new cluster is syncing, AllReady must still serve the previous (old) cluster.
@@ -87,14 +89,14 @@ func TestClusterStoreSwapServesPreviousUntilSynced(t *testing.T) {
 func TestClusterStoreSwapWithoutSyncedPreviousDrops(t *testing.T) {
 	store := NewClustersStore()
 	secret := "istio-system/s0"
-	id := cluster.ID("c0")
+	id := testClusterID
 
 	// Initial cluster that never synced.
-	old := testStoreCluster(id, "kubeconfig-old")
+	old := testStoreCluster("kubeconfig-old")
 	store.Swap(secret, id, old)
 
 	// Update before the old cluster ever synced.
-	newCluster := testStoreCluster(id, "kubeconfig-new")
+	newCluster := testStoreCluster("kubeconfig-new")
 	store.Swap(secret, id, newCluster)
 
 	ready := store.AllReady()

--- a/pkg/kube/multicluster/collections.go
+++ b/pkg/kube/multicluster/collections.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 
 	"istio.io/istio/pkg/cluster"
+	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/log"
@@ -79,8 +80,11 @@ func NestedManyCollectionsFromLocalAndRemote[T any](
 	opts krt.OptionsBuilder,
 ) krt.Collection[krt.Collection[T]] {
 	clustersCollection := ctrl.Clusters()
+	// use a custom syncer to make globalCollection sync when all local and remote collections
+	// have synced
+	syncer := &combinedSyncer[T]{name: "Global" + name, local: localCollections}
 	globalCollection := krt.NewStaticCollection(
-		localCollections[0],
+		syncer,
 		localCollections,
 		opts.WithName("Global"+name)...,
 	)
@@ -109,7 +113,7 @@ func NestedManyCollectionsFromLocalAndRemote[T any](
 		return cols
 	}, opts.WithName("Remote"+name)...)
 
-	remoteCollections.RegisterBatch(func(o []krt.Event[krt.Collection[T]]) {
+	reg := remoteCollections.RegisterBatch(func(o []krt.Event[krt.Collection[T]]) {
 		for _, e := range o {
 			l := e.Latest()
 			switch e.Event {
@@ -120,7 +124,50 @@ func NestedManyCollectionsFromLocalAndRemote[T any](
 			}
 		}
 	}, true)
+	syncer.setRemote(reg, remoteCollections)
 	return globalCollection
+}
+
+// combinedSyncer reports synced only when all of the local collections are synced and the remote
+// clusters' collections have been discovered, propagated into the global collection, and synced
+// themselves.
+type combinedSyncer[T any] struct {
+	name       string
+	local      []krt.Collection[T]
+	mu         sync.RWMutex
+	remote     krt.Syncer
+	collection krt.Collection[krt.Collection[T]]
+}
+
+func (s *combinedSyncer[T]) setRemote(remoteSyncer krt.Syncer, remoteCollections krt.Collection[krt.Collection[T]]) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.remote = remoteSyncer
+	s.collection = remoteCollections
+}
+
+func (s *combinedSyncer[T]) HasSynced() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, c := range s.local {
+		if !c.HasSynced() {
+			return false
+		}
+	}
+	if s.remote == nil || !s.remote.HasSynced() {
+		return false
+	}
+	// The container is synced (all remote collections have been added), now ensure each of them has synced too.
+	for _, c := range s.collection.List() {
+		if !c.HasSynced() {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *combinedSyncer[T]) WaitUntilSynced(stop <-chan struct{}) bool {
+	return kube.WaitForCacheSync(s.name, stop, s.HasSynced)
 }
 
 // collectionCacheByClusterMany is a thread-safe cache of slices of krt collections keyed by cluster ID.

--- a/pkg/kube/multicluster/remote_config_source.go
+++ b/pkg/kube/multicluster/remote_config_source.go
@@ -21,6 +21,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
 
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/kclient"
@@ -43,7 +44,9 @@ type remoteConfigSource interface {
 }
 
 type secretConfigSource struct {
-	client kclient.Client[*corev1.Secret]
+	client   kclient.Client[*corev1.Secret]
+	handlers []cache.ResourceEventHandlerRegistration
+	mu       sync.Mutex
 }
 
 func newSecretConfigSource(client kclient.Client[*corev1.Secret]) *secretConfigSource {
@@ -51,7 +54,9 @@ func newSecretConfigSource(client kclient.Client[*corev1.Secret]) *secretConfigS
 }
 
 func (s *secretConfigSource) AddEventHandler(handler func(key types.NamespacedName, event controllers.EventType)) {
-	s.client.AddEventHandler(controllers.EventHandler[*corev1.Secret]{
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.handlers = append(s.handlers, s.client.AddEventHandler(controllers.EventHandler[*corev1.Secret]{
 		AddFunc: func(obj *corev1.Secret) {
 			handler(types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}, controllers.EventAdd)
 		},
@@ -61,11 +66,23 @@ func (s *secretConfigSource) AddEventHandler(handler func(key types.NamespacedNa
 		DeleteFunc: func(obj *corev1.Secret) {
 			handler(types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}, controllers.EventDelete)
 		},
-	})
+	}))
 }
 
 func (s *secretConfigSource) HasSynced() bool {
-	return s.client.HasSynced()
+	if !s.client.HasSynced() {
+		return false
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, h := range s.handlers {
+		if !h.HasSynced() {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (s *secretConfigSource) Start(stop <-chan struct{}) {
@@ -89,6 +106,9 @@ type fileConfigSource struct {
 	// deferredHandlers stores AddEventHandler registrations made before Start() initializes the collection.
 	// They are registered against the collection once Start() finishes creating it.
 	deferredHandlers []func(types.NamespacedName, controllers.EventType)
+	// handlers stores the collection registrations so HasSynced can verify that each handler has
+	// processed the initial state, not just that the collection itself has synced.
+	handlers []krt.HandlerRegistration
 }
 
 func newFileConfigSource(root string) *fileConfigSource {
@@ -118,14 +138,16 @@ func (f *fileConfigSource) Start(stop <-chan struct{}) {
 		}
 
 		f.mu.Lock()
+		defer f.mu.Unlock()
 		f.collection = collection
 		deferredHandlers := f.deferredHandlers
 		f.deferredHandlers = nil
-		f.mu.Unlock()
 
 		// Register deferred handlers that arrived before the collection was initialized.
 		for _, handler := range deferredHandlers {
-			registerHandler(collection, handler)
+			if reg := registerHandler(collection, handler); reg != nil {
+				f.handlers = append(f.handlers, reg)
+			}
 		}
 	})
 }
@@ -136,7 +158,15 @@ func (f *fileConfigSource) HasSynced() bool {
 	if f.collection == nil {
 		return false
 	}
-	return f.collection.HasSynced()
+	if !f.collection.HasSynced() {
+		return false
+	}
+	for _, h := range f.handlers {
+		if !h.HasSynced() {
+			return false
+		}
+	}
+	return true
 }
 
 func (f *fileConfigSource) Get(key types.NamespacedName) *remoteConfig {
@@ -163,15 +193,15 @@ func (f *fileConfigSource) AddEventHandler(handler func(key types.NamespacedName
 	}
 
 	f.mu.Lock()
-	collection := f.collection
-	if collection == nil {
+	defer f.mu.Unlock()
+	if f.collection == nil {
 		f.deferredHandlers = append(f.deferredHandlers, handler)
-		f.mu.Unlock()
 		return
 	}
-	f.mu.Unlock()
 
-	registerHandler(collection, handler)
+	if reg := registerHandler(f.collection, handler); reg != nil {
+		f.handlers = append(f.handlers, reg)
+	}
 }
 
 // registerHandler adapts KRT file collection events into controller queue keys.
@@ -179,15 +209,8 @@ func (f *fileConfigSource) AddEventHandler(handler func(key types.NamespacedName
 // so updates enqueue old and new cluster IDs when they differ. This ensures a kubeconfig
 // file changing from cluster A to cluster B reconciles both keys so the old
 // cluster can be deleted and the new cluster can be added.
-func registerHandler(collection krt.Collection[KubeconfigFile], handler func(key types.NamespacedName, event controllers.EventType)) {
-	if handler == nil {
-		return
-	}
-	if collection == nil {
-		return
-	}
-
-	collection.Register(func(ev krt.Event[KubeconfigFile]) {
+func registerHandler(collection krt.Collection[KubeconfigFile], handler func(key types.NamespacedName, event controllers.EventType)) krt.HandlerRegistration {
+	return collection.Register(func(ev krt.Event[KubeconfigFile]) {
 		oldClusterID := ""
 		if ev.Old != nil {
 			oldClusterID = ev.Old.ClusterID

--- a/pkg/kube/multicluster/secretcontroller.go
+++ b/pkg/kube/multicluster/secretcontroller.go
@@ -212,12 +212,12 @@ func NewController(opts ControllerOptions) *Controller {
 }
 
 func (c *Controller) buildClustersCollection(optsBuilder krt.OptionsBuilder) {
-	// Wait for the remote config source to sync and mark the cluster store as ready.
+	// Wait for the remote config source, queue and cluster store to sync and then mark the cluster store as ready.
 	// Run() also waits on the same source before starting the queue; this goroutine
 	// separately gates the KRT-backed clusters collection on source sync.
 	// For the file-backed source, sync will not begin until Run() calls Start().
 	go func() {
-		if !kube.WaitForCacheSync("multicluster remote config source", c.stop, c.source.HasSynced) {
+		if !kube.WaitForCacheSync("multicluster remote config source", c.stop, c.source.HasSynced, c.queue.HasSynced, c.cs.HasSynced) {
 			log.Errorf("Timed out waiting for remote config source to sync")
 		}
 		c.cs.MarkSynced()

--- a/releasenotes/notes/ambient-multicluster-sync-gating.yaml
+++ b/releasenotes/notes/ambient-multicluster-sync-gating.yaml
@@ -1,0 +1,12 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue: []
+releaseNotes:
+  - |
+    **Fixed** a bug in Istiod ambient multi-cluster mode where the aggregated (local + remote)
+    collections could report themselves as synced before the remote clusters had been discovered
+    and synced. As a result, Istiod could begin serving with local-cluster-only data, temporarily
+    omitting workloads, services, and endpoints from remote clusters at startup. The aggregated
+    collections now wait for the multi-cluster controller and every remote cluster's collections to
+    sync before being marked ready.

--- a/tests/util/leak/check.go
+++ b/tests/util/leak/check.go
@@ -267,8 +267,18 @@ func interestingGoroutine(g string) (*goroutine, error) {
 // interestingGoroutines returns all goroutines we care about for the purpose
 // of leak checking. It excludes testing or runtime ones.
 func interestingGoroutines() ([]*goroutine, error) {
+	// runtime.Stack truncates the dump to the buffer size instead of growing it. For
+	// goroutine-heavy tests the full dump can exceed a fixed buffer, and a truncated dump
+	// yields a partial goroutine chunk that fails to parse. Grow the buffer until it fits.
 	buf := make([]byte, 2<<20)
-	buf = buf[:runtime.Stack(buf, true)]
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			buf = buf[:n]
+			break
+		}
+		buf = make([]byte, 2*len(buf))
+	}
 	var gs []*goroutine
 	for _, g := range strings.Split(string(buf), "\n\n") {
 		gr, err := interestingGoroutine(g)


### PR DESCRIPTION
**Please provide a description of this PR:**
Ambient Index was being marked as Synced whenever Local Collections where synced, but we were never waiting for Remote Cluster Collections to be marked as Synced, this could lead to inconsistencies in Istiod start up.

Other fixes:
- modified `ClusterStore` to avoid dropping Ready Clusters during in-place updates. This avoids Ambient dropping cluster collections entirely during cluster secret updates.
- `triggerRecomputeOnSync` was only waiting for clusters to become synced which actually also returns when the cluster timed out during the initial sync, but then skipped calling the recomputation. This meant that the cluster was effectively lost. I've changed this to actually wait until the initial sync is fully done.
- `AllReady` was scheduling recomputation for unready clusters, but was not doing so for timed out clusters which could eventually become ready, fixed this by also scheduling a recompute in this case.