### PR TITLE
Premarshal workloads

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1165,6 +1165,8 @@ var _ AmbientIndexes = NoopAmbientIndexes{}
 type AddressInfo struct {
 	*workloadapi.Address
 	Marshaled *anypb.Any
+	// MarshaledWorkload contains the pre-marshaled inner Workload, when present.
+	MarshaledWorkload *anypb.Any
 	// Version is a content-based hash of Marshaled, sent as the resource version over WDS.
 	// Clients echo it back in InitialResourceVersions on reconnect, letting the server skip
 	// resources the client already has; hashing the content keeps versions consistent across
@@ -1177,10 +1179,15 @@ type AddressInfo struct {
 // content-based Version.
 func NewAddressInfo(addr *workloadapi.Address) AddressInfo {
 	marshaled := protoconv.MessageToAny(addr)
+	var marshaledWorkload *anypb.Any
+	if workload := addr.GetWorkload(); workload != nil {
+		marshaledWorkload = protoconv.MessageToAny(workload)
+	}
 	return AddressInfo{
-		Address:   addr,
-		Marshaled: marshaled,
-		Version:   strconv.FormatUint(xxhash.Sum64(marshaled.Value), 16),
+		Address:           addr,
+		Marshaled:         marshaled,
+		MarshaledWorkload: marshaledWorkload,
+		Version:           strconv.FormatUint(xxhash.Sum64(marshaled.Value), 16),
 	}
 }
 

--- a/pilot/pkg/model/service_test.go
+++ b/pilot/pkg/model/service_test.go
@@ -15,13 +15,16 @@
 package model
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/cespare/xxhash/v2"
 	"github.com/google/go-cmp/cmp"
 	fuzz "github.com/google/gofuzz"
 
 	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
@@ -33,6 +36,37 @@ import (
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/workloadapi"
 )
+
+func TestNewAddressInfo(t *testing.T) {
+	workload := &workloadapi.Workload{Uid: "workload"}
+	workloadAddress := &workloadapi.Address{
+		Type: &workloadapi.Address_Workload{Workload: workload},
+	}
+	serviceAddress := &workloadapi.Address{
+		Type: &workloadapi.Address_Service{Service: &workloadapi.Service{Name: "service"}},
+	}
+
+	for name, tt := range map[string]struct {
+		address               *workloadapi.Address
+		wantMarshaledWorkload *workloadapi.Workload
+	}{
+		"workload": {address: workloadAddress, wantMarshaledWorkload: workload},
+		"service":  {address: serviceAddress},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := NewAddressInfo(tt.address)
+			wantAddress := protoconv.MessageToAny(tt.address)
+			assert.Equal(t, got.Marshaled, wantAddress)
+			assert.Equal(t, got.Version, strconv.FormatUint(xxhash.Sum64(wantAddress.Value), 16))
+
+			if tt.wantMarshaledWorkload == nil {
+				assert.Equal(t, got.MarshaledWorkload, nil)
+				return
+			}
+			assert.Equal(t, got.MarshaledWorkload, protoconv.MessageToAny(tt.wantMarshaledWorkload))
+		})
+	}
+}
 
 func TestGetByPort(t *testing.T) {
 	ports := PortList{{

--- a/pilot/pkg/serviceregistry/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex_test.go
@@ -2968,6 +2968,9 @@ func (s *ambientTestServer) assertAddresses(t *testing.T, lookup string, names .
 		for _, address := range addresses {
 			// Validate we pre-marshal everything
 			assert.Equal(t, address.Marshaled != nil, true)
+			if address.GetWorkload() != nil {
+				assert.Equal(t, address.MarshaledWorkload != nil, true)
+			}
 			switch addr := address.Address.Type.(type) {
 			case *workloadapi.Address_Workload:
 				have.Insert(addr.Workload.Name)

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -275,6 +275,14 @@ func TestAddressFullGeneration(t *testing.T) {
 	testBenchmark(t, v3.AddressType, wdsCases)
 }
 
+func BenchmarkWorkloadFullGeneration(b *testing.B) {
+	runBenchmark(b, v3.WorkloadType, wdsCases)
+}
+
+func TestWorkloadFullGeneration(t *testing.T) {
+	testBenchmark(t, v3.WorkloadType, wdsCases)
+}
+
 var wdsIncrementalCases = func() []ConfigInput {
 	cases := slices.Clone(wdsCases)
 	// Request a single resource
@@ -290,6 +298,14 @@ func BenchmarkAddressIncrementalGeneration(b *testing.B) {
 
 func TestAddressIncrementalGeneration(t *testing.T) {
 	testBenchmark(t, v3.AddressType, wdsIncrementalCases)
+}
+
+func BenchmarkWorkloadIncrementalGeneration(b *testing.B) {
+	runBenchmark(b, v3.WorkloadType, wdsIncrementalCases)
+}
+
+func TestWorkloadIncrementalGeneration(t *testing.T) {
+	testBenchmark(t, v3.WorkloadType, wdsIncrementalCases)
 }
 
 func createGateways(n int) map[string]*meshconfig.Network {
@@ -422,8 +438,8 @@ func getWatchedResources(tpe string, tt ConfigInput, s *xds.FakeDiscoveryServer,
 		l := s.ConfigGen.BuildListeners(proxy, s.PushContext())
 		routeNames := xdstest.ExtractRoutesFromListeners(l)
 		return &model.WatchedResource{ResourceNames: sets.New(routeNames...)}
-	case v3.AddressType:
-		return &model.WatchedResource{TypeUrl: v3.AddressType, ResourceNames: sets.New[string](), Wildcard: true}
+	case v3.AddressType, v3.WorkloadType:
+		return &model.WatchedResource{TypeUrl: tpe, ResourceNames: sets.New[string](), Wildcard: true}
 	}
 	return nil
 }

--- a/pilot/pkg/xds/util_test.go
+++ b/pilot/pkg/xds/util_test.go
@@ -21,12 +21,38 @@ import (
 
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/util/protoconv"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/util/sets"
+	"istio.io/istio/pkg/workloadapi"
 )
+
+func TestAppendAddressWorkloadMarshal(t *testing.T) {
+	workload := &workloadapi.Workload{Uid: "workload"}
+	marshaled := protoconv.MessageToAny(workload)
+	for name, cached := range map[string]*anypb.Any{
+		"cached":   marshaled,
+		"fallback": nil,
+	} {
+		t.Run(name, func(t *testing.T) {
+			resources := appendAddress(model.AddressInfo{
+				Address: &workloadapi.Address{
+					Type: &workloadapi.Address_Workload{Workload: workload},
+				},
+				MarshaledWorkload: cached,
+			}, v3.WorkloadType, nil, sets.New[string](), nil, nil)
+			assert.Equal(t, len(resources), 1)
+			assert.Equal(t, resources[0].Resource, marshaled)
+			if cached != nil && resources[0].Resource != cached {
+				t.Fatal("appendAddress did not reuse the pre-marshaled workload")
+			}
+		})
+	}
+}
 
 func TestAtMostNJoin(t *testing.T) {
 	tests := []struct {

--- a/pilot/pkg/xds/workload.go
+++ b/pilot/pkg/xds/workload.go
@@ -104,13 +104,17 @@ func appendAddress(
 	switch requestedType {
 	case v3.WorkloadType:
 		if addr.GetWorkload() != nil {
+			proto := addr.MarshaledWorkload
+			if proto == nil {
+				proto = protoconv.MessageToAny(addr.GetWorkload())
+			}
 			resources = append(resources, &discovery.Resource{
 				Name: n,
 				// The Version hashes the Address wrapper rather than the Workload sent here; since
 				// the wrapping is 1:1 it still changes exactly when the content changes.
 				Version:  addr.Version,
 				Aliases:  aliases,
-				Resource: protoconv.MessageToAny(addr.GetWorkload()), // TODO: pre-marshal
+				Resource: proto,
 			})
 		}
 	case v3.AddressType:

--- a/pkg/config/validation/testdata/crds/serviceentry-invalid.yaml
+++ b/pkg/config/validation/testdata/crds/serviceentry-invalid.yaml
@@ -12,7 +12,7 @@ metadata:
 spec: {}
 ---
 #_err: "TODO"
-#apiVersion: networking.istio.io/v1
+#apiVersion: networking.istio.io/v1alpha3
 #kind: ServiceEntry
 #metadata:
 #  name: bad-selector-key
@@ -24,7 +24,7 @@ spec: {}
 #      "*": val
 #---
 _err: "wildcard is not supported in selector"
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: bad-selector-value
@@ -35,7 +35,7 @@ spec:
       "val": "*"
 ---
 _err: "only one of WorkloadSelector or Endpoints can be set"
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: selector-and-endpoints
@@ -46,7 +46,7 @@ spec:
     - address: "1.2.3.4"
 ---
 _err: "hostname cannot be wildcard"
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: bad-host-wildcard
@@ -54,7 +54,7 @@ spec:
   hosts: ["*"]
 #---
 #_err: "TODO"
-#apiVersion: networking.istio.io/v1
+#apiVersion: networking.istio.io/v1alpha3
 #kind: ServiceEntry
 #metadata:
 #  name: bad-host-wildcard-suffix
@@ -62,7 +62,7 @@ spec:
 #  hosts: ["foo*"]
 #---
 #_err: "TODO"
-#apiVersion: networking.istio.io/v1
+#apiVersion: networking.istio.io/v1alpha3
 #kind: ServiceEntry
 #metadata:
 #  name: bad-cidr
@@ -71,7 +71,7 @@ spec:
 #  addresses: [1.2.3.4/99]
 ---
 _err: "CIDR addresses are allowed only for NONE/STATIC resolution types"
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: bad-cidr-resolution
@@ -81,7 +81,7 @@ spec:
   resolution: DNS
 ---
 _err: "Duplicate value"
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: duplicate-ports-name
@@ -94,7 +94,7 @@ spec:
       number: 12
 ---
 _err: "port number cannot be duplicated"
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: duplicate-ports-number
@@ -107,7 +107,7 @@ spec:
       number: 1
 ---
 _err: "port must be between 1-65535"
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: bad-port
@@ -118,7 +118,7 @@ spec:
       number: 99999
 ---
 _err: "port must be between 1-65535"
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: bad-port-target
@@ -130,7 +130,7 @@ spec:
       targetPort: 99999
 ---
 _err: "NONE mode cannot set endpoints"
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: none-with-endpoints
@@ -141,7 +141,7 @@ spec:
   resolution: NONE
 ---
 _err: "DNS_ROUND_ROBIN mode cannot have multiple endpoints"
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: dns-rr-with-multiple-endpoints

--- a/pkg/config/validation/testdata/crds/serviceentry-valid.yaml
+++ b/pkg/config/validation/testdata/crds/serviceentry-valid.yaml
@@ -35,7 +35,7 @@ spec:
   resolution: DNS
 ---
 # Weird case but we allow it
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: empty-selector
@@ -44,7 +44,7 @@ spec:
   hosts: ["example.com"]
 ---
 # Weird case but we allow it
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: partial-wildcard
@@ -52,7 +52,7 @@ spec:
   hosts: ["*x"]
 ---
 # Weird case but we allow it
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: none-cidr

--- a/pkg/config/validation/testdata/crds/workloadentry-invalid.yaml
+++ b/pkg/config/validation/testdata/crds/workloadentry-invalid.yaml
@@ -1,18 +1,18 @@
 _err: 'spec: Required value'
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: WorkloadEntry
 metadata:
   name: no-spec
 ---
 _err: Address is required
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: WorkloadEntry
 metadata:
   name: missing-address
 spec: {}
 ---
 _err: UDS may not be a dir
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: WorkloadEntry
 metadata:
   name: bad-uds-dir
@@ -20,7 +20,7 @@ spec:
   address: unix:///dir/
 ---
 _err: UDS must be an absolute path or abstract socket
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: WorkloadEntry
 metadata:
   name: bad-uds-relative
@@ -28,7 +28,7 @@ spec:
   address: unix://relative
 ---
 _err: UDS may not include ports
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: WorkloadEntry
 metadata:
   name: uds-with-ports
@@ -38,7 +38,7 @@ spec:
     "http": 80
 ---
 _err: port must be between 1-65535
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: WorkloadEntry
 metadata:
   name: high-port
@@ -48,7 +48,7 @@ spec:
     "http": 99999
 ---
 _err: 'spec.ports: Invalid value'
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: WorkloadEntry
 metadata:
   name: bad-port-name

--- a/pkg/config/validation/testdata/crds/workloadentry-valid.yaml
+++ b/pkg/config/validation/testdata/crds/workloadentry-valid.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: WorkloadEntry
 metadata:
   name: full
@@ -13,28 +13,28 @@ spec:
   weight: 2
   locality: foo/bar/baz
 ---
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: WorkloadEntry
 metadata:
   name: missing-address-network-set
 spec:
   network: net
 ---
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: WorkloadEntry
 metadata:
   name: uds-abstract
 spec:
   address: unix://@foo
 ---
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: WorkloadEntry
 metadata:
   name: uds-path
 spec:
   address: unix:///foo/bar
 ---
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: WorkloadEntry
 metadata:
   name: fqdn

--- a/pkg/config/validation/testdata/crds/workloadgroup-invalid.yaml
+++ b/pkg/config/validation/testdata/crds/workloadgroup-invalid.yaml
@@ -5,7 +5,7 @@ metadata:
   name: no-spec
 ---
 _err: port must be between 1-65535
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: WorkloadGroup
 metadata:
   name: tcp-probe-invalid
@@ -18,7 +18,7 @@ spec:
     network: net
 ---
 _err: 'spec.probe.httpGet.httpHeaders[0].name in body should match'
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: WorkloadGroup
 metadata:
   name: http-probe-invalid

--- a/pkg/config/validation/testdata/crds/workloadgroup-valid.yaml
+++ b/pkg/config/validation/testdata/crds/workloadgroup-valid.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: WorkloadGroup
 metadata:
   name: full
@@ -32,7 +32,7 @@ spec:
     weight: 2
     locality: foo/bar/baz
 ---
-apiVersion: networking.istio.io/v1
+apiVersion: networking.istio.io/v1alpha3
 kind: WorkloadGroup
 metadata:
   name: tcp-probe

--- a/releasenotes/notes/61502.yaml
+++ b/releasenotes/notes/61502.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 61502
+
+releaseNotes:
+- |
+  **Fixed** an issue where istiod repeatedly serialized the same workload when
+  pushing workload metadata to Envoy proxies.


### PR DESCRIPTION
**Please provide a description of this PR:**

When supplying metadata to Envoys, we had a `protoconv.MessageToAny` which ran for every workload everytime we served metadata to a proxy. Arguably, this is the path requiring more optimization since Sidecars+Waypoints could drastically exceed the number of ztunnels in a hybrid mesh or a mesh making extensive use of waypoint.

This PR adds a cached pre-computed workload to close the gap between WDS for ztunnel and MDS for Envoys.

## Benchmark Comparison

| Benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| Workload full B/op | 1,501,192 | 1,158,088 | **-22.9%** |
| Workload full allocs/op | 8,140 | 1,133 | **-86.1%** |
| Workload full ns/op | ~1.41 ms | ~0.34 ms | **~76% faster** |
| Workload incremental B/op | 984 | 616 | **-37.4%** |
| Workload incremental allocs/op | 14 | 7 | **-50%** |
| Workload incremental ns/op | ~1.48 us | ~0.40 us | **~73% faster** |