### PR TITLE
log api generator authorization denials

### DIFF
--- a/pilot/pkg/networking/apigen/apigen.go
+++ b/pilot/pkg/networking/apigen/apigen.go
@@ -159,11 +159,11 @@ func (g *APIGenerator) authorize(proxy *model.Proxy, req *model.PushRequest) err
 		if proxy != nil {
 			id = proxy.ID
 		}
-		log.Warnf("ADS: api generator denied unauthenticated request from %q; the caller sees the stream close and may silently retry", id)
+		log.Warnf("ADS: api generator denied unauthenticated request from %q", id)
 		return grpcstatus.Error(codes.Unauthenticated, "the api generator requires an authenticated control-plane identity")
 	}
 	if proxy.VerifiedIdentity.Namespace != systemNamespace {
-		log.Warnf("ADS: api generator denied %q (identity %q), restricted to the control-plane namespace %q; the caller sees the stream close and may silently retry",
+		log.Warnf("ADS: api generator denied %q (identity %q), restricted to the control-plane namespace %q",
 			proxy.ID, proxy.VerifiedIdentity.String(), systemNamespace)
 		return grpcstatus.Error(codes.PermissionDenied, "the api generator is restricted to the control-plane (root) namespace")
 	}

--- a/pilot/pkg/networking/apigen/apigen.go
+++ b/pilot/pkg/networking/apigen/apigen.go
@@ -155,9 +155,16 @@ func (g *APIGenerator) authorize(proxy *model.Proxy, req *model.PushRequest) err
 		systemNamespace = req.Push.Mesh.GetRootNamespace()
 	}
 	if proxy == nil || proxy.VerifiedIdentity == nil {
+		id := "<none>"
+		if proxy != nil {
+			id = proxy.ID
+		}
+		log.Warnf("ADS: api generator denied unauthenticated request from %q; the caller sees the stream close and may silently retry", id)
 		return grpcstatus.Error(codes.Unauthenticated, "the api generator requires an authenticated control-plane identity")
 	}
 	if proxy.VerifiedIdentity.Namespace != systemNamespace {
+		log.Warnf("ADS: api generator denied %q (identity %q), restricted to the control-plane namespace %q; the caller sees the stream close and may silently retry",
+			proxy.ID, proxy.VerifiedIdentity.String(), systemNamespace)
 		return grpcstatus.Error(codes.PermissionDenied, "the api generator is restricted to the control-plane (root) namespace")
 	}
 	return nil


### PR DESCRIPTION
**Please provide a description of this PR:**

this is follow-up to #61234. A denied caller currently sees only the stream close and may silently retry forever; the server logs nothing at any level. Log the denial with the caller identity so operators can tell an auth rejection from an empty response. No behavior change.