### PR TITLE
fix: use http2 by default for jwks resolution

### DIFF
--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -182,6 +182,7 @@ func newJwksResolverWithCABundlePaths(
 				Proxy:             http.ProxyFromEnvironment,
 				DisableKeepAlives: true,
 				DialContext:       blockedCIDRDialContext,
+				ForceAttemptHTTP2: true,
 			},
 		},
 	}
@@ -208,6 +209,7 @@ func newJwksResolverWithCABundlePaths(
 				Proxy:             http.ProxyFromEnvironment,
 				DisableKeepAlives: true,
 				DialContext:       blockedCIDRDialContext,
+				ForceAttemptHTTP2: true,
 				TLSClientConfig: &tls.Config{
 					// nolint: gosec // user explicitly opted into insecure
 					InsecureSkipVerify: features.JwksResolverInsecureSkipVerify,

--- a/releasenotes/notes/61250.yaml
+++ b/releasenotes/notes/61250.yaml
@@ -1,0 +1,12 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+issue:
+  - 61250
+releaseNotes:
+  - |
+    **Fixed** the JWKS resolver forcing all public-key fetches to HTTP/1.1. The custom
+    `TLSClientConfig` and `DialContext` used for TLS pinning and CIDR blocking caused Go's
+    `net/http` to disable automatic HTTP/2, so ALPN never negotiated h2. HTTP/2 is now
+    re-enabled (matching `http.DefaultTransport`), fixing JWKS fetches that fail over HTTP/1.1
+    through some HTTP CONNECT proxies.


### PR DESCRIPTION
**Please provide a description of this PR:**

If we set a custom TLSClientConfig or DialContext on our transports, http2 will not be sent as a supported protocol during ALPN. We change this to always try http2 now by setting `ForceAttemptHTTP2 = true` in our custom transport construction. This matches the behaviour of the `DefaultTransport`

Fixes #61250 