### PR TITLE
[release-1.29] block cloud metadata by default and validate jwks body in jwks resolver

### DIFF
--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -32,7 +32,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -40,6 +39,7 @@ import (
 
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/monitoring"
+	"istio.io/istio/pkg/security"
 )
 
 const (
@@ -274,6 +274,11 @@ func (r *JwksResolver) GetPublicKey(issuer string, jwksURI string, timeout time.
 		resp, err = r.getRemoteContentWithRetry(jwksURI, networkFetchRetryCountOnMainFlow, timeout)
 		if err != nil {
 			log.Errorf("Failed to fetch public key from jwks URI %q: %v", jwksURI, err)
+		} else if err = validateJWKSFormat(resp); err != nil {
+			// Reject a response that is not a JWKS so an SSRF-controlled jwksURI cannot get an
+			// arbitrary fetched body embedded verbatim as an inline JWKS and read back via config_dump.
+			log.Errorf("Content fetched from jwks URI %q is not a valid JWKS: %v", jwksURI, err)
+			resp = nil
 		}
 		pubKey = string(resp)
 	}
@@ -601,32 +606,52 @@ func (r *JwksResolver) Close() {
 }
 
 // blockedCIDRDialContext is a custom dialContext that blocks connections to IP addresses
-// in CIDR ranges using the dialer's Control callback, which receives the resolved
-// IP address for each connection attempt.
-func blockedCIDRDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
-	dialer := &net.Dialer{}
+// in CIDR ranges configured via BlockedCIDRsInJWKURIs. See security.BlockedIPDialContext
+// for why this is done at the dial level rather than by inspecting the jwksURI upfront.
+var blockedCIDRDialContext = security.BlockedIPDialContext(&net.Dialer{}, jwksBlockedIP)
 
-	if len(features.BlockedCIDRsInJWKURIs) > 0 {
-		dialer.Control = func(network, address string, c syscall.RawConn) error {
-			host, _, err := net.SplitHostPort(address)
-			if err != nil {
-				return err
-			}
-			ip := net.ParseIP(host)
-			if ip == nil {
-				return fmt.Errorf("unable to parse IP from resolved address %s", address)
-			}
-			for _, cidr := range features.BlockedCIDRsInJWKURIs {
-				if cidr.Contains(ip) {
-					return fmt.Errorf("connection to %s (resolved IP %s) blocked: IP is in blocked CIDR range %s",
-						addr, ip.String(), cidr.String())
-				}
-			}
-			return nil
+// jwksBlockedIP blocks link-local addresses (which include cloud instance metadata endpoints such
+// as 169.254.169.254) and well-known cloud metadata addresses outside the link-local range, neither
+// of which has a legitimate use as a JWKS host, plus any operator-configured ranges from
+// BlockedCIDRsInJWKURIs. This mirrors the always-on default applied to Wasm module fetches
+// (pkg/wasm/ssrf.go). Private (RFC1918/ULA) and loopback ranges are not blocked by default since
+// in-cluster OIDC providers (e.g. Keycloak) legitimately live in private space; operators can add
+// them via BLOCKED_CIDRS_IN_JWKS_URIS.
+func jwksBlockedIP(ip net.IP) error {
+	if security.IsLinkLocal(ip) {
+		return fmt.Errorf("connection blocked: resolved IP %s is link-local", ip.String())
+	}
+	if security.IsKnownCloudMetadataAddress(ip) {
+		return fmt.Errorf("connection blocked: resolved IP %s is a known cloud metadata address", ip.String())
+	}
+	for _, cidr := range features.BlockedCIDRsInJWKURIs {
+		if cidr.Contains(ip) {
+			return fmt.Errorf("connection blocked: resolved IP %s is in blocked CIDR range %s", ip.String(), cidr.String())
 		}
 	}
+	return nil
+}
 
-	return dialer.DialContext(ctx, network, addr)
+// validateJWKSFormat reports an error if body does not look like a JWKS: a JSON object with a
+// "keys" array (RFC 7517). It is deliberately loose - it does not validate individual keys - and
+// exists to stop an arbitrary fetched response (e.g. from an SSRF-controlled jwksURI pointed at an
+// internal endpoint) from being embedded verbatim into a proxy's config as an inline JWKS and read
+// back through config_dump.
+func validateJWKSFormat(body []byte) error {
+	var doc struct {
+		Keys *json.RawMessage `json:"keys"`
+	}
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return fmt.Errorf("not valid JSON: %w", err)
+	}
+	if doc.Keys == nil {
+		return fmt.Errorf("missing \"keys\" field")
+	}
+	var keys []json.RawMessage
+	if err := json.Unmarshal(*doc.Keys, &keys); err != nil {
+		return fmt.Errorf("\"keys\" is not an array: %w", err)
+	}
+	return nil
 }
 
 // Compare two JWKS responses, returning true if there is a difference and false otherwise

--- a/pilot/pkg/model/jwks_resolver_test.go
+++ b/pilot/pkg/model/jwks_resolver_test.go
@@ -16,13 +16,16 @@ package model
 
 import (
 	"fmt"
+	"net"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model/test"
 	"istio.io/istio/pkg/monitoring/monitortest"
+	pkgtest "istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/retry"
 )
 
@@ -812,4 +815,61 @@ func TestBuildLocalJwksFailsClosed(t *testing.T) {
 	if strings.Contains(jwksStr, `"d":`) || strings.Contains(jwksStr, `"p":`) || strings.Contains(jwksStr, `"q":`) {
 		t.Errorf("BuildLocalJwks() contains private key fields - security vulnerability! JWKS: %s", jwksStr)
 	}
+}
+
+func TestValidateJWKSFormat(t *testing.T) {
+	cases := []struct {
+		name    string
+		body    string
+		wantErr bool
+	}{
+		{"valid jwks", `{"keys":[{"kty":"RSA","e":"AQAB","n":"abc"}]}`, false},
+		{"valid empty keys", `{"keys":[]}`, false},
+		{"not json", `<html>not a jwks</html>`, true},
+		{"mesh config json (ssrf debug body)", `{"proxyListenPort":15001,"defaultConfig":{}}`, true},
+		{"missing keys field", `{"foo":"bar"}`, true},
+		{"keys not an array", `{"keys":"nope"}`, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateJWKSFormat([]byte(tc.body))
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validateJWKSFormat(%q) err=%v, wantErr=%v", tc.body, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestJwksBlockedIP(t *testing.T) {
+	// default behavior: link-local and known cloud metadata are blocked; loopback, private, and
+	// public are allowed (private/loopback are opt-in via BLOCKED_CIDRS_IN_JWKS_URIS).
+	cases := []struct {
+		name    string
+		ip      string
+		blocked bool
+	}{
+		{"link-local metadata", "169.254.169.254", true},
+		{"link-local v6", "fe80::1", true},
+		{"alibaba metadata cgnat", "100.100.100.200", true},
+		{"aws imds v6", "fd00:ec2::254", true},
+		{"loopback allowed by default", "127.0.0.1", false},
+		{"private allowed by default", "10.0.0.1", false},
+		{"public allowed", "8.8.8.8", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := jwksBlockedIP(net.ParseIP(tc.ip)); (err != nil) != tc.blocked {
+				t.Errorf("jwksBlockedIP(%s) err=%v, blocked=%v", tc.ip, err, tc.blocked)
+			}
+		})
+	}
+
+	// operator-configured CIDR is additive to the always-on defaults.
+	t.Run("configured cidr", func(t *testing.T) {
+		_, cidr, _ := net.ParseCIDR("192.168.0.0/16")
+		pkgtest.SetForTest(t, &features.BlockedCIDRsInJWKURIs, []*net.IPNet{cidr})
+		if err := jwksBlockedIP(net.ParseIP("192.168.1.5")); err == nil {
+			t.Errorf("jwksBlockedIP(192.168.1.5) should be blocked by configured CIDR")
+		}
+	})
 }

--- a/pkg/security/dial.go
+++ b/pkg/security/dial.go
@@ -1,0 +1,88 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package security
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"syscall"
+)
+
+// BlockedIPDialContext returns a DialContext (suitable for http.Transport.DialContext) that
+// rejects a connection when isBlocked returns a non-nil error for the address's resolved IP.
+//
+// The check is implemented via the dialer's Control callback, which fires after DNS resolution
+// but before the socket connects. This means the block applies uniformly to the original request
+// and to every redirect hop a client follows, and cannot be bypassed by redirecting to a hostname
+// that resolves to a blocked address (a check against the pre-fetch URL or Location header string
+// alone cannot catch this).
+//
+// dialer is copied and only its Control field is overridden, so callers keep their own
+// Timeout/KeepAlive/etc settings.
+func BlockedIPDialContext(dialer *net.Dialer, isBlocked func(net.IP) error) func(ctx context.Context, network, addr string) (net.Conn, error) {
+	d := *dialer
+	d.Control = func(network, address string, c syscall.RawConn) error {
+		host, _, err := net.SplitHostPort(address)
+		if err != nil {
+			return err
+		}
+		ip := net.ParseIP(host)
+		if ip == nil {
+			return fmt.Errorf("unable to parse IP from resolved address %s", address)
+		}
+		return isBlocked(ip)
+	}
+	return d.DialContext
+}
+
+// IsLinkLocal reports whether ip is in a link-local range (169.254.0.0/16, fe80::/10). This
+// includes cloud provider instance metadata endpoints (e.g. 169.254.169.254) and has no
+// legitimate use as a remote fetch target.
+func IsLinkLocal(ip net.IP) bool {
+	return ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()
+}
+
+// knownCloudMetadataRanges are cloud provider instance metadata addresses that fall outside
+// the link-local range and so aren't caught by IsLinkLocal: Alibaba Cloud's metadata service
+// lives in RFC 6598 carrier-grade-NAT space (not private, loopback, or link-local by any
+// net.IP predicate), and AWS's IPv6 IMDS endpoint lives in ULA space reserved by AWS
+// specifically for this. Each is reserved by its provider for this one purpose and has no
+// other legitimate use, unlike the general private/ULA ranges these otherwise sit in.
+var knownCloudMetadataRanges = func() []*net.IPNet {
+	var nets []*net.IPNet
+	for _, cidr := range []string{
+		"100.100.100.200/32", // Alibaba Cloud metadata service
+		"fd00:ec2::/32",      // AWS IMDS IPv6 endpoint
+	} {
+		_, n, err := net.ParseCIDR(cidr)
+		if err != nil {
+			panic(err) // static list; only fails on a programming error
+		}
+		nets = append(nets, n)
+	}
+	return nets
+}()
+
+// IsKnownCloudMetadataAddress reports whether ip is a well-known cloud provider instance
+// metadata address not otherwise covered by IsLinkLocal.
+func IsKnownCloudMetadataAddress(ip net.IP) bool {
+	for _, n := range knownCloudMetadataRanges {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/security/dial_test.go
+++ b/pkg/security/dial_test.go
@@ -1,0 +1,112 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package security
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIsLinkLocal(t *testing.T) {
+	cases := []struct {
+		ip      string
+		blocked bool
+	}{
+		{"169.254.169.254", true}, // cloud metadata endpoint
+		{"169.254.0.1", true},
+		{"fe80::1", true},
+		{"10.0.0.1", false},
+		{"172.16.0.1", false},
+		{"192.168.1.1", false},
+		{"127.0.0.1", false},
+		{"8.8.8.8", false},
+	}
+	for _, c := range cases {
+		t.Run(c.ip, func(t *testing.T) {
+			ip := net.ParseIP(c.ip)
+			if ip == nil {
+				t.Fatalf("failed to parse test IP %s", c.ip)
+			}
+			if got := IsLinkLocal(ip); got != c.blocked {
+				t.Errorf("IsLinkLocal(%s) = %v, want %v", c.ip, got, c.blocked)
+			}
+		})
+	}
+}
+
+func TestIsKnownCloudMetadataAddress(t *testing.T) {
+	cases := []struct {
+		ip      string
+		blocked bool
+	}{
+		{"100.100.100.200", true},  // Alibaba Cloud metadata (RFC 6598 CGNAT space)
+		{"100.100.100.199", false}, // just outside the /32
+		{"fd00:ec2::230", true},    // AWS IMDS IPv6 endpoint
+		{"fd00:ec2::1", true},      // still within fd00:ec2::/32
+		{"fd12:3456::1", false},    // ULA space, but not AWS's reserved prefix
+		{"10.0.0.1", false},
+		{"169.254.169.254", false}, // link-local, covered by IsLinkLocal instead
+	}
+	for _, c := range cases {
+		t.Run(c.ip, func(t *testing.T) {
+			ip := net.ParseIP(c.ip)
+			if ip == nil {
+				t.Fatalf("failed to parse test IP %s", c.ip)
+			}
+			if got := IsKnownCloudMetadataAddress(ip); got != c.blocked {
+				t.Errorf("IsKnownCloudMetadataAddress(%s) = %v, want %v", c.ip, got, c.blocked)
+			}
+		})
+	}
+}
+
+func TestBlockedIPDialContext(t *testing.T) {
+	blockLoopback := func(ip net.IP) error {
+		if ip.IsLoopback() {
+			return errors.New("blocked: loopback")
+		}
+		return nil
+	}
+
+	t.Run("blocks matching predicate", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		defer ts.Close()
+
+		dialCtx := BlockedIPDialContext(&net.Dialer{}, blockLoopback)
+		client := &http.Client{Transport: &http.Transport{DialContext: dialCtx}}
+
+		_, err := client.Get(ts.URL)
+		if err == nil {
+			t.Fatal("expected request to a blocked address to fail, got nil error")
+		}
+	})
+
+	t.Run("allows non-matching predicate", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		defer ts.Close()
+
+		dialCtx := BlockedIPDialContext(&net.Dialer{}, func(ip net.IP) error { return nil })
+		client := &http.Client{Transport: &http.Transport{DialContext: dialCtx}}
+
+		resp, err := client.Get(ts.URL)
+		if err != nil {
+			t.Fatalf("expected request to succeed, got error: %v", err)
+		}
+		resp.Body.Close()
+	})
+}

--- a/releasenotes/notes/jwks-ssrf-default-block.yaml
+++ b/releasenotes/notes/jwks-ssrf-default-block.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+releaseNotes:
+  - |
+    **Fixed** an SSRF gap in istiod's `RequestAuthentication` `jwksUri` fetching. istiod now
+    blocks link-local and known cloud metadata addresses (such as `169.254.169.254`) at the dial
+    level by default and rejects fetched responses that are not a valid JWKS. Private and loopback
+    ranges remain reachable and can be blocked with `BLOCKED_CIDRS_IN_JWKS_URIS`.


### PR DESCRIPTION
Backport of #61230, includes the pkg/security/dial.go helper from #61112 it depends on. Fixes #61360