### PR TITLE
envoy wds reconnect memory consumption

### DIFF
--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -387,7 +387,7 @@ func shouldRespondDelta(con *Connection, request *discovery.DeltaDiscoveryReques
 		}
 
 		res, wildcard, _ := deltaWatchedResources(nil, request)
-		skip := request.TypeUrl == v3.AddressType && wildcard
+		skip := requiresResourceNamesModification(request.TypeUrl) && wildcard
 		if skip {
 			// Due to the high resource count in WDS at scale, we do not store ResourceName.
 			// See the workload generator for more information on why we don't use this.

--- a/pilot/pkg/xds/workload_test.go
+++ b/pilot/pkg/xds/workload_test.go
@@ -266,6 +266,39 @@ func TestWorkloadReconnect(t *testing.T) {
 		}})
 		expectAddedAndRemoved(ads.ExpectResponse(), []string{"Kubernetes//Pod/default/pod"}, nil)
 	})
+	t.Run("wildcard retains no resource names", func(t *testing.T) {
+		// A live client reconnecting to a new istiod instance sends initial_resource_versions
+		// carrying (nearly) the entire resource universe it holds. Wildcard connections never
+		// read the per-connection watch set, so storing those names is O(clients * universe)
+		// memory for nothing.
+		for name, typeURL := range map[string]string{"address": v3.AddressType, "workload": v3.WorkloadType} {
+			t.Run(name, func(t *testing.T) {
+				expect := buildExpect(t)
+				s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
+					KubernetesObjects: []runtime.Object{mkPod("pod", "sa", "127.0.0.1", "not-node")},
+				})
+				ads := s.ConnectDeltaADS().WithType(typeURL).WithMetadata(model.NodeMetadata{NodeName: "node"})
+				expect(ads.RequestResponseAck(&discovery.DeltaDiscoveryRequest{}), "Kubernetes//Pod/default/pod")
+				ads.Cleanup()
+
+				// Reconnect with initial_resource_versions carrying the retained resource.
+				ads = s.ConnectDeltaADS().WithType(typeURL).WithMetadata(model.NodeMetadata{NodeName: "node"})
+				ads.Request(&discovery.DeltaDiscoveryRequest{
+					InitialResourceVersions: map[string]string{
+						"Kubernetes//Pod/default/pod": "stale",
+					},
+				})
+				expect(ads.ExpectResponse(), "Kubernetes//Pod/default/pod")
+				for _, c := range s.Discovery.AllClients() {
+					w := c.Proxy().GetWatchedResource(typeURL)
+					if w == nil {
+						t.Fatalf("connection %v missing watched resource %v", c.ID(), typeURL)
+					}
+					assert.Equal(t, len(w.ResourceNames), 0)
+				}
+			})
+		}
+	})
 }
 
 func TestWorkload(t *testing.T) {

--- a/releasenotes/notes/delta-wds-watchset-retention.yaml
+++ b/releasenotes/notes/delta-wds-watchset-retention.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+releaseNotes:
+  - |
+    **Fixed** an issue where istiod permanently retained a copy of every workload resource name for each
+    envoy MDS (WDS, used for telemetry metadata lookups) connection that sent `initial_resource_versions`.


### PR DESCRIPTION
**Please provide a description of this PR:**

Envoy proxies request WDS (used for metadata lookup to enrich telemetry) when HBONE is enabled. These WDS connections use a different type URL than ztunnel connections and a check was not updated to account for this type mismatch. This caused Envoy reconnections to consume a significant amount of memory in istiod which ztunnel reconnections don't.