### PR TITLE
Fix wasm imagefetcher https downgrade

### DIFF
--- a/pkg/wasm/imagefetcher.go
+++ b/pkg/wasm/imagefetcher.go
@@ -64,6 +64,10 @@ func (o ImageFetcherOption) String() string {
 
 type ImageFetcher struct {
 	fetchOpts []remote.Option
+	// insecure mirrors ImageFetcherOption.Insecure: whether the operator has explicitly
+	// allowlisted this registry (via WASM_INSECURE_REGISTRIES) to be accessed without
+	// transport security.
+	insecure bool
 }
 
 // ssrfProtectionTransport wraps http.RoundTripper to block SSRF via bearer realm
@@ -188,7 +192,17 @@ func NewImageFetcher(ctx context.Context, opt ImageFetcherOption) *ImageFetcher 
 
 	return &ImageFetcher{
 		fetchOpts: append(fetchOpts, remote.WithContext(ctx)),
+		insecure:  opt.Insecure,
 	}
+}
+
+// shouldRetryPlaintext reports whether PrepareFetch may retry a failed HTTPS fetch over
+// plaintext HTTP. The registry is untrusted input: a MITM or attacker-controlled registry
+// can trigger arbitrary error strings on the HTTPS attempt, so err alone must never be
+// sufficient to authorize a transport downgrade. Retrying is only safe for a registry the
+// operator has already, out of band, declared acceptable to speak to insecurely (insecure).
+func shouldRetryPlaintext(insecure bool, err error) bool {
+	return insecure && err != nil && strings.Contains(err.Error(), "server gave HTTP response")
 }
 
 // PrepareFetch is the entrypoint for fetching Wasm binary from Wasm Image Specification compatible images.
