### PR TITLE
krt: sketch out method based approach

### DIFF
--- a/pilot/pkg/config/kube/file/controller.go
+++ b/pilot/pkg/config/kube/file/controller.go
@@ -82,7 +82,7 @@ func NewController(
 	for _, s := range schemas.All() {
 		gvk := s.GroupVersionKind()
 		if _, ok := collections.Pilot.FindByGroupVersionKind(gvk); ok {
-			collection := krt.NewCollection(mainCollection, func(ctx krt.HandlerContext, c ConfigKind) *config.Config {
+			collection := krt.NewCollection(mainCollection.AsCollection(), func(ctx krt.HandlerContext, c ConfigKind) *config.Config {
 				if c.GroupVersionKind == gvk {
 					return c.Config
 				}

--- a/pilot/pkg/config/kube/gateway/status_test.go
+++ b/pilot/pkg/config/kube/gateway/status_test.go
@@ -45,8 +45,8 @@ func TestStatusCollections(t *testing.T) {
 		Obj:    &v1.ConfigMap{},
 		Status: "hello world",
 	}
-	fakeCol := krt.NewStaticCollection[Status](nil, []Status{obj1}, krt.WithStop(stop))
-	status.RegisterStatus(c.status, fakeCol, func(i *v1.ConfigMap) string {
+	fakeCol := krt.NewMutableCollection[Status](nil, []Status{obj1}, krt.WithStop(stop))
+	status.RegisterStatus(c.status, fakeCol.AsCollection(), func(i *v1.ConfigMap) string {
 		return ""
 	}, c.tagWatcher.AccessUnprotected())
 

--- a/pilot/pkg/config/memory/controller.go
+++ b/pilot/pkg/config/memory/controller.go
@@ -89,7 +89,7 @@ func (c *Controller) Run(stop <-chan struct{}) {
 
 func (c *Controller) KrtCollection(kind config.GroupVersionKind) krt.Collection[config.Config] {
 	if data, ok := c.store.data[kind]; ok {
-		return data.collection
+		return data.collection.AsCollection()
 	}
 
 	return nil

--- a/pilot/pkg/config/memory/store.go
+++ b/pilot/pkg/config/memory/store.go
@@ -80,8 +80,8 @@ func newStore(
 		syncer:         &syncer{make(chan struct{})},
 	}
 	for _, s := range schemas.All() {
-		collection := krt.NewStaticCollection[config.Config](out.syncer, nil, opts.WithName(s.Kind())...)
-		index := krt.NewNamespaceIndex(collection)
+		collection := krt.NewMutableCollection[config.Config](out.syncer, nil, opts.WithName(s.Kind())...)
+		index := krt.NewNamespaceIndex(collection.AsCollection())
 		out.data[s.GroupVersionKind()] = kindStore{
 			collection: collection,
 			index:      index,

--- a/pilot/pkg/model/fake_store.go
+++ b/pilot/pkg/model/fake_store.go
@@ -72,10 +72,10 @@ func NewFakeStore() *FakeStore {
 
 	for _, s := range collections.Pilot.All() {
 		opts := krt.NewOptionsBuilder(f.stop, "fake-store", krt.GlobalDebugHandler)
-		collection := krt.NewStaticCollection[config.Config](f.syncer, nil, opts.WithName(s.Kind())...)
+		collection := krt.NewMutableCollection[config.Config](f.syncer, nil, opts.WithName(s.Kind())...)
 		kindStore := kindStore{
 			collection: collection,
-			index:      krt.NewNamespaceIndex(collection),
+			index:      krt.NewNamespaceIndex(collection.AsCollection()),
 		}
 		f.store[s.GroupVersionKind()] = kindStore
 	}
@@ -200,7 +200,7 @@ func (s *FakeStore) HasSynced() bool {
 
 func (s *FakeStore) KrtCollection(typ config.GroupVersionKind) krt.Collection[config.Config] {
 	if kindStore, ok := s.store[typ]; ok {
-		return kindStore.collection
+		return kindStore.collection.AsCollection()
 	}
 
 	return nil

--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -236,8 +236,8 @@ func newController(
 	if !workloadEntryController {
 		s.inputs.Namespaces = multiclusterController.ConfigCluster().Namespaces()
 		s.inputs.ServiceEntries = store.KrtCollection(gvk.ServiceEntry)
-		s.inputs.ExternalWorkloads = krt.NewStaticCollection[*model.WorkloadInstance](nil, nil, s.opts.WithName("inputs/ExternalWorkloads")...)
-		s.inputs.ExternalWorkloadsByIP = krt.NewIndex(s.inputs.ExternalWorkloads, "ip", func(wi *model.WorkloadInstance) []string {
+		s.inputs.ExternalWorkloads = krt.NewMutableCollection[*model.WorkloadInstance](nil, nil, s.opts.WithName("inputs/ExternalWorkloads")...)
+		s.inputs.ExternalWorkloadsByIP = krt.NewIndex(s.inputs.ExternalWorkloads.AsCollection(), "ip", func(wi *model.WorkloadInstance) []string {
 			return []string{wi.Endpoint.FirstAddressOrNil()}
 		})
 		if features.EnableAlphaGatewayAPI {
@@ -279,7 +279,7 @@ func (s *Controller) buildCollections() {
 
 	if !s.workloadEntryController {
 		allWorkloads := krt.JoinCollection(
-			[]krt.Collection[*model.WorkloadInstance]{wleWorkloads, s.inputs.ExternalWorkloads},
+			[]krt.Collection[*model.WorkloadInstance]{wleWorkloads, s.inputs.ExternalWorkloads.AsCollection()},
 			s.opts.WithName("outputs/AllWorkloads")...,
 		)
 		workloadsByNamespace := krt.NewNamespaceIndex(allWorkloads)

--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -375,7 +375,7 @@ func (h *manyCollection[I, O]) dump() CollectionDump {
 	return CollectionDump{
 		Outputs:         eraseMap(h.collectionState.outputs),
 		Inputs:          inputs,
-		InputCollection: h.parent.(internalCollection[I]).name(),
+		InputCollection: h.parent.name(),
 		Synced:          h.HasSynced(),
 	}
 }
@@ -581,7 +581,7 @@ func NewCollection[I, O any](c Collection[I], hf TransformationSingle[I, O], opt
 		// NOTE: this will print Collection[nil, nil] if I or O are interfaces
 		o.name = fmt.Sprintf("Collection[%v,%v]", ptr.TypeName[I](), ptr.TypeName[O]())
 	}
-	return newManyCollection(c, hm, o, nil)
+	return newCollection(newManyCollection(c, hm, o, nil))
 }
 
 // NewManyCollection transforms a Collection[I] to a Collection[O] by applying the provided transformation function.
@@ -592,7 +592,7 @@ func NewManyCollection[I, O any](c Collection[I], hf TransformationMulti[I, O], 
 	if o.name == "" {
 		o.name = fmt.Sprintf("ManyCollection[%v,%v]", ptr.TypeName[I](), ptr.TypeName[O]())
 	}
-	return newManyCollection[I, O](c, hf, o, nil)
+	return newCollection(newManyCollection[I, O](c, hf, o, nil))
 }
 
 func newManyCollection[I, O any](
@@ -600,15 +600,13 @@ func newManyCollection[I, O any](
 	hf TransformationMulti[I, O],
 	opts collectionOptions,
 	onPrimaryInputEventHandler func([]Event[I]),
-) Collection[O] {
-	c := cc.(internalCollection[I])
-
+) internalCollection[O] {
 	h := &manyCollection[I, O]{
 		transformation: hf,
 		collectionName: opts.name,
 		id:             nextUID(),
 		log:            log.WithLabels("owner", opts.name),
-		parent:         c,
+		parent:         cc,
 		dependencyState: dependencyState[I]{
 			collectionDependencies:       sets.New[collectionUID](),
 			collectionDependencyHandlers: map[collectionUID]HandlerRegistration{},
@@ -751,10 +749,6 @@ func (h *manyCollection[I, O]) List() (res []O) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 	return maps.Values(h.collectionState.outputs)
-}
-
-func (h *manyCollection[I, O]) Register(f func(o Event[O])) HandlerRegistration {
-	return registerHandlerAsBatched(h, f)
 }
 
 func (h *manyCollection[I, O]) RegisterBatch(f func(o []Event[O]), runExistingState bool) HandlerRegistration {

--- a/pkg/kube/krt/collection_test.go
+++ b/pkg/kube/krt/collection_test.go
@@ -226,7 +226,7 @@ func TestCollectionSimple(t *testing.T) {
 	c.RunAndWait(stop)
 	SimplePods := SimplePodCollection(pods, opts)
 
-	assert.Equal(t, fetcherSorted(SimplePods)(), nil)
+	assert.Equal(t, SimplePods.ListSorted(), nil)
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "name",
@@ -234,15 +234,15 @@ func TestCollectionSimple(t *testing.T) {
 		},
 	}
 	pc.Create(pod)
-	assert.Equal(t, fetcherSorted(SimplePods)(), nil)
+	assert.Equal(t, SimplePods.ListSorted(), nil)
 
 	pod.Status = corev1.PodStatus{PodIP: "1.2.3.4"}
 	pc.UpdateStatus(pod)
-	assert.EventuallyEqual(t, fetcherSorted(SimplePods), []SimplePod{{NewNamed(pod), Labeled{}, "1.2.3.4"}})
+	assert.EventuallyEqual(t, SimplePods.ListSorted, []SimplePod{{NewNamed(pod), Labeled{}, "1.2.3.4"}})
 
 	pod.Status.PodIP = "1.2.3.5"
 	pc.UpdateStatus(pod)
-	assert.EventuallyEqual(t, fetcherSorted(SimplePods), []SimplePod{{NewNamed(pod), Labeled{}, "1.2.3.5"}})
+	assert.EventuallyEqual(t, SimplePods.ListSorted, []SimplePod{{NewNamed(pod), Labeled{}, "1.2.3.5"}})
 
 	// check we get updates if we add a handler later
 	tt := assert.NewTracker[string](t)
@@ -250,7 +250,7 @@ func TestCollectionSimple(t *testing.T) {
 	tt.WaitUnordered("add/namespace/name")
 
 	pc.Delete(pod.Name, pod.Namespace)
-	assert.EventuallyEqual(t, fetcherSorted(SimplePods), nil)
+	assert.EventuallyEqual(t, SimplePods.ListSorted, nil)
 	tt.WaitUnordered("delete/namespace/name")
 }
 
@@ -648,13 +648,13 @@ func TestCollectionMultipleFetchAllAndKey(t *testing.T) {
 func TestCollectionFetchWithSuppressChange(t *testing.T) {
 	stop := test.NewStop(t)
 	opts := testOptions(t)
-	source := krt.NewStaticCollection[SimplePod](nil, nil, opts.WithName("SimplePod")...)
+	source := krt.NewMutableCollection[SimplePod](nil, nil, opts.WithName("SimplePod")...)
 	tt := assert.NewTracker[string](t)
 	counts := atomic.NewUint64(0)
 
 	Collection := krt.NewSingleton(func(ctx krt.HandlerContext) *Static {
 		counts.Inc()
-		pods := krt.PartialFetchComparable(ctx, source,
+		pods := krt.PartialFetchComparable(ctx, source.AsCollection(),
 			func(a SimplePod) Named {
 				return a.Named
 			},

--- a/pkg/kube/krt/conformance_test.go
+++ b/pkg/kube/krt/conformance_test.go
@@ -37,7 +37,11 @@ import (
 )
 
 type Rig[T any] interface {
-	krt.Collection[T]
+	GetKey(string) *T
+	List() []T
+	Metadata() krt.Metadata
+	Register(func(krt.Event[T])) krt.HandlerRegistration
+	WaitUntilSynced(<-chan struct{}) bool
 	CreateObject(key string)
 	// ReplaceKey removes oldKey and adds newKey.
 	// This is used to test that List() consistency: if List() changes from [a,b,c] to [a,b,d],
@@ -68,6 +72,10 @@ func (r *informerRig) ReplaceKey(oldKey, newKey string) {
 
 type staticRig struct {
 	krt.StaticCollection[Named]
+}
+
+func (r *staticRig) Register(f func(krt.Event[Named])) krt.HandlerRegistration {
+	return r.AsCollection().Register(f)
 }
 
 func (r *staticRig) CreateObject(key string) {
@@ -153,6 +161,10 @@ type fileRig struct {
 	t        test.Failer
 }
 
+func (r *fileRig) Register(f func(krt.Event[Named])) krt.HandlerRegistration {
+	return r.AsCollection().Register(f)
+}
+
 var metadata = krt.Metadata{"foo": "bar"}
 
 func (r *fileRig) CreateObject(key string) {
@@ -202,7 +214,7 @@ func TestConformance(t *testing.T) {
 	})
 	t.Run("static list", func(t *testing.T) {
 		factory := func(t *testing.T) Rig[Named] {
-			col := krt.NewStaticCollection[Named](nil, nil, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler), krt.WithMetadata(metadata))
+			col := krt.NewMutableCollection[Named](nil, nil, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler), krt.WithMetadata(metadata))
 			rig := &staticRig{
 				StaticCollection: col,
 			}
@@ -224,16 +236,16 @@ func TestConformance(t *testing.T) {
 	})
 	t.Run("join", func(t *testing.T) {
 		factory := func(t *testing.T) Rig[Named] {
-			col1 := krt.NewStaticCollection[Named](nil, nil,
+			col1 := krt.NewMutableCollection[Named](nil, nil,
 				krt.WithStop(test.NewStop(t)),
 				krt.WithDebugging(krt.GlobalDebugHandler),
 				krt.WithName("join-conformance-1"))
-			col2 := krt.NewStaticCollection[Named](nil, nil,
+			col2 := krt.NewMutableCollection[Named](nil, nil,
 				krt.WithStop(test.NewStop(t)),
 				krt.WithDebugging(krt.GlobalDebugHandler),
 				krt.WithName("join-conformance-2"))
 			j := krt.JoinCollection(
-				[]krt.Collection[Named]{col1, col2},
+				[]krt.Collection[Named]{col1.AsCollection(), col2.AsCollection()},
 				krt.WithStop(test.NewStop(t)),
 				krt.WithDebugging(krt.GlobalDebugHandler),
 				krt.WithMetadata(metadata),
@@ -248,10 +260,10 @@ func TestConformance(t *testing.T) {
 	})
 	t.Run("manyCollection", func(t *testing.T) {
 		factory := func(t *testing.T) Rig[Named] {
-			namespaces := krt.NewStaticCollection[string](nil, nil, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler))
-			names := krt.NewStaticCollection[string](nil, nil, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler))
-			col := krt.NewManyCollection(namespaces, func(ctx krt.HandlerContext, ns string) []Named {
-				names := krt.Fetch[string](ctx, names)
+			namespaces := krt.NewMutableCollection[string](nil, nil, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler))
+			names := krt.NewMutableCollection[string](nil, nil, krt.WithStop(test.NewStop(t)), krt.WithDebugging(krt.GlobalDebugHandler))
+			col := krt.NewManyCollection(namespaces.AsCollection(), func(ctx krt.HandlerContext, ns string) []Named {
+				names := krt.Fetch[string](ctx, names.AsCollection())
 				return slices.Map(names, func(e string) Named {
 					return Named{Namespace: ns, Name: e}
 				})

--- a/pkg/kube/krt/core.go
+++ b/pkg/kube/krt/core.go
@@ -15,17 +15,64 @@
 package krt
 
 import (
+	"cmp"
+
 	"istio.io/istio/pkg/kube/controllers"
 	istiolog "istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/slices"
 )
 
 var log = istiolog.RegisterScope("krt", "")
 
 type Metadata map[string]any
 
-// Collection is the core resource type for krt, representing a collection of objects. Items can be listed, or fetched
-// directly. Most importantly, consumers can subscribe to events when objects change.
-type Collection[T any] interface {
+// Collection is the core resource type for krt, representing a collection of objects. Items can be listed, fetched,
+// or watched for changes. The implementation is kept behind a private pointer type so Collection can expose convenience
+// methods while retaining normal nil semantics.
+type Collection[T any] = *collection[T]
+
+type collection[T any] struct {
+	internalCollection[T]
+}
+
+func newCollection[T any](c internalCollection[T]) Collection[T] {
+	if c == nil {
+		return nil
+	}
+	return &collection[T]{internalCollection: c}
+}
+
+func (t *collection[T]) Fetch(ctx HandlerContext, opts ...FetchOption) []T {
+	return Fetch(ctx, t, opts...)
+}
+
+func (t *collection[T]) FetchOne(ctx HandlerContext, opts ...FetchOption) *T {
+	return FetchOne(ctx, t, opts...)
+}
+
+func (t *collection[T]) FetchOrList(ctx HandlerContext, opts ...FetchOption) []T {
+	return FetchOrList(ctx, t, opts...)
+}
+
+func (t *collection[T]) ListSorted() []T {
+	return t.ListSortedBy(GetKey)
+}
+
+func (t *collection[T]) ListSortedBy[K cmp.Ordered](extract func(T) K) []T {
+	return slices.SortBy(t.List(), extract)
+}
+
+// Register adds an event watcher to the collection. Any time an item in the collection changes, the handler is called.
+func (t *collection[T]) Register(f func(Event[T])) HandlerRegistration {
+	return registerHandlerAsBatched(t.internalCollection, f)
+}
+
+func (t *collection[T]) internal() internalCollection[T] {
+	return t.internalCollection
+}
+
+// collectionTrait is the implementation contract wrapped by Collection.
+type collectionTrait[T any] interface {
 	// GetKey returns an object by its key, if present. Otherwise, nil is returned.
 	GetKey(k string) *T
 
@@ -54,17 +101,6 @@ type Collection[T any] interface {
 type EventStream[T any] interface {
 	Syncer
 
-	// Register adds an event watcher to the collection. Any time an item in the collection changes, the handler will be
-	// called. Typically, usage of Register is done internally in krt via composition of Collections with Transformations
-	// (NewCollection, NewManyCollection, NewSingleton); however, at boundaries of the system (connecting to something not
-	// using krt), registering directly is expected.
-	// Handlers have the following semantics:
-	// * On each event, all handlers are called.
-	// * Each handler has its own unbounded event queue. Slow handlers will cause this queue to accumulate, but will not block
-	//   other handlers.
-	// * Events will be sent in order, and will not be dropped or deduplicated.
-	Register(f func(o Event[T])) HandlerRegistration
-
 	// RegisterBatch registers a handler that accepts multiple events at once. This can be useful as an optimization.
 	// Otherwise, behaves the same as Register.
 	// Additionally, skipping the default behavior of "send all current state through the handler" can be turned off.
@@ -73,10 +109,10 @@ type EventStream[T any] interface {
 	RegisterBatch(f func(o []Event[T]), runExistingState bool) HandlerRegistration
 }
 
-// internalCollection is a superset of Collection for internal usage. All collections must implement this type, but
-// we only expose some functions to external users for simplicity.
+// internalCollection extends collectionTrait for internal usage. All collection implementations must implement this
+// type, but the additional methods remain hidden from external users by the Collection wrapper.
 type internalCollection[T any] interface {
-	Collection[T]
+	collectionTrait[T]
 
 	// Name is a human facing name for this collection.
 	// Note this may not be universally unique

--- a/pkg/kube/krt/debug.go
+++ b/pkg/kube/krt/debug.go
@@ -64,32 +64,30 @@ func (p DebugCollection) MarshalJSON() ([]byte, error) {
 }
 
 // maybeRegisterCollectionForDebugging registers the collection in the debugger, if one is enabled
-func maybeRegisterCollectionForDebugging[T any](c Collection[T], handler *DebugHandler) {
+func maybeRegisterCollectionForDebugging[T any](c internalCollection[T], handler *DebugHandler) {
 	if handler == nil {
 		return
 	}
-	cc := c.(internalCollection[T])
 	handler.mu.Lock()
 	defer handler.mu.Unlock()
 	if handler.debugCollections == nil {
 		handler.debugCollections = make(map[collectionUID]DebugCollection)
 	}
-	handler.debugCollections[cc.uid()] = DebugCollection{
-		name: cc.name(),
-		dump: cc.dump,
-		uid:  cc.uid(),
+	handler.debugCollections[c.uid()] = DebugCollection{
+		name: c.name(),
+		dump: c.dump,
+		uid:  c.uid(),
 	}
 }
 
 // maybeUnregisterCollectionFromDebugger removes the collection from the debugger, if one is enabled
-func maybeUnregisterCollectionFromDebugger[T any](c Collection[T], handler *DebugHandler) {
+func maybeUnregisterCollectionFromDebugger[T any](c internalCollection[T], handler *DebugHandler) {
 	if handler == nil {
 		return
 	}
-	cc := c.(internalCollection[T])
 	handler.mu.Lock()
 	defer handler.mu.Unlock()
-	delete(handler.debugCollections, cc.uid())
+	delete(handler.debugCollections, c.uid())
 }
 
 // nolint: unused // (not true, not sure why it thinks it is!)

--- a/pkg/kube/krt/dependency_state_test.go
+++ b/pkg/kube/krt/dependency_state_test.go
@@ -99,10 +99,10 @@ func TestCollectionChangingFilterKeyDependency(t *testing.T) {
 	tt.WaitOrdered("update/ns/my-pod")
 
 	// Access the internal manyCollection to inspect indexedDependencies directly.
-	mc := Bindings.(*manyCollection[*corev1.Pod, WaypointBinding])
+	mc := Bindings.internal().(*manyCollection[*corev1.Pod, WaypointBinding])
 
 	// Get the UID of the ConfigMaps collection (the secondary dependency).
-	configMapsUID := configMaps.(internalCollection[*corev1.ConfigMap]).uid()
+	configMapsUID := configMaps.uid()
 
 	// After relabeling, the reverse-index must only contain the new key, not the old one.
 	mc.mu.RLock()

--- a/pkg/kube/krt/fetch.go
+++ b/pkg/kube/krt/fetch.go
@@ -71,7 +71,7 @@ func Fetch[T any](ctx HandlerContext, cc Collection[T], opts ...FetchOption) []T
 }
 
 func fetch[T any](ctx HandlerContext, cc Collection[T], allowMissingContext bool, opts ...FetchOption) []T {
-	c := cc.(internalCollection[T])
+	c := cc.internal()
 	d := &dependency{
 		id:             c.uid(),
 		collectionName: c.name(),

--- a/pkg/kube/krt/files/files.go
+++ b/pkg/kube/krt/files/files.go
@@ -216,7 +216,7 @@ func NewFileCollection[F any, O any](w *FolderWatch[F], transform func(F) *O, op
 			return readSnapshot[F, O](w, transform)
 		},
 	}
-	sc := krt.NewStaticCollection[O](nil, res.read(), opts...)
+	sc := krt.NewMutableCollection[O](nil, res.read(), opts...)
 	w.subscribe(func() {
 		now := res.read()
 		sc.Reset(now)

--- a/pkg/kube/krt/files/files_test.go
+++ b/pkg/kube/krt/files/files_test.go
@@ -85,7 +85,7 @@ func newKubernetesFromFiles[T controllers.Object](fw *krtfiles.FolderWatch[contr
 			return &t
 		}
 		return nil
-	}, opts...)
+	}, opts...).AsCollection()
 }
 
 func parseInputs(f io.Reader) ([]controllers.Object, error) {

--- a/pkg/kube/krt/index.go
+++ b/pkg/kube/krt/index.go
@@ -62,7 +62,7 @@ func NewIndex[K comparable, O any](
 	name string,
 	extract func(o O) []K,
 ) Index[K, O] {
-	idx := c.(internalCollection[O]).index(name, func(o O) []string {
+	idx := c.internal().index(name, func(o O) []string {
 		return slices.Map(extract(o), func(e K) string {
 			return toString(e)
 		})
@@ -128,7 +128,7 @@ func (i index[K, O]) AsCollection(opts ...CollectionOption) IndexCollection[K, O
 			maybeUnregisterCollectionFromDebugger(c, o.debugger)
 		}()
 	}
-	return c
+	return newCollection[IndexObject[K, O]](c)
 }
 
 // Fetch fetches all entries from the index with dependency tracking
@@ -190,7 +190,7 @@ func (i indexCollection[K, O]) uid() collectionUID {
 func (i indexCollection[K, O]) dump() CollectionDump {
 	return CollectionDump{
 		Outputs:         i.dumpOutput(),
-		InputCollection: i.idx.c.(internalCollection[O]).name(),
+		InputCollection: i.idx.c.name(),
 		Synced:          i.HasSynced(),
 	}
 }
@@ -257,14 +257,6 @@ func (i indexCollection[K, O]) HasSynced() bool {
 
 func (i indexCollection[K, O]) Metadata() Metadata {
 	return i.metadata
-}
-
-func (i indexCollection[K, O]) Register(f func(o Event[IndexObject[K, O]])) HandlerRegistration {
-	return i.RegisterBatch(func(events []Event[IndexObject[K, O]]) {
-		for _, o := range events {
-			f(o)
-		}
-	}, true)
 }
 
 func (i indexCollection[K, O]) RegisterBatch(f func(o []Event[IndexObject[K, O]]), runExistingState bool) HandlerRegistration {

--- a/pkg/kube/krt/informer.go
+++ b/pkg/kube/krt/informer.go
@@ -109,10 +109,6 @@ func (i *informer[I]) Metadata() Metadata {
 	return i.metadata
 }
 
-func (i *informer[I]) Register(f func(o Event[I])) HandlerRegistration {
-	return registerHandlerAsBatched[I](i, f)
-}
-
 func (i *informer[I]) RegisterBatch(f func(o []Event[I]), runExistingState bool) HandlerRegistration {
 	// Note: runExistingState is NOT respected here.
 	// Informer doesn't expose a way to do that. However, due to the runtime model of informers, this isn't a dealbreaker;
@@ -229,7 +225,7 @@ func WrapClient[I controllers.ComparableObject](c kclient.Informer[I], opts ...C
 
 		<-o.stop
 	}()
-	return h
+	return newCollection[I](h)
 }
 
 // NewInformer creates a Collection[I] sourced from

--- a/pkg/kube/krt/join.go
+++ b/pkg/kube/krt/join.go
@@ -114,10 +114,6 @@ func (j *join[T]) List() []T {
 	return res
 }
 
-func (j *join[T]) Register(f func(o Event[T])) HandlerRegistration {
-	return registerHandlerAsBatched(j, f)
-}
-
 func (j *join[T]) RegisterBatch(f func(o []Event[T]), runExistingState bool) HandlerRegistration {
 	// Fast path for unchecked overlap: register directly with sub-collections (old behavior)
 	// This avoids the indirection layer of handleSubCollectionEvents and eventHandlers.Distribute
@@ -383,7 +379,7 @@ func JoinCollection[T any](cs []Collection[T], opts ...CollectionOption) Collect
 	}
 	synced := make(chan struct{})
 	c := slices.Map(cs, func(e Collection[T]) internalCollection[T] {
-		return e.(internalCollection[T])
+		return e.internal()
 	})
 	if o.stop == nil {
 		panic("no stop channel")
@@ -420,7 +416,7 @@ func JoinCollection[T any](cs []Collection[T], opts ...CollectionOption) Collect
 			close(synced)
 			log.Infof("%v synced", o.name)
 		}()
-		return j
+		return newCollection[T](j)
 	}
 
 	// Checked mode: set up centralized event handling with conflict resolution
@@ -460,5 +456,5 @@ func JoinCollection[T any](cs []Collection[T], opts ...CollectionOption) Collect
 		}
 	}()
 
-	return j
+	return newCollection[T](j)
 }

--- a/pkg/kube/krt/map.go
+++ b/pkg/kube/krt/map.go
@@ -39,7 +39,7 @@ type mappedIndexer[T any, U any] struct {
 	mapFunc        func(T) U
 }
 
-var _ Collection[any] = &mapCollection[any, any]{}
+var _ collectionTrait[any] = &mapCollection[any, any]{}
 
 // nolint: unused // (not true, its to implement an interface)
 func (m *mappedIndexer[T, U]) Lookup(k string) []U {
@@ -76,10 +76,6 @@ func (m *mapCollection[T, U]) List() []U {
 		}
 	}
 	return res
-}
-
-func (m *mapCollection[T, U]) Register(handler func(Event[U])) HandlerRegistration {
-	return registerHandlerAsBatched(m, handler)
 }
 
 func (m *mapCollection[T, U]) RegisterBatch(handler func([]Event[U]), runExistingState bool) HandlerRegistration {
@@ -158,7 +154,7 @@ func MapCollection[T, U any](
 	if o.name == "" {
 		o.name = fmt.Sprintf("Map[%v]", ptr.TypeName[T]())
 	}
-	ic := collection.(internalCollection[T])
+	ic := collection.internal()
 	metadata := o.metadata
 	if metadata == nil {
 		metadata = ic.Metadata()
@@ -177,7 +173,7 @@ func MapCollection[T, U any](
 			maybeUnregisterCollectionFromDebugger(m, o.debugger)
 		}()
 	}
-	return m
+	return newCollection[U](m)
 }
 
 // Used only to make assertions internally about Collection invariants

--- a/pkg/kube/krt/map_test.go
+++ b/pkg/kube/krt/map_test.go
@@ -237,13 +237,13 @@ func TestNestedMapCollection(t *testing.T) {
 			IP: p.Status.PodIP,
 		}
 	})
-	MultiPods := krt.NewStaticCollection(
+	MultiPods := krt.NewMutableCollection(
 		nil,
 		[]krt.Collection[SimplePod]{simplePods},
 		opts.WithName("MultiPods")...,
 	)
 	AllPods := krt.NestedJoinWithMergeCollection(
-		MultiPods,
+		MultiPods.AsCollection(),
 		func(ts []SimplePod) *SimplePod {
 			return &ts[0]
 		},

--- a/pkg/kube/krt/mergejoin.go
+++ b/pkg/kube/krt/mergejoin.go
@@ -177,10 +177,6 @@ func (j *mergejoin[T]) GetKey(k string) *T {
 	return nil
 }
 
-func (j *mergejoin[T]) Register(f func(e Event[T])) HandlerRegistration {
-	return registerHandlerAsBatched(j, f)
-}
-
 func (j *mergejoin[T]) RegisterBatch(f func(e []Event[T]), runExistingState bool) HandlerRegistration {
 	j.mu.Lock()
 	defer j.mu.Unlock()
@@ -442,5 +438,5 @@ func JoinWithMergeCollection[T any](cs []Collection[T], merge func(ts []T) *T, o
 	// The queue will process the initial state and mark ourselves as synced (from the NewWithSync callback)
 	go j.runQueue()
 
-	return j
+	return newCollection[T](j)
 }

--- a/pkg/kube/krt/nestedjoinmerge.go
+++ b/pkg/kube/krt/nestedjoinmerge.go
@@ -40,10 +40,10 @@ func (j *nestedjoinmerge[T]) dump() CollectionDump {
 	innerCols := j.collections.List()
 	dumpsByCollectionUID := make(map[string]InputDump, len(innerCols))
 	for _, c := range innerCols {
-		if c == nil {
+		if c.internalCollection == nil {
 			continue
 		}
-		ic := c.(internalCollection[T])
+		ic := c.internal()
 		icDump := ic.dump()
 		dumpsByCollectionUID[GetKey(ic)] = InputDump{
 			Outputs:      maps.Keys(icDump.Outputs),
@@ -70,7 +70,7 @@ func NestedJoinWithMergeCollection[T any](collections Collection[Collection[T]],
 		o.name = fmt.Sprintf("NestedJoinWithMerge[%v]", ptr.TypeName[T]())
 	}
 
-	ics := collections.(internalCollection[Collection[T]])
+	ics := collections.internal()
 	synced := make(chan struct{})
 
 	j := &nestedjoinmerge[T]{
@@ -110,7 +110,7 @@ func NestedJoinWithMergeCollection[T any](collections Collection[Collection[T]],
 	// NewWithSync callback).
 	go j.runQueue()
 
-	return j
+	return newCollection[T](j)
 }
 
 func (j *nestedjoinmerge[T]) runQueue() {
@@ -121,7 +121,7 @@ func (j *nestedjoinmerge[T]) runQueue() {
 			switch ev.Event {
 			case controllers.EventAdd:
 				j.mu.Lock()
-				j.updateSubscriptionLocked(nil, ev.Latest().(internalCollection[T]), true)
+				j.updateSubscriptionLocked(nil, ev.Latest().internal(), true)
 				j.mu.Unlock()
 			case controllers.EventUpdate:
 				j.handleCollectionUpdate(ev)
@@ -213,14 +213,14 @@ func (j *nestedjoinmerge[T]) unregisterAll(containerReg HandlerRegistration) {
 }
 
 func (j *nestedjoinmerge[T]) handleCollectionUpdate(e Event[Collection[T]]) {
-	innerCollection := e.Latest().(internalCollection[T])
+	innerCollection := e.Latest().internal()
 	log.Debugf("NestedJoinWithMergeCollection: Collection %s (uid %s) updated, recalculating merged values", innerCollection.name(), innerCollection.uid())
 	// Get all of the elements in the old collection
 	oldCollectionValue := *e.Old
 	newCollectionValue := *e.New
 	// Wait for the new collection to be synced before we process the update.
 	if !newCollectionValue.WaitUntilSynced(j.stop) {
-		log.Warnf("NestedJoinWithMergeCollection: Collection %s not synced, skipping update event", newCollectionValue.(internalCollection[T]).uid())
+		log.Warnf("NestedJoinWithMergeCollection: Collection %s not synced, skipping update event", newCollectionValue.uid())
 	}
 	// Stop the world and update our outputs with new state for everything in the collection.
 	j.mu.Lock()
@@ -232,7 +232,7 @@ func (j *nestedjoinmerge[T]) handleCollectionUpdate(e Event[Collection[T]]) {
 	// we intentionally don't run the existing state for the new collection because we are going to recalculate everything anyway.
 	// TODO: even though we drop the old subscription after List is called
 	// we still might have missed Delete events for items that are not present in the oldItems list.
-	j.updateSubscriptionLocked(oldCollectionValue.(internalCollection[T]), newCollectionValue.(internalCollection[T]), false)
+	j.updateSubscriptionLocked(oldCollectionValue.internal(), newCollectionValue.internal(), false)
 	// Convert it to a map for easy lookup
 	oldItemsMap := make(map[Key[T]]T, len(oldItems))
 	for _, i := range oldItems {
@@ -330,7 +330,7 @@ func (j *nestedjoinmerge[T]) handleCollectionDelete(e Event[Collection[T]]) {
 	// Unsubscribe from the collection
 	// TODO: even though we drop the old subscription after List is called
 	// we still might have missed Delete events for items that are not present in the oldItems list.
-	j.updateSubscriptionLocked(e.Latest().(internalCollection[T]), nil, false)
+	j.updateSubscriptionLocked(e.Latest().internal(), nil, false)
 
 	items := sets.NewWithLength[Key[T]](len(oldItems))
 	// First loop through the collection to get the deleted items by their keys

--- a/pkg/kube/krt/nestedjoinmerge_test.go
+++ b/pkg/kube/krt/nestedjoinmerge_test.go
@@ -52,14 +52,14 @@ func TestNestedJoinWithMergeSimpleCollection(t *testing.T) {
 			Selector: o.Spec.Selector,
 		}
 	}, opts.WithName("SimpleServices")...)
-	MultiServices := krt.NewStaticCollection(
+	MultiServices := krt.NewMutableCollection(
 		nil,
 		[]krt.Collection[SimpleService]{SimpleServices},
 		opts.WithName("MultiServices")...,
 	)
 
 	AllServices := krt.NestedJoinWithMergeCollection(
-		MultiServices,
+		MultiServices.AsCollection(),
 		func(ts []SimpleService) *SimpleService {
 			if len(ts) == 0 {
 				return nil
@@ -196,13 +196,13 @@ func (c testCluster) ResourceName() string {
 func TestNestedJoinWithMergeCollectionSwap(t *testing.T) {
 	opts := testOptions(t)
 
-	clusters := krt.NewStaticCollection(nil, []testCluster{{name: "c0", gen: 1, service: "a", version: "v1"}},
+	clusters := krt.NewMutableCollection(nil, []testCluster{{name: "c0", gen: 1, service: "a", version: "v1"}},
 		opts.WithName("Clusters")...)
-	perCluster := krt.NewCollection(clusters, func(ctx krt.HandlerContext, c testCluster) *krt.Collection[SimpleService] {
+	perCluster := krt.NewCollection(clusters.AsCollection(), func(ctx krt.HandlerContext, c testCluster) *krt.Collection[SimpleService] {
 		// The collection's name depends only on the cluster, not on its generation, so a rebuilt
 		// collection replaces the previous one under the same key. This mirrors how the per-cluster
 		// informers are named in multicluster.
-		var col krt.Collection[SimpleService] = krt.NewStaticCollection(nil, []SimpleService{{
+		col := krt.NewStaticCollection(nil, []SimpleService{{
 			Named:    Named{"namespace", c.service},
 			Selector: map[string]string{"app": c.version},
 		}}, opts.With(krt.WithName(fmt.Sprintf("Services[%s]", c.name)))...)
@@ -298,14 +298,14 @@ func TestNestedJoinWithMergeAndIndexSimpleCollection(t *testing.T) {
 			IP:       o.Spec.ClusterIP,
 		}
 	}, opts.WithName("SimpleServices")...)
-	MultiServices := krt.NewStaticCollection(
+	MultiServices := krt.NewMutableCollection(
 		nil,
 		[]krt.Collection[SimpleService]{SimpleServices},
 		opts.WithName("MultiServices")...,
 	)
 
 	AllServices := krt.NestedJoinWithMergeCollection(
-		MultiServices,
+		MultiServices.AsCollection(),
 		func(ts []SimpleService) *SimpleService {
 			if len(ts) == 0 {
 				return nil

--- a/pkg/kube/krt/singleton.go
+++ b/pkg/kube/krt/singleton.go
@@ -69,7 +69,7 @@ func NewStatic[T any](initial *T, startSynced bool, opts ...CollectionOption) St
 			maybeUnregisterCollectionFromDebugger(x, o.debugger)
 		}()
 	}
-	return collectionAdapter[T]{x}
+	return collectionAdapter[T]{newCollection[T](x)}
 }
 
 // static represents a Collection of a single static value. This can be explicitly Set() to override it
@@ -97,10 +97,6 @@ func (d *static[T]) List() []T {
 
 func (d *static[T]) Metadata() Metadata {
 	return d.metadata
-}
-
-func (d *static[T]) Register(f func(o Event[T])) HandlerRegistration {
-	return registerHandlerAsBatched[T](d, f)
 }
 
 func (d *static[T]) RegisterBatch(f func(o []Event[T]), runExistingState bool) HandlerRegistration {
@@ -242,18 +238,18 @@ func tryGetKey[T any](a T) (string, bool) {
 	return "", false
 }
 
-var _ Collection[dummyValue] = &static[dummyValue]{}
+var _ collectionTrait[dummyValue] = &static[dummyValue]{}
 
 type collectionAdapter[T any] struct {
 	c Collection[T]
 }
 
 func (c collectionAdapter[T]) MarkSynced() {
-	c.c.(*static[T]).synced.Store(true)
+	c.c.internal().(*static[T]).synced.Store(true)
 }
 
 func (c collectionAdapter[T]) Set(t *T) {
-	c.c.(*static[T]).Set(t)
+	c.c.internal().(*static[T]).Set(t)
 }
 
 func (c collectionAdapter[T]) Get() *T {
@@ -280,7 +276,7 @@ func (c collectionAdapter[T]) AsCollection() Collection[T] {
 
 // Every thing that collectionAdapter adapts has a uid so this is safe
 func (c collectionAdapter[T]) uid() collectionUID {
-	return c.c.(uidable).uid()
+	return c.c.uid()
 }
 
 var (

--- a/pkg/kube/krt/static.go
+++ b/pkg/kube/krt/static.go
@@ -41,7 +41,18 @@ type staticList[T any] struct {
 	indexes        map[string]staticListIndex[T]
 }
 
-func NewStaticCollection[T any](synced Syncer, vals []T, opts ...CollectionOption) StaticCollection[T] {
+func (s StaticCollection[T]) AsCollection() Collection[T] {
+	return newCollection[T](s.staticList)
+}
+
+// NewStaticCollection creates a read-only collection initialized with the provided values.
+// Callers that need to update the collection after creation should use NewMutableCollection.
+func NewStaticCollection[T any](synced Syncer, vals []T, opts ...CollectionOption) Collection[T] {
+	return NewMutableCollection(synced, vals, opts...).AsCollection()
+}
+
+// NewMutableCollection creates a StaticCollection that callers can update directly.
+func NewMutableCollection[T any](synced Syncer, vals []T, opts ...CollectionOption) StaticCollection[T] {
 	o := buildCollectionOptions(opts...)
 	if o.name == "" {
 		o.name = fmt.Sprintf("Static[%v]", ptr.TypeName[T]())
@@ -325,10 +336,6 @@ func (s *staticList[T]) List() []T {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return maps.Values(s.vals)
-}
-
-func (s *staticList[T]) Register(f func(o Event[T])) HandlerRegistration {
-	return registerHandlerAsBatched(s, f)
 }
 
 func (s *staticList[T]) HasSynced() bool {

--- a/pkg/kube/krt/static_test.go
+++ b/pkg/kube/krt/static_test.go
@@ -24,6 +24,19 @@ import (
 func TestStaticCollection(t *testing.T) {
 	opts := testOptions(t)
 	c := krt.NewStaticCollection[Named](nil, []Named{{"ns", "a"}}, opts.WithName("c")...)
+	assert.Equal(t, c == nil, false)
+	assert.Equal(t, c.HasSynced(), true, "should start synced")
+	assert.Equal(t, c.List(), []Named{{"ns", "a"}})
+}
+
+func TestNilCollection(t *testing.T) {
+	var c krt.Collection[Named]
+	assert.Equal(t, c == nil, true)
+}
+
+func TestMutableCollection(t *testing.T) {
+	opts := testOptions(t)
+	c := krt.NewMutableCollection[Named](nil, []Named{{"ns", "a"}}, opts.WithName("c")...)
 	assert.Equal(t, c.Synced().HasSynced(), true, "should start synced")
 	assert.Equal(t, c.List(), []Named{{"ns", "a"}})
 

--- a/pkg/kube/krt/status.go
+++ b/pkg/kube/krt/status.go
@@ -40,7 +40,7 @@ func NewStatusManyCollection[I controllers.Object, IStatus, O any](
 		name:   o.name + " status",
 		synced: statusCh,
 	}
-	status := NewStaticCollection[ObjectWithStatus[I, IStatus]](statusSynced, nil, statusOpts...)
+	status := NewMutableCollection[ObjectWithStatus[I, IStatus]](statusSynced, nil, statusOpts...)
 	// When input is deleted, the transformation function wouldn't run.
 	// So we need to handle that explicitly
 	cleanupOnRemoval := func(i []Event[I]) {
@@ -72,7 +72,7 @@ func NewStatusManyCollection[I controllers.Object, IStatus, O any](
 		}
 	}()
 
-	return status, primary
+	return newCollection[ObjectWithStatus[I, IStatus]](status), newCollection[O](primary)
 }
 
 func NewStatusCollection[I controllers.Object, IStatus, O any](

--- a/pkg/kube/multicluster/collections_test.go
+++ b/pkg/kube/multicluster/collections_test.go
@@ -75,7 +75,7 @@ func TestNestedCollectionsRebuiltOnClusterUpdate(t *testing.T) {
 
 	opts := krt.NewOptionsBuilder(stop, "test", krt.GlobalDebugHandler)
 	local := krt.NewStaticCollection[*v1.Service](nil, nil, opts.WithName("LocalServices")...)
-	var localCollection krt.Collection[*v1.Service] = local
+	localCollection := local
 	nested := NestedCollectionFromLocalAndRemote(
 		c.controller,
 		localCollection,

--- a/pkg/kube/multicluster/kubeconfig_files.go
+++ b/pkg/kube/multicluster/kubeconfig_files.go
@@ -55,7 +55,7 @@ func NewKubeconfigCollection(
 		return &k
 	}, opts...)
 
-	return collection, nil
+	return collection.AsCollection(), nil
 }
 
 func parseKubeconfig(data []byte) ([]KubeconfigFile, error) {

--- a/pkg/kube/multicluster/remote_config_source.go
+++ b/pkg/kube/multicluster/remote_config_source.go
@@ -210,6 +210,9 @@ func (f *fileConfigSource) AddEventHandler(handler func(key types.NamespacedName
 // file changing from cluster A to cluster B reconciles both keys so the old
 // cluster can be deleted and the new cluster can be added.
 func registerHandler(collection krt.Collection[KubeconfigFile], handler func(key types.NamespacedName, event controllers.EventType)) krt.HandlerRegistration {
+	if handler == nil || collection == nil {
+		return nil
+	}
 	return collection.Register(func(ev krt.Event[KubeconfigFile]) {
 		oldClusterID := ""
 		if ev.Old != nil {

--- a/pkg/kube/multicluster/remote_config_source_test.go
+++ b/pkg/kube/multicluster/remote_config_source_test.go
@@ -99,10 +99,10 @@ func TestFileConfigSourceDuplicateClusterID(t *testing.T) {
 
 func TestRegisterHandlerEnqueuesOldAndNewClusterID(t *testing.T) {
 	stop := test.NewStop(t)
-	collection := krt.NewStaticCollection[KubeconfigFile](nil, nil, krt.WithStop(stop))
+	collection := krt.NewMutableCollection[KubeconfigFile](nil, nil, krt.WithStop(stop))
 
 	tracker := assert.NewTracker[string](t)
-	registerHandler(collection, func(key types.NamespacedName, event controllers.EventType) {
+	registerHandler(collection.AsCollection(), func(key types.NamespacedName, event controllers.EventType) {
 		tracker.Record(fmt.Sprintf("%s/%s", event.String(), key.String()))
 	})
 


### PR DESCRIPTION
The goal is to be able to provide high level ergonomic functions on a collection without every collection needing to manually implement. For example Register+RegisterBatch today becomes Register (high level helper) + RegisterBatch (raw interface).

Similarly, we add ListSorted, etc. https://github.com/istio/istio/pull/61386 has other future improvements around optimizations that are _not_ included here to keep it smaller