### PR TITLE
istioctl: verify istiod cert when using token auth for xds

### DIFF
--- a/istioctl/pkg/internaldebug/internal-debug_test.go
+++ b/istioctl/pkg/internaldebug/internal-debug_test.go
@@ -19,6 +19,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -40,6 +42,7 @@ import (
 	"istio.io/istio/istioctl/pkg/multixds"
 	"istio.io/istio/istioctl/pkg/xds"
 	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/util/assert"
 )
 
@@ -108,6 +111,7 @@ func TestInternalDebug(t *testing.T) {
 					},
 				}, metav1.CreateOptions{})
 				assert.NoError(t, err)
+				createRootCertConfigMap(t, client)
 			}
 			verifyExecTestOutput(t, DebugCommand(ctx), c)
 		})
@@ -240,6 +244,8 @@ func TestInternalDebugWithMultiIstiod(t *testing.T) {
 				},
 			}, metav1.CreateOptions{})
 			require.NoError(t, err)
+
+			createRootCertConfigMap(t, client)
 
 			verifyExecTestOutput(t, DebugCommand(ctx), c.testcase)
 			require.Equal(t, c.ExceptGetXdsResponseCall, getXdsResponseCall)
@@ -474,5 +480,20 @@ func init() {
 			},
 		}
 		return tf
