### PR TITLE
telemetry: fix stats interval duration rendering in the bootstrap

### DIFF
--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -328,7 +328,7 @@ func getStatsOptions(meta *model.BootstrapNodeMetadata) []option.Instance {
 		d, err := time.ParseDuration(v)
 		if err == nil {
 			statsFlushInterval = d
-			options = append(options, option.EnvoyStatsFlushInterval(statsFlushInterval))
+			options = append(options, option.EnvoyStatsFlushInterval(durationpb.New(statsFlushInterval)))
 		} else {
 			log.Warnf("Failed to parse stats flush interval %v: %v", v, err)
 		}
@@ -341,8 +341,7 @@ func getStatsOptions(meta *model.BootstrapNodeMetadata) []option.Instance {
 		} else if statsEvictionInterval%statsFlushInterval != 0 {
 			log.Warnf("StatsEvictionInterval must be a multiple of the StatsFlushInterval")
 		} else {
-			duration := &durationpb.Duration{Seconds: int64(statsEvictionInterval.Seconds())}
-			options = append(options, option.EnvoyStatsEvictionInterval(duration))
+			options = append(options, option.EnvoyStatsEvictionInterval(durationpb.New(statsEvictionInterval)))
 		}
 	}
 

--- a/pkg/bootstrap/instance_test.go
+++ b/pkg/bootstrap/instance_test.go
@@ -233,6 +233,20 @@ func TestGolden(t *testing.T) {
 			},
 		},
 		{
+			base: "stats_interval_minutes",
+			annotations: map[string]string{
+				"sidecar.istio.io/statsFlushInterval":    "1m",
+				"sidecar.istio.io/statsEvictionInterval": "5m",
+			},
+		},
+		{
+			base: "stats_interval_subsecond",
+			annotations: map[string]string{
+				"sidecar.istio.io/statsFlushInterval":    "500ms",
+				"sidecar.istio.io/statsEvictionInterval": "2500ms",
+			},
+		},
+		{
 			base: "global_downstream_max_connections_meta",
 			envVars: map[string]string{
 				GlobalDownstreamMaxConnections: "10000",

--- a/pkg/bootstrap/option/instances.go
+++ b/pkg/bootstrap/option/instances.go
@@ -16,7 +16,6 @@ package option
 
 import (
 	"strings"
-	"time"
 
 	"google.golang.org/protobuf/types/known/durationpb"
 
@@ -328,8 +327,8 @@ func EnvoyHistogramBuckets(value []HistogramBucket) Instance {
 	return newOption("histogram_buckets", value)
 }
 
-func EnvoyStatsFlushInterval(interval time.Duration) Instance {
-	return newOption("stats_flush_interval", interval)
+func EnvoyStatsFlushInterval(interval *durationpb.Duration) Instance {
+	return newEnvoyDurationOption("stats_flush_interval", interval)
 }
 
 func EnvoyStatsEvictionInterval(interval *durationpb.Duration) Instance {

--- a/pkg/bootstrap/testdata/stats_interval_minutes.proxycfg
+++ b/pkg/bootstrap/testdata/stats_interval_minutes.proxycfg
@@ -1,0 +1,14 @@
+config_path:                      "/etc/istio/proxy"
+binary_path:                      "/usr/local/bin/envoy"
+service_cluster:                  "istio-proxy"
+drain_duration:                   {seconds: 5}
+discovery_address:                "mypilot:15011"
+statsd_udp_address:               "10.1.1.1:9125"
+envoy_metrics_service:            {address: "metrics-service:15000", tls_settings: { mode: MUTUAL, client_certificate: "/etc/istio/ms/client.pem", private_key: "/etc/istio/ms/key.pem", ca_certificates: "/etc/istio/ms/ca.pem"}}
+envoy_access_log_service:         {address: "accesslog-service:15000"}
+proxy_admin_port:                 15005
+control_plane_auth_policy:        MUTUAL_TLS
+stat_name_length:                 200
+tracing:                          { zipkin: { address: "localhost:6000" } }
+
+# Sets all relevant options to values different than default

--- a/pkg/bootstrap/testdata/stats_interval_minutes_golden.json
+++ b/pkg/bootstrap/testdata/stats_interval_minutes_golden.json
@@ -1,0 +1,662 @@
+{
+  "application_log_config": {
+    "log_format": {
+      "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
+    }
+  },
+  "node": {
+    "id": "sidecar~1.2.3.4~foo~bar",
+    "cluster": "istio-proxy",
+    "locality": {
+    },
+    "metadata": {"ANNOTATIONS":{"sidecar.istio.io/statsEvictionInterval":"5m","sidecar.istio.io/statsFlushInterval":"1m"},"ENVOY_PROMETHEUS_PORT":15090,"ENVOY_STATUS_PORT":15021,"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","ISTIO_VERSION":"binary-1.0","METADATA_DISCOVERY":"false","OUTLIER_LOG_PATH":"/dev/stdout","PILOT_SAN":["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"],"PROXY_CONFIG":{"binaryPath":"/usr/local/bin/envoy","configPath":"/tmp/bootstrap/stats_interval_minutes","controlPlaneAuthPolicy":"MUTUAL_TLS","customConfigFile":"envoy_bootstrap.json","discoveryAddress":"mypilot:15011","drainDuration":"5s","envoyAccessLogService":{"address":"accesslog-service:15000"},"envoyMetricsService":{"address":"metrics-service:15000","tlsSettings":{"caCertificates":"/etc/istio/ms/ca.pem","clientCertificate":"/etc/istio/ms/client.pem","mode":"MUTUAL","privateKey":"/etc/istio/ms/key.pem"}},"proxyAdminPort":15005,"serviceCluster":"istio-proxy","statNameLength":200,"statsdUdpAddress":"10.1.1.1:9125","statusPort":15020,"tracing":{"zipkin":{"address":"localhost:6000"}}},"WORKLOAD_IDENTITY_SOCKET_FILE":"test.sock","sidecar.istio.io/statsEvictionInterval":"5m","sidecar.istio.io/statsFlushInterval":"1m"}
+  },
+  "layered_runtime": {
+    "layers": [
+      {
+        "name": "global config",
+        "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.coalesce_lb_rebuilds_on_batch_update":false,"envoy.reloadable_features.fixed_heap_use_allocated":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"re2.max_program_size.error_level":"32768"}
+      },
+      {
+        "name": "admin",
+        "admin_layer": {}
+      }
+    ]
+  },
+  "bootstrap_extensions": [
+    {
+      "name": "envoy.bootstrap.internal_listener",
+      "typed_config": {
+        "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
+        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
+        "value": {
+          "buffer_size_kb": 64
+        }
+      }
+    }
+  ],
+  "stats_flush_interval": "60s",
+  "stats_eviction_interval": "300s",
+  "stats_config": {
+    "use_all_default_tags": false,
+    "stats_tags": [
+      {
+        "tag_name": "cluster_name",
+        "regex": "^cluster(\\.(.+);)"
+      },
+      {
+        "tag_name": "http_conn_manager_prefix",
+        "regex": "^http\\.(((?:[_.[:digit:]\\w]*|[_\\[\\]aAbBcCdDeEfF[:digit:]\\w\\:]*));\\.)"
+      },
+      {
+        "tag_name": "thread_name",
+        "regex": "^server(\\.(.+))\\.watchdog"
+      },
+      {
+        "tag_name": "tcp_prefix",
+        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
+        "tag_name": "response_code"
+      },
+      {
+        "tag_name": "response_code_class",
+        "regex": "_rq(_(\\dxx))$"
+      },
+      {
+        "tag_name": "http_conn_manager_listener_prefix",
+        "regex": "^listener(?=\\.).*?\\.http\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
+      },
+      {
+        "tag_name": "listener_address",
+        "regex": "^listener\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
+      },
+      {
+        "tag_name": "mongo_prefix",
+        "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
+      },
+      {
+        "regex": "(cache\\.(.+?)\\.)",
+        "tag_name": "cache"
+      },
+      {
+        "regex": "(component\\.(.+?)\\.)",
+        "tag_name": "component"
+      },
+      {
+        "regex": "(tag\\.(.+?);\\.)",
+        "tag_name": "tag"
+      },
+      {
+        "regex": "(wasm_filter\\.(.+?)\\.)",
+        "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "rbac(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
+      }
+    ],
+    "stats_matcher": {
+      "inclusion_list": {
+        "patterns": [
+          {
+          "prefix": "reporter="
+          },
+          {
+          "prefix": "cluster_manager"
+          },
+          {
+          "prefix": "listener_manager"
+          },
+          {
+          "prefix": "server"
+          },
+          {
+          "prefix": "cluster.xds-grpc"
+          },
+          {
+          "prefix": "wasm"
+          },
+          {
+          "suffix": "rbac.allowed"
+          },
+          {
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
+          },
+          {
+          "safe_regex": {"regex":"vhost\\..*\\.route\\..*"}
+          },
+          {
+          "prefix": "component"
+          },
+          {
+          "prefix": "istio"
+          }
+        ]
+      }
+    }
+  },
+  "admin": {
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
+    "profile_path": "/var/lib/istio/data/envoy.prof",
+    "address": {
+      "socket_address": {
+        "address": "127.0.0.1",
+        "port_value": 15005
+      }
+    }
+  },
+  "dynamic_resources": {
+    "lds_config": {
+      "ads": {},
+      "initial_fetch_timeout": "0s",
+      "resource_api_version": "V3"
+    },
+    "cds_config": {
+      "ads": {},
+      "initial_fetch_timeout": "0s",
+      "resource_api_version": "V3"
+    },
+    "ads_config": {
+      "api_type": "DELTA_GRPC",
+      "set_node_on_first_message_only": true,
+      "transport_api_version": "V3",
+      "grpc_services": [
+        {
+          "envoy_grpc": {
+            "cluster_name": "xds-grpc"
+          }
+        }
+      ]
+    }
+  },
+  "static_resources": {
+    "clusters": [
+      {
+        "name": "prometheus_stats",
+        "alt_stat_name": "prometheus_stats;",
+        "type": "STATIC",
+        "connect_timeout": "0.250s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "prometheus_stats",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {
+                    "protocol": "TCP",
+                    "address": "127.0.0.1",
+                    "port_value": 15005
+                  }
+                }
+              }
+            }]
+          }]
+        }
+      },
+      {
+        "name": "agent",
+        "alt_stat_name": "agent;",
+        "type": "STATIC",
+        "connect_timeout": "0.250s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "agent",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {
+                    "protocol": "TCP",
+                    "address": "127.0.0.1",
+                    "port_value": 15020
+                  }
+                }
+              }
+            }]
+          }]
+        }
+      },
+      {
+        "name": "sds-grpc",
+        "alt_stat_name": "sds-grpc;",
+        "type": "STATIC",
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+           "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+           "explicit_http_config": {
+            "http2_protocol_options": {}
+           }
+          }
+        },
+        "connect_timeout": "1s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "sds-grpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "pipe": {
+                    "path": "./var/run/secrets/workload-spiffe-uds/test.sock"
+                  }
+                }
+              }
+            }]
+          }]
+        }
+      },
+      {
+        "name": "xds-grpc",
+        "alt_stat_name": "xds-grpc;",
+        "type" : "STATIC",
+        "connect_timeout": "1s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "xds-grpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "pipe": {
+                    "path": "/tmp/XDS"
+                  }
+                }
+              }
+            }]
+          }]
+        },
+        "circuit_breakers": {
+          "thresholds": [
+            {
+              "priority": "DEFAULT",
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 100000
+            },
+            {
+              "priority": "HIGH",
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 100000
+            }
+          ]
+        },
+        "upstream_connection_options": {
+          "tcp_keepalive": {
+            "keepalive_time": 300
+          }
+        },
+        "max_requests_per_connection": 1,
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+           "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+           "explicit_http_config": {
+            "http2_protocol_options": {}
+           }
+          }
+        }
+      }
+      
+      ,
+      {
+        "name": "zipkin",
+        "alt_stat_name": "zipkin;",
+        "type": "STRICT_DNS",
+        "respect_dns_ttl": true,
+        "dns_lookup_family": "V4_ONLY",
+        "dns_refresh_rate": "30s",
+        "connect_timeout": "1s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "zipkin",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {"address": "localhost", "port_value": 6000}
+                }
+              }
+            }]
+          }]
+        }
+      }
+      
+      ,
+      {
+        "name": "envoy_metrics_service",
+        "alt_stat_name": "envoy_metrics_service;",
+        "type": "STRICT_DNS",
+        "transport_socket": {"name":"envoy.transport_sockets.tls","typed_config":{"@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext","common_tls_context":{"alpn_protocols":["h2"],"combined_validation_context":{"default_validation_context":{},"validation_context_sds_secret_config":{"name":"file-root:/etc/istio/ms/ca.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}},"tls_certificate_sds_secret_configs":[{"name":"file-cert:/etc/istio/ms/client.pem~/etc/istio/ms/key.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}]}}},
+        "respect_dns_ttl": true,
+        "dns_lookup_family": "V4_ONLY",
+        "connect_timeout": "1s",
+        "lb_policy": "ROUND_ROBIN",
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+           "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+           "explicit_http_config": {
+            "http2_protocol_options": {}
+           }
+          }
+        },
+        "load_assignment": {
+          "cluster_name": "envoy_metrics_service",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {"address": "metrics-service", "port_value": 15000}
+                }
+              }
+            }]
+          }]
+        }
+      }
+      
+      
+      ,
+      {
+        "name": "envoy_accesslog_service",
+        "alt_stat_name": "envoy_accesslog_service;",
+        "type": "STRICT_DNS",
+        "respect_dns_ttl": true,
+        "dns_lookup_family": "V4_ONLY",
+        "connect_timeout": "1s",
+        "lb_policy": "ROUND_ROBIN",
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+           "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+           "explicit_http_config": {
+            "http2_protocol_options": {}
+           }
+          }
+        },
+        "load_assignment": {
+          "cluster_name": "envoy_accesslog_service",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {"address": "accesslog-service", "port_value": 15000}
+                }
+              }
+            }]
+          }]
+        }
+      }
+      
+      
+    ],
+    "listeners":[
+      {
+        "name": "0.0.0.0_15090",
+        
+        "address": {
+          "socket_address": {
+            "protocol": "TCP",
+            "address": "0.0.0.0",
+            
+            "port_value": 15090
+          }
+        },
+        "ignore_global_conn_limit": true,
+        "bypass_overload_manager": true,
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "codec_type": "AUTO",
+                  "stat_prefix": "stats",
+                  "route_config": {
+                    "virtual_hosts": [
+                      {
+                        "name": "backend",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/stats/prometheus"
+                            },
+                            "route": {
+                              "cluster": "prometheus_stats"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": [
+                  {
+                    "name": "envoy.filters.http.compressor.brotli",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor",
+                      "compressor_library": {
+                        "name": "stats_brotli",
+                        "typed_config": {
+                          "@type": "type.googleapis.com/envoy.extensions.compression.brotli.compressor.v3.Brotli"
+                        }
+                      },
+                      "response_direction_config": {
+                        "common_config": {
+                          "content_type": [
+                            "text/plain",
+                            "application/vnd.google.protobuf",
+                            "application/openmetrics-text",
+                            "application/openmetrics-protobuf"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.compressor.zstd",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor",
+                      "compressor_library": {
+                        "name": "stats_zstd",
+                        "typed_config": {
+                          "@type": "type.googleapis.com/envoy.extensions.compression.zstd.compressor.v3.Zstd"
+                        }
+                      },
+                      "response_direction_config": {
+                        "common_config": {
+                          "content_type": [
+                            "text/plain",
+                            "application/vnd.google.protobuf",
+                            "application/openmetrics-text",
+                            "application/openmetrics-protobuf"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.compressor.gzip",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor",
+                      "compressor_library": {
+                        "name": "stats_gzip",
+                        "typed_config": {
+                          "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
+                        }
+                      },
+                      "response_direction_config": {
+                        "common_config": {
+                          "content_type": [
+                            "text/plain",
+                            "application/vnd.google.protobuf",
+                            "application/openmetrics-text",
+                            "application/openmetrics-protobuf"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                    }
+                  }
+                ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "0.0.0.0_15021",
+        "address": {
+           "socket_address": {
+             "protocol": "TCP",
+             "address": "0.0.0.0",
+             "port_value": 15021
+           }
+        },
+        "ignore_global_conn_limit": true,
+        "bypass_overload_manager": true,
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "codec_type": "AUTO",
+                  "stat_prefix": "agent",
+                  "route_config": {
+                    "virtual_hosts": [
+                      {
+                        "name": "backend",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/healthz/ready"
+                            },
+                            "route": {
+                              "cluster": "agent"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": [{
+                    "name": "envoy.filters.http.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                    }
+                  }]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "overload_manager": {
+    "resource_monitors": [
+      {
+        "name": "envoy.resource_monitors.global_downstream_max_connections",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig",
+          "max_active_downstream_connections": 2147483647
+        }
+      }
+    ]
+  }
+  ,
+  "tracing": {
+    "http": {
+      "name": "envoy.tracers.zipkin",
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.config.trace.v3.ZipkinConfig",
+        "collector_cluster": "zipkin",
+        "collector_endpoint": "/api/v2/spans",
+        "collector_endpoint_version": "HTTP_JSON",
+        "trace_id_128bit": true,
+        "shared_span_context": false
+      }
+    }
+  }
+  
+  ,
+  "stats_sinks": [
+    
+    {
+      "name": "envoy.stat_sinks.metrics_service",
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.config.metrics.v3.MetricsServiceConfig",
+        "transport_api_version": "V3",
+        "grpc_service": {
+          "envoy_grpc": {
+            "cluster_name": "envoy_metrics_service"
+          }
+        }
+      }
+    }
+    
+    
+    ,
+    
+    
+    {
+      "name": "envoy.stat_sinks.statsd",
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.config.metrics.v3.StatsdSink",
+        "address": {
+          "socket_address": {"address": "10.1.1.1", "port_value": 9125}
+        }
+      }
+    }
+    
+  ]
+  
+  
+  ,
+  "cluster_manager": {
+    "outlier_detection": {
+      "event_log_path": "/dev/stdout"
+    },
+    "enable_deferred_cluster_creation": true
+  }
+  ,
+  "deferred_stat_options": {
+    "enable_deferred_creation_stats": true
+  }
+}

--- a/pkg/bootstrap/testdata/stats_interval_subsecond.proxycfg
+++ b/pkg/bootstrap/testdata/stats_interval_subsecond.proxycfg
@@ -1,0 +1,14 @@
+config_path:                      "/etc/istio/proxy"
+binary_path:                      "/usr/local/bin/envoy"
+service_cluster:                  "istio-proxy"
+drain_duration:                   {seconds: 5}
+discovery_address:                "mypilot:15011"
+statsd_udp_address:               "10.1.1.1:9125"
+envoy_metrics_service:            {address: "metrics-service:15000", tls_settings: { mode: MUTUAL, client_certificate: "/etc/istio/ms/client.pem", private_key: "/etc/istio/ms/key.pem", ca_certificates: "/etc/istio/ms/ca.pem"}}
+envoy_access_log_service:         {address: "accesslog-service:15000"}
+proxy_admin_port:                 15005
+control_plane_auth_policy:        MUTUAL_TLS
+stat_name_length:                 200
+tracing:                          { zipkin: { address: "localhost:6000" } }
+
+# Sets all relevant options to values different than default

--- a/pkg/bootstrap/testdata/stats_interval_subsecond_golden.json
+++ b/pkg/bootstrap/testdata/stats_interval_subsecond_golden.json
@@ -1,0 +1,662 @@
+{
+  "application_log_config": {
+    "log_format": {
+      "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
+    }
+  },
+  "node": {
+    "id": "sidecar~1.2.3.4~foo~bar",
+    "cluster": "istio-proxy",
+    "locality": {
+    },
+    "metadata": {"ANNOTATIONS":{"sidecar.istio.io/statsEvictionInterval":"2500ms","sidecar.istio.io/statsFlushInterval":"500ms"},"ENVOY_PROMETHEUS_PORT":15090,"ENVOY_STATUS_PORT":15021,"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","ISTIO_VERSION":"binary-1.0","METADATA_DISCOVERY":"false","OUTLIER_LOG_PATH":"/dev/stdout","PILOT_SAN":["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"],"PROXY_CONFIG":{"binaryPath":"/usr/local/bin/envoy","configPath":"/tmp/bootstrap/stats_interval_subsecond","controlPlaneAuthPolicy":"MUTUAL_TLS","customConfigFile":"envoy_bootstrap.json","discoveryAddress":"mypilot:15011","drainDuration":"5s","envoyAccessLogService":{"address":"accesslog-service:15000"},"envoyMetricsService":{"address":"metrics-service:15000","tlsSettings":{"caCertificates":"/etc/istio/ms/ca.pem","clientCertificate":"/etc/istio/ms/client.pem","mode":"MUTUAL","privateKey":"/etc/istio/ms/key.pem"}},"proxyAdminPort":15005,"serviceCluster":"istio-proxy","statNameLength":200,"statsdUdpAddress":"10.1.1.1:9125","statusPort":15020,"tracing":{"zipkin":{"address":"localhost:6000"}}},"WORKLOAD_IDENTITY_SOCKET_FILE":"test.sock","sidecar.istio.io/statsEvictionInterval":"2500ms","sidecar.istio.io/statsFlushInterval":"500ms"}
+  },
+  "layered_runtime": {
+    "layers": [
+      {
+        "name": "global config",
+        "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.coalesce_lb_rebuilds_on_batch_update":false,"envoy.reloadable_features.fixed_heap_use_allocated":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"re2.max_program_size.error_level":"32768"}
+      },
+      {
+        "name": "admin",
+        "admin_layer": {}
+      }
+    ]
+  },
+  "bootstrap_extensions": [
+    {
+      "name": "envoy.bootstrap.internal_listener",
+      "typed_config": {
+        "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
+        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
+        "value": {
+          "buffer_size_kb": 64
+        }
+      }
+    }
+  ],
+  "stats_flush_interval": "0.500000000s",
+  "stats_eviction_interval": "2.500000000s",
+  "stats_config": {
+    "use_all_default_tags": false,
+    "stats_tags": [
+      {
+        "tag_name": "cluster_name",
+        "regex": "^cluster(\\.(.+);)"
+      },
+      {
+        "tag_name": "http_conn_manager_prefix",
+        "regex": "^http\\.(((?:[_.[:digit:]\\w]*|[_\\[\\]aAbBcCdDeEfF[:digit:]\\w\\:]*));\\.)"
+      },
+      {
+        "tag_name": "thread_name",
+        "regex": "^server(\\.(.+))\\.watchdog"
+      },
+      {
+        "tag_name": "tcp_prefix",
+        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
+        "tag_name": "response_code"
+      },
+      {
+        "tag_name": "response_code_class",
+        "regex": "_rq(_(\\dxx))$"
+      },
+      {
+        "tag_name": "http_conn_manager_listener_prefix",
+        "regex": "^listener(?=\\.).*?\\.http\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
+      },
+      {
+        "tag_name": "listener_address",
+        "regex": "^listener\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
+      },
+      {
+        "tag_name": "mongo_prefix",
+        "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
+      },
+      {
+        "regex": "(cache\\.(.+?)\\.)",
+        "tag_name": "cache"
+      },
+      {
+        "regex": "(component\\.(.+?)\\.)",
+        "tag_name": "component"
+      },
+      {
+        "regex": "(tag\\.(.+?);\\.)",
+        "tag_name": "tag"
+      },
+      {
+        "regex": "(wasm_filter\\.(.+?)\\.)",
+        "tag_name": "wasm_filter"
+      },
+      {
+        "tag_name": "authz_enforce_result",
+        "regex": "rbac(\\.(allowed|denied))"
+      },
+      {
+        "tag_name": "authz_dry_run_action",
+        "regex": "(\\.istio_dry_run_(allow|deny)_)"
+      },
+      {
+        "tag_name": "authz_dry_run_result",
+        "regex": "(\\.shadow_(allowed|denied))"
+      }
+    ],
+    "stats_matcher": {
+      "inclusion_list": {
+        "patterns": [
+          {
+          "prefix": "reporter="
+          },
+          {
+          "prefix": "cluster_manager"
+          },
+          {
+          "prefix": "listener_manager"
+          },
+          {
+          "prefix": "server"
+          },
+          {
+          "prefix": "cluster.xds-grpc"
+          },
+          {
+          "prefix": "wasm"
+          },
+          {
+          "suffix": "rbac.allowed"
+          },
+          {
+          "suffix": "rbac.denied"
+          },
+          {
+          "suffix": "shadow_allowed"
+          },
+          {
+          "suffix": "shadow_denied"
+          },
+          {
+          "safe_regex": {"regex":"vhost\\..*\\.route\\..*"}
+          },
+          {
+          "prefix": "component"
+          },
+          {
+          "prefix": "istio"
+          }
+        ]
+      }
+    }
+  },
+  "admin": {
+    "access_log": [
+      {
+        "name": "envoy.access_loggers.file",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+          "path": "/dev/null"
+        }
+      }
+    ],
+    "profile_path": "/var/lib/istio/data/envoy.prof",
+    "address": {
+      "socket_address": {
+        "address": "127.0.0.1",
+        "port_value": 15005
+      }
+    }
+  },
+  "dynamic_resources": {
+    "lds_config": {
+      "ads": {},
+      "initial_fetch_timeout": "0s",
+      "resource_api_version": "V3"
+    },
+    "cds_config": {
+      "ads": {},
+      "initial_fetch_timeout": "0s",
+      "resource_api_version": "V3"
+    },
+    "ads_config": {
+      "api_type": "DELTA_GRPC",
+      "set_node_on_first_message_only": true,
+      "transport_api_version": "V3",
+      "grpc_services": [
+        {
+          "envoy_grpc": {
+            "cluster_name": "xds-grpc"
+          }
+        }
+      ]
+    }
+  },
+  "static_resources": {
+    "clusters": [
+      {
+        "name": "prometheus_stats",
+        "alt_stat_name": "prometheus_stats;",
+        "type": "STATIC",
+        "connect_timeout": "0.250s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "prometheus_stats",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {
+                    "protocol": "TCP",
+                    "address": "127.0.0.1",
+                    "port_value": 15005
+                  }
+                }
+              }
+            }]
+          }]
+        }
+      },
+      {
+        "name": "agent",
+        "alt_stat_name": "agent;",
+        "type": "STATIC",
+        "connect_timeout": "0.250s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "agent",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {
+                    "protocol": "TCP",
+                    "address": "127.0.0.1",
+                    "port_value": 15020
+                  }
+                }
+              }
+            }]
+          }]
+        }
+      },
+      {
+        "name": "sds-grpc",
+        "alt_stat_name": "sds-grpc;",
+        "type": "STATIC",
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+           "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+           "explicit_http_config": {
+            "http2_protocol_options": {}
+           }
+          }
+        },
+        "connect_timeout": "1s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "sds-grpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "pipe": {
+                    "path": "./var/run/secrets/workload-spiffe-uds/test.sock"
+                  }
+                }
+              }
+            }]
+          }]
+        }
+      },
+      {
+        "name": "xds-grpc",
+        "alt_stat_name": "xds-grpc;",
+        "type" : "STATIC",
+        "connect_timeout": "1s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "xds-grpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "pipe": {
+                    "path": "/tmp/XDS"
+                  }
+                }
+              }
+            }]
+          }]
+        },
+        "circuit_breakers": {
+          "thresholds": [
+            {
+              "priority": "DEFAULT",
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 100000
+            },
+            {
+              "priority": "HIGH",
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 100000
+            }
+          ]
+        },
+        "upstream_connection_options": {
+          "tcp_keepalive": {
+            "keepalive_time": 300
+          }
+        },
+        "max_requests_per_connection": 1,
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+           "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+           "explicit_http_config": {
+            "http2_protocol_options": {}
+           }
+          }
+        }
+      }
+      
+      ,
+      {
+        "name": "zipkin",
+        "alt_stat_name": "zipkin;",
+        "type": "STRICT_DNS",
+        "respect_dns_ttl": true,
+        "dns_lookup_family": "V4_ONLY",
+        "dns_refresh_rate": "30s",
+        "connect_timeout": "1s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "zipkin",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {"address": "localhost", "port_value": 6000}
+                }
+              }
+            }]
+          }]
+        }
+      }
+      
+      ,
+      {
+        "name": "envoy_metrics_service",
+        "alt_stat_name": "envoy_metrics_service;",
+        "type": "STRICT_DNS",
+        "transport_socket": {"name":"envoy.transport_sockets.tls","typed_config":{"@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext","common_tls_context":{"alpn_protocols":["h2"],"combined_validation_context":{"default_validation_context":{},"validation_context_sds_secret_config":{"name":"file-root:/etc/istio/ms/ca.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}},"tls_certificate_sds_secret_configs":[{"name":"file-cert:/etc/istio/ms/client.pem~/etc/istio/ms/key.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}]}}},
+        "respect_dns_ttl": true,
+        "dns_lookup_family": "V4_ONLY",
+        "connect_timeout": "1s",
+        "lb_policy": "ROUND_ROBIN",
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+           "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+           "explicit_http_config": {
+            "http2_protocol_options": {}
+           }
+          }
+        },
+        "load_assignment": {
+          "cluster_name": "envoy_metrics_service",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {"address": "metrics-service", "port_value": 15000}
+                }
+              }
+            }]
+          }]
+        }
+      }
+      
+      
+      ,
+      {
+        "name": "envoy_accesslog_service",
+        "alt_stat_name": "envoy_accesslog_service;",
+        "type": "STRICT_DNS",
+        "respect_dns_ttl": true,
+        "dns_lookup_family": "V4_ONLY",
+        "connect_timeout": "1s",
+        "lb_policy": "ROUND_ROBIN",
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+           "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+           "explicit_http_config": {
+            "http2_protocol_options": {}
+           }
+          }
+        },
+        "load_assignment": {
+          "cluster_name": "envoy_accesslog_service",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {"address": "accesslog-service", "port_value": 15000}
+                }
+              }
+            }]
+          }]
+        }
+      }
+      
+      
+    ],
+    "listeners":[
+      {
+        "name": "0.0.0.0_15090",
+        
+        "address": {
+          "socket_address": {
+            "protocol": "TCP",
+            "address": "0.0.0.0",
+            
+            "port_value": 15090
+          }
+        },
+        "ignore_global_conn_limit": true,
+        "bypass_overload_manager": true,
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "codec_type": "AUTO",
+                  "stat_prefix": "stats",
+                  "route_config": {
+                    "virtual_hosts": [
+                      {
+                        "name": "backend",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/stats/prometheus"
+                            },
+                            "route": {
+                              "cluster": "prometheus_stats"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": [
+                  {
+                    "name": "envoy.filters.http.compressor.brotli",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor",
+                      "compressor_library": {
+                        "name": "stats_brotli",
+                        "typed_config": {
+                          "@type": "type.googleapis.com/envoy.extensions.compression.brotli.compressor.v3.Brotli"
+                        }
+                      },
+                      "response_direction_config": {
+                        "common_config": {
+                          "content_type": [
+                            "text/plain",
+                            "application/vnd.google.protobuf",
+                            "application/openmetrics-text",
+                            "application/openmetrics-protobuf"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.compressor.zstd",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor",
+                      "compressor_library": {
+                        "name": "stats_zstd",
+                        "typed_config": {
+                          "@type": "type.googleapis.com/envoy.extensions.compression.zstd.compressor.v3.Zstd"
+                        }
+                      },
+                      "response_direction_config": {
+                        "common_config": {
+                          "content_type": [
+                            "text/plain",
+                            "application/vnd.google.protobuf",
+                            "application/openmetrics-text",
+                            "application/openmetrics-protobuf"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.compressor.gzip",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor",
+                      "compressor_library": {
+                        "name": "stats_gzip",
+                        "typed_config": {
+                          "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
+                        }
+                      },
+                      "response_direction_config": {
+                        "common_config": {
+                          "content_type": [
+                            "text/plain",
+                            "application/vnd.google.protobuf",
+                            "application/openmetrics-text",
+                            "application/openmetrics-protobuf"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                    }
+                  }
+                ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "0.0.0.0_15021",
+        "address": {
+           "socket_address": {
+             "protocol": "TCP",
+             "address": "0.0.0.0",
+             "port_value": 15021
+           }
+        },
+        "ignore_global_conn_limit": true,
+        "bypass_overload_manager": true,
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "codec_type": "AUTO",
+                  "stat_prefix": "agent",
+                  "route_config": {
+                    "virtual_hosts": [
+                      {
+                        "name": "backend",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/healthz/ready"
+                            },
+                            "route": {
+                              "cluster": "agent"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": [{
+                    "name": "envoy.filters.http.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                    }
+                  }]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "overload_manager": {
+    "resource_monitors": [
+      {
+        "name": "envoy.resource_monitors.global_downstream_max_connections",
+        "typed_config": {
+          "@type": "type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig",
+          "max_active_downstream_connections": 2147483647
+        }
+      }
+    ]
+  }
+  ,
+  "tracing": {
+    "http": {
+      "name": "envoy.tracers.zipkin",
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.config.trace.v3.ZipkinConfig",
+        "collector_cluster": "zipkin",
+        "collector_endpoint": "/api/v2/spans",
+        "collector_endpoint_version": "HTTP_JSON",
+        "trace_id_128bit": true,
+        "shared_span_context": false
+      }
+    }
+  }
+  
+  ,
+  "stats_sinks": [
+    
+    {
+      "name": "envoy.stat_sinks.metrics_service",
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.config.metrics.v3.MetricsServiceConfig",
+        "transport_api_version": "V3",
+        "grpc_service": {
+          "envoy_grpc": {
+            "cluster_name": "envoy_metrics_service"
+          }
+        }
+      }
+    }
+    
+    
+    ,
+    
+    
+    {
+      "name": "envoy.stat_sinks.statsd",
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.config.metrics.v3.StatsdSink",
+        "address": {
+          "socket_address": {"address": "10.1.1.1", "port_value": 9125}
+        }
+      }
+    }
+    
+  ]
+  
+  
+  ,
+  "cluster_manager": {
+    "outlier_detection": {
+      "event_log_path": "/dev/stdout"
+    },
+    "enable_deferred_cluster_creation": true
+  }
+  ,
+  "deferred_stat_options": {
+    "enable_deferred_creation_stats": true
+  }
+}

--- a/releasenotes/notes/fix-stats-interval-duration-rendering.yaml
+++ b/releasenotes/notes/fix-stats-interval-duration-rendering.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: telemetry
+releaseNotes:
+- |
+  **Fixed** the `sidecar.istio.io/statsFlushInterval` annotation producing an invalid Envoy
+  bootstrap for values of one minute or more, and for sub-second values, which prevented the
+  proxy from starting.
+- |
+  **Fixed** the `sidecar.istio.io/statsEvictionInterval` annotation silently truncating
+  sub-second precision.


### PR DESCRIPTION
**Please provide a description of this PR:**

Both stats interval annotations are rendered into the Envoy bootstrap as protobuf JSON durations,
which accept only a decimal number of seconds with an `s` suffix. Two paths in `getStatsOptions`
do not produce that form.

1. `stats_flush_interval` is passed through `newOption`, so no duration converter is applied and the
   value is rendered with Go's `time.Duration.String()`. `1m` renders as `1m0s` and `500ms` renders
   as `500ms`. Envoy rejects both, so the proxy fails to start. This is the same class of failure
   reported in #58500 and fixed for the eviction interval in #58518; the flush interval was not
   covered by that fix.

2. `stats_eviction_interval` is built as `&durationpb.Duration{Seconds: int64(d.Seconds())}`, so
   `Nanos` is never populated and sub-second precision is dropped. With `statsFlushInterval: 500ms`
   and `statsEvictionInterval: 2500ms` the multiple check passes and the interval is silently
   emitted as `2s`. Whole-second values are unaffected.

`envoyDurationConverter` already renders nanoseconds correctly, so both cases are fixed by routing
through it with `durationpb.New`.

Rendered bootstrap values, before and after this change:

```
statsFlushInterval: 1m           before "1m0s"    after "60s"
statsFlushInterval: 500ms        before "500ms"   after "0.500000000s"
statsEvictionInterval: 2500ms    before "2s"      after "2.500000000s"
```

`EnvoyStatsFlushInterval` now takes a `*durationpb.Duration`, matching `EnvoyStatsEvictionInterval`.
It is called from `pkg/bootstrap/config.go` only. Golden cases are added for minute-scale and
sub-second intervals. The diff size is almost entirely the two generated golden bootstraps; the
functional change is four lines.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [x] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
