### PR TITLE
[release-1.30] Make colliding Service port names unique

### DIFF
--- a/pilot/pkg/config/kube/gatewaycommon/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gatewaycommon/deploymentcontroller.go
@@ -911,6 +911,7 @@ func extractServicePorts(gw gateway.Gateway, listenerSets []gateway.Listener) []
 		AppProtocol: &tcp,
 	})
 	portNums := sets.New[int32]()
+	usedNames := sets.New("status-port")
 	allListeners := append(slices.Clone(gw.Spec.Listeners), listenerSets...)
 	for i, l := range allListeners {
 		if portNums.Contains(l.Port) {
@@ -922,6 +923,7 @@ func extractServicePorts(gw gateway.Gateway, listenerSets []gateway.Listener) []
 			// Should not happen since name is required, but in case an invalid resource gets in...
 			name = fmt.Sprintf("%s-%d", strings.ToLower(string(l.Protocol)), i)
 		}
+		name = uniquePortName(name, l.Port, usedNames)
 		appProtocol := strings.ToLower(string(l.Protocol))
 		svcPorts = append(svcPorts, corev1.ServicePort{
 			Name:        name,
@@ -930,6 +932,27 @@ func extractServicePorts(gw gateway.Gateway, listenerSets []gateway.Listener) []
 		})
 	}
 	return svcPorts
+}
+
+// uniquePortName returns name truncated to the 63-character Service port name limit, disambiguated
+// against already-used names. Distinct listener names can sanitize to the same port name (periods
+// map to dashes, and names may differ only past character 63); duplicate port names invalidate the
+// whole Service, blocking every unpublished port. The listener port number is the disambiguator
+// since each port appears once per Service.
+func uniquePortName(name string, port int32, used sets.Set[string]) string {
+	if len(name) > 63 {
+		name = name[:63]
+	}
+	candidate := name
+	for suffix := fmt.Sprintf("-%d", port); used.Contains(candidate); suffix += "x" {
+		trimmed := name
+		if len(trimmed)+len(suffix) > 63 {
+			trimmed = trimmed[:63-len(suffix)]
+		}
+		candidate = trimmed + suffix
+	}
+	used.Insert(candidate)
+	return candidate
 }
 
 // ListenerName allows periods and 253 chars.

--- a/pilot/pkg/config/kube/gatewaycommon/deploymentcontroller_test.go
+++ b/pilot/pkg/config/kube/gatewaycommon/deploymentcontroller_test.go
@@ -1497,3 +1497,36 @@ func TestDeploymentControllerWaitsForPushContext(t *testing.T) {
 		retry.Timeout(time.Second*5),
 		retry.Message("expected reconciliation after PushContext became ready, but none occurred"))
 }
+
+// TestExtractServicePortsUniqueNames proves listener names that sanitize to the same Service port
+// name still produce unique port names. ListenerName allows periods and 253 characters; Service
+// port names allow neither, so "web.a"/"web-a" or names differing only past character 63 collide
+// after sanitizing. Duplicate port names make the entire Service invalid, so one colliding listener
+// blocks every unpublished port on the Gateway.
+func TestExtractServicePortsUniqueNames(t *testing.T) {
+	long := strings.Repeat("a", 63)
+	gw := k8s.Gateway{
+		Spec: k8s.GatewaySpec{
+			Listeners: []k8s.Listener{
+				{Name: "web.a", Port: 80, Protocol: k8s.HTTPProtocolType},
+				{Name: "web-a", Port: 81, Protocol: k8s.HTTPProtocolType},
+				{Name: k8s.SectionName(long + "-first"), Port: 82, Protocol: k8s.HTTPProtocolType},
+				{Name: k8s.SectionName(long + "-second"), Port: 83, Protocol: k8s.HTTPProtocolType},
+			},
+		},
+	}
+	ports := extractServicePorts(gw, nil)
+	seen := map[string]int32{}
+	for _, p := range ports {
+		if prev, ok := seen[p.Name]; ok {
+			t.Fatalf("duplicate Service port name %q for ports %d and %d; a Service with duplicate port names is rejected entirely", p.Name, prev, p.Port)
+		}
+		if len(p.Name) > 63 {
+			t.Fatalf("port name %q exceeds 63 characters", p.Name)
+		}
+		seen[p.Name] = p.Port
+	}
+	if len(ports) != 5 { // status-port + 4 listeners
+		t.Fatalf("expected 5 ports, got %d", len(ports))
+	}
+}

--- a/releasenotes/notes/service-port-name-collision.yaml
+++ b/releasenotes/notes/service-port-name-collision.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue: []
+releaseNotes:
+  - |
+    **Fixed** generated Gateway `Service`s being rejected when two listener names sanitize to the
+    same Service port name (names differing only by periods versus dashes, or only past the
+    63-character limit), which blocked every unpublished port on the Gateway. Colliding port names
+    are now disambiguated with the listener's port number.


### PR DESCRIPTION
Manual cherry-pick of #61258. Fixes #61278