### PR TITLE
[WIP] Allow sidecars to send traffic to workload waypoints

### DIFF
--- a/docs/ambient/sidecar-to-ambient-migration.md
+++ b/docs/ambient/sidecar-to-ambient-migration.md
@@ -1,0 +1,275 @@
+# Sidecar to Ambient
+
+This guide walks through migrating a sidecar-based Istio deployment to ambient mode
+with zero downtime. It uses a `sleep` client calling a `helloworld`
+service with two versions (v1/v2) and a 50/50 traffic split.
+
+It uses a workload waypoint for each version of the service.
+
+## Prerequisites
+
+- Istio installed with the **ambient** profile (istiod, ztunnel, istio-cni)
+  ```bash
+  helm install istio-base istio/base -n istio-system --create-namespace --wait
+  helm install istiod istio/istiod --namespace istio-system --set profile=ambient --wait
+  helm install istio-cni istio/cni -n istio-system --set profile=ambient --wait
+  helm install ztunnel istio/ztunnel -n istio-system --wait
+  ```
+- Gateway API CRDs installed:
+  ```bash
+  kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.2/standard-install.yaml
+  ```
+
+## Starting State
+
+Create two namespaces with sidecar injection enabled and deploy the sample
+applications:
+
+```bash
+kubectl create ns client
+kubectl label ns client istio-injection=enabled
+kubectl apply -f samples/sleep/sleep.yaml -n client
+
+kubectl create ns server
+kubectl label ns server istio-injection=enabled
+kubectl apply -f samples/helloworld/helloworld.yaml -n server
+```
+
+This gives you:
+
+- **client**: `sleep` deployment (sidecar-injected)
+- **server**: `helloworld-v1` and `helloworld-v2` deployments (sidecar-injected)
+  with a shared `helloworld` Service
+
+Next, create per-version Services and an HTTPRoute to split traffic 50/50:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: helloworld-v1
+  namespace: server
+spec:
+  selector:
+    app: helloworld
+    version: v1
+  ports:
+    - port: 5000
+      name: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: helloworld-v2
+  namespace: server
+spec:
+  selector:
+    app: helloworld
+    version: v2
+  ports:
+    - port: 5000
+      name: http
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: helloworld
+  namespace: server
+spec:
+  parentRefs:
+    - kind: Service
+      group: ""
+      name: helloworld
+      port: 5000
+  rules:
+    - backendRefs:
+        - name: helloworld-v1
+          port: 5000
+          weight: 50
+        - name: helloworld-v2
+          port: 5000
+          weight: 50
+```
+
+## Step 1: Deploy Workload Waypoints
+
+Unlike service waypoints, workload waypoints are safe to use during sidecar-to-ambient interop because they only apply
+AuthorizationPolicy and RequestAuthentication. This avoids the double policy issues where both the sidecar and the waypoint would
+apply routing rules like retries, timeouts, and fault injection.
+
+### 1a. Create workload waypoint Gateways
+
+Create a waypoint for each workload version:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: helloworld-v1-waypoint
+  namespace: server
+  labels:
+    istio.io/waypoint-for: workload
+spec:
+  gatewayClassName: istio-waypoint
+  listeners:
+    - name: mesh
+      port: 15008
+      protocol: HBONE
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: helloworld-v2-waypoint
+  namespace: server
+  labels:
+    istio.io/waypoint-for: workload
+spec:
+  gatewayClassName: istio-waypoint
+  listeners:
+    - name: mesh
+      port: 15008
+      protocol: HBONE
+```
+
+### 1b. Label workloads to use their waypoints
+
+The `istio.io/use-waypoint` label must be on the **workloads** (pods), not the
+Services. Add the label to the pod template in each Deployment:
+
+```bash
+kubectl patch deployment helloworld-v1 -n server --type merge -p '
+  {"spec":{"template":{"metadata":{"labels":{"istio.io/use-waypoint":"helloworld-v1-waypoint"}}}}}'
+
+kubectl patch deployment helloworld-v2 -n server --type merge -p '
+  {"spec":{"template":{"metadata":{"labels":{"istio.io/use-waypoint":"helloworld-v2-waypoint"}}}}}'
+```
+
+### Verify
+
+```bash
+# Waypoint pods should be Running and Gateways should show PROGRAMMED=True
+kubectl get pods -n server
+kubectl get gateway -n server
+
+# Confirm workloads have waypoints assigned
+istioctl ztunnel-config workloads | grep helloworld
+```
+
+## Step 2: Migrate Server Namespace to Ambient
+
+### 2a. Switch the namespace label
+
+Remove the sidecar injection label and add the ambient label:
+
+```bash
+kubectl label ns server istio-injection- istio.io/dataplane-mode=ambient
+```
+
+### 2b. Restart server deployments
+
+The pods need to restart to drop their sidecars:
+
+```bash
+kubectl rollout restart deployment helloworld-v1 helloworld-v2 -n server
+kubectl rollout status deployment helloworld-v1 helloworld-v2 -n server
+```
+
+### Verify
+
+```bash
+# Pods should now be 1/1 (no sidecar)
+kubectl get pods -n server
+
+# Generate traffic to verify connectivity
+kubectl exec deploy/sleep -n client -- curl -s helloworld.server:5000/hello
+
+# Waypoint access logs should show traffic flowing through them
+kubectl logs deploy/helloworld-v1-waypoint -n server --tail=5
+kubectl logs deploy/helloworld-v2-waypoint -n server --tail=5
+```
+
+### 2c. Create the service waypoint
+
+You must create the service waypoint before switching the client to Ambient otherwise when the client is updated to ambient it will bypass the workload waypoints.
+
+TODO: Is this the expected behavior? Should sidecars send traffic through workload waypoints but ambient workloads bypass them?
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: helloworld-waypoint
+  namespace: server
+spec:
+  gatewayClassName: istio-waypoint
+  listeners:
+    - name: mesh
+      port: 15008
+      protocol: HBONE
+```
+
+### 2d. Label the Service
+
+```bash
+kubectl label service helloworld istio.io/use-waypoint=helloworld-waypoint -n server
+```
+
+## Step 3: Migrate Client Namespace to Ambient
+
+### 3a. Switch the namespace label
+
+```bash
+kubectl label ns client istio-injection- istio.io/dataplane-mode=ambient
+```
+
+### 3b. Restart client deployment
+
+```bash
+kubectl rollout restart deployment sleep -n client
+kubectl rollout status deployment sleep -n client
+```
+
+### Verify
+
+```bash
+# Pod should be 1/1 (no sidecar)
+kubectl get pods -n client
+
+# Service waypoint should now handle traffic
+kubectl logs deploy/helloworld-waypoint -n server --tail=5
+
+# Traffic should not flow through the workload waypoints
+kubectl logs deploy/helloworld-v1-waypoint -n server --tail=5
+kubectl logs deploy/helloworld-v2-waypoint -n server --tail=5
+```
+
+## Step 4: Clean Up Workload Waypoints
+
+With the service waypoint handling all traffic, the workload waypoints are no longer
+needed.
+
+### 4a. Remove waypoint labels from workloads
+
+```bash
+kubectl patch deployment helloworld-v1 -n server --type merge -p '
+  {"spec":{"template":{"metadata":{"labels":{"istio.io/use-waypoint":null}}}}}'
+
+kubectl patch deployment helloworld-v2 -n server --type merge -p '
+  {"spec":{"template":{"metadata":{"labels":{"istio.io/use-waypoint":null}}}}}'
+```
+
+### 4b. Delete the workload waypoint Gateways
+
+```bash
+kubectl delete gateway helloworld-v1-waypoint helloworld-v2-waypoint -n server
+```
+
+### Verify
+
+```bash
+# Only the service waypoint should remain
+kubectl get gateway -n server
+
+# Traffic continues flowing through the service waypoint
+kubectl logs deploy/helloworld-waypoint -n server --tail=5
+```

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -19,7 +19,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"net"
+	"net/netip"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -2698,6 +2701,41 @@ func (ps *PushContext) SupportsTunnel(n network.ID, ip string) bool {
 		}
 	}
 	return false
+}
+
+// WorkloadWaypointForAddress returns the waypoint proxy address for the workload at the given IP,
+// or empty string if the workload has no waypoint. Used by sidecars to route through workload waypoints.
+func (ps *PushContext) WorkloadWaypointForAddress(n network.ID, ip string) string {
+	infos, _ := ps.ambientIndex.AddressInformation(sets.New(n.String() + "/" + ip))
+	for _, wl := range ExtractWorkloadsFromAddresses(infos) {
+		wp := wl.Workload.GetWaypoint()
+		if wp == nil {
+			continue
+		}
+		port := wp.GetHboneMtlsPort()
+		if port == 0 {
+			port = 15008
+		}
+		switch dest := wp.GetDestination().(type) {
+		case *workloadapi.GatewayAddress_Address:
+			addr, ok := netip.AddrFromSlice(dest.Address.Address)
+			if !ok {
+				continue
+			}
+			return net.JoinHostPort(addr.String(), strconv.Itoa(int(port)))
+		case *workloadapi.GatewayAddress_Hostname:
+			svcKey := dest.Hostname.Namespace + "/" + dest.Hostname.Hostname
+			svcInfo := ps.ambientIndex.ServiceInfo(svcKey)
+			if svcInfo != nil && len(svcInfo.Service.Addresses) > 0 {
+				addr, ok := netip.AddrFromSlice(svcInfo.Service.Addresses[0].Address)
+				if !ok {
+					continue
+				}
+				return net.JoinHostPort(addr.String(), strconv.Itoa(int(port)))
+			}
+		}
+	}
+	return ""
 }
 
 // WorkloadsForWaypoint returns all workloads associated with a given waypoint identified by it's WaypointKey

--- a/pilot/pkg/xds/endpoints/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder.go
@@ -819,6 +819,14 @@ func buildEnvoyLbEndpoint(b *EndpointBuilder, e *model.IstioEndpoint, mtlsEnable
 		tunnel = true
 	}
 
+	// For sidecar proxies, check if the destination workload has a workload waypoint.
+	// Workload waypoints only apply AuthorizationPolicy/RequestAuthentication,
+	// so there is no double-policy concern with the sidecar's outbound service policies.
+	workloadWaypoint := ""
+	if !toServiceWaypoint && tunnel && isSidecarProxy(b.proxy) {
+		workloadWaypoint = b.push.WorkloadWaypointForAddress(e.Network, e.Addresses[0])
+	}
+
 	if tunnel {
 		// Currently, Envoy cannot support tunneling to multiple IP families.
 		// TODO(https://github.com/envoyproxy/envoy/issues/36318)
@@ -837,18 +845,20 @@ func buildEnvoyLbEndpoint(b *EndpointBuilder, e *model.IstioEndpoint, mtlsEnable
 			// // If there are multiple VIPs, we just use one. Hostname would be ideal here but isn't supported.
 			address = serviceVIPs[0]
 			port = b.port
+		} else if workloadWaypoint != "" {
+			// Workload waypoints do not apply service policies that are problematic to apply twice.
+			waypoint = workloadWaypoint
 		}
-		// We intentionally do not take into account waypoints here.
-		// 1. Workload waypoints: sidecar/ingress do not support sending traffic directly to workloads, only to services,
-		//    so these are not applicable.
-		// 2. Service waypoints: in ztunnel, we would defer handling service traffic if the service has a waypoint, and instead
-		//    send to the waypoint. However, with sidecars this is problematic. We don't know which service is the intended destination
-		//    until *after* we apply policies. If we then sent to a service waypoint, we apply service policies twice.
-		//    This can be problematic: double mirroring, fault injection, request manipulation, ....
-		//    Instead, we consider this to workload traffic. This gives the same behavior as if we were an application doing internal load balancing
-		//    with ztunnel.
-		//    Note: there is a pretty valid case for wanting to send to the service from ingress. This gives a two tier delegation.
-		//    However, it's not safe to do that by default; perhaps a future API could opt into this.
+		// We intentionally do not take into account Service waypoints here.
+		// In ztunnel, we would defer handling service traffic if the service has a waypoint, and instead
+		// send to the waypoint. However, with sidecars this is problematic. We don't know which service is the intended destination
+		// until *after* we apply policies. If we then sent to a service waypoint, we apply service policies twice.
+		// This can be problematic: double mirroring, fault injection, request manipulation, ....
+		// Instead, we consider this to workload traffic. This gives the same behavior as if we were an application doing internal load balancing
+		// with ztunnel.
+		// Note: there is a pretty valid case for wanting to send to the service from ingress. This gives a two tier delegation.
+		// However, it's not safe to do that by default; perhaps a future API could opt into this.
+
 		// Support connecting to server side waypoint proxy, if the destination has one. This is for sidecars and ingress.
 		// Setup tunnel metadata so requests will go through the tunnel
 		target := ptr.NonEmptyOrDefault(waypoint, net.JoinHostPort(address, strconv.Itoa(port)))

--- a/pilot/pkg/xds/endpoints/endpoint_builder_test.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder_test.go
@@ -16,6 +16,7 @@ package endpoints
 
 import (
 	"fmt"
+	"net"
 	"reflect"
 	"testing"
 
@@ -36,8 +37,12 @@ import (
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/network"
 	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/util/sets"
 	"istio.io/istio/pkg/workloadapi"
+
+	"istio.io/istio/pilot/pkg/networking/util"
 )
 
 // TestWeightedWaypointEndpointsFailsClosed verifies weighted waypoint routing never falls back to direct endpoints.
@@ -145,6 +150,7 @@ func TestWeightedWaypointEndpointsFailsClosed(t *testing.T) {
 type mockAmbientIndex struct {
 	model.NoopAmbientIndexes
 	serviceInfos []*model.ServiceInfo
+	addressInfos map[string][]model.AddressInfo
 }
 
 func (m *mockAmbientIndex) ServiceInfo(key string) *model.ServiceInfo {
@@ -155,6 +161,19 @@ func (m *mockAmbientIndex) ServiceInfo(key string) *model.ServiceInfo {
 		}
 	}
 	return nil
+}
+
+func (m *mockAmbientIndex) AddressInformation(addresses sets.String) ([]model.AddressInfo, sets.String) {
+	if m.addressInfos == nil {
+		return nil, nil
+	}
+	var result []model.AddressInfo
+	for addr := range addresses {
+		if infos, ok := m.addressInfos[addr]; ok {
+			result = append(result, infos...)
+		}
+	}
+	return result, nil
 }
 
 // MockDiscovery is an in-memory ServiceDiscover with mock services
@@ -865,6 +884,173 @@ func TestBuildClusterLoadAssignment_InferenceServicePortFiltering(t *testing.T) 
 
 			if totalEndpoints != tt.expectedEndpoints {
 				t.Errorf("expected %d endpoints, got %d", tt.expectedEndpoints, totalEndpoints)
+			}
+		})
+	}
+}
+
+func TestBuildEnvoyLbEndpoint_WorkloadWaypoint(t *testing.T) {
+	waypointIP := net.ParseIP("10.0.1.50").To4()
+	workloadIP := "10.0.0.5"
+
+	tests := []struct {
+		name            string
+		proxy           *model.Proxy
+		waypoint        *workloadapi.GatewayAddress
+		expectWaypoint  bool
+		expectedAddress string
+	}{
+		{
+			name: "sidecar with workload waypoint routes through waypoint",
+			proxy: &model.Proxy{
+				Type: model.SidecarProxy,
+				Metadata: &model.NodeMetadata{
+					Namespace: "default",
+				},
+			},
+			waypoint: &workloadapi.GatewayAddress{
+				Destination: &workloadapi.GatewayAddress_Address{
+					Address: &workloadapi.NetworkAddress{
+						Address: waypointIP,
+					},
+				},
+				HboneMtlsPort: 15008,
+			},
+			expectWaypoint:  true,
+			expectedAddress: "10.0.1.50:15008",
+		},
+		{
+			name: "sidecar without workload waypoint routes directly",
+			proxy: &model.Proxy{
+				Type: model.SidecarProxy,
+				Metadata: &model.NodeMetadata{
+					Namespace: "default",
+				},
+			},
+			waypoint:       nil,
+			expectWaypoint: false,
+		},
+		{
+			name: "gateway proxy does not use workload waypoint",
+			proxy: &model.Proxy{
+				Type: model.Router,
+				Metadata: &model.NodeMetadata{
+					Namespace: "default",
+				},
+			},
+			waypoint: &workloadapi.GatewayAddress{
+				Destination: &workloadapi.GatewayAddress_Address{
+					Address: &workloadapi.NetworkAddress{
+						Address: waypointIP,
+					},
+				},
+				HboneMtlsPort: 15008,
+			},
+			expectWaypoint: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			test.SetForTest(t, &features.EnableHBONESend, true)
+			test.SetForTest(t, &features.PreferHBONESend, true)
+
+			svc := &model.Service{
+				Hostname: "svc-b.default.svc.cluster.local",
+				Attributes: model.ServiceAttributes{
+					Name:      "svc-b",
+					Namespace: "default",
+				},
+				Ports: model.PortList{{Port: 8080, Protocol: protocol.HTTP, Name: "http"}},
+			}
+
+			ep := &model.IstioEndpoint{
+				Addresses:       []string{workloadIP},
+				EndpointPort:    8080,
+				ServicePortName: "http",
+				TLSMode:         model.IstioMutualTLSModeLabel,
+				Labels: map[string]string{
+					model.TunnelLabel: model.TunnelHTTP,
+				},
+			}
+
+			addressInfos := map[string][]model.AddressInfo{}
+			netKey := string(network.ID("")) + "/" + workloadIP
+			workload := &workloadapi.Workload{
+				Addresses:      [][]byte{net.ParseIP(workloadIP).To4()},
+				TunnelProtocol: workloadapi.TunnelProtocol_HBONE,
+				Waypoint:       tt.waypoint,
+			}
+			addressInfos[netKey] = []model.AddressInfo{{
+				Address: &workloadapi.Address{
+					Type: &workloadapi.Address_Workload{
+						Workload: workload,
+					},
+				},
+			}}
+
+			env := model.NewEnvironment()
+			configStore := model.NewFakeStore()
+			env.ConfigStore = configStore
+			env.Watcher = meshwatcher.NewTestWatcher(&meshconfig.MeshConfig{RootNamespace: "istio-system"})
+			env.NetworksWatcher = meshwatcher.NewFixedNetworksWatcher(nil)
+			env.ServiceDiscovery = &localServiceDiscovery{services: []*model.Service{svc}}
+			env.AmbientIndexes = &mockAmbientIndex{addressInfos: addressInfos}
+
+			xdsUpdater := xdsfake.NewFakeXDS()
+			if err := env.InitNetworksManager(xdsUpdater); err != nil {
+				t.Fatal(err)
+			}
+			env.VirtualServiceController = model.NewVirtualServiceController(
+				configStore,
+				model.VSControllerOptions{KrtDebugger: krt.GlobalDebugHandler},
+				env.Watcher,
+			)
+			stop := test.NewStop(t)
+			go configStore.Run(stop)
+			go env.VirtualServiceController.Run(stop)
+			kube.WaitForCacheSync("test", stop, configStore.HasSynced)
+			kube.WaitForCacheSync("test", stop, env.VirtualServiceController.HasSynced)
+			env.Init()
+
+			push := model.NewPushContext()
+			push.InitContext(env, nil, nil)
+			env.SetPushContext(push)
+
+			tt.proxy.SetSidecarScope(push)
+
+			b := &EndpointBuilder{
+				hostname: "svc-b.default.svc.cluster.local",
+				port:     8080,
+				push:     push,
+				proxy:    tt.proxy,
+				service:  svc,
+				dir:      model.TrafficDirectionOutbound,
+				nodeType: tt.proxy.Type,
+			}
+			b.mtlsChecker = newMtlsChecker(push, tt.proxy.SidecarScope.AuthnPolicies, 8080, nil, "")
+
+			lbEp := buildEnvoyLbEndpoint(b, ep, true, false)
+
+			tunnelMeta := lbEp.Metadata.GetFilterMetadata()[util.OriginalDstMetadataKey]
+			if tt.expectWaypoint {
+				if tunnelMeta == nil {
+					t.Fatal("expected tunnel metadata but got nil")
+				}
+				wp := tunnelMeta.GetFields()["waypoint"]
+				if wp == nil {
+					t.Fatal("expected waypoint field in tunnel metadata but got nil")
+				}
+				if wp.GetStringValue() != tt.expectedAddress {
+					t.Errorf("expected waypoint address %q, got %q", tt.expectedAddress, wp.GetStringValue())
+				}
+			} else {
+				if tunnelMeta != nil {
+					wp := tunnelMeta.GetFields()["waypoint"]
+					if wp != nil && wp.GetStringValue() != "" {
+						t.Errorf("expected no waypoint but got %q", wp.GetStringValue())
+					}
+				}
 			}
 		})
 	}

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -610,7 +610,8 @@ spec:
 `).ApplyOrFail(t)
 				opt.Check = check.And(
 					check.OK(),
-					check.RequestHeader("Istio-Custom-Header", "user-defined-value"))
+					check.RequestHeader("Istio-Custom-Header", "user-defined-value"),
+				)
 				src.CallOrFail(t, opt)
 			})
 			t.NewSubTest("subset").Run(func(t framework.TestContext) {
@@ -656,7 +657,8 @@ spec:
 				opt.Count = 10
 				opt.Check = check.And(
 					check.OK(),
-					check.Hostname(exp))
+					check.Hostname(exp),
+				)
 				src.CallOrFail(t, opt)
 			})
 		})
