### PR TITLE
telemetry: apply proxy-namespace targetRef Telemetry to cross-namespace waypoint services

### DIFF
--- a/pilot/pkg/model/telemetry.go
+++ b/pilot/pkg/model/telemetry.go
@@ -479,16 +479,27 @@ func (t *Telemetries) applicableTelemetries(proxy *Proxy, svc *Service) computed
 	}
 
 	matcher := PolicyMatcherForProxy(proxy).WithService(svc).WithRootNamespace(t.RootNamespace)
-	for _, telemetry := range t.NamespaceToTelemetries[namespace] {
-		spec := telemetry.Spec
-		// Namespace wide policy; already handled above
-		if len(spec.GetSelector().GetMatchLabels()) == 0 && len(GetTargetRefs(spec)) == 0 {
-			continue
-		}
-		if matcher.ShouldAttachPolicy(gvk.Telemetry, telemetry.NamespacedName(), spec) {
-			ct = appendApplicableTelemetries(ct, telemetry, spec)
-		} else {
-			log.Debug("There isn't a match between the workload and the policy. Policy is ignored.")
+	// Selector/targetRef policies live in the proxy's own namespace (for example a
+	// Telemetry with targetRefs: Gateway/<waypoint>). When a waypoint serves a service
+	// in another namespace, `namespace` was rewritten to the service's namespace above,
+	// so scan both. The service namespace is scanned last so its policies take
+	// precedence, matching the ordering of the namespace-wide lookups.
+	policyNamespaces := []string{proxy.ConfigNamespace}
+	if namespace != proxy.ConfigNamespace {
+		policyNamespaces = append(policyNamespaces, namespace)
+	}
+	for _, ns := range policyNamespaces {
+		for _, telemetry := range t.NamespaceToTelemetries[ns] {
+			spec := telemetry.Spec
+			// Namespace wide policy; already handled above
+			if len(spec.GetSelector().GetMatchLabels()) == 0 && len(GetTargetRefs(spec)) == 0 {
+				continue
+			}
+			if matcher.ShouldAttachPolicy(gvk.Telemetry, telemetry.NamespacedName(), spec) {
+				ct = appendApplicableTelemetries(ct, telemetry, spec)
+			} else {
+				log.Debug("There isn't a match between the workload and the policy. Policy is ignored.")
+			}
 		}
 	}
 

--- a/pilot/pkg/model/telemetry_test.go
+++ b/pilot/pkg/model/telemetry_test.go
@@ -754,6 +754,21 @@ func TestTelemetryFilters(t *testing.T) {
 			},
 		},
 	}
+	// A Telemetry in the waypoint's own namespace targeting the waypoint Gateway.
+	// It must apply to every service the waypoint serves, including services in
+	// other namespaces.
+	targetRefsWaypointGateway := &tpb.Telemetry{
+		TargetRefs: []*v1beta1.PolicyTargetReference{{
+			Group: gvk.KubernetesGateway.Group,
+			Kind:  gvk.KubernetesGateway.Kind,
+			Name:  "waypoint",
+		}},
+		Metrics: []*tpb.Metrics{
+			{
+				Overrides: overrides,
+			},
+		},
+	}
 	emptyWaypointMetrics := `{"disable_host_header_fallback":true,"reporter":"SERVER_GATEWAY"}`
 	cfg := `{"metrics":[{"dimensions":{"add":"bar"},"name":"requests_total","tags_to_remove":["remove"]}]}`
 
@@ -1156,6 +1171,27 @@ func TestTelemetryFilters(t *testing.T) {
 			want: map[string]string{
 				"istio.stats": `{"disable_host_header_fallback":true,"metrics":[{"dimensions":{"add":"otherBar"}` +
 					`,"name":"request_duration_milliseconds","tags_to_remove":["removeOther"]}],"reporter":"SERVER_GATEWAY"}`,
+			},
+		},
+		{
+			name: "waypoint gateway targetRef applies to cross namespace service",
+			cfgs: []config.Config{
+				newTelemetry("default", targetRefsWaypointGateway),
+			},
+			service: &Service{
+				Attributes: ServiceAttributes{
+					Name:            "sample-svc",
+					Namespace:       "other",
+					ServiceRegistry: provider.Kubernetes,
+				},
+			},
+			proxy:            waypoint,
+			class:            networking.ListenerClassSidecarInbound,
+			protocol:         networking.ListenerProtocolHTTP,
+			defaultProviders: &meshconfig.MeshConfig_DefaultProviders{Metrics: []string{"prometheus"}},
+			want: map[string]string{
+				"istio.stats": `{"disable_host_header_fallback":true,"metrics":[{"dimensions":{"add":"bar"},"name":"requests_total"` +
+					`,"tags_to_remove":["remove"]}],"reporter":"SERVER_GATEWAY"}`,
 			},
 		},
 		{

--- a/releasenotes/notes/waypoint-crossns-targetref-telemetry.yaml
+++ b/releasenotes/notes/waypoint-crossns-targetref-telemetry.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: telemetry
+issue:
+  - 61538
+releaseNotes:
+  - |
+    **Fixed** a regression where a `Telemetry` resource in a waypoint's own namespace, selected by
+    `targetRefs` or `selector`, was not applied when the waypoint served a Service in a different
+    namespace. Access logging, metrics and tracing configured this way were silently dropped for
+    every cross-namespace Service the waypoint handled.


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes #61538.

`applicableTelemetries` rewrites the local `namespace` variable to the Service's namespace when a waypoint proxy serves a Service in a different namespace, so that Service namespace's namespace-wide `Telemetry` is picked up (added in #60673). The selector/targetRef scan that follows reuses that rewritten value:

```go
for _, telemetry := range t.NamespaceToTelemetries[namespace] {
```

so a `Telemetry` in the waypoint's *own* namespace selected by `targetRefs` or `selector` is never considered for a cross-namespace Service. Since attaching one `Telemetry` to the waypoint Gateway is the documented way to configure a waypoint, and waypoints usually live in a shared namespace serving Services across many application namespaces, that resource effectively stops applying.

Measured on a waypoint serving ~80 Services across ~70 namespaces: access logging configured that way was present on 1 of 82 HTTP filter chains and 1 of 48 TCP chains instead of all of them, and tracing fell back to the mesh default provider (changing span `service_name` from the destination Service to the waypoint).

This change scans both the proxy namespace and the Service namespace for selector/targetRef policies, Service namespace last so its policies keep precedence — matching the ordering already used for the namespace-wide lookups above. When the two namespaces are the same the behaviour is unchanged.

Namespace-wide `Telemetry` was never affected, because both namespaces are already visited explicitly.

Adds `TestTelemetryFilters/waypoint gateway targetRef applies to cross namespace service`, which fails before the change and passes after.