### PR TITLE
[release-1.30] krt: cleanup debugger registrations of dead collections (#61263)

### DIFF
--- a/pilot/pkg/autoregistration/controller_test.go
+++ b/pilot/pkg/autoregistration/controller_test.go
@@ -164,8 +164,8 @@ var (
 )
 
 func TestNonAutoRegisteredWorkloads(t *testing.T) {
-	store := memory.NewController(memory.Make(collections.All))
 	stop := test.NewStop(t)
+	store := memory.NewController(collections.All, false)
 	go store.Run(stop)
 	c := NewController(store, "", time.Duration(math.MaxInt64))
 	createOrFail(t, store, wgA)
@@ -355,8 +355,8 @@ func TestAutoregistrationLifecycle(t *testing.T) {
 
 func TestAutoregistrationDisabled(t *testing.T) {
 	test.SetForTest(t, &features.WorkloadEntryAutoRegistration, false)
-	store := memory.NewController(memory.Make(collections.All))
 	stop := test.NewStop(t)
+	store := memory.NewController(collections.All, false)
 	go store.Run(stop)
 	createOrFail(t, store, weB)
 
@@ -538,8 +538,8 @@ func TestWorkloadEntryFromGroupHBONE(t *testing.T) {
 }
 
 func TestNonAutoregisteredWorkloads_UnsuitableForHealthChecks_WorkloadEntryNotFound(t *testing.T) {
-	store := memory.NewController(memory.Make(collections.All))
 	stop := test.NewStop(t)
+	store := memory.NewController(collections.All, false)
 	go store.Run(stop)
 	createOrFail(t, store, weB)
 
@@ -584,8 +584,8 @@ func TestNonAutoregisteredWorkloads_UnsuitableForHealthChecks_ShouldNotBeTreated
 		t.Run(tc.name, func(t *testing.T) {
 			we := tc.we()
 
-			store := memory.NewController(memory.Make(collections.All))
 			stop := test.NewStop(t)
+			store := memory.NewController(collections.All, false)
 			go store.Run(stop)
 			createOrFail(t, store, we)
 
@@ -615,8 +615,8 @@ func TestNonAutoregisteredWorkloads_SuitableForHealthChecks_ShouldBeTreatedAsCon
 			we := weB.DeepCopy()
 			we.Annotations["proxy.istio.io/health-checks-enabled"] = value
 
-			store := memory.NewController(memory.Make(collections.All))
 			stop := test.NewStop(t)
+			store := memory.NewController(collections.All, false)
 			go store.Run(stop)
 			createOrFail(t, store, we)
 
@@ -784,7 +784,7 @@ func TestNonAutoregisteredWorkloads_SuitableForHealthChecks_ShouldUpdateHealthCo
 }
 
 func setup(t *testing.T) (*Controller, *Controller, model.ConfigStoreController) {
-	store := memory.NewController(memory.Make(collections.All))
+	store := memory.NewController(collections.All, false)
 	c1 := NewController(store, "pilot-1", time.Duration(math.MaxInt64))
 	c2 := NewController(store, "pilot-2", time.Duration(math.MaxInt64))
 	createOrFail(t, store, wgA)

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -356,9 +356,8 @@ func (s *Server) initConfigSources(args *PilotArgs) (err error) {
 			if err != nil {
 				return fmt.Errorf("failed to dial XDS %s %v", configSource.Address, err)
 			}
-			store := memory.Make(collections.Pilot)
 			// TODO: enable namespace filter for memory controller
-			configController := memory.NewController(store)
+			configController := memory.NewController(collections.Pilot, false)
 			configController.RegisterHasSyncedHandler(xdsMCP.HasSynced)
 			xdsMCP.Store = configController
 			err = xdsMCP.Run()

--- a/pilot/pkg/config/aggregate/config_test.go
+++ b/pilot/pkg/config/aggregate/config_test.go
@@ -30,6 +30,7 @@ import (
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/resource"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/retry"
 )
 
@@ -38,8 +39,11 @@ func TestAggregateStoreBasicMake(t *testing.T) {
 
 	schema1 := collections.HTTPRoute
 	schema2 := collections.GatewayClass
-	store1 := memory.NewController(memory.Make(collection.SchemasFor(schema1)))
-	store2 := memory.NewController(memory.Make(collection.SchemasFor(schema2)))
+	store1 := memory.NewController(collection.SchemasFor(schema1), false)
+	store2 := memory.NewController(collection.SchemasFor(schema2), false)
+	stop := test.NewStop(t)
+	go store1.Run(stop)
+	go store2.Run(stop)
 
 	stores := []model.ConfigStoreController{store1, store2}
 
@@ -53,7 +57,8 @@ func TestAggregateStoreBasicMake(t *testing.T) {
 func TestAggregateStoreMakeValidationFailure(t *testing.T) {
 	g := NewWithT(t)
 
-	store1 := memory.NewController(memory.Make(collection.SchemasFor(schemaFor("SomeConfig", "broken message name"))))
+	store1 := memory.NewController(collection.SchemasFor(schemaFor("SomeConfig", "broken message name")), false)
+	go store1.Run(test.NewStop(t))
 
 	stores := []model.ConfigStoreController{store1}
 
@@ -65,8 +70,11 @@ func TestAggregateStoreMakeValidationFailure(t *testing.T) {
 func TestAggregateStoreGet(t *testing.T) {
 	g := NewWithT(t)
 
-	store1 := memory.NewController(memory.Make(collection.SchemasFor(collections.GatewayClass)))
-	store2 := memory.NewController(memory.Make(collection.SchemasFor(collections.GatewayClass)))
+	store1 := memory.NewController(collection.SchemasFor(collections.GatewayClass), false)
+	store2 := memory.NewController(collection.SchemasFor(collections.GatewayClass), false)
+	stop := test.NewStop(t)
+	go store1.Run(stop)
+	go store2.Run(stop)
 
 	configReturn := &config.Config{
 		Meta: config.Meta{
@@ -90,8 +98,11 @@ func TestAggregateStoreGet(t *testing.T) {
 func TestAggregateStoreList(t *testing.T) {
 	g := NewWithT(t)
 
-	store1 := memory.NewController(memory.Make(collection.SchemasFor(collections.HTTPRoute)))
-	store2 := memory.NewController(memory.Make(collection.SchemasFor(collections.HTTPRoute)))
+	store1 := memory.NewController(collection.SchemasFor(collections.HTTPRoute), false)
+	store2 := memory.NewController(collection.SchemasFor(collections.HTTPRoute), false)
+	stop := test.NewStop(t)
+	go store1.Run(stop)
+	go store2.Run(stop)
 
 	if _, err := store1.Create(config.Config{
 		Meta: config.Meta{
@@ -122,8 +133,11 @@ func TestAggregateStoreList(t *testing.T) {
 func TestAggregateStoreWrite(t *testing.T) {
 	g := NewWithT(t)
 
-	store1 := memory.NewController(memory.Make(collection.SchemasFor(collections.HTTPRoute)))
-	store2 := memory.NewController(memory.Make(collection.SchemasFor(collections.HTTPRoute)))
+	store1 := memory.NewController(collection.SchemasFor(collections.HTTPRoute), false)
+	store2 := memory.NewController(collection.SchemasFor(collections.HTTPRoute), false)
+	stop := test.NewStop(t)
+	go store1.Run(stop)
+	go store2.Run(stop)
 
 	stores := []model.ConfigStoreController{store1, store2}
 
@@ -157,8 +171,11 @@ func TestAggregateStoreWrite(t *testing.T) {
 func TestAggregateStoreWriteWithoutWriter(t *testing.T) {
 	g := NewWithT(t)
 
-	store1 := memory.NewController(memory.Make(collection.SchemasFor(collections.HTTPRoute)))
-	store2 := memory.NewController(memory.Make(collection.SchemasFor(collections.HTTPRoute)))
+	store1 := memory.NewController(collection.SchemasFor(collections.HTTPRoute), false)
+	store2 := memory.NewController(collection.SchemasFor(collections.HTTPRoute), false)
+	stop := test.NewStop(t)
+	go store1.Run(stop)
+	go store2.Run(stop)
 
 	stores := []model.ConfigStoreController{store1, store2}
 
@@ -178,7 +195,8 @@ func TestAggregateStoreWriteWithoutWriter(t *testing.T) {
 func TestAggregateStoreFails(t *testing.T) {
 	g := NewWithT(t)
 
-	store1 := memory.NewController(memory.Make(collection.SchemasFor(schemaFor("OtherConfig", "istio.networking.v1alpha3.Gateway"))))
+	store1 := memory.NewController(collection.SchemasFor(schemaFor("OtherConfig", "istio.networking.v1alpha3.Gateway")), false)
+	go store1.Run(test.NewStop(t))
 
 	stores := []model.ConfigStoreController{store1}
 
@@ -213,12 +231,10 @@ func TestAggregateStoreCache(t *testing.T) {
 	stop := make(chan struct{})
 	defer func() { close(stop) }()
 
-	store1 := memory.Make(collection.SchemasFor(collections.HTTPRoute))
-	controller1 := memory.NewController(store1)
+	controller1 := memory.NewController(collection.SchemasFor(collections.HTTPRoute), false)
 	go controller1.Run(stop)
 
-	store2 := memory.Make(collection.SchemasFor(collections.HTTPRoute))
-	controller2 := memory.NewController(store2)
+	controller2 := memory.NewController(collection.SchemasFor(collections.HTTPRoute), false)
 	go controller2.Run(stop)
 
 	stores := []model.ConfigStoreController{controller1, controller2}

--- a/pilot/pkg/config/file/store.go
+++ b/pilot/pkg/config/file/store.go
@@ -192,7 +192,7 @@ func NewKubeSource(schemas collection.Schemas) *KubeSource {
 	return &KubeSource{
 		name:    name,
 		schemas: &schemas,
-		inner:   memory.NewController(memory.MakeSkipValidation(schemas)),
+		inner:   memory.NewController(schemas, true),
 		shas:    make(map[kubeResourceKey]resourceSha),
 		byFile:  make(map[string]map[kubeResourceKey]config.GroupVersionKind),
 	}

--- a/pilot/pkg/config/kube/extensions/controller_test.go
+++ b/pilot/pkg/config/kube/extensions/controller_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestTranslation(t *testing.T) {
 	// Create a memory store
-	store := memory.NewController(memory.MakeSkipValidation(collections.PilotGatewayAPI()))
+	store := memory.NewController(collections.PilotGatewayAPI(), true)
 
 	// Create a WasmPlugin config
 	wasmPlugin := config.Config{

--- a/pilot/pkg/config/memory/controller.go
+++ b/pilot/pkg/config/memory/controller.go
@@ -27,12 +27,15 @@ type Controller struct {
 	hasSynced func() bool
 	store     *Store
 	handlers  []krt.HandlerRegistration
+	stop      chan struct{}
 }
 
-// NewController return an implementation of ConfigStoreController
-func NewController(store *Store) *Controller {
+// Make return an implementation of ConfigStoreController
+func NewController(schemas collection.Schemas, skipValidation bool) *Controller {
+	stop := make(chan struct{})
 	return &Controller{
-		store: store,
+		stop:  stop,
+		store: newStore(schemas, skipValidation, stop),
 	}
 }
 
@@ -81,7 +84,7 @@ func (c *Controller) Run(stop <-chan struct{}) {
 	// marked as synced on run to allow clients to store data before the store is marked as synced
 	c.store.markSynced()
 	<-stop
-	close(c.store.stop)
+	close(c.stop)
 }
 
 func (c *Controller) KrtCollection(kind config.GroupVersionKind) krt.Collection[config.Config] {

--- a/pilot/pkg/config/memory/controller_test.go
+++ b/pilot/pkg/config/memory/controller_test.go
@@ -21,6 +21,7 @@ import (
 	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/test/mock"
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/test"
 )
 
 const (
@@ -29,28 +30,25 @@ const (
 )
 
 func TestControllerEvents(t *testing.T) {
-	store := memory.Make(collections.Mocks)
-	ctl := memory.NewController(store)
+	ctl := memory.NewController(collections.Mocks, false)
 	// Note that the operations must go through the controller since the store does not trigger back events
 	mock.CheckCacheEvents(ctl, ctl, TestNamespace, 5, t)
 }
 
 func TestControllerCacheFreshness(t *testing.T) {
-	store := memory.Make(collections.Mocks)
-	ctl := memory.NewController(store)
+	ctl := memory.NewController(collections.Mocks, false)
 	mock.CheckCacheFreshness(ctl, TestNamespace, t)
 }
 
 func TestControllerClientSync(t *testing.T) {
-	store := memory.Make(collections.Mocks)
-	ctl := memory.NewController(store)
-	mock.CheckCacheSync(store, ctl, TestNamespace, 5, t)
+	ctl := memory.NewController(collections.Mocks, false)
+	mock.CheckCacheSync(ctl, ctl, TestNamespace, 5, t)
 }
 
 func TestControllerHashSynced(t *testing.T) {
-	store := memory.Make(collections.Mocks)
 	var v int32
-	ctl := memory.NewController(store)
+	ctl := memory.NewController(collections.Mocks, false)
+	go ctl.Run(test.NewStop(t))
 
 	ctl.RegisterHasSyncedHandler(func() bool {
 		return atomic.LoadInt32(&v) > 0

--- a/pilot/pkg/config/memory/store.go
+++ b/pilot/pkg/config/memory/store.go
@@ -35,16 +35,10 @@ var (
 
 const ResourceVersion string = "ResourceVersion"
 
-// Make creates an in-memory config store from a config schemas
-// It is with validation
-func Make(schemas collection.Schemas) *Store {
-	return newStore(schemas, false)
-}
-
-// MakeSkipValidation creates an in-memory config store from a config schemas
-// It is without validation
-func MakeSkipValidation(schemas collection.Schemas) *Store {
-	return newStore(schemas, true)
+// Make creates an in-memory config store for the specified schemas,
+// skipValidation can optionally skip validations.
+func Make(schemas collection.Schemas, skipValidation bool, stop <-chan struct{}) *Store {
+	return newStore(schemas, false, stop)
 }
 
 type syncer struct {
@@ -76,15 +70,14 @@ func (c *syncer) markSynced() {
 func newStore(
 	schemas collection.Schemas,
 	skipValidation bool,
+	stop <-chan struct{},
 ) *Store {
-	stop := make(chan struct{})
 	opts := krt.NewOptionsBuilder(stop, "memory", krt.GlobalDebugHandler)
 	out := Store{
 		schemas:        schemas,
 		data:           make(map[config.GroupVersionKind]kindStore),
 		skipValidation: skipValidation,
 		syncer:         &syncer{make(chan struct{})},
-		stop:           stop,
 	}
 	for _, s := range schemas.All() {
 		collection := krt.NewStaticCollection[config.Config](out.syncer, nil, opts.WithName(s.Kind())...)
@@ -107,7 +100,6 @@ type Store struct {
 	data           map[config.GroupVersionKind]kindStore
 	skipValidation bool
 	syncer         *syncer
-	stop           chan struct{}
 }
 
 func (cr *Store) hasSynced() bool {

--- a/pilot/pkg/config/memory/store_test.go
+++ b/pilot/pkg/config/memory/store_test.go
@@ -24,15 +24,16 @@ import (
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/test"
 )
 
 func TestStoreInvariant(t *testing.T) {
-	store := Make(collections.Mocks)
+	store := Make(collections.Mocks, false, test.NewStop(t))
 	mock.CheckMapInvariant(store, t, "some-namespace", 10)
 }
 
 func TestIstioConfig(t *testing.T) {
-	store := Make(collections.Pilot)
+	store := Make(collections.Pilot, false, test.NewStop(t))
 	mock.CheckIstioConfigTypes(store, "some-namespace", t)
 }
 
@@ -104,7 +105,7 @@ func BenchmarkStoreDelete(b *testing.B) {
 
 // make a new store and add 1000 configs to it
 func initStore(b *testing.B) model.ConfigStore {
-	s := MakeSkipValidation(collections.Pilot)
+	s := Make(collections.Pilot, true, test.NewStop(b))
 	cfg := config.Config{
 		Meta: config.Meta{
 			GroupVersionKind: gvk.ServiceEntry,

--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -1550,6 +1550,7 @@ func TestGetPoliciesForWorkloadWithJwksResolver(t *testing.T) {
 
 func getTestAuthenticationPolicies(configs []*config.Config, t *testing.T) *AuthenticationPolicies {
 	configStore := NewFakeStore()
+	go configStore.Run(pkgtest.NewStop(t))
 	for _, cfg := range configs {
 		log.Infof("add config %s", cfg.Name)
 		if _, err := configStore.Create(*cfg); err != nil {

--- a/pilot/pkg/model/proxy_config_test.go
+++ b/pilot/pkg/model/proxy_config_test.go
@@ -29,6 +29,7 @@ import (
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/util/protomarshal"
 )
@@ -328,7 +329,8 @@ func TestEffectiveProxyConfig(t *testing.T) {
 					"test": "selector",
 				}, map[string]string{
 					annotation.ProxyConfig.Name: "{ \"concurrency\": 5 }",
-				}),
+				},
+			),
 			expected: &meshconfig.ProxyConfig{
 				Concurrency: v(3),
 				Image: &v1beta1.ProxyImage{
@@ -393,7 +395,8 @@ func TestEffectiveProxyConfig(t *testing.T) {
 				"test-ns",
 				map[string]string{
 					"test": "selector",
-				}, map[string]string{}),
+				}, map[string]string{},
+			),
 			expected: &meshconfig.ProxyConfig{ProxyMetadata: map[string]string{
 				"A": "1",
 			}},
@@ -422,7 +425,8 @@ func TestEffectiveProxyConfig(t *testing.T) {
 			},
 			proxy: newMeta(
 				"test-ns",
-				map[string]string{}, map[string]string{}),
+				map[string]string{}, map[string]string{},
+			),
 			expected: &meshconfig.ProxyConfig{ProxyMetadata: map[string]string{
 				"A": "1",
 			}},
@@ -468,6 +472,7 @@ func newProxyConfigStore(t *testing.T, configs []config.Config) ConfigStore {
 	t.Helper()
 
 	store := NewFakeStore()
+	go store.Run(test.NewStop(t))
 	for _, cfg := range configs {
 		store.Create(cfg)
 	}

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -432,6 +432,7 @@ func TestEnvoyFilters(t *testing.T) {
 func TestEnvoyFilterOrder(t *testing.T) {
 	env := &Environment{}
 	store := NewFakeStore()
+	go store.Run(test.NewStop(t))
 
 	ctime := time.Now()
 
@@ -619,6 +620,7 @@ func buildPatchStruct(config string) *structpb.Struct {
 func TestEnvoyFilterOrderAcrossNamespaces(t *testing.T) {
 	env := &Environment{}
 	store := NewFakeStore()
+	go store.Run(test.NewStop(t))
 
 	proxy := &Proxy{
 		Metadata:        &NodeMetadata{IstioVersion: "foobar"},
@@ -1000,6 +1002,7 @@ func TestEnvoyFilterUpdate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			env := &Environment{}
 			store := NewFakeStore()
+			go store.Run(test.NewStop(t))
 			for _, cfg := range initialEnvoyFilters {
 				_, _ = store.Create(cfg)
 			}
@@ -1123,6 +1126,7 @@ func TestEnvoyFilterUpdate(t *testing.T) {
 func TestTrafficExtensions(t *testing.T) {
 	env := &Environment{}
 	store := NewFakeStore()
+	go store.Run(test.NewStop(t))
 
 	trafficExtensions := map[string]config.Config{
 		"invalid-type": {
@@ -1965,7 +1969,8 @@ func TestInitPushContext(t *testing.T) {
 
 	// Check to ensure the update is identical to the old one
 	// There is probably a better way to do this.
-	diff := cmp.Diff(old, newPush,
+	diff := cmp.Diff(
+		old, newPush,
 		// Allow looking into exported fields for parts of push context
 		cmp.AllowUnexported(PushContext{}, exportToDefaults{}, serviceIndex{}, virtualServiceIndex{},
 			destinationRuleIndex{}, gatewayIndex{}, consolidatedDestRules{}, IstioEgressListenerWrapper{}, SidecarScope{},
@@ -1992,6 +1997,7 @@ func TestSidecarScope(t *testing.T) {
 	ps.ServiceIndex.HostnameAndNamespace["svc3.istio-system.cluster.local"] = map[string]*Service{"istio-system": nil}
 
 	configStore := NewFakeStore()
+	go configStore.Run(test.NewStop(t))
 	sidecarWithWorkloadSelector := &networking.Sidecar{
 		WorkloadSelector: &networking.WorkloadSelector{
 			Labels: map[string]string{"app": "foo"},
@@ -2205,6 +2211,7 @@ func TestBestEffortInferServiceMTLSMode(t *testing.T) {
 	ps.Mesh = env.Mesh()
 
 	configStore := NewFakeStore()
+	go configStore.Run(test.NewStop(t))
 
 	// Add beta policies
 	_, _ = configStore.Create(*createTestPeerAuthenticationResource("default", wholeNS, time.Now(), nil, securityBeta.PeerAuthentication_MutualTLS_STRICT))
@@ -3511,11 +3518,13 @@ func TestInitVirtualService(t *testing.T) {
 		})
 	}
 
-	testCase(false,
+	testCase(
+		false,
 		sets.New("delegate.ns2", "public.ns3", "private.ns1", "match-ns1.ns5", "match-ns1.ns1", "match-ns7.ns7"),
 		sets.New("invisible.ns5"),
 	)
-	testCase(true,
+	testCase(
+		true,
 		sets.New("delegate.ns2", "public.ns3", "private.ns1", "match-ns1.ns5", "match-ns1.ns1"),
 		sets.New("invisible.ns5"),
 	)

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -3313,6 +3313,7 @@ func TestSidecarScopeAuthnPolicies(t *testing.T) {
 	}
 
 	configStore := NewFakeStore()
+	go configStore.Run(test.NewStop(t))
 	for _, cfg := range peerAuthnConfigs {
 		if _, err := configStore.Create(cfg); err != nil {
 			t.Fatalf("failed to create config: %v", err)

--- a/pilot/pkg/networking/apigen/apigen_test.go
+++ b/pilot/pkg/networking/apigen/apigen_test.go
@@ -79,8 +79,7 @@ func TestAPIGen(t *testing.T) {
 			Generator: "api",
 		}}
 		adscConn := ds.ConnectUnstarted(ds.SetupProxy(proxy), xds.APIWatches())
-		store := memory.Make(collections.Pilot)
-		configController := memory.NewController(store)
+		configController := memory.NewController(collections.Pilot, false)
 		adscConn.Store = configController
 		err := adscConn.Run()
 		if err != nil {
@@ -111,7 +110,7 @@ func TestAPIGenRequiresControlPlaneIdentity(t *testing.T) {
 	// The generator captures the feature flag at construction, so each subtest builds its
 	// own generator after setting the flag.
 	newGen := func() *apigen.APIGenerator {
-		return apigen.NewGenerator(memory.NewController(memory.Make(collections.Pilot)))
+		return apigen.NewGenerator(memory.NewController(collections.Pilot, false))
 	}
 	w := &model.WatchedResource{TypeUrl: gvk.AuthorizationPolicy.String()}
 
@@ -175,8 +174,7 @@ func TestAPIGenWithMulAddresses(t *testing.T) {
 			Generator: "api",
 		}}
 		adscConn := ds.ConnectUnstarted(ds.SetupProxy(proxy), xds.APIWatches())
-		store := memory.Make(collections.Pilot)
-		configController := memory.NewController(store)
+		configController := memory.NewController(collections.Pilot, false)
 		adscConn.Store = configController
 		err := adscConn.Run()
 		if err != nil {

--- a/pilot/pkg/networking/core/accesslog_test.go
+++ b/pilot/pkg/networking/core/accesslog_test.go
@@ -255,7 +255,7 @@ func newTestEnvironment(t *testing.T) *model.Environment {
 		},
 	})
 
-	configStore := memory.NewController(memory.Make(collections.Pilot))
+	configStore := memory.NewController(collections.Pilot, false)
 	configStore.Create(config.Config{
 		Meta: config.Meta{
 			Name:             "test",

--- a/pilot/pkg/networking/core/envoyfilter/listener_patch_test.go
+++ b/pilot/pkg/networking/core/envoyfilter/listener_patch_test.go
@@ -63,7 +63,7 @@ var testMesh = &meshconfig.MeshConfig{
 }
 
 func buildEnvoyFilterConfigStore(configPatches []*networking.EnvoyFilter_EnvoyConfigObjectPatch) model.ConfigStoreController {
-	store := memory.NewController(memory.Make(collections.Pilot))
+	store := memory.NewController(collections.Pilot, false)
 
 	for i, cp := range configPatches {
 		_, err := store.Create(config.Config{
@@ -84,7 +84,7 @@ func buildEnvoyFilterConfigStore(configPatches []*networking.EnvoyFilter_EnvoyCo
 }
 
 func buildEnvoyFilterConfigStoreWithPriorities(configPatches []*networking.EnvoyFilter_EnvoyConfigObjectPatch, priorities []int32) model.ConfigStoreController {
-	store := memory.NewController(memory.Make(collections.Pilot))
+	store := memory.NewController(collections.Pilot, false)
 
 	for i, cp := range configPatches {
 		_, err := store.Create(config.Config{

--- a/pilot/pkg/networking/core/fake.go
+++ b/pilot/pkg/networking/core/fake.go
@@ -126,7 +126,7 @@ func NewConfigGenTest(t test.Failer, opts TestOptions) *ConfigGenTest {
 	configs := getConfigs(t, opts)
 	cc := opts.ConfigController
 	if cc == nil {
-		cc = memory.NewController(memory.MakeSkipValidation(collections.PilotGatewayAPI()))
+		cc = memory.NewController(collections.PilotGatewayAPI(), true)
 	}
 	controllers := []model.ConfigStoreController{cc}
 	if opts.CreateConfigStore != nil {
@@ -179,7 +179,8 @@ func NewConfigGenTest(t test.Failer, opts TestOptions) *ConfigGenTest {
 		mc,
 		env.Watcher,
 		serviceentry.WithClusterID(opts.ClusterID),
-		serviceentry.WithKRTDebugger(krt.GlobalDebugHandler))
+		serviceentry.WithKRTDebugger(krt.GlobalDebugHandler),
+	)
 	// TODO allow passing in registry, for k8s, mem registry
 	serviceDiscovery.AddRegistry(se)
 	msd := memregistry.NewServiceDiscovery(opts.Services...)

--- a/pilot/pkg/networking/core/loadbalancer/loadbalancer_test.go
+++ b/pilot/pkg/networking/core/loadbalancer/loadbalancer_test.go
@@ -1150,7 +1150,7 @@ func buildEnvForClustersWithDistribute(t *testing.T, distribute []*networking.Lo
 		},
 	}
 
-	configStore := memory.NewController(memory.Make(collections.Pilot))
+	configStore := memory.NewController(collections.Pilot, false)
 
 	env := model.NewEnvironment()
 	env.ServiceDiscovery = serviceDiscovery
@@ -1217,7 +1217,7 @@ func buildEnvForClustersWithFailover(t *testing.T) *model.Environment {
 		},
 	}
 
-	configStore := memory.NewController(memory.Make(collections.Pilot))
+	configStore := memory.NewController(collections.Pilot, false)
 
 	env := model.NewEnvironment()
 	env.ServiceDiscovery = serviceDiscovery
@@ -1279,7 +1279,7 @@ func buildEnvForClustersWithFailoverPriority(t *testing.T, failoverPriority []st
 		},
 	}
 
-	configStore := memory.NewController(memory.Make(collections.Pilot))
+	configStore := memory.NewController(collections.Pilot, false)
 
 	env := model.NewEnvironment()
 	env.ServiceDiscovery = serviceDiscovery
@@ -1347,7 +1347,7 @@ func buildEnvForClustersWithMixedFailoverPriorityAndLocalityFailover(t *testing.
 		},
 	}
 
-	configStore := memory.NewController(memory.Make(collections.Pilot))
+	configStore := memory.NewController(collections.Pilot, false)
 
 	env := model.NewEnvironment()
 	env.ServiceDiscovery = serviceDiscovery

--- a/pilot/pkg/security/authz/builder/builder_test.go
+++ b/pilot/pkg/security/authz/builder/builder_test.go
@@ -32,6 +32,7 @@ import (
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/util/protomarshal"
 )
 
@@ -431,7 +432,7 @@ func convertTCP(in []*listener.Filter) []proto.Message {
 }
 
 func newAuthzPolicies(t *testing.T, policies []*config.Config) *model.AuthorizationPolicies {
-	store := memory.Make(collections.Pilot)
+	store := memory.Make(collections.Pilot, false, test.NewStop(t))
 	for _, p := range policies {
 		if _, err := store.Create(*p); err != nil {
 			t.Fatalf("newAuthzPolicies: %v", err)

--- a/pilot/pkg/serviceregistry/ambient/services.go
+++ b/pilot/pkg/serviceregistry/ambient/services.go
@@ -88,7 +88,7 @@ func (a Builder) ServicesCollection(
 	})
 
 	WorkloadServices := krt.NewManyCollection(
-		allTypedServiceInfosByHostname.AsCollection(),
+		allTypedServiceInfosByHostname.AsCollection(opts.WithName("AllTypedServiceInfosByHostname")...),
 		func(ctx krt.HandlerContext, ios krt.IndexObject[string, TypedServiceInfo]) []model.ServiceInfo {
 			if len(ios.Objects) == 0 {
 				return nil
@@ -164,7 +164,8 @@ func GlobalNestedWorkloadServicesCollection(
 	LocalServiceInfosWithCluster := krt.MapCollection(
 		localServiceInfos,
 		wrapObjectWithCluster[model.ServiceInfo](localCluster.ID),
-		opts.WithName("LocalServiceInfosWithCluster")...)
+		opts.WithName("LocalServiceInfosWithCluster")...,
+	)
 
 	checkServiceScope := features.EnableAmbientMultiNetwork
 
@@ -201,7 +202,8 @@ func GlobalNestedWorkloadServicesCollection(
 						return ""
 					}
 					return nw.Network
-				}, false),
+				}, false,
+			),
 				append(
 					opts,
 					krt.WithName(fmt.Sprintf("ambient/ServiceServiceInfos[%s]", cluster.ID)),

--- a/pilot/pkg/serviceregistry/serviceentry/controller_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller_test.go
@@ -90,8 +90,7 @@ func initServiceDiscovery(t test.Failer) (model.ConfigStore, *Controller, *xdsfa
 // initServiceDiscoveryWithoutEvents initializes a test setup with no events. This avoids excessive attempts to push
 // EDS updates to a full queue
 func initServiceDiscoveryWithoutEvents(t test.Failer) (model.ConfigStore, *Controller) {
-	store := memory.Make(collections.Pilot)
-	configController := memory.NewController(store)
+	configController := memory.NewController(collections.Pilot, false)
 
 	stop := test.NewStop(t)
 	go configController.Run(stop)
@@ -124,8 +123,7 @@ func initServiceDiscoveryWithoutEvents(t test.Failer) (model.ConfigStore, *Contr
 }
 
 func initServiceDiscoveryWithOpts(t test.Failer, workloadOnly bool, opts ...Option) (model.ConfigStore, *Controller, *xdsfake.Updater) {
-	store := memory.Make(collections.Pilot)
-	configController := memory.NewController(store)
+	configController := memory.NewController(collections.Pilot, false)
 
 	stop := test.NewStop(t)
 	go configController.Run(stop)
@@ -162,7 +160,8 @@ func TestServiceDiscoveryServices(t *testing.T) {
 	expectedServices := []*model.Service{
 		makeService(
 			"*.istio.io", "httpDNSRR", "httpDNSRR",
-			[]string{constants.UnspecifiedIP}, "", "", map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSRoundRobinLB),
+			[]string{constants.UnspecifiedIP}, "", "", map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSRoundRobinLB,
+		),
 		makeService("*.google.com", "httpDNS", "httpDNS",
 			[]string{constants.UnspecifiedIP}, "", "", map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSLB),
 		makeService("tcpstatic.com", "tcpStatic", "tcpStatic",
@@ -171,7 +170,8 @@ func TestServiceDiscoveryServices(t *testing.T) {
 
 	createConfigs([]*config.Config{httpDNS, httpDNSRR, tcpStatic}, store, t)
 
-	expectEvents(t, fx,
+	expectEvents(
+		t, fx,
 		Event{Type: "xds full", ID: "*.google.com"},
 		Event{Type: "xds full", ID: "*.istio.io"},
 		Event{Type: "xds full", ID: "tcpstatic.com"},
@@ -415,7 +415,8 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 		expectServiceInstances(t, sd, httpStaticOverlayUpdatedNs, 0, instances)
 		// svcUpdate is not triggered since `httpStatic` is there and has instances, so we should
 		// not delete the endpoints shards of "*.google.com". We xpect a full push as the service has changed.
-		expectEvents(t, events,
+		expectEvents(
+			t, events,
 			Event{Type: "eds", ID: "*.google.com", Namespace: httpStaticOverlayUpdated.Namespace},
 			Event{Type: "xds full", ID: "*.google.com"},
 		)
@@ -424,7 +425,8 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 		deleteConfigs([]*config.Config{httpStatic}, store, t)
 		// svcUpdate is triggered since "*.google.com" in same namespace is deleted and
 		// we need to delete endpoint shards. We expect a full push as the service has changed.
-		expectEvents(t, events,
+		expectEvents(
+			t, events,
 			Event{Type: "service", ID: "*.google.com", Namespace: httpStatic.Namespace},
 			Event{Type: "eds", ID: "*.google.com", Namespace: httpStatic.Namespace},
 			Event{Type: "xds full", ID: "*.google.com"},
@@ -446,7 +448,8 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 			makeInstance(httpStaticOverlay, "httpStaticOverlay-1", []string{"6.6.6.6"}, 4567, httpStaticOverlay.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"other": "bar"}, PlainText))
 		expectServiceInstances(t, sd, httpStatic, 0, instances)
 		// Service change, so we need a full push
-		expectEvents(t, events,
+		expectEvents(
+			t, events,
 			Event{Type: "service", ID: "*.google.com", Namespace: httpStaticOverlay.Namespace},
 			Event{Type: "eds", ID: "*.google.com", Namespace: httpStaticOverlay.Namespace},
 			Event{Type: "xds full", ID: "*.google.com"},
@@ -521,7 +524,8 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 
 		// restore this config and remove the added host.
 		createConfigs([]*config.Config{httpStaticOverlayUpdated}, store, t)
-		expectEvents(t, events,
+		expectEvents(
+			t, events,
 			Event{Type: "service", ID: "other.com", Namespace: httpStatic.Namespace},
 			Event{Type: "eds", ID: "other.com", Namespace: httpStatic.Namespace},
 			Event{Type: "xds full", ID: "other.com"},
@@ -565,7 +569,8 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 
 		// now update the config
 		createConfigs([]*config.Config{tcpDNSUpdated}, store, t)
-		expectEvents(t, events,
+		expectEvents(
+			t, events,
 			Event{Type: "xds full", ID: "tcpdns.com"},
 			Event{Type: "eds", ID: "tcpdns.com"},
 		) // service deleted
@@ -643,7 +648,8 @@ func TestServiceDiscoveryServiceInstancesForDnsRoundRobinLB(t *testing.T) {
 		makeInstance(se1, "dns-round-robin-1-0", []string{"1.1.1.1"}, 445, se1.Spec.(*networking.ServiceEntry).Ports[1], map[string]string{}, PlainText),
 	}
 	expectServiceInstances(t, sd, se1, 0, expectedPrimary)
-	expectEvents(t, events,
+	expectEvents(
+		t, events,
 		Event{Type: "service", ID: "example.com", Namespace: se1.Namespace},
 		Event{Type: "eds", ID: "example.com", Namespace: se1.Namespace, EndpointCount: len(expectedPrimary)},
 		Event{Type: "xds full", ID: se1.Spec.(*networking.ServiceEntry).Hosts[0]},
@@ -654,7 +660,8 @@ func TestServiceDiscoveryServiceInstancesForDnsRoundRobinLB(t *testing.T) {
 		makeInstance(seMulti, "dns-round-robin-3-0", []string{"3.3.3.3"}, 444, seMulti.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{}, PlainText),
 	}
 	expectServiceInstances(t, sd, seMulti, 0, expectedMul)
-	expectEvents(t, events,
+	expectEvents(
+		t, events,
 		Event{Type: "service", ID: "muladdrs.example.com", Namespace: seMulti.Namespace},
 		Event{Type: "eds", ID: "muladdrs.example.com", Namespace: seMulti.Namespace, EndpointCount: len(expectedMul)},
 		Event{Type: "xds full", ID: seMulti.Spec.(*networking.ServiceEntry).Hosts[0]},
@@ -679,7 +686,8 @@ func TestServiceDiscoveryServiceInstancesForDnsRoundRobinLB(t *testing.T) {
 	}
 	expectServiceInstances(t, sd, se1, 0, expectedPrimary)
 	expectServiceInstances(t, sd, otherNs, 0, otherNsExpected)
-	expectEvents(t, events,
+	expectEvents(
+		t, events,
 		Event{Type: "service", ID: "example.com", Namespace: otherNs.Namespace},
 		Event{Type: "eds", ID: "example.com", Namespace: otherNs.Namespace, EndpointCount: len(otherNsExpected)},
 		Event{Type: "xds full", ID: otherNs.Spec.(*networking.ServiceEntry).Hosts[0]},
@@ -696,7 +704,8 @@ func TestServiceDiscoveryServiceInstancesForDnsRoundRobinLB(t *testing.T) {
 	}
 
 	createConfigs([]*config.Config{se2}, store, t)
-	expectEvents(t, events,
+	expectEvents(
+		t, events,
 		Event{Type: "service", ID: "example.com", Namespace: se2.Namespace},
 		Event{Type: "xds full", ID: se2.Spec.(*networking.ServiceEntry).Hosts[0]},
 	)
@@ -762,7 +771,8 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 		}
 		expectProxyInstances(t, sd, instances, []string{"2.2.2.2"})
 		expectServiceInstances(t, sd, selector, 0, instances)
-		expectEvents(t, events,
+		expectEvents(
+			t, events,
 			Event{Type: "proxy", ID: "2.2.2.2"},
 			Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 2},
 		)
@@ -789,7 +799,8 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 		expectProxyInstances(t, sd, instances, []string{"2.2.2.2"})
 		expectServiceInstances(t, sd, selector, 0, []*model.ServiceInstance{})
 		expectServiceInstances(t, sd, updated, 0, instances)
-		expectEvents(t, events,
+		expectEvents(
+			t, events,
 			Event{Type: "service", ID: "updated.com", Namespace: selector.Namespace},
 			Event{Type: "service", ID: "selector.com", Namespace: selector.Namespace},
 			Event{Type: "eds", ID: "updated.com", Namespace: selector.Namespace},
@@ -818,7 +829,8 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 		expectProxyInstances(t, sd, instances, []string{"2.2.2.2"})
 		expectServiceInstances(t, sd, selector, 0, instances)
 		expectServiceInstances(t, sd, updated, 0, []*model.ServiceInstance{})
-		expectEvents(t, events,
+		expectEvents(
+			t, events,
 			Event{Type: "service", ID: "selector.com", Namespace: selector.Namespace},
 			Event{Type: "service", ID: "updated.com", Namespace: selector.Namespace},
 			Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace},
@@ -852,7 +864,8 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 		}
 		expectProxyInstances(t, sd, instances, []string{"4.4.4.4"})
 		expectServiceInstances(t, sd, dnsSelector, 0, instances)
-		expectEvents(t, events,
+		expectEvents(
+			t, events,
 			Event{Type: "eds", ID: "dns.selector.com", Namespace: dnsSelector.Namespace},
 			Event{Type: "xds full", ID: "dns.selector.com"},
 			// cannot void proxy update for dns workload
@@ -876,7 +889,8 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 			makeInstanceWithServiceAccount(selector, "wl2", []string{"3.3.3.3"}, 445,
 				selector.Spec.(*networking.ServiceEntry).Ports[1], map[string]string{"app": "wle"}, "default"))
 		expectServiceInstances(t, sd, selector, 0, instances)
-		expectEvents(t, events,
+		expectEvents(
+			t, events,
 			Event{Type: "proxy", ID: "3.3.3.3"},
 			Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 4},
 		)
@@ -898,7 +912,8 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 			makeInstanceWithServiceAccount(selector, "wl2", []string{"3.3.3.3"}, 445,
 				selector.Spec.(*networking.ServiceEntry).Ports[1], map[string]string{"app": "wle"}, "default"))
 		expectServiceInstances(t, sd, selector, 0, instances)
-		expectEvents(t, events,
+		expectEvents(
+			t, events,
 			Event{Type: "proxy", ID: "abc.def"},
 		)
 	})
@@ -933,7 +948,8 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 		}
 		expectProxyInstances(t, sd, instances, []string{"2.2.2.2"})
 		expectServiceInstances(t, sd, selector, 0, instances)
-		expectEvents(t, events,
+		expectEvents(
+			t, events,
 			Event{Type: "proxy", ID: "2.2.2.2"},
 			Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 2},
 		)
@@ -958,7 +974,8 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 		expectProxyInstances(t, sd, nil, []string{"2.2.2.2"})
 		expectProxyInstances(t, sd, instances, []string{"9.9.9.9"})
 		expectServiceInstances(t, sd, selector, 0, instances)
-		expectEvents(t, events,
+		expectEvents(
+			t, events,
 			// Event{Type: "proxy", ID: "9.9.9.9"},
 			Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 2},
 		)
@@ -966,22 +983,26 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 
 	t.Run("cleanup", func(t *testing.T) {
 		deleteConfigs([]*config.Config{wle, wle3}, store, t)
-		expectEvents(t, events,
+		expectEvents(
+			t, events,
 			Event{Type: "eds", ID: "selector.com"},
 		)
 		deleteConfigs([]*config.Config{selector}, store, t)
-		expectEvents(t, events,
+		expectEvents(
+			t, events,
 			Event{Type: "eds", ID: "selector.com"},
 			Event{Type: "service", ID: "selector.com"},
 			Event{Type: "xds full", ID: "selector.com"},
 		)
 		deleteConfigs([]*config.Config{dnsWle}, store, t)
 		// no xds full event since dnsWle contains an IP address
-		expectEvents(t, events,
+		expectEvents(
+			t, events,
 			Event{Type: "eds", ID: "dns.selector.com", Namespace: dnsSelector.Namespace},
 		)
 		deleteConfigs([]*config.Config{dnsSelector}, store, t)
-		expectEvents(t, events,
+		expectEvents(
+			t, events,
 			Event{Type: "eds", ID: "dns.selector.com", Namespace: dnsSelector.Namespace},
 			Event{Type: "service", ID: "dns.selector.com"},
 			Event{Type: "xds full", ID: "dns.selector.com"},
@@ -1053,7 +1074,8 @@ func TestServiceDiscoveryWorkloadChangeLabel(t *testing.T) {
 		}
 		expectProxyInstances(t, sd, instances, []string{"2.2.2.2"})
 		expectServiceInstances(t, sd, selector, 0, instances)
-		expectEvents(t, events,
+		expectEvents(
+			t, events,
 			Event{Type: "proxy", ID: "2.2.2.2"},
 			Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 2},
 		)
@@ -1070,7 +1092,8 @@ func TestServiceDiscoveryWorkloadChangeLabel(t *testing.T) {
 	t.Run("change label removing one", func(t *testing.T) {
 		// Add a WLE, we expect this to update
 		createConfigs([]*config.Config{wle}, store, t)
-		expectEvents(t, events,
+		expectEvents(
+			t, events,
 			Event{Type: "proxy", ID: "2.2.2.2"},
 			Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 2},
 		)
@@ -1093,7 +1116,8 @@ func TestServiceDiscoveryWorkloadChangeLabel(t *testing.T) {
 		expectProxyInstances(t, sd, instances[:2], []string{"2.2.2.2"})
 		expectProxyInstances(t, sd, instances[2:], []string{"3.3.3.3"})
 		expectServiceInstances(t, sd, selector, 0, instances)
-		expectEvents(t, events,
+		expectEvents(
+			t, events,
 			Event{Type: "proxy", ID: "3.3.3.3"},
 			Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 4},
 		)
@@ -1185,7 +1209,8 @@ func TestWorkloadInstanceFullPush(t *testing.T) {
 		}
 		expectProxyInstances(t, sd, instances, []string{"postman-echo.com"})
 		expectServiceInstances(t, sd, selectorDNS, 0, instances)
-		expectEvents(t, events,
+		expectEvents(
+			t, events,
 			Event{Type: "eds", ID: "selector.com", Namespace: selectorDNS.Namespace},
 			Event{Type: "xds full", ID: "selector.com"},
 			Event{Type: "proxy", ID: "postman-echo.com"},
@@ -1492,7 +1517,8 @@ func TestServiceDiscoveryWorkloadInstance(t *testing.T) {
 		}
 		expectProxyInstances(t, sd, instances, []string{"2.2.2.2"})
 		expectServiceInstances(t, sd, dnsSelector, 0, instances)
-		expectEvents(t, events,
+		expectEvents(
+			t, events,
 			Event{Type: "eds", ID: "dns.selector.com", Namespace: dnsSelector.Namespace, EndpointCount: 2},
 			Event{Type: "xds full", ID: "dns.selector.com"},
 			Event{Type: "proxy", ID: "2.2.2.2"},

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -81,7 +81,7 @@ func setupTest(t *testing.T) (model.ConfigStoreController, kubernetes.Interface,
 			MeshServiceController: aggregate.NewController(aggregate.Options{MeshHolder: meshWatcher}),
 		},
 	)
-	configController := memory.NewController(memory.Make(collections.Pilot))
+	configController := memory.NewController(collections.Pilot, false)
 
 	stop := istiotest.NewStop(t)
 	go configController.Run(stop)

--- a/pilot/test/xds/fake.go
+++ b/pilot/test/xds/fake.go
@@ -183,7 +183,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	mc := multicluster.NewFakeController()
 	creds := kubesecrets.NewMulticluster(opts.DefaultClusterName, mc)
 
-	configController := memory.NewController(memory.MakeSkipValidation(collections.PilotGatewayAPI()))
+	configController := memory.NewController(collections.PilotGatewayAPI(), true)
 	clientBuilder := opts.KubeClientBuilder
 	if clientBuilder == nil {
 		clientBuilder = func(objects ...runtime.Object) kubelib.Client {

--- a/pkg/adsc/adsc_test.go
+++ b/pkg/adsc/adsc_test.go
@@ -40,6 +40,7 @@ import (
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/test/util/retry"
 )
@@ -406,7 +407,7 @@ func TestADSC_handleMCP(t *testing.T) {
 	rev := "test-rev"
 	adsc := &ADSC{
 		VersionInfo: map[string]string{},
-		Store:       memory.Make(collections.Pilot),
+		Store:       memory.Make(collections.Pilot, false, test.NewStop(t)),
 		cfg: &ADSConfig{
 			Config: Config{
 				Revision: rev,

--- a/pkg/config/analysis/analyzers/analyzers_bench_test.go
+++ b/pkg/config/analysis/analyzers/analyzers_bench_test.go
@@ -29,6 +29,7 @@ import (
 	"istio.io/istio/pkg/config/schema/collections"
 	resource2 "istio.io/istio/pkg/config/schema/resource"
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/test"
 )
 
 // This is a very basic benchmark on unit test data, so it doesn't tell us anything about how an analyzer performs at scale
@@ -77,7 +78,7 @@ func benchmarkAnalyzersArtificialBlankData(count int, b *testing.B) {
 	defer validationScope.SetOutputLevel(oldLevel)
 
 	// Generate blank test data
-	store := memory.MakeSkipValidation(collections.All)
+	store := memory.Make(collections.All, true, test.NewStop(b))
 	collections.All.ForEach(func(s resource2.Schema) bool {
 		for i := 0; i < count; i++ {
 			name := resource.NewFullName("default", resource.LocalName(fmt.Sprintf("%s-%d", s.Kind(), i)))

--- a/pkg/config/analysis/local/analyze_test.go
+++ b/pkg/config/analysis/local/analyze_test.go
@@ -33,6 +33,7 @@ import (
 	"istio.io/istio/pkg/config/resource"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
 )
 
@@ -144,6 +145,7 @@ func TestAddInMemorySource(t *testing.T) {
 	sa := NewSourceAnalyzer(blankCombinedAnalyzer, "", "", nil)
 
 	src := model.NewFakeStore()
+	go src.Run(test.NewStop(t))
 	sa.AddSource(src)
 	assert.Equal(t, sa.meshCfg, mesh.DefaultMeshConfig()) // Base default meshcfg
 	g.Expect(sa.meshNetworks.Networks).To(HaveLen(0))

--- a/pkg/config/analysis/local/istiod_analyze.go
+++ b/pkg/config/analysis/local/istiod_analyze.go
@@ -115,7 +115,7 @@ func NewIstiodAnalyzer(analyzer analysis.CombinedAnalyzer, namespace,
 		analyzer:           analyzer,
 		namespace:          namespace,
 		cluster:            "default",
-		internalStore:      memory.NewController(memory.Make(collection.SchemasFor(collections.MeshNetworks, collections.MeshConfig))),
+		internalStore:      memory.NewController(collection.SchemasFor(collections.MeshNetworks, collections.MeshConfig), false),
 		istioNamespace:     istioNamespace,
 		kubeResources:      kubeResources,
 		collectionReporter: cr,
@@ -322,7 +322,8 @@ func isIstioConfigMap(obj any) bool {
 
 var secretFieldSelector = fields.AndSelectors(
 	fields.OneTermNotEqualSelector("type", "helm.sh/release.v1"),
-	fields.OneTermNotEqualSelector("type", string(v1.SecretTypeServiceAccountToken))).String()
+	fields.OneTermNotEqualSelector("type", string(v1.SecretTypeServiceAccountToken)),
+).String()
 
 func (sa *IstiodAnalyzer) GetFiltersByGVK() map[config.GroupVersionKind]kubetypes.Filter {
 	return map[config.GroupVersionKind]kubetypes.Filter{

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -905,6 +905,7 @@ func createWebhook(t testing.TB, cfg *Config, pcResources int) *Webhook {
 	// mesh config
 	m := mesh.DefaultMeshConfig()
 	store := model.NewFakeStore()
+	go store.Run(test.NewStop(t))
 	for i := 0; i < pcResources; i++ {
 		store.Create(newProxyConfig(fmt.Sprintf("pc-%d", i), "istio-system", &v1beta12.ProxyConfig{
 			Concurrency: &wrapperspb.Int32Value{Value: int32(i % 5)},

--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -232,6 +232,8 @@ type manyCollection[I, O any] struct {
 	// onPrimaryInputEventHandler is a specialized internal handler that runs synchronously when a primary input changes
 	onPrimaryInputEventHandler func(o []Event[I])
 
+	debugger *DebugHandler
+
 	syncer Syncer
 }
 
@@ -622,6 +624,7 @@ func newManyCollection[I, O any](
 		synced:                     make(chan struct{}),
 		stop:                       opts.stop,
 		onPrimaryInputEventHandler: onPrimaryInputEventHandler,
+		debugger:                   opts.debugger,
 	}
 
 	if opts.metadata != nil {
@@ -632,7 +635,7 @@ func newManyCollection[I, O any](
 		name:   h.collectionName,
 		synced: h.synced,
 	}
-	maybeRegisterCollectionForDebugging(h, opts.debugger)
+	maybeRegisterCollectionForDebugging(h, h.debugger)
 
 	// Create our queue. When it syncs (that is, all items that were present when Run() was called), we mark ourselves as synced.
 	h.queue = queue.NewWithSync(func() {
@@ -649,6 +652,7 @@ func newManyCollection[I, O any](
 }
 
 func (h *manyCollection[I, O]) runQueue() {
+	defer maybeUnregisterCollectionFromDebugger(h, h.debugger)
 	c := h.parent
 	// Wait for primary dependency to be ready
 	if !c.WaitUntilSynced(h.stop) {

--- a/pkg/kube/krt/debug.go
+++ b/pkg/kube/krt/debug.go
@@ -17,18 +17,20 @@ package krt
 import (
 	"encoding/json"
 	"sync"
+
+	"istio.io/istio/pkg/maps"
 )
 
 // DebugHandler allows attaching a variety of collections to it and then dumping them
 type DebugHandler struct {
-	debugCollections []DebugCollection
+	debugCollections map[collectionUID]DebugCollection
 	mu               sync.RWMutex
 }
 
 func (p *DebugHandler) MarshalJSON() ([]byte, error) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
-	return json.Marshal(p.debugCollections)
+	return json.Marshal(maps.Values(p.debugCollections))
 }
 
 var GlobalDebugHandler = new(DebugHandler)
@@ -69,11 +71,25 @@ func maybeRegisterCollectionForDebugging[T any](c Collection[T], handler *DebugH
 	cc := c.(internalCollection[T])
 	handler.mu.Lock()
 	defer handler.mu.Unlock()
-	handler.debugCollections = append(handler.debugCollections, DebugCollection{
+	if handler.debugCollections == nil {
+		handler.debugCollections = make(map[collectionUID]DebugCollection)
+	}
+	handler.debugCollections[cc.uid()] = DebugCollection{
 		name: cc.name(),
 		dump: cc.dump,
 		uid:  cc.uid(),
-	})
+	}
+}
+
+// maybeUnregisterCollectionFromDebugger removes the collection from the debugger, if one is enabled
+func maybeUnregisterCollectionFromDebugger[T any](c Collection[T], handler *DebugHandler) {
+	if handler == nil {
+		return
+	}
+	cc := c.(internalCollection[T])
+	handler.mu.Lock()
+	defer handler.mu.Unlock()
+	delete(handler.debugCollections, cc.uid())
 }
 
 // nolint: unused // (not true, not sure why it thinks it is!)

--- a/pkg/kube/krt/debug_test.go
+++ b/pkg/kube/krt/debug_test.go
@@ -1,0 +1,166 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package krt
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/kclient"
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/assert"
+)
+
+type dbgNamed struct {
+	Name string
+}
+
+func (n dbgNamed) ResourceName() string { return n.Name }
+
+// blockingSyncer never reports as synced; WaitUntilSynced only returns (false) once stopped.
+// It is used to drive collections into their stop-before-sync code paths.
+type blockingSyncer struct{}
+
+func (blockingSyncer) HasSynced() bool { return false }
+
+func (blockingSyncer) WaitUntilSynced(stop <-chan struct{}) bool {
+	<-stop
+	return false
+}
+
+// debugCount returns the number of collections currently registered with the debugger.
+func debugCount(dh *DebugHandler) int {
+	dh.mu.RLock()
+	defer dh.mu.RUnlock()
+	return len(dh.debugCollections)
+}
+
+func merge(ts []dbgNamed) *dbgNamed {
+	if len(ts) == 0 {
+		return nil
+	}
+	return &ts[0]
+}
+
+// TestDebuggerUnregistration verifies that every collection type unregisters itself from the
+// debugger once its stop channel is closed. Otherwise, collections that are created and destroyed
+// over the lifetime of the process (e.g. per-cluster ambient collections) leak debugger
+// registrations forever.
+func TestDebuggerUnregistration(t *testing.T) {
+	// Each case builds one or more collections against a fresh DebugHandler, waits for them to
+	// register, then closes the stop channel and asserts every registration is cleaned up.
+	cases := map[string]func(_ *testing.T, opts OptionsBuilder){
+		"informer": func(t *testing.T, opts OptionsBuilder) {
+			c := kube.NewFakeClient()
+			kc := kclient.New[*corev1.ConfigMap](c)
+			_ = WrapClient(kc, opts.WithName("cms")...)
+			// Run the client on a separate, cleanup-closed stop so the informer's workqueue drains
+			// at test cleanup rather than when the collection stop closes. This avoids a spurious
+			// goroutine-leak report from the fake client's slow-draining workqueue.
+			c.RunAndWait(test.NewStop(t))
+		},
+		"static": func(_ *testing.T, opts OptionsBuilder) {
+			_ = NewStaticCollection[dbgNamed](nil, nil, opts.WithName("static")...)
+		},
+		"singleton": func(_ *testing.T, opts OptionsBuilder) {
+			_ = NewStatic[dbgNamed](nil, true, opts.WithName("singleton")...).AsCollection()
+		},
+		"map": func(_ *testing.T, opts OptionsBuilder) {
+			base := NewStaticCollection[dbgNamed](nil, nil, opts.WithName("base")...)
+			_ = MapCollection(base, func(n dbgNamed) dbgNamed { return n }, opts.WithName("map")...)
+		},
+		"index": func(_ *testing.T, opts OptionsBuilder) {
+			base := NewStaticCollection[dbgNamed](nil, nil, opts.WithName("base")...)
+			idx := NewIndex(base, "name", func(n dbgNamed) []string { return []string{n.Name} })
+			_ = idx.AsCollection(opts.WithName("idx")...)
+		},
+		"manyCollection": func(_ *testing.T, opts OptionsBuilder) {
+			base := NewStaticCollection[dbgNamed](nil, nil, opts.WithName("base")...)
+			_ = NewCollection(base, func(ctx HandlerContext, n dbgNamed) *dbgNamed {
+				return &n
+			}, opts.WithName("many")...)
+		},
+		"mergejoin": func(_ *testing.T, opts OptionsBuilder) {
+			c1 := NewStaticCollection[dbgNamed](nil, nil, opts.WithName("c1")...)
+			c2 := NewStaticCollection[dbgNamed](nil, nil, opts.WithName("c2")...)
+			_ = JoinWithMergeCollection([]Collection[dbgNamed]{c1, c2}, merge, opts.WithName("merge")...)
+		},
+		"nestedjoinmerge": func(_ *testing.T, opts OptionsBuilder) {
+			inner := NewStaticCollection[dbgNamed](nil, nil, opts.WithName("inner")...)
+			multi := NewStaticCollection(nil, []Collection[dbgNamed]{inner}, opts.WithName("multi")...)
+			_ = NestedJoinWithMergeCollection(multi, merge, opts.WithName("nested")...)
+		},
+	}
+
+	for name, build := range cases {
+		t.Run(name, func(t *testing.T) {
+			dh := &DebugHandler{}
+			stop := make(chan struct{})
+			opts := NewOptionsBuilder(stop, "test", dh)
+
+			build(t, opts)
+
+			// Collections register synchronously on construction.
+			assert.EventuallyEqual(t, func() bool { return debugCount(dh) > 0 }, true)
+
+			close(stop)
+			assert.EventuallyEqual(t, func() int { return debugCount(dh) }, 0)
+		})
+	}
+}
+
+// TestDebuggerUnregistrationBeforeSync verifies the stop-before-sync code paths: a collection that
+// is stopped before it ever finishes syncing must still unregister from the debugger. Each of the
+// queue-backed collections returns early (without running its queue) when its inputs never sync, so
+// this exercises the unregistration on those early-return paths. Inputs use a never-syncing static
+// collection so no informer/workqueue is involved.
+func TestDebuggerUnregistrationBeforeSync(t *testing.T) {
+	cases := map[string]func(_ *testing.T, opts OptionsBuilder){
+		"manyCollection": func(_ *testing.T, opts OptionsBuilder) {
+			// Primary never syncs, so runQueue returns before running the queue.
+			base := NewStaticCollection[dbgNamed](blockingSyncer{}, nil, opts.WithName("base")...)
+			_ = NewCollection(base, func(ctx HandlerContext, n dbgNamed) *dbgNamed {
+				return &n
+			}, opts.WithName("many")...)
+		},
+		"mergejoin": func(_ *testing.T, opts OptionsBuilder) {
+			c1 := NewStaticCollection[dbgNamed](blockingSyncer{}, nil, opts.WithName("c1")...)
+			c2 := NewStaticCollection[dbgNamed](blockingSyncer{}, nil, opts.WithName("c2")...)
+			_ = JoinWithMergeCollection([]Collection[dbgNamed]{c1, c2}, merge, opts.WithName("merge")...)
+		},
+		"nestedjoinmerge": func(_ *testing.T, opts OptionsBuilder) {
+			inner := NewStaticCollection[dbgNamed](blockingSyncer{}, nil, opts.WithName("inner")...)
+			multi := NewStaticCollection(blockingSyncer{}, []Collection[dbgNamed]{inner}, opts.WithName("multi")...)
+			_ = NestedJoinWithMergeCollection(multi, merge, opts.WithName("nested")...)
+		},
+	}
+
+	for name, build := range cases {
+		t.Run(name, func(t *testing.T) {
+			dh := &DebugHandler{}
+			stop := make(chan struct{})
+			opts := NewOptionsBuilder(stop, "test", dh)
+
+			build(t, opts)
+
+			assert.EventuallyEqual(t, func() bool { return debugCount(dh) > 0 }, true)
+
+			close(stop)
+			assert.EventuallyEqual(t, func() int { return debugCount(dh) }, 0)
+		})
+	}
+}

--- a/pkg/kube/krt/index.go
+++ b/pkg/kube/krt/index.go
@@ -122,6 +122,12 @@ func (i index[K, O]) AsCollection(opts ...CollectionOption) IndexCollection[K, O
 		c.metadata = o.metadata
 	}
 	maybeRegisterCollectionForDebugging(c, o.debugger)
+	if o.debugger != nil && o.stopProvided {
+		go func() {
+			<-o.stop
+			maybeUnregisterCollectionFromDebugger(c, o.debugger)
+		}()
+	}
 	return c
 }
 

--- a/pkg/kube/krt/informer.go
+++ b/pkg/kube/krt/informer.go
@@ -216,8 +216,10 @@ func WrapClient[I controllers.ComparableObject](c kclient.Informer[I], opts ...C
 		h.metadata = o.metadata
 	}
 
+	maybeRegisterCollectionForDebugging(h, o.debugger)
 	go func() {
 		defer c.ShutdownHandlers()
+		defer maybeUnregisterCollectionFromDebugger(h, o.debugger)
 		// First, wait for the informer to populate. We ignore handlers which have their own syncing
 		if !kube.WaitForCacheSync(o.name, o.stop, c.HasSyncedIgnoringHandlers) {
 			return
@@ -227,7 +229,6 @@ func WrapClient[I controllers.ComparableObject](c kclient.Informer[I], opts ...C
 
 		<-o.stop
 	}()
-	maybeRegisterCollectionForDebugging(h, o.debugger)
 	return h
 }
 

--- a/pkg/kube/krt/internal.go
+++ b/pkg/kube/krt/internal.go
@@ -63,6 +63,7 @@ func buildCollectionOptions(opts ...CollectionOption) collectionOptions {
 	for _, o := range opts {
 		o(c)
 	}
+	c.stopProvided = c.stop != nil
 	if c.stop == nil {
 		// TODO: https://github.com/istio/istio/issues/58791
 		// if EnableAssertions {
@@ -80,9 +81,14 @@ func buildCollectionOptions(opts ...CollectionOption) collectionOptions {
 
 // collectionOptions tracks options for a collection
 type collectionOptions struct {
-	name          string
-	augmentation  func(o any) any
-	stop          <-chan struct{}
+	name         string
+	augmentation func(o any) any
+	stop         <-chan struct{}
+	// stopProvided reports whether the caller explicitly supplied a stop channel (via WithStop).
+	// When false, `stop` is a manufactured default that is never closed, so any goroutine waiting
+	// on it would leak. Lifecycle goroutines (e.g. debugger unregistration) must not be started in
+	// that case.
+	stopProvided  bool
 	debugger      *DebugHandler
 	joinUnchecked bool
 

--- a/pkg/kube/krt/map.go
+++ b/pkg/kube/krt/map.go
@@ -171,6 +171,12 @@ func MapCollection[T, U any](
 		metadata:       metadata,
 	}
 	maybeRegisterCollectionForDebugging[U](m, o.debugger)
+	if o.debugger != nil && o.stopProvided {
+		go func() {
+			<-o.stop
+			maybeUnregisterCollectionFromDebugger(m, o.debugger)
+		}()
+	}
 	return m
 }
 
@@ -180,7 +186,8 @@ func assertKeyMatch[T, U any](original T, mapped U, name string) {
 	originalKey := GetKey(original)
 	mappedKey := GetKey(mapped)
 	if originalKey != mappedKey {
-		msg := fmt.Sprintf("MapCollection invariant violation in %s: T and U must have matching keys: (%T)%s != (%T)%s",
+		msg := fmt.Sprintf(
+			"MapCollection invariant violation in %s: T and U must have matching keys: (%T)%s != (%T)%s",
 			name,
 			original,
 			originalKey,

--- a/pkg/kube/krt/mergejoin.go
+++ b/pkg/kube/krt/mergejoin.go
@@ -58,7 +58,8 @@ type mergejoin[T any] struct {
 	queue    queue.Instance
 	metadata Metadata
 
-	syncer Syncer
+	syncer   Syncer
+	debugger *DebugHandler
 }
 
 type joinCollectionIndex[T any] struct {
@@ -359,6 +360,7 @@ func (j *mergejoin[T]) updateIndexLocked(e Event[T], key Key[T]) {
 }
 
 func (j *mergejoin[T]) runQueue() {
+	defer maybeUnregisterCollectionFromDebugger(j, j.debugger)
 	// Wait until all underlying collections are synced before registering
 	syncers := slices.Map(j.collections.getCollections(), func(c Collection[T]) cache.InformerSynced {
 		return c.HasSynced
@@ -426,6 +428,7 @@ func JoinWithMergeCollection[T any](cs []Collection[T], merge func(ts []T) *T, o
 			name:   o.name,
 			synced: synced,
 		},
+		debugger: o.debugger,
 	}
 
 	maybeRegisterCollectionForDebugging(j, o.debugger)

--- a/pkg/kube/krt/nestedjoinmerge.go
+++ b/pkg/kube/krt/nestedjoinmerge.go
@@ -85,6 +85,7 @@ func NestedJoinWithMergeCollection[T any](collections Collection[Collection[T]],
 			merge:          merge,
 			synced:         synced,
 			stop:           o.stop,
+			debugger:       o.debugger,
 		},
 		collections: ics,
 		regs:        make(map[collectionUID]HandlerRegistration),
@@ -142,6 +143,7 @@ func NestedJoinWithMergeCollection[T any](collections Collection[Collection[T]],
 }
 
 func (j *nestedjoinmerge[T]) runQueue(initialCollections []Collection[T], subscriptionFunc func([]Event[T]), reg HandlerRegistration) {
+	defer maybeUnregisterCollectionFromDebugger(j, j.debugger)
 	// We subscribed to the container collection (reg) and to each sub-collection (j.regs); all of
 	// these may outlive us. Once we are stopped, unregister them (and their goroutines) so we don't
 	// leak them.

--- a/pkg/kube/krt/singleton.go
+++ b/pkg/kube/krt/singleton.go
@@ -63,6 +63,12 @@ func NewStatic[T any](initial *T, startSynced bool, opts ...CollectionOption) St
 		x.metadata = o.metadata
 	}
 	maybeRegisterCollectionForDebugging(x, o.debugger)
+	if o.debugger != nil && o.stopProvided {
+		go func() {
+			<-o.stop
+			maybeUnregisterCollectionFromDebugger(x, o.debugger)
+		}()
+	}
 	return collectionAdapter[T]{x}
 }
 

--- a/pkg/kube/krt/static.go
+++ b/pkg/kube/krt/static.go
@@ -74,6 +74,12 @@ func NewStaticCollection[T any](synced Syncer, vals []T, opts ...CollectionOptio
 		staticList: sl,
 	}
 	maybeRegisterCollectionForDebugging[T](c, o.debugger)
+	if o.debugger != nil && o.stopProvided {
+		go func() {
+			<-o.stop
+			maybeUnregisterCollectionFromDebugger(c, o.debugger)
+		}()
+	}
 	return c
 }
 

--- a/releasenotes/notes/krt-debugger-leak.yaml
+++ b/releasenotes/notes/krt-debugger-leak.yaml
@@ -1,0 +1,12 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+issue:
+  - 60033
+
+releaseNotes:
+  - |
+    **Fixed** a memory leak in ambient multi-cluster mode where collections were registered with the
+    krt debugger but never unregistered when a remote cluster was removed or its configuration changed,
+    causing debugger registrations to accumulate over time.

--- a/tests/fuzz/autoregistration_controller_fuzzer.go
+++ b/tests/fuzz/autoregistration_controller_fuzzer.go
@@ -106,7 +106,7 @@ func FuzzWE(data []byte) int {
 		return 0
 	}
 
-	store := memory.NewController(memory.Make(collections.All))
+	store := memory.NewController(collections.All, false)
 	c := autoregistration.NewController(store, "", keepalive.Infinity)
 	err = createStore(store, wgA)
 	if err != nil {

--- a/tests/fuzz/pilot_model_fuzzer.go
+++ b/tests/fuzz/pilot_model_fuzzer.go
@@ -192,7 +192,10 @@ func FuzzInitContext(data []byte) int {
 	}
 
 	env := &model.Environment{}
+	stop := make(chan struct{})
+	defer close(stop)
 	store := model.NewFakeStore()
+	go store.Run(stop)
 
 	env.ConfigStore = store
 	sd := memory.NewServiceDiscovery(services...)


### PR DESCRIPTION
**Please provide a description of this PR:**
Cherry-pick https://github.com/istio/istio/pull/61263 into 1.30

Closes https://github.com/istio/istio/issues/61312 