### PR TITLE
on-demand wds memory cleanup

### DIFF
--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -307,6 +307,13 @@ func (s *DiscoveryServer) processDeltaRequest(req *discovery.DeltaDiscoveryReque
 		s.computeProxyState(con.proxy, request)
 	}
 
+	if !requiresResourceNamesModification(req.TypeUrl) {
+		// Only the workload generator uses InitialResourceVersions past this point. The map can
+		// hold the client's entire resource set on reconnect; release it before generation.
+		request.Delta.InitialResourceVersions = nil
+		req.InitialResourceVersions = nil
+	}
+
 	err := s.pushDeltaXds(con, con.proxy.GetWatchedResource(req.TypeUrl), request)
 	if err != nil {
 		return err
@@ -420,7 +427,14 @@ func shouldRespondDelta(con *Connection, request *discovery.DeltaDiscoveryReques
 
 	// Update resource names, and record ACK if required.
 	con.proxy.UpdateWatchedResource(request.TypeUrl, func(wr *model.WatchedResource) *model.WatchedResource {
-		wr.ResourceNames, _, subChanged = deltaWatchedResources(wr.ResourceNames, request)
+		if requiresResourceNamesModification(request.TypeUrl) && wr.Wildcard {
+			// As on initial requests, wildcard subscriptions to generator-managed types do not
+			// store ResourceNames; track subscription changes without persisting the names.
+			_, _, subChanged = deltaWatchedResources(nil, request)
+			wr.ResourceNames = nil
+		} else {
+			wr.ResourceNames, _, subChanged = deltaWatchedResources(wr.ResourceNames, request)
+		}
 		if !spontaneousReq {
 			// Clear last error, we got an ACK.
 			// Otherwise, this is just a change in resource subscription, so leave the last ACK info in place.

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -429,8 +429,9 @@ func shouldRespondDelta(con *Connection, request *discovery.DeltaDiscoveryReques
 	con.proxy.UpdateWatchedResource(request.TypeUrl, func(wr *model.WatchedResource) *model.WatchedResource {
 		if requiresResourceNamesModification(request.TypeUrl) && wr.Wildcard {
 			// As on initial requests, wildcard subscriptions to generator-managed types do not
-			// store ResourceNames; track subscription changes without persisting the names.
-			_, _, subChanged = deltaWatchedResources(nil, request)
+			// store ResourceNames. With no stored set to diff against, any named (un)subscription
+			// counts as a change.
+			subChanged = len(request.ResourceNamesSubscribe) > 0 || len(request.ResourceNamesUnsubscribe) > 0
 			wr.ResourceNames = nil
 		} else {
 			wr.ResourceNames, _, subChanged = deltaWatchedResources(wr.ResourceNames, request)

--- a/pilot/pkg/xds/workload_test.go
+++ b/pilot/pkg/xds/workload_test.go
@@ -289,13 +289,25 @@ func TestWorkloadReconnect(t *testing.T) {
 					},
 				})
 				expect(ads.ExpectResponse(), "Kubernetes//Pod/default/pod")
-				for _, c := range s.Discovery.AllClients() {
-					w := c.Proxy().GetWatchedResource(typeURL)
-					if w == nil {
-						t.Fatalf("connection %v missing watched resource %v", c.ID(), typeURL)
+				assertNoWatchedNames := func() {
+					t.Helper()
+					for _, c := range s.Discovery.AllClients() {
+						w := c.Proxy().GetWatchedResource(typeURL)
+						if w == nil {
+							t.Fatalf("connection %v missing watched resource %v", c.ID(), typeURL)
+						}
+						assert.Equal(t, len(w.ResourceNames), 0)
 					}
-					assert.Equal(t, len(w.ResourceNames), 0)
 				}
+				assertNoWatchedNames()
+
+				// A spontaneous subscription on the same stream takes the subsequent-request
+				// path; it must not accumulate names either.
+				ads.Request(&discovery.DeltaDiscoveryRequest{
+					ResourceNamesSubscribe: []string{"Kubernetes//Pod/default/pod"},
+				})
+				expect(ads.ExpectResponse(), "Kubernetes//Pod/default/pod")
+				assertNoWatchedNames()
 			})
 		}
 	})

--- a/pilot/pkg/xds/workload_test.go
+++ b/pilot/pkg/xds/workload_test.go
@@ -273,6 +273,7 @@ func TestWorkloadReconnect(t *testing.T) {
 		// memory for nothing.
 		for name, typeURL := range map[string]string{"address": v3.AddressType, "workload": v3.WorkloadType} {
 			t.Run(name, func(t *testing.T) {
+				test.SetForTest(t, &features.EnableUnsafeAssertions, true)
 				expect := buildExpect(t)
 				s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
 					KubernetesObjects: []runtime.Object{mkPod("pod", "sa", "127.0.0.1", "not-node")},
@@ -305,6 +306,14 @@ func TestWorkloadReconnect(t *testing.T) {
 				// path; it must not accumulate names either.
 				ads.Request(&discovery.DeltaDiscoveryRequest{
 					ResourceNamesSubscribe: []string{"Kubernetes//Pod/default/pod"},
+				})
+				expect(ads.ExpectResponse(), "Kubernetes//Pod/default/pod")
+				assertNoWatchedNames()
+
+				// A spontaneous unsubscription has no stored set to diff against; it must still
+				// be detected as a change rather than tripping the subscription-change assertion.
+				ads.Request(&discovery.DeltaDiscoveryRequest{
+					ResourceNamesUnsubscribe: []string{"Kubernetes//Pod/default/pod"},
 				})
 				expect(ads.ExpectResponse(), "Kubernetes//Pod/default/pod")
 				assertNoWatchedNames()

--- a/releasenotes/notes/delta-xds-reconnect-memory.yaml
+++ b/releasenotes/notes/delta-xds-reconnect-memory.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+releaseNotes:
+  - |
+    **Improved** delta xDS memory usage: wildcard WDS subscriptions no longer accumulate resource names
+    from subsequent requests, and the `initial_resource_versions` map sent on reconnect is released
+    before response generation for types that do not use it.


### PR DESCRIPTION
**Please provide a description of this PR:**
clean up potentially large memory allocations on the on-demand delta paths for wds

follow up to #61345 for on-demand