### PR TITLE
Enhance logging and metrics for mesh config loads

### DIFF
--- a/pkg/config/mesh/kubemesh/watcher.go
+++ b/pkg/config/mesh/kubemesh/watcher.go
@@ -48,10 +48,12 @@ func NewConfigMapSource(client kube.Client, namespace, name, key string, opts kr
 	clt.Start(opts.Stop())
 
 	cmKey := types.NamespacedName{Namespace: namespace, Name: name}.String()
-	return krt.NewSingleton(func(ctx krt.HandlerContext) *string {
+	sourceName := fmt.Sprintf("ConfigMap_%s_%s", name, key)
+	source := krt.NewSingleton(func(ctx krt.HandlerContext) *string {
 		cm := ptr.Flatten(krt.FetchOne(ctx, cms, krt.FilterKey(cmKey)))
 		return meshConfigMapData(cm, key)
-	}, opts.WithName(fmt.Sprintf("ConfigMap_%s_%s", name, key))...)
+	}, opts.WithName(sourceName)...)
+	return meshwatcher.MeshConfigSource{Singleton: source, Name: sourceName}
 }
 
 func meshConfigMapData(cm *v1.ConfigMap, key string) *string {

--- a/pkg/config/mesh/kubemesh/watcher_test.go
+++ b/pkg/config/mesh/kubemesh/watcher_test.go
@@ -31,6 +31,7 @@ import (
 	"istio.io/istio/pkg/config/mesh/meshwatcher"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/krt/krttest"
+	"istio.io/istio/pkg/monitoring/monitortest"
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/util/protomarshal"
@@ -190,6 +191,7 @@ func assertMeshConfig(t *testing.T, w mesh.Watcher, v string) {
 }
 
 func TestNewConfigMapWatcher(t *testing.T) {
+	mt := monitortest.New(t)
 	yaml := "trustDomain: something.new"
 	m, err := mesh.ApplyMeshConfigDefaults(yaml)
 	if err != nil {
@@ -207,6 +209,7 @@ func TestNewConfigMapWatcher(t *testing.T) {
 	cms := client.Kube().CoreV1().ConfigMaps(namespace)
 	opts := krttest.Options(t)
 	primaryMeshConfig := NewConfigMapSource(client, namespace, name, MeshConfigKey, opts)
+	assert.Equal(t, primaryMeshConfig.Name, "ConfigMap_istio_mesh")
 	col := meshwatcher.NewCollection(opts, primaryMeshConfig)
 	col.AsCollection().WaitUntilSynced(opts.Stop())
 	w := meshwatcher.ConfigAdapter(col)
@@ -261,4 +264,5 @@ func TestNewConfigMapWatcher(t *testing.T) {
 			}, step.expect)
 		})
 	}
+	mt.Assert("istiod_mesh_config_load_errors_total", nil, monitortest.Exactly(3))
 }

--- a/pkg/config/mesh/meshwatcher/collection.go
+++ b/pkg/config/mesh/meshwatcher/collection.go
@@ -17,6 +17,8 @@ package meshwatcher
 import (
 	"os"
 	"path"
+	"strings"
+	"sync/atomic"
 
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/filewatcher"
@@ -25,18 +27,26 @@ import (
 	"istio.io/istio/pkg/log"
 )
 
-// MeshConfigSource provides an input to the full mesh config (which is made by merging multiple sources)
-type MeshConfigSource = krt.Singleton[string]
+// MeshConfigSource provides a named mesh config input.
+type MeshConfigSource struct {
+	krt.Singleton[string]
+	Name string
+}
 
 // NewFileSource creates a MeshConfigSource from a file. The file must exist.
 func NewFileSource(fileWatcher filewatcher.FileWatcher, filename string, opts krt.OptionsBuilder) (MeshConfigSource, error) {
-	return krtfiles.NewFileSingleton[string](fileWatcher, filename, func(filename string) (string, error) {
+	sourceName := "Mesh_File_" + path.Base(filename)
+	source, err := krtfiles.NewFileSingleton[string](fileWatcher, filename, func(filename string) (string, error) {
 		b, err := os.ReadFile(filename)
 		if err != nil {
 			return "", err
 		}
 		return string(b), nil
-	}, opts.WithName("Mesh_File_"+path.Base(filename))...)
+	}, opts.WithName(sourceName)...)
+	if err != nil {
+		return MeshConfigSource{}, err
+	}
+	return MeshConfigSource{Singleton: source, Name: sourceName}, nil
 }
 
 // NewCollection builds a new mesh config built by applying the provided sources.
@@ -46,9 +56,13 @@ func NewCollection(opts krt.OptionsBuilder, sources ...MeshConfigSource) krt.Sin
 		// There is no real reason for this other than to enforce we don't accidentally put more sources
 		panic("currently only 2 sources are supported")
 	}
