### PR TITLE
Update proxy upstream master + backport normalization test fix

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,7 +4,7 @@
     "name": "PROXY_REPO_SHA",
     "repoName": "proxy",
     "file": "",
-    "lastStableSHA": "1e22c91b6125dfaba226af3997b33b31420411d7"
+    "lastStableSHA": "e24425788d54983f3c89a7608b634328c385e16a"
   },
   {
     "_comment": "",

--- a/tests/integration/security/normalization_test.go
+++ b/tests/integration/security/normalization_test.go
@@ -198,7 +198,7 @@ func TestNormalization(t *testing.T) {
 						{`/%c0%afadmin`, `/%c0%afadmin`},
 						{`/.../admin`, `/.../admin`},
 						{`/..../admin`, `/..../admin`},
-						{`/..;/admin`, `/..;/admin`},
+						{`/..;/admin`, `/admin`},
 						{`/;/admin`, `/;/admin`},
 						{`/admin;a=b`, `/admin;a=b`},
 						{`/admin;a=b/xyz`, `/admin;a=b/xyz`},


### PR DESCRIPTION
Resolves security istio integration test suite failures in https://github.com/istio/istio/pull/61516 since this commit with test adjustment https://github.com/istio/istio/commit/071f94c30ff21663c60c0bcd41d76ec1aa1a30b3 is needed after latest Envoy CVE-2026-73551