### PR TITLE
apply serviceentry visibility check to canary waypoints

### DIFF
--- a/pilot/pkg/serviceregistry/ambient/services.go
+++ b/pilot/pkg/serviceregistry/ambient/services.go
@@ -286,7 +286,7 @@ func serviceServiceBuilder(
 
 		svc := constructService(ctx, s, waypoint, domainSuffix, nsAnnotations, networkGetter)
 		svc.IngressUseWaypoint = waypointStatus.IngressUseWaypoint
-		svc.WeightedWaypoints = buildWeightedWaypoints(ctx, waypoints, namespaces, s.ObjectMeta, waypoint, &waypointStatus)
+		svc.WeightedWaypoints = buildWeightedWaypoints(ctx, waypoints, namespaces, nil, s.ObjectMeta, waypoint, &waypointStatus)
 
 		svcInfo := &model.ServiceInfo{
 			Service:       svc,
@@ -487,7 +487,7 @@ func serviceEntriesInfo(
 		log.Warnf("ServiceEntry %s/%s has dynamic DNS resolution but no valid waypoint", s.Namespace, s.Name)
 	}
 
-	weighted := buildWeightedWaypoints(ctx, waypoints, namespaces, s.ObjectMeta, w, &waypoint)
+	weighted := buildWeightedWaypoints(ctx, waypoints, namespaces, visibility, s.ObjectMeta, w, &waypoint)
 
 	vis := krt.FetchOne(ctx, visibility.AsCollection())
 	// Resolve the ServiceEntry's visibility once from the precompiled serviceEntryVisibility; it is

--- a/pilot/pkg/serviceregistry/ambient/services_test.go
+++ b/pilot/pkg/serviceregistry/ambient/services_test.go
@@ -102,6 +102,29 @@ func TestServiceEntryServices(t *testing.T) {
 		},
 	}
 
+	// A second waypoint in the ServiceEntry's own namespace, used as a canary target.
+	canaryAddr := &workloadapi.GatewayAddress{
+		Destination: &workloadapi.GatewayAddress_Hostname{
+			Hostname: &workloadapi.NamespacedHostname{
+				Namespace: "ns",
+				Hostname:  "canary.example",
+			},
+		},
+		HboneMtlsPort: 15008,
+	}
+	canaryWaypoint := Waypoint{
+		Named: krt.Named{
+			Name:      "canary",
+			Namespace: "ns",
+		},
+		TrafficType: constants.AllTraffic,
+		Address:     canaryAddr,
+		AllowedRoutes: WaypointSelector{
+			FromNamespaces: gatewayv1.NamespacesFromSelector,
+			Selector:       labels.ValidatedSetSelector(map[string]string{v1.LabelMetadataName: "ns"}),
+		},
+	}
+
 	cases := []struct {
 		name   string
 		inputs []any
@@ -1357,6 +1380,166 @@ func TestServiceEntryServices(t *testing.T) {
 						AppProtocol: workloadapi.AppProtocol_HTTP11,
 					}},
 					// Visibility PUBLIC (zero value): cross-namespace binding is allowed.
+				},
+			},
+		},
+		{
+			// The canary path must apply the same NAMESPACE-visibility guard as the primary:
+			// the primary binds in-namespace, but the cross-namespace canary is refused and no
+			// weighted waypoints are emitted.
+			name: "NAMESPACE visibility refuses cross-namespace canary waypoint",
+			inputs: []any{
+				ns,
+				waypoint,
+				crossNsWaypoint,
+				meshwatcher.MeshConfigResource{MeshConfig: &meshConfig.MeshConfig{
+					ServiceEntryVisibility: &meshConfig.ServiceEntryVisibility{
+						DefaultVisibility: meshConfig.ServiceEntryVisibility_NAMESPACE,
+					},
+				}},
+			},
+			se: &networkingclient.ServiceEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ns-crossns-canary",
+					Namespace: "ns",
+					Labels: map[string]string{
+						label.IoIstioUseWaypoint.Name:                "waypoint",
+						label.IoIstioUseWaypointCanary.Name:          "waypoint",
+						label.IoIstioUseWaypointCanaryNamespace.Name: "other",
+					},
+					Annotations: map[string]string{
+						annotation.IoIstioUseWaypointCanaryWeight.Name: "20",
+					},
+				},
+				Spec: networking.ServiceEntry{
+					Addresses:  []string{"1.2.3.4"},
+					Hosts:      []string{"a.example.com"},
+					Ports:      []*networking.ServicePort{{Number: 80, Name: "http", Protocol: "HTTP"}},
+					Resolution: networking.ServiceEntry_STATIC,
+				},
+			},
+			result: []*workloadapi.Service{
+				{
+					Name:      "ns-crossns-canary",
+					Namespace: "ns",
+					Hostname:  "a.example.com",
+					Addresses: []*workloadapi.NetworkAddress{{
+						Network: testNW,
+						Address: netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice(),
+					}},
+					Waypoint: waypointAddr,
+					Ports: []*workloadapi.Port{{
+						ServicePort: 80,
+						TargetPort:  80,
+						AppProtocol: workloadapi.AppProtocol_HTTP11,
+					}},
+					Visibility: workloadapi.Service_NAMESPACE,
+					// WeightedWaypoints intentionally absent: the cross-namespace canary is refused.
+				},
+			},
+			waypointErr: ReportWaypointCrossNamespaceForbidden("other/waypoint"),
+		},
+		{
+			name: "NAMESPACE visibility keeps same-namespace canary waypoint",
+			inputs: []any{
+				ns,
+				waypoint,
+				canaryWaypoint,
+				meshwatcher.MeshConfigResource{MeshConfig: &meshConfig.MeshConfig{
+					ServiceEntryVisibility: &meshConfig.ServiceEntryVisibility{
+						DefaultVisibility: meshConfig.ServiceEntryVisibility_NAMESPACE,
+					},
+				}},
+			},
+			se: &networkingclient.ServiceEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ns-samens-canary",
+					Namespace: "ns",
+					Labels: map[string]string{
+						label.IoIstioUseWaypoint.Name:       "waypoint",
+						label.IoIstioUseWaypointCanary.Name: "canary",
+					},
+					Annotations: map[string]string{
+						annotation.IoIstioUseWaypointCanaryWeight.Name: "20",
+					},
+				},
+				Spec: networking.ServiceEntry{
+					Addresses:  []string{"1.2.3.4"},
+					Hosts:      []string{"a.example.com"},
+					Ports:      []*networking.ServicePort{{Number: 80, Name: "http", Protocol: "HTTP"}},
+					Resolution: networking.ServiceEntry_STATIC,
+				},
+			},
+			result: []*workloadapi.Service{
+				{
+					Name:      "ns-samens-canary",
+					Namespace: "ns",
+					Hostname:  "a.example.com",
+					Addresses: []*workloadapi.NetworkAddress{{
+						Network: testNW,
+						Address: netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice(),
+					}},
+					Waypoint: waypointAddr,
+					WeightedWaypoints: []*workloadapi.WeightedWaypoint{
+						{Destination: waypointAddr, Weight: 80},
+						{Destination: canaryAddr, Weight: 20},
+					},
+					Ports: []*workloadapi.Port{{
+						ServicePort: 80,
+						TargetPort:  80,
+						AppProtocol: workloadapi.AppProtocol_HTTP11,
+					}},
+					Visibility: workloadapi.Service_NAMESPACE,
+				},
+			},
+		},
+		{
+			name: "PUBLIC visibility keeps cross-namespace canary waypoint",
+			inputs: []any{
+				ns,
+				waypoint,
+				crossNsWaypoint,
+			},
+			se: &networkingclient.ServiceEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "public-crossns-canary",
+					Namespace: "ns",
+					Labels: map[string]string{
+						label.IoIstioUseWaypoint.Name:                "waypoint",
+						label.IoIstioUseWaypointCanary.Name:          "waypoint",
+						label.IoIstioUseWaypointCanaryNamespace.Name: "other",
+					},
+					Annotations: map[string]string{
+						annotation.IoIstioUseWaypointCanaryWeight.Name: "20",
+					},
+				},
+				Spec: networking.ServiceEntry{
+					Addresses:  []string{"1.2.3.4"},
+					Hosts:      []string{"a.example.com"},
+					Ports:      []*networking.ServicePort{{Number: 80, Name: "http", Protocol: "HTTP"}},
+					Resolution: networking.ServiceEntry_STATIC,
+				},
+			},
+			result: []*workloadapi.Service{
+				{
+					Name:      "public-crossns-canary",
+					Namespace: "ns",
+					Hostname:  "a.example.com",
+					Addresses: []*workloadapi.NetworkAddress{{
+						Network: testNW,
+						Address: netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice(),
+					}},
+					Waypoint: waypointAddr,
+					WeightedWaypoints: []*workloadapi.WeightedWaypoint{
+						{Destination: waypointAddr, Weight: 80},
+						{Destination: crossNsWaypointAddr, Weight: 20},
+					},
+					Ports: []*workloadapi.Port{{
+						ServicePort: 80,
+						TargetPort:  80,
+						AppProtocol: workloadapi.AppProtocol_HTTP11,
+					}},
+					// Visibility PUBLIC (zero value): cross-namespace canary is allowed.
 				},
 			},
 		},

