### PR TITLE
Fix ambient multi-network trust domain handling

### DIFF
--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -127,6 +127,13 @@ spec:
         - name: NETWORK
           value: {{ .Values.network | quote }}
         {{- end }}
+        {{- $trustDomains := list }}
+        {{- range .Values.meshConfig.trustDomainAliases }}{{- $trustDomains = append $trustDomains . }}{{- end }}
+        {{- range .Values.meshConfig.caCertificates }}{{- range .trustDomains }}{{- $trustDomains = append $trustDomains . }}{{- end }}{{- end }}
+        {{- with (uniq $trustDomains) }}
+        - name: TRUST_DOMAINS
+          value: {{ join "," . | quote }}
+        {{- end }}
         - name: RUST_LOG
           value: {{ .Values.logLevel | quote }}
         - name: RUST_BACKTRACE

--- a/manifests/charts/ztunnel/values.yaml
+++ b/manifests/charts/ztunnel/values.yaml
@@ -88,8 +88,8 @@ _internal_defaults_do_not_set:
     clusterName: ""
 
   # meshConfig defines runtime configuration of components.
-  # For ztunnel, only defaultConfig is used, but this is nested under `meshConfig` for consistency with other
-  # components.
+  # For ztunnel, only the accepted trust domains and defaultConfig are used, but this is nested under
+  # `meshConfig` for consistency with other components.
   # TODO: https://github.com/istio/istio/issues/43248
   meshConfig:
     defaultConfig:

--- a/operator/pkg/render/manifest.go
+++ b/operator/pkg/render/manifest.go
@@ -403,6 +403,18 @@ func translateIstioOperatorToHelm(base values.Map) (values.Map, error) {
 		}
 	}
 
+	// ztunnel is not given the mesh config, but needs to know which trust domains to accept on inbound
+	// connections - the same set Envoy validates against.
+	for _, f := range []string{"trustDomainAliases", "caCertificates"} {
+		v, ok := base.GetPath("spec.meshConfig." + f)
+		if !ok {
+			continue
+		}
+		if err := base.SetPath("spec.values.ztunnel.meshConfig."+f, v); err != nil {
+			return nil, err
+		}
+	}
+
 	// Propagate component enablement to values. This is used for cross-chart dependencies.
 	if err := base.SetPath("spec.values.pilot.enabled", base.GetPathBool("spec.components.pilot.enabled")); err != nil {
 		return nil, err

--- a/pilot/pkg/serviceregistry/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex.go
@@ -102,10 +102,11 @@ type Builder struct {
 // index maintains an index of ambient WorkloadInfo objects by various keys.
 // These are intentionally pre-computed based on events such that lookups are efficient.
 type index struct {
-	services  servicesCollection
-	workloads workloadsCollection
-	waypoints waypointsCollection
-	networks  NetworkCollections
+	services           servicesCollection
+	workloads          workloadsCollection
+	waypoints          waypointsCollection
+	networks           NetworkCollections
+	clusterMeshConfigs MeshConfigCollections
 
 	namespaces krt.Collection[model.NamespaceInfo]
 

--- a/pilot/pkg/serviceregistry/ambient/ambientindex_multicluster_test.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex_multicluster_test.go
@@ -31,6 +31,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/config/mesh/meshwatcher"
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/kclient/clienttest"
 	"istio.io/istio/pkg/kube/krt"
@@ -39,6 +40,7 @@ import (
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/istio/pkg/util/protomarshal"
 	"istio.io/istio/pkg/workloadapi"
 	"istio.io/istio/tests/util/leak"
 )
@@ -47,6 +49,7 @@ type ambientclients struct {
 	pc    clienttest.TestClient[*corev1.Pod]
 	sc    clienttest.TestClient[*corev1.Service]
 	sec   clienttest.TestWriter[*corev1.Secret]
+	cm    clienttest.TestWriter[*corev1.ConfigMap]
 	ns    clienttest.TestWriter[*corev1.Namespace]
 	grc   clienttest.TestWriter[*k8sv1.Gateway]
 	gwcls clienttest.TestWriter[*k8sv1.GatewayClass]
@@ -450,6 +453,7 @@ func TestMulticlusterAmbientIndex_TestServiceMerging(t *testing.T) {
 				pa:    clienttest.NewWriter[*clientsecurityv1beta1.PeerAuthentication](t, cl),
 				authz: clienttest.NewWriter[*clientsecurityv1beta1.AuthorizationPolicy](t, cl),
 				sec:   clienttest.NewWriter[*corev1.Secret](t, cl),
+				cm:    clienttest.NewWriter[*corev1.ConfigMap](t, cl),
 			},
 		})
 	})
