### PR TITLE
istioctl: deactivate previous default revision's validating webhook on tag set default

### DIFF
--- a/istioctl/pkg/tag/generate.go
+++ b/istioctl/pkg/tag/generate.go
@@ -290,7 +290,7 @@ func generateValidatingWebhook(config *tagWebhookConfig, opts *GenerateOptions) 
 	}
 	mfs, _, err := helm.Render("istio", config.IstioNamespace, "default", vals, nil)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 	var validatingWebhookYAML string
 	for _, m := range mfs {

--- a/istioctl/pkg/tag/tag.go
+++ b/istioctl/pkg/tag/tag.go
@@ -320,6 +320,16 @@ func setTag(ctx context.Context, kubeClient kube.CLIClient, tagName, revision, i
 	if err := Create(kubeClient, tagYAML, istioNS); err != nil {
 		return fmt.Errorf("failed to apply tag webhook MutatingWebhookConfiguration to cluster: %v", err)
 	}
+
+	if tagName == DefaultRevisionName {
+		// Deactivate the previous default install's validating webhook, mirroring the injection webhook handled in
+		// Generate. This runs after the apply above so the tag-managed istiod-default-validator already carries
+		// istio.io/tag=default and is excluded, leaving only the previous default revision's validator.
+		if err := DeactivateIstioValidationWebhook(ctx, kubeClient.Kube()); err != nil {
+			return fmt.Errorf("failed deactivating previous default revision validation webhook: %v", err)
+		}
+	}
+
 	fmt.Fprintf(w, tagCreatedStr, tagName, revision, tagName)
 	return nil
 }

--- a/istioctl/pkg/tag/tag_test.go
+++ b/istioctl/pkg/tag/tag_test.go
@@ -17,6 +17,7 @@ package tag
 import (
 	"bytes"
 	"context"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -719,6 +720,73 @@ func TestRemoveDefaultTagDeletesValidatingWebhook(t *testing.T) {
 	vwhs, _ := client.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(context.Background(), metav1.ListOptions{})
 	if len(vwhs.Items) != 0 {
 		t.Errorf("expected ValidatingWebhookConfiguration %q to be deleted, got %d", vwhBaseTemplateName, len(vwhs.Items))
+	}
+}
+
+func TestDeactivateIstioValidationWebhook(t *testing.T) {
+	// Tag-managed default validator as it exists after the apply: carries istio.io/tag=default and so is excluded
+	// by the selector. It must NOT be deactivated here.
+	alias := &admitv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: vwhBaseTemplateName,
+			Labels: map[string]string{
+				label.IoIstioRev.Name: "default",
+				label.IoIstioTag.Name: "default",
+			},
+		},
+		Webhooks: []admitv1.ValidatingWebhook{{Name: "validation.istio.io"}},
+	}
+	// Previous default install's validator (istio.io/rev=default, no istio.io/tag); must be deactivated in place.
+	prev := &admitv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "istio-validator-istio-system",
+			Labels: map[string]string{label.IoIstioRev.Name: "default"},
+		},
+		Webhooks: []admitv1.ValidatingWebhook{
+			{Name: "validation.istio.io"},
+			{Name: "rev.validation.istio.io"},
+		},
+	}
+	// Unrelated per-revision validator; must be untouched.
+	other := &admitv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "istio-validator-1-20-0-istio-system",
+			Labels: map[string]string{label.IoIstioRev.Name: "1-20-0"},
+		},
+		Webhooks: []admitv1.ValidatingWebhook{{Name: "validation.istio.io"}},
+	}
+	client := fake.NewClientset(alias, prev, other)
+
+	if err := DeactivateIstioValidationWebhook(context.Background(), client); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The previous default install's validator is neutralized with NeverMatch selectors, not deleted.
+	got, err := client.AdmissionregistrationV1().ValidatingWebhookConfigurations().
+		Get(context.Background(), "istio-validator-istio-system", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected istio-validator-istio-system to still exist: %v", err)
+	}
+	for _, wh := range got.Webhooks {
+		if !reflect.DeepEqual(wh.NamespaceSelector, util.NeverMatch) || !reflect.DeepEqual(wh.ObjectSelector, util.NeverMatch) {
+			t.Errorf("expected webhook %q to be deactivated with NeverMatch selectors, got ns=%v obj=%v",
+				wh.Name, wh.NamespaceSelector, wh.ObjectSelector)
+		}
+	}
+
+	// The tag-managed alias and the unrelated per-revision validator must be left as-is.
+	for _, name := range []string{vwhBaseTemplateName, "istio-validator-1-20-0-istio-system"} {
+		vwh, err := client.AdmissionregistrationV1().ValidatingWebhookConfigurations().
+			Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected %q to still exist: %v", name, err)
+		}
+		for _, wh := range vwh.Webhooks {
+			if wh.NamespaceSelector != nil || wh.ObjectSelector != nil {
+				t.Errorf("expected %q webhook %q to be untouched, got ns=%v obj=%v",
+					name, wh.Name, wh.NamespaceSelector, wh.ObjectSelector)
+			}
+		}
 	}
 }
 