--- a/pilot/pkg/serviceregistry/ambient/waypoints.go
+++ b/pilot/pkg/serviceregistry/ambient/waypoints.go
@@ -170,19 +170,26 @@ func fetchWaypointForService(ctx krt.HandlerContext, Waypoints krt.Collection[Wa
 			w.Namespace, w.Name, w.TrafficType, o.Namespace, o.Name)
 		return nil, ReportWaypointUnsupportedTrafficType(w.ResourceName(), constants.ServiceTraffic)
 	}
-	// A NAMESPACE-visibility ServiceEntry must not bind to a waypoint in another namespace: that would
-	// expose it to the waypoint's namespace. Refuse here so every consumer is covered.
-	// ServiceEntryVisibility is nil for consumers it doesn't govern (e.g. Kubernetes Services).
-	if ServiceEntryVisibility != nil && w.Namespace != o.Namespace {
-		var nsLabels map[string]string
-		if ns := krt.FetchOne(ctx, Namespaces, krt.FilterKey(o.Namespace)); ns != nil {
-			nsLabels = (*ns).Labels
-		}
-		if krt.FetchOne(ctx, ServiceEntryVisibility.AsCollection()).VisibilityFor(nsLabels) == model.ServiceVisibilityNamespace {
-			return nil, ReportWaypointCrossNamespaceForbidden(w.ResourceName())
-		}
+	if crossNamespaceWaypointForbidden(ctx, Namespaces, ServiceEntryVisibility, o.Namespace, w.Namespace) {
+		return nil, ReportWaypointCrossNamespaceForbidden(w.ResourceName())
 	}
 	return w, nil
+}
+
+// crossNamespaceWaypointForbidden refuses a cross-namespace waypoint (primary or canary) for a
+// NAMESPACE-visibility ServiceEntry. ServiceEntryVisibility is nil for consumers it doesn't govern
+// (e.g. Kubernetes Services).
+func crossNamespaceWaypointForbidden(ctx krt.HandlerContext, Namespaces krt.Collection[*v1.Namespace],
+	ServiceEntryVisibility krt.Singleton[model.ServiceEntryVisibilityMatcher], objNamespace, waypointNamespace string,
+) bool {
+	if ServiceEntryVisibility == nil || waypointNamespace == objNamespace {
+		return false
+	}
+	var nsLabels map[string]string
+	if ns := krt.FetchOne(ctx, Namespaces, krt.FilterKey(objNamespace)); ns != nil {
+		nsLabels = (*ns).Labels
+	}
+	return krt.FetchOne(ctx, ServiceEntryVisibility.AsCollection()).VisibilityFor(nsLabels) == model.ServiceVisibilityNamespace
 }
 
 func fetchWaypointForWorkload(ctx krt.HandlerContext, Waypoints krt.Collection[Waypoint],
@@ -294,11 +301,13 @@ func ResolveUseWaypointCanary(
 	return named, weight, valid
 }
 
-// resolveCanaryWaypoint applies the primary waypoint attachment and traffic-type checks.
+// resolveCanaryWaypoint applies the primary waypoint attachment, traffic-type and
+// ServiceEntry-visibility checks.
 func resolveCanaryWaypoint(
 	ctx krt.HandlerContext,
 	waypoints krt.Collection[Waypoint],
 	namespaces krt.Collection[*v1.Namespace],
+	serviceEntryVisibility krt.Singleton[model.ServiceEntryVisibilityMatcher],
 	fallbackNamespace string,
 	named *krt.Named,
 ) (*Waypoint, *model.StatusMessage) {
@@ -312,6 +321,9 @@ func resolveCanaryWaypoint(
 	if w.TrafficType != constants.ServiceTraffic && w.TrafficType != constants.AllTraffic {
 		return nil, ReportWaypointUnsupportedTrafficType(w.ResourceName(), constants.ServiceTraffic)
 	}
+	if crossNamespaceWaypointForbidden(ctx, namespaces, serviceEntryVisibility, fallbackNamespace, w.Namespace) {
+		return nil, ReportWaypointCrossNamespaceForbidden(w.ResourceName())
+	}
 	return w, nil
 }
 
@@ -321,6 +333,7 @@ func buildWeightedWaypoints(
 	ctx krt.HandlerContext,
 	waypoints krt.Collection[Waypoint],
 	namespaces krt.Collection[*v1.Namespace],
+	serviceEntryVisibility krt.Singleton[model.ServiceEntryVisibilityMatcher],
 	o metav1.ObjectMeta,
 	primary *Waypoint,
 	status *model.WaypointBindingStatus,
@@ -340,7 +353,7 @@ func buildWeightedWaypoints(
 		status.Error = ReportWaypointCanaryInvalidWeight(named.ResourceName())
 		return nil
 	}
-	canary, cerr := resolveCanaryWaypoint(ctx, waypoints, namespaces, o.Namespace, named)
+	canary, cerr := resolveCanaryWaypoint(ctx, waypoints, namespaces, serviceEntryVisibility, o.Namespace, named)
 	if cerr != nil {
 		status.Error = cerr
 		return nil

--- a/releasenotes/notes/canary-waypoint-se-visibility.yaml
+++ b/releasenotes/notes/canary-waypoint-se-visibility.yaml
@@ -1,0 +1,16 @@
+apiVersion: release-notes/v2
+
+kind: security-fix
+
+area: traffic-management
+
+issue: []
+
+releaseNotes:
+- |
+  **Fixed** the `istio.io/use-waypoint-canary` label bypassing the `serviceEntryVisibility`
+  NAMESPACE isolation: a NAMESPACE-visibility `ServiceEntry` could route its canary share of
+  traffic through a waypoint in another namespace. The canary waypoint is now subject to the
+  same cross-namespace refusal as the primary.
+
+  **Credit**: This issue was reported by Raphael Zanarelli.


### PR DESCRIPTION
**Please provide a description of this PR:**

The use-waypoint-canary path skipped the NAMESPACE-visibility cross-namespace check the primary waypoint path enforces, so a NAMESPACE-visibility ServiceEntry could route canary traffic through a cross-namespace waypoint. Apply the same refusal to canary resolution.