### PR TITLE
AmbientIndexes: Reduce memory churn for pod->service lookups

### DIFF
--- a/pilot/pkg/serviceregistry/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/ambient/workloads.go
@@ -55,6 +55,32 @@ import (
 	"istio.io/istio/pkg/workloadapi"
 )
 
+// workloadServicesSelectorIndex indexes each ServiceInfo under one key per entry of its label
+// selector: a service in namespace ns selecting app=foo,tier=api is indexed under "ns/app=foo"
+// and "ns/tier=api". Looking up a workload's labels the same way finds every service that could
+// select it (a matching selector is a subset of the workload's labels, so each of its keys is
+// searched) without materializing the whole namespace. A candidate sharing one key is not
+// necessarily a match: callers must still verify with FilterSelectsNonEmpty.
+// Selectorless services are not indexed (see matchingServicesWithoutSelectors).
+func workloadServicesSelectorIndex(c krt.Collection[model.ServiceInfo]) krt.Index[string, model.ServiceInfo] {
+	return krt.NewIndex(c, "selectorPairs", func(s model.ServiceInfo) []string {
+		return selectorPairKeys(s.Service.GetNamespace(), s.LabelSelector.Labels)
+	})
+}
+
+// selectorPairKeys builds one selector index key per label pair. Namespaces cannot contain "/"
+// and label keys/values cannot contain "=", so the encoding is unambiguous.
+func selectorPairKeys(namespace string, lbls map[string]string) []string {
+	if len(lbls) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(lbls))
+	for k, v := range lbls {
+		keys = append(keys, namespace+"/"+k+"="+v)
+	}
+	return keys
+}
+
 // WorkloadsCollection builds out the core Workload object type used in ambient mode.
 // A Workload represents a single addressable unit of compute -- typically a Pod or a VM.
 // Workloads can come from a variety of sources; these are joined together to build one complete `Collection[WorkloadInfo]`.
