### PR TITLE
krt: add LookupFiltered to indexes

### DIFF
--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -246,19 +246,24 @@ type collectionIndex[I, O any] struct {
 	parent  *manyCollection[I, O]
 }
 
-func (c collectionIndex[I, O]) Lookup(key string) []O {
+func (c collectionIndex[I, O]) LookupFiltered(key string, filter func(O) bool) []O {
 	c.parent.mu.RLock()
 	defer c.parent.mu.RUnlock()
 	keys := c.index[key]
 
-	res := make([]O, 0, len(keys))
+	var res []O
+	if filter == nil {
+		res = make([]O, 0, len(keys))
+	}
 	for k := range keys {
 		v, f := c.parent.collectionState.outputs[k]
 		if !f {
 			log.WithLabels("key", k).Errorf("invalid index state, object does not exist")
 			continue
 		}
-		res = append(res, v)
+		if filter == nil || filter(v) {
+			res = append(res, v)
+		}
 	}
 	return res
 }

--- a/pkg/kube/krt/core.go
+++ b/pkg/kube/krt/core.go
@@ -139,7 +139,7 @@ type internalCollection[T any] interface {
 }
 
 type indexer[T any] interface {
-	Lookup(key string) []T
+	LookupFiltered(key string, filter func(T) bool) []T
 }
 
 type uidable interface {

--- a/pkg/kube/krt/fetch.go
+++ b/pkg/kube/krt/fetch.go
@@ -116,7 +116,8 @@ func fetch[T any](ctx HandlerContext, cc Collection[T], allowMissingContext bool
 		}
 	} else if d.filter.index != nil {
 		// Otherwise from an index; fetch from there. Often this is a list of a namespace
-		list = d.filter.index.list().([]T)
+		list = d.filter.index.listFiltered(matches).([]T)
+		prefiltered = true
 	} else {
 		// Otherwise get everything
 		list = c.ListFiltered(matches)

--- a/pkg/kube/krt/filter.go
+++ b/pkg/kube/krt/filter.go
@@ -40,7 +40,7 @@ type filter struct {
 
 type indexFilter struct {
 	filterUID    collectionUID
-	list         func() any
+	listFiltered func(any) any
 	indexMatches func(any) bool
 	extractKeys  objectKeyExtractor
 	key          string
@@ -123,8 +123,8 @@ func FilterIndex[K comparable, I any](idx Index[K, I], k K) FetchOption {
 		// Index is used to pre-filter on the List, and also to match in Matches. Provide type-erased methods for both
 		h.filter.index = &indexFilter{
 			filterUID: idx.id(),
-			list: func() any {
-				return idx.Lookup(k)
+			listFiltered: func(filter any) any {
+				return idx.LookupFiltered(k, filter.(func(I) bool))
 			},
 			indexMatches: func(a any) bool {
 				return idx.objectHasKey(a.(I), k)

--- a/pkg/kube/krt/index.go
+++ b/pkg/kube/krt/index.go
@@ -27,6 +27,9 @@ import (
 
 type Index[K comparable, O any] interface {
 	Lookup(k K) []O
+	// LookupFiltered returns objects matching the key and filter. A nil filter returns all objects for the key.
+	// The filter must not modify the collection or its objects.
+	LookupFiltered(k K, filter func(O) bool) []O
 	AsCollection(opts ...CollectionOption) IndexCollection[K, O]
 	Fetch(ctx HandlerContext, key K, opts ...FetchOption) []O
 	objectHasKey(obj O, k K) bool
@@ -153,10 +156,16 @@ func (i index[K, O]) id() collectionUID {
 
 // Lookup finds all objects matching a given key
 func (i index[K, O]) Lookup(k K) []O {
+	return i.LookupFiltered(k, nil)
+}
+
+// LookupFiltered finds objects matching a given key that are accepted by filter.
+// A nil filter returns all objects matching the key.
+func (i index[K, O]) LookupFiltered(k K, filter func(O) bool) []O {
 	if i.indexer == nil {
 		return nil
 	}
-	return i.indexer.Lookup(toString(k))
+	return i.indexer.LookupFiltered(toString(k), filter)
 }
 
 func toString(rk any) string {

--- a/pkg/kube/krt/index_test.go
+++ b/pkg/kube/krt/index_test.go
@@ -27,11 +27,137 @@ import (
 	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/kube/kclient/clienttest"
 	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
 )
+
+func TestLookupFiltered(t *testing.T) {
+	opts := testOptions(t)
+	objects := []Named{{Namespace: "ns", Name: "a"}, {Namespace: "ns", Name: "b"}, {Namespace: "other", Name: "c"}}
+	static := krt.NewStaticCollection[Named](nil, objects, opts.WithName("static")...)
+	left := krt.NewStaticCollection[Named](nil, objects[:1], opts.WithName("left")...)
+	right := krt.NewStaticCollection[Named](nil, objects[1:], opts.WithName("right")...)
+	collections := map[string]krt.Collection[Named]{
+		"static": static,
+		"derived": krt.NewCollection(static, func(_ krt.HandlerContext, n Named) *Named {
+			return &n
+		}, opts.WithName("derived")...),
+		"joined": krt.JoinCollection([]krt.Collection[Named]{left, right}, opts.WithName("joined")...),
+		"merged": krt.JoinWithMergeCollection([]krt.Collection[Named]{left, right}, func(ns []Named) *Named {
+			return &ns[0]
+		}, opts.WithName("merged")...),
+	}
+	for name, col := range collections {
+		t.Run(name, func(t *testing.T) {
+			col.WaitUntilSynced(opts.Stop())
+			checkLookupFiltered(t, col, func(n Named) string { return n.Namespace })
+		})
+	}
+	t.Run("mapped", func(t *testing.T) {
+		col := krt.MapCollection(static, func(n Named) SimplePod { return SimplePod{Named: n} }, opts.WithName("mapped")...)
+		col.WaitUntilSynced(opts.Stop())
+		checkLookupFiltered(t, col, func(p SimplePod) string { return p.Namespace })
+	})
+	t.Run("informer", func(t *testing.T) {
+		client := kube.NewFakeClient(
+			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "a"}},
+			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "b"}},
+			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "other", Name: "c"}},
+		)
+		col := krt.NewInformer[*corev1.ConfigMap](client, opts.WithName("informer")...)
+		client.RunAndWait(opts.Stop())
+		col.WaitUntilSynced(opts.Stop())
+		checkLookupFiltered(t, col, func(n *corev1.ConfigMap) string { return n.Namespace })
+	})
+}
+
+func checkLookupFiltered[T any](t *testing.T, col krt.Collection[T], namespace func(T) string) {
+	t.Helper()
+	idx := krt.NewIndex(col, "namespace", func(n T) []string { return []string{namespace(n)} })
+	keys := func(objects []T) []string {
+		return slices.Sort(slices.Map(objects, func(obj T) string { return krt.GetKey(obj) }))
+	}
+	assert.Equal(t, keys(idx.LookupFiltered("ns", nil)), []string{"ns/a", "ns/b"})
+	assert.Equal(t, keys(idx.LookupFiltered("ns", func(T) bool { return true })), []string{"ns/a", "ns/b"})
+	assert.Equal(t, len(idx.LookupFiltered("ns", func(T) bool { return false })), 0)
+	assert.Equal(t, len(idx.LookupFiltered("missing", func(T) bool {
+		t.Fatal("filter called for missing key")
+		return true
+	})), 0)
+	var calls int
+	filter := func(obj T) bool {
+		calls++
+		assert.Equal(t, namespace(obj), "ns")
+		return krt.GetKey(obj) == "ns/b"
+	}
+	assert.Equal(t, keys(idx.LookupFiltered("ns", filter)), []string{"ns/b"})
+	assert.Equal(t, calls, 2)
+	calls = 0
+	assert.Equal(t, keys(krt.FetchOrList(nil, col, krt.FilterIndex(idx, "ns"), krt.FilterGeneric(func(obj any) bool {
+		return filter(obj.(T))
+	}))), []string{"ns/b"})
+	assert.Equal(t, calls, 2)
+	// Filtering must not change the index's stored results.
+	assert.Equal(t, keys(idx.Lookup("ns")), []string{"ns/a", "ns/b"})
+}
+
+func BenchmarkLookupFiltered(b *testing.B) {
+	scope := log.FindScope("krt")
+	level := scope.GetOutputLevel()
+	scope.SetOutputLevel(log.InfoLevel)
+	b.Cleanup(func() { scope.SetOutputLevel(level) })
+	for _, size := range []int{100, 10000} {
+		b.Run(strconv.Itoa(size), func(b *testing.B) {
+			objects := make([]Named, size)
+			for i := range objects {
+				objects[i] = Named{Namespace: "ns", Name: strconv.Itoa(i)}
+			}
+			col := krt.NewStaticCollection[Named](nil, objects, krt.WithStop(test.NewStop(b)))
+			idx := krt.NewIndex(col, "namespace", func(n Named) []string { return []string{n.Namespace} })
+			filter := func(n Named) bool { return n.Name == "0" }
+			for name, lookup := range map[string]func() []Named{
+				"Lookup":         func() []Named { return slices.FilterInPlace(idx.Lookup("ns"), filter) },
+				"LookupFiltered": func() []Named { return idx.LookupFiltered("ns", filter) },
+				"Fetch": func() []Named {
+					return krt.FetchOrList(nil, col, krt.FilterIndex(idx, "ns"), krt.FilterGeneric(func(obj any) bool {
+						return filter(obj.(Named))
+					}))
+				},
+			} {
+				b.Run(name, func(b *testing.B) {
+					b.ReportAllocs()
+					for b.Loop() {
+						if len(lookup()) != 1 {
+							b.Fatal("expected one matching object")
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestIndexFetchFilteredUpdates(t *testing.T) {
+	opts := testOptions(t)
+	pod := SimplePod{Named: Named{Namespace: "ns", Name: "a"}, IP: "unmatched"}
+	pods := krt.NewMutableCollection[SimplePod](nil, []SimplePod{pod}, opts.WithName("pods")...)
+	idx := krt.NewIndex(pods.AsCollection(), "namespace", func(p SimplePod) []string { return []string{p.Namespace} })
+	result := krt.NewSingleton(func(ctx krt.HandlerContext) *string {
+		matches := idx.Fetch(ctx, "ns", krt.FilterGeneric(func(obj any) bool { return obj.(SimplePod).IP == "matched" }))
+		return ptr.Of(strconv.Itoa(len(matches)))
+	}, opts.WithName("result")...)
+	result.AsCollection().WaitUntilSynced(opts.Stop())
+	assert.Equal(t, result.Get(), ptr.Of("0"))
+	pod.IP = "matched"
+	pods.UpdateObject(pod)
+	assert.EventuallyEqual(t, result.Get, ptr.Of("1"))
+	pod.IP = "unmatched"
+	pods.UpdateObject(pod)
+	assert.EventuallyEqual(t, result.Get, ptr.Of("0"))
+}
 
 func TestIndex(t *testing.T) {
 	stop := test.NewStop(t)

--- a/pkg/kube/krt/index_test.go
+++ b/pkg/kube/krt/index_test.go
@@ -78,7 +78,7 @@ func checkLookupFiltered[T any](t *testing.T, col krt.Collection[T], namespace f
 	t.Helper()
 	idx := krt.NewIndex(col, "namespace", func(n T) []string { return []string{namespace(n)} })
 	keys := func(objects []T) []string {
-		return slices.Sort(slices.Map(objects, func(obj T) string { return krt.GetKey(obj) }))
+		return slices.Sort(slices.Map(objects, krt.GetKey[T]))
 	}
 	assert.Equal(t, keys(idx.LookupFiltered("ns", nil)), []string{"ns/a", "ns/b"})
 	assert.Equal(t, keys(idx.LookupFiltered("ns", func(T) bool { return true })), []string{"ns/a", "ns/b"})

--- a/pkg/kube/krt/informer.go
+++ b/pkg/kube/krt/informer.go
@@ -149,10 +149,19 @@ type informerIndex[I any] struct {
 }
 
 // nolint: unused // (not true)
-func (ii *informerIndex[I]) Lookup(key string) []I {
-	return slices.Map(ii.idx.Lookup(key), func(i any) I {
-		return i.(I)
-	})
+func (ii *informerIndex[I]) LookupFiltered(key string, filter func(I) bool) []I {
+	objects := ii.idx.Lookup(key)
+	var res []I
+	if filter == nil {
+		res = make([]I, 0, len(objects))
+	}
+	for _, obj := range objects {
+		v := obj.(I)
+		if filter == nil || filter(v) {
+			res = append(res, v)
+		}
+	}
+	return res
 }
 
 // nolint: unused // (not true)

--- a/pkg/kube/krt/join.go
+++ b/pkg/kube/krt/join.go
@@ -325,11 +325,11 @@ type joinIndexer[T any] struct {
 }
 
 // nolint: unused // (not true)
-func (j joinIndexer[T]) Lookup(key string) []T {
+func (j joinIndexer[T]) LookupFiltered(key string, filter func(T) bool) []T {
 	var res []T
 	first := true
 	for _, i := range j.indexers {
-		l := i.Lookup(key)
+		l := i.LookupFiltered(key, filter)
 		if len(l) > 0 && first {
 			// Optimization: re-use the first returned slice
 			res = l

--- a/pkg/kube/krt/map.go
+++ b/pkg/kube/krt/map.go
@@ -42,8 +42,22 @@ type mappedIndexer[T any, U any] struct {
 var _ collectionTrait[any] = &mapCollection[any, any]{}
 
 // nolint: unused // (not true, its to implement an interface)
-func (m *mappedIndexer[T, U]) Lookup(k string) []U {
-	keys := m.indexer.Lookup(k)
+func (m *mappedIndexer[T, U]) LookupFiltered(k string, filter func(U) bool) []U {
+	if filter != nil {
+		var res []U
+		m.indexer.LookupFiltered(k, func(obj T) bool {
+			mapped := m.mapFunc(obj)
+			if EnableAssertions {
+				assertKeyMatch(obj, mapped, m.fromCollection)
+			}
+			if filter(mapped) {
+				res = append(res, mapped)
+			}
+			return false
+		})
+		return res
+	}
+	keys := m.indexer.LookupFiltered(k, nil)
 	res := make([]U, 0, len(keys))
 	for _, obj := range keys {
 		if EnableAssertions {

--- a/pkg/kube/krt/mergejoin.go
+++ b/pkg/kube/krt/mergejoin.go
@@ -67,19 +67,24 @@ type joinCollectionIndex[T any] struct {
 	parent  *mergejoin[T]
 }
 
-func (c joinCollectionIndex[T]) Lookup(key string) []T {
+func (c joinCollectionIndex[T]) LookupFiltered(key string, filter func(T) bool) []T {
 	c.parent.mu.RLock()
 	defer c.parent.mu.RUnlock()
 	keys := c.index[key]
 
-	res := make([]T, 0, len(keys))
+	var res []T
+	if filter == nil {
+		res = make([]T, 0, len(keys))
+	}
 	for k := range keys {
 		v, f := c.parent.outputs[k]
 		if !f {
 			log.WithLabels("key", k).Errorf("invalid index state, object does not exist")
 			continue
 		}
-		res = append(res, v)
+		if filter == nil || filter(v) {
+			res = append(res, v)
+		}
 	}
 	return res
 }

--- a/pkg/kube/krt/static.go
+++ b/pkg/kube/krt/static.go
@@ -273,19 +273,24 @@ type staticListIndex[T any] struct {
 }
 
 // nolint: unused // (not true)
-func (s staticListIndex[T]) Lookup(key string) []T {
+func (s staticListIndex[T]) LookupFiltered(key string, filter func(T) bool) []T {
 	s.parent.mu.RLock()
 	defer s.parent.mu.RUnlock()
 	keys := s.index[key]
 
-	res := make([]T, 0, len(keys))
+	var res []T
+	if filter == nil {
+		res = make([]T, 0, len(keys))
+	}
 	for k := range keys {
 		v, f := s.parent.vals[k]
 		if !f {
 			log.WithLabels("key", k).Errorf("invalid index state, object does not exist")
 			continue
 		}
-		res = append(res, v)
+		if filter == nil || filter(v) {
+			res = append(res, v)
+		}
 	}
 	return res
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
Same concept as https://github.com/istio/istio/pull/61553 but for indexes, adding a `LookupFiltered` which avoids allocating big slices when filtering an index scan.

Related to https://github.com/istio/istio/issues/61382