### PR TITLE
re-enable mesh httproute 307 redirect

### DIFF
--- a/tests/integration/ambient/gateway_conformance_test.go
+++ b/tests/integration/ambient/gateway_conformance_test.go
@@ -69,9 +69,6 @@ var skippedTests = map[string]string{
 	// The following tests were added in v1.5.0
 	"HTTPRouteHTTPSListenerDetectMisdirectedRequests": "TODO",
 
-	// Fixed upstream, waiting for new gateway api release to pick up fix
-	"MeshHTTPRoute307Redirect": "TODO",
-
 	// The following tests were added in v1.6.0
 	"GatewayListenerUnsupportedProtocol": "TODO",
 }

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -66,9 +66,6 @@ var skippedTests = map[string]string{
 	// The following tests were added in v1.5.0
 	"HTTPRouteHTTPSListenerDetectMisdirectedRequests": "TODO",
 
-	// Fixed upstream, waiting for new gateway api release to pick up fix
-	"MeshHTTPRoute307Redirect": "TODO",
-
 	// The following tests were added in v1.6.0
 	"GatewayListenerUnsupportedProtocol": "TODO",
 	"TCPRouteWeightedRouting":            "TODO: flaky in dual-stack and multicluster environments",


### PR DESCRIPTION
**Please provide a description of this PR:**

This test was fixed upstream by https://github.com/kubernetes-sigs/gateway-api/pull/4806 and included in Gateway API v1.6 https://github.com/kubernetes-sigs/gateway-api/releases#release-v1.6.0