@@ -203,10 +217,11 @@ func (o *ImageFetcher) PrepareFetch(url string) (binaryFetcher func() ([]byte, e
 	wasmLog.Infof("fetching image %s from registry %s with tag %s", ref.Context().RepositoryStr(),
 		ref.Context().RegistryStr(), ref.Identifier())
 
-	// fallback to http based request, inspired by [helm](https://github.com/helm/helm/blob/12f1bc0acdeb675a8c50a78462ed3917fb7b2e37/pkg/registry/client.go#L594)
-	// only deal with https fallback instead of attributing all other type of errors to URL parsing error
+	// Fallback to a plaintext HTTP request, inspired by [helm](https://github.com/helm/helm/blob/12f1bc0acdeb675a8c50a78462ed3917fb7b2e37/pkg/registry/client.go#L594).
+	// Only retried when shouldRetryPlaintext allows it - i.e. for a registry the operator has
+	// already allowlisted as insecure, never on the strength of the registry's response alone.
 	desc, err := remote.Get(ref, o.fetchOpts...)
-	if err != nil && strings.Contains(err.Error(), "server gave HTTP response") {
+	if shouldRetryPlaintext(o.insecure, err) {
 		wasmLog.Infof("fetching image with plain text from %s", url)
 		ref, err = name.ParseReference(url, name.Insecure)
 		if err == nil {

--- a/pkg/wasm/imagefetcher.go
+++ b/pkg/wasm/imagefetcher.go
@@ -198,11 +198,11 @@ func NewImageFetcher(ctx context.Context, opt ImageFetcherOption) *ImageFetcher 
 
 // shouldRetryPlaintext reports whether PrepareFetch may retry a failed HTTPS fetch over
 // plaintext HTTP. The registry is untrusted input: a MITM or attacker-controlled registry
-// can trigger arbitrary error strings on the HTTPS attempt, so err alone must never be
+// can trigger arbitrary error strings on the HTTPS attempt, so fetchErr alone must never be
 // sufficient to authorize a transport downgrade. Retrying is only safe for a registry the
-// operator has already, out of band, declared acceptable to speak to insecurely (insecure).
-func shouldRetryPlaintext(insecure bool, fetchErr error) bool {
-	return insecure && fetchErr != nil && strings.Contains(fetchErr.Error(), "server gave HTTP response")
+// operator has already, out of band, declared acceptable to speak to insecurely (allowInsecureHTTPDowngrade).
+func shouldRetryPlaintext(allowInsecureHTTPDowngrade bool, fetchErr error) bool {
+	return allowInsecureHTTPDowngrade && fetchErr != nil && strings.Contains(fetchErr.Error(), "server gave HTTP response")
 }
 
 // PrepareFetch is the entrypoint for fetching Wasm binary from Wasm Image Specification compatible images.

--- a/pkg/wasm/imagefetcher.go
+++ b/pkg/wasm/imagefetcher.go
@@ -64,10 +64,10 @@ func (o ImageFetcherOption) String() string {
 
 type ImageFetcher struct {
 	fetchOpts []remote.Option
-	// insecure mirrors ImageFetcherOption.Insecure: whether the operator has explicitly
-	// allowlisted this registry (via WASM_INSECURE_REGISTRIES) to be accessed without
-	// transport security.
-	insecure bool
+	// allowInsecureHTTPDowngrade mirrors ImageFetcherOption.Insecure: whether the operator has
+	// explicitly allowlisted this registry (via WASM_INSECURE_REGISTRIES) to be accessed without
+	// transport security. This is what gates PrepareFetch's HTTPS-to-HTTP retry.
+	allowInsecureHTTPDowngrade bool
 }
 
 // ssrfProtectionTransport wraps http.RoundTripper to block SSRF via bearer realm
@@ -191,8 +191,8 @@ func NewImageFetcher(ctx context.Context, opt ImageFetcherOption) *ImageFetcher 
 	fetchOpts = append(fetchOpts, remote.WithTransport(&ssrfProtectionTransport{inner: transport}))
 
 	return &ImageFetcher{
-		fetchOpts: append(fetchOpts, remote.WithContext(ctx)),
-		insecure:  opt.Insecure,
+		fetchOpts:                  append(fetchOpts, remote.WithContext(ctx)),
+		allowInsecureHTTPDowngrade: opt.Insecure,
 	}
 }
 
@@ -201,8 +201,8 @@ func NewImageFetcher(ctx context.Context, opt ImageFetcherOption) *ImageFetcher 
 // can trigger arbitrary error strings on the HTTPS attempt, so err alone must never be
 // sufficient to authorize a transport downgrade. Retrying is only safe for a registry the
 // operator has already, out of band, declared acceptable to speak to insecurely (insecure).
-func shouldRetryPlaintext(insecure bool, err error) bool {
-	return insecure && err != nil && strings.Contains(err.Error(), "server gave HTTP response")
+func shouldRetryPlaintext(insecure bool, fetchErr error) bool {
+	return insecure && fetchErr != nil && strings.Contains(fetchErr.Error(), "server gave HTTP response")
 }
 
 // PrepareFetch is the entrypoint for fetching Wasm binary from Wasm Image Specification compatible images.
@@ -222,7 +222,7 @@ func (o *ImageFetcher) PrepareFetch(url string) (binaryFetcher func() ([]byte, e
 	// Only retried when shouldRetryPlaintext allows it - i.e. for a registry the operator has
 	// already allowlisted as insecure, never on the base of the registry's response alone.
 	desc, err := remote.Get(ref, o.fetchOpts...)
-	if shouldRetryPlaintext(o.insecure, err) {
+	if shouldRetryPlaintext(o.allowInsecureHTTPDowngrade, err) {
 		wasmLog.Infof("fetching image with plain text from %s", url)
 		ref, err = name.ParseReference(url, name.Insecure)
 		if err == nil {

--- a/pkg/wasm/imagefetcher.go
+++ b/pkg/wasm/imagefetcher.go
@@ -217,9 +217,10 @@ func (o *ImageFetcher) PrepareFetch(url string) (binaryFetcher func() ([]byte, e
 	wasmLog.Infof("fetching image %s from registry %s with tag %s", ref.Context().RepositoryStr(),
 		ref.Context().RegistryStr(), ref.Identifier())
 
-	// Fallback to a plaintext HTTP request, inspired by [helm](https://github.com/helm/helm/blob/12f1bc0acdeb675a8c50a78462ed3917fb7b2e37/pkg/registry/client.go#L594).
+	// Fallback to a plaintext HTTP request, inspired by helm's registry client
+	// (https://github.com/helm/helm/blob/12f1bc0acdeb675a8c50a78462ed3917fb7b2e37/pkg/registry/client.go#L594).
 	// Only retried when shouldRetryPlaintext allows it - i.e. for a registry the operator has
-	// already allowlisted as insecure, never on the strength of the registry's response alone.
+	// already allowlisted as insecure, never on the base of the registry's response alone.
 	desc, err := remote.Get(ref, o.fetchOpts...)
 	if shouldRetryPlaintext(o.insecure, err) {
 		wasmLog.Infof("fetching image with plain text from %s", url)

--- a/pkg/wasm/imagefetcher_test.go
+++ b/pkg/wasm/imagefetcher_test.go
@@ -21,8 +21,10 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"reflect"
@@ -265,6 +267,82 @@ func TestImageFetcher_Fetch(t *testing.T) {
 			t.Errorf("ImageFetcher.binaryFetcher get unexpected error '%v', but want '%v'", actual, expErr)
 		}
 	})
+}
+
+// TestShouldRetryPlaintext guards against pswg#24: a registry response must never be
+// sufficient on its own to authorize retrying over plaintext HTTP.
+func TestShouldRetryPlaintext(t *testing.T) {
+	downgradeErr := errors.New("http: server gave HTTP response to HTTPS client")
+	otherErr := errors.New("dial tcp: connection refused")
+
+	cases := []struct {
+		name     string
+		insecure bool
+		err      error
+		want     bool
+	}{
+		{name: "not allowlisted, downgrade signal: no retry", insecure: false, err: downgradeErr, want: false},
+		{name: "allowlisted, downgrade signal: retry", insecure: true, err: downgradeErr, want: true},
+		{name: "allowlisted, unrelated error: no retry", insecure: true, err: otherErr, want: false},
+		{name: "allowlisted, no error: no retry", insecure: true, err: nil, want: false},
+		{name: "not allowlisted, no error: no retry", insecure: false, err: nil, want: false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := shouldRetryPlaintext(c.insecure, c.err); got != c.want {
+				t.Errorf("shouldRetryPlaintext(%v, %v) = %v, want %v", c.insecure, c.err, got, c.want)
+			}
+		})
+	}
+}
+
+// schemeAwareErrorTransport always fails, but the error text reveals which scheme the
+// request actually went out on - letting a test tell a plaintext retry apart from the
+// original HTTPS attempt without needing a real TLS handshake or a second registry.
+type schemeAwareErrorTransport struct{}
+
+func (schemeAwareErrorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.Scheme == "https" {
+		return nil, errors.New("http: server gave HTTP response to HTTPS client")
+	}
+	return nil, errors.New("plaintext attempt reached the wire")
+}
+
+// TestImageFetcher_PrepareFetch_HTTPSDowngrade guards against pswg#24 end-to-end through
+// the real PrepareFetch: an HTTPS failure that looks exactly like the registry
+// TLS-downgrade signal must only trigger a plaintext retry when the operator has already,
+// out of band, allowlisted this registry as insecure - never based on the response alone.
+func TestImageFetcher_PrepareFetch_HTTPSDowngrade(t *testing.T) {
+	cases := []struct {
+		name          string
+		insecure      bool
+		expectRetried bool
+	}{
+		{name: "not allowlisted: stays on HTTPS, no plaintext attempt", insecure: false, expectRetried: false},
+		{name: "allowlisted: plaintext retry attempted", insecure: true, expectRetried: true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fetcher := &ImageFetcher{
+				fetchOpts: []remote.Option{remote.WithTransport(schemeAwareErrorTransport{}), remote.WithAuth(authn.Anonymous)},
+				insecure:  c.insecure,
+			}
+
+			_, _, err := fetcher.PrepareFetch("example.com/some/image:latest")
+			if err == nil {
+				t.Fatal("expected an error since the transport never succeeds")
+			}
+
+			retried := strings.Contains(err.Error(), "plaintext attempt reached the wire")
+			if retried != c.expectRetried {
+				t.Errorf("got err %q (plaintext retry observed=%v), want retried=%v", err, retried, c.expectRetried)
+			}
+			if !c.insecure && !strings.Contains(err.Error(), "server gave HTTP response") {
+				t.Errorf("expected the original HTTPS error to surface unmodified, got: %v", err)
+			}
+		})
+	}
 }
 
 func TestExtractDockerImage(t *testing.T) {

--- a/pkg/wasm/imagefetcher_test.go
+++ b/pkg/wasm/imagefetcher_test.go
@@ -269,8 +269,6 @@ func TestImageFetcher_Fetch(t *testing.T) {
 	})
 }
 
-// TestShouldRetryPlaintext guards against pswg#24: a registry response must never be
-// sufficient on its own to authorize retrying over plaintext HTTP.
 func TestShouldRetryPlaintext(t *testing.T) {
 	downgradeErr := errors.New("http: server gave HTTP response to HTTPS client")
 	otherErr := errors.New("dial tcp: connection refused")
@@ -308,10 +306,6 @@ func (schemeAwareErrorTransport) RoundTrip(req *http.Request) (*http.Response, e
 	return nil, errors.New("plaintext attempt reached the wire")
 }
 
-// TestImageFetcher_PrepareFetch_HTTPSDowngrade guards against pswg#24 end-to-end through
-// the real PrepareFetch: an HTTPS failure that looks exactly like the registry
-// TLS-downgrade signal must only trigger a plaintext retry when the operator has already,
-// out of band, allowlisted this registry as insecure - never based on the response alone.
 func TestImageFetcher_PrepareFetch_HTTPSDowngrade(t *testing.T) {
 	cases := []struct {
 		name          string

--- a/pkg/wasm/imagefetcher_test.go
+++ b/pkg/wasm/imagefetcher_test.go
@@ -319,8 +319,8 @@ func TestImageFetcher_PrepareFetch_HTTPSDowngrade(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			fetcher := &ImageFetcher{
-				fetchOpts: []remote.Option{remote.WithTransport(schemeAwareErrorTransport{}), remote.WithAuth(authn.Anonymous)},
-				insecure:  c.insecure,
+				fetchOpts:                  []remote.Option{remote.WithTransport(schemeAwareErrorTransport{}), remote.WithAuth(authn.Anonymous)},
+				allowInsecureHTTPDowngrade: c.insecure,
 			}
 
 			_, _, err := fetcher.PrepareFetch("example.com/some/image:latest")

--- a/releasenotes/notes/wasm-imagefetcher-https-downgrade.yaml
+++ b/releasenotes/notes/wasm-imagefetcher-https-downgrade.yaml
@@ -1,0 +1,12 @@
+apiVersion: release-notes/v2
+kind: security-fix
+area: extensibility
+issue: []
+releaseNotes:
+  - |
+    **Fixed** the Wasm OCI image fetcher deciding to retry a failed HTTPS fetch over
+    plaintext HTTP based on the error returned by the registry. Since the registry is
+    untrusted input, a MITM or malicious registry could trigger this fallback on demand
+    to force plaintext transport and, without an optional module digest pinned, serve an
+    arbitrary Wasm binary. The plaintext retry is now only attempted for registries the
+    operator has explicitly allowlisted via `WASM_INSECURE_REGISTRIES`.

--- a/releasenotes/notes/wasm-imagefetcher-https-downgrade.yaml
+++ b/releasenotes/notes/wasm-imagefetcher-https-downgrade.yaml
@@ -10,3 +10,5 @@ releaseNotes:
     to force plaintext transport and, without an optional module digest pinned, serve an
     arbitrary Wasm binary. The plaintext retry is now only attempted for registries the
     operator has explicitly allowlisted via `WASM_INSECURE_REGISTRIES`.
+
+    **Credit**: This vulnerability was discovered and reported by Adam Korczynski.


### PR DESCRIPTION
**Please provide a description of this PR:**

- the Wasm OCI image fetcher deciding to retry a failed HTTPS fetch over plaintext HTTP based on the error returned by the registry. The plaintext retry is now only attempted for registries the operator has explicitly allowlisted via `WASM_INSECURE_REGISTRIES