### PR TITLE
fix: select default DNS proxy address by IP family

### DIFF
--- a/pilot/pkg/networking/core/networkfilter.go
+++ b/pilot/pkg/networking/core/networkfilter.go
@@ -15,8 +15,6 @@
 package core
 
 import (
-	"net"
-	"strconv"
 	"time"
 
 	mysql "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/mysql_proxy/v3"
@@ -52,7 +50,6 @@ import (
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
-	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/wellknown"
 )
 
@@ -122,28 +119,8 @@ func buildAllowAnyDynamicDNSDNSCacheConfig(meta *model.NodeMetadata) *dfp.DnsCac
 	if meta == nil || !bool(meta.DNSCapture) {
 		return cfg
 	}
-	addr := meta.DNSProxyAddr
-	host, portStr, err := net.SplitHostPort(addr)
-	if err != nil {
-		log.Warnf("failed to parse DNSProxyAddr %q, falling back to 127.0.0.1:15053: %v", addr, err)
-		host, portStr = "127.0.0.1", "15053"
-	}
-	if host == "localhost" {
-		host = "127.0.0.1"
-	}
-	port, err := strconv.ParseUint(portStr, 10, 32)
-	if err != nil {
-		port = 15053
-	}
 	caresConfig, err := anypb.New(&cares.CaresDnsResolverConfig{
-		Resolvers: []*core.Address{{
-			Address: &core.Address_SocketAddress{
-				SocketAddress: &core.SocketAddress{
-					Address:       host,
-					PortSpecifier: &core.SocketAddress_PortValue{PortValue: uint32(port)},
-				},
-			},
-		}},
+		Resolvers: []*core.Address{util.GetDNSProxyAddress(meta.InstanceIPs, meta.DNSProxyAddr)},
 	})
 	if err == nil {
 		cfg.TypedDnsResolverConfig = &core.TypedExtensionConfig{

--- a/pilot/pkg/networking/core/networkfilter_test.go
+++ b/pilot/pkg/networking/core/networkfilter_test.go
@@ -898,56 +898,80 @@ func node(version *model.IstioVersion) *model.Proxy {
 
 func TestBuildAllowAnyDynamicDNSDNSCacheConfig(t *testing.T) {
 	tests := []struct {
-		name           string
-		meta           *model.NodeMetadata
-		expectResolver bool
-		expectHost     string
-		expectPort     uint32
+		name               string
+		meta               *model.NodeMetadata
+		expectLookupFamily cluster.Cluster_DnsLookupFamily
+		expectResolver     bool
+		expectHost         string
+		expectPort         uint32
 	}{
 		{
-			name:           "nil metadata — no resolver set",
-			meta:           nil,
-			expectResolver: false,
+			name:               "nil metadata — no resolver set",
+			meta:               nil,
+			expectLookupFamily: cluster.Cluster_V4_ONLY,
+			expectResolver:     false,
 		},
 		{
-			name:           "DNS_CAPTURE disabled — no resolver set",
-			meta:           &model.NodeMetadata{DNSCapture: false},
-			expectResolver: false,
+			name:               "DNS_CAPTURE disabled — no resolver set",
+			meta:               &model.NodeMetadata{DNSCapture: false},
+			expectLookupFamily: cluster.Cluster_V4_ONLY,
+			expectResolver:     false,
 		},
 		{
-			name:           "DNS_CAPTURE enabled with explicit addr",
-			meta:           &model.NodeMetadata{DNSCapture: true, DNSProxyAddr: "10.0.0.1:15053"},
-			expectResolver: true,
-			expectHost:     "10.0.0.1",
-			expectPort:     15053,
+			name:               "DNS_CAPTURE enabled with explicit addr",
+			meta:               &model.NodeMetadata{DNSCapture: true, DNSProxyAddr: "10.0.0.1:15053"},
+			expectLookupFamily: cluster.Cluster_V4_ONLY,
+			expectResolver:     true,
+			expectHost:         "10.0.0.1",
+			expectPort:         15053,
 		},
 		{
-			name:           "DNS_CAPTURE enabled, empty addr falls back to defaults",
-			meta:           &model.NodeMetadata{DNSCapture: true},
-			expectResolver: true,
-			expectHost:     "127.0.0.1",
-			expectPort:     15053,
+			name:               "DNS_CAPTURE enabled, empty addr falls back to IPv4 defaults",
+			meta:               &model.NodeMetadata{DNSCapture: true, InstanceIPs: []string{"10.0.0.1"}},
+			expectLookupFamily: cluster.Cluster_V4_ONLY,
+			expectResolver:     true,
+			expectHost:         "127.0.0.1",
+			expectPort:         15053,
 		},
 		{
-			name:           "DNS_CAPTURE enabled, localhost resolved to 127.0.0.1",
-			meta:           &model.NodeMetadata{DNSCapture: true, DNSProxyAddr: "localhost:15053"},
-			expectResolver: true,
-			expectHost:     "127.0.0.1",
-			expectPort:     15053,
+			name:               "DNS_CAPTURE enabled, localhost resolved to 127.0.0.1",
+			meta:               &model.NodeMetadata{DNSCapture: true, DNSProxyAddr: "localhost:15053", InstanceIPs: []string{"10.0.0.1"}},
+			expectLookupFamily: cluster.Cluster_V4_ONLY,
+			expectResolver:     true,
+			expectHost:         "127.0.0.1",
+			expectPort:         15053,
 		},
 		{
-			name:           "DNS_CAPTURE enabled, custom port",
-			meta:           &model.NodeMetadata{DNSCapture: true, DNSProxyAddr: "127.0.0.1:53"},
-			expectResolver: true,
-			expectHost:     "127.0.0.1",
-			expectPort:     53,
+			name:               "DNS_CAPTURE enabled, empty addr falls back to IPv6 defaults",
+			meta:               &model.NodeMetadata{DNSCapture: true, InstanceIPs: []string{"2001:db8::1"}},
+			expectLookupFamily: cluster.Cluster_V6_ONLY,
+			expectResolver:     true,
+			expectHost:         "::1",
+			expectPort:         15053,
 		},
 		{
-			name:           "DNS_CAPTURE enabled, invalid addr falls back to defaults",
-			meta:           &model.NodeMetadata{DNSCapture: true, DNSProxyAddr: "not-a-valid-addr"},
-			expectResolver: true,
-			expectHost:     "127.0.0.1",
-			expectPort:     15053,
+			name:               "DNS_CAPTURE enabled, localhost resolved to ::1",
+			meta:               &model.NodeMetadata{DNSCapture: true, DNSProxyAddr: "localhost:15053", InstanceIPs: []string{"2001:db8::1"}},
+			expectLookupFamily: cluster.Cluster_V6_ONLY,
+			expectResolver:     true,
+			expectHost:         "::1",
+			expectPort:         15053,
+		},
+		{
+			name:               "DNS_CAPTURE enabled, custom port",
+			meta:               &model.NodeMetadata{DNSCapture: true, DNSProxyAddr: "127.0.0.1:53"},
+			expectLookupFamily: cluster.Cluster_V4_ONLY,
+			expectResolver:     true,
+			expectHost:         "127.0.0.1",
+			expectPort:         53,
+		},
+		{
+			name:               "DNS_CAPTURE enabled, invalid addr falls back to IPv6 defaults",
+			meta:               &model.NodeMetadata{DNSCapture: true, DNSProxyAddr: "not-a-valid-addr", InstanceIPs: []string{"2001:db8::1"}},
+			expectLookupFamily: cluster.Cluster_V6_ONLY,
+			expectResolver:     true,
+			expectHost:         "::1",
+			expectPort:         15053,
 		},
 	}
 	for _, tc := range tests {
@@ -956,8 +980,8 @@ func TestBuildAllowAnyDynamicDNSDNSCacheConfig(t *testing.T) {
 			if cfg.Name != util.AllowAnyDFPDNSCacheName {
 				t.Errorf("expected cache name %q, got %q", util.AllowAnyDFPDNSCacheName, cfg.Name)
 			}
-			if cfg.DnsLookupFamily != cluster.Cluster_V4_ONLY {
-				t.Errorf("expected dns lookup family V4_ONLY, got %v", cfg.DnsLookupFamily)
+			if cfg.DnsLookupFamily != tc.expectLookupFamily {
+				t.Errorf("expected dns lookup family %v, got %v", tc.expectLookupFamily, cfg.DnsLookupFamily)
 			}
 			if cfg.GetMaxHosts().GetValue() != uint32(features.AllowAnyDynamicDNSMaxHosts) {
 				t.Errorf("expected max hosts %d, got %d", features.AllowAnyDynamicDNSMaxHosts, cfg.GetMaxHosts().GetValue())

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -140,6 +140,32 @@ func SelectDNSLookupFamily(proxyIPAddresses []string) cluster.Cluster_DnsLookupF
 	}
 }
 
+// GetDNSProxyAddress returns the configured DNS proxy address. Localhost and fallback addresses
+// use the proxy's IP family; IPv4 is used when the proxy IPs are unknown or dual stack.
+func GetDNSProxyAddress(proxyIPAddresses []string, dnsProxyAddr string) *core.Address {
+	localhost := model.LocalhostAddressPrefix
+	if len(proxyIPAddresses) > 0 && networkutil.AllIPv6(proxyIPAddresses) {
+		localhost = model.LocalhostIPv6AddressPrefix
+	}
+	fallbackAddr := net.JoinHostPort(localhost, "15053")
+	if dnsProxyAddr == "" {
+		dnsProxyAddr = fallbackAddr
+	}
+	host, portStr, err := net.SplitHostPort(dnsProxyAddr)
+	if err != nil {
+		log.Warnf("failed to parse DNSProxyAddr %q, falling back to %s: %v", dnsProxyAddr, fallbackAddr, err)
+		host, portStr = localhost, "15053"
+	}
+	if host == "localhost" {
+		host = localhost
+	}
+	port, err := strconv.ParseUint(portStr, 10, 32)
+	if err != nil {
+		port = 15053
+	}
+	return BuildAddress(host, uint32(port))
+}
+
 // ALPNH2Only advertises that Proxy is going to use HTTP/2 when talking to the cluster.
 var ALPNH2Only = pm.ALPNH2Only
 

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -2067,3 +2067,34 @@ func TestSelectDNSLookupFamily(t *testing.T) {
 		})
 	}
 }
+
+func TestGetDNSProxyAddress(t *testing.T) {
+	tests := []struct {
+		name         string
+		ips          []string
+		dnsProxyAddr string
+		wantHost     string
+		wantPort     uint32
+	}{
+		{"no ips defaults to v4", nil, "", model.LocalhostAddressPrefix, 15053},
+		{"ipv4 localhost", []string{"10.0.0.1"}, "localhost:15053", model.LocalhostAddressPrefix, 15053},
+		{"ipv6 localhost", []string{"2001:db8::1"}, "localhost:15053", model.LocalhostIPv6AddressPrefix, 15053},
+		{"dual stack defaults to v4", []string{"10.0.0.1", "2001:db8::1"}, "", model.LocalhostAddressPrefix, 15053},
+		{"custom address", []string{"2001:db8::1"}, "10.0.0.1:53", "10.0.0.1", 53},
+		{"invalid address falls back to ipv6", []string{"2001:db8::1"}, "invalid", model.LocalhostIPv6AddressPrefix, 15053},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sa := GetDNSProxyAddress(tc.ips, tc.dnsProxyAddr).GetSocketAddress()
+			if sa == nil {
+				t.Fatal("expected SocketAddress")
+			}
+			if sa.Address != tc.wantHost {
+				t.Errorf("expected host %q, got %q", tc.wantHost, sa.Address)
+			}
+			if sa.GetPortValue() != tc.wantPort {
+				t.Errorf("expected port %d, got %d", tc.wantPort, sa.GetPortValue())
+			}
+		})
+	}
+}

--- a/releasenotes/notes/61330.yaml
+++ b/releasenotes/notes/61330.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 61330
+releaseNotes:
+  - |
+    **Fixed** `ALLOW_ANY_DYNAMIC_DNS` traffic failing in IPv6-only clusters because Envoy used the
+    IPv4 loopback address to reach the DNS proxy.

--- a/tests/integration/telemetry/policy/dynamicdns/traffic_allow_any_dynamic_dns_test.go
+++ b/tests/integration/telemetry/policy/dynamicdns/traffic_allow_any_dynamic_dns_test.go
@@ -105,10 +105,6 @@ func TestAllowAnyDynamicDNSPolicy(t *testing.T) {
 			}).BuildOrFail(t)
 
 		t.NewSubTest("http-via-dfp").Run(func(t framework.TestContext) {
-			if len(t.Settings().IPFamilies) == 1 && t.Settings().IPFamilies[0] == "IPv6" {
-				t.Skip("https://github.com/istio/istio/issues/61330")
-			}
-
 			baseline := clusterUpstreamRqTotal(t, client, "AllowAnyDynamicDNSCluster")
 			passthroughBaseline := clusterUpstreamRqTotal(t, client, "PassthroughCluster")
 
@@ -211,10 +207,6 @@ outboundTrafficPolicy:
 			}).BuildOrFail(t)
 
 		t.NewSubTest("http-to-external-with-tls-origination").Run(func(t framework.TestContext) {
-			if len(t.Settings().IPFamilies) == 1 && t.Settings().IPFamilies[0] == "IPv6" {
-				t.Skip("https://github.com/istio/istio/issues/61330")
-			}
-
 			baseline := clusterUpstreamRqTotal(t, client, "AllowAnyDynamicDNSCluster")
 
 			client.CallOrFail(t, echo.CallOptions{


### PR DESCRIPTION
Use `[::1]:15053` as the default DNS proxy address for IPv6-only proxies instead of `127.0.0.1:15053`, allowing the dynamic forward proxy to reach the Istio DNS proxy. This re-enables the integration tests disabled in #61331 and adds IP-family coverage.

Fixes #61330