### PR TITLE
test: speed up TestConvertResources

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion_test.go
+++ b/pilot/pkg/config/kube/gateway/conversion_test.go
@@ -842,6 +842,7 @@ func TestConvertResources(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			stop := test.NewStop(t)
 			input := readConfig(t, fmt.Sprintf("testdata/%s.yaml", tt.name), validator, tt.validationIgnorer)
 			kc := kube.NewFakeClient(input...)


### PR DESCRIPTION
Part of #37555

**Root cause**: `TestConvertResources` runs 28 subtests serially. Each builds a fake client, controller, and golden comparison, costing ~7s on a fast machine and ~9-20s in CI (9s measured in the issue; ~20s reported in 2025-11). There is no sleep to remove: the cost is structural (fake client + controller startup per subtest).

**Fix**: mark each subtest `t.Parallel()`.

The subtests share no mutable state:
- `features.EnableGatewayAPIGatewayClassController` / `EnableGatewayAPIInferenceExtension` are set once on the parent via `test.SetForTest` before the loop and only read by subtests (a static value for their whole lifetime).
- the shared `crdvalidation.Validator` is read-only after construction (its `byGvk`/`structural`/`cel` maps are populated at build time).
- `ValidationIgnorer` carries its own `sync.RWMutex`.
- each subtest gets its own `test.NewStop(t)` channel and fake client.

**Measurement** (go test ./pilot/pkg/config/kube/gateway/ -run TestConvertResources -count=1, same machine, alternating before/after runs):

| run | time |
|---|---|
| before | 6.868s / 6.979s |
| after | 3.411s / 3.455s |

**Tested with**:

```
go test ./pilot/pkg/config/kube/gateway/ -run 'TestConvertResources' -count=5 -race   # ok, 70.3s
go test ./pilot/pkg/config/kube/gateway/ -run 'TestConvertResources' -count=50        # ok, 157.5s
go test ./pilot/pkg/config/kube/gateway/ -count=1                                     # whole package ok, 6.0s
```

**Risk**: parallelizing instead of shortening waits, so no timing-dependent behavior was touched. Golden files are read per-subtest (parallel-safe); no shared file writes. No production code changed (test-only).