### PR TITLE
tests: skip TestAllowAnyDynamicDNS{Policy|WithTLS} in IPv6 environment

### DIFF
--- a/tests/integration/telemetry/policy/dynamicdns/traffic_allow_any_dynamic_dns_test.go
+++ b/tests/integration/telemetry/policy/dynamicdns/traffic_allow_any_dynamic_dns_test.go
@@ -105,6 +105,8 @@ func TestAllowAnyDynamicDNSPolicy(t *testing.T) {
 			}).BuildOrFail(t)
 
 		t.NewSubTest("http-via-dfp").Run(func(t framework.TestContext) {
+			t.Skipf("https://github.com/istio/istio/issues/61330")
+
 			baseline := clusterUpstreamRqTotal(t, client, "AllowAnyDynamicDNSCluster")
 			passthroughBaseline := clusterUpstreamRqTotal(t, client, "PassthroughCluster")
 
@@ -207,6 +209,8 @@ outboundTrafficPolicy:
 			}).BuildOrFail(t)
 
 		t.NewSubTest("http-to-external-with-tls-origination").Run(func(t framework.TestContext) {
+			t.Skipf("https://github.com/istio/istio/issues/61330")
+
 			baseline := clusterUpstreamRqTotal(t, client, "AllowAnyDynamicDNSCluster")
 
 			client.CallOrFail(t, echo.CallOptions{

--- a/tests/integration/telemetry/policy/dynamicdns/traffic_allow_any_dynamic_dns_test.go
+++ b/tests/integration/telemetry/policy/dynamicdns/traffic_allow_any_dynamic_dns_test.go
@@ -105,7 +105,9 @@ func TestAllowAnyDynamicDNSPolicy(t *testing.T) {
 			}).BuildOrFail(t)
 
 		t.NewSubTest("http-via-dfp").Run(func(t framework.TestContext) {
-			t.Skipf("https://github.com/istio/istio/issues/61330")
+			if len(t.Settings().IPFamilies) == 1 && t.Settings().IPFamilies[0] == "IPv6" {
+				t.Skip("https://github.com/istio/istio/issues/61330")
+			}
 
 			baseline := clusterUpstreamRqTotal(t, client, "AllowAnyDynamicDNSCluster")
 			passthroughBaseline := clusterUpstreamRqTotal(t, client, "PassthroughCluster")
@@ -209,7 +211,9 @@ outboundTrafficPolicy:
 			}).BuildOrFail(t)
 
 		t.NewSubTest("http-to-external-with-tls-origination").Run(func(t framework.TestContext) {
-			t.Skipf("https://github.com/istio/istio/issues/61330")
+			if len(t.Settings().IPFamilies) == 1 && t.Settings().IPFamilies[0] == "IPv6" {
+				t.Skip("https://github.com/istio/istio/issues/61330")
+			}
 
 			baseline := clusterUpstreamRqTotal(t, client, "AllowAnyDynamicDNSCluster")
 


### PR DESCRIPTION
**Please provide a description of this PR:**

The root cause isn't trivial, so I disable these tests until #61330 is fixed.