### PR TITLE
fix(istio): init CommonLbConfig for DFP wildcard cluster

### DIFF
--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -551,8 +551,9 @@ func (cb *ClusterBuilder) buildCluster(name string, discoveryType cluster.Cluste
 // from the Host/:authority header. Optional TLS origination is applied when OutboundTrafficPolicy tls is configured.
 func (cb *ClusterBuilder) buildAllowAnyDFPCluster(tls *networking.ClientTLSSettings) *clusterWrapper {
 	c := &cluster.Cluster{
-		Name:     util.AllowAnyDynamicDNSCluster,
-		LbPolicy: cluster.Cluster_CLUSTER_PROVIDED,
+		Name:           util.AllowAnyDynamicDNSCluster,
+		LbPolicy:       cluster.Cluster_CLUSTER_PROVIDED,
+		CommonLbConfig: &cluster.Cluster_CommonLbConfig{},
 		ClusterDiscoveryType: &cluster.Cluster_ClusterType{ClusterType: &cluster.Cluster_CustomClusterType{
 			Name: "envoy.clusters.dynamic_forward_proxy",
 			TypedConfig: protoconv.MessageToAny(&dfpcluster.ClusterConfig{
@@ -602,8 +603,9 @@ func (cb *ClusterBuilder) buildAllowAnyDFPCluster(tls *networking.ClientTLSSetti
 // and upstream protocol settings.
 func (cb *ClusterBuilder) buildDFPCluster(name string, service *model.Service, port *model.Port) *clusterWrapper {
 	c := &cluster.Cluster{
-		Name:     name,
-		LbPolicy: cluster.Cluster_CLUSTER_PROVIDED,
+		Name:           name,
+		LbPolicy:       cluster.Cluster_CLUSTER_PROVIDED,
+		CommonLbConfig: &cluster.Cluster_CommonLbConfig{},
 		ClusterDiscoveryType: &cluster.Cluster_ClusterType{ClusterType: &cluster.Cluster_CustomClusterType{
 			Name: "envoy.clusters.dynamic_forward_proxy",
 			TypedConfig: protoconv.MessageToAny(&dfpcluster.ClusterConfig{

--- a/pilot/pkg/networking/core/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/cluster_builder_test.go
@@ -4020,6 +4020,10 @@ func TestBuildAllowAnyDFPClusterTLSSettings(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			c := cb.buildAllowAnyDFPCluster(tc.tls).cluster
 
+			if c.CommonLbConfig == nil {
+				t.Error("expected CommonLbConfig to be set, got nil")
+			}
+
 			if tc.expectTLS {
 				if c.TransportSocket == nil {
 					t.Fatal("expected TransportSocket to be set for TLS mode")

--- a/pilot/pkg/networking/core/cluster_test.go
+++ b/pilot/pkg/networking/core/cluster_test.go
@@ -1438,6 +1438,23 @@ func TestApplyOutlierDetection(t *testing.T) {
 	}
 }
 
+// TestApplyOutlierDetectionNilCommonLbConfig guards against a nil pointer panic when
+// CommonLbConfig is unset on the cluster passed in, which is the case for DFP clusters
+// built by buildDFPCluster and buildAllowAnyDFPCluster.
+func TestApplyOutlierDetectionNilCommonLbConfig(t *testing.T) {
+	g := NewWithT(t)
+
+	c := &cluster.Cluster{}
+	g.Expect(c.CommonLbConfig).To(BeNil())
+
+	applyOutlierDetection(&model.Service{}, c, &networking.OutlierDetection{
+		MinHealthPercent: 10,
+	})
+
+	g.Expect(c.CommonLbConfig).ToNot(BeNil())
+	g.Expect(c.CommonLbConfig.HealthyPanicThreshold.GetValue()).To(Equal(float64(10)))
+}
+
 func TestApplyOutlierDetectionErrorCodes(t *testing.T) {
 	g := NewWithT(t)
 

--- a/pilot/pkg/networking/core/cluster_traffic_policy.go
+++ b/pilot/pkg/networking/core/cluster_traffic_policy.go
@@ -327,6 +327,9 @@ func applyLoadBalancer(
 	if c.LbPolicy == cluster.Cluster_CLUSTER_PROVIDED {
 		return
 	}
+	if c.CommonLbConfig == nil {
+		c.CommonLbConfig = &cluster.Cluster_CommonLbConfig{}
+	}
 	// If HealthyPanicThreshold is unset, disable it when service supports unhealthy endpoints as enabling it "may" send traffic to unready
 	// end points when load balancer is in panic mode.
 	if c.CommonLbConfig.HealthyPanicThreshold == nil && svc.SupportsUnhealthyEndpoints() {
@@ -554,6 +557,9 @@ func applyOutlierDetection(service *model.Service, c *cluster.Cluster, outlier *
 		// below minimum health percentage.
 		if service.ForcesSupportUnhealthyEndpoints() {
 			minHealthPercent = 0
+		}
+		if c.CommonLbConfig == nil {
+			c.CommonLbConfig = &cluster.Cluster_CommonLbConfig{}
 		}
 		c.CommonLbConfig.HealthyPanicThreshold = &xdstype.Percent{Value: float64(minHealthPercent)}
 	}

--- a/releasenotes/notes/61450.yaml
+++ b/releasenotes/notes/61450.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 61450
+releaseNotes:
+- |
+  **Fixed** a panic when `outlierDetection` is applied to a DNS-proxying (DFP) wildcard cluster.
+  `CommonLbConfig` was nil on the clusters built by `buildDFPCluster`, so setting
+  `HealthyPanicThreshold` dereferenced a nil pointer. It is now initialized for both the DFP and
+  allow-any DFP clusters, with a nil guard before the assignment.


### PR DESCRIPTION
**Please provide a description of this PR:**

A DFP wildcard cluster panics when outlierDetection is applied. `CommonLbConfig` is nil for the DFP clusters built by `buildDFPCluster`, and `cluster_traffic_policy.go:558` dereferences it when setting `HealthyPanicThreshold`.

This change initializes `CommonLbConfig` in `buildDFPCluster` and `buildAllowAnyDFPCluster`, and adds a nil guard before the assignment in `applyLoadBalancer` and `applyOutlierDetection`.

Verified red to green. The `pilot/pkg/networking/core` tests pass. The diff is minimal and contains no formatting changes.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
