### PR TITLE
istioctl: sanitize kubeconfig from multicluster secrets before building analyze clients

### DIFF
--- a/istioctl/pkg/analyze/analyze.go
+++ b/istioctl/pkg/analyze/analyze.go
@@ -552,17 +552,15 @@ func getClients(ctx cli.Context) ([]*Client, error) {
 	for _, s := range secrets.Items {
 		for _, cfg := range s.Data {
 			// Secrets in this namespace are untrusted input from the perspective of this
-			// process, exactly as istiod treats them in DefaultBuildClientsFromConfig. Reject
-			// kubeconfigs using exec, file-based, or other unsafe auth before building any
-			// client from them.
-			if _, err := kube.NewUntrustedRestConfig(cfg); err != nil {
+			// process, exactly as istiod treats them in DefaultBuildClientsFromConfig. Sanitize
+			// the kubeconfig - rejecting exec, file-based, or other unsafe auth - and build the
+			// client from the sanitized rest.Config itself, not from the original bytes, so a
+			// gap between what's validated and what's used can't reopen this.
+			restConfig, err := kube.NewUntrustedRestConfig(cfg)
+			if err != nil {
 				return nil, fmt.Errorf("kubeconfig in secret %s/%s is not allowed: %v", s.Namespace, s.Name, err)
 			}
-			clientConfig, err := clientcmd.NewClientConfigFromBytes(cfg)
-			if err != nil {
-				return nil, err
-			}
-			rawConfig, err := clientConfig.RawConfig()
+			rawConfig, err := clientcmd.Load(cfg)
 			if err != nil {
 				return nil, err
 			}
@@ -570,7 +568,7 @@ func getClients(ctx cli.Context) ([]*Client, error) {
 			if curContext == nil {
 				continue
 			}
-			client, err := kube.NewCLIClient(clientConfig,
+			client, err := kube.NewCLIClient(kube.NewClientConfigForRestConfig(restConfig),
 				kube.WithRevision(revisionSpecified),
 				kube.WithCluster(cluster.ID(curContext.Cluster)))
 			if err != nil {

--- a/istioctl/pkg/analyze/analyze.go
+++ b/istioctl/pkg/analyze/analyze.go
@@ -551,6 +551,13 @@ func getClients(ctx cli.Context) ([]*Client, error) {
 	}
 	for _, s := range secrets.Items {
 		for _, cfg := range s.Data {
+			// Secrets in this namespace are untrusted input from the perspective of this
+			// process, exactly as istiod treats them in DefaultBuildClientsFromConfig. Reject
+			// kubeconfigs using exec, file-based, or other unsafe auth before building any
+			// client from them.
+			if _, err := kube.NewUntrustedRestConfig(cfg); err != nil {
+				return nil, fmt.Errorf("kubeconfig in secret %s/%s is not allowed: %v", s.Namespace, s.Name, err)
+			}
 			clientConfig, err := clientcmd.NewClientConfigFromBytes(cfg)
 			if err != nil {
 				return nil, err

--- a/istioctl/pkg/analyze/analyze_test.go
+++ b/istioctl/pkg/analyze/analyze_test.go
@@ -19,10 +19,14 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"istio.io/istio/istioctl/pkg/cli"
 	"istio.io/istio/istioctl/pkg/util/testutil"
 	"istio.io/istio/pkg/config/analysis/diag"
+	"istio.io/istio/pkg/kube/multicluster"
 )
 
 func TestErrorOnIssuesFound(t *testing.T) {
@@ -76,6 +80,108 @@ func TestSkipPodsInFiles(t *testing.T) {
 	}
 	analyze := Analyze(cli.NewFakeContext(nil))
 	testutil.VerifyOutput(t, analyze, c)
+}
+
+// TestGetClientsRejectsUnsafeMultiClusterSecret guards against pswg#23: a multicluster
+// secret in istio-system is untrusted input, and a kubeconfig exec plugin in it must never
+// reach client construction, since client-go would run it as a local process.
+func TestGetClientsRejectsUnsafeMultiClusterSecret(t *testing.T) {
+	g := NewWithT(t)
+
+	maliciousKubeconfig := []byte(`
+apiVersion: v1
+kind: Config
+clusters:
+- name: remote
+  cluster:
+    server: https://remote.example.com
+contexts:
+- name: remote-context
+  context:
+    cluster: remote
+    user: attacker
+current-context: remote-context
+users:
+- name: attacker
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1
+      command: /bin/sh
+      args: ["-c", "touch /tmp/pwned-by-istioctl"]
+      interactiveMode: Never
+`)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "remote-cluster-secret",
+			Namespace: "istio-system",
+			Labels: map[string]string{
+				multicluster.MultiClusterSecretLabel: "true",
+			},
+		},
+		Data: map[string][]byte{
+			"remote-cluster": maliciousKubeconfig,
+		},
+	}
+
+	ctx := cli.NewFakeContext(&cli.NewFakeContextOption{
+		IstioNamespace: "istio-system",
+		Objects:        []runtime.Object{secret},
+	})
+
+	_, err := getClients(ctx)
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("exec is not allowed"))
+}
+
+// TestGetClientsAllowsLegitimateTokenSecret makes sure the sanitization added for pswg#23
+// doesn't reject the kind of secret istioctl create-remote-secret actually produces.
+func TestGetClientsAllowsLegitimateTokenSecret(t *testing.T) {
+	g := NewWithT(t)
+
+	legitKubeconfig := []byte(`
+apiVersion: v1
+kind: Config
+clusters:
+- name: remote
+  cluster:
+    server: https://127.0.0.1:6443
+    insecure-skip-tls-verify: true
+contexts:
+- name: remote-context
+  context:
+    cluster: remote
+    user: remote-sa
+current-context: remote-context
+users:
+- name: remote-sa
+  user:
+    token: some-bearer-token
+`)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "remote-cluster-secret",
+			Namespace: "istio-system",
+			Labels: map[string]string{
+				multicluster.MultiClusterSecretLabel: "true",
+			},
+		},
+		Data: map[string][]byte{
+			"remote-cluster": legitKubeconfig,
+		},
+	}
+
+	ctx := cli.NewFakeContext(&cli.NewFakeContextOption{
+		IstioNamespace: "istio-system",
+		Objects:        []runtime.Object{secret},
+	})
+
+	clients, err := getClients(ctx)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(clients).To(HaveLen(2)) // local fake client + the sanitized remote one
 }
 
 func TestRunSpecificAnalyzer(t *testing.T) {

--- a/istioctl/pkg/analyze/analyze_test.go
+++ b/istioctl/pkg/analyze/analyze_test.go
@@ -84,9 +84,6 @@ func TestSkipPodsInFiles(t *testing.T) {
 	testutil.VerifyOutput(t, analyze, c)
 }
 
-// TestGetClientsRejectsUnsafeMultiClusterSecret guards against pswg#23: a multicluster
-// secret in istio-system is untrusted input, and a kubeconfig exec plugin in it must never
-// reach client construction, since client-go would run it as a local process.
 func TestGetClientsRejectsUnsafeMultiClusterSecret(t *testing.T) {
 	g := NewWithT(t)
 
@@ -137,8 +134,6 @@ users:
 	g.Expect(err.Error()).To(ContainSubstring("exec is not allowed"))
 }
 
-// TestGetClientsAllowsLegitimateTokenSecret makes sure the sanitization added for pswg#23
-// doesn't reject the kind of secret istioctl create-remote-secret actually produces.
 func TestGetClientsAllowsLegitimateTokenSecret(t *testing.T) {
 	g := NewWithT(t)
 
@@ -189,9 +184,6 @@ users:
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(clients).To(HaveLen(2)) // local fake client + the sanitized remote one
 
-	// The client must be built from the sanitized rest.Config itself (not just validated and
-	// then discarded), while still carrying the cluster ID and revision the original code path
-	// set from the raw kubeconfig - this is what pswg#23's review comment asked to confirm.
 	remote := clients[1]
 	g.Expect(remote.remote).To(BeTrue())
 	g.Expect(remote.client.ClusterID()).To(Equal(cluster.ID("remote")))

--- a/istioctl/pkg/analyze/analyze_test.go
+++ b/istioctl/pkg/analyze/analyze_test.go
@@ -25,7 +25,9 @@ import (
 
 	"istio.io/istio/istioctl/pkg/cli"
 	"istio.io/istio/istioctl/pkg/util/testutil"
+	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/analysis/diag"
+	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/multicluster"
 )
 
@@ -140,6 +142,10 @@ users:
 func TestGetClientsAllowsLegitimateTokenSecret(t *testing.T) {
 	g := NewWithT(t)
 
+	oldRevision := revisionSpecified
+	revisionSpecified = "canary"
+	t.Cleanup(func() { revisionSpecified = oldRevision })
+
 	legitKubeconfig := []byte(`
 apiVersion: v1
 kind: Config
@@ -182,6 +188,17 @@ users:
 
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(clients).To(HaveLen(2)) // local fake client + the sanitized remote one
+
+	// The client must be built from the sanitized rest.Config itself (not just validated and
+	// then discarded), while still carrying the cluster ID and revision the original code path
+	// set from the raw kubeconfig - this is what pswg#23's review comment asked to confirm.
+	remote := clients[1]
+	g.Expect(remote.remote).To(BeTrue())
+	g.Expect(remote.client.ClusterID()).To(Equal(cluster.ID("remote")))
+
+	cliClient, ok := remote.client.(kube.CLIClient)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(cliClient.Revision()).To(Equal("canary"))
 }
 
 func TestRunSpecificAnalyzer(t *testing.T) {

--- a/releasenotes/notes/analyze-multicluster-secret-sanitize.yaml
+++ b/releasenotes/notes/analyze-multicluster-secret-sanitize.yaml
@@ -1,0 +1,13 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+issue: []
+releaseNotes:
+  - |
+    **Fixed** `istioctl analyze` building Kubernetes clients directly from `istio-system`
+    multicluster secrets without sanitizing the kubeconfig, which could allow a crafted
+    secret to run an `exec` credential plugin (or read local files via other unsafe auth
+    fields) on the machine running `istioctl`. The kubeconfig is now sanitized the same
+    way istiod already sanitizes these secrets.
+
+    **Credit**: This vulnerability was discovered and reported by Adam Korczynski.


### PR DESCRIPTION
**Please provide a description of this PR:**

istioctl: sanitize kubeconfig from multicluster secrets before building analyze clients
