### PR TITLE
aws test fix: point vm resolver at loopback to fail DNS fast

### DIFF
--- a/pkg/test/framework/components/echo/kube/templates/vm_deployment.yaml
+++ b/pkg/test/framework/components/echo/kube/templates/vm_deployment.yaml
@@ -28,12 +28,13 @@ spec:
       # for nameservers, search namespaces, etc. ndots is set to 1 so that
       # the application will first try to resolve the hostname (a, a.ns, etc.) as is
       # before attempting to add the search namespaces.
-      # nameserver is 127.0.0.1 with nothing on :53 so lookups fail fast instead of
-      # hanging on clusters without egress, which leaves envoy STRICT_DNS clusters warming.
+      # nameserver is a loopback address with nothing on :53 so lookups fail fast instead
+      # of hanging on clusters without egress, which leaves envoy STRICT_DNS clusters warming.
+      # not 127.0.0.1: the pilot dns test uses it as a server that must not be captured.
       dnsPolicy: None
       dnsConfig:
         nameservers:
-        - "127.0.0.1"
+        - "127.0.0.2"
         options:
         - name: "ndots"
           value: "1"

--- a/pkg/test/framework/components/echo/kube/templates/vm_deployment.yaml
+++ b/pkg/test/framework/components/echo/kube/templates/vm_deployment.yaml
@@ -28,10 +28,12 @@ spec:
       # for nameservers, search namespaces, etc. ndots is set to 1 so that
       # the application will first try to resolve the hostname (a, a.ns, etc.) as is
       # before attempting to add the search namespaces.
+      # nameserver is 127.0.0.1 with nothing on :53 so lookups fail fast instead of
+      # hanging on clusters without egress, which leaves envoy STRICT_DNS clusters warming.
       dnsPolicy: None
       dnsConfig:
         nameservers:
-        - "8.8.8.8"
+        - "127.0.0.1"
         options:
         - name: "ndots"
           value: "1"


### PR DESCRIPTION
**Please provide a description of this PR:**

`integ-security-multicluster` fails ~50% on `master` and `release-1.31` since the move to AWS prow, always from the vm echo with `503 UC` to cross-network endpoints (example https://aws.prow.istio.io/view/s3/istio-prow/pr-logs/pull/istio_istio/61476/integ-security-multicluster_istio_release-1.31/2096363811127693312) 

The vm pod uses `8.8.8.8` as its resolver, which aws prow blackholes, so the `STRICT_DNS` clusters for `fake.external.com` never finish warming and envoy delays its CDS resubscribe by about a minute on every forced reconnect 

Leaving the vm with stale plaintext clusters when the test flips mtls mode. Nothing on the vm ever needed a real answer from `8.8.8.8`: istiod comes from /etc/hosts, mesh names from the agent dns proxy, and the external endpoint is a cluster-internal name it could never resolve, so on gcp it only ever returned nxdomain. Using `127.0.0.1` with nothing on :53 makes those lookups fail instantly on any cluster and fixes the test without touching the infra.

cc @zirain @jewertow @jgreeer @Stevenjin8 