### PR TITLE
guard nil ResourceNames in workload generator

### DIFF
--- a/pilot/pkg/xds/workload.go
+++ b/pilot/pkg/xds/workload.go
@@ -189,11 +189,9 @@ func (e WorkloadGenerator) generateDeltasOndemand(
 	// the internal book-keeping to subscribe to the Pods, so that we push updates to those Pods.
 	// subs can be nil if the watch was created without tracked resource names; Merge on a nil set panics.
 	if subs == nil {
-		subs = have
-	} else {
-		subs = subs.Merge(have)
+		subs = sets.New[string]()
 	}
-	w.ResourceNames = subs
+	w.ResourceNames = subs.Merge(have)
 	return resources, removed.UnsortedList(), model.XdsLogDetails{}, true, nil
 }
 

--- a/pilot/pkg/xds/workload.go
+++ b/pilot/pkg/xds/workload.go
@@ -187,7 +187,13 @@ func (e WorkloadGenerator) generateDeltasOndemand(
 	defer proxy.Unlock()
 	// For on-demand, we may have requested a VIP but gotten Pod IPs back. We need to update
 	// the internal book-keeping to subscribe to the Pods, so that we push updates to those Pods.
-	w.ResourceNames = subs.Merge(have)
+	// subs can be nil if the watch was created without tracked resource names; Merge on a nil set panics.
+	if subs == nil {
+		subs = have
+	} else {
+		subs = subs.Merge(have)
+	}
+	w.ResourceNames = subs
 	return resources, removed.UnsortedList(), model.XdsLogDetails{}, true, nil
 }
 

--- a/releasenotes/notes/wds-ondemand-nil-resourcenames.yaml
+++ b/releasenotes/notes/wds-ondemand-nil-resourcenames.yaml
@@ -1,6 +1,0 @@
-apiVersion: release-notes/v2
-kind: bug-fix
-area: traffic-management
-releaseNotes:
-- |
-  **Fixed** a potential panic in the workload xDS generator when an on-demand watch has no tracked resource names.

--- a/releasenotes/notes/wds-ondemand-nil-resourcenames.yaml
+++ b/releasenotes/notes/wds-ondemand-nil-resourcenames.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+- |
+  **Fixed** a potential panic in the workload xDS generator when an on-demand watch has no tracked resource names.


### PR DESCRIPTION
**Please provide a description of this PR:**

ResourceNames can be nil for watches where delta.go elides tracking, and Merge on a nil set panics. Not reachable with current callers since on-demand watches always get a non-nil set, but the invariant is implicit and far from this code, and code copied from this pattern has hit the panic downstream.