### PR TITLE
ambient: fix remote networks leak

### DIFF
--- a/pilot/pkg/serviceregistry/ambient/ambientindex_multicluster_test.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex_multicluster_test.go
@@ -221,16 +221,19 @@ func TestAmbientMulticlusterIndex_WaypointForWorkloadTraffic(t *testing.T) {
 						},
 					})
 
-					// Ensure the namespace network is set in up in the collection before doing other assertions
-					assert.EventuallyEqual(t, func() bool {
-						networks := s.networks.SystemNamespaceNetworkByCluster.Lookup(client.clusterID)
-						if len(networks) == 0 {
-							return false
+					// A cluster's network is read from the topology label on its own system namespace, so wait
+					// for that namespace to reach the cluster's informer before making other assertions.
+					assert.EventuallyEqual(t, func() string {
+						cl := s.mcController.ClusterStore().GetByID(client.clusterID)
+						if cl == nil || !cl.HasSynced() {
+							return ""
 						}
-
-						nw := networks[0].Network
-						return string(nw) == clusterToNetwork[client.clusterID]
-					}, true)
+						ns := cl.Namespaces().GetKey(systemNS)
+						if ns == nil {
+							return ""
+						}
+						return (*ns).Labels[label.TopologyNetwork.Name]
+					}, clusterToNetwork[client.clusterID])
 				}
 				if networkGatewayIps[client.clusterID] != "" {
 					s.addNetworkGatewayForClient(t, networkGatewayIps[client.clusterID], clusterToNetwork[client.clusterID], client.grc)

--- a/pilot/pkg/serviceregistry/ambient/networks.go
+++ b/pilot/pkg/serviceregistry/ambient/networks.go
@@ -70,11 +70,16 @@ func (c NetworkCollections) FetchLocalNetworkID(ctx krt.HandlerContext) network.
 // label on its system namespace. A cluster whose system namespace is absent, or carries no label, is
 // part of the default (empty) network.
 func (c NetworkCollections) FetchRemoteSystemNamespaceNetwork(ctx krt.HandlerContext, namespaces krt.Collection[*v1.Namespace]) network.ID {
-	ns := ptr.Flatten(krt.FetchOne(ctx, namespaces, krt.FilterKey(c.systemNamespace)))
-	if ns == nil {
+	nw := krt.PartialFetchComparable(ctx, namespaces, func(ns *v1.Namespace) string {
+		if ns == nil {
+			return ""
+		}
+		return ns.Labels[label.TopologyNetwork.Name]
+	}, krt.FilterKey(c.systemNamespace))
+	if len(nw) == 0 {
 		return ""
 	}
-	return network.ID(ns.Labels[label.TopologyNetwork.Name])
+	return network.ID(nw[0])
 }
 
 func (c NetworkCollections) HasSynced() bool {

--- a/pilot/pkg/serviceregistry/ambient/networks.go
+++ b/pilot/pkg/serviceregistry/ambient/networks.go
@@ -28,7 +28,6 @@ import (
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
-	kubectrl "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/kube/multicluster"
 	"istio.io/istio/pkg/log"
@@ -46,13 +45,11 @@ func (n NetworkGateway) ResourceName() string {
 }
 
 type NetworkCollections struct {
-	LocalSystemNamespace          krt.Singleton[ClusterNetwork]
-	RemoteSystemNamespaceNetworks krt.Collection[ClusterNetwork]
-	// SystemNamespaceNetworkByCluster is an index of cluster ID to the system namespace network
-	// for that cluster.
-	SystemNamespaceNetworkByCluster krt.Index[cluster.ID, ClusterNetwork]
-	NetworkGateways                 krt.Collection[NetworkGateway]
-	GatewaysByNetwork               krt.Index[network.ID, NetworkGateway]
+	LocalSystemNamespace krt.Singleton[ClusterNetwork]
+	NetworkGateways      krt.Collection[NetworkGateway]
+	GatewaysByNetwork    krt.Index[network.ID, NetworkGateway]
+	// systemNamespace is the namespace whose topology label names the network a cluster belongs to.
+	systemNamespace string
 }
 
 type ClusterNetwork struct {
@@ -67,6 +64,17 @@ func (c ClusterNetwork) ResourceName() string {
 // FetchLocalNetworkID fetches the local network ID from a ClusterNetwork singleton within a KRT handler context.
 func (c NetworkCollections) FetchLocalNetworkID(ctx krt.HandlerContext) network.ID {
 	return ptr.OrEmpty(krt.FetchOne(ctx, c.LocalSystemNamespace.AsCollection())).Network
+}
+
+// FetchRemoteSystemNamespaceNetwork returns the network a remote cluster belongs to, read from the topology
+// label on its system namespace. A cluster whose system namespace is absent, or carries no label, is
+// part of the default (empty) network.
+func (c NetworkCollections) FetchRemoteSystemNamespaceNetwork(ctx krt.HandlerContext, namespaces krt.Collection[*v1.Namespace]) network.ID {
+	ns := ptr.Flatten(krt.FetchOne(ctx, namespaces, krt.FilterKey(c.systemNamespace)))
+	if ns == nil {
+		return ""
+	}
+	return network.ID(ns.Labels[label.TopologyNetwork.Name])
 }
 
 func (c NetworkCollections) HasSynced() bool {
@@ -97,34 +105,9 @@ func buildGlobalNetworkCollections(
 			Network:   network.ID(nw),
 		}
 	}, opts.WithName("LocalSystemNamespaceNetwork")...)
-	RemoteSystemNamespaceNetworks := krt.NewCollection(ctrl.Clusters(), func(ctx krt.HandlerContext, c *multicluster.Cluster) *ClusterNetwork {
-		if !kubectrl.WaitForCacheSync(fmt.Sprintf("remote cluster[%s] namespaces", c.ID), opts.Stop(), c.HasSynced) {
-			log.Errorf("Timed out waiting for cluster %s to sync namespaces", c.ID)
-			return nil
-		}
-		ns := ptr.Flatten(krt.FetchOne(ctx, c.Namespaces(), krt.FilterKey(options.SystemNamespace)))
-		if ns == nil {
-			// If the namespace for the remote cluster is not found, we default to the empty string
-			// to indicate that this cluster is a part of the default network
-			return &ClusterNetwork{
-				ClusterID: c.ID,
-				Network:   "",
-			}
-		}
-		nw, f := ns.Labels[label.TopologyNetwork.Name]
-		if !f {
-			nw = ""
-		}
-		return &ClusterNetwork{
-			ClusterID: c.ID,
-			Network:   network.ID(nw),
-		}
-	}, opts.WithName("RemoteSystemNamespaceNetworks")...)
-
-	RemoteSystemNamespaceNetworksByCluster := krt.NewIndex(RemoteSystemNamespaceNetworks, "cluster", func(o ClusterNetwork) []cluster.ID {
-		return []cluster.ID{o.ClusterID}
-	})
-
+	// N.B there is deliberately no aggregated collection of remote clusters' networks. A cluster's
+	// network is read straight from its own namespaces collection, by the per-cluster collections that
+	// need it, via FetchRemoteSystemNamespaceNetwork.
 	localNetworkGateways := krt.NewManyCollection(localGateways, func(ctx krt.HandlerContext, gw *gatewayv1.Gateway) []krt.ObjectWithCluster[NetworkGateway] {
 		return k8sGatewayToNetworkGatewaysWithCluster(options.ClusterID, gw, options.ClusterID)
 	}, opts.WithName("LocalNetworkGateways")...)
@@ -196,11 +179,10 @@ func buildGlobalNetworkCollections(
 	})
 
 	return NetworkCollections{
-		SystemNamespaceNetworkByCluster: RemoteSystemNamespaceNetworksByCluster,
-		NetworkGateways:                 MergedNetworkGateways,
-		GatewaysByNetwork:               GatewaysByNetwork,
-		LocalSystemNamespace:            LocalSystemNamespaceNetwork,
-		RemoteSystemNamespaceNetworks:   RemoteSystemNamespaceNetworks,
+		NetworkGateways:      MergedNetworkGateways,
+		GatewaysByNetwork:    GatewaysByNetwork,
+		LocalSystemNamespace: LocalSystemNamespaceNetwork,
+		systemNamespace:      options.SystemNamespace,
 	}
 }
 
@@ -237,6 +219,7 @@ func BuildNetworkCollections(
 		LocalSystemNamespace: SystemNamespaceNetwork,
 		NetworkGateways:      NetworkGateways,
 		GatewaysByNetwork:    GatewaysByNetwork,
+		systemNamespace:      options.SystemNamespace,
 	}
 }
 

--- a/pilot/pkg/serviceregistry/ambient/services.go
+++ b/pilot/pkg/serviceregistry/ambient/services.go
@@ -203,13 +203,7 @@ func GlobalNestedWorkloadServicesCollection(
 				false,
 				checkServiceScope,
 				func(ctx krt.HandlerContext) network.ID {
-					nw := krt.FetchOne(ctx, globalNetworks.RemoteSystemNamespaceNetworks, krt.FilterIndex(globalNetworks.SystemNamespaceNetworkByCluster, cluster.ID))
-					if nw == nil {
-						log.Warnf("Cluster %s does not have network assigned yet, skipping", cluster.ID)
-						ctx.DiscardResult()
-						return ""
-					}
-					return nw.Network
+					return globalNetworks.FetchRemoteSystemNamespaceNetwork(ctx, namespaces)
 				}, false,
 			),
 				append(

--- a/pilot/pkg/serviceregistry/ambient/waypoints.go
+++ b/pilot/pkg/serviceregistry/ambient/waypoints.go
@@ -410,6 +410,7 @@ func GlobalWaypointsCollection(
 		pods := c.Pods()
 		podsByNamespace := krt.NewNamespaceIndex(pods)
 		gateways := c.Gateways()
+		namespaces := c.Namespaces()
 
 		clusterWaypoints := krt.NewCollection(gateways, func(ctx krt.HandlerContext, gateway *gatewayv1.Gateway) *Waypoint {
 			if len(gateway.Status.Addresses) == 0 {
@@ -442,12 +443,7 @@ func GlobalWaypointsCollection(
 				trafficType = tt
 			}
 
-			nw := krt.FetchOne(ctx, globalNetworks.RemoteSystemNamespaceNetworks, krt.FilterIndex(globalNetworks.SystemNamespaceNetworkByCluster, c.ID))
-			if nw == nil {
-				log.Warnf("Cluster %s does not have a network, skipping global workloads", c.ID)
-				return nil
-			}
-			clusterNetwork := nw.Network
+			clusterNetwork := globalNetworks.FetchRemoteSystemNamespaceNetwork(ctx, namespaces)
 
 			return makeWaypoint(gateway, gatewayClass, serviceAccounts, trafficType, clusterNetwork)
 		}, opts...)

--- a/pilot/pkg/serviceregistry/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/ambient/workloads.go
@@ -346,13 +346,7 @@ func MergedGlobalWorkloadsCollection(
 					domainSuffix,
 					c.ID,
 					func(ctx krt.HandlerContext) network.ID {
-						nw := krt.FetchOne(ctx, globalNetworks.RemoteSystemNamespaceNetworks, krt.FilterIndex(globalNetworks.SystemNamespaceNetworkByCluster, c.ID))
-						if nw == nil {
-							log.Warnf("Cluster %s does not have a network, skipping global workloads", c.ID)
-							ctx.DiscardResult()
-							return ""
-						}
-						return nw.Network
+						return globalNetworks.FetchRemoteSystemNamespaceNetwork(ctx, namespaces)
 					},
 					globalNetworks.GatewaysByNetwork,
 					flags,
@@ -391,13 +385,7 @@ func MergedGlobalWorkloadsCollection(
 					namespaces,
 					c.ID,
 					func(ctx krt.HandlerContext) network.ID {
-						nw := krt.FetchOne(ctx, globalNetworks.RemoteSystemNamespaceNetworks, krt.FilterIndex(globalNetworks.SystemNamespaceNetworkByCluster, c.ID))
-						if nw == nil {
-							log.Warnf("Cluster %s does not have a network, skipping global workloads", c.ID)
-							ctx.DiscardResult()
-							return ""
-						}
-						return nw.Network
+						return globalNetworks.FetchRemoteSystemNamespaceNetwork(ctx, namespaces)
 					},
 					globalNetworks.GatewaysByNetwork,
 					flags,
@@ -435,13 +423,7 @@ func MergedGlobalWorkloadsCollection(
 					globalWorkloadServices,
 					c.ID,
 					func(ctx krt.HandlerContext) network.ID {
-						nw := krt.FetchOne(ctx, globalNetworks.RemoteSystemNamespaceNetworks, krt.FilterIndex(globalNetworks.SystemNamespaceNetworkByCluster, c.ID))
-						if nw == nil {
-							log.Warnf("Cluster %s does not have a network, skipping global workloads", c.ID)
-							ctx.DiscardResult()
-							return ""
-						}
-						return nw.Network
+						return globalNetworks.FetchRemoteSystemNamespaceNetwork(ctx, namespaces)
 					},
 					globalNetworks.GatewaysByNetwork,
 					flags,
@@ -477,13 +459,7 @@ func MergedGlobalWorkloadsCollection(
 					domainSuffix,
 					c.ID,
 					func(ctx krt.HandlerContext) network.ID {
-						nw := krt.FetchOne(ctx, globalNetworks.RemoteSystemNamespaceNetworks, krt.FilterIndex(globalNetworks.SystemNamespaceNetworkByCluster, c.ID))
-						if nw == nil {
-							log.Warnf("Cluster %s does not have a network, skipping global workloads", c.ID)
-							ctx.DiscardResult()
-							return ""
-						}
-						return nw.Network
+						return globalNetworks.FetchRemoteSystemNamespaceNetwork(ctx, namespaces)
 					},
 				),
 				append(

--- a/releasenotes/notes/ambient-remote-networks-leak.yaml
+++ b/releasenotes/notes/ambient-remote-networks-leak.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 60033
+releaseNotes:
+  - |
+    **Fixed** a memory leak affecting Istiod ambient multi-cluster mode where rotating a remote cluster's
+    credentials leaked that cluster's entire cached state.


### PR DESCRIPTION
**Please provide a description of this PR:**
Ambient's `RemoteSystemNamespaceNetworks` triggered a memory leak whenever a cluster secret was rotated because the Cluster internal collections (`c.Namespaces`) was fetched directly, then these collections were stopped on rotation remained referenced by the ManyCollection internals that fetched them.
Replaced this collection with a helper function to fetch the system namespace network given a namespace collection, since in every caller we already have access to the `Namespaces` collection safely and we can just fetch the system namespace there.

I believe this should fix the last leak reported by @h0tbird [here](https://github.com/istio/istio/issues/60033#issuecomment-5354680753)