### PR TITLE
Default nativeNftables to true for the OpenShift platform

### DIFF
--- a/manifests/charts/base/files/profile-platform-openshift.yaml
+++ b/manifests/charts/base/files/profile-platform-openshift.yaml
@@ -3,6 +3,8 @@
 # If you want to make a change in this file, edit the original one and run "make gen".
 
 # The OpenShift profile provides a basic set of settings to run Istio on OpenShift
+global:
+  nativeNftables: true
 cni:
   cniBinDir: /var/lib/cni/bin
   cniConfDir: /etc/cni/multus/net.d

--- a/manifests/charts/default/files/profile-platform-openshift.yaml
+++ b/manifests/charts/default/files/profile-platform-openshift.yaml
@@ -3,6 +3,8 @@
 # If you want to make a change in this file, edit the original one and run "make gen".
 
 # The OpenShift profile provides a basic set of settings to run Istio on OpenShift
+global:
+  nativeNftables: true
 cni:
   cniBinDir: /var/lib/cni/bin
   cniConfDir: /etc/cni/multus/net.d

--- a/manifests/charts/gateway/files/profile-platform-openshift.yaml
+++ b/manifests/charts/gateway/files/profile-platform-openshift.yaml
@@ -3,6 +3,8 @@
 # If you want to make a change in this file, edit the original one and run "make gen".
 
 # The OpenShift profile provides a basic set of settings to run Istio on OpenShift
+global:
+  nativeNftables: true
 cni:
   cniBinDir: /var/lib/cni/bin
   cniConfDir: /etc/cni/multus/net.d

--- a/manifests/charts/gateways/istio-egress/files/profile-platform-openshift.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-platform-openshift.yaml
@@ -3,6 +3,8 @@
 # If you want to make a change in this file, edit the original one and run "make gen".
 
 # The OpenShift profile provides a basic set of settings to run Istio on OpenShift
+global:
+  nativeNftables: true
 cni:
   cniBinDir: /var/lib/cni/bin
   cniConfDir: /etc/cni/multus/net.d

--- a/manifests/charts/gateways/istio-ingress/files/profile-platform-openshift.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-platform-openshift.yaml
@@ -3,6 +3,8 @@
 # If you want to make a change in this file, edit the original one and run "make gen".
 
 # The OpenShift profile provides a basic set of settings to run Istio on OpenShift
+global:
+  nativeNftables: true
 cni:
   cniBinDir: /var/lib/cni/bin
   cniConfDir: /etc/cni/multus/net.d

--- a/manifests/charts/istio-cni/files/profile-platform-openshift.yaml
+++ b/manifests/charts/istio-cni/files/profile-platform-openshift.yaml
@@ -3,6 +3,8 @@
 # If you want to make a change in this file, edit the original one and run "make gen".
 
 # The OpenShift profile provides a basic set of settings to run Istio on OpenShift
+global:
+  nativeNftables: true
 cni:
   cniBinDir: /var/lib/cni/bin
   cniConfDir: /etc/cni/multus/net.d

--- a/manifests/charts/istio-control/istio-discovery/files/profile-platform-openshift.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-platform-openshift.yaml
@@ -3,6 +3,8 @@
 # If you want to make a change in this file, edit the original one and run "make gen".
 
 # The OpenShift profile provides a basic set of settings to run Istio on OpenShift
+global:
+  nativeNftables: true
 cni:
   cniBinDir: /var/lib/cni/bin
   cniConfDir: /etc/cni/multus/net.d

--- a/manifests/charts/ztunnel/files/profile-platform-openshift.yaml
+++ b/manifests/charts/ztunnel/files/profile-platform-openshift.yaml
@@ -3,6 +3,8 @@
 # If you want to make a change in this file, edit the original one and run "make gen".
 
 # The OpenShift profile provides a basic set of settings to run Istio on OpenShift
+global:
+  nativeNftables: true
 cni:
   cniBinDir: /var/lib/cni/bin
   cniConfDir: /etc/cni/multus/net.d

--- a/manifests/helm-profiles/platform-openshift.yaml
+++ b/manifests/helm-profiles/platform-openshift.yaml
@@ -1,4 +1,6 @@
 # The OpenShift profile provides a basic set of settings to run Istio on OpenShift
+global:
+  nativeNftables: true
 cni:
   cniBinDir: /var/lib/cni/bin
   cniConfDir: /etc/cni/multus/net.d

--- a/releasenotes/notes/openshift-native-nftables.yaml
+++ b/releasenotes/notes/openshift-native-nftables.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+  - |
+    **Updated** the OpenShift platform profile to default `global.nativeNftables` to `true` for both sidecar and ambient
+    mode installations. This can still be overridden by explicitly setting `global.nativeNftables=false`.


### PR DESCRIPTION
This PR updates the OpenShift platform profiles to set `global.nativeNftables` to `true` by default for both sidecar and ambient installations. OpenShift already supports native nftables, so this change removes the need for users to explicitly set `global.nativeNftables=true` during installation. Users can still opt out by setting `--set global.nativeNftables=false` if needed.
