### PR TITLE
credentials: include service account groups in SubjectAccessReview

### DIFF
--- a/pilot/pkg/credentials/kube/secrets.go
+++ b/pilot/pkg/credentials/kube/secrets.go
@@ -202,6 +202,12 @@ func (s *CredentialsController) Authorize(serviceAccount, namespace string) erro
 					Resource:  "secrets",
 				},
 				User: user,
+				// Groups must be sent alongside the user, otherwise RoleBindings and
+				// ClusterRoleBindings that grant access to a group are not evaluated and the
+				// review comes back denied. These are the groups the Kubernetes API server
+				// assigns to every service account. system:authenticated is intentionally
+				// excluded: it covers every authenticated identity, not just service accounts.
+				Groups: sa.MakeGroupNames(namespace),
 			},
 		}, metav1.CreateOptions{})
 		if err != nil {

--- a/pilot/pkg/credentials/kube/secrets_test.go
+++ b/pilot/pkg/credentials/kube/secrets_test.go
@@ -358,6 +358,28 @@ func allowIdentities(c kube.Client, identities ...string) {
 	})
 }
 
+func allowGroups(c kube.Client, groups ...string) {
+	allowed := sets.New(groups...)
+	c.Kube().(*fake.Clientset).Fake.PrependReactor("create", "subjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		a := action.(k8stesting.CreateAction).GetObject().(*authorizationv1.SubjectAccessReview)
+		for _, group := range a.Spec.Groups {
+			if allowed.Contains(group) {
+				return true, &authorizationv1.SubjectAccessReview{
+					Status: authorizationv1.SubjectAccessReviewStatus{
+						Allowed: true,
+					},
+				}, nil
+			}
+		}
+		return true, &authorizationv1.SubjectAccessReview{
+			Status: authorizationv1.SubjectAccessReviewStatus{
+				Allowed: false,
+				Reason:  fmt.Sprintf("groups %v cannot access secrets", a.Spec.Groups),
+			},
+		}, nil
+	})
+}
+
 func TestForCluster(t *testing.T) {
 	stop := test.NewStop(t)
 	localClient := kube.NewFakeClient()
@@ -422,6 +444,37 @@ func TestAuthorize(t *testing.T) {
 				t.Fatal(err)
 			}
 			got := con.Authorize(tt.sa, tt.ns)
+			if (got == nil) != tt.allowed {
+				t.Fatalf("expected allowed=%v, got error=%v", tt.allowed, got)
+			}
+		})
+	}
+}
+
+// TestAuthorizeGroups ensures the authorization check reports the Kubernetes groups a service
+// account belongs to, so that RBAC rules bound to a group rather than to the service account
+// itself are honored.
+func TestAuthorizeGroups(t *testing.T) {
+	cases := []struct {
+		name string
+		// grantedTo is the group a RoleBinding grants secret access to.
+		grantedTo string
+		allowed   bool
+	}{
+		{"namespace service accounts", "system:serviceaccounts:ns-local", true},
+		{"all service accounts", "system:serviceaccounts", true},
+		{"another namespace", "system:serviceaccounts:ns-other", false},
+		// Istio deliberately does not claim system:authenticated on behalf of the proxy, so a
+		// grant to that group must not be enough to read secrets.
+		{"all authenticated users", "system:authenticated", false},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			client := kube.NewFakeClient()
+			allowGroups(client, tt.grantedTo)
+			con := NewCredentialsController(client, nil, true)
+			client.RunAndWait(test.NewStop(t))
+			got := con.Authorize("sa-any", "ns-local")
 			if (got == nil) != tt.allowed {
 				t.Fatalf("expected allowed=%v, got error=%v", tt.allowed, got)
 			}

--- a/releasenotes/notes/sds-subject-access-review-groups.yaml
+++ b/releasenotes/notes/sds-subject-access-review-groups.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+issue:
+  - 58120
+releaseNotes:
+  - |
+    **Fixed** a bug where the authorization check for gateway secret access did not include the
+    service account's Kubernetes groups. As a result, `RoleBinding` and `ClusterRoleBinding` rules
+    granting secret access to groups such as `system:serviceaccounts:<namespace>` were ignored,
+    and gateways were denied access to credentials they had been granted.


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes #58120

The `SubjectAccessReview` used to authorize a gateway's access to credentials sets `Spec.User` but
leaves `Spec.Groups` empty, so the API server evaluates RBAC as if the service account belonged to
no groups. RBAC matches a rule if the user *or* any of its groups matches a binding subject, so every
`RoleBinding`/`ClusterRoleBinding` whose subject `kind` is `Group` is skipped:

* `subjects: [{kind: ServiceAccount, name: my-sa, namespace: my-ns}]` — works today.
* `subjects: [{kind: Group, name: "system:serviceaccounts:my-ns"}]` — silently ignored; the gateway
  is denied with `... is not authorized to read secrets`.

Since granting to `system:serviceaccounts:<namespace>` is the idiomatic way to cover every service
account in a namespace, operators see denials that contradict the RBAC they applied.

This sends the groups Kubernetes actually assigns to a service account, using the upstream
`serviceaccount.MakeGroupNames` helper. Behaviour is otherwise unchanged: the fix can only allow
access that was already granted via RBAC and wrongly denied — it cannot grant anything an operator
has not configured, and it cannot revoke anything.

**`system:authenticated` is deliberately not claimed.** The API server does attach it to
authenticated service accounts, so including it would be marginally more faithful, but it covers
every authenticated identity rather than just service accounts, and it is not needed for the
reported scenario. A unit test pins this behaviour so the decision is explicit rather than
accidental. Happy to add it if maintainers would prefer full fidelity.

The authorization cache is keyed on the username, and the groups are derived deterministically from
`(namespace, serviceAccount)`, so no cache changes are needed.

**Tests:** `TestAuthorizeGroups` covers a grant to the namespace group and to
`system:serviceaccounts` (both now allowed), plus negative cases for another namespace's group and
for `system:authenticated`. The two positive cases fail without this change with
`groups [] cannot access secrets`. Existing tests and their helper are untouched.

**Docs:** no istio.io change proposed — nothing there documents this contract, and the existing
guidance was never wrong, just incomplete in what Istio honoured.

**Backport:** the reporters hit this on released versions (1.26.x). Per `RELEASE_BRANCHES.md` I'm
raising it here rather than assuming — would maintainers consider this backport-eligible, and if so,
to which branches? Happy to defer entirely on that call.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [X] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
