### PR TITLE
fix: delete per-revision leases on uninstall

### DIFF
--- a/operator/pkg/uninstall/prune.go
+++ b/operator/pkg/uninstall/prune.go
@@ -75,6 +75,7 @@ func NamespacedResources() []schema.GroupVersionKind {
 		{Group: "policy", Version: "v1", Kind: "PodDisruptionBudget"},
 		{Group: "autoscaling", Version: "v2", Kind: "HorizontalPodAutoscaler"},
 		gvk.EnvoyFilter.Kubernetes(),
+		{Group: "coordination.k8s.io", Version: "v1", Kind: "Lease"},
 	}
 	return res
 }

--- a/pilot/pkg/leaderelection/k8sleaderelection/k8sresourcelock/leaselock.go
+++ b/pilot/pkg/leaderelection/k8sleaderelection/k8sresourcelock/leaselock.go
@@ -59,6 +59,7 @@ func (ll *LeaseLock) Create(ctx context.Context, ler LeaderElectionRecord) error
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ll.LeaseMeta.Name,
 			Namespace: ll.LeaseMeta.Namespace,
+			Labels:    ll.LeaseMeta.Labels,
 		},
 		Spec: LeaderElectionRecordToLeaseSpec(&ler),
 	}
@@ -86,6 +87,12 @@ func (ll *LeaseLock) Update(ctx context.Context, ler LeaderElectionRecord) error
 		return errors.New("lease not initialized, call get or create first")
 	}
 	ll.lease.Spec = LeaderElectionRecordToLeaseSpec(&ler)
+	for key, value := range ll.LeaseMeta.Labels {
+		if ll.lease.Labels == nil {
+			ll.lease.Labels = make(map[string]string)
+		}
+		ll.lease.Labels[key] = value
+	}
 	ensureHolderKey(ler, ll.lease)
 
 	lease, err := ll.Client.Leases(ll.LeaseMeta.Namespace).Update(ctx, ll.lease, metav1.UpdateOptions{})

--- a/pilot/pkg/leaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/leaderelection.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"istio.io/api/label"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/leaderelection/k8sleaderelection"
 	"istio.io/istio/pilot/pkg/leaderelection/k8sleaderelection/k8sresourcelock"
@@ -177,8 +178,15 @@ func (l *LeaderElection) create() (*k8sleaderelection.LeaderElector, error) {
 			// See below, where we disable KeyComparison as well
 			leaseKey = ""
 		}
+		leaseMeta := metav1.ObjectMeta{Namespace: l.namespace, Name: l.electionID}
+		if l.perRevision {
+			leaseMeta.Labels = map[string]string{
+				label.IoIstioRev.Name:         l.revision,
+				"operator.istio.io/component": "Pilot",
+			}
+		}
 		lock = &k8sresourcelock.LeaseLock{
-			LeaseMeta: metav1.ObjectMeta{Namespace: l.namespace, Name: l.electionID},
+			LeaseMeta: leaseMeta,
 			Client:    l.client.CoordinationV1(),
 			LockConfig: k8sresourcelock.ResourceLockConfig{
 				Identity: l.name,

--- a/pilot/pkg/leaderelection/leaderelection_test.go
+++ b/pilot/pkg/leaderelection/leaderelection_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"go.uber.org/atomic"
+	coordinationv1 "k8s.io/api/coordination/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -142,6 +143,43 @@ func TestPerRevisionElection(t *testing.T) {
 	_, stop4 := createPerRevisionElection(t, "pod4", "not-foo", watcher, true, client)
 	close(stop3)
 	close(stop4)
+}
+
+func TestPerRevisionLeaseLabels(t *testing.T) {
+	client := fake.NewClientset()
+	watcher := &fakeDefaultWatcher{"canary"}
+	_, stop := createPerRevisionElection(t, "pod1", "canary", watcher, true, client)
+	defer close(stop)
+
+	leases, err := client.CoordinationV1().Leases("ns").List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(leases.Items) != 1 {
+		t.Fatalf("expected 1 lease, got %d", len(leases.Items))
+	}
+	lease := leases.Items[0]
+	if got := lease.Labels["istio.io/rev"]; got != "canary" {
+		t.Errorf("expected label istio.io/rev=canary, got %v", lease.Labels)
+	}
+	if got := lease.Labels["operator.istio.io/component"]; got != "Pilot" {
+		t.Errorf("expected label operator.istio.io/component=Pilot, got %v", lease.Labels)
+	}
+}
+
+func TestPerRevisionLeaseLabelsExistingLease(t *testing.T) {
+	client := fake.NewClientset(&coordinationv1.Lease{ObjectMeta: metav1.ObjectMeta{
+		Name: "test-lock-canary", Namespace: "ns",
+	}})
+	watcher := &fakeDefaultWatcher{"canary"}
+	_, stop := createPerRevisionElection(t, "pod1", "canary", watcher, true, client)
+	defer close(stop)
+
+	retry.UntilOrFail(t, func() bool {
+		lease, err := client.CoordinationV1().Leases("ns").Get(context.TODO(), "test-lock-canary", metav1.GetOptions{})
+		return err == nil && lease.Labels["istio.io/rev"] == "canary" &&
+			lease.Labels["operator.istio.io/component"] == "Pilot"
+	}, retry.Timeout(time.Second*5), retry.Delay(time.Millisecond*100))
 }
 
 func TestPrioritizedLeaderElection(t *testing.T) {


### PR DESCRIPTION
## Description

Fixes #61155.

`istioctl uninstall --revision` did not remove per-revision leader-election Leases, leaving resources such as `istio-gateway-deployment-<revision>` and `istio-gateway-status-leader-<revision>` behind.

The uninstall pruner selects namespaced resources by revision and component labels, but Leases were not included in its resource list and per-revision Leases were created without those labels.

## Changes

- Include `coordination.k8s.io/v1` Leases in namespaced uninstall pruning.
- Add `istio.io/rev` and `operator.istio.io/component=Pilot` labels to per-revision Leases.
- Apply the labels when an existing legacy Lease is updated, covering upgrades from older Istio versions.
- Add tests for newly created and existing unlabelled Leases.

## Testing

- `go test ./pilot/pkg/leaderelection/... ./operator/pkg/uninstall/...`