### PR TITLE
Switch from value to pointer for workload/service collections

### DIFF
--- a/pilot/pkg/config/kube/agentgateway/agentgateway_controller.go
+++ b/pilot/pkg/config/kube/agentgateway/agentgateway_controller.go
@@ -529,9 +529,9 @@ func (c *Controller) buildAddressCollections(opts krt.OptionsBuilder) krt.Collec
 		true,
 	)
 
-	inferencePoolsInfo := krt.NewCollection(inputs.InferencePools, inferencePoolBuilder(c.domainSuffix),
+	inferencePoolsInfo := krt.NewManyCollection(inputs.InferencePools, inferencePoolBuilder(c.domainSuffix),
 		opts.WithName("InferencePools")...)
-	services = krt.JoinCollection([]krt.Collection[model.ServiceInfo]{services, inferencePoolsInfo}, krt.WithJoinUnchecked())
+	services = krt.JoinCollection([]krt.Collection[*model.ServiceInfo]{services, inferencePoolsInfo}, krt.WithJoinUnchecked())
 
 	nodeLocality := ambient.NodesCollection(inputs.Nodes, opts.WithName("NodeLocality")...)
 	workloads := builder.WorkloadsCollection(
@@ -554,8 +554,8 @@ func (c *Controller) buildAddressCollections(opts krt.OptionsBuilder) krt.Collec
 	workloadAddresses := krt.MapCollection(workloads, func(t model.WorkloadInfo) Address {
 		return Address{Workload: &t}
 	})
-	svcAddresses := krt.MapCollection(services, func(t model.ServiceInfo) Address {
-		return Address{Service: &t}
+	svcAddresses := krt.MapCollection(services, func(t *model.ServiceInfo) Address {
+		return Address{Service: t}
 	})
 
 	adpAddresses := krt.JoinCollection([]krt.Collection[Address]{svcAddresses, workloadAddresses}, opts.WithName("Addresses")...)

--- a/pilot/pkg/config/kube/agentgateway/agentgateway_controller.go
+++ b/pilot/pkg/config/kube/agentgateway/agentgateway_controller.go
@@ -551,8 +551,8 @@ func (c *Controller) buildAddressCollections(opts krt.OptionsBuilder) krt.Collec
 	)
 
 	// Build address collections
-	workloadAddresses := krt.MapCollection(workloads, func(t model.WorkloadInfo) Address {
-		return Address{Workload: &t}
+	workloadAddresses := krt.MapCollection(workloads, func(t *model.WorkloadInfo) Address {
+		return Address{Workload: t}
 	})
 	svcAddresses := krt.MapCollection(services, func(t *model.ServiceInfo) Address {
 		return Address{Service: t}

--- a/pilot/pkg/config/kube/agentgateway/agentgateway_controller.go
+++ b/pilot/pkg/config/kube/agentgateway/agentgateway_controller.go
@@ -529,7 +529,7 @@ func (c *Controller) buildAddressCollections(opts krt.OptionsBuilder) krt.Collec
 		true,
 	)
 
-	inferencePoolsInfo := krt.NewManyCollection(inputs.InferencePools, inferencePoolBuilder(c.domainSuffix),
+	inferencePoolsInfo := krt.NewPointerCollection(inputs.InferencePools, inferencePoolBuilder(c.domainSuffix),
 		opts.WithName("InferencePools")...)
 	services = krt.JoinCollection([]krt.Collection[*model.ServiceInfo]{services, inferencePoolsInfo}, krt.WithJoinUnchecked())
 

--- a/pilot/pkg/config/kube/agentgateway/service.go
+++ b/pilot/pkg/config/kube/agentgateway/service.go
@@ -45,9 +45,9 @@ func (i Address) Equals(other Address) bool {
 		return false
 	}
 	if i.Workload != nil {
-		return i.Workload.Equals(*other.Workload)
+		return i.Workload.Equals(other.Workload)
 	}
-	return i.Service.Equals(*other.Service)
+	return i.Service.Equals(other.Service)
 }
 
 func (i Address) IntoProto() *workloadapi.Address {

--- a/pilot/pkg/config/kube/agentgateway/service.go
+++ b/pilot/pkg/config/kube/agentgateway/service.go
@@ -75,8 +75,8 @@ func serviceToAddress(s *workloadapi.Service) *workloadapi.Address {
 	}
 }
 
-func inferencePoolBuilder(domainSuffix string) krt.TransformationMulti[*inferencev1.InferencePool, *model.ServiceInfo] {
-	return func(ctx krt.HandlerContext, s *inferencev1.InferencePool) []*model.ServiceInfo {
+func inferencePoolBuilder(domainSuffix string) krt.TransformationSingle[*inferencev1.InferencePool, model.ServiceInfo] {
+	return func(ctx krt.HandlerContext, s *inferencev1.InferencePool) *model.ServiceInfo {
 		portNames := map[int32]model.ServicePortName{}
 		ports := []*workloadapi.Port{{
 			ServicePort: uint32(s.Spec.TargetPorts[0].Number), //nolint:gosec // G115: InferencePool TargetPort is int32 with validation 1-65535, always safe
@@ -96,7 +96,7 @@ func inferencePoolBuilder(domainSuffix string) krt.TransformationMulti[*inferenc
 		for k, v := range s.Spec.Selector.MatchLabels {
 			selector[string(k)] = string(v)
 		}
-		return []*model.ServiceInfo{precomputeService(&model.ServiceInfo{
+		return precomputeService(&model.ServiceInfo{
 			Service:       svc,
 			PortNames:     portNames,
 			LabelSelector: model.NewSelector(selector),
@@ -107,6 +107,6 @@ func inferencePoolBuilder(domainSuffix string) krt.TransformationMulti[*inferenc
 				},
 				Kind: kind.InferencePool,
 			},
-		})}
+		})
 	}
 }

--- a/pilot/pkg/config/kube/agentgateway/service.go
+++ b/pilot/pkg/config/kube/agentgateway/service.go
@@ -24,7 +24,6 @@ import (
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/kube/krt"
-	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/workloadapi"
 )
 
@@ -62,11 +61,7 @@ func InferenceHostname(name, namespace, domainSuffix string) host.Name {
 	return host.Name(name + "." + namespace + "." + "inference" + "." + domainSuffix) // Format: "%s.%s.svc.%s"
 }
 
-func precomputeServicePtr(w *model.ServiceInfo) *model.ServiceInfo {
-	return ptr.Of(precomputeService(*w))
-}
-
-func precomputeService(w model.ServiceInfo) model.ServiceInfo {
+func precomputeService(w *model.ServiceInfo) *model.ServiceInfo {
 	w.AsAddress = model.NewAddressInfo(serviceToAddress(w.Service))
 	w.MarshaledAddress = w.AsAddress.Marshaled
 	return w
@@ -80,8 +75,8 @@ func serviceToAddress(s *workloadapi.Service) *workloadapi.Address {
 	}
 }
 
-func inferencePoolBuilder(domainSuffix string) krt.TransformationSingle[*inferencev1.InferencePool, model.ServiceInfo] {
-	return func(ctx krt.HandlerContext, s *inferencev1.InferencePool) *model.ServiceInfo {
+func inferencePoolBuilder(domainSuffix string) krt.TransformationMulti[*inferencev1.InferencePool, *model.ServiceInfo] {
+	return func(ctx krt.HandlerContext, s *inferencev1.InferencePool) []*model.ServiceInfo {
 		portNames := map[int32]model.ServicePortName{}
 		ports := []*workloadapi.Port{{
 			ServicePort: uint32(s.Spec.TargetPorts[0].Number), //nolint:gosec // G115: InferencePool TargetPort is int32 with validation 1-65535, always safe
@@ -101,7 +96,7 @@ func inferencePoolBuilder(domainSuffix string) krt.TransformationSingle[*inferen
 		for k, v := range s.Spec.Selector.MatchLabels {
 			selector[string(k)] = string(v)
 		}
-		return precomputeServicePtr(&model.ServiceInfo{
+		return []*model.ServiceInfo{precomputeService(&model.ServiceInfo{
 			Service:       svc,
 			PortNames:     portNames,
 			LabelSelector: model.NewSelector(selector),
@@ -112,6 +107,6 @@ func inferencePoolBuilder(domainSuffix string) krt.TransformationSingle[*inferen
 				},
 				Kind: kind.InferencePool,
 			},
-		})
+		})}
 	}
 }

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -2702,13 +2702,13 @@ func (ps *PushContext) SupportsTunnel(n network.ID, ip string) bool {
 
 // WorkloadsForWaypoint returns all workloads associated with a given waypoint identified by it's WaypointKey
 // Used when calculating the workloads which should be configured for a specific waypoint proxy
-func (ps *PushContext) WorkloadsForWaypoint(key WaypointKey) []WorkloadInfo {
+func (ps *PushContext) WorkloadsForWaypoint(key WaypointKey) []*WorkloadInfo {
 	return ps.ambientIndex.WorkloadsForWaypoint(key)
 }
 
 // ServicesForWaypoint returns all services associated with a given waypoint identified by it's WaypointKey
 // Used when calculating the services which should be configured for a specific waypoint proxy
-func (ps *PushContext) ServicesForWaypoint(key WaypointKey) []ServiceInfo {
+func (ps *PushContext) ServicesForWaypoint(key WaypointKey) []*ServiceInfo {
 	return ps.ambientIndex.ServicesForWaypoint(key)
 }
 

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1488,7 +1488,10 @@ func (i ServiceInfo) GetNamespace() string {
 	return i.Service.Namespace
 }
 
-func (i ServiceInfo) Equals(other ServiceInfo) bool {
+func (i *ServiceInfo) Equals(other *ServiceInfo) bool {
+	if i == nil || other == nil {
+		return i == other
+	}
 	return equalUsingPremarshaled(i.Service, i.MarshaledAddress, other.Service, other.MarshaledAddress) &&
 		maps.Equal(i.LabelSelector.Labels, other.LabelSelector.Labels) &&
 		maps.Equal(i.PortNames, other.PortNames) &&
@@ -1542,7 +1545,10 @@ type WorkloadInfo struct {
 	Waypoint  WaypointBindingStatus
 }
 
-func (i WorkloadInfo) Equals(other WorkloadInfo) bool {
+func (i *WorkloadInfo) Equals(other *WorkloadInfo) bool {
+	if i == nil || other == nil {
+		return i == other
+	}
 	return equalUsingPremarshaled(i.Workload, i.MarshaledAddress, other.Workload, other.MarshaledAddress) &&
 		maps.Equal(i.Labels, other.Labels) &&
 		i.Source == other.Source &&

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1020,8 +1020,8 @@ type AmbientIndexes interface {
 		currentSubs sets.String,
 	) sets.String
 	Policies(requested sets.Set[ConfigKey]) []WorkloadAuthorization
-	ServicesForWaypoint(WaypointKey) []ServiceInfo
-	WorkloadsForWaypoint(WaypointKey) []WorkloadInfo
+	ServicesForWaypoint(WaypointKey) []*ServiceInfo
+	WorkloadsForWaypoint(WaypointKey) []*WorkloadInfo
 	// ServiceScope returns service information for services matching the key.
 	// The key idenitifies a service and is in form of namespace/hostname string.
 	ServiceInfo(key string) *ServiceInfo
@@ -1140,7 +1140,7 @@ func (u NoopAmbientIndexes) Policies(sets.Set[ConfigKey]) []WorkloadAuthorizatio
 	return nil
 }
 
-func (u NoopAmbientIndexes) ServicesForWaypoint(WaypointKey) []ServiceInfo {
+func (u NoopAmbientIndexes) ServicesForWaypoint(WaypointKey) []*ServiceInfo {
 	return nil
 }
 
@@ -1148,7 +1148,7 @@ func (u NoopAmbientIndexes) Waypoint(string, string) []netip.Addr {
 	return nil
 }
 
-func (u NoopAmbientIndexes) WorkloadsForWaypoint(WaypointKey) []WorkloadInfo {
+func (u NoopAmbientIndexes) WorkloadsForWaypoint(WaypointKey) []*WorkloadInfo {
 	return nil
 }
 
@@ -1285,11 +1285,11 @@ type ServiceInfo struct {
 	VisibilityConfigured bool
 }
 
-func (i ServiceInfo) GetLabelSelector() map[string]string {
+func (i *ServiceInfo) GetLabelSelector() map[string]string {
 	return i.LabelSelector.Labels
 }
 
-func (i ServiceInfo) GetStatusTarget() TypedObject {
+func (i *ServiceInfo) GetStatusTarget() TypedObject {
 	return i.Source
 }
 
@@ -1358,7 +1358,7 @@ func (c *Condition) Equals(v *Condition) bool {
 		c.Status == v.Status
 }
 
-func (i ServiceInfo) GetConditions(currentConditions map[string]Condition) ConditionSet {
+func (i *ServiceInfo) GetConditions(currentConditions map[string]Condition) ConditionSet {
 	set := ConditionSet{
 		// Write all conditions here, then override if we want them set.
 		// This ensures we can properly prune the condition if its no longer needed (such as if there is no waypoint attached at all).
@@ -1476,15 +1476,15 @@ func (i WaypointBindingStatus) Equals(other WaypointBindingStatus) bool {
 		ptr.Equal(i.Error, other.Error)
 }
 
-func (i ServiceInfo) NamespacedName() types.NamespacedName {
+func (i *ServiceInfo) NamespacedName() types.NamespacedName {
 	return types.NamespacedName{Name: i.Service.Name, Namespace: i.Service.Namespace}
 }
 
-func (i ServiceInfo) GetName() string {
+func (i *ServiceInfo) GetName() string {
 	return i.Service.Name
 }
 
-func (i ServiceInfo) GetNamespace() string {
+func (i *ServiceInfo) GetNamespace() string {
 	return i.Service.Namespace
 }
 
@@ -1502,12 +1502,12 @@ func (i *ServiceInfo) Equals(other *ServiceInfo) bool {
 		i.VisibilityConfigured == other.VisibilityConfigured
 }
 
-func (i ServiceInfo) ResourceName() string {
+func (i *ServiceInfo) ResourceName() string {
 	return serviceResourceName(i.Service)
 }
 
 // WaypointRef returns the waypoint this service is attached to, if any.
-func (i ServiceInfo) WaypointRef() *workloadapi.GatewayAddress {
+func (i *ServiceInfo) WaypointRef() *workloadapi.GatewayAddress {
 	return i.Service.GetWaypoint()
 }
 
@@ -1570,11 +1570,11 @@ func (i *WorkloadInfo) Clone() *WorkloadInfo {
 	}
 }
 
-func (i WorkloadInfo) GetStatusTarget() TypedObject {
+func (i *WorkloadInfo) GetStatusTarget() TypedObject {
 	return i.Source
 }
 
-func (i WorkloadInfo) GetConditions(currentConditions map[string]Condition) ConditionSet {
+func (i *WorkloadInfo) GetConditions(currentConditions map[string]Condition) ConditionSet {
 	set := ConditionSet{
 		WaypointBound: nil,
 	}
@@ -1594,12 +1594,12 @@ func (i WorkloadInfo) GetConditions(currentConditions map[string]Condition) Cond
 	return set
 }
 
-func (i WorkloadInfo) ResourceName() string {
+func (i *WorkloadInfo) ResourceName() string {
 	return workloadResourceName(i.Workload)
 }
 
 // WaypointRef returns the waypoint this workload is attached to, if any.
-func (i WorkloadInfo) WaypointRef() *workloadapi.GatewayAddress {
+func (i *WorkloadInfo) WaypointRef() *workloadapi.GatewayAddress {
 	return i.Workload.GetWaypoint()
 }
 
@@ -1781,7 +1781,7 @@ func ExtractWorkloadsFromAddresses(addrs []AddressInfo) []WorkloadInfo {
 	})
 }
 
-func SortWorkloadsByCreationTime(workloads []WorkloadInfo) []WorkloadInfo {
+func SortWorkloadsByCreationTime(workloads []*WorkloadInfo) []*WorkloadInfo {
 	sort.SliceStable(workloads, func(i, j int) bool {
 		if workloads[i].CreationTime.Equal(workloads[j].CreationTime) {
 			return workloads[i].Workload.Uid < workloads[j].Workload.Uid

--- a/pilot/pkg/model/service_test.go
+++ b/pilot/pkg/model/service_test.go
@@ -1312,6 +1312,32 @@ func TestGetTrafficDistribution(t *testing.T) {
 	}
 }
 
+func TestInfoEqualsPointers(t *testing.T) {
+	t.Run("service", func(t *testing.T) {
+		var nilInfo *ServiceInfo
+		assert.Equal(t, nilInfo.Equals(nil), true)
+		assert.Equal(t, nilInfo.Equals(&ServiceInfo{}), false)
+
+		first := &ServiceInfo{Service: &workloadapi.Service{Namespace: "ns", Hostname: "svc.example.com"}}
+		second := &ServiceInfo{Service: &workloadapi.Service{Namespace: "ns", Hostname: "svc.example.com"}}
+		assert.Equal(t, first.Equals(second), true)
+		second.Scope = Global
+		assert.Equal(t, first.Equals(second), false)
+	})
+
+	t.Run("workload", func(t *testing.T) {
+		var nilInfo *WorkloadInfo
+		assert.Equal(t, nilInfo.Equals(nil), true)
+		assert.Equal(t, nilInfo.Equals(&WorkloadInfo{}), false)
+
+		first := &WorkloadInfo{Workload: &workloadapi.Workload{Uid: "cluster0//Pod/ns/pod"}}
+		second := &WorkloadInfo{Workload: &workloadapi.Workload{Uid: "cluster0//Pod/ns/pod"}}
+		assert.Equal(t, first.Equals(second), true)
+		second.Source.Kind = kind.Pod
+		assert.Equal(t, first.Equals(second), false)
+	})
+}
+
 func TestServiceInfoWaypointConditions(t *testing.T) {
 	base := func() ServiceInfo {
 		return ServiceInfo{

--- a/pilot/pkg/networking/core/listener_waypoint.go
+++ b/pilot/pkg/networking/core/listener_waypoint.go
@@ -385,7 +385,7 @@ func (lb *ListenerBuilder) findServiceWaypoint(svc *model.Service) (host.Name, b
 }
 
 // This is the regular waypoint flow, where we terminate the tunnel, and then re-encap.
-func (lb *ListenerBuilder) buildWaypointInternal(wls []model.WorkloadInfo, svcs []*model.Service) *listener.Listener {
+func (lb *ListenerBuilder) buildWaypointInternal(wls []*model.WorkloadInfo, svcs []*model.Service) *listener.Listener {
 	isAmbientEastWestGateway := isAmbientEastWestGateway(lb.node)
 	ipMatcher := &matcher.IPMatcher{}
 	svcHostnameMap := &matcher.Matcher_MatcherTree_MatchMap{

--- a/pilot/pkg/networking/core/waypoint.go
+++ b/pilot/pkg/networking/core/waypoint.go
@@ -55,7 +55,7 @@ type waypointServices struct {
 }
 
 // findWaypointResources returns workloads and services associated with the waypoint proxy
-func findWaypointResources(node *model.Proxy, push *model.PushContext) ([]model.WorkloadInfo, *waypointServices) {
+func findWaypointResources(node *model.Proxy, push *model.PushContext) ([]*model.WorkloadInfo, *waypointServices) {
 	var key model.WaypointKey
 	if isAmbientEastWestGateway(node) {
 		key = model.WaypointKeyForNetworkGatewayProxy(node)

--- a/pilot/pkg/serviceregistry/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex.go
@@ -75,11 +75,11 @@ func (n NamespaceHostname) String() string {
 }
 
 type workloadsCollection struct {
-	krt.Collection[model.WorkloadInfo]
-	ByAddress                krt.Index[networkAddress, model.WorkloadInfo]
-	ByServiceKey             krt.Index[string, model.WorkloadInfo]
-	ByOwningWaypointHostname krt.Index[NamespaceHostname, model.WorkloadInfo]
-	ByOwningWaypointIP       krt.Index[networkAddress, model.WorkloadInfo]
+	krt.Collection[*model.WorkloadInfo]
+	ByAddress                krt.Index[networkAddress, *model.WorkloadInfo]
+	ByServiceKey             krt.Index[string, *model.WorkloadInfo]
+	ByOwningWaypointHostname krt.Index[NamespaceHostname, *model.WorkloadInfo]
+	ByOwningWaypointIP       krt.Index[networkAddress, *model.WorkloadInfo]
 }
 
 type waypointsCollection struct {
@@ -357,7 +357,7 @@ func New(options Options) Index {
 	if features.EnableAmbientStatus {
 		workloadEntriesWriter := kclient.NewWriteClient[*networkingclient.WorkloadEntry](client)
 		statusqueue.Register(a.statusQueue, "istio-ambient-workloadentry", Workloads,
-			func(info model.WorkloadInfo) (kclient.Patcher, map[string]model.Condition) {
+			func(info *model.WorkloadInfo) (kclient.Patcher, map[string]model.Condition) {
 				if info.Source.Kind != kind.WorkloadEntry {
 					return nil, nil
 				}
@@ -365,11 +365,11 @@ func New(options Options) Index {
 			})
 	}
 
-	WorkloadAddressIndex := krt.NewIndex[networkAddress, model.WorkloadInfo](Workloads, "networkAddress", networkAddressFromWorkload)
-	WorkloadServiceIndex := krt.NewIndex[string, model.WorkloadInfo](Workloads, "service", func(o model.WorkloadInfo) []string {
+	WorkloadAddressIndex := krt.NewIndex(Workloads, "networkAddress", networkAddressFromWorkload)
+	WorkloadServiceIndex := krt.NewIndex(Workloads, "service", func(o *model.WorkloadInfo) []string {
 		return maps.Keys(o.Workload.Services)
 	})
-	WorkloadWaypointIndexHostname := krt.NewIndex(Workloads, "namespaceHostname", func(w model.WorkloadInfo) []NamespaceHostname {
+	WorkloadWaypointIndexHostname := krt.NewIndex(Workloads, "namespaceHostname", func(w *model.WorkloadInfo) []NamespaceHostname {
 		// Filter out waypoints.
 		if w.Labels[label.GatewayManaged.Name] == constants.ManagedGatewayMeshControllerLabel {
 			return nil
@@ -392,7 +392,7 @@ func New(options Options) Index {
 			Hostname:  waypointAddress.Hostname,
 		}}
 	})
-	WorkloadWaypointIndexIP := krt.NewIndex(Workloads, "waypointIp", func(w model.WorkloadInfo) []networkAddress {
+	WorkloadWaypointIndexIP := krt.NewIndex(Workloads, "waypointIp", func(w *model.WorkloadInfo) []networkAddress {
 		// Filter out waypoints.
 		if w.Labels[label.GatewayManaged.Name] == constants.ManagedGatewayMeshControllerLabel {
 			return nil
@@ -419,11 +419,11 @@ func New(options Options) Index {
 		return []networkAddress{netaddr}
 	})
 	Workloads.RegisterBatch(krt.BatchedEventFilter(
-		func(a model.WorkloadInfo) *workloadapi.Workload {
+		func(a *model.WorkloadInfo) *workloadapi.Workload {
 			// Only trigger push if the XDS object changed; the rest is just for computation of others
 			return a.Workload
 		},
-		PushXdsAddress(a.XDSUpdater, model.WorkloadInfo.ResourceName, model.WorkloadInfo.WaypointRef),
+		PushXdsAddress(a.XDSUpdater, (*model.WorkloadInfo).ResourceName, (*model.WorkloadInfo).WaypointRef),
 	), false)
 
 	if features.EnableIngressWaypointRouting {
@@ -536,7 +536,7 @@ func translateKubernetesCondition(conds []metav1.Condition) map[string]model.Con
 func (a *index) Lookup(key string) []model.AddressInfo {
 	// 1. Workload UID
 	if w := a.workloads.GetKey(key); w != nil {
-		return []model.AddressInfo{w.AsAddress}
+		return []model.AddressInfo{(*w).AsAddress}
 	}
 
 	// 2. Workload by IP
@@ -766,7 +766,7 @@ func (a *index) WorkloadsForWaypoint(key model.WaypointKey) []model.WorkloadInfo
 		}) {
 			name := res.ResourceName()
 			if _, f := out[name]; !f {
-				out[name] = res
+				out[name] = *res
 			}
 		}
 	}
@@ -778,7 +778,7 @@ func (a *index) WorkloadsForWaypoint(key model.WaypointKey) []model.WorkloadInfo
 		}) {
 			name := res.ResourceName()
 			if _, f := out[name]; !f {
-				out[name] = res
+				out[name] = *res
 			}
 		}
 	}

--- a/pilot/pkg/serviceregistry/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex.go
@@ -55,9 +55,9 @@ import (
 type Index interface {
 	Lookup(key string) []model.AddressInfo
 	All() []model.AddressInfo
-	AllLocalNetworkGlobalServices(key model.WaypointKey) []model.ServiceInfo
-	WorkloadsForWaypoint(key model.WaypointKey) []model.WorkloadInfo
-	ServicesForWaypoint(key model.WaypointKey) []model.ServiceInfo
+	AllLocalNetworkGlobalServices(key model.WaypointKey) []*model.ServiceInfo
+	WorkloadsForWaypoint(key model.WaypointKey) []*model.WorkloadInfo
+	ServicesForWaypoint(key model.WaypointKey) []*model.ServiceInfo
 	Run(stop <-chan struct{})
 	HasSynced() bool
 	model.AmbientIndexes
@@ -307,7 +307,7 @@ func New(options Options) Index {
 		if s.LabelSelector.Labels[label.GatewayManaged.Name] == constants.ManagedGatewayEastWestControllerLabel {
 			return nil
 		}
-		return serviceOwningWaypointHostnames(*s)
+		return serviceOwningWaypointHostnames(s)
 	})
 	ServiceInfosByOwningWaypointIP := krt.NewIndex(WorkloadServices, "owningWaypointIp", func(s *model.ServiceInfo) []networkAddress {
 		// Filter out waypoint services
@@ -318,7 +318,7 @@ func New(options Options) Index {
 		if s.LabelSelector.Labels[label.GatewayManaged.Name] == constants.ManagedGatewayEastWestControllerLabel {
 			return nil
 		}
-		return serviceOwningWaypointAddresses(*s)
+		return serviceOwningWaypointAddresses(s)
 	})
 	WorkloadServices.RegisterBatch(krt.BatchedEventFilter(
 		func(a *model.ServiceInfo) *model.XDSServiceInfo {
@@ -607,8 +607,8 @@ func (a *index) All() []model.AddressInfo {
 
 // AllLocalNetworkGlobalServices returns all known globally scoped services and local
 // waypoints containing global services. Result is un-ordered
-func (a *index) AllLocalNetworkGlobalServices(key model.WaypointKey) []model.ServiceInfo {
-	var res []model.ServiceInfo
+func (a *index) AllLocalNetworkGlobalServices(key model.WaypointKey) []*model.ServiceInfo {
+	var res []*model.ServiceInfo
 	// TODO(jaellio): Improve this to use a more efficient lookup/index since this is in the
 	// hot path for east west gateway updates/configuration.
 	for _, svc := range a.services.List() {
@@ -629,7 +629,7 @@ func (a *index) AllLocalNetworkGlobalServices(key model.WaypointKey) []model.Ser
 				// Check is the any of the services owned by the waypoint are global
 				// If they are global, then the waypoint should be considered global
 				if resp.Scope == model.Global {
-					res = append(res, *svc)
+					res = append(res, svc)
 					log.Debugf("Adding non global waypoint service %s/%s in network %s for the network"+
 						"gateway, as it is a waypoint containing global services", svc.Service.Namespace,
 						svc.Service.Name, key.Network)
@@ -637,7 +637,7 @@ func (a *index) AllLocalNetworkGlobalServices(key model.WaypointKey) []model.Ser
 				}
 			}
 		} else {
-			res = append(res, *svc)
+			res = append(res, svc)
 			log.Debugf("Adding global service %s/%s in network %s for the network gateway",
 				svc.Service.Namespace, svc.Service.Name, key.Network)
 		}
@@ -671,7 +671,7 @@ func (a *index) AddressInformation(addresses sets.String) ([]model.AddressInfo, 
 }
 
 // serviceOwningWaypoints returns the complete waypoint set fronting this service.
-func serviceOwningWaypoints(s model.ServiceInfo) []*workloadapi.GatewayAddress {
+func serviceOwningWaypoints(s *model.ServiceInfo) []*workloadapi.GatewayAddress {
 	if s.Service == nil {
 		return nil
 	}
@@ -691,7 +691,7 @@ func serviceOwningWaypoints(s model.ServiceInfo) []*workloadapi.GatewayAddress {
 }
 
 // serviceOwningWaypointHostnames adapts serviceOwningWaypoints for hostname indexes.
-func serviceOwningWaypointHostnames(s model.ServiceInfo) []NamespaceHostname {
+func serviceOwningWaypointHostnames(s *model.ServiceInfo) []NamespaceHostname {
 	var out []NamespaceHostname
 	for _, waypoint := range serviceOwningWaypoints(s) {
 		wa := waypoint.GetHostname()
@@ -704,7 +704,7 @@ func serviceOwningWaypointHostnames(s model.ServiceInfo) []NamespaceHostname {
 }
 
 // serviceOwningWaypointAddresses adapts serviceOwningWaypoints for IP indexes.
-func serviceOwningWaypointAddresses(s model.ServiceInfo) []networkAddress {
+func serviceOwningWaypointAddresses(s *model.ServiceInfo) []networkAddress {
 	var out []networkAddress
 	for _, waypoint := range serviceOwningWaypoints(s) {
 		wa := waypoint.GetAddress()
@@ -717,14 +717,14 @@ func serviceOwningWaypointAddresses(s model.ServiceInfo) []networkAddress {
 	return out
 }
 
-func (a *index) ServicesForWaypoint(key model.WaypointKey) []model.ServiceInfo {
+func (a *index) ServicesForWaypoint(key model.WaypointKey) []*model.ServiceInfo {
 	if key.IsNetworkGateway && features.EnableAmbientMultiNetwork {
 		// If this is a network gateway waypoint, we only return the global services
 		// that are local to this network and waypoints with global services
 		return a.AllLocalNetworkGlobalServices(key)
 	}
 
-	out := map[string]model.ServiceInfo{}
+	out := map[string]*model.ServiceInfo{}
 
 	for _, host := range key.Hostnames {
 		for _, res := range a.services.ByOwningWaypointHostname.Lookup(NamespaceHostname{
@@ -733,7 +733,7 @@ func (a *index) ServicesForWaypoint(key model.WaypointKey) []model.ServiceInfo {
 		}) {
 			name := res.ResourceName()
 			if _, f := out[name]; !f {
-				out[name] = *res
+				out[name] = res
 			}
 		}
 	}
@@ -745,7 +745,7 @@ func (a *index) ServicesForWaypoint(key model.WaypointKey) []model.ServiceInfo {
 		}) {
 			name := res.ResourceName()
 			if _, f := out[name]; !f {
-				out[name] = *res
+				out[name] = res
 			}
 		}
 	}
@@ -753,12 +753,12 @@ func (a *index) ServicesForWaypoint(key model.WaypointKey) []model.ServiceInfo {
 	return maps.Values(out)
 }
 
-func (a *index) WorkloadsForWaypoint(key model.WaypointKey) []model.WorkloadInfo {
+func (a *index) WorkloadsForWaypoint(key model.WaypointKey) []*model.WorkloadInfo {
 	if key.IsNetworkGateway {
 		// TODO(jaellio): Support workloads for gateway waypoint
 		return nil
 	}
-	out := map[string]model.WorkloadInfo{}
+	out := map[string]*model.WorkloadInfo{}
 	for _, host := range key.Hostnames {
 		for _, res := range a.workloads.ByOwningWaypointHostname.Lookup(NamespaceHostname{
 			Namespace: key.Namespace,
@@ -766,7 +766,7 @@ func (a *index) WorkloadsForWaypoint(key model.WaypointKey) []model.WorkloadInfo
 		}) {
 			name := res.ResourceName()
 			if _, f := out[name]; !f {
-				out[name] = *res
+				out[name] = res
 			}
 		}
 	}
@@ -778,7 +778,7 @@ func (a *index) WorkloadsForWaypoint(key model.WaypointKey) []model.WorkloadInfo
 		}) {
 			name := res.ResourceName()
 			if _, f := out[name]; !f {
-				out[name] = *res
+				out[name] = res
 			}
 		}
 	}

--- a/pilot/pkg/serviceregistry/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex.go
@@ -46,6 +46,7 @@ import (
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/network"
+	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/sets"
 	"istio.io/istio/pkg/workloadapi"
@@ -86,10 +87,10 @@ type waypointsCollection struct {
 }
 
 type servicesCollection struct {
-	krt.Collection[model.ServiceInfo]
-	ByAddress                krt.Index[networkAddress, model.ServiceInfo]
-	ByOwningWaypointHostname krt.Index[NamespaceHostname, model.ServiceInfo]
-	ByOwningWaypointIP       krt.Index[networkAddress, model.ServiceInfo]
+	krt.Collection[*model.ServiceInfo]
+	ByAddress                krt.Index[networkAddress, *model.ServiceInfo]
+	ByOwningWaypointHostname krt.Index[NamespaceHostname, *model.ServiceInfo]
+	ByOwningWaypointIP       krt.Index[networkAddress, *model.ServiceInfo]
 }
 
 type Builder struct {
@@ -277,7 +278,7 @@ func New(options Options) Index {
 		)
 		statusQueue := statusqueue.NewQueue(options.StatusNotifier)
 		statusqueue.Register(statusQueue, "istio-ambient-service", WorkloadServices,
-			func(info model.ServiceInfo) (kclient.Patcher, map[string]model.Condition) {
+			func(info *model.ServiceInfo) (kclient.Patcher, map[string]model.Condition) {
 				// Since we have 1 collection for multiple types, we need to split these out
 				if info.Source.Kind == kind.ServiceEntry {
 					return kclient.ToPatcher(serviceEntriesWriter), getConditions(info.Source.NamespacedName, serviceEntries)
@@ -295,8 +296,8 @@ func New(options Options) Index {
 		a.statusQueue = statusQueue
 	}
 
-	ServiceAddressIndex := krt.NewIndex[networkAddress, model.ServiceInfo](WorkloadServices, "serviceAddress", networkAddressFromService)
-	ServiceInfosByOwningWaypointHostname := krt.NewIndex(WorkloadServices, "namespaceHostname", func(s model.ServiceInfo) []NamespaceHostname {
+	ServiceAddressIndex := krt.NewIndex(WorkloadServices, "serviceAddress", networkAddressFromService)
+	ServiceInfosByOwningWaypointHostname := krt.NewIndex(WorkloadServices, "namespaceHostname", func(s *model.ServiceInfo) []NamespaceHostname {
 		// Filter out waypoint services
 		// TODO: we are looking at the *selector* -- we should be looking the labels themselves or something equivalent.
 		if s.LabelSelector.Labels[label.GatewayManaged.Name] == constants.ManagedGatewayMeshControllerLabel {
@@ -306,9 +307,9 @@ func New(options Options) Index {
 		if s.LabelSelector.Labels[label.GatewayManaged.Name] == constants.ManagedGatewayEastWestControllerLabel {
 			return nil
 		}
-		return serviceOwningWaypointHostnames(s)
+		return serviceOwningWaypointHostnames(*s)
 	})
-	ServiceInfosByOwningWaypointIP := krt.NewIndex(WorkloadServices, "owningWaypointIp", func(s model.ServiceInfo) []networkAddress {
+	ServiceInfosByOwningWaypointIP := krt.NewIndex(WorkloadServices, "owningWaypointIp", func(s *model.ServiceInfo) []networkAddress {
 		// Filter out waypoint services
 		if s.LabelSelector.Labels[label.GatewayManaged.Name] == constants.ManagedGatewayMeshControllerLabel {
 			return nil
@@ -317,17 +318,17 @@ func New(options Options) Index {
 		if s.LabelSelector.Labels[label.GatewayManaged.Name] == constants.ManagedGatewayEastWestControllerLabel {
 			return nil
 		}
-		return serviceOwningWaypointAddresses(s)
+		return serviceOwningWaypointAddresses(*s)
 	})
 	WorkloadServices.RegisterBatch(krt.BatchedEventFilter(
-		func(a model.ServiceInfo) *model.XDSServiceInfo {
+		func(a *model.ServiceInfo) *model.XDSServiceInfo {
 			// Only trigger push if the XDS object changed; the rest is just for computation of others
 			return &model.XDSServiceInfo{
 				Service:            a.Service,
 				DNSConnectStrategy: a.DNSConnectStrategy,
 			}
 		},
-		PushXdsAddress(a.XDSUpdater, model.ServiceInfo.ResourceName, model.ServiceInfo.WaypointRef),
+		PushXdsAddress(a.XDSUpdater, (*model.ServiceInfo).ResourceName, (*model.ServiceInfo).WaypointRef),
 	), false)
 
 	NamespacesInfo := krt.NewCollection(Namespaces, func(ctx krt.HandlerContext, i *corev1.Namespace) *model.NamespaceInfo {
@@ -565,7 +566,7 @@ func (a *index) Lookup(key string) []model.AddressInfo {
 
 func (a *index) lookupService(key string) *model.ServiceInfo {
 	// 1. namespace/hostname format
-	s := a.services.GetKey(key)
+	s := ptr.Flatten(a.services.GetKey(key))
 	if s != nil {
 		return s
 	}
@@ -576,7 +577,7 @@ func (a *index) lookupService(key string) *model.ServiceInfo {
 		network: network,
 		ip:      ip,
 	})
-	return slices.First(services)
+	return ptr.Flatten(slices.First(services))
 }
 
 func (a *index) inRevision(obj any) bool {
@@ -628,7 +629,7 @@ func (a *index) AllLocalNetworkGlobalServices(key model.WaypointKey) []model.Ser
 				// Check is the any of the services owned by the waypoint are global
 				// If they are global, then the waypoint should be considered global
 				if resp.Scope == model.Global {
-					res = append(res, svc)
+					res = append(res, *svc)
 					log.Debugf("Adding non global waypoint service %s/%s in network %s for the network"+
 						"gateway, as it is a waypoint containing global services", svc.Service.Namespace,
 						svc.Service.Name, key.Network)
@@ -636,7 +637,7 @@ func (a *index) AllLocalNetworkGlobalServices(key model.WaypointKey) []model.Ser
 				}
 			}
 		} else {
-			res = append(res, svc)
+			res = append(res, *svc)
 			log.Debugf("Adding global service %s/%s in network %s for the network gateway",
 				svc.Service.Namespace, svc.Service.Name, key.Network)
 		}
@@ -732,7 +733,7 @@ func (a *index) ServicesForWaypoint(key model.WaypointKey) []model.ServiceInfo {
 		}) {
 			name := res.ResourceName()
 			if _, f := out[name]; !f {
-				out[name] = res
+				out[name] = *res
 			}
 		}
 	}
@@ -744,7 +745,7 @@ func (a *index) ServicesForWaypoint(key model.WaypointKey) []model.ServiceInfo {
 		}) {
 			name := res.ResourceName()
 			if _, f := out[name]; !f {
-				out[name] = res
+				out[name] = *res
 			}
 		}
 	}

--- a/pilot/pkg/serviceregistry/ambient/ambientindex_multicluster_test.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex_multicluster_test.go
@@ -645,7 +645,7 @@ func TestMulticlusterAmbientIndex_SplitHorizon(t *testing.T) {
 		if svc.Scope != model.Global {
 			return fmt.Errorf("expected service scope to be Global, got %s", svc.Scope)
 		}
-		gwwl := s.workloads.GetKey("NetworkGateway/remote-network/172.0.1.2/0")
+		gwwl := ptr.Flatten(s.workloads.GetKey("NetworkGateway/remote-network/172.0.1.2/0"))
 		if gwwl == nil {
 			return fmt.Errorf("expected network gateway workload to exist, but it does not")
 		}
@@ -682,7 +682,7 @@ func TestMulticlusterAmbientIndex_SplitHorizon(t *testing.T) {
 		if len(ais) != 3 {
 			return fmt.Errorf("expected 3 pods, got %d", len(ais))
 		}
-		shwl := s.workloads.GetKey(splitHorizonName)
+		shwl := ptr.Flatten(s.workloads.GetKey(splitHorizonName))
 		if shwl == nil {
 			return fmt.Errorf("expected split horizon workload to exist, but it does not")
 		}
@@ -730,7 +730,7 @@ func TestMulticlusterAmbientIndex_SplitHorizon(t *testing.T) {
 		if len(ais) != 3 {
 			return fmt.Errorf("expected 3 pods, got %d", len(ais))
 		}
-		shwl := s.workloads.GetKey(splitHorizonName)
+		shwl := ptr.Flatten(s.workloads.GetKey(splitHorizonName))
 		if shwl == nil {
 			return fmt.Errorf("expected split horizon workload to exist, but it does not")
 		}
@@ -759,7 +759,7 @@ func TestMulticlusterAmbientIndex_SplitHorizon(t *testing.T) {
 		if len(ais) != 3 {
 			return fmt.Errorf("expected 3 pods, got %d", len(ais))
 		}
-		shwl := s.workloads.GetKey(splitHorizonName)
+		shwl := ptr.Flatten(s.workloads.GetKey(splitHorizonName))
 		if shwl == nil {
 			return fmt.Errorf("expected split horizon workload to exist, but it does not")
 		}

--- a/pilot/pkg/serviceregistry/ambient/ambientindex_multicluster_test.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex_multicluster_test.go
@@ -381,9 +381,9 @@ func TestMulticlusterAmbientIndex_ServicesForWaypoint(t *testing.T) {
 			[]int32{80}, map[string]string{"app": "waypoint"}, "10.0.0.2")
 		s.assertEvent(s.t, s.svcXdsName("svc1"))
 
-		svc1Host := ptr.ToList(ptr.Flatten(s.services.GetKey(fmt.Sprintf("%s/%s", testNS, s.hostnameForService("svc1")))))
+		svc1Host := []*model.ServiceInfo{ptr.Flatten(s.services.GetKey(fmt.Sprintf("%s/%s", testNS, s.hostnameForService("svc1"))))}
 		assert.Equal(t, len(svc1Host), 1)
-		assert.EventuallyEqual(t, func() []model.ServiceInfo {
+		assert.EventuallyEqual(t, func() []*model.ServiceInfo {
 			return s.ServicesForWaypoint(wpKey)
 		}, svc1Host)
 	})
@@ -402,9 +402,9 @@ func TestMulticlusterAmbientIndex_ServicesForWaypoint(t *testing.T) {
 			[]int32{80}, map[string]string{"app": "waypoint"}, "10.0.0.1")
 		s.assertEvent(s.t, s.svcXdsName("svc1"))
 
-		svc1Host := ptr.ToList(ptr.Flatten(s.services.GetKey(fmt.Sprintf("%s/%s", testNS, s.hostnameForService("svc1")))))
+		svc1Host := []*model.ServiceInfo{ptr.Flatten(s.services.GetKey(fmt.Sprintf("%s/%s", testNS, s.hostnameForService("svc1"))))}
 		assert.Equal(t, len(svc1Host), 1)
-		assert.EventuallyEqual(t, func() []model.ServiceInfo {
+		assert.EventuallyEqual(t, func() []*model.ServiceInfo {
 			return s.ServicesForWaypoint(wpKey)
 		}, svc1Host)
 	})
@@ -423,9 +423,9 @@ func TestMulticlusterAmbientIndex_ServicesForWaypoint(t *testing.T) {
 			[]int32{80}, map[string]string{"app": "waypoint"}, "10.0.0.1")
 		s.assertEvent(s.t, s.svcXdsName("svc1"))
 
-		svc1Host := ptr.ToList(ptr.Flatten(s.services.GetKey(fmt.Sprintf("%s/%s", testNS, s.hostnameForService("svc1")))))
+		svc1Host := []*model.ServiceInfo{ptr.Flatten(s.services.GetKey(fmt.Sprintf("%s/%s", testNS, s.hostnameForService("svc1"))))}
 		assert.Equal(t, len(svc1Host), 1)
-		assert.EventuallyEqual(t, func() []model.ServiceInfo {
+		assert.EventuallyEqual(t, func() []*model.ServiceInfo {
 			return s.ServicesForWaypoint(wpKey)
 		}, svc1Host)
 	})

--- a/pilot/pkg/serviceregistry/ambient/ambientindex_multicluster_test.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex_multicluster_test.go
@@ -381,7 +381,7 @@ func TestMulticlusterAmbientIndex_ServicesForWaypoint(t *testing.T) {
 			[]int32{80}, map[string]string{"app": "waypoint"}, "10.0.0.2")
 		s.assertEvent(s.t, s.svcXdsName("svc1"))
 
-		svc1Host := ptr.ToList(s.services.GetKey(fmt.Sprintf("%s/%s", testNS, s.hostnameForService("svc1"))))
+		svc1Host := ptr.ToList(ptr.Flatten(s.services.GetKey(fmt.Sprintf("%s/%s", testNS, s.hostnameForService("svc1")))))
 		assert.Equal(t, len(svc1Host), 1)
 		assert.EventuallyEqual(t, func() []model.ServiceInfo {
 			return s.ServicesForWaypoint(wpKey)
@@ -402,7 +402,7 @@ func TestMulticlusterAmbientIndex_ServicesForWaypoint(t *testing.T) {
 			[]int32{80}, map[string]string{"app": "waypoint"}, "10.0.0.1")
 		s.assertEvent(s.t, s.svcXdsName("svc1"))
 
-		svc1Host := ptr.ToList(s.services.GetKey(fmt.Sprintf("%s/%s", testNS, s.hostnameForService("svc1"))))
+		svc1Host := ptr.ToList(ptr.Flatten(s.services.GetKey(fmt.Sprintf("%s/%s", testNS, s.hostnameForService("svc1")))))
 		assert.Equal(t, len(svc1Host), 1)
 		assert.EventuallyEqual(t, func() []model.ServiceInfo {
 			return s.ServicesForWaypoint(wpKey)
@@ -423,7 +423,7 @@ func TestMulticlusterAmbientIndex_ServicesForWaypoint(t *testing.T) {
 			[]int32{80}, map[string]string{"app": "waypoint"}, "10.0.0.1")
 		s.assertEvent(s.t, s.svcXdsName("svc1"))
 
-		svc1Host := ptr.ToList(s.services.GetKey(fmt.Sprintf("%s/%s", testNS, s.hostnameForService("svc1"))))
+		svc1Host := ptr.ToList(ptr.Flatten(s.services.GetKey(fmt.Sprintf("%s/%s", testNS, s.hostnameForService("svc1")))))
 		assert.Equal(t, len(svc1Host), 1)
 		assert.EventuallyEqual(t, func() []model.ServiceInfo {
 			return s.ServicesForWaypoint(wpKey)

--- a/pilot/pkg/serviceregistry/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex_test.go
@@ -977,7 +977,7 @@ func TestAmbientIndex_ServicesForWaypoint(t *testing.T) {
 			[]int32{80}, map[string]string{"app": "waypoint"}, "10.0.0.2")
 		s.assertEvent(s.t, s.svcXdsName("svc1"))
 
-		svc1Host := ptr.ToList(s.services.GetKey(fmt.Sprintf("%s/%s", testNS, s.hostnameForService("svc1"))))
+		svc1Host := ptr.ToList(ptr.Flatten(s.services.GetKey(fmt.Sprintf("%s/%s", testNS, s.hostnameForService("svc1")))))
 		assert.Equal(t, len(svc1Host), 1)
 		assert.EventuallyEqual(t, func() []model.ServiceInfo {
 			return s.ServicesForWaypoint(wpKey)
@@ -999,7 +999,7 @@ func TestAmbientIndex_ServicesForWaypoint(t *testing.T) {
 			[]int32{80}, map[string]string{"app": "waypoint"}, "10.0.0.1")
 		s.assertEvent(s.t, s.svcXdsName("svc1"))
 
-		svc1Host := ptr.ToList(s.services.GetKey(fmt.Sprintf("%s/%s", testNS, s.hostnameForService("svc1"))))
+		svc1Host := ptr.ToList(ptr.Flatten(s.services.GetKey(fmt.Sprintf("%s/%s", testNS, s.hostnameForService("svc1")))))
 		assert.Equal(t, len(svc1Host), 1)
 		assert.EventuallyEqual(t, func() []model.ServiceInfo {
 			return s.ServicesForWaypoint(wpKey)
@@ -1020,7 +1020,7 @@ func TestAmbientIndex_ServicesForWaypoint(t *testing.T) {
 			[]int32{80}, map[string]string{"app": "waypoint"}, "10.0.0.1")
 		s.assertEvent(s.t, s.svcXdsName("svc1"))
 
-		svc1Host := ptr.ToList(s.services.GetKey(fmt.Sprintf("%s/%s", testNS, s.hostnameForService("svc1"))))
+		svc1Host := ptr.ToList(ptr.Flatten(s.services.GetKey(fmt.Sprintf("%s/%s", testNS, s.hostnameForService("svc1")))))
 		assert.Equal(t, len(svc1Host), 1)
 		assert.EventuallyEqual(t, func() []model.ServiceInfo {
 			return s.ServicesForWaypoint(wpKey)

--- a/pilot/pkg/serviceregistry/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/ambient/ambientindex_test.go
@@ -977,11 +977,14 @@ func TestAmbientIndex_ServicesForWaypoint(t *testing.T) {
 			[]int32{80}, map[string]string{"app": "waypoint"}, "10.0.0.2")
 		s.assertEvent(s.t, s.svcXdsName("svc1"))
 
-		svc1Host := ptr.ToList(ptr.Flatten(s.services.GetKey(fmt.Sprintf("%s/%s", testNS, s.hostnameForService("svc1")))))
+		svc1Host := []*model.ServiceInfo{ptr.Flatten(s.services.GetKey(fmt.Sprintf("%s/%s", testNS, s.hostnameForService("svc1"))))}
 		assert.Equal(t, len(svc1Host), 1)
-		assert.EventuallyEqual(t, func() []model.ServiceInfo {
+		assert.EventuallyEqual(t, func() []*model.ServiceInfo {
 			return s.ServicesForWaypoint(wpKey)
 		}, svc1Host)
+		if got := s.ServicesForWaypoint(wpKey); len(got) != 1 || got[0] != svc1Host[0] {
+			t.Fatal("ServicesForWaypoint must return the stored ServiceInfo pointer")
+		}
 	})
 	t.Run("ip", func(t *testing.T) {
 		s := newAmbientTestServer(t, testC, testNW, "")
@@ -999,9 +1002,9 @@ func TestAmbientIndex_ServicesForWaypoint(t *testing.T) {
 			[]int32{80}, map[string]string{"app": "waypoint"}, "10.0.0.1")
 		s.assertEvent(s.t, s.svcXdsName("svc1"))
 
-		svc1Host := ptr.ToList(ptr.Flatten(s.services.GetKey(fmt.Sprintf("%s/%s", testNS, s.hostnameForService("svc1")))))
+		svc1Host := []*model.ServiceInfo{ptr.Flatten(s.services.GetKey(fmt.Sprintf("%s/%s", testNS, s.hostnameForService("svc1"))))}
 		assert.Equal(t, len(svc1Host), 1)
-		assert.EventuallyEqual(t, func() []model.ServiceInfo {
+		assert.EventuallyEqual(t, func() []*model.ServiceInfo {
 			return s.ServicesForWaypoint(wpKey)
 		}, svc1Host)
 	})
@@ -1020,9 +1023,9 @@ func TestAmbientIndex_ServicesForWaypoint(t *testing.T) {
 			[]int32{80}, map[string]string{"app": "waypoint"}, "10.0.0.1")
 		s.assertEvent(s.t, s.svcXdsName("svc1"))
 
-		svc1Host := ptr.ToList(ptr.Flatten(s.services.GetKey(fmt.Sprintf("%s/%s", testNS, s.hostnameForService("svc1")))))
+		svc1Host := []*model.ServiceInfo{ptr.Flatten(s.services.GetKey(fmt.Sprintf("%s/%s", testNS, s.hostnameForService("svc1"))))}
 		assert.Equal(t, len(svc1Host), 1)
-		assert.EventuallyEqual(t, func() []model.ServiceInfo {
+		assert.EventuallyEqual(t, func() []*model.ServiceInfo {
 			return s.ServicesForWaypoint(wpKey)
 		}, svc1Host)
 	})
@@ -2060,10 +2063,16 @@ func TestWorkloadsForWaypoint(t *testing.T) {
 
 			assertWaypoint := func(t *testing.T, waypointHostname string, expected ...string) {
 				t.Helper()
-				wl := sets.New(slices.Map(s.WorkloadsForWaypoint(model.WaypointKey{
+				workloads := s.WorkloadsForWaypoint(model.WaypointKey{
 					Namespace: testNS,
 					Hostnames: []string{waypointHostname},
-				}), func(e model.WorkloadInfo) string {
+				})
+				for _, workload := range workloads {
+					if stored := ptr.Flatten(s.workloads.GetKey(workload.ResourceName())); stored != workload {
+						t.Fatal("WorkloadsForWaypoint must return the stored WorkloadInfo pointer")
+					}
+				}
+				wl := sets.New(slices.Map(workloads, func(e *model.WorkloadInfo) string {
 					return e.ResourceName()
 				})...)
 				assert.Equal(t, wl, sets.New(expected...))
@@ -3307,40 +3316,40 @@ func TestPushXdsAddressWaypointRefs(t *testing.T) {
 		},
 	}
 	waypointRef := model.WaypointReference{Namespace: "default", Hostname: "waypoint.default.svc.cluster.local"}
-	attached := model.WorkloadInfo{Workload: &workloadapi.Workload{Uid: "cluster0//Pod/default/a", Waypoint: waypoint}}
-	unattached := model.WorkloadInfo{Workload: &workloadapi.Workload{Uid: "cluster0//Pod/default/a"}}
+	attached := &model.WorkloadInfo{Workload: &workloadapi.Workload{Uid: "cluster0//Pod/default/a", Waypoint: waypoint}}
+	unattached := &model.WorkloadInfo{Workload: &workloadapi.Workload{Uid: "cluster0//Pod/default/a"}}
 
 	cases := []struct {
 		name  string
-		event krt.Event[model.WorkloadInfo]
+		event krt.Event[*model.WorkloadInfo]
 		want  sets.Set[model.WaypointReference]
 	}{
 		{
 			name:  "workload without waypoint",
-			event: krt.Event[model.WorkloadInfo]{New: &unattached, Event: controllers.EventAdd},
+			event: krt.Event[*model.WorkloadInfo]{New: &unattached, Event: controllers.EventAdd},
 			want:  sets.New[model.WaypointReference](),
 		},
 		{
 			name:  "workload attached to waypoint",
-			event: krt.Event[model.WorkloadInfo]{New: &attached, Event: controllers.EventAdd},
+			event: krt.Event[*model.WorkloadInfo]{New: &attached, Event: controllers.EventAdd},
 			want:  sets.New(waypointRef),
 		},
 		{
 			// The waypoint a workload detaches from must still see the change to drop its config
 			name:  "workload detached from waypoint",
-			event: krt.Event[model.WorkloadInfo]{Old: &attached, New: &unattached, Event: controllers.EventUpdate},
+			event: krt.Event[*model.WorkloadInfo]{Old: &attached, New: &unattached, Event: controllers.EventUpdate},
 			want:  sets.New(waypointRef),
 		},
 		{
 			name:  "attached workload deleted",
-			event: krt.Event[model.WorkloadInfo]{Old: &attached, Event: controllers.EventDelete},
+			event: krt.Event[*model.WorkloadInfo]{Old: &attached, Event: controllers.EventDelete},
 			want:  sets.New(waypointRef),
 		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			rec := &pushRequestRecorder{}
-			PushXdsAddress(rec, model.WorkloadInfo.ResourceName, model.WorkloadInfo.WaypointRef)([]krt.Event[model.WorkloadInfo]{tt.event})
+			PushXdsAddress(rec, (*model.WorkloadInfo).ResourceName, (*model.WorkloadInfo).WaypointRef)([]krt.Event[*model.WorkloadInfo]{tt.event})
 			assert.Equal(t, rec.req.WaypointsUpdated, tt.want)
 			assert.Equal(t, rec.req.AddressesUpdated, sets.New("cluster0//Pod/default/a"))
 		})

--- a/pilot/pkg/serviceregistry/ambient/helpers.go
+++ b/pilot/pkg/serviceregistry/ambient/helpers.go
@@ -204,7 +204,7 @@ func networkAddressFromWorkload(wl model.WorkloadInfo) []networkAddress {
 	return networkAddrs
 }
 
-func networkAddressFromService(s model.ServiceInfo) []networkAddress {
+func networkAddressFromService(s *model.ServiceInfo) []networkAddress {
 	networkAddrs := make([]networkAddress, 0, len(s.Service.Addresses))
 	for _, addr := range s.Service.Addresses {
 		// mustByteIPToString is ok since this is from our IP constructed

--- a/pilot/pkg/serviceregistry/ambient/helpers.go
+++ b/pilot/pkg/serviceregistry/ambient/helpers.go
@@ -57,7 +57,7 @@ func workloadToAddress(w *workloadapi.Workload) *workloadapi.Address {
 	}
 }
 
-func modelWorkloadToAddressInfo(w model.WorkloadInfo) model.AddressInfo {
+func modelWorkloadToAddressInfo(w *model.WorkloadInfo) model.AddressInfo {
 	return w.AsAddress
 }
 
@@ -195,7 +195,7 @@ func namespacedHostname(namespace, hostname string) string {
 	return namespace + "/" + hostname
 }
 
-func networkAddressFromWorkload(wl model.WorkloadInfo) []networkAddress {
+func networkAddressFromWorkload(wl *model.WorkloadInfo) []networkAddress {
 	networkAddrs := make([]networkAddress, 0, len(wl.Workload.Addresses))
 	for _, addr := range wl.Workload.Addresses {
 		// mustByteIPToString is ok since this is from our IP constructed

--- a/pilot/pkg/serviceregistry/ambient/multicluster.go
+++ b/pilot/pkg/serviceregistry/ambient/multicluster.go
@@ -480,14 +480,14 @@ func (a *index) buildGlobalCollections(
 		if s.LabelSelector.Labels[label.GatewayManaged.Name] == constants.ManagedGatewayMeshControllerLabel {
 			return nil
 		}
-		return serviceOwningWaypointHostnames(*s)
+		return serviceOwningWaypointHostnames(s)
 	})
 	SplitHorizonServiceInfosByOwningWaypointIP := krt.NewIndex(SplitHorizonServices, "owningWaypointIp", func(s *model.ServiceInfo) []networkAddress {
 		// Filter out waypoint services
 		if s.LabelSelector.Labels[label.GatewayManaged.Name] == constants.ManagedGatewayMeshControllerLabel {
 			return nil
 		}
-		return serviceOwningWaypointAddresses(*s)
+		return serviceOwningWaypointAddresses(s)
 	})
 
 	if features.EnableIngressWaypointRouting {

--- a/pilot/pkg/serviceregistry/ambient/multicluster.go
+++ b/pilot/pkg/serviceregistry/ambient/multicluster.go
@@ -288,11 +288,11 @@ func (a *index) buildGlobalCollections(
 		return res
 	})
 
-	coalescedWorkloads := krt.NewManyCollection(
+	coalescedWorkloads := krt.NewPointerCollection(
 		workloadNetworkServiceIndex.AsCollection(
 			opts.WithName("workloadNetworkServiceIndex")...,
 		),
-		func(ctx krt.HandlerContext, i krt.IndexObject[string, *model.WorkloadInfo]) []*model.WorkloadInfo {
+		func(ctx krt.HandlerContext, i krt.IndexObject[string, *model.WorkloadInfo]) *model.WorkloadInfo {
 			parts := strings.Split(i.Key, ";")
 			if len(parts) != 2 {
 				log.Errorf("Invalid key %s for SplitHorizonWorkloads, expected <network>;<service>", i.Key)
@@ -339,18 +339,17 @@ func (a *index) buildGlobalCollections(
 				log.Warnf("Multiple gateways found for network %s, using the first one", networkID)
 			}
 			gw := gws[0]
-			wi := a.createSplitHorizonWorkload(svcName, (*svc).Service, &gw, capacity, meshCfg)
-			return []*model.WorkloadInfo{wi}
+			return a.createSplitHorizonWorkload(svcName, (*svc).Service, &gw, capacity, meshCfg)
 		}, opts.WithName("CoalesedWorkloads")...,
 	)
-	networkLocalWorkloads := krt.NewManyCollection(GlobalWorkloads, func(ctx krt.HandlerContext, wi *model.WorkloadInfo) []*model.WorkloadInfo {
+	networkLocalWorkloads := krt.NewPointerCollection(GlobalWorkloads, func(ctx krt.HandlerContext, wi *model.WorkloadInfo) *model.WorkloadInfo {
 		if strings.HasPrefix(wi.Workload.Uid, "NetworkGateway/") {
-			return []*model.WorkloadInfo{wi}
+			return wi
 		}
 		if wi.Workload.Network != GlobalNetworks.FetchLocalNetworkID(ctx).String() {
 			return nil
 		}
-		return []*model.WorkloadInfo{wi}
+		return wi
 	}, opts.WithName("NetworkLocalWorkloads")...)
 
 	SplitHorizonWorkloads := krt.JoinCollection(
@@ -414,16 +413,16 @@ func (a *index) buildGlobalCollections(
 		return []networkAddress{netaddr}
 	})
 
-	SplitHorizonServices := krt.NewManyCollection(
+	SplitHorizonServices := krt.NewPointerCollection(
 		GlobalMergedWorkloadServices,
-		func(ctx krt.HandlerContext, svc *model.ServiceInfo) []*model.ServiceInfo {
+		func(ctx krt.HandlerContext, svc *model.ServiceInfo) *model.ServiceInfo {
 			if svc.Scope != model.Global {
-				return []*model.ServiceInfo{svc}
+				return svc
 			}
 
 			wls := GlobalWorkloadServiceIndex.Fetch(ctx, svc.ResourceName())
 			if len(wls) == 0 {
-				return []*model.ServiceInfo{svc}
+				return svc
 			}
 
 			// Since we merge the workloads in the remote cluster, we need to input the
@@ -443,7 +442,7 @@ func (a *index) buildGlobalCollections(
 				sans.Insert(spiffe.MustGenSpiffeURI(meshCfg.MeshConfig, wl.Workload.Namespace, wl.Workload.ServiceAccount))
 			}
 			if sans.IsEmpty() {
-				return []*model.ServiceInfo{svc}
+				return svc
 			}
 			sans = sans.Union(sets.New(svc.Service.SubjectAltNames...))
 
@@ -458,7 +457,7 @@ func (a *index) buildGlobalCollections(
 				DNSConnectStrategy: svc.DNSConnectStrategy,
 			}
 			newSvcInfo.Service.SubjectAltNames = sans.UnsortedList()
-			return []*model.ServiceInfo{precomputeService(newSvcInfo)}
+			return precomputeService(newSvcInfo)
 		},
 		opts.WithName("SplitHorizonServices")...,
 	)

--- a/pilot/pkg/serviceregistry/ambient/multicluster.go
+++ b/pilot/pkg/serviceregistry/ambient/multicluster.go
@@ -176,7 +176,7 @@ func (a *index) buildGlobalCollections(
 		)
 		statusQueue := statusqueue.NewQueue(options.StatusNotifier)
 		statusqueue.Register(statusQueue, "istio-ambient-service", LocalWorkloadServices,
-			func(info model.ServiceInfo) (kclient.Patcher, map[string]model.Condition) {
+			func(info *model.ServiceInfo) (kclient.Patcher, map[string]model.Condition) {
 				// Since we have 1 collection for multiple types, we need to split these out
 				if info.Source.Kind == kind.ServiceEntry {
 					return kclient.ToPatcher(serviceEntriesWriter), getConditions(info.Source.NamespacedName, localServiceEntryInformers)
@@ -216,7 +216,9 @@ func (a *index) buildGlobalCollections(
 
 	GlobalMergedWorkloadServices := krt.MapCollection(
 		GlobalMergedWorkloadServicesWithCluster,
-		unwrapObjectWithCluster,
+		func(obj krt.ObjectWithCluster[model.ServiceInfo]) *model.ServiceInfo {
+			return obj.Object
+		},
 		opts.WithName("GlobalMergedServiceInfos")...,
 	)
 
@@ -306,11 +308,11 @@ func (a *index) buildGlobalCollections(
 			svcName := parts[1]
 			svc := krt.FetchOne(ctx, GlobalMergedWorkloadServices, krt.FilterKey(svcName))
 
-			if svc == nil {
+			if svc == nil || *svc == nil {
 				log.Errorf("Failed to find service %s to coalesce workloads", svcName)
 				return nil
 			}
-			if svc.Scope != model.Global {
+			if (*svc).Scope != model.Global {
 				return nil
 			}
 
@@ -337,7 +339,7 @@ func (a *index) buildGlobalCollections(
 				log.Warnf("Multiple gateways found for network %s, using the first one", networkID)
 			}
 			gw := gws[0]
-			wi := a.createSplitHorizonWorkload(svcName, svc.Service, &gw, capacity, meshCfg)
+			wi := a.createSplitHorizonWorkload(svcName, (*svc).Service, &gw, capacity, meshCfg)
 			return []model.WorkloadInfo{wi}
 		}, opts.WithName("CoalesedWorkloads")...,
 	)
@@ -412,16 +414,16 @@ func (a *index) buildGlobalCollections(
 		return []networkAddress{netaddr}
 	})
 
-	SplitHorizonServices := krt.NewCollection(
+	SplitHorizonServices := krt.NewManyCollection(
 		GlobalMergedWorkloadServices,
-		func(ctx krt.HandlerContext, svc model.ServiceInfo) *model.ServiceInfo {
+		func(ctx krt.HandlerContext, svc *model.ServiceInfo) []*model.ServiceInfo {
 			if svc.Scope != model.Global {
-				return &svc
+				return []*model.ServiceInfo{svc}
 			}
 
 			wls := GlobalWorkloadServiceIndex.Fetch(ctx, svc.ResourceName())
 			if len(wls) == 0 {
-				return &svc
+				return []*model.ServiceInfo{svc}
 			}
 
 			// Since we merge the workloads in the remote cluster, we need to input the
@@ -441,7 +443,7 @@ func (a *index) buildGlobalCollections(
 				sans.Insert(spiffe.MustGenSpiffeURI(meshCfg.MeshConfig, wl.Workload.Namespace, wl.Workload.ServiceAccount))
 			}
 			if sans.IsEmpty() {
-				return &svc
+				return []*model.ServiceInfo{svc}
 			}
 			sans = sans.Union(sets.New(svc.Service.SubjectAltNames...))
 
@@ -456,37 +458,37 @@ func (a *index) buildGlobalCollections(
 				DNSConnectStrategy: svc.DNSConnectStrategy,
 			}
 			newSvcInfo.Service.SubjectAltNames = sans.UnsortedList()
-			return precomputeServicePtr(newSvcInfo)
+			return []*model.ServiceInfo{precomputeService(newSvcInfo)}
 		},
 		opts.WithName("SplitHorizonServices")...,
 	)
 
 	SplitHorizonServices.RegisterBatch(krt.BatchedEventFilter(
-		func(a model.ServiceInfo) *model.XDSServiceInfo {
+		func(a *model.ServiceInfo) *model.XDSServiceInfo {
 			// Only trigger push if the XDS object changed; the rest is just for computation of others
 			return &model.XDSServiceInfo{
 				Service:            a.Service,
 				DNSConnectStrategy: a.DNSConnectStrategy,
 			}
 		},
-		PushXdsAddress(a.XDSUpdater, model.ServiceInfo.ResourceName, model.ServiceInfo.WaypointRef),
+		PushXdsAddress(a.XDSUpdater, (*model.ServiceInfo).ResourceName, (*model.ServiceInfo).WaypointRef),
 	), false)
 
 	SplitHorizonServiceAddressIndex := krt.NewIndex(SplitHorizonServices, "serviceAddress", networkAddressFromService)
-	SplitHorizonServiceInfosByOwningWaypointHostname := krt.NewIndex(SplitHorizonServices, "namespaceHostname", func(s model.ServiceInfo) []NamespaceHostname {
+	SplitHorizonServiceInfosByOwningWaypointHostname := krt.NewIndex(SplitHorizonServices, "namespaceHostname", func(s *model.ServiceInfo) []NamespaceHostname {
 		// Filter out waypoint services
 		// TODO: we are looking at the *selector* -- we should be looking the labels themselves or something equivalent.
 		if s.LabelSelector.Labels[label.GatewayManaged.Name] == constants.ManagedGatewayMeshControllerLabel {
 			return nil
 		}
-		return serviceOwningWaypointHostnames(s)
+		return serviceOwningWaypointHostnames(*s)
 	})
-	SplitHorizonServiceInfosByOwningWaypointIP := krt.NewIndex(SplitHorizonServices, "owningWaypointIp", func(s model.ServiceInfo) []networkAddress {
+	SplitHorizonServiceInfosByOwningWaypointIP := krt.NewIndex(SplitHorizonServices, "owningWaypointIp", func(s *model.ServiceInfo) []networkAddress {
 		// Filter out waypoint services
 		if s.LabelSelector.Labels[label.GatewayManaged.Name] == constants.ManagedGatewayMeshControllerLabel {
 			return nil
 		}
-		return serviceOwningWaypointAddresses(s)
+		return serviceOwningWaypointAddresses(*s)
 	})
 
 	if features.EnableIngressWaypointRouting {
@@ -562,9 +564,10 @@ func mergeServiceInfosWithCluster(
 		// Precompute the svc info here
 		if svcInfosLen == 1 {
 			obj := serviceInfos[0]
+			merged := *obj.Object
 			return &krt.ObjectWithCluster[model.ServiceInfo]{
 				ClusterID: obj.ClusterID,
-				Object:    precomputeServicePtr(obj.Object),
+				Object:    precomputeService(&merged),
 			}
 		}
 
@@ -588,9 +591,10 @@ func mergeServiceInfosWithCluster(
 				return nil
 			}
 			// otherwise, skip merging
+			merged := *base.Object
 			return &krt.ObjectWithCluster[model.ServiceInfo]{
 				ClusterID: base.ClusterID,
-				Object:    precomputeServicePtr(base.Object),
+				Object:    precomputeService(&merged),
 			}
 		}
 
@@ -626,8 +630,9 @@ func mergeServiceInfosWithCluster(
 			}
 		}
 
-		// Prevent modifying the underlying workloadapi.Service
-		base.Object.Service = protomarshal.Clone(base.Object.Service)
+		// Never modify a ServiceInfo published by an input collection.
+		merged := *base.Object
+		merged.Service = protomarshal.Clone(base.Object.Service)
 
 		// TODO: Do we need to merge anything else?
 
@@ -635,7 +640,7 @@ func mergeServiceInfosWithCluster(
 		orderedVips := slices.SortBy(vips.UnsortedList(), func(a simpleNetworkAddress) string {
 			return a.network + "/" + a.ip.String()
 		})
-		base.Object.Service.Addresses = slices.Map(orderedVips, func(a simpleNetworkAddress) *workloadapi.NetworkAddress {
+		merged.Service.Addresses = slices.Map(orderedVips, func(a simpleNetworkAddress) *workloadapi.NetworkAddress {
 			na := &workloadapi.NetworkAddress{
 				Network: a.network,
 				Address: a.ip.Addr().AsSlice(),
@@ -645,12 +650,12 @@ func mergeServiceInfosWithCluster(
 			}
 			return na
 		})
-		base.Object.Service.SubjectAltNames = sans.UnsortedList()
+		merged.Service.SubjectAltNames = sans.UnsortedList()
 
 		// Remember, we have to re-precompute the serviceinfo since we changed it
 		return &krt.ObjectWithCluster[model.ServiceInfo]{
 			ClusterID: base.ClusterID,
-			Object:    precomputeServicePtr(base.Object),
+			Object:    precomputeService(&merged),
 		}
 	}
 }

--- a/pilot/pkg/serviceregistry/ambient/multicluster.go
+++ b/pilot/pkg/serviceregistry/ambient/multicluster.go
@@ -265,7 +265,7 @@ func (a *index) buildGlobalCollections(
 	if features.EnableAmbientStatus {
 		workloadEntriesWriter := kclient.NewWriteClient[*networkingclient.WorkloadEntry](localCluster.Client)
 		statusqueue.Register(a.statusQueue, "istio-ambient-workloadentry", GlobalWorkloads,
-			func(info model.WorkloadInfo) (kclient.Patcher, map[string]model.Condition) {
+			func(info *model.WorkloadInfo) (kclient.Patcher, map[string]model.Condition) {
 				if info.Source.Kind != kind.WorkloadEntry {
 					return nil, nil
 				}
@@ -273,14 +273,14 @@ func (a *index) buildGlobalCollections(
 			})
 	}
 
-	GlobalWorkloadServiceIndex := krt.NewIndex(GlobalWorkloads, "service", func(o model.WorkloadInfo) []string {
+	GlobalWorkloadServiceIndex := krt.NewIndex(GlobalWorkloads, "service", func(o *model.WorkloadInfo) []string {
 		return maps.Keys(o.Workload.Services)
 	})
 
 	// This allows us to find all the workloads that correspond to a service, network pair.
 	// This will allow us to build coalesced workloads that represent all the workloads in a remote network,
 	// for a given service. This helps reduce the number of XDS objects we to proxies.
-	workloadNetworkServiceIndex := krt.NewIndex(GlobalWorkloads, "network;service", func(o model.WorkloadInfo) []string {
+	workloadNetworkServiceIndex := krt.NewIndex(GlobalWorkloads, "network;service", func(o *model.WorkloadInfo) []string {
 		res := make([]string, 0, len(o.Workload.Services))
 		for svc := range o.Workload.Services {
 			res = append(res, strings.Join([]string{o.Workload.Network, svc}, ";"))
@@ -292,7 +292,7 @@ func (a *index) buildGlobalCollections(
 		workloadNetworkServiceIndex.AsCollection(
 			opts.WithName("workloadNetworkServiceIndex")...,
 		),
-		func(ctx krt.HandlerContext, i krt.IndexObject[string, model.WorkloadInfo]) []model.WorkloadInfo {
+		func(ctx krt.HandlerContext, i krt.IndexObject[string, *model.WorkloadInfo]) []*model.WorkloadInfo {
 			parts := strings.Split(i.Key, ";")
 			if len(parts) != 2 {
 				log.Errorf("Invalid key %s for SplitHorizonWorkloads, expected <network>;<service>", i.Key)
@@ -340,39 +340,39 @@ func (a *index) buildGlobalCollections(
 			}
 			gw := gws[0]
 			wi := a.createSplitHorizonWorkload(svcName, (*svc).Service, &gw, capacity, meshCfg)
-			return []model.WorkloadInfo{wi}
+			return []*model.WorkloadInfo{wi}
 		}, opts.WithName("CoalesedWorkloads")...,
 	)
-	networkLocalWorkloads := krt.NewCollection(GlobalWorkloads, func(ctx krt.HandlerContext, wi model.WorkloadInfo) *model.WorkloadInfo {
+	networkLocalWorkloads := krt.NewManyCollection(GlobalWorkloads, func(ctx krt.HandlerContext, wi *model.WorkloadInfo) []*model.WorkloadInfo {
 		if strings.HasPrefix(wi.Workload.Uid, "NetworkGateway/") {
-			return &wi
+			return []*model.WorkloadInfo{wi}
 		}
 		if wi.Workload.Network != GlobalNetworks.FetchLocalNetworkID(ctx).String() {
 			return nil
 		}
-		return &wi
+		return []*model.WorkloadInfo{wi}
 	}, opts.WithName("NetworkLocalWorkloads")...)
 
 	SplitHorizonWorkloads := krt.JoinCollection(
-		[]krt.Collection[model.WorkloadInfo]{
+		[]krt.Collection[*model.WorkloadInfo]{
 			coalescedWorkloads,
 			networkLocalWorkloads,
 		},
 		opts.WithName("SplitHorizonWorkloads")...,
 	)
 	SplitHorizonWorkloads.RegisterBatch(krt.BatchedEventFilter(
-		func(a model.WorkloadInfo) *workloadapi.Workload {
+		func(a *model.WorkloadInfo) *workloadapi.Workload {
 			// Only trigger push if the XDS object changed; the rest is just for computation of others
 			return a.Workload
 		},
-		PushXdsAddress(a.XDSUpdater, model.WorkloadInfo.ResourceName, model.WorkloadInfo.WaypointRef),
+		PushXdsAddress(a.XDSUpdater, (*model.WorkloadInfo).ResourceName, (*model.WorkloadInfo).WaypointRef),
 	), false)
 
 	SplitHorizonWorkloadAddressIndex := krt.NewIndex(SplitHorizonWorkloads, "networkAddress", networkAddressFromWorkload)
-	SplitHorizonWorkloadServiceIndex := krt.NewIndex(SplitHorizonWorkloads, "service", func(o model.WorkloadInfo) []string {
+	SplitHorizonWorkloadServiceIndex := krt.NewIndex(SplitHorizonWorkloads, "service", func(o *model.WorkloadInfo) []string {
 		return maps.Keys(o.Workload.Services)
 	})
-	SplitHorizonWorkloadWaypointIndexHostname := krt.NewIndex(SplitHorizonWorkloads, "namespaceHostname", func(w model.WorkloadInfo) []NamespaceHostname {
+	SplitHorizonWorkloadWaypointIndexHostname := krt.NewIndex(SplitHorizonWorkloads, "namespaceHostname", func(w *model.WorkloadInfo) []NamespaceHostname {
 		// Filter out waypoints.
 		if w.Labels[label.GatewayManaged.Name] == constants.ManagedGatewayMeshControllerLabel {
 			return nil
@@ -391,7 +391,7 @@ func (a *index) buildGlobalCollections(
 			Hostname:  waypointAddress.Hostname,
 		}}
 	})
-	SplitHorizonWorkloadWaypointIndexIP := krt.NewIndex(SplitHorizonWorkloads, "waypointIp", func(w model.WorkloadInfo) []networkAddress {
+	SplitHorizonWorkloadWaypointIndexIP := krt.NewIndex(SplitHorizonWorkloads, "waypointIp", func(w *model.WorkloadInfo) []networkAddress {
 		// Filter out waypoints.
 		if w.Labels[label.GatewayManaged.Name] == constants.ManagedGatewayMeshControllerLabel {
 			return nil
@@ -701,9 +701,15 @@ func wrapObjectWithCluster[T any](clusterID cluster.ID) func(obj T) krt.ObjectWi
 	}
 }
 
+func wrapPointerObjectWithCluster[T any](clusterID cluster.ID) func(obj *T) krt.ObjectWithCluster[T] {
+	return func(obj *T) krt.ObjectWithCluster[T] {
+		return krt.ObjectWithCluster[T]{ClusterID: clusterID, Object: obj}
+	}
+}
+
 func (a *index) createSplitHorizonWorkload(
 	svcNamespacedName string, svc *workloadapi.Service, networkGateway *NetworkGateway, capacity uint32, meshCfg *MeshConfig,
-) model.WorkloadInfo {
+) *model.WorkloadInfo {
 	hboneMtlsPort := networkGateway.HBONEPort
 	if hboneMtlsPort == 0 {
 		hboneMtlsPort = 15008
@@ -748,7 +754,7 @@ func (a *index) createSplitHorizonWorkload(
 		}
 	}
 
-	wi := model.WorkloadInfo{
+	wi := &model.WorkloadInfo{
 		Workload: &wl,
 		Source:   model.TypedObject{Kind: kind.KubernetesGateway},
 		Labels:   labelutil.AugmentLabels(nil, networkGateway.Cluster, "", "", networkGateway.Network),

--- a/pilot/pkg/serviceregistry/ambient/multicluster_test.go
+++ b/pilot/pkg/serviceregistry/ambient/multicluster_test.go
@@ -58,3 +58,20 @@ func TestMergeServiceInfosDoesNotModifyInputs(t *testing.T) {
 		t.Fatal("merge must create a new ServiceInfo and Service")
 	}
 }
+
+func TestWorkloadPointerIdentity(t *testing.T) {
+	input := &model.WorkloadInfo{Workload: &workloadapi.Workload{Uid: "workload"}}
+	if got := precomputeWorkload(input); got != input {
+		t.Fatal("precomputeWorkload must retain its newly allocated input")
+	}
+
+	wrapped := wrapPointerObjectWithCluster[model.WorkloadInfo]("local")(input)
+	if wrapped.Object != input {
+		t.Fatal("workload wrapper must retain the producer pointer")
+	}
+
+	merged := mergeWorkloadInfosWithCluster("local")([]krt.ObjectWithCluster[model.WorkloadInfo]{wrapped})
+	if merged.Object != input {
+		t.Fatal("workload merge must retain the selected producer pointer")
+	}
+}

--- a/pilot/pkg/serviceregistry/ambient/multicluster_test.go
+++ b/pilot/pkg/serviceregistry/ambient/multicluster_test.go
@@ -13,3 +13,48 @@
 // limitations under the License.
 
 package ambient
+
+import (
+	"testing"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/cluster"
+	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/test/util/assert"
+	"istio.io/istio/pkg/workloadapi"
+)
+
+func TestMergeServiceInfosDoesNotModifyInputs(t *testing.T) {
+	input := &model.ServiceInfo{
+		Service: &workloadapi.Service{
+			Name:            "svc",
+			Namespace:       "ns",
+			Hostname:        "svc.ns.svc.cluster.local",
+			Addresses:       []*workloadapi.NetworkAddress{{Network: "network-1", Address: []byte{1, 2, 3, 4}}},
+			SubjectAltNames: []string{"original"},
+		},
+		Scope: model.Global,
+	}
+	other := &model.ServiceInfo{
+		Service: &workloadapi.Service{
+			Name:            "svc",
+			Namespace:       "ns",
+			Hostname:        "svc.ns.svc.cluster.local",
+			Addresses:       []*workloadapi.NetworkAddress{{Network: "network-2", Address: []byte{5, 6, 7, 8}}},
+			SubjectAltNames: []string{"other"},
+		},
+		Scope: model.Global,
+	}
+
+	merged := mergeServiceInfosWithCluster("local")([]krt.ObjectWithCluster[model.ServiceInfo]{
+		{ClusterID: cluster.ID("local"), Object: input},
+		{ClusterID: cluster.ID("remote"), Object: other},
+	})
+
+	assert.Equal(t, input.Service.Addresses, []*workloadapi.NetworkAddress{{Network: "network-1", Address: []byte{1, 2, 3, 4}}})
+	assert.Equal(t, input.Service.SubjectAltNames, []string{"original"})
+	assert.Equal(t, input.MarshaledAddress, nil)
+	if merged.Object == input || merged.Object.Service == input.Service {
+		t.Fatal("merge must create a new ServiceInfo and Service")
+	}
+}

--- a/pilot/pkg/serviceregistry/ambient/services.go
+++ b/pilot/pkg/serviceregistry/ambient/services.go
@@ -61,8 +61,8 @@ func (a Builder) ServicesCollection(
 	serviceEntryVisibility krt.Singleton[model.ServiceEntryVisibilityMatcher],
 	opts krt.OptionsBuilder,
 	precompute bool,
-) krt.Collection[model.ServiceInfo] {
-	ServicesInfo := krt.NewCollection(services, a.serviceServiceBuilder(waypoints, namespaces, meshConfig, precompute),
+) krt.Collection[*model.ServiceInfo] {
+	ServicesInfo := krt.NewManyCollection(services, a.serviceServiceBuilder(waypoints, namespaces, meshConfig, precompute),
 		append(
 			opts.WithName("ServicesInfo"),
 			krt.WithMetadata(krt.Metadata{
@@ -78,18 +78,18 @@ func (a Builder) ServicesCollection(
 			}),
 		)...)
 
-	allTypedServiceInfos := krt.JoinCollection([]krt.Collection[TypedServiceInfo]{ServicesInfo, ServiceEntriesInfo},
+	allTypedServiceInfos := krt.JoinCollection([]krt.Collection[*TypedServiceInfo]{ServicesInfo, ServiceEntriesInfo},
 		append(opts.WithName("AllTypedServiceInfo"), krt.WithMetadata(krt.Metadata{
 			multicluster.ClusterKRTMetadataKey: clusterID,
 		}))...)
 
-	allTypedServiceInfosByHostname := krt.NewIndex(allTypedServiceInfos, "TypedServiceInfosByHostname", func(ts TypedServiceInfo) []string {
+	allTypedServiceInfosByHostname := krt.NewIndex(allTypedServiceInfos, "TypedServiceInfosByHostname", func(ts *TypedServiceInfo) []string {
 		return []string{ts.Service.Hostname}
 	})
 
 	WorkloadServices := krt.NewManyCollection(
 		allTypedServiceInfosByHostname.AsCollection(opts.WithName("AllTypedServiceInfosByHostname")...),
-		func(ctx krt.HandlerContext, ios krt.IndexObject[string, TypedServiceInfo]) []model.ServiceInfo {
+		func(ctx krt.HandlerContext, ios krt.IndexObject[string, *TypedServiceInfo]) []*model.ServiceInfo {
 			if len(ios.Objects) == 0 {
 				return nil
 			}
@@ -106,14 +106,14 @@ func (a Builder) ServicesCollection(
 
 // selectWorkloadServices resolves the set of services sharing a hostname down to one winner per
 // namespace and marks the single canonical service.
-func selectWorkloadServices(typedServiceInfos []TypedServiceInfo) []model.ServiceInfo {
-	bestByNamespace := make(map[string]model.ServiceInfo)
+func selectWorkloadServices(typedServiceInfos []*TypedServiceInfo) []*model.ServiceInfo {
+	bestByNamespace := make(map[string]*model.ServiceInfo)
 
 	// check if a is a better ServiceInfo than b
 	// better meaning both:
 	//     a is older than b
 	//     b is not a Kubernetes Service
-	isBetter := func(a, b model.ServiceInfo) bool {
+	isBetter := func(a, b *model.ServiceInfo) bool {
 		return a.CreationTime.Before(b.CreationTime) && b.Source.Kind != kind.Service
 	}
 	// Pick the winner for each namespace: a Kubernetes Service always wins, else the oldest.
@@ -135,17 +135,17 @@ func selectWorkloadServices(typedServiceInfos []TypedServiceInfo) []model.Servic
 		si := bestByNamespace[ns]
 		switch {
 		case si.Source.Kind == kind.Service:
-			canonical = &si
+			canonical = si
 		case si.Service.GetVisibility() == workloadapi.Service_NAMESPACE:
 			continue
 		default:
-			if canonical == nil || isBetter(si, *canonical) {
-				canonical = &si
+			if canonical == nil || isBetter(si, canonical) {
+				canonical = si
 			}
 		}
 	}
 	if canonical != nil {
-		bestByNamespace[canonical.GetNamespace()] = setCanonical(*canonical)
+		bestByNamespace[canonical.GetNamespace()] = setCanonical(canonical)
 	}
 
 	return maps.Values(bestByNamespace)
@@ -153,7 +153,7 @@ func selectWorkloadServices(typedServiceInfos []TypedServiceInfo) []model.Servic
 
 func GlobalNestedWorkloadServicesCollection(
 	localCluster *multicluster.Cluster,
-	localServiceInfos krt.Collection[model.ServiceInfo],
+	localServiceInfos krt.Collection[*model.ServiceInfo],
 	localWaypoints krt.Collection[Waypoint],
 	ctrl *multicluster.Controller,
 	localServiceEntries krt.Collection[*networkingclient.ServiceEntry],
@@ -167,7 +167,9 @@ func GlobalNestedWorkloadServicesCollection(
 	// This will contain the serviceinfos derived from Services AND ServiceEntries
 	LocalServiceInfosWithCluster := krt.MapCollection(
 		localServiceInfos,
-		wrapObjectWithCluster[model.ServiceInfo](localCluster.ID),
+		func(obj *model.ServiceInfo) krt.ObjectWithCluster[model.ServiceInfo] {
+			return krt.ObjectWithCluster[model.ServiceInfo]{ClusterID: localCluster.ID, Object: obj}
+		},
 		opts.WithName("LocalServiceInfosWithCluster")...,
 	)
 
@@ -191,7 +193,7 @@ func GlobalNestedWorkloadServicesCollection(
 			waypoints := *waypointsPtr
 			namespaces := cluster.Namespaces()
 			// N.B Never precompute the service info for remote clusters; the merge function will do that
-			servicesInfo := krt.NewCollection(services, serviceServiceBuilder(
+			servicesInfo := krt.NewManyCollection(services, serviceServiceBuilder(
 				waypoints,
 				namespaces,
 				meshConfig,
@@ -212,8 +214,8 @@ func GlobalNestedWorkloadServicesCollection(
 
 			servicesInfoWithCluster := krt.MapCollection(
 				servicesInfo,
-				func(o model.ServiceInfo) krt.ObjectWithCluster[model.ServiceInfo] {
-					return krt.ObjectWithCluster[model.ServiceInfo]{ClusterID: cluster.ID, Object: &o}
+				func(o *model.ServiceInfo) krt.ObjectWithCluster[model.ServiceInfo] {
+					return krt.ObjectWithCluster[model.ServiceInfo]{ClusterID: cluster.ID, Object: o}
 				},
 				append(
 					opts,
@@ -236,8 +238,8 @@ func serviceServiceBuilder(
 	checkServiceScope bool,
 	networkGetter func(ctx krt.HandlerContext) network.ID,
 	precompute bool,
-) krt.TransformationSingle[*v1.Service, model.ServiceInfo] {
-	return func(ctx krt.HandlerContext, s *v1.Service) *model.ServiceInfo {
+) krt.TransformationMulti[*v1.Service, *model.ServiceInfo] {
+	return func(ctx krt.HandlerContext, s *v1.Service) []*model.ServiceInfo {
 		serviceScope := model.Local
 		if checkServiceScope {
 			meshCfg := krt.FetchOne(ctx, meshConfig.AsCollection())
@@ -298,10 +300,10 @@ func serviceServiceBuilder(
 			CreationTime:  s.CreationTimestamp.Time,
 		}
 		if precompute {
-			return precomputeServicePtr(svcInfo)
+			return []*model.ServiceInfo{precomputeService(svcInfo)}
 		}
 
-		return svcInfo
+		return []*model.ServiceInfo{svcInfo}
 	}
 }
 
@@ -314,8 +316,8 @@ func typedServiceServiceBuilder(
 	checkServiceScope bool,
 	networkGetter func(ctx krt.HandlerContext) network.ID,
 	precompute bool,
-) krt.TransformationSingle[*v1.Service, TypedServiceInfo] {
-	return func(ctx krt.HandlerContext, s *v1.Service) *TypedServiceInfo {
+) krt.TransformationMulti[*v1.Service, *TypedServiceInfo] {
+	return func(ctx krt.HandlerContext, s *v1.Service) []*TypedServiceInfo {
 		svcInfo := serviceServiceBuilder(waypoints,
 			namespaces,
 			meshConfig,
@@ -324,10 +326,10 @@ func typedServiceServiceBuilder(
 			checkServiceScope,
 			networkGetter,
 			precompute)(ctx, s)
-		if svcInfo == nil {
+		if len(svcInfo) == 0 {
 			return nil
 		}
-		return &TypedServiceInfo{ServiceInfo: *svcInfo}
+		return []*TypedServiceInfo{{ServiceInfo: svcInfo[0]}}
 	}
 }
 
@@ -393,7 +395,7 @@ func (a Builder) serviceServiceBuilder(
 	namespaces krt.Collection[*v1.Namespace],
 	meshConfig krt.Singleton[MeshConfig],
 	precompute bool,
-) krt.TransformationSingle[*v1.Service, TypedServiceInfo] {
+) krt.TransformationMulti[*v1.Service, *TypedServiceInfo] {
 	return typedServiceServiceBuilder(
 		waypoints,
 		namespaces,
@@ -416,23 +418,23 @@ func MakeSource(o controllers.Object) model.TypedObject {
 
 // TypedServiceInfo is a wrapper around ServiceInfo to avoid key conflicts during processing
 type TypedServiceInfo struct {
-	model.ServiceInfo
+	*model.ServiceInfo
 }
 
 func (t TypedServiceInfo) ResourceName() string {
 	return t.Source.Kind.String() + "/" + t.GetNamespace() + "/" + t.GetName() + "/" + t.Service.GetHostname()
 }
 
-func (t TypedServiceInfo) Equals(other TypedServiceInfo) bool {
-	return t.ServiceInfo.Equals(&other.ServiceInfo)
+func (t *TypedServiceInfo) Equals(other *TypedServiceInfo) bool {
+	return t.ServiceInfo.Equals(other.ServiceInfo)
 }
 
 func (a Builder) serviceEntryServiceBuilder(
 	waypoints krt.Collection[Waypoint],
 	namespaces krt.Collection[*v1.Namespace],
 	visibility krt.Singleton[model.ServiceEntryVisibilityMatcher],
-) krt.TransformationMulti[*networkingclient.ServiceEntry, TypedServiceInfo] {
-	return func(ctx krt.HandlerContext, s *networkingclient.ServiceEntry) []TypedServiceInfo {
+) krt.TransformationMulti[*networkingclient.ServiceEntry, *TypedServiceInfo] {
+	return func(ctx krt.HandlerContext, s *networkingclient.ServiceEntry) []*TypedServiceInfo {
 		waypoint, waypointError := fetchWaypointForService(ctx, waypoints, namespaces, visibility, s.ObjectMeta)
 
 		ns := krt.FetchOne(ctx, namespaces, krt.FilterKey(s.Namespace))
@@ -447,8 +449,8 @@ func (a Builder) serviceEntryServiceBuilder(
 			ctx, s, waypoints, namespaces, waypoint, waypointError,
 			nsAnnotations, nsLabels, visibility, a.Networks.FetchLocalNetworkID,
 		)
-		return slices.Map(serviceInfos, func(si model.ServiceInfo) TypedServiceInfo {
-			return TypedServiceInfo{ServiceInfo: si}
+		return slices.Map(serviceInfos, func(si *model.ServiceInfo) *TypedServiceInfo {
+			return &TypedServiceInfo{ServiceInfo: si}
 		})
 	}
 }
@@ -464,7 +466,7 @@ func serviceEntriesInfo(
 	nsLabels map[string]string,
 	visibility krt.Singleton[model.ServiceEntryVisibilityMatcher],
 	networkGetter func(ctx krt.HandlerContext) network.ID,
-) []model.ServiceInfo {
+) []*model.ServiceInfo {
 	sel := model.NewSelector(s.Spec.GetWorkloadSelector().GetLabels())
 	portNames := map[int32]model.ServicePortName{}
 	for _, p := range s.Spec.Ports {
@@ -504,12 +506,12 @@ func serviceEntriesInfo(
 	// condition. The status value itself comes from the WDS Service.Visibility set above.
 	visibilityConfigured := vis.Configured()
 	services := constructServiceEntries(ctx, s, w, nsAnnotations, networkGetter)
-	result := make([]model.ServiceInfo, 0, len(services))
+	result := make([]*model.ServiceInfo, 0, len(services))
 	for _, e := range services {
 		e.Visibility = wdsVisibility(resolvedVisibility)
 		e.IngressUseWaypoint = waypoint.IngressUseWaypoint
 		e.WeightedWaypoints = weighted
-		result = append(result, precomputeService(model.ServiceInfo{
+		result = append(result, precomputeService(&model.ServiceInfo{
 			Service:              e,
 			PortNames:            portNames,
 			LabelSelector:        sel,
@@ -746,11 +748,7 @@ func getVIPs(svc *v1.Service) []string {
 	return res
 }
 
-func precomputeServicePtr(w *model.ServiceInfo) *model.ServiceInfo {
-	return ptr.Of(precomputeService(*w))
-}
-
-func precomputeService(w model.ServiceInfo) model.ServiceInfo {
+func precomputeService(w *model.ServiceInfo) *model.ServiceInfo {
 	w.AsAddress = model.NewAddressInfo(serviceToAddress(w.Service))
 	w.MarshaledAddress = w.AsAddress.Marshaled
 	return w
@@ -759,10 +757,14 @@ func precomputeService(w model.ServiceInfo) model.ServiceInfo {
 // setCanonical sets the canonical field in a WDS service without mangling the ServiceInfo.
 // The ServiceInfo is passed by value so every field is carried over to the returned copy; only
 // the cloned Service proto and the precomputed address fields differ from the input.
-func setCanonical(se model.ServiceInfo) model.ServiceInfo {
-	se.Service = protomarshal.ShallowClone(se.Service)
-	se.Service.Canonical = true
-	return precomputeService(se)
+func setCanonical(se *model.ServiceInfo) *model.ServiceInfo {
+	if se.Service.Canonical {
+		return se
+	}
+	result := *se
+	result.Service = protomarshal.ShallowClone(se.Service)
+	result.Service.Canonical = true
+	return precomputeService(&result)
 }
 
 // ingressUseWaypointFromLabels returns whether the ingress-use-waypoint label is

--- a/pilot/pkg/serviceregistry/ambient/services.go
+++ b/pilot/pkg/serviceregistry/ambient/services.go
@@ -424,7 +424,7 @@ func (t TypedServiceInfo) ResourceName() string {
 }
 
 func (t TypedServiceInfo) Equals(other TypedServiceInfo) bool {
-	return t.ServiceInfo.Equals(other.ServiceInfo)
+	return t.ServiceInfo.Equals(&other.ServiceInfo)
 }
 
 func (a Builder) serviceEntryServiceBuilder(

--- a/pilot/pkg/serviceregistry/ambient/services.go
+++ b/pilot/pkg/serviceregistry/ambient/services.go
@@ -751,8 +751,7 @@ func precomputeService(w *model.ServiceInfo) *model.ServiceInfo {
 }
 
 // setCanonical sets the canonical field in a WDS service without mangling the ServiceInfo.
-// The ServiceInfo is passed by value so every field is carried over to the returned copy; only
-// the cloned Service proto and the precomputed address fields differ from the input.
+// It copies the ServiceInfo and clones the Service proto before modifying and precomputing the result.
 func setCanonical(se *model.ServiceInfo) *model.ServiceInfo {
 	if se.Service.Canonical {
 		return se

--- a/pilot/pkg/serviceregistry/ambient/services.go
+++ b/pilot/pkg/serviceregistry/ambient/services.go
@@ -62,7 +62,7 @@ func (a Builder) ServicesCollection(
 	opts krt.OptionsBuilder,
 	precompute bool,
 ) krt.Collection[*model.ServiceInfo] {
-	ServicesInfo := krt.NewManyCollection(services, a.serviceServiceBuilder(waypoints, namespaces, meshConfig, precompute),
+	ServicesInfo := krt.NewPointerCollection(services, a.serviceServiceBuilder(waypoints, namespaces, meshConfig, precompute),
 		append(
 			opts.WithName("ServicesInfo"),
 			krt.WithMetadata(krt.Metadata{
@@ -191,7 +191,7 @@ func GlobalNestedWorkloadServicesCollection(
 			waypoints := *waypointsPtr
 			namespaces := cluster.Namespaces()
 			// N.B Never precompute the service info for remote clusters; the merge function will do that
-			servicesInfo := krt.NewManyCollection(services, serviceServiceBuilder(
+			servicesInfo := krt.NewPointerCollection(services, serviceServiceBuilder(
 				waypoints,
 				namespaces,
 				meshConfig,
@@ -234,8 +234,8 @@ func serviceServiceBuilder(
 	checkServiceScope bool,
 	networkGetter func(ctx krt.HandlerContext) network.ID,
 	precompute bool,
-) krt.TransformationMulti[*v1.Service, *model.ServiceInfo] {
-	return func(ctx krt.HandlerContext, s *v1.Service) []*model.ServiceInfo {
+) krt.TransformationSingle[*v1.Service, model.ServiceInfo] {
+	return func(ctx krt.HandlerContext, s *v1.Service) *model.ServiceInfo {
 		serviceScope := model.Local
 		if checkServiceScope {
 			meshCfg := krt.FetchOne(ctx, meshConfig.AsCollection())
@@ -296,10 +296,10 @@ func serviceServiceBuilder(
 			CreationTime:  s.CreationTimestamp.Time,
 		}
 		if precompute {
-			return []*model.ServiceInfo{precomputeService(svcInfo)}
+			return precomputeService(svcInfo)
 		}
 
-		return []*model.ServiceInfo{svcInfo}
+		return svcInfo
 	}
 }
 
@@ -312,8 +312,8 @@ func typedServiceServiceBuilder(
 	checkServiceScope bool,
 	networkGetter func(ctx krt.HandlerContext) network.ID,
 	precompute bool,
-) krt.TransformationMulti[*v1.Service, *TypedServiceInfo] {
-	return func(ctx krt.HandlerContext, s *v1.Service) []*TypedServiceInfo {
+) krt.TransformationSingle[*v1.Service, TypedServiceInfo] {
+	return func(ctx krt.HandlerContext, s *v1.Service) *TypedServiceInfo {
 		svcInfo := serviceServiceBuilder(waypoints,
 			namespaces,
 			meshConfig,
@@ -322,10 +322,10 @@ func typedServiceServiceBuilder(
 			checkServiceScope,
 			networkGetter,
 			precompute)(ctx, s)
-		if len(svcInfo) == 0 {
+		if svcInfo == nil {
 			return nil
 		}
-		return []*TypedServiceInfo{{ServiceInfo: svcInfo[0]}}
+		return &TypedServiceInfo{ServiceInfo: svcInfo}
 	}
 }
 
@@ -391,7 +391,7 @@ func (a Builder) serviceServiceBuilder(
 	namespaces krt.Collection[*v1.Namespace],
 	meshConfig krt.Singleton[MeshConfig],
 	precompute bool,
-) krt.TransformationMulti[*v1.Service, *TypedServiceInfo] {
+) krt.TransformationSingle[*v1.Service, TypedServiceInfo] {
 	return typedServiceServiceBuilder(
 		waypoints,
 		namespaces,

--- a/pilot/pkg/serviceregistry/ambient/services.go
+++ b/pilot/pkg/serviceregistry/ambient/services.go
@@ -167,9 +167,7 @@ func GlobalNestedWorkloadServicesCollection(
 	// This will contain the serviceinfos derived from Services AND ServiceEntries
 	LocalServiceInfosWithCluster := krt.MapCollection(
 		localServiceInfos,
-		func(obj *model.ServiceInfo) krt.ObjectWithCluster[model.ServiceInfo] {
-			return krt.ObjectWithCluster[model.ServiceInfo]{ClusterID: localCluster.ID, Object: obj}
-		},
+		wrapPointerObjectWithCluster[model.ServiceInfo](localCluster.ID),
 		opts.WithName("LocalServiceInfosWithCluster")...,
 	)
 
@@ -214,9 +212,7 @@ func GlobalNestedWorkloadServicesCollection(
 
 			servicesInfoWithCluster := krt.MapCollection(
 				servicesInfo,
-				func(o *model.ServiceInfo) krt.ObjectWithCluster[model.ServiceInfo] {
-					return krt.ObjectWithCluster[model.ServiceInfo]{ClusterID: cluster.ID, Object: o}
-				},
+				wrapPointerObjectWithCluster[model.ServiceInfo](cluster.ID),
 				append(
 					opts,
 					krt.WithName(fmt.Sprintf("ServiceServiceInfosWithCluster[%s]", cluster.ID)),

--- a/pilot/pkg/serviceregistry/ambient/services_test.go
+++ b/pilot/pkg/serviceregistry/ambient/services_test.go
@@ -2301,10 +2301,10 @@ func TestServiceServices(t *testing.T) {
 				true,
 			)
 			res := builder(krt.TestingDummyContext{}, tt.svc)
-			if len(res) == 0 {
+			if res == nil {
 				assert.Equal(t, nil, tt.result)
 			} else {
-				assert.Equal(t, res[0].Service, tt.result)
+				assert.Equal(t, res.Service, tt.result)
 			}
 		})
 	}
@@ -2356,11 +2356,11 @@ func TestPreferSamePresetNotMutated(t *testing.T) {
 	// Process a "poisoner" Service (PreferSameZone + PNRA) before a plain Service
 	// using PreferSameZone. The plain Service must NOT inherit ALLOW_ALL.
 	_ = builder(ctx, mkSvc("poisoner-zone", "1.2.3.4", "PreferSameZone", true))
-	victimZone := builder(ctx, mkSvc("victim-zone", "1.2.3.5", "PreferSameZone", false))[0]
+	victimZone := builder(ctx, mkSvc("victim-zone", "1.2.3.5", "PreferSameZone", false))
 
 	// Same scenario for PreferSameNode.
 	_ = builder(ctx, mkSvc("poisoner-node", "1.2.3.6", "PreferSameNode", true))
-	victimNode := builder(ctx, mkSvc("victim-node", "1.2.3.7", "PreferSameNode", false))[0]
+	victimNode := builder(ctx, mkSvc("victim-node", "1.2.3.7", "PreferSameNode", false))
 
 	assert.Equal(t,
 		victimZone.Service.LoadBalancing.HealthPolicy, workloadapi.LoadBalancing_ONLY_HEALTHY)
@@ -2495,7 +2495,7 @@ func TestServiceConditions(t *testing.T) {
 				true,
 			)
 			res := builder(krt.TestingDummyContext{}, tt.svc)
-			assert.Equal(t, res[0].GetConditions(nil), tt.conditions) // TODO: Test transitions for conditions
+			assert.Equal(t, res.GetConditions(nil), tt.conditions) // TODO: Test transitions for conditions
 		})
 	}
 }

--- a/pilot/pkg/serviceregistry/ambient/services_test.go
+++ b/pilot/pkg/serviceregistry/ambient/services_test.go
@@ -1378,7 +1378,7 @@ func TestServiceEntryServices(t *testing.T) {
 				krt.NewStatic(matcher, true),
 			)
 			wrapper := builder(krt.TestingDummyContext{}, tt.se)
-			res := slices.Map(wrapper, func(e TypedServiceInfo) *workloadapi.Service {
+			res := slices.Map(wrapper, func(e *TypedServiceInfo) *workloadapi.Service {
 				return e.Service
 			})
 			assert.Equal(t, res, tt.result)
@@ -1395,8 +1395,8 @@ func TestSelectWorkloadServices(t *testing.T) {
 	older := time.Unix(100, 0)
 	newer := time.Unix(200, 0)
 
-	si := func(ns, name string, k kind.Kind, vis workloadapi.Service_Visibility, created time.Time) TypedServiceInfo {
-		return TypedServiceInfo{ServiceInfo: model.ServiceInfo{
+	si := func(ns, name string, k kind.Kind, vis workloadapi.Service_Visibility, created time.Time) *TypedServiceInfo {
+		return &TypedServiceInfo{ServiceInfo: &model.ServiceInfo{
 			Service: &workloadapi.Service{
 				Name:       name,
 				Namespace:  ns,
@@ -1410,7 +1410,7 @@ func TestSelectWorkloadServices(t *testing.T) {
 
 	// run returns the winning service name per namespace and the name of the single canonical
 	// service ("" if none).
-	run := func(t *testing.T, inputs []TypedServiceInfo) (map[string]string, string) {
+	run := func(t *testing.T, inputs []*TypedServiceInfo) (map[string]string, string) {
 		winners := map[string]string{}
 		canonical := ""
 		for _, s := range selectWorkloadServices(inputs) {
@@ -1427,7 +1427,7 @@ func TestSelectWorkloadServices(t *testing.T) {
 
 	cases := []struct {
 		name          string
-		inputs        []TypedServiceInfo
+		inputs        []*TypedServiceInfo
 		wantWinners   map[string]string
 		wantCanonical string
 	}{
@@ -1435,7 +1435,7 @@ func TestSelectWorkloadServices(t *testing.T) {
 			// Same namespace, same hostname: the older SE owns the slot. Because the owner is
 			// NAMESPACE-scoped, nothing is canonical (out-of-namespace clients see no service).
 			name: "same namespace: older NAMESPACE beats newer PUBLIC, nothing canonical",
-			inputs: []TypedServiceInfo{
+			inputs: []*TypedServiceInfo{
 				si("ns", "pub", kind.ServiceEntry, workloadapi.Service_PUBLIC, newer),
 				si("ns", "nslocal", kind.ServiceEntry, workloadapi.Service_NAMESPACE, older),
 			},
@@ -1446,7 +1446,7 @@ func TestSelectWorkloadServices(t *testing.T) {
 			// A Kubernetes Service must be canonical over an older ServiceEntry that camps its
 			// hostname -- age must not let the SE capture it.
 			name: "kube Service is canonical over an older camping PUBLIC ServiceEntry",
-			inputs: []TypedServiceInfo{
+			inputs: []*TypedServiceInfo{
 				si("team-a", "svc", kind.Service, workloadapi.Service_PUBLIC, newer),
 				si("team-b", "camp", kind.ServiceEntry, workloadapi.Service_PUBLIC, older),
 			},
@@ -1456,7 +1456,7 @@ func TestSelectWorkloadServices(t *testing.T) {
 		{
 			// Cross namespace: the PUBLIC SE is canonical; the NAMESPACE SE owns only its namespace.
 			name: "cross namespace: PUBLIC is canonical, NAMESPACE is not",
-			inputs: []TypedServiceInfo{
+			inputs: []*TypedServiceInfo{
 				si("team-a", "nslocal", kind.ServiceEntry, workloadapi.Service_NAMESPACE, older),
 				si("team-b", "pub", kind.ServiceEntry, workloadapi.Service_PUBLIC, newer),
 			},
@@ -1470,7 +1470,7 @@ func TestSelectWorkloadServices(t *testing.T) {
 			// Order-independence: same result for the inputs and their reverse.
 			reverse := slices.Clone(tc.inputs)
 			slices.Reverse(reverse)
-			for _, order := range [][]TypedServiceInfo{tc.inputs, reverse} {
+			for _, order := range [][]*TypedServiceInfo{tc.inputs, reverse} {
 				winners, canonical := run(t, order)
 				assert.Equal(t, winners, tc.wantWinners)
 				assert.Equal(t, canonical, tc.wantCanonical)
@@ -1479,17 +1479,12 @@ func TestSelectWorkloadServices(t *testing.T) {
 	}
 }
 
-// Test_setCanonical asserts setCanonical propagates every ServiceInfo field to the canonical
-// copy. The reflection check keeps the fixture fully populated as fields are added; without it a
-// new field would default to zero and the equality below would pass without covering it. The
-// input is a fixed point of setCanonical: Canonical is already true and the marshaled address is
-// precomputed, so output must equal input exactly.
+// Test_setCanonical asserts setCanonical creates a canonical copy without modifying its input.
 func Test_setCanonical(t *testing.T) {
 	svc := &workloadapi.Service{
 		Name:      "name",
 		Namespace: "ns",
 		Hostname:  "host.example.com",
-		Canonical: true,
 	}
 	ai := model.NewAddressInfo(serviceToAddress(svc))
 	se := model.ServiceInfo{
@@ -1512,8 +1507,17 @@ func Test_setCanonical(t *testing.T) {
 			t.Errorf("field %q must be non-zero so this test covers it", rt.Field(i).Name)
 		}
 	}
-	seCopy := setCanonical(se)
-	assert.Equal(t, &se, &seCopy)
+	seCopy := setCanonical(&se)
+	assert.Equal(t, se.Service.Canonical, false)
+	assert.Equal(t, seCopy.Service.Canonical, true)
+	if seCopy == &se || seCopy.Service == se.Service {
+		t.Fatal("setCanonical must create a new ServiceInfo and Service")
+	}
+
+	alreadyCanonical := setCanonical(seCopy)
+	if alreadyCanonical != seCopy {
+		t.Fatal("setCanonical must retain an already canonical ServiceInfo")
+	}
 }
 
 func TestServiceServices(t *testing.T) {
@@ -2297,10 +2301,10 @@ func TestServiceServices(t *testing.T) {
 				true,
 			)
 			res := builder(krt.TestingDummyContext{}, tt.svc)
-			if res == nil {
+			if len(res) == 0 {
 				assert.Equal(t, nil, tt.result)
 			} else {
-				assert.Equal(t, res.Service, tt.result)
+				assert.Equal(t, res[0].Service, tt.result)
 			}
 		})
 	}
@@ -2352,11 +2356,11 @@ func TestPreferSamePresetNotMutated(t *testing.T) {
 	// Process a "poisoner" Service (PreferSameZone + PNRA) before a plain Service
 	// using PreferSameZone. The plain Service must NOT inherit ALLOW_ALL.
 	_ = builder(ctx, mkSvc("poisoner-zone", "1.2.3.4", "PreferSameZone", true))
-	victimZone := builder(ctx, mkSvc("victim-zone", "1.2.3.5", "PreferSameZone", false))
+	victimZone := builder(ctx, mkSvc("victim-zone", "1.2.3.5", "PreferSameZone", false))[0]
 
 	// Same scenario for PreferSameNode.
 	_ = builder(ctx, mkSvc("poisoner-node", "1.2.3.6", "PreferSameNode", true))
-	victimNode := builder(ctx, mkSvc("victim-node", "1.2.3.7", "PreferSameNode", false))
+	victimNode := builder(ctx, mkSvc("victim-node", "1.2.3.7", "PreferSameNode", false))[0]
 
 	assert.Equal(t,
 		victimZone.Service.LoadBalancing.HealthPolicy, workloadapi.LoadBalancing_ONLY_HEALTHY)
@@ -2491,7 +2495,7 @@ func TestServiceConditions(t *testing.T) {
 				true,
 			)
 			res := builder(krt.TestingDummyContext{}, tt.svc)
-			assert.Equal(t, res.GetConditions(nil), tt.conditions) // TODO: Test transitions for conditions
+			assert.Equal(t, res[0].GetConditions(nil), tt.conditions) // TODO: Test transitions for conditions
 		})
 	}
 }

--- a/pilot/pkg/serviceregistry/ambient/sidecar_interop.go
+++ b/pilot/pkg/serviceregistry/ambient/sidecar_interop.go
@@ -32,7 +32,7 @@ import (
 // serviceEDS captures the inputs that affect gateway EDS for a waypoint-bound service.
 type serviceEDS struct {
 	ServiceKey       string
-	WaypointInstance []model.WorkloadInfo
+	WaypointInstance []*model.WorkloadInfo
 	UseWaypoint      bool
 	// Included so weight changes trigger EDS for the bound service.
 	WeightedWaypoints []*workloadapi.WeightedWaypoint
@@ -54,7 +54,7 @@ func (s serviceEDS) Equals(other serviceEDS) bool {
 	}
 	// assumes builder sorted the slices
 	for i := range s.WaypointInstance {
-		if !s.WaypointInstance[i].Equals(&other.WaypointInstance[i]) {
+		if !s.WaypointInstance[i].Equals(other.WaypointInstance[i]) {
 			return false
 		}
 	}
@@ -98,9 +98,9 @@ func weightedWaypointEqual(a, b *workloadapi.WeightedWaypoint) bool {
 // Ideally, the information we are using in Envoy and the event trigger are using the same data directly.
 func RegisterEdsShim(
 	xdsUpdater model.XDSUpdater,
-	Workloads krt.Collection[model.WorkloadInfo],
+	Workloads krt.Collection[*model.WorkloadInfo],
 	Namespaces krt.Collection[model.NamespaceInfo],
-	WorkloadsByServiceKey krt.Index[string, model.WorkloadInfo],
+	WorkloadsByServiceKey krt.Index[string, *model.WorkloadInfo],
 	Services krt.Collection[*model.ServiceInfo],
 	ServicesByAddress krt.Index[networkAddress, *model.ServiceInfo],
 	opts krt.OptionsBuilder,
@@ -122,7 +122,7 @@ func RegisterEdsShim(
 				return nil
 			}
 			// Track every waypoint whose endpoints can appear in the gateway CLA.
-			var workloads []model.WorkloadInfo
+			var workloads []*model.WorkloadInfo
 			for _, wp := range serviceOwningWaypoints(*svc) {
 				var waypointServiceKey string
 				switch addr := wp.Destination.(type) {
@@ -144,7 +144,7 @@ func RegisterEdsShim(
 				workloads = append(workloads, WorkloadsByServiceKey.Fetch(ctx, waypointServiceKey)...)
 			}
 			// for comparison in Equals
-			workloads = slices.SortBy(workloads, func(i model.WorkloadInfo) string {
+			workloads = slices.SortBy(workloads, func(i *model.WorkloadInfo) string {
 				return i.Workload.Uid
 			})
 			return &serviceEDS{

--- a/pilot/pkg/serviceregistry/ambient/sidecar_interop.go
+++ b/pilot/pkg/serviceregistry/ambient/sidecar_interop.go
@@ -101,8 +101,8 @@ func RegisterEdsShim(
 	Workloads krt.Collection[model.WorkloadInfo],
 	Namespaces krt.Collection[model.NamespaceInfo],
 	WorkloadsByServiceKey krt.Index[string, model.WorkloadInfo],
-	Services krt.Collection[model.ServiceInfo],
-	ServicesByAddress krt.Index[networkAddress, model.ServiceInfo],
+	Services krt.Collection[*model.ServiceInfo],
+	ServicesByAddress krt.Index[networkAddress, *model.ServiceInfo],
 	opts krt.OptionsBuilder,
 ) {
 	// Helps us avoid race conditions in tests.
@@ -111,8 +111,8 @@ func RegisterEdsShim(
 	multiNetworkEnabled := features.EnableAmbientMultiNetwork
 	ServiceEds := krt.NewCollection(
 		Services,
-		func(ctx krt.HandlerContext, svc model.ServiceInfo) *serviceEDS {
-			useWaypoint := ingressUseWaypoint(svc, krt.FetchOne(ctx, Namespaces, krt.FilterKey(svc.Service.Namespace)))
+		func(ctx krt.HandlerContext, svc *model.ServiceInfo) *serviceEDS {
+			useWaypoint := ingressUseWaypoint(*svc, krt.FetchOne(ctx, Namespaces, krt.FilterKey(svc.Service.Namespace)))
 			if !useWaypoint && (!multiNetworkEnabled || svc.Scope != model.Global) {
 				// Currently, we only need this for ingress/east west gateway -> waypoint usage
 				// If we extend this to sidecars, etc we can drop this.
@@ -123,7 +123,7 @@ func RegisterEdsShim(
 			}
 			// Track every waypoint whose endpoints can appear in the gateway CLA.
 			var workloads []model.WorkloadInfo
-			for _, wp := range serviceOwningWaypoints(svc) {
+			for _, wp := range serviceOwningWaypoints(*svc) {
 				var waypointServiceKey string
 				switch addr := wp.Destination.(type) {
 				case *workloadapi.GatewayAddress_Hostname:
@@ -139,7 +139,7 @@ func RegisterEdsShim(
 					if waypointSvc == nil {
 						continue
 					}
-					waypointServiceKey = waypointSvc.ResourceName()
+					waypointServiceKey = (*waypointSvc).ResourceName()
 				}
 				workloads = append(workloads, WorkloadsByServiceKey.Fetch(ctx, waypointServiceKey)...)
 			}
@@ -164,15 +164,15 @@ func RegisterEdsShim(
 
 func (a *index) ServicesWithWaypoint(key string) []model.ServiceWaypointInfo {
 	res := []model.ServiceWaypointInfo{}
-	var svcs []model.ServiceInfo
+	var svcs []*model.ServiceInfo
 	if key == "" {
 		svcs = a.services.List()
-	} else {
-		svcs = ptr.ToList(a.services.GetKey(key))
+	} else if svc := ptr.Flatten(a.services.GetKey(key)); svc != nil {
+		svcs = []*model.ServiceInfo{svc}
 	}
 	for _, s := range svcs {
 		wp := s.Service.GetWaypoint()
-		useWaypoint := ingressUseWaypoint(s, a.namespaces.GetKey(s.Service.Namespace))
+		useWaypoint := ingressUseWaypoint(*s, a.namespaces.GetKey(s.Service.Namespace))
 		wi := model.ServiceWaypointInfo{
 			Service:            s.Service,
 			IngressUseWaypoint: useWaypoint,

--- a/pilot/pkg/serviceregistry/ambient/sidecar_interop.go
+++ b/pilot/pkg/serviceregistry/ambient/sidecar_interop.go
@@ -123,7 +123,7 @@ func RegisterEdsShim(
 			}
 			// Track every waypoint whose endpoints can appear in the gateway CLA.
 			var workloads []*model.WorkloadInfo
-			for _, wp := range serviceOwningWaypoints(*svc) {
+			for _, wp := range serviceOwningWaypoints(svc) {
 				var waypointServiceKey string
 				switch addr := wp.Destination.(type) {
 				case *workloadapi.GatewayAddress_Hostname:

--- a/pilot/pkg/serviceregistry/ambient/sidecar_interop.go
+++ b/pilot/pkg/serviceregistry/ambient/sidecar_interop.go
@@ -54,7 +54,7 @@ func (s serviceEDS) Equals(other serviceEDS) bool {
 	}
 	// assumes builder sorted the slices
 	for i := range s.WaypointInstance {
-		if !s.WaypointInstance[i].Equals(other.WaypointInstance[i]) {
+		if !s.WaypointInstance[i].Equals(&other.WaypointInstance[i]) {
 			return false
 		}
 	}

--- a/pilot/pkg/serviceregistry/ambient/waypoints_test.go
+++ b/pilot/pkg/serviceregistry/ambient/waypoints_test.go
@@ -409,7 +409,7 @@ func TestServiceOwningWaypoints(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := serviceOwningWaypoints(model.ServiceInfo{Service: tc.svc})
+			got := serviceOwningWaypoints(&model.ServiceInfo{Service: tc.svc})
 			assert.Equal(t, got, tc.want)
 		})
 	}

--- a/pilot/pkg/serviceregistry/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/ambient/workloads.go
@@ -75,7 +75,7 @@ func (a Builder) WorkloadsCollection(
 	WorkloadServicesNamespaceIndex := krt.NewNamespaceIndex(workloadServices)
 	EndpointSlicesByIPIndex := endpointSliceAddressIndex(endpointSlices)
 	// Workloads coming from pods. There should be one workload for each (running) Pod.
-	PodWorkloads := krt.NewManyCollection(
+	PodWorkloads := krt.NewPointerCollection(
 		pods,
 		a.podWorkloadBuilder(
 			meshConfig,
@@ -91,7 +91,7 @@ func (a Builder) WorkloadsCollection(
 		opts.WithName("PodWorkloads")...,
 	)
 	// Workloads coming from workloadEntries. These are 1:1 with WorkloadEntry.
-	WorkloadEntryWorkloads := krt.NewManyCollection(
+	WorkloadEntryWorkloads := krt.NewPointerCollection(
 		workloadEntries,
 		a.workloadEntryWorkloadBuilder(meshConfig, authPoliciesByNs, peerAuthsByNs, waypoints, workloadServices, WorkloadServicesNamespaceIndex, namespaces),
 		opts.WithName("WorkloadEntryWorkloads")...,
@@ -158,7 +158,7 @@ func MergedGlobalWorkloadsCollection(
 ) krt.Collection[*model.WorkloadInfo] {
 	LocalWorkloadServicesNamespaceIndex := krt.NewNamespaceIndex(localWorkloadServices)
 	LocalEndpointSlicesByIPIndex := endpointSliceAddressIndex(localCluster.EndpointSlices())
-	LocalPodWorkloads := krt.NewManyCollection(
+	LocalPodWorkloads := krt.NewPointerCollection(
 		localCluster.Pods(),
 		podWorkloadBuilder(
 			meshConfig,
@@ -185,7 +185,7 @@ func MergedGlobalWorkloadsCollection(
 		wrapPointerObjectWithCluster[model.WorkloadInfo](localCluster.ID),
 		opts.WithName("LocalPodWorkloadsWithCluster")...,
 	)
-	LocalWorkloadEntryWorkloads := krt.NewManyCollection(
+	LocalWorkloadEntryWorkloads := krt.NewPointerCollection(
 		workloadEntries,
 		workloadEntryWorkloadBuilder(
 			meshConfig,
@@ -332,7 +332,7 @@ func MergedGlobalWorkloadsCollection(
 			WorkloadServicesNamespaceIndex := krt.NewNamespaceIndex(globalWorkloadServices)
 			EndpointSlicesByIPIndex := endpointSliceAddressIndex(endpointSlices)
 			// Workloads coming from pods. There should be one workload for each (running) Pod.
-			PodWorkloads := krt.NewManyCollection(
+			PodWorkloads := krt.NewPointerCollection(
 				pods,
 				podWorkloadBuilder(
 					meshConfig,
@@ -374,7 +374,7 @@ func MergedGlobalWorkloadsCollection(
 				)...,
 			)
 			// Workloads coming from workloadEntries. These are 1:1 with WorkloadEntry.
-			WorkloadEntryWorkloads := krt.NewManyCollection(
+			WorkloadEntryWorkloads := krt.NewPointerCollection(
 				workloadEntries,
 				workloadEntryWorkloadBuilder(
 					meshConfig,
@@ -517,8 +517,8 @@ func workloadEntryWorkloadBuilder(
 	gatewaysByNetwork krt.Index[network.ID, NetworkGateway],
 	flags FeatureFlags,
 	canSkipPrecompute bool,
-) krt.TransformationMulti[*networkingclient.WorkloadEntry, *model.WorkloadInfo] {
-	return func(ctx krt.HandlerContext, wle *networkingclient.WorkloadEntry) []*model.WorkloadInfo {
+) krt.TransformationSingle[*networkingclient.WorkloadEntry, model.WorkloadInfo] {
+	return func(ctx krt.HandlerContext, wle *networkingclient.WorkloadEntry) *model.WorkloadInfo {
 		// WLE can put labels in multiple places; normalize this
 		wle = serviceentry.ConvertClientWorkloadEntry(wle)
 		meshCfg := krt.FetchOne(ctx, meshConfig.AsCollection())
@@ -587,9 +587,9 @@ func workloadEntryWorkloadBuilder(
 		}
 		if canSkipPrecompute && network != localNetworkGetter(ctx).String() {
 			// Remote network workload that will be coalesced into a split-horizon workload; skip precompute
-			return []*model.WorkloadInfo{wi}
+			return wi
 		}
-		return []*model.WorkloadInfo{precomputeWorkload(wi)}
+		return precomputeWorkload(wi)
 	}
 }
 
@@ -601,7 +601,7 @@ func (a Builder) workloadEntryWorkloadBuilder(
 	workloadServices krt.Collection[*model.ServiceInfo],
 	workloadServicesNamespaceIndex krt.Index[string, *model.ServiceInfo],
 	namespaces krt.Collection[*v1.Namespace],
-) krt.TransformationMulti[*networkingclient.WorkloadEntry, *model.WorkloadInfo] {
+) krt.TransformationSingle[*networkingclient.WorkloadEntry, model.WorkloadInfo] {
 	return workloadEntryWorkloadBuilder(
 		meshConfig,
 		a.Networks.FetchLocalNetworkID,
@@ -662,8 +662,8 @@ func podWorkloadBuilder(
 	gatewaysByNetwork krt.Index[network.ID, NetworkGateway],
 	flags FeatureFlags,
 	canSkipPrecompute bool,
-) krt.TransformationMulti[*v1.Pod, *model.WorkloadInfo] {
-	return func(ctx krt.HandlerContext, p *v1.Pod) []*model.WorkloadInfo {
+) krt.TransformationSingle[*v1.Pod, model.WorkloadInfo] {
+	return func(ctx krt.HandlerContext, p *v1.Pod) *model.WorkloadInfo {
 		// Pod Is Pending but have a pod IP should be a valid workload, we should build it ,
 		// Such as the pod have initContainer which is initialing.
 		// See https://github.com/istio/istio/issues/48854
@@ -745,9 +745,9 @@ func podWorkloadBuilder(
 		}
 		if canSkipPrecompute && network != localNetworkGetter(ctx).String() {
 			// Remote network workload that will be coalesced into a split-horizon workload; skip precompute
-			return []*model.WorkloadInfo{wi}
+			return wi
 		}
-		return []*model.WorkloadInfo{precomputeWorkload(wi)}
+		return precomputeWorkload(wi)
 	}
 }
 
@@ -761,7 +761,7 @@ func (a Builder) podWorkloadBuilder(
 	endpointSlicesAddressIndex krt.Index[TargetRef, *discovery.EndpointSlice],
 	namespaces krt.Collection[*v1.Namespace],
 	nodes krt.Collection[Node],
-) krt.TransformationMulti[*v1.Pod, *model.WorkloadInfo] {
+) krt.TransformationSingle[*v1.Pod, model.WorkloadInfo] {
 	return podWorkloadBuilder(
 		meshConfig,
 		a.Networks.FetchLocalNetworkID,

--- a/pilot/pkg/serviceregistry/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/ambient/workloads.go
@@ -57,7 +57,7 @@ import (
 
 // WorkloadsCollection builds out the core Workload object type used in ambient mode.
 // A Workload represents a single addressable unit of compute -- typically a Pod or a VM.
-// Workloads can come from a variety of sources; these are joined together to build one complete `Collection[WorkloadInfo]`.
+// Workloads can come from a variety of sources; these are joined together to build one complete `Collection[*WorkloadInfo]`.
 func (a Builder) WorkloadsCollection(
 	pods krt.Collection[*v1.Pod],
 	nodes krt.Collection[Node],
@@ -71,11 +71,11 @@ func (a Builder) WorkloadsCollection(
 	endpointSlices krt.Collection[*discovery.EndpointSlice],
 	namespaces krt.Collection[*v1.Namespace],
 	opts krt.OptionsBuilder,
-) krt.Collection[model.WorkloadInfo] {
+) krt.Collection[*model.WorkloadInfo] {
 	WorkloadServicesNamespaceIndex := krt.NewNamespaceIndex(workloadServices)
 	EndpointSlicesByIPIndex := endpointSliceAddressIndex(endpointSlices)
 	// Workloads coming from pods. There should be one workload for each (running) Pod.
-	PodWorkloads := krt.NewCollection(
+	PodWorkloads := krt.NewManyCollection(
 		pods,
 		a.podWorkloadBuilder(
 			meshConfig,
@@ -91,7 +91,7 @@ func (a Builder) WorkloadsCollection(
 		opts.WithName("PodWorkloads")...,
 	)
 	// Workloads coming from workloadEntries. These are 1:1 with WorkloadEntry.
-	WorkloadEntryWorkloads := krt.NewCollection(
+	WorkloadEntryWorkloads := krt.NewManyCollection(
 		workloadEntries,
 		a.workloadEntryWorkloadBuilder(meshConfig, authPoliciesByNs, peerAuthsByNs, waypoints, workloadServices, WorkloadServicesNamespaceIndex, namespaces),
 		opts.WithName("WorkloadEntryWorkloads")...,
@@ -113,14 +113,14 @@ func (a Builder) WorkloadsCollection(
 		a.endpointSlicesBuilder(meshConfig, workloadServices),
 		opts.WithName("EndpointSliceWorkloads")...)
 
-	NetworkGatewayWorkloads := krt.NewManyFromNothing[model.WorkloadInfo](func(ctx krt.HandlerContext) []model.WorkloadInfo {
+	NetworkGatewayWorkloads := krt.NewManyFromNothing[*model.WorkloadInfo](func(ctx krt.HandlerContext) []*model.WorkloadInfo {
 		meshCfg := krt.FetchOne(ctx, meshConfig.AsCollection())
 		all := LookupAllNetworkGateway(ctx, a.Networks.NetworkGateways)
 		return slices.Map(all, convertGateway(meshCfg))
 	}, opts.WithName("NetworkGatewayWorkloads")...)
 
 	Workloads := krt.JoinCollection(
-		[]krt.Collection[model.WorkloadInfo]{
+		[]krt.Collection[*model.WorkloadInfo]{
 			PodWorkloads,
 			WorkloadEntryWorkloads,
 			ServiceEntryWorkloads,
@@ -155,10 +155,10 @@ func MergedGlobalWorkloadsCollection(
 	flags FeatureFlags,
 	domainSuffix string,
 	opts krt.OptionsBuilder,
-) krt.Collection[model.WorkloadInfo] {
+) krt.Collection[*model.WorkloadInfo] {
 	LocalWorkloadServicesNamespaceIndex := krt.NewNamespaceIndex(localWorkloadServices)
 	LocalEndpointSlicesByIPIndex := endpointSliceAddressIndex(localCluster.EndpointSlices())
-	LocalPodWorkloads := krt.NewCollection(
+	LocalPodWorkloads := krt.NewManyCollection(
 		localCluster.Pods(),
 		podWorkloadBuilder(
 			meshConfig,
@@ -182,10 +182,10 @@ func MergedGlobalWorkloadsCollection(
 	)
 	LocalPodWorkloadsWithCluster := krt.MapCollection(
 		LocalPodWorkloads,
-		wrapObjectWithCluster[model.WorkloadInfo](localCluster.ID),
+		wrapPointerObjectWithCluster[model.WorkloadInfo](localCluster.ID),
 		opts.WithName("LocalPodWorkloadsWithCluster")...,
 	)
-	LocalWorkloadEntryWorkloads := krt.NewCollection(
+	LocalWorkloadEntryWorkloads := krt.NewManyCollection(
 		workloadEntries,
 		workloadEntryWorkloadBuilder(
 			meshConfig,
@@ -206,7 +206,7 @@ func MergedGlobalWorkloadsCollection(
 	)
 	LocalWorkloadEntryWorkloadsWithCluster := krt.MapCollection(
 		LocalWorkloadEntryWorkloads,
-		wrapObjectWithCluster[model.WorkloadInfo](localCluster.ID),
+		wrapPointerObjectWithCluster[model.WorkloadInfo](localCluster.ID),
 		opts.WithName("LocalWorkloadEntryWorkloadsWithCluster")...,
 	)
 	// Workloads coming from serviceEntries. These are inlined workloadEntries (under `spec.endpoints`); these serviceEntries will
@@ -229,7 +229,7 @@ func MergedGlobalWorkloadsCollection(
 	)
 	LocalServiceEntryWorkloadsWithCluster := krt.MapCollection(
 		LocalServiceEntryWorkloads,
-		wrapObjectWithCluster[model.WorkloadInfo](localCluster.ID),
+		wrapPointerObjectWithCluster[model.WorkloadInfo](localCluster.ID),
 		opts.WithName("LocalServiceEntryWorkloadsWithCluster")...,
 	)
 	// Workloads coming from endpointSlices. These are for *manually added* endpoints. Typically, Kubernetes will insert each pod
@@ -249,11 +249,11 @@ func MergedGlobalWorkloadsCollection(
 	)
 	LocalEndpointSliceWorkloadsWithCluster := krt.MapCollection(
 		LocalEndpointSliceWorkloads,
-		wrapObjectWithCluster[model.WorkloadInfo](localCluster.ID),
+		wrapPointerObjectWithCluster[model.WorkloadInfo](localCluster.ID),
 		opts.WithName("LocalEndpointSliceWorkloadsWithCluster")...,
 	)
 
-	GlobalNetworkGatewayWorkloads := krt.NewManyFromNothing[model.WorkloadInfo](func(ctx krt.HandlerContext) []model.WorkloadInfo {
+	GlobalNetworkGatewayWorkloads := krt.NewManyFromNothing[*model.WorkloadInfo](func(ctx krt.HandlerContext) []*model.WorkloadInfo {
 		meshCfg := krt.FetchOne(ctx, meshConfig.AsCollection())
 		return slices.Map(LookupAllNetworkGateway(
 			ctx,
@@ -262,7 +262,7 @@ func MergedGlobalWorkloadsCollection(
 	}, opts.WithName("LocalNetworkGatewayWorkloads")...)
 	LocalNetworkGatewayWorkloadsWithCluster := krt.MapCollection(
 		GlobalNetworkGatewayWorkloads,
-		wrapObjectWithCluster[model.WorkloadInfo](localCluster.ID),
+		wrapPointerObjectWithCluster[model.WorkloadInfo](localCluster.ID),
 		opts.WithName("LocalNetworkGatewayWorkloadsWithCluster")...,
 	)
 	GlobalWorkloadInfosWithCluster := multicluster.NestedManyCollectionsFromLocalAndRemote(
@@ -332,7 +332,7 @@ func MergedGlobalWorkloadsCollection(
 			WorkloadServicesNamespaceIndex := krt.NewNamespaceIndex(globalWorkloadServices)
 			EndpointSlicesByIPIndex := endpointSliceAddressIndex(endpointSlices)
 			// Workloads coming from pods. There should be one workload for each (running) Pod.
-			PodWorkloads := krt.NewCollection(
+			PodWorkloads := krt.NewManyCollection(
 				pods,
 				podWorkloadBuilder(
 					meshConfig,
@@ -364,7 +364,7 @@ func MergedGlobalWorkloadsCollection(
 			)
 			PodWorkloadsWithCluster := krt.MapCollection(
 				PodWorkloads,
-				wrapObjectWithCluster[model.WorkloadInfo](c.ID),
+				wrapPointerObjectWithCluster[model.WorkloadInfo](c.ID),
 				append(
 					opts,
 					krt.WithName(fmt.Sprintf("PodWorkloadsWithCluster[%s]", c.ID)),
@@ -374,7 +374,7 @@ func MergedGlobalWorkloadsCollection(
 				)...,
 			)
 			// Workloads coming from workloadEntries. These are 1:1 with WorkloadEntry.
-			WorkloadEntryWorkloads := krt.NewCollection(
+			WorkloadEntryWorkloads := krt.NewManyCollection(
 				workloadEntries,
 				workloadEntryWorkloadBuilder(
 					meshConfig,
@@ -403,7 +403,7 @@ func MergedGlobalWorkloadsCollection(
 			)
 			WorkloadEntryWorkloadsWithCluster := krt.MapCollection(
 				WorkloadEntryWorkloads,
-				wrapObjectWithCluster[model.WorkloadInfo](c.ID),
+				wrapPointerObjectWithCluster[model.WorkloadInfo](c.ID),
 				append(
 					opts,
 					krt.WithName(fmt.Sprintf("WorkloadEntryWorkloadsWithCluster[%s]", c.ID)),
@@ -440,7 +440,7 @@ func MergedGlobalWorkloadsCollection(
 			)
 			ServiceEntryWorkloadsWithCluster := krt.MapCollection(
 				ServiceEntryWorkloads,
-				wrapObjectWithCluster[model.WorkloadInfo](c.ID),
+				wrapPointerObjectWithCluster[model.WorkloadInfo](c.ID),
 				append(
 					opts,
 					krt.WithName(fmt.Sprintf("ServiceEntryWorkloadsWithCluster[%s]", c.ID)),
@@ -473,7 +473,7 @@ func MergedGlobalWorkloadsCollection(
 				)...)
 			EndpointSliceWorkloadsWithCluster := krt.MapCollection(
 				EndpointSliceWorkloads,
-				wrapObjectWithCluster[model.WorkloadInfo](c.ID),
+				wrapPointerObjectWithCluster[model.WorkloadInfo](c.ID),
 				append(
 					opts,
 					krt.WithName(fmt.Sprintf("EndpointSliceWorkloadsWithCluster[%s]", c.ID)),
@@ -498,7 +498,9 @@ func MergedGlobalWorkloadsCollection(
 		mergeWorkloadInfosWithCluster(localClusterID),
 		opts.WithName("MergedGlobalWorkloadsWithCluster")...,
 	)
-	return krt.MapCollection(col, unwrapObjectWithCluster[model.WorkloadInfo], opts.WithName("MergedGlobalWorkloads")...)
+	return krt.MapCollection(col, func(obj krt.ObjectWithCluster[model.WorkloadInfo]) *model.WorkloadInfo {
+		return obj.Object
+	}, opts.WithName("MergedGlobalWorkloads")...)
 }
 
 func workloadEntryWorkloadBuilder(
@@ -515,8 +517,8 @@ func workloadEntryWorkloadBuilder(
 	gatewaysByNetwork krt.Index[network.ID, NetworkGateway],
 	flags FeatureFlags,
 	canSkipPrecompute bool,
-) krt.TransformationSingle[*networkingclient.WorkloadEntry, model.WorkloadInfo] {
-	return func(ctx krt.HandlerContext, wle *networkingclient.WorkloadEntry) *model.WorkloadInfo {
+) krt.TransformationMulti[*networkingclient.WorkloadEntry, *model.WorkloadInfo] {
+	return func(ctx krt.HandlerContext, wle *networkingclient.WorkloadEntry) []*model.WorkloadInfo {
 		// WLE can put labels in multiple places; normalize this
 		wle = serviceentry.ConvertClientWorkloadEntry(wle)
 		meshCfg := krt.FetchOne(ctx, meshConfig.AsCollection())
@@ -585,9 +587,9 @@ func workloadEntryWorkloadBuilder(
 		}
 		if canSkipPrecompute && network != localNetworkGetter(ctx).String() {
 			// Remote network workload that will be coalesced into a split-horizon workload; skip precompute
-			return wi
+			return []*model.WorkloadInfo{wi}
 		}
-		return precomputeWorkloadPtr(wi)
+		return []*model.WorkloadInfo{precomputeWorkload(wi)}
 	}
 }
 
@@ -599,7 +601,7 @@ func (a Builder) workloadEntryWorkloadBuilder(
 	workloadServices krt.Collection[*model.ServiceInfo],
 	workloadServicesNamespaceIndex krt.Index[string, *model.ServiceInfo],
 	namespaces krt.Collection[*v1.Namespace],
-) krt.TransformationSingle[*networkingclient.WorkloadEntry, model.WorkloadInfo] {
+) krt.TransformationMulti[*networkingclient.WorkloadEntry, *model.WorkloadInfo] {
 	return workloadEntryWorkloadBuilder(
 		meshConfig,
 		a.Networks.FetchLocalNetworkID,
@@ -660,8 +662,8 @@ func podWorkloadBuilder(
 	gatewaysByNetwork krt.Index[network.ID, NetworkGateway],
 	flags FeatureFlags,
 	canSkipPrecompute bool,
-) krt.TransformationSingle[*v1.Pod, model.WorkloadInfo] {
-	return func(ctx krt.HandlerContext, p *v1.Pod) *model.WorkloadInfo {
+) krt.TransformationMulti[*v1.Pod, *model.WorkloadInfo] {
+	return func(ctx krt.HandlerContext, p *v1.Pod) []*model.WorkloadInfo {
 		// Pod Is Pending but have a pod IP should be a valid workload, we should build it ,
 		// Such as the pod have initContainer which is initialing.
 		// See https://github.com/istio/istio/issues/48854
@@ -743,9 +745,9 @@ func podWorkloadBuilder(
 		}
 		if canSkipPrecompute && network != localNetworkGetter(ctx).String() {
 			// Remote network workload that will be coalesced into a split-horizon workload; skip precompute
-			return wi
+			return []*model.WorkloadInfo{wi}
 		}
-		return precomputeWorkloadPtr(wi)
+		return []*model.WorkloadInfo{precomputeWorkload(wi)}
 	}
 }
 
@@ -759,7 +761,7 @@ func (a Builder) podWorkloadBuilder(
 	endpointSlicesAddressIndex krt.Index[TargetRef, *discovery.EndpointSlice],
 	namespaces krt.Collection[*v1.Namespace],
 	nodes krt.Collection[Node],
-) krt.TransformationSingle[*v1.Pod, model.WorkloadInfo] {
+) krt.TransformationMulti[*v1.Pod, *model.WorkloadInfo] {
 	return podWorkloadBuilder(
 		meshConfig,
 		a.Networks.FetchLocalNetworkID,
@@ -885,14 +887,14 @@ func serviceEntryWorkloadBuilder(
 	networkGetter func(krt.HandlerContext) network.ID,
 	gatewaysByNetwork krt.Index[network.ID, NetworkGateway],
 	flags FeatureFlags,
-) krt.TransformationMulti[*networkingclient.ServiceEntry, model.WorkloadInfo] {
+) krt.TransformationMulti[*networkingclient.ServiceEntry, *model.WorkloadInfo] {
 	serviceEntryInfosByNamespaceAndName := krt.NewIndex(workloadServices, "serviceEntryInfosByNamespaceAndName", func(si *model.ServiceInfo) []string {
 		if si.Source.Kind != kind.ServiceEntry {
 			return nil
 		}
 		return []string{si.Source.NamespacedName.Namespace + "/" + si.Source.NamespacedName.Name}
 	})
-	return func(ctx krt.HandlerContext, se *networkingclient.ServiceEntry) []model.WorkloadInfo {
+	return func(ctx krt.HandlerContext, se *networkingclient.ServiceEntry) []*model.WorkloadInfo {
 		eps := se.Spec.Endpoints
 		// If we have a DNS service, endpoints are not required
 		implicitEndpoints := len(eps) == 0 &&
@@ -922,7 +924,7 @@ func serviceEntryWorkloadBuilder(
 		if len(eps) == 0 {
 			return nil
 		}
-		res := make([]model.WorkloadInfo, 0, len(eps))
+		res := make([]*model.WorkloadInfo, 0, len(eps))
 
 		meshCfg := krt.FetchOne(ctx, meshConfig.AsCollection())
 
@@ -985,7 +987,7 @@ func serviceEntryWorkloadBuilder(
 			w.CanonicalName, w.CanonicalRevision = kubelabels.CanonicalService(se.Labels, w.WorkloadName)
 
 			setTunnelProtocol(se.Labels, se.Annotations, w, flags)
-			res = append(res, precomputeWorkload(model.WorkloadInfo{
+			res = append(res, precomputeWorkload(&model.WorkloadInfo{
 				Workload:     w,
 				Labels:       se.Labels,
 				Source:       model.TypedObject{Kind: kind.WorkloadEntry},
@@ -1003,7 +1005,7 @@ func (a Builder) serviceEntryWorkloadBuilder(
 	waypoints krt.Collection[Waypoint],
 	namespaces krt.Collection[*v1.Namespace],
 	workloadServices krt.Collection[*model.ServiceInfo],
-) krt.TransformationMulti[*networkingclient.ServiceEntry, model.WorkloadInfo] {
+) krt.TransformationMulti[*networkingclient.ServiceEntry, *model.WorkloadInfo] {
 	return serviceEntryWorkloadBuilder(
 		meshConfig,
 		authPoliciesByNs,
@@ -1024,8 +1026,8 @@ func endpointSlicesBuilder(
 	domainSuffix string,
 	clusterID cluster.ID,
 	networkGetter func(krt.HandlerContext) network.ID,
-) krt.TransformationMulti[*discovery.EndpointSlice, model.WorkloadInfo] {
-	return func(ctx krt.HandlerContext, es *discovery.EndpointSlice) []model.WorkloadInfo {
+) krt.TransformationMulti[*discovery.EndpointSlice, *model.WorkloadInfo] {
+	return func(ctx krt.HandlerContext, es *discovery.EndpointSlice) []*model.WorkloadInfo {
 		// EndpointSlices carry port information and a list of IPs.
 		// We only care about EndpointSlices that are for a Service.
 		// Otherwise, it is just an arbitrary bag of IP addresses for some user-specific purpose, which doesn't have a clear
@@ -1039,7 +1041,7 @@ func endpointSlicesBuilder(
 			// may be removed in the near future.
 			return nil
 		}
-		var res []model.WorkloadInfo
+		var res []*model.WorkloadInfo
 		seen := sets.New[string]()
 		meshCfg := krt.FetchOne(ctx, meshConfig.AsCollection())
 
@@ -1144,7 +1146,7 @@ func endpointSlicesBuilder(
 				Waypoint:              nil, // Not supported. In theory, we could allow it as an EndpointSlice label, but there is no real use case.
 				Locality:              nil, // Not supported. We could maybe, there is a "zone", but it doesn't seem to be well supported
 			}
-			res = append(res, precomputeWorkload(model.WorkloadInfo{
+			res = append(res, precomputeWorkload(&model.WorkloadInfo{
 				Workload:     w,
 				Labels:       nil,
 				Source:       model.TypedObject{Kind: kind.EndpointSlice},
@@ -1159,7 +1161,7 @@ func endpointSlicesBuilder(
 func (a Builder) endpointSlicesBuilder(
 	meshConfig krt.Singleton[MeshConfig],
 	workloadServices krt.Collection[*model.ServiceInfo],
-) krt.TransformationMulti[*discovery.EndpointSlice, model.WorkloadInfo] {
+) krt.TransformationMulti[*discovery.EndpointSlice, *model.WorkloadInfo] {
 	return endpointSlicesBuilder(
 		meshConfig,
 		workloadServices,
@@ -1387,8 +1389,8 @@ func gatewayUID(gw model.NetworkGateway) string {
 // convertGateway always converts a NetworkGateway into a Workload.
 // Workloads have a NetworkGateway field, which is effectively a pointer to another object (Service or Workload); in order
 // to facilitate this we need to translate our Gateway model down into a WorkloadInfo ztunnel can understand.
-func convertGateway(mesh *MeshConfig) func(gw NetworkGateway) model.WorkloadInfo {
-	return func(gw NetworkGateway) model.WorkloadInfo {
+func convertGateway(mesh *MeshConfig) func(gw NetworkGateway) *model.WorkloadInfo {
+	return func(gw NetworkGateway) *model.WorkloadInfo {
 		wl := &workloadapi.Workload{
 			Uid:            gatewayUID(gw.NetworkGateway),
 			Name:           gatewayUID(gw.NetworkGateway),
@@ -1404,7 +1406,7 @@ func convertGateway(mesh *MeshConfig) func(gw NetworkGateway) model.WorkloadInfo
 			wl.Hostname = gw.Addr
 		}
 
-		return precomputeWorkload(model.WorkloadInfo{Workload: wl})
+		return precomputeWorkload(&model.WorkloadInfo{Workload: wl})
 	}
 }
 
@@ -1491,11 +1493,7 @@ func endpointSliceAddressIndex(EndpointSlices krt.Collection[*discovery.Endpoint
 	})
 }
 
-func precomputeWorkloadPtr(w *model.WorkloadInfo) *model.WorkloadInfo {
-	return ptr.Of(precomputeWorkload(*w))
-}
-
-func precomputeWorkload(w model.WorkloadInfo) model.WorkloadInfo {
+func precomputeWorkload(w *model.WorkloadInfo) *model.WorkloadInfo {
 	w.AsAddress = model.NewAddressInfo(workloadToAddress(w.Workload))
 	w.MarshaledAddress = w.AsAddress.Marshaled
 	return w

--- a/pilot/pkg/serviceregistry/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/ambient/workloads.go
@@ -65,7 +65,7 @@ func (a Builder) WorkloadsCollection(
 	authPoliciesByNs krt.Index[string, model.WorkloadAuthorization],
 	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
-	workloadServices krt.Collection[model.ServiceInfo],
+	workloadServices krt.Collection[*model.ServiceInfo],
 	workloadEntries krt.Collection[*networkingclient.WorkloadEntry],
 	serviceEntries krt.Collection[*networkingclient.ServiceEntry],
 	endpointSlices krt.Collection[*discovery.EndpointSlice],
@@ -147,7 +147,7 @@ func MergedGlobalWorkloadsCollection(
 	localPeerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	globalWaypoints krt.Collection[krt.Collection[Waypoint]],
 	waypointsByCluster krt.Index[cluster.ID, krt.Collection[Waypoint]],
-	localWorkloadServices krt.Collection[model.ServiceInfo],
+	localWorkloadServices krt.Collection[*model.ServiceInfo],
 	globalWorkloadServices krt.Collection[krt.Collection[krt.ObjectWithCluster[model.ServiceInfo]]],
 	globalWorkloadServicesByCluster krt.Index[cluster.ID, krt.Collection[krt.ObjectWithCluster[model.ServiceInfo]]],
 	globalNetworks NetworkCollections,
@@ -317,7 +317,9 @@ func MergedGlobalWorkloadsCollection(
 			globalWorkloadServicesWithCluster := *workloadServicesPtr
 			globalWorkloadServices := krt.MapCollection(
 				globalWorkloadServicesWithCluster,
-				unwrapObjectWithCluster[model.ServiceInfo],
+				func(obj krt.ObjectWithCluster[model.ServiceInfo]) *model.ServiceInfo {
+					return obj.Object
+				},
 				append(
 					opts,
 					krt.WithName(fmt.Sprintf("WorkloadServices[%s]", c.ID)),
@@ -505,8 +507,8 @@ func workloadEntryWorkloadBuilder(
 	authPoliciesByNs krt.Index[string, model.WorkloadAuthorization],
 	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
-	workloadServices krt.Collection[model.ServiceInfo],
-	workloadServicesNamespaceIndex krt.Index[string, model.ServiceInfo],
+	workloadServices krt.Collection[*model.ServiceInfo],
+	workloadServicesNamespaceIndex krt.Index[string, *model.ServiceInfo],
 	namespaces krt.Collection[*v1.Namespace],
 	clusterID cluster.ID,
 	networkGetter func(krt.HandlerContext) network.ID,
@@ -525,7 +527,7 @@ func workloadEntryWorkloadBuilder(
 		fo := []krt.FetchOption{krt.FilterIndex(workloadServicesNamespaceIndex, wle.Namespace), krt.FilterSelectsNonEmpty(wle.GetLabels())}
 		if !flags.EnableK8SServiceSelectWorkloadEntries {
 			fo = append(fo, krt.FilterGeneric(func(a any) bool {
-				return a.(model.ServiceInfo).Source.Kind == kind.ServiceEntry
+				return a.(*model.ServiceInfo).Source.Kind == kind.ServiceEntry
 			}))
 		}
 		services := krt.Fetch(ctx, workloadServices, fo...)
@@ -594,8 +596,8 @@ func (a Builder) workloadEntryWorkloadBuilder(
 	authPoliciesByNs krt.Index[string, model.WorkloadAuthorization],
 	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
-	workloadServices krt.Collection[model.ServiceInfo],
-	workloadServicesNamespaceIndex krt.Index[string, model.ServiceInfo],
+	workloadServices krt.Collection[*model.ServiceInfo],
+	workloadServicesNamespaceIndex krt.Index[string, *model.ServiceInfo],
 	namespaces krt.Collection[*v1.Namespace],
 ) krt.TransformationSingle[*networkingclient.WorkloadEntry, model.WorkloadInfo] {
 	return workloadEntryWorkloadBuilder(
@@ -647,8 +649,8 @@ func podWorkloadBuilder(
 	authPoliciesByNs krt.Index[string, model.WorkloadAuthorization],
 	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
-	workloadServices krt.Collection[model.ServiceInfo],
-	workloadServicesNamespaceIndex krt.Index[string, model.ServiceInfo],
+	workloadServices krt.Collection[*model.ServiceInfo],
+	workloadServicesNamespaceIndex krt.Index[string, *model.ServiceInfo],
 	endpointSlicesAddressIndex krt.Index[TargetRef, *discovery.EndpointSlice],
 	namespaces krt.Collection[*v1.Namespace],
 	nodes krt.Collection[Node],
@@ -686,7 +688,7 @@ func podWorkloadBuilder(
 		fo := []krt.FetchOption{krt.FilterIndex(workloadServicesNamespaceIndex, p.Namespace), krt.FilterSelectsNonEmpty(p.GetLabels())}
 		if !features.EnableServiceEntrySelectPods {
 			fo = append(fo, krt.FilterGeneric(func(a any) bool {
-				return a.(model.ServiceInfo).Source.Kind == kind.Service
+				return a.(*model.ServiceInfo).Source.Kind == kind.Service
 			}))
 		}
 		services := krt.Fetch(ctx, workloadServices, fo...)
@@ -752,8 +754,8 @@ func (a Builder) podWorkloadBuilder(
 	authPoliciesByNs krt.Index[string, model.WorkloadAuthorization],
 	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
-	workloadServices krt.Collection[model.ServiceInfo],
-	workloadServicesNamespaceIndex krt.Index[string, model.ServiceInfo],
+	workloadServices krt.Collection[*model.ServiceInfo],
+	workloadServicesNamespaceIndex krt.Index[string, *model.ServiceInfo],
 	endpointSlicesAddressIndex krt.Index[TargetRef, *discovery.EndpointSlice],
 	namespaces krt.Collection[*v1.Namespace],
 	nodes krt.Collection[Node],
@@ -796,12 +798,12 @@ func getPodIPs(p *v1.Pod) []v1.PodIP {
 func matchingServicesWithoutSelectors(
 	ctx krt.HandlerContext,
 	p *v1.Pod,
-	alreadyMatchingServices []model.ServiceInfo,
-	workloadServices krt.Collection[model.ServiceInfo],
+	alreadyMatchingServices []*model.ServiceInfo,
+	workloadServices krt.Collection[*model.ServiceInfo],
 	endpointSlicesAddressIndex krt.Index[TargetRef, *discovery.EndpointSlice],
 	domainSuffix string,
-) []model.ServiceInfo {
-	var res []model.ServiceInfo
+) []*model.ServiceInfo {
+	var res []*model.ServiceInfo
 	// Build out our set of already-matched services to avoid double-selecting a service
 	seen := sets.NewWithLength[string](len(alreadyMatchingServices))
 	for _, s := range alreadyMatchingServices {
@@ -830,7 +832,7 @@ func matchingServicesWithoutSelectors(
 		serviceKey := es.Namespace + "/" + hostname
 		svcs := krt.Fetch(ctx, workloadServices, krt.FilterKey(serviceKey), krt.FilterGeneric(func(a any) bool {
 			// Only find Service, not Service Entry
-			return a.(model.ServiceInfo).Source.Kind == kind.Service
+			return a.(*model.ServiceInfo).Source.Kind == kind.Service
 		}))
 		if len(svcs) == 0 {
 			// no service found
@@ -878,13 +880,13 @@ func serviceEntryWorkloadBuilder(
 	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
 	namespaces krt.Collection[*v1.Namespace],
-	workloadServices krt.Collection[model.ServiceInfo],
+	workloadServices krt.Collection[*model.ServiceInfo],
 	clusterID cluster.ID,
 	networkGetter func(krt.HandlerContext) network.ID,
 	gatewaysByNetwork krt.Index[network.ID, NetworkGateway],
 	flags FeatureFlags,
 ) krt.TransformationMulti[*networkingclient.ServiceEntry, model.WorkloadInfo] {
-	serviceEntryInfosByNamespaceAndName := krt.NewIndex(workloadServices, "serviceEntryInfosByNamespaceAndName", func(si model.ServiceInfo) []string {
+	serviceEntryInfosByNamespaceAndName := krt.NewIndex(workloadServices, "serviceEntryInfosByNamespaceAndName", func(si *model.ServiceInfo) []string {
 		if si.Source.Kind != kind.ServiceEntry {
 			return nil
 		}
@@ -913,7 +915,7 @@ func serviceEntryWorkloadBuilder(
 			return nil
 		}
 		if implicitEndpoints {
-			eps = slices.Map(allServices, func(si model.ServiceInfo) *networkingv1alpha3.WorkloadEntry {
+			eps = slices.Map(allServices, func(si *model.ServiceInfo) *networkingv1alpha3.WorkloadEntry {
 				return &networkingv1alpha3.WorkloadEntry{Address: si.Service.Hostname}
 			})
 		}
@@ -930,7 +932,7 @@ func serviceEntryWorkloadBuilder(
 				// For implicit endpoints, we generate each one from the hostname it was from.
 				// Otherwise, use all.
 				// [i] is safe here since we these are constructed to mirror each other
-				services = []model.ServiceInfo{allServices[i]}
+				services = []*model.ServiceInfo{allServices[i]}
 			}
 
 			policies := buildWorkloadPolicies(ctx, authPoliciesByNs, peerAuthsByNs, meshCfg, se.Labels, se.Namespace)
@@ -1000,7 +1002,7 @@ func (a Builder) serviceEntryWorkloadBuilder(
 	peerAuthsByNs krt.Index[string, *securityclient.PeerAuthentication],
 	waypoints krt.Collection[Waypoint],
 	namespaces krt.Collection[*v1.Namespace],
-	workloadServices krt.Collection[model.ServiceInfo],
+	workloadServices krt.Collection[*model.ServiceInfo],
 ) krt.TransformationMulti[*networkingclient.ServiceEntry, model.WorkloadInfo] {
 	return serviceEntryWorkloadBuilder(
 		meshConfig,
@@ -1018,7 +1020,7 @@ func (a Builder) serviceEntryWorkloadBuilder(
 
 func endpointSlicesBuilder(
 	meshConfig krt.Singleton[MeshConfig],
-	workloadServices krt.Collection[model.ServiceInfo],
+	workloadServices krt.Collection[*model.ServiceInfo],
 	domainSuffix string,
 	clusterID cluster.ID,
 	networkGetter func(krt.HandlerContext) network.ID,
@@ -1045,7 +1047,7 @@ func endpointSlicesBuilder(
 		serviceKey := es.Namespace + "/" + string(kube.ServiceHostname(serviceName, es.Namespace, domainSuffix))
 		svcs := krt.Fetch(ctx, workloadServices, krt.FilterKey(serviceKey), krt.FilterGeneric(func(a any) bool {
 			// Only find Service, not Service Entry
-			return a.(model.ServiceInfo).Source.Kind == kind.Service
+			return a.(*model.ServiceInfo).Source.Kind == kind.Service
 		}))
 		if len(svcs) == 0 {
 			// no service found
@@ -1156,7 +1158,7 @@ func endpointSlicesBuilder(
 
 func (a Builder) endpointSlicesBuilder(
 	meshConfig krt.Singleton[MeshConfig],
-	workloadServices krt.Collection[model.ServiceInfo],
+	workloadServices krt.Collection[*model.ServiceInfo],
 ) krt.TransformationMulti[*discovery.EndpointSlice, model.WorkloadInfo] {
 	return endpointSlicesBuilder(
 		meshConfig,
@@ -1217,7 +1219,7 @@ func fetchPeerAuthentications(
 	return auths
 }
 
-func constructServicesFromWorkloadEntry(p *networkingv1alpha3.WorkloadEntry, services []model.ServiceInfo) map[string]*workloadapi.PortList {
+func constructServicesFromWorkloadEntry(p *networkingv1alpha3.WorkloadEntry, services []*model.ServiceInfo) map[string]*workloadapi.PortList {
 	res := map[string]*workloadapi.PortList{}
 	for _, svc := range services {
 		n := namespacedHostname(svc.Service.Namespace, svc.Service.Hostname)
@@ -1272,7 +1274,7 @@ func workloadName(pod *v1.Pod) string {
 	return objMeta.Name
 }
 
-func constructServices(p *v1.Pod, services []model.ServiceInfo) map[string]*workloadapi.PortList {
+func constructServices(p *v1.Pod, services []*model.ServiceInfo) map[string]*workloadapi.PortList {
 	res := map[string]*workloadapi.PortList{}
 	for _, svc := range services {
 		n := namespacedHostname(svc.Service.Namespace, svc.Service.Hostname)
@@ -1344,12 +1346,12 @@ func implicitWaypointPolicies(
 	ctx krt.HandlerContext,
 	Waypoints krt.Collection[Waypoint],
 	waypoint *Waypoint,
-	services []model.ServiceInfo,
+	services []*model.ServiceInfo,
 ) []string {
 	if !flags.DefaultAllowFromWaypoint {
 		return nil
 	}
-	serviceWaypointKeys := slices.MapFilter(services, func(si model.ServiceInfo) *string {
+	serviceWaypointKeys := slices.MapFilter(services, func(si *model.ServiceInfo) *string {
 		if si.Waypoint.ResourceName == "" || (waypoint != nil && waypoint.ResourceName() == si.Waypoint.ResourceName) {
 			return nil
 		}

--- a/pilot/pkg/serviceregistry/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/ambient/workloads_test.go
@@ -876,7 +876,7 @@ func TestPodWorkloads(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := krttest.NewMock(t, tt.inputs)
 			a := newAmbientUnitTest(t)
-			WorkloadServices := krttest.GetMockCollection[model.ServiceInfo](mock)
+			WorkloadServices := krttest.GetMockPointers[model.ServiceInfo](mock)
 			WorkloadServicesNamespaceIndex := krt.NewNamespaceIndex(WorkloadServices)
 			EndpointSlices := krttest.GetMockCollection[*discovery.EndpointSlice](mock)
 			EndpointSlicesAddressIndex := endpointSliceAddressIndex(EndpointSlices)
@@ -1486,7 +1486,7 @@ func TestWorkloadEntryWorkloads(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := krttest.NewMock(t, tt.inputs)
 			a := newAmbientUnitTest(t)
-			WorkloadServices := krttest.GetMockCollection[model.ServiceInfo](mock)
+			WorkloadServices := krttest.GetMockPointers[model.ServiceInfo](mock)
 			WorkloadServicesNamespaceIndex := krt.NewNamespaceIndex(WorkloadServices)
 			builder := a.workloadEntryWorkloadBuilder(
 				GetMeshConfig(mock),
@@ -1733,7 +1733,7 @@ func TestWorkloadEntryConditions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := krttest.NewMock(t, tt.inputs)
 			a := newAmbientUnitTest(t)
-			WorkloadServices := krttest.GetMockCollection[model.ServiceInfo](mock)
+			WorkloadServices := krttest.GetMockPointers[model.ServiceInfo](mock)
 			WorkloadServicesNamespaceIndex := krt.NewNamespaceIndex(WorkloadServices)
 			builder := a.workloadEntryWorkloadBuilder(
 				GetMeshConfig(mock),
@@ -1986,7 +1986,7 @@ func TestServiceEntryWorkloads(t *testing.T) {
 				krt.NewNamespaceIndex(krttest.GetMockCollection[*securityclient.PeerAuthentication](mock)),
 				krttest.GetMockCollection[Waypoint](mock),
 				krttest.GetMockCollection[*v1.Namespace](mock),
-				krttest.GetMockCollection[model.ServiceInfo](mock),
+				krttest.GetMockPointers[model.ServiceInfo](mock),
 			)
 			res := builder(krt.TestingDummyContext{}, tt.se)
 			wl := slices.Map(res, func(e model.WorkloadInfo) *workloadapi.Workload {
@@ -2105,7 +2105,7 @@ func TestEndpointSliceWorkloads(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := krttest.NewMock(t, tt.inputs)
 			a := newAmbientUnitTest(t)
-			WorkloadServices := krttest.GetMockCollection[model.ServiceInfo](mock)
+			WorkloadServices := krttest.GetMockPointers[model.ServiceInfo](mock)
 			builder := a.endpointSlicesBuilder(
 				GetMeshConfig(mock),
 				WorkloadServices,

--- a/pilot/pkg/serviceregistry/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/ambient/workloads_test.go
@@ -893,8 +893,8 @@ func TestPodWorkloads(t *testing.T) {
 			)
 			wrapper := builder(krt.TestingDummyContext{}, tt.pod)
 			var res *workloadapi.Workload
-			if wrapper != nil {
-				res = wrapper.Workload
+			if len(wrapper) > 0 {
+				res = wrapper[0].Workload
 			}
 			assert.Equal(t, res, tt.result)
 		})
@@ -1499,8 +1499,8 @@ func TestWorkloadEntryWorkloads(t *testing.T) {
 			)
 			wrapper := builder(krt.TestingDummyContext{}, tt.we)
 			var res *workloadapi.Workload
-			if wrapper != nil {
-				res = wrapper.Workload
+			if len(wrapper) > 0 {
+				res = wrapper[0].Workload
 			}
 			assert.Equal(t, res, tt.result)
 		})
@@ -1745,7 +1745,7 @@ func TestWorkloadEntryConditions(t *testing.T) {
 				krttest.GetMockCollection[*v1.Namespace](mock),
 			)
 			wrapper := builder(krt.TestingDummyContext{}, tt.we)
-			assert.Equal(t, wrapper.GetConditions(nil), tt.conditions)
+			assert.Equal(t, wrapper[0].GetConditions(nil), tt.conditions)
 		})
 	}
 }
@@ -1989,7 +1989,7 @@ func TestServiceEntryWorkloads(t *testing.T) {
 				krttest.GetMockPointers[model.ServiceInfo](mock),
 			)
 			res := builder(krt.TestingDummyContext{}, tt.se)
-			wl := slices.Map(res, func(e model.WorkloadInfo) *workloadapi.Workload {
+			wl := slices.Map(res, func(e *model.WorkloadInfo) *workloadapi.Workload {
 				return e.Workload
 			})
 			slices.SortFunc(wl, func(a, b *workloadapi.Workload) int {
@@ -2111,7 +2111,7 @@ func TestEndpointSliceWorkloads(t *testing.T) {
 				WorkloadServices,
 			)
 			res := builder(krt.TestingDummyContext{}, tt.slice)
-			wl := slices.Map(res, func(e model.WorkloadInfo) *workloadapi.Workload {
+			wl := slices.Map(res, func(e *model.WorkloadInfo) *workloadapi.Workload {
 				return e.Workload
 			})
 			assert.Equal(t, wl, tt.result)

--- a/pilot/pkg/serviceregistry/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/ambient/workloads_test.go
@@ -893,8 +893,8 @@ func TestPodWorkloads(t *testing.T) {
 			)
 			wrapper := builder(krt.TestingDummyContext{}, tt.pod)
 			var res *workloadapi.Workload
-			if len(wrapper) > 0 {
-				res = wrapper[0].Workload
+			if wrapper != nil {
+				res = wrapper.Workload
 			}
 			assert.Equal(t, res, tt.result)
 		})
@@ -1499,8 +1499,8 @@ func TestWorkloadEntryWorkloads(t *testing.T) {
 			)
 			wrapper := builder(krt.TestingDummyContext{}, tt.we)
 			var res *workloadapi.Workload
-			if len(wrapper) > 0 {
-				res = wrapper[0].Workload
+			if wrapper != nil {
+				res = wrapper.Workload
 			}
 			assert.Equal(t, res, tt.result)
 		})
@@ -1745,7 +1745,7 @@ func TestWorkloadEntryConditions(t *testing.T) {
 				krttest.GetMockCollection[*v1.Namespace](mock),
 			)
 			wrapper := builder(krt.TestingDummyContext{}, tt.we)
-			assert.Equal(t, wrapper[0].GetConditions(nil), tt.conditions)
+			assert.Equal(t, wrapper.GetConditions(nil), tt.conditions)
 		})
 	}
 }

--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -565,8 +565,8 @@ func (h *manyCollection[I, O]) Metadata() Metadata {
 }
 
 // NewCollection transforms a Collection[I] to a Collection[O] by applying the provided transformation function.
-// This applies for one-to-one relationships between I and O.
-// For zero-to-one, use NewSingleton. For one-to-many, use NewManyCollection.
+// This applies for zero-or-one relationships between I and O, storing O by value.
+// For pointer outputs, use NewPointerCollection. For one-to-many, use NewManyCollection.
 func NewCollection[I, O any](c Collection[I], hf TransformationSingle[I, O], opts ...CollectionOption) Collection[O] {
 	// For implementation simplicity, represent TransformationSingle as a TransformationMulti so we can share an implementation.
 	hm := func(ctx HandlerContext, i I) []O {
@@ -584,9 +584,28 @@ func NewCollection[I, O any](c Collection[I], hf TransformationSingle[I, O], opt
 	return newCollection(newManyCollection(c, hm, o, nil))
 }
 
+// NewPointerCollection applies a zero-or-one transformation and stores the exact
+// non-nil pointer returned by the transformation. A nil result omits the output.
+// As with other collections, an equal recomputation retains the previously published
+// value. Published objects must not be mutated.
+func NewPointerCollection[I, O any](c Collection[I], hf TransformationSingle[I, O], opts ...CollectionOption) Collection[*O] {
+	hm := func(ctx HandlerContext, i I) []*O {
+		res := hf(ctx, i)
+		if res == nil {
+			return nil
+		}
+		return []*O{res}
+	}
+	o := buildCollectionOptions(opts...)
+	if o.name == "" {
+		o.name = fmt.Sprintf("PointerCollection[%v,%v]", ptr.TypeName[I](), ptr.TypeName[O]())
+	}
+	return newCollection(newManyCollection(c, hm, o, nil))
+}
+
 // NewManyCollection transforms a Collection[I] to a Collection[O] by applying the provided transformation function.
 // This applies for one-to-many relationships between I and O.
-// For zero-to-one, use NewSingleton. For one-to-one, use NewCollection.
+// For zero-to-one, use NewSingleton. For one-to-one, use NewCollection or NewPointerCollection.
 func NewManyCollection[I, O any](c Collection[I], hf TransformationMulti[I, O], opts ...CollectionOption) Collection[O] {
 	o := buildCollectionOptions(opts...)
 	if o.name == "" {

--- a/pkg/kube/krt/collection_test.go
+++ b/pkg/kube/krt/collection_test.go
@@ -861,3 +861,56 @@ func TestCollectionMetadata(t *testing.T) {
 
 	assert.Equal(t, SimplePods.Metadata(), meta)
 }
+
+func TestPointerCollection(t *testing.T) {
+	stop := test.NewStop(t)
+	input := krt.NewMutableCollection(nil, []SimplePod{
+		{Named: Named{Name: "included"}, IP: "1.1.1.1"},
+		{Named: Named{Name: "omitted"}},
+	}, krt.WithStop(stop))
+	latestTransformResult := atomic.NewPointer[SimplePod](nil)
+	collection := krt.NewPointerCollection(input.AsCollection(), func(_ krt.HandlerContext, pod SimplePod) *SimplePod {
+		if pod.IP == "" {
+			return nil
+		}
+		latestTransformResult.Store(&pod)
+		return &pod
+	}, krt.WithStop(stop))
+
+	assert.EventuallyEqual(t, collection.HasSynced, true)
+	got := collection.List()
+	assert.Equal(t, len(got), 1)
+	if got[0] != latestTransformResult.Load() {
+		t.Fatal("collection must retain the pointer returned by the transformation")
+	}
+
+	original := got[0]
+	input.UpdateObject(SimplePod{Named: Named{Name: "included"}, IP: "2.2.2.2"})
+	assert.EventuallyEqual(t, func() string { return collection.List()[0].IP }, "2.2.2.2")
+	if collection.List()[0] == original {
+		t.Fatal("recomputation must publish the new transformation result")
+	}
+	assert.Equal(t, original.IP, "1.1.1.1")
+
+	retainedResult := collection.List()[0]
+	input.UpdateObject(SimplePod{Named: Named{Name: "included"}, IP: "2.2.2.2"})
+	assert.EventuallyEqual(t, func() bool { return latestTransformResult.Load() != retainedResult }, true)
+	discardedResult := latestTransformResult.Load()
+	if collection.List()[0] != retainedResult {
+		t.Fatal("an equal result must retain the previously published pointer")
+	}
+	if collection.List()[0] == discardedResult {
+		t.Fatal("an equal transformation result must be discarded")
+	}
+
+	input.UpdateObject(SimplePod{Named: Named{Name: "included"}})
+	assert.EventuallyEqual(t, func() int { return len(collection.List()) }, 0)
+	input.UpdateObject(SimplePod{Named: Named{Name: "included"}, IP: "3.3.3.3"})
+	assert.EventuallyEqual(t, func() string {
+		got := collection.List()
+		if len(got) == 0 {
+			return ""
+		}
+		return got[0].IP
+	}, "3.3.3.3")
+}

--- a/pkg/kube/krt/collection_test.go
+++ b/pkg/kube/krt/collection_test.go
@@ -53,6 +53,18 @@ type RenamedSimplePod struct {
 	SimplePod
 }
 
+type pointerNamed string
+
+func (p *pointerNamed) ResourceName() string {
+	return string(*p)
+}
+
+func TestObjectWithClusterPointerReceiverKey(t *testing.T) {
+	value := pointerNamed("key")
+	wrapped := krt.ObjectWithCluster[pointerNamed]{Object: &value}
+	assert.Equal(t, krt.GetKey(wrapped), "key")
+}
+
 func (r RenamedSimplePod) ResourceName() string {
 	return r.Key
 }

--- a/pkg/kube/krt/helpers.go
+++ b/pkg/kube/krt/helpers.go
@@ -44,6 +44,9 @@ func (o ObjectWithCluster[T]) ResourceName() string {
 	if o.Object == nil {
 		return ""
 	}
+	if rn, ok := any(o.Object).(ResourceNamer); ok {
+		return rn.ResourceName()
+	}
 	return GetKey(*o.Object)
 }
 

--- a/pkg/kube/krt/krttest/helpers.go
+++ b/pkg/kube/krt/krttest/helpers.go
@@ -20,6 +20,7 @@ import (
 
 	kubelib "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
@@ -64,6 +65,16 @@ func GetMockCollection[T any](mc *MockCollection) krt.Collection[T] {
 	return krt.NewStaticCollection(
 		nil, // Always synced
 		extractType[T](&mc.inputs),
+		krt.WithStop(test.NewStop(mc.t)),
+		krt.WithDebugging(krt.GlobalDebugHandler),
+	)
+}
+
+func GetMockPointers[T any](mc *MockCollection) krt.Collection[*T] {
+	values := extractType[T](&mc.inputs)
+	return krt.NewStaticCollection(
+		nil, // Always synced
+		slices.Map(values, ptr.Of),
 		krt.WithStop(test.NewStop(mc.t)),
 		krt.WithDebugging(krt.GlobalDebugHandler),
 	)


### PR DESCRIPTION
**Please provide a description of this PR:**

Converts from values to pointers for the "final" workload/service collections and their indexes. The change from by-value to pointer provides vastly more efficient queries of AddressInfo/WorkloadInfo for xDS generators, particularly in large meshes.

Besides the plain reduction in the size of slices being allocated, filtering which would pass candidates through the `any` interface is much more efficient. Filtering no longer requires boxing (heap allocating) the value during conversion to `any` which was particularly inefficient because each value was individually boxed for filtering. This means filtering 20k items would require 20k individual allocations, eliminated by this pull.

| Candidates | Values | Pointers | Allocation reduction |
| ---: | ---: | ---: | ---: |
| 10 | ~2.96 us/op, 4,648 B/op, 27 allocs/op | ~1.19 us/op, 600 B/op, 17 allocs/op | 10 allocs/op |
| 100 | ~23.8 us/op, 41,800 B/op, 117 allocs/op | ~7.5 us/op, 1,416 B/op, 17 allocs/op | 100 allocs/op |
| 1,000 | ~260 us/op, 413,320 B/op, 1,017 allocs/op | ~82 us/op, 8,712 B/op, 17 allocs/op | 1,000 allocs/op |

The table illustrates this linear savings in individual allocations. Generated from:

```go
func BenchmarkFetchServiceInfoBySelector(b *testing.B) {
	log.FindScope("krt").SetOutputLevel(log.InfoLevel)
	newService := func(i int) *model.ServiceInfo {
		return &model.ServiceInfo{
			Service: &workloadapi.Service{
				Name:      fmt.Sprintf("service-%d", i),
				Namespace: "ns",
				Hostname:  fmt.Sprintf("service-%d.ns.svc.cluster.local", i),
			},
			LabelSelector: model.NewSelector(map[string]string{"app": fmt.Sprintf("app-%d", i)}),
		}
	}

	for _, count := range []int{10, 100, 1000} {
		b.Run(fmt.Sprintf("candidates=%d", count), func(b *testing.B) {
			values := make([]model.ServiceInfo, 0, count)
			pointers := make([]*model.ServiceInfo, 0, count)
			for i := range count {
				values = append(values, *newService(i))
				pointers = append(pointers, newService(i))
			}

			valueCollection := krt.NewStaticCollection(nil, values)
			valueIndex := krt.NewNamespaceIndex(valueCollection)
			pointerCollection := krt.NewStaticCollection(nil, pointers)
			pointerIndex := krt.NewNamespaceIndex(pointerCollection)
			workloadLabels := map[string]string{"app": "app-0"}

			b.Run("values", func(b *testing.B) {
				b.ReportAllocs()
				for b.Loop() {
					result := valueIndex.Fetch(krt.TestingDummyContext{}, "ns", krt.FilterSelectsNonEmpty(workloadLabels))
					if len(result) != 1 {
						b.Fatalf("unexpected result count: %d", len(result))
					}
				}
			})
			b.Run("pointers", func(b *testing.B) {
				b.ReportAllocs()
				for b.Loop() {
					result := pointerIndex.Fetch(krt.TestingDummyContext{}, "ns", krt.FilterSelectsNonEmpty(workloadLabels))
					if len(result) != 1 {
						b.Fatalf("unexpected result count: %d", len(result))
					}
				}
			})
		})
	}
}
```

Switching from singular to many collections is purely to avoid using double pointers. If this isn't desirable, we could either accept double pointers or make adjustments to krt to allow for more ergonomic generations of pointer collections.