### PR TITLE
Fix nil pointer panic when applying outlier detection to DFP cluster

### DIFF
--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -602,8 +602,9 @@ func (cb *ClusterBuilder) buildAllowAnyDFPCluster(tls *networking.ClientTLSSetti
 // and upstream protocol settings.
 func (cb *ClusterBuilder) buildDFPCluster(name string, service *model.Service, port *model.Port) *clusterWrapper {
 	c := &cluster.Cluster{
-		Name:     name,
-		LbPolicy: cluster.Cluster_CLUSTER_PROVIDED,
+		Name:           name,
+		LbPolicy:       cluster.Cluster_CLUSTER_PROVIDED,
+		CommonLbConfig: &cluster.Cluster_CommonLbConfig{},
 		ClusterDiscoveryType: &cluster.Cluster_ClusterType{ClusterType: &cluster.Cluster_CustomClusterType{
 			Name: "envoy.clusters.dynamic_forward_proxy",
 			TypedConfig: protoconv.MessageToAny(&dfpcluster.ClusterConfig{

--- a/pilot/pkg/networking/core/cluster_dfp_sidecar_test.go
+++ b/pilot/pkg/networking/core/cluster_dfp_sidecar_test.go
@@ -17,11 +17,13 @@ package core
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	dfpcluster "github.com/envoyproxy/go-control-plane/envoy/extensions/clusters/dynamic_forward_proxy/v3"
 	upstream "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	. "github.com/onsi/gomega"
+	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
 	networking "istio.io/api/networking/v1alpha3"
@@ -135,6 +137,23 @@ func TestSidecarDynamicDNSClusters(t *testing.T) {
 			expectAutoSni:           true,
 			expectAutoSanValidation: true,
 			expectTransportTLS:      true,
+		},
+		{
+			name:     "HTTP with outlier detection",
+			protocol: "HTTP",
+			port:     80,
+			destinationRule: &networking.DestinationRule{
+				Host: "*.svc.cluster.local",
+				TrafficPolicy: &networking.TrafficPolicy{
+					OutlierDetection: &networking.OutlierDetection{
+						BaseEjectionTime:     durationpb.New(30 * time.Second),
+						Consecutive5xxErrors: wrappers.UInt32(2),
+						Interval:             durationpb.New(2 * time.Minute),
+						MaxEjectionPercent:   100,
+					},
+				},
+			},
+			expectCluster: true,
 		},
 		{
 			name:          "Unsupported protocol TCP",


### PR DESCRIPTION
**What this PR does / why we need it:**

Fixes a nil pointer panic in istiod when a DestinationRule with a wildcard host (e.g. `*.external.domain`) also configures `outlierDetection`:

```
panic: runtime error: invalid memory address or nil pointer dereference
.../pilot/pkg/networking/core/cluster_traffic_policy.go:519 applyOutlierDetection
```

**Root cause:** `buildDFPCluster()` (used for wildcard hostnames with `DYNAMIC_DNS` resolution via dynamic forward proxy) did not initialize `CommonLbConfig` on the Envoy cluster. `applyOutlierDetection()` then dereferences `c.CommonLbConfig.HealthyPanicThreshold` unconditionally when `minHealthPercent >= 0`, panicking on the nil `CommonLbConfig`. Non-wildcard services were unaffected because `buildCluster()` initializes `CommonLbConfig`.

**Fix:** initialize `CommonLbConfig` in `buildDFPCluster()`, matching `buildCluster()`.

**Testing:**
- Added regression test case "HTTP with outlier detection" to `TestSidecarDynamicDNSClusters` in `cluster_dfp_sidecar_test.go` — a wildcard-host DestinationRule with outlier detection previously crashed istiod.

**Which issue this PR fixes:**

Fixes #61433

**Release notes:**
```release-note
Fixed a panic in istiod when applying outlier detection to a DestinationRule with a wildcard hostname.
```
