### PR TITLE
[release-1.29] Reduce AuthorizationPolicy scanning by indexing on namespace (#61256)

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -328,6 +328,8 @@ func New(options Options) Index {
 		Waypoints,
 		opts,
 	)
+	authPoliciesByNs := selectingWorkloadAuthzByNs(AuthorizationPolicies)
+
 	// these are workloadapi-style services combined from kube services and service entries
 	WorkloadServices := a.builder.ServicesCollection(options.ClusterID, Services, ServiceEntries, Waypoints, Namespaces, a.meshConfig, opts, true)
 
@@ -438,7 +440,7 @@ func New(options Options) Index {
 		Pods,
 		NodeLocality,
 		a.meshConfig,
-		AuthorizationPolicies,
+		authPoliciesByNs,
 		PeerAuthsByNs,
 		Waypoints,
 		WorkloadServices,
@@ -963,6 +965,18 @@ func PushXdsAddress[T any](xds model.XDSUpdater, f func(T) string) func(events [
 			Reason:           model.NewReasonStats(model.AmbientUpdate),
 		})
 	}
+}
+
+func selectingWorkloadAuthzByNs(c krt.Collection[model.WorkloadAuthorization]) krt.Index[string, model.WorkloadAuthorization] {
+	return krt.NewIndex(c, "selectingWorklodAuthorizationsByNs", func(wa model.WorkloadAuthorization) []string {
+		if wa.Authorization == nil {
+			return nil // filter policy which are invalid
+		}
+		if wa.GetLabelSelector() == nil {
+			return nil
+		}
+		return []string{wa.Authorization.Namespace}
+	})
 }
 
 type MeshConfig = meshwatcher.MeshConfigResource

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/multicluster.go
@@ -194,6 +194,7 @@ func (a *index) buildGlobalCollections(
 		LocalWaypoints,
 		opts,
 	)
