### PR TITLE
implement a fix for ScopedAddressPushes causing missed mds incrementals

### DIFF
--- a/pilot/pkg/xds/delta_test.go
+++ b/pilot/pkg/xds/delta_test.go
@@ -32,6 +32,7 @@ import (
 	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/slices"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/util/sets"
@@ -245,6 +246,60 @@ func TestDeltaEDS(t *testing.T) {
 	if len(resp.RemovedResources) != 0 {
 		t.Fatalf("received unexpected removed eds resource %v", resp.RemovedResources)
 	}
+}
+
+func TestDeltaWorkloadAddressOnlyUpdate(t *testing.T) {
+	test.SetForTest(t, &features.ScopedAddressPushes, true)
+	store := newTestAmbientStore()
+	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{AmbientIndex: store})
+	s.MemRegistry.AddHTTPService(edsIncSvc, edsIncVip, 8080)
+	s.EnsureSynced(t)
+
+	ads := s.ConnectDeltaADS().WithType(v3.EndpointType).WithNodeType(model.Router)
+	ads.RequestResponseAck(&discovery.DeltaDiscoveryRequest{
+		ResourceNamesSubscribe: []string{"outbound|8080||" + edsIncSvc},
+	})
+	ads.Request(&discovery.DeltaDiscoveryRequest{
+		TypeUrl:                v3.WorkloadType,
+		ResourceNamesSubscribe: []string{"*"},
+	})
+	resp := ads.ExpectEmptyResponse()
+	assert.Equal(t, resp.TypeUrl, v3.WorkloadType)
+	ads.Request(&discovery.DeltaDiscoveryRequest{TypeUrl: resp.TypeUrl, ResponseNonce: resp.Nonce})
+
+	wl := &model.WorkloadInfo{Workload: &workloadapi.Workload{
+		Uid:       "Kubernetes//Pod/default/x",
+		Namespace: "default",
+		Name:      "x",
+	}}
+	store.AddWorkloadInfo(wl)
+	s.Discovery.ConfigUpdate(&model.PushRequest{
+		AddressesUpdated: sets.New(wl.ResourceName()),
+		ConfigsUpdated:   sets.New(model.ConfigKey{Kind: kind.Address, Name: wl.ResourceName()}),
+	})
+	resp = ads.ExpectResponse()
+	assert.Equal(t, resp.TypeUrl, v3.WorkloadType)
+	assert.Equal(t, len(resp.Resources), 1)
+	assert.Equal(t, resp.Resources[0].Name, wl.ResourceName())
+	got := &workloadapi.Workload{}
+	assert.NoError(t, resp.Resources[0].Resource.UnmarshalTo(got))
+	assert.Equal(t, got, wl.Workload)
+	assert.Equal(t, len(resp.RemovedResources), 0)
+	ads.Request(&discovery.DeltaDiscoveryRequest{TypeUrl: resp.TypeUrl, ResponseNonce: resp.Nonce})
+	// Address-only pushes must not produce an EDS response on the same connection.
+	ads.ExpectNoResponse()
+
+	store.RemoveWorkloadInfo(wl)
+	s.Discovery.ConfigUpdate(&model.PushRequest{
+		AddressesUpdated: sets.New(wl.ResourceName()),
+		ConfigsUpdated:   sets.New(model.ConfigKey{Kind: kind.Address, Name: wl.ResourceName()}),
+	})
+	resp = ads.ExpectResponse()
+	assert.Equal(t, resp.TypeUrl, v3.WorkloadType)
+	assert.Equal(t, len(resp.Resources), 0)
+	assert.Equal(t, resp.RemovedResources, []string{wl.ResourceName()})
+	ads.Request(&discovery.DeltaDiscoveryRequest{TypeUrl: resp.TypeUrl, ResponseNonce: resp.Nonce})
+	ads.ExpectNoResponse()
 }
 
 func TestDeltaReconnectRequests(t *testing.T) {

--- a/pilot/pkg/xds/proxy_dependencies.go
+++ b/pilot/pkg/xds/proxy_dependencies.go
@@ -88,9 +88,9 @@ func proxyDependentOnConfig(proxy *model.Proxy, config model.ConfigKey, push *mo
 	if UnAffectedConfigKinds[proxy.Type].Contains(config.Kind) {
 		return false
 	}
-	// Ambient Address updates only matter to proxies subscribed to Workload Address resources;
-	// anything sidecars and gateways need from those changes is surfaced as ServiceEntry or
-	// Endpoints updates.
+	// Keep Address config keys only for AddressType subscribers. WorkloadType subscribers
+	// are selected in DefaultProxyNeedsPush via AddressesUpdated without retaining config keys.
+	// Other sidecar and gateway dependencies are surfaced as ServiceEntry or Endpoints updates.
 	if features.ScopedAddressPushes && config.Kind == kind.Address {
 		return proxy.GetWatchedResource(v3.AddressType) != nil
 	}
@@ -140,5 +140,6 @@ func DefaultProxyNeedsPush(proxy *model.Proxy, req *model.PushRequest) (*model.P
 	}
 
 	req = filterRelevantUpdates(proxy, req)
-	return req, len(req.ConfigsUpdated) > 0
+	workloadsUpdated := len(req.AddressesUpdated) > 0 && proxy.GetWatchedResource(v3.WorkloadType) != nil
+	return req, workloadsUpdated || len(req.ConfigsUpdated) > 0
 }

--- a/pilot/pkg/xds/proxy_dependencies_test.go
+++ b/pilot/pkg/xds/proxy_dependencies_test.go
@@ -40,6 +40,40 @@ import (
 	"istio.io/istio/pkg/util/sets"
 )
 
+func TestWorkloadSubscriberNeedsAddressPush(t *testing.T) {
+	test.SetForTest(t, &features.ScopedAddressPushes, true)
+	push := core.NewConfigGenTest(t, core.TestOptions{}).PushContext()
+	const addr = "Kubernetes//Pod/default/x"
+	for _, nodeType := range []model.NodeType{model.Router, model.SidecarProxy} {
+		for _, subscribed := range []bool{true, false} {
+			t.Run(fmt.Sprintf("%s/subscribed=%v", nodeType, subscribed), func(t *testing.T) {
+				proxy := &model.Proxy{
+					Type:             nodeType,
+					Metadata:         &model.NodeMetadata{},
+					WatchedResources: map[string]*model.WatchedResource{},
+				}
+				if subscribed {
+					proxy.NewWatchedResource(v3.WorkloadType, nil)
+				}
+				req := &model.PushRequest{
+					Push:             push,
+					AddressesUpdated: sets.New(addr),
+					ConfigsUpdated:   sets.New(model.ConfigKey{Kind: kind.Address, Name: addr}),
+				}
+				filtered, needsPush := DefaultProxyNeedsPush(proxy, req)
+				assert.Equal(t, needsPush, subscribed)
+				assert.Equal(t, len(filtered.ConfigsUpdated), 0)
+				assert.Equal(t, filtered.AddressesUpdated, sets.New(addr))
+				assert.Equal(t, req.ConfigsUpdated, sets.New(model.ConfigKey{Kind: kind.Address, Name: addr}))
+
+				req.AddressesUpdated = nil
+				_, needsPush = DefaultProxyNeedsPush(proxy, req)
+				assert.Equal(t, needsPush, false)
+			})
+		}
+	}
+}
+
 func TestProxyNeedsPush(t *testing.T) {
 	const (
 		svcName        = "svc1.com"

--- a/releasenotes/notes/61648.yaml
+++ b/releasenotes/notes/61648.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed** an issue where Envoy proxies subscribed to Workload metadata discovery (MDS) did not
+    receive incremental workload updates for Address-only changes when
+    `AMBIENT_SCOPED_ADDRESS_PUSHES` was enabled (the default).


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes an issue with ScopedAddressPushes where proxies subscribed to WDS Metadata Discovery could miss an incremental update which was being driven by an Address-only change.