### PR TITLE
[release-1.29] Reduce PeerAuthentication scanning by indexing on namespace

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -433,12 +433,13 @@ func New(options Options) Index {
 	}, opts.WithName("NamespacesInfo")...)
 
 	NodeLocality := NodesCollection(Nodes, opts.WithName("NodeLocality")...)
+	PeerAuthsByNs := krt.NewNamespaceIndex(PeerAuths)
 	Workloads := a.builder.WorkloadsCollection(
 		Pods,
 		NodeLocality,
 		a.meshConfig,
 		AuthorizationPolicies,
-		PeerAuths,
+		PeerAuthsByNs,
 		Waypoints,
 		WorkloadServices,
 		WorkloadEntries,

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/multicluster.go
@@ -287,6 +287,7 @@ func (a *index) buildGlobalCollections(
 	GlobalNodeLocality := GlobalNodesCollection(GlobalNodesWithCluster, opts.WithName("GlobalNodeLocalityWithCluster")...)
 	GlobalNodeLocalityByCluster := nestedCollectionIndexByCluster(GlobalNodeLocality)
 
+	localPeerAuthsByNs := krt.NewNamespaceIndex(localPeerAuths)
 	GlobalWorkloads := MergedGlobalWorkloadsCollection(
 		localCluster,
 		LocalWaypoints,
@@ -298,7 +299,7 @@ func (a *index) buildGlobalCollections(
 		GlobalNodeLocalityByCluster,
 		options.MeshConfig,
 		AuthorizationPolicies,
-		localPeerAuths,
+		localPeerAuthsByNs,
 		GlobalWaypoints,
 		WaypointsByCluster,
 		LocalWorkloadServices,

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
@@ -65,7 +65,7 @@ func (a Builder) WorkloadsCollection(
 	nodes krt.Collection[Node],
 	meshConfig krt.Singleton[MeshConfig],
 	authorizationPolicies krt.Collection[model.WorkloadAuthorization],
-	peerAuths krt.Collection[*securityclient.PeerAuthentication],
+	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
 	workloadServices krt.Collection[model.ServiceInfo],
 	workloadEntries krt.Collection[*networkingclient.WorkloadEntry],
@@ -82,7 +82,7 @@ func (a Builder) WorkloadsCollection(
 		a.podWorkloadBuilder(
 			meshConfig,
 			authorizationPolicies,
-			peerAuths,
+			peerAuthsByNs,
 			waypoints,
 			workloadServices,
 			WorkloadServicesNamespaceIndex,
@@ -96,14 +96,14 @@ func (a Builder) WorkloadsCollection(
 	// Workloads coming from workloadEntries. These are 1:1 with WorkloadEntry.
 	WorkloadEntryWorkloads := krt.NewCollection(
 		workloadEntries,
-		a.workloadEntryWorkloadBuilder(meshConfig, authorizationPolicies, peerAuths, waypoints, workloadServices, WorkloadServicesNamespaceIndex, namespaces),
+		a.workloadEntryWorkloadBuilder(meshConfig, authorizationPolicies, peerAuthsByNs, waypoints, workloadServices, WorkloadServicesNamespaceIndex, namespaces),
 		opts.WithName("WorkloadEntryWorkloads")...,
 	)
 	// Workloads coming from serviceEntries. These are inlined workloadEntries (under `spec.endpoints`); these serviceEntries will
 	// also be generating `workloadapi.Service` definitions in the `ServicesCollection` logic.
 	ServiceEntryWorkloads := krt.NewManyCollection(
 		serviceEntries,
-		a.serviceEntryWorkloadBuilder(meshConfig, authorizationPolicies, peerAuths, waypoints, namespaces, workloadServices),
+		a.serviceEntryWorkloadBuilder(meshConfig, authorizationPolicies, peerAuthsByNs, waypoints, namespaces, workloadServices),
 		opts.WithName("ServiceEntryWorkloads")...,
 	)
 	// Workloads coming from endpointSlices. These are for *manually added* endpoints. Typically, Kubernetes will insert each pod
@@ -147,7 +147,7 @@ func MergedGlobalWorkloadsCollection(
 	nodesByCluster krt.Index[cluster.ID, krt.Collection[krt.ObjectWithCluster[Node]]],
 	meshConfig krt.Singleton[MeshConfig],
 	localAuthorizationPolicies krt.Collection[model.WorkloadAuthorization],
-	localPeerAuths krt.Collection[*securityclient.PeerAuthentication],
+	localPeerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	globalWaypoints krt.Collection[krt.Collection[Waypoint]],
 	waypointsByCluster krt.Index[cluster.ID, krt.Collection[Waypoint]],
 	localWorkloadServices krt.Collection[model.ServiceInfo],
@@ -175,7 +175,7 @@ func MergedGlobalWorkloadsCollection(
 			meshConfig,
 			localNetworkGetter,
 			localAuthorizationPolicies,
-			localPeerAuths,
+			localPeerAuthsByNs,
 			localWaypoints,
 			localWorkloadServices,
 			LocalWorkloadServicesNamespaceIndex,
@@ -204,7 +204,7 @@ func MergedGlobalWorkloadsCollection(
 			meshConfig,
 			localNetworkGetter,
 			localAuthorizationPolicies,
-			localPeerAuths,
+			localPeerAuthsByNs,
 			localWaypoints,
 			localWorkloadServices,
 			LocalWorkloadServicesNamespaceIndex,
@@ -230,7 +230,7 @@ func MergedGlobalWorkloadsCollection(
 		serviceEntryWorkloadBuilder(
 			meshConfig,
 			localAuthorizationPolicies,
-			localPeerAuths,
+			localPeerAuthsByNs,
 			localWaypoints,
 			localCluster.Namespaces(),
 			localWorkloadServices,
@@ -414,7 +414,7 @@ func MergedGlobalWorkloadsCollection(
 					meshConfig,
 					localNetworkGetter,
 					localAuthorizationPolicies,
-					localPeerAuths,
+					localPeerAuthsByNs,
 					waypoints,
 					globalWorkloadServices,
 					WorkloadServicesNamespaceIndex,
@@ -466,7 +466,7 @@ func MergedGlobalWorkloadsCollection(
 					meshConfig,
 					localNetworkGetter,
 					localAuthorizationPolicies,
-					localPeerAuths,
+					localPeerAuthsByNs,
 					waypoints,
 					globalWorkloadServices,
 					WorkloadServicesNamespaceIndex,
@@ -514,7 +514,7 @@ func MergedGlobalWorkloadsCollection(
 				serviceEntryWorkloadBuilder(
 					meshConfig,
 					localAuthorizationPolicies,
-					localPeerAuths,
+					localPeerAuthsByNs,
 					waypoints,
 					namespaces,
 					globalWorkloadServices,
@@ -646,7 +646,7 @@ func workloadEntryWorkloadBuilder(
 	meshConfig krt.Singleton[MeshConfig],
 	localNetworkGetter func(krt.HandlerContext) network.ID,
 	authorizationPolicies krt.Collection[model.WorkloadAuthorization],
-	peerAuths krt.Collection[*securityclient.PeerAuthentication],
+	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
 	workloadServices krt.Collection[model.ServiceInfo],
 	workloadServicesNamespaceIndex krt.Index[string, model.ServiceInfo],
@@ -662,7 +662,7 @@ func workloadEntryWorkloadBuilder(
 		// WLE can put labels in multiple places; normalize this
 		wle = serviceentry.ConvertClientWorkloadEntry(wle)
 		meshCfg := krt.FetchOne(ctx, meshConfig.AsCollection())
-		policies := buildWorkloadPolicies(ctx, authorizationPolicies, peerAuths, meshCfg, wle.Labels, wle.Namespace)
+		policies := buildWorkloadPolicies(ctx, authorizationPolicies, peerAuthsByNs, meshCfg, wle.Labels, wle.Namespace)
 
 		appTunnel, targetWaypoint := computeWaypoint(ctx, waypoints, namespaces, wle.ObjectMeta)
 
@@ -730,7 +730,7 @@ func workloadEntryWorkloadBuilder(
 func (a Builder) workloadEntryWorkloadBuilder(
 	meshConfig krt.Singleton[MeshConfig],
 	authorizationPolicies krt.Collection[model.WorkloadAuthorization],
-	peerAuths krt.Collection[*securityclient.PeerAuthentication],
+	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
 	workloadServices krt.Collection[model.ServiceInfo],
 	workloadServicesNamespaceIndex krt.Index[string, model.ServiceInfo],
@@ -743,7 +743,7 @@ func (a Builder) workloadEntryWorkloadBuilder(
 		meshConfig,
 		localNetworkGetter,
 		authorizationPolicies,
-		peerAuths,
+		peerAuthsByNs,
 		waypoints,
 		workloadServices,
 		workloadServicesNamespaceIndex,
@@ -787,7 +787,7 @@ func podWorkloadBuilder(
 	meshConfig krt.Singleton[MeshConfig],
 	localNetworkGetter func(krt.HandlerContext) network.ID,
 	authorizationPolicies krt.Collection[model.WorkloadAuthorization],
-	peerAuths krt.Collection[*securityclient.PeerAuthentication],
+	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
 	workloadServices krt.Collection[model.ServiceInfo],
 	workloadServicesNamespaceIndex krt.Index[string, model.ServiceInfo],
@@ -826,7 +826,7 @@ func podWorkloadBuilder(
 			return nil
 		}
 		meshCfg := krt.FetchOne(ctx, meshConfig.AsCollection())
-		policies := buildWorkloadPolicies(ctx, authorizationPolicies, peerAuths, meshCfg, p.Labels, p.Namespace)
+		policies := buildWorkloadPolicies(ctx, authorizationPolicies, peerAuthsByNs, meshCfg, p.Labels, p.Namespace)
 		fo := []krt.FetchOption{krt.FilterIndex(workloadServicesNamespaceIndex, p.Namespace), krt.FilterSelectsNonEmpty(p.GetLabels())}
 		if !features.EnableServiceEntrySelectPods {
 			fo = append(fo, krt.FilterGeneric(func(a any) bool {
@@ -896,7 +896,7 @@ func podWorkloadBuilder(
 func (a Builder) podWorkloadBuilder(
 	meshConfig krt.Singleton[MeshConfig],
 	authorizationPolicies krt.Collection[model.WorkloadAuthorization],
-	peerAuths krt.Collection[*securityclient.PeerAuthentication],
+	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
 	workloadServices krt.Collection[model.ServiceInfo],
 	workloadServicesNamespaceIndex krt.Index[string, model.ServiceInfo],
@@ -912,7 +912,7 @@ func (a Builder) podWorkloadBuilder(
 		meshConfig,
 		localNetworkGetter,
 		authorizationPolicies,
-		peerAuths,
+		peerAuthsByNs,
 		waypoints,
 		workloadServices,
 		workloadServicesNamespaceIndex,
@@ -1001,7 +1001,7 @@ func matchingServicesWithoutSelectors(
 func buildWorkloadPolicies(
 	ctx krt.HandlerContext,
 	authorizationPolicies krt.Collection[model.WorkloadAuthorization],
-	peerAuths krt.Collection[*securityclient.PeerAuthentication],
+	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	meshCfg *MeshConfig,
 	workloadLabels map[string]string,
 	workloadNamespace string,
@@ -1026,7 +1026,7 @@ func buildWorkloadPolicies(
 		return t.ResourceName()
 	}))
 	// We could do a non-FilterGeneric but krt currently blows up if we depend on the same collection twice
-	auths := fetchPeerAuthentications(ctx, peerAuths, meshCfg, workloadNamespace, workloadLabels)
+	auths := fetchPeerAuthentications(ctx, peerAuthsByNs, meshCfg, workloadNamespace, workloadLabels)
 	policies = append(policies, convertedSelectorPeerAuthentications(meshCfg.GetRootNamespace(), auths)...)
 	return policies
 }
@@ -1034,7 +1034,7 @@ func buildWorkloadPolicies(
 func serviceEntryWorkloadBuilder(
 	meshConfig krt.Singleton[MeshConfig],
 	authorizationPolicies krt.Collection[model.WorkloadAuthorization],
-	peerAuths krt.Collection[*securityclient.PeerAuthentication],
+	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
 	namespaces krt.Collection[*v1.Namespace],
 	workloadServices krt.Collection[model.ServiceInfo],
@@ -1092,7 +1092,7 @@ func serviceEntryWorkloadBuilder(
 				services = []model.ServiceInfo{allServices[i]}
 			}
 
-			policies := buildWorkloadPolicies(ctx, authorizationPolicies, peerAuths, meshCfg, se.Labels, se.Namespace)
+			policies := buildWorkloadPolicies(ctx, authorizationPolicies, peerAuthsByNs, meshCfg, se.Labels, se.Namespace)
 
 			var appTunnel *workloadapi.ApplicationTunnel
 			var targetWaypoint *Waypoint
@@ -1156,7 +1156,7 @@ func serviceEntryWorkloadBuilder(
 func (a Builder) serviceEntryWorkloadBuilder(
 	meshConfig krt.Singleton[MeshConfig],
 	authorizationPolicies krt.Collection[model.WorkloadAuthorization],
-	peerAuths krt.Collection[*securityclient.PeerAuthentication],
+	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
 	namespaces krt.Collection[*v1.Namespace],
 	workloadServices krt.Collection[model.ServiceInfo],
@@ -1164,7 +1164,7 @@ func (a Builder) serviceEntryWorkloadBuilder(
 	return serviceEntryWorkloadBuilder(
 		meshConfig,
 		authorizationPolicies,
-		peerAuths,
+		peerAuthsByNs,
 		waypoints,
 		namespaces,
 		workloadServices,
@@ -1362,25 +1362,28 @@ func pickTrustDomain(mesh *MeshConfig) string {
 
 func fetchPeerAuthentications(
 	ctx krt.HandlerContext,
-	peerAuths krt.Collection[*securityclient.PeerAuthentication],
+	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	meshCfg *MeshConfig,
 	ns string,
 	matchLabels map[string]string,
 ) []*securityclient.PeerAuthentication {
-	return krt.Fetch(ctx, peerAuths, krt.FilterGeneric(func(a any) bool {
-		pol := a.(*securityclient.PeerAuthentication)
-		if pol.Namespace == meshCfg.GetRootNamespace() && pol.Spec.Selector == nil {
-			return true
-		}
-		if pol.Namespace != ns {
-			return false
-		}
-		sel := pol.Spec.Selector
+	// Policies in the workload's own namespace apply if they have no selector or their selector matches.
+	auths := peerAuthsByNs.Fetch(ctx, ns, krt.FilterGeneric(func(a any) bool {
+		sel := a.(*securityclient.PeerAuthentication).Spec.Selector
 		if sel == nil {
 			return true // No selector matches everything
 		}
 		return labels.Instance(sel.MatchLabels).SubsetOf(matchLabels)
 	}))
+	// Mesh-wide policies live in the root namespace and must not have a selector. When the workload is
+	// itself in the root namespace, these are already covered by the fetch above.
+	if rootNamespace := meshCfg.GetRootNamespace(); ns != rootNamespace {
+		rootAuths := peerAuthsByNs.Fetch(ctx, rootNamespace, krt.FilterGeneric(func(a any) bool {
+			return a.(*securityclient.PeerAuthentication).Spec.Selector == nil
+		}))
+		auths = append(auths, rootAuths...)
+	}
+	return auths
 }
 
 func constructServicesFromWorkloadEntry(p *networkingv1alpha3.WorkloadEntry, services []model.ServiceInfo) map[string]*workloadapi.PortList {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
@@ -837,7 +837,7 @@ func TestPodWorkloads(t *testing.T) {
 			builder := a.builder.podWorkloadBuilder(
 				GetMeshConfig(mock),
 				krttest.GetMockCollection[model.WorkloadAuthorization](mock),
-				krttest.GetMockCollection[*securityclient.PeerAuthentication](mock),
+				krt.NewNamespaceIndex(krttest.GetMockCollection[*securityclient.PeerAuthentication](mock)),
 				krttest.GetMockCollection[Waypoint](mock),
 				WorkloadServices,
 				WorkloadServicesNamespaceIndex,
@@ -1446,7 +1446,7 @@ func TestWorkloadEntryWorkloads(t *testing.T) {
 			builder := a.builder.workloadEntryWorkloadBuilder(
 				GetMeshConfig(mock),
 				krttest.GetMockCollection[model.WorkloadAuthorization](mock),
-				krttest.GetMockCollection[*securityclient.PeerAuthentication](mock),
+				krt.NewNamespaceIndex(krttest.GetMockCollection[*securityclient.PeerAuthentication](mock)),
 				krttest.GetMockCollection[Waypoint](mock),
 				WorkloadServices,
 				WorkloadServicesNamespaceIndex,
@@ -1695,7 +1695,7 @@ func TestServiceEntryWorkloads(t *testing.T) {
 			builder := a.builder.serviceEntryWorkloadBuilder(
 				GetMeshConfig(mock),
 				krttest.GetMockCollection[model.WorkloadAuthorization](mock),
-				krttest.GetMockCollection[*securityclient.PeerAuthentication](mock),
+				krt.NewNamespaceIndex(krttest.GetMockCollection[*securityclient.PeerAuthentication](mock)),
 				krttest.GetMockCollection[Waypoint](mock),
 				krttest.GetMockCollection[*v1.Namespace](mock),
 				krttest.GetMockCollection[model.ServiceInfo](mock),

--- a/pkg/kube/krt/index.go
+++ b/pkg/kube/krt/index.go
@@ -28,6 +28,7 @@ import (
 type Index[K comparable, O any] interface {
 	Lookup(k K) []O
 	AsCollection(opts ...CollectionOption) IndexCollection[K, O]
+	Fetch(ctx HandlerContext, key K, opts ...FetchOption) []O
 	objectHasKey(obj O, k K) bool
 	extractKeys(o O) []K
 	id() collectionUID
@@ -122,6 +123,11 @@ func (i index[K, O]) AsCollection(opts ...CollectionOption) IndexCollection[K, O
 	}
 	maybeRegisterCollectionForDebugging(c, o.debugger)
 	return c
+}
+
+// Fetch fetches all entries from the index with dependency tracking
+func (i index[K, O]) Fetch(ctx HandlerContext, key K, opts ...FetchOption) []O {
+	return Fetch(ctx, i.c, append([]FetchOption{FilterIndex(i, key)}, opts...)...)
 }
 
 // nolint: unused // (not true)

--- a/pkg/kube/krt/index_test.go
+++ b/pkg/kube/krt/index_test.go
@@ -113,10 +113,10 @@ func TestIndexCollection(t *testing.T) {
 	})
 	Collection := krt.NewSingleton[string](func(ctx krt.HandlerContext) *string {
 		// two fetches by the same index
-		a := krt.Fetch(ctx, SimplePods, krt.FilterIndex(IPIndex, "2.2.2.2"))
-		b := krt.Fetch(ctx, SimplePods, krt.FilterIndex(IPIndex, "3.3.3.3"))
+		a := IPIndex.Fetch(ctx, "2.2.2.2")
+		b := IPIndex.Fetch(ctx, "3.3.3.3")
 		// a third fetch on the same SimplePods but with another index
-		c := krt.Fetch(ctx, SimplePods, krt.FilterIndex(LabelIndex, "marker=true"))
+		c := LabelIndex.Fetch(ctx, "marker=true")
 
 		pods := append(a, b...)
 		pods = append(pods, c...)
@@ -284,7 +284,7 @@ func TestReverseIndex(t *testing.T) {
 		return []string{o.IP}
 	})
 	Collection := krt.NewSingleton(func(ctx krt.HandlerContext) *PodCounts {
-		idxPods := krt.Fetch(ctx, SimplePods, krt.FilterIndex(IPIndex, "1.2.3.5"))
+		idxPods := IPIndex.Fetch(ctx, "1.2.3.5")
 		namePods := krt.Fetch(ctx, SimplePods, krt.FilterKeys("namespace/name", "namespace/name3"))
 		return &PodCounts{
 			ByIP:   len(idxPods),

--- a/releasenotes/notes/peerauth-by-ns.yaml
+++ b/releasenotes/notes/peerauth-by-ns.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Improved** performance when fetching PeerAuthentications for a given workload.


### PR DESCRIPTION
**Please provide a description of this PR:**
cherry-pick of https://github.com/istio/istio/pull/61295

Also backported krt.Index.Fetch capability to make the backport trivial.