### PR TITLE
gate node untaint on ztunnel readiness

### DIFF
--- a/pilot/pkg/controllers/untaint/nodeuntainter.go
+++ b/pilot/pkg/controllers/untaint/nodeuntainter.go
@@ -30,6 +30,7 @@ import (
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/kube/kubetypes"
 	istiolog "istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/util/sets"
 )
 
 var log = istiolog.RegisterScope("untaint", "CNI node-untaint controller")
@@ -38,22 +39,30 @@ var istioCniLabels = map[string]string{
 	"k8s-app": "istio-cni-node",
 }
 
-type NodeUntainter struct {
-	podsClient  kclient.Client[*v1.Pod]
-	nodesClient kclient.Client[*v1.Node]
-	cnilabels   labels.Instance
-	ourNs       string
-	queue       controllers.Queue
-	taintName   string
+var ztunnelLabels = map[string]string{
+	"app": "ztunnel",
 }
 
-func filterNamespace(ns string) func(any) bool {
+type NodeUntainter struct {
+	podsClient    kclient.Client[*v1.Pod]
+	nodesClient   kclient.Client[*v1.Node]
+	cnilabels     labels.Instance
+	ztunnellabels labels.Instance
+	cniNs         string
+	systemNs      string
+	checkZtunnel  bool
+	queue         controllers.Queue
+	taintName     string
+}
+
+func filterNamespaces(nses ...string) func(any) bool {
+	set := sets.New(nses...)
 	return func(obj any) bool {
 		object := controllers.ExtractObject(obj)
 		if object == nil {
 			return false
 		}
-		return ns == object.GetNamespace()
+		return set.Contains(object.GetNamespace())
 	}
 }
 
@@ -63,18 +72,23 @@ func NewNodeUntainter(stop <-chan struct{}, kubeClient kubelib.Client, cniNs, sy
 	if ns == "" {
 		ns = sysNs
 	}
+	// watch both the cni namespace and the system namespace: istio-cni may run in a
+	// dedicated namespace while ztunnel always runs in the system namespace.
 	podsClient := kclient.NewFiltered[*v1.Pod](kubeClient, kclient.Filter{
-		ObjectFilter:    kubetypes.NewStaticObjectFilter(filterNamespace(ns)),
+		ObjectFilter:    kubetypes.NewStaticObjectFilter(filterNamespaces(ns, sysNs)),
 		ObjectTransform: kubelib.StripPodUnusedFields,
 		FieldSelector:   "status.phase!=Failed",
 	})
 	nodes := kclient.NewFiltered[*v1.Node](kubeClient, kclient.Filter{ObjectTransform: kubelib.StripNodeUnusedFields})
 	nt := &NodeUntainter{
-		podsClient:  podsClient,
-		nodesClient: nodes,
-		cnilabels:   labels.Instance(istioCniLabels),
-		ourNs:       ns,
-		taintName:   features.NodeUntaintTaintName,
+		podsClient:    podsClient,
+		nodesClient:   nodes,
+		cnilabels:     labels.Instance(istioCniLabels),
+		ztunnellabels: labels.Instance(ztunnelLabels),
+		cniNs:         ns,
+		systemNs:      sysNs,
+		checkZtunnel:  features.NodeUntaintCheckZtunnel,
+		taintName:     features.NodeUntaintTaintName,
 	}
 	nt.setup(stop, debugger)
 	return nt
@@ -87,7 +101,7 @@ func (n *NodeUntainter) setup(stop <-chan struct{}, debugger *krt.DebugHandler) 
 
 	readyCniPods := krt.NewCollection(pods, func(ctx krt.HandlerContext, p *v1.Pod) **v1.Pod {
 		log.Debugf("cniPods event: %s", p.Name)
-		if p.Namespace != n.ourNs {
+		if p.Namespace != n.cniNs {
 			return nil
 		}
 		if !n.cnilabels.SubsetOf(p.ObjectMeta.Labels) {
@@ -100,8 +114,29 @@ func (n *NodeUntainter) setup(stop <-chan struct{}, debugger *krt.DebugHandler) 
 		return &p
 	}, opts.WithName("cni-pods")...)
 
-	// these are all the nodes that have a ready cni pod. if the cni pod is ready,
-	// it means we are ok scheduling pods to it.
+	readyZtunnelPods := krt.NewCollection(pods, func(ctx krt.HandlerContext, p *v1.Pod) **v1.Pod {
+		log.Debugf("ztunnelPods event: %s", p.Name)
+		if p.Namespace != n.systemNs {
+			return nil
+		}
+		if !n.ztunnellabels.SubsetOf(p.ObjectMeta.Labels) {
+			return nil
+		}
+		if !IsPodReadyConditionTrue(p.Status) {
+			return nil
+		}
+		log.Debugf("ztunnel pod %s on node %s ready!", p.Name, p.Spec.NodeName)
+		return &p
+	}, opts.WithName("ztunnel-pods")...)
+
+	ztunnelByNode := krt.NewIndex(readyZtunnelPods, "node", func(p *v1.Pod) []string {
+		if p.Spec.NodeName == "" {
+			return nil
+		}
+		return []string{p.Spec.NodeName}
+	})
+
+	// nodes with a ready cni pod, and (when ambient) a ready ztunnel pod too.
 	readyCniNodes := krt.NewCollection(readyCniPods, func(ctx krt.HandlerContext, p *v1.Pod) **v1.Node {
 		pnode := krt.FetchOne(ctx, nodes, krt.FilterKey(p.Spec.NodeName))
 		if pnode == nil {
@@ -110,6 +145,13 @@ func (n *NodeUntainter) setup(stop <-chan struct{}, debugger *krt.DebugHandler) 
 		node := *pnode
 		if !n.hasTaint(node) {
 			return nil
+		}
+		if n.checkZtunnel {
+			// Fetch registers a dependency, so this recomputes when ztunnel readiness changes.
+			if len(krt.Fetch(ctx, readyZtunnelPods, krt.FilterIndex(ztunnelByNode, node.Name))) == 0 {
+				log.Debugf("node %s has a ready cni pod but no ready ztunnel, keeping it tainted", node.Name)
+				return nil
+			}
 		}
 		return pnode
 	}, opts.WithName("ready-cni-nodes")...)

--- a/pilot/pkg/controllers/untaint/nodeuntainter_test.go
+++ b/pilot/pkg/controllers/untaint/nodeuntainter_test.go
@@ -38,11 +38,17 @@ var cniPodLabels = map[string]string{
 	"some-other": "label",
 }
 
+var ztunnelPodLabels = map[string]string{
+	"app": "ztunnel",
+}
+
 type nodeTainterTestServer struct {
 	client kubelib.Client
 	pc     clienttest.TestClient[*corev1.Pod]
 	nc     clienttest.TestClient[*corev1.Node]
 	t      *testing.T
+	cniNs  string
+	sysNs  string
 }
 
 func setupLogging() {
@@ -55,11 +61,15 @@ func setupLogging() {
 }
 
 func newNodeUntainterTestServer(t *testing.T) *nodeTainterTestServer {
+	return newNodeUntainterTestServerNs(t, systemNS, systemNS)
+}
+
+func newNodeUntainterTestServerNs(t *testing.T, cniNs, sysNs string) *nodeTainterTestServer {
 	stop := make(chan struct{})
 	t.Cleanup(func() { close(stop) })
 	client := kubelib.NewFakeClient()
 
-	nodeUntainter := NewNodeUntainter(stop, client, systemNS, systemNS, krt.GlobalDebugHandler)
+	nodeUntainter := NewNodeUntainter(stop, client, cniNs, sysNs, krt.GlobalDebugHandler)
 	go nodeUntainter.Run(stop)
 	client.RunAndWait(stop)
 	kubelib.WaitForCacheSync("test", stop, nodeUntainter.HasSynced)
@@ -72,17 +82,21 @@ func newNodeUntainterTestServer(t *testing.T) *nodeTainterTestServer {
 		t:      t,
 		pc:     pc,
 		nc:     nc,
+		cniNs:  cniNs,
+		sysNs:  sysNs,
 	}
 }
 
 func TestNodeUntainter(t *testing.T) {
 	setupLogging()
 	test.SetForTest(t, &features.EnableNodeUntaintControllers, true)
+	test.SetForTest(t, &features.NodeUntaintCheckZtunnel, true)
 	s := newNodeUntainterTestServer(t)
 	s.addTaintedNodes(t, "node1", "node2", "node3")
 	s.addPod(t, "node3", true, map[string]string{"k8s-app": "other-app"}, "")
 	s.addCniPod(t, "node2", false)
 	s.addCniPod(t, "node1", true)
+	s.addZtunnelPod(t, "node1", true)
 	s.assertNodeUntainted(t, "node1")
 	s.assertNodeTainted(t, "node2")
 	s.assertNodeTainted(t, "node3")
@@ -90,10 +104,12 @@ func TestNodeUntainter(t *testing.T) {
 
 func TestNodeUntainterOnlyUntaintsWhenIstiocniInourNs(t *testing.T) {
 	test.SetForTest(t, &features.EnableNodeUntaintControllers, true)
+	test.SetForTest(t, &features.NodeUntaintCheckZtunnel, true)
 	s := newNodeUntainterTestServer(t)
 	s.addTaintedNodes(t, "node1", "node2")
 	s.addPod(t, "node2", true, cniPodLabels, "default")
 	s.addCniPod(t, "node1", true)
+	s.addZtunnelPod(t, "node1", true)
 
 	// wait for the untainter to run
 	s.assertNodeUntainted(t, "node1")
@@ -103,6 +119,7 @@ func TestNodeUntainterOnlyUntaintsWhenIstiocniInourNs(t *testing.T) {
 func TestNodeUntainterWithCustomTaintName(t *testing.T) {
 	setupLogging()
 	test.SetForTest(t, &features.EnableNodeUntaintControllers, true)
+	test.SetForTest(t, &features.NodeUntaintCheckZtunnel, true)
 	test.SetForTest(t, &features.NodeUntaintTaintName, "custom.io/not-ready")
 
 	s := newNodeUntainterTestServer(t)
@@ -119,11 +136,68 @@ func TestNodeUntainterWithCustomTaintName(t *testing.T) {
 
 	s.addCniPod(t, "node1", true)
 	s.addCniPod(t, "node2", true)
+	s.addZtunnelPod(t, "node1", true)
+	s.addZtunnelPod(t, "node2", true)
 
 	s.assertNodeUntainted(t, "node1")
 	// node2 still has the `cni.istio.io/not-ready` taint rather than the `custom.io/not-ready` one.
 	// The untaint controller should not remove it, as it only manages the `custom.io/not-ready` taint.
 	s.assertNodeHasTaintKey(t, "node2", "cni.istio.io/not-ready")
+}
+
+func TestNodeStaysTaintedWhileZtunnelNotReady(t *testing.T) {
+	setupLogging()
+	test.SetForTest(t, &features.EnableNodeUntaintControllers, true)
+	test.SetForTest(t, &features.NodeUntaintCheckZtunnel, true)
+	s := newNodeUntainterTestServer(t)
+	s.addTaintedNodes(t, "node1")
+
+	// cni is ready but ztunnel is wedged (0/1): the node must stay tainted.
+	s.addCniPod(t, "node1", true)
+	s.addZtunnelPod(t, "node1", false)
+	s.assertNodeTainted(t, "node1")
+
+	// once ztunnel becomes ready the node gets untainted.
+	s.markZtunnelReady(t, "node1")
+	s.assertNodeUntainted(t, "node1")
+}
+
+func TestNodeStaysTaintedWithNoZtunnel(t *testing.T) {
+	setupLogging()
+	test.SetForTest(t, &features.EnableNodeUntaintControllers, true)
+	test.SetForTest(t, &features.NodeUntaintCheckZtunnel, true)
+	s := newNodeUntainterTestServer(t)
+	s.addTaintedNodes(t, "node1")
+
+	// cni ready, no ztunnel pod on the node at all: stays tainted.
+	s.addCniPod(t, "node1", true)
+	s.assertNodeTainted(t, "node1")
+}
+
+func TestNodeUntaintedWithCniAndZtunnelInSeparateNamespaces(t *testing.T) {
+	setupLogging()
+	test.SetForTest(t, &features.EnableNodeUntaintControllers, true)
+	test.SetForTest(t, &features.NodeUntaintCheckZtunnel, true)
+	// istio-cni in its own namespace, ztunnel in the system namespace.
+	s := newNodeUntainterTestServerNs(t, "istio-cni", systemNS)
+	s.addTaintedNodes(t, "node1")
+
+	s.addCniPod(t, "node1", true)
+	s.addZtunnelPod(t, "node1", true)
+	s.assertNodeUntainted(t, "node1")
+}
+
+// In sidecar mode there is no ztunnel, so the ztunnel gate is off and a ready
+// istio-cni is enough to untaint the node.
+func TestNodeUntaintedInSidecarModeIgnoresZtunnel(t *testing.T) {
+	setupLogging()
+	test.SetForTest(t, &features.EnableNodeUntaintControllers, true)
+	test.SetForTest(t, &features.NodeUntaintCheckZtunnel, false)
+	s := newNodeUntainterTestServer(t)
+	s.addTaintedNodes(t, "node1")
+
+	s.addCniPod(t, "node1", true)
+	s.assertNodeUntainted(t, "node1")
 }
 
 func (s *nodeTainterTestServer) assertNodeTainted(t *testing.T, node string) {
@@ -182,13 +256,35 @@ func (s *nodeTainterTestServer) addTaintedNodes(t *testing.T, nodes ...string) {
 }
 
 func (s *nodeTainterTestServer) addCniPod(t *testing.T, node string, markReady bool) {
-	s.addPod(t, node, markReady, cniPodLabels, systemNS)
+	s.addPod(t, node, markReady, cniPodLabels, s.cniNs)
+}
+
+func (s *nodeTainterTestServer) addZtunnelPod(t *testing.T, node string, markReady bool) {
+	s.addPod(t, node, markReady, ztunnelPodLabels, s.sysNs)
+}
+
+// markZtunnelReady flips an already-created ztunnel pod to Ready.
+func (s *nodeTainterTestServer) markZtunnelReady(t *testing.T, node string) {
+	t.Helper()
+	name := "ztunnel-" + node
+	p := s.pc.Get(name, s.sysNs)
+	if p == nil {
+		t.Fatalf("ztunnel pod for node %s not found", node)
+	}
+	// Get returns the shared cache object; copy before mutating to avoid racing the controller.
+	p = p.DeepCopy()
+	setPodReady(p)
+	s.pc.UpdateStatus(p)
 }
 
 func (s *nodeTainterTestServer) addPod(t *testing.T, node string, markReady bool, labels map[string]string, ns string) {
 	t.Helper()
 	ip := "1.2.3.4"
-	name := "istio-cni-" + node
+	prefix := "istio-cni-"
+	if labels["app"] == "ztunnel" {
+		prefix = "ztunnel-"
+	}
+	name := prefix + node
 	if ns == "" {
 		ns = systemNS
 	}

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -181,6 +181,14 @@ var (
 		"The taint key used by the node-untaint controller to identify nodes that should be untainted.",
 	).Get()
 
+	// registerAmbient (not env.Register): forced false in sidecar mode, where there is no ztunnel.
+	NodeUntaintCheckZtunnel = registerAmbient(
+		"PILOT_NODE_UNTAINT_CHECK_ZTUNNEL",
+		true,  // with ambient: also require ztunnel ready before untainting
+		false, // without ambient: no ztunnel exists, keep istio-cni-only behavior
+		"If enabled, the node-untaint controller also requires ztunnel to be ready on a node before "+
+			"removing the readiness taint. Only applies when ambient is enabled.")
+
 	EnableIPAutoallocate = env.Register(
 		"PILOT_ENABLE_IP_AUTOALLOCATE",
 		true,

--- a/releasenotes/notes/52073.yaml
+++ b/releasenotes/notes/52073.yaml
@@ -1,0 +1,13 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+issue:
+  - 52073
+
+releaseNotes:
+  - |
+    **Fixed** the ambient node-untaint controller removing the `cni.istio.io/not-ready` taint when
+    only istio-cni was ready. It now also waits for ztunnel to be ready on the node, so pods are not
+    scheduled onto a node whose ztunnel is still wedged. This can be disabled with
+    `PILOT_NODE_UNTAINT_CHECK_ZTUNNEL=false`, and only applies when ambient is enabled.


### PR DESCRIPTION
**Please provide a description of this PR:**

first piece of the [ambient node taint manager proposal](https://docs.google.com/document/d/12iqHucQy9g2rTVI156IPFb8KlitVqSfr1zCsNwS92WE/edit)

while exploring different scenarious we noticed the `untaint controller` only watches `istio-cni`, so a node gets untainted while `ztunnel` is still wedged and pods pile up on it. 

this PR makes it also wait for ztunnel before removing the taint. this is flag protected improvement (with default on/true) (turned off in sidecar mode. part of #52073