### PR TITLE
ambient: fix multi cluster update stale snapshot

### DIFF
--- a/pkg/kube/multicluster/collections.go
+++ b/pkg/kube/multicluster/collections.go
@@ -117,7 +117,7 @@ func NestedManyCollectionsFromLocalAndRemote[T any](
 		return cols
 	}, opts.WithName("Remote"+name)...)
 
-	// Return a joined collection fo local and remote collections, this ensures that cluster updates swap collections atomically.
+	// Return a joined collection for local and remote collections, this ensures that cluster updates swap collections atomically.
 	// We don't need to check if the inner collections are syncced, downstream consumers (like NestedJoin collections) will do this.
 	return krt.JoinCollection(
 		[]krt.Collection[krt.Collection[T]]{localContainer, remoteCollections},

--- a/pkg/kube/multicluster/collections.go
+++ b/pkg/kube/multicluster/collections.go
@@ -15,11 +15,11 @@
 package multicluster
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"sync"
 
 	"istio.io/istio/pkg/cluster"
-	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/log"
@@ -80,16 +80,14 @@ func NestedManyCollectionsFromLocalAndRemote[T any](
 	opts krt.OptionsBuilder,
 ) krt.Collection[krt.Collection[T]] {
 	clustersCollection := ctrl.Clusters()
-	// use a custom syncer to make globalCollection sync when all local and remote collections
-	// have synced
-	syncer := &combinedSyncer[T]{name: "Global" + name, local: localCollections}
-	globalCollection := krt.NewStaticCollection(
-		syncer,
+	// The local collections are fixed for the lifetime of the process, so a static container is enough.
+	localContainer := krt.NewStaticCollection(
+		nil,
 		localCollections,
-		opts.WithName("Global"+name)...,
+		opts.WithName("Local"+name)...,
 	)
 	cache := &collectionCacheByClusterMany[T]{
-		collections: make(map[cluster.ID][]krt.Collection[T]),
+		collections: make(map[cluster.ID]clusterCollections[T]),
 	}
 	clustersCollection.Register(func(e krt.Event[*Cluster]) {
 		if e.Event != controllers.EventDelete {
@@ -100,8 +98,14 @@ func NestedManyCollectionsFromLocalAndRemote[T any](
 			log.Debugf("clusterID %s doesn't exist in cache %v. Removal is a no-op", old.ID, cache)
 		}
 	})
+	// TODO: the transformation function here could actually race with the cluster deletion above.
 	remoteCollections := krt.NewManyCollection(clustersCollection, func(ctx krt.HandlerContext, c *Cluster) []krt.Collection[T] {
-		if existing := cache.Get(c.ID); existing != nil {
+		// Cache is keyed on the kubeconfig SHA and not just the cluster ID because a credential rotation
+		// replaces the *Cluster with a new client, new informers and a new stop channel.
+		// The previous generation is stopped once the new one syncs. Reusing
+		// its collections would leave us serving a snapshot frozen at rotation time, from informers that
+		// are no longer running.
+		if existing := cache.Get(c.ID, c.kubeConfigSha); existing != nil {
 			return existing
 		}
 		cols := clusterToCollections(ctx, c)
@@ -109,83 +113,52 @@ func NestedManyCollectionsFromLocalAndRemote[T any](
 			log.Warnf("no collections for %s returned for cluster %v", name, c.ID)
 			return nil
 		}
-		cache.Insert(c.ID, cols)
+		cache.Insert(c.ID, c.kubeConfigSha, cols)
 		return cols
 	}, opts.WithName("Remote"+name)...)
 
-	reg := remoteCollections.RegisterBatch(func(o []krt.Event[krt.Collection[T]]) {
-		for _, e := range o {
-			l := e.Latest()
-			switch e.Event {
-			case controllers.EventAdd, controllers.EventUpdate:
-				globalCollection.UpdateObject(l)
-			case controllers.EventDelete:
-				globalCollection.DeleteObject(krt.GetKey(l))
-			}
-		}
-	}, true)
-	syncer.setRemote(reg, remoteCollections)
-	return globalCollection
+	// Return a joined collection fo local and remote collections, this ensures that cluster updates swap collections atomically.
+	// We don't need to check if the inner collections are syncced, downstream consumers (like NestedJoin collections) will do this.
+	return krt.JoinCollection(
+		[]krt.Collection[krt.Collection[T]]{localContainer, remoteCollections},
+		opts.With(krt.WithName("Global"+name), krt.WithJoinUnchecked())...,
+	)
 }
 
-// combinedSyncer reports synced only when all of the local collections are synced and the remote
-// clusters' collections have been discovered, propagated into the global collection, and synced
-// themselves.
-type combinedSyncer[T any] struct {
-	name       string
-	local      []krt.Collection[T]
-	mu         sync.RWMutex
-	remote     krt.Syncer
-	collection krt.Collection[krt.Collection[T]]
+// clusterCollections holds the krt collections built for one generation of a cluster. The kubeconfig
+// SHA identifies the generation: it is what changes when a cluster's credentials are rotated, and it is
+// what Cluster.Equals compares.
+type clusterCollections[T any] struct {
+	kubeConfigSha [sha256.Size]byte
+	collections   []krt.Collection[T]
 }
 
-func (s *combinedSyncer[T]) setRemote(remoteSyncer krt.Syncer, remoteCollections krt.Collection[krt.Collection[T]]) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.remote = remoteSyncer
-	s.collection = remoteCollections
-}
-
-func (s *combinedSyncer[T]) HasSynced() bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	for _, c := range s.local {
-		if !c.HasSynced() {
-			return false
-		}
-	}
-	if s.remote == nil || !s.remote.HasSynced() {
-		return false
-	}
-	// The container is synced (all remote collections have been added), now ensure each of them has synced too.
-	for _, c := range s.collection.List() {
-		if !c.HasSynced() {
-			return false
-		}
-	}
-	return true
-}
-
-func (s *combinedSyncer[T]) WaitUntilSynced(stop <-chan struct{}) bool {
-	return kube.WaitForCacheSync(s.name, stop, s.HasSynced)
-}
-
-// collectionCacheByClusterMany is a thread-safe cache of slices of krt collections keyed by cluster ID.
+// collectionCacheByClusterMany is a thread-safe cache of slices of krt collections keyed by cluster ID
+// and generation.
 type collectionCacheByClusterMany[T any] struct {
-	collections map[cluster.ID][]krt.Collection[T]
+	collections map[cluster.ID]clusterCollections[T]
 	sync.RWMutex
 }
 
-func (c *collectionCacheByClusterMany[T]) Get(clusterID cluster.ID) []krt.Collection[T] {
+// Get returns the cached collections for the cluster, but only if they were built for the requested
+// generation. A generation mismatch reports a miss so the caller rebuilds.
+func (c *collectionCacheByClusterMany[T]) Get(clusterID cluster.ID, kubeConfigSha [sha256.Size]byte) []krt.Collection[T] {
 	c.RLock()
 	defer c.RUnlock()
-	return c.collections[clusterID]
+	existing, ok := c.collections[clusterID]
+	if !ok || existing.kubeConfigSha != kubeConfigSha {
+		return nil
+	}
+	return existing.collections
 }
 
-func (c *collectionCacheByClusterMany[T]) Insert(clusterID cluster.ID, cols []krt.Collection[T]) {
+func (c *collectionCacheByClusterMany[T]) Insert(clusterID cluster.ID, kubeConfigSha [sha256.Size]byte, cols []krt.Collection[T]) {
 	c.Lock()
 	defer c.Unlock()
-	c.collections[clusterID] = cols
+	c.collections[clusterID] = clusterCollections[T]{
+		kubeConfigSha: kubeConfigSha,
+		collections:   cols,
+	}
 }
 
 func (c *collectionCacheByClusterMany[T]) Remove(clusterID cluster.ID) bool {

--- a/pkg/kube/multicluster/collections_test.go
+++ b/pkg/kube/multicluster/collections_test.go
@@ -1,0 +1,120 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicluster
+
+import (
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+
+	"istio.io/istio/pkg/cluster"
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/ptr"
+	"istio.io/istio/pkg/slices"
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/assert"
+	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/istio/pkg/util/sets"
+)
+
+func fakeClientWithService(name string) kube.Client {
+	return kube.NewFakeClient(
+		&v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: "ns", Labels: map[string]string{"kubernetes.io/metadata.name": "ns"}},
+		},
+		&v1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ns"},
+		},
+	)
+}
+
+// TestNestedCollectionsRebuiltOnClusterUpdate verifies that updating a cluster's credentials (a secret
+// update carrying a new kubeconfig for the same cluster ID) replaces that cluster's nested collections
+// with new ones built on the new client.
+//
+// The previous generation's client and informers are shut down once the new generation syncs, so
+// continuing to serve its collections would freeze the cluster's contents at rotation time.
+func TestNestedCollectionsRebuiltOnClusterUpdate(t *testing.T) {
+	stop := test.NewStop(t)
+	c := buildTestController(t, true)
+
+	// Hand out a different client for each generation of the cluster, with distinguishable contents.
+	nextClient := fakeClientWithService("initial")
+	c.controller.ClientBuilder = func(kubeConfig []byte, clusterID cluster.ID, configOverrides ...func(*rest.Config)) (kube.Client, error) {
+		ret := nextClient
+		nextClient = fakeClientWithService("later")
+		return ret, nil
+	}
+
+	opts := krt.NewOptionsBuilder(stop, "test", krt.GlobalDebugHandler)
+	local := krt.NewStaticCollection[*v1.Service](nil, nil, opts.WithName("LocalServices")...)
+	var localCollection krt.Collection[*v1.Service] = local
+	nested := NestedCollectionFromLocalAndRemote(
+		c.controller,
+		localCollection,
+		func(ctx krt.HandlerContext, cl *Cluster) *krt.Collection[*v1.Service] {
+			if !cl.hasInitialCollections() {
+				return nil
+			}
+			return ptr.Of(cl.Services())
+		},
+		"Services",
+		opts,
+	)
+
+	// remote returns the key (the collection's uid) and contents of the single remote cluster's
+	// collection, so we can tell a rebuilt collection from a reused one.
+	localKey := krt.GetKey(localCollection)
+	type remoteState struct {
+		key      string
+		services sets.String
+	}
+	remote := func() remoteState {
+		for _, col := range nested.List() {
+			if krt.GetKey(col) == localKey {
+				continue
+			}
+			return remoteState{
+				key: krt.GetKey(col),
+				services: sets.New(slices.Map(col.List(), func(s *v1.Service) string {
+					return s.Name
+				})...),
+			}
+		}
+		return remoteState{}
+	}
+
+	c.AddSecret("s0", "c0")
+	c.Run(stop)
+	retry.UntilOrFail(t, c.controller.HasSynced, retry.Timeout(2*time.Second))
+	assert.EventuallyEqual(t, func() sets.String { return remote().services }, sets.New("initial"))
+	before := remote()
+
+	// Rotate the credentials: same cluster ID, new kubeconfig.
+	c.AddSecret("s0", "c0")
+
+	// The cluster's collection must now be served from the new client...
+	assert.EventuallyEqual(t, func() sets.String { return remote().services }, sets.New("later"))
+	// ...by a newly built collection, and the previous one must be dropped rather than accumulated.
+	after := remote()
+	if after.key == before.key {
+		t.Fatalf("expected the cluster's collection to be rebuilt on update, but it is still %v", after.key)
+	}
+	assert.Equal(t, len(nested.List()), 2, "expected only the local and the current remote collection")
+}

--- a/releasenotes/notes/multicluster-rebuild-collections-on-update.yaml
+++ b/releasenotes/notes/multicluster-rebuild-collections-on-update.yaml
@@ -1,0 +1,12 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 60033
+releaseNotes:
+  - |
+    **Fixed** ambient multi-cluster serving a stale snapshot of a remote cluster after its credentials
+    were rotated. The per-cluster collections were cached by cluster ID alone, so a secret update
+    carrying a new kubeconfig kept reusing the collections built for the previous generation, whose
+    client and informers are shut down once the new one syncs. They are now cached per generation and
+    rebuilt on the new client.


### PR DESCRIPTION
**Please provide a description of this PR:**
Fix Ambient Multi Cluster using a stale snapshot of cluster resources, this bug was introduced in https://github.com/istio/istio/pull/61296/changes while fixing other issues.

Modified the multicluster cache to also take into account the cluster config sha, and rebuild collections when the sha changes.
Also changed the returned collection to be a `JoinCollection` of local and remote collections, this prevents possible missing collections (since we delete+add inner collections) during cluster updates.
Removed `combinedSyncer`, I'm pretty sure this is no longer necessary, we shouldn't need to check for the sync status of the inner collections, downstream consumers will actually check this.