### PR TITLE
pilot: Support physical AWS zone ID locality

### DIFF
--- a/manifests/charts/base/files/profile-compatibility-version-1.25.yaml
+++ b/manifests/charts/base/files/profile-compatibility-version-1.25.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.27 behavioral changes
     ENABLE_NATIVE_SIDECARS: "false"
     # 1.28 behavioral changes

--- a/manifests/charts/base/files/profile-compatibility-version-1.26.yaml
+++ b/manifests/charts/base/files/profile-compatibility-version-1.26.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.27 behavioral changes
     ENABLE_NATIVE_SIDECARS: "false"
     # 1.28 behavioral changes

--- a/manifests/charts/base/files/profile-compatibility-version-1.27.yaml
+++ b/manifests/charts/base/files/profile-compatibility-version-1.27.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.28 behavioral changes
     DISABLE_SHADOW_HOST_SUFFIX: "false"
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"

--- a/manifests/charts/base/files/profile-compatibility-version-1.28.yaml
+++ b/manifests/charts/base/files/profile-compatibility-version-1.28.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
     # 1.30 behavioral changes

--- a/manifests/charts/base/files/profile-compatibility-version-1.29.yaml
+++ b/manifests/charts/base/files/profile-compatibility-version-1.29.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.30 behavioral changes
     PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
     # 1.31 behavioral changes

--- a/manifests/charts/base/files/profile-compatibility-version-1.31.yaml
+++ b/manifests/charts/base/files/profile-compatibility-version-1.31.yaml
@@ -5,7 +5,3 @@
 pilot:
   env:
     PILOT_ENABLE_AWS_ZONE_ID: "false"
-    # 1.31 behavioral changes
-    PILOT_ENABLE_STRICT_GATEWAY_MERGING: "false"
-    PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
-    PILOT_AUTO_SEND_UNHEALTHY_ENDPOINTS: "false"

--- a/manifests/charts/default/files/profile-compatibility-version-1.25.yaml
+++ b/manifests/charts/default/files/profile-compatibility-version-1.25.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.27 behavioral changes
     ENABLE_NATIVE_SIDECARS: "false"
     # 1.28 behavioral changes

--- a/manifests/charts/default/files/profile-compatibility-version-1.26.yaml
+++ b/manifests/charts/default/files/profile-compatibility-version-1.26.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.27 behavioral changes
     ENABLE_NATIVE_SIDECARS: "false"
     # 1.28 behavioral changes

--- a/manifests/charts/default/files/profile-compatibility-version-1.27.yaml
+++ b/manifests/charts/default/files/profile-compatibility-version-1.27.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.28 behavioral changes
     DISABLE_SHADOW_HOST_SUFFIX: "false"
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"

--- a/manifests/charts/default/files/profile-compatibility-version-1.28.yaml
+++ b/manifests/charts/default/files/profile-compatibility-version-1.28.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
     # 1.30 behavioral changes

--- a/manifests/charts/default/files/profile-compatibility-version-1.29.yaml
+++ b/manifests/charts/default/files/profile-compatibility-version-1.29.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.30 behavioral changes
     PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
     # 1.31 behavioral changes

--- a/manifests/charts/default/files/profile-compatibility-version-1.30.yaml
+++ b/manifests/charts/default/files/profile-compatibility-version-1.30.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.31 behavioral changes
     PILOT_ENABLE_STRICT_GATEWAY_MERGING: "false"
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"

--- a/manifests/charts/default/files/profile-compatibility-version-1.31.yaml
+++ b/manifests/charts/default/files/profile-compatibility-version-1.31.yaml
@@ -5,7 +5,3 @@
 pilot:
   env:
     PILOT_ENABLE_AWS_ZONE_ID: "false"
-    # 1.31 behavioral changes
-    PILOT_ENABLE_STRICT_GATEWAY_MERGING: "false"
-    PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
-    PILOT_AUTO_SEND_UNHEALTHY_ENDPOINTS: "false"

--- a/manifests/charts/gateway/files/profile-compatibility-version-1.25.yaml
+++ b/manifests/charts/gateway/files/profile-compatibility-version-1.25.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.27 behavioral changes
     ENABLE_NATIVE_SIDECARS: "false"
     # 1.28 behavioral changes

--- a/manifests/charts/gateway/files/profile-compatibility-version-1.26.yaml
+++ b/manifests/charts/gateway/files/profile-compatibility-version-1.26.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.27 behavioral changes
     ENABLE_NATIVE_SIDECARS: "false"
     # 1.28 behavioral changes

--- a/manifests/charts/gateway/files/profile-compatibility-version-1.27.yaml
+++ b/manifests/charts/gateway/files/profile-compatibility-version-1.27.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.28 behavioral changes
     DISABLE_SHADOW_HOST_SUFFIX: "false"
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"

