### PR TITLE
add adsz watch summary to debug

### DIFF
--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -114,6 +114,16 @@ type AdsClient struct {
 	Metadata     *model.NodeMetadata `json:"metadata,omitempty"`
 	Locality     *core.Locality      `json:"locality,omitempty"`
 	Watches      map[string][]string `json:"watches,omitempty"`
+	// WatchesSummary summarizes each watch without listing resource names, which can be
+	// very numerous at scale; pass ?brief to omit the name lists entirely.
+	WatchesSummary map[string]WatchSummary `json:"watchesSummary,omitempty"`
+}
+
+// WatchSummary summarizes one watched type: the number of resource names tracked and whether
+// the subscription is wildcard. Wildcard WDS watches intentionally track no names.
+type WatchSummary struct {
+	Count    int  `json:"count"`
+	Wildcard bool `json:"wildcard,omitempty"`
 }
 
 // AdsClients is collection of AdsClient connected to this Istiod.
@@ -197,6 +207,7 @@ func (s *DiscoveryServer) AddDebugHandlers(mux, internalMux *http.ServeMux, enab
 	s.addDebugHandler(mux, internalMux, "/debug/ndsz", "Status and debug interface for NDS", s.typedConfigDumpHandler("nds"))
 	s.addDebugHandler(mux, internalMux, "/debug/adsz", "Status and debug interface for ADS", s.adsz)
 	s.addDebugHandler(mux, internalMux, "/debug/adsz?push=true", "Initiates push of the current state to all connected endpoints", s.adsz)
+	s.addDebugHandler(mux, internalMux, "/debug/adsz?brief", "Status and debug interface for ADS, omitting watched resource names", s.adsz)
 
 	s.addDebugHandler(mux, internalMux, "/debug/syncz", "Synchronization status of all Envoys connected to this Pilot instance", s.Syncz)
 
@@ -562,21 +573,28 @@ func (s *DiscoveryServer) adsz(w http.ResponseWriter, req *http.Request) {
 		connections = s.SortedClients()
 	}
 
+	brief := req.URL.Query().Has("brief")
 	adsClients := &AdsClients{}
 	adsClients.Total = len(connections)
 	for _, c := range connections {
 		adsClient := AdsClient{
-			ConnectionID: c.ID(),
-			ConnectedAt:  c.ConnectedAt(),
-			PeerAddress:  c.Peer(),
-			Labels:       c.proxy.Labels,
-			Metadata:     c.proxy.Metadata,
-			Locality:     c.proxy.Locality,
-			Watches:      map[string][]string{},
+			ConnectionID:   c.ID(),
+			ConnectedAt:    c.ConnectedAt(),
+			PeerAddress:    c.Peer(),
+			Labels:         c.proxy.Labels,
+			Metadata:       c.proxy.Metadata,
+			Locality:       c.proxy.Locality,
+			WatchesSummary: map[string]WatchSummary{},
+		}
+		if !brief {
+			adsClient.Watches = map[string][]string{}
 		}
 		c.proxy.RLock()
 		for k, wr := range c.proxy.WatchedResources {
-			adsClient.Watches[k] = wr.ResourceNames.UnsortedList()
+			adsClient.WatchesSummary[k] = WatchSummary{Count: len(wr.ResourceNames), Wildcard: wr.Wildcard}
+			if !brief {
+				adsClient.Watches[k] = wr.ResourceNames.UnsortedList()
+			}
 		}
 		c.proxy.RUnlock()
 		adsClients.Connected = append(adsClients.Connected, adsClient)

--- a/pilot/pkg/xds/debug_test.go
+++ b/pilot/pkg/xds/debug_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"istio.io/istio/istioctl/pkg/util/configdump"
 	"istio.io/istio/pilot/pkg/features"
@@ -238,6 +239,68 @@ func TestDebugHandlers(t *testing.T) {
 	debug.ServeHTTP(rr, req)
 	if rr.Code != 200 {
 		t.Errorf("Error in generatating debug endpoint list")
+	}
+}
+
+func TestAdszWatches(t *testing.T) {
+	s := xdsfake.NewFakeDiscoveryServer(t, xdsfake.FakeOptions{
+		KubernetesObjects: []runtime.Object{mkPod("pod", "sa", "127.0.0.1", "node")},
+	})
+
+	// Wildcard WDS subscription: the watch is tracked but resource names are intentionally elided.
+	wildcard := s.ConnectDeltaADS().WithType(v3.WorkloadType).
+		WithID("sidecar~1.1.1.1~wildcard.default~default.svc.cluster.local")
+	wildcard.Request(&discovery.DeltaDiscoveryRequest{})
+	wildcard.ExpectResponse()
+
+	// On-demand WDS subscription: subscribed and resolved names are tracked.
+	ondemand := s.ConnectDeltaADS().WithType(v3.AddressType).
+		WithID("ztunnel~2.2.2.2~ondemand.default~default.svc.cluster.local")
+	ondemand.Request(&discovery.DeltaDiscoveryRequest{
+		ResourceNamesSubscribe:   []string{"*"},
+		ResourceNamesUnsubscribe: []string{"*"},
+	})
+	ondemand.ExpectEmptyResponse()
+	ondemand.RequestResponseAck(&discovery.DeltaDiscoveryRequest{
+		ResourceNamesSubscribe: []string{"/127.0.0.1"},
+	})
+
+	adsz := func(path string) xds.AdsClients {
+		t.Helper()
+		rr := httptest.NewRecorder()
+		s.DiscoveryDebug.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, path, nil))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("%v returned %v", path, rr.Code)
+		}
+		got := xds.AdsClients{}
+		if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+			t.Fatal(err)
+		}
+		return got
+	}
+
+	full := adsz("/debug/adsz")
+	assert.Equal(t, full.Total, 2)
+	for _, c := range full.Connected {
+		switch {
+		case strings.HasPrefix(c.ConnectionID, "wildcard.default"):
+			assert.Equal(t, c.WatchesSummary[v3.WorkloadType], xds.WatchSummary{Count: 0, Wildcard: true})
+			assert.Equal(t, len(c.Watches[v3.WorkloadType]), 0)
+		case strings.HasPrefix(c.ConnectionID, "ondemand.default"):
+			assert.Equal(t, c.WatchesSummary[v3.AddressType], xds.WatchSummary{Count: 2, Wildcard: false})
+			assert.Equal(t, sets.New(c.Watches[v3.AddressType]...), sets.New("/127.0.0.1", "Kubernetes//Pod/default/pod"))
+		default:
+			t.Fatalf("unexpected connection %v", c.ConnectionID)
+		}
+	}
+
+	brief := adsz("/debug/adsz?brief")
+	assert.Equal(t, brief.Total, 2)
+	for _, c := range brief.Connected {
+		assert.Equal(t, len(c.Watches), 0)
+		if len(c.WatchesSummary) == 0 {
+			t.Fatalf("connection %v missing watches summary", c.ConnectionID)
+		}
 	}
 }
 

--- a/releasenotes/notes/adsz-watches-summary.yaml
+++ b/releasenotes/notes/adsz-watches-summary.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+releaseNotes:
+  - |
+    **Added** a per-type watch summary (resource name count and wildcard flag) to the `/debug/adsz`
+    endpoint, and a `?brief` parameter that omits the watched resource name lists, which can be very
+    large in big meshes.


### PR DESCRIPTION
**Please provide a description of this PR:**

Add a watch summary to the adsz debug output. Useful at scales which make listing the full watch list impractical.
Add a ?brief mode to the adsz debug endpoint. This allows the request to elide the full watch list when summary is all that's needed or scale makes the full list impractical.