@@ -474,6 +478,7 @@ func TestMulticlusterAmbientIndex_TestServiceMerging(t *testing.T) {
 			pa:    s.pa,
 			authz: s.authz,
 			sec:   s.sec,
+			cm:    s.cm,
 		},
 	}
 	remoteClient.ns.Create(&corev1.Namespace{
@@ -565,7 +570,9 @@ func TestMulticlusterAmbientIndex_SplitHorizon(t *testing.T) {
 	test.SetForTest(t, &features.EnableAmbientMultiNetwork, true)
 	s := newAmbientTestServer(t, testC, testNW, "")
 	// Test that we're propagating the trust domain correctly
-	s.meshConfig.Mesh().TrustDomain = s.DomainSuffix
+	meshCfg := protomarshal.Clone(s.meshConfig.Mesh())
+	meshCfg.TrustDomain = s.DomainSuffix
+	s.meshConfig.(meshwatcher.TestWatcher).Set(meshCfg)
 	s.AddSecret("s1", "remote-cluster") // overlapping ips
 	remoteClients := krt.NewCollection(s.mcController.Clusters(), func(_ krt.HandlerContext, c *multicluster.Cluster) **remoteAmbientClients {
 		cl := c.Client
@@ -582,6 +589,7 @@ func TestMulticlusterAmbientIndex_SplitHorizon(t *testing.T) {
 				pa:    clienttest.NewWriter[*clientsecurityv1beta1.PeerAuthentication](t, cl),
 				authz: clienttest.NewWriter[*clientsecurityv1beta1.AuthorizationPolicy](t, cl),
 				sec:   clienttest.NewWriter[*corev1.Secret](t, cl),
+				cm:    clienttest.NewWriter[*corev1.ConfigMap](t, cl),
 			},
 		})
 	})
@@ -606,6 +614,7 @@ func TestMulticlusterAmbientIndex_SplitHorizon(t *testing.T) {
 			pa:    s.pa,
 			authz: s.authz,
 			sec:   s.sec,
+			cm:    s.cm,
 		},
 	}
 	remoteClient.ns.Create(&corev1.Namespace{
@@ -736,6 +745,44 @@ func TestMulticlusterAmbientIndex_SplitHorizon(t *testing.T) {
 		}
 		if shwl.Workload.Capacity.GetValue() != 2 {
 			return fmt.Errorf("expected split horizon workload to have capacity 2, got %d", shwl.Workload.Capacity.GetValue())
+		}
+		return nil
+	})
+
+	// A cluster that has its own mesh config issues identities in its own trust domain, not ours.
+	remoteClient.cm.Create(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "istio",
+			Namespace: systemNS,
+		},
+		Data: map[string]string{"mesh": "trustDomain: remote.example.com"},
+	})
+	retry.UntilSuccessOrFail(t, func() error {
+		gwwl := s.workloads.GetKey("NetworkGateway/remote-network/172.0.1.2/0")
+		if gwwl == nil {
+			return fmt.Errorf("expected network gateway workload to exist, but it does not")
+		}
+		if gwwl.Workload.TrustDomain != "remote.example.com" {
+			return fmt.Errorf("expected network gateway workload to have trust domain remote.example.com, got %s",
+				gwwl.Workload.TrustDomain,
+			)
+		}
+		shwl := s.workloads.GetKey(splitHorizonName)
+		if shwl == nil {
+			return fmt.Errorf("expected split horizon workload to exist, but it does not")
+		}
+		if shwl.Workload.TrustDomain != "remote.example.com" {
+			return fmt.Errorf("expected split horizon workload to have trust domain remote.example.com, got %s",
+				shwl.Workload.TrustDomain,
+			)
+		}
+		svc := s.lookupService("ns1/svc2.ns1.svc.company.com")
+		if svc == nil {
+			return fmt.Errorf("service not found")
+		}
+		want := []string{"spiffe://remote.example.com/ns/ns1/sa/sa1"}
+		if !reflect.DeepEqual(svc.Service.SubjectAltNames, want) {
+			return fmt.Errorf("expected service subject alt names %v, got %v", want, svc.Service.SubjectAltNames)
 		}
 		return nil
 	})

--- a/pilot/pkg/serviceregistry/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex_test.go
@@ -2413,6 +2413,7 @@ func newAmbientTestServerFromOptions(t *testing.T, networkID network.ID, options
 			pa:    clienttest.NewWriter[*clientsecurityv1beta1.PeerAuthentication](t, cl),
 			authz: clienttest.NewWriter[*clientsecurityv1beta1.AuthorizationPolicy](t, cl),
 			sec:   clienttest.NewWriter[*corev1.Secret](t, cl),
+			cm:    clienttest.NewWriter[*corev1.ConfigMap](t, cl),
 		},
 	}
 

