### PR TITLE
fix Test ambient index flake

### DIFF
--- a/pilot/pkg/serviceregistry/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex_test.go
@@ -1339,7 +1339,7 @@ func TestAmbientIndex_Policy(t *testing.T) {
 				}
 			})
 			// All pods have an event (since we're only testing one namespace)
-			s.assertEvent(t, s.podXdsName("pod1"), s.podXdsName("pod2"), s.podXdsName("waypoint-ns-pod"), s.podXdsName("waypoint2-sa"))
+			s.assertEvent(t, s.podXdsName("pod1"), s.podXdsName("pod2"), s.podXdsName("waypoint-ns-pod"), s.podXdsName("waypoint2-sa"), xdsConvertedPeerAuthSelector)
 			assert.Equal(t,
 				s.lookup(s.addrXdsName("127.0.0.1"))[0].Address.GetWorkload().AuthorizationPolicies,
 				[]string{fmt.Sprintf("istio-system/%s", staticStrictPolicyName)}) // Effective mode is STRICT so set static policy


### PR DESCRIPTION
**Please provide a description of this PR:**

I won't go too much into the details, but we weren't witing for a `xdsConvertedPeerAuthSelector` event, which sometimes led to future ones to become merged, and the wrong number of events firing.

Steps to repro:

```
go test -v -count=1000 -tags=assert -race \
   ./pilot/pkg/serviceregistry/ambient \
   -run '^TestAmbientIndex_Policy/base$' \
   -cpu=1 \
   -failfast | tee result.txt
```