### PR TITLE
Helm 4: apply failurePolicy SSA fix to default chart webhook

### DIFF
--- a/manifests/charts/default/templates/validatingwebhook.yaml
+++ b/manifests/charts/default/templates/validatingwebhook.yaml
@@ -23,9 +23,6 @@ webhooks:
         namespace: {{ .Values.global.istioNamespace | quote }}
         path: "/validate"
       {{- end }}
-      {{- if .Values.base.validationCABundle }}
-      caBundle: "{{ .Values.base.validationCABundle }}"
-      {{- end }}
     rules:
       - operations:
           - CREATE
@@ -39,10 +36,7 @@ webhooks:
           - "*"
         resources:
           - "*"
-    {{- if .Values.base.validationCABundle }}
-    # Disable webhook controller in Pilot to stop patching it
-    failurePolicy: Fail
-    {{- else if .Values.base.validationFailurePolicy }}
+    {{- if .Values.base.validationFailurePolicy }}
     failurePolicy: {{ .Values.base.validationFailurePolicy }}
     {{- else if not .Release.IsUpgrade }}
     # Fail open until the validation webhook is ready. The webhook controller

--- a/manifests/charts/default/values.yaml
+++ b/manifests/charts/default/values.yaml
@@ -18,6 +18,13 @@ _internal_defaults_do_not_set:
     # Validation webhook configuration url
     # For example: https://$remotePilotAddress:15017/validate
     validationURL: ""
+    # Validation webhook caBundle value. Useful when running pilot with a well known cert
+    validationCABundle: ""
+    # Override the failurePolicy for the validation webhook.
+    # By default, the webhook starts with "Ignore" and istiod flips it to "Fail" once ready.
+    # Set to "Fail" to avoid the flip-flop, which is useful for server-side apply tools
+    # that do not support .Release.IsUpgrade (e.g. helm template | kubectl apply --server-side).
+    # validationFailurePolicy: Fail
 
   istiodRemote:
     # Sidecar injector mutating webhook configuration url

--- a/manifests/charts/default/values.yaml
+++ b/manifests/charts/default/values.yaml
@@ -18,8 +18,6 @@ _internal_defaults_do_not_set:
     # Validation webhook configuration url
     # For example: https://$remotePilotAddress:15017/validate
     validationURL: ""
-    # Validation webhook caBundle value. Useful when running pilot with a well known cert
-    validationCABundle: ""
     # Override the failurePolicy for the validation webhook.
     # By default, the webhook starts with "Ignore" and istiod flips it to "Fail" once ready.
     # Set to "Fail" to avoid the flip-flop, which is useful for server-side apply tools

