### PR TITLE
multicluster: rework interface to avoid leaks

### DIFF
--- a/pilot/pkg/serviceregistry/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex.go
@@ -172,7 +172,7 @@ func New(options Options) Index {
 	Nodes := LocalCluster.Nodes()
 	Gateways := LocalCluster.Gateways()
 
-	client := LocalCluster.Client
+	client := LocalCluster.Client()
 	filter := kclient.Filter{
 		ObjectFilter: client.ObjectFilter(),
 	}

--- a/pilot/pkg/serviceregistry/ambient/ambientindex_multicluster_test.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex_multicluster_test.go
@@ -14,6 +14,7 @@
 package ambient
 
 import (
+	"cmp"
 	"fmt"
 	"reflect"
 	"strings"
@@ -36,6 +37,7 @@ import (
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/kube/multicluster"
 	"istio.io/istio/pkg/ptr"
+	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/test/util/retry"
@@ -131,28 +133,91 @@ func TestAmbientMulticlusterIndex_WaypointForWorkloadTraffic(t *testing.T) {
 			s := newAmbientTestServer(t, testC, testNW, "")
 			s.AddSecret("s1", "c1") // overlapping ips
 			s.AddSecret("s2", "c2") // Non-overlapping ips
-			remoteClients := krt.NewCollection(s.mcController.Clusters(), func(_ krt.HandlerContext, c *multicluster.Cluster) **remoteAmbientClients {
-				cl := c.Client
-				return ptr.Of(&remoteAmbientClients{
-					clusterID: c.ID,
-					ambientclients: &ambientclients{
-						pc:    clienttest.NewDirectClient[*corev1.Pod, corev1.Pod, *corev1.PodList](t, cl),
-						sc:    clienttest.NewDirectClient[*corev1.Service, corev1.Service, *corev1.ServiceList](t, cl),
-						ns:    clienttest.NewWriter[*corev1.Namespace](t, cl),
-						grc:   clienttest.NewWriter[*k8sv1.Gateway](t, cl),
-						gwcls: clienttest.NewWriter[*k8sv1.GatewayClass](t, cl),
-						se:    clienttest.NewWriter[*apiv1alpha3.ServiceEntry](t, cl),
-						we:    clienttest.NewWriter[*apiv1alpha3.WorkloadEntry](t, cl),
-						pa:    clienttest.NewWriter[*clientsecurityv1beta1.PeerAuthentication](t, cl),
-						authz: clienttest.NewWriter[*clientsecurityv1beta1.AuthorizationPolicy](t, cl),
-						sec:   clienttest.NewWriter[*corev1.Secret](t, cl),
-					},
+			stop := test.NewStop(t)
+
+			// Build the test clients for every cluster through the multicluster nested collection API.
+			// That API is the only way to reach a cluster from outside the multicluster package, so the
+			// test never needs a raw *Cluster: the local cluster's clients are the "local" collection and
+			// each remote cluster contributes a single-element collection built inside its own lifecycle.
+			localClients := krt.NewStaticCollection(nil, []*remoteAmbientClients{{
+				clusterID: s.clusterID,
+				ambientclients: &ambientclients{
+					pc:    s.pc,
+					sc:    s.sc,
+					ns:    s.ns,
+					grc:   s.grc,
+					gwcls: s.gwcls,
+					se:    s.se,
+					we:    s.we,
+					pa:    s.pa,
+					authz: s.authz,
+					sec:   s.sec,
+				},
+			}}, krt.WithName("LocalAmbientClients"), krt.WithStop(stop))
+
+			clientCollections := multicluster.NestedCollectionFromLocalAndRemote(
+				s.mcController,
+				localClients,
+				func(ctx krt.HandlerContext, c multicluster.ClusterCollections) *krt.Collection[*remoteAmbientClients] {
+					cl := c.Client()
+					var col krt.Collection[*remoteAmbientClients] = krt.NewStaticCollection(nil, []*remoteAmbientClients{{
+						clusterID: c.ID(),
+						ambientclients: &ambientclients{
+							pc:    clienttest.NewDirectClient[*corev1.Pod, corev1.Pod, *corev1.PodList](t, cl),
+							sc:    clienttest.NewDirectClient[*corev1.Service, corev1.Service, *corev1.ServiceList](t, cl),
+							ns:    clienttest.NewWriter[*corev1.Namespace](t, cl),
+							grc:   clienttest.NewWriter[*k8sv1.Gateway](t, cl),
+							gwcls: clienttest.NewWriter[*k8sv1.GatewayClass](t, cl),
+							se:    clienttest.NewWriter[*apiv1alpha3.ServiceEntry](t, cl),
+							we:    clienttest.NewWriter[*apiv1alpha3.WorkloadEntry](t, cl),
+							pa:    clienttest.NewWriter[*clientsecurityv1beta1.PeerAuthentication](t, cl),
+							authz: clienttest.NewWriter[*clientsecurityv1beta1.AuthorizationPolicy](t, cl),
+							sec:   clienttest.NewWriter[*corev1.Secret](t, cl),
+						},
+					}}, krt.WithName(fmt.Sprintf("AmbientClients[%s]", c.ID())), krt.WithStop(c.GetStop()))
+					return &col
+				},
+				"GlobalAmbientClients",
+				krt.NewOptionsBuilder(stop, "TestClients", nil),
+			)
+
+			// The local cluster is kept first, and the remotes sorted by ID, so the order in which the
+			// clusters happen to show up in the collection cannot change what this test does.
+			listClients := func() []*remoteAmbientClients {
+				var out []*remoteAmbientClients
+				for _, col := range clientCollections.List() {
+					out = append(out, col.List()...)
+				}
+				slices.SortFunc(out, func(a, b *remoteAmbientClients) int {
+					if (a.clusterID == s.clusterID) != (b.clusterID == s.clusterID) {
+						if a.clusterID == s.clusterID {
+							return -1
+						}
+						return 1
+					}
+					return cmp.Compare(a.clusterID, b.clusterID)
 				})
+				return out
+			}
+			assert.EventuallyEqual(t, func() int { return len(listClients()) }, 3)
+			clients := listClients()
+			remoteClients := slices.Filter(clients, func(c *remoteAmbientClients) bool {
+				return c.clusterID != s.clusterID
 			})
 
-			assert.EventuallyEqual(t, func() int {
-				return len(remoteClients.List())
-			}, 2)
+			// The per-cluster namespace collections already carry the cluster metadata, so they can be
+			// nested and indexed as-is. Nothing is derived from them here (we only read them), so no
+			// per-cluster stop channel is needed.
+			namespaceCollections := multicluster.NestedCollectionFromLocalAndRemote(
+				s.mcController,
+				s.mcController.ConfigCluster().Namespaces(),
+				func(ctx krt.HandlerContext, i multicluster.ClusterCollections) *krt.Collection[*corev1.Namespace] {
+					return ptr.Of(i.Namespaces())
+				},
+				"GlobalNamespacesTest",
+				krt.NewOptionsBuilder(stop, "TestNamespaces", nil),
+			)
+			namespacesByCluster := multicluster.NestedCollectionIndexByCluster(namespaceCollections)
 
 			differentCIDRIPs := map[string]string{
 				"waypoint": "10.1.0.10",
@@ -179,24 +244,6 @@ func TestAmbientMulticlusterIndex_WaypointForWorkloadTraffic(t *testing.T) {
 				"c1":       "77.1.2.49",
 				"c2":       "", // c2 and cluster0 share the same network, so no gw
 			}
-			rClients := remoteClients.List()
-			clients := append([]*remoteAmbientClients{
-				{
-					clusterID: s.clusterID,
-					ambientclients: &ambientclients{
-						pc:    s.pc,
-						sc:    s.sc,
-						ns:    s.ns,
-						grc:   s.grc,
-						gwcls: s.gwcls,
-						se:    s.se,
-						we:    s.we,
-						pa:    s.pa,
-						authz: s.authz,
-						sec:   s.sec,
-					},
-				},
-			}, rClients...)
 			for _, client := range clients {
 				// Test ambient index already creates istio-system namespace
 				if client.clusterID != s.clusterID {
@@ -224,11 +271,11 @@ func TestAmbientMulticlusterIndex_WaypointForWorkloadTraffic(t *testing.T) {
 					// A cluster's network is read from the topology label on its own system namespace, so wait
 					// for that namespace to reach the cluster's informer before making other assertions.
 					assert.EventuallyEqual(t, func() string {
-						cl := s.mcController.ClusterStore().GetByID(client.clusterID)
-						if cl == nil || !cl.HasSynced() {
+						collections := namespacesByCluster.Lookup(client.clusterID)
+						if len(collections) == 0 {
 							return ""
 						}
-						ns := cl.Namespaces().GetKey(systemNS)
+						ns := collections[0].GetKey(systemNS)
 						if ns == nil {
 							return ""
 						}
@@ -308,7 +355,7 @@ func TestAmbientMulticlusterIndex_WaypointForWorkloadTraffic(t *testing.T) {
 			s.assertEvent(t, s.podXdsName("pod1"))
 			s.deleteWaypoint(t, "test-wp")
 
-			for _, rc := range remoteClients.List() {
+			for _, rc := range remoteClients {
 				// Removing the service changes the WDS workload in that cluster due to service attachments.
 				// Note that we should NOT get an event changing the service attachment in our local cluster.
 				// We also get a service event because we lost an IP
@@ -1000,7 +1047,7 @@ func TestMulticlusterAmbientIndex_ClusterLifecycleNoLeak(t *testing.T) {
 		EnableK8SServiceSelectWorkloadEntries: features.EnableK8SServiceSelectWorkloadEntries,
 	}, "", false /* runClient */)
 	clusters := s.mcController.Clusters()
-	cl := s.mcController.ConfigCluster().Client
+	cl := s.mcController.ConfigCluster().Client()
 
 	waitRemoteClusters := func(t *testing.T, n int) {
 		t.Helper()

--- a/pilot/pkg/serviceregistry/ambient/ambientindex_multicluster_test.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex_multicluster_test.go
@@ -32,7 +32,6 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/constants"
-	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/kclient/clienttest"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/kube/multicluster"
@@ -65,6 +64,116 @@ type remoteAmbientClients struct {
 
 func (r *remoteAmbientClients) ResourceName() string {
 	return string(r.clusterID)
+}
+
+// clusterGeneration identifies one generation of a remote cluster: its ID, plus the stop channel that
+// is closed when that generation is torn down. A credential rotation replaces the generation, which a
+// nested collection surfaces by rebuilding the cluster's contribution with the new stop channel.
+type clusterGeneration struct {
+	id   cluster.ID
+	stop <-chan struct{}
+}
+
+func (c clusterGeneration) ResourceName() string {
+	return string(c.id)
+}
+
+// clusterClients holds the ambient test clients for every cluster the multicluster controller knows
+// about.
+//
+// They are built through the multicluster nested collection API, which is the only way to reach a
+// cluster from outside the multicluster package: tests never hold a raw *Cluster. The local cluster's
+// clients are the "local" collection and each remote cluster contributes a single-element collection
+// built inside its own lifecycle, so a cluster's clients appear when it syncs and go away with it.
+type clusterClients struct {
+	// local is the config cluster's clients, which the ambient test server already owns.
+	local *remoteAmbientClients
+	// localID identifies local within the flattened collection.
+	localID     cluster.ID
+	collections krt.Collection[krt.Collection[*remoteAmbientClients]]
+}
+
+func (s *ambientTestServer) newClusterClients(t *testing.T, stop <-chan struct{}) *clusterClients {
+	t.Helper()
+	local := &remoteAmbientClients{
+		clusterID: s.clusterID,
+		ambientclients: &ambientclients{
+			pc:    s.pc,
+			sc:    s.sc,
+			ns:    s.ns,
+			grc:   s.grc,
+			gwcls: s.gwcls,
+			se:    s.se,
+			we:    s.we,
+			pa:    s.pa,
+			authz: s.authz,
+			sec:   s.sec,
+		},
+	}
+	localCollection := krt.NewStaticCollection(nil, []*remoteAmbientClients{local},
+		krt.WithName("LocalAmbientClients"), krt.WithStop(stop))
+
+	return &clusterClients{
+		local:   local,
+		localID: s.clusterID,
+		collections: multicluster.NestedCollectionFromLocalAndRemote(
+			s.mcController,
+			localCollection,
+			func(ctx krt.HandlerContext, c multicluster.ClusterCollections) *krt.Collection[*remoteAmbientClients] {
+				cl := c.Client()
+				// krt.NewStaticCollection returns a concrete StaticCollection, so the interface value
+				// has to be named to take its address.
+				var col krt.Collection[*remoteAmbientClients] = krt.NewStaticCollection(nil, []*remoteAmbientClients{{
+					clusterID: c.ID(),
+					ambientclients: &ambientclients{
+						pc:    clienttest.NewDirectClient[*corev1.Pod, corev1.Pod, *corev1.PodList](t, cl),
+						sc:    clienttest.NewDirectClient[*corev1.Service, corev1.Service, *corev1.ServiceList](t, cl),
+						ns:    clienttest.NewWriter[*corev1.Namespace](t, cl),
+						grc:   clienttest.NewWriter[*k8sv1.Gateway](t, cl),
+						gwcls: clienttest.NewWriter[*k8sv1.GatewayClass](t, cl),
+						se:    clienttest.NewWriter[*apiv1alpha3.ServiceEntry](t, cl),
+						we:    clienttest.NewWriter[*apiv1alpha3.WorkloadEntry](t, cl),
+						pa:    clienttest.NewWriter[*clientsecurityv1beta1.PeerAuthentication](t, cl),
+						authz: clienttest.NewWriter[*clientsecurityv1beta1.AuthorizationPolicy](t, cl),
+						sec:   clienttest.NewWriter[*corev1.Secret](t, cl),
+					},
+				}}, krt.WithName(fmt.Sprintf("AmbientClients[%s]", c.ID())), krt.WithStop(c.GetStop()))
+				return &col
+			},
+			"GlobalAmbientClients",
+			krt.NewOptionsBuilder(stop, "TestClients", nil),
+		),
+	}
+}
+
+// remotes returns the remote clusters' clients, sorted by cluster ID so that the order in which
+// clusters happen to appear in the collection cannot change what a test does.
+func (c *clusterClients) remotes() []*remoteAmbientClients {
+	var out []*remoteAmbientClients
+	for _, col := range c.collections.List() {
+		for _, client := range col.List() {
+			if client.clusterID != c.localID {
+				out = append(out, client)
+			}
+		}
+	}
+	slices.SortFunc(out, func(a, b *remoteAmbientClients) int {
+		return cmp.Compare(a.clusterID, b.clusterID)
+	})
+	return out
+}
+
+// all returns the local cluster's clients followed by remotes().
+func (c *clusterClients) all() []*remoteAmbientClients {
+	return append([]*remoteAmbientClients{c.local}, c.remotes()...)
+}
+
+// waitForRemotes blocks until exactly n remote clusters have contributed their clients, and returns
+// them. A cluster only reaches the collection once it has completed its initial sync.
+func (c *clusterClients) waitForRemotes(t *testing.T, n int) []*remoteAmbientClients {
+	t.Helper()
+	assert.EventuallyEqual(t, func() int { return len(c.remotes()) }, n)
+	return c.remotes()
 }
 
 func TestAmbientMulticlusterIndex_WaypointForWorkloadTraffic(t *testing.T) {
@@ -135,75 +244,9 @@ func TestAmbientMulticlusterIndex_WaypointForWorkloadTraffic(t *testing.T) {
 			s.AddSecret("s2", "c2") // Non-overlapping ips
 			stop := test.NewStop(t)
 
-			// Build the test clients for every cluster through the multicluster nested collection API.
-			// That API is the only way to reach a cluster from outside the multicluster package, so the
-			// test never needs a raw *Cluster: the local cluster's clients are the "local" collection and
-			// each remote cluster contributes a single-element collection built inside its own lifecycle.
-			localClients := krt.NewStaticCollection(nil, []*remoteAmbientClients{{
-				clusterID: s.clusterID,
-				ambientclients: &ambientclients{
-					pc:    s.pc,
-					sc:    s.sc,
-					ns:    s.ns,
-					grc:   s.grc,
-					gwcls: s.gwcls,
-					se:    s.se,
-					we:    s.we,
-					pa:    s.pa,
-					authz: s.authz,
-					sec:   s.sec,
-				},
-			}}, krt.WithName("LocalAmbientClients"), krt.WithStop(stop))
-
-			clientCollections := multicluster.NestedCollectionFromLocalAndRemote(
-				s.mcController,
-				localClients,
-				func(ctx krt.HandlerContext, c multicluster.ClusterCollections) *krt.Collection[*remoteAmbientClients] {
-					cl := c.Client()
-					var col krt.Collection[*remoteAmbientClients] = krt.NewStaticCollection(nil, []*remoteAmbientClients{{
-						clusterID: c.ID(),
-						ambientclients: &ambientclients{
-							pc:    clienttest.NewDirectClient[*corev1.Pod, corev1.Pod, *corev1.PodList](t, cl),
-							sc:    clienttest.NewDirectClient[*corev1.Service, corev1.Service, *corev1.ServiceList](t, cl),
-							ns:    clienttest.NewWriter[*corev1.Namespace](t, cl),
-							grc:   clienttest.NewWriter[*k8sv1.Gateway](t, cl),
-							gwcls: clienttest.NewWriter[*k8sv1.GatewayClass](t, cl),
-							se:    clienttest.NewWriter[*apiv1alpha3.ServiceEntry](t, cl),
-							we:    clienttest.NewWriter[*apiv1alpha3.WorkloadEntry](t, cl),
-							pa:    clienttest.NewWriter[*clientsecurityv1beta1.PeerAuthentication](t, cl),
-							authz: clienttest.NewWriter[*clientsecurityv1beta1.AuthorizationPolicy](t, cl),
-							sec:   clienttest.NewWriter[*corev1.Secret](t, cl),
-						},
-					}}, krt.WithName(fmt.Sprintf("AmbientClients[%s]", c.ID())), krt.WithStop(c.GetStop()))
-					return &col
-				},
-				"GlobalAmbientClients",
-				krt.NewOptionsBuilder(stop, "TestClients", nil),
-			)
-
-			// The local cluster is kept first, and the remotes sorted by ID, so the order in which the
-			// clusters happen to show up in the collection cannot change what this test does.
-			listClients := func() []*remoteAmbientClients {
-				var out []*remoteAmbientClients
-				for _, col := range clientCollections.List() {
-					out = append(out, col.List()...)
-				}
-				slices.SortFunc(out, func(a, b *remoteAmbientClients) int {
-					if (a.clusterID == s.clusterID) != (b.clusterID == s.clusterID) {
-						if a.clusterID == s.clusterID {
-							return -1
-						}
-						return 1
-					}
-					return cmp.Compare(a.clusterID, b.clusterID)
-				})
-				return out
-			}
-			assert.EventuallyEqual(t, func() int { return len(listClients()) }, 3)
-			clients := listClients()
-			remoteClients := slices.Filter(clients, func(c *remoteAmbientClients) bool {
-				return c.clusterID != s.clusterID
-			})
+			cc := s.newClusterClients(t, stop)
+			remoteClients := cc.waitForRemotes(t, 2)
+			clients := cc.all()
 
 			// The per-cluster namespace collections already carry the cluster metadata, so they can be
 			// nested and indexed as-is. Nothing is derived from them here (we only read them), so no
@@ -482,47 +525,11 @@ func TestMulticlusterAmbientIndex_TestServiceMerging(t *testing.T) {
 	test.SetForTest(t, &features.EnableAmbientMultiNetwork, true)
 	s := newAmbientTestServer(t, testC, testNW, "")
 	s.AddSecret("s1", "remote-cluster") // overlapping ips
-	remoteClients := krt.NewCollection(s.mcController.Clusters(), func(_ krt.HandlerContext, c *multicluster.Cluster) **remoteAmbientClients {
-		cl := c.Client
-		return ptr.Of(&remoteAmbientClients{
-			clusterID: c.ID,
-			ambientclients: &ambientclients{
-				pc:    clienttest.NewDirectClient[*corev1.Pod, corev1.Pod, *corev1.PodList](t, cl),
-				sc:    clienttest.NewDirectClient[*corev1.Service, corev1.Service, *corev1.ServiceList](t, cl),
-				ns:    clienttest.NewWriter[*corev1.Namespace](t, cl),
-				grc:   clienttest.NewWriter[*k8sv1.Gateway](t, cl),
-				gwcls: clienttest.NewWriter[*k8sv1.GatewayClass](t, cl),
-				se:    clienttest.NewWriter[*apiv1alpha3.ServiceEntry](t, cl),
-				we:    clienttest.NewWriter[*apiv1alpha3.WorkloadEntry](t, cl),
-				pa:    clienttest.NewWriter[*clientsecurityv1beta1.PeerAuthentication](t, cl),
-				authz: clienttest.NewWriter[*clientsecurityv1beta1.AuthorizationPolicy](t, cl),
-				sec:   clienttest.NewWriter[*corev1.Secret](t, cl),
-			},
-		})
-	})
+	cc := s.newClusterClients(t, test.NewStop(t))
 
 	const remoteNetwork = "remote-network"
-
-	assert.EventuallyEqual(t, func() int {
-		return len(remoteClients.List())
-	}, 1)
-
-	remoteClient := remoteClients.List()[0]
-	localClient := remoteAmbientClients{
-		clusterID: s.clusterID,
-		ambientclients: &ambientclients{
-			pc:    s.pc,
-			sc:    s.sc,
-			ns:    s.ns,
-			grc:   s.grc,
-			gwcls: s.gwcls,
-			se:    s.se,
-			we:    s.we,
-			pa:    s.pa,
-			authz: s.authz,
-			sec:   s.sec,
-		},
-	}
+	remoteClient := cc.waitForRemotes(t, 1)[0]
+	localClient := cc.local
 	remoteClient.ns.Create(&corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   systemNS,
@@ -614,47 +621,11 @@ func TestMulticlusterAmbientIndex_SplitHorizon(t *testing.T) {
 	// Test that we're propagating the trust domain correctly
 	s.meshConfig.Mesh().TrustDomain = s.DomainSuffix
 	s.AddSecret("s1", "remote-cluster") // overlapping ips
-	remoteClients := krt.NewCollection(s.mcController.Clusters(), func(_ krt.HandlerContext, c *multicluster.Cluster) **remoteAmbientClients {
-		cl := c.Client
-		return ptr.Of(&remoteAmbientClients{
-			clusterID: c.ID,
-			ambientclients: &ambientclients{
-				pc:    clienttest.NewDirectClient[*corev1.Pod, corev1.Pod, *corev1.PodList](t, cl),
-				sc:    clienttest.NewDirectClient[*corev1.Service, corev1.Service, *corev1.ServiceList](t, cl),
-				ns:    clienttest.NewWriter[*corev1.Namespace](t, cl),
-				grc:   clienttest.NewWriter[*k8sv1.Gateway](t, cl),
-				gwcls: clienttest.NewWriter[*k8sv1.GatewayClass](t, cl),
-				se:    clienttest.NewWriter[*apiv1alpha3.ServiceEntry](t, cl),
-				we:    clienttest.NewWriter[*apiv1alpha3.WorkloadEntry](t, cl),
-				pa:    clienttest.NewWriter[*clientsecurityv1beta1.PeerAuthentication](t, cl),
-				authz: clienttest.NewWriter[*clientsecurityv1beta1.AuthorizationPolicy](t, cl),
-				sec:   clienttest.NewWriter[*corev1.Secret](t, cl),
-			},
-		})
-	})
+	cc := s.newClusterClients(t, test.NewStop(t))
 
 	const remoteNetwork = "remote-network"
-
-	assert.EventuallyEqual(t, func() int {
-		return len(remoteClients.List())
-	}, 1)
-
-	remoteClient := remoteClients.List()[0]
-	localClient := remoteAmbientClients{
-		clusterID: s.clusterID,
-		ambientclients: &ambientclients{
-			pc:    s.pc,
-			sc:    s.sc,
-			ns:    s.ns,
-			grc:   s.grc,
-			gwcls: s.gwcls,
-			se:    s.se,
-			we:    s.we,
-			pa:    s.pa,
-			authz: s.authz,
-			sec:   s.sec,
-		},
-	}
+	remoteClient := cc.waitForRemotes(t, 1)[0]
+	localClient := cc.local
 	remoteClient.ns.Create(&corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   systemNS,
@@ -874,47 +845,11 @@ func TestMulticlusterAmbientIndex_SplitHorizonPreservesWaypoint(t *testing.T) {
 	s := newAmbientTestServer(t, testC, testNW, "")
 	s.meshConfig.Mesh().TrustDomain = s.DomainSuffix
 	s.AddSecret("s1", "remote-cluster")
-	remoteClients := krt.NewCollection(s.mcController.Clusters(), func(_ krt.HandlerContext, c *multicluster.Cluster) **remoteAmbientClients {
-		cl := c.Client
-		return ptr.Of(&remoteAmbientClients{
-			clusterID: c.ID,
-			ambientclients: &ambientclients{
-				pc:    clienttest.NewDirectClient[*corev1.Pod, corev1.Pod, *corev1.PodList](t, cl),
-				sc:    clienttest.NewDirectClient[*corev1.Service, corev1.Service, *corev1.ServiceList](t, cl),
-				ns:    clienttest.NewWriter[*corev1.Namespace](t, cl),
-				grc:   clienttest.NewWriter[*k8sv1.Gateway](t, cl),
-				gwcls: clienttest.NewWriter[*k8sv1.GatewayClass](t, cl),
-				se:    clienttest.NewWriter[*apiv1alpha3.ServiceEntry](t, cl),
-				we:    clienttest.NewWriter[*apiv1alpha3.WorkloadEntry](t, cl),
-				pa:    clienttest.NewWriter[*clientsecurityv1beta1.PeerAuthentication](t, cl),
-				authz: clienttest.NewWriter[*clientsecurityv1beta1.AuthorizationPolicy](t, cl),
-				sec:   clienttest.NewWriter[*corev1.Secret](t, cl),
-			},
-		})
-	})
+	cc := s.newClusterClients(t, test.NewStop(t))
 
 	const remoteNetwork = "remote-network"
-
-	assert.EventuallyEqual(t, func() int {
-		return len(remoteClients.List())
-	}, 1)
-
-	remoteClient := remoteClients.List()[0]
-	localClient := remoteAmbientClients{
-		clusterID: s.clusterID,
-		ambientclients: &ambientclients{
-			pc:    s.pc,
-			sc:    s.sc,
-			ns:    s.ns,
-			grc:   s.grc,
-			gwcls: s.gwcls,
-			se:    s.se,
-			we:    s.we,
-			pa:    s.pa,
-			authz: s.authz,
-			sec:   s.sec,
-		},
-	}
+	remoteClient := cc.waitForRemotes(t, 1)[0]
+	localClient := cc.local
 	remoteClient.ns.Create(&corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   systemNS,
@@ -1046,12 +981,44 @@ func TestMulticlusterAmbientIndex_ClusterLifecycleNoLeak(t *testing.T) {
 		DefaultAllowFromWaypoint:              features.DefaultAllowFromWaypoint,
 		EnableK8SServiceSelectWorkloadEntries: features.EnableK8SServiceSelectWorkloadEntries,
 	}, "", false /* runClient */)
-	clusters := s.mcController.Clusters()
 	cl := s.mcController.ConfigCluster().Client()
+	stop := test.NewStop(t)
+
+	// Track the clusters through the nested collection API rather than a raw *Cluster collection. Each
+	// remote cluster contributes one clusterGeneration carrying the stop channel of the generation that
+	// produced it, which is what lets this test observe a credential rotation and the teardown of the
+	// generation it replaced.
+	generations := multicluster.NestedCollectionFromLocalAndRemote(
+		s.mcController,
+		krt.NewStaticCollection[clusterGeneration](nil, nil, krt.WithName("LocalGenerations"), krt.WithStop(stop)),
+		func(ctx krt.HandlerContext, c multicluster.ClusterCollections) *krt.Collection[clusterGeneration] {
+			var col krt.Collection[clusterGeneration] = krt.NewStaticCollection(nil,
+				[]clusterGeneration{{id: c.ID(), stop: c.GetStop()}},
+				krt.WithName(fmt.Sprintf("Generation[%s]", c.ID())), krt.WithStop(c.GetStop()))
+			return &col
+		},
+		"GlobalClusterGenerations",
+		krt.NewOptionsBuilder(stop, "TestGenerations", nil),
+	)
+	remoteGenerations := func() []clusterGeneration {
+		var out []clusterGeneration
+		for _, col := range generations.List() {
+			out = append(out, col.List()...)
+		}
+		return out
+	}
+	generationStop := func(id cluster.ID) <-chan struct{} {
+		for _, g := range remoteGenerations() {
+			if g.id == id {
+				return g.stop
+			}
+		}
+		return nil
+	}
 
 	waitRemoteClusters := func(t *testing.T, n int) {
 		t.Helper()
-		assert.EventuallyEqual(t, func() int { return len(clusters.List()) }, n)
+		assert.EventuallyEqual(t, func() int { return len(remoteGenerations()) }, n)
 	}
 
 	// Warm-up: create a remote cluster BEFORE running the client. Global collections lazily wire up
@@ -1079,42 +1046,24 @@ func TestMulticlusterAmbientIndex_ClusterLifecycleNoLeak(t *testing.T) {
 	t.Run("update-then-remove-cluster", func(t *testing.T) {
 		leak.Check(t)
 
-		swapped := make(chan struct{}, 1)
-		reg := clusters.RegisterBatch(func(events []krt.Event[*multicluster.Cluster]) {
-			for _, e := range events {
-				if e.Event == controllers.EventUpdate && e.Latest().ID == "remote-cluster-2" {
-					select {
-					case swapped <- struct{}{}:
-					default:
-					}
-				}
-			}
-		}, false)
-		defer reg.UnregisterHandler()
-		reg.WaitUntilSynced(test.NewStop(t))
-
 		s.AddSecret("s2", "remote-cluster-2")
 		waitRemoteClusters(t, 2)
 
 		// Update the cluster: re-adding the secret with a fresh kubeconfig swaps in a new Cluster (new
 		// stop + collections), tearing down the old one. This is the teardown path we verify doesn't
 		// leak. The cluster count stays at 2 across the update, so waitRemoteClusters would return
-		// immediately without the swap having propagated into the collection. Instead, observe the swap
-		// on the Clusters collection directly: capture the current cluster's stop channel and wait for
-		// an event carrying a remote-cluster-2 with a *different* stop (the swap surfaces as a delete of
-		// the not-yet-ready cluster followed by an add once it syncs, not necessarily a single update).
-		var oldStop <-chan struct{}
-		for _, c := range clusters.List() {
-			if c.ID == "remote-cluster-2" {
-				oldStop = c.GetStop()
-			}
+		// immediately without the swap having propagated into the collection. The rotation is a new
+		// generation, so it rebuilds the cluster's contribution: wait for remote-cluster-2 to be
+		// reported with a stop channel other than the one it had.
+		oldStop := generationStop("remote-cluster-2")
+		if oldStop == nil {
+			t.Fatal("remote-cluster-2 is not in the generations collection")
 		}
 		s.AddSecret("s2", "remote-cluster-2")
-		select {
-		case <-swapped:
-		case <-time.After(30 * time.Second):
-			t.Fatal("timed out waiting for remote-cluster-2 swap event")
-		}
+		assert.EventuallyEqual(t, func() bool {
+			current := generationStop("remote-cluster-2")
+			return current != nil && current != oldStop
+		}, true, retry.Timeout(30*time.Second))
 		<-oldStop
 
 		// Remove so the subtest ends back at the single warm-up cluster, matching the leak.Check baseline.

--- a/pilot/pkg/serviceregistry/ambient/ambientindex_multicluster_test.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex_multicluster_test.go
@@ -956,14 +956,14 @@ func TestMulticlusterAmbientIndex_SplitHorizonPreservesWaypoint(t *testing.T) {
 	})
 }
 
-func (a *ambientTestServer) DeleteSecret(secretName string) {
-	a.t.Helper()
-	a.sec.Delete(secretName, secretNamespace)
+func (s *ambientTestServer) DeleteSecret(secretName string) {
+	s.t.Helper()
+	s.sec.Delete(secretName, secretNamespace)
 }
 
-func (a *ambientTestServer) AddSecret(secretName, clusterID string) {
+func (s *ambientTestServer) AddSecret(secretName, clusterID string) {
 	kubeconfig++
-	a.sec.CreateOrUpdate(makeSecret(secretNamespace, secretName, clusterCredential{clusterID, fmt.Appendf(nil, "kubeconfig-%d", kubeconfig)}))
+	s.sec.CreateOrUpdate(makeSecret(secretNamespace, secretName, clusterCredential{clusterID, fmt.Appendf(nil, "kubeconfig-%d", kubeconfig)}))
 }
 
 // TestMulticlusterAmbientIndex_ClusterLifecycleNoLeak verifies that adding and then removing a

--- a/pilot/pkg/serviceregistry/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex_test.go
@@ -401,7 +401,8 @@ func TestAmbientIndex_ServiceOverlap(t *testing.T) {
 		// initial foo.com created in namespace original, this one should be canonical until deleted
 		// for now we'll just number it "11"
 		addServiceEntry(s, 11, "foo.com", "original")
-		s.assertUnorderedEvent(t, s.xdsNamespacedHostname("foo.com", "original"),
+		s.assertUnorderedEvent(
+			t, s.xdsNamespacedHostname("foo.com", "original"),
 			s.seIPXdsNameForCluster("se-11", "10.10.0.11", s.ClusterID, "original"),
 		)
 		s.assertAddresses(t, testNW+"/10.255.0.11", "se-11")
@@ -410,7 +411,8 @@ func TestAmbientIndex_ServiceOverlap(t *testing.T) {
 
 		// first SE in testNS
 		addServiceEntry(s, 1, "foo.com", testNS)
-		s.assertUnorderedEvent(t, s.xdsNamespacedHostname("foo.com"),
+		s.assertUnorderedEvent(
+			t, s.xdsNamespacedHostname("foo.com"),
 			s.seIPXdsName("se-1", "10.10.0.1"),
 		)
 		s.assertAddresses(t, testNW+"/10.255.0.1", "se-1")
@@ -426,7 +428,8 @@ func TestAmbientIndex_ServiceOverlap(t *testing.T) {
 		// remove the existing canonical from "original" namespace
 		s.deleteServiceEntry(t, "se-11", "original")
 		// expecting 2 delete events and also an event for marking se-1 canonical
-		s.assertUnorderedEvent(t, s.xdsNamespacedHostname("foo.com", "original"),
+		s.assertUnorderedEvent(
+			t, s.xdsNamespacedHostname("foo.com", "original"),
 			s.seIPXdsNameForCluster("se-11", "10.10.0.11", s.ClusterID, "original"),
 			s.xdsNamespacedHostname("foo.com", testNS),
 		)
@@ -449,7 +452,8 @@ func TestAmbientIndex_ServiceOverlap(t *testing.T) {
 		// initial *.foo.com created in namespace original, this one should be canonical until deleted
 		// for now we'll just number it "11"
 		addServiceEntry(s, 11, "*.foo.com", "original")
-		s.assertUnorderedEvent(t, s.xdsNamespacedHostname("*.foo.com", "original"),
+		s.assertUnorderedEvent(
+			t, s.xdsNamespacedHostname("*.foo.com", "original"),
 			s.seIPXdsNameForCluster("se-11", "10.10.0.11", s.ClusterID, "original"),
 		)
 		s.assertAddresses(t, testNW+"/10.255.0.11", "se-11")
@@ -458,7 +462,8 @@ func TestAmbientIndex_ServiceOverlap(t *testing.T) {
 
 		// first SE in testNS
 		addServiceEntry(s, 1, "*.foo.com", testNS)
-		s.assertUnorderedEvent(t, s.xdsNamespacedHostname("*.foo.com"),
+		s.assertUnorderedEvent(
+			t, s.xdsNamespacedHostname("*.foo.com"),
 			s.seIPXdsName("se-1", "10.10.0.1"),
 		)
 		s.assertAddresses(t, testNW+"/10.255.0.1", "se-1")
@@ -474,7 +479,8 @@ func TestAmbientIndex_ServiceOverlap(t *testing.T) {
 		// remove the existing canonical from "original" namespace
 		s.deleteServiceEntry(t, "se-11", "original")
 		// expecting 2 delete events and also an event for marking se-1 canonical
-		s.assertUnorderedEvent(t, s.xdsNamespacedHostname("*.foo.com", "original"),
+		s.assertUnorderedEvent(
+			t, s.xdsNamespacedHostname("*.foo.com", "original"),
 			s.seIPXdsNameForCluster("se-11", "10.10.0.11", s.ClusterID, "original"),
 			s.xdsNamespacedHostname("*.foo.com", testNS),
 		)
@@ -764,7 +770,8 @@ func TestAmbientIndex_WaypointAddressAddedToWorkloads(t *testing.T) {
 
 	s.addWaypoint(t, "10.0.0.2", "waypoint-ns", constants.AllTraffic, true)
 	// All these workloads updated, so push them
-	s.assertEvent(t, s.podXdsName("pod1"),
+	s.assertEvent(
+		t, s.podXdsName("pod1"),
 		s.podXdsName("pod2"),
 		s.podXdsName("pod3"),
 	)
@@ -781,7 +788,8 @@ func TestAmbientIndex_WaypointAddressAddedToWorkloads(t *testing.T) {
 		map[string]string{label.GatewayManaged.Name: constants.ManagedGatewayMeshControllerLabel},
 		map[string]string{},
 		[]int32{80}, map[string]string{label.IoK8sNetworkingGatewayGatewayName.Name: "waypoint-ns"}, "10.0.0.2")
-	s.assertEvent(t,
+	s.assertEvent(
+		t,
 		s.podXdsName("waypoint-ns-pod"),
 		s.svcXdsName("waypoint-ns"),
 	)
@@ -801,7 +809,8 @@ func TestAmbientIndex_WaypointAddressAddedToWorkloads(t *testing.T) {
 		map[string]string{label.GatewayManaged.Name: constants.ManagedGatewayMeshControllerLabel},
 		map[string]string{},
 		[]int32{80}, map[string]string{label.IoK8sNetworkingGatewayGatewayName.Name: "waypoint-sa2"}, "10.0.0.3")
-	s.assertEvent(t,
+	s.assertEvent(
+		t,
 		s.podXdsName("waypoint-sa2-pod"),
 		s.svcXdsName("waypoint-sa2"),
 	)
@@ -864,7 +873,8 @@ func TestAmbientIndex_WaypointAddressAddedToWorkloads(t *testing.T) {
 		[]int32{80}, map[string]string{"app": "a"}, "10.0.0.1")
 	s.assertAddresses(t, s.addrXdsName("10.0.0.1"), "pod1", "pod2", "pod3", "svc1")
 	// Send update for the workloads as well...
-	s.assertEvent(t, s.podXdsName("pod1"),
+	s.assertEvent(
+		t, s.podXdsName("pod1"),
 		s.podXdsName("pod2"),
 		s.podXdsName("pod3"),
 		s.svcXdsName("svc1"),
@@ -1649,7 +1659,8 @@ func TestDefaultAllowWaypointPolicy(t *testing.T) {
 			})
 
 			t.Run("attach policy to workload", func(t *testing.T) {
-				assert.EventuallyEqual(t,
+				assert.EventuallyEqual(
+					t,
 					func() []string {
 						return s.lookup(s.addrXdsName("127.0.0.1"))[0].GetWorkload().GetAuthorizationPolicies()
 					},
@@ -1789,7 +1800,7 @@ func TestRBACConvert(t *testing.T) {
 								Name:      pol[0].Name,
 								Namespace: pol[0].Namespace,
 							},
-							Spec: *((pol[0].Spec).(*auth.AuthorizationPolicy)), //nolint: govet
+							Spec: *pol[0].Spec.(*auth.AuthorizationPolicy), //nolint: govet
 						})
 					case gvk.PeerAuthentication: // we assume all crds in the same file are of the same type
 						var rootCfg, nsCfg, workloadCfg *config.Config
@@ -1828,7 +1839,7 @@ func TestRBACConvert(t *testing.T) {
 									Name:      pol[0].Name,
 									Namespace: pol[0].Namespace,
 								},
-								Spec: *((pol[0].Spec).(*auth.PeerAuthentication)), //nolint: govet
+								Spec: *pol[0].Spec.(*auth.PeerAuthentication), //nolint: govet
 							}, nil, nil)
 						} else {
 							var workloadPA, nsPA, rootPA *clientsecurityv1beta1.PeerAuthentication
@@ -1839,7 +1850,7 @@ func TestRBACConvert(t *testing.T) {
 										Name:      workloadCfg.Name,
 										Namespace: workloadCfg.Namespace,
 									},
-									Spec: *((workloadCfg.Spec).(*auth.PeerAuthentication)), //nolint: govet
+									Spec: *workloadCfg.Spec.(*auth.PeerAuthentication), //nolint: govet
 								}
 							}
 							if nsCfg != nil {
@@ -1849,7 +1860,7 @@ func TestRBACConvert(t *testing.T) {
 										Name:      nsCfg.Name,
 										Namespace: nsCfg.Namespace,
 									},
-									Spec: *((nsCfg.Spec).(*auth.PeerAuthentication)), //nolint: govet
+									Spec: *nsCfg.Spec.(*auth.PeerAuthentication), //nolint: govet
 								}
 							}
 
@@ -1860,7 +1871,7 @@ func TestRBACConvert(t *testing.T) {
 										Name:      rootCfg.Name,
 										Namespace: rootCfg.Namespace,
 									},
-									Spec: *((rootCfg.Spec).(*auth.PeerAuthentication)), //nolint: govet
+									Spec: *rootCfg.Spec.(*auth.PeerAuthentication), //nolint: govet
 								}
 							}
 
@@ -2358,7 +2369,7 @@ func newAmbientTestServer(t *testing.T, clusterID cluster.ID, networkID network.
 }
 
 func newAmbientTestServerFromOptions(t *testing.T, networkID network.ID, options Options, runClient bool) *ambientTestServer {
-	cl := options.MultiClusterController.ConfigCluster().Client
+	cl := options.MultiClusterController.ConfigCluster().Client()
 	for _, crd := range []schema.GroupVersionResource{
 		gvr.AuthorizationPolicy,
 		gvr.PeerAuthentication,

--- a/pilot/pkg/serviceregistry/ambient/multicluster.go
+++ b/pilot/pkg/serviceregistry/ambient/multicluster.go
@@ -49,7 +49,7 @@ import (
 )
 
 func (a *index) buildGlobalCollections(
-	localCluster *multicluster.Cluster,
+	localCluster multicluster.ClusterCollections,
 	localAuthzPolicies krt.Collection[*securityclient.AuthorizationPolicy],
 	localPeerAuths krt.Collection[*securityclient.PeerAuthentication],
 	localGatewayClasses krt.Collection[*gatewayv1.GatewayClass],
@@ -71,16 +71,16 @@ func (a *index) buildGlobalCollections(
 
 	LocalGatewaysWithCluster := krt.MapCollection(LocalGateways, func(obj *gatewayv1.Gateway) krt.ObjectWithCluster[*gatewayv1.Gateway] {
 		return krt.ObjectWithCluster[*gatewayv1.Gateway]{
-			ClusterID: localCluster.ID,
+			ClusterID: localCluster.ID(),
 			Object:    &obj,
 		}
 	}, opts.WithName("LocalGatewaysWithCluster")...)
 	GlobalGatewaysWithCluster := multicluster.NestedCollectionFromLocalAndRemote(
 		a.mcController,
 		LocalGatewaysWithCluster,
-		func(ctx krt.HandlerContext, c *multicluster.Cluster) *krt.Collection[krt.ObjectWithCluster[*gatewayv1.Gateway]] {
-			if !kube.WaitForCacheSync(fmt.Sprintf("ambient/informer/gateways[%s]", c.ID), a.stop, c.Gateways().HasSynced) {
-				log.Warnf("Failed to sync gateways informer for cluster %s", c.ID)
+		func(ctx krt.HandlerContext, c multicluster.ClusterCollections) *krt.Collection[krt.ObjectWithCluster[*gatewayv1.Gateway]] {
+			if !kube.WaitForCacheSync(fmt.Sprintf("ambient/informer/gateways[%s]", c.ID()), a.stop, c.Gateways().HasSynced) {
+				log.Warnf("Failed to sync gateways informer for cluster %s", c.ID())
 				return nil
 			}
 
@@ -88,13 +88,13 @@ func (a *index) buildGlobalCollections(
 			// stop is being used to shutdown the collection (it should always be the cluster stop, NEVER
 			// the top-level stop associated with the ambient controller)
 			opts := []krt.CollectionOption{
-				krt.WithName(fmt.Sprintf("ambient/GatewaysWithCluster[%s]", c.ID)),
+				krt.WithName(fmt.Sprintf("ambient/GatewaysWithCluster[%s]", c.ID())),
 				krt.WithDebugging(opts.Debugger()),
 				krt.WithStop(c.GetStop()),
 			}
 			return ptr.Of(krt.MapCollection(c.Gateways(), func(obj *gatewayv1.Gateway) krt.ObjectWithCluster[*gatewayv1.Gateway] {
 				return krt.ObjectWithCluster[*gatewayv1.Gateway]{
-					ClusterID: c.ID,
+					ClusterID: c.ID(),
 					Object:    &obj,
 				}
 			}, opts...))
@@ -147,7 +147,7 @@ func (a *index) buildGlobalCollections(
 	LocalServiceEntryVisibility := model.ServiceEntryVisibilityCollection(LocalMeshConfig.AsCollection(), opts)
 
 	LocalWorkloadServices := builder.ServicesCollection(
-		localCluster.ID,
+		localCluster.ID(),
 		localCluster.Services(),
 		localServiceEntries,
 		LocalWaypoints,
@@ -159,9 +159,9 @@ func (a *index) buildGlobalCollections(
 	)
 	// All of this is local only, but we need to do it here so we don't have to rebuild collections in ambientindex
 	if features.EnableAmbientStatus {
-		serviceEntriesWriter := kclient.NewWriteClient[*networkingclient.ServiceEntry](localCluster.Client)
-		servicesWriter := kclient.NewWriteClient[*v1.Service](localCluster.Client)
-		authorizationPoliciesWriter := kclient.NewWriteClient[*securityclient.AuthorizationPolicy](localCluster.Client)
+		serviceEntriesWriter := kclient.NewWriteClient[*networkingclient.ServiceEntry](localCluster.Client())
+		servicesWriter := kclient.NewWriteClient[*v1.Service](localCluster.Client())
+		authorizationPoliciesWriter := kclient.NewWriteClient[*securityclient.AuthorizationPolicy](localCluster.Client())
 
 		WaypointPolicyStatus := WaypointPolicyStatusCollection(
 			localAuthzPolicies,
@@ -210,7 +210,7 @@ func (a *index) buildGlobalCollections(
 
 	GlobalMergedWorkloadServicesWithCluster := krt.NestedJoinWithMergeCollection(
 		GlobalWorkloadServicesWithCluster,
-		mergeServiceInfosWithCluster(localCluster.ID),
+		mergeServiceInfosWithCluster(localCluster.ID()),
 		opts.WithName("GlobalMergedServiceInfosWithCluster")...,
 	)
 
@@ -261,7 +261,7 @@ func (a *index) buildGlobalCollections(
 		opts,
 	)
 	if features.EnableAmbientStatus {
-		workloadEntriesWriter := kclient.NewWriteClient[*networkingclient.WorkloadEntry](localCluster.Client)
+		workloadEntriesWriter := kclient.NewWriteClient[*networkingclient.WorkloadEntry](localCluster.Client())
 		statusqueue.Register(a.statusQueue, "istio-ambient-workloadentry", GlobalWorkloads,
 			func(info model.WorkloadInfo) (kclient.Patcher, map[string]model.Condition) {
 				if info.Source.Kind != kind.WorkloadEntry {

--- a/pilot/pkg/serviceregistry/ambient/networks.go
+++ b/pilot/pkg/serviceregistry/ambient/networks.go
@@ -120,18 +120,18 @@ func buildGlobalNetworkCollections(
 	GlobalNetworkGateways := multicluster.NestedCollectionFromLocalAndRemote(
 		ctrl,
 		localNetworkGateways,
-		func(ctx krt.HandlerContext, c *multicluster.Cluster) *krt.Collection[krt.ObjectWithCluster[NetworkGateway]] {
+		func(ctx krt.HandlerContext, c multicluster.ClusterCollections) *krt.Collection[krt.ObjectWithCluster[NetworkGateway]] {
 			opts := []krt.CollectionOption{
-				krt.WithName(fmt.Sprintf("NetworkGateways[%s]", c.ID)),
+				krt.WithName(fmt.Sprintf("NetworkGateways[%s]", c.ID())),
 				krt.WithDebugging(opts.Debugger()),
 				krt.WithStop(c.GetStop()),
 				krt.WithMetadata(krt.Metadata{
-					multicluster.ClusterKRTMetadataKey: c.ID,
+					multicluster.ClusterKRTMetadataKey: c.ID(),
 				}),
 			}
-			gatewaysPtr := krt.FetchOne(ctx, gateways, krt.FilterIndex(gatewaysByCluster, c.ID))
+			gatewaysPtr := krt.FetchOne(ctx, gateways, krt.FilterIndex(gatewaysByCluster, c.ID()))
 			if gatewaysPtr == nil {
-				log.Warnf("No gateways found for cluster %s", c.ID)
+				log.Warnf("No gateways found for cluster %s", c.ID())
 				return nil
 			}
 			gateways := *gatewaysPtr
@@ -144,7 +144,7 @@ func buildGlobalNetworkCollections(
 					if innerGw == nil {
 						return nil
 					}
-					return k8sGatewayToNetworkGatewaysWithCluster(c.ID, innerGw, options.ClusterID)
+					return k8sGatewayToNetworkGatewaysWithCluster(c.ID(), innerGw, options.ClusterID)
 				},
 				opts...,
 			)

--- a/pilot/pkg/serviceregistry/ambient/nodes.go
+++ b/pilot/pkg/serviceregistry/ambient/nodes.go
@@ -65,36 +65,36 @@ func nodeLocality(k *v1.Node) *Node {
 
 // GlobalNodesCollection builds a nested collection of per-cluster node locality collections.
 func GlobalNodesCollection(
-	localCluster *multicluster.Cluster,
+	localCluster multicluster.ClusterCollections,
 	localNodeLocality krt.Collection[Node],
 	ctrl *multicluster.Controller,
 	opts krt.OptionsBuilder,
 ) krt.Collection[krt.Collection[krt.ObjectWithCluster[Node]]] {
 	localNodeLocalityWithCluster := krt.MapCollection(
 		localNodeLocality,
-		wrapObjectWithCluster[Node](localCluster.ID),
+		wrapObjectWithCluster[Node](localCluster.ID()),
 		append(
 			opts.WithName("LocalNodeLocalityWithCluster"),
-			krt.WithMetadata(krt.Metadata{multicluster.ClusterKRTMetadataKey: localCluster.ID}),
+			krt.WithMetadata(krt.Metadata{multicluster.ClusterKRTMetadataKey: localCluster.ID()}),
 		)...,
 	)
 	return multicluster.NestedCollectionFromLocalAndRemote(
 		ctrl,
 		localNodeLocalityWithCluster,
-		func(ctx krt.HandlerContext, c *multicluster.Cluster) *krt.Collection[krt.ObjectWithCluster[Node]] {
-			if !kube.WaitForCacheSync(fmt.Sprintf("ambient/informer/nodes[%s]", c.ID), opts.Stop(), c.Nodes().HasSynced) {
-				log.Warnf("Failed to sync nodes informer for cluster %s", c.ID)
+		func(ctx krt.HandlerContext, c multicluster.ClusterCollections) *krt.Collection[krt.ObjectWithCluster[Node]] {
+			if !kube.WaitForCacheSync(fmt.Sprintf("ambient/informer/nodes[%s]", c.ID()), opts.Stop(), c.Nodes().HasSynced) {
+				log.Warnf("Failed to sync nodes informer for cluster %s", c.ID())
 				return nil
 			}
 			clusterOpts := []krt.CollectionOption{
-				krt.WithName(fmt.Sprintf("ambient/NodeLocalityWithCluster[%s]", c.ID)),
+				krt.WithName(fmt.Sprintf("ambient/NodeLocalityWithCluster[%s]", c.ID())),
 				krt.WithDebugging(opts.Debugger()),
 				krt.WithStop(c.GetStop()),
-				krt.WithMetadata(krt.Metadata{multicluster.ClusterKRTMetadataKey: c.ID}),
+				krt.WithMetadata(krt.Metadata{multicluster.ClusterKRTMetadataKey: c.ID()}),
 			}
 			nodes := krt.NewCollection(c.Nodes(), func(ctx krt.HandlerContext, k *v1.Node) *krt.ObjectWithCluster[Node] {
 				return &krt.ObjectWithCluster[Node]{
-					ClusterID: c.ID,
+					ClusterID: c.ID(),
 					Object:    nodeLocality(k),
 				}
 			}, clusterOpts...)

--- a/pilot/pkg/serviceregistry/ambient/services.go
+++ b/pilot/pkg/serviceregistry/ambient/services.go
@@ -152,7 +152,7 @@ func selectWorkloadServices(typedServiceInfos []TypedServiceInfo) []model.Servic
 }
 
 func GlobalNestedWorkloadServicesCollection(
-	localCluster *multicluster.Cluster,
+	localCluster multicluster.ClusterCollections,
 	localServiceInfos krt.Collection[model.ServiceInfo],
 	localWaypoints krt.Collection[Waypoint],
 	ctrl *multicluster.Controller,
@@ -167,7 +167,7 @@ func GlobalNestedWorkloadServicesCollection(
 	// This will contain the serviceinfos derived from Services AND ServiceEntries
 	LocalServiceInfosWithCluster := krt.MapCollection(
 		localServiceInfos,
-		wrapObjectWithCluster[model.ServiceInfo](localCluster.ID),
+		wrapObjectWithCluster[model.ServiceInfo](localCluster.ID()),
 		opts.WithName("LocalServiceInfosWithCluster")...,
 	)
 
@@ -177,15 +177,15 @@ func GlobalNestedWorkloadServicesCollection(
 	return multicluster.NestedCollectionFromLocalAndRemote(
 		ctrl,
 		LocalServiceInfosWithCluster,
-		func(ctx krt.HandlerContext, cluster *multicluster.Cluster) *krt.Collection[krt.ObjectWithCluster[model.ServiceInfo]] {
+		func(ctx krt.HandlerContext, cluster multicluster.ClusterCollections) *krt.Collection[krt.ObjectWithCluster[model.ServiceInfo]] {
 			opts := []krt.CollectionOption{
 				krt.WithDebugging(opts.Debugger()),
 				krt.WithStop(cluster.GetStop()),
 			}
 			services := cluster.Services()
-			waypointsPtr := krt.FetchOne(ctx, globalWaypoints, krt.FilterIndex(waypointsByCluster, cluster.ID))
+			waypointsPtr := krt.FetchOne(ctx, globalWaypoints, krt.FilterIndex(waypointsByCluster, cluster.ID()))
 			if waypointsPtr == nil {
-				log.Warnf("Cluster %s does not have waypoints assigned, skipping", cluster.ID)
+				log.Warnf("Cluster %s does not have waypoints assigned, skipping", cluster.ID())
 				return nil
 			}
 			waypoints := *waypointsPtr
@@ -204,20 +204,20 @@ func GlobalNestedWorkloadServicesCollection(
 			),
 				append(
 					opts,
-					krt.WithName(fmt.Sprintf("ambient/ServiceServiceInfos[%s]", cluster.ID)),
+					krt.WithName(fmt.Sprintf("ambient/ServiceServiceInfos[%s]", cluster.ID())),
 					krt.WithMetadata(krt.Metadata{
-						multicluster.ClusterKRTMetadataKey: cluster.ID,
+						multicluster.ClusterKRTMetadataKey: cluster.ID(),
 					}),
 				)...)
 
 			servicesInfoWithCluster := krt.MapCollection(
 				servicesInfo,
 				func(o model.ServiceInfo) krt.ObjectWithCluster[model.ServiceInfo] {
-					return krt.ObjectWithCluster[model.ServiceInfo]{ClusterID: cluster.ID, Object: &o}
+					return krt.ObjectWithCluster[model.ServiceInfo]{ClusterID: cluster.ID(), Object: &o}
 				},
 				append(
 					opts,
-					krt.WithName(fmt.Sprintf("ServiceServiceInfosWithCluster[%s]", cluster.ID)),
+					krt.WithName(fmt.Sprintf("ServiceServiceInfosWithCluster[%s]", cluster.ID())),
 				)...,
 			)
 			return ptr.Of(servicesInfoWithCluster)

--- a/pilot/pkg/serviceregistry/ambient/waypoints.go
+++ b/pilot/pkg/serviceregistry/ambient/waypoints.go
@@ -393,19 +393,19 @@ func gatewayToWaypointTransform(
 }
 
 func GlobalWaypointsCollection(
-	localCluster *multicluster.Cluster,
+	localCluster multicluster.ClusterCollections,
 	localWaypoints krt.Collection[Waypoint],
 	ctrl *multicluster.Controller,
 	gatewayClasses krt.Collection[*gatewayv1.GatewayClass],
 	globalNetworks NetworkCollections,
 	opts krt.OptionsBuilder,
 ) krt.Collection[krt.Collection[Waypoint]] {
-	return multicluster.NestedCollectionFromLocalAndRemote(ctrl, localWaypoints, func(ctx krt.HandlerContext, c *multicluster.Cluster) *krt.Collection[Waypoint] {
+	return multicluster.NestedCollectionFromLocalAndRemote(ctrl, localWaypoints, func(ctx krt.HandlerContext, c multicluster.ClusterCollections) *krt.Collection[Waypoint] {
 		opts := []krt.CollectionOption{
-			krt.WithName(fmt.Sprintf("Waypoints[%s]", c.ID)),
+			krt.WithName(fmt.Sprintf("Waypoints[%s]", c.ID())),
 			krt.WithDebugging(opts.Debugger()),
 			krt.WithStop(c.GetStop()),
-			krt.WithMetadata(krt.Metadata{multicluster.ClusterKRTMetadataKey: c.ID}),
+			krt.WithMetadata(krt.Metadata{multicluster.ClusterKRTMetadataKey: c.ID()}),
 		}
 		pods := c.Pods()
 		podsByNamespace := krt.NewNamespaceIndex(pods)
@@ -556,7 +556,7 @@ func (w WaypointSelector) Equals(other WaypointSelector) bool {
 	if w.FromNamespaces != other.FromNamespaces {
 		return false
 	}
-	if (w.Selector) == nil != (other.Selector == nil) {
+	if w.Selector == nil != (other.Selector == nil) {
 		return false
 	}
 	if w.Selector == nil && other.Selector == nil {

--- a/pilot/pkg/serviceregistry/ambient/waypoints.go
+++ b/pilot/pkg/serviceregistry/ambient/waypoints.go
@@ -400,56 +400,57 @@ func GlobalWaypointsCollection(
 	globalNetworks NetworkCollections,
 	opts krt.OptionsBuilder,
 ) krt.Collection[krt.Collection[Waypoint]] {
-	return multicluster.NestedCollectionFromLocalAndRemote(ctrl, localWaypoints, func(ctx krt.HandlerContext, c multicluster.ClusterCollections) *krt.Collection[Waypoint] {
-		opts := []krt.CollectionOption{
-			krt.WithName(fmt.Sprintf("Waypoints[%s]", c.ID())),
-			krt.WithDebugging(opts.Debugger()),
-			krt.WithStop(c.GetStop()),
-			krt.WithMetadata(krt.Metadata{multicluster.ClusterKRTMetadataKey: c.ID()}),
-		}
-		pods := c.Pods()
-		podsByNamespace := krt.NewNamespaceIndex(pods)
-		gateways := c.Gateways()
-		namespaces := c.Namespaces()
-
-		clusterWaypoints := krt.NewCollection(gateways, func(ctx krt.HandlerContext, gateway *gatewayv1.Gateway) *Waypoint {
-			if len(gateway.Status.Addresses) == 0 {
-				// gateway.Status.Addresses should only be populated once the Waypoint's deployment has at least 1 ready pod, it should never be removed after going ready
-				// ignore Kubernetes Gateways which aren't waypoints
-				return nil
+	return multicluster.NestedCollectionFromLocalAndRemote(ctrl, localWaypoints,
+		func(ctx krt.HandlerContext, c multicluster.ClusterCollections) *krt.Collection[Waypoint] {
+			opts := []krt.CollectionOption{
+				krt.WithName(fmt.Sprintf("Waypoints[%s]", c.ID())),
+				krt.WithDebugging(opts.Debugger()),
+				krt.WithStop(c.GetStop()),
+				krt.WithMetadata(krt.Metadata{multicluster.ClusterKRTMetadataKey: c.ID()}),
 			}
+			pods := c.Pods()
+			podsByNamespace := krt.NewNamespaceIndex(pods)
+			gateways := c.Gateways()
+			namespaces := c.Namespaces()
 
-			instances := podsByNamespace.Fetch(ctx, gateway.Namespace, krt.FilterLabel(map[string]string{
-				label.IoK8sNetworkingGatewayGatewayName.Name: gateway.Name,
-			}))
+			clusterWaypoints := krt.NewCollection(gateways, func(ctx krt.HandlerContext, gateway *gatewayv1.Gateway) *Waypoint {
+				if len(gateway.Status.Addresses) == 0 {
+					// gateway.Status.Addresses should only be populated once the Waypoint's deployment has at least 1 ready pod,
+					// it should never be removed after going ready ignore Kubernetes Gateways which aren't waypoints
+					return nil
+				}
 
-			serviceAccounts := slices.Map(instances, func(p *v1.Pod) string {
-				return p.Spec.ServiceAccountName
-			})
+				instances := podsByNamespace.Fetch(ctx, gateway.Namespace, krt.FilterLabel(map[string]string{
+					label.IoK8sNetworkingGatewayGatewayName.Name: gateway.Name,
+				}))
 
-			// default traffic type if neither GatewayClass nor Gateway specify a type
-			trafficType := constants.ServiceTraffic
+				serviceAccounts := slices.Map(instances, func(p *v1.Pod) string {
+					return p.Spec.ServiceAccountName
+				})
 
-			gatewayClass := ptr.OrEmpty(krt.FetchOne(ctx, gatewayClasses, krt.FilterKey(string(gateway.Spec.GatewayClassName))))
-			if gatewayClass == nil {
-				log.Warnf("could not find GatewayClass %s in local cluster for Gateway %s/%s", gateway.Spec.GatewayClassName, gateway.Namespace, gateway.Name)
-			} else if tt, found := gatewayClass.Labels[label.IoIstioWaypointFor.Name]; found {
-				// Check for a declared traffic type that is allowed to pass through the Waypoint's GatewayClass
-				trafficType = tt
-			}
+				// default traffic type if neither GatewayClass nor Gateway specify a type
+				trafficType := constants.ServiceTraffic
 
-			// Check for a declared traffic type that is allowed to pass through the Waypoint
-			if tt, found := gateway.Labels[label.IoIstioWaypointFor.Name]; found {
-				trafficType = tt
-			}
+				gatewayClass := ptr.OrEmpty(krt.FetchOne(ctx, gatewayClasses, krt.FilterKey(string(gateway.Spec.GatewayClassName))))
+				if gatewayClass == nil {
+					log.Warnf("could not find GatewayClass %s in local cluster for Gateway %s/%s", gateway.Spec.GatewayClassName, gateway.Namespace, gateway.Name)
+				} else if tt, found := gatewayClass.Labels[label.IoIstioWaypointFor.Name]; found {
+					// Check for a declared traffic type that is allowed to pass through the Waypoint's GatewayClass
+					trafficType = tt
+				}
 
-			clusterNetwork := globalNetworks.FetchRemoteSystemNamespaceNetwork(ctx, namespaces)
+				// Check for a declared traffic type that is allowed to pass through the Waypoint
+				if tt, found := gateway.Labels[label.IoIstioWaypointFor.Name]; found {
+					trafficType = tt
+				}
 
-			return makeWaypoint(gateway, gatewayClass, serviceAccounts, trafficType, clusterNetwork)
-		}, opts...)
+				clusterNetwork := globalNetworks.FetchRemoteSystemNamespaceNetwork(ctx, namespaces)
 
-		return ptr.Of(clusterWaypoints)
-	}, "Waypoints", opts)
+				return makeWaypoint(gateway, gatewayClass, serviceAccounts, trafficType, clusterNetwork)
+			}, opts...)
+
+			return ptr.Of(clusterWaypoints)
+		}, "Waypoints", opts)
 }
 
 func (a Builder) WaypointsCollection(

--- a/pilot/pkg/serviceregistry/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/ambient/workloads.go
@@ -111,7 +111,8 @@ func (a Builder) WorkloadsCollection(
 	EndpointSliceWorkloads := krt.NewManyCollection(
 		endpointSlices,
 		a.endpointSlicesBuilder(meshConfig, workloadServices),
-		opts.WithName("EndpointSliceWorkloads")...)
+		opts.WithName("EndpointSliceWorkloads")...,
+	)
 
 	NetworkGatewayWorkloads := krt.NewManyFromNothing[model.WorkloadInfo](func(ctx krt.HandlerContext) []model.WorkloadInfo {
 		meshCfg := krt.FetchOne(ctx, meshConfig.AsCollection())
@@ -129,12 +130,13 @@ func (a Builder) WorkloadsCollection(
 		},
 		// Each collection has its own unique UID as the key. This guarantees an object can exist in only a single collection
 		// This enables us to use the JoinUnchecked optimization.
-		append(opts.WithName("Workloads"), krt.WithJoinUnchecked())...)
+		append(opts.WithName("Workloads"), krt.WithJoinUnchecked())...,
+	)
 	return Workloads
 }
 
 func MergedGlobalWorkloadsCollection(
-	localCluster *multicluster.Cluster,
+	localCluster multicluster.ClusterCollections,
 	localWaypoints krt.Collection[Waypoint],
 	localNodeLocalities krt.Collection[Node],
 	ctrl *multicluster.Controller,
@@ -172,7 +174,7 @@ func MergedGlobalWorkloadsCollection(
 			localCluster.Namespaces(),
 			localNodeLocalities,
 			domainSuffix,
-			localCluster.ID,
+			localCluster.ID(),
 			globalNetworks.FetchLocalNetworkID,
 			globalNetworks.GatewaysByNetwork,
 			flags,
@@ -182,7 +184,7 @@ func MergedGlobalWorkloadsCollection(
 	)
 	LocalPodWorkloadsWithCluster := krt.MapCollection(
 		LocalPodWorkloads,
-		wrapObjectWithCluster[model.WorkloadInfo](localCluster.ID),
+		wrapObjectWithCluster[model.WorkloadInfo](localCluster.ID()),
 		opts.WithName("LocalPodWorkloadsWithCluster")...,
 	)
 	LocalWorkloadEntryWorkloads := krt.NewCollection(
@@ -196,7 +198,7 @@ func MergedGlobalWorkloadsCollection(
 			localWorkloadServices,
 			LocalWorkloadServicesNamespaceIndex,
 			localCluster.Namespaces(),
-			localCluster.ID,
+			localCluster.ID(),
 			globalNetworks.FetchLocalNetworkID,
 			globalNetworks.GatewaysByNetwork,
 			flags,
@@ -206,7 +208,7 @@ func MergedGlobalWorkloadsCollection(
 	)
 	LocalWorkloadEntryWorkloadsWithCluster := krt.MapCollection(
 		LocalWorkloadEntryWorkloads,
-		wrapObjectWithCluster[model.WorkloadInfo](localCluster.ID),
+		wrapObjectWithCluster[model.WorkloadInfo](localCluster.ID()),
 		opts.WithName("LocalWorkloadEntryWorkloadsWithCluster")...,
 	)
 	// Workloads coming from serviceEntries. These are inlined workloadEntries (under `spec.endpoints`); these serviceEntries will
@@ -220,7 +222,7 @@ func MergedGlobalWorkloadsCollection(
 			localWaypoints,
 			localCluster.Namespaces(),
 			localWorkloadServices,
-			localCluster.ID,
+			localCluster.ID(),
 			globalNetworks.FetchLocalNetworkID,
 			globalNetworks.GatewaysByNetwork,
 			flags,
@@ -229,7 +231,7 @@ func MergedGlobalWorkloadsCollection(
 	)
 	LocalServiceEntryWorkloadsWithCluster := krt.MapCollection(
 		LocalServiceEntryWorkloads,
-		wrapObjectWithCluster[model.WorkloadInfo](localCluster.ID),
+		wrapObjectWithCluster[model.WorkloadInfo](localCluster.ID()),
 		opts.WithName("LocalServiceEntryWorkloadsWithCluster")...,
 	)
 	// Workloads coming from endpointSlices. These are for *manually added* endpoints. Typically, Kubernetes will insert each pod
@@ -239,17 +241,18 @@ func MergedGlobalWorkloadsCollection(
 	// on when we will build from an EndpointSlice.
 	LocalEndpointSliceWorkloads := krt.NewManyCollection(
 		localCluster.EndpointSlices(),
-		endpointSlicesBuilder(meshConfig,
+		endpointSlicesBuilder(
+			meshConfig,
 			localWorkloadServices,
 			domainSuffix,
-			localCluster.ID,
+			localCluster.ID(),
 			globalNetworks.FetchLocalNetworkID,
 		),
 		opts.WithName("LocalEndpointSliceWorkloads")...,
 	)
 	LocalEndpointSliceWorkloadsWithCluster := krt.MapCollection(
 		LocalEndpointSliceWorkloads,
-		wrapObjectWithCluster[model.WorkloadInfo](localCluster.ID),
+		wrapObjectWithCluster[model.WorkloadInfo](localCluster.ID()),
 		opts.WithName("LocalEndpointSliceWorkloadsWithCluster")...,
 	)
 
@@ -262,7 +265,7 @@ func MergedGlobalWorkloadsCollection(
 	}, opts.WithName("LocalNetworkGatewayWorkloads")...)
 	LocalNetworkGatewayWorkloadsWithCluster := krt.MapCollection(
 		GlobalNetworkGatewayWorkloads,
-		wrapObjectWithCluster[model.WorkloadInfo](localCluster.ID),
+		wrapObjectWithCluster[model.WorkloadInfo](localCluster.ID()),
 		opts.WithName("LocalNetworkGatewayWorkloadsWithCluster")...,
 	)
 	GlobalWorkloadInfosWithCluster := multicluster.NestedManyCollectionsFromLocalAndRemote(
@@ -274,14 +277,14 @@ func MergedGlobalWorkloadsCollection(
 			LocalEndpointSliceWorkloadsWithCluster,
 			LocalNetworkGatewayWorkloadsWithCluster,
 		},
-		func(ctx krt.HandlerContext, c *multicluster.Cluster) []krt.Collection[krt.ObjectWithCluster[model.WorkloadInfo]] {
+		func(ctx krt.HandlerContext, c multicluster.ClusterCollections) []krt.Collection[krt.ObjectWithCluster[model.WorkloadInfo]] {
 			opts := []krt.CollectionOption{
 				krt.WithDebugging(opts.Debugger()),
 				krt.WithStop(c.GetStop()),
 			}
 			endpointSlices := c.EndpointSlices()
 			pods := c.Pods()
-			waypointsPtr := krt.FetchOne(ctx, globalWaypoints, krt.FilterIndex(waypointsByCluster, c.ID))
+			waypointsPtr := krt.FetchOne(ctx, globalWaypoints, krt.FilterIndex(waypointsByCluster, c.ID()))
 			// This usually happens because the event for a new cluster
 			// triggers the global services|waypoints|etc. transformations in parallel
 			// with this transformation. This Fetch is racing
@@ -290,28 +293,28 @@ func MergedGlobalWorkloadsCollection(
 			// to avoid hacks like this, we can deal with eventually consistent
 			// collection state for now.
 			if waypointsPtr == nil {
-				log.Warnf("Cluster %s does not have waypoints, skipping global workloads", c.ID)
+				log.Warnf("Cluster %s does not have waypoints, skipping global workloads", c.ID())
 				return nil
 			}
 			waypoints := *waypointsPtr
 
 			namespaces := c.Namespaces()
-			clusteredNodesPtr := krt.FetchOne(ctx, globalNodes, krt.FilterIndex(nodesByCluster, c.ID))
+			clusteredNodesPtr := krt.FetchOne(ctx, globalNodes, krt.FilterIndex(nodesByCluster, c.ID()))
 			if clusteredNodesPtr == nil {
-				log.Warnf("Cluster %s does not have nodes, skipping global workloads", c.ID)
+				log.Warnf("Cluster %s does not have nodes, skipping global workloads", c.ID())
 				return nil
 			}
 			clusteredNodes := *clusteredNodesPtr
 
-			workloadServicesPtr := krt.FetchOne(ctx, globalWorkloadServices, krt.FilterIndex(globalWorkloadServicesByCluster, c.ID))
+			workloadServicesPtr := krt.FetchOne(ctx, globalWorkloadServices, krt.FilterIndex(globalWorkloadServicesByCluster, c.ID()))
 			if workloadServicesPtr == nil {
-				log.Warnf("Cluster %s does not have workload services, skipping global workloads", c.ID)
+				log.Warnf("Cluster %s does not have workload services, skipping global workloads", c.ID())
 				return nil
 			}
 
 			nodes := krt.MapCollection(clusteredNodes, unwrapObjectWithCluster, append(
 				opts,
-				krt.WithName(fmt.Sprintf("NodeLocality[%s]", c.ID)),
+				krt.WithName(fmt.Sprintf("NodeLocality[%s]", c.ID())),
 			)...)
 
 			globalWorkloadServicesWithCluster := *workloadServicesPtr
@@ -320,9 +323,9 @@ func MergedGlobalWorkloadsCollection(
 				unwrapObjectWithCluster[model.ServiceInfo],
 				append(
 					opts,
-					krt.WithName(fmt.Sprintf("WorkloadServices[%s]", c.ID)),
+					krt.WithName(fmt.Sprintf("WorkloadServices[%s]", c.ID())),
 					krt.WithMetadata(krt.Metadata{
-						multicluster.ClusterKRTMetadataKey: c.ID,
+						multicluster.ClusterKRTMetadataKey: c.ID(),
 					}),
 				)...,
 			)
@@ -344,7 +347,7 @@ func MergedGlobalWorkloadsCollection(
 					namespaces,
 					nodes,
 					domainSuffix,
-					c.ID,
+					c.ID(),
 					func(ctx krt.HandlerContext) network.ID {
 						return globalNetworks.FetchRemoteSystemNamespaceNetwork(ctx, namespaces)
 					},
@@ -354,20 +357,20 @@ func MergedGlobalWorkloadsCollection(
 				),
 				append(
 					opts,
-					krt.WithName(fmt.Sprintf("PodWorkloads[%s]", c.ID)),
+					krt.WithName(fmt.Sprintf("PodWorkloads[%s]", c.ID())),
 					krt.WithMetadata(krt.Metadata{
-						multicluster.ClusterKRTMetadataKey: c.ID,
+						multicluster.ClusterKRTMetadataKey: c.ID(),
 					}),
 				)...,
 			)
 			PodWorkloadsWithCluster := krt.MapCollection(
 				PodWorkloads,
-				wrapObjectWithCluster[model.WorkloadInfo](c.ID),
+				wrapObjectWithCluster[model.WorkloadInfo](c.ID()),
 				append(
 					opts,
-					krt.WithName(fmt.Sprintf("PodWorkloadsWithCluster[%s]", c.ID)),
+					krt.WithName(fmt.Sprintf("PodWorkloadsWithCluster[%s]", c.ID())),
 					krt.WithMetadata(krt.Metadata{
-						multicluster.ClusterKRTMetadataKey: c.ID,
+						multicluster.ClusterKRTMetadataKey: c.ID(),
 					}),
 				)...,
 			)
@@ -383,7 +386,7 @@ func MergedGlobalWorkloadsCollection(
 					globalWorkloadServices,
 					WorkloadServicesNamespaceIndex,
 					namespaces,
-					c.ID,
+					c.ID(),
 					func(ctx krt.HandlerContext) network.ID {
 						return globalNetworks.FetchRemoteSystemNamespaceNetwork(ctx, namespaces)
 					},
@@ -393,20 +396,20 @@ func MergedGlobalWorkloadsCollection(
 				),
 				append(
 					opts,
-					krt.WithName(fmt.Sprintf("WorkloadEntryWorkloads[%s]", c.ID)),
+					krt.WithName(fmt.Sprintf("WorkloadEntryWorkloads[%s]", c.ID())),
 					krt.WithMetadata(krt.Metadata{
-						multicluster.ClusterKRTMetadataKey: c.ID,
+						multicluster.ClusterKRTMetadataKey: c.ID(),
 					}),
 				)...,
 			)
 			WorkloadEntryWorkloadsWithCluster := krt.MapCollection(
 				WorkloadEntryWorkloads,
-				wrapObjectWithCluster[model.WorkloadInfo](c.ID),
+				wrapObjectWithCluster[model.WorkloadInfo](c.ID()),
 				append(
 					opts,
-					krt.WithName(fmt.Sprintf("WorkloadEntryWorkloadsWithCluster[%s]", c.ID)),
+					krt.WithName(fmt.Sprintf("WorkloadEntryWorkloadsWithCluster[%s]", c.ID())),
 					krt.WithMetadata(krt.Metadata{
-						multicluster.ClusterKRTMetadataKey: c.ID,
+						multicluster.ClusterKRTMetadataKey: c.ID(),
 					}),
 				)...,
 			)
@@ -421,7 +424,7 @@ func MergedGlobalWorkloadsCollection(
 					waypoints,
 					namespaces,
 					globalWorkloadServices,
-					c.ID,
+					c.ID(),
 					func(ctx krt.HandlerContext) network.ID {
 						return globalNetworks.FetchRemoteSystemNamespaceNetwork(ctx, namespaces)
 					},
@@ -430,20 +433,20 @@ func MergedGlobalWorkloadsCollection(
 				),
 				append(
 					opts,
-					krt.WithName(fmt.Sprintf("ServiceEntryWorkloads[%s]", c.ID)),
+					krt.WithName(fmt.Sprintf("ServiceEntryWorkloads[%s]", c.ID())),
 					krt.WithMetadata(krt.Metadata{
-						multicluster.ClusterKRTMetadataKey: c.ID,
+						multicluster.ClusterKRTMetadataKey: c.ID(),
 					}),
 				)...,
 			)
 			ServiceEntryWorkloadsWithCluster := krt.MapCollection(
 				ServiceEntryWorkloads,
-				wrapObjectWithCluster[model.WorkloadInfo](c.ID),
+				wrapObjectWithCluster[model.WorkloadInfo](c.ID()),
 				append(
 					opts,
-					krt.WithName(fmt.Sprintf("ServiceEntryWorkloadsWithCluster[%s]", c.ID)),
+					krt.WithName(fmt.Sprintf("ServiceEntryWorkloadsWithCluster[%s]", c.ID())),
 					krt.WithMetadata(krt.Metadata{
-						multicluster.ClusterKRTMetadataKey: c.ID,
+						multicluster.ClusterKRTMetadataKey: c.ID(),
 					}),
 				)...,
 			)
@@ -454,29 +457,31 @@ func MergedGlobalWorkloadsCollection(
 			// on when we will build from an EndpointSlice.
 			EndpointSliceWorkloads := krt.NewManyCollection(
 				endpointSlices,
-				endpointSlicesBuilder(meshConfig,
+				endpointSlicesBuilder(
+					meshConfig,
 					globalWorkloadServices,
 					domainSuffix,
-					c.ID,
+					c.ID(),
 					func(ctx krt.HandlerContext) network.ID {
 						return globalNetworks.FetchRemoteSystemNamespaceNetwork(ctx, namespaces)
 					},
 				),
 				append(
 					opts,
-					krt.WithName(fmt.Sprintf("EndpointSliceWorkloads[%s]", c.ID)),
+					krt.WithName(fmt.Sprintf("EndpointSliceWorkloads[%s]", c.ID())),
 					krt.WithMetadata(krt.Metadata{
-						multicluster.ClusterKRTMetadataKey: c.ID,
+						multicluster.ClusterKRTMetadataKey: c.ID(),
 					}),
-				)...)
+				)...,
+			)
 			EndpointSliceWorkloadsWithCluster := krt.MapCollection(
 				EndpointSliceWorkloads,
-				wrapObjectWithCluster[model.WorkloadInfo](c.ID),
+				wrapObjectWithCluster[model.WorkloadInfo](c.ID()),
 				append(
 					opts,
-					krt.WithName(fmt.Sprintf("EndpointSliceWorkloadsWithCluster[%s]", c.ID)),
+					krt.WithName(fmt.Sprintf("EndpointSliceWorkloadsWithCluster[%s]", c.ID())),
 					krt.WithMetadata(krt.Metadata{
-						multicluster.ClusterKRTMetadataKey: c.ID,
+						multicluster.ClusterKRTMetadataKey: c.ID(),
 					}),
 				)...,
 			)

--- a/pkg/kube/multicluster/cluster.go
+++ b/pkg/kube/multicluster/cluster.go
@@ -41,7 +41,98 @@ var _ krt.ResourceNamer = &Cluster{}
 
 const ClusterKRTMetadataKey = "cluster"
 
-// Cluster defines cluster struct
+// ClusterCollections is a restricted, read-only view over one generation of a Cluster: its ID, its
+// client, its stop channel and the krt collections built from its informers. It exists so that code
+// outside this package can derive krt collections from a cluster's informers without ever holding
+// the *Cluster itself.
+//
+// Deriving a krt collection registers a handler on the source collection, and
+// that registration lives until the derived collection is stopped. A remote cluster's collections
+// are per-generation — they are discarded when the cluster is removed or its credentials rotate — so
+// a derived collection that is not stopped with the cluster keeps its registration, its informer and
+// the whole *Cluster alive for the lifetime of the process. Handing out only this view keeps the set
+// of places that can make that mistake small enough to audit.
+//
+// A ClusterCollections is only produced where deriving collections is safe:
+//   - in the callbacks of NestedCollectionFromLocalAndRemote and
+//     NestedManyCollectionsFromLocalAndRemote, which run inside the cluster's lifecycle and whose
+//     results are dropped when the cluster goes away;
+//   - from Controller.ConfigCluster, whose cluster lives for the lifetime of the process (its stop
+//     channel is the controller's, so passing it to krt.WithStop is a no-op but still correct).
+//
+// Rules for callers:
+//   - Build every derived collection with krt.WithStop(cc.GetStop()), never with a process-wide stop
+//     channel.
+//   - Do not retain a ClusterCollections, or the collections it returns, past the call that received
+//     it. After a credential rotation the same cluster ID is served by a new generation; the old
+//     collections are frozen at rotation time, fed by informers that are no longer running.
+//   - Use Client() for things that do not create an informer — write clients, object filters, direct
+//     API calls.
+type ClusterCollections struct {
+	cluster *Cluster
+}
+
+// ID returns the ID of the cluster.
+func (cc ClusterCollections) ID() cluster.ID {
+	return cc.cluster.ID
+}
+
+// Client returns the cluster's kube client.
+//
+// Building a *new* informer on it — one for a (resource, filter) combination the cluster does not
+// already have — requires starting it yourself:
+//
+//	inf := kclient.NewFiltered[T](cc.Client(), filter)
+//	inf.Start(cc.GetStop())
+//	col := krt.WrapClient(inf, krt.WithStop(cc.GetStop()), ...)
+//
+// Prefer the collection accessors below, which are already started and synced.
+func (cc ClusterCollections) Client() kube.Client {
+	return cc.cluster.Client
+}
+
+// GetStop returns the stop channel for the cluster. Every collection derived from this view must be
+// built with krt.WithStop(cc.GetStop()) so it is torn down with the cluster.
+func (cc ClusterCollections) GetStop() <-chan struct{} {
+	return cc.cluster.stop
+}
+
+// Namespaces returns the namespaces collection.
+func (cc ClusterCollections) Namespaces() krt.Collection[*corev1.Namespace] {
+	return cc.cluster.namespaces()
+}
+
+// Pods returns the pods collection.
+func (cc ClusterCollections) Pods() krt.Collection[*corev1.Pod] {
+	return cc.cluster.pods()
+}
+
+// Services returns the services collection.
+func (cc ClusterCollections) Services() krt.Collection[*corev1.Service] {
+	return cc.cluster.services()
+}
+
+// EndpointSlices returns the endpointSlices collection.
+func (cc ClusterCollections) EndpointSlices() krt.Collection[*discovery.EndpointSlice] {
+	return cc.cluster.endpointSlices()
+}
+
+// Nodes returns the nodes collection.
+func (cc ClusterCollections) Nodes() krt.Collection[*corev1.Node] {
+	return cc.cluster.nodes()
+}
+
+// Gateways returns the gateways collection.
+func (cc ClusterCollections) Gateways() krt.Collection[*gatewayv1.Gateway] {
+	return cc.cluster.gateways()
+}
+
+// Cluster defines cluster struct.
+//
+// A Cluster owns one generation of a remote (or the config) cluster: its client, its informers, its
+// stop channel and the krt collections built from those informers. The collections are deliberately
+// unexported; code outside this package gets at them through ClusterCollections, which documents the
+// rules that keep derived collections from outliving the cluster they read from.
 type Cluster struct {
 	// ID of the cluster.
 	ID cluster.ID
@@ -88,33 +179,33 @@ type remoteClusterCollections struct {
 	gateways       krt.Collection[*gatewayv1.Gateway]
 }
 
-// Namespaces returns the namespaces collection.
-func (c *Cluster) Namespaces() krt.Collection[*corev1.Namespace] {
+// namespaces returns the namespaces collection.
+func (c *Cluster) namespaces() krt.Collection[*corev1.Namespace] {
 	return c.remoteClusterCollections.Load().namespaces
 }
 
-// Pods returns the pods collection.
-func (c *Cluster) Pods() krt.Collection[*corev1.Pod] {
+// pods returns the pods collection.
+func (c *Cluster) pods() krt.Collection[*corev1.Pod] {
 	return c.remoteClusterCollections.Load().pods
 }
 
-// Services returns the services collection.
-func (c *Cluster) Services() krt.Collection[*corev1.Service] {
+// services returns the services collection.
+func (c *Cluster) services() krt.Collection[*corev1.Service] {
 	return c.remoteClusterCollections.Load().services
 }
 
-// EndpointSlices returns the endpointSlices collection.
-func (c *Cluster) EndpointSlices() krt.Collection[*discovery.EndpointSlice] {
+// endpointSlices returns the endpointSlices collection.
+func (c *Cluster) endpointSlices() krt.Collection[*discovery.EndpointSlice] {
 	return c.remoteClusterCollections.Load().endpointSlices
 }
 
-// Nodes returns the nodes collection.
-func (c *Cluster) Nodes() krt.Collection[*corev1.Node] {
+// nodes returns the nodes collection.
+func (c *Cluster) nodes() krt.Collection[*corev1.Node] {
 	return c.remoteClusterCollections.Load().nodes
 }
 
-// Gateways returns the gateways collection.
-func (c *Cluster) Gateways() krt.Collection[*gatewayv1.Gateway] {
+// gateways returns the gateways collection.
+func (c *Cluster) gateways() krt.Collection[*gatewayv1.Gateway] {
 	return c.remoteClusterCollections.Load().gateways
 }
 
@@ -173,12 +264,12 @@ func (c *Cluster) Run(mesh meshwatcher.WatcherCollection, handlers []handler, ac
 	if c.remoteClusterCollections.Load() != nil {
 		log.Infof("Configuring cluster %s with existing informers", c.ID)
 		syncers := []krt.Syncer{
-			c.Namespaces(),
-			c.Gateways(),
-			c.Services(),
-			c.Nodes(),
-			c.EndpointSlices(),
-			c.Pods(),
+			c.namespaces(),
+			c.gateways(),
+			c.services(),
+			c.nodes(),
+			c.endpointSlices(),
+			c.pods(),
 		}
 		for _, syncer := range syncers {
 			if !syncer.WaitUntilSynced(c.stop) {
@@ -256,12 +347,12 @@ func (c *Cluster) Run(mesh meshwatcher.WatcherCollection, handlers []handler, ac
 
 	// Also wait for KRT collections to sync
 	krtSyncers := []krt.Syncer{
-		c.Namespaces(),
-		c.Gateways(),
-		c.Services(),
-		c.Nodes(),
-		c.EndpointSlices(),
-		c.Pods(),
+		c.namespaces(),
+		c.gateways(),
+		c.services(),
+		c.nodes(),
+		c.endpointSlices(),
+		c.pods(),
 	}
 	for _, syncer := range krtSyncers {
 		if !syncer.WaitUntilSynced(c.stop) {
@@ -415,12 +506,12 @@ func (c *Cluster) reportStatus(status string) {
 
 func (c *Cluster) hasInitialCollections() bool {
 	return c.remoteClusterCollections.Load() != nil &&
-		c.Namespaces() != nil &&
-		c.Gateways() != nil &&
-		c.Services() != nil &&
-		c.Nodes() != nil &&
-		c.EndpointSlices() != nil &&
-		c.Pods() != nil
+		c.namespaces() != nil &&
+		c.gateways() != nil &&
+		c.services() != nil &&
+		c.nodes() != nil &&
+		c.endpointSlices() != nil &&
+		c.pods() != nil
 }
 
 // WaitUntilSynced waits for the cluster to be fully synced.

--- a/pkg/kube/multicluster/collections.go
+++ b/pkg/kube/multicluster/collections.go
@@ -44,8 +44,8 @@ func NestedCollectionIndexByCluster[T any](
 }
 
 // NestedCollectionFromLocalAndRemote builds a collection of collections that merges
-// a local collection with per-cluster remote collections derived from the Controller's
-// Clusters() collection.
+// a local collection with per-cluster remote collections derived from the Controller's clusters
+// collection.
 //
 // See NestedManyCollectionsFromLocalAndRemote for the contract clusterToCollection must honor.
 func NestedCollectionFromLocalAndRemote[T any](
@@ -72,7 +72,7 @@ func NestedCollectionFromLocalAndRemote[T any](
 
 // NestedManyCollectionsFromLocalAndRemote builds a collection of collections that merges
 // multiple local collections with per-cluster remote collections derived from the Controller's
-// Clusters() collection. This is a generalization of NestedCollectionFromLocalAndRemote for
+// clusters collection. This is a generalization of NestedCollectionFromLocalAndRemote for
 // cases where each cluster produces multiple collections instead of one.
 //
 // clusterToCollections is called once per cluster generation — a cluster whose credentials rotate is
@@ -97,7 +97,7 @@ func NestedManyCollectionsFromLocalAndRemote[T any](
 	name string,
 	opts krt.OptionsBuilder,
 ) krt.Collection[krt.Collection[T]] {
-	clustersCollection := ctrl.Clusters()
+	clustersCollection := ctrl.clusters
 	// The local collections are fixed for the lifetime of the process, so a static container is enough.
 	localContainer := krt.NewStaticCollection(
 		nil,

--- a/pkg/kube/multicluster/collections.go
+++ b/pkg/kube/multicluster/collections.go
@@ -46,17 +46,19 @@ func NestedCollectionIndexByCluster[T any](
 // NestedCollectionFromLocalAndRemote builds a collection of collections that merges
 // a local collection with per-cluster remote collections derived from the Controller's
 // Clusters() collection.
+//
+// See NestedManyCollectionsFromLocalAndRemote for the contract clusterToCollection must honor.
 func NestedCollectionFromLocalAndRemote[T any](
 	ctrl *Controller,
 	localCollection krt.Collection[T],
-	clusterToCollection krt.TransformationSingle[*Cluster, krt.Collection[T]],
+	clusterToCollection krt.TransformationSingle[ClusterCollections, krt.Collection[T]],
 	name string,
 	opts krt.OptionsBuilder,
 ) krt.Collection[krt.Collection[T]] {
 	return NestedManyCollectionsFromLocalAndRemote(
 		ctrl,
 		[]krt.Collection[T]{localCollection},
-		func(ctx krt.HandlerContext, c *Cluster) []krt.Collection[T] {
+		func(ctx krt.HandlerContext, c ClusterCollections) []krt.Collection[T] {
 			col := clusterToCollection(ctx, c)
 			if col == nil {
 				return nil
@@ -72,10 +74,26 @@ func NestedCollectionFromLocalAndRemote[T any](
 // multiple local collections with per-cluster remote collections derived from the Controller's
 // Clusters() collection. This is a generalization of NestedCollectionFromLocalAndRemote for
 // cases where each cluster produces multiple collections instead of one.
+//
+// clusterToCollections is called once per cluster generation — a cluster whose credentials rotate is
+// a new generation and is rebuilt from scratch. It receives a ClusterCollections view rather than the
+// *Cluster, and it must:
+//   - build every collection it returns with krt.WithStop(c.GetStop()), so the handler registrations
+//     it makes on the cluster's informer-backed collections are released when the cluster goes away.
+//     Using a process-wide stop channel instead leaks the registration, the informers and the cluster
+//     itself;
+//   - return nil if it cannot build the collections yet (for example a krt.Fetch on another
+//     per-cluster collection that has not been computed yet). The cluster is then omitted until the
+//     transformation is recomputed;
+//   - not retain the ClusterCollections, or the collections it returns, past the call.
+//
+// The returned collections are cached per (cluster ID, kubeconfig SHA) so that unrelated recomputes
+// of the clusters collection do not rebuild them, and they are dropped from the cache when the
+// cluster is deleted.
 func NestedManyCollectionsFromLocalAndRemote[T any](
 	ctrl *Controller,
 	localCollections []krt.Collection[T],
-	clusterToCollections func(krt.HandlerContext, *Cluster) []krt.Collection[T],
+	clusterToCollections func(krt.HandlerContext, ClusterCollections) []krt.Collection[T],
 	name string,
 	opts krt.OptionsBuilder,
 ) krt.Collection[krt.Collection[T]] {
@@ -108,7 +126,7 @@ func NestedManyCollectionsFromLocalAndRemote[T any](
 		if existing := cache.Get(c.ID, c.kubeConfigSha); existing != nil {
 			return existing
 		}
-		cols := clusterToCollections(ctx, c)
+		cols := clusterToCollections(ctx, ClusterCollections{cluster: c})
 		if cols == nil {
 			log.Warnf("no collections for %s returned for cluster %v", name, c.ID)
 			return nil

--- a/pkg/kube/multicluster/collections_test.go
+++ b/pkg/kube/multicluster/collections_test.go
@@ -79,8 +79,8 @@ func TestNestedCollectionsRebuiltOnClusterUpdate(t *testing.T) {
 	nested := NestedCollectionFromLocalAndRemote(
 		c.controller,
 		localCollection,
-		func(ctx krt.HandlerContext, cl *Cluster) *krt.Collection[*v1.Service] {
-			if !cl.hasInitialCollections() {
+		func(ctx krt.HandlerContext, cl ClusterCollections) *krt.Collection[*v1.Service] {
+			if !cl.cluster.hasInitialCollections() {
 				return nil
 			}
 			return ptr.Of(cl.Services())
@@ -242,8 +242,8 @@ func TestNestedCollectionFromLocalAndRemoteRotation(t *testing.T) {
 			return NestedCollectionFromLocalAndRemote(
 				ctrl,
 				local,
-				func(ctx krt.HandlerContext, cl *Cluster) *krt.Collection[*v1.Service] {
-					if !cl.hasInitialCollections() {
+				func(ctx krt.HandlerContext, cl ClusterCollections) *krt.Collection[*v1.Service] {
+					if !cl.cluster.hasInitialCollections() {
 						return nil
 					}
 					return ptr.Of(cl.Services())
@@ -267,20 +267,21 @@ func TestNestedManyCollectionsFromLocalAndRemoteRotation(t *testing.T) {
 			return NestedManyCollectionsFromLocalAndRemote(
 				ctrl,
 				[]krt.Collection[*v1.Service]{local},
-				func(ctx krt.HandlerContext, cl *Cluster) []krt.Collection[*v1.Service] {
-					if !cl.hasInitialCollections() {
+				func(ctx krt.HandlerContext, cl ClusterCollections) []krt.Collection[*v1.Service] {
+					if !cl.cluster.hasInitialCollections() {
 						return nil
 					}
 					// The mirror is named after the cluster and stopped with it, the way per-cluster
 					// collections are built in the ambient index.
 					// NewCollection rather than MapCollection: the mirror renames what it holds, and a
 					// mapped collection must keep the keys of the one it maps.
-					mirror := krt.NewCollection(cl.Services(), func(ctx krt.HandlerContext, svc *v1.Service) **v1.Service {
-						out := svc.DeepCopy()
-						out.Name = "mirror-" + svc.Name
-						return &out
-					},
-						krt.WithName(fmt.Sprintf("MirrorServices[%s]", cl.ID)),
+					mirror := krt.NewCollection(
+						cl.Services(), func(ctx krt.HandlerContext, svc *v1.Service) **v1.Service {
+							out := svc.DeepCopy()
+							out.Name = "mirror-" + svc.Name
+							return &out
+						},
+						krt.WithName(fmt.Sprintf("MirrorServices[%s]", cl.ID())),
 						krt.WithStop(cl.GetStop()),
 						krt.WithDebugging(opts.Debugger()),
 					)

--- a/pkg/kube/multicluster/secretcontroller.go
+++ b/pkg/kube/multicluster/secretcontroller.go
@@ -236,11 +236,6 @@ func (c *Controller) buildClustersCollection(optsBuilder krt.OptionsBuilder) {
 	}, optsBuilder.WithName("RemoteClusters")...)
 }
 
-// Clusters returns the krt collection of remote Clusters.
-func (c *Controller) Clusters() krt.Collection[*Cluster] {
-	return c.clusters
-}
-
 // ConfigCluster returns a collections view of the local/config cluster. Unlike remote clusters, the
 // config cluster lives for the lifetime of the process, so collections derived from it need no
 // special teardown. See ClusterCollections.

--- a/pkg/kube/multicluster/secretcontroller.go
+++ b/pkg/kube/multicluster/secretcontroller.go
@@ -241,14 +241,11 @@ func (c *Controller) Clusters() krt.Collection[*Cluster] {
 	return c.clusters
 }
 
-// ConfigCluster returns the local/config cluster.
-func (c *Controller) ConfigCluster() *Cluster {
-	return c.configCluster
-}
-
-// ClusterStore returns the underlying ClusterStore.
-func (c *Controller) ClusterStore() *ClusterStore {
-	return c.cs
+// ConfigCluster returns a collections view of the local/config cluster. Unlike remote clusters, the
+// config cluster lives for the lifetime of the process, so collections derived from it need no
+// special teardown. See ClusterCollections.
+func (c *Controller) ConfigCluster() ClusterCollections {
+	return ClusterCollections{cluster: c.configCluster}
 }
 
 type ComponentBuilder interface {

--- a/pkg/kube/multicluster/secretcontroller_test.go
+++ b/pkg/kube/multicluster/secretcontroller_test.go
@@ -410,7 +410,7 @@ func TestListRemoteClusters(t *testing.T) {
 		SourceSecret types.NamespacedName
 	}
 	getSimpleClusters := func() []simpleCluster {
-		clusters := c.controller.Clusters().List()
+		clusters := c.controller.clusters.List()
 		sorted := slices.SortBy(clusters, func(cl *Cluster) cluster.ID { return cl.ID })
 		return slices.Map(sorted, func(cl *Cluster) simpleCluster {
 			return simpleCluster{ID: cl.ID, SourceSecret: cl.SourceSecret}
@@ -1147,7 +1147,7 @@ func TestKRTClustersCollection(t *testing.T) {
 	// Build derived KRT collections to track cluster lifecycle via iteration counter.
 	// Start at 1 so the first remote cluster gets iter=2, matching the config cluster's iter=1.
 	iter := uberatomic.NewInt32(1)
-	remoteResults := krt.NewCollection(c.Clusters(), func(_ krt.HandlerContext, cl *Cluster) *krtTestResult {
+	remoteResults := krt.NewCollection(c.clusters, func(_ krt.HandlerContext, cl *Cluster) *krtTestResult {
 		return &krtTestResult{
 			ID:   cl.ID,
 			Iter: iter.Inc(),
@@ -1165,9 +1165,9 @@ func TestKRTClustersCollection(t *testing.T) {
 	assert.NoError(t, c.Run(stopCh))
 
 	t.Run("sync timeout", func(t *testing.T) {
-		retry.UntilOrFail(t, c.Clusters().HasSynced, retry.Timeout(2*time.Second))
+		retry.UntilOrFail(t, c.clusters.HasSynced, retry.Timeout(2*time.Second))
 	})
-	kube.WaitForCacheSync("test", stopCh, c.Clusters().HasSynced, allResults.HasSynced)
+	kube.WaitForCacheSync("test", stopCh, c.clusters.HasSynced, allResults.HasSynced)
 
 	for _, step := range steps {
 		t.Run(step.name, func(t *testing.T) {
@@ -1216,7 +1216,7 @@ func TestKRTClustersCollectionSyncTimeoutEviction(t *testing.T) {
 	secrets := clienttest.NewWriter[*v1.Secret](t, client)
 	client.RunAndWait(stopCh)
 	assert.NoError(t, c.Run(stopCh))
-	retry.UntilOrFail(t, c.Clusters().HasSynced, retry.Timeout(2*time.Second))
+	retry.UntilOrFail(t, c.clusters.HasSynced, retry.Timeout(2*time.Second))
 
 	// Add a secret — the cluster will be stored but never sync
 	secrets.Create(makeSecret(secretNamespace, "s0", clusterCredential{"c0", []byte("kubeconfig0")}))
@@ -1228,14 +1228,14 @@ func TestKRTClustersCollectionSyncTimeoutEviction(t *testing.T) {
 
 	// But the KRT Clusters() collection should NOT include it (it's not synced yet and AllReady filters it out)
 	assert.EventuallyEqual(t, func() int {
-		return len(c.Clusters().List())
+		return len(c.clusters.List())
 	}, 0)
 
 	// Wait for RemoteClusterTimeout to fire, then wait a bit more to confirm no panic/segfault
 	time.Sleep(features.RemoteClusterTimeout + 500*time.Millisecond)
 
 	// The cluster should still not be in the Clusters() collection after timeout
-	assert.Equal(t, len(c.Clusters().List()), 0)
+	assert.Equal(t, len(c.clusters.List()), 0)
 
 	// Verify the cluster timed out via the ClusterStore
 	cl := c.cs.GetByID("c0")


### PR DESCRIPTION
**Please provide a description of this PR:**
This doesn't change any functionallity, only changes the `multicluster` package interface to avoid exposing "unsafe" methods outside the package, mainly KRT collections which, when used outside of multicluster Nested collections could end up generating goroutine and memory leaks.

Changes:
- `Cluster`'s KRT collection accessors have been made private
- `ClusterCollections` is a new wrapper struct that publicly exposes the KRT collection accessors, it's sent as a parameter to `NestedCollectionFromLocalAndRemote` and `NestedManyCollectionsFromLocalAndRemote` transformer functions which are "safe" places to build derived collections and for `ConfigCluster()` which has a global lifetime.
- `ClusterStore()` public method has been removed, it is currently only used inside the multicluster package.
- Made `Clusters()` Collection private, it should not be used outside this package.
- Refactored tests to not depend directly on the Cluster Collection or mutlicluster internals.