### PR TITLE
fix TestCNIRaceRepair to actually test repair

### DIFF
--- a/tests/integration/ambient/util.go
+++ b/tests/integration/ambient/util.go
@@ -133,6 +133,9 @@ func ScaleCNIDaemonsetToZeroPods(ctx framework.TestContext, c cluster.Cluster, s
 	}, retry.Delay(1*time.Second), retry.Timeout(80*time.Second))
 }
 
+// WaitForStalledPodOrFail waits for a pod that cannot get a sandbox. This is what happens when the
+// istio-cni plugin is left in the node CNI config with no agent behind it, so the pod never starts
+// and no init container ever runs.
 func WaitForStalledPodOrFail(t framework.TestContext, cluster cluster.Cluster, ns namespace.Instance) {
 	retry.UntilSuccessOrFail(t, func() error {
 		pods, err := cluster.Kube().CoreV1().Pods(ns.Name()).List(context.TODO(), metav1.ListOptions{})
@@ -142,7 +145,6 @@ func WaitForStalledPodOrFail(t framework.TestContext, cluster cluster.Cluster, n
 		if len(pods.Items) == 0 {
 			return fmt.Errorf("still waiting the pod in namespace %v to start", ns.Name())
 		}
-		// Verify that every pod is in broken state due to CNI plugin failure.
 		for _, p := range pods.Items {
 			for _, cState := range p.Status.ContainerStatuses {
 				waiting := cState.State.Waiting
@@ -161,7 +163,27 @@ func WaitForStalledPodOrFail(t framework.TestContext, cluster cluster.Cluster, n
 					}
 				}
 			}
+		}
+		return fmt.Errorf("cannot find any pod stalled on sandbox creation")
+	}, retry.Delay(1*time.Second), retry.Timeout(80*time.Second))
+}
+
+// WaitForBrokenPodOrFail waits for a pod that got a sandbox but no istio redirection, so
+// istio-validation crashloops. This is the state the CNI repair controller acts on.
+func WaitForBrokenPodOrFail(t framework.TestContext, cluster cluster.Cluster, ns namespace.Instance) {
+	retry.UntilSuccessOrFail(t, func() error {
+		pods, err := cluster.Kube().CoreV1().Pods(ns.Name()).List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			return err
+		}
+		if len(pods.Items) == 0 {
+			return fmt.Errorf("still waiting the pod in namespace %v to start", ns.Name())
+		}
+		for _, p := range pods.Items {
 			for _, cState := range p.Status.InitContainerStatuses {
+				if cState.Name != constants.ValidationContainerName {
+					continue
+				}
 				terminated := cState.LastTerminationState.Terminated
 
 				scopes.Framework.Infof("checking pod status terminated")
@@ -170,8 +192,8 @@ func WaitForStalledPodOrFail(t framework.TestContext, cluster cluster.Cluster, n
 				}
 			}
 		}
-		return fmt.Errorf("cannot find any pod with wanted failure status")
-	}, retry.Delay(1*time.Second), retry.Timeout(80*time.Second))
+		return fmt.Errorf("cannot find any pod with a crashlooping %s", constants.ValidationContainerName)
+	}, retry.Delay(1*time.Second), retry.Timeout(2*time.Minute))
 }
 
 func PatchCNIDaemonSet(ctx framework.TestContext, c cluster.Cluster, systemNamespace string, patch []byte) *appsv1.DaemonSet {

--- a/tests/integration/pilot/cni_race_test.go
+++ b/tests/integration/pilot/cni_race_test.go
@@ -72,7 +72,7 @@ func TestCNIRaceRepair(t *testing.T) {
 			if _, err := shell.Execute(true, rolloutCmd); err != nil {
 				t.Fatalf("failed to rollout restart deployments %v", err)
 			}
-			util.WaitForStalledPodOrFail(t, c, ns)
+			util.WaitForBrokenPodOrFail(t, c, ns)
 
 			t.Log("Redeploy CNI and verify repair takes effect by evicting the broken pod")
 			// Now bring back CNI Daemonset, and pod in the echo namespace should be repaired.
@@ -81,6 +81,10 @@ func TestCNIRaceRepair(t *testing.T) {
 		})
 }
 
+// waitForRepairOrFail waits until every pod is actually working again. The repair controller
+// defaults to repairPods mode, which fixes the pod in place instead of deleting it, so
+// LastTerminationState keeps the original istio-validation failure for the life of the pod.
+// Check the current state instead.
 func waitForRepairOrFail(t framework.TestContext, cluster cluster.Cluster, ns namespace.Instance) {
 	retry.UntilSuccessOrFail(t, func() error {
 		pods, err := cluster.Kube().CoreV1().Pods(ns.Name()).List(context.TODO(), metav1.ListOptions{})
@@ -90,15 +94,26 @@ func waitForRepairOrFail(t framework.TestContext, cluster cluster.Cluster, ns na
 		if len(pods.Items) == 0 {
 			return errors.New("no pod found")
 		}
-		// Verify that no pod is broken by the race condition now.
 		for _, p := range pods.Items {
+			// skip pods on their way out from the rollout restart
+			if p.DeletionTimestamp != nil {
+				continue
+			}
+			found := false
 			for _, container := range p.Status.InitContainerStatuses {
-				if state := container.LastTerminationState.Terminated; state != nil && state.ExitCode ==
-					constants.ValidationErrorCode {
-					return errors.New("there are still pods in broken state due to CNI race condition")
+				if container.Name != constants.ValidationContainerName {
+					continue
 				}
+				found = true
+				if state := container.State.Terminated; state == nil || state.ExitCode != 0 {
+					return fmt.Errorf("pod %s/%s still broken, %s state: %v",
+						p.Namespace, p.Name, container.Name, container.State)
+				}
+			}
+			if !found {
+				return fmt.Errorf("pod %s/%s has no %s status yet", p.Namespace, p.Name, constants.ValidationContainerName)
 			}
 		}
 		return nil
-	}, retry.Delay(1*time.Second), retry.Timeout(80*time.Second))
+	}, retry.Delay(1*time.Second), retry.Timeout(2*time.Minute))
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

`TestCNIRaceRepair` only ever passed by accident. `WaitForStalledPodOrFail` accepted either a pod stuck on sandbox creation or one whose istio-validation exited `126`, but `waitForRepairOrFail` then required that no pod has an init container with `LastTerminationState` exit code `126`. Default repair mode is `repairPods`, which fixes the pod in place and never deletes it, so that `126` **sticks** around for the life of the pod and the check can never pass.

That means the test only went green on the sandbox path, where the pod never starts and the repair controller is never exercised (~19s runs). Since sep 8 master lands on the other side of that race and every `integ-cni` and `integ-pilot-cni-nftables` run fails on the 80s timeout.

Now waits for the crashlooping `istio-validation` specifically so repair is actually exercised, and checks the current init container state instead of `LastTerminationState`. Split the two stall shapes into separate helpers since ambient cniupgrade wants the sandbox one.

cc @Stevenjin8 