--- a/operator/pkg/helm/helm_test.go
+++ b/operator/pkg/helm/helm_test.go
@@ -326,7 +326,7 @@ func TestRender(t *testing.T) {
 			diffSelect:  "ValidatingWebhookConfiguration:*:istiod-default-validator",
 		},
 		{
-			desc:        "default-webhook-cabundle-policy",
+			desc:        "default-webhook-failure-policy",
 			releaseName: "istiod",
 			namespace:   "istio-system",
 			chartName:   "default",

--- a/operator/pkg/helm/helm_test.go
+++ b/operator/pkg/helm/helm_test.go
@@ -333,6 +333,14 @@ func TestRender(t *testing.T) {
 			diffSelect:  "ValidatingWebhookConfiguration:*:istiod-default-validator",
 		},
 		{
+			desc:        "default-webhook-upgrade",
+			releaseName: "istiod",
+			namespace:   "istio-system",
+			chartName:   "default",
+			diffSelect:  "ValidatingWebhookConfiguration:*:istiod-default-validator",
+			isUpgrade:   true,
+		},
+		{
 			desc:        "istiod-waypoint-workload-socket",
 			releaseName: "istiod",
 			namespace:   "istio-system",

--- a/operator/pkg/helm/helm_test.go
+++ b/operator/pkg/helm/helm_test.go
@@ -326,6 +326,13 @@ func TestRender(t *testing.T) {
 			diffSelect:  "ValidatingWebhookConfiguration:*:istiod-default-validator",
 		},
 		{
+			desc:        "default-webhook-cabundle-policy",
+			releaseName: "istiod",
+			namespace:   "istio-system",
+			chartName:   "default",
+			diffSelect:  "ValidatingWebhookConfiguration:*:istiod-default-validator",
+		},
+		{
 			desc:        "istiod-waypoint-workload-socket",
 			releaseName: "istiod",
 			namespace:   "istio-system",

--- a/operator/pkg/helm/testdata/input/default-webhook-cabundle-policy.yaml
+++ b/operator/pkg/helm/testdata/input/default-webhook-cabundle-policy.yaml
@@ -1,0 +1,5 @@
+spec:
+  values:
+    base:
+      validationCABundle: dGVzdC1jYQ==
+      validationFailurePolicy: Ignore

--- a/operator/pkg/helm/testdata/input/default-webhook-cabundle-policy.yaml
+++ b/operator/pkg/helm/testdata/input/default-webhook-cabundle-policy.yaml
@@ -1,5 +1,0 @@
-spec:
-  values:
-    base:
-      validationCABundle: dGVzdC1jYQ==
-      validationFailurePolicy: Ignore

--- a/operator/pkg/helm/testdata/input/default-webhook-failure-policy.yaml
+++ b/operator/pkg/helm/testdata/input/default-webhook-failure-policy.yaml
@@ -1,0 +1,4 @@
+spec:
+  values:
+    base:
+      validationFailurePolicy: Fail

--- a/operator/pkg/helm/testdata/output/default-webhook-cabundle-policy.golden.yaml
+++ b/operator/pkg/helm/testdata/output/default-webhook-cabundle-policy.golden.yaml
@@ -5,27 +5,25 @@ metadata:
   labels:
     app: istiod
     istio: istiod
-    istio.io/rev: {{ .Values.revision | default "default" | quote }}
+    istio.io/rev: "default"
     istio.io/tag: "default"
     # Required to make sure this resource is removed
     # when purging Istio resources
     operator.istio.io/component: Pilot
     app.kubernetes.io/name: "istiod"
-    {{- include "istio.labels" . | nindent 4 }}
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "istiod"
+    app.kubernetes.io/part-of: "istio"
+    app.kubernetes.io/version: "1.0.0"
+    helm.sh/chart: istio-default-1.0.0
 webhooks:
   - name: validation.istio.io
     clientConfig:
-      {{- if .Values.base.validationURL }}
-      url: {{ .Values.base.validationURL }}
-      {{- else }}
       service:
-        name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-        namespace: {{ .Values.global.istioNamespace | quote }}
+        name: istiod
+        namespace: "istio-system"
         path: "/validate"
-      {{- end }}
-      {{- if .Values.base.validationCABundle }}
-      caBundle: "{{ .Values.base.validationCABundle }}"
-      {{- end }}
+      caBundle: "dGVzdC1jYQ=="
     rules:
       - operations:
           - CREATE
@@ -39,21 +37,11 @@ webhooks:
           - "*"
         resources:
           - "*"
-    {{- if .Values.base.validationCABundle }}
     # Disable webhook controller in Pilot to stop patching it
     failurePolicy: Fail
-    {{- else if .Values.base.validationFailurePolicy }}
-    failurePolicy: {{ .Values.base.validationFailurePolicy }}
-    {{- else if not .Release.IsUpgrade }}
-    # Fail open until the validation webhook is ready. The webhook controller
-    # will update this to `Fail` and patch in the `caBundle` when the webhook
-    # endpoint is ready.
-    failurePolicy: Ignore
-    {{- end }}
     sideEffects: None
     admissionReviewVersions: ["v1"]
     objectSelector:
       matchExpressions:
         - key: istio.io/rev
           operator: DoesNotExist
----

--- a/operator/pkg/helm/testdata/output/default-webhook-failure-policy.golden.yaml
+++ b/operator/pkg/helm/testdata/output/default-webhook-failure-policy.golden.yaml
@@ -23,7 +23,6 @@ webhooks:
         name: istiod
         namespace: "istio-system"
         path: "/validate"
-      caBundle: "dGVzdC1jYQ=="
     rules:
       - operations:
           - CREATE
@@ -37,7 +36,6 @@ webhooks:
           - "*"
         resources:
           - "*"
-    # Disable webhook controller in Pilot to stop patching it
     failurePolicy: Fail
     sideEffects: None
     admissionReviewVersions: ["v1"]

--- a/operator/pkg/helm/testdata/output/default-webhook-upgrade.golden.yaml
+++ b/operator/pkg/helm/testdata/output/default-webhook-upgrade.golden.yaml
@@ -1,0 +1,44 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: istiod-default-validator
+  labels:
+    app: istiod
+    istio: istiod
+    istio.io/rev: "default"
+    istio.io/tag: "default"
+    # Required to make sure this resource is removed
+    # when purging Istio resources
+    operator.istio.io/component: Pilot
+    app.kubernetes.io/name: "istiod"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "istiod"
+    app.kubernetes.io/part-of: "istio"
+    app.kubernetes.io/version: "1.0.0"
+    helm.sh/chart: istio-default-1.0.0
+webhooks:
+  - name: validation.istio.io
+    clientConfig:
+      service:
+        name: istiod
+        namespace: "istio-system"
+        path: "/validate"
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - security.istio.io
+          - networking.istio.io
+          - telemetry.istio.io
+          - extensions.istio.io
+        apiVersions:
+          - "*"
+        resources:
+          - "*"
+    sideEffects: None
+    admissionReviewVersions: ["v1"]
+    objectSelector:
+      matchExpressions:
+        - key: istio.io/rev
+          operator: DoesNotExist

--- a/releasenotes/notes/default-chart-webhook-failurepolicy.yaml
+++ b/releasenotes/notes/default-chart-webhook-failurepolicy.yaml
@@ -5,6 +5,6 @@ issue:
   - 61613
 releaseNotes:
   - |
-    **Fixed** the `default` chart's `ValidatingWebhookConfiguration` still hardcoding `failurePolicy: Ignore`
-    with no `caBundle` support, which caused the same field manager conflict on `helm upgrade` with
-    server-side apply that was previously fixed for the `base` and `istiod` charts.
+    **Fixed** the `default` chart's `ValidatingWebhookConfiguration` still hardcoding `failurePolicy: Ignore`,
+    which caused the same field manager conflict on `helm upgrade` with server-side apply that was
+    previously fixed for the `base` and `istiod` charts.

--- a/releasenotes/notes/default-chart-webhook-failurepolicy.yaml
+++ b/releasenotes/notes/default-chart-webhook-failurepolicy.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+  - 61613
+releaseNotes:
+  - |
+    **Fixed** the `default` chart's `ValidatingWebhookConfiguration` still hardcoding `failurePolicy: Ignore`
+    with no `caBundle` support, which caused the same field manager conflict on `helm upgrade` with
+    server-side apply that was previously fixed for the `base` and `istiod` charts.


### PR DESCRIPTION
Fixes #61613

The `default` chart's `manifests/charts/default/templates/validatingwebhook.yaml` has `failurePolicy: Ignore` causing the same field manager conflict on `helm upgrade` with server-side apply (Helm 4, Flux) that #59367/#59488 already fixed for the `istio-discovery` and `base` charts.

This applies the same fix as in https://github.com/istio/istio/pull/59459 to the default chart.