### PR TITLE
cni: avoid panic on invalid pod IPs

### DIFF
--- a/cni/pkg/util/podutil.go
+++ b/cni/pkg/util/podutil.go
@@ -160,12 +160,20 @@ func GetPodIPsIfPresent(pod *corev1.Pod) []netip.Addr {
 	var podIPs []netip.Addr
 	if len(pod.Status.PodIPs) != 0 {
 		for _, pip := range pod.Status.PodIPs {
-			ip := netip.MustParseAddr(pip.IP)
+			ip, err := netip.ParseAddr(pip.IP)
+			if err != nil {
+				log.Warnf("failed to parse pod IP %q for pod %s/%s: %v", pip.IP, pod.Namespace, pod.Name, err)
+				continue
+			}
 			podIPs = append(podIPs, ip)
 		}
 	} else if len(pod.Status.PodIP) != 0 {
-		ip := netip.MustParseAddr(pod.Status.PodIP)
-		podIPs = append(podIPs, ip)
+		ip, err := netip.ParseAddr(pod.Status.PodIP)
+		if err != nil {
+			log.Warnf("failed to parse pod IP %q for pod %s/%s: %v", pod.Status.PodIP, pod.Namespace, pod.Name, err)
+		} else {
+			podIPs = append(podIPs, ip)
+		}
 	}
 	return podIPs
 }

--- a/cni/pkg/util/podutil_test.go
+++ b/cni/pkg/util/podutil_test.go
@@ -15,6 +15,8 @@
 package util
 
 import (
+	"net/netip"
+	"slices"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -112,6 +114,45 @@ func TestGetPodIPsIfNoPodIPPresent(t *testing.T) {
 
 	podIPs := GetPodIPsIfPresent(pod)
 	assert.Equal(t, len(podIPs), 0)
+}
+
+func TestGetPodIPsIfPresentSkipsInvalidIPs(t *testing.T) {
+	tests := []struct {
+		name   string
+		status corev1.PodStatus
+		want   []netip.Addr
+	}{
+		{
+			name: "invalid PodIPs entry",
+			status: corev1.PodStatus{
+				PodIPs: []corev1.PodIP{{IP: "not-an-ip"}, {IP: "2.2.2.2"}},
+			},
+			want: []netip.Addr{netip.MustParseAddr("2.2.2.2")},
+		},
+		{
+			name: "invalid legacy PodIP",
+			status: corev1.PodStatus{
+				PodIP: "not-an-ip",
+			},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+				Status: tt.status,
+			}
+
+			if got := GetPodIPsIfPresent(pod); !slices.Equal(got, tt.want) {
+				t.Fatalf("GetPodIPsIfPresent() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }
 
 func TestEnablementSelectorMatches(t *testing.T) {


### PR DESCRIPTION
**Please provide a description of this PR:**

Use `netip.ParseAddr` instead of `netip.MustParseAddr` in `GetPodIPsIfPresent` so malformed pod IPs are logged and skipped instead of panicking the CNI agent