### PR TITLE
waypoint: program routes for an Istio canary behind a foreign primary

### DIFF
--- a/pilot/pkg/config/kube/agentgateway/waypoint_collections.go
+++ b/pilot/pkg/config/kube/agentgateway/waypoint_collections.go
@@ -16,7 +16,6 @@ package agentgateway
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -65,22 +64,19 @@ func BuildWaypointServiceBindings(
 	opts krt.OptionsBuilder,
 ) krt.Collection[WaypointServiceBinding] {
 	return krt.NewManyCollection(services, func(ctx krt.HandlerContext, svc *corev1.Service) []WaypointServiceBinding {
-		// check if the service or its namespace has the use-waypoint label
-		primary := resolveUseWaypoint(ctx, svc.ObjectMeta, namespaces)
-		if primary == nil {
+		refs := ambient.ResolveWaypointRefs(ctx, namespaces, svc.ObjectMeta)
+		if len(refs) == 0 {
 			return nil
 		}
 		// The primary must exist for the service to be fronted at all, whatever class it is.
-		primaryGw := ptr.Flatten(krt.FetchOne(ctx, gateways, krt.FilterKey(primary.ResourceName())))
+		primaryGw := ptr.Flatten(krt.FetchOne(ctx, gateways, krt.FilterKey(refs[0].ResourceName())))
 		if primaryGw == nil {
 			return nil
 		}
 
 		fronting := []*gatewayv1.Gateway{primaryGw}
-		// A canary with an unparseable weight is ignored by the ambient index too, so it fronts
-		// nothing and needs no config.
-		if canary, _, validWeight := ambient.ResolveUseWaypointCanary(ctx, namespaces, svc.ObjectMeta); canary != nil && validWeight &&
-			canary.ResourceName() != primary.ResourceName() {
+		// A missing canary Gateway drops only the canary binding, not the service's.
+		for _, canary := range refs[1:] {
 			if gw := ptr.Flatten(krt.FetchOne(ctx, gateways, krt.FilterKey(canary.ResourceName()))); gw != nil {
 				fronting = append(fronting, gw)
 			}
@@ -100,30 +96,4 @@ func BuildWaypointServiceBindings(
 		}
 		return bindings
 	}, opts.WithName("WaypointServiceBindings")...)
-}
-
-// resolveUseWaypoint looks up the use-waypoint label on a service or its namespace
-// and returns the referenced waypoint gateway, if any.
-func resolveUseWaypoint(
-	ctx krt.HandlerContext,
-	meta metav1.ObjectMeta,
-	namespaces krt.Collection[*corev1.Namespace],
-) *krt.Named {
-	// Check object labels first
-	// These labels take precedence over namespace labels
-	wp, isNone := ambient.GetUseWaypoint(meta, meta.Namespace)
-	if isNone {
-		return nil
-	}
-	if wp != nil {
-		return wp
-	}
-
-	// Fall back to namespace labels
-	ns := ptr.Flatten(krt.FetchOne(ctx, namespaces, krt.FilterKey(meta.Namespace)))
-	if ns == nil {
-		return nil
-	}
-	wp, _ = ambient.GetUseWaypoint(ns.ObjectMeta, meta.Namespace)
-	return wp
 }

--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -591,39 +591,19 @@ func waypointManagedByAnotherController(ctx RouteContext, parentRef parentRefere
 		return false
 	}
 
-	primary := resolveUseWaypointRef(ctx, meta)
-	if primary == nil {
-		return false
-	}
 	if ctx.Gateways == nil || ctx.GatewayClasses == nil {
 		return false
 	}
-	if !waypointClassManagedByAnotherController(ctx, *primary) {
+	refs := ambient.ResolveWaypointRefs(ctx.Krt, ctx.Namespaces, meta)
+	if len(refs) == 0 {
 		return false
 	}
-	// Ignore canaries that do not front the service.
-	canary, _, validWeight := ambient.ResolveUseWaypointCanary(ctx.Krt, ctx.Namespaces, meta)
-	if canary == nil || !validWeight || canary.ResourceName() == primary.ResourceName() {
-		return true
+	for _, ref := range refs {
+		if !waypointClassManagedByAnotherController(ctx, ref) {
+			return false
+		}
 	}
-	return waypointClassManagedByAnotherController(ctx, *canary)
-}
-
-// resolveUseWaypointRef resolves the object's primary waypoint, including namespace inheritance.
-func resolveUseWaypointRef(ctx RouteContext, meta metav1.ObjectMeta) *krt.Named {
-	wp, isNone := ambient.GetUseWaypoint(meta, meta.Namespace)
-	if isNone {
-		return nil
-	}
-	if wp != nil {
-		return wp
-	}
-	ns := ptr.Flatten(krt.FetchOne(ctx.Krt, ctx.Namespaces, krt.FilterKey(meta.Namespace)))
-	if ns == nil {
-		return nil
-	}
-	wp, _ = ambient.GetUseWaypoint(ns.ObjectMeta, meta.Namespace)
-	return wp
+	return true
 }
 
 // waypointClassManagedByAnotherController reports whether the waypoint's class is foreign.

--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -48,6 +48,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	creds "istio.io/istio/pilot/pkg/model/credentials"
 	"istio.io/istio/pilot/pkg/model/kstatus"
+	"istio.io/istio/pilot/pkg/serviceregistry/ambient"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
@@ -570,46 +571,64 @@ func waypointConfigured(labels map[string]string) bool {
 	return false
 }
 
+// waypointManagedByAnotherController reports whether all waypoints fronting parentRef are foreign.
 func waypointManagedByAnotherController(ctx RouteContext, parentRef parentReference) bool {
-	var labels map[string]string
+	var meta metav1.ObjectMeta
 	switch parentRef.Kind {
 	case gvk.Service:
 		svc := ptr.Flatten(krt.FetchOne(ctx.Krt, ctx.Services, krt.FilterKey(parentRef.Namespace+"/"+parentRef.Name)))
 		if svc == nil {
 			return false
 		}
-		labels = svc.Labels
+		meta = svc.ObjectMeta
 	case gvk.ServiceEntry:
 		svc := ptr.Flatten(krt.FetchOne(ctx.Krt, ctx.ServiceEntries, krt.FilterKey(parentRef.Namespace+"/"+parentRef.Name)))
 		if svc == nil {
 			return false
 		}
-		labels = svc.Labels
+		meta = svc.ObjectMeta
 	default:
 		return false
 	}
 
-	waypointName, found := labels[label.IoIstioUseWaypoint.Name]
-	if !found {
-		ns := ptr.Flatten(krt.FetchOne(ctx.Krt, ctx.Namespaces, krt.FilterKey(parentRef.Namespace)))
-		if ns == nil {
-			return false
-		}
-		labels = ns.Labels
-		waypointName, found = labels[label.IoIstioUseWaypoint.Name]
-	}
-	if !found || waypointName == "" || strings.EqualFold(waypointName, "none") {
+	primary := resolveUseWaypointRef(ctx, meta)
+	if primary == nil {
 		return false
 	}
 	if ctx.Gateways == nil || ctx.GatewayClasses == nil {
 		return false
 	}
-
-	waypointNamespace := parentRef.Namespace
-	if namespace := labels[label.IoIstioUseWaypointNamespace.Name]; namespace != "" {
-		waypointNamespace = namespace
+	if !waypointClassManagedByAnotherController(ctx, *primary) {
+		return false
 	}
-	waypoint := ptr.Flatten(krt.FetchOne(ctx.Krt, ctx.Gateways, krt.FilterKey(waypointNamespace+"/"+waypointName)))
+	// Ignore canaries that do not front the service.
+	canary, _, validWeight := ambient.ResolveUseWaypointCanary(ctx.Krt, ctx.Namespaces, meta)
+	if canary == nil || !validWeight || canary.ResourceName() == primary.ResourceName() {
+		return true
+	}
+	return waypointClassManagedByAnotherController(ctx, *canary)
+}
+
+// resolveUseWaypointRef resolves the object's primary waypoint, including namespace inheritance.
+func resolveUseWaypointRef(ctx RouteContext, meta metav1.ObjectMeta) *krt.Named {
+	wp, isNone := ambient.GetUseWaypoint(meta, meta.Namespace)
+	if isNone {
+		return nil
+	}
+	if wp != nil {
+		return wp
+	}
+	ns := ptr.Flatten(krt.FetchOne(ctx.Krt, ctx.Namespaces, krt.FilterKey(meta.Namespace)))
+	if ns == nil {
+		return nil
+	}
+	wp, _ = ambient.GetUseWaypoint(ns.ObjectMeta, meta.Namespace)
+	return wp
+}
+
+// waypointClassManagedByAnotherController reports whether the waypoint's class is foreign.
+func waypointClassManagedByAnotherController(ctx RouteContext, ref krt.Named) bool {
+	waypoint := ptr.Flatten(krt.FetchOne(ctx.Krt, ctx.Gateways, krt.FilterKey(ref.ResourceName())))
 	if waypoint == nil {
 		return false
 	}

--- a/pilot/pkg/config/kube/gateway/conversion_test.go
+++ b/pilot/pkg/config/kube/gateway/conversion_test.go
@@ -717,6 +717,13 @@ func TestConvertResources(t *testing.T) {
 		{name: "mesh"},
 		{name: "foreign-waypoint"},
 		{
+			name: "foreign-waypoint-canary",
+			validationIgnorer: crdvalidation.NewValidationIgnorer(
+				"default/canary-echo",
+				"default/agentgateway-echo",
+			),
+		},
+		{
 			name: "invalid",
 			validationIgnorer: crdvalidation.NewValidationIgnorer(
 				"default/^invalid-backendRef-kind-",

--- a/pilot/pkg/config/kube/gateway/testdata/foreign-waypoint-canary.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/foreign-waypoint-canary.status.yaml.golden
@@ -1,0 +1,140 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: istio-waypoint
+spec: null
+status:
+  conditions:
+  - lastTransitionTime: fake
+    message: Handled by Istio controller
+    reason: Accepted
+    status: "True"
+    type: Accepted
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: istio-canary
+  namespace: default
+spec: null
+status:
+  conditions:
+  - lastTransitionTime: fake
+    message: Resource accepted
+    reason: Accepted
+    status: "True"
+    type: Accepted
+  - lastTransitionTime: fake
+    message: 'Failed to assign to any requested addresses: hostname "istio-canary.default.svc.domain.suffix"
+      not found'
+    reason: AddressNotUsable
+    status: "False"
+    type: Programmed
+  - lastTransitionTime: fake
+    message: All references resolved
+    reason: ResolvedRefs
+    status: "True"
+    type: ResolvedRefs
+  listeners:
+  - attachedRoutes: 0
+    conditions:
+    - lastTransitionTime: fake
+      message: No errors found
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: No errors found
+      reason: NoConflicts
+      status: "False"
+      type: Conflicted
+    - lastTransitionTime: fake
+      message: No errors found
+      reason: Programmed
+      status: "True"
+      type: Programmed
+    - lastTransitionTime: fake
+      message: No errors found
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    name: mesh
+    supportedKinds: []
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: agentgateway-echo
+  namespace: default
+spec: null
+status:
+  parents: []
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: canary-echo
+  namespace: default
+spec: null
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: fake
+      message: Route was valid
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: All references resolved
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: istio.io/gateway-controller
+    parentRef:
+      group: ""
+      kind: Service
+      name: canary-echo
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: foreign-canary-mcp
+  namespace: default
+spec: null
+status:
+  parents: []
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: invalid-weight-mcp
+  namespace: default
+spec: null
+status:
+  parents: []
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: istio-canary-mcp
+  namespace: default
+spec: null
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: fake
+      message: Route was valid
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: All references resolved
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: istio.io/gateway-controller
+    parentRef:
+      group: networking.istio.io
+      kind: ServiceEntry
+      name: istio-canary-mcp
+---

--- a/pilot/pkg/config/kube/gateway/testdata/foreign-waypoint-canary.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/foreign-waypoint-canary.yaml
@@ -1,0 +1,252 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: example
+spec:
+  controllerName: example.com/waypoint-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: istio-waypoint
+spec:
+  controllerName: istio.io/mesh-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: istio-agentgateway-waypoint
+spec:
+  controllerName: istio.io/agentgateway-waypoint-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: foreign-primary
+  namespace: default
+spec:
+  gatewayClassName: example
+  listeners:
+  - name: mesh
+    port: 15008
+    protocol: HBONE
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: agentgateway-primary
+  namespace: default
+spec:
+  gatewayClassName: istio-agentgateway-waypoint
+  listeners:
+  - name: mesh
+    port: 15008
+    protocol: HBONE
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: foreign-canary
+  namespace: default
+spec:
+  gatewayClassName: example
+  listeners:
+  - name: mesh
+    port: 15008
+    protocol: HBONE
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: istio-canary
+  namespace: default
+spec:
+  gatewayClassName: istio-waypoint
+  listeners:
+  - name: mesh
+    port: 15008
+    protocol: HBONE
+---
+# Keep the route when only the canary is ours.
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: istio-canary-mcp
+  namespace: default
+  labels:
+    istio.io/use-waypoint: foreign-primary
+    istio.io/use-waypoint-canary: istio-canary
+  annotations:
+    istio.io/use-waypoint-canary-weight: "50"
+spec:
+  hosts:
+  - istio-canary-mcp.example.com
+  resolution: STATIC
+  ports:
+  - name: http
+    number: 80
+    protocol: HTTP
+  endpoints:
+  - address: 0.0.0.1
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: istio-canary-mcp
+  namespace: default
+spec:
+  parentRefs:
+  - group: networking.istio.io
+    kind: ServiceEntry
+    name: istio-canary-mcp
+  rules:
+  - filters:
+    - type: RequestHeaderModifier
+      requestHeaderModifier:
+        add:
+        - name: my-added-header
+          value: added-value
+    backendRefs:
+    - name: echo
+      port: 80
+---
+# Drop the route when both waypoints are foreign.
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: foreign-canary-mcp
+  namespace: default
+  labels:
+    istio.io/use-waypoint: foreign-primary
+    istio.io/use-waypoint-canary: foreign-canary
+  annotations:
+    istio.io/use-waypoint-canary-weight: "50"
+spec:
+  hosts:
+  - foreign-canary-mcp.example.com
+  resolution: STATIC
+  ports:
+  - name: http
+    number: 80
+    protocol: HTTP
+  endpoints:
+  - address: 0.0.0.2
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: foreign-canary-mcp
+  namespace: default
+spec:
+  parentRefs:
+  - group: networking.istio.io
+    kind: ServiceEntry
+    name: foreign-canary-mcp
+  rules:
+  - backendRefs:
+    - name: echo
+      port: 80
+---
+# Ignore a canary with an invalid weight.
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: invalid-weight-mcp
+  namespace: default
+  labels:
+    istio.io/use-waypoint: foreign-primary
+    istio.io/use-waypoint-canary: istio-canary
+  annotations:
+    istio.io/use-waypoint-canary-weight: "500"
+spec:
+  hosts:
+  - invalid-weight-mcp.example.com
+  resolution: STATIC
+  ports:
+  - name: http
+    number: 80
+    protocol: HTTP
+  endpoints:
+  - address: 0.0.0.3
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: invalid-weight-mcp
+  namespace: default
+spec:
+  parentRefs:
+  - group: networking.istio.io
+    kind: ServiceEntry
+    name: invalid-weight-mcp
+  rules:
+  - backendRefs:
+    - name: echo
+      port: 80
+---
+# Keep a Service route for an Istio canary with an agentgateway primary.
+apiVersion: v1
+kind: Service
+metadata:
+  name: canary-echo
+  namespace: default
+  labels:
+    istio.io/use-waypoint: agentgateway-primary
+    istio.io/use-waypoint-canary: istio-canary
+  annotations:
+    istio.io/use-waypoint-canary-weight: "50"
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: canary-echo
+  namespace: default
+spec:
+  parentRefs:
+  - group: ""
+    kind: Service
+    name: canary-echo
+  rules:
+  - filters:
+    - type: RequestHeaderModifier
+      requestHeaderModifier:
+        add:
+        - name: my-added-header
+          value: added-value
+    backendRefs:
+    - name: echo
+      port: 80
+---
+# Drop a Service route with only an agentgateway waypoint.
+apiVersion: v1
+kind: Service
+metadata:
+  name: agentgateway-echo
+  namespace: default
+  labels:
+    istio.io/use-waypoint: agentgateway-primary
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: agentgateway-echo
+  namespace: default
+spec:
+  parentRefs:
+  - group: ""
+    kind: Service
+    name: agentgateway-echo
+  rules:
+  - backendRefs:
+    - name: echo
+      port: 80

--- a/pilot/pkg/config/kube/gateway/testdata/foreign-waypoint-canary.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/foreign-waypoint-canary.yaml.golden
@@ -1,0 +1,50 @@
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  annotations:
+    internal.istio.io/parents: HTTPRoute/canary-echo.default
+    internal.istio.io/route-semantics: gateway
+  name: default~canary-echo.default.svc.domain.suffix
+  namespace: default
+spec:
+  gateways:
+  - mesh
+  hosts:
+  - canary-echo.default.svc.domain.suffix
+  http:
+  - headers:
+      request:
+        add:
+          my-added-header: added-value
+    name: default.canary-echo.0
+    route:
+    - destination:
+        host: echo.default.svc.domain.suffix
+        port:
+          number: 80
+---
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  annotations:
+    internal.istio.io/parents: HTTPRoute/istio-canary-mcp.default
+    internal.istio.io/route-semantics: gateway
+  name: default~istio-canary-mcp.example.com
+  namespace: default
+spec:
+  gateways:
+  - mesh
+  hosts:
+  - istio-canary-mcp.example.com
+  http:
+  - headers:
+      request:
+        add:
+          my-added-header: added-value
+    name: default.istio-canary-mcp.0
+    route:
+    - destination:
+        host: echo.default.svc.domain.suffix
+        port:
+          number: 80
+---

--- a/pilot/pkg/serviceregistry/ambient/waypoints.go
+++ b/pilot/pkg/serviceregistry/ambient/waypoints.go
@@ -102,50 +102,24 @@ func fetchWaypointForTarget(
 	namespaces krt.Collection[*v1.Namespace],
 	o metav1.ObjectMeta,
 ) (*Waypoint, *model.StatusMessage) {
-	// namespace to be used when the annotation doesn't include a namespace
-	fallbackNamespace := o.Namespace
-	// try fetching the waypoint defined on the object itself
-	wp, isNone := GetUseWaypoint(o, fallbackNamespace)
-	if isNone {
-		// we've got a local override here opting out of waypoint
+	wp := ResolveUseWaypoint(ctx, namespaces, o)
+	if wp == nil {
+		// neither o nor its namespace has a use-waypoint label, or o opted out with "none"
 		return nil, nil
 	}
-	if wp != nil {
-		// plausible the object has a waypoint defined but that waypoint's underlying gateway is not ready, in this case we'd return nil here even if
-		// the namespace-defined waypoint is ready and would not be nil... is this OK or should we handle that? Could lead to odd behavior when
-		// o was reliant on the namespace waypoint and then gets a use-waypoint label added before that gateway is ready.
-		// goes from having a waypoint to having no waypoint and then eventually gets a waypoint back
-		w := krt.FetchOne[Waypoint](ctx, waypoints, krt.FilterKey(wp.ResourceName()))
-		if w != nil {
-			if !w.AllowsAttachmentFromNamespaceOrLookup(ctx, namespaces, fallbackNamespace) {
-				return nil, ReportWaypointAttachmentDenied(w.ResourceName())
-			}
-			return w, nil
-		}
+	// plausible the object has a waypoint defined but that waypoint's underlying gateway is not ready, in this case we'd return nil here even if
+	// the namespace-defined waypoint is ready and would not be nil... is this OK or should we handle that? Could lead to odd behavior when
+	// o was reliant on the namespace waypoint and then gets a use-waypoint label added before that gateway is ready.
+	// goes from having a waypoint to having no waypoint and then eventually gets a waypoint back
+	w := krt.FetchOne[Waypoint](ctx, waypoints, krt.FilterKey(wp.ResourceName()))
+	if w == nil {
 		// Todo: we may need to pull this from Waypoint, it could be for other reasons
 		return nil, ReportWaypointIsNotReady(wp.ResourceName())
 	}
-
-	// try fetching the namespace-defined waypoint
-	namespace := ptr.OrEmpty[*v1.Namespace](krt.FetchOne[*v1.Namespace](ctx, namespaces, krt.FilterKey(o.Namespace)))
-	// this probably should never be nil. How would o exist in a namespace we know nothing about? maybe edge case of starting the controller or ns delete?
-	if namespace != nil {
-		// toss isNone, we don't need to know /why/ we got nil
-		wp, _ := GetUseWaypoint(namespace.ObjectMeta, fallbackNamespace)
-		if wp != nil {
-			w := krt.FetchOne[Waypoint](ctx, waypoints, krt.FilterKey(wp.ResourceName()))
-			if w != nil {
-				if !w.AllowsAttachmentFromNamespace(namespace) {
-					return nil, ReportWaypointAttachmentDenied(w.ResourceName())
-				}
-				return w, nil
-			}
-			return nil, ReportWaypointIsNotReady(wp.ResourceName())
-		}
+	if !w.AllowsAttachmentFromNamespaceOrLookup(ctx, namespaces, o.Namespace) {
+		return nil, ReportWaypointAttachmentDenied(w.ResourceName())
 	}
-
-	// neither o nor it's namespace has a use-waypoint label
-	return nil, nil
+	return w, nil
 }
 
 // SAFETY: if fetching waypoints for a ServiceEntry visibility must be taken into account. For Kubernetes services a nil visibility singleton is expected
@@ -229,6 +203,29 @@ func GetUseWaypoint(meta metav1.ObjectMeta, defaultNamespace string) (named *krt
 	return nil, false
 }
 
+// ResolveUseWaypoint resolves the primary waypoint reference for o: the use-waypoint label on the
+// object itself, falling back to its namespace's, honoring the "none" opt-out. Nil if o names no
+// waypoint. Only the reference is resolved; whether the waypoint exists is up to the caller.
+func ResolveUseWaypoint(
+	ctx krt.HandlerContext,
+	namespaces krt.Collection[*v1.Namespace],
+	o metav1.ObjectMeta,
+) *krt.Named {
+	wp, isNone := GetUseWaypoint(o, o.Namespace)
+	if isNone {
+		return nil
+	}
+	if wp != nil {
+		return wp
+	}
+	ns := ptr.OrEmpty(krt.FetchOne(ctx, namespaces, krt.FilterKey(o.Namespace)))
+	if ns == nil {
+		return nil
+	}
+	wp, _ = GetUseWaypoint(ns.ObjectMeta, o.Namespace)
+	return wp
+}
+
 func (w Waypoint) ResourceName() string {
 	return w.GetNamespace() + "/" + w.GetName()
 }
@@ -292,6 +289,28 @@ func ResolveUseWaypointCanary(
 	}
 	weight, valid = getCanaryWeight(o, nsMeta)
 	return named, weight, valid
+}
+
+// ResolveWaypointRefs returns references to every waypoint fronting o: the primary and, when o
+// declares a usable canary (distinct from the primary, with a valid weight), the canary. Empty when
+// o names no waypoint or opts out with "none". This is the reference-level counterpart of
+// buildWeightedWaypoints: a canary that helper ignores fronts nothing here either. Only references
+// are resolved; existence, attachment and traffic-type checks on the waypoints are the caller's.
+func ResolveWaypointRefs(
+	ctx krt.HandlerContext,
+	namespaces krt.Collection[*v1.Namespace],
+	o metav1.ObjectMeta,
+) []krt.Named {
+	primary := ResolveUseWaypoint(ctx, namespaces, o)
+	if primary == nil {
+		return nil
+	}
+	refs := []krt.Named{*primary}
+	if canary, _, valid := ResolveUseWaypointCanary(ctx, namespaces, o); canary != nil && valid &&
+		canary.ResourceName() != primary.ResourceName() {
+		refs = append(refs, *canary)
+	}
+	return refs
 }
 
 // resolveCanaryWaypoint applies the primary waypoint attachment and traffic-type checks.
@@ -581,20 +600,6 @@ func (w Waypoint) AllowsAttachmentFromNamespaceOrLookup(ctx krt.HandlerContext, 
 	default:
 		// Should be impossible
 		return w.Namespace == namespace
-	}
-}
-
-func (w Waypoint) AllowsAttachmentFromNamespace(namespace *v1.Namespace) bool {
-	switch w.AllowedRoutes.FromNamespaces {
-	case gatewayv1.NamespacesFromAll:
-		return true
-	case gatewayv1.NamespacesFromSelector:
-		return w.AllowedRoutes.Selector.Matches(labels.Set(namespace.GetLabels()))
-	case gatewayv1.NamespacesFromSame:
-		return w.Namespace == namespace.Name
-	default:
-		// Should be impossible
-		return w.Namespace == namespace.Name
 	}
 }
 

--- a/pilot/pkg/serviceregistry/ambient/waypoints_test.go
+++ b/pilot/pkg/serviceregistry/ambient/waypoints_test.go
@@ -17,6 +17,7 @@ package ambient
 import (
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -277,6 +278,189 @@ func assertWaypointSelector(t *testing.T, result, expected WaypointSelector) {
 		assert.Equal(t, result.Selector, nil)
 	} else {
 		assert.Equal(t, result.Selector.String(), expected.Selector.String())
+	}
+}
+
+func TestResolveUseWaypoint(t *testing.T) {
+	useWaypoint := label.IoIstioUseWaypoint.Name
+	useWaypointNamespace := label.IoIstioUseWaypointNamespace.Name
+	tests := []struct {
+		name       string
+		object     metav1.ObjectMeta
+		namespaces []*corev1.Namespace
+		want       *krt.Named
+	}{
+		{
+			name:   "object waypoint",
+			object: metav1.ObjectMeta{Namespace: "app", Labels: map[string]string{useWaypoint: "object-wp"}},
+			want:   &krt.Named{Namespace: "app", Name: "object-wp"},
+		},
+		{
+			name: "object waypoint with namespace override",
+			object: metav1.ObjectMeta{
+				Namespace: "app",
+				Labels: map[string]string{
+					useWaypoint:          "object-wp",
+					useWaypointNamespace: "infra",
+				},
+			},
+			want: &krt.Named{Namespace: "infra", Name: "object-wp"},
+		},
+		{
+			name:   "namespace waypoint",
+			object: metav1.ObjectMeta{Namespace: "app"},
+			namespaces: []*corev1.Namespace{{
+				ObjectMeta: metav1.ObjectMeta{Name: "app", Labels: map[string]string{useWaypoint: "namespace-wp"}},
+			}},
+			want: &krt.Named{Namespace: "app", Name: "namespace-wp"},
+		},
+		{
+			name:   "object waypoint takes precedence",
+			object: metav1.ObjectMeta{Namespace: "app", Labels: map[string]string{useWaypoint: "object-wp"}},
+			namespaces: []*corev1.Namespace{{
+				ObjectMeta: metav1.ObjectMeta{Name: "app", Labels: map[string]string{useWaypoint: "namespace-wp"}},
+			}},
+			want: &krt.Named{Namespace: "app", Name: "object-wp"},
+		},
+		{
+			name:   "object none opts out of namespace waypoint",
+			object: metav1.ObjectMeta{Namespace: "app", Labels: map[string]string{useWaypoint: "none"}},
+			namespaces: []*corev1.Namespace{{
+				ObjectMeta: metav1.ObjectMeta{Name: "app", Labels: map[string]string{useWaypoint: "namespace-wp"}},
+			}},
+		},
+		{
+			name:   "namespace none",
+			object: metav1.ObjectMeta{Namespace: "app"},
+			namespaces: []*corev1.Namespace{{
+				ObjectMeta: metav1.ObjectMeta{Name: "app", Labels: map[string]string{useWaypoint: "none"}},
+			}},
+		},
+		{
+			name:   "no waypoint",
+			object: metav1.ObjectMeta{Namespace: "app"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			namespaces := krt.NewStaticCollection[*corev1.Namespace](nil, tt.namespaces)
+			got := ResolveUseWaypoint(krt.TestingDummyContext{}, namespaces, tt.object)
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}
+
+func TestResolveWaypointRefs(t *testing.T) {
+	useWaypoint := label.IoIstioUseWaypoint.Name
+	useCanary := label.IoIstioUseWaypointCanary.Name
+	useCanaryNamespace := label.IoIstioUseWaypointCanaryNamespace.Name
+	canaryWeight := annotation.IoIstioUseWaypointCanaryWeight.Name
+	tests := []struct {
+		name       string
+		object     metav1.ObjectMeta
+		namespaces []*corev1.Namespace
+		want       []krt.Named
+	}{
+		{
+			name: "primary only",
+			object: metav1.ObjectMeta{
+				Namespace: "app",
+				Labels:    map[string]string{useWaypoint: "primary"},
+			},
+			want: []krt.Named{{Namespace: "app", Name: "primary"}},
+		},
+		{
+			name: "primary and canary",
+			object: metav1.ObjectMeta{
+				Namespace:   "app",
+				Labels:      map[string]string{useWaypoint: "primary", useCanary: "canary"},
+				Annotations: map[string]string{canaryWeight: "10"},
+			},
+			want: []krt.Named{
+				{Namespace: "app", Name: "primary"},
+				{Namespace: "app", Name: "canary"},
+			},
+		},
+		{
+			name: "cross namespace canary",
+			object: metav1.ObjectMeta{
+				Namespace: "app",
+				Labels: map[string]string{
+					useWaypoint:        "primary",
+					useCanary:          "canary",
+					useCanaryNamespace: "infra",
+				},
+			},
+			want: []krt.Named{
+				{Namespace: "app", Name: "primary"},
+				{Namespace: "infra", Name: "canary"},
+			},
+		},
+		{
+			name:   "namespace primary and canary",
+			object: metav1.ObjectMeta{Namespace: "app"},
+			namespaces: []*corev1.Namespace{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "app",
+					Labels:      map[string]string{useWaypoint: "primary", useCanary: "canary"},
+					Annotations: map[string]string{canaryWeight: "25"},
+				},
+			}},
+			want: []krt.Named{
+				{Namespace: "app", Name: "primary"},
+				{Namespace: "app", Name: "canary"},
+			},
+		},
+		{
+			name: "object primary does not inherit namespace canary",
+			object: metav1.ObjectMeta{
+				Namespace: "app",
+				Labels:    map[string]string{useWaypoint: "primary"},
+			},
+			namespaces: []*corev1.Namespace{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "app",
+					Labels:      map[string]string{useWaypoint: "namespace-primary", useCanary: "namespace-canary"},
+					Annotations: map[string]string{canaryWeight: "25"},
+				},
+			}},
+			want: []krt.Named{{Namespace: "app", Name: "primary"}},
+		},
+		{
+			name: "invalid canary weight is ignored",
+			object: metav1.ObjectMeta{
+				Namespace:   "app",
+				Labels:      map[string]string{useWaypoint: "primary", useCanary: "canary"},
+				Annotations: map[string]string{canaryWeight: "101"},
+			},
+			want: []krt.Named{{Namespace: "app", Name: "primary"}},
+		},
+		{
+			name: "canary matching primary is ignored",
+			object: metav1.ObjectMeta{
+				Namespace:   "app",
+				Labels:      map[string]string{useWaypoint: "primary", useCanary: "primary"},
+				Annotations: map[string]string{canaryWeight: "10"},
+			},
+			want: []krt.Named{{Namespace: "app", Name: "primary"}},
+		},
+		{
+			name: "canary without primary is ignored",
+			object: metav1.ObjectMeta{
+				Namespace:   "app",
+				Labels:      map[string]string{useCanary: "canary"},
+				Annotations: map[string]string{canaryWeight: "10"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			namespaces := krt.NewStaticCollection[*corev1.Namespace](nil, tt.namespaces)
+			got := ResolveWaypointRefs(krt.TestingDummyContext{}, namespaces, tt.object)
+			assert.Equal(t, got, tt.want)
+		})
 	}
 }
 

--- a/releasenotes/notes/envoy-canary-waypoint-routes.yaml
+++ b/releasenotes/notes/envoy-canary-waypoint-routes.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - https://github.com/istio/istio/issues/61326
+releaseNotes:
+- |
+  **Fixed** an issue where an Istio waypoint that a service referenced only as its canary, via the
+  `istio.io/use-waypoint-canary` label, was not programmed with the routes attached to that service
+  when the primary waypoint belonged to another controller. The canary served its share of the
+  connections with default routing, ignoring the route's rules.


### PR DESCRIPTION
**Please provide a description of this PR:**

## Problem

This is the mirror of #61036, which #61037 fixed for the agentgateway side. When a service names an agentgateway waypoint as its primary (`istio.io/use-waypoint`) and an Istio waypoint as its canary (`istio.io/use-waypoint-canary`), ztunnel shifts the configured share of connections to the Istio canary, but that waypoint is never programmed with the routes attached to the service.

The canary does receive the service itself: `buildWeightedWaypoints` and `serviceOwningWaypoints` resolve the weighted set by name with no GatewayClass check, so it gets listeners and clusters. What it does not receive is any route config, so it serves its share of the traffic as plain passthrough, ignoring the route's matches, rewrites, splits, mirrors and filters. The failure is silent: requests still reach the backend, and because the parentRef is dropped rather than rejected the HTTPRoute carries no `istio.io/gateway-controller` ancestor status at all.

## Cause

`waypointManagedByAnotherController` reads only the `istio.io/use-waypoint` label, resolves that single Gateway's class, and drops the Service or ServiceEntry parentRef when the class belongs to another controller. The canary label is never consulted - there is no canary awareness anywhere in `pilot/pkg/config/kube/gateway`. With an agentgateway primary the route is skipped entirely, no mesh VirtualService is produced, and `buildWaypointInboundHTTPRouteConfig` falls back to `buildSidecarInboundHTTPRouteConfig`.

## Fix

Waypoint reference resolution is now centralized in the ambient package. The ambient index, gateway conversion, and agentgateway controller share the same logic for primary inheritance, namespace overrides, none, canary validity, and duplicate canaries.

Gateway conversion skips a route only when every effective waypoint is managed by another controller. Therefore, an Istio canary behind an agentgateway primary receives the service’s routes.

## Tests

Added focused unit tests for shared waypoint resolution, plus golden coverage for Service and ServiceEntry parents with mixed Istio and foreign waypoint controllers.

Fixes https://github.com/istio/istio/issues/61326

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [X] Ambient
- [X] Networking