### PR TITLE
installer: support setting nodePort for network gateway ports

### DIFF
--- a/manifests/charts/gateway/templates/_helpers.tpl
+++ b/manifests/charts/gateway/templates/_helpers.tpl
@@ -49,6 +49,9 @@ Expects a dict with keys: ports (the networkGatewayPorts map), name (port name),
   port: {{ $cfg.port }}
   targetPort: {{ $cfg.targetPort | default .defaultTargetPort }}
   protocol: {{ $cfg.protocol | default "TCP" }}
+{{- with $cfg.nodePort }}
+  nodePort: {{ . }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -287,6 +287,9 @@
               },
               "protocol": {
                 "type": "string"
+              },
+              "nodePort": {
+                "type": "integer"
               }
             },
             "required": ["port"]

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -134,6 +134,7 @@ _internal_defaults_do_not_set:
   networkGateway: ""
 
   # Ports for the network gateway service. Only used when networkGateway is set.
+  # Each port may optionally set "nodePort" to override the default node port allocation.
   networkGatewayPorts:
     status-port:
       port: 15021

--- a/operator/pkg/helm/testdata/input/gateway-network-gateway-port-override.yaml
+++ b/operator/pkg/helm/testdata/input/gateway-network-gateway-port-override.yaml
@@ -8,6 +8,7 @@ spec:
       tls:
         port: 443
         targetPort: 15443
+        nodePort: 30443
       tls-istiod:
         port: 15012
         targetPort: 15012

--- a/operator/pkg/helm/testdata/output/gateway-network-gateway-port-override.golden.yaml
+++ b/operator/pkg/helm/testdata/output/gateway-network-gateway-port-override.golden.yaml
@@ -27,6 +27,7 @@ spec:
     port: 443
     targetPort: 15443
     protocol: TCP
+    nodePort: 30443
   - name: tls-istiod
     port: 15012
     targetPort: 15012

--- a/releasenotes/notes/gateway-network-gateway-nodeport.yaml
+++ b/releasenotes/notes/gateway-network-gateway-nodeport.yaml
@@ -1,0 +1,18 @@
+apiVersion: release-notes/v2
+
+kind: feature
+area: installation
+
+# issue is a list of GitHub issues resolved in this note.
+# If issue is not in the current repo, specify its full URL instead.
+issue:
+  - https://github.com/istio/istio/issues/61569
+
+# releaseNotes is a markdown listing of any user facing changes. This will appear in the
+# release notes.
+releaseNotes:
+- |
+  **Added** support for specifying a custom `nodePort` for each port in the network gateway configuration.
+
+# upgradeNotes is a markdown listing of any changes that will affect the upgrade
+# process. This will appear in the release notes.


### PR DESCRIPTION
**Please provide a description of this PR:**

**Added** support for specifying a custom `nodePort` for each port in the network gateway configuration.
Fixes #61569 