### PR TITLE
[release-1.30] check referencegrant before resolving cross-namespace tls refs

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -2238,22 +2238,27 @@ func buildTLS(
 		validCertCount := 0
 		var combinedErr *ConfigError
 		for i, certRef := range tls.CertificateRefs {
-			cred, err := buildSecretReference(ctx, certRef, gw, secrets)
-			if err != nil {
-				combinedErr = joinErrors(combinedErr, err)
-				continue
-			}
 			credNs := ptr.OrDefault((*string)(certRef.Namespace), namespace)
 			sameNamespace := credNs == namespace
 			objectKind := schematypes.GvkFromObject(gw)
-			if !sameNamespace && !grants.SecretAllowed(ctx, objectKind, creds.ToResourceName(cred), namespace) {
-				combinedErr = joinErrors(combinedErr, &ConfigError{
-					Reason: InvalidListenerRefNotPermitted,
-					Message: fmt.Sprintf(
-						"certificateRef %v/%v not accessible to a Gateway in namespace %q (missing a ReferenceGrant?)",
-						certRef.Name, credNs, namespace,
-					),
-				})
+			// Authorize cross-namespace refs before resolving the target, so status never
+			// reveals whether the referent exists when no ReferenceGrant allows it (CWE-203).
+			if !sameNamespace {
+				resourceName := creds.ToResourceName(creds.ToKubernetesGatewayResource(credNs, string(certRef.Name)))
+				if !grants.SecretAllowed(ctx, objectKind, resourceName, namespace) {
+					combinedErr = joinErrors(combinedErr, &ConfigError{
+						Reason: InvalidListenerRefNotPermitted,
+						Message: fmt.Sprintf(
+							"certificateRef %v/%v not accessible to a Gateway in namespace %q (missing a ReferenceGrant?)",
+							certRef.Name, credNs, namespace,
+						),
+					})
+					continue
+				}
+			}
+			cred, err := buildSecretReference(ctx, certRef, gw, secrets)
+			if err != nil {
+				combinedErr = joinErrors(combinedErr, err)
 				continue
 			}
 			credNames[i] = cred
@@ -2278,18 +2283,21 @@ func buildTLS(
 				}
 			}
 			caCertRef := gatewayTLS.Validation.CACertificateRefs[0]
-			cred, err := buildCaCertificateReference(ctx, caCertRef, gw, configMaps, secrets)
-			if err != nil {
-				return out, err
-			}
-			if cred.Namespace != namespace && !grants.SecretAllowed(ctx, schematypes.GvkFromObject(gw), cred.ResourceName, namespace) {
+			// Authorize cross-namespace refs before resolving the target, so status never
+			// reveals whether the referent exists when no ReferenceGrant allows it (CWE-203).
+			caNamespace, caResourceName := caCertificateResourceName(caCertRef, gw)
+			if caNamespace != namespace && !grants.SecretAllowed(ctx, schematypes.GvkFromObject(gw), caResourceName, namespace) {
 				return out, &ConfigError{
 					Reason: InvalidListenerRefNotPermitted,
 					Message: fmt.Sprintf(
 						"caCertificateRef %v/%v not accessible to a Gateway in namespace %q (missing a ReferenceGrant?)",
-						cred.Namespace, caCertRef.Name, namespace,
+						caNamespace, caCertRef.Name, namespace,
 					),
 				}
+			}
+			cred, err := buildCaCertificateReference(ctx, caCertRef, gw, configMaps, secrets)
+			if err != nil {
+				return out, err
 			}
 			out.Mode = istio.ServerTLSSettings_MUTUAL
 			out.CaCertCredentialName = cred.ResourceName
@@ -2358,6 +2366,21 @@ func buildSecretReference(
 		}
 	}
 	return creds.ToKubernetesGatewayResource(secret.Namespace, secret.Name), nil
+}
+
+// caCertificateResourceName returns the CA reference's SDS resource identity
+// without fetching the referenced object, so authorization can run before
+// resolution. The returned resourceName matches SecretResource.ResourceName
+// produced by buildCaCertificateReference.
+func caCertificateResourceName(ref k8s.ObjectReference, gw controllers.Object) (namespace, resourceName string) {
+	namespace = ptr.OrDefault((*string)(ref.Namespace), gw.GetNamespace())
+	name := string(ref.Name)
+	resourceType := creds.KubernetesConfigMapType
+	if gatewaycommon.NormalizeReference(&ref.Group, &ref.Kind, config.GroupVersionKind{}) == gvk.Secret {
+		resourceType = creds.KubernetesGatewaySecretType
+	}
+	resourceName = fmt.Sprintf("%s://%s/%s%s", resourceType, namespace, name, creds.SdsCaSuffix)
+	return namespace, resourceName
 }
 
 func buildCaCertificateReference(

--- a/pilot/pkg/config/kube/gateway/conversion_test.go
+++ b/pilot/pkg/config/kube/gateway/conversion_test.go
@@ -791,6 +791,12 @@ func TestConvertResources(t *testing.T) {
 		{name: "reference-grant-multiple-to"},
 		{name: "http-grpc-same-host"},
 		{name: "empty-backend-refs"},
+		{
+			name: "frontend-tls-refgrant",
+			validationIgnorer: crdvalidation.NewValidationIgnorer(
+				"certs/^existing-",
+			),
+		},
 	}
 	test.SetForTest(t, &features.EnableGatewayAPIGatewayClassController, false)
 	test.SetForTest(t, &features.EnableGatewayAPIInferenceExtension, true)

--- a/pilot/pkg/config/kube/gateway/testdata/frontend-tls-refgrant.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/frontend-tls-refgrant.status.yaml.golden
@@ -1,0 +1,225 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: istio
+spec: null
+status:
+  conditions:
+  - lastTransitionTime: fake
+    message: Handled by Istio controller
+    reason: Accepted
+    status: "True"
+    type: Accepted
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: cacert-exists
+  namespace: istio-system
+spec: null
+status:
+  addresses:
+  - type: IPAddress
+    value: 1.2.3.4
+  conditions:
+  - lastTransitionTime: fake
+    message: Resource accepted
+    reason: Accepted
+    status: "True"
+    type: Accepted
+  - lastTransitionTime: fake
+    message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:443
+    reason: Programmed
+    status: "True"
+    type: Programmed
+  listeners:
+  - attachedRoutes: 0
+    conditions:
+    - lastTransitionTime: fake
+      message: caCertificateRef certs/existing-ca not accessible to a Gateway in namespace
+        "istio-system" (missing a ReferenceGrant?)
+      reason: NoValidCACertificate
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: No errors found
+      reason: NoConflicts
+      status: "False"
+      type: Conflicted
+    - lastTransitionTime: fake
+      message: Bad TLS configuration
+      reason: Invalid
+      status: "False"
+      type: Programmed
+    - lastTransitionTime: fake
+      message: caCertificateRef certs/existing-ca not accessible to a Gateway in namespace
+        "istio-system" (missing a ReferenceGrant?)
+      reason: RefNotPermitted
+      status: "False"
+      type: ResolvedRefs
+    name: https
+    supportedKinds:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+    - group: gateway.networking.k8s.io
+      kind: GRPCRoute
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: cacert-missing
+  namespace: istio-system
+spec: null
+status:
+  addresses:
+  - type: IPAddress
+    value: 1.2.3.4
+  conditions:
+  - lastTransitionTime: fake
+    message: Resource accepted
+    reason: Accepted
+    status: "True"
+    type: Accepted
+  - lastTransitionTime: fake
+    message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:443
+    reason: Programmed
+    status: "True"
+    type: Programmed
+  listeners:
+  - attachedRoutes: 0
+    conditions:
+    - lastTransitionTime: fake
+      message: caCertificateRef certs/missing-ca not accessible to a Gateway in namespace
+        "istio-system" (missing a ReferenceGrant?)
+      reason: NoValidCACertificate
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: No errors found
+      reason: NoConflicts
+      status: "False"
+      type: Conflicted
+    - lastTransitionTime: fake
+      message: Bad TLS configuration
+      reason: Invalid
+      status: "False"
+      type: Programmed
+    - lastTransitionTime: fake
+      message: caCertificateRef certs/missing-ca not accessible to a Gateway in namespace
+        "istio-system" (missing a ReferenceGrant?)
+      reason: RefNotPermitted
+      status: "False"
+      type: ResolvedRefs
+    name: https
+    supportedKinds:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+    - group: gateway.networking.k8s.io
+      kind: GRPCRoute
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: cert-exists
+  namespace: istio-system
+spec: null
+status:
+  addresses:
+  - type: IPAddress
+    value: 1.2.3.4
+  conditions:
+  - lastTransitionTime: fake
+    message: Resource accepted
+    reason: Accepted
+    status: "True"
+    type: Accepted
+  - lastTransitionTime: fake
+    message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:443
+    reason: Programmed
+    status: "True"
+    type: Programmed
+  listeners:
+  - attachedRoutes: 0
+    conditions:
+    - lastTransitionTime: fake
+      message: certificateRef existing-cert/certs not accessible to a Gateway in namespace
+        "istio-system" (missing a ReferenceGrant?)
+      reason: NoValidCACertificate
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: No errors found
+      reason: NoConflicts
+      status: "False"
+      type: Conflicted
+    - lastTransitionTime: fake
+      message: Bad TLS configuration
+      reason: Invalid
+      status: "False"
+      type: Programmed
+    - lastTransitionTime: fake
+      message: certificateRef existing-cert/certs not accessible to a Gateway in namespace
+        "istio-system" (missing a ReferenceGrant?)
+      reason: RefNotPermitted
+      status: "False"
+      type: ResolvedRefs
+    name: https
+    supportedKinds:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+    - group: gateway.networking.k8s.io
+      kind: GRPCRoute
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: cert-missing
+  namespace: istio-system
+spec: null
+status:
+  addresses:
+  - type: IPAddress
+    value: 1.2.3.4
+  conditions:
+  - lastTransitionTime: fake
+    message: Resource accepted
+    reason: Accepted
+    status: "True"
+    type: Accepted
+  - lastTransitionTime: fake
+    message: Resource programmed, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:443
+    reason: Programmed
+    status: "True"
+    type: Programmed
+  listeners:
+  - attachedRoutes: 0
+    conditions:
+    - lastTransitionTime: fake
+      message: certificateRef missing-cert/certs not accessible to a Gateway in namespace
+        "istio-system" (missing a ReferenceGrant?)
+      reason: NoValidCACertificate
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: No errors found
+      reason: NoConflicts
+      status: "False"
+      type: Conflicted
+    - lastTransitionTime: fake
+      message: Bad TLS configuration
+      reason: Invalid
+      status: "False"
+      type: Programmed
+    - lastTransitionTime: fake
+      message: certificateRef missing-cert/certs not accessible to a Gateway in namespace
+        "istio-system" (missing a ReferenceGrant?)
+      reason: RefNotPermitted
+      status: "False"
+      type: ResolvedRefs
+    name: https
+    supportedKinds:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+    - group: gateway.networking.k8s.io
+      kind: GRPCRoute
+---

--- a/pilot/pkg/config/kube/gateway/testdata/frontend-tls-refgrant.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/frontend-tls-refgrant.yaml
@@ -1,0 +1,151 @@
+# Regression test for the cross-namespace existence oracle (CWE-203).
+# All four listeners reference material in namespace "certs" with NO ReferenceGrant.
+# Grant-first authorization must make existing-vs-missing indistinguishable:
+# every listener must report ResolvedRefs=False / RefNotPermitted with no "not found".
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: istio
+spec:
+  controllerName: istio.io/gateway-controller
+---
+# caCertificateRef -> EXISTING ConfigMap in another namespace, no grant.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: cacert-exists
+  namespace: istio-system
+spec:
+  gatewayClassName: istio
+  addresses:
+  - value: istio-ingressgateway
+    type: Hostname
+  tls:
+    frontend:
+      default:
+        validation:
+          caCertificateRefs:
+          - group: ""
+            kind: ConfigMap
+            namespace: certs
+            name: existing-ca
+  listeners:
+  - name: https
+    hostname: "a.example.com"
+    port: 443
+    protocol: HTTPS
+    allowedRoutes:
+      namespaces:
+        from: All
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - name: my-cert
+---
+# caCertificateRef -> MISSING ConfigMap in another namespace, no grant.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: cacert-missing
+  namespace: istio-system
+spec:
+  gatewayClassName: istio
+  addresses:
+  - value: istio-ingressgateway
+    type: Hostname
+  tls:
+    frontend:
+      default:
+        validation:
+          caCertificateRefs:
+          - group: ""
+            kind: ConfigMap
+            namespace: certs
+            name: missing-ca
+  listeners:
+  - name: https
+    hostname: "b.example.com"
+    port: 443
+    protocol: HTTPS
+    allowedRoutes:
+      namespaces:
+        from: All
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - name: my-cert
+---
+# certificateRef (Secret) -> EXISTING Secret in another namespace, no grant.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: cert-exists
+  namespace: istio-system
+spec:
+  gatewayClassName: istio
+  addresses:
+  - value: istio-ingressgateway
+    type: Hostname
+  listeners:
+  - name: https
+    hostname: "c.example.com"
+    port: 443
+    protocol: HTTPS
+    allowedRoutes:
+      namespaces:
+        from: All
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - name: existing-cert
+        namespace: certs
+---
+# certificateRef (Secret) -> MISSING Secret in another namespace, no grant.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: cert-missing
+  namespace: istio-system
+spec:
+  gatewayClassName: istio
+  addresses:
+  - value: istio-ingressgateway
+    type: Hostname
+  listeners:
+  - name: https
+    hostname: "d.example.com"
+    port: 443
+    protocol: HTTPS
+    allowedRoutes:
+      namespaces:
+        from: All
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - name: missing-cert
+        namespace: certs
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: existing-ca
+  namespace: certs
+data:
+  ca.crt: |
+    -----BEGIN CERTIFICATE-----
+    MIIDCzCCAfOgAwIBAgIQbfOzhcKTldFipQ1X2Wff1zANBgkqhkiG9w0BAQsFADAv
+    MRkwFwYDVQQKExBrOHMuY2x1c3Rlci5sb2NhbDESMBAGA1UEAxMJTXkgQ0EgQ0Ew
+    HhcNMjAwMTAxMDAwMDAwWhcNMzAwMTAxMDAwMDAwWjAvMRkwFwYDVQQKExBrOHMu
+    Y2x1c3Rlci5sb2NhbDESMBAGA1UEAxMJTXkgQ0EgQ0EwggEiMA0GCSqGSIb3DQEB
+    AQUAA4IBDwAwggEKAoIBAQDVE1YvVMhLPFVDzHUJHDfLPQVsBLGXOMsCP2OjCC0K
+    -----END CERTIFICATE-----
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: existing-cert
+  namespace: certs
+type: kubernetes.io/tls
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCg==
+  tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCg==

--- a/releasenotes/notes/gateway-tls-ref-grant-order.yaml
+++ b/releasenotes/notes/gateway-tls-ref-grant-order.yaml
@@ -1,0 +1,14 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+releaseNotes:
+- |
+  **Fixed** a Gateway API issue where a cross-namespace TLS `certificateRef` or
+  `caCertificateRef` was resolved before the `ReferenceGrant` authorization
+  check, so a listener's `ResolvedRefs` status could distinguish whether the
+  referenced Secret or ConfigMap existed even when no grant permitted the
+  reference. Authorization now runs first, returning `RefNotPermitted` for any
+  ungranted cross-namespace reference.
+
+  **Credit**: This issue was reported by Darryl Jaskolski.


### PR DESCRIPTION
Backport of #61303, status golden regenerated for 1.30 condition rendering. Fixes #61363