### PR TITLE
eds: avoid full push on shard creation

### DIFF
--- a/pilot/pkg/model/endpointshards.go
+++ b/pilot/pkg/model/endpointshards.go
@@ -286,7 +286,8 @@ const (
 	NoPush PushType = iota
 	// IncrementalPush just pushes endpoints.
 	IncrementalPush
-	// FullPush triggers full push - typically used for new services.
+	// FullPush triggers full push - used when endpoint changes require regenerating more than EDS,
+	// such as a change to the set of service accounts backing a service.
 	FullPush
 )
 
@@ -316,23 +317,19 @@ func (e *EndpointIndex) UpdateServiceEndpoints(
 
 	pushType := IncrementalPush
 	// Find endpoint shard for this service, if it is available - otherwise create a new one.
-	ep, created := e.GetOrCreateEndpointShard(hostname, namespace)
-	// If we create a new endpoint shard, that means we have not seen the service earlier. We should do a full push.
-	if created {
-		if logPushType {
-			log.Infof("Full push, new service %s/%s", namespace, hostname)
-		} else {
-			log.Infof("Cache Update, new service %s/%s", namespace, hostname)
-		}
-		pushType = FullPush
-	}
+	// Creating a shard means we have not seen endpoints for this service before, but it does not
+	// warrant a full push. Endpoints are recorded below regardless of the push type, and registries
+	// trigger their own service update (a kind.ServiceEntry ConfigUpdate, see initRegistryEventHandlers)
+	// whenever a service is added, which re-initializes the service registry and picks these endpoints
+	// up. If the service is not known yet, an endpoint-only push is simply a no-op until it is.
+	ep, _ := e.GetOrCreateEndpointShard(hostname, namespace)
 
 	ep.Lock()
 	defer ep.Unlock()
 	oldIstioEndpoints := ep.Shards[shard]
 	newIstioEndpoints, needPush := endpointUpdateRequiresPush(oldIstioEndpoints, istioEndpoints)
 
-	if pushType != FullPush && !needPush {
+	if !needPush {
 		log.Debugf("No push, either old endpoint health status did not change or new endpoint came with unhealthy status, %v", hostname)
 		pushType = NoPush
 	}
@@ -343,8 +340,7 @@ func (e *EndpointIndex) UpdateServiceEndpoints(
 	saUpdated := updateShardServiceAccount(ep, hostname)
 
 	// For existing endpoints, we need to do full push if service accounts change.
-	if saUpdated && pushType != FullPush {
-		// Avoid extra logging if already a full push
+	if saUpdated {
 		if logPushType {
 			log.Infof("Full push, service accounts changed, %v", hostname)
 		} else {

--- a/pilot/pkg/model/endpointshards_test.go
+++ b/pilot/pkg/model/endpointshards_test.go
@@ -186,3 +186,35 @@ func TestUpdateServiceEndpoints(t *testing.T) {
 		})
 	}
 }
+
+// Receiving endpoints for a service we have not seen before creates its shard, but creating the
+// shard alone must not require a full push: the endpoints are recorded either way, and a service
+// only becomes visible to config generation via its own update, which re-initializes the service
+// registry and picks them up.
+//
+// Note that the service account check applies independently and does force a full push whenever the
+// endpoints introduce a service account, which is the common case for real workloads.
+func TestUpdateServiceEndpointsNewShardPushType(t *testing.T) {
+	shardKey := ShardKey{Cluster: "c1"}
+
+	t.Run("without service accounts", func(t *testing.T) {
+		endpoints := NewEndpointIndex(DisabledCache{})
+		pushType := endpoints.UpdateServiceEndpoints(shardKey, "foo.com", "foo", []*IstioEndpoint{
+			{Addresses: []string{"10.172.0.1"}, Namespace: "foo", HostName: "foo.com"},
+		}, true)
+		assert.Equal(t, pushType, IncrementalPush)
+
+		// The endpoints are recorded regardless, so a later service update can pick them up.
+		eps, ok := endpoints.ShardsForService("foo.com", "foo")
+		assert.Equal(t, ok, true)
+		assert.Equal(t, len(eps.Shards[shardKey]), 1)
+	})
+
+	t.Run("new service account still requires a full push", func(t *testing.T) {
+		endpoints := NewEndpointIndex(DisabledCache{})
+		pushType := endpoints.UpdateServiceEndpoints(shardKey, "foo.com", "foo", []*IstioEndpoint{
+			{Addresses: []string{"10.172.0.1"}, Namespace: "foo", HostName: "foo.com", ServiceAccount: "sa"},
+		}, true)
+		assert.Equal(t, pushType, FullPush)
+	})
+}


### PR DESCRIPTION
**Please provide a description of this PR:**
This is a small optimization and code cleanup, whenever an EDS shard is created there is actually no need to trigger a "full" push, since ServiceRegistries will actually trigger a "full" push when services are created. In most cases ServiceAccounts also change when a shard is created, this continues to trigger a "full" push.