--- a/istioctl/pkg/tag/util.go
+++ b/istioctl/pkg/tag/util.go
@@ -61,6 +61,18 @@ func GetWebhooksWithRevision(ctx context.Context, client kubernetes.Interface, r
 	return webhooks.Items, nil
 }
 
+// GetValidatingWebhooksWithRevision returns validating webhooks tagged with istio.io/rev=<rev> and NOT TAGGED with
+// istio.io/tag. This retrieves the validating webhook created at revision installation rather than tag webhooks.
+func GetValidatingWebhooksWithRevision(ctx context.Context, client kubernetes.Interface, rev string) ([]admitv1.ValidatingWebhookConfiguration, error) {
+	webhooks, err := client.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s,!%s", label.IoIstioRev.Name, rev, label.IoIstioTag.Name),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return webhooks.Items, nil
+}
+
 // GetServicesWithRevision returns services tagged with istio.io/rev=<rev> and NOT TAGGED with istio.io/tag.
 // This retrieves the services created at revision installation rather than tag services.
 func GetServicesWithRevision(ctx context.Context, client kubernetes.Interface, istioNS, rev string) ([]corev1.Service, error) {
@@ -220,6 +232,43 @@ func DeactivateIstioInjectionWebhook(ctx context.Context, client kubernetes.Inte
 		webhook.Webhooks[i] = wh
 	}
 	admit := client.AdmissionregistrationV1().MutatingWebhookConfigurations()
+	_, err = admit.Update(ctx, &webhook, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeactivateIstioValidationWebhook deactivates the previous default revision's ValidatingWebhookConfiguration
+// (labeled istio.io/rev=default and not istio.io/tag) if it exists. Like DeactivateIstioInjectionWebhook, it is used
+// rather than deleting the webhook so the user can later switch back to the previous default revision.
+//
+// This must run AFTER the tag-managed istiod-default-validator has been applied: at that point that validator carries
+// istio.io/tag=default and is excluded by the selector, leaving only the previous default install's validator to
+// deactivate.
+func DeactivateIstioValidationWebhook(ctx context.Context, client kubernetes.Interface) error {
+	vwhs, err := GetValidatingWebhooksWithRevision(ctx, client, DefaultRevisionName)
+	if err != nil {
+		return err
+	}
+	if len(vwhs) == 0 {
+		// no previous default revision validator, no action required.
+		return nil
+	}
+	if len(vwhs) > 1 {
+		return fmt.Errorf("expected a single validating webhook for default revision")
+	}
+	webhook := vwhs[0]
+	for i := range webhook.Webhooks {
+		wh := webhook.Webhooks[i]
+		// mirror DeactivateIstioInjectionWebhook: make the webhook ineffectual without deleting it by adding a
+		// nonsense match.
+		wh.NamespaceSelector = util.NeverMatch
+		wh.ObjectSelector = util.NeverMatch
+		webhook.Webhooks[i] = wh
+	}
+	admit := client.AdmissionregistrationV1().ValidatingWebhookConfigurations()
 	_, err = admit.Update(ctx, &webhook, metav1.UpdateOptions{})
 	if err != nil {
 		return err

--- a/releasenotes/notes/istioctl-tag-set-default-vwc.yaml
+++ b/releasenotes/notes/istioctl-tag-set-default-vwc.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+  - |
+    **Fixed** `istioctl tag set default` not deactivating the previous default revision's `ValidatingWebhookConfiguration`,
+    which could leave it validating (and, if the previous control plane was removed, failing closed) alongside the new
+    `istiod-default-validator`. This mirrors the deactivation already performed on the default revision's injection
+    `MutatingWebhookConfiguration`.


### PR DESCRIPTION
**Please provide a description of this PR:**

When running `istioctl tag set default`, the previous default revision's injection `MutatingWebhookConfiguration` is deactivated (via `DeactivateIstioInjectionWebhook`), but its `ValidatingWebhookConfiguration` was left active. As a result, the old default-revision validating webhook kept validating resources alongside the newly created `istiod-default-validator`, which is an asymmetry with how the injection webhook is handled.

This PR makes the validating webhook path symmetric with the injection path:

- Add `DeactivateIstioValidationWebhook`, a mirror of `DeactivateIstioInjectionWebhook`. It looks up the default revision's `ValidatingWebhookConfiguration` (label `istio.io/rev=default` and **not** labeled `istio.io/tag`, via the new `GetValidatingWebhooksWithRevision`) and sets `NeverMatch` namespace/object selectors instead of deleting it — so the user can still switch back to the previous default revision. It is a no-op when none exists and errors if more than one is found.
- Call it from `Generate` right after the injection-webhook deactivation, gated on `!opts.Generate` so it only runs for `tag set` (not `tag generate`), matching the existing injection behavior.
- The tag-managed `istiod-default-validator` (which carries `istio.io/tag`) is deliberately excluded by the `!istio.io/tag` selector, so it is never touched.

Also fixes a pre-existing swallowed error in `generateValidatingWebhook`, where a `helm.Render` failure returned `nil` instead of the error.

Adds unit test `TestDeactivateIstioValidationWebhook` covering: the tag-managed validator is untouched, the previous default-revision validator gets `NeverMatch` selectors, and other-revision validators are untouched.