@@ -72,7 +98,7 @@ func (a Builder) WorkloadsCollection(
 	namespaces krt.Collection[*v1.Namespace],
 	opts krt.OptionsBuilder,
 ) krt.Collection[model.WorkloadInfo] {
-	WorkloadServicesNamespaceIndex := krt.NewNamespaceIndex(workloadServices)
+	WorkloadServicesSelectorIndex := workloadServicesSelectorIndex(workloadServices)
 	EndpointSlicesByIPIndex := endpointSliceAddressIndex(endpointSlices)
 	// Workloads coming from pods. There should be one workload for each (running) Pod.
 	PodWorkloads := krt.NewCollection(
@@ -83,7 +109,7 @@ func (a Builder) WorkloadsCollection(
 			peerAuthsByNs,
 			waypoints,
 			workloadServices,
-			WorkloadServicesNamespaceIndex,
+			WorkloadServicesSelectorIndex,
 			EndpointSlicesByIPIndex,
 			namespaces,
 			nodes,
@@ -93,7 +119,7 @@ func (a Builder) WorkloadsCollection(
 	// Workloads coming from workloadEntries. These are 1:1 with WorkloadEntry.
 	WorkloadEntryWorkloads := krt.NewCollection(
 		workloadEntries,
-		a.workloadEntryWorkloadBuilder(meshConfig, authorizationPolicies, peerAuthsByNs, waypoints, workloadServices, WorkloadServicesNamespaceIndex, namespaces),
+		a.workloadEntryWorkloadBuilder(meshConfig, authorizationPolicies, peerAuthsByNs, waypoints, workloadServices, WorkloadServicesSelectorIndex, namespaces),
 		opts.WithName("WorkloadEntryWorkloads")...,
 	)
 	// Workloads coming from serviceEntries. These are inlined workloadEntries (under `spec.endpoints`); these serviceEntries will
@@ -156,7 +182,7 @@ func MergedGlobalWorkloadsCollection(
 	domainSuffix string,
 	opts krt.OptionsBuilder,
 ) krt.Collection[model.WorkloadInfo] {
-	LocalWorkloadServicesNamespaceIndex := krt.NewNamespaceIndex(localWorkloadServices)
+	LocalWorkloadServicesSelectorIndex := workloadServicesSelectorIndex(localWorkloadServices)
 	LocalEndpointSlicesByIPIndex := endpointSliceAddressIndex(localCluster.EndpointSlices())
 	LocalPodWorkloads := krt.NewCollection(
 		localCluster.Pods(),
@@ -167,7 +193,7 @@ func MergedGlobalWorkloadsCollection(
 			localPeerAuthsByNs,
 			localWaypoints,
 			localWorkloadServices,
-			LocalWorkloadServicesNamespaceIndex,
+			LocalWorkloadServicesSelectorIndex,
 			LocalEndpointSlicesByIPIndex,
 			localCluster.Namespaces(),
 			localNodeLocalities,
@@ -194,7 +220,7 @@ func MergedGlobalWorkloadsCollection(
 			localPeerAuthsByNs,
 			localWaypoints,
 			localWorkloadServices,
-			LocalWorkloadServicesNamespaceIndex,
+			LocalWorkloadServicesSelectorIndex,
 			localCluster.Namespaces(),
 			localCluster.ID,
 			globalNetworks.FetchLocalNetworkID,
@@ -327,7 +353,7 @@ func MergedGlobalWorkloadsCollection(
 				)...,
 			)
 
-			WorkloadServicesNamespaceIndex := krt.NewNamespaceIndex(globalWorkloadServices)
+			WorkloadServicesSelectorIndex := workloadServicesSelectorIndex(globalWorkloadServices)
 			EndpointSlicesByIPIndex := endpointSliceAddressIndex(endpointSlices)
 			// Workloads coming from pods. There should be one workload for each (running) Pod.
 			PodWorkloads := krt.NewCollection(
@@ -339,7 +365,7 @@ func MergedGlobalWorkloadsCollection(
 					localPeerAuthsByNs,
 					waypoints,
 					globalWorkloadServices,
-					WorkloadServicesNamespaceIndex,
+					WorkloadServicesSelectorIndex,
 					EndpointSlicesByIPIndex,
 					namespaces,
 					nodes,
@@ -381,7 +407,7 @@ func MergedGlobalWorkloadsCollection(
 					localPeerAuthsByNs,
 					waypoints,
 					globalWorkloadServices,
-					WorkloadServicesNamespaceIndex,
+					WorkloadServicesSelectorIndex,
 					namespaces,
 					c.ID,
 					func(ctx krt.HandlerContext) network.ID {
@@ -506,7 +532,7 @@ func workloadEntryWorkloadBuilder(
 	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
 	workloadServices krt.Collection[model.ServiceInfo],
-	workloadServicesNamespaceIndex krt.Index[string, model.ServiceInfo],
+	workloadServicesSelectorIndex krt.Index[string, model.ServiceInfo],
 	namespaces krt.Collection[*v1.Namespace],
 	clusterID cluster.ID,
 	networkGetter func(krt.HandlerContext) network.ID,
@@ -522,7 +548,12 @@ func workloadEntryWorkloadBuilder(
 
 		appTunnel, targetWaypoint, waypointErr := computeWaypoint(ctx, waypoints, namespaces, wle.ObjectMeta)
 
-		fo := []krt.FetchOption{krt.FilterIndex(workloadServicesNamespaceIndex, wle.Namespace), krt.FilterSelectsNonEmpty(wle.GetLabels())}
+		fo := []krt.FetchOption{
+			// find candidate ServiceInfos
+			krt.FilterIndexes(workloadServicesSelectorIndex, selectorPairKeys(wle.Namespace, wle.GetLabels())...),
+			// filter to ServiceInfos which exactly select
+			krt.FilterSelectsNonEmpty(wle.GetLabels()),
+		}
 		if !flags.EnableK8SServiceSelectWorkloadEntries {
 			fo = append(fo, krt.FilterGeneric(func(a any) bool {
 				return a.(model.ServiceInfo).Source.Kind == kind.ServiceEntry
@@ -595,7 +626,7 @@ func (a Builder) workloadEntryWorkloadBuilder(
 	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
 	workloadServices krt.Collection[model.ServiceInfo],
-	workloadServicesNamespaceIndex krt.Index[string, model.ServiceInfo],
+	workloadServicesSelectorIndex krt.Index[string, model.ServiceInfo],
 	namespaces krt.Collection[*v1.Namespace],
 ) krt.TransformationSingle[*networkingclient.WorkloadEntry, model.WorkloadInfo] {
 	return workloadEntryWorkloadBuilder(
@@ -605,7 +636,7 @@ func (a Builder) workloadEntryWorkloadBuilder(
 		peerAuthsByNs,
 		waypoints,
 		workloadServices,
-		workloadServicesNamespaceIndex,
+		workloadServicesSelectorIndex,
 		namespaces,
 		a.ClusterID,
 		a.Networks.FetchLocalNetworkID,
@@ -648,7 +679,7 @@ func podWorkloadBuilder(
 	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
 	workloadServices krt.Collection[model.ServiceInfo],
-	workloadServicesNamespaceIndex krt.Index[string, model.ServiceInfo],
+	workloadServicesSelectorIndex krt.Index[string, model.ServiceInfo],
 	endpointSlicesAddressIndex krt.Index[TargetRef, *discovery.EndpointSlice],
 	namespaces krt.Collection[*v1.Namespace],
 	nodes krt.Collection[Node],
@@ -683,7 +714,12 @@ func podWorkloadBuilder(
 		}
 		meshCfg := krt.FetchOne(ctx, meshConfig.AsCollection())
 		policies := buildWorkloadPolicies(ctx, authorizationPolicies, peerAuthsByNs, meshCfg, p.Labels, p.Namespace)
-		fo := []krt.FetchOption{krt.FilterIndex(workloadServicesNamespaceIndex, p.Namespace), krt.FilterSelectsNonEmpty(p.GetLabels())}
+		fo := []krt.FetchOption{
+			// find candidate ServiceInfos
+			krt.FilterIndexes(workloadServicesSelectorIndex, selectorPairKeys(p.Namespace, p.GetLabels())...),
+			// filter to ServiceInfos which exactly select
+			krt.FilterSelectsNonEmpty(p.GetLabels()),
+		}
 		if !features.EnableServiceEntrySelectPods {
 			fo = append(fo, krt.FilterGeneric(func(a any) bool {
 				return a.(model.ServiceInfo).Source.Kind == kind.Service
@@ -753,7 +789,7 @@ func (a Builder) podWorkloadBuilder(
 	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
 	workloadServices krt.Collection[model.ServiceInfo],
-	workloadServicesNamespaceIndex krt.Index[string, model.ServiceInfo],
+	workloadServicesSelectorIndex krt.Index[string, model.ServiceInfo],
 	endpointSlicesAddressIndex krt.Index[TargetRef, *discovery.EndpointSlice],
 	namespaces krt.Collection[*v1.Namespace],
 	nodes krt.Collection[Node],
@@ -765,7 +801,7 @@ func (a Builder) podWorkloadBuilder(
 		peerAuthsByNs,
 		waypoints,
 		workloadServices,
-		workloadServicesNamespaceIndex,
+		workloadServicesSelectorIndex,
 		endpointSlicesAddressIndex,
 		namespaces,
 		nodes,

--- a/pilot/pkg/serviceregistry/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/ambient/workloads_test.go
@@ -231,6 +231,49 @@ func TestPodWorkloads(t *testing.T) {
 			},
 		},
 		{
+			name: "pod without labels does not match selector services",
+			inputs: []any{
+				model.ServiceInfo{
+					Service: &workloadapi.Service{
+						Name:      "svc",
+						Namespace: "ns",
+						Hostname:  "hostname",
+						Ports: []*workloadapi.Port{{
+							ServicePort: 80,
+							TargetPort:  8080,
+						}},
+					},
+					LabelSelector: model.NewSelector(map[string]string{"app": "foo"}),
+				},
+			},
+			pod: &v1.Pod{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "ns",
+				},
+				Spec: v1.PodSpec{},
+				Status: v1.PodStatus{
+					Phase:      v1.PodRunning,
+					Conditions: podReady,
+					PodIP:      "1.2.3.4",
+				},
+			},
+			result: &workloadapi.Workload{
+				Uid:               "cluster0//Pod/ns/name",
+				Name:              "name",
+				Namespace:         "ns",
+				Addresses:         [][]byte{netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice()},
+				Network:           testNW,
+				CanonicalName:     "name",
+				CanonicalRevision: "latest",
+				WorkloadType:      workloadapi.WorkloadType_POD,
+				WorkloadName:      "name",
+				Status:            workloadapi.WorkloadStatus_HEALTHY,
+				ClusterId:         testC,
+			},
+		},
+		{
 			name: "pod with service named ports",
 			inputs: []any{
 				model.ServiceInfo{
@@ -832,7 +875,7 @@ func TestPodWorkloads(t *testing.T) {
 			mock := krttest.NewMock(t, tt.inputs)
 			a := newAmbientUnitTest(t)
 			WorkloadServices := krttest.GetMockCollection[model.ServiceInfo](mock)
-			WorkloadServicesNamespaceIndex := krt.NewNamespaceIndex(WorkloadServices)
+			WorkloadServicesSelectorIndex := workloadServicesSelectorIndex(WorkloadServices)
 			EndpointSlices := krttest.GetMockCollection[*discovery.EndpointSlice](mock)
 			EndpointSlicesAddressIndex := endpointSliceAddressIndex(EndpointSlices)
 			builder := a.podWorkloadBuilder(
@@ -841,7 +884,7 @@ func TestPodWorkloads(t *testing.T) {
 				krt.NewNamespaceIndex(krttest.GetMockCollection[*securityclient.PeerAuthentication](mock)),
 				krttest.GetMockCollection[Waypoint](mock),
 				WorkloadServices,
-				WorkloadServicesNamespaceIndex,
+				WorkloadServicesSelectorIndex,
 				EndpointSlicesAddressIndex,
 				krttest.GetMockCollection[*v1.Namespace](mock),
 				krttest.GetMockCollection[Node](mock),
@@ -1442,14 +1485,14 @@ func TestWorkloadEntryWorkloads(t *testing.T) {
 			mock := krttest.NewMock(t, tt.inputs)
 			a := newAmbientUnitTest(t)
 			WorkloadServices := krttest.GetMockCollection[model.ServiceInfo](mock)
-			WorkloadServicesNamespaceIndex := krt.NewNamespaceIndex(WorkloadServices)
+			WorkloadServicesSelectorIndex := workloadServicesSelectorIndex(WorkloadServices)
 			builder := a.workloadEntryWorkloadBuilder(
 				GetMeshConfig(mock),
 				krttest.GetMockCollection[model.WorkloadAuthorization](mock),
 				krt.NewNamespaceIndex(krttest.GetMockCollection[*securityclient.PeerAuthentication](mock)),
 				krttest.GetMockCollection[Waypoint](mock),
 				WorkloadServices,
-				WorkloadServicesNamespaceIndex,
+				WorkloadServicesSelectorIndex,
 				krttest.GetMockCollection[*v1.Namespace](mock),
 			)
 			wrapper := builder(krt.TestingDummyContext{}, tt.we)
@@ -1689,14 +1732,14 @@ func TestWorkloadEntryConditions(t *testing.T) {
 			mock := krttest.NewMock(t, tt.inputs)
 			a := newAmbientUnitTest(t)
 			WorkloadServices := krttest.GetMockCollection[model.ServiceInfo](mock)
-			WorkloadServicesNamespaceIndex := krt.NewNamespaceIndex(WorkloadServices)
+			WorkloadServicesSelectorIndex := workloadServicesSelectorIndex(WorkloadServices)
 			builder := a.workloadEntryWorkloadBuilder(
 				GetMeshConfig(mock),
 				krttest.GetMockCollection[model.WorkloadAuthorization](mock),
 				krt.NewNamespaceIndex(krttest.GetMockCollection[*securityclient.PeerAuthentication](mock)),
 				krttest.GetMockCollection[Waypoint](mock),
 				WorkloadServices,
-				WorkloadServicesNamespaceIndex,
+				WorkloadServicesSelectorIndex,
 				krttest.GetMockCollection[*v1.Namespace](mock),
 			)
 			wrapper := builder(krt.TestingDummyContext{}, tt.we)

--- a/pkg/kube/krt/bench_test.go
+++ b/pkg/kube/krt/bench_test.go
@@ -261,3 +261,59 @@ func BenchmarkControllers(b *testing.B) {
 		benchmark(b, NewLegacy)
 	})
 }
+
+type benchService struct {
+	krt.Named
+	Selector map[string]string
+}
+
+func (s benchService) GetLabelSelector() map[string]string {
+	return s.Selector
+}
+
+// BenchmarkFetchSelectorMatch compares two ways of fetching the services whose label selector
+// matches a given workload: a namespace index (materializes every service in the namespace,
+// then filters) versus a selector-pair index (looks up only the candidates sharing a selector
+// pair with the workload). This is the access pattern of the ambient workload builders.
+func BenchmarkFetchSelectorMatch(b *testing.B) {
+	log.FindScope("krt").SetOutputLevel(log.InfoLevel)
+	const numServices = 1000
+	services := make([]benchService, 0, numServices)
+	for i := 0; i < numServices; i++ {
+		services = append(services, benchService{
+			Named:    krt.Named{Namespace: "ns", Name: fmt.Sprintf("svc-%d", i)},
+			Selector: map[string]string{"app": fmt.Sprintf("app-%d", i)},
+		})
+	}
+	podLabels := map[string]string{"app": "app-42", "other": "label"}
+
+	Services := krt.NewStaticCollection(nil, services)
+	NamespaceIndex := krt.NewNamespaceIndex(Services)
+	PairIndex := krt.NewIndex(Services, "selectorPairs", func(s benchService) []string {
+		keys := make([]string, 0, len(s.Selector))
+		for k, v := range s.Selector {
+			keys = append(keys, s.Namespace+"/"+k+"="+v)
+		}
+		return keys
+	})
+	pairKeys := make([]string, 0, len(podLabels))
+	for k, v := range podLabels {
+		pairKeys = append(pairKeys, "ns/"+k+"="+v)
+	}
+
+	run := func(b *testing.B, opt krt.FetchOption) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			got := krt.Fetch(krt.TestingDummyContext{}, Services, opt, krt.FilterSelectsNonEmpty(podLabels))
+			if len(got) != 1 || got[0].Name != "svc-42" {
+				b.Fatalf("unexpected fetch result: %v", got)
+			}
+		}
+	}
+	b.Run("namespace-index", func(b *testing.B) {
+		run(b, krt.FilterIndex(NamespaceIndex, "ns"))
+	})
+	b.Run("selector-pair-index", func(b *testing.B) {
+		run(b, krt.FilterIndexes(PairIndex, pairKeys...))
+	})
+}

--- a/pkg/kube/krt/filter.go
+++ b/pkg/kube/krt/filter.go
@@ -22,6 +22,7 @@ import (
 
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/slices"
+	"istio.io/istio/pkg/util/sets"
 	"istio.io/istio/pkg/util/smallset"
 )
 
@@ -43,7 +44,7 @@ type indexFilter struct {
 	list         func() any
 	indexMatches func(any) bool
 	extractKeys  objectKeyExtractor
-	key          string
+	keys         []string
 }
 
 type objectKeyExtractor = func(o any) []string
@@ -61,7 +62,7 @@ func (f *filter) reverseIndexKey() ([]string, indexedDependencyType, objectKeyEx
 		return f.keys.List(), getKeyType, getKeyExtractor, 0, true
 	}
 	if f.index != nil {
-		return []string{f.index.key}, indexType, f.index.extractKeys, f.index.filterUID, true
+		return f.index.keys, indexType, f.index.extractKeys, f.index.filterUID, true
 	}
 	return nil, unknownIndexType, nil, 0, false
 }
@@ -119,22 +120,46 @@ func FilterSelects(lbls map[string]string) FetchOption {
 
 // FilterIndex selects only objects matching a key in an index.
 func FilterIndex[K comparable, I any](idx Index[K, I], k K) FetchOption {
+	return FilterIndexes(idx, k)
+}
+
+// FilterIndexes selects only objects matching at least one of the provided keys in an index.
+// An object matching multiple keys is only returned once. No keys matches nothing.
+func FilterIndexes[K comparable, I any](idx Index[K, I], ks ...K) FetchOption {
 	return func(h *dependency) {
 		// Index is used to pre-filter on the List, and also to match in Matches. Provide type-erased methods for both
 		h.filter.index = &indexFilter{
 			filterUID: idx.id(),
 			list: func() any {
-				return idx.Lookup(k)
+				if len(ks) == 1 {
+					return idx.Lookup(ks[0])
+				}
+				// Union the per-key lookups, deduplicating objects that match multiple keys.
+				res := []I{}
+				seen := sets.New[string]()
+				for _, k := range ks {
+					for _, o := range idx.Lookup(k) {
+						if seen.InsertContains(GetKey(o)) {
+							continue
+						}
+						res = append(res, o)
+					}
+				}
+				return res
 			},
 			indexMatches: func(a any) bool {
-				return idx.objectHasKey(a.(I), k)
+				return slices.ContainsFunc(ks, func(k K) bool {
+					return idx.objectHasKey(a.(I), k)
+				})
 			},
 			extractKeys: func(o any) []string {
 				return slices.Map(idx.extractKeys(o.(I)), func(e K) string {
 					return toString(e)
 				})
 			},
-			key: toString(k),
+			keys: slices.Map(ks, func(k K) string {
+				return toString(k)
+			}),
 		}
 	}
 }

--- a/pkg/kube/krt/index_test.go
+++ b/pkg/kube/krt/index_test.go
@@ -282,6 +282,79 @@ func TestIndexAsCollection(t *testing.T) {
 	})
 }
 
+func TestFilterIndexes(t *testing.T) {
+	stop := test.NewStop(t)
+	opts := testOptions(t)
+	c := kube.NewFakeClient()
+	kpc := kclient.New[*corev1.Pod](c)
+	pc := clienttest.Wrap(t, kpc)
+	podsCol := krt.WrapClient[*corev1.Pod](kpc, opts.WithName("Pods")...)
+	c.RunAndWait(stop)
+	SimplePods := SimplePodCollection(podsCol, opts)
+	LabelIndex := krt.NewIndex[string, SimplePod](SimplePods, "label", func(o SimplePod) []string {
+		var out []string
+		for k, v := range o.GetLabels() {
+			out = append(out, k+"="+v)
+		}
+		return out
+	})
+	collect := func(pods []SimplePod) *string {
+		names := slices.Sort(slices.Map(pods, SimplePod.ResourceName))
+		return ptr.Of(strings.Join(names, ","))
+	}
+	// Fetch by two keys of the index; a pod matching both must be returned only once.
+	Both := krt.NewSingleton[string](func(ctx krt.HandlerContext) *string {
+		return collect(krt.Fetch(ctx, SimplePods, krt.FilterIndexes(LabelIndex, "a=1", "b=2")))
+	}, opts.WithName("Both")...)
+	// Fetch by no keys; matches nothing, no matter what churns.
+	None := krt.NewSingleton[string](func(ctx krt.HandlerContext) *string {
+		return collect(krt.Fetch(ctx, SimplePods, krt.FilterIndexes(LabelIndex)))
+	}, opts.WithName("None")...)
+	Both.AsCollection().WaitUntilSynced(stop)
+	None.AsCollection().WaitUntilSynced(stop)
+
+	assertBoth := func(want string) {
+		t.Helper()
+		assert.EventuallyEqual(t, Both.Get, ptr.Of(want))
+		assert.Equal(t, None.Get(), ptr.Of(""))
+	}
+
+	mkPod := func(name string, lbls map[string]string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ns", Labels: lbls},
+			Status:     corev1.PodStatus{PodIP: "1.2.3.4"},
+		}
+	}
+
+	// Pods entering via each key show up...
+	pod1 := mkPod("pod1", map[string]string{"a": "1"})
+	pc.CreateOrUpdateStatus(pod1)
+	assertBoth("ns/pod1")
+	pod2 := mkPod("pod2", map[string]string{"b": "2"})
+	pc.CreateOrUpdateStatus(pod2)
+	assertBoth("ns/pod1,ns/pod2")
+	// ...a pod matching both keys shows up exactly once...
+	pod3 := mkPod("pod3", map[string]string{"a": "1", "b": "2"})
+	pc.CreateOrUpdateStatus(pod3)
+	assertBoth("ns/pod1,ns/pod2,ns/pod3")
+	// ...and one matching neither does not show up.
+	pod4 := mkPod("pod4", map[string]string{"c": "3"})
+	pc.CreateOrUpdateStatus(pod4)
+	assertBoth("ns/pod1,ns/pod2,ns/pod3")
+
+	// An update moving a pod out of all fetched keys triggers recomputation.
+	pod1.Labels = map[string]string{"c": "3"}
+	pc.CreateOrUpdateStatus(pod1)
+	assertBoth("ns/pod2,ns/pod3")
+	// An update moving it back in under the other key does too.
+	pod1.Labels = map[string]string{"b": "2"}
+	pc.CreateOrUpdateStatus(pod1)
+	assertBoth("ns/pod1,ns/pod2,ns/pod3")
+
+	pc.Delete(pod2.Name, pod2.Namespace)
+	assertBoth("ns/pod1,ns/pod3")
+}
+
 type PodCounts struct {
 	ByIP   int
 	ByName int

--- a/releasenotes/notes/ambient-workload-service-selector-index.yaml
+++ b/releasenotes/notes/ambient-workload-service-selector-index.yaml
@@ -1,0 +1,13 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+issue:
+  - 61382
+
+releaseNotes:
+  - |
+    **Improved** ambient workload building to look up matching services through a
+    label-selector index instead of scanning every service in the workload's namespace.
+    This substantially reduces istiod memory allocation and CPU under pod churn in
+    namespaces with many services.


### PR DESCRIPTION
**Please provide a description of this PR:**
fixes #61382

Indexes ServiceInfos by `namespace X labelSelector kv` rather than simply namespace for lookup in pod/wle -> service resolution. Using more specific indexing reduces over-broad service selection for namespaces which contain many services and serviceinfos. The over-broad namespace index required allocating memory for every ServiceInfo (once copying it into the lookup slice and again for the filter check) even if there was no possibility of it selecting the pod/wle.

To support this, krt gains `FilterIndexes`, This is a multi-key index fetch with union-and-dedup semantics; `FilterIndex` becomes the single-key case.

Benchmarking (`BenchmarkFetchSelectorMatch`, 1000 services in one namespace) shows ~90x less memory allocated and ~48x fewer allocations per lookup.