### PR TITLE
fix TestBinarySizes

### DIFF
--- a/tests/binary/binaries_test.go
+++ b/tests/binary/binaries_test.go
@@ -115,7 +115,7 @@ func TestBinarySizes(t *testing.T) {
 		"pilot-discovery": {60, 125},
 		"bug-report":      {60, 80},
 		"client":          {15, 30},
-		"server":          {15, 32},
+		"server":          {15, 35},
 		"envoy":           {60, 168},
 		"ztunnel":         {12, 19},
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**

unblock https://github.com/istio/istio/pull/61179

```
=== RUN   TestBinarySizes/server
    binaries_test.go:134: Actual size: 33mb. Range: [15mb, 32mb]
    binaries_test.go:136: Binary size of 33mb was greater than max allowed size 32mb
```