### PR TITLE
ignore quic-go updates on release-1.29 and release-1.30

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -83,6 +83,7 @@ updates:
       - dependency-name: "github.com/prometheus/prometheus"
       - dependency-name: "helm.sh/helm/v3"
       - dependency-name: "github.com/moby/buildkit"
+      - dependency-name: "github.com/quic-go/quic-go"
     groups:
       all-dependencies:
         patterns:
@@ -95,6 +96,7 @@ updates:
           - "github.com/prometheus/prometheus"
           - "helm.sh/helm/v3"
           - "github.com/moby/buildkit"
+          - "github.com/quic-go/quic-go"
 
   - package-ecosystem: "gomod"
     directories:
@@ -115,6 +117,7 @@ updates:
       - dependency-name: "helm.sh/helm/v3"
       - dependency-name: "google.golang.org/grpc"
       - dependency-name: "github.com/moby/buildkit"
+      - dependency-name: "github.com/quic-go/quic-go"
     groups:
       all-dependencies:
         patterns:
@@ -128,6 +131,7 @@ updates:
           - "helm.sh/helm/v3"
           - "google.golang.org/grpc"
           - "github.com/moby/buildkit"
+          - "github.com/quic-go/quic-go"
 
   # Ignore all dependency updates in samples/
   # We do not care about the dependencies in the samples/ directory as they are not meant


### PR DESCRIPTION
quic-go 0.62+ requires go 1.26 which release branches can't take, pin at 0.61.0. Closes #61550 and #61551.