--- a/manifests/charts/gateway/files/profile-compatibility-version-1.28.yaml
+++ b/manifests/charts/gateway/files/profile-compatibility-version-1.28.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
     # 1.30 behavioral changes

--- a/manifests/charts/gateway/files/profile-compatibility-version-1.29.yaml
+++ b/manifests/charts/gateway/files/profile-compatibility-version-1.29.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.30 behavioral changes
     PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
     # 1.31 behavioral changes

--- a/manifests/charts/gateway/files/profile-compatibility-version-1.30.yaml
+++ b/manifests/charts/gateway/files/profile-compatibility-version-1.30.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.31 behavioral changes
     PILOT_ENABLE_STRICT_GATEWAY_MERGING: "false"
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"

--- a/manifests/charts/gateway/files/profile-compatibility-version-1.31.yaml
+++ b/manifests/charts/gateway/files/profile-compatibility-version-1.31.yaml
@@ -5,7 +5,3 @@
 pilot:
   env:
     PILOT_ENABLE_AWS_ZONE_ID: "false"
-    # 1.31 behavioral changes
-    PILOT_ENABLE_STRICT_GATEWAY_MERGING: "false"
-    PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
-    PILOT_AUTO_SEND_UNHEALTHY_ENDPOINTS: "false"

--- a/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.25.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.25.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.27 behavioral changes
     ENABLE_NATIVE_SIDECARS: "false"
     # 1.28 behavioral changes

--- a/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.26.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.26.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.27 behavioral changes
     ENABLE_NATIVE_SIDECARS: "false"
     # 1.28 behavioral changes

--- a/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.27.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.27.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.28 behavioral changes
     DISABLE_SHADOW_HOST_SUFFIX: "false"
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"

--- a/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.28.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.28.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
     # 1.30 behavioral changes

--- a/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.29.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.29.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.30 behavioral changes
     PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
     # 1.31 behavioral changes

--- a/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.30.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.30.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.31 behavioral changes
     PILOT_ENABLE_STRICT_GATEWAY_MERGING: "false"
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"

--- a/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.31.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.31.yaml
@@ -5,7 +5,3 @@
 pilot:
   env:
     PILOT_ENABLE_AWS_ZONE_ID: "false"
-    # 1.31 behavioral changes
-    PILOT_ENABLE_STRICT_GATEWAY_MERGING: "false"
-    PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
-    PILOT_AUTO_SEND_UNHEALTHY_ENDPOINTS: "false"

--- a/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.25.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.25.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.27 behavioral changes
     ENABLE_NATIVE_SIDECARS: "false"
     # 1.28 behavioral changes

--- a/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.26.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.26.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.27 behavioral changes
     ENABLE_NATIVE_SIDECARS: "false"
     # 1.28 behavioral changes

--- a/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.27.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.27.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.28 behavioral changes
     DISABLE_SHADOW_HOST_SUFFIX: "false"
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"

--- a/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.28.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.28.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
     # 1.30 behavioral changes

--- a/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.29.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.29.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.30 behavioral changes
     PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
     # 1.31 behavioral changes

--- a/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.30.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.30.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.31 behavioral changes
     PILOT_ENABLE_STRICT_GATEWAY_MERGING: "false"
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"

--- a/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.31.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.31.yaml
@@ -5,7 +5,3 @@
 pilot:
   env:
     PILOT_ENABLE_AWS_ZONE_ID: "false"
-    # 1.31 behavioral changes
-    PILOT_ENABLE_STRICT_GATEWAY_MERGING: "false"
-    PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
-    PILOT_AUTO_SEND_UNHEALTHY_ENDPOINTS: "false"

--- a/manifests/charts/istio-cni/files/profile-compatibility-version-1.25.yaml
+++ b/manifests/charts/istio-cni/files/profile-compatibility-version-1.25.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.27 behavioral changes
     ENABLE_NATIVE_SIDECARS: "false"
     # 1.28 behavioral changes

--- a/manifests/charts/istio-cni/files/profile-compatibility-version-1.26.yaml
+++ b/manifests/charts/istio-cni/files/profile-compatibility-version-1.26.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.27 behavioral changes
     ENABLE_NATIVE_SIDECARS: "false"
     # 1.28 behavioral changes

--- a/manifests/charts/istio-cni/files/profile-compatibility-version-1.27.yaml
+++ b/manifests/charts/istio-cni/files/profile-compatibility-version-1.27.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.28 behavioral changes
     DISABLE_SHADOW_HOST_SUFFIX: "false"
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"

--- a/manifests/charts/istio-cni/files/profile-compatibility-version-1.28.yaml
+++ b/manifests/charts/istio-cni/files/profile-compatibility-version-1.28.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
     # 1.30 behavioral changes

--- a/manifests/charts/istio-cni/files/profile-compatibility-version-1.29.yaml
+++ b/manifests/charts/istio-cni/files/profile-compatibility-version-1.29.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.30 behavioral changes
     PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
     # 1.31 behavioral changes

