### PR TITLE
ambient: fix *index.All() extra allocations

### DIFF
--- a/pilot/pkg/serviceregistry/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex.go
@@ -590,13 +590,15 @@ func (a *index) inRevision(obj any) bool {
 
 // All return all known workloads and services. Result is un-ordered
 func (a *index) All() []model.AddressInfo {
+	allWl := a.workloads.List()
+	allSvc := a.services.List()
 	// Add all workloads
-	res := make([]model.AddressInfo, 0, len(a.workloads.List())+len(a.services.List()))
-	for _, wl := range a.workloads.List() {
+	res := make([]model.AddressInfo, 0, len(allWl)+len(allSvc))
+	for _, wl := range allWl {
 		res = append(res, wl.AsAddress)
 	}
 	// Add all services
-	for _, s := range a.services.List() {
+	for _, s := range allSvc {
 		res = append(res, s.AsAddress)
 	}
 	return res


### PR DESCRIPTION
**Please provide a description of this PR:**

Presently `*index.All()` requires 5 large allocations (maybe 6):
1. wl list (just for len)
2. svc list (again, just for len)
3. res
4. wl list (for use)
5. svc list (for use)
6. (maybe) growing res in append if the number of wl+svc has changed between the list for sizing and the list for use. Potentially this could happen multiple times, but generally probably just once unless there's tremendous churn/instability happening.

This pull reduces those allocations to 3 (wl, svc, res) in order to reduce overall churn and gc load. In large meshes this starts to matter. Because res is sized directly from the slices that will actually populate it, we should never regress to an additional large allocation to grow res in append.