### PR TITLE
Use service IP in east-west migration tests

### DIFF
--- a/tests/integration/ambient/sidecar_migration_test.go
+++ b/tests/integration/ambient/sidecar_migration_test.go
@@ -193,8 +193,11 @@ func runEastWestClientFirstMigration(ctx framework.TestContext, env *testEnv) {
 // eastWestTraffic returns a traffic.Config for east-west HTTP traffic from source to server.
 func eastWestTraffic(source echo.Caller, server echo.Instance) traffic.Config {
 	return migrationTrafficConfig(source, echo.CallOptions{
-		To:   server,
-		Port: echo.Port{Name: "http"},
+		To: server,
+		// Use service IP instead of DNS name to avoid failing the test on transient DNS resolution
+		// errors. The entire Istio data path is still being tested.
+		Address: server.Address(),
+		Port:    echo.Port{Name: "http"},
 	})
 }
 
@@ -202,10 +205,13 @@ func eastWestTraffic(source echo.Caller, server echo.Instance) traffic.Config {
 func verifyAmbient(ctx framework.TestContext, source echo.Caller, server echo.Instance) {
 	ctx.Helper()
 	if _, err := source.Call(echo.CallOptions{
-		To:    server,
-		Port:  echo.Port{Name: "http"},
-		Count: 1,
-		Check: check.And(check.OK(), IsL4()),
+		To: server,
+		// Use service IP instead of DNS name to avoid failing the test on transient DNS resolution
+		// errors. The entire Istio data path is still being tested.
+		Address: server.Address(),
+		Port:    echo.Port{Name: "http"},
+		Count:   1,
+		Check:   check.And(check.OK(), IsL4()),
 	}); err != nil {
 		ctx.Fatal(err)
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**

This PR tries to address recent flakiness we've been having in some of the sidecar->ambient migration tests. The failures are transient DNS resolution errors.

Since it's hard to reproduce these flakes and investigate the root cause, I'm making a slightly risky assumption that these are test infra failures rather than some genuine Istio bug. If that's true, we could just avoid relying on DNS for the data path measurements: We deliberately put a high bar of 100% request success to catch any data path errors during the risky parts of the migration. Including DNS in the mix (which has no impact on the data path) just adds potential noise without adding value.

Hopefully fixes #61665.