### PR TITLE
security: emit clearRouteCache into generated ext_authz filter config

### DIFF
--- a/pilot/pkg/security/authz/builder/builder_test.go
+++ b/pilot/pkg/security/authz/builder/builder_test.go
@@ -61,6 +61,23 @@ var (
 			},
 		},
 	}
+	// ClearRouteCache left unset (defaults to false) to verify the field is
+	// correctly omitted from the generated ext_authz filter when not configured.
+	meshConfigGRPCClearRouteCacheDefault = &meshconfig.MeshConfig{
+		ExtensionProviders: []*meshconfig.MeshConfig_ExtensionProvider{
+			{
+				Name: "default",
+				Provider: &meshconfig.MeshConfig_ExtensionProvider_EnvoyExtAuthzGrpc{
+					EnvoyExtAuthzGrpc: &meshconfig.MeshConfig_ExtensionProvider_EnvoyExternalAuthorizationGrpcProvider{
+						Service:       "my-custom-ext-authz.foo.svc.cluster.local",
+						Port:          9000,
+						FailOpen:      true,
+						StatusOnError: "403",
+					},
+				},
+			},
+		},
+	}
 	meshConfigGRPC = &meshconfig.MeshConfig{
 		ExtensionProviders: []*meshconfig.MeshConfig_ExtensionProvider{
 			{
@@ -107,6 +124,23 @@ var (
 						HeadersToUpstreamOnAllow:   []string{"Authorization", "x-prefix-*", "*-suffix"},
 						HeadersToDownstreamOnDeny:  []string{"Set-cookie", "x-prefix-*", "*-suffix"},
 						HeadersToDownstreamOnAllow: []string{"Set-cookie", "x-prefix-*", "*-suffix"},
+					},
+				},
+			},
+		},
+	}
+	// ClearRouteCache left unset (defaults to false) to verify the field is
+	// correctly omitted from the generated ext_authz filter when not configured.
+	meshConfigHTTPClearRouteCacheDefault = &meshconfig.MeshConfig{
+		ExtensionProviders: []*meshconfig.MeshConfig_ExtensionProvider{
+			{
+				Name: "default",
+				Provider: &meshconfig.MeshConfig_ExtensionProvider_EnvoyExtAuthzHttp{
+					EnvoyExtAuthzHttp: &meshconfig.MeshConfig_ExtensionProvider_EnvoyExternalAuthorizationHttpProvider{
+						Service:       "foo/my-custom-ext-authz.foo.svc.cluster.local",
+						Port:          9000,
+						FailOpen:      true,
+						StatusOnError: "403",
 					},
 				},
 			},
@@ -176,10 +210,28 @@ func TestGenerator_GenerateHTTP(t *testing.T) {
 			want:       []string{"custom-grpc-provider-out1.yaml", "custom-grpc-provider-out2.yaml"},
 		},
 		{
+			name:       "custom-grpc-provider-clear-route-cache-default",
+			meshConfig: meshConfigGRPCClearRouteCacheDefault,
+			input:      "custom-simple-http-in.yaml",
+			want: []string{
+				"custom-grpc-provider-clear-route-cache-default-out1.yaml",
+				"custom-grpc-provider-clear-route-cache-default-out2.yaml",
+			},
+		},
+		{
 			name:       "custom-http-provider",
 			meshConfig: meshConfigHTTP,
 			input:      "custom-simple-http-in.yaml",
 			want:       []string{"custom-http-provider-out1.yaml", "custom-http-provider-out2.yaml"},
+		},
+		{
+			name:       "custom-http-provider-clear-route-cache-default",
+			meshConfig: meshConfigHTTPClearRouteCacheDefault,
+			input:      "custom-simple-http-in.yaml",
+			want: []string{
+				"custom-http-provider-clear-route-cache-default-out1.yaml",
+				"custom-http-provider-clear-route-cache-default-out2.yaml",
+			},
 		},
 		{
 			name:       "custom-bad-multiple-providers",

--- a/pilot/pkg/security/authz/builder/builder_test.go
+++ b/pilot/pkg/security/authz/builder/builder_test.go
@@ -51,10 +51,11 @@ var (
 				Name: "default",
 				Provider: &meshconfig.MeshConfig_ExtensionProvider_EnvoyExtAuthzGrpc{
 					EnvoyExtAuthzGrpc: &meshconfig.MeshConfig_ExtensionProvider_EnvoyExternalAuthorizationGrpcProvider{
-						Service:       "my-custom-ext-authz.foo.svc.cluster.local",
-						Port:          9000,
-						FailOpen:      true,
-						StatusOnError: "403",
+						Service:         "my-custom-ext-authz.foo.svc.cluster.local",
+						Port:            9000,
+						FailOpen:        true,
+						ClearRouteCache: true,
+						StatusOnError:   "403",
 					},
 				},
 			},
@@ -66,11 +67,12 @@ var (
 				Name: "default",
 				Provider: &meshconfig.MeshConfig_ExtensionProvider_EnvoyExtAuthzGrpc{
 					EnvoyExtAuthzGrpc: &meshconfig.MeshConfig_ExtensionProvider_EnvoyExternalAuthorizationGrpcProvider{
-						Service:       "foo/my-custom-ext-authz.foo.svc.cluster.local",
-						Port:          9000,
-						Timeout:       &durationpb.Duration{Nanos: 2000 * 1000},
-						FailOpen:      true,
-						StatusOnError: "403",
+						Service:         "foo/my-custom-ext-authz.foo.svc.cluster.local",
+						Port:            9000,
+						Timeout:         &durationpb.Duration{Nanos: 2000 * 1000},
+						FailOpen:        true,
+						ClearRouteCache: true,
+						StatusOnError:   "403",
 						IncludeRequestBodyInCheck: &meshconfig.MeshConfig_ExtensionProvider_EnvoyExternalAuthorizationRequestBody{
 							MaxRequestBytes:     4096,
 							AllowPartialMessage: true,
@@ -90,6 +92,7 @@ var (
 						Port:                         9000,
 						Timeout:                      &durationpb.Duration{Seconds: 10},
 						FailOpen:                     true,
+						ClearRouteCache:              true,
 						StatusOnError:                "403",
 						PathPrefix:                   "/check",
 						IncludeRequestHeadersInCheck: []string{"x-custom-id", "x-prefix-*", "*-suffix"},

--- a/pilot/pkg/security/authz/builder/extauthz.go
+++ b/pilot/pkg/security/authz/builder/extauthz.go
@@ -297,6 +297,7 @@ func generateHTTPConfig(hostname, cluster string, status *envoytypev3.HttpStatus
 	http := &extauthzhttp.ExtAuthz{
 		StatusOnError:       status,
 		FailureModeAllow:    config.FailOpen,
+		ClearRouteCache:     config.ClearRouteCache,
 		TransportApiVersion: core.ApiVersion_V3,
 		Services: &extauthzhttp.ExtAuthz_HttpService{
 			HttpService: service,
@@ -328,6 +329,7 @@ func generateGRPCConfig(
 	http := &extauthzhttp.ExtAuthz{
 		StatusOnError:    status,
 		FailureModeAllow: config.FailOpen,
+		ClearRouteCache:  config.ClearRouteCache,
 		Services: &extauthzhttp.ExtAuthz_GrpcService{
 			GrpcService: grpc,
 		},

--- a/pilot/pkg/security/authz/builder/testdata/http/custom-grpc-provider-clear-route-cache-default-out1.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/custom-grpc-provider-clear-route-cache-default-out1.yaml
@@ -1,0 +1,33 @@
+name: envoy.filters.http.rbac
+typedConfig:
+  '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC
+  shadowRules:
+    action: DENY
+    policies:
+      istio-ext-authz-default-ns[foo]-policy[httpbin-1]-rule[0]:
+        permissions:
+        - andRules:
+            rules:
+            - orRules:
+                rules:
+                - urlPath:
+                    path:
+                      exact: /httpbin1
+        principals:
+        - andIds:
+            ids:
+            - any: true
+      istio-ext-authz-default-ns[foo]-policy[httpbin-2]-rule[0]:
+        permissions:
+        - andRules:
+            rules:
+            - orRules:
+                rules:
+                - urlPath:
+                    path:
+                      exact: /httpbin2
+        principals:
+        - andIds:
+            ids:
+            - any: true
+  shadowRulesStatPrefix: istio_ext_authz_

--- a/pilot/pkg/security/authz/builder/testdata/http/custom-grpc-provider-clear-route-cache-default-out2.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/custom-grpc-provider-clear-route-cache-default-out2.yaml
@@ -1,0 +1,19 @@
+name: envoy.filters.http.ext_authz
+typedConfig:
+  '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+  failureModeAllow: true
+  filterEnabledMetadata:
+    filter: envoy.filters.http.rbac
+    path:
+    - key: istio_ext_authz_shadow_effective_policy_id
+    value:
+      stringMatch:
+        prefix: istio-ext-authz-default
+  grpcService:
+    envoyGrpc:
+      authority: my-custom-ext-authz.foo.svc.cluster.local
+      clusterName: outbound|9000||my-custom-ext-authz.foo.svc.cluster.local
+    timeout: 600s
+  statusOnError:
+    code: Forbidden
+  transportApiVersion: V3

--- a/pilot/pkg/security/authz/builder/testdata/http/custom-grpc-provider-no-namespace-out2.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/custom-grpc-provider-no-namespace-out2.yaml
@@ -1,6 +1,7 @@
 name: envoy.filters.http.ext_authz
 typedConfig:
   '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+  clearRouteCache: true
   failureModeAllow: true
   filterEnabledMetadata:
     filter: envoy.filters.http.rbac

--- a/pilot/pkg/security/authz/builder/testdata/http/custom-grpc-provider-out2.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/custom-grpc-provider-out2.yaml
@@ -1,6 +1,7 @@
 name: envoy.filters.http.ext_authz
 typedConfig:
   '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+  clearRouteCache: true
   failureModeAllow: true
   filterEnabledMetadata:
     filter: envoy.filters.http.rbac

--- a/pilot/pkg/security/authz/builder/testdata/http/custom-http-provider-clear-route-cache-default-out1.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/custom-http-provider-clear-route-cache-default-out1.yaml
@@ -1,0 +1,33 @@
+name: envoy.filters.http.rbac
+typedConfig:
+  '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC
+  shadowRules:
+    action: DENY
+    policies:
+      istio-ext-authz-default-ns[foo]-policy[httpbin-1]-rule[0]:
+        permissions:
+        - andRules:
+            rules:
+            - orRules:
+                rules:
+                - urlPath:
+                    path:
+                      exact: /httpbin1
+        principals:
+        - andIds:
+            ids:
+            - any: true
+      istio-ext-authz-default-ns[foo]-policy[httpbin-2]-rule[0]:
+        permissions:
+        - andRules:
+            rules:
+            - orRules:
+                rules:
+                - urlPath:
+                    path:
+                      exact: /httpbin2
+        principals:
+        - andIds:
+            ids:
+            - any: true
+  shadowRulesStatPrefix: istio_ext_authz_

--- a/pilot/pkg/security/authz/builder/testdata/http/custom-http-provider-clear-route-cache-default-out2.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/custom-http-provider-clear-route-cache-default-out2.yaml
@@ -1,0 +1,19 @@
+name: envoy.filters.http.ext_authz
+typedConfig:
+  '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+  failureModeAllow: true
+  filterEnabledMetadata:
+    filter: envoy.filters.http.rbac
+    path:
+    - key: istio_ext_authz_shadow_effective_policy_id
+    value:
+      stringMatch:
+        prefix: istio-ext-authz-default
+  httpService:
+    serverUri:
+      cluster: outbound|9000||my-custom-ext-authz.foo.svc.cluster.local
+      timeout: 600s
+      uri: http://my-custom-ext-authz.foo.svc.cluster.local
+  statusOnError:
+    code: Forbidden
+  transportApiVersion: V3

--- a/pilot/pkg/security/authz/builder/testdata/http/custom-http-provider-out2.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/custom-http-provider-out2.yaml
@@ -9,6 +9,7 @@ typedConfig:
       prefix: x-prefix-
     - ignoreCase: true
       suffix: -suffix
+  clearRouteCache: true
   failureModeAllow: true
   filterEnabledMetadata:
     filter: envoy.filters.http.rbac

--- a/pilot/pkg/security/authz/builder/testdata/http/extended-custom-grpc-provider-clear-route-cache-default-out1.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/extended-custom-grpc-provider-clear-route-cache-default-out1.yaml
@@ -1,0 +1,33 @@
+name: envoy.filters.http.rbac
+typedConfig:
+  '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC
+  shadowRules:
+    action: DENY
+    policies:
+      istio-ext-authz-default-ns[foo]-policy[httpbin-1]-rule[0]:
+        permissions:
+        - andRules:
+            rules:
+            - orRules:
+                rules:
+                - urlPath:
+                    path:
+                      exact: /httpbin1
+        principals:
+        - andIds:
+            ids:
+            - any: true
+      istio-ext-authz-default-ns[foo]-policy[httpbin-2]-rule[0]:
+        permissions:
+        - andRules:
+            rules:
+            - orRules:
+                rules:
+                - urlPath:
+                    path:
+                      exact: /httpbin2
+        principals:
+        - andIds:
+            ids:
+            - any: true
+  shadowRulesStatPrefix: istio_ext_authz_

--- a/pilot/pkg/security/authz/builder/testdata/http/extended-custom-grpc-provider-clear-route-cache-default-out2.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/extended-custom-grpc-provider-clear-route-cache-default-out2.yaml
@@ -1,0 +1,19 @@
+name: envoy.filters.http.ext_authz
+typedConfig:
+  '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+  failureModeAllow: true
+  filterEnabledMetadata:
+    filter: envoy.filters.http.rbac
+    path:
+    - key: istio_ext_authz_shadow_effective_policy_id
+    value:
+      stringMatch:
+        prefix: istio-ext-authz-default
+  grpcService:
+    envoyGrpc:
+      authority: my-custom-ext-authz.foo.svc.cluster.local
+      clusterName: outbound|9000||my-custom-ext-authz.foo.svc.cluster.local
+    timeout: 600s
+  statusOnError:
+    code: Forbidden
+  transportApiVersion: V3

--- a/pilot/pkg/security/authz/builder/testdata/http/extended-custom-grpc-provider-no-namespace-out2.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/extended-custom-grpc-provider-no-namespace-out2.yaml
@@ -1,6 +1,7 @@
 name: envoy.filters.http.ext_authz
 typedConfig:
   '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+  clearRouteCache: true
   failureModeAllow: true
   filterEnabledMetadata:
     filter: envoy.filters.http.rbac

--- a/pilot/pkg/security/authz/builder/testdata/http/extended-custom-grpc-provider-out2.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/extended-custom-grpc-provider-out2.yaml
@@ -1,6 +1,7 @@
 name: envoy.filters.http.ext_authz
 typedConfig:
   '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+  clearRouteCache: true
   failureModeAllow: true
   filterEnabledMetadata:
     filter: envoy.filters.http.rbac

--- a/pilot/pkg/security/authz/builder/testdata/http/extended-custom-http-provider-clear-route-cache-default-out1.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/extended-custom-http-provider-clear-route-cache-default-out1.yaml
@@ -1,0 +1,33 @@
+name: envoy.filters.http.rbac
+typedConfig:
+  '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC
+  shadowRules:
+    action: DENY
+    policies:
+      istio-ext-authz-default-ns[foo]-policy[httpbin-1]-rule[0]:
+        permissions:
+        - andRules:
+            rules:
+            - orRules:
+                rules:
+                - urlPath:
+                    path:
+                      exact: /httpbin1
+        principals:
+        - andIds:
+            ids:
+            - any: true
+      istio-ext-authz-default-ns[foo]-policy[httpbin-2]-rule[0]:
+        permissions:
+        - andRules:
+            rules:
+            - orRules:
+                rules:
+                - urlPath:
+                    path:
+                      exact: /httpbin2
+        principals:
+        - andIds:
+            ids:
+            - any: true
+  shadowRulesStatPrefix: istio_ext_authz_

--- a/pilot/pkg/security/authz/builder/testdata/http/extended-custom-http-provider-clear-route-cache-default-out2.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/extended-custom-http-provider-clear-route-cache-default-out2.yaml
@@ -1,0 +1,19 @@
+name: envoy.filters.http.ext_authz
+typedConfig:
+  '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+  failureModeAllow: true
+  filterEnabledMetadata:
+    filter: envoy.filters.http.rbac
+    path:
+    - key: istio_ext_authz_shadow_effective_policy_id
+    value:
+      stringMatch:
+        prefix: istio-ext-authz-default
+  httpService:
+    serverUri:
+      cluster: outbound|9000||my-custom-ext-authz.foo.svc.cluster.local
+      timeout: 600s
+      uri: http://my-custom-ext-authz.foo.svc.cluster.local
+  statusOnError:
+    code: Forbidden
+  transportApiVersion: V3

--- a/pilot/pkg/security/authz/builder/testdata/http/extended-custom-http-provider-out2.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/extended-custom-http-provider-out2.yaml
@@ -9,6 +9,7 @@ typedConfig:
       prefix: x-prefix-
     - ignoreCase: true
       suffix: -suffix
+  clearRouteCache: true
   failureModeAllow: true
   filterEnabledMetadata:
     filter: envoy.filters.http.rbac

--- a/releasenotes/notes/61558.yaml
+++ b/releasenotes/notes/61558.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+issue:
+  - 61558
+releaseNotes:
+  - |
+    **Fixed** the `clearRouteCache` field of the `envoyExtAuthzHttp` and `envoyExtAuthzGrpc`
+    extension providers being accepted in `meshConfig` but not applied to the generated
+    Envoy `ext_authz` filter configuration.


### PR DESCRIPTION
**Please provide a description of this PR:**

`meshConfig.extensionProviders[].envoyExtAuthzHttp.clearRouteCache` (and the equivalent
`envoyExtAuthzGrpc.clearRouteCache`) is accepted by Istio's MeshConfig but was never
translated into the generated Envoy `envoy.filters.http.ext_authz` filter's
`clear_route_cache` field. This breaks the documented pattern where an ext_authz service
returns headers that are meant to affect route selection on the allowed request.

This PR wires `config.ClearRouteCache` through to `extauthzhttp.ExtAuthz.ClearRouteCache`
for both the HTTP and gRPC ext_authz provider builders, updates existing unit test
fixtures/golden files to cover it, and adds a release note.




Fixes #61558