### PR TITLE
Fix ExternalName alias resolution for ports not declared on the alias service

### DIFF
--- a/pilot/pkg/networking/core/route/route.go
+++ b/pilot/pkg/networking/core/route/route.go
@@ -259,7 +259,13 @@ func buildSidecarVirtualHostsForVirtualService(
 		Mesh:                      push.Mesh,
 		Push:                      push,
 		LookupService: func(name host.Name) *model.Service {
-			return serviceRegistry[name]
+			if svc, ok := serviceRegistry[name]; ok {
+				return svc
+			}
+			// Fallback to unfiltered lookup for alias resolution: serviceRegistry is port-filtered,
+			// but a VirtualService destination may reference an ExternalName service that doesn't
+			// declare the listener port.
+			return push.ServiceForHostname(node, name)
 		},
 		LookupDestinationCluster: GetDestinationCluster,
 		LookupHash: func(destination *networking.HTTPRouteDestination) *networking.LoadBalancerSettings_ConsistentHashLB {

--- a/pilot/pkg/networking/core/sidecar_simulation_test.go
+++ b/pilot/pkg/networking/core/sidecar_simulation_test.go
@@ -1426,6 +1426,97 @@ spec:
 			},
 		},
 	})
+
+	// VirtualService with alias as destination on a port the alias doesn't declare.
+	// This is the scenario that exercises the LookupService fallback added in the fix:
+	// alias (port 80 only) is absent from the port-81-filtered servicesByName map, so
+	// without the fallback GetDestinationCluster never sees the ExternalName field and
+	// produces the wrong cluster name: outbound|80||alias... (non-existent → 503).
+	// With the fallback, the unfiltered scope lookup finds alias, the ExternalName
+	// redirect fires, and the cluster resolves to outbound|80||concrete... (valid).
+	appAndPartialAlias := `apiVersion: v1
+kind: Service
+metadata:
+  name: alias
+  namespace: default
+spec:
+  type: ExternalName
+  externalName: concrete.default.svc.cluster.local
+  ports:
+  - name: http
+    port: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: concrete
+  namespace: default
+spec:
+  clusterIP: 1.2.3.4
+  ports:` + ports + `
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: app
+  namespace: default
+spec:
+  clusterIP: 1.2.3.5
+  ports:
+  - name: http
+    port: 80
+  - name: auto
+    port: 81`
+	runSimulationTest(t, nil, xds.FakeOptions{}, simulationTest{
+		config: `apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: route-via-alias
+  namespace: default
+spec:
+  hosts:
+  - app.default.svc.cluster.local
+  http:
+  - route:
+    - destination:
+        host: alias.default.svc.cluster.local
+        port:
+          number: 80`,
+		kubeConfig: appAndPartialAlias,
+		calls: []simulation.Expect{
+			{
+				// alias declares port 80 only. The call arrives on port 81, so alias is
+				// absent from the port-filtered servicesByName map used to build the
+				// port-81 route config. The LookupService fallback must find alias via
+				// the unfiltered scope and trigger the ExternalName redirect so that the
+				// cluster resolves to concrete, not to the non-existent alias cluster.
+				Name: "VS destination is ExternalName alias missing listener port; ExternalName redirect must fire via fallback",
+				Call: simulation.Call{
+					Address:    "1.2.3.5",
+					Port:       81,
+					Protocol:   simulation.HTTP,
+					HostHeader: "app.default.svc.cluster.local",
+				},
+				Result: simulation.Result{
+					ClusterMatched: "outbound|80||concrete.default.svc.cluster.local",
+				},
+			},
+			{
+				// Baseline: alias declares port 80, so it IS in the port-filtered map.
+				// The ExternalName redirect fires on the standard path without the fallback.
+				Name: "VS destination is ExternalName alias on declared port; ExternalName redirect fires normally",
+				Call: simulation.Call{
+					Address:    "1.2.3.5",
+					Port:       80,
+					Protocol:   simulation.HTTP,
+					HostHeader: "app.default.svc.cluster.local",
+				},
+				Result: simulation.Result{
+					ClusterMatched: "outbound|80||concrete.default.svc.cluster.local",
+				},
+			},
+		},
+	})
 }
 
 func TestPassthroughTraffic(t *testing.T) {

--- a/releasenotes/notes/externalname-alias-port-filtered.yaml
+++ b/releasenotes/notes/externalname-alias-port-filtered.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 61519
+
+releaseNotes:
+  - |
+    **Fixed** a bug where traffic sent through an `ExternalName` service failed with
+    `503 cluster_not_found` when the request used a port that the `ExternalName` service
+    did not declare.


### PR DESCRIPTION
Resolves: https://github.com/istio/istio/issues/61519 

`LookupService` (used for ExternalName alias resolution during route building) reads
only the **port-filtered** service registry. An ExternalName service that doesn't declare
the current listener port isn't found, so the alias→concrete rewrite in
`GetDestinationCluster` is skipped and the route points at `outbound|<port>||<alias>` —
a cluster that never exists (aliases don't generate CDS clusters). Result:
`503 cluster_not_found`.

## The fix

If the alias isn't found in the port-specific list, fall back to a normal service
lookup that isn't limited by port. Nothing else changes — the common case behaves
exactly as before, and this only relaxes the port restriction that was causing the
alias to be missed. This is the approach suggested in istio/istio#54310.

## How it was verified

- Added a test that routes to an alias on a port it doesn't declare — it fails
  without the fix and passes with it.
- Reproduced it on a real cluster: the request returned 503 before the fix and
  200 after. (using the script attached to #61519)
  