### PR TITLE
serviceregistry: move proxy update from serviceentry to kube controller

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -98,7 +98,8 @@ var (
 	// currently missing pods. This helps distinguish transient errors from permanent ones
 	endpointsWithNoPods = monitoring.NewSum(
 		"pilot_k8s_endpoints_with_no_pods",
-		"Endpoints that does not have any corresponding pods.")
+		"Endpoints that does not have any corresponding pods.",
+	)
 
 	endpointsPendingPodUpdate = monitoring.NewGauge(
 		"pilot_k8s_endpoints_pending_pod",
@@ -654,7 +655,8 @@ func registerHandlers[T controllers.ComparableObject](c *Controller,
 					return handler(ptr.Empty[T](), obj, model.EventDelete)
 				})
 			},
-		})
+		},
+	)
 }
 
 // HasSynced returns true after the initial state synchronization
@@ -991,11 +993,12 @@ func (c *Controller) workloadInstanceHandler(si *model.WorkloadInstance, event m
 
 	// this is from a workload entry. Store it in separate index so that
 	// the InstancesByPort can use these as well as the k8s pods.
+	var previous *model.WorkloadInstance
 	switch event {
 	case model.EventDelete:
-		c.workloadInstancesIndex.Delete(si)
+		previous = c.workloadInstancesIndex.Delete(si)
 	default: // add or update
-		c.workloadInstancesIndex.Insert(si)
+		previous = c.workloadInstancesIndex.Insert(si)
 	}
 
 	// find the workload entry's service by label selector
@@ -1013,6 +1016,13 @@ func (c *Controller) workloadInstanceHandler(si *model.WorkloadInstance, event m
 		return kube.ServiceHostname(e.Name, e.Namespace, c.opts.DomainSuffix)
 	})
 	c.endpoints.pushEDS(matchedHostnames, si.Namespace)
+
+	// we should trigger a proxy update if any service has selected this workload or
+	// if the labels have changed, as this may affect which services select this workload.
+	labelsChanged := previous != nil && !previous.Endpoint.Labels.Equals(si.Endpoint.Labels)
+	if c.opts.XDSUpdater != nil && (len(matchedServices) > 0 || labelsChanged) {
+		c.opts.XDSUpdater.ProxyUpdate(c.Cluster(), si.Endpoint.FirstAddressOrNil())
+	}
 }
 
 func (c *Controller) onSystemNamespaceEvent(_, ns *v1.Namespace, ev model.Event) error {

--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -86,9 +86,7 @@ type Inputs struct {
 	ServiceEntries  krt.Collection[config.Config]
 	// TODO: this should be a joined collection with multi cluster workloads
 	ExternalWorkloads krt.StaticCollection[*model.WorkloadInstance]
-	// ExternalWorkloadsByIP attributes a service instance event back to the workload kind that produced it.
-	ExternalWorkloadsByIP krt.Index[string, *model.WorkloadInstance]
-	XBackends             krt.Collection[config.Config]
+	XBackends         krt.Collection[config.Config]
 }
 
 type Outputs struct {
@@ -237,9 +235,6 @@ func newController(
 		s.inputs.Namespaces = multiclusterController.ConfigCluster().Namespaces()
 		s.inputs.ServiceEntries = store.KrtCollection(gvk.ServiceEntry)
 		s.inputs.ExternalWorkloads = krt.NewStaticCollection[*model.WorkloadInstance](nil, nil, s.opts.WithName("inputs/ExternalWorkloads")...)
-		s.inputs.ExternalWorkloadsByIP = krt.NewIndex(s.inputs.ExternalWorkloads, "ip", func(wi *model.WorkloadInstance) []string {
-			return []string{wi.Endpoint.FirstAddressOrNil()}
-		})
 		if features.EnableAlphaGatewayAPI {
 			s.inputs.XBackends = store.KrtCollection(gvk.XBackend)
 		}
@@ -256,12 +251,10 @@ func newController(
 			s.handlers,
 			s.outputs.ServiceInstancesByNamespaceHost.RegisterBatch(s.pushServiceEndpointUpdates, false),
 			s.outputs.Services.RegisterBatch(s.pushServiceUpdates, false),
-			s.outputs.ServiceInstancesByIP.AsCollection(s.opts.WithName("outputs/ServiceInstancesByIPCollection")...).
-				RegisterBatch(s.pushPodProxyUpdates, false),
+			s.outputs.ServiceInstances.RegisterBatch(s.pushProxyUpdates, false),
 		)
 	}
-	// Register EDS/XDS push handlers for WLEs
-	s.handlers = append(s.handlers, s.outputs.Workloads.RegisterBatch(s.pushWorkloadUpdates, false))
+	s.handlers = append(s.handlers, s.outputs.Workloads.RegisterBatch(s.notifyWorkloadHandlers, false))
 
 	return s
 }
@@ -372,44 +365,46 @@ func (s *Controller) pushServiceUpdates(events []krt.Event[ServiceWithInstances]
 	}
 }
 
