### PR TITLE
Update proxy SHA and normalization test for Envoy CVE-2026-73551 path parameter fix

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,7 +4,7 @@
     "name": "PROXY_REPO_SHA",
     "repoName": "proxy",
     "file": "",
-    "lastStableSHA": "ec516d1be7a5c93b1a78261ea0bd6c261008a220"
+    "lastStableSHA": "0a12a02f0db52f6d229ec0fbe0f2091e1c02098b"
   },
   {
     "_comment": "",

--- a/tests/integration/security/normalization_test.go
+++ b/tests/integration/security/normalization_test.go
@@ -198,7 +198,7 @@ func TestNormalization(t *testing.T) {
 						{`/%c0%afadmin`, `/%c0%afadmin`},
 						{`/.../admin`, `/.../admin`},
 						{`/..../admin`, `/..../admin`},
-						{`/..;/admin`, `/..;/admin`},
+						{`/..;/admin`, `/admin`},
 						{`/;/admin`, `/;/admin`},
 						{`/admin;a=b`, `/admin;a=b`},
 						{`/admin;a=b/xyz`, `/admin;a=b/xyz`},


### PR DESCRIPTION
Envoy's security patch (envoyproxy/envoy#47001) now strips path parameters from dot/dotdot segments when normalize_path is enabled, correctly resolving /..;/admin to /admin. Update the test expectation to reflect this intentional security hardening.