### PR TITLE
istioctl analyze: propagate mesh config file errors

### DIFF
--- a/istioctl/pkg/analyze/analyze.go
+++ b/istioctl/pkg/analyze/analyze.go
@@ -228,7 +228,9 @@ func Analyze(ctx cli.Context) *cobra.Command {
 			// If we explicitly specify mesh config, use it.
 			// This takes precedence over default mesh config or mesh config from a running Kube instance.
 			if meshCfgFile != "" {
-				_ = sa.AddFileKubeMeshConfig(meshCfgFile)
+				if err := sa.AddFileKubeMeshConfig(meshCfgFile); err != nil {
+					return fmt.Errorf("failed to load mesh config file %q: %w", meshCfgFile, err)
+				}
 			}
 
 			// If we're not using kube (files only), add defaults for some resources we expect to be provided by Istio

--- a/istioctl/pkg/analyze/analyze_test.go
+++ b/istioctl/pkg/analyze/analyze_test.go
@@ -15,6 +15,8 @@
 package analyze
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -82,6 +84,32 @@ func TestSkipPodsInFiles(t *testing.T) {
 	}
 	analyze := Analyze(cli.NewFakeContext(nil))
 	testutil.VerifyOutput(t, analyze, c)
+}
+
+func TestAnalyzeReturnsMeshConfigFileError(t *testing.T) {
+	meshConfigPath := filepath.Join(t.TempDir(), "mesh-config.yaml")
+	invalidMeshConfig := `extensionProviders:
+- name: ext-authz
+  envoyExtAuthzGrpc:
+    service: ext-authz.example.svc.cluster.local
+    port: 9000
+    statusOnError: 503
+`
+	if err := os.WriteFile(meshConfigPath, []byte(invalidMeshConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	analyze := Analyze(cli.NewFakeContext(nil))
+	analyze.SetArgs([]string{"--use-kube=false", "--meshConfigFile", meshConfigPath})
+	analyze.SilenceUsage = true
+
+	err := analyze.Execute()
+	if err == nil {
+		t.Fatal("expected invalid mesh config file to return an error")
+	}
+	if !strings.Contains(err.Error(), "failed to load mesh config file") {
+		t.Fatalf("expected mesh config file error, got %v", err)
+	}
 }
 
 func TestGetClientsRejectsUnsafeMultiClusterSecret(t *testing.T) {

--- a/releasenotes/notes/istioctl-analyze-mesh-config-file-error.yaml
+++ b/releasenotes/notes/istioctl-analyze-mesh-config-file-error.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+issue: []
+releaseNotes:
+- |
+  **Improved** `istioctl analyze` error reporting when an explicitly specified `--meshConfigFile` cannot be read or parsed.


### PR DESCRIPTION
**Please provide a description of this PR:**
- istioctl analyze ignored errors returned by AddFileKubeMeshConfig when --meshConfigFile was explicitly provided.
- Propagates the error to the caller.

Related to #61563.