### PR TITLE
tests: skip TestMultiRevisionRouteStatusHandling if GW API is not supported

### DIFF
--- a/tests/integration/pilot/revisions/revisions_test.go
+++ b/tests/integration/pilot/revisions/revisions_test.go
@@ -137,9 +137,7 @@ func TestMultiRevision(t *testing.T) {
 func TestMultiRevisionRouteStatusHandling(t *testing.T) {
 	framework.NewTest(t).
 		Run(func(t framework.TestContext) {
-			if err := crd.DeployGatewayAPI(t); err != nil {
-				t.Fatal(err)
-			}
+			crd.DeployGatewayAPIOrSkip(t)
 			cfg := istio.DefaultConfigOrFail(t, t)
 			stable := namespace.NewOrFail(t, namespace.Config{
 				Prefix:   "stable",


### PR DESCRIPTION
**Please provide a description of this PR:**

The test called `crd.DeployGatewayAPI()` directly and treated the unsupported-version error as fatal, causing failures on k8s 1.24-1.30. Use `DeployGatewayAPIOrSkip()` to properly skip instead.