--- a/manifests/charts/istio-cni/files/profile-compatibility-version-1.30.yaml
+++ b/manifests/charts/istio-cni/files/profile-compatibility-version-1.30.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.31 behavioral changes
     PILOT_ENABLE_STRICT_GATEWAY_MERGING: "false"
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"

--- a/manifests/charts/istio-cni/files/profile-compatibility-version-1.31.yaml
+++ b/manifests/charts/istio-cni/files/profile-compatibility-version-1.31.yaml
@@ -5,7 +5,3 @@
 pilot:
   env:
     PILOT_ENABLE_AWS_ZONE_ID: "false"
-    # 1.31 behavioral changes
-    PILOT_ENABLE_STRICT_GATEWAY_MERGING: "false"
-    PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
-    PILOT_AUTO_SEND_UNHEALTHY_ENDPOINTS: "false"

--- a/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.25.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.25.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.27 behavioral changes
     ENABLE_NATIVE_SIDECARS: "false"
     # 1.28 behavioral changes

--- a/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.26.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.26.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.27 behavioral changes
     ENABLE_NATIVE_SIDECARS: "false"
     # 1.28 behavioral changes

--- a/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.27.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.27.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.28 behavioral changes
     DISABLE_SHADOW_HOST_SUFFIX: "false"
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"

--- a/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.28.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.28.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
     # 1.30 behavioral changes

--- a/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.29.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.29.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.30 behavioral changes
     PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
     # 1.31 behavioral changes

--- a/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.30.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.30.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.31 behavioral changes
     PILOT_ENABLE_STRICT_GATEWAY_MERGING: "false"
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"

--- a/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.31.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.31.yaml
@@ -5,7 +5,3 @@
 pilot:
   env:
     PILOT_ENABLE_AWS_ZONE_ID: "false"
-    # 1.31 behavioral changes
-    PILOT_ENABLE_STRICT_GATEWAY_MERGING: "false"
-    PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
-    PILOT_AUTO_SEND_UNHEALTHY_ENDPOINTS: "false"

--- a/manifests/charts/ztunnel/files/profile-compatibility-version-1.25.yaml
+++ b/manifests/charts/ztunnel/files/profile-compatibility-version-1.25.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.27 behavioral changes
     ENABLE_NATIVE_SIDECARS: "false"
     # 1.28 behavioral changes

--- a/manifests/charts/ztunnel/files/profile-compatibility-version-1.26.yaml
+++ b/manifests/charts/ztunnel/files/profile-compatibility-version-1.26.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.27 behavioral changes
     ENABLE_NATIVE_SIDECARS: "false"
     # 1.28 behavioral changes

--- a/manifests/charts/ztunnel/files/profile-compatibility-version-1.27.yaml
+++ b/manifests/charts/ztunnel/files/profile-compatibility-version-1.27.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.28 behavioral changes
     DISABLE_SHADOW_HOST_SUFFIX: "false"
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"

--- a/manifests/charts/ztunnel/files/profile-compatibility-version-1.28.yaml
+++ b/manifests/charts/ztunnel/files/profile-compatibility-version-1.28.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
     # 1.30 behavioral changes

--- a/manifests/charts/ztunnel/files/profile-compatibility-version-1.29.yaml
+++ b/manifests/charts/ztunnel/files/profile-compatibility-version-1.29.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.30 behavioral changes
     PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
     # 1.31 behavioral changes

--- a/manifests/charts/ztunnel/files/profile-compatibility-version-1.30.yaml
+++ b/manifests/charts/ztunnel/files/profile-compatibility-version-1.30.yaml
@@ -4,6 +4,7 @@
 
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.31 behavioral changes
     PILOT_ENABLE_STRICT_GATEWAY_MERGING: "false"
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"

--- a/manifests/charts/ztunnel/files/profile-compatibility-version-1.31.yaml
+++ b/manifests/charts/ztunnel/files/profile-compatibility-version-1.31.yaml
@@ -5,7 +5,3 @@
 pilot:
   env:
     PILOT_ENABLE_AWS_ZONE_ID: "false"
-    # 1.31 behavioral changes
-    PILOT_ENABLE_STRICT_GATEWAY_MERGING: "false"
-    PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"
-    PILOT_AUTO_SEND_UNHEALTHY_ENDPOINTS: "false"

--- a/manifests/helm-profiles/compatibility-version-1.25.yaml
+++ b/manifests/helm-profiles/compatibility-version-1.25.yaml
@@ -1,5 +1,6 @@
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.27 behavioral changes
     ENABLE_NATIVE_SIDECARS: "false"
     # 1.28 behavioral changes

--- a/manifests/helm-profiles/compatibility-version-1.26.yaml
+++ b/manifests/helm-profiles/compatibility-version-1.26.yaml
@@ -1,5 +1,6 @@
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.27 behavioral changes
     ENABLE_NATIVE_SIDECARS: "false"
     # 1.28 behavioral changes