+	var hasValidConfig atomic.Bool
 	return krt.NewSingleton[MeshConfigResource](
 		func(ctx krt.HandlerContext) *MeshConfigResource {
 			meshCfg := mesh.DefaultMeshConfig()
+			appliedConfig := false
+			appliedSource := ""
+			failedSources := []string{}
 
 			for _, attempt := range sources {
 				s := krt.FetchOne(ctx, attempt.AsCollection())
@@ -61,21 +75,38 @@ func NewCollection(opts krt.OptionsBuilder, sources ...MeshConfigSource) krt.Sin
 				}
 				n, err := mesh.ApplyMeshConfig(*s, meshCfg)
 				if err != nil {
+					meshConfigLoadErrors.Increment()
+					failedSources = append(failedSources, attempt.Name)
 					// For backwards compatibility, keep inconsistent behavior
 					// TODO(https://github.com/istio/istio/issues/54615) align this.
 					if len(sources) == 1 {
-						log.Warnf("invalid mesh config, using last known state: %v", err)
+						if hasValidConfig.Load() {
+							log.Errorf("invalid mesh config from %s, using last known state: %v", attempt.Name, err)
+						} else {
+							log.Errorf("invalid mesh config from %s, no last known state, using default mesh configuration: %v", attempt.Name, err)
+						}
 						// We never want a nil mesh config. If it fails, we discard the result but allow falling back to the
 						// default if there is no last known state.
 						// We may consider failing hard on startup instead of silently ignoring errors.
 						ctx.DiscardResult()
 						return &MeshConfigResource{mesh.DefaultMeshConfig()}
 					}
-					log.Warnf("invalid mesh config, ignoring: %v", err)
+					log.Errorf("invalid mesh config from %s, ignoring: %v", attempt.Name, err)
 					continue
 				}
 				meshCfg = n
+				appliedConfig = true
+				appliedSource = attempt.Name
 			}
+			if len(failedSources) > 0 {
+				failed := strings.Join(failedSources, ", ")
+				if appliedConfig {
+					log.Warnf("mesh configuration loaded with errors from %s, using configuration from %s along with defaults", failed, appliedSource)
+				} else {
+					log.Warnf("mesh configuration loaded with errors from %s, using default mesh configuration", failed)
+				}
+			}
+			hasValidConfig.Store(appliedConfig)
 			return &MeshConfigResource{meshCfg}
 		}, opts.WithName("MeshConfig")...,
 	)

--- a/pkg/config/mesh/meshwatcher/monitoring.go
+++ b/pkg/config/mesh/meshwatcher/monitoring.go
@@ -1,0 +1,22 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package meshwatcher
+
+import "istio.io/istio/pkg/monitoring"
+
+var meshConfigLoadErrors = monitoring.NewSum(
+	"istiod_mesh_config_load_errors_total",
+	"Total number of errors encountered while loading mesh configuration sources.",
+)

--- a/releasenotes/notes/61563.yaml
+++ b/releasenotes/notes/61563.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+issue:
+  - 61563
+releaseNotes:
+  - |
+    **Improved** mesh configuration load failures with source-specific error and fallback logging and the `istiod_mesh_config_load_errors_total` counter.


### PR DESCRIPTION
* Improved mesh configuration load failures to log at error level and identify whether istiod retained the last known configuration or used the default configuration.
* Also emit `istiod_mesh_config_load_errors_total` metric so errors to load mesh configs can be tracked.

Fixes #61563 