### PR TITLE
tests: skip ambient waypoint tests on k8s < 1.31

### DIFF
--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -394,6 +394,7 @@ func TestServerSideLB(t *testing.T) {
 
 func TestWaypointChanges(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
+		skipIfGatewayAPIUnsupported(t)
 		waypointName := "waypoint-service"
 		getGracePeriod := func(want int64) bool {
 			pods, err := kubetest.NewPodFetch(t.AllClusters()[0], apps.Namespace.Name(), label.IoK8sNetworkingGatewayGatewayName.Name+"="+waypointName)()
@@ -430,6 +431,7 @@ func TestWaypointChanges(t *testing.T) {
 
 func TestOtherRevisionIgnored(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
+		skipIfGatewayAPIUnsupported(t)
 		// This is a negative test, ensuring gateways with tags other
 		// than my tags do not get controlled by me.
 		nsConfig, err := namespace.New(t, namespace.Config{
@@ -470,6 +472,7 @@ func TestOtherRevisionIgnored(t *testing.T) {
 
 func TestRemoveAddWaypoint(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
+		skipIfGatewayAPIUnsupported(t)
 		for _, c := range t.Clusters() {
 			istioctl.NewOrFail(t, istioctl.Config{
 				Cluster: c,
@@ -545,6 +548,7 @@ func TestRemoveAddWaypoint(t *testing.T) {
 
 func TestBogusUseWaypoint(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
+		skipIfGatewayAPIUnsupported(t)
 		check := func(t framework.TestContext) {
 			dst := apps.Captured
 			for _, src := range apps.All {
@@ -579,6 +583,7 @@ func TestBogusUseWaypoint(t *testing.T) {
 
 func TestServerRouting(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
+		skipIfGatewayAPIUnsupported(t)
 		runTestToServiceWaypoint(t, func(t framework.TestContext, src echo.Instance, dst echo.Target, opt echo.CallOptions) {
 			// Need waypoint proxy and HTTP
 			if opt.Scheme != scheme.HTTP {
@@ -660,6 +665,7 @@ spec:
 
 func TestWaypointEnvoyFilter(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
+		skipIfGatewayAPIUnsupported(t)
 		runTestToServiceWaypoint(t, func(t framework.TestContext, src echo.Instance, dst echo.Target, opt echo.CallOptions) {
 			// Need at least one waypoint proxy and HTTP
 			if opt.Scheme != scheme.HTTP {
@@ -733,6 +739,7 @@ spec:
 
 func TestTrafficSplit(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
+		skipIfGatewayAPIUnsupported(t)
 		if t.Settings().AmbientMultiNetwork {
 			t.Skip("https://github.com/istio/istio/issues/58140")
 		}
@@ -1087,6 +1094,7 @@ spec:
 
 func TestAuthorizationServiceAttached(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
+		skipIfGatewayAPIUnsupported(t)
 		maybeSetupMultiCluster(t)
 		applyDrainingWorkaround(t)
 		src := apps.Captured
@@ -1334,6 +1342,7 @@ spec:
 
 func TestAuthorizationWaypointDefaultDeny(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
+		skipIfGatewayAPIUnsupported(t)
 		applyDrainingWorkaround(t)
 		runTestContextIndividual(t, func(t framework.TestContext, src echo.Instance, dst echo.Instance, opt echo.CallOptions) {
 			if !dst.Config().HasAnyWaypointProxy() {
@@ -1738,6 +1747,9 @@ func TestL7JWT(t *testing.T) {
 
 func TestDestinationRule(t *testing.T) {
 	dst := apps.ServiceAddressedWaypoint
+	if len(dst) == 0 {
+		t.Skip("requires gateway API (k8s 1.31+)")
+	}
 	cases := []struct {
 		name   string
 		config string
@@ -3159,6 +3171,7 @@ func runIngressTest(t *testing.T, f func(t framework.TestContext, src ingress.In
 func TestL7Telemetry(t *testing.T) {
 	framework.NewTest(t).
 		Run(func(tc framework.TestContext) {
+			skipIfGatewayAPIUnsupported(tc)
 			// ensure that some traffic from each captured workload is
 			// sent to each waypoint proxy. This will likely have happened in
 			// the other tests (without the teardown), but we want to make
@@ -3211,6 +3224,7 @@ func TestL7Telemetry(t *testing.T) {
 func TestCustomizeMetrics(t *testing.T) {
 	framework.NewTest(t).
 		Run(func(t framework.TestContext) {
+			skipIfGatewayAPIUnsupported(t)
 			t.ConfigIstio().YAML(apps.Namespace.Name(), `
 apiVersion: telemetry.istio.io/v1
 kind: Telemetry
@@ -3470,6 +3484,7 @@ func TestAPIServer(t *testing.T) {
 
 func TestDirect(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
+		skipIfGatewayAPIUnsupported(t)
 		t.NewSubTest("waypoint").Run(func(t framework.TestContext) {
 			c := common.NewCaller()
 			for _, cluster := range t.Clusters() {
@@ -3772,6 +3787,7 @@ func TestServiceRestart(t *testing.T) {
 	}
 
 	framework.NewTest(t).Run(func(t framework.TestContext) {
+		skipIfGatewayAPIUnsupported(t)
 		generators := []traffic.Generator{}
 		mkGen := func(src echo.Caller, dst echo.Instances) {
 			g := traffic.NewGenerator(t, traffic.Config{
@@ -3817,6 +3833,7 @@ func TestZtunnelRestart(t *testing.T) {
 	const sidecarSuccessThreshold = .9
 
 	framework.NewTest(t).Run(func(t framework.TestContext) {
+		skipIfGatewayAPIUnsupported(t)
 		mkGen := func(src echo.Caller, dst echo.Instances) traffic.Generator {
 			g := traffic.NewGenerator(t, traffic.Config{
 				Source: src,
@@ -3865,6 +3882,7 @@ func TestServiceDynamicEnroll(t *testing.T) {
 	successThreshold := 0.5
 
 	framework.NewTest(t).Run(func(t framework.TestContext) {
+		skipIfGatewayAPIUnsupported(t)
 		if t.Settings().AmbientMultiNetwork {
 			t.Skip("https://github.com/istio/istio/issues/58228")
 		}
@@ -4023,6 +4041,7 @@ func daemonsetsetComplete(ds *appsv1.DaemonSet) bool {
 func TestWaypointWithInvalidBackend(t *testing.T) {
 	framework.NewTest(t).
 		Run(func(t framework.TestContext) {
+			skipIfGatewayAPIUnsupported(t)
 			// We should expect a 500 error since the backend is invalid.
 			t.ConfigIstio().
 				Eval(apps.Namespace.Name(), apps.Namespace.Name(), `apiVersion: gateway.networking.k8s.io/v1
@@ -4065,6 +4084,7 @@ spec:
 func TestWaypointWithSidecarBackend(t *testing.T) {
 	framework.NewTest(t).
 		Run(func(t framework.TestContext) {
+			skipIfGatewayAPIUnsupported(t)
 			// Ensure we go through the waypoint (verified by modifying the request) and that we are doing mTLS.
 			t.ConfigIstio().
 				Eval(apps.Namespace.Name(), apps.Namespace.Name(), `apiVersion: gateway.networking.k8s.io/v1

--- a/tests/integration/ambient/gateway_conformance_test.go
+++ b/tests/integration/ambient/gateway_conformance_test.go
@@ -80,6 +80,7 @@ func TestGatewayConformance(t *testing.T) {
 	framework.
 		NewTest(t).
 		Run(func(ctx framework.TestContext) {
+			skipIfGatewayAPIUnsupported(ctx)
 			// Precreate the GatewayConformance namespaces, and apply the Image Pull Secret to them.
 			if ctx.Settings().Image.PullSecret != "" {
 				for _, ns := range conformanceNamespaces {

--- a/tests/integration/ambient/main_test.go
+++ b/tests/integration/ambient/main_test.go
@@ -20,6 +20,9 @@ import (
 	"context"
 	"testing"
 
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"istio.io/api/label"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/test/framework"
@@ -37,8 +40,6 @@ import (
 	"istio.io/istio/pkg/test/framework/resource/config/apply"
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/tests/integration/security/util/cert"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (

--- a/tests/integration/ambient/main_test.go
+++ b/tests/integration/ambient/main_test.go
@@ -20,9 +20,6 @@ import (
 	"context"
 	"testing"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"istio.io/api/label"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/test/framework"
@@ -40,6 +37,8 @@ import (
 	"istio.io/istio/pkg/test/framework/resource/config/apply"
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/tests/integration/security/util/cert"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
@@ -275,21 +274,21 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 	}
 
 	builder = builder.WithConfig(echo.Config{
-			Service:        Captured,
-			Namespace:      apps.Namespace,
-			Ports:          ports.All(),
-			ServiceAccount: true,
-			Subsets: []echo.SubsetConfig{
-				{
-					Replicas: 1,
-					Version:  "v1",
-				},
-				{
-					Replicas: 1,
-					Version:  "v2",
-				},
+		Service:        Captured,
+		Namespace:      apps.Namespace,
+		Ports:          ports.All(),
+		ServiceAccount: true,
+		Subsets: []echo.SubsetConfig{
+			{
+				Replicas: 1,
+				Version:  "v1",
 			},
-		}).
+			{
+				Replicas: 1,
+				Version:  "v2",
+			},
+		},
+	}).
 		WithConfig(echo.Config{
 			Service:        Uncaptured,
 			Namespace:      apps.Namespace,

--- a/tests/integration/ambient/main_test.go
+++ b/tests/integration/ambient/main_test.go
@@ -27,6 +27,7 @@ import (
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/ambient"
+	"istio.io/istio/pkg/test/framework/components/crd"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	cdeployment "istio.io/istio/pkg/test/framework/components/echo/common/deployment"
 	"istio.io/istio/pkg/test/framework/components/echo/common/ports"
@@ -178,6 +179,12 @@ var inMesh = match.Matcher(func(instance echo.Instance) bool {
 	return instance.Config().HasProxyCapabilities()
 })
 
+func skipIfGatewayAPIUnsupported(t framework.TestContext) {
+	if !crd.SupportsGatewayAPI(t) {
+		t.Skip("requires gateway API (k8s 1.31+)")
+	}
+}
+
 func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) error {
 	var err error
 	apps.Namespace, err = namespace.New(t, namespace.Config{
@@ -208,61 +215,66 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 		headlessPorts[i] = p
 	}
 	builder := deployment.New(t).
-		WithClusters(t.Clusters()...).
-		WithConfig(echo.Config{
-			Service:               WorkloadAddressedWaypoint,
-			Namespace:             apps.Namespace,
-			Ports:                 ports.All(),
-			ServiceAccount:        true,
-			WorkloadWaypointProxy: "waypoint-workload",
-			Subsets: []echo.SubsetConfig{
-				{
-					Replicas: 1,
-					Version:  "v1",
-					Labels: map[string]string{
-						"app":                         WorkloadAddressedWaypoint,
-						"version":                     "v1",
-						label.IoIstioUseWaypoint.Name: "waypoint-workload",
+		WithClusters(t.Clusters()...)
+
+	if crd.SupportsGatewayAPI(t) {
+		builder = builder.
+			WithConfig(echo.Config{
+				Service:               WorkloadAddressedWaypoint,
+				Namespace:             apps.Namespace,
+				Ports:                 ports.All(),
+				ServiceAccount:        true,
+				WorkloadWaypointProxy: "waypoint-workload",
+				Subsets: []echo.SubsetConfig{
+					{
+						Replicas: 1,
+						Version:  "v1",
+						Labels: map[string]string{
+							"app":                         WorkloadAddressedWaypoint,
+							"version":                     "v1",
+							label.IoIstioUseWaypoint.Name: "waypoint-workload",
+						},
+					},
+					{
+						Replicas: 1,
+						Version:  "v2",
+						Labels: map[string]string{
+							"app":                         WorkloadAddressedWaypoint,
+							"version":                     "v2",
+							label.IoIstioUseWaypoint.Name: "waypoint-workload",
+						},
 					},
 				},
-				{
-					Replicas: 1,
-					Version:  "v2",
-					Labels: map[string]string{
-						"app":                         WorkloadAddressedWaypoint,
-						"version":                     "v2",
-						label.IoIstioUseWaypoint.Name: "waypoint-workload",
+			}).
+			WithConfig(echo.Config{
+				Service:              ServiceAddressedWaypoint,
+				Namespace:            apps.Namespace,
+				Ports:                ports.All(),
+				ServiceLabels:        map[string]string{label.IoIstioUseWaypoint.Name: "waypoint-service"},
+				ServiceAccount:       true,
+				ServiceWaypointProxy: "waypoint-service",
+				Subsets: []echo.SubsetConfig{
+					{
+						Replicas: 1,
+						Version:  "v1",
+						Labels: map[string]string{
+							"app":     ServiceAddressedWaypoint,
+							"version": "v1",
+						},
+					},
+					{
+						Replicas: 1,
+						Version:  "v2",
+						Labels: map[string]string{
+							"app":     ServiceAddressedWaypoint,
+							"version": "v2",
+						},
 					},
 				},
-			},
-		}).
-		WithConfig(echo.Config{
-			Service:              ServiceAddressedWaypoint,
-			Namespace:            apps.Namespace,
-			Ports:                ports.All(),
-			ServiceLabels:        map[string]string{label.IoIstioUseWaypoint.Name: "waypoint-service"},
-			ServiceAccount:       true,
-			ServiceWaypointProxy: "waypoint-service",
-			Subsets: []echo.SubsetConfig{
-				{
-					Replicas: 1,
-					Version:  "v1",
-					Labels: map[string]string{
-						"app":     ServiceAddressedWaypoint,
-						"version": "v1",
-					},
-				},
-				{
-					Replicas: 1,
-					Version:  "v2",
-					Labels: map[string]string{
-						"app":     ServiceAddressedWaypoint,
-						"version": "v2",
-					},
-				},
-			},
-		}).
-		WithConfig(echo.Config{
+			})
+	}
+
+	builder = builder.WithConfig(echo.Config{
 			Service:        Captured,
 			Namespace:      apps.Namespace,
 			Ports:          ports.All(),
@@ -361,6 +373,10 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 	if err := cdeployment.DeployExternalServiceEntry(t.ConfigIstio(), apps.Namespace, apps.ExternalNamespace, false).
 		Apply(apply.CleanupConditionally); err != nil {
 		return err
+	}
+
+	if !crd.SupportsGatewayAPI(t) {
+		return nil
 	}
 
 	if apps.WaypointProxies == nil {

--- a/tests/integration/ambient/traffic_test.go
+++ b/tests/integration/ambient/traffic_test.go
@@ -28,6 +28,7 @@ func TestTraffic(t *testing.T) {
 	framework.NewTest(t).
 		TopLevel().
 		Run(func(t framework.TestContext) {
+			skipIfGatewayAPIUnsupported(t)
 			deployments := deployment.NewOrFail(t, deployment.Config{
 				IncludeExtAuthz: false,
 			})

--- a/tests/integration/ambient/trafficextension_lua_test.go
+++ b/tests/integration/ambient/trafficextension_lua_test.go
@@ -98,6 +98,7 @@ func uninstallLuaTrafficExtension(ctx framework.TestContext, filterName, path st
 func TestLuaTrafficExtension_HeaderInjection(t *testing.T) {
 	framework.NewTest(t).
 		Run(func(t framework.TestContext) {
+			skipIfGatewayAPIUnsupported(t)
 			testCases := []struct {
 				desc         string
 				name         string
@@ -150,6 +151,7 @@ func TestLuaTrafficExtension_HeaderInjection(t *testing.T) {
 func TestLuaTrafficExtension_ResponseModification(t *testing.T) {
 	framework.NewTest(t).
 		Run(func(t framework.TestContext) {
+			skipIfGatewayAPIUnsupported(t)
 			filterName := "lua-response-modifier"
 			targetType := "service"
 			targetName := GetTarget().Instances().ServiceName()
@@ -176,6 +178,7 @@ func TestLuaTrafficExtension_ResponseModification(t *testing.T) {
 func TestLuaTrafficExtension_MultipleFilters(t *testing.T) {
 	framework.NewTest(t).
 		Run(func(t framework.TestContext) {
+			skipIfGatewayAPIUnsupported(t)
 			targetType := "service"
 			targetName := GetTarget().Instances().ServiceName()
 
@@ -215,6 +218,7 @@ func TestLuaTrafficExtension_MultipleFilters(t *testing.T) {
 func TestLuaTrafficExtension_PhaseOrdering(t *testing.T) {
 	framework.NewTest(t).
 		Run(func(t framework.TestContext) {
+			skipIfGatewayAPIUnsupported(t)
 			targetType := "service"
 			targetName := GetTarget().Instances().ServiceName()
 

--- a/tests/integration/ambient/trafficextension_wasm_test.go
+++ b/tests/integration/ambient/trafficextension_wasm_test.go
@@ -110,6 +110,7 @@ func uninstallTrafficExtensionWasm(ctx framework.TestContext, filterName, path s
 func TestTrafficExtension_WasmConfigurations(t *testing.T) {
 	framework.NewTest(t).
 		Run(func(t framework.TestContext) {
+			skipIfGatewayAPIUnsupported(t)
 			testCases := []struct {
 				desc         string
 				name         string

--- a/tests/integration/ambient/wasm_test.go
+++ b/tests/integration/ambient/wasm_test.go
@@ -197,6 +197,7 @@ func getTargetRefValues(targetType, targetName string) (kind, group, name string
 func TestWasmPluginConfigurations(t *testing.T) {
 	framework.NewTest(t).
 		Run(func(t framework.TestContext) {
+			skipIfGatewayAPIUnsupported(t)
 			testCases := []struct {
 				desc         string
 				name         string

--- a/tests/integration/ambient/waypoint/main_test.go
+++ b/tests/integration/ambient/waypoint/main_test.go
@@ -124,6 +124,9 @@ func TestCrossNamespaceWaypoint(t *testing.T) {
 	framework.
 		NewTest(t).
 		Run(func(t framework.TestContext) {
+			if !crd.SupportsGatewayAPI(t) {
+				t.Skip("requires gateway API (k8s 1.31+)")
+			}
 			if t.Settings().AmbientMultiNetwork {
 				t.Skip("https://github.com/istio/istio/issues/57878")
 			}

--- a/tests/integration/ambient/waypoint_canary_test.go
+++ b/tests/integration/ambient/waypoint_canary_test.go
@@ -65,6 +65,7 @@ var acceptAny = func(echo.CallResult, error) error { return nil }
 // simply yields fewer successes, so an assertion can never pass on failed traffic.
 func TestWeightedWaypointTrafficShift(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
+		skipIfGatewayAPIUnsupported(t)
 		newCanaryWaypoints(t)
 		src := apps.Captured[0]
 		dst := apps.Captured
@@ -95,6 +96,7 @@ func TestWeightedWaypointTrafficShift(t *testing.T) {
 // primary waypoint, so traffic keeps flowing rather than blackholing.
 func TestWeightedWaypointCanaryNotReady(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
+		skipIfGatewayAPIUnsupported(t)
 		newServiceWaypoint(t, canaryPrimaryWP)
 		src := apps.Captured[0]
 		dst := apps.Captured
@@ -117,6 +119,7 @@ func TestWeightedWaypointCanaryNotReady(t *testing.T) {
 // requests would be allowed (200) instead of denied (403).
 func TestWeightedWaypointPolicyPropagation(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
+		skipIfGatewayAPIUnsupported(t)
 		ns := apps.Namespace.Name()
 		newCanaryWaypoints(t)
 		src := apps.Captured[0]
@@ -176,6 +179,7 @@ spec:
 // chosen waypoint, so the destination sees that waypoint's SA.
 func TestWeightedWaypointIngressTrafficShift(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
+		skipIfGatewayAPIUnsupported(t)
 		if t.Settings().AmbientMultiNetwork {
 			t.Skip("https://github.com/istio/istio/issues/54245")
 		}

--- a/tests/integration/ambient/waypoint_test.go
+++ b/tests/integration/ambient/waypoint_test.go
@@ -61,6 +61,7 @@ func TestWaypointStatus(t *testing.T) {
 	framework.
 		NewTest(t).
 		Run(func(t framework.TestContext) {
+			skipIfGatewayAPIUnsupported(t)
 			t.NewSubTest("gateway class").Run(func(t framework.TestContext) {
 				client := t.Clusters().Default().GatewayAPI().GatewayV1().GatewayClasses()
 
@@ -111,6 +112,7 @@ func TestWaypoint(t *testing.T) {
 	framework.
 		NewTest(t).
 		Run(func(t framework.TestContext) {
+			skipIfGatewayAPIUnsupported(t)
 			nsConfig := namespace.NewOrFail(t, namespace.Config{
 				Prefix: "waypoint",
 				Inject: false,
@@ -231,6 +233,7 @@ func TestSimpleHTTPSandwich(t *testing.T) {
 	framework.
 		NewTest(t).
 		Run(func(t framework.TestContext) {
+			skipIfGatewayAPIUnsupported(t)
 			config := `
 apiVersion: networking.istio.io/v1beta1
 kind: ProxyConfig
@@ -451,6 +454,7 @@ func TestWaypointDNS(t *testing.T) {
 	framework.
 		NewTest(t).
 		Run(func(t framework.TestContext) {
+			skipIfGatewayAPIUnsupported(t)
 			t.NewSubTest("without waypoint").Run(func(t framework.TestContext) {
 				runTest(t, check.OK())
 			})
@@ -556,6 +560,7 @@ func TestWaypointAsEgressGateway(t *testing.T) {
 	framework.
 		NewTest(t).
 		Run(func(t framework.TestContext) {
+			skipIfGatewayAPIUnsupported(t)
 			egressNamespace, err := namespace.Claim(t, namespace.Config{
 				Prefix: "egress",
 				Inject: false,
@@ -895,6 +900,7 @@ spec:
 
 func TestIngressToWaypoint(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
+		skipIfGatewayAPIUnsupported(t)
 		// Apply a deny-all waypoint policy. This allows us to test the traffic traverses the waypoint
 		t.ConfigIstio().Eval(apps.Namespace.Name(), map[string]string{
 			"Waypoint": apps.ServiceAddressedWaypoint.Config().ServiceWaypointProxy,
@@ -1123,6 +1129,7 @@ spec:
 
 func TestTCPRoute(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
+		skipIfGatewayAPIUnsupported(t)
 		t.ConfigIstio().YAML(apps.Namespace.Name(), `apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: TCPRoute
 metadata:
@@ -1184,6 +1191,7 @@ spec:
 
 func TestTLSRoute(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
+		skipIfGatewayAPIUnsupported(t)
 		t.ConfigIstio().YAML(apps.Namespace.Name(), `apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: TLSRoute
 metadata:
@@ -1267,6 +1275,7 @@ func TestWaypointAsEgressGatewayForWildcardEntries(t *testing.T) {
 	framework.
 		NewTest(t).
 		Run(func(t framework.TestContext) {
+			skipIfGatewayAPIUnsupported(t)
 			if _, v6 := getSupportedIPFamilies(t); v6 {
 				t.Skip("TODO: skipping test as wildcard DNS doesn't support resolving to IPv6 address")
 			}
@@ -1455,6 +1464,7 @@ func TestWaypointDNSConnectStrategy(t *testing.T) {
 	framework.
 		NewTest(t).
 		Run(func(t framework.TestContext) {
+			skipIfGatewayAPIUnsupported(t)
 			egressNamespace, err := namespace.Claim(t, namespace.Config{
 				Prefix: "connect-strategy-egress",
 				Inject: false,

--- a/tests/integration/ambient/xfcc_client_identity_test.go
+++ b/tests/integration/ambient/xfcc_client_identity_test.go
@@ -42,6 +42,7 @@ const xfccClientIdentityAnnotation = "ambient.istio.io/xfcc-include-client-ident
 // SPIFFE identity. Without the annotation XFCC does not contain the client URI.
 func TestWaypointXFCCClientIdentity(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
+		skipIfGatewayAPIUnsupported(t)
 		runTestToServiceWaypoint(t, func(t framework.TestContext, src echo.Instance, dst echo.Target, opt echo.CallOptions) {
 			if opt.Scheme != scheme.HTTP {
 				return


### PR DESCRIPTION
**Please provide a description of this PR:**

Gateway API v1.5.0 requires the isIP() CEL function which is only available in k8s 1.31+. Waypoint proxies depend on Gateway API CRDs so tests that create or interact with waypoints cannot run on older clusters. Rather than skipping the entire ambient suite, conditionally deploy waypoint echo configs and waypoint proxies in the setup, and skip individual waypoint-dependent tests with a shared helper.