### PR TITLE
tests: skip TestAmbientStableRevisionLabelsGatewayStatus on k8s < 1.31

### DIFF
--- a/tests/integration/helm/upgrade/helm_upgrade_test.go
+++ b/tests/integration/helm/upgrade/helm_upgrade_test.go
@@ -124,5 +124,6 @@ func TestInPlaceUpgradeWebhookFailurePolicy(t *testing.T) {
 func TestAmbientStableRevisionLabelsGatewayStatus(t *testing.T) {
 	framework.
 		NewTest(t).
+		RequireKubernetesMinorVersion(31).
 		Run(runMultipleTagsFunc(true, true))
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

`TestAmbientStableRevisionLabelsGatewayStatus` fails consistently in postsubmit jobs on clusters older than 1.31, because of this check in the setup chain: https://github.com/istio/istio/blob/47320ba1a73b49a4a54a3f03e9e810f4854a2ae9/pkg/test/framework/components/crd/gateway.go#L38

This PR adds `RequireKubernetesMinorVersion(31)` so the framework skips the test before any setup runs on clusters below 1.31.