### PR TITLE
[release-1.29] bump prometheus/common to 0.71.0 and fix deprecated expfmt call

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/client_model v0.6.2
-	github.com/prometheus/common v0.70.1
+	github.com/prometheus/common v0.71.0
 	github.com/prometheus/procfs v0.22.0
 	github.com/prometheus/prometheus v0.311.3
 	github.com/quic-go/quic-go v0.61.0

--- a/go.sum
+++ b/go.sum
@@ -388,8 +388,8 @@ github.com/prometheus/client_golang/exp v0.0.0-20260325093428-d8591d0db856 h1:1Y
 github.com/prometheus/client_golang/exp v0.0.0-20260325093428-d8591d0db856/go.mod h1:Vf0QcmVhGqpjLxZOaWrFSep86vchQtJmbztFaMM4f6Q=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=
 github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
-github.com/prometheus/common v0.70.1 h1:1HvjP4D5oL3t8RsPlwxA9onvvStjtIHYE5XuuwOi/PY=
-github.com/prometheus/common v0.70.1/go.mod h1:VdFUQDMZK3VLkurFUVhia6uys/0suUp86TJz5qbJRhc=
+github.com/prometheus/common v0.71.0 h1:9KDAKb7Mj3HEVKyFCK6Dc/HIwlBzZIN2l7/lrHl3KK8=
+github.com/prometheus/common v0.71.0/go.mod h1:CLJ5H8TEsGX8bl31BdMkfhIZ+QmZ9tBPPotUxUbfcmk=
 github.com/prometheus/otlptranslator v1.0.0 h1:s0LJW/iN9dkIH+EnhiD3BlkkP5QVIUVEoIwkU+A6qos=
 github.com/prometheus/otlptranslator v1.0.0/go.mod h1:vRYWnXvI6aWGpsdY/mOT/cbeVRBlPWtBNDb7kGR3uKM=
 github.com/prometheus/procfs v0.22.0 h1:6q9+/JL9IKAPbCmBrv9n5O5Ty3NKnciV5X7YGw0oics=

--- a/pilot/cmd/pilot-agent/status/server_test.go
+++ b/pilot/cmd/pilot-agent/status/server_test.go
@@ -487,7 +487,7 @@ my_other_metric{} 0
 			}))
 			defer envoy.Close()
 			app := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				format := expfmt.NegotiateIncludingOpenMetrics(r.Header)
+				format := negotiateFormat(r.Header)
 				var negotiatedMetrics string
 				if strings.Contains(string(format), "text/plain") {
 					negotiatedMetrics = appText004
@@ -620,7 +620,7 @@ my_other_metric{} 0
 	}))
 	t.Cleanup(envoyServer.Close)
 	app := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		format := expfmt.NegotiateIncludingOpenMetrics(r.Header)
+		format := negotiateFormat(r.Header)
 		var negotiatedMetrics string
 		if format == FmtText {
 			negotiatedMetrics = appText
@@ -1566,4 +1566,17 @@ func TestingRegistry(t test.Failer) prometheus.Gatherer {
 		t.Fatal(err)
 	}
 	return r
+}
+
+// negotiateFormat mirrors the deprecated expfmt.NegotiateIncludingOpenMetrics.
+func negotiateFormat(h http.Header) expfmt.Format {
+	om001, _ := expfmt.NewOpenMetricsFormat(expfmt.OpenMetricsVersion_0_0_1)
+	return expfmt.NegotiateAccept(h,
+		expfmt.NewFormat(expfmt.TypeOpenMetrics),
+		om001,
+		expfmt.NewFormat(expfmt.TypeProtoDelim),
+		expfmt.NewFormat(expfmt.TypeProtoText),
+		expfmt.NewFormat(expfmt.TypeProtoCompact),
+		expfmt.NewFormat(expfmt.TypeTextPlain),
+	)
 }


### PR DESCRIPTION
Manual cherrypick of #61586. Fixes #61685