### PR TITLE
follow up: prevent partial apply from two sources

### DIFF
--- a/pkg/config/mesh/kubemesh/watcher_test.go
+++ b/pkg/config/mesh/kubemesh/watcher_test.go
@@ -68,7 +68,7 @@ func TestExtraConfigmap(t *testing.T) {
 		key: "ingressClass: user",
 	})
 	cmUserinvalid := makeConfigMapWithName(extraCmName, "1", map[string]string{
-		key: "ingressClass: 1",
+		key: "ingressClass: user\nconnectTimeout: -1s",
 	})
 	setup := func(t *testing.T) (corev1.ConfigMapInterface, mesh.Watcher) {
 		client := kube.NewFakeClient()
@@ -123,9 +123,13 @@ func TestExtraConfigmap(t *testing.T) {
 		if _, err := cms.Create(context.Background(), cmCore, metav1.CreateOptions{}); err != nil {
 			t.Fatal(err)
 		}
+		assertMeshConfig(t, w, "core")
+		mt := monitortest.New(t)
 		if _, err := cms.Create(context.Background(), cmUserinvalid, metav1.CreateOptions{}); err != nil {
 			t.Fatal(err)
 		}
+		mt.Assert("istiod_mesh_config_load_errors_total", nil, monitortest.Exactly(1))
+		// The valid source would also fail if the invalid source mutated the accumulated config.
 		assertMeshConfig(t, w, "core")
 	})
 	t.Run("many updates", func(t *testing.T) {

--- a/pkg/config/mesh/meshwatcher/collection.go
+++ b/pkg/config/mesh/meshwatcher/collection.go
@@ -25,6 +25,7 @@ import (
 	"istio.io/istio/pkg/kube/krt"
 	krtfiles "istio.io/istio/pkg/kube/krt/files"
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/util/protomarshal"
 )
 
 // MeshConfigSource provides a named mesh config input.
@@ -73,7 +74,7 @@ func NewCollection(opts krt.OptionsBuilder, sources ...MeshConfigSource) krt.Sin
 					log.Debugf("mesh configuration source missing")
 					continue
 				}
-				n, err := mesh.ApplyMeshConfig(*s, meshCfg)
+				n, err := mesh.ApplyMeshConfig(*s, protomarshal.Clone(meshCfg))
 				if err != nil {
 					meshConfigLoadErrors.Increment()
 					failedSources = append(failedSources, attempt.Name)


### PR DESCRIPTION
This a follow up for #61603. Prevents a partial apply from first invalid source when there are two sources for mesh config by applying it over a clone first.

Related https://github.com/istio/istio/issues/61563




Release note there in the first PR.