### PR TITLE
update normalization test for envoy path parameter fix

### DIFF
--- a/tests/integration/security/normalization_test.go
+++ b/tests/integration/security/normalization_test.go
@@ -198,7 +198,7 @@ func TestNormalization(t *testing.T) {
 						{`/%c0%afadmin`, `/%c0%afadmin`},
 						{`/.../admin`, `/.../admin`},
 						{`/..../admin`, `/..../admin`},
-						{`/..;/admin`, `/..;/admin`},
+						{`/..;/admin`, `/admin`},
 						{`/;/admin`, `/;/admin`},
 						{`/admin;a=b`, `/admin;a=b`},
 						{`/admin;a=b/xyz`, `/admin;a=b/xyz`},


### PR DESCRIPTION
**Please provide a description of this PR:**

envoy resolves dotdot segments with path parameters (/..;/admin -> /admin) even with normalization NONE after the q3 path parameter fixes. 

Putting hold until envoy envoyproxy/envoy@5248810ce3ec8b056cde0e79d7823d423b34b551 is picked and that proxy bump lands here, then cherry-pick to release-1.31. Same as #61483