### PR TITLE
fix panic on malformed sub claim in oidc jwt authenticator

### DIFF
--- a/releasenotes/notes/oidc-sub-claim-panic.yaml
+++ b/releasenotes/notes/oidc-sub-claim-panic.yaml
@@ -1,0 +1,15 @@
+apiVersion: release-notes/v2
+
+kind: security-fix
+
+area: security
+
+issue: []
+
+releaseNotes:
+- |
+  **Fixed** a panic in istiod when the OIDC/JWT authenticator received a token with a malformed
+  `sub` claim. The subject is now validated to have exactly the
+  `system:serviceaccount:<namespace>:<serviceaccount>` form before use.
+
+  **Credit**: This issue was reported by Kaizhe Huang.

--- a/security/pkg/server/ca/authenticate/oidc.go
+++ b/security/pkg/server/ca/authenticate/oidc.go
@@ -101,10 +101,11 @@ func (j *JwtAuthenticator) authenticate(ctx context.Context, bearerToken string)
 	if err := idToken.Claims(&sa); err != nil {
 		return nil, fmt.Errorf("failed to extract claims from ID token: %v", err)
 	}
-	if !strings.HasPrefix(sa.Sub, "system:serviceaccount") {
+	// "system:serviceaccount:<namespace>:<serviceaccount>" and nothing else
+	parts := strings.Split(sa.Sub, ":")
+	if len(parts) != 4 || parts[0] != "system" || parts[1] != "serviceaccount" || parts[2] == "" || parts[3] == "" {
 		return nil, fmt.Errorf("invalid sub %v", sa.Sub)
 	}
-	parts := strings.Split(sa.Sub, ":")
 	ns := parts[2]
 	ksa := parts[3]
 	if !checkAudience(sa.Aud, j.audiences) {

--- a/security/pkg/server/ca/authenticate/oidc_test.go
+++ b/security/pkg/server/ca/authenticate/oidc_test.go
@@ -175,6 +175,25 @@ func TestOIDCAuthenticate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to generate JWT: %v", err)
 	}
+	// Create JWT tokens with malformed subjects: too few segments (used to panic),
+	// too many segments, empty segments, wrong prefix segment
+	malformedSubs := []string{
+		"system:serviceaccount",
+		"system:serviceaccount:ns",
+		"system:serviceaccountfoo:a:b",
+		"system:serviceaccount:a:b:c",
+		"system:serviceaccount::b",
+		"system:serviceaccount:a:",
+	}
+	malformedSubTokens := map[string]string{}
+	for _, sub := range malformedSubs {
+		claimsMalformedSub := `{"iss": "` + server.URL + `", "aud": ["baz.svc.id.goog"], "sub": "` + sub + `", "exp": ` + expStr + `}`
+		tokenMalformedSub, err := generateJWT(&key, []byte(claimsMalformedSub))
+		if err != nil {
+			t.Fatalf("failed to generate JWT: %v", err)
+		}
+		malformedSubTokens[sub] = tokenMalformedSub
+	}
 
 	tests := map[string]struct {
 		token      string
@@ -201,6 +220,16 @@ func TestOIDCAuthenticate(t *testing.T) {
 			token:     tokenInvalidSubject,
 			expectErr: true,
 		},
+	}
+	for sub, tokenMalformedSub := range malformedSubTokens {
+		tests["Token with malformed subject "+sub] = struct {
+			token      string
+			expectErr  bool
+			expectedID string
+		}{
+			token:     tokenMalformedSub,
+			expectErr: true,
+		}
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
**Please provide a description of this PR:**

OIDC JWT authenticator indexed the sub claim segments without a length check, so a verified token with a short sub panics istiod. Validate the sub is exactly system:serviceaccount:<ns>:<sa> before use.