--- a/manifests/helm-profiles/compatibility-version-1.27.yaml
+++ b/manifests/helm-profiles/compatibility-version-1.27.yaml
@@ -1,5 +1,6 @@
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.28 behavioral changes
     DISABLE_SHADOW_HOST_SUFFIX: "false"
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"

--- a/manifests/helm-profiles/compatibility-version-1.28.yaml
+++ b/manifests/helm-profiles/compatibility-version-1.28.yaml
@@ -1,5 +1,6 @@
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.29 behavioral changes
     DISABLE_TRACK_REMAINING_CB_METRICS: "false"
     # 1.30 behavioral changes

--- a/manifests/helm-profiles/compatibility-version-1.29.yaml
+++ b/manifests/helm-profiles/compatibility-version-1.29.yaml
@@ -1,5 +1,6 @@
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.30 behavioral changes
     PILOT_SIDECAR_PICK_BEST_SERVICE_NAMESPACE: "false"
     # 1.31 behavioral changes

--- a/manifests/helm-profiles/compatibility-version-1.30.yaml
+++ b/manifests/helm-profiles/compatibility-version-1.30.yaml
@@ -1,5 +1,6 @@
 pilot:
   env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"
     # 1.31 behavioral changes
     PILOT_ENABLE_STRICT_GATEWAY_MERGING: "false"
     PILOT_SPAWN_UPSTREAM_SPAN_FOR_GATEWAY: "false"

--- a/manifests/helm-profiles/compatibility-version-1.31.yaml
+++ b/manifests/helm-profiles/compatibility-version-1.31.yaml
@@ -1,0 +1,3 @@
+pilot:
+  env:
+    PILOT_ENABLE_AWS_ZONE_ID: "false"