-func (s *Controller) pushWorkloadUpdates(events []krt.Event[*model.WorkloadInstance]) {
+func (s *Controller) notifyWorkloadHandlers(events []krt.Event[*model.WorkloadInstance]) {
 	for _, e := range events {
 		if !e.Latest().DNSServiceEntryOnly {
 			s.NotifyWorkloadInstanceHandlers(e.Latest(), model.Event(e.Event))
 		}
-
-		if e.Event == controllers.EventAdd ||
-			e.Event == controllers.EventUpdate && !(*e.Old).Endpoint.Labels.Equals((*e.New).Endpoint.Labels) {
-			s.XdsUpdater.ProxyUpdate(s.Cluster(), (*e.New).Endpoint.FirstAddressOrNil())
-		}
 	}
 }
 
-// pushPodProxyUpdates forces a pod's own proxy to recompute when this registry's instances for
-// that pod change.
-//
-// A proxy snapshots model.Proxy.ServiceTargets when its xDS stream is established and reuses it for
-// every later push. A pod only becomes an endpoint here once it is Ready, which is after that
-// snapshot, and the incremental endpoint update that follows does not refresh it.
-//
-// Triggering off the derived instance collection rather than the pod event is what makes this
-// reliable: krt updates a collection's indexes before dispatching handlers, so GetProxyServiceTargets,
-// which reads this same index, observes the new state. It also collapses a workload's per-port
-// instances into one event per IP.
-func (s *Controller) pushPodProxyUpdates(events []krt.Event[krt.IndexObject[string, *model.ServiceInstance]]) {
+type proxyKey struct {
+	cluster cluster.ID
+	address string
+}
+
+// pushProxyUpdates forces a workload's own proxy to recompute when this registry's instances for
+// that workload change.
+func (s *Controller) pushProxyUpdates(events []krt.Event[*model.ServiceInstance]) {
+	// A workload has one instance per service port, and may be selected by several ServiceEntries;
+	// collapse those into a single push per proxy.
+	pushed := sets.New[proxyKey]()
 	for _, e := range events {
-		ip := e.Latest().Key
-		if ip == "" {
+		// we only care for Add events since Deletes can happen when instances become unhealthy
+		if e.Event != controllers.EventAdd {
 			continue
 		}
-		// Only pods. ExternalWorkloads also carries WorkloadEntry-derived instances from non-config
-		// clusters, whose proxies connect elsewhere and are pushed by pushWorkloadUpdates.
-		if !slices.ContainsFunc(s.inputs.ExternalWorkloadsByIP.Lookup(ip), func(wi *model.WorkloadInstance) bool {
-			return wi.Kind == model.PodKind
-		}) {
+
+		si := e.Latest()
+		// skip service entry inline instances
+		if len(si.Service.Attributes.LabelSelectors) == 0 {
 			continue
 		}
-		s.XdsUpdater.ProxyUpdate(s.Cluster(), ip)
+		ep := si.Endpoint
+		key := proxyKey{
+			// ServiceEntry can select pods and WorkloadEntries from any cluster, use their own cluster ID.
+			cluster: ep.Locality.ClusterID,
+			address: ep.FirstAddressOrNil(),
+		}
+		if key.address == "" || pushed.InsertContains(key) {
+			continue
+		}
+		s.XdsUpdater.ProxyUpdate(key.cluster, key.address)
 	}
 }
 

--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -15,6 +15,7 @@
 package serviceentry
 
 import (
+	"strconv"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
@@ -106,8 +107,8 @@ type Outputs struct {
 	ServiceInstancesByNamespaceHost krt.Collection[InstancesByNamespaceHost]
 	// ServiceInstances is a collection of all service instances.
 	// Its main purpose is to allow searching for service instances by IP.
-	ServiceInstances     krt.Collection[*model.ServiceInstance]
-	ServiceInstancesByIP krt.Index[string, *model.ServiceInstance]
+	ServiceInstances     krt.Collection[*WorkloadServiceInstance]
+	ServiceInstancesByIP krt.Index[string, *WorkloadServiceInstance]
 	// Workloads is a collection of local workload instances.
 	// Use cases:
 	// - Notifying workload instance handlers.
@@ -121,7 +122,7 @@ type ServiceWithInstances struct {
 	// should probably be handled elsewhere.
 	// ref: https://github.com/istio/istio/pull/50068
 	TargetPorts []uint32
-	Instances   []*model.ServiceInstance
+	Instances   []*WorkloadServiceInstance
 }
 
 func (swi ServiceWithInstances) ResourceName() string {
@@ -131,7 +132,7 @@ func (swi ServiceWithInstances) ResourceName() string {
 func (swi ServiceWithInstances) Equals(other ServiceWithInstances) bool {
 	return slices.Equal(swi.TargetPorts, other.TargetPorts) &&
 		swi.Service.Equals(other.Service) &&
-		slices.EqualFunc(swi.Instances, other.Instances, func(a, b *model.ServiceInstance) bool {
+		slices.EqualFunc(swi.Instances, other.Instances, func(a, b *WorkloadServiceInstance) bool {
 			return a.Endpoint.Equals(b.Endpoint)
 		})
 }
@@ -139,7 +140,7 @@ func (swi ServiceWithInstances) Equals(other ServiceWithInstances) bool {
 type InstancesByNamespaceHost struct {
 	Namespace             string
 	Hostname              string
-	Instances             []*model.ServiceInstance
+	Instances             []*WorkloadServiceInstance
 	HasDNSServiceEndpoint bool
 }
 
@@ -150,9 +151,29 @@ func (s InstancesByNamespaceHost) ResourceName() string {
 func (s InstancesByNamespaceHost) Equals(other InstancesByNamespaceHost) bool {
 	return s.Namespace == other.Namespace && s.Hostname == other.Hostname &&
 		s.HasDNSServiceEndpoint == other.HasDNSServiceEndpoint &&
-		slices.EqualFunc(s.Instances, other.Instances, func(a, b *model.ServiceInstance) bool {
+		slices.EqualFunc(s.Instances, other.Instances, func(a, b *WorkloadServiceInstance) bool {
 			return a.Equals(b)
 		})
+}
+
+type WorkloadServiceInstance struct {
+	Namespace   string
+	Name        string
+	Service     *model.Service       `json:"service,omitempty"`
+	ServicePort *model.Port          `json:"servicePort,omitempty"`
+	Endpoint    *model.IstioEndpoint `json:"endpoint,omitempty"`
+}
+
+func (wsi *WorkloadServiceInstance) ResourceName() string {
+	return wsi.Namespace + "/" + wsi.Name + "/" + wsi.Service.ResourceName() + "/" + wsi.Endpoint.Key() + "/" + strconv.Itoa(wsi.ServicePort.Port)
+}
+
+func (wsi *WorkloadServiceInstance) Equals(other *WorkloadServiceInstance) bool {
+	return wsi.Namespace == other.Namespace &&
+		wsi.Name == other.Name &&
+		wsi.ServicePort.Equals(other.ServicePort) &&
+		wsi.Endpoint.Equals(other.Endpoint) &&
+		wsi.Service.Equals(other.Service)
 }
 
 type Option func(*Controller)
@@ -297,11 +318,11 @@ func (s *Controller) buildCollections() {
 		mergedServicesInstances := mergeServicesInstancesByNamespaceHost(servicesByNsHost.AsCollection(), s.opts)
 
 		// derive service instances from merged services
-		serviceInstances := krt.NewManyCollection(mergedServicesInstances, func(ctx krt.HandlerContext, swi InstancesByNamespaceHost) []*model.ServiceInstance {
+		serviceInstances := krt.NewManyCollection(mergedServicesInstances, func(ctx krt.HandlerContext, swi InstancesByNamespaceHost) []*WorkloadServiceInstance {
 			return swi.Instances
 		}, s.opts.WithName("outputs/ServiceInstances")...)
 
-		serviceInstancesByIP := krt.NewIndex(serviceInstances, "ip", func(si *model.ServiceInstance) []string {
+		serviceInstancesByIP := krt.NewIndex(serviceInstances, "ip", func(si *WorkloadServiceInstance) []string {
 			return []string{si.Endpoint.FirstAddressOrNil()}
 		})
 
@@ -328,7 +349,7 @@ func (s *Controller) pushServiceEndpointUpdates(events []krt.Event[InstancesByNa
 			s.XdsUpdater.SvcUpdate(shard, obj.Hostname, obj.Namespace, model.EventDelete)
 			s.XdsUpdater.EDSUpdate(shard, obj.Hostname, obj.Namespace, nil)
 		} else {
-			instances := slices.Map(obj.Instances, func(i *model.ServiceInstance) *model.IstioEndpoint {
+			instances := slices.Map(obj.Instances, func(i *WorkloadServiceInstance) *model.IstioEndpoint {
 				return i.Endpoint
 			})
 			s.XdsUpdater.EDSUpdate(shard, obj.Hostname, obj.Namespace, instances)
@@ -380,13 +401,15 @@ type proxyKey struct {
 
 // pushProxyUpdates forces a workload's own proxy to recompute when this registry's instances for
 // that workload change.
-func (s *Controller) pushProxyUpdates(events []krt.Event[*model.ServiceInstance]) {
+func (s *Controller) pushProxyUpdates(events []krt.Event[*WorkloadServiceInstance]) {
 	// A workload has one instance per service port, and may be selected by several ServiceEntries;
 	// collapse those into a single push per proxy.
 	pushed := sets.New[proxyKey]()
 	for _, e := range events {
-		// we only care for Add events since Deletes can happen when instances become unhealthy
-		if e.Event != controllers.EventAdd {
+		// Updates carry no information the proxy doesn't already have (Service/ServicePort/Endpoint
+		// changes are pushed through other means); only Add (gained a match) and Delete (lost a match)
+		// require the workload's own proxy to recompute its ServiceTargets.
+		if e.Event == controllers.EventUpdate {
 			continue
 		}
 
@@ -395,6 +418,16 @@ func (s *Controller) pushProxyUpdates(events []krt.Event[*model.ServiceInstance]
 		if len(si.Service.Attributes.LabelSelectors) == 0 {
 			continue
 		}
+
+		if e.Event == controllers.EventDelete {
+			external := s.inputs.ExternalWorkloads.GetKey(si.Namespace + "/" + si.Name)
+			we := s.inputs.WorkloadEntries.GetKey(si.Namespace + "/" + si.Name)
+			if external == nil && we == nil {
+				// this workload no longer exists, we don't need to update any proxy
+				continue
+			}
+		}
+
 		ep := si.Endpoint
 		key := proxyKey{
 			// ServiceEntry can select pods and WorkloadEntries from any cluster, use their own cluster ID.
@@ -478,7 +511,7 @@ func (s *Controller) ResyncEDS() {
 
 	shard := model.ShardKeyFromRegistry(s)
 	for _, io := range s.outputs.ServiceInstancesByNamespaceHost.List() {
-		instances := slices.Map(io.Instances, func(i *model.ServiceInstance) *model.IstioEndpoint {
+		instances := slices.Map(io.Instances, func(i *WorkloadServiceInstance) *model.IstioEndpoint {
 			return i.Endpoint
 		})
 		s.XdsUpdater.EDSUpdate(shard, io.Hostname, io.Namespace, instances)
@@ -496,7 +529,13 @@ func (s *Controller) GetProxyServiceTargets(node *model.Proxy) []model.ServiceTa
 	for _, ip := range node.IPAddresses {
 		for _, i := range s.outputs.ServiceInstancesByIP.Lookup(ip) {
 			if node.Metadata.Namespace == "" || i.Service.Attributes.Namespace == node.Metadata.Namespace {
-				out = append(out, model.ServiceInstanceToTarget(i))
+				out = append(out, model.ServiceTarget{
+					Service: i.Service,
+					Port: model.ServiceInstancePort{
+						ServicePort: i.ServicePort,
+						TargetPort:  i.Endpoint.EndpointPort,
+					},
+				})
 			}
 		}
 	}

--- a/pilot/pkg/serviceregistry/serviceentry/controller_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller_test.go
@@ -806,6 +806,8 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 			Event{Type: "eds", ID: "updated.com", Namespace: selector.Namespace},
 			Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace},
 			Event{Type: "xds", ID: "selector.com,updated.com"},
+			// the workload is now an endpoint of updated.com instead of selector.com
+			Event{Type: "proxy", ID: "2.2.2.2"},
 		)
 	})
 
@@ -836,6 +838,7 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 			Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace},
 			Event{Type: "eds", ID: "updated.com", Namespace: selector.Namespace},
 			Event{Type: "xds", ID: "selector.com,updated.com"},
+			Event{Type: "proxy", ID: "2.2.2.2"},
 		)
 	})
 
@@ -912,10 +915,8 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 			makeInstanceWithServiceAccount(selector, "wl2", []string{"3.3.3.3"}, 445,
 				selector.Spec.(*networking.ServiceEntry).Ports[1], map[string]string{"app": "wle"}, "default"))
 		expectServiceInstances(t, sd, selector, 0, instances)
-		expectEvents(
-			t, events,
-			Event{Type: "proxy", ID: "abc.def"},
-		)
+		// The workload produces no instance, so nothing is pushed for it.
+		events.AssertEmpty(t, 40*time.Millisecond)
 	})
 
 	t.Run("deletion", func(t *testing.T) {
@@ -976,8 +977,8 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 		expectServiceInstances(t, sd, selector, 0, instances)
 		expectEvents(
 			t, events,
-			// Event{Type: "proxy", ID: "9.9.9.9"},
 			Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 2},
+			Event{Type: "proxy", ID: "9.9.9.9"},
 		)
 	})
 
@@ -1084,9 +1085,7 @@ func TestServiceDiscoveryWorkloadChangeLabel(t *testing.T) {
 		instances = []*model.ServiceInstance{}
 		expectServiceInstances(t, sd, selector, 0, instances)
 		expectProxyInstances(t, sd, instances, []string{"2.2.2.2"})
-		expectEvents(t, events,
-			Event{Type: "proxy", ID: "2.2.2.2"},
-			Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 0})
+		expectEvents(t, events, Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 0})
 	})
 
 	t.Run("change label removing one", func(t *testing.T) {
@@ -1133,9 +1132,7 @@ func TestServiceDiscoveryWorkloadChangeLabel(t *testing.T) {
 		}
 		expectServiceInstances(t, sd, selector, 0, instances)
 		expectProxyInstances(t, sd, instances, []string{"3.3.3.3"})
-		expectEvents(t, events,
-			Event{Type: "proxy", ID: "2.2.2.2"},
-			Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 2})
+		expectEvents(t, events, Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 2})
 	})
 }
 
@@ -1542,6 +1539,7 @@ func TestServiceDiscoveryWorkloadInstanceChangeLabel(t *testing.T) {
 		serviceAccount         string
 		tlsmode                string
 		expectedProxyInstances []expectedProxyInstances
+		expectProxyUpdate      bool
 	}
 
 	t.Run("service entry", func(t *testing.T) {
@@ -1564,12 +1562,13 @@ func TestServiceDiscoveryWorkloadInstanceChangeLabel(t *testing.T) {
 			name: "change label removing all 0",
 			instances: []testWorkloadInstance{
 				{
-					name:           selector.Name,
-					namespace:      selector.Namespace,
-					address:        "2.2.2.2",
-					labels:         map[string]string{"app": "wle"},
-					serviceAccount: "default",
-					tlsmode:        model.IstioMutualTLSModeLabel,
+					name:              selector.Name,
+					namespace:         selector.Namespace,
+					address:           "2.2.2.2",
+					labels:            map[string]string{"app": "wle"},
+					expectProxyUpdate: true,
+					serviceAccount:    "default",
+					tlsmode:           model.IstioMutualTLSModeLabel,
 					expectedProxyInstances: []expectedProxyInstances{
 						{
 							instancesWithSA: []*model.ServiceInstance{
@@ -1606,12 +1605,13 @@ func TestServiceDiscoveryWorkloadInstanceChangeLabel(t *testing.T) {
 			name: "change label removing all 1",
 			instances: []testWorkloadInstance{
 				{
-					name:           selector.Name,
-					namespace:      selector.Namespace,
-					address:        "2.2.2.2",
-					labels:         map[string]string{"app": "wle"},
-					serviceAccount: "default",
-					tlsmode:        model.IstioMutualTLSModeLabel,
+					name:              selector.Name,
+					namespace:         selector.Namespace,
+					address:           "2.2.2.2",
+					labels:            map[string]string{"app": "wle"},
+					expectProxyUpdate: true,
+					serviceAccount:    "default",
+					tlsmode:           model.IstioMutualTLSModeLabel,
 					expectedProxyInstances: []expectedProxyInstances{
 						{
 							instancesWithSA: []*model.ServiceInstance{
@@ -1629,12 +1629,13 @@ func TestServiceDiscoveryWorkloadInstanceChangeLabel(t *testing.T) {
 					},
 				},
 				{
-					name:           "another-name",
-					namespace:      selector.Namespace,
-					address:        "3.3.3.3",
-					labels:         map[string]string{"app": "wle"},
-					serviceAccount: "default",
-					tlsmode:        model.IstioMutualTLSModeLabel,
+					name:              "another-name",
+					namespace:         selector.Namespace,
+					address:           "3.3.3.3",
+					labels:            map[string]string{"app": "wle"},
+					expectProxyUpdate: true,
+					serviceAccount:    "default",
+					tlsmode:           model.IstioMutualTLSModeLabel,
 					expectedProxyInstances: []expectedProxyInstances{
 						{
 							instancesWithSA: []*model.ServiceInstance{
@@ -1715,10 +1716,14 @@ func TestServiceDiscoveryWorkloadInstanceChangeLabel(t *testing.T) {
 				}
 
 				expectServiceInstances(t, sd, selector, 0, totalInstances)
-				// The instance's own proxy is forced to recompute: which services it backs just changed.
-				expectEvents(t, events,
-					Event{Type: "eds", ID: selector.Spec.(*networking.ServiceEntry).Hosts[0], Namespace: selector.Namespace, EndpointCount: len(totalInstances)},
-					Event{Type: "proxy", ID: instance.address})
+				wantEvents := []Event{{
+					Type: "eds", ID: selector.Spec.(*networking.ServiceEntry).Hosts[0],
+					Namespace: selector.Namespace, EndpointCount: len(totalInstances),
+				}}
+				if instance.expectProxyUpdate {
+					wantEvents = append(wantEvents, Event{Type: "proxy", ID: instance.address})
+				}
+				expectEvents(t, events, wantEvents...)
 			}
 		})
 	}
@@ -1775,7 +1780,7 @@ func TestPodEndpointForcesOwnProxyPush(t *testing.T) {
 // The push is scoped to pods, and a WorkloadEntry from a non-config cluster lands in
 // ExternalWorkloads alongside them. model.PodKind is the zero value of workloadKind, so without the
 // explicit Kind check the scoping would hold only by accident.
-func TestWorkloadEntryEndpointDoesNotDoublePushProxy(t *testing.T) {
+func TestWorkloadEntryEndpointPushesProxyOnce(t *testing.T) {
 	store, sd, events := initServiceDiscovery(t)
 
 	createConfigs([]*config.Config{selector}, store, t)
@@ -1796,7 +1801,6 @@ func TestWorkloadEntryEndpointDoesNotDoublePushProxy(t *testing.T) {
 	}
 	callInstanceHandlers([]*model.WorkloadInstance{wle}, sd, model.EventAdd, t)
 
-	// Membership must still resolve; only the extra push is suppressed.
 	proxy := &model.Proxy{IPAddresses: []string{"2.2.2.2"}, Metadata: &model.NodeMetadata{}}
 	retry.UntilSuccessOrFail(t, func() error {
 		if got := len(sd.GetProxyServiceTargets(proxy)); got != 2 {
@@ -1805,9 +1809,10 @@ func TestWorkloadEntryEndpointDoesNotDoublePushProxy(t *testing.T) {
 		return nil
 	}, retry.Timeout(5*time.Second))
 
-	// The eds event proves the instance landed; no "proxy" event may accompany it. The match returns
-	// as soon as the wanted set empties, so assert on the event that arrives last.
-	expectEvents(t, events, Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 2})
+	// The workload produces one instance per port, but its proxy is only pushed once.
+	expectEvents(t, events,
+		Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 2},
+		Event{Type: "proxy", ID: "2.2.2.2"})
 	select {
 	case e := <-events.Events:
 		t.Fatalf("expected no further events for a WorkloadEntry-derived instance, got %q/%v", e.Type, e.ID)

--- a/pilot/pkg/serviceregistry/serviceentry/controller_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller_test.go
@@ -228,7 +228,7 @@ func TestServiceDiscoveryServiceDeleteOverlapping(t *testing.T) {
 			ServiceAccount: "default",
 		})
 
-	expected := []*model.ServiceInstance{
+	expected := []*WorkloadServiceInstance{
 		makeInstanceWithServiceAccount(selector, "wl", []string{"2.2.2.2"}, 444,
 			selector.Spec.(*networking.ServiceEntry).Ports[0],
 			map[string]string{"app": "wle"}, "default"),
@@ -300,7 +300,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 	}()
 
 	// Setup the expected instances for `httpStatic`. This will be added/removed from as we add various configs
-	baseInstances := []*model.ServiceInstance{
+	baseInstances := []*WorkloadServiceInstance{
 		makeInstance(httpStatic, "httpStatic-0", []string{"2.2.2.2"}, 7080, httpStatic.Spec.(*networking.ServiceEntry).Ports[0], nil, MTLS),
 		makeInstance(httpStatic, "httpStatic-0", []string{"2.2.2.2"}, 18080, httpStatic.Spec.(*networking.ServiceEntry).Ports[1], nil, MTLS),
 		makeInstance(httpStatic, "httpStatic-1", []string{"3.3.3.3"}, 1080, httpStatic.Spec.(*networking.ServiceEntry).Ports[0], nil, MTLS),
@@ -390,7 +390,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 	t.Run("different namespace", func(t *testing.T) {
 		// Update the SE for the same host in a different ns, expect these instances to get added
 		createConfigs([]*config.Config{httpStaticOverlayUpdatedNs}, store, t)
-		instances := []*model.ServiceInstance{
+		instances := []*WorkloadServiceInstance{
 			makeInstance(httpStaticOverlayUpdatedNs, "httpStaticOverlay-0", []string{"5.5.5.5"}, 4567, httpStaticOverlayUpdatedNs.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"overlay": "bar"}, PlainText),
 			makeInstance(httpStaticOverlayUpdatedNs, "httpStaticOverlay-1", []string{"7.7.7.7"}, 4567, httpStaticOverlayUpdatedNs.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"namespace": "bar"}, PlainText),
 		}
@@ -408,7 +408,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 		deleteConfigs([]*config.Config{httpStaticOverlayUpdated}, store, t)
 		expectServiceInstances(t, sd, httpStatic, 0, baseInstances)
 		// Check the other namespace is untouched
-		instances := []*model.ServiceInstance{
+		instances := []*WorkloadServiceInstance{
 			makeInstance(httpStaticOverlayUpdatedNs, "httpStaticOverlay-0", []string{"5.5.5.5"}, 4567, httpStaticOverlayUpdatedNs.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"overlay": "bar"}, PlainText),
 			makeInstance(httpStaticOverlayUpdatedNs, "httpStaticOverlay-1", []string{"7.7.7.7"}, 4567, httpStaticOverlayUpdatedNs.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"namespace": "bar"}, PlainText),
 		}
@@ -511,7 +511,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 			se.Hosts = []string{"other.com"}
 			return &c
 		}()
-		instances2 := []*model.ServiceInstance{
+		instances2 := []*WorkloadServiceInstance{
 			makeInstance(otherHost, "httpStaticOverlay-0", []string{"5.5.5.5"}, 4567, httpStaticHost.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"overlay": "bar"}, PlainText),
 			makeInstance(otherHost, "httpStaticOverlay-1", []string{"6.6.6.6"}, 4567, httpStaticHost.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"other": "bar"}, PlainText),
 		}
@@ -534,7 +534,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 
 	t.Run("change dns endpoints", func(t *testing.T) {
 		// Setup the expected instances for DNS. This will be added/removed from as we add various configs
-		instances1 := []*model.ServiceInstance{
+		instances1 := []*WorkloadServiceInstance{
 			makeInstance(tcpDNS, "tcpDNS-0", []string{"lon.google.com"}, 444, tcpDNS.Spec.(*networking.ServiceEntry).Ports[0],
 				nil, MTLS),
 			makeInstance(tcpDNS, "tcpDNS-1", []string{"in.google.com"}, 444, tcpDNS.Spec.(*networking.ServiceEntry).Ports[0],
@@ -554,7 +554,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 			return &c
 		}()
 
-		instances2 := []*model.ServiceInstance{
+		instances2 := []*WorkloadServiceInstance{
 			makeInstance(tcpDNS, "tcpDNS-0", []string{"lon.google.com"}, 444, tcpDNS.Spec.(*networking.ServiceEntry).Ports[0],
 				nil, MTLS),
 		}
@@ -643,7 +643,7 @@ func TestServiceDiscoveryServiceInstancesForDnsRoundRobinLB(t *testing.T) {
 	}
 
 	createConfigs([]*config.Config{se1}, store, t)
-	expectedPrimary := []*model.ServiceInstance{
+	expectedPrimary := []*WorkloadServiceInstance{
 		makeInstance(se1, "dns-round-robin-1-0", []string{"1.1.1.1"}, 444, se1.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{}, PlainText),
 		makeInstance(se1, "dns-round-robin-1-0", []string{"1.1.1.1"}, 445, se1.Spec.(*networking.ServiceEntry).Ports[1], map[string]string{}, PlainText),
 	}
@@ -656,7 +656,7 @@ func TestServiceDiscoveryServiceInstancesForDnsRoundRobinLB(t *testing.T) {
 	)
 
 	createConfigs([]*config.Config{seMulti}, store, t)
-	expectedMul := []*model.ServiceInstance{
+	expectedMul := []*WorkloadServiceInstance{
 		makeInstance(seMulti, "dns-round-robin-3-0", []string{"3.3.3.3"}, 444, seMulti.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{}, PlainText),
 	}
 	expectServiceInstances(t, sd, seMulti, 0, expectedMul)
@@ -680,7 +680,7 @@ func TestServiceDiscoveryServiceInstancesForDnsRoundRobinLB(t *testing.T) {
 	}
 
 	createConfigs([]*config.Config{otherNs}, store, t)
-	otherNsExpected := []*model.ServiceInstance{
+	otherNsExpected := []*WorkloadServiceInstance{
 		makeInstance(otherNs, "dns-round-robin-1-0", []string{"1.1.1.1"}, 444, otherNs.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{}, PlainText),
 		makeInstance(otherNs, "dns-round-robin-1-0", []string{"1.1.1.1"}, 445, otherNs.Spec.(*networking.ServiceEntry).Ports[1], map[string]string{}, PlainText),
 	}
@@ -748,7 +748,7 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 	t.Run("service entry", func(t *testing.T) {
 		// Add just the ServiceEntry with selector. We should see no instances
 		createConfigs([]*config.Config{selector}, store, t)
-		instances := []*model.ServiceInstance{}
+		instances := []*WorkloadServiceInstance{}
 		expectProxyInstances(t, sd, instances, []string{"2.2.2.2"})
 		expectServiceInstances(t, sd, selector, 0, instances)
 		expectEvents(t, events,
@@ -761,7 +761,7 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 		// Add a WLE, we expect this to update
 		createConfigs([]*config.Config{wle}, store, t)
 
-		instances := []*model.ServiceInstance{
+		instances := []*WorkloadServiceInstance{
 			makeInstanceWithServiceAccount(selector, "wl", []string{"2.2.2.2"}, 444,
 				selector.Spec.(*networking.ServiceEntry).Ports[0],
 				map[string]string{"app": "wle"}, "default"),
@@ -786,7 +786,7 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 			return &d
 		}()
 
-		instances := []*model.ServiceInstance{
+		instances := []*WorkloadServiceInstance{
 			makeInstanceWithServiceAccount(updated, "wl", []string{"2.2.2.2"}, 444,
 				updated.Spec.(*networking.ServiceEntry).Ports[0],
 				map[string]string{"app": "wle"}, "default"),
@@ -797,7 +797,7 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 
 		createConfigs([]*config.Config{updated}, store, t)
 		expectProxyInstances(t, sd, instances, []string{"2.2.2.2"})
-		expectServiceInstances(t, sd, selector, 0, []*model.ServiceInstance{})
+		expectServiceInstances(t, sd, selector, 0, []*WorkloadServiceInstance{})
 		expectServiceInstances(t, sd, updated, 0, instances)
 		expectEvents(
 			t, events,
@@ -812,7 +812,7 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 	})
 
 	t.Run("restore service entry host", func(t *testing.T) {
-		instances := []*model.ServiceInstance{
+		instances := []*WorkloadServiceInstance{
 			makeInstanceWithServiceAccount(selector, "wl", []string{"2.2.2.2"}, 444,
 				selector.Spec.(*networking.ServiceEntry).Ports[0],
 				map[string]string{"app": "wle"}, "default"),
@@ -830,7 +830,7 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 		createConfigs([]*config.Config{selector}, store, t)
 		expectProxyInstances(t, sd, instances, []string{"2.2.2.2"})
 		expectServiceInstances(t, sd, selector, 0, instances)
-		expectServiceInstances(t, sd, updated, 0, []*model.ServiceInstance{})
+		expectServiceInstances(t, sd, updated, 0, []*WorkloadServiceInstance{})
 		expectEvents(
 			t, events,
 			Event{Type: "service", ID: "selector.com", Namespace: selector.Namespace},
@@ -845,7 +845,7 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 	t.Run("add dns service entry", func(t *testing.T) {
 		// Add just the ServiceEntry with selector. We should see no instances
 		createConfigs([]*config.Config{dnsSelector}, store, t)
-		instances := []*model.ServiceInstance{}
+		instances := []*WorkloadServiceInstance{}
 		expectProxyInstances(t, sd, instances, []string{"4.4.4.4"})
 		expectServiceInstances(t, sd, dnsSelector, 0, instances)
 		expectEvents(t, events,
@@ -857,7 +857,7 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 	t.Run("add dns workload", func(t *testing.T) {
 		// Add a WLE, we expect this to update
 		createConfigs([]*config.Config{dnsWle}, store, t)
-		instances := []*model.ServiceInstance{
+		instances := []*WorkloadServiceInstance{
 			makeInstanceWithServiceAccount(dnsSelector, "dnswl", []string{"4.4.4.4"}, 444,
 				selector.Spec.(*networking.ServiceEntry).Ports[0],
 				map[string]string{"app": "dns-wle"}, "default"),
@@ -879,7 +879,7 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 	t.Run("another workload", func(t *testing.T) {
 		// Add a different WLE
 		createConfigs([]*config.Config{wle2}, store, t)
-		instances := []*model.ServiceInstance{
+		instances := []*WorkloadServiceInstance{
 			makeInstanceWithServiceAccount(selector, "wl", []string{"2.2.2.2"}, 444,
 				selector.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"app": "wle"}, "default"),
 			makeInstanceWithServiceAccount(selector, "wl", []string{"2.2.2.2"}, 445,
@@ -902,7 +902,7 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 	t.Run("ignore host workload", func(t *testing.T) {
 		// Add a WLE with host address. Should be ignored by static service entry.
 		createConfigs([]*config.Config{wle3}, store, t)
-		instances := []*model.ServiceInstance{
+		instances := []*WorkloadServiceInstance{
 			makeInstanceWithServiceAccount(selector, "wl", []string{"2.2.2.2"}, 444,
 				selector.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"app": "wle"}, "default"),
 			makeInstanceWithServiceAccount(selector, "wl", []string{"2.2.2.2"}, 445,
@@ -922,7 +922,7 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 	t.Run("deletion", func(t *testing.T) {
 		// Delete the configs, it should be gone
 		deleteConfigs([]*config.Config{wle2}, store, t)
-		instances := []*model.ServiceInstance{
+		instances := []*WorkloadServiceInstance{
 			makeInstanceWithServiceAccount(selector, "wl", []string{"2.2.2.2"}, 444,
 				selector.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"app": "wle"}, "default"),
 			makeInstanceWithServiceAccount(selector, "wl", []string{"2.2.2.2"}, 445,
@@ -934,14 +934,14 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 
 		// Delete the other config
 		deleteConfigs([]*config.Config{wle}, store, t)
-		instances = []*model.ServiceInstance{}
+		instances = []*WorkloadServiceInstance{}
 		expectServiceInstances(t, sd, selector, 0, instances)
 		expectProxyInstances(t, sd, instances, []string{"2.2.2.2"})
 		expectEvents(t, events, Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 0})
 
 		// Add the config back
 		createConfigs([]*config.Config{wle}, store, t)
-		instances = []*model.ServiceInstance{
+		instances = []*WorkloadServiceInstance{
 			makeInstanceWithServiceAccount(selector, "wl", []string{"2.2.2.2"}, 444,
 				selector.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"app": "wle"}, "default"),
 			makeInstanceWithServiceAccount(selector, "wl", []string{"2.2.2.2"}, 445,
@@ -965,7 +965,7 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 		}()
 		// Update the configs
 		createConfigs([]*config.Config{updated}, store, t)
-		instances := []*model.ServiceInstance{
+		instances := []*WorkloadServiceInstance{
 			makeInstanceWithServiceAccount(selector, "wl", []string{"9.9.9.9"}, 444,
 				selector.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"app": "wle"}, "default"),
 			makeInstanceWithServiceAccount(selector, "wl", []string{"9.9.9.9"}, 445,
@@ -979,6 +979,9 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 			t, events,
 			Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 2},
 			Event{Type: "proxy", ID: "9.9.9.9"},
+			// The WorkloadEntry still exists (just moved address), so the old address's proxy
+			// (if still connected there) is pushed too, to drop the stale ServiceTarget.
+			Event{Type: "proxy", ID: "2.2.2.2"},
 		)
 	})
 
@@ -1053,7 +1056,7 @@ func TestServiceDiscoveryWorkloadChangeLabel(t *testing.T) {
 	t.Run("service entry", func(t *testing.T) {
 		// Add just the ServiceEntry with selector. We should see no instances
 		createConfigs([]*config.Config{selector}, store, t)
-		instances := []*model.ServiceInstance{}
+		instances := []*WorkloadServiceInstance{}
 		expectProxyInstances(t, sd, instances, []string{"2.2.2.2"})
 		expectServiceInstances(t, sd, selector, 0, instances)
 		expectEvents(t, events,
@@ -1065,7 +1068,7 @@ func TestServiceDiscoveryWorkloadChangeLabel(t *testing.T) {
 	t.Run("change label removing all", func(t *testing.T) {
 		// Add a WLE, we expect this to update
 		createConfigs([]*config.Config{wle}, store, t)
-		instances := []*model.ServiceInstance{
+		instances := []*WorkloadServiceInstance{
 			makeInstanceWithServiceAccount(selector, "wl", []string{"2.2.2.2"}, 444,
 				selector.Spec.(*networking.ServiceEntry).Ports[0],
 				map[string]string{"app": "wle"}, "default"),
@@ -1082,10 +1085,15 @@ func TestServiceDiscoveryWorkloadChangeLabel(t *testing.T) {
 		)
 
 		createConfigs([]*config.Config{wle2}, store, t)
-		instances = []*model.ServiceInstance{}
+		instances = []*WorkloadServiceInstance{}
 		expectServiceInstances(t, sd, selector, 0, instances)
 		expectProxyInstances(t, sd, instances, []string{"2.2.2.2"})
-		expectEvents(t, events, Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 0})
+		expectEvents(t, events,
+			Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 0},
+			// The WorkloadEntry still exists (relabeled), so it no longer matches selector.com -
+			// push its own proxy so it drops the stale ServiceTarget.
+			Event{Type: "proxy", ID: "2.2.2.2"},
+		)
 	})
 
 	t.Run("change label removing one", func(t *testing.T) {
@@ -1098,7 +1106,7 @@ func TestServiceDiscoveryWorkloadChangeLabel(t *testing.T) {
 		)
 		// add a wle, expect this to be an add
 		createConfigs([]*config.Config{wle3}, store, t)
-		instances := []*model.ServiceInstance{
+		instances := []*WorkloadServiceInstance{
 			makeInstanceWithServiceAccount(selector, "wl", []string{"2.2.2.2"}, 444,
 				selector.Spec.(*networking.ServiceEntry).Ports[0],
 				map[string]string{"app": "wle"}, "default"),
@@ -1122,7 +1130,7 @@ func TestServiceDiscoveryWorkloadChangeLabel(t *testing.T) {
 		)
 
 		createConfigs([]*config.Config{wle2}, store, t)
-		instances = []*model.ServiceInstance{
+		instances = []*WorkloadServiceInstance{
 			makeInstanceWithServiceAccount(selector, "wl3", []string{"3.3.3.3"}, 444,
 				selector.Spec.(*networking.ServiceEntry).Ports[0],
 				map[string]string{"app": "wle"}, "default"),
@@ -1132,7 +1140,12 @@ func TestServiceDiscoveryWorkloadChangeLabel(t *testing.T) {
 		}
 		expectServiceInstances(t, sd, selector, 0, instances)
 		expectProxyInstances(t, sd, instances, []string{"3.3.3.3"})
-		expectEvents(t, events, Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 2})
+		expectEvents(t, events,
+			Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 2},
+			// The WorkloadEntry still exists (relabeled), so it no longer matches selector.com -
+			// push its own proxy so it drops the stale ServiceTarget.
+			Event{Type: "proxy", ID: "2.2.2.2"},
+		)
 	})
 }
 
@@ -1183,7 +1196,7 @@ func TestWorkloadInstanceFullPush(t *testing.T) {
 	t.Run("service entry", func(t *testing.T) {
 		// Add just the ServiceEntry with selector. We should see no instances
 		createConfigs([]*config.Config{selectorDNS}, store, t)
-		instances := []*model.ServiceInstance{}
+		instances := []*WorkloadServiceInstance{}
 		expectProxyInstances(t, sd, instances, []string{"4.4.4.4"})
 		expectServiceInstances(t, sd, selectorDNS, 0, instances)
 		expectEvents(t, events,
@@ -1196,7 +1209,7 @@ func TestWorkloadInstanceFullPush(t *testing.T) {
 		// Add a WLE, we expect this to update
 		createConfigs([]*config.Config{wle}, store, t)
 
-		instances := []*model.ServiceInstance{
+		instances := []*WorkloadServiceInstance{
 			makeInstanceWithServiceAccount(selectorDNS, "wl", []string{"postman-echo.com"}, 444,
 				selectorDNS.Spec.(*networking.ServiceEntry).Ports[0],
 				map[string]string{"app": "wle"}, "default"),
@@ -1216,7 +1229,7 @@ func TestWorkloadInstanceFullPush(t *testing.T) {
 
 	t.Run("full push for new instance", func(t *testing.T) {
 		callInstanceHandlers([]*model.WorkloadInstance{fi1}, sd, model.EventAdd, t)
-		instances := []*model.ServiceInstance{
+		instances := []*WorkloadServiceInstance{
 			makeInstanceWithServiceAccount(selectorDNS, "additional-name", []string{"4.4.4.4"}, 444,
 				selectorDNS.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"app": "wle"}, "default"),
 			makeInstanceWithServiceAccount(selectorDNS, "additional-name", []string{"4.4.4.4"}, 445,
@@ -1254,7 +1267,7 @@ func TestWorkloadInstanceFullPush(t *testing.T) {
 
 	t.Run("full push on delete workload instance", func(t *testing.T) {
 		callInstanceHandlers([]*model.WorkloadInstance{fi1}, sd, model.EventDelete, t)
-		instances := []*model.ServiceInstance{
+		instances := []*WorkloadServiceInstance{
 			makeInstanceWithServiceAccount(selectorDNS, "another-name", []string{"2.2.2.2"}, 444,
 				selectorDNS.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"app": "wle"}, "default"),
 			makeInstanceWithServiceAccount(selectorDNS, "another-name", []string{"2.2.2.2"}, 445,
@@ -1281,7 +1294,7 @@ func TestWorkloadInstanceFullPush(t *testing.T) {
 
 	t.Run("full push on delete workload instance with multiple addresses", func(t *testing.T) {
 		callInstanceHandlers([]*model.WorkloadInstance{fiwithmulAddrs}, sd, model.EventDelete, t)
-		instances := []*model.ServiceInstance{
+		instances := []*WorkloadServiceInstance{
 			makeInstanceWithServiceAccount(selectorDNS, "another-name", []string{"2.2.2.2"}, 444,
 				selectorDNS.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"app": "wle"}, "default"),
 			makeInstanceWithServiceAccount(selectorDNS, "another-name", []string{"2.2.2.2"}, 445,
@@ -1353,7 +1366,7 @@ func TestServiceDiscoveryWorkloadInstance(t *testing.T) {
 	t.Run("service entry", func(t *testing.T) {
 		// Add just the ServiceEntry with selector. We should see no instances
 		createConfigs([]*config.Config{selector}, store, t)
-		instances := []*model.ServiceInstance{}
+		instances := []*WorkloadServiceInstance{}
 		expectProxyInstances(t, sd, instances, []string{"2.2.2.2"})
 		expectServiceInstances(t, sd, selector, 0, instances)
 		expectEvents(t, events,
@@ -1364,7 +1377,7 @@ func TestServiceDiscoveryWorkloadInstance(t *testing.T) {
 
 	t.Run("add another service entry", func(t *testing.T) {
 		createConfigs([]*config.Config{dnsSelector}, store, t)
-		instances := []*model.ServiceInstance{}
+		instances := []*WorkloadServiceInstance{}
 		expectProxyInstances(t, sd, instances, []string{"2.2.2.2"})
 		expectServiceInstances(t, sd, dnsSelector, 0, instances)
 		expectEvents(t, events,
@@ -1376,7 +1389,7 @@ func TestServiceDiscoveryWorkloadInstance(t *testing.T) {
 	t.Run("add workload instance", func(t *testing.T) {
 		// Add a workload instance, we expect this to update
 		callInstanceHandlers([]*model.WorkloadInstance{fi1}, sd, model.EventAdd, t)
-		instances := []*model.ServiceInstance{
+		instances := []*WorkloadServiceInstance{
 			makeInstanceWithServiceAccount(selector, "selector", []string{"2.2.2.2"}, 444,
 				selector.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"app": "wle"}, "default"),
 			makeInstanceWithServiceAccount(selector, "selector", []string{"2.2.2.2"}, 445,
@@ -1392,7 +1405,7 @@ func TestServiceDiscoveryWorkloadInstance(t *testing.T) {
 	t.Run("another workload instance", func(t *testing.T) {
 		// Add a different instance
 		callInstanceHandlers([]*model.WorkloadInstance{fi2}, sd, model.EventAdd, t)
-		instances := []*model.ServiceInstance{
+		instances := []*WorkloadServiceInstance{
 			makeInstanceWithServiceAccount(selector, "selector", []string{"2.2.2.2"}, 444,
 				selector.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"app": "wle"}, "default"),
 			makeInstanceWithServiceAccount(selector, "selector", []string{"2.2.2.2"}, 445,
@@ -1413,7 +1426,7 @@ func TestServiceDiscoveryWorkloadInstance(t *testing.T) {
 	t.Run("add workload instance with multiple addresses", func(t *testing.T) {
 		// Add a workload instance, we expect this to update
 		callInstanceHandlers([]*model.WorkloadInstance{fi4}, sd, model.EventAdd, t)
-		instances := []*model.ServiceInstance{
+		instances := []*WorkloadServiceInstance{
 			makeInstanceWithServiceAccount(selector, "selector", []string{"2.2.2.2"}, 444,
 				selector.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"app": "wle"}, "default"),
 			makeInstanceWithServiceAccount(selector, "selector", []string{"2.2.2.2"}, 445,
@@ -1439,7 +1452,7 @@ func TestServiceDiscoveryWorkloadInstance(t *testing.T) {
 	t.Run("delete workload instance", func(t *testing.T) {
 		// Delete the instances, it should be gone
 		callInstanceHandlers([]*model.WorkloadInstance{fi2}, sd, model.EventDelete, t)
-		instances := []*model.ServiceInstance{
+		instances := []*WorkloadServiceInstance{
 			makeInstanceWithServiceAccount(selector, "selector", []string{"2.2.2.2"}, 444,
 				selector.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"app": "wle"}, "default"),
 			makeInstanceWithServiceAccount(selector, "selector", []string{"2.2.2.2"}, 445,
@@ -1456,7 +1469,7 @@ func TestServiceDiscoveryWorkloadInstance(t *testing.T) {
 
 		// Delete the instance with multiple addresses, it should be gone
 		callInstanceHandlers([]*model.WorkloadInstance{fi4}, sd, model.EventDelete, t)
-		instances = []*model.ServiceInstance{
+		instances = []*WorkloadServiceInstance{
 			makeInstanceWithServiceAccount(selector, "selector", []string{"2.2.2.2"}, 444,
 				selector.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"app": "wle"}, "default"),
 			makeInstanceWithServiceAccount(selector, "selector", []string{"2.2.2.2"}, 445,
@@ -1488,7 +1501,7 @@ func TestServiceDiscoveryWorkloadInstance(t *testing.T) {
 
 		// Delete f1 event
 		callInstanceHandlers([]*model.WorkloadInstance{fi1}, sd, model.EventDelete, t)
-		instances = []*model.ServiceInstance{}
+		instances = []*WorkloadServiceInstance{}
 		expectProxyInstances(t, sd, instances, []string{"2.2.2.2"})
 		expectServiceInstances(t, sd, selector, 0, instances)
 		expectEvents(t, events, Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 0})
@@ -1506,7 +1519,7 @@ func TestServiceDiscoveryWorkloadInstance(t *testing.T) {
 
 		// Add f3 event
 		callInstanceHandlers([]*model.WorkloadInstance{fi3}, sd, model.EventAdd, t)
-		instances = []*model.ServiceInstance{
+		instances = []*WorkloadServiceInstance{
 			makeInstanceWithServiceAccount(dnsSelector, "another-name", []string{"2.2.2.2"}, 444,
 				dnsSelector.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"app": "dns-wle"}, "default"),
 			makeInstanceWithServiceAccount(dnsSelector, "another-name", []string{"2.2.2.2"}, 445,
@@ -1527,7 +1540,7 @@ func TestServiceDiscoveryWorkloadInstanceChangeLabel(t *testing.T) {
 	store, sd, events := initServiceDiscovery(t)
 
 	type expectedProxyInstances struct {
-		instancesWithSA []*model.ServiceInstance
+		instancesWithSA []*WorkloadServiceInstance
 		address         string
 	}
 
@@ -1545,7 +1558,7 @@ func TestServiceDiscoveryWorkloadInstanceChangeLabel(t *testing.T) {
 	t.Run("service entry", func(t *testing.T) {
 		// Add just the ServiceEntry with selector. We should see no instances
 		createConfigs([]*config.Config{selector}, store, t)
-		instances := []*model.ServiceInstance{}
+		instances := []*WorkloadServiceInstance{}
 		expectProxyInstances(t, sd, instances, []string{"2.2.2.2"})
 		expectServiceInstances(t, sd, selector, 0, instances)
 		expectEvents(t, events,
@@ -1571,7 +1584,7 @@ func TestServiceDiscoveryWorkloadInstanceChangeLabel(t *testing.T) {
 					tlsmode:           model.IstioMutualTLSModeLabel,
 					expectedProxyInstances: []expectedProxyInstances{
 						{
-							instancesWithSA: []*model.ServiceInstance{
+							instancesWithSA: []*WorkloadServiceInstance{
 								makeInstanceWithServiceAccount(selector,
 									selector.Name,
 									[]string{"2.2.2.2"}, 444,
@@ -1586,15 +1599,16 @@ func TestServiceDiscoveryWorkloadInstanceChangeLabel(t *testing.T) {
 					},
 				},
 				{
-					name:           selector.Name,
-					namespace:      selector.Namespace,
-					address:        "2.2.2.2",
-					labels:         map[string]string{"app": "wle2"},
-					serviceAccount: "default",
-					tlsmode:        model.IstioMutualTLSModeLabel,
+					name:              selector.Name,
+					namespace:         selector.Namespace,
+					address:           "2.2.2.2",
+					labels:            map[string]string{"app": "wle2"},
+					expectProxyUpdate: true, // relabeled workload still exists, but no longer matches selector.com
+					serviceAccount:    "default",
+					tlsmode:           model.IstioMutualTLSModeLabel,
 					expectedProxyInstances: []expectedProxyInstances{
 						{
-							instancesWithSA: []*model.ServiceInstance{}, // The instance labels don't match the se anymore, so adding this wi removes 2 instances
+							instancesWithSA: []*WorkloadServiceInstance{}, // The instance labels don't match the se anymore, so adding this wi removes 2 instances
 							address:         "2.2.2.2",
 						},
 					},
@@ -1614,7 +1628,7 @@ func TestServiceDiscoveryWorkloadInstanceChangeLabel(t *testing.T) {
 					tlsmode:           model.IstioMutualTLSModeLabel,
 					expectedProxyInstances: []expectedProxyInstances{
 						{
-							instancesWithSA: []*model.ServiceInstance{
+							instancesWithSA: []*WorkloadServiceInstance{
 								makeInstanceWithServiceAccount(selector,
 									selector.Name,
 									[]string{"2.2.2.2"}, 444,
@@ -1638,7 +1652,7 @@ func TestServiceDiscoveryWorkloadInstanceChangeLabel(t *testing.T) {
 					tlsmode:           model.IstioMutualTLSModeLabel,
 					expectedProxyInstances: []expectedProxyInstances{
 						{
-							instancesWithSA: []*model.ServiceInstance{
+							instancesWithSA: []*WorkloadServiceInstance{
 								makeInstanceWithServiceAccount(selector,
 									selector.Name,
 									[]string{"2.2.2.2"}, 444,
@@ -1651,7 +1665,7 @@ func TestServiceDiscoveryWorkloadInstanceChangeLabel(t *testing.T) {
 							address: "2.2.2.2",
 						},
 						{
-							instancesWithSA: []*model.ServiceInstance{
+							instancesWithSA: []*WorkloadServiceInstance{
 								makeInstanceWithServiceAccount(selector,
 									"another-name",
 									[]string{"3.3.3.3"}, 444,
@@ -1666,15 +1680,16 @@ func TestServiceDiscoveryWorkloadInstanceChangeLabel(t *testing.T) {
 					},
 				},
 				{
-					name:           selector.Name,
-					namespace:      selector.Namespace,
-					address:        "2.2.2.2",
-					labels:         map[string]string{"app": "wle2"},
-					serviceAccount: "default",
-					tlsmode:        model.IstioMutualTLSModeLabel,
+					name:              selector.Name,
+					namespace:         selector.Namespace,
+					address:           "2.2.2.2",
+					labels:            map[string]string{"app": "wle2"},
+					expectProxyUpdate: true, // relabeled workload still exists, but no longer matches selector.com
+					serviceAccount:    "default",
+					tlsmode:           model.IstioMutualTLSModeLabel,
 					expectedProxyInstances: []expectedProxyInstances{
 						{
-							instancesWithSA: []*model.ServiceInstance{
+							instancesWithSA: []*WorkloadServiceInstance{
 								makeInstanceWithServiceAccount(selector,
 									"another-name",
 									[]string{"3.3.3.3"}, 444,
@@ -1709,7 +1724,7 @@ func TestServiceDiscoveryWorkloadInstanceChangeLabel(t *testing.T) {
 
 				callInstanceHandlers([]*model.WorkloadInstance{wi}, sd, model.EventAdd, t)
 
-				totalInstances := []*model.ServiceInstance{}
+				totalInstances := []*WorkloadServiceInstance{}
 				for _, expectedProxyInstance := range instance.expectedProxyInstances {
 					expectProxyInstances(t, sd, expectedProxyInstance.instancesWithSA, []string{expectedProxyInstance.address})
 					totalInstances = append(totalInstances, expectedProxyInstance.instancesWithSA...)
@@ -1820,9 +1835,128 @@ func TestWorkloadEntryEndpointPushesProxyOnce(t *testing.T) {
 	}
 }
 
-func expectProxyInstances(t testing.TB, sd *Controller, expected []*model.ServiceInstance, ips []string) {
+// Editing a ServiceEntry's WorkloadSelector so it no longer matches a WorkloadEntry it used to
+// select must push that workload's own proxy, so it drops the stale ServiceTarget - the same as
+// if the workload had been relabeled out from under the (unchanged) service.
+func TestServiceEntrySelectorChangeForcesProxyPush(t *testing.T) {
+	store, sd, events := initServiceDiscovery(t)
+
+	createConfigs([]*config.Config{selector}, store, t)
+	expectEvents(t, events,
+		Event{Type: "service", ID: "selector.com", Namespace: selector.Namespace},
+		Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace},
+		Event{Type: "xds", ID: "selector.com"})
+
+	wle := createWorkloadEntry("wl", selector.Name,
+		&networking.WorkloadEntry{
+			Address:        "2.2.2.2",
+			Labels:         map[string]string{"app": "wle"},
+			ServiceAccount: "default",
+		})
+	createConfigs([]*config.Config{wle}, store, t)
+	expectEvents(t, events,
+		Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 2},
+		Event{Type: "proxy", ID: "2.2.2.2"})
+
+	proxy := &model.Proxy{IPAddresses: []string{"2.2.2.2"}, Metadata: &model.NodeMetadata{}}
+	retry.UntilSuccessOrFail(t, func() error {
+		if got := len(sd.GetProxyServiceTargets(proxy)); got != 2 {
+			return fmt.Errorf("expected 2 service targets before the selector change, got %d", got)
+		}
+		return nil
+	}, retry.Timeout(5*time.Second))
+
+	// The service is modified - not the workload - so that it no longer matches the WorkloadEntry.
+	updated := selector.DeepCopy()
+	updated.Spec.(*networking.ServiceEntry).WorkloadSelector.Labels = map[string]string{"app": "other"}
+	createConfigs([]*config.Config{&updated}, store, t)
+
+	// The WorkloadEntry still exists, so its own proxy is pushed to recompute its (now empty)
+	// ServiceTargets for selector.com. The selector edit also changes Service.Attributes, which
+	// triggers the usual config-update push for every proxy in the namespace.
+	expectEvents(t, events,
+		Event{Type: "service", ID: "selector.com", Namespace: selector.Namespace},
+		Event{Type: "xds", ID: "selector.com"},
+		Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 0},
+		Event{Type: "proxy", ID: "2.2.2.2"})
+
+	retry.UntilSuccessOrFail(t, func() error {
+		if got := len(sd.GetProxyServiceTargets(proxy)); got != 0 {
+			return fmt.Errorf("expected 0 service targets after the selector change, got %d", got)
+		}
+		return nil
+	}, retry.Timeout(5*time.Second))
+}
+
+// Removing a workload entirely - rather than just unselecting it - must not push its own proxy:
+// there is no useful recomputation left to trigger, since the workload (and its proxy connection,
+// if any) is going away. Covers both a WorkloadEntry config deletion and an external (pod) deletion.
+func TestWorkloadRemovalSkipsOwnProxyPush(t *testing.T) {
+	t.Run("WorkloadEntry deleted", func(t *testing.T) {
+		store, _, events := initServiceDiscovery(t)
+
+		createConfigs([]*config.Config{selector}, store, t)
+		expectEvents(t, events,
+			Event{Type: "service", ID: "selector.com", Namespace: selector.Namespace},
+			Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace},
+			Event{Type: "xds", ID: "selector.com"})
+
+		wle := createWorkloadEntry("wl", selector.Name,
+			&networking.WorkloadEntry{
+				Address:        "2.2.2.2",
+				Labels:         map[string]string{"app": "wle"},
+				ServiceAccount: "default",
+			})
+		createConfigs([]*config.Config{wle}, store, t)
+		expectEvents(t, events,
+			Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 2},
+			Event{Type: "proxy", ID: "2.2.2.2"})
+
+		deleteConfigs([]*config.Config{wle}, store, t)
+		// Only the EDS teardown is expected - no proxy push, since the WorkloadEntry is gone, not
+		// just unselected.
+		expectEvents(t, events, Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 0})
+	})
+
+	t.Run("pod deleted", func(t *testing.T) {
+		store, sd, events := initServiceDiscovery(t)
+
+		createConfigs([]*config.Config{selector}, store, t)
+		expectEvents(t, events,
+			Event{Type: "service", ID: "selector.com", Namespace: selector.Namespace},
+			Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace},
+			Event{Type: "xds", ID: "selector.com"})
+
+		pod := &model.WorkloadInstance{
+			Name:      "pod-1",
+			Namespace: selector.Namespace,
+			Kind:      model.PodKind,
+			Endpoint: &model.IstioEndpoint{
+				Addresses: []string{"2.2.2.2"},
+				Labels:    map[string]string{"app": "wle"},
+			},
+		}
+		callInstanceHandlers([]*model.WorkloadInstance{pod}, sd, model.EventAdd, t)
+		expectEvents(t, events,
+			Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 2},
+			Event{Type: "proxy", ID: "2.2.2.2"})
+
+		callInstanceHandlers([]*model.WorkloadInstance{pod}, sd, model.EventDelete, t)
+		expectEvents(t, events, Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 0})
+	})
+}
+
+func expectProxyInstances(t testing.TB, sd *Controller, expected []*WorkloadServiceInstance, ips []string) {
 	t.Helper()
-	expectProxyTargets(t, sd, slices.Map(expected, model.ServiceInstanceToTarget), ips)
+	expectProxyTargets(t, sd, slices.Map(expected, func(e *WorkloadServiceInstance) model.ServiceTarget {
+		return model.ServiceTarget{
+			Service: e.Service,
+			Port: model.ServiceInstancePort{
+				ServicePort: e.ServicePort,
+				TargetPort:  e.Endpoint.EndpointPort,
+			},
+		}
+	}), ips)
 }
 
 func expectProxyTargets(t testing.TB, sd *Controller, expected []model.ServiceTarget, ips []string) {
@@ -1844,7 +1978,7 @@ func expectEvents(t testing.TB, ch *xdsfake.Updater, events ...Event) {
 	ch.StrictMatchOrFail(t, events...)
 }
 
-func expectServiceInstances(t testing.TB, sd *Controller, cfg *config.Config, port int, expected ...[]*model.ServiceInstance) {
+func expectServiceInstances(t testing.TB, sd *Controller, cfg *config.Config, port int, expected ...[]*WorkloadServiceInstance) {
 	t.Helper()
 	svcs := convertServices(*cfg, nil, false)
 	if len(svcs) != len(expected) {
@@ -1880,7 +2014,7 @@ func TestServiceDiscoveryGetProxyServiceTargets(t *testing.T) {
 
 	createConfigs([]*config.Config{httpStatic, tcpStatic}, store, t)
 
-	expectProxyInstances(t, sd, []*model.ServiceInstance{
+	expectProxyInstances(t, sd, []*WorkloadServiceInstance{
 		makeInstance(httpStatic, "httpStatic", []string{"2.2.2.2"}, 7080, httpStatic.Spec.(*networking.ServiceEntry).Ports[0], nil, MTLS),
 		makeInstance(httpStatic, "httpStatic", []string{"2.2.2.2"}, 18080, httpStatic.Spec.(*networking.ServiceEntry).Ports[1], nil, MTLS),
 		makeInstance(tcpStatic, "tcpStatic", []string{"2.2.2.2"}, 444, tcpStatic.Spec.(*networking.ServiceEntry).Ports[0], nil, MTLS),
@@ -1893,7 +2027,7 @@ func TestServiceDiscoveryInstances(t *testing.T) {
 
 	createConfigs([]*config.Config{httpDNS, tcpStatic}, store, t)
 
-	expectServiceInstances(t, sd, httpDNS, 0, []*model.ServiceInstance{
+	expectServiceInstances(t, sd, httpDNS, 0, []*WorkloadServiceInstance{
 		makeInstance(httpDNS, "httpDNS-0", []string{"us.google.com"}, 7080, httpDNS.Spec.(*networking.ServiceEntry).Ports[0], nil, MTLS),
 		makeInstance(httpDNS, "httpDNS-0", []string{"us.google.com"}, 18080, httpDNS.Spec.(*networking.ServiceEntry).Ports[1], nil, MTLS),
 		makeInstance(httpDNS, "httpDNS-1", []string{"uk.google.com"}, 1080, httpDNS.Spec.(*networking.ServiceEntry).Ports[0], nil, MTLS),
@@ -1909,7 +2043,7 @@ func TestServiceDiscoveryInstances1Port(t *testing.T) {
 
 	createConfigs([]*config.Config{httpDNS, tcpStatic}, store, t)
 
-	expectServiceInstances(t, sd, httpDNS, 80, []*model.ServiceInstance{
+	expectServiceInstances(t, sd, httpDNS, 80, []*WorkloadServiceInstance{
 		makeInstance(httpDNS, "httpDNS-0", []string{"us.google.com"}, 7080, httpDNS.Spec.(*networking.ServiceEntry).Ports[0], nil, MTLS),
 		makeInstance(httpDNS, "httpDNS-1", []string{"uk.google.com"}, 1080, httpDNS.Spec.(*networking.ServiceEntry).Ports[0], nil, MTLS),
 		makeInstance(httpDNS, "httpDNS-2", []string{"de.google.com"}, 80, httpDNS.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"foo": "bar"}, MTLS),
@@ -1939,7 +2073,7 @@ func TestNonServiceConfig(t *testing.T) {
 
 	// Now create some service entries and verify that it's added to the registry.
 	createConfigs([]*config.Config{httpDNS, tcpStatic}, store, t)
-	expectServiceInstances(t, sd, httpDNS, 80, []*model.ServiceInstance{
+	expectServiceInstances(t, sd, httpDNS, 80, []*WorkloadServiceInstance{
 		makeInstance(httpDNS, "httpDNS-0", []string{"us.google.com"}, 7080, httpDNS.Spec.(*networking.ServiceEntry).Ports[0], nil, MTLS),
 		makeInstance(httpDNS, "httpDNS-1", []string{"uk.google.com"}, 1080, httpDNS.Spec.(*networking.ServiceEntry).Ports[0], nil, MTLS),
 		makeInstance(httpDNS, "httpDNS-2", []string{"de.google.com"}, 80, httpDNS.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"foo": "bar"}, MTLS),
@@ -2116,8 +2250,8 @@ func sortServiceTargets(instances []model.ServiceTarget) {
 	})
 }
 
-func sortServiceInstances(instances []*model.ServiceInstance) {
-	slices.SortStableFunc(instances, func(a, b *model.ServiceInstance) int {
+func sortServiceInstances(instances []*WorkloadServiceInstance) {
+	slices.SortStableFunc(instances, func(a, b *WorkloadServiceInstance) int {
 		return cmp.Compare(a.ResourceName(), b.ResourceName())
 	})
 }

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -340,7 +340,7 @@ func convertServiceEntryToInstances(
 	meshConfig krt.Collection[meshwatcher.MeshConfigResource],
 	clusterID cluster.ID,
 	networkIDFn networkIDCallback,
-) []*model.ServiceInstance {
+) []*WorkloadServiceInstance {
 	serviceEntry := cfg.Spec.(*networking.ServiceEntry)
 	endpointsNum := len(serviceEntry.Endpoints)
 	hostnameToServiceInstance := false
@@ -349,7 +349,7 @@ func convertServiceEntryToInstances(
 		endpointsNum = 1
 	}
 
-	out := make([]*model.ServiceInstance, 0, len(serviceEntry.Ports)*endpointsNum)
+	out := make([]*WorkloadServiceInstance, 0, len(serviceEntry.Ports)*endpointsNum)
 	if hostnameToServiceInstance {
 		for _, serviceEntryPort := range serviceEntry.Ports {
 			// Note: only convert the hostname to service instance if WorkloadSelector is not set
@@ -360,7 +360,9 @@ func convertServiceEntryToInstances(
 			if serviceEntryPort.TargetPort > 0 {
 				endpointPort = serviceEntryPort.TargetPort
 			}
-			out = append(out, &model.ServiceInstance{
+			out = append(out, &WorkloadServiceInstance{
+				Namespace: cfg.Namespace,
+				Name:      cfg.Name,
 				Endpoint: &model.IstioEndpoint{
 					Addresses:            []string{string(service.Hostname)},
 					EndpointPort:         endpointPort,
@@ -386,7 +388,7 @@ func convertServiceEntryToInstances(
 				Name:      cfg.Name + "-" + strconv.Itoa(i),
 			}
 			wli := convertWorkloadEntryToWorkloadInstance(ctx, endpoint, meta, meshConfig, cfg.Namespace, clusterID, networkIDFn)
-			out = append(out, convertWorkloadInstanceToServiceInstance(wli, service, serviceEntry.Ports)...)
+			out = append(out, convertWorkloadInstanceToInstances(wli, service, serviceEntry.Ports)...)
 		}
 	}
 	return out
@@ -407,10 +409,10 @@ func getTLSModeFromWorkloadEntry(wle *networking.WorkloadEntry) string {
 
 // The workload instance has pointer to the service and its service port.
 // We need to create our own but we can retain the endpoint already created.
-func convertWorkloadInstanceToServiceInstance(workloadInstance *model.WorkloadInstance, service *model.Service,
+func convertWorkloadInstanceToInstances(workloadInstance *model.WorkloadInstance, service *model.Service,
 	serviceEntryPorts []*networking.ServicePort,
-) []*model.ServiceInstance {
-	out := make([]*model.ServiceInstance, 0, len(serviceEntryPorts))
+) []*WorkloadServiceInstance {
+	out := make([]*WorkloadServiceInstance, 0, len(serviceEntryPorts))
 	for _, serviceEntryPort := range serviceEntryPorts {
 		var targetPort uint32
 		addrs := workloadInstance.Endpoint.Addresses
@@ -438,7 +440,9 @@ func convertWorkloadInstanceToServiceInstance(workloadInstance *model.WorkloadIn
 			ep.WorkloadName = workloadInstance.Name
 		}
 
-		out = append(out, &model.ServiceInstance{
+		out = append(out, &WorkloadServiceInstance{
+			Namespace:   workloadInstance.Namespace,
+			Name:        workloadInstance.Name,
 			Endpoint:    ep,
 			Service:     service,
 			ServicePort: convertPort(serviceEntryPort),
@@ -585,10 +589,10 @@ func services(
 				TargetPorts: slices.Map(se.Ports, func(p *networking.ServicePort) uint32 {
 					return p.TargetPort
 				}),
-				Instances: make([]*model.ServiceInstance, 0, len(selectedWorkloads)*len(se.Ports)),
+				Instances: make([]*WorkloadServiceInstance, 0, len(selectedWorkloads)*len(se.Ports)),
 			}
 			for _, wi := range selectedWorkloads {
-				swi.Instances = append(swi.Instances, convertWorkloadInstanceToServiceInstance(wi, service, se.Ports)...)
+				swi.Instances = append(swi.Instances, convertWorkloadInstanceToInstances(wi, service, se.Ports)...)
 			}
 			res = append(res, swi)
 		}
@@ -617,7 +621,7 @@ func mergeServicesInstancesByNamespaceHost(
 		sortServicesByCreationTime(s.Objects)
 
 		ports := sets.New[int]()
-		instances := make([]*model.ServiceInstance, 0)
+		instances := make([]*WorkloadServiceInstance, 0)
 		anyDNSServiceEndpoint := false
 		for _, swi := range s.Objects {
 			for _, si := range swi.Instances {

--- a/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
@@ -654,7 +654,7 @@ const (
 // nolint: unparam
 func makeInstanceWithServiceAccount(cfg *config.Config, workloadName string, addresses []string, port int,
 	svcPort *networking.ServicePort, svcLabels map[string]string, serviceAccount string,
-) *model.ServiceInstance {
+) *WorkloadServiceInstance {
 	i := makeInstance(cfg, workloadName, addresses, port, svcPort, svcLabels, MTLSUnlabelled)
 	i.Endpoint.ServiceAccount = spiffe.MustGenSpiffeURIForTrustDomain("cluster.local", i.Service.Attributes.Namespace, serviceAccount)
 	return i
@@ -694,7 +694,7 @@ func makeTarget(cfg *config.Config, address string, port int,
 // nolint: unparam
 func makeInstance(cfg *config.Config, workloadName string, addresses []string, port int,
 	svcPort *networking.ServicePort, svcLabels map[string]string, mtlsMode MTLSMode,
-) *model.ServiceInstance {
+) *WorkloadServiceInstance {
 	services := convertServices(*cfg, nil, false)
 	svc := services[0] // default
 	getSvc := false
@@ -720,8 +720,10 @@ func makeInstance(cfg *config.Config, workloadName string, addresses []string, p
 		}
 		svcLabels[label.SecurityTlsMode.Name] = model.IstioMutualTLSModeLabel
 	}
-	return &model.ServiceInstance{
-		Service: svc,
+	return &WorkloadServiceInstance{
+		Namespace: cfg.Namespace,
+		Name:      workloadName,
+		Service:   svc,
 		Endpoint: &model.IstioEndpoint{
 			Addresses:            addresses,
 			EndpointPort:         uint32(port),
@@ -901,24 +903,24 @@ func testConvertServiceBody(t *testing.T, canonicalServiceForMeshExternal bool) 
 func TestConvertInstances(t *testing.T) {
 	serviceInstanceTests := []struct {
 		externalSvc *config.Config
-		out         []*model.ServiceInstance
+		out         []*WorkloadServiceInstance
 	}{
 		{
 			// single instance with multiple ports
 			externalSvc: httpNone,
 			// DNS type none means service should not have a registered instance
-			out: []*model.ServiceInstance{},
+			out: []*WorkloadServiceInstance{},
 		},
 		{
 			// service entry tcp
 			externalSvc: tcpNone,
 			// DNS type none means service should not have a registered instance
-			out: []*model.ServiceInstance{},
+			out: []*WorkloadServiceInstance{},
 		},
 		{
 			// service entry static
 			externalSvc: httpStatic,
-			out: []*model.ServiceInstance{
+			out: []*WorkloadServiceInstance{
 				makeInstance(httpStatic, "httpStatic-0", []string{"2.2.2.2"}, 7080,
 					httpStatic.Spec.(*networking.ServiceEntry).Ports[0], nil, MTLS),
 				makeInstance(httpStatic, "httpStatic-0", []string{"2.2.2.2"}, 18080,
@@ -936,7 +938,7 @@ func TestConvertInstances(t *testing.T) {
 		{
 			// service entry DNS with no endpoints
 			externalSvc: httpDNSnoEndpoints,
-			out: []*model.ServiceInstance{
+			out: []*WorkloadServiceInstance{
 				makeInstance(httpDNSnoEndpoints, "httpDNSnoEndpoints", []string{"google.com"}, 80,
 					httpDNSnoEndpoints.Spec.(*networking.ServiceEntry).Ports[0], nil, PlainText),
 				makeInstance(httpDNSnoEndpoints, "httpDNSnoEndpoints", []string{"google.com"}, 8080,
@@ -950,7 +952,7 @@ func TestConvertInstances(t *testing.T) {
 		{
 			// service entry DNS with no endpoints using round robin
 			externalSvc: httpDNSRRnoEndpoints,
-			out: []*model.ServiceInstance{
+			out: []*WorkloadServiceInstance{
 				makeInstance(httpDNSRRnoEndpoints, "httpDNSRRnoEndpoints", []string{"api.istio.io"}, 80,
 					httpDNSnoEndpoints.Spec.(*networking.ServiceEntry).Ports[0], nil, PlainText),
 				makeInstance(httpDNSRRnoEndpoints, "httpDNSRRnoEndpoints", []string{"api.istio.io"}, 8080,
@@ -960,12 +962,12 @@ func TestConvertInstances(t *testing.T) {
 		{
 			// service entry DNS with workload selector and no endpoints
 			externalSvc: selectorDNS,
-			out:         []*model.ServiceInstance{},
+			out:         []*WorkloadServiceInstance{},
 		},
 		{
 			// service entry dns
 			externalSvc: httpDNS,
-			out: []*model.ServiceInstance{
+			out: []*WorkloadServiceInstance{
 				makeInstance(httpDNS, "httpDNS-0", []string{"us.google.com"}, 7080,
 					httpDNS.Spec.(*networking.ServiceEntry).Ports[0], nil, MTLS),
 				makeInstance(httpDNS, "httpDNS-0", []string{"us.google.com"}, 18080,
@@ -983,7 +985,7 @@ func TestConvertInstances(t *testing.T) {
 		{
 			// service entry dns with target port
 			externalSvc: dnsTargetPort,
-			out: []*model.ServiceInstance{
+			out: []*WorkloadServiceInstance{
 				makeInstance(dnsTargetPort, "dnsTargetPort", []string{"google.com"}, 8080,
 					dnsTargetPort.Spec.(*networking.ServiceEntry).Ports[0], nil, PlainText),
 			},
@@ -991,7 +993,7 @@ func TestConvertInstances(t *testing.T) {
 		{
 			// service entry tcp DNS
 			externalSvc: tcpDNS,
-			out: []*model.ServiceInstance{
+			out: []*WorkloadServiceInstance{
 				makeInstance(tcpDNS, "tcpDNS-0", []string{"lon.google.com"}, 444,
 					tcpDNS.Spec.(*networking.ServiceEntry).Ports[0], nil, MTLS),
 				makeInstance(tcpDNS, "tcpDNS-1", []string{"in.google.com"}, 444,
@@ -1001,7 +1003,7 @@ func TestConvertInstances(t *testing.T) {
 		{
 			// service entry tcp static
 			externalSvc: tcpStatic,
-			out: []*model.ServiceInstance{
+			out: []*WorkloadServiceInstance{
 				makeInstance(tcpStatic, "tcpStatic-0", []string{"1.1.1.1"}, 444,
 					tcpStatic.Spec.(*networking.ServiceEntry).Ports[0], nil, MTLS),
 				makeInstance(tcpStatic, "tcpStatic-1", []string{"2.2.2.2"}, 444,
@@ -1011,7 +1013,7 @@ func TestConvertInstances(t *testing.T) {
 		{
 			// service entry unix domain socket static
 			externalSvc: udsLocal,
-			out: []*model.ServiceInstance{
+			out: []*WorkloadServiceInstance{
 				makeInstance(udsLocal, "udsLocal-0", []string{"/test/sock"}, 0,
 					udsLocal.Spec.(*networking.ServiceEntry).Ports[0], nil, MTLS),
 			},
@@ -1022,7 +1024,7 @@ func TestConvertInstances(t *testing.T) {
 		t.Run(strings.Join(tt.externalSvc.Spec.(*networking.ServiceEntry).Hosts, "_"), func(t *testing.T) {
 			s := &Controller{}
 			ss := convertServices(*tt.externalSvc, nil, false)
-			instances := make([]*model.ServiceInstance, 0)
+			instances := make([]*WorkloadServiceInstance, 0)
 			for _, service := range ss {
 				instances = append(
 					instances,
@@ -1047,7 +1049,7 @@ func TestConvertWorkloadEntryToServiceInstances(t *testing.T) {
 		wle       *networking.WorkloadEntry
 		se        *config.Config
 		clusterID cluster.ID
-		out       []*model.ServiceInstance
+		out       []*WorkloadServiceInstance
 	}{
 		{
 			name: "simple",
@@ -1056,7 +1058,7 @@ func TestConvertWorkloadEntryToServiceInstances(t *testing.T) {
 				Labels:  labels,
 			},
 			se: selector,
-			out: []*model.ServiceInstance{
+			out: []*WorkloadServiceInstance{
 				makeInstance(selector, "selector", []string{"1.1.1.1"}, 444,
 					selector.Spec.(*networking.ServiceEntry).Ports[0], labels, PlainText),
 				makeInstance(selector, "selector", []string{"1.1.1.1"}, 445,
@@ -1071,7 +1073,7 @@ func TestConvertWorkloadEntryToServiceInstances(t *testing.T) {
 				ServiceAccount: "default",
 			},
 			se: selector,
-			out: []*model.ServiceInstance{
+			out: []*WorkloadServiceInstance{
 				makeInstanceWithServiceAccount(selector, "selector", []string{"1.1.1.1"}, 444,
 					selector.Spec.(*networking.ServiceEntry).Ports[0], labels, "default"),
 				makeInstanceWithServiceAccount(selector, "selector", []string{"1.1.1.1"}, 445,
@@ -1088,7 +1090,7 @@ func TestConvertWorkloadEntryToServiceInstances(t *testing.T) {
 				},
 			},
 			se: selector,
-			out: []*model.ServiceInstance{
+			out: []*WorkloadServiceInstance{
 				makeInstance(selector, "selector", []string{"1.1.1.1"}, 444,
 					selector.Spec.(*networking.ServiceEntry).Ports[0], labels, PlainText),
 				makeInstance(selector, "selector", []string{"1.1.1.1"}, 8080,
@@ -1106,7 +1108,7 @@ func TestConvertWorkloadEntryToServiceInstances(t *testing.T) {
 			},
 			se:        selector,
 			clusterID: "fakeCluster",
-			out: []*model.ServiceInstance{
+			out: []*WorkloadServiceInstance{
 				makeInstanceWithServiceAccount(selector, "selector", []string{"1.1.1.1"}, 444,
 					selector.Spec.(*networking.ServiceEntry).Ports[0], labels, "default"),
 				makeInstanceWithServiceAccount(selector, "selector", []string{"1.1.1.1"}, 445,
@@ -1132,9 +1134,9 @@ func TestConvertWorkloadEntryToServiceInstances(t *testing.T) {
 				tt.clusterID,
 				s.networkIDCallback,
 			)
-			instances := make([]*model.ServiceInstance, 0, len(services))
+			instances := make([]*WorkloadServiceInstance, 0, len(services))
 			for _, service := range services {
-				instances = append(instances, convertWorkloadInstanceToServiceInstance(wli, service, tt.se.Spec.(*networking.ServiceEntry).Ports)...)
+				instances = append(instances, convertWorkloadInstanceToInstances(wli, service, tt.se.Spec.(*networking.ServiceEntry).Ports)...)
 			}
 			sortServiceInstances(instances)
 			sortServiceInstances(tt.out)

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -741,11 +741,31 @@ func TestWorkloadInstances(t *testing.T) {
 		expectServiceEndpoints(t, fx, expectedSvc, 80, instances)
 	})
 
+	t.Run("Service selects WorkloadEntry: proxy push on selection change", func(t *testing.T) {
+		store, kube, fx := setupTest(t)
+		makeService(t, kube, service)
+		fx.WaitOrFail(t, "service")
+
+		// The Service selects the WorkloadEntry, so the workload's own proxy has a new service
+		// target and must recompute.
+		makeIstioObject(t, store, workloadEntry)
+		fx.MatchOrFail(t, xdsfake.Event{Type: "proxy", ID: "2.3.4.5"})
+
+		// Labels change so the Service no longer selects it: the proxy must drop the target.
+		unselected := workloadEntry.DeepCopy()
+		unselected.Spec = &networking.WorkloadEntry{
+			Address: "2.3.4.5",
+			Labels:  map[string]string{"app": "not-selected"},
+		}
+		makeIstioObject(t, store, unselected)
+		fx.MatchOrFail(t, xdsfake.Event{Type: "proxy", ID: "2.3.4.5"})
+	})
+
 	t.Run("Service selects WorkloadEntry: wle occur earlier", func(t *testing.T) {
 		store, kube, fx := setupTest(t)
 		makeIstioObject(t, store, workloadEntry)
-		// 	Other than proxy update, no event pushed when workload entry created as no service entry
-		fx.WaitOrFail(t, "proxy")
+		// No event is pushed when the workload entry is created: no service entry, and no Kubernetes
+		// Service selects it yet, so nothing about it has changed for any proxy.
 		fx.AssertEmpty(t, 40*time.Millisecond)
 
 		makeService(t, kube, service)
@@ -787,8 +807,8 @@ func TestWorkloadInstances(t *testing.T) {
 		store, kube, fx := setupTest(t)
 		makeIstioObject(t, store, workloadEntry)
 
-		// 	Other than proxy update, no event pushed when workload entry created as no service entry
-		fx.WaitOrFail(t, "proxy")
+		// No event is pushed when the workload entry is created: no service entry, and no Kubernetes
+		// Service selects it yet, so nothing about it has changed for any proxy.
 		fx.AssertEmpty(t, 200*time.Millisecond)
 
 		makePod(t, kube, pod)

--- a/releasenotes/notes/serviceentry-workload-proxy-push.yaml
+++ b/releasenotes/notes/serviceentry-workload-proxy-push.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed** a pod in a remote cluster, selected by a `ServiceEntry` may not have been recomputed
+    when it became an endpoint of that service. The recompute was addressed to the cluster istiod
+    runs in rather than the cluster the pod belongs to.
+  - |
+    **Fixed** a WorkloadEntry selected by a `Service` not having its corresponding proxy recomputed
+    when it became an endpoint of that service.


### PR DESCRIPTION
**Please provide a description of this PR:**
Move `WorkloadEntry` related `ProxyUpdate` calls into KubeController, it allows us to fix a bunch of issues and simplify the event handling logic in ServiceEntry controller as well as get rid of the `ExternalWorkloadsByIP` index to only filter events by Pods.
Related to https://github.com/istio/istio/pull/61158

This means:
- kube: WorkloadEntry related ProxyUpdates are now called after the kube indexes are updated, preventing race conditions in which proxies could recompute before the controllers workload indexes were updated. We can also now only push ProxyUpdate when services actually select a WorkloadEntry, reducing the number of ProxyUpdates that can happen.
- serviceentry: ensure that we send ProxyUpdate when services actually select a WorkloadEntry or Pod, this prevents race conditions in which triggered WorkloadEntry ProxyUpdates could be recomputed without the ServiceInstances collection being updates yet. we can also dedup multiple service instances for the same address, which we weren't doing.
- ProxyUpdates triggered by the ServiceEntry controller ere always scoped to the controller's own `clusterID` (which is the ConfigCluster) but this is actually invalid in multicluster scenarios, since the proxies themselves are on other clusters and not on the ConfigCluster.