### PR TITLE
[release-1.30] update normalization test for envoy path parameter fix

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,7 +4,7 @@
     "name": "PROXY_REPO_SHA",
     "repoName": "proxy",
     "file": "",
-    "lastStableSHA": "03bdd9c760bed55d600ef777218563dc5bbefa7f"
+    "lastStableSHA": "d0be92e32144764a68281478ee9f56c0fa9cea7f"
   },
   {
     "_comment": "",

--- a/tests/integration/security/normalization_test.go
+++ b/tests/integration/security/normalization_test.go
@@ -198,7 +198,7 @@ func TestNormalization(t *testing.T) {
 						{`/%c0%afadmin`, `/%c0%afadmin`},
 						{`/.../admin`, `/.../admin`},
 						{`/..../admin`, `/..../admin`},
-						{`/..;/admin`, `/..;/admin`},
+						{`/..;/admin`, `/admin`},
 						{`/;/admin`, `/;/admin`},
 						{`/admin;a=b`, `/admin;a=b`},
 						{`/admin;a=b/xyz`, `/admin;a=b/xyz`},


### PR DESCRIPTION
envoy now resolves dotdot segments with path parameters (/..;/admin -> /admin) even with normalization NONE, after the q3 security fixes in the proxy bump. test-only change, direct to release branch since master's proxy does not have the envoy fix yet. Unblocks #61471