### PR TITLE
cni: validate pod IPs from plugin events

### DIFF
--- a/cni/pkg/nodeagent/cni-watcher.go
+++ b/cni/pkg/nodeagent/cni-watcher.go
@@ -190,10 +190,17 @@ func (s *CniPluginServer) ReconcileCNIAddEvent(ctx context.Context, addCmd CNIPl
 	var podIps []netip.Addr
 	for _, configuredPodIPs := range addCmd.IPs {
 		// net.ip is implicitly convertible to netip as slice
-		ip, _ := netip.AddrFromSlice(configuredPodIPs.Address.IP)
+		ip, ok := netip.AddrFromSlice(configuredPodIPs.Address.IP)
+		if !ok {
+			log.Warnf("skipping invalid IP address from CNI event: %v", configuredPodIPs.Address.IP)
+			continue
+		}
 		// We ignore the mask of the IPNet - it's fine if the IPNet defines
 		// a block grant of addresses, we just need one for checking routes.
 		podIps = append(podIps, ip.Unmap())
+	}
+	if len(podIps) == 0 {
+		return fmt.Errorf("CNI event contained no valid pod IPs")
 	}
 	// Note that we use the IP info from the CNI plugin here - the Pod struct as reported by K8S doesn't have this info
 	// yet (because the K8S control plane doesn't), so it will be empty there.

--- a/cni/pkg/nodeagent/cni-watcher_test.go
+++ b/cni/pkg/nodeagent/cni-watcher_test.go
@@ -338,9 +338,20 @@ func TestCNIPluginServerPrefersCNIProvidedPodIP(t *testing.T) {
 	// serialize our fake plugin event
 	addEvent, err := processAddEvent(payload)
 	assert.Equal(t, err, nil)
+	addEvent.IPs = append([]IPConfig{{}}, addEvent.IPs...)
+
+	// An event with no valid IPs should fail without calling the dataplane.
+	err = pluginServer.ReconcileCNIAddEvent(ctx, CNIPluginAddEvent{
+		Netns:        valid.Netns,
+		PodName:      valid.PodName,
+		PodNamespace: valid.PodNamespace,
+		IPs:          []IPConfig{{}},
+	})
+	assert.Error(t, err)
 
 	// Push it thru the handler
-	pluginServer.ReconcileCNIAddEvent(ctx, addEvent)
+	err = pluginServer.ReconcileCNIAddEvent(ctx, addEvent)
+	assert.NoError(t, err)
 
 	waitForMockCalls()
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Add validation to detect invalid IP addresses from CNI events and skip invalid ones.