### PR TITLE
fix: remove GatewayListenerUnsupportedProtocol Gateway API test skip

### DIFF
--- a/tests/integration/ambient/gateway_conformance_test.go
+++ b/tests/integration/ambient/gateway_conformance_test.go
@@ -68,9 +68,6 @@ var conformanceNamespaces = []string{
 var skippedTests = map[string]string{
 	// The following tests were added in v1.5.0
 	"HTTPRouteHTTPSListenerDetectMisdirectedRequests": "TODO",
-
-	// The following tests were added in v1.6.0
-	"GatewayListenerUnsupportedProtocol": "TODO",
 }
 
 func TestGatewayConformance(t *testing.T) {

--- a/tests/integration/pilot/agentgateway/gateway_conformance_test.go
+++ b/tests/integration/pilot/agentgateway/gateway_conformance_test.go
@@ -64,8 +64,7 @@ var conformanceNamespaces = []string{
 
 var skippedTests = map[string]string{
 	// The following tests were added in v1.6.0
-	"GatewayInvalidParametersRef":        "TODO",
-	"GatewayListenerUnsupportedProtocol": "TODO",
+	"GatewayInvalidParametersRef": "TODO",
 }
 
 func TestGatewayConformanceAgentgateway(t *testing.T) {

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -65,9 +65,6 @@ var conformanceNamespaces = []string{
 var skippedTests = map[string]string{
 	// The following tests were added in v1.5.0
 	"HTTPRouteHTTPSListenerDetectMisdirectedRequests": "TODO",
-
-	// The following tests were added in v1.6.0
-	"GatewayListenerUnsupportedProtocol": "TODO",
 }
 
 func TestGatewayConformance(t *testing.T) {


### PR DESCRIPTION
**Please provide a description of this PR:**

Removing Gateway API v1.6 conformance test skip for GatewayListenerUnsupportedProtocol; it appears that the fix is already in place and we are reporting the correct status for unsupported protocols, but the test skip wasn't removed.