+	authPoliciesByNs := selectingWorkloadAuthzByNs(AuthorizationPolicies)
 
 	LocalWorkloadServices := a.builder.ServicesCollection(
 		localCluster.ID,
@@ -298,7 +299,7 @@ func (a *index) buildGlobalCollections(
 		GlobalNodeLocality,
 		GlobalNodeLocalityByCluster,
 		options.MeshConfig,
-		AuthorizationPolicies,
+		authPoliciesByNs,
 		localPeerAuthsByNs,
 		GlobalWaypoints,
 		WaypointsByCluster,

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
@@ -64,7 +64,7 @@ func (a Builder) WorkloadsCollection(
 	pods krt.Collection[*v1.Pod],
 	nodes krt.Collection[Node],
 	meshConfig krt.Singleton[MeshConfig],
-	authorizationPolicies krt.Collection[model.WorkloadAuthorization],
+	authPoliciesByNs krt.Index[string, model.WorkloadAuthorization],
 	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
 	workloadServices krt.Collection[model.ServiceInfo],
@@ -81,7 +81,7 @@ func (a Builder) WorkloadsCollection(
 		pods,
 		a.podWorkloadBuilder(
 			meshConfig,
-			authorizationPolicies,
+			authPoliciesByNs,
 			peerAuthsByNs,
 			waypoints,
 			workloadServices,
@@ -96,14 +96,14 @@ func (a Builder) WorkloadsCollection(
 	// Workloads coming from workloadEntries. These are 1:1 with WorkloadEntry.
 	WorkloadEntryWorkloads := krt.NewCollection(
 		workloadEntries,
-		a.workloadEntryWorkloadBuilder(meshConfig, authorizationPolicies, peerAuthsByNs, waypoints, workloadServices, WorkloadServicesNamespaceIndex, namespaces),
+		a.workloadEntryWorkloadBuilder(meshConfig, authPoliciesByNs, peerAuthsByNs, waypoints, workloadServices, WorkloadServicesNamespaceIndex, namespaces),
 		opts.WithName("WorkloadEntryWorkloads")...,
 	)
 	// Workloads coming from serviceEntries. These are inlined workloadEntries (under `spec.endpoints`); these serviceEntries will
 	// also be generating `workloadapi.Service` definitions in the `ServicesCollection` logic.
 	ServiceEntryWorkloads := krt.NewManyCollection(
 		serviceEntries,
-		a.serviceEntryWorkloadBuilder(meshConfig, authorizationPolicies, peerAuthsByNs, waypoints, namespaces, workloadServices),
+		a.serviceEntryWorkloadBuilder(meshConfig, authPoliciesByNs, peerAuthsByNs, waypoints, namespaces, workloadServices),
 		opts.WithName("ServiceEntryWorkloads")...,
 	)
 	// Workloads coming from endpointSlices. These are for *manually added* endpoints. Typically, Kubernetes will insert each pod
@@ -146,7 +146,7 @@ func MergedGlobalWorkloadsCollection(
 	globalNodes krt.Collection[krt.Collection[krt.ObjectWithCluster[Node]]],
 	nodesByCluster krt.Index[cluster.ID, krt.Collection[krt.ObjectWithCluster[Node]]],
 	meshConfig krt.Singleton[MeshConfig],
-	localAuthorizationPolicies krt.Collection[model.WorkloadAuthorization],
+	localAuthPoliciesByNs krt.Index[string, model.WorkloadAuthorization],
 	localPeerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	globalWaypoints krt.Collection[krt.Collection[Waypoint]],
 	waypointsByCluster krt.Index[cluster.ID, krt.Collection[Waypoint]],
@@ -174,7 +174,7 @@ func MergedGlobalWorkloadsCollection(
 		podWorkloadBuilder(
 			meshConfig,
 			localNetworkGetter,
-			localAuthorizationPolicies,
+			localAuthPoliciesByNs,
 			localPeerAuthsByNs,
 			localWaypoints,
 			localWorkloadServices,
@@ -203,7 +203,7 @@ func MergedGlobalWorkloadsCollection(
 		workloadEntryWorkloadBuilder(
 			meshConfig,
 			localNetworkGetter,
-			localAuthorizationPolicies,
+			localAuthPoliciesByNs,
 			localPeerAuthsByNs,
 			localWaypoints,
 			localWorkloadServices,
@@ -229,7 +229,7 @@ func MergedGlobalWorkloadsCollection(
 		serviceEntries,
 		serviceEntryWorkloadBuilder(
 			meshConfig,
-			localAuthorizationPolicies,
+			localAuthPoliciesByNs,
 			localPeerAuthsByNs,
 			localWaypoints,
 			localCluster.Namespaces(),
@@ -413,7 +413,7 @@ func MergedGlobalWorkloadsCollection(
 				podWorkloadBuilder(
 					meshConfig,
 					localNetworkGetter,
-					localAuthorizationPolicies,
+					localAuthPoliciesByNs,
 					localPeerAuthsByNs,
 					waypoints,
 					globalWorkloadServices,
@@ -465,7 +465,7 @@ func MergedGlobalWorkloadsCollection(
 				workloadEntryWorkloadBuilder(
 					meshConfig,
 					localNetworkGetter,
-					localAuthorizationPolicies,
+					localAuthPoliciesByNs,
 					localPeerAuthsByNs,
 					waypoints,
 					globalWorkloadServices,
@@ -513,7 +513,7 @@ func MergedGlobalWorkloadsCollection(
 				serviceEntries,
 				serviceEntryWorkloadBuilder(
 					meshConfig,
-					localAuthorizationPolicies,
+					localAuthPoliciesByNs,
 					localPeerAuthsByNs,
 					waypoints,
 					namespaces,
@@ -645,7 +645,7 @@ func MergedGlobalWorkloadsCollection(
 func workloadEntryWorkloadBuilder(
 	meshConfig krt.Singleton[MeshConfig],
 	localNetworkGetter func(krt.HandlerContext) network.ID,
-	authorizationPolicies krt.Collection[model.WorkloadAuthorization],
+	authPoliciesByNs krt.Index[string, model.WorkloadAuthorization],
 	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
 	workloadServices krt.Collection[model.ServiceInfo],
@@ -662,7 +662,7 @@ func workloadEntryWorkloadBuilder(
 		// WLE can put labels in multiple places; normalize this
 		wle = serviceentry.ConvertClientWorkloadEntry(wle)
 		meshCfg := krt.FetchOne(ctx, meshConfig.AsCollection())
-		policies := buildWorkloadPolicies(ctx, authorizationPolicies, peerAuthsByNs, meshCfg, wle.Labels, wle.Namespace)
+		policies := buildWorkloadPolicies(ctx, authPoliciesByNs, peerAuthsByNs, meshCfg, wle.Labels, wle.Namespace)
 
 		appTunnel, targetWaypoint := computeWaypoint(ctx, waypoints, namespaces, wle.ObjectMeta)
 
@@ -729,7 +729,7 @@ func workloadEntryWorkloadBuilder(
 
 func (a Builder) workloadEntryWorkloadBuilder(
 	meshConfig krt.Singleton[MeshConfig],
-	authorizationPolicies krt.Collection[model.WorkloadAuthorization],
+	authPoliciesByNs krt.Index[string, model.WorkloadAuthorization],
 	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
 	workloadServices krt.Collection[model.ServiceInfo],
@@ -742,7 +742,7 @@ func (a Builder) workloadEntryWorkloadBuilder(
 	return workloadEntryWorkloadBuilder(
 		meshConfig,
 		localNetworkGetter,
-		authorizationPolicies,
+		authPoliciesByNs,
 		peerAuthsByNs,
 		waypoints,
 		workloadServices,
@@ -786,7 +786,7 @@ func computeWaypoint(
 func podWorkloadBuilder(
 	meshConfig krt.Singleton[MeshConfig],
 	localNetworkGetter func(krt.HandlerContext) network.ID,
-	authorizationPolicies krt.Collection[model.WorkloadAuthorization],
+	authPoliciesByNs krt.Index[string, model.WorkloadAuthorization],
 	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
 	workloadServices krt.Collection[model.ServiceInfo],
@@ -826,7 +826,7 @@ func podWorkloadBuilder(
 			return nil
 		}
 		meshCfg := krt.FetchOne(ctx, meshConfig.AsCollection())
-		policies := buildWorkloadPolicies(ctx, authorizationPolicies, peerAuthsByNs, meshCfg, p.Labels, p.Namespace)
+		policies := buildWorkloadPolicies(ctx, authPoliciesByNs, peerAuthsByNs, meshCfg, p.Labels, p.Namespace)
 		fo := []krt.FetchOption{krt.FilterIndex(workloadServicesNamespaceIndex, p.Namespace), krt.FilterSelectsNonEmpty(p.GetLabels())}
 		if !features.EnableServiceEntrySelectPods {
 			fo = append(fo, krt.FilterGeneric(func(a any) bool {
@@ -895,7 +895,7 @@ func podWorkloadBuilder(
 
 func (a Builder) podWorkloadBuilder(
 	meshConfig krt.Singleton[MeshConfig],
-	authorizationPolicies krt.Collection[model.WorkloadAuthorization],
+	authPoliciesByNs krt.Index[string, model.WorkloadAuthorization],
 	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
 	workloadServices krt.Collection[model.ServiceInfo],
@@ -911,7 +911,7 @@ func (a Builder) podWorkloadBuilder(
 	return podWorkloadBuilder(
 		meshConfig,
 		localNetworkGetter,
-		authorizationPolicies,
+		authPoliciesByNs,
 		peerAuthsByNs,
 		waypoints,
 		workloadServices,
@@ -1000,7 +1000,7 @@ func matchingServicesWithoutSelectors(
 
 func buildWorkloadPolicies(
 	ctx krt.HandlerContext,
-	authorizationPolicies krt.Collection[model.WorkloadAuthorization],
+	authPoliciesByNs krt.Index[string, model.WorkloadAuthorization],
 	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	meshCfg *MeshConfig,
 	workloadLabels map[string]string,
@@ -1009,19 +1009,15 @@ func buildWorkloadPolicies(
 	// We need to filter from the policies that are present, which apply to us.
 	// We only want label selector ones; global ones are not attached to the final WorkloadInfo
 	// In general we just take all of the policies
-	basePolicies := krt.Fetch(
-		ctx,
-		authorizationPolicies,
+	opts := []krt.FetchOption{
 		krt.FilterSelects(workloadLabels),
-		krt.FilterGeneric(func(a any) bool {
-			wa := a.(model.WorkloadAuthorization)
-			if wa.Authorization == nil {
-				return false // filter policy which are invalid, only exist to hold the error condition
-			}
-			nsMatch := wa.Authorization.Namespace == meshCfg.RootNamespace || wa.Authorization.Namespace == workloadNamespace
-			return nsMatch && wa.GetLabelSelector() != nil
-		}),
-	)
+	}
+	basePolicies := authPoliciesByNs.Fetch(ctx, meshCfg.RootNamespace, opts...)
+	if workloadNamespace != meshCfg.RootNamespace {
+		if nsPolicies := authPoliciesByNs.Fetch(ctx, workloadNamespace, opts...); len(nsPolicies) > 0 {
+			basePolicies = append(basePolicies, nsPolicies...)
+		}
+	}
 	policies := slices.Sort(slices.Map(basePolicies, func(t model.WorkloadAuthorization) string {
 		return t.ResourceName()
 	}))
@@ -1033,7 +1029,7 @@ func buildWorkloadPolicies(
 
 func serviceEntryWorkloadBuilder(
 	meshConfig krt.Singleton[MeshConfig],
-	authorizationPolicies krt.Collection[model.WorkloadAuthorization],
+	authPoliciesByNs krt.Index[string, model.WorkloadAuthorization],
 	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
 	namespaces krt.Collection[*v1.Namespace],
@@ -1092,7 +1088,7 @@ func serviceEntryWorkloadBuilder(
 				services = []model.ServiceInfo{allServices[i]}
 			}
 
-			policies := buildWorkloadPolicies(ctx, authorizationPolicies, peerAuthsByNs, meshCfg, se.Labels, se.Namespace)
+			policies := buildWorkloadPolicies(ctx, authPoliciesByNs, peerAuthsByNs, meshCfg, se.Labels, se.Namespace)
 
 			var appTunnel *workloadapi.ApplicationTunnel
 			var targetWaypoint *Waypoint
@@ -1155,7 +1151,7 @@ func serviceEntryWorkloadBuilder(
 
 func (a Builder) serviceEntryWorkloadBuilder(
 	meshConfig krt.Singleton[MeshConfig],
-	authorizationPolicies krt.Collection[model.WorkloadAuthorization],
+	authPoliciesByNs krt.Index[string, model.WorkloadAuthorization],
 	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
 	namespaces krt.Collection[*v1.Namespace],
@@ -1163,7 +1159,7 @@ func (a Builder) serviceEntryWorkloadBuilder(
 ) krt.TransformationMulti[*networkingclient.ServiceEntry, model.WorkloadInfo] {
 	return serviceEntryWorkloadBuilder(
 		meshConfig,
-		authorizationPolicies,
+		authPoliciesByNs,
 		peerAuthsByNs,
 		waypoints,
 		namespaces,

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
@@ -825,6 +825,51 @@ func TestPodWorkloads(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "pod with invalid authz",
+			inputs: []any{
+				// no label selector
+				model.WorkloadAuthorization{
+					LabelSelector: model.NewSelector(nil),
+					Authorization: &security.Authorization{Name: "local-ns", Namespace: "ns"},
+				},
+				// no Authorization
+				model.WorkloadAuthorization{
+					LabelSelector: model.NewSelector(map[string]string{"app": "foo"}),
+					Authorization: nil,
+				},
+			},
+			pod: &v1.Pod{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "ns",
+					Labels: map[string]string{
+						"app": "foo",
+					},
+				},
+				Spec: v1.PodSpec{},
+				Status: v1.PodStatus{
+					Phase:      v1.PodRunning,
+					Conditions: podReady,
+					PodIP:      "1.2.3.4",
+				},
+			},
+			result: &workloadapi.Workload{
+				Uid:                   "cluster0//Pod/ns/name",
+				Name:                  "name",
+				Namespace:             "ns",
+				Addresses:             [][]byte{netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice()},
+				Network:               testNW,
+				CanonicalName:         "foo",
+				CanonicalRevision:     "latest",
+				WorkloadType:          workloadapi.WorkloadType_POD,
+				WorkloadName:          "name",
+				Status:                workloadapi.WorkloadStatus_HEALTHY,
+				ClusterId:             testC,
+				AuthorizationPolicies: []string{},
+			},
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
@@ -836,7 +881,7 @@ func TestPodWorkloads(t *testing.T) {
 			EndpointSlicesAddressIndex := endpointSliceAddressIndex(EndpointSlices)
 			builder := a.builder.podWorkloadBuilder(
 				GetMeshConfig(mock),
-				krttest.GetMockCollection[model.WorkloadAuthorization](mock),
+				selectingWorkloadAuthzByNs(krttest.GetMockCollection[model.WorkloadAuthorization](mock)),
 				krt.NewNamespaceIndex(krttest.GetMockCollection[*securityclient.PeerAuthentication](mock)),
 				krttest.GetMockCollection[Waypoint](mock),
 				WorkloadServices,
@@ -1445,7 +1490,7 @@ func TestWorkloadEntryWorkloads(t *testing.T) {
 			WorkloadServicesNamespaceIndex := krt.NewNamespaceIndex(WorkloadServices)
 			builder := a.builder.workloadEntryWorkloadBuilder(
 				GetMeshConfig(mock),
-				krttest.GetMockCollection[model.WorkloadAuthorization](mock),
+				selectingWorkloadAuthzByNs(krttest.GetMockCollection[model.WorkloadAuthorization](mock)),
 				krt.NewNamespaceIndex(krttest.GetMockCollection[*securityclient.PeerAuthentication](mock)),
 				krttest.GetMockCollection[Waypoint](mock),
 				WorkloadServices,
@@ -1694,7 +1739,7 @@ func TestServiceEntryWorkloads(t *testing.T) {
 			a := newAmbientUnitTest(t)
 			builder := a.builder.serviceEntryWorkloadBuilder(
 				GetMeshConfig(mock),
-				krttest.GetMockCollection[model.WorkloadAuthorization](mock),
+				selectingWorkloadAuthzByNs(krttest.GetMockCollection[model.WorkloadAuthorization](mock)),
 				krt.NewNamespaceIndex(krttest.GetMockCollection[*securityclient.PeerAuthentication](mock)),
 				krttest.GetMockCollection[Waypoint](mock),
 				krttest.GetMockCollection[*v1.Namespace](mock),

--- a/releasenotes/notes/61254.yaml
+++ b/releasenotes/notes/61254.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - https://github.com/istio/istio/issues/61254
+releaseNotes:
+  - |
+    **Fixed** an issue where istiod CPU usage increased as the number of AuthorizationPolicies increased.


### PR DESCRIPTION
* Reduce AuthorizationPolicy scanning by indexing on namespace

Only look at AuthorizationPolicies that are in the same namespace and root namespace. This drops the number of policies that are examined for every pod, WorkloadEntry and ServiceEntry.

* create the index we need

The Authorization must be present to get the namespace. A LabelSelector is required so we match exactly.

**Please provide a description of this PR:**

manual cherry-pick of https://github.com/istio/istio/pull/61256
fixes https://github.com/istio/istio/issues/61417