--- a/operator/pkg/helm/helm_test.go
+++ b/operator/pkg/helm/helm_test.go
@@ -28,6 +28,7 @@ import (
 	"helm.sh/helm/v4/pkg/chart/common"
 	commonutil "helm.sh/helm/v4/pkg/chart/common/util"
 	"helm.sh/helm/v4/pkg/engine"
+	appsv1 "k8s.io/api/apps/v1"
 	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/istioctl/pkg/install/k8sversion"
@@ -98,6 +99,56 @@ func renderWithOptions(releaseName, namespace, directory string, iop values.Map,
 
 	mfs, err := manifest.Parse(results)
 	return mfs, warnings, err
+}
+
+func TestAWSZoneIDCompatibility(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		version  string
+		override string
+		want     string
+	}{
+		{name: "default"},
+		{name: "1.25", version: "1.25", want: "false"},
+		{name: "1.26", version: "1.26", want: "false"},
+		{name: "1.27", version: "1.27", want: "false"},
+		{name: "1.28", version: "1.28", want: "false"},
+		{name: "1.29", version: "1.29", want: "false"},
+		{name: "1.30", version: "1.30", want: "false"},
+		{name: "1.31", version: "1.31", want: "false"},
+		{name: "explicit disable", override: "false", want: "false"},
+		{name: "override profile", version: "1.31", override: "true", want: "true"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			vals := values.MakeMap(tc.version, "spec", "values", "compatibilityVersion")
+			if tc.override != "" {
+				require.NoError(t, vals.SetPath("spec.values.pilot.env.PILOT_ENABLE_AWS_ZONE_ID", tc.override))
+			}
+			mfs, _, err := Render("istiod", "istio-system", "istio-control/istio-discovery", vals, nil)
+			require.NoError(t, err)
+			for _, mf := range mfs {
+				if mf.GetKind() != "Deployment" || mf.GetName() != "istiod" {
+					continue
+				}
+				var deployment appsv1.Deployment
+				require.NoError(t, yaml.Unmarshal([]byte(mf.Content), &deployment))
+				for _, container := range deployment.Spec.Template.Spec.Containers {
+					if container.Name != "discovery" {
+						continue
+					}
+					var got string
+					for _, env := range container.Env {
+						if env.Name == "PILOT_ENABLE_AWS_ZONE_ID" {
+							got = env.Value
+						}
+					}
+					require.Equal(t, tc.want, got)
+					return
+				}
+			}
+			t.Fatal("Istiod container not found")
+		})
+	}
 }
 
 func TestRender(t *testing.T) {

--- a/pilot/pkg/features/experimental.go
+++ b/pilot/pkg/features/experimental.go
@@ -196,6 +196,10 @@ var (
 	Enable100ContinueHeaders = env.Register("ENABLE_100_CONTINUE_HEADERS", true,
 		"If enabled, istiod will proxy 100-continue headers as is").Get()
 
+	EnableAWSZoneID = env.Register("PILOT_ENABLE_AWS_ZONE_ID", false,
+		"Use topology.k8s.aws/zone-id for Kubernetes workload locality when the label exists. "+
+			"Applies to sidecar and ambient modes.").Get()
+
 	EnableLocalityWeightedLbConfig = env.Register("ENABLE_LOCALITY_WEIGHTED_LB_CONFIG", false,
 		"If enabled, always set LocalityWeightedLbConfig for a cluster, "+
 			" otherwise only apply it when locality lb is specified by DestinationRule for a service").Get()

--- a/pilot/pkg/features/experimental.go
+++ b/pilot/pkg/features/experimental.go
@@ -196,7 +196,7 @@ var (
 	Enable100ContinueHeaders = env.Register("ENABLE_100_CONTINUE_HEADERS", true,
 		"If enabled, istiod will proxy 100-continue headers as is").Get()
 
-	EnableAWSZoneID = env.Register("PILOT_ENABLE_AWS_ZONE_ID", false,
+	EnableAWSZoneID = env.Register("PILOT_ENABLE_AWS_ZONE_ID", true,
 		"Use topology.k8s.aws/zone-id for Kubernetes workload locality when the label exists. "+
 			"Applies to sidecar and ambient modes.").Get()
 

--- a/pilot/pkg/serviceregistry/ambient/nodes.go
+++ b/pilot/pkg/serviceregistry/ambient/nodes.go
@@ -20,6 +20,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	"istio.io/api/label"
+	"istio.io/istio/pilot/pkg/features"
+	labelutil "istio.io/istio/pilot/pkg/serviceregistry/util/label"
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/krt"
@@ -50,6 +52,11 @@ func nodeLocality(k *v1.Node) *Node {
 	}
 	region := k.GetLabels()[v1.LabelTopologyRegion]
 	zone := k.GetLabels()[v1.LabelTopologyZone]
+	if features.EnableAWSZoneID {
+		if zoneID := k.GetLabels()[labelutil.LabelTopologyAWSZoneID]; zoneID != "" {
+			zone = zoneID
+		}
+	}
 	subzone := k.GetLabels()[label.TopologySubzone.Name]
 
 	if region != "" || zone != "" || subzone != "" {

--- a/pilot/pkg/serviceregistry/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/ambient/workloads_test.go
@@ -33,6 +33,7 @@ import (
 	securityclient "istio.io/client-go/pkg/apis/security/v1"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
+	labelutil "istio.io/istio/pilot/pkg/serviceregistry/util/label"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/kind"
@@ -46,6 +47,35 @@ import (
 	"istio.io/istio/pkg/workloadapi"
 	"istio.io/istio/pkg/workloadapi/security"
 )
+
+func TestNodeLocalityAWSZoneID(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		enabled  bool
+		zone     string
+		zoneID   string
+		wantZone string
+	}{
+		{name: "disabled", zone: "us-east-1d", zoneID: "use1-az6", wantZone: "us-east-1d"},
+		{name: "enabled", enabled: true, zone: "us-east-1d", zoneID: "use1-az6", wantZone: "use1-az6"},
+		{name: "missing label", enabled: true, zone: "us-east-1d", wantZone: "us-east-1d"},
+		{name: "no zone name", enabled: true, zoneID: "use1-az6", wantZone: "use1-az6"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			test.SetForTest(t, &features.EnableAWSZoneID, tc.enabled)
+			node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node", Labels: map[string]string{
+				v1.LabelTopologyRegion: "us-east-1", v1.LabelTopologyZone: tc.zone, label.TopologySubzone.Name: "rack1",
+			}}}
+			if tc.zoneID != "" {
+				node.Labels[labelutil.LabelTopologyAWSZoneID] = tc.zoneID
+			}
+			assert.Equal(t, nodeLocality(node), &Node{Name: "node", Locality: &workloadapi.Locality{
+				Region: "us-east-1", Zone: tc.wantZone, Subzone: "rack1",
+			}})
+			assert.Equal(t, node.Labels[v1.LabelTopologyZone], tc.zone)
+		})
+	}
+}
 
 func TestPodWorkloads(t *testing.T) {
 	waypointAddr := &workloadapi.GatewayAddress{

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -763,6 +763,11 @@ func (c *Controller) getPodLocality(pod *v1.Pod) string {
 
 	region := getLabelValue(node.ObjectMeta, NodeRegionLabelGA, NodeRegionLabel)
 	zone := getLabelValue(node.ObjectMeta, NodeZoneLabelGA, NodeZoneLabel)
+	if features.EnableAWSZoneID {
+		if zoneID := node.Labels[labelutil.LabelTopologyAWSZoneID]; zoneID != "" {
+			zone = zoneID
+		}
+	}
 	subzone := getLabelValue(node.ObjectMeta, label.TopologySubzone.Name, "")
 
 	if region == "" && zone == "" && subzone == "" {

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -311,6 +311,44 @@ func TestController_GetPodLocality(t *testing.T) {
 	}
 }
 
+func TestController_AWSZoneIDLocality(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		enabled  bool
+		zoneID   string
+		locality map[string]string
+		want     string
+	}{
+		{name: "disabled", zoneID: "use1-az6", want: "us-east-1/us-east-1d/rack1"},
+		{name: "enabled", enabled: true, zoneID: "use1-az6", want: "us-east-1/use1-az6/rack1"},
+		{name: "missing label", enabled: true, want: "us-east-1/us-east-1d/rack1"},
+		{
+			name: "pod override", enabled: true, zoneID: "use1-az6",
+			locality: map[string]string{label.TopologyLocality.Name: "custom.zone.rack"}, want: "custom/zone/rack",
+		},
+		{
+			name: "legacy pod override", enabled: true, zoneID: "use1-az6",
+			locality: map[string]string{pm.LocalityLabel: "custom.zone.rack"}, want: "custom/zone/rack",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			test.SetForTest(t, &features.EnableAWSZoneID, tc.enabled)
+			controller, fx := NewFakeControllerWithOptions(t, FakeControllerOptions{})
+			nodeLabels := map[string]string{
+				NodeRegionLabelGA: "us-east-1", NodeZoneLabelGA: "us-east-1d", label.TopologySubzone.Name: "rack1",
+			}
+			if tc.zoneID != "" {
+				nodeLabels[labelutil.LabelTopologyAWSZoneID] = tc.zoneID
+			}
+			addNodes(t, controller, generateNode("node", nodeLabels))
+			pod := generatePod([]string{"10.0.0.1"}, "pod", "default", "", "node", tc.locality, nil)
+			addPods(t, controller, fx, pod)
+			assert.Equal(t, controller.getPodLocality(pod), tc.want)
+			assert.Equal(t, controller.nodes.Get("node", "").Labels[NodeZoneLabelGA], "us-east-1d")
+		})
+	}
+}
+
 func TestProxyK8sHostnameLabel(t *testing.T) {
 	clusterID := cluster.ID("fakeCluster")
 	controller, fx := NewFakeControllerWithOptions(t, FakeControllerOptions{

--- a/pilot/pkg/serviceregistry/util/label/label.go
+++ b/pilot/pkg/serviceregistry/util/label/label.go
@@ -33,6 +33,9 @@ const (
 	LabelTopologyRegion  = "topology.kubernetes.io/region"
 )
 
+// LabelTopologyAWSZoneID identifies the same physical AWS zone across accounts.
+const LabelTopologyAWSZoneID = "topology.k8s.aws/zone-id"
+
 // AugmentLabels adds additional labels to the those provided.
 func AugmentLabels(in labels.Instance, clusterID cluster.ID, locality, k8sNode string, networkID network.ID) labels.Instance {
 	// Copy the original labels to a new map.

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -79,18 +79,20 @@ const (
 func TestPreferCloseAWSZoneID(t *testing.T) {
 	for _, tc := range []struct {
 		name         string
-		enabled      bool
+		disabled     bool
 		native       bool
 		secondZoneID string
 		want         map[string]uint32
 	}{
-		{name: "disabled", secondZoneID: "use1-az6", want: map[string]uint32{"10.0.1.1": 0, "10.0.1.2": 1}},
-		{name: "annotation", enabled: true, secondZoneID: "use1-az6", want: map[string]uint32{"10.0.1.1": 1, "10.0.1.2": 0}},
-		{name: "service field", enabled: true, native: true, secondZoneID: "use1-az6", want: map[string]uint32{"10.0.1.1": 1, "10.0.1.2": 0}},
-		{name: "no local endpoint", enabled: true, secondZoneID: "use1-az4", want: map[string]uint32{"10.0.1.1": 0, "10.0.1.2": 0}},
+		{name: "disabled", disabled: true, secondZoneID: "use1-az6", want: map[string]uint32{"10.0.1.1": 0, "10.0.1.2": 1}},
+		{name: "annotation", secondZoneID: "use1-az6", want: map[string]uint32{"10.0.1.1": 1, "10.0.1.2": 0}},
+		{name: "service field", native: true, secondZoneID: "use1-az6", want: map[string]uint32{"10.0.1.1": 1, "10.0.1.2": 0}},
+		{name: "no local endpoint", secondZoneID: "use1-az4", want: map[string]uint32{"10.0.1.1": 0, "10.0.1.2": 0}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			test.SetForTest(t, &features.EnableAWSZoneID, tc.enabled)
+			if tc.disabled {
+				test.SetForTest(t, &features.EnableAWSZoneID, false)
+			}
 			node := func(name, zone, id string) *v1.Node {
 				return &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: map[string]string{
 					v1.LabelTopologyRegion: "us-east-1", v1.LabelTopologyZone: zone, labelutil.LabelTopologyAWSZoneID: id,

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -29,25 +29,34 @@ import (
 	"testing"
 	"time"
 
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	uatomic "go.uber.org/atomic"
+	v1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 
+	"istio.io/api/annotation"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/serviceregistry/memory"
+	labelutil "istio.io/istio/pilot/pkg/serviceregistry/util/label"
 	"istio.io/istio/pilot/pkg/xds"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	xdsfake "istio.io/istio/pilot/test/xds"
 	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/pkg/adsc"
+	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/env"
@@ -66,6 +75,96 @@ const (
 	edsIncSvc = "eds.test.svc.cluster.local"
 	edsIncVip = "10.10.1.2"
 )
+
+func TestPreferCloseAWSZoneID(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		enabled      bool
+		native       bool
+		secondZoneID string
+		want         map[string]uint32
+	}{
+		{name: "disabled", secondZoneID: "use1-az6", want: map[string]uint32{"10.0.1.1": 0, "10.0.1.2": 1}},
+		{name: "annotation", enabled: true, secondZoneID: "use1-az6", want: map[string]uint32{"10.0.1.1": 1, "10.0.1.2": 0}},
+		{name: "service field", enabled: true, native: true, secondZoneID: "use1-az6", want: map[string]uint32{"10.0.1.1": 1, "10.0.1.2": 0}},
+		{name: "no local endpoint", enabled: true, secondZoneID: "use1-az4", want: map[string]uint32{"10.0.1.1": 0, "10.0.1.2": 0}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			test.SetForTest(t, &features.EnableAWSZoneID, tc.enabled)
+			node := func(name, zone, id string) *v1.Node {
+				return &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: map[string]string{
+					v1.LabelTopologyRegion: "us-east-1", v1.LabelTopologyZone: zone, labelutil.LabelTopologyAWSZoneID: id,
+				}}}
+			}
+			pod := func(name, ip string) *v1.Pod {
+				return &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+					Spec:       v1.PodSpec{NodeName: name},
+					Status: v1.PodStatus{PodIP: ip, Phase: v1.PodRunning, Conditions: []v1.PodCondition{
+						{Type: v1.PodReady, Status: v1.ConditionTrue},
+					}},
+				}
+			}
+			svc := &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "cache", Namespace: "default"},
+				Spec:       v1.ServiceSpec{ClusterIP: "10.10.0.1", Ports: []v1.ServicePort{{Name: "grpc", Port: 18000}}},
+			}
+			if tc.native {
+				svc.Spec.TrafficDistribution = ptr.Of(v1.ServiceTrafficDistributionPreferClose)
+			} else {
+				svc.Annotations = map[string]string{annotation.NetworkingTrafficDistribution.Name: "PreferClose"}
+			}
+			slice := &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{Name: "cache", Namespace: "default", Labels: map[string]string{
+					discoveryv1.LabelServiceName: "cache",
+				}},
+				AddressType: discoveryv1.AddressTypeIPv4,
+				Ports:       []discoveryv1.EndpointPort{{Name: ptr.Of("grpc"), Port: ptr.Of(int32(18000))}},
+				Endpoints: []discoveryv1.Endpoint{
+					{
+						Addresses: []string{"10.0.1.1"}, TargetRef: &v1.ObjectReference{Kind: "Pod", Name: "cache1", Namespace: "default"},
+						Conditions: discoveryv1.EndpointConditions{Ready: ptr.Of(true)},
+					},
+					{
+						Addresses: []string{"10.0.1.2"}, TargetRef: &v1.ObjectReference{Kind: "Pod", Name: "cache2", Namespace: "default"},
+						Conditions: discoveryv1.EndpointConditions{Ready: ptr.Of(true)},
+					},
+				},
+			}
+			s := xdsfake.NewFakeDiscoveryServer(t, xdsfake.FakeOptions{
+				DefaultClusterName: "reader",
+				KubernetesObjectsByCluster: map[cluster.ID][]k8sruntime.Object{
+					"reader": {node("reader", "us-east-1d", "use1-az6"), pod("reader", "10.0.0.1")},
+					"cache": {
+						svc, slice,
+						node("cache1", "us-east-1d", "use1-az2"), pod("cache1", "10.0.1.1"),
+						node("cache2", "us-east-1a", tc.secondZoneID), pod("cache2", "10.0.1.2"),
+					},
+				},
+			})
+			metadata := model.NodeMetadata{ClusterID: "reader", Namespace: "default", NodeName: "reader", Generator: "grpc"}
+			ads := s.ConnectADS().WithType(v3.EndpointType)
+			defer ads.Cleanup()
+			response := ads.RequestResponseAck(t, &discovery.DiscoveryRequest{
+				ResourceNames: []string{"outbound|18000||cache.default.svc.cluster.local"},
+				Node: &core.Node{
+					Id:       "sidecar~10.0.0.1~reader.default~default.svc.cluster.local",
+					Metadata: metadata.ToStruct(),
+					Locality: &core.Locality{Region: "us-east-1", Zone: "us-east-1d"},
+				},
+			})
+			assignments := xdstest.UnmarshalClusterLoadAssignment(t, response.Resources)
+			assert.Equal(t, len(assignments), 1)
+			priorities := map[string]uint32{}
+			for _, locality := range assignments[0].Endpoints {
+				for _, ep := range locality.LbEndpoints {
+					priorities[ep.GetEndpoint().GetAddress().GetSocketAddress().Address] = locality.Priority
+				}
+			}
+			assert.Equal(t, priorities, tc.want)
+		})
+	}
+}
 
 func TestIncrementalPush(t *testing.T) {
 	s := xdsfake.NewFakeDiscoveryServer(t, xdsfake.FakeOptions{

--- a/releasenotes/notes/aws-zone-id-locality.yaml
+++ b/releasenotes/notes/aws-zone-id-locality.yaml
@@ -1,0 +1,13 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+- |
+  **Added** `PILOT_ENABLE_AWS_ZONE_ID` to prefer the physical AWS zone ID node labels that are
+  stable across AWS accounts for Kubernetes locality in sidecar and ambient modes. Disabled by
+  default.
+upgradeNotes:
+- title: Use AWS zone IDs for locality
+  content: |
+    Before enabling this option, check that all participating AWS nodes have the stable physical
+    zone ID labels: `topology.k8s.aws/zone-id`. This is a default in AWS EKS 1.30+.

--- a/releasenotes/notes/aws-zone-id-locality.yaml
+++ b/releasenotes/notes/aws-zone-id-locality.yaml
@@ -3,11 +3,15 @@ kind: feature
 area: traffic-management
 releaseNotes:
 - |
-  **Added** `PILOT_ENABLE_AWS_ZONE_ID` to prefer the physical AWS zone ID node labels that are
-  stable across AWS accounts for Kubernetes locality in sidecar and ambient modes. Disabled by
-  default.
+  **Added** support for physical AWS zone IDs in Kubernetes workload locality for sidecar and
+  ambient modes. Istio prefers nonempty canonical `topology.k8s.aws/zone-id` node labels when
+  present. `PILOT_ENABLE_AWS_ZONE_ID` defaults to `true`.
 upgradeNotes:
 - title: Use AWS zone IDs for locality
   content: |
-    Before enabling this option, check that all participating AWS nodes have the stable physical
-    zone ID labels: `topology.k8s.aws/zone-id`. This is a default in AWS EKS 1.30+.
+    Select `compatibilityVersion=1.31` or an earlier available profile to keep zone names. You can
+    also set `PILOT_ENABLE_AWS_ZONE_ID=false` on Istiod. For Helm overrides, use
+    `pilot.env.PILOT_ENABLE_AWS_ZONE_ID`.
+
+    Check node label coverage before using zone IDs. EKS supplies `topology.k8s.aws/zone-id` from
+    version 1.30.


### PR DESCRIPTION
**Please provide a description of this PR:**

#### Context

AWS zone names are logical and can identify _different_ physical zones across accounts. That is, Account A's `us-east-1a` is not guaranteed to be Account B's `us-east-1a`. 

AWS also has physical IDs that are _consistent_ across accounts. Account A's `use1-az1` is guaranteed to be Account B's `use1-az1`. These physical IDs are part of AWS EKS nodes from EKS 1.30+ in the node label: `topology.k8s.aws/zone-id`.

When locality preference is enabled, in the case of inter-cluster communication that spans AWS accounts on the same mesh network, Istio can give remote endpoints in other physical zones _local priority_ due to the current unreliable AWS zone name populated in the standard Kubernetes node label: `topology.kubernetes.io/zone`.

Related:
- [AWS provider #1185](https://github.com/kubernetes/cloud-provider-aws/issues/1185)
- [AWS provider #300](https://github.com/kubernetes/cloud-provider-aws/issues/300)

#### Intent

Add `PILOT_ENABLE_AWS_ZONE_ID` (default `false`) to prefer `topology.k8s.aws/zone-id` for Kubernetes workload locality in sidecar and ambient modes. The Service field and Istio annotation for PreferClose both use this locality, as does `DestinationRule...localityLbSetting`.

Missing labels retain the existing fallback. Explicit sidecar pod locality overrides retain precedence. Kubernetes node labels stay unchanged.

#### Notes

- I guarded this feature with `PILOT_ENABLE_AWS_ZONE_ID` but a point could be made for it to simply be default code. I can't think of a scenario where you wouldn't actually want this when locality is enabled. Will defer to reviewers for the call.

- Validation: registry tests cover the option, fallback, and pod overrides. Cross-account gRPC xDS tests cover both PreferClose forms and no local endpoint. Regression tests reject the original locality code.