### PR TITLE
Run gateway conformance less

### DIFF
--- a/tests/integration/ambient/gateway_conformance_test.go
+++ b/tests/integration/ambient/gateway_conformance_test.go
@@ -72,7 +72,8 @@ var skippedTests = map[string]string{
 
 func TestGatewayConformance(t *testing.T) {
 	framework.
-		NewTest(t).
+		// FIXME (stevenjin8) gateway api conformance tests are extremely CPU heavy, probably because they done do any kind of backoff when checking state.
+		NewFullTest(t).
 		Run(func(ctx framework.TestContext) {
 			skipIfGatewayAPIUnsupported(ctx)
 			// Precreate the GatewayConformance namespaces, and apply the Image Pull Secret to them.

--- a/tests/integration/ambient/gateway_conformance_test.go
+++ b/tests/integration/ambient/gateway_conformance_test.go
@@ -72,7 +72,6 @@ var skippedTests = map[string]string{
 
 func TestGatewayConformance(t *testing.T) {
 	framework.
-		// FIXME (stevenjin8) gateway api conformance tests are extremely CPU heavy, probably because they done do any kind of backoff when checking state.
 		NewFullTest(t).
 		Run(func(ctx framework.TestContext) {
 			skipIfGatewayAPIUnsupported(ctx)

--- a/tests/integration/pilot/filebasedkubeconfig/main_test.go
+++ b/tests/integration/pilot/filebasedkubeconfig/main_test.go
@@ -52,7 +52,6 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
 		Label(label.Full).
-		Label(label.Multicluster).
 		RequireMultiPrimary().
 		RequireMinClusters(2).
 		Setup(istio.Setup(&i, setupConfigForMountedKubeconfigs, createEmptyMountedKubeconfigSecrets)).

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -69,7 +69,6 @@ var skippedTests = map[string]string{
 
 func TestGatewayConformance(t *testing.T) {
 	framework.
-		// FIXME (stevenjin8) gateway api conformance tests are extremely CPU heavy, probably because they done do any kind of backoff when checking state.
 		NewFullTest(t).
 		Run(func(ctx framework.TestContext) {
 			crd.DeployGatewayAPIOrSkip(ctx)

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -69,7 +69,8 @@ var skippedTests = map[string]string{
 
 func TestGatewayConformance(t *testing.T) {
 	framework.
-		NewTest(t).
+		// FIXME (stevenjin8) gateway api conformance tests are extremely CPU heavy, probably because they done do any kind of backoff when checking state.
+		NewFullTest(t).
 		Run(func(ctx framework.TestContext) {
 			crd.DeployGatewayAPIOrSkip(ctx)
 

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -149,7 +149,7 @@ test.integration.kube.presubmit: | $(JUNIT_REPORT) check-go-tag
 # Defines a target to run a standard set of tests in various different environments (IPv6, distroless, ARM, etc).
 .PHONY: test.integration.kube.environment
 test.integration.kube.environment: | $(JUNIT_REPORT) check-go-tag
-	$(call run-test-with-tags,./tests/integration/security/ ./tests/integration/pilot/,$(INTEGRATION_TEST_TAGS_ENVIRONMENT),-run="TestReachability|TestTraffic|TestGatewayConformance",$(_INTEGRATION_TEST_ENVIRONMENT_SELECT_FLAGS))
+	$(call run-test-with-tags,./tests/integration/security/ ./tests/integration/pilot/,$(INTEGRATION_TEST_TAGS_ENVIRONMENT),-run="TestReachability|TestTraffic",$(_INTEGRATION_TEST_ENVIRONMENT_SELECT_FLAGS))
 
 # Agentgateway support is currently experimental. Only used to run agentgateway tests as optional
 .PHONY: test.integration.kube.agentgateway


### PR DESCRIPTION
**Please provide a description of this PR:**

I don't think we need to run gateway conformance in every deployment model.