### PR TITLE
[release-1.29] update normalization test for envoy path parameter fix

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,7 +4,7 @@
     "name": "PROXY_REPO_SHA",
     "repoName": "proxy",
     "file": "",
-    "lastStableSHA": "0abaaf1a3a063570b3d9e69816c29d41f55ebb9e"
+    "lastStableSHA": "9a779adc392eb01bac79610815ec630280c2a949"
   },
   {
     "_comment": "",

--- a/tests/integration/security/normalization_test.go
+++ b/tests/integration/security/normalization_test.go
@@ -198,7 +198,7 @@ func TestNormalization(t *testing.T) {
 						{`/%c0%afadmin`, `/%c0%afadmin`},
 						{`/.../admin`, `/.../admin`},
 						{`/..../admin`, `/..../admin`},
-						{`/..;/admin`, `/..;/admin`},
+						{`/..;/admin`, `/admin`},
 						{`/;/admin`, `/;/admin`},
 						{`/admin;a=b`, `/admin;a=b`},
 						{`/admin;a=b/xyz`, `/admin;a=b/xyz`},


### PR DESCRIPTION
envoy now resolves dotdot segments with path parameters (/..;/admin -> /admin) even with normalization NONE, after the q3 security fixes in the proxy bump. test-only change, direct to release branch since master's proxy does not have the envoy fix yet. Unblocks #61472