@@ -731,7 +733,8 @@ spec:
 				check.RequestHeaders(map[string]string{
 					"X-Lua-Inbound":   "hello world",
 					"X-Vhost-Inbound": "hello world",
-				}))
+				}),
+			)
 			src.CallOrFail(t, opt)
 		})
 	})
@@ -801,7 +804,8 @@ spec:
 							}
 						}
 						return nil
-					})
+					},
+				)
 				src.CallOrFail(t, opt)
 			})
 
@@ -822,7 +826,8 @@ spec:
 							}
 						}
 						return nil
-					})
+					},
+				)
 				src.CallOrFail(t, opt)
 			})
 		})
@@ -1447,8 +1452,8 @@ func TestAuthorizationL7(t *testing.T) {
 			// Ensure we don't get stuck on old connections with old RBAC rules. This causes 45s test times
 			// due to draining.
 			opt.NewConnectionPerRequest = true
-			if src.Config().HasSidecar() && dst.Config().HasAnyWaypointProxy() {
-				// TODO: sidecar -> workload waypoint support
+			if src.Config().HasSidecar() && dst.Config().HasServiceAddressedWaypointProxy() {
+				// Sidecars do not route through service waypoints to avoid double-applying VirtualService
 				t.Skip("https://github.com/istio/istio/issues/51445")
 			}
 
@@ -1572,9 +1577,12 @@ spec:
 					// Only waypoint proxy can handle L7 policies
 					opt.Check = CheckDeny
 				case dst.Config().HasWorkloadAddressedWaypointProxy() && !dst.Config().HasServiceAddressedWaypointProxy():
-					// send traffic to the workload instead of the service so it will redirect to the WL waypoint
-					opt.Address = dst.MustWorkloads().Addresses()[0]
-					opt.Port = echo.Port{ServicePort: ports.All().MustForName(opt.Port.Name).WorkloadPort}
+					if !src.Config().HasSidecar() {
+						// For non-sidecar sources (ztunnel), send to workload IP so ztunnel redirects to waypoint.
+						// Sidecars route via the service VIP, which already has waypoint tunnel metadata.
+						opt.Address = dst.MustWorkloads().Addresses()[0]
+						opt.Port = echo.Port{ServicePort: ports.All().MustForName(opt.Port.Name).WorkloadPort}
+					}
 				}
 			}
 			if src == dst {
@@ -1673,9 +1681,12 @@ func TestL7JWT(t *testing.T) {
 
 				switch {
 				case dst.Config().HasWorkloadAddressedWaypointProxy() && !dst.Config().HasServiceAddressedWaypointProxy():
-					// send traffic to the workload instead of the service so it will redirect to the WL waypoint
-					opt.Address = dst.MustWorkloads().Addresses()[0]
-					opt.Port = echo.Port{ServicePort: ports.All().MustForName(opt.Port.Name).WorkloadPort}
+					if !src.Config().HasSidecar() {
+						// For non-sidecar sources (ztunnel), send to workload IP so ztunnel redirects to waypoint.
+						// Sidecars route via the service VIP, which already has waypoint tunnel metadata.
+						opt.Address = dst.MustWorkloads().Addresses()[0]
+						opt.Port = echo.Port{ServicePort: ports.All().MustForName(opt.Port.Name).WorkloadPort}
+					}
 					if src == dst {
 						t.Skip("self call is not captured, L7 features will not work")
 					}
@@ -2892,7 +2903,8 @@ func RunReachability(testCases []reachability.TestCase, t framework.TestContext)
 					tpe = "positive"
 					opt.Check = check.And(
 						check.OK(),
-						check.ReachedTargetClusters(t))
+						check.ReachedTargetClusters(t),
+					)
 					if expectMTLS {
 						opt.Check = check.And(opt.Check, check.MTLSForHTTP())
 					}

--- a/tests/integration/ambient/waypoint_test.go
+++ b/tests/integration/ambient/waypoint_test.go
@@ -937,6 +937,23 @@ spec:
 			if t.Settings().AmbientMultiNetwork {
 				t.Skip("https://github.com/istio/istio/issues/54245")
 			}
+			// Apply a deny-all policy on the workload waypoint
+			t.ConfigIstio().Eval(apps.Namespace.Name(), map[string]string{
+				"Waypoint": apps.WorkloadAddressedWaypoint.Config().WorkloadWaypointProxy,
+			}, `
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: deny-all-workload-waypoint
+spec:
+  targetRefs:
+  - kind: Gateway
+    group: gateway.networking.k8s.io
+    name: {{.Waypoint}}
+  action: DENY
+  rules:
+  - {}
+`).ApplyOrFail(t)
 			for _, src := range apps.Sidecar {
 				for _, dst := range apps.WorkloadAddressedWaypoint {
 					for _, dstWl := range dst.WorkloadsOrFail(t) {
@@ -945,8 +962,8 @@ spec:
 								opt = opt.DeepCopy()
 								opt.Address = dstWl.Address()
 								opt.Port = echo.Port{ServicePort: ports.All().MustForName(opt.Port.Name).WorkloadPort}
-								// Sidecar does not currently traverse waypoint, so we expect to bypass it and get success
-								opt.Check = check.OK()
+								// Sidecar now traverses workload waypoint, so traffic should be denied
+								opt.Check = CheckDeny
 								src.CallOrFail(t, opt)
 							})
 						}


### PR DESCRIPTION
**Please provide a description of this PR:**
This is primarily a proof of concept. Included is a migration guide that details what the process would look like.

When a destination workload has a workload-waypoint and the sidecar proxy supports tunneling, the sidecar will get endpoints for the workload waypoint.

Allowing sidecars to tunnel to workload waypoints avoids the double policy problems with service waypoints but opens the door for migrating sidecars to ambient without a gap in policy enforcement.