### PR TITLE
serviceentry: empty selectors should match nothing

### DIFF
--- a/pilot/pkg/serviceregistry/serviceentry/controller_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller_test.go
@@ -716,6 +716,29 @@ func TestServiceDiscoveryServiceInstancesForDnsRoundRobinLB(t *testing.T) {
 	expectServiceInstances(t, sd, otherNs, 0, otherNsExpected)
 }
 
+func TestEmptyWorkloadSelectorMatchesNoWorkloads(t *testing.T) {
+	store, sd, events := initServiceDiscovery(t)
+
+	se := selector.DeepCopy()
+	se.Name = "empty-selector"
+	se.Spec.(*networking.ServiceEntry).WorkloadSelector = &networking.WorkloadSelector{
+		Labels: map[string]string{},
+	}
+	wle := createWorkloadEntry("wl", se.Namespace, &networking.WorkloadEntry{
+		Address: "2.2.2.2",
+		Labels:  map[string]string{"app": "wle"},
+	})
+
+	createConfigs([]*config.Config{&se}, store, t)
+	expectEvents(t, events,
+		Event{Type: "service", ID: "selector.com", Namespace: se.Namespace},
+		Event{Type: "eds", ID: "selector.com", Namespace: se.Namespace},
+		Event{Type: "xds", ID: "selector.com"})
+
+	createConfigs([]*config.Config{wle}, store, t)
+	expectServiceInstances(t, sd, &se, 0, []*WorkloadServiceInstance{})
+}
+
 func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 	store, sd, events := initServiceDiscovery(t)
 

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -559,18 +559,24 @@ func services(
 		}
 
 		dnsService := isDNSTypeService(services[0])
-		selectedWorkloads := workloadsByNamespace.Fetch(
-			ctx,
-			cfg.Namespace,
-			krt.FilterLabel(se.WorkloadSelector.Labels),
-			krt.FilterGeneric(func(o any) bool {
-				wi := o.(*model.WorkloadInstance)
-				if wi.DNSServiceEntryOnly && !dnsService {
-					return false
-				}
-				return true
-			}),
-		)
+		var selectedWorkloads []*model.WorkloadInstance
+
+		// SE with empty workload selector will not select any workloads
+		if len(se.WorkloadSelector.Labels) != 0 {
+			selectedWorkloads = workloadsByNamespace.Fetch(
+				ctx,
+				cfg.Namespace,
+				krt.FilterLabel(se.WorkloadSelector.Labels),
+				krt.FilterGeneric(func(o any) bool {
+					wi := o.(*model.WorkloadInstance)
+					if wi.DNSServiceEntryOnly && !dnsService {
+						return false
+					}
+					return true
+				}),
+			)
+		}
+
 		// krt fetching does not guarantee order, so we need to sort the selected workloads to ensure determinism
 		slices.SortStableFunc(selectedWorkloads, func(a, b *model.WorkloadInstance) int {
 			if r := cmp.Compare(a.Kind, b.Kind); r != 0 {

--- a/releasenotes/notes/serviceentry-empty-workload-selector.yaml
+++ b/releasenotes/notes/serviceentry-empty-workload-selector.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed** ServiceEntries with a present but empty workload selector incorrectly matching all workloads in their namespace.


### PR DESCRIPTION
**Please provide a description of this PR:**
This bug was introduced in https://github.com/istio/istio/pull/58951, previously a ServiceEntry with a non-nil empty selector would **not match any workloads**, currently it **matches every workload**. This PR reverts to the previous behavior of not matching any.