### PR TITLE
fix(gateway): clean up stale shadow services

### DIFF
--- a/pilot/pkg/config/kube/gateway/controller.go
+++ b/pilot/pkg/config/kube/gateway/controller.go
@@ -300,7 +300,7 @@ func NewController(
 	// Create a queue for handling service updates.
 	// We create the queue even if the env var is off just to prevent nil pointer issues.
 	c.shadowServiceReconciler = controllers.NewQueue("inference pool shadow service reconciler",
-		controllers.WithReconciler(c.reconcileShadowService(kc, InferencePools, inputs.Services)),
+		controllers.WithGenericReconciler(c.reconcileShadowService(kc, InferencePools, inputs.Services)),
 		controllers.WithMaxAttempts(5))
 
 	if features.EnableGatewayAPIInferenceExtension {
@@ -433,23 +433,26 @@ func NewController(
 			}), false),
 		outputs.InferencePools.Register(func(e krt.Event[InferencePool]) {
 			obj := e.Latest()
-			c.shadowServiceReconciler.Add(types.NamespacedName{
+			request := shadowServiceReconcileRequest{key: types.NamespacedName{
 				Namespace: obj.shadowService.key.Namespace,
 				Name:      obj.shadowService.poolName,
-			})
+			}}
+			if e.Event == controllers.EventDelete {
+				request.delete = true
+				request.poolUID = obj.shadowService.poolUID
+			}
+			c.shadowServiceReconciler.Add(request)
 		}),
