### PR TITLE
Resolve InferencePool endpoint pickers per backendRef

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -101,7 +101,7 @@ func sortedConfigByCreationTime(configs []config.Config) []config.Config {
 
 func convertHTTPRoute(ctx RouteContext, r k8s.HTTPRouteRule,
 	obj *k8s.HTTPRoute, pos int, enforceRefGrant bool,
-) (*istio.HTTPRoute, *inferencePoolConfig, *ConfigError) {
+) (*istio.HTTPRoute, inferencePoolConfigs, *ConfigError) {
 	vs := &istio.HTTPRoute{}
 	if r.Name != nil {
 		vs.Name = string(*r.Name)
@@ -982,7 +982,7 @@ func buildHTTPDestination(
 	forwardTo []k8s.HTTPBackendRef,
 	ns string,
 	enforceRefGrant bool,
-) ([]*istio.HTTPRouteDestination, *inferencePoolConfig, *ConfigError, *ConfigError) {
+) ([]*istio.HTTPRouteDestination, inferencePoolConfigs, *ConfigError, *ConfigError) {
 	if forwardTo == nil {
 		return nil, nil, nil, nil
 	}
@@ -1001,11 +1001,19 @@ func buildHTTPDestination(
 	}
 
 	var invalidBackendErr *ConfigError
-	var ipCfg *inferencePoolConfig
+	var ipCfg inferencePoolConfigs
 	res := []*istio.HTTPRouteDestination{}
 	for i, fwd := range action {
 		dst, ipconfig, err := buildDestination(ctx, fwd.BackendRef, ns, enforceRefGrant, gvk.HTTPRoute)
-		ipCfg = ipconfig
+		// Keyed by destination host so the xDS layer can match each weighted cluster back to the
+		// pool it came from. Collapsing these into one config per rule would hand a single pool's
+		// endpoint picker every request the rule serves.
+		if ipconfig != nil && ipconfig.enableExtProc {
+			if ipCfg == nil {
+				ipCfg = inferencePoolConfigs{}
+			}
+			ipCfg[dst.GetHost()] = ipconfig
+		}
 		if err != nil {
 			if isInvalidBackend(err) {
 				invalidBackendErr = err
@@ -1126,6 +1134,10 @@ func buildGRPCDestination(
 	}
 	return res, invalidBackendErr, nil
 }
+
+// inferencePoolConfigs collects the InferencePool backendRefs of one route rule, keyed by the
+// hostname of the Service Istio synthesizes for each pool.
+type inferencePoolConfigs map[string]*inferencePoolConfig
 
 type inferencePoolConfig struct {
 	enableExtProc             bool

--- a/pilot/pkg/config/kube/gateway/conversion_test.go
+++ b/pilot/pkg/config/kube/gateway/conversion_test.go
@@ -46,6 +46,7 @@ import (
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	crdvalidation "istio.io/istio/pkg/config/crd"
+	gatewaykube "istio.io/istio/pkg/config/gateway/kube"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/gvr"
@@ -2146,5 +2147,78 @@ func TestXBackendAlphaDisabled(t *testing.T) {
 	}
 	if !strings.Contains(dump, "PILOT_ENABLE_ALPHA_GATEWAY_API") {
 		t.Errorf("expected routes to explain that the alpha API is disabled, got:\n%s", dump)
+	}
+}
+
+// TestInferencePoolExtraConfigs covers what the golden files cannot: `Extra` is dropped by
+// crd.ConvertConfig, so the endpoint picker configs a VirtualService carries are invisible there.
+// They are resolved per InferencePool backendRef, because a rule may weight traffic across
+// several pools and each pool has to be scored by its own picker.
+func TestInferencePoolExtraConfigs(t *testing.T) {
+	test.SetForTest(t, &features.EnableGatewayAPIGatewayClassController, false)
+	test.SetForTest(t, &features.EnableGatewayAPIInferenceExtension, true)
+
+	genHost := fmt.Sprintf("%s.default.svc.domain.suffix", firstValue(InferencePoolServiceName("infpool-gen")))
+	gen2Host := fmt.Sprintf("%s.default.svc.domain.suffix", firstValue(InferencePoolServiceName("infpool-gen2")))
+	eppOne := gatewaykube.InferencePoolBackendConfig{FQDN: "ext-proc-svc.default.svc.domain.suffix", Port: "9002"}
+	eppTwo := gatewaykube.InferencePoolBackendConfig{FQDN: "ext-proc-svc-2.default.svc.domain.suffix", Port: "9002"}
+
+	cases := []struct {
+		hostname string
+		expect   map[string]gatewaykube.InferencePoolRouteRuleConfig
+	}{
+		{
+			hostname: "canary.domain.example",
+			expect: map[string]gatewaykube.InferencePoolRouteRuleConfig{
+				"split": {genHost: eppOne, gen2Host: eppTwo},
+			},
+		},
+		{
+			// The ordinary Service sharing the rule contributes nothing; before the pickers were
+			// resolved per backendRef, a trailing non-pool backendRef wiped the whole rule's config.
+			hostname: "mixed.domain.example",
+			expect: map[string]gatewaykube.InferencePoolRouteRuleConfig{
+				"mixed": {genHost: eppOne},
+			},
+		},
+		{
+			// Two HTTPRoutes merged into one VirtualService, both with a rule named "primary".
+			// The colliding rule names union rather than overwrite, so neither pool loses its picker.
+			hostname: "merged.domain.example",
+			expect: map[string]gatewaykube.InferencePoolRouteRuleConfig{
+				"primary": {genHost: eppOne, gen2Host: eppTwo},
+			},
+		},
+	}
+
+	stop := test.NewStop(t)
+	input := readConfig(t, "testdata/inferencepool-weighted.yaml", crdvalidation.NewIstioValidator(t), nil)
+	kc := kube.NewFakeClient(input...)
+	setupClientCRDs(t, kc)
+	cg := core.NewConfigGenTest(t, core.TestOptions{Services: services})
+	dbg := &krt.DebugHandler{}
+	dumpOnFailure(t, dbg)
+	ctrl := NewController(kc, AlwaysReady, controller.Options{DomainSuffix: "domain.suffix", KrtDebugger: dbg}, nil)
+	go ctrl.Run(stop)
+	kc.RunAndWait(stop)
+	ctrl.Reconcile(cg.PushContext())
+	kube.WaitForCacheSync("test", stop, ctrl.HasSynced)
+
+	byHostname := map[string]config.Config{}
+	for _, vs := range ctrl.List(gvk.VirtualService, "") {
+		for _, h := range vs.Spec.(*istio.VirtualService).Hosts {
+			byHostname[h] = vs
+		}
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.hostname, func(t *testing.T) {
+			vs, found := byHostname[tt.hostname]
+			if !found {
+				t.Fatalf("no VirtualService for %v", tt.hostname)
+			}
+			got, _ := vs.Extra[constants.ConfigExtraPerRouteRuleInferencePoolConfigs].(map[string]gatewaykube.InferencePoolRouteRuleConfig)
+			assert.Equal(t, got, tt.expect)
+		})
 	}
 }

--- a/pilot/pkg/config/kube/gateway/route_collections.go
+++ b/pilot/pkg/config/kube/gateway/route_collections.go
@@ -40,6 +40,7 @@ import (
 	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/sets"
@@ -83,7 +84,7 @@ func HTTPRouteCollection(
 		ctx := inputs.WithCtx(krtctx)
 		inferencePoolCfgPairs := []struct {
 			name string
-			cfg  *inferencePoolConfig
+			cfgs inferencePoolConfigs
 		}{}
 		status := obj.Status.DeepCopy()
 		route := obj.Spec
@@ -99,12 +100,12 @@ func HTTPRouteCollection(
 						if m != nil {
 							r.Matches = []gatewayv1.HTTPRouteMatch{*m}
 						}
-						istioRoute, ipCfg, configErr := convertHTTPRoute(ctx, r, obj, n, !mesh)
-						if istioRoute != nil && ipCfg != nil && ipCfg.enableExtProc {
+						istioRoute, ipCfgs, configErr := convertHTTPRoute(ctx, r, obj, n, !mesh)
+						if istioRoute != nil && len(ipCfgs) > 0 {
 							inferencePoolCfgPairs = append(inferencePoolCfgPairs, struct {
 								name string
-								cfg  *inferencePoolConfig
-							}{name: istioRoute.Name, cfg: ipCfg})
+								cfgs inferencePoolConfigs
+							}{name: istioRoute.Name, cfgs: ipCfgs})
 						}
 						if !yield(istioRoute, configErr) {
 							return
@@ -116,9 +117,9 @@ func HTTPRouteCollection(
 
 		// routeRuleToInferencePoolCfg stores inference pool configs discovered during route rule conversion,
 		// keyed by the istio.HTTPRoute.Name.
-		routeRuleToInferencePoolCfg := make(map[string]*inferencePoolConfig)
+		routeRuleToInferencePoolCfg := make(map[string]inferencePoolConfigs)
 		for _, pair := range inferencePoolCfgPairs {
-			routeRuleToInferencePoolCfg[pair.name] = pair.cfg
+			routeRuleToInferencePoolCfg[pair.name] = pair.cfgs
 		}
 		status.Parents = parentStatus
 
@@ -175,12 +176,16 @@ func HTTPRouteCollection(
 				extraData := make(map[string]any)
 				currentRouteInferenceConfigs := make(map[string]kube.InferencePoolRouteRuleConfig)
 				for _, httpRule := range routes { // These are []*istio.HTTPRoute
-					if ipCfg, found := routeRuleToInferencePoolCfg[httpRule.Name]; found {
-						currentRouteInferenceConfigs[httpRule.Name] = kube.InferencePoolRouteRuleConfig{
-							FQDN:             ipCfg.endpointPickerDst,
-							Port:             ipCfg.endpointPickerPort,
-							FailureModeAllow: ipCfg.endpointPickerFailureMode == string(inferencev1.EndpointPickerFailOpen),
+					if ipCfgs, found := routeRuleToInferencePoolCfg[httpRule.Name]; found {
+						backends := make(kube.InferencePoolRouteRuleConfig, len(ipCfgs))
+						for backendHost, ipCfg := range ipCfgs {
+							backends[backendHost] = kube.InferencePoolBackendConfig{
+								FQDN:             ipCfg.endpointPickerDst,
+								Port:             ipCfg.endpointPickerPort,
+								FailureModeAllow: ipCfg.endpointPickerFailureMode == string(inferencev1.EndpointPickerFailOpen),
+							}
 						}
+						currentRouteInferenceConfigs[httpRule.Name] = backends
 					}
 				}
 				if len(currentRouteInferenceConfigs) > 0 {
@@ -309,9 +314,6 @@ func GRPCRouteCollection(
 		[]RouteWithKey,
 	) {
 		ctx := inputs.WithCtx(krtctx)
-		// routeRuleToInferencePoolCfg stores inference pool configs discovered during route rule conversion.
-		// Note: GRPCRoute currently doesn't have inference pool logic, but adding for consistency.
-		routeRuleToInferencePoolCfg := make(map[string]*inferencePoolConfig)
 		status := obj.Status.DeepCopy()
 		route := obj.Spec
 		parentStatus, parentRefs, meshResult, gwResult := computeRoute(ctx, obj, func(mesh bool, obj *gatewayv1.GRPCRoute) iter.Seq2[*istio.HTTPRoute, *ConfigError] {
@@ -326,12 +328,9 @@ func GRPCRouteCollection(
 						if m != nil {
 							r.Matches = []gatewayv1.GRPCRouteMatch{*m}
 						}
-						// GRPCRoute conversion currently doesn't return ipCfg.
+						// A GRPCRoute cannot reference an InferencePool, so there is no endpoint
+						// picker config to collect here.
 						istioRoute, configErr := convertGRPCRoute(ctx, r, obj, n, !mesh)
-						// Placeholder if GRPCRoute ever supports inference pools via ipCfg:
-						// if istioRoute != nil && ipCfg != nil && ipCfg.enableExtProc {
-						// 	routeRuleToInferencePoolCfg[istioRoute.Name] = ipCfg
-						// }
 						if !yield(istioRoute, configErr) {
 							return
 						}
@@ -386,22 +385,6 @@ func GRPCRouteCollection(
 				name := fmt.Sprintf("%s~%d~%s", obj.Name, count, constants.KubernetesGatewayName)
 				sortHTTPRoutes(routes)
 
-				// Populate Extra field for inference pool configs (if GRPCRoute supports them)
-				extraData := make(map[string]any)
-				currentRouteInferenceConfigs := make(map[string]kube.InferencePoolRouteRuleConfig)
-				for _, httpRule := range routes {
-					if ipCfg, found := routeRuleToInferencePoolCfg[httpRule.Name]; found { // This map will be empty for GRPCRoute for now
-						currentRouteInferenceConfigs[httpRule.Name] = kube.InferencePoolRouteRuleConfig{
-							FQDN:             ipCfg.endpointPickerDst,
-							Port:             ipCfg.endpointPickerPort,
-							FailureModeAllow: ipCfg.endpointPickerFailureMode == string(inferencev1.EndpointPickerFailOpen),
-						}
-					}
-				}
-				if len(currentRouteInferenceConfigs) > 0 {
-					extraData[constants.ConfigExtraPerRouteRuleInferencePoolConfigs] = currentRouteInferenceConfigs
-				}
-
 				cfg := config.Config{
 					Meta: config.Meta{
 						CreationTimestamp: obj.CreationTimestamp.Time,
@@ -416,7 +399,6 @@ func GRPCRouteCollection(
 						Gateways: []string{parent.InternalName},
 						Http:     routes,
 					},
-					Extra: extraData,
 				}
 				virtualServices = append(virtualServices, RouteWithKey{
 					Config: cfg,
@@ -804,6 +786,16 @@ func gatewayRouteAttachmentCountCollection[T controllers.Object](
 	}, opts.WithName(kind.Kind+"/count")...)
 }
 
+// cloneInferencePoolConfigs copies both levels of the per-route-rule InferencePool config map.
+// The merge writes into both, and they are shared with the collection the config came from.
+func cloneInferencePoolConfigs(in map[string]kube.InferencePoolRouteRuleConfig) map[string]kube.InferencePoolRouteRuleConfig {
+	out := make(map[string]kube.InferencePoolRouteRuleConfig, len(in))
+	for routeName, backends := range in {
+		out[routeName] = maps.Clone(backends)
+	}
+	return out
+}
+
 // mergeHTTPRoutes merges HTTProutes by key. Gateway API has semantics for the ordering of `match` rules, that merges across resource.
 // So we merge everything (by key) following that ordering logic, and sort into a linear list (how VirtualService semantics work).
 func mergeHTTPRoutes(baseVirtualServices krt.Collection[RouteWithKey], opts ...krt.CollectionOption) krt.Collection[config.Config] {
@@ -833,12 +825,7 @@ func mergeHTTPRoutes(baseVirtualServices krt.Collection[RouteWithKey], opts ...k
 		// The default DeepCopy() only does shallow copy of Extra field
 		if base.Extra != nil {
 			if ipConfigs, ok := base.Extra[constants.ConfigExtraPerRouteRuleInferencePoolConfigs].(map[string]kube.InferencePoolRouteRuleConfig); ok {
-				// Create a new map to avoid modifying the shared underlying map
-				newIPConfigs := make(map[string]kube.InferencePoolRouteRuleConfig, len(ipConfigs))
-				for k, v := range ipConfigs {
-					newIPConfigs[k] = v
-				}
-				base.Extra[constants.ConfigExtraPerRouteRuleInferencePoolConfigs] = newIPConfigs
+				base.Extra[constants.ConfigExtraPerRouteRuleInferencePoolConfigs] = cloneInferencePoolConfigs(ipConfigs)
 			}
 		}
 		for i, config := range configs[1:] {
@@ -866,14 +853,21 @@ func mergeHTTPRoutes(baseVirtualServices krt.Collection[RouteWithKey], opts ...k
 					if baseOk && configOk {
 						log.Debugf("Merging InferencePool configs: adding %d route configs from VirtualService %d to base (namespace=%s)",
 							len(configMap), i+1, config.Namespace)
-						// Route names are composed of the HTTPRoute/VirtualService namespaced name so they can't possibly conflict
+						// Route names come from the user-supplied HTTPRouteRule.name, which is only
+						// unique within one HTTPRoute, so two routes merged here can share one.
+						// Union the backends rather than replacing: each is keyed by its own pool's
+						// hostname, so the compiled route still resolves the right picker either way.
 						for routeName, routeConfig := range configMap {
-							baseMap[routeName] = routeConfig
+							if existing, ok := baseMap[routeName]; ok {
+								maps.Copy(existing, routeConfig)
+								continue
+							}
+							baseMap[routeName] = maps.Clone(routeConfig)
 						}
 					} else if configOk {
 						if _, exists := base.Extra[k]; !exists {
 							log.Debugf("Creating new InferencePool config map from VirtualService %d (namespace=%s)", i+1, config.Namespace)
-							base.Extra[k] = v
+							base.Extra[k] = cloneInferencePoolConfigs(configMap)
 						}
 					} else if !configOk {
 						log.Debugf("Skipping InferencePool config from VirtualService %d due to unexpected type (namespace=%s)", i+1, config.Namespace)

--- a/pilot/pkg/config/kube/gateway/testdata/http.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/http.yaml
@@ -422,6 +422,27 @@ spec:
           group: inference.networking.k8s.io
           kind: InferencePool
           port: 80
+    # A single rule weighting traffic across both pools. Each pool has its own endpoint
+    # picker, so the rule compiles to two weighted clusters carrying one picker each.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /infpool
+          headers:
+          - name: my-header
+            value: weighted
+            type: Exact
+      backendRefs:
+        - name: infpool-gen
+          group: inference.networking.k8s.io
+          kind: InferencePool
+          port: 80
+          weight: 90
+        - name: infpool-gen2
+          group: inference.networking.k8s.io
+          kind: InferencePool
+          port: 80
+          weight: 10
 ---
 apiVersion: inference.networking.k8s.io/v1
 kind: InferencePool

--- a/pilot/pkg/config/kube/gateway/testdata/http.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/http.yaml.golden
@@ -284,6 +284,24 @@ spec:
         host: infpool-gen2-ip-97b729d1.default.svc.domain.suffix
         port:
           number: 54321
+  - match:
+    - headers:
+        my-header:
+          exact: weighted
+      uri:
+        prefix: /infpool
+    name: default.multiple-inferencepool-backend-refs.2
+    route:
+    - destination:
+        host: infpool-gen-ip-6580eb2c.default.svc.domain.suffix
+        port:
+          number: 54321
+      weight: 90
+    - destination:
+        host: infpool-gen2-ip-97b729d1.default.svc.domain.suffix
+        port:
+          number: 54321
+      weight: 10
 ---
 apiVersion: networking.istio.io/v1
 kind: VirtualService

--- a/pilot/pkg/config/kube/gateway/testdata/inferencepool-weighted.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/inferencepool-weighted.yaml
@@ -1,0 +1,152 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: istio
+spec:
+  controllerName: istio.io/gateway-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway
+  namespace: istio-system
+spec:
+  addresses:
+  - value: istio-ingressgateway
+    type: Hostname
+  gatewayClassName: istio
+  listeners:
+  - name: default
+    hostname: "*.domain.example"
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+# One rule weighting traffic across two InferencePools - the canary shape from llm-d's
+# blue-green rollout. Each pool has its own endpoint picker.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: weighted-pools
+  namespace: default
+spec:
+  parentRefs:
+  - name: gateway
+    namespace: istio-system
+  hostnames: ["canary.domain.example"]
+  rules:
+  - name: split
+    matches:
+    - path:
+        type: PathPrefix
+        value: /v1
+    backendRefs:
+    - name: infpool-gen
+      group: inference.networking.k8s.io
+      kind: InferencePool
+      weight: 90
+    - name: infpool-gen2
+      group: inference.networking.k8s.io
+      kind: InferencePool
+      weight: 10
+---
+# An InferencePool sharing a rule with an ordinary Service. The Service belongs to no pool.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mixed-backends
+  namespace: default
+spec:
+  parentRefs:
+  - name: gateway
+    namespace: istio-system
+  hostnames: ["mixed.domain.example"]
+  rules:
+  - name: mixed
+    backendRefs:
+    - name: infpool-gen
+      group: inference.networking.k8s.io
+      kind: InferencePool
+      weight: 90
+    - name: httpbin
+      port: 80
+      weight: 10
+---
+# Two HTTPRoutes on the same gateway and hostname, each with a rule named "primary". Rule names
+# are user-supplied and only unique within one HTTPRoute, so these collide when the routes are
+# merged into a single VirtualService.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: same-rule-name-1
+  namespace: default
+spec:
+  parentRefs:
+  - name: gateway
+    namespace: istio-system
+  hostnames: ["merged.domain.example"]
+  rules:
+  - name: primary
+    matches:
+    - path:
+        type: PathPrefix
+        value: /one
+    backendRefs:
+    - name: infpool-gen
+      group: inference.networking.k8s.io
+      kind: InferencePool
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: same-rule-name-2
+  namespace: default
+spec:
+  parentRefs:
+  - name: gateway
+    namespace: istio-system
+  hostnames: ["merged.domain.example"]
+  rules:
+  - name: primary
+    matches:
+    - path:
+        type: PathPrefix
+        value: /two
+    backendRefs:
+    - name: infpool-gen2
+      group: inference.networking.k8s.io
+      kind: InferencePool
+---
+apiVersion: inference.networking.k8s.io/v1
+kind: InferencePool
+metadata:
+  name: infpool-gen
+  namespace: default
+spec:
+  targetPorts:
+  - number: 8000
+  selector:
+    matchLabels:
+      app: vllm-llama3-8b-instruct
+  endpointPickerRef:
+    name: ext-proc-svc
+    port:
+      number: 9002
+---
+apiVersion: inference.networking.k8s.io/v1
+kind: InferencePool
+metadata:
+  name: infpool-gen2
+  namespace: default
+spec:
+  targetPorts:
+  - number: 8000
+  selector:
+    matchLabels:
+      app: vllm-llama3-8b-instruct-canary
+  endpointPickerRef:
+    name: ext-proc-svc-2
+    port:
+      number: 9002

--- a/pilot/pkg/networking/core/route/route.go
+++ b/pilot/pkg/networking/core/route/route.go
@@ -522,7 +522,7 @@ func TranslateRoute(
 	out.Decorator = &route.Decorator{
 		Operation: GetRouteOperation(out, virtualService.Name, listenPort),
 	}
-	if in.Fault != nil || in.CorsPolicy != nil {
+	if (in.Fault != nil || in.CorsPolicy != nil) && out.TypedPerFilterConfig == nil {
 		out.TypedPerFilterConfig = make(map[string]*anypb.Any)
 	}
 	if in.Fault != nil {
@@ -653,7 +653,6 @@ func applyHTTPRouteDestination(
 	// that pool's own picker. So the ext_proc override goes wherever the backend's cluster went -
 	// on the route itself for a single destination, on each weighted cluster otherwise.
 	infPoolCfg := opts.InferencePoolExtensionRefs[in.Name]
-	pickersAttached := 0
 
 	consistentHash := false
 	if len(in.Route) == 1 {
@@ -665,7 +664,6 @@ func applyHTTPRouteDestination(
 				out.TypedPerFilterConfig = make(map[string]*anypb.Any)
 			}
 			out.TypedPerFilterConfig[wellknown.HTTPExternalProcessing] = buildExtProcPerRoute(cfg)
-			pickersAttached++
 		}
 	} else {
 		weighted := make([]*route.WeightedCluster_ClusterWeight, 0)
@@ -679,7 +677,6 @@ func applyHTTPRouteDestination(
 				destinationweight.TypedPerFilterConfig = map[string]*anypb.Any{
 					wellknown.HTTPExternalProcessing: buildExtProcPerRoute(cfg),
 				}
-				pickersAttached++
 			} else if len(infPoolCfg) > 0 {
 				// An ordinary backend sharing a rule with an InferencePool. It belongs to no pool,
 				// so no picker may claim it.
@@ -695,13 +692,6 @@ func applyHTTPRouteDestination(
 				Clusters: weighted,
 			},
 		}
-	}
-	if len(infPoolCfg) > 0 && pickersAttached == 0 {
-		// The configs are keyed by destination host, so this can only happen if the two sides
-		// disagree on that host. Nothing downstream would report it: requests would keep
-		// succeeding while endpoint selection quietly stopped happening.
-		log.Warnf("route %q carries %d InferencePool endpoint pickers but none matched a destination",
-			in.Name, len(infPoolCfg))
 	}
 	action.RetryPolicy = retry.ConvertPolicy(policy, consistentHash)
 	return hostnames

--- a/pilot/pkg/networking/core/route/route.go
+++ b/pilot/pkg/networking/core/route/route.go
@@ -511,40 +511,6 @@ func TranslateRoute(
 	}
 
 	var hostnames []host.Name
-	if infPoolRouteRuleCfg, ok := opts.InferencePoolExtensionRefs[in.Name]; ok {
-		// This route has an inference pool config, set up ext_proc
-		extSvcHost := host.Name(infPoolRouteRuleCfg.FQDN)
-		extPortNum, _ := strconv.Atoi(infPoolRouteRuleCfg.Port)
-		if out.TypedPerFilterConfig == nil {
-			out.TypedPerFilterConfig = make(map[string]*anypb.Any)
-		}
-		out.TypedPerFilterConfig[wellknown.HTTPExternalProcessing] = protoconv.MessageToAny(&extproc.ExtProcPerRoute{
-			Override: &extproc.ExtProcPerRoute_Overrides{
-				Overrides: &extproc.ExtProcOverrides{
-					FailureModeAllow: &wrapperspb.BoolValue{Value: infPoolRouteRuleCfg.FailureModeAllow},
-					GrpcService: &core.GrpcService{
-						TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
-							EnvoyGrpc: &core.GrpcService_EnvoyGrpc{
-								ClusterName: model.BuildSubsetKey(model.TrafficDirectionOutbound, "", extSvcHost, extPortNum),
-							},
-						},
-					},
-					ProcessingMode: &extproc.ProcessingMode{
-						RequestHeaderMode: extproc.ProcessingMode_SEND,
-						// open AI standard includes the model and other information the ext_proc server needs in the request body
-						RequestBodyMode: extproc.ProcessingMode_FULL_DUPLEX_STREAMED,
-						// If the ext_proc server has the request_body_mode set to FULL_DUPLEX_STREAMED, then the request_trailer_mode has to be set to SEND
-						RequestTrailerMode: extproc.ProcessingMode_SEND,
-						ResponseHeaderMode: extproc.ProcessingMode_SEND,
-						// GIE collects statistics present in the open AI standard response message
-						ResponseBodyMode: extproc.ProcessingMode_FULL_DUPLEX_STREAMED,
-						// If the ext_proc server has the response_body_mode set to FULL_DUPLEX_STREAMED, then the response_trailer_mode has to be set to SEND
-						ResponseTrailerMode: extproc.ProcessingMode_SEND,
-					},
-				},
-			},
-		})
-	}
 	if in.Redirect != nil {
 		ApplyRedirect(out, in.Redirect, listenPort, opts.IsTLS)
 	} else if in.DirectResponse != nil {
@@ -682,11 +648,25 @@ func applyHTTPRouteDestination(
 		// No VS policy set, use mesh defaults
 		policy = opts.Mesh.GetDefaultHttpRetryPolicy()
 	}
+	// An endpoint picker belongs to an InferencePool backendRef, not to the rule as a whole: a
+	// rule may weight traffic across several pools, and each pool's share has to be scored by
+	// that pool's own picker. So the ext_proc override goes wherever the backend's cluster went -
+	// on the route itself for a single destination, on each weighted cluster otherwise.
+	infPoolCfg := opts.InferencePoolExtensionRefs[in.Name]
+	pickersAttached := 0
+
 	consistentHash := false
 	if len(in.Route) == 1 {
 		hostnames = append(hostnames, processDestination(in.Route[0], opts, listenerPort, out, action))
 		hash := opts.LookupHash(in.Route[0])
 		consistentHash = hash != nil
+		if cfg, ok := infPoolCfg[in.Route[0].GetDestination().GetHost()]; ok {
+			if out.TypedPerFilterConfig == nil {
+				out.TypedPerFilterConfig = make(map[string]*anypb.Any)
+			}
+			out.TypedPerFilterConfig[wellknown.HTTPExternalProcessing] = buildExtProcPerRoute(cfg)
+			pickersAttached++
+		}
 	} else {
 		weighted := make([]*route.WeightedCluster_ClusterWeight, 0)
 		for _, dst := range in.Route {
@@ -695,6 +675,18 @@ func applyHTTPRouteDestination(
 				continue
 			}
 			destinationweight, hostname := processWeightedDestination(dst, opts, listenerPort, action)
+			if cfg, ok := infPoolCfg[dst.GetDestination().GetHost()]; ok {
+				destinationweight.TypedPerFilterConfig = map[string]*anypb.Any{
+					wellknown.HTTPExternalProcessing: buildExtProcPerRoute(cfg),
+				}
+				pickersAttached++
+			} else if len(infPoolCfg) > 0 {
+				// An ordinary backend sharing a rule with an InferencePool. It belongs to no pool,
+				// so no picker may claim it.
+				destinationweight.TypedPerFilterConfig = map[string]*anypb.Any{
+					wellknown.HTTPExternalProcessing: extProcDisabled,
+				}
+			}
 			weighted = append(weighted, destinationweight)
 			hostnames = append(hostnames, hostname)
 		}
@@ -704,8 +696,53 @@ func applyHTTPRouteDestination(
 			},
 		}
 	}
+	if len(infPoolCfg) > 0 && pickersAttached == 0 {
+		// The configs are keyed by destination host, so this can only happen if the two sides
+		// disagree on that host. Nothing downstream would report it: requests would keep
+		// succeeding while endpoint selection quietly stopped happening.
+		log.Warnf("route %q carries %d InferencePool endpoint pickers but none matched a destination",
+			in.Name, len(infPoolCfg))
+	}
 	action.RetryPolicy = retry.ConvertPolicy(policy, consistentHash)
 	return hostnames
+}
+
+// extProcDisabled turns ext_proc off for one backend. Used for a backend that shares a route
+// rule with an InferencePool but is not one itself.
+var extProcDisabled = protoconv.MessageToAny(&extproc.ExtProcPerRoute{
+	Override: &extproc.ExtProcPerRoute_Disabled{Disabled: true},
+})
+
+// buildExtProcPerRoute returns the ext_proc override that sends requests for one InferencePool
+// backendRef to that pool's endpoint picker.
+func buildExtProcPerRoute(cfg kube.InferencePoolBackendConfig) *anypb.Any {
+	extPortNum, _ := strconv.Atoi(cfg.Port)
+	return protoconv.MessageToAny(&extproc.ExtProcPerRoute{
+		Override: &extproc.ExtProcPerRoute_Overrides{
+			Overrides: &extproc.ExtProcOverrides{
+				FailureModeAllow: &wrapperspb.BoolValue{Value: cfg.FailureModeAllow},
+				GrpcService: &core.GrpcService{
+					TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
+						EnvoyGrpc: &core.GrpcService_EnvoyGrpc{
+							ClusterName: model.BuildSubsetKey(model.TrafficDirectionOutbound, "", host.Name(cfg.FQDN), extPortNum),
+						},
+					},
+				},
+				ProcessingMode: &extproc.ProcessingMode{
+					RequestHeaderMode: extproc.ProcessingMode_SEND,
+					// open AI standard includes the model and other information the ext_proc server needs in the request body
+					RequestBodyMode: extproc.ProcessingMode_FULL_DUPLEX_STREAMED,
+					// If the ext_proc server has the request_body_mode set to FULL_DUPLEX_STREAMED, then the request_trailer_mode has to be set to SEND
+					RequestTrailerMode: extproc.ProcessingMode_SEND,
+					ResponseHeaderMode: extproc.ProcessingMode_SEND,
+					// GIE collects statistics present in the open AI standard response message
+					ResponseBodyMode: extproc.ProcessingMode_FULL_DUPLEX_STREAMED,
+					// If the ext_proc server has the response_body_mode set to FULL_DUPLEX_STREAMED, then the response_trailer_mode has to be set to SEND
+					ResponseTrailerMode: extproc.ProcessingMode_SEND,
+				},
+			},
+		},
+	})
 }
 
 // processDestination processes a single destination in a route. It specifies to which cluster the route should

--- a/pilot/pkg/networking/core/route/route_test.go
+++ b/pilot/pkg/networking/core/route/route_test.go
@@ -1585,6 +1585,31 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(extProcPerRoute.GetOverrides().GetFailureModeAllow().GetValue()).To(BeFalse())
 	})
 
+	t.Run("for virtual service with an inference pool and a cors policy", func(t *testing.T) {
+		g := NewWithT(t)
+		cg := core.NewConfigGenTest(t, core.TestOptions{})
+
+		// A CORS filter on the rule must not cost it its endpoint picker. Both are written
+		// into the same per-filter map, and a route that loses ext_proc keeps returning 200
+		// with no picker involved, so nothing downstream reports the loss.
+		routeOpts := buildRouteOpts(serviceRegistry, nil)
+		routeOpts.InferencePoolExtensionRefs = map[string]kube.InferencePoolRouteRuleConfig{
+			"routeA": {"*.example.org": {FQDN: "ext-proc-svc.test-namespace.svc.cluster.local", Port: "9002"}},
+		}
+		withCors := virtualServicePlain.DeepCopy()
+		withCors.Spec.(*networking.VirtualService).Http[0].CorsPolicy = &networking.CorsPolicy{
+			AllowOrigins: []*networking.StringMatch{
+				{MatchType: &networking.StringMatch_Exact{Exact: "https://example.com"}},
+			},
+		}
+
+		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), withCors, 8080, gatewayNames, routeOpts)
+		xdstest.ValidateRoutes(t, routes)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(routes[0].GetTypedPerFilterConfig()).To(HaveKey(wellknown.CORS))
+		g.Expect(routes[0].GetTypedPerFilterConfig()).To(HaveKey(wellknown.HTTPExternalProcessing))
+	})
+
 	t.Run("for virtual service with routing to an service with inference semantics with failuremode override", func(t *testing.T) {
 		g := NewWithT(t)
 		cg := core.NewConfigGenTest(t, core.TestOptions{})

--- a/pilot/pkg/networking/core/route/route_test.go
+++ b/pilot/pkg/networking/core/route/route_test.go
@@ -1566,7 +1566,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 
 		routeOpts := buildRouteOpts(serviceRegistry, nil)
 		routeOpts.InferencePoolExtensionRefs = map[string]kube.InferencePoolRouteRuleConfig{
-			"routeA": {FQDN: "ext-proc-svc.test-namespace.svc.cluster.local", Port: "9002"},
+			"routeA": {"*.example.org": {FQDN: "ext-proc-svc.test-namespace.svc.cluster.local", Port: "9002"}},
 		}
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServicePlain, 8080, gatewayNames, routeOpts)
 		xdstest.ValidateRoutes(t, routes)
@@ -1591,7 +1591,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 
 		routeOpts := buildRouteOpts(serviceRegistry, nil)
 		routeOpts.InferencePoolExtensionRefs = map[string]kube.InferencePoolRouteRuleConfig{
-			"routeA": {FQDN: "ext-proc-svc.test-namespace.svc.cluster.local", Port: "9002", FailureModeAllow: true},
+			"routeA": {"*.example.org": {FQDN: "ext-proc-svc.test-namespace.svc.cluster.local", Port: "9002", FailureModeAllow: true}},
 		}
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServicePlain, 8080, gatewayNames, routeOpts)
 		xdstest.ValidateRoutes(t, routes)
@@ -1609,6 +1609,85 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(extProcPerRoute.GetOverrides().GetProcessingMode().GetResponseHeaderMode()).To(Equal(extproc.ProcessingMode_SEND))
 		g.Expect(extProcPerRoute.GetOverrides().GetFailureModeAllow().GetValue()).To(BeTrue())
 	})
+
+	t.Run("for virtual service splitting across two inference pools", func(t *testing.T) {
+		g := NewWithT(t)
+		cg := core.NewConfigGenTest(t, core.TestOptions{})
+
+		routeOpts := buildRouteOpts(serviceRegistry, nil)
+		routeOpts.InferencePoolExtensionRefs = map[string]kube.InferencePoolRouteRuleConfig{
+			"routeA": {
+				poolAHost: {FQDN: "epp-a.test-namespace.svc.cluster.local", Port: "9002"},
+				poolBHost: {FQDN: "epp-b.test-namespace.svc.cluster.local", Port: "9002", FailureModeAllow: true},
+			},
+		}
+		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceTwoInferencePools, 8080, gatewayNames, routeOpts)
+		xdstest.ValidateRoutes(t, routes)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		// A rule-wide override would hand one pool's picker every request on the rule, including
+		// the share weighted to the other pool.
+		g.Expect(routes[0].GetTypedPerFilterConfig()).NotTo(HaveKey(wellknown.HTTPExternalProcessing))
+
+		clusters := routes[0].GetRoute().GetWeightedClusters().GetClusters()
+		g.Expect(clusters).To(HaveLen(2))
+		g.Expect(clusters[0].GetWeight().GetValue()).To(Equal(uint32(90)))
+		g.Expect(clusters[1].GetWeight().GetValue()).To(Equal(uint32(10)))
+
+		aOverrides := extProcOverrides(t, clusters[0])
+		g.Expect(pickerCluster(aOverrides)).To(Equal("outbound|9002||epp-a.test-namespace.svc.cluster.local"))
+		g.Expect(aOverrides.GetFailureModeAllow().GetValue()).To(BeFalse())
+		g.Expect(aOverrides.GetProcessingMode().GetRequestBodyMode()).To(Equal(extproc.ProcessingMode_FULL_DUPLEX_STREAMED))
+
+		bOverrides := extProcOverrides(t, clusters[1])
+		g.Expect(pickerCluster(bOverrides)).To(Equal("outbound|9002||epp-b.test-namespace.svc.cluster.local"))
+		g.Expect(bOverrides.GetFailureModeAllow().GetValue()).To(BeTrue())
+		g.Expect(bOverrides.GetProcessingMode().GetRequestBodyMode()).To(Equal(extproc.ProcessingMode_FULL_DUPLEX_STREAMED))
+	})
+
+	t.Run("for virtual service splitting between an inference pool and an ordinary service", func(t *testing.T) {
+		g := NewWithT(t)
+		cg := core.NewConfigGenTest(t, core.TestOptions{})
+
+		routeOpts := buildRouteOpts(serviceRegistry, nil)
+		routeOpts.InferencePoolExtensionRefs = map[string]kube.InferencePoolRouteRuleConfig{
+			"routeA": {poolAHost: {FQDN: "epp-a.test-namespace.svc.cluster.local", Port: "9002"}},
+		}
+		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceInferencePoolAndService, 8080, gatewayNames, routeOpts)
+		xdstest.ValidateRoutes(t, routes)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(routes[0].GetTypedPerFilterConfig()).NotTo(HaveKey(wellknown.HTTPExternalProcessing))
+
+		clusters := routes[0].GetRoute().GetWeightedClusters().GetClusters()
+		g.Expect(clusters).To(HaveLen(2))
+		g.Expect(pickerCluster(extProcOverrides(t, clusters[0]))).To(Equal("outbound|9002||epp-a.test-namespace.svc.cluster.local"))
+
+		// The plain Service belongs to no pool, so no picker may score its share.
+		perRoute := new(extproc.ExtProcPerRoute)
+		g.Expect(clusters[1].GetTypedPerFilterConfig()).To(HaveKey(wellknown.HTTPExternalProcessing))
+		if err := clusters[1].GetTypedPerFilterConfig()[wellknown.HTTPExternalProcessing].UnmarshalTo(perRoute); err != nil {
+			t.Fatalf("couldn't unmarshal any proto: %v", err)
+		}
+		g.Expect(perRoute.GetDisabled()).To(BeTrue())
+	})
+
+	t.Run("for a redirect rule that also lists an inference pool backend", func(t *testing.T) {
+		g := NewWithT(t)
+		cg := core.NewConfigGenTest(t, core.TestOptions{})
+
+		routeOpts := buildRouteOpts(serviceRegistry, nil)
+		routeOpts.InferencePoolExtensionRefs = map[string]kube.InferencePoolRouteRuleConfig{
+			"routeA": {poolAHost: {FQDN: "epp-a.test-namespace.svc.cluster.local", Port: "9002"}},
+		}
+		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceRedirectWithInferencePool, 8080, gatewayNames, routeOpts)
+		xdstest.ValidateRoutes(t, routes)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		// The redirect answers the request, so there is no backend for a picker to score.
+		g.Expect(routes[0].Action).To(BeAssignableToTypeOf(&envoyroute.Route_Redirect{}))
+		g.Expect(routes[0].GetTypedPerFilterConfig()).NotTo(HaveKey(wellknown.HTTPExternalProcessing))
+	})
+
 	t.Run("for virtualservices with with wildcard hosts outside of the serviceregistry (on port 80)", func(t *testing.T) {
 		g := NewWithT(t)
 		cg := core.NewConfigGenTest(t, core.TestOptions{
@@ -1730,6 +1809,126 @@ var virtualServicePlain = config.Config{
 			},
 		},
 	},
+}
+
+// Hostnames of the Services Istio synthesizes for an InferencePool. The endpoint picker config
+// is keyed by these, which is how a weighted cluster is matched back to the pool it came from.
+const (
+	poolAHost = "pool-a-ip-1a2b3c4d.test-namespace.svc.cluster.local"
+	poolBHost = "pool-b-ip-5e6f7a8b.test-namespace.svc.cluster.local"
+)
+
+// The canary shape from llm-d's blue-green rollout: one rule, two InferencePools, 90:10.
+var virtualServiceTwoInferencePools = config.Config{
+	Meta: config.Meta{
+		GroupVersionKind: gvk.VirtualService,
+		Name:             "acme",
+	},
+	Spec: &networking.VirtualService{
+		Hosts:    []string{},
+		Gateways: []string{"some-gateway"},
+		Http: []*networking.HTTPRoute{
+			{
+				Name: "routeA",
+				Route: []*networking.HTTPRouteDestination{
+					{
+						Destination: &networking.Destination{
+							Host: poolAHost,
+							Port: &networking.PortSelector{Number: 54321},
+						},
+						Weight: 90,
+					},
+					{
+						Destination: &networking.Destination{
+							Host: poolBHost,
+							Port: &networking.PortSelector{Number: 54321},
+						},
+						Weight: 10,
+					},
+				},
+			},
+		},
+	},
+}
+
+// Gateway API lets a rule carry both a RequestRedirect filter and backendRefs. The redirect
+// answers the request, so the backends are never dialed.
+var virtualServiceRedirectWithInferencePool = config.Config{
+	Meta: config.Meta{
+		GroupVersionKind: gvk.VirtualService,
+		Name:             "acme",
+	},
+	Spec: &networking.VirtualService{
+		Hosts:    []string{},
+		Gateways: []string{"some-gateway"},
+		Http: []*networking.HTTPRoute{
+			{
+				Name: "routeA",
+				Redirect: &networking.HTTPRedirect{
+					Uri:          "example.org",
+					RedirectCode: 308,
+				},
+				Route: []*networking.HTTPRouteDestination{
+					{
+						Destination: &networking.Destination{
+							Host: poolAHost,
+							Port: &networking.PortSelector{Number: 54321},
+						},
+						Weight: 100,
+					},
+				},
+			},
+		},
+	},
+}
+
+var virtualServiceInferencePoolAndService = config.Config{
+	Meta: config.Meta{
+		GroupVersionKind: gvk.VirtualService,
+		Name:             "acme",
+	},
+	Spec: &networking.VirtualService{
+		Hosts:    []string{},
+		Gateways: []string{"some-gateway"},
+		Http: []*networking.HTTPRoute{
+			{
+				Name: "routeA",
+				Route: []*networking.HTTPRouteDestination{
+					{
+						Destination: &networking.Destination{
+							Host: poolAHost,
+							Port: &networking.PortSelector{Number: 54321},
+						},
+						Weight: 90,
+					},
+					{
+						Destination: &networking.Destination{
+							Host: "*.example.org",
+							Port: &networking.PortSelector{Number: 8484},
+						},
+						Weight: 10,
+					},
+				},
+			},
+		},
+	},
+}
+
+func extProcOverrides(t *testing.T, cw *envoyroute.WeightedCluster_ClusterWeight) *extproc.ExtProcOverrides {
+	t.Helper()
+	cfg, ok := cw.GetTypedPerFilterConfig()[wellknown.HTTPExternalProcessing]
+	if !ok {
+		t.Fatalf("weighted cluster %q has no %s config", cw.GetName(), wellknown.HTTPExternalProcessing)
+	}
+	perRoute := new(extproc.ExtProcPerRoute)
+	if err := cfg.UnmarshalTo(perRoute); err != nil {
+		t.Fatalf("couldn't unmarshal any proto: %v", err)
+	}
+	return perRoute.GetOverrides()
+}
+
+func pickerCluster(o *extproc.ExtProcOverrides) string {
+	return o.GetGrpcService().GetTargetSpecifier().(*envoycore.GrpcService_EnvoyGrpc_).EnvoyGrpc.GetClusterName()
 }
 
 var virtualServiceWithTimeout = config.Config{

--- a/pkg/config/gateway/kube/inferenceextension.go
+++ b/pkg/config/gateway/kube/inferenceextension.go
@@ -14,11 +14,19 @@
 
 package kube
 
-// InferencePoolRouteRuleConfig holds configuration for an inference pool associated with a route.
-// This data is stored in the `Extra` field of a `config.Config` for a VirtualService.
-// The map is keyed by the `HTTPRoute.Name`.
-type InferencePoolRouteRuleConfig struct {
+// InferencePoolBackendConfig is what a single InferencePool backendRef contributes to a route
+// rule: where to reach the pool's endpoint picker, and whether a picker failure fails open.
+type InferencePoolBackendConfig struct {
 	FQDN             string
 	Port             string
 	FailureModeAllow bool
 }
+
+// InferencePoolRouteRuleConfig holds the InferencePool backends of a single route rule, keyed by
+// the hostname of the Service Istio synthesizes for each of them. A rule may weight traffic
+// across several pools and each pool has its own endpoint picker, so this is resolved per
+// backendRef rather than once per rule.
+//
+// This data is stored in the `Extra` field of a `config.Config` for a VirtualService, in a map
+// keyed by the `HTTPRoute.Name`.
+type InferencePoolRouteRuleConfig map[string]InferencePoolBackendConfig

--- a/releasenotes/notes/61594.yaml
+++ b/releasenotes/notes/61594.yaml
@@ -1,0 +1,12 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 61594
+releaseNotes:
+  - |
+    **Fixed** an `HTTPRoute` rule with several `InferencePool` backendRefs configuring only one
+    endpoint picker. The picker of the last backendRef listed scored every request on the rule,
+    so the other pools' pickers were never invoked, and a pool with no ready endpoints failed
+    the whole rule rather than its own weighted share. Each pool now gets its own picker,
+    attached to its own weighted cluster.

--- a/releasenotes/notes/61594.yaml
+++ b/releasenotes/notes/61594.yaml
@@ -10,3 +10,13 @@ releaseNotes:
     so the other pools' pickers were never invoked, and a pool with no ready endpoints failed
     the whole rule rather than its own weighted share. Each pool now gets its own picker,
     attached to its own weighted cluster.
+  - |
+    **Fixed** two `HTTPRoute`s sharing a `rules[].name` on the same gateway overwriting each
+    other's endpoint picker. Rule names only have to be unique within one `HTTPRoute`, but the
+    pickers were keyed by name across all of them, so a route could be served by another
+    route's picker. Pickers are now resolved per backendRef, so a shared name no longer moves
+    one route's picker onto another.
+  - |
+    **Fixed** a route rule losing its `InferencePool` endpoint picker when it also carried a
+    CORS filter. Both are written into the same per-filter configuration, and the CORS path
+    replaced the map rather than adding to it.


### PR DESCRIPTION
An `HTTPRoute` rule weighting traffic across several `InferencePool` `backendRefs` got one endpoint picker for the whole rule, so one pool's picker scored every request and the others were never invoked. `override_host` hides this in the happy path - the right pod still answers with a 200 - but when the winning picker's pool has no ready endpoints it returns `ImmediateResponse` 503 for the entire rule, including traffic weighted to a healthy pool. 

Pickers are now resolved per `backendRef` and attached to the cluster that backend compiles to, so an empty pool costs only its own weight share. On a two-pool reproducer, attribution moves from 0/100 to 92/8 across a 90:10 split and the canary outage drops from 163 of 163 requests to 21, none bound for the healthy pool.

> [!IMPORTANT]
> This also removes endpoint-picker overrides from rules combining `RequestRedirect` with `InferencePool`  backendRefs. Previously, the picker could run before the redirect despite no request being forwarded to the pool. Redirects now proceed without invoking the picker.

Fixes #61594