--- a/pilot/pkg/serviceregistry/ambient/meshconfigs.go
+++ b/pilot/pkg/serviceregistry/ambient/meshconfigs.go
@@ -1,0 +1,151 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ambient
+
+import (
+	"fmt"
+
+	"istio.io/istio/pkg/cluster"
+	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/config/mesh/kubemesh"
+	"istio.io/istio/pkg/config/mesh/meshwatcher"
+	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/kube/multicluster"
+	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/ptr"
+)
+
+const (
+	// defaultMeshConfigMapName is the default name of the ConfigMap with the mesh config
+	// The actual name can be different - use getMeshConfigMapName
+	defaultMeshConfigMapName = "istio"
+)
+
+// ClusterMeshConfig is the subset of a cluster's own mesh config that the local cluster needs in order
+// to send traffic to it. Only the fields listed here are read from remote clusters; the rest of a remote
+// cluster's mesh config must not influence local configuration.
+type ClusterMeshConfig struct {
+	ClusterID cluster.ID
+	// TrustDomain is the trust domain workloads in the cluster are issued identities in.
+	TrustDomain string
+}
+
+func (c ClusterMeshConfig) ResourceName() string {
+	return c.ClusterID.String()
+}
+
+type MeshConfigCollections struct {
+	ClusterMeshConfigs krt.Collection[ClusterMeshConfig]
+
+	localClusterID cluster.ID
+}
+
+// FetchTrustDomain returns the trust domain workloads in the given cluster are issued identities in.
+// Clusters we cannot read the mesh config from fall back to the local trust domain, which is correct
+// for a mesh using a single trust domain throughout.
+func (c MeshConfigCollections) FetchTrustDomain(ctx krt.HandlerContext, id cluster.ID) string {
+	if cfg := krt.FetchOne(ctx, c.ClusterMeshConfigs, krt.FilterKey(id.String())); cfg != nil {
+		return cfg.TrustDomain
+	}
+	if id != c.localClusterID {
+		log.Debugf("no mesh config for cluster %s, using the local trust domain", id)
+	}
+	if local := krt.FetchOne(ctx, c.ClusterMeshConfigs, krt.FilterKey(c.localClusterID.String())); local != nil {
+		return local.TrustDomain
+	}
+	return constants.DefaultClusterLocalDomain
+}
+
+func buildGlobalMeshConfigCollections(
+	ctrl *multicluster.Controller,
+	localMeshConfig meshwatcher.WatcherCollection,
+	options Options,
+	opts krt.OptionsBuilder,
+) MeshConfigCollections {
+	GlobalClusterMeshConfigs := multicluster.NestedCollectionFromLocalAndRemote(
+		ctrl,
+		localClusterMeshConfig(localMeshConfig, options, opts).AsCollection(),
+		func(ctx krt.HandlerContext, c *multicluster.Cluster) *krt.Collection[ClusterMeshConfig] {
+			// N.B the cluster stop is used here, never the top-level stop, so the informer goes away with
+			// the cluster.
+			clusterOpts := krt.NewOptionsBuilder(c.GetStop(), fmt.Sprintf("ambient/mesh[%s]/", c.ID), opts.Debugger())
+			source := kubemesh.NewConfigMapSource(
+				c.Client,
+				options.SystemNamespace,
+				getMeshConfigMapName(options.Revision),
+				kubemesh.MeshConfigKey,
+				clusterOpts,
+			)
+			mesh := meshwatcher.NewCollection(clusterOpts, source)
+			return ptr.Of(krt.NewSingleton(func(ctx krt.HandlerContext) *ClusterMeshConfig {
+				if krt.FetchOne(ctx, source.AsCollection()) == nil {
+					// The cluster has no readable mesh config; leave it out so we fall back to ours rather
+					// than to the defaults, which would claim the mesh-wide default trust domain.
+					return nil
+				}
+				return &ClusterMeshConfig{
+					ClusterID:   c.ID,
+					TrustDomain: krt.FetchOne(ctx, mesh.AsCollection()).GetTrustDomain(),
+				}
+			}, clusterOpts.WithName("ClusterMeshConfig")...).AsCollection())
+		},
+		"ClusterMeshConfigs",
+		opts,
+	)
+
+	ClusterMeshConfigs := krt.NestedJoinWithMergeCollection(
+		GlobalClusterMeshConfigs,
+		func(configs []ClusterMeshConfig) *ClusterMeshConfig {
+			if len(configs) == 0 {
+				return nil
+			}
+			// Keys are cluster IDs, so there is never more than one.
+			return &configs[0]
+		},
+		opts.WithName("MergedClusterMeshConfigs")...,
+	)
+
+	return MeshConfigCollections{
+		ClusterMeshConfigs: ClusterMeshConfigs,
+		localClusterID:     options.ClusterID,
+	}
+}
+
+func localClusterMeshConfig(
+	localMeshConfig meshwatcher.WatcherCollection,
+	options Options,
+	opts krt.OptionsBuilder,
+) krt.Singleton[ClusterMeshConfig] {
+	return krt.NewSingleton(func(ctx krt.HandlerContext) *ClusterMeshConfig {
+		mesh := krt.FetchOne(ctx, localMeshConfig.AsCollection())
+		if mesh == nil {
+			return nil
+		}
+		return &ClusterMeshConfig{
+			ClusterID:   options.ClusterID,
+			TrustDomain: mesh.GetTrustDomain(),
+		}
+	}, opts.WithName("LocalClusterMeshConfig")...)
+}
+
+// getMeshConfigMapName returns the mesh ConfigMap name based on the revision. Remote clusters are
+// assumed to run the same revision as we do.
+func getMeshConfigMapName(revision string) string {
+	name := defaultMeshConfigMapName
+	if revision == "" || revision == "default" {
+		return name
+	}
+	return name + "-" + revision
+}

