### PR TITLE
cni: Mark pod partially enrolled on host IP set failure

### DIFF
--- a/cni/pkg/nodeagent/meshdataplane_linux.go
+++ b/cni/pkg/nodeagent/meshdataplane_linux.go
@@ -131,7 +131,7 @@ func (s *meshDataplane) flushBranchENIRules() {
 // For any other failure after that point, returns a standard Error (which indicates the
 // function call can be retried).
 //
-// If the *last* step of sending the pod to ztunnel fails, then the pod will still be annotated
+// If a step after injecting the pod rules fails, then the pod will still be annotated
 // with a partially-captured status (indicating it has been mutated/redirected, and thus potentially
 // needs cleanup) and the error will be returned, indicating that the function call can be retried.
 func (s *meshDataplane) AddPodToMesh(ctx context.Context, pod *corev1.Pod, podIPs []netip.Addr, netNs string) error {
@@ -167,6 +167,9 @@ func (s *meshDataplane) AddPodToMesh(ctx context.Context, pod *corev1.Pod, podIP
 	// Handle node healthcheck probe rewrites
 	if _, err := s.addPodToHostAddrSet(pod, podIPs); err != nil {
 		log.Errorf("failed to add pod to addressSet, pod will fail healthchecks: %v", err)
+		if annotationErr := util.AnnotatePartiallyEnrolledPod(s.kubeClient, &pod.ObjectMeta); annotationErr != nil {
+			return annotationErr
+		}
 		// Adding pod to ipset should always be an upsert, so should not fail
 		// unless we have a kernel incompatibility - thus it should either
 		// never fail, or isn't usefully retryable.

--- a/cni/pkg/nodeagent/server_linux_test.go
+++ b/cni/pkg/nodeagent/server_linux_test.go
@@ -121,6 +121,43 @@ func TestMeshDataplaneAddsAnnotationOnAddWithPartialError(t *testing.T) {
 	assert.Equal(t, pod.Annotations[annotation.AmbientRedirection.Name], constants.AmbientRedirectionPending)
 }
 
+func TestMeshDataplaneAddsPartialAnnotationOnAddressSetFailure(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+			UID:       types.UID("test"),
+		},
+	}
+	fakeCtx := context.Background()
+	podIP := netip.MustParseAddr("99.9.9.1")
+	podIPs := []netip.Addr{podIP}
+
+	server := &fakeServer{}
+	server.On("AddPodToMesh", fakeCtx, pod, podIPs, "").Return(nil)
+
+	fakeClientSet := fake.NewClientset(pod)
+	fakeIPSetDeps := ipset.FakeNLDeps()
+	fakeIPSetDeps.On(
+		"addIP",
+		"foo-v4",
+		podIP,
+		uint8(unix.IPPROTO_TCP),
+		string(pod.UID),
+		true,
+	).Return(errors.New("address set failure"))
+	ipsetInstance := ipset.IPSet{V4Name: "foo-v4", Prefix: "foo", Deps: fakeIPSetDeps}
+	m := getFakeDPWithAddressSet(server, fakeClientSet, set.NewIPSetWrapper(ipsetInstance))
+
+	err := m.AddPodToMesh(fakeCtx, pod, podIPs, "")
+	assert.Error(t, err)
+
+	updatedPod, err := fakeClientSet.CoreV1().Pods(pod.Namespace).Get(fakeCtx, pod.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, updatedPod.Annotations[annotation.AmbientRedirection.Name], constants.AmbientRedirectionPending)
+	fakeIPSetDeps.AssertExpectations(t)
+}
+
 func TestMeshDataplaneDoesntAnnotateOnAddWithNonretryableError(t *testing.T) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**Please provide a description of this PR:**

Track partial enrollment on host IP set failures so cleanup can handle them