### PR TITLE
Don't skip TestCrossNamespaceWaypoint when in ambient multi-network mode

### DIFF
--- a/pkg/test/framework/components/istio/eastwest.go
+++ b/pkg/test/framework/components/istio/eastwest.go
@@ -57,7 +57,6 @@ func (i *istioImpl) deployEastWestGateway(cluster cluster.Cluster, revision stri
 		"--cluster", cluster.Name(),
 		"--network", cluster.NetworkName(),
 		"--revision", revision,
-		"--mesh", meshID,
 	}
 	if !i.env.IsMultiCluster() {
 		args = []string{"--single-cluster"}
@@ -136,7 +135,6 @@ func (i *istioImpl) deployAmbientEastWestGateway(cluster cluster.Cluster) error 
 	args := []string{
 		"--cluster", cluster.Name(),
 		"--network", cluster.NetworkName(),
-		"--mesh", meshID,
 		"--ambient",
 	}
 	if !i.env.IsMultiCluster() {

--- a/tests/integration/ambient/waypoint/main_test.go
+++ b/tests/integration/ambient/waypoint/main_test.go
@@ -56,12 +56,17 @@ func TestMain(m *testing.M) {
 		Setup(istio.Setup(&i, func(ctx resource.Context, cfg *istio.Config) {
 			ctx.Settings().SkipVMs()
 			ctx.Settings().SkipTProxy = true
+
+			cfg.EnableCNI = false
+			cfg.DeployGatewayAPI = true
+			cfg.DeployEastWestGW = false
 			if ctx.Settings().AmbientMultiNetwork {
 				cfg.DeployEastWestGW = true
+				cfg.SkipDeployCrossClusterSecrets = false
+				cfg.Values["pilot.env.AMBIENT_ENABLE_MULTI_NETWORK"] = "true"
+				cfg.Values["pilot.env.AMBIENT_ENABLE_BAGGAGE"] = "true"
 			}
-			cfg.EnableCNI = false
-			cfg.DeployEastWestGW = false
-			cfg.DeployGatewayAPI = true
+
 			cfg.ControlPlaneValues = `
 profile: ambient
 meshConfig:
@@ -126,9 +131,6 @@ func TestCrossNamespaceWaypoint(t *testing.T) {
 		Run(func(t framework.TestContext) {
 			if !crd.SupportsGatewayAPI(t) {
 				t.Skip("requires gateway API (k8s 1.31+)")
-			}
-			if t.Settings().AmbientMultiNetwork {
-				t.Skip("https://github.com/istio/istio/issues/57878")
 			}
 			// Steps:
 			// 1. create namespace for the waypoint


### PR DESCRIPTION
**Please provide a description of this PR:**

I'm not sure why this test was skipped in the first place. The linked justification bug is not relevant for the test. I suspect that the test was failing because E/W gateways weren't deployed, but that was incorrectly attributed to a compatibility issue between ambient and sidecar.

NOTE: I also removed the mesh parameter from script invokcations when generating E/W gateway configs - that parameter does not do anything anymore.