--- a/pilot/pkg/serviceregistry/ambient/multicluster.go
+++ b/pilot/pkg/serviceregistry/ambient/multicluster.go
@@ -114,6 +114,13 @@ func (a *index) buildGlobalCollections(
 		opts,
 	)
 	a.networks = GlobalNetworks
+	GlobalMeshConfigs := buildGlobalMeshConfigCollections(
+		a.mcController,
+		LocalMeshConfig,
+		options,
+		opts,
+	)
+	a.clusterMeshConfigs = GlobalMeshConfigs
 	builder := Builder{
 		DomainSuffix: a.DomainSuffix,
 		ClusterID:    a.ClusterID,
@@ -247,6 +254,7 @@ func (a *index) buildGlobalCollections(
 		GlobalNodeLocality,
 		GlobalNodeLocalityByCluster,
 		options.MeshConfig,
+		GlobalMeshConfigs,
 		authPoliciesByNs,
 		localPeerAuthsByNs,
 		GlobalWaypoints,
@@ -323,11 +331,6 @@ func (a *index) buildGlobalCollections(
 				}
 			}
 			gws := LookupNetworkGateway(ctx, networkID, GlobalNetworks.GatewaysByNetwork)
-			meshCfg := krt.FetchOne(ctx, a.meshConfig.AsCollection())
-			if meshCfg == nil {
-				log.Errorf("Failed to find mesh config for network %s", networkID)
-				return nil
-			}
 			if len(gws) == 0 {
 				log.Warnf("No network gateway found for network %s", networkID)
 				return nil
@@ -337,7 +340,7 @@ func (a *index) buildGlobalCollections(
 				log.Warnf("Multiple gateways found for network %s, using the first one", networkID)
 			}
 			gw := gws[0]
-			wi := a.createSplitHorizonWorkload(svcName, svc.Service, &gw, capacity, meshCfg)
+			wi := a.createSplitHorizonWorkload(ctx, svcName, svc.Service, &gw, capacity)
 			return []model.WorkloadInfo{wi}
 		}, opts.WithName("CoalesedWorkloads")...,
 	)
@@ -426,11 +429,6 @@ func (a *index) buildGlobalCollections(
 
 			// Since we merge the workloads in the remote cluster, we need to input the
 			// service account sans of the remote workloads through the SubjectAlNames field.
-			meshCfg := krt.FetchOne(ctx, a.meshConfig.AsCollection())
-			if meshCfg == nil {
-				log.Errorf("Failed to find mesh config")
-				return nil
-			}
 			localNetwork := GlobalNetworks.FetchLocalNetworkID(ctx).String()
 			sans := sets.String{}
 
@@ -438,7 +436,8 @@ func (a *index) buildGlobalCollections(
 				if wl.Workload.Network == localNetwork {
 					continue
 				}
-				sans.Insert(spiffe.MustGenSpiffeURI(meshCfg.MeshConfig, wl.Workload.Namespace, wl.Workload.ServiceAccount))
+				trustDomain := a.clusterMeshConfigs.FetchTrustDomain(ctx, cluster.ID(wl.Workload.ClusterId))
+				sans.Insert(spiffe.MustGenSpiffeURIForTrustDomain(trustDomain, wl.Workload.Namespace, wl.Workload.ServiceAccount))
 			}
 			if sans.IsEmpty() {
 				return &svc
@@ -697,7 +696,7 @@ func wrapObjectWithCluster[T any](clusterID cluster.ID) func(obj T) krt.ObjectWi
 }
 
 func (a *index) createSplitHorizonWorkload(
-	svcNamespacedName string, svc *workloadapi.Service, networkGateway *NetworkGateway, capacity uint32, meshCfg *MeshConfig,
+	ctx krt.HandlerContext, svcNamespacedName string, svc *workloadapi.Service, networkGateway *NetworkGateway, capacity uint32,
 ) model.WorkloadInfo {
 	hboneMtlsPort := networkGateway.HBONEPort
 	if hboneMtlsPort == 0 {
@@ -709,7 +708,7 @@ func (a *index) createSplitHorizonWorkload(
 		Name:           uid,
 		Namespace:      svc.Namespace,
 		Network:        networkGateway.Network.String(),
-		TrustDomain:    pickTrustDomain(meshCfg),
+		TrustDomain:    pickTrustDomain(a.clusterMeshConfigs.FetchTrustDomain(ctx, networkGateway.Cluster)),
 		Capacity:       &wrapperspb.UInt32Value{Value: capacity},
 		WorkloadType:   workloadapi.WorkloadType_POD, // TODO(stevenjin8): What is the correct type here?
 		TunnelProtocol: workloadapi.TunnelProtocol_HBONE,

--- a/pilot/pkg/serviceregistry/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/ambient/workloads.go
@@ -114,9 +114,8 @@ func (a Builder) WorkloadsCollection(
 		opts.WithName("EndpointSliceWorkloads")...)
 
 	NetworkGatewayWorkloads := krt.NewManyFromNothing[model.WorkloadInfo](func(ctx krt.HandlerContext) []model.WorkloadInfo {
-		meshCfg := krt.FetchOne(ctx, meshConfig.AsCollection())
 		all := LookupAllNetworkGateway(ctx, a.Networks.NetworkGateways)
-		return slices.Map(all, convertGateway(meshCfg))
+		return slices.Map(all, convertGateway(ctx, localTrustDomain(meshConfig)))
 	}, opts.WithName("NetworkGatewayWorkloads")...)
 
 	Workloads := krt.JoinCollection(
@@ -143,6 +142,7 @@ func MergedGlobalWorkloadsCollection(
 	globalNodes krt.Collection[krt.Collection[krt.ObjectWithCluster[Node]]],
 	nodesByCluster krt.Index[cluster.ID, krt.Collection[krt.ObjectWithCluster[Node]]],
 	meshConfig krt.Singleton[MeshConfig],
+	clusterMeshConfigs MeshConfigCollections,
 	localAuthPoliciesByNs krt.Index[string, model.WorkloadAuthorization],
 	localPeerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	globalWaypoints krt.Collection[krt.Collection[Waypoint]],
@@ -162,6 +162,7 @@ func MergedGlobalWorkloadsCollection(
 		localCluster.Pods(),
 		podWorkloadBuilder(
 			meshConfig,
+			clusterMeshConfigs.FetchTrustDomain,
 			globalNetworks.FetchLocalNetworkID,
 			localAuthPoliciesByNs,
 			localPeerAuthsByNs,
@@ -189,6 +190,7 @@ func MergedGlobalWorkloadsCollection(
 		workloadEntries,
 		workloadEntryWorkloadBuilder(
 			meshConfig,
+			clusterMeshConfigs.FetchTrustDomain,
 			globalNetworks.FetchLocalNetworkID,
 			localAuthPoliciesByNs,
 			localPeerAuthsByNs,
@@ -215,6 +217,7 @@ func MergedGlobalWorkloadsCollection(
 		serviceEntries,
 		serviceEntryWorkloadBuilder(
 			meshConfig,
+			clusterMeshConfigs.FetchTrustDomain,
 			localAuthPoliciesByNs,
 			localPeerAuthsByNs,
 			localWaypoints,
@@ -239,7 +242,8 @@ func MergedGlobalWorkloadsCollection(
 	// on when we will build from an EndpointSlice.
 	LocalEndpointSliceWorkloads := krt.NewManyCollection(
 		localCluster.EndpointSlices(),
-		endpointSlicesBuilder(meshConfig,
+		endpointSlicesBuilder(
+			clusterMeshConfigs.FetchTrustDomain,
 			localWorkloadServices,
 			domainSuffix,
 			localCluster.ID,
@@ -254,11 +258,10 @@ func MergedGlobalWorkloadsCollection(
 	)
 
 	GlobalNetworkGatewayWorkloads := krt.NewManyFromNothing[model.WorkloadInfo](func(ctx krt.HandlerContext) []model.WorkloadInfo {
-		meshCfg := krt.FetchOne(ctx, meshConfig.AsCollection())
 		return slices.Map(LookupAllNetworkGateway(
 			ctx,
 			globalNetworks.NetworkGateways,
-		), convertGateway(meshCfg))
+		), convertGateway(ctx, clusterMeshConfigs.FetchTrustDomain))
 	}, opts.WithName("LocalNetworkGatewayWorkloads")...)
 	LocalNetworkGatewayWorkloadsWithCluster := krt.MapCollection(
 		GlobalNetworkGatewayWorkloads,
@@ -334,6 +337,7 @@ func MergedGlobalWorkloadsCollection(
 				pods,
 				podWorkloadBuilder(
 					meshConfig,
+					clusterMeshConfigs.FetchTrustDomain,
 					globalNetworks.FetchLocalNetworkID,
 					localAuthPoliciesByNs,
 					localPeerAuthsByNs,
@@ -376,6 +380,7 @@ func MergedGlobalWorkloadsCollection(
 				workloadEntries,
 				workloadEntryWorkloadBuilder(
 					meshConfig,
+					clusterMeshConfigs.FetchTrustDomain,
 					globalNetworks.FetchLocalNetworkID,
 					localAuthPoliciesByNs,
 					localPeerAuthsByNs,
@@ -416,6 +421,7 @@ func MergedGlobalWorkloadsCollection(
 				serviceEntries,
 				serviceEntryWorkloadBuilder(
 					meshConfig,
+					clusterMeshConfigs.FetchTrustDomain,
 					localAuthPoliciesByNs,
 					localPeerAuthsByNs,
 					waypoints,
@@ -454,7 +460,8 @@ func MergedGlobalWorkloadsCollection(
 			// on when we will build from an EndpointSlice.
 			EndpointSliceWorkloads := krt.NewManyCollection(
 				endpointSlices,
-				endpointSlicesBuilder(meshConfig,
+				endpointSlicesBuilder(
+					clusterMeshConfigs.FetchTrustDomain,
 					globalWorkloadServices,
 					domainSuffix,
 					c.ID,
@@ -501,6 +508,7 @@ func MergedGlobalWorkloadsCollection(
 
 func workloadEntryWorkloadBuilder(
 	meshConfig krt.Singleton[MeshConfig],
+	trustDomain func(krt.HandlerContext, cluster.ID) string,
 	localNetworkGetter func(krt.HandlerContext) network.ID,
 	authPoliciesByNs krt.Index[string, model.WorkloadAuthorization],
 	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
@@ -550,7 +558,7 @@ func workloadEntryWorkloadBuilder(
 			Status:                workloadapi.WorkloadStatus_HEALTHY, // TODO: WE can be unhealthy
 			Waypoint:              targetWaypoint.GetAddress(),
 			ApplicationTunnel:     appTunnel,
-			TrustDomain:           pickTrustDomain(meshCfg),
+			TrustDomain:           pickTrustDomain(trustDomain(ctx, clusterID)),
 			Locality:              getWorkloadEntryLocality(&wle.Spec),
 		}
 		if wle.Spec.Weight > 0 {
@@ -600,6 +608,7 @@ func (a Builder) workloadEntryWorkloadBuilder(
 ) krt.TransformationSingle[*networkingclient.WorkloadEntry, model.WorkloadInfo] {
 	return workloadEntryWorkloadBuilder(
 		meshConfig,
+		localTrustDomain(meshConfig),
 		a.Networks.FetchLocalNetworkID,
 		authPoliciesByNs,
 		peerAuthsByNs,
@@ -643,6 +652,7 @@ func computeWaypoint(
 
 func podWorkloadBuilder(
 	meshConfig krt.Singleton[MeshConfig],
+	trustDomain func(krt.HandlerContext, cluster.ID) string,
 	localNetworkGetter func(krt.HandlerContext) network.ID,
 	authPoliciesByNs krt.Index[string, model.WorkloadAuthorization],
 	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
@@ -720,7 +730,7 @@ func podWorkloadBuilder(
 			Services:              constructServices(p, services),
 			AuthorizationPolicies: policies,
 			Status:                status,
-			TrustDomain:           pickTrustDomain(meshCfg),
+			TrustDomain:           pickTrustDomain(trustDomain(ctx, clusterID)),
 			Locality:              getPodLocality(ctx, nodes, p),
 		}
 
@@ -760,6 +770,7 @@ func (a Builder) podWorkloadBuilder(
 ) krt.TransformationSingle[*v1.Pod, model.WorkloadInfo] {
 	return podWorkloadBuilder(
 		meshConfig,
+		localTrustDomain(meshConfig),
 		a.Networks.FetchLocalNetworkID,
 		authPoliciesByNs,
 		peerAuthsByNs,
@@ -874,6 +885,7 @@ func buildWorkloadPolicies(
 
 func serviceEntryWorkloadBuilder(
 	meshConfig krt.Singleton[MeshConfig],
+	trustDomain func(krt.HandlerContext, cluster.ID) string,
 	authPoliciesByNs krt.Index[string, model.WorkloadAuthorization],
 	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
@@ -966,7 +978,7 @@ func serviceEntryWorkloadBuilder(
 				Status:                workloadapi.WorkloadStatus_HEALTHY,
 				Waypoint:              targetWaypoint.GetAddress(),
 				ApplicationTunnel:     appTunnel,
-				TrustDomain:           pickTrustDomain(meshCfg),
+				TrustDomain:           pickTrustDomain(trustDomain(ctx, clusterID)),
 				Locality:              getWorkloadEntryLocality(wle),
 			}
 			if wle.Weight > 0 {
@@ -1004,6 +1016,7 @@ func (a Builder) serviceEntryWorkloadBuilder(
 ) krt.TransformationMulti[*networkingclient.ServiceEntry, model.WorkloadInfo] {
 	return serviceEntryWorkloadBuilder(
 		meshConfig,
+		localTrustDomain(meshConfig),
 		authPoliciesByNs,
 		peerAuthsByNs,
 		waypoints,
@@ -1017,7 +1030,7 @@ func (a Builder) serviceEntryWorkloadBuilder(
 }
 
 func endpointSlicesBuilder(
-	meshConfig krt.Singleton[MeshConfig],
+	trustDomain func(krt.HandlerContext, cluster.ID) string,
 	workloadServices krt.Collection[model.ServiceInfo],
 	domainSuffix string,
 	clusterID cluster.ID,
@@ -1039,7 +1052,6 @@ func endpointSlicesBuilder(
 		}
 		var res []model.WorkloadInfo
 		seen := sets.New[string]()
-		meshCfg := krt.FetchOne(ctx, meshConfig.AsCollection())
 
 		// The slice must be for a single service, based on the label above.
 		serviceKey := es.Namespace + "/" + string(kube.ServiceHostname(serviceName, es.Namespace, domainSuffix))
@@ -1130,7 +1142,7 @@ func endpointSlicesBuilder(
 				Addresses:   addresses,
 				Hostname:    "",
 				Network:     network.String(),
-				TrustDomain: pickTrustDomain(meshCfg),
+				TrustDomain: pickTrustDomain(trustDomain(ctx, clusterID)),
 				Services:    services,
 				Status:      health,
 				ClusterId:   string(clusterID),
@@ -1159,7 +1171,7 @@ func (a Builder) endpointSlicesBuilder(
 	workloadServices krt.Collection[model.ServiceInfo],
 ) krt.TransformationMulti[*discovery.EndpointSlice, model.WorkloadInfo] {
 	return endpointSlicesBuilder(
-		meshConfig,
+		localTrustDomain(meshConfig),
 		workloadServices,
 		a.DomainSuffix,
 		a.ClusterID,
@@ -1184,9 +1196,19 @@ func setTunnelProtocol(labels, annotations map[string]string, w *workloadapi.Wor
 	// enum field would be rejected.
 }
 
-func pickTrustDomain(mesh *MeshConfig) string {
-	if td := mesh.GetTrustDomain(); td != "cluster.local" {
-		return td
+// localTrustDomain resolves any cluster to the local mesh config's trust domain. It is used where the
+// local cluster is the only one.
+func localTrustDomain(meshConfig krt.Singleton[MeshConfig]) func(krt.HandlerContext, cluster.ID) string {
+	return func(ctx krt.HandlerContext, _ cluster.ID) string {
+		return krt.FetchOne(ctx, meshConfig.AsCollection()).GetTrustDomain()
+	}
+}
+
+// pickTrustDomain elides the trust domain when it is the mesh-wide default, which ztunnel assumes when
+// the field is unset.
+func pickTrustDomain(trustDomain string) string {
+	if trustDomain != constants.DefaultClusterLocalDomain {
+		return trustDomain
 	}
 	return ""
 }
@@ -1385,7 +1407,7 @@ func gatewayUID(gw model.NetworkGateway) string {
 // convertGateway always converts a NetworkGateway into a Workload.
 // Workloads have a NetworkGateway field, which is effectively a pointer to another object (Service or Workload); in order
 // to facilitate this we need to translate our Gateway model down into a WorkloadInfo ztunnel can understand.
-func convertGateway(mesh *MeshConfig) func(gw NetworkGateway) model.WorkloadInfo {
+func convertGateway(ctx krt.HandlerContext, trustDomain func(krt.HandlerContext, cluster.ID) string) func(gw NetworkGateway) model.WorkloadInfo {
 	return func(gw NetworkGateway) model.WorkloadInfo {
 		wl := &workloadapi.Workload{
 			Uid:            gatewayUID(gw.NetworkGateway),
@@ -1393,7 +1415,7 @@ func convertGateway(mesh *MeshConfig) func(gw NetworkGateway) model.WorkloadInfo
 			ServiceAccount: gw.ServiceAccount.Name,
 			Namespace:      gw.ServiceAccount.Namespace,
 			Network:        gw.Network.String(),
-			TrustDomain:    pickTrustDomain(mesh),
+			TrustDomain:    pickTrustDomain(trustDomain(ctx, gw.Cluster)),
 		}
 
 		if ip, err := netip.ParseAddr(gw.Addr); err == nil {

--- a/releasenotes/notes/ambient-remote-trust-domain.yaml
+++ b/releasenotes/notes/ambient-remote-trust-domain.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue: [61608, 58427]
+releaseNotes:
+  - |
+    **Fixed** ambient workloads and east-west gateways in remote clusters being advertised with the
+    local cluster's trust domain, causing connections to them to fail when clusters use different
+    trust domains. The trust domain is now read from each cluster's own mesh config.

--- a/releasenotes/notes/ztunnel-trust-domains.yaml
+++ b/releasenotes/notes/ztunnel-trust-domains.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue: [61608, 58427]
+releaseNotes:
+  - |
+    **Fixed** ztunnel rejecting inbound connections from trust domains the mesh is configured to
+    accept through `meshConfig.trustDomainAliases` or `meshConfig.caCertificates[].trustDomains`.
+    These settings previously applied only to sidecars, waypoints and gateways.


### PR DESCRIPTION
Ambient multi-network assumes every cluster in the mesh issues identities in the
local cluster's trust domain. When clusters use different trust domains, istiod
advertises the wrong SAN for anything in a remote cluster and the HBONE handshake
fails, even when both clusters chain to the same root CA:

```
src.identity="spiffe://domain1.local/ns/sample/sa/curl" src.cluster="c1"
dst.workload="NetworkGateway/network2/172.20.255.101/0"
dst.identity="spiffe://domain1.local/ns/istio-system/sa/istio-eastwestgateway"
error="io error: invalid peer certificate: Other(OtherError(identity verification error:
  peer did not present the expected SAN
  (spiffe://domain1.local/ns/istio-system/sa/istio-eastwestgateway),
  got spiffe://domain2.local/ns/istio-system/sa/istio-eastwestgateway))"
```

`domain1.local` is the *calling* cluster's trust domain; the gateway it is dialling lives
in the cluster that uses `domain2.local`. istiod stamped its own trust domain onto a
workload in another cluster.

Tracked in #61608. This is a sidecar/ambient gap rather than a missing feature. The Kubernetes registry
already builds a per-cluster mesh watcher for remote clusters, and the comment on it
names the reason:

https://github.com/istio/istio/blob/9c6b89c06753fcdcf741d10a5687e8c9d56a59d1/pilot/pkg/serviceregistry/kube/controller/multicluster.go#L174-L175

```go
// Create per-cluster mesh watcher for remote clusters
// This allows controllers to detect cluster-specific settings that may be relevant
// for the local proxies, e.g. trust domain.
```

The ambient index has no equivalent, so a workload that works on a sidecar breaks
when the namespace is moved to ambient. #58428 propagated the trust domain to the
east-west gateway workload, which fixed the single-trust-domain case; this finishes
it for the multi-trust-domain case.

Two separate defects, one commit each:

**1. `ambient: read the trust domain from each cluster's own mesh config`**

`pickTrustDomain` reads the local `MeshConfig` for every workload, whatever cluster
it is in. Adds a krt collection of per-cluster mesh configs, keyed by cluster ID, and
resolves the trust domain from the cluster the workload belongs to. Covers pods,
WorkloadEntries, ServiceEntries, EndpointSlices, east-west gateway workloads and
split-horizon workloads/services.

A cluster whose mesh ConfigMap cannot be read is left out of the collection so the
lookup falls back to the local trust domain rather than to the built-in default. That
is the same fallback as #59474, for the same reason: during an upgrade the remote
`istio-reader` ClusterRole may not yet grant access.

**2. `ztunnel: tell the dataplane which trust domains to accept`**

`TrustDomainsForValidation` — `meshConfig.trustDomain`, its `trustDomainAliases`, and
every `caCertificates[].trustDomains` — is what sidecars, waypoints and gateways
validate inbound peers against. ztunnel cannot see any of it: it is not given the mesh
config, and `ztunnel` is a `FlattenValues` component so `spec.values.meshConfig` is
dropped before the chart renders.

Renders the additional trust domains onto the DaemonSet as `TRUST_DOMAINS`. ztunnel
still derives the trust domain it belongs to from its own certificate, so this carries
only the extra ones and with none configured the variable is absent and nothing changes.

Fixes #61608. **Requires https://github.com/istio/ztunnel/pull/2092** — this commit only supplies the
value; ztunnel ignores `TRUST_DOMAINS` until that PR merges. Merging this one first is
harmless.

### Testing

`TestMulticlusterAmbientIndex_SplitHorizon` is extended to give the remote cluster its
own mesh config and assert the gateway workload, the split-horizon workload and the
merged service SANs all pick it up, . It fails on master without the change:

```
expected network gateway workload to have trust domain remote.example.com, got company.com
```

Verified end to end on two kind clusters (Kubernetes 1.36.1) with separate trust domains
(`domain1.local` / `domain2.local`) chaining to one shared root, over an ambient east-west
gateway:

| c2 accepts `domain1.local` via | waypoint | result |
| --- | --- | --- |
| `trustDomainAliases` | none | HTTP 200 |
| `trustDomainAliases` | bound in both clusters | HTTP 200 |
| `caCertificates[].trustDomains` | none | HTTP 200 |
| `caCertificates[].trustDomains` | bound in both clusters | HTTP 200 |

All four measured on this PR's build. Where a waypoint is involved it is deployed and bound
in both clusters, per "all clusters must have identically named waypoint deployments".

Putting the released `istio/pilot:1.31.0` back in the calling cluster, with everything else
unchanged, reproduces the error above. A control run with both clusters on a single shared
trust domain and no `trustDomainAliases`/`caCertificates` also passes, with `TRUST_DOMAINS`
absent from the DaemonSet — the single-trust-domain path is unchanged.

### Notes for reviewers

- `getMeshConfigMapName` is now a third copy of the same helper (`pilot/pkg/bootstrap`
  and the kube controller each have one). Happy to hoist it into a shared package in
  this PR or a follow-up, whichever you prefer.
- This touches both `pilot/` and `manifests/` + `operator/`, so it needs
  `wg-user-experience-maintainers` as well as the pilot/ambient owners. Happy to split
  the chart commit into its own PR if that is easier to review.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [X] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [X] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [X] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