-		// Reconcile shadow services if users break them.
+		// Reconcile shadow services if users modify or delete them.
 		inputs.Services.Register(func(o krt.Event[*corev1.Service]) {
 			obj := o.Latest()
 			// We only care about services that are tagged with the internal service semantics label.
 			if obj.GetLabels()[constants.InternalServiceSemantics] != constants.ServiceSemanticsInferencePool {
 				return
 			}
-			// We only care about delete events
 			if o.Event != controllers.EventDelete && o.Event != controllers.EventUpdate {
 				return
 			}
-
 			poolName, ok := obj.Labels[InferencePoolRefLabel]
 			if !ok && o.Event == controllers.EventUpdate && o.Old != nil {
 				// Try and find the label from the old object
@@ -463,12 +466,13 @@ func NewController(
 				return
 			}
 
-			// Add it back
-			c.shadowServiceReconciler.Add(types.NamespacedName{
+			// Service events only repair the shadow service. Deletion is driven by the
+			// derived InferencePool delete event, which carries the pool UID.
+			c.shadowServiceReconciler.Add(shadowServiceReconcileRequest{key: types.NamespacedName{
 				Namespace: obj.Namespace,
 				Name:      poolName,
-			})
-			log.Infof("Re-adding shadow service for deleted inference pool service %s/%s",
+			}})
+			log.Debugf("queueing reconciliation for inference pool service %s/%s",
 				obj.Namespace, obj.Name)
 		}),
 	)

--- a/pilot/pkg/config/kube/gateway/inferencepool_collection.go
+++ b/pilot/pkg/config/kube/gateway/inferencepool_collection.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -91,6 +92,12 @@ type InferencePool struct {
 	shadowService  shadowServiceInfo
 	extRef         extRefInfo
 	gatewayParents sets.Set[types.NamespacedName] // Gateways that reference this InferencePool
+}
+
+type shadowServiceReconcileRequest struct {
+	key     types.NamespacedName
+	delete  bool
+	poolUID types.UID
 }
 
 func (i InferencePool) ResourceName() string {
@@ -572,13 +579,65 @@ func (c *Controller) reconcileShadowService(
 	kubeClient kube.Client,
 	inferencePools krt.Collection[InferencePool],
 	servicesCollection krt.Collection[*corev1.Service],
-) func(key types.NamespacedName) error {
-	return func(key types.NamespacedName) error {
+) func(any) error {
+	return func(item any) error {
+		request, ok := item.(shadowServiceReconcileRequest)
+		if !ok {
+			return fmt.Errorf("unexpected shadow service reconcile request type %T", item)
+		}
+		key := request.key
+		if request.delete {
+			// The pool may have been recreated before this request was processed.
+			// In that case the normal reconciliation path will manage the service.
+			if inferencePools.GetKey(key.String()) != nil {
+				return nil
+			}
+			livePool, err := kubeClient.GatewayAPIInference().InferenceV1().InferencePools(key.Namespace).
+				Get(context.Background(), key.Name, metav1.GetOptions{})
+			if err != nil && !apierrors.IsNotFound(err) {
+				return err
+			}
+			// A revision handoff or same-name recreation can remove the pool from this
+			// controller's collection without making its old delete request authoritative.
+			if livePool != nil && (livePool.UID != request.poolUID || !c.inRevision(livePool)) {
+				return nil
+			}
+			serviceName, err := InferencePoolServiceName(key.Name)
+			if err != nil {
+				return err
+			}
+			existingService := ptr.Flatten(servicesCollection.GetKey(key.Namespace + "/" + serviceName))
+			if existingService == nil {
+				return nil
+			}
+			canManage, reason := c.canDeleteShadowServiceForInference(existingService, key.Name, request.poolUID)
+			if !canManage {
+				log.Debugf("skipping deletion of service %s/%s, managed by another controller: %s",
+					key.Namespace, serviceName, reason)
+				return nil
+			}
+			var preconditions *metav1.Preconditions
+			if existingService.UID != "" || existingService.ResourceVersion != "" {
+				preconditions = &metav1.Preconditions{}
+				if existingService.UID != "" {
+					preconditions.UID = ptr.Of(existingService.UID)
+				}
+				if existingService.ResourceVersion != "" {
+					preconditions.ResourceVersion = ptr.Of(existingService.ResourceVersion)
+				}
+			}
+			err = kubeClient.Kube().CoreV1().Services(key.Namespace).
+				Delete(context.Background(), serviceName, metav1.DeleteOptions{Preconditions: preconditions})
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+
 		// Find the InferencePool that matches the key
 		pool := inferencePools.GetKey(key.String())
 		if pool == nil {
-			// we'll generally ignore these scenarios, since the InferencePool may have been deleted
-			log.Debugf("inferencepool no longer exists", key.String())
+			log.Debugf("inferencepool %s no longer exists", key.String())
 			return nil
 		}
 
@@ -625,6 +684,33 @@ func (c *Controller) canManageShadowServiceForInference(obj *corev1.Service) (bo
 	_, inferencePoolManaged := obj.GetLabels()[InferencePoolRefLabel]
 	// We can manage if it has no manager or if we are the manager
 	return inferencePoolManaged, obj.GetResourceVersion()
+}
+
+func (c *Controller) canDeleteShadowServiceForInference(
+	obj *corev1.Service,
+	poolName string,
+	poolUID types.UID,
+) (bool, string) {
+	if poolUID == "" {
+		return false, "missing InferencePool UID"
+	}
+	canManage, reason := c.canManageShadowServiceForInference(obj)
+	if !canManage {
+		return false, reason
+	}
+	if obj.Labels[InferencePoolRefLabel] != poolName {
+		return false, fmt.Sprintf("unexpected %s label", InferencePoolRefLabel)
+	}
+	if obj.Labels[constants.InternalServiceSemantics] != constants.ServiceSemanticsInferencePool {
+		return false, fmt.Sprintf("unexpected %s label", constants.InternalServiceSemantics)
+	}
+	for _, owner := range obj.OwnerReferences {
+		if owner.APIVersion == gvk.InferencePool.GroupVersion() &&
+			owner.Kind == gvk.InferencePool.Kind && owner.Name == poolName && owner.UID == poolUID {
+			return true, ""
+		}
+	}
+	return false, "missing matching InferencePool owner reference"
 }
 
 func indexHTTPRouteByInferencePool(o *gatewayv1.HTTPRoute) []string {

--- a/pilot/pkg/config/kube/gateway/inferencepool_test.go
+++ b/pilot/pkg/config/kube/gateway/inferencepool_test.go
@@ -19,13 +19,18 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	inferencev1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 
+	"istio.io/api/label"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
@@ -345,4 +350,182 @@ func TestReconcileInferencePool(t *testing.T) {
 			assert.Equal(t, service.OwnerReferences[0].Name, tc.inferencePool.Name)
 		})
 	}
+}
+
+func TestReconcileInferencePoolDeletesShadowServiceAfterLastRoute(t *testing.T) {
+	test.SetForTest(t, &features.EnableGatewayAPIInferenceExtension, true)
+
+	pool := NewInferencePool("test-pool", InNamespace("default"))
+	pool.UID = types.UID("pool-uid")
+	pool.Spec.TargetPorts = []inferencev1.Port{{Number: 8080}}
+	pool.Spec.EndpointPickerRef.Port = &inferencev1.Port{Number: 5421}
+	route := NewHTTPRoute("test-route", InNamespace("default"),
+		WithParentRefAndStatus("test-gateway", "default", "istio.io/gateway-controller"),
+		WithBackendRef(pool.Name, pool.Namespace),
+	)
+	secondRoute := NewHTTPRoute("second-route", InNamespace("default"),
+		WithParentRefAndStatus("test-gateway", "default", "istio.io/gateway-controller"),
+		WithBackendRef(pool.Name, pool.Namespace),
+	)
+	controller := setupController(t,
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+		NewGateway("test-gateway", InNamespace("default"), WithGatewayClass("istio")),
+		route,
+		secondRoute,
+		pool,
+	)
+
+	serviceName, err := InferencePoolServiceName(pool.Name)
+	assert.NoError(t, err)
+	assert.EventuallyEqual(t, func() bool {
+		_, err := controller.client.Kube().CoreV1().Services(pool.Namespace).
+			Get(t.Context(), serviceName, metav1.GetOptions{})
+		return err == nil
+	}, true)
+
+	assert.NoError(t, controller.client.GatewayAPI().GatewayV1().HTTPRoutes(route.Namespace).
+		Delete(t.Context(), route.Name, metav1.DeleteOptions{}))
+	assert.EventuallyEqual(t, func() bool {
+		_, err := controller.client.Kube().CoreV1().Services(pool.Namespace).
+			Get(t.Context(), serviceName, metav1.GetOptions{})
+		return err == nil
+	}, true)
+
+	assert.NoError(t, controller.client.GatewayAPI().GatewayV1().HTTPRoutes(secondRoute.Namespace).
+		Delete(t.Context(), secondRoute.Name, metav1.DeleteOptions{}))
+	assert.EventuallyEqual(t, func() bool {
+		_, err := controller.client.Kube().CoreV1().Services(pool.Namespace).
+			Get(t.Context(), serviceName, metav1.GetOptions{})
+		return apierrors.IsNotFound(err)
+	}, true)
+}
+
+func TestReconcileInferencePoolDoesNotDeleteShadowServiceOnStartup(t *testing.T) {
+	test.SetForTest(t, &features.EnableGatewayAPIInferenceExtension, true)
+
+	poolName := "test-pool"
+	namespace := "default"
+	serviceName, err := InferencePoolServiceName(poolName)
+	assert.NoError(t, err)
+	poolUID := types.UID("pool-uid")
+	pool := NewInferencePool(poolName, InNamespace(namespace))
+	pool.UID = poolUID
+	pool.Spec.TargetPorts = []inferencev1.Port{{Number: 8080}}
+	pool.Spec.EndpointPickerRef.Port = &inferencev1.Port{Number: 5421}
+	controller := setupController(t,
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}},
+		pool,
+		managedShadowServiceForTest(serviceName, poolName, namespace, poolUID),
+	)
+
+	_, err = controller.client.Kube().CoreV1().Services(namespace).
+		Get(t.Context(), serviceName, metav1.GetOptions{})
+	assert.NoError(t, err)
+}
+
+func TestReconcileInferencePoolDoesNotDeleteShadowServiceWhenFeatureDisabled(t *testing.T) {
+	test.SetForTest(t, &features.EnableGatewayAPIInferenceExtension, false)
+
+	poolName := "test-pool"
+	namespace := "default"
+	serviceName, err := InferencePoolServiceName(poolName)
+	assert.NoError(t, err)
+	controller := setupController(t,
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}},
+		managedShadowServiceForTest(serviceName, poolName, namespace, types.UID("pool-uid")),
+	)
+
+	_, err = controller.client.Kube().CoreV1().Services(namespace).
+		Get(t.Context(), serviceName, metav1.GetOptions{})
+	assert.NoError(t, err)
+}
+
+func TestReconcileInferencePoolDoesNotDeleteShadowServiceAfterRevisionHandoff(t *testing.T) {
+	test.SetForTest(t, &features.EnableGatewayAPIInferenceExtension, true)
+
+	poolName := "test-pool"
+	namespace := "default"
+	poolUID := types.UID("pool-uid")
+	serviceName, err := InferencePoolServiceName(poolName)
+	assert.NoError(t, err)
+	pool := NewInferencePool(poolName, InNamespace(namespace))
+	pool.UID = poolUID
+	pool.Labels = map[string]string{label.IoIstioRev.Name: "canary"}
+	service := managedShadowServiceForTest(serviceName, poolName, namespace, poolUID)
+	controller := setupControllerWithRevision(t, "stable",
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}},
+		pool,
+		service,
+	)
+	opts := krt.NewOptionsBuilder(test.NewStop(t), "test", nil)
+	services := krt.NewStaticCollection(nil, []*corev1.Service{service}, opts.WithName("Services")...)
+	reconcile := controller.reconcileShadowService(controller.client, controller.outputs.InferencePools, services)
+
+	assert.NoError(t, reconcile(shadowServiceReconcileRequest{
+		key:     types.NamespacedName{Namespace: namespace, Name: poolName},
+		delete:  true,
+		poolUID: poolUID,
+	}))
+	_, err = controller.client.Kube().CoreV1().Services(namespace).Get(t.Context(), serviceName, metav1.GetOptions{})
+	assert.NoError(t, err)
+}
+
+func TestCanDeleteShadowServiceForInference(t *testing.T) {
+	poolName := "test-pool"
+	base := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Labels: map[string]string{
+			InferencePoolRefLabel:              poolName,
+			constants.InternalServiceSemantics: constants.ServiceSemanticsInferencePool,
+		},
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: gvk.InferencePool.GroupVersion(), Kind: gvk.InferencePool.Kind,
+			Name: poolName, UID: types.UID("pool-uid"),
+		}},
+	}}
+
+	testCases := []struct {
+		name    string
+		mutate  func(*corev1.Service)
+		allowed bool
+	}{
+		{name: "matching managed service", allowed: true},
+		{name: "different pool label", mutate: func(s *corev1.Service) {
+			s.Labels[InferencePoolRefLabel] = "other-pool"
+		}},
+		{name: "missing internal semantics", mutate: func(s *corev1.Service) {
+			delete(s.Labels, constants.InternalServiceSemantics)
+		}},
+		{name: "missing owner reference", mutate: func(s *corev1.Service) {
+			s.OwnerReferences = nil
+		}},
+		{name: "different pool UID", mutate: func(s *corev1.Service) {
+			s.OwnerReferences[0].UID = types.UID("other-pool-uid")
+		}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			service := base.DeepCopy()
+			if tc.mutate != nil {
+				tc.mutate(service)
+			}
+			allowed, _ := (&Controller{}).canDeleteShadowServiceForInference(
+				service, poolName, types.UID("pool-uid"))
+			assert.Equal(t, allowed, tc.allowed)
+		})
+	}
+}
+
+func managedShadowServiceForTest(serviceName, poolName, namespace string, poolUID types.UID) *corev1.Service {
+	return &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name: serviceName, Namespace: namespace, UID: types.UID("service-uid"), ResourceVersion: "1",
+		Labels: map[string]string{
+			InferencePoolRefLabel:              poolName,
+			constants.InternalServiceSemantics: constants.ServiceSemanticsInferencePool,
+		},
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: gvk.InferencePool.GroupVersion(), Kind: gvk.InferencePool.Kind,
+			Name: poolName, UID: poolUID,
+		}},
+	}}
 }


### PR DESCRIPTION
Deleting the last HTTPRoute that references an InferencePool can leave its shadow Service behind. Clean up the Service only on an explicit derived-pool delete event, with pool UID, revision, and Service ownership checks to protect startup and revision handoffs.

Read the Service directly from the Kubernetes API during deletion so cleanup also works when the Service informer has not observed a newly created Service. Keep UID and resourceVersion deletion preconditions to avoid deleting a replacement Service.

Tests cover last-route deletion, startup, disabled inference support, revision handoff, ownership validation, and deletion before the Service cache catches up. The multi-route test also checks that no Service deletion occurs while another route still references the pool.

Validation:
- The new cache-lag regression test fails against the previous implementation.
- `go test -tags=assert -race ./pilot/pkg/config/kube/gateway -count=1 -timeout=10m`

Fixes #61565