+	}
+}
+
+func createRootCertConfigMap(t *testing.T, client kube.CLIClient) {
+	t.Helper()
+	rootCert, err := os.ReadFile(filepath.Join(env.IstioSrc, "tests/testdata/certs/pilot/root-cert.pem"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.Kube().CoreV1().ConfigMaps("istio-system").Create(context.TODO(), &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "istio-ca-root-cert", Namespace: "istio-system"},
+		Data:       map[string]string{"root-cert.pem": string(rootCert)},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/istioctl/pkg/multixds/gather.go
+++ b/istioctl/pkg/multixds/gather.go
@@ -183,6 +183,21 @@ func mergeShards(responses map[string]*discovery.DiscoveryResponse) (*discovery.
 	return &retval, nil
 }
 
+// defaultSan sets the expected istiod SAN when dialing an IP or localhost address,
+// since istiod certificates only contain DNS SANs. An explicit --authority wins.
+func defaultSan(centralOpts *clioptions.CentralControlPlaneOptions, istioNamespace string, kubeClient kube.CLIClient) {
+	if centralOpts.XDSSAN != "" || centralOpts.Plaintext || centralOpts.InsecureSkipVerify {
+		return
+	}
+	host, _, err := net.SplitHostPort(centralOpts.Xds)
+	if err != nil {
+		host = centralOpts.Xds
+	}
+	if host == "localhost" || net.ParseIP(host) != nil {
+		centralOpts.XDSSAN = makeSan(istioNamespace, kubeClient.Revision())
+	}
+}
+
 func makeSan(istioNamespace, revision string) string {
 	// istiod only adds istiod-<revision> to its cert for non-default revisions, see getDNSNames in pilot/pkg/bootstrap.
 	if revision == "" || revision == "default" {
@@ -252,6 +267,7 @@ func MultiRequestAndProcessXds(all bool, dr *discovery.DiscoveryRequest, central
 		serviceAccount = tokenServiceAccount
 	}
 	if centralOpts.Xds != "" {
+		defaultSan(&centralOpts, istioNamespace, kubeClient)
 		dialOpts, err := xds.DialOptions(centralOpts, ns, serviceAccount, kubeClient)
 		if err != nil {
 			return nil, err
@@ -275,6 +291,7 @@ func MultiRequestAndProcessXds(all bool, dr *discovery.DiscoveryRequest, central
 				centralOpts.Xds = addr.host
 				centralOpts.GCPProject = addr.gcpProject
 				centralOpts.IstiodAddr = addr.istiod
+				defaultSan(&centralOpts, istioNamespace, kubeClient)
 				dialOpts, err := xds.DialOptions(centralOpts, istioNamespace, tokenServiceAccount, kubeClient)
 				if err != nil {
 					return nil, err

--- a/istioctl/pkg/multixds/gather.go
+++ b/istioctl/pkg/multixds/gather.go
@@ -184,7 +184,8 @@ func mergeShards(responses map[string]*discovery.DiscoveryResponse) (*discovery.
 }
 
 func makeSan(istioNamespace, revision string) string {
-	if revision == "" {
+	// istiod only adds istiod-<revision> to its cert for non-default revisions, see getDNSNames in pilot/pkg/bootstrap.
+	if revision == "" || revision == "default" {
 		return fmt.Sprintf("istiod.%s.svc", istioNamespace)
 	}
 	return fmt.Sprintf("istiod-%s.%s.svc", revision, istioNamespace)

--- a/istioctl/pkg/multixds/gather_test.go
+++ b/istioctl/pkg/multixds/gather_test.go
@@ -14,7 +14,12 @@
 
 package multixds
 
-import "testing"
+import (
+	"testing"
+
+	"istio.io/istio/istioctl/pkg/clioptions"
+	"istio.io/istio/pkg/kube"
+)
 
 func TestMakeSan(t *testing.T) {
 	cases := []struct {
@@ -29,5 +34,29 @@ func TestMakeSan(t *testing.T) {
 		if got := makeSan("istio-system", c.revision); got != c.want {
 			t.Errorf("makeSan(%q) = %q, want %q", c.revision, got, c.want)
 		}
+	}
+}
+
+func TestDefaultSan(t *testing.T) {
+	cases := []struct {
+		name string
+		opts clioptions.CentralControlPlaneOptions
+		want string
+	}{
+		{"ip address", clioptions.CentralControlPlaneOptions{Xds: "172.18.6.116:15012"}, "istiod.istio-system.svc"},
+		{"localhost", clioptions.CentralControlPlaneOptions{Xds: "localhost:15012"}, "istiod.istio-system.svc"},
+		{"ip without port", clioptions.CentralControlPlaneOptions{Xds: "172.18.6.116"}, "istiod.istio-system.svc"},
+		{"dns name kept", clioptions.CentralControlPlaneOptions{Xds: "istiod.example.com:15012"}, ""},
+		{"explicit authority wins", clioptions.CentralControlPlaneOptions{Xds: "172.18.6.116:15012", XDSSAN: "custom.san"}, "custom.san"},
+		{"insecure skips", clioptions.CentralControlPlaneOptions{Xds: "172.18.6.116:15012", InsecureSkipVerify: true}, ""},
+		{"plaintext skips", clioptions.CentralControlPlaneOptions{Xds: "172.18.6.116:15012", Plaintext: true}, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			defaultSan(&c.opts, "istio-system", kube.NewFakeClient())
+			if c.opts.XDSSAN != c.want {
+				t.Errorf("XDSSAN = %q, want %q", c.opts.XDSSAN, c.want)
+			}
+		})
 	}
 }

--- a/istioctl/pkg/multixds/gather_test.go
+++ b/istioctl/pkg/multixds/gather_test.go
@@ -1,0 +1,33 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multixds
+
+import "testing"
+
+func TestMakeSan(t *testing.T) {
+	cases := []struct {
+		revision string
+		want     string
+	}{
+		{"", "istiod.istio-system.svc"},
+		{"default", "istiod.istio-system.svc"},
+		{"canary", "istiod-canary.istio-system.svc"},
+	}
+	for _, c := range cases {
+		if got := makeSan("istio-system", c.revision); got != c.want {
+			t.Errorf("makeSan(%q) = %q, want %q", c.revision, got, c.want)
+		}
+	}
+}

--- a/istioctl/pkg/proxystatus/proxystatus_test.go
+++ b/istioctl/pkg/proxystatus/proxystatus_test.go
@@ -19,6 +19,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -38,6 +40,7 @@ import (
 	"istio.io/istio/istioctl/pkg/multixds"
 	"istio.io/istio/istioctl/pkg/xds"
 	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/util/assert"
 )
 
@@ -138,6 +141,7 @@ func TestProxyStatus(t *testing.T) {
 					},
 				}, metav1.CreateOptions{})
 				assert.NoError(t, err)
+				createRootCertConfigMap(t, client)
 			}
 			verifyExecTestOutput(t, XdsStatusCommand(ctx), c)
 		})
@@ -195,5 +199,20 @@ func init() {
 			},
 		}
 		return tf
+	}
+}
+
+func createRootCertConfigMap(t *testing.T, client kube.CLIClient) {
+	t.Helper()
+	rootCert, err := os.ReadFile(filepath.Join(env.IstioSrc, "tests/testdata/certs/pilot/root-cert.pem"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.Kube().CoreV1().ConfigMaps("istio-system").Create(context.TODO(), &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "istio-ca-root-cert", Namespace: "istio-system"},
+		Data:       map[string]string{"root-cert.pem": string(rootCert)},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/istioctl/pkg/version/version.go
+++ b/istioctl/pkg/version/version.go
@@ -108,8 +108,9 @@ func XdsVersionCommand(ctx cli.Context) *cobra.Command {
 	var opts clioptions.ControlPlaneOptions
 	var centralOpts clioptions.CentralControlPlaneOptions
 	var xdsResponses *discovery.DiscoveryResponse
-	versionCmd := istioVersion.CobraCommandWithOptions(istioVersion.CobraOptions{
-		GetRemoteVersion: xdsRemoteVersionWrapper(ctx, &opts, &centralOpts, &xdsResponses),
+	var versionCmd *cobra.Command
+	versionCmd = istioVersion.CobraCommandWithOptions(istioVersion.CobraOptions{
+		GetRemoteVersion: xdsRemoteVersionWrapper(ctx, &versionCmd, &opts, &centralOpts, &xdsResponses),
 		GetProxyVersions: xdsProxyVersionWrapper(&xdsResponses),
 	})
 	opts.AttachControlPlaneFlags(versionCmd)
@@ -160,7 +161,7 @@ func XdsVersionCommand(ctx cli.Context) *cobra.Command {
 // xdsRemoteVersionWrapper uses outXDS to share the XDS response with xdsProxyVersionWrapper.
 // (Screwy API on istioVersion.CobraCommandWithOptions)
 // nolint: lll
-func xdsRemoteVersionWrapper(ctx cli.Context, opts *clioptions.ControlPlaneOptions, centralOpts *clioptions.CentralControlPlaneOptions, outXDS **discovery.DiscoveryResponse) func() (*istioVersion.MeshInfo, error) {
+func xdsRemoteVersionWrapper(ctx cli.Context, pc **cobra.Command, opts *clioptions.ControlPlaneOptions, centralOpts *clioptions.CentralControlPlaneOptions, outXDS **discovery.DiscoveryResponse) func() (*istioVersion.MeshInfo, error) {
 	return func() (*istioVersion.MeshInfo, error) {
 		xdsRequest := discovery.DiscoveryRequest{
 			TypeUrl: xds.TypeDebugSyncronization,
@@ -171,6 +172,7 @@ func xdsRemoteVersionWrapper(ctx cli.Context, opts *clioptions.ControlPlaneOptio
 		}
 		xdsResponse, err := multixds.RequestAndProcessXds(&xdsRequest, *centralOpts, ctx.IstioNamespace(), kubeClient)
 		if err != nil {
+			fmt.Fprintf((*pc).ErrOrStderr(), "unable to retrieve the control plane version over XDS: %v\n", err)
 			return nil, err
 		}
 		*outXDS = xdsResponse

--- a/istioctl/pkg/xds/client.go
+++ b/istioctl/pkg/xds/client.go
@@ -25,10 +25,13 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/istio/istioctl/pkg/clioptions"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 	"istio.io/istio/pkg/adsc"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/kube"
 )
 
@@ -101,16 +104,30 @@ func DialOptions(opts clioptions.CentralControlPlaneOptions,
 	if isMCP {
 		return mcpDialOptions(ctx, opts.GCPProject, k8sCreds)
 	}
+	tlsCfg, err := tlsConfig(ctx, opts, ns, kubeClient)
+	if err != nil {
+		return nil, err
+	}
 	return []grpc.DialOption{
-		// nolint: gosec
-		// Only runs over istioctl experimental
-		// TODO: https://github.com/istio/istio/issues/41937
-		grpc.WithTransportCredentials(credentials.NewTLS(
-			&tls.Config{
-				// Always skip verifying, because without it we always get "certificate signed by unknown authority".
-				// We don't set the XDSSAN for the same reason.
-				InsecureSkipVerify: true,
-			})),
+		grpc.WithTransportCredentials(credentials.NewTLS(tlsCfg)),
 		grpc.WithPerRPCCredentials(k8sCreds),
 	}, nil
+}
+
+// tlsConfig verifies istiod against the root in the istio-ca-root-cert configmap unless --insecure is set.
+func tlsConfig(ctx context.Context, opts clioptions.CentralControlPlaneOptions, ns string, kubeClient kube.CLIClient) (*tls.Config, error) {
+	cfg := &adsc.Config{
+		Address:            opts.Xds,
+		XDSSAN:             opts.XDSSAN,
+		InsecureSkipVerify: opts.InsecureSkipVerify,
+	}
+	if !opts.InsecureSkipVerify {
+		cm, err := kubeClient.Kube().CoreV1().ConfigMaps(ns).Get(ctx, controller.CACertNamespaceConfigMap, metav1.GetOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to read the XDS root cert from configmap %s/%s (use --cert-dir, or --insecure to skip verification): %w",
+				ns, controller.CACertNamespaceConfigMap, err)
+		}
+		cfg.XDSRootCA = []byte(cm.Data[constants.CACertNamespaceConfigMapDataName])
+	}
+	return adsc.TLSConfig(cfg)
 }

--- a/istioctl/pkg/xds/client_test.go
+++ b/istioctl/pkg/xds/client_test.go
@@ -1,0 +1,119 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xds
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"istio.io/istio/istioctl/pkg/clioptions"
+	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
+	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/test/env"
+)
+
+func rootCertConfigMap(t *testing.T, ns, data string) *corev1.ConfigMap {
+	t.Helper()
+	if data == "" {
+		pem, err := os.ReadFile(filepath.Join(env.IstioSrc, "tests/testdata/certs/pilot/root-cert.pem"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		data = string(pem)
+	}
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: controller.CACertNamespaceConfigMap, Namespace: ns},
+		Data:       map[string]string{constants.CACertNamespaceConfigMapDataName: data},
+	}
+}
+
+func TestTLSConfig(t *testing.T) {
+	const ns = "istio-system"
+	cases := []struct {
+		name           string
+		opts           clioptions.CentralControlPlaneOptions
+		objects        []runtime.Object
+		wantServerName string
+		wantInsecure   bool
+		wantErr        bool
+	}{
+		{
+			name:           "server name from authority",
+			opts:           clioptions.CentralControlPlaneOptions{XDSSAN: "istiod.istio-system.svc", Xds: "localhost:15012"},
+			objects:        []runtime.Object{rootCertConfigMap(t, ns, "")},
+			wantServerName: "istiod.istio-system.svc",
+		},
+		{
+			name:           "server name from xds address",
+			opts:           clioptions.CentralControlPlaneOptions{Xds: "istiod.example.com:15012"},
+			objects:        []runtime.Object{rootCertConfigMap(t, ns, "")},
+			wantServerName: "istiod.example.com",
+		},
+		{
+			name:           "insecure does not need the root cert",
+			opts:           clioptions.CentralControlPlaneOptions{Xds: "localhost:15012", InsecureSkipVerify: true},
+			wantServerName: "localhost",
+			wantInsecure:   true,
+		},
+		{
+			name:    "missing configmap fails closed",
+			opts:    clioptions.CentralControlPlaneOptions{XDSSAN: "istiod.istio-system.svc"},
+			wantErr: true,
+		},
+		{
+			name:    "configmap in another namespace fails closed",
+			opts:    clioptions.CentralControlPlaneOptions{XDSSAN: "istiod.istio-system.svc"},
+			objects: []runtime.Object{rootCertConfigMap(t, "default", "")},
+			wantErr: true,
+		},
+		{
+			name:    "invalid root cert fails closed",
+			opts:    clioptions.CentralControlPlaneOptions{XDSSAN: "istiod.istio-system.svc"},
+			objects: []runtime.Object{rootCertConfigMap(t, ns, "not a cert")},
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := kube.NewFakeClient(tc.objects...)
+			got, err := tlsConfig(context.Background(), tc.opts, ns, client)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got config %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.ServerName != tc.wantServerName {
+				t.Errorf("ServerName = %q, want %q", got.ServerName, tc.wantServerName)
+			}
+			if got.InsecureSkipVerify != tc.wantInsecure {
+				t.Errorf("InsecureSkipVerify = %v, want %v", got.InsecureSkipVerify, tc.wantInsecure)
+			}
+			if !tc.wantInsecure && got.RootCAs == nil {
+				t.Error("RootCAs not set")
+			}
+		})
+	}
+}

--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -110,6 +110,9 @@ type Config struct {
 	// Mirrors Envoy file.
 	XDSRootCAFile string
 
+	// XDSRootCA is the PEM root CA for the XDS connection. Takes precedence over XDSRootCAFile.
+	XDSRootCA []byte
+
 	// InsecureSkipVerify skips client verification the server's certificate chain and host name.
 	InsecureSkipVerify bool
 
@@ -311,7 +314,7 @@ func dialWithConfig(ctx context.Context, config *Config) (*grpc.ClientConn, erro
 	var err error
 	// If we need MTLS - CertDir or Secrets provider is set.
 	if len(config.CertDir) > 0 || config.SecretManager != nil {
-		tlsCfg, err := tlsConfig(config)
+		tlsCfg, err := TLSConfig(config)
 		if err != nil {
 			return nil, err
 		}
@@ -331,14 +334,17 @@ func dialWithConfig(ctx context.Context, config *Config) (*grpc.ClientConn, erro
 	return conn, nil
 }
 
-func tlsConfig(config *Config) (*tls.Config, error) {
+// TLSConfig builds the client TLS config for the XDS connection from config.
+func TLSConfig(config *Config) (*tls.Config, error) {
 	var serverCABytes []byte
 	var err error
 
 	getClientCertificate := getClientCertFn(config)
 
 	// Load the root CAs
-	if config.XDSRootCAFile != "" {
+	if len(config.XDSRootCA) > 0 {
+		serverCABytes = config.XDSRootCA
+	} else if config.XDSRootCAFile != "" {
 		serverCABytes, err = os.ReadFile(config.XDSRootCAFile)
 		if err != nil {
 			return nil, err
@@ -358,9 +364,12 @@ func tlsConfig(config *Config) (*tls.Config, error) {
 		}
 	}
 
-	serverCAs := x509.NewCertPool()
-	if ok := serverCAs.AppendCertsFromPEM(serverCABytes); !ok {
-		return nil, err
+	var serverCAs *x509.CertPool
+	if len(serverCABytes) > 0 {
+		serverCAs = x509.NewCertPool()
+		if ok := serverCAs.AppendCertsFromPEM(serverCABytes); !ok {
+			return nil, fmt.Errorf("failed to parse root CA certificates")
+		}
 	}
 
 	shost, _, _ := net.SplitHostPort(config.Address)

--- a/pkg/kube/rpc_creds.go
+++ b/pkg/kube/rpc_creds.go
@@ -99,7 +99,8 @@ func (its *tokenSupplier) GetRequestMetadata(ctx context.Context, uri ...string)
 
 // RequireTransportSecurity fulfills the grpc/credentials.PerRPCCredentials interface
 func (its *tokenSupplier) RequireTransportSecurity() bool {
-	return false
+	// The token is a bearer credential, never send it over an unauthenticated transport.
+	return true
 }
 
 func createServiceAccountToken(ctx context.Context, client Client,

--- a/releasenotes/notes/41937.yaml
+++ b/releasenotes/notes/41937.yaml
@@ -5,6 +5,6 @@ issue:
   - 41937
 releaseNotes:
 - |
-  **Fixed** `istioctl` skipping verification of the istiod certificate when connecting to XDS with a service account token (`istioctl proxy-status`, `istioctl x internal-debug`, and `--xds-address` in general). istioctl now verifies the server against the Istio root certificate from the `istio-ca-root-cert` configmap and the expected server name (`--authority`, or the host of `--xds-address`). Pass `--insecure` (or set `ISTIOCTL_INSECURE=true`) to explicitly skip verification.
+  **Fixed** `istioctl` skipping verification of the istiod certificate when connecting to XDS with a service account token (`istioctl proxy-status`, `istioctl x internal-debug`, and `--xds-address` in general). istioctl now verifies the server against the Istio root certificate from the `istio-ca-root-cert` configmap and the expected server name: `--authority` if set, the host of `--xds-address` if it is a DNS name, or `istiod.<istio-namespace>.svc` when connecting to an IP address or localhost. Pass `--insecure` (or set `ISTIOCTL_INSECURE=true`) to explicitly skip verification.
 
   **Credit**: This issue was reported by Leon Zlobecki.

--- a/releasenotes/notes/41937.yaml
+++ b/releasenotes/notes/41937.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: security-fix
+area: istioctl
+issue:
+  - 41937
+releaseNotes:
+- |
+  **Fixed** `istioctl` skipping verification of the istiod certificate when connecting to XDS with a service account token (`istioctl proxy-status`, `istioctl x internal-debug`, and `--xds-address` in general). istioctl now verifies the server against the Istio root certificate from the `istio-ca-root-cert` configmap and the expected server name (`--authority`, or the host of `--xds-address`). Pass `--insecure` (or set `ISTIOCTL_INSECURE=true`) to explicitly skip verification.
+
+  **Credit**: This issue was reported by Leon Zlobecki.


### PR DESCRIPTION
**Please provide a description of this PR:**

istioctl proxy-status, x internal-debug and --xds-address used `InsecureSkipVerify` unconditionally and sent the SA token to whatever answered. Verify against the istio-ca-root-cert root and the expected server name via adsc.TLSConfig, skip only with `--insecure`. 

Note: behavior change: `--xds-address` pointing at an IP or localhost now needs `--authority istiod.istio-system.svc` or `--insecure` / `ISTIOCTL_INSECURE=true` to skip verification.

Fixes #41937