### PR TITLE
Fix Flaky CRD controller test

### DIFF
--- a/pilot/pkg/config/kube/crdclient/client_test.go
+++ b/pilot/pkg/config/kube/crdclient/client_test.go
@@ -169,7 +169,7 @@ func TestClient(t *testing.T) {
 	store, _ := makeClient(t, collections.PilotGatewayAPI().Union(collections.Kube), nil)
 	configName := "test"
 	configNamespace := "test-ns"
-	timeout := retry.Timeout(time.Millisecond * 200)
+	timeout := retry.Timeout(time.Second)
 	for _, r := range collections.PilotGatewayAPI().All() {
 		name := r.Kind()
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
**Please provide a description of this PR:**

Fairly sure this test is flaking because it does not have enough time. For example, [here](https://aws.prow.istio.io/view/s3/istio-prow/pr-logs/pull/istio_istio/61612/unit-tests_istio/2097316888978657280), fails with

```
{Failed      client_test.go:245: retry.UntilSuccessOrFail: timeout while waiting after 1 attempts (last error: get(AuthorizationPolicy) => got &{{security.istio.io/v1/AuthorizationPolicy  test test-ns  map[] map[foo:bar]  0001-01-01 00:00:00 +0000 UTC [] 0}   map[]}, expected item to be deleted)}
```

Notice